### PR TITLE
Trigger auto-heal on Change Contract failures

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - Test
       - Thread Gates
+      - Change Contract
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -266,7 +266,7 @@ Railway can skip deployment when commit check status is not green. This repo now
 
 - Workflow: `.github/workflows/auto-heal-deploy-gates.yml`
 - Trigger:
-  - `workflow_run` when `Test` or `Thread Gates` completes on `main` with non-success conclusion
+  - `workflow_run` when `Test`, `Thread Gates`, or `Change Contract` completes on `main` with non-success conclusion
   - Manual `workflow_dispatch` with optional commit SHA
 - Script: `api/scripts/auto_heal_deploy_gates.py`
 

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -155,7 +155,7 @@ To reduce Railway skipped deploys caused by failed required checks on `main`, CI
 - Script: `api/scripts/auto_heal_deploy_gates.py`
 
 Behavior:
-1. Trigger when `Test` or `Thread Gates` finishes on `main` with non-success conclusion.
+1. Trigger when `Test`, `Thread Gates`, or `Change Contract` finishes on `main` with non-success conclusion.
 2. Detect failing required contexts from branch protection.
 3. Rerun failed GitHub Actions jobs for those required contexts.
 4. Re-check status until green or timeout; upload `auto_heal_report.json`.


### PR DESCRIPTION
Add Change Contract to auto-heal workflow_run triggers so deploy-blocking post-merge failures are also detected and remediated automatically.