### PR TITLE
fix(ci): use correct GitHub issues create API

### DIFF
--- a/.github/workflows/public-deploy-contract.yml
+++ b/.github/workflows/public-deploy-contract.yml
@@ -91,7 +91,7 @@ jobs:
                 body,
               });
             } else {
-              await github.rest.issues.createIssue({
+              await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,


### PR DESCRIPTION
Fixes the public deploy contract workflow alert step by switching from an invalid github-script method (`github.rest.issues.createIssue`) to the correct one (`github.rest.issues.create`).

This unblocks automatic issue creation/update when public deployment drift is detected.
