### PR TITLE
feat(deploy): enforce and monitor public deploy contract

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: Install API dependencies
         run: |

--- a/.github/workflows/public-deploy-contract.yml
+++ b/.github/workflows/public-deploy-contract.yml
@@ -1,0 +1,106 @@
+name: Public Deploy Contract
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: public-deploy-contract-main
+  cancel-in-progress: true
+
+jobs:
+  validate-public-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install API dependencies
+        run: |
+          cd api && pip install -e ".[dev]"
+
+      - name: Validate public deployment contract
+        id: validate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          cd api
+          python scripts/validate_public_deploy_contract.py \
+            --repo "${{ github.repository }}" \
+            --branch main \
+            --json > ../public_deploy_contract_report.json
+          code=$?
+          cd ..
+          cat public_deploy_contract_report.json
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload public deploy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public_deploy_contract_report_${{ github.sha }}
+          path: public_deploy_contract_report.json
+
+      - name: Create or update deploy drift issue
+        if: ${{ steps.validate.outputs.exit_code != '0' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('public_deploy_contract_report.json', 'utf8'));
+            const title = 'Public deployment contract failing on main';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'Automated check detected public deployment drift.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              `- Expected SHA: \`${report.expected_sha || 'unknown'}\``,
+              `- Result: \`${report.result || 'blocked'}\``,
+              `- Reason: ${report.reason || 'n/a'}`,
+              '',
+              'Failing checks:',
+              ...(Array.isArray(report.failing_checks) && report.failing_checks.length
+                ? report.failing_checks.map((x) => `- \`${x}\``)
+                : ['- (none reported)']),
+              '',
+              'Raw report:',
+              '```json',
+              JSON.stringify(report, null, 2).slice(0, 6000),
+              '```',
+            ].join('\n');
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data.items[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.createIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
+
+      - name: Fail when contract is not satisfied
+        if: ${{ steps.validate.outputs.exit_code != '0' }}
+        run: |
+          echo "Public deployment contract failed"
+          exit 1

--- a/api/scripts/validate_merged_change_contract.py
+++ b/api/scripts/validate_merged_change_contract.py
@@ -15,7 +15,9 @@ def _default_endpoints(api_base: str, web_base: str) -> list[str]:
     return [
         f"{api_base.rstrip('/')}/api/health",
         f"{api_base.rstrip('/')}/api/ideas",
+        f"{api_base.rstrip('/')}/api/gates/main-head",
         f"{web_base.rstrip('/')}/",
+        f"{web_base.rstrip('/')}/gates",
         f"{web_base.rstrip('/')}/api-health",
     ]
 

--- a/api/scripts/validate_pr_to_public.py
+++ b/api/scripts/validate_pr_to_public.py
@@ -15,6 +15,8 @@ def _default_endpoints(api_base: str, web_base: str) -> list[str]:
     return [
         f"{api_base.rstrip('/')}/api/health",
         f"{api_base.rstrip('/')}/api/ideas",
+        f"{api_base.rstrip('/')}/api/gates/main-head",
+        f"{web_base.rstrip('/')}/gates",
         f"{web_base.rstrip('/')}/api-health",
     ]
 

--- a/api/scripts/validate_public_deploy_contract.py
+++ b/api/scripts/validate_public_deploy_contract.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate public Railway + Vercel deployment contract against main SHA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from app.services import release_gate_service as gates
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate public deployment contract (Railway API + Vercel web)."
+    )
+    parser.add_argument("--repo", default="seeker71/Coherence-Network")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--api-base", default="https://coherence-network-production.up.railway.app")
+    parser.add_argument("--web-base", default="https://coherence-network.vercel.app")
+    parser.add_argument("--expected-sha", default="")
+    parser.add_argument("--timeout", type=float, default=8.0)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    token = os.getenv("GITHUB_TOKEN")
+    report = gates.evaluate_public_deploy_contract_report(
+        repository=args.repo,
+        branch=args.branch,
+        api_base=args.api_base,
+        web_base=args.web_base,
+        expected_sha=args.expected_sha.strip() or None,
+        timeout=max(1.0, args.timeout),
+        github_token=token,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _emit(report)
+    if str(report.get("result")) == "public_contract_passed":
+        return
+    sys.exit(2)
+
+
+def _emit(report: dict[str, object]) -> None:
+    print(f"Repository: {report.get('repository')}")
+    print(f"Branch: {report.get('branch')}")
+    print(f"Expected SHA: {report.get('expected_sha')}")
+    print(f"Result: {report.get('result')}")
+    if report.get("reason"):
+        print(f"Reason: {report.get('reason')}")
+    checks = report.get("checks", [])
+    if isinstance(checks, list):
+        for item in checks:
+            if not isinstance(item, dict):
+                continue
+            print(
+                f"- {item.get('name')}: ok={item.get('ok')} "
+                f"status={item.get('status_code')} url={item.get('url')}"
+            )
+            if item.get("observed_sha") is not None:
+                print(f"  observed_sha={item.get('observed_sha')} sha_match={item.get('sha_match')}")
+            if item.get("web_updated_at") is not None:
+                print(
+                    "  web_updated_at="
+                    f"{item.get('web_updated_at')} sha_match={item.get('sha_match')} "
+                    f"api_status={item.get('api_status')}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -169,8 +169,11 @@ From repository root:
 
 This checks:
 - `GET <railway-api-domain>/api/health`
+- `GET <railway-api-domain>/api/gates/main-head`
 - `GET <vercel-web-domain>/`
+- `GET <vercel-web-domain>/gates`
 - `GET <vercel-web-domain>/api-health`
+- `GET <vercel-web-domain>/api/health-proxy`
 - CORS header alignment (`Origin: <vercel-web-domain>` against API health endpoint)
 
 Use this as a quick connectivity + CORS check after each deployment.
@@ -182,18 +185,18 @@ A Vercel `404` on the project domain usually means the domain is not attached to
 Verify in Vercel dashboard:
 1. **Project selected**: correct repository imported.
 2. **Root Directory**: `web/`.
-3. **Domains**: the exact domain (for example `coherencenetwork.vercel.app`) is listed under this project.
+3. **Domains**: the exact domain (for example `coherence-network.vercel.app`) is listed under this project.
 4. **Latest deployment**: Production deployment status is **Ready**.
 5. **Environment variable**: `NEXT_PUBLIC_API_URL=https://coherence-network-production.up.railway.app` in Production scope.
 
 Quick CLI checks from your machine:
 
 ```bash
-curl -I https://coherencenetwork.vercel.app/
-curl -I https://coherencenetwork.vercel.app/api-health
+curl -I https://coherence-network.vercel.app/
+curl -I https://coherence-network.vercel.app/api-health
 ./scripts/verify_web_api_deploy.sh \
   https://coherence-network-production.up.railway.app \
-  https://coherencenetwork.vercel.app
+  https://coherence-network.vercel.app
 ```
 
 Expected: non-404 responses on `/` and `/api-health`, plus passing CORS check.
@@ -233,8 +236,8 @@ In Vercel dashboard, verify all of the following:
 CLI checks from your machine:
 
 ```bash
-curl -I https://coherencenetwork.vercel.app/
-curl -I https://coherencenetwork.vercel.app/api-health
+curl -I https://coherence-network.vercel.app/
+curl -I https://coherence-network.vercel.app/api-health
 ```
 
 Helpful header clues:
@@ -269,6 +272,7 @@ Railway can skip deployment when commit check status is not green. This repo now
   - `workflow_run` when `Test`, `Thread Gates`, or `Change Contract` completes on `main` with non-success conclusion
   - Manual `workflow_dispatch` with optional commit SHA
 - Script: `api/scripts/auto_heal_deploy_gates.py`
+- Complementary monitor: `.github/workflows/public-deploy-contract.yml` validates public Railway + Vercel contract and opens/updates an issue when drift is detected.
 
 What it does:
 1. Resolves target SHA on `main`.

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -160,3 +160,24 @@ Behavior:
 3. Rerun failed GitHub Actions jobs for those required contexts.
 4. Re-check status until reruns finish with success (or fail/timeout); upload `auto_heal_report.json`.
 5. Guard against recursion with one-attempt trigger (`run_attempt == 1`) and per-SHA concurrency.
+
+## Public Deploy Drift Monitor (Main + Schedule)
+
+To detect production drift even when CI checks are green:
+
+- Workflow: `.github/workflows/public-deploy-contract.yml`
+- Script: `api/scripts/validate_public_deploy_contract.py`
+- Trigger:
+  - Push to `main`
+  - Every 30 minutes (`cron`)
+  - Manual run (`workflow_dispatch`)
+
+Contract checks:
+1. Railway `/api/health` responds `200`.
+2. Railway `/api/gates/main-head` responds `200` and returns SHA equal to GitHub `main` head.
+3. Vercel `/gates` page responds `200`.
+4. Vercel `/api/health-proxy` responds `200`, reports `api.status=ok`, and `web.updated_at` equals GitHub `main` head.
+
+If contract fails:
+- Workflow uploads `public_deploy_contract_report.json`.
+- Workflow opens or updates issue: `Public deployment contract failing on main`.

--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -91,8 +91,11 @@ check_cors() {
 
 fail=0
 check_url "Railway API health" "${API_URL%/}/api/health" || fail=1
+check_url "Railway gates main head" "${API_URL%/}/api/gates/main-head" || fail=1
 check_url "Vercel web root" "${WEB_URL%/}/" || fail=1
+check_url "Vercel gates page" "${WEB_URL%/}/gates" || fail=1
 check_url "Vercel API health page" "${WEB_URL%/}/api-health" || fail=1
+check_url "Vercel API health proxy" "${WEB_URL%/}/api/health-proxy" || fail=1
 check_cors "${API_URL%/}/api/health" "${WEB_URL%/}" || fail=1
 
 if [[ "$fail" -eq 0 ]]; then


### PR DESCRIPTION
## Why
Railway currently serves an older API build (`/api/gates/main-head` = 404), while web is up to date. Existing checks were too shallow to catch this drift automatically.

## What changed
- Added strict public deployment contract validator (`api/scripts/validate_public_deploy_contract.py`)
- Added reusable service function (`evaluate_public_deploy_contract_report`)
- Added scheduled + push workflow (`.github/workflows/public-deploy-contract.yml`)
  - Runs on push to main, every 30 minutes, and manually
  - Uploads machine-readable report artifact
  - Opens/updates an issue when contract fails
- Tightened existing gate defaults to include `/api/gates/main-head` and `/gates`
- Extended deploy smoke script to include gate endpoints and health proxy
- Updated docs for domain correctness and monitoring flow
- Updated auto-heal workflow Python runtime to 3.13

## Local validation
- `cd api && .venv/bin/pytest -q` -> 68 passed
- `cd api && .venv/bin/python scripts/validate_public_deploy_contract.py --repo seeker71/Coherence-Network --branch main --json` -> blocked (expected, catches current Railway drift)
- `bash scripts/verify_web_api_deploy.sh https://coherence-network-production.up.railway.app https://coherence-network.vercel.app` -> fails on Railway `/api/gates/main-head` (expected)
