### PR TITLE
Automate healing of deploy-blocking check failures

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -1,0 +1,61 @@
+name: Auto Heal Deploy Gates
+
+on:
+  workflow_run:
+    workflows:
+      - Test
+      - Thread Gates
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to inspect (optional)"
+        required: false
+        type: string
+
+jobs:
+  heal-main-checks:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.conclusion != 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install API dependencies
+        run: |
+          cd api && pip install -e ".[dev]"
+
+      - name: Auto-heal failed required checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.event.workflow_run.head_sha }}
+        run: |
+          cd api
+          python scripts/auto_heal_deploy_gates.py \
+            --repo "${{ github.repository }}" \
+            --branch main \
+            --base main \
+            --sha "$TARGET_SHA" \
+            --timeout-seconds 900 \
+            --poll-seconds 30 \
+            --json > ../auto_heal_report.json
+          cat ../auto_heal_report.json
+
+      - name: Upload auto-heal report
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto_heal_report_${{ github.sha }}
+          path: auto_heal_report.json

--- a/api/scripts/auto_heal_deploy_gates.py
+++ b/api/scripts/auto_heal_deploy_gates.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Detect and heal failed required checks that block deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+from app.services import release_gate_service as gates
+
+
+def _build_gate(
+    sha: str,
+    commit_status: dict[str, Any],
+    check_runs: list[dict[str, Any]],
+    required_contexts: list[str],
+) -> dict[str, Any]:
+    pseudo_pr: dict[str, Any] = {
+        "number": 0,
+        "draft": False,
+        "mergeable_state": "clean",
+        "head": {"sha": sha},
+    }
+    return gates.evaluate_pr_gates(pseudo_pr, commit_status, check_runs, required_contexts)
+
+
+def _emit(payload: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    print(f"Repo: {payload.get('repo')}")
+    print(f"SHA: {payload.get('sha')}")
+    print(f"Result: {payload.get('result')}")
+    if payload.get("reason"):
+        print(f"Reason: {payload.get('reason')}")
+    initial = payload.get("initial_gate")
+    if isinstance(initial, dict):
+        print(
+            "Initial gate:"
+            f" combined={initial.get('combined_status_state')}"
+            f" missing={initial.get('missing_required_contexts')}"
+            f" failing={initial.get('failing_required_contexts')}"
+        )
+    actions = payload.get("actions")
+    if isinstance(actions, list):
+        for action in actions:
+            if isinstance(action, dict):
+                print(f"Action: run_id={action.get('run_id')} accepted={action.get('accepted')}")
+    final = payload.get("final_gate")
+    if isinstance(final, dict):
+        print(
+            "Final gate:"
+            f" ready_to_merge={final.get('ready_to_merge')}"
+            f" combined={final.get('combined_status_state')}"
+            f" missing={final.get('missing_required_contexts')}"
+            f" failing={final.get('failing_required_contexts')}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Auto-heal required check failures that block Railway deployment."
+    )
+    parser.add_argument("--repo", default="seeker71/Coherence-Network")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--base", default="main")
+    parser.add_argument("--sha", default="")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        out = {"result": "blocked", "reason": "GITHUB_TOKEN is required"}
+        _emit(out, as_json=args.json)
+        sys.exit(2)
+
+    sha = args.sha.strip() or gates.get_branch_head_sha(args.repo, args.branch, github_token=token)
+    if not sha:
+        out = {"result": "blocked", "reason": f"Unable to resolve head SHA for branch {args.branch}"}
+        _emit(out, as_json=args.json)
+        sys.exit(2)
+
+    required_contexts = gates.get_required_contexts(args.repo, args.base, github_token=token) or []
+    commit_status = gates.get_commit_status(args.repo, sha, github_token=token)
+    check_runs = gates.get_check_runs(args.repo, sha, github_token=token)
+    initial_gate = _build_gate(sha, commit_status, check_runs, required_contexts)
+
+    report: dict[str, Any] = {
+        "repo": args.repo,
+        "sha": sha,
+        "base": args.base,
+        "required_contexts": required_contexts,
+        "initial_gate": initial_gate,
+        "actions": [],
+    }
+
+    if initial_gate.get("ready_to_merge"):
+        report["result"] = "already_green"
+        report["final_gate"] = initial_gate
+        _emit(report, as_json=args.json)
+        sys.exit(0)
+
+    failing_required = initial_gate.get("failing_required_contexts", [])
+    failing_required = failing_required if isinstance(failing_required, list) else []
+    run_ids = gates.collect_rerunnable_actions_run_ids(failing_required, check_runs)
+    for run_id in run_ids:
+        action = gates.rerun_actions_failed_jobs(args.repo, run_id, token)
+        report["actions"].append(action)
+
+    started = time.time()
+    final_gate = initial_gate
+    while True:
+        commit_status = gates.get_commit_status(args.repo, sha, github_token=token)
+        check_runs = gates.get_check_runs(args.repo, sha, github_token=token)
+        final_gate = _build_gate(sha, commit_status, check_runs, required_contexts)
+        if final_gate.get("ready_to_merge"):
+            report["result"] = "healed" if run_ids else "green_without_rerun"
+            report["final_gate"] = final_gate
+            _emit(report, as_json=args.json)
+            sys.exit(0)
+        if time.time() - started >= args.timeout_seconds:
+            break
+        time.sleep(max(1, args.poll_seconds))
+
+    report["result"] = "blocked"
+    if not run_ids:
+        report["reason"] = "No rerunnable failed required checks were found"
+    else:
+        report["reason"] = "Checks remained non-green after retry window"
+    report["final_gate"] = final_gate
+    _emit(report, as_json=args.json)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/tests/test_release_gate_service.py
+++ b/api/tests/test_release_gate_service.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from app.services.release_gate_service import evaluate_collective_review_gates, evaluate_pr_gates
+from app.services.release_gate_service import (
+    collect_rerunnable_actions_run_ids,
+    evaluate_collective_review_gates,
+    evaluate_pr_gates,
+    extract_actions_run_id,
+)
 
 
 def test_evaluate_pr_gates_ready_when_required_checks_pass() -> None:
@@ -71,3 +76,68 @@ def test_evaluate_collective_review_gates_fails_without_approvals() -> None:
     out = evaluate_collective_review_gates(pr, reviews, min_approvals=1, min_unique_approvers=1)
     assert out["collective_review_passed"] is False
     assert out["approval_events"] == 0
+
+
+def test_extract_actions_run_id_from_details_url() -> None:
+    run_id = extract_actions_run_id(
+        "https://github.com/seeker71/Coherence-Network/actions/runs/14001234567/job/39210012345"
+    )
+    assert run_id == 14001234567
+
+
+def test_collect_rerunnable_actions_run_ids_filters_by_required_and_failure() -> None:
+    failing_required_contexts = ["Test", "Thread Gates"]
+    check_runs = [
+        {
+            "name": "Test",
+            "conclusion": "failure",
+            "details_url": "https://github.com/seeker71/Coherence-Network/actions/runs/111/job/1",
+            "app": {"slug": "github-actions"},
+        },
+        {
+            "name": "Thread Gates",
+            "conclusion": "timed_out",
+            "details_url": "https://github.com/seeker71/Coherence-Network/actions/runs/222/job/2",
+            "app": {"slug": "github-actions"},
+        },
+        {
+            "name": "Vercel",
+            "conclusion": "failure",
+            "details_url": "https://vercel.com/build/123",
+            "app": {"slug": "vercel"},
+        },
+        {
+            "name": "Test",
+            "conclusion": "success",
+            "details_url": "https://github.com/seeker71/Coherence-Network/actions/runs/333/job/3",
+            "app": {"slug": "github-actions"},
+        },
+    ]
+
+    run_ids = collect_rerunnable_actions_run_ids(failing_required_contexts, check_runs)
+    assert run_ids == [111, 222]
+
+
+def test_collect_rerunnable_actions_run_ids_fallbacks_when_required_unknown() -> None:
+    check_runs = [
+        {
+            "name": "Test",
+            "conclusion": "failure",
+            "details_url": "https://github.com/seeker71/Coherence-Network/actions/runs/444/job/9",
+            "app": {"slug": "github-actions"},
+        },
+        {
+            "name": "Change Contract",
+            "conclusion": "cancelled",
+            "details_url": "https://github.com/seeker71/Coherence-Network/actions/runs/555/job/4",
+            "app": {"slug": "github-actions"},
+        },
+        {
+            "name": "Vercel",
+            "conclusion": "failure",
+            "details_url": "https://vercel.com/build/456",
+            "app": {"slug": "vercel"},
+        },
+    ]
+    run_ids = collect_rerunnable_actions_run_ids([], check_runs)
+    assert run_ids == [444, 555]

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -146,3 +146,16 @@ export PIPELINE_AUTO_RECOVER=1
 ```
 
 The watchdog runs the pipeline in a loop; every 90s it checks `api/logs/restart_requested.json`. When present (e.g. from stale_version), it stops the pipeline and restarts it.
+
+## CI/CD Gate Auto-Heal (Main Deploy Path)
+
+To reduce Railway skipped deploys caused by failed required checks on `main`, CI includes:
+
+- Workflow: `.github/workflows/auto-heal-deploy-gates.yml`
+- Script: `api/scripts/auto_heal_deploy_gates.py`
+
+Behavior:
+1. Trigger when `Test` or `Thread Gates` finishes on `main` with non-success conclusion.
+2. Detect failing required contexts from branch protection.
+3. Rerun failed GitHub Actions jobs for those required contexts.
+4. Re-check status until green or timeout; upload `auto_heal_report.json`.


### PR DESCRIPTION
## Summary
- add deploy-gate auto-heal script to detect failed checks that block Railway deploys
- rerun failed GitHub Actions jobs for failing required contexts (or all failed actions checks when required contexts are unavailable)
- add workflow to trigger auto-heal on failed main CI runs
- document the process in deploy and monitoring docs

## Validation
- `cd api && .venv/bin/pytest -q tests/test_release_gate_service.py`
- `cd api && .venv/bin/python scripts/auto_heal_deploy_gates.py --help`
- `cd api && GITHUB_TOKEN="$(gh auth token)" .venv/bin/python scripts/auto_heal_deploy_gates.py --repo seeker71/Coherence-Network --branch main --base main --timeout-seconds 10 --poll-seconds 2 --json`
