### PR TITLE
Prevent auto-heal recursion and check storms

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: auto-heal-deploy-gates-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   heal-main-checks:
     if: >
@@ -21,6 +25,7 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.run_attempt == 1 &&
         github.event.workflow_run.conclusion != 'success'
       )
     runs-on: ubuntu-latest

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -279,6 +279,10 @@ What it does:
 6. Polls check state until retried runs complete with `success` (or timeout/failure).
 7. Uploads `auto_heal_report.json` as workflow artifact.
 
+Safety controls:
+- Concurrency per SHA (`cancel-in-progress: true`) to avoid parallel healer races.
+- `workflow_run.run_attempt == 1` guard so reruns of failed checks do not recursively retrigger healer loops.
+
 Manual run (local):
 
 ```bash

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -159,3 +159,4 @@ Behavior:
 2. Detect failing required contexts from branch protection.
 3. Rerun failed GitHub Actions jobs for those required contexts.
 4. Re-check status until reruns finish with success (or fail/timeout); upload `auto_heal_report.json`.
+5. Guard against recursion with one-attempt trigger (`run_attempt == 1`) and per-SHA concurrency.


### PR DESCRIPTION
Add run_attempt guard and per-SHA concurrency to auto-heal workflow so failed-check reruns do not recursively trigger unbounded auto-heal runs.