### PR TITLE
Fix Vercel `/api-health` fetch failures using Next.js proxy route

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -157,11 +157,96 @@ If you need to validate worker behavior temporarily, run it manually in a contro
    - `NEXT_PUBLIC_API_URL=https://<api-domain>`
 4. Deploy.
 
+### CLI smoke check (Railway + Vercel)
+
+From repository root:
+
+```bash
+./scripts/verify_web_api_deploy.sh \
+  https://<railway-api-domain> \
+  https://<vercel-web-domain>
+```
+
+This checks:
+- `GET <railway-api-domain>/api/health`
+- `GET <vercel-web-domain>/`
+- `GET <vercel-web-domain>/api-health`
+- CORS header alignment (`Origin: <vercel-web-domain>` against API health endpoint)
+
+Use this as a quick connectivity + CORS check after each deployment.
+
+### If Vercel domain returns 404
+
+A Vercel `404` on the project domain usually means the domain is not attached to the correct project or there is no active deployment for that domain.
+
+Verify in Vercel dashboard:
+1. **Project selected**: correct repository imported.
+2. **Root Directory**: `web/`.
+3. **Domains**: the exact domain (for example `coherencenetwork.vercel.app`) is listed under this project.
+4. **Latest deployment**: Production deployment status is **Ready**.
+5. **Environment variable**: `NEXT_PUBLIC_API_URL=https://coherence-network-production.up.railway.app` in Production scope.
+
+Quick CLI checks from your machine:
+
+```bash
+curl -I https://coherencenetwork.vercel.app/
+curl -I https://coherencenetwork.vercel.app/api-health
+./scripts/verify_web_api_deploy.sh \
+  https://coherence-network-production.up.railway.app \
+  https://coherencenetwork.vercel.app
+```
+
+Expected: non-404 responses on `/` and `/api-health`, plus passing CORS check.
+
+### Vercel error: `No Output Directory named "public" found`
+
+If Vercel shows:
+- `No Output Directory named "public" found after the Build completed.`
+
+it means the project is being treated like a generic static site, not a Next.js app.
+
+Fix:
+1. In Vercel Project Settings, set **Framework Preset** to **Next.js**.
+2. Confirm **Root Directory** is `web/`.
+3. Clear any custom **Output Directory** (leave empty for Next.js).
+4. Redeploy.
+
+Repository guardrail added:
+- `web/vercel.json` now pins `"framework": "nextjs"` so Vercel does not expect a static `public/` output.
+
+### Interpreting Vercel build logs
+
+If logs show entries like:
+- `Vercel CLI <version>`
+- `Installing dependencies...`
+- `Running "npm run build"`
+- `> next build`
+
+that only confirms build execution started. A `404` on `https://<project>.vercel.app` after this usually indicates **domain/deployment routing**, not a Next.js compile error.
+
+In Vercel dashboard, verify all of the following:
+1. **Project Settings → General → Root Directory** is `web/`.
+2. **Project Settings → Git** has the correct Production Branch.
+3. **Deployments** has a Production deployment with status **Ready** (not just queued/building).
+4. **Settings → Domains** includes the exact hostname you are opening.
+
+CLI checks from your machine:
+
+```bash
+curl -I https://coherencenetwork.vercel.app/
+curl -I https://coherencenetwork.vercel.app/api-health
+```
+
+Helpful header clues:
+- `server: Vercel` + `404` + `x-vercel-error` => routing/domain attachment issue.
+- `200/3xx` on `/` and `/api-health` => project/domain is connected correctly.
+
 ### Verify Vercel deployment
 
 1. Open the Vercel URL.
 2. Confirm pages load.
 3. Confirm UI requests API successfully (browser network tab, no CORS errors).
+   - `/api-health` now uses a server-side proxy route (`/api/health-proxy`) to avoid browser CORS issues while still validating upstream API reachability.
 
 ---
 

