### PR TITLE
Fail closed until retried checks finish successfully

### DIFF
--- a/api/scripts/auto_heal_deploy_gates.py
+++ b/api/scripts/auto_heal_deploy_gates.py
@@ -28,6 +28,55 @@ def _build_gate(
     return gates.evaluate_pr_gates(pseudo_pr, commit_status, check_runs, required_contexts)
 
 
+def _failed_actions_runs(check_runs: list[dict[str, Any]]) -> list[int]:
+    return gates.collect_rerunnable_actions_run_ids([], check_runs)
+
+
+def _actions_run_states(check_runs: list[dict[str, Any]]) -> dict[int, dict[str, str]]:
+    states: dict[int, dict[str, str]] = {}
+    for run in check_runs:
+        details_url = run.get("details_url")
+        if not isinstance(details_url, str):
+            continue
+        app = run.get("app")
+        app_slug = app.get("slug") if isinstance(app, dict) else None
+        if app_slug != "github-actions":
+            continue
+        run_id = gates.extract_actions_run_id(details_url)
+        if run_id is None:
+            continue
+        states[run_id] = {
+            "status": str(run.get("status") or ""),
+            "conclusion": str(run.get("conclusion") or ""),
+        }
+    return states
+
+
+def _rerun_state_summary(
+    check_runs: list[dict[str, Any]],
+    rerun_ids: list[int],
+) -> tuple[bool, list[int], list[int], dict[int, dict[str, str]]]:
+    if not rerun_ids:
+        return True, [], [], {}
+    state_map = _actions_run_states(check_runs)
+    pending: list[int] = []
+    failed: list[int] = []
+    for run_id in rerun_ids:
+        state = state_map.get(run_id)
+        if not state:
+            pending.append(run_id)
+            continue
+        status = state.get("status", "")
+        conclusion = state.get("conclusion", "")
+        if status != "completed":
+            pending.append(run_id)
+            continue
+        if conclusion != "success":
+            failed.append(run_id)
+    ok = not pending and not failed
+    return ok, pending, failed, state_map
+
+
 def _emit(payload: dict[str, Any], as_json: bool) -> None:
     if as_json:
         print(json.dumps(payload, indent=2))
@@ -46,11 +95,20 @@ def _emit(payload: dict[str, Any], as_json: bool) -> None:
             f" missing={initial.get('missing_required_contexts')}"
             f" failing={initial.get('failing_required_contexts')}"
         )
+    failed_actions = payload.get("failed_actions_runs")
+    if isinstance(failed_actions, list):
+        print(f"Initial failed actions runs: {failed_actions}")
     actions = payload.get("actions")
     if isinstance(actions, list):
         for action in actions:
             if isinstance(action, dict):
                 print(f"Action: run_id={action.get('run_id')} accepted={action.get('accepted')}")
+    rerun_pending = payload.get("rerun_pending_runs")
+    if isinstance(rerun_pending, list):
+        print(f"Rerun pending runs: {rerun_pending}")
+    rerun_failed = payload.get("rerun_failed_runs")
+    if isinstance(rerun_failed, list):
+        print(f"Rerun failed runs: {rerun_failed}")
     final = payload.get("final_gate")
     if isinstance(final, dict):
         print(
@@ -98,10 +156,11 @@ def main() -> None:
         "base": args.base,
         "required_contexts": required_contexts,
         "initial_gate": initial_gate,
+        "failed_actions_runs": _failed_actions_runs(check_runs),
         "actions": [],
     }
 
-    if initial_gate.get("ready_to_merge"):
+    if initial_gate.get("ready_to_merge") and not report["failed_actions_runs"]:
         report["result"] = "already_green"
         report["final_gate"] = initial_gate
         _emit(report, as_json=args.json)
@@ -110,6 +169,8 @@ def main() -> None:
     failing_required = initial_gate.get("failing_required_contexts", [])
     failing_required = failing_required if isinstance(failing_required, list) else []
     run_ids = gates.collect_rerunnable_actions_run_ids(failing_required, check_runs)
+    if not run_ids:
+        run_ids = _failed_actions_runs(check_runs)
     for run_id in run_ids:
         action = gates.rerun_actions_failed_jobs(args.repo, run_id, token)
         report["actions"].append(action)
@@ -120,18 +181,32 @@ def main() -> None:
         commit_status = gates.get_commit_status(args.repo, sha, github_token=token)
         check_runs = gates.get_check_runs(args.repo, sha, github_token=token)
         final_gate = _build_gate(sha, commit_status, check_runs, required_contexts)
-        if final_gate.get("ready_to_merge"):
+        final_failed_actions = _failed_actions_runs(check_runs)
+        rerun_ok, rerun_pending, rerun_failed, rerun_states = _rerun_state_summary(
+            check_runs,
+            run_ids,
+        )
+        report["rerun_pending_runs"] = rerun_pending
+        report["rerun_failed_runs"] = rerun_failed
+        report["rerun_states"] = rerun_states
+        if final_gate.get("ready_to_merge") and not final_failed_actions and rerun_ok:
             report["result"] = "healed" if run_ids else "green_without_rerun"
             report["final_gate"] = final_gate
+            report["final_failed_actions_runs"] = final_failed_actions
             _emit(report, as_json=args.json)
             sys.exit(0)
         if time.time() - started >= args.timeout_seconds:
+            report["final_failed_actions_runs"] = final_failed_actions
             break
         time.sleep(max(1, args.poll_seconds))
 
     report["result"] = "blocked"
     if not run_ids:
-        report["reason"] = "No rerunnable failed required checks were found"
+        report["reason"] = "No rerunnable failed checks were found"
+    elif report.get("rerun_failed_runs"):
+        report["reason"] = "Retry completed but one or more checks still failed"
+    elif report.get("rerun_pending_runs"):
+        report["reason"] = "Retry did not settle before timeout"
     else:
         report["reason"] = "Checks remained non-green after retry window"
     report["final_gate"] = final_gate

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -276,7 +276,7 @@ What it does:
 3. Evaluates failing required contexts.
 4. Finds rerunnable GitHub Actions workflow runs for those failed required checks.
 5. Calls GitHub API `rerun-failed-jobs` for each run.
-6. Polls check state until green or timeout.
+6. Polls check state until retried runs complete with `success` (or timeout/failure).
 7. Uploads `auto_heal_report.json` as workflow artifact.
 
 Manual run (local):
@@ -294,7 +294,7 @@ GITHUB_TOKEN=<token> python scripts/auto_heal_deploy_gates.py \
 
 Exit codes:
 - `0`: checks already green or healed to green
-- `2`: still blocked (non-rerunnable failure or retries did not heal)
+- `2`: still blocked (non-rerunnable failure, retry still failed, or retry timeout)
 
 2. **API URL alignment**
    - Vercel `NEXT_PUBLIC_API_URL` must point to Railway API domain (https).

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -158,4 +158,4 @@ Behavior:
 1. Trigger when `Test`, `Thread Gates`, or `Change Contract` finishes on `main` with non-success conclusion.
 2. Detect failing required contexts from branch protection.
 3. Rerun failed GitHub Actions jobs for those required contexts.
-4. Re-check status until green or timeout; upload `auto_heal_report.json`.
+4. Re-check status until reruns finish with success (or fail/timeout); upload `auto_heal_report.json`.


### PR DESCRIPTION
Ensure deploy auto-heal only reports success after rerun jobs settle with success. If rerun remains failed or times out, report blocked.