### PR TITLE
chore(ci): use Python 3.13 in workflows

### DIFF
--- a/.github/workflows/asset_value_update.yml
+++ b/.github/workflows/asset_value_update.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.13"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/change-contract.yml
+++ b/.github/workflows/change-contract.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: Install API dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: Install API dependencies
         run: |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.13 recommended (latest stable); 3.9+ minimum supported
 - Node.js 20+
 - Docker (optional for local Neo4j/Postgres)
 

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -141,14 +141,14 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 |-------------|----------------|------|
 | Workflow at .github/workflows/test.yml | `.github/workflows/test.yml` | `test_workflow_file_exists` |
 | Triggers on push and pull_request (main/master) | workflow `on:` | `test_workflow_triggers_on_push_and_pull_request` |
-| Python 3.9+ | setup-python step | `test_workflow_uses_python_39_or_newer` |
+| Python 3.13 (latest CI runtime), 3.9+ contract | setup-python step | `test_workflow_uses_python_39_or_newer` |
 | pip install -e ".[dev]" in api/ | Install step | `test_workflow_installs_api_dev_deps` |
 | pytest -v in api/ | Run API tests step | `test_workflow_runs_pytest_in_api` |
 | README CI badge (workflow test.yml) | README.md | `test_readme_has_ci_badge` |
 
 **Files:** `.github/workflows/test.yml`, `README.md`, `api/tests/test_ci_pipeline.py`
 
-**Contract (spec 004):** Workflow present; runs on push/PR to main or master; installs Python 3.9+, API dev deps, runs pytest -v in api/; README contains badge for test.yml. Tests define the contract; do not modify tests to make implementation pass.
+**Contract (spec 004):** Workflow present; runs on push/PR to main or master; installs Python 3.9+ (currently pinned to 3.13 in CI), API dev deps, runs pytest -v in api/; README contains badge for test.yml. Tests define the contract; do not modify tests to make implementation pass.
 
 ---
 


### PR DESCRIPTION
## Summary\n- bump workflow Python runtimes to 3.13 where configured\n- align setup action in asset value workflow to setup-python@v5\n- update setup/spec coverage docs to reflect 3.13 CI runtime and 3.9+ compatibility contract\n\n## Validation\n- ..................................................................       [100%]
66 passed in 0.37s (66 passed)