### PR TITLE
docs: clarify troubleshooting for script import/venv issues

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -65,7 +65,7 @@ Copy `api/.env.example` to `api/.env` and fill required keys.
 | Problem | Fix |
 |---------|-----|
 | `pytest: command not found` | Use `.venv/bin/pytest` or `python -m pytest` in the venv |
-| Import/module errors | Ensure `pip install -e ".[dev]"` ran in active venv |
+| `ModuleNotFoundError` / import error when running scripts | If venv activation is missing, use the explicit venv path (`api/.venv/bin/python api/scripts/<script>.py`) and ensure `pip install -e ".[dev]"` ran in the active venv |
 | Port 8000 in use | Start API on another port (`--port 8001`) |
 
 ## Deployment


### PR DESCRIPTION
### Motivation
- The Troubleshooting guidance needed to explicitly cover `ModuleNotFoundError`/import errors that occur when running `api/scripts/*`, and to call out venv activation vs using the explicit venv Python path so tests/specs are satisfied.

### Description
- Updated `docs/SETUP.md` Troubleshooting table to mention `ModuleNotFoundError` / import errors when running scripts and to recommend using the explicit venv Python path (e.g. `api/.venv/bin/python api/scripts/<script>.py`) and ensuring `pip install -e ".[dev]"` ran in the venv.

### Testing
- Ran `pytest -q api/tests/test_setup_docs.py` and `pytest -q api/tests`, and both test runs completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb0eadf34832fbb96962d35396d24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates `docs/SETUP.md` troubleshooting guidance to explicitly cover `ModuleNotFoundError`/import errors when running `api/scripts/*`, recommending running scripts with the venv’s Python path and confirming `pip install -e "[dev]"` was executed in the active venv.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bfe9821a6be2bfc1fd4b6b40ca0d16d6751240b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->