### PR TITLE
Guard auto-track workflow when API secrets are missing

### DIFF
--- a/.github/workflows/auto_track_contributions.yml
+++ b/.github/workflows/auto_track_contributions.yml
@@ -10,13 +10,16 @@ jobs:
   track-contribution:
     if: github.event.pull_request.merged == true || github.event_name == 'push'
     runs-on: ubuntu-latest
-    
+    env:
+      API_URL: ${{ secrets.COHERENCE_API_URL }}
+      API_KEY: ${{ secrets.COHERENCE_API_KEY }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Get commit info
         id: commit_info
         run: |
@@ -24,27 +27,25 @@ jobs:
           COMMIT_HASH=$(git log -1 --format='%H')
           FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $COMMIT_HASH | wc -l)
           LINES_ADDED=$(git diff-tree --no-commit-id --numstat -r $COMMIT_HASH | awk '{sum+=$1} END {print sum}')
-          
+
           echo "author_email=$AUTHOR_EMAIL" >> $GITHUB_OUTPUT
           echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
           echo "files_changed=$FILES_CHANGED" >> $GITHUB_OUTPUT
           echo "lines_added=$LINES_ADDED" >> $GITHUB_OUTPUT
-      
+
       - name: Calculate contribution cost
         id: calc_cost
         run: |
           FILES=${{ steps.commit_info.outputs.files_changed }}
           LINES=${{ steps.commit_info.outputs.lines_added }}
-          
+
           # Base cost: $10 per file + $0.50 per line
           COST=$(echo "($FILES * 10) + ($LINES * 0.5)" | bc)
-          
+
           echo "cost=$COST" >> $GITHUB_OUTPUT
-      
+
       - name: Record contribution
-        env:
-          API_URL: ${{ secrets.COHERENCE_API_URL }}
-          API_KEY: ${{ secrets.COHERENCE_API_KEY }}
+        if: env.API_URL != '' && env.API_KEY != ''
         run: |
           curl -X POST "$API_URL/v1/contributions" \
             -H "Content-Type: application/json" \
@@ -60,9 +61,14 @@ jobs:
                 "repository": "${{ github.repository }}"
               }
             }'
-      
+
+      - name: Skip tracking when API secrets are unavailable
+        if: env.API_URL == '' || env.API_KEY == ''
+        run: |
+          echo "Skipping contribution tracking because COHERENCE_API_URL/COHERENCE_API_KEY is not configured for this run."
+
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.API_URL != '' && env.API_KEY != ''
         uses: actions/github-script@v6
         with:
           script: |
@@ -71,4 +77,16 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.name,
               body: '✅ Contribution recorded! Cost: $$${{ steps.calc_cost.outputs.cost }}\nVerify at: https://api.coherencycoin.com/v1/contributions/commit/${{ steps.commit_info.outputs.commit_hash }}'
+            })
+
+      - name: Comment on PR when tracking is skipped
+        if: github.event_name == 'pull_request' && (env.API_URL == '' || env.API_KEY == '')
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              body: '⚠️ Contribution tracking skipped because COHERENCE_API_URL/COHERENCE_API_KEY are not available in this workflow run.'
             })


### PR DESCRIPTION
### Motivation
- Prevent workflow failures when `COHERENCE_API_URL`/`COHERENCE_API_KEY` are not configured (common for forks) which produced `curl: (3) URL rejected: No host part in the URL`.

### Description
- Wire `API_URL` and `API_KEY` at the job level from `secrets.COHERENCE_API_URL` and `secrets.COHERENCE_API_KEY` so all steps can evaluate availability via `env`.
- Guard the contribution POST step with `if: env.API_URL != '' && env.API_KEY != ''` so `curl` is only called when the endpoint and key are present.
- Add a skip step that runs when the secrets are missing and logs a clear message explaining why tracking was skipped.
- Split PR commenting into success and skipped paths so pull requests receive an appropriate comment in either case.

### Testing
- Validated workflow syntax with `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/auto_track_contributions.yml').read_text()); print('YAML OK')"`, which succeeded.
- Committed the change and confirmed the commit was created with `git commit` (commit `1e05d58`).
- Created the PR via the PR creation helper (`mcp__make_pr__make_pr`) and confirmed the PR metadata was prepared successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb237462c832f9871cb0e84e21ed5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only conditional changes that primarily prevent failures when secrets are absent; no application/runtime code impact.
> 
> **Overview**
> Guards the `Auto-Track Contributions` GitHub Action so it no longer fails when `COHERENCE_API_URL`/`COHERENCE_API_KEY` are unavailable (e.g., forked PRs).
> 
> Moves the API secrets to job-level `env`, conditionally runs the `curl` contribution POST only when both are present, and adds an explicit “skip” step plus separate PR comments for success vs skipped tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c1e9912373463b599fef62c87f9dfd7f493d898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->