### PR TITLE
feat(ci): audit and track new external tools on schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "daily"
+      time: "08:10"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "daily"
+      time: "08:20"
+      timezone: "UTC"
+    open-pull-requests-limit: 10

--- a/.github/workflows/asset_value_update.yml
+++ b/.github/workflows/asset_value_update.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/auto_track_contributions.yml
+++ b/.github/workflows/auto_track_contributions.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/external-tools-audit.yml
+++ b/.github/workflows/external-tools-audit.yml
@@ -1,0 +1,121 @@
+name: External Tools Audit
+
+on:
+  schedule:
+    - cron: "0 9 * * 2,5"
+  workflow_dispatch:
+
+jobs:
+  audit-tools:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Audit external tools registry
+        id: audit
+        run: |
+          set +e
+          python scripts/audit_external_tools.py --json --fail-on-untracked > external_tools_audit_report.json
+          code=$?
+          cat external_tools_audit_report.json
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: external_tools_audit_report_${{ github.sha }}
+          path: external_tools_audit_report.json
+
+      - name: Create or update external tools drift issue
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('external_tools_audit_report.json', 'utf8'));
+            const title = 'External tools registry drift detected';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'Automated audit detected new/untracked external tools.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              '',
+              'Untracked github actions:',
+              ...(report.untracked.github_actions.length
+                ? report.untracked.github_actions.map((x) => `- \`${x}\``)
+                : ['- (none)']),
+              '',
+              'Untracked workflow CLI tools:',
+              ...(report.untracked.workflow_cli_tools.length
+                ? report.untracked.workflow_cli_tools.map((x) => `- \`${x}\``)
+                : ['- (none)']),
+              '',
+              'Untracked dependency ecosystems:',
+              ...(report.untracked.dependency_ecosystems.length
+                ? report.untracked.dependency_ecosystems.map((x) => `- \`${x}\``)
+                : ['- (none)']),
+              '',
+              'Raw report:',
+              '```json',
+              JSON.stringify(report, null, 2).slice(0, 6000),
+              '```'
+            ].join('\n');
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data.items[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
+
+      - name: Resolve external tools drift issue when audit passes
+        if: ${{ steps.audit.outputs.exit_code == '0' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'External tools registry drift detected';
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length === 0) {
+              return;
+            }
+            const issue = existing.data.items[0];
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Resolved by workflow run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}. External tools registry audit is passing.`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+            });
+
+      - name: Fail when untracked tools are detected
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        run: |
+          echo "External tool audit failed"
+          exit 1

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -182,3 +182,27 @@ If contract fails:
 - Workflow uploads `public_deploy_contract_report.json`.
 - Workflow opens or updates issue: `Public deployment contract failing on main`.
 - If Railway secrets are configured (`RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT`, `RAILWAY_SERVICE`), workflow triggers `railway redeploy` and re-validates for up to 20 minutes before deciding pass/fail.
+
+## External Tool Drift Monitor (Twice Weekly)
+
+To track newly added external tools and keep upgrade cadence:
+
+- Workflow: `.github/workflows/external-tools-audit.yml`
+- Script: `scripts/audit_external_tools.py`
+- Registry: `docs/system_audit/external_tools_registry.json`
+- Trigger:
+  - Tuesdays + Fridays (`cron`)
+  - Manual run (`workflow_dispatch`)
+
+Behavior:
+1. Discover external GitHub Actions, workflow CLI tools, and dependency ecosystems.
+2. Compare discovered set against tracked registry.
+3. Upload `external_tools_audit_report.json`.
+4. Open/update issue `External tools registry drift detected` if new tools appear.
+5. Close the issue automatically once registry is updated and audit passes.
+
+Dependency update cadence:
+- Dependabot config in `.github/dependabot.yml` runs daily for:
+  - GitHub Actions
+  - Python (`/api`)
+  - npm (`/web`)

--- a/docs/system_audit/external_tools_registry.json
+++ b/docs/system_audit/external_tools_registry.json
@@ -1,0 +1,33 @@
+{
+  "policy": {
+    "minimum_checks_per_week": 2,
+    "notes": "Track external tool additions and version drift; review and update this registry when intentionally adding new tools."
+  },
+  "github_actions": [
+    "actions/checkout@v4",
+    "actions/github-script@v7",
+    "actions/setup-node@v4",
+    "actions/setup-python@v5",
+    "actions/upload-artifact@v4"
+  ],
+  "workflow_cli_tools": [
+    "bc",
+    "cat",
+    "cd",
+    "curl",
+    "echo",
+    "gh",
+    "git",
+    "jq",
+    "npm",
+    "pip",
+    "python",
+    "railway",
+    "sleep"
+  ],
+  "dependency_ecosystems": [
+    "github-actions",
+    "npm",
+    "pip"
+  ]
+}

--- a/scripts/audit_external_tools.py
+++ b/scripts/audit_external_tools.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Audit external tooling usage and detect untracked additions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def _load_registry(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _discover_workflow_actions(workflows_dir: Path) -> set[str]:
+    actions: set[str] = set()
+    uses_re = re.compile(r"^\s*uses:\s*([^\s]+)\s*$")
+    for wf in sorted(workflows_dir.glob("*.yml")):
+        text = wf.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            m = uses_re.match(line)
+            if not m:
+                continue
+            action = m.group(1).strip()
+            if action.startswith("./"):
+                continue
+            actions.add(action)
+    return actions
+
+
+def _extract_command(line: str) -> str | None:
+    s = line.strip()
+    if not s or s.startswith("#"):
+        return None
+    if s.startswith("- "):
+        s = s[2:].strip()
+    if not s:
+        return None
+    # Handle command substitution assignments like VAR=$(git log -1 ...)
+    assignment_cmd = re.match(r"^[A-Za-z_][A-Za-z0-9_]*=\$\((.+)\)\s*$", s)
+    if assignment_cmd:
+        s = assignment_cmd.group(1).strip()
+
+    # Strip simple VAR=... prefixes with following command.
+    while re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", s):
+        parts = s.split(None, 1)
+        if len(parts) == 1:
+            return None
+        s = parts[1].strip()
+    if not s:
+        return None
+    token = re.split(r"[ \t|;&()]+", s, maxsplit=1)[0]
+    token = token.strip()
+    if not token:
+        return None
+    if token.startswith(('"', "'", "-", "${", "steps.", "}") ):
+        return None
+    shell_keywords = {
+        "if",
+        "then",
+        "else",
+        "elif",
+        "fi",
+        "for",
+        "do",
+        "done",
+        "while",
+        "case",
+        "esac",
+        "in",
+        "function",
+        "{",
+        "}",
+        "set",
+        "exit",
+        "break",
+        "continue",
+        "local",
+    }
+    if token in shell_keywords:
+        return None
+    return token
+
+
+def _discover_workflow_cli_tools(workflows_dir: Path) -> set[str]:
+    tools: set[str] = set()
+    run_re = re.compile(r"^(\s*)run:\s*\|\s*$")
+    for wf in sorted(workflows_dir.glob("*.yml")):
+        lines = wf.read_text(encoding="utf-8").splitlines()
+        i = 0
+        in_continuation = False
+        while i < len(lines):
+            m = run_re.match(lines[i])
+            if not m:
+                i += 1
+                continue
+            indent = len(m.group(1))
+            i += 1
+            in_continuation = False
+            while i < len(lines):
+                raw = lines[i]
+                if raw.strip() == "":
+                    i += 1
+                    continue
+                current_indent = len(raw) - len(raw.lstrip(" "))
+                if current_indent <= indent:
+                    break
+                stripped = raw.strip()
+                if in_continuation:
+                    in_continuation = stripped.endswith("\\")
+                    i += 1
+                    continue
+                cmd = _extract_command(stripped)
+                if cmd:
+                    tools.add(cmd)
+                in_continuation = stripped.endswith("\\")
+                i += 1
+    return tools
+
+
+def _discover_dependency_ecosystems(repo_root: Path) -> set[str]:
+    ecosystems: set[str] = set()
+    if (repo_root / ".github" / "workflows").exists():
+        ecosystems.add("github-actions")
+    if (repo_root / "api" / "requirements.txt").exists() or (repo_root / "api" / "pyproject.toml").exists():
+        ecosystems.add("pip")
+    if (repo_root / "web" / "package.json").exists():
+        ecosystems.add("npm")
+    return ecosystems
+
+
+def build_report(registry: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    workflows_dir = repo_root / ".github" / "workflows"
+    discovered_actions = sorted(_discover_workflow_actions(workflows_dir))
+    discovered_tools = sorted(_discover_workflow_cli_tools(workflows_dir))
+    discovered_ecosystems = sorted(_discover_dependency_ecosystems(repo_root))
+
+    tracked_actions = set(registry.get("github_actions", []))
+    tracked_tools = set(registry.get("workflow_cli_tools", []))
+    tracked_ecosystems = set(registry.get("dependency_ecosystems", []))
+
+    untracked_actions = sorted(set(discovered_actions) - tracked_actions)
+    untracked_tools = sorted(set(discovered_tools) - tracked_tools)
+    untracked_ecosystems = sorted(set(discovered_ecosystems) - tracked_ecosystems)
+
+    report = {
+        "policy": registry.get("policy", {}),
+        "discovered": {
+            "github_actions": discovered_actions,
+            "workflow_cli_tools": discovered_tools,
+            "dependency_ecosystems": discovered_ecosystems,
+        },
+        "tracked": {
+            "github_actions": sorted(tracked_actions),
+            "workflow_cli_tools": sorted(tracked_tools),
+            "dependency_ecosystems": sorted(tracked_ecosystems),
+        },
+        "untracked": {
+            "github_actions": untracked_actions,
+            "workflow_cli_tools": untracked_tools,
+            "dependency_ecosystems": untracked_ecosystems,
+        },
+        "ok": not (untracked_actions or untracked_tools or untracked_ecosystems),
+    }
+    return report
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--registry",
+        default="docs/system_audit/external_tools_registry.json",
+        help="Path to external tools registry JSON",
+    )
+    p.add_argument("--json", action="store_true", help="Output JSON report")
+    p.add_argument("--fail-on-untracked", action="store_true", help="Exit non-zero when untracked tools are found")
+    args = p.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    registry = _load_registry(repo_root / args.registry)
+    report = build_report(registry, repo_root)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"Audit OK: {report['ok']}")
+        print(f"Untracked github actions: {report['untracked']['github_actions']}")
+        print(f"Untracked workflow CLI tools: {report['untracked']['workflow_cli_tools']}")
+        print(f"Untracked dependency ecosystems: {report['untracked']['dependency_ecosystems']}")
+
+    if args.fail_on_untracked and not report["ok"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add external tool registry at `docs/system_audit/external_tools_registry.json`
- add `scripts/audit_external_tools.py` to detect newly added external tools
- add twice-weekly workflow `.github/workflows/external-tools-audit.yml` (Tue/Fri) that:
  - audits discovered tools vs registry
  - uploads machine-readable report artifact
  - opens/updates issue on drift
  - auto-closes issue when resolved
- add Dependabot config (`.github/dependabot.yml`) with daily checks for:
  - GitHub Actions
  - pip (`/api`)
  - npm (`/web`)
- normalize remaining `actions/checkout@v3` to `@v4`

## Validation
- `python3 scripts/audit_external_tools.py --fail-on-untracked` -> pass
- `cd api && .venv/bin/pytest -q` -> 68 passed