--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${1:-https://coherence-network-production.up.railway.app}"
+WEB_URL="${2:-https://coherence-network.vercel.app}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+check_url() {
+  local name="$1"
+  local url="$2"
+  local slug
+  slug="$(echo "$name" | tr "[:upper:]" "[:lower:]" | tr -cs "a-z0-9" "_")"
+  local headers_file="$TMP_DIR/${slug}.headers.txt"
+  local body_file="$TMP_DIR/${slug}.body.txt"
+
+  echo
+  echo "==> ${name}: ${url}"
+
+  if ! curl -sS -L -D "$headers_file" -o "$body_file" "$url" >/dev/null; then
+    echo "FAIL: request error"
+    sed -n '1,12p' "$headers_file" 2>/dev/null || true
+    return 1
+  fi
+
+  local status
+  status="$(awk 'toupper($1) ~ /^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+  local server
+  server="$(awk 'tolower($1) == "server:" { print $2 }' "$headers_file" | tail -n 1 | tr -d '\r')"
+  local vercel_error
+  vercel_error="$(awk 'tolower($1) == "x-vercel-error:" { print $2 }' "$headers_file" | tail -n 1 | tr -d '\r')"
+
+  if [[ -z "${status}" ]]; then
+    echo "FAIL: could not read HTTP status"
+    return 1
+  fi
+
+  echo "HTTP status: ${status}"
+  [[ -n "$server" ]] && echo "Server: ${server}"
+
+  if [[ "$status" -ge 200 && "$status" -lt 400 ]]; then
+    echo "PASS"
+    return 0
+  fi
+
+  echo "FAIL: non-success HTTP status"
+  echo "Response preview:"
+  head -c 250 "$body_file" || true
+  echo
+
+  if [[ "$status" == "404" && "$server" == "Vercel" ]]; then
+    [[ -n "$vercel_error" ]] && echo "x-vercel-error: ${vercel_error}"
+    echo "Hint: Vercel 404 usually means the domain is not assigned to the intended project"
+    echo "or no production deployment is active for that project/domain."
+    echo "Check: Project → Settings → Domains and ensure this exact hostname is attached."
+    echo "Check: Deployments → Production has a recent Ready deployment on your production branch."
+  fi
+
+  return 1
+}
+
+check_cors() {
+  local api_health_url="$1"
+  local web_origin="$2"
+  local headers_file="$TMP_DIR/cors_headers.txt"
+
+  echo
+  echo "==> CORS check: ${api_health_url} with Origin ${web_origin}"
+
+  if ! curl -sS -D "$headers_file" -o /dev/null -H "Origin: ${web_origin}" "$api_health_url" >/dev/null; then
+    echo "FAIL: request error"
+    return 1
+  fi
+
+  local status acao
+  status="$(awk 'toupper($1) ~ /^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+  acao="$(awk 'tolower($1) == "access-control-allow-origin:" { print $2 }' "$headers_file" | tail -n 1 | tr -d '\r')"
+
+  echo "HTTP status: ${status:-unknown}"
+  echo "Access-Control-Allow-Origin: ${acao:-<missing>}"
+
+  if [[ "$status" -ge 200 && "$status" -lt 400 ]] && ([[ "$acao" == "*" ]] || [[ "$acao" == "$web_origin" ]]); then
+    echo "PASS"
+    return 0
+  fi
+
+  echo "FAIL: CORS origin is not allowed or health endpoint failed"
+  return 1
+}
+
+fail=0
+check_url "Railway API health" "${API_URL%/}/api/health" || fail=1
+check_url "Vercel web root" "${WEB_URL%/}/" || fail=1
+check_url "Vercel API health page" "${WEB_URL%/}/api-health" || fail=1
+check_cors "${API_URL%/}/api/health" "${WEB_URL%/}" || fail=1
+
+if [[ "$fail" -eq 0 ]]; then
+  echo
+  echo "Deployment verification passed: Railway API and Vercel web are reachable and CORS is aligned."
+else
+  echo
+  echo "Deployment verification failed: at least one endpoint or CORS check failed."
+  exit 1
+fi

--- a/web/app/api-health/page.tsx
+++ b/web/app/api-health/page.tsx
@@ -5,12 +5,13 @@ import { useEffect, useState } from "react";
 export default function ApiHealthPage() {
   const apiUrl =
     process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const proxyUrl = "/api/health-proxy";
   const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
   const [data, setData] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`${apiUrl}/api/health`)
+    fetch(proxyUrl)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -23,12 +24,12 @@ export default function ApiHealthPage() {
         setError(String(e));
         setStatus("error");
       });
-  }, [apiUrl]);
+  }, [proxyUrl]);
 
   return (
     <main className="min-h-screen flex flex-col items-center justify-center p-8">
       <h1 className="text-2xl font-bold mb-4">API Health</h1>
-      {status === "loading" && <p>Checking {apiUrl}/api/health...</p>}
+      {status === "loading" && <p>Checking API health via {proxyUrl} (upstream: {apiUrl}/api/health)...</p>}
       {status === "ok" && data && (
         <pre className="bg-gray-100 p-4 rounded text-left">
           {JSON.stringify(data, null, 2)}
@@ -36,7 +37,7 @@ export default function ApiHealthPage() {
       )}
       {status === "error" && (
         <p className="text-red-600">
-          API not reachable: {error}. Is the API running?
+          API not reachable: {error}. Check NEXT_PUBLIC_API_URL and Railway availability.
         </p>
       )}
     </main>

--- a/web/app/api/health-proxy/route.ts
+++ b/web/app/api/health-proxy/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export async function GET() {
+  try {
+    const upstream = await fetch(`${API_URL}/api/health`, {
+      cache: "no-store",
+    });
+
+    const text = await upstream.text();
+    return new NextResponse(text, {
+      status: upstream.status,
+      headers: {
+        "content-type": upstream.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "Upstream API unreachable",
+        api_url: API_URL,
+        details: String(error),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
### Motivation

- The `/api-health` diagnostic page was failing on Vercel with `TypeError: Failed to fetch` due to browser cross-origin fetch/CORS/network restrictions when calling the upstream API directly. 
- Provide a same-origin server-side proxy so the diagnostic page can validate upstream API reachability without browser CORS blocking.

### Description

- Add a Next.js server route at `web/app/api/health-proxy/route.ts` which fetches the upstream `NEXT_PUBLIC_API_URL/api/health` server-side and returns the upstream response (including content-type and status). 
- Update the client diagnostic page `web/app/api-health/page.tsx` to call the new same-origin endpoint `/api/health-proxy` and improve its error text to guide operators toward checking `NEXT_PUBLIC_API_URL` and Railway availability. 
- Update `docs/DEPLOY.md` to mention the proxy-based `/api-health` behavior and include a CLI smoke-check section. 
- Add a CLI verification script `scripts/verify_web_api_deploy.sh` for quick Railway + Vercel connectivity and CORS checks, and include `web/vercel.json` to pin the Vercel framework to `nextjs`.

### Testing

- Ran `cd web && npm run build` which completed successfully and showed the new route in the build output (`ƒ /api/health-proxy`).
- Ran the local dev server with `cd web && npm run dev -- --port 3000` and exercised `/api-health` successfully in development. 
- Executed an automated Playwright script to load `http://127.0.0.1:3000/api-health` and saved a screenshot demonstrating the updated proxy-based behavior (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901aaacafc832fb501562e521bc93e)