### PR TITLE
feat(api): value lineage and payout attribution contract

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,7 +9,17 @@ from sqlalchemy import text
 
 from app.adapters.graph_store import InMemoryGraphStore
 from app.adapters.postgres_store import PostgresGraphStore, Base
-from app.routers import assets, contributions, contributors, distributions, friction, gates, health, ideas
+from app.routers import (
+    assets,
+    contributions,
+    contributors,
+    distributions,
+    friction,
+    gates,
+    health,
+    ideas,
+    value_lineage,
+)
 
 app = FastAPI(title="Coherence Contribution Network API", version="1.0.0")
 
@@ -81,3 +91,4 @@ app.include_router(ideas.router, prefix="/api", tags=["ideas"])
 app.include_router(friction.router, prefix="/api", tags=["friction"])
 app.include_router(gates.router, prefix="/api", tags=["gates"])
 app.include_router(health.router, prefix="/api", tags=["health"])
+app.include_router(value_lineage.router, prefix="/api", tags=["value-lineage"])

--- a/api/app/models/value_lineage.py
+++ b/api/app/models/value_lineage.py
@@ -1,0 +1,71 @@
+"""Models for idea->spec->implementation->usage->payout lineage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class LineageContributors(BaseModel):
+    idea: Optional[str] = None
+    spec: Optional[str] = None
+    implementation: Optional[str] = None
+    review: Optional[str] = None
+
+
+class LineageLinkCreate(BaseModel):
+    idea_id: str = Field(min_length=1)
+    spec_id: str = Field(min_length=1)
+    implementation_refs: list[str] = Field(default_factory=list)
+    contributors: LineageContributors
+    estimated_cost: float = Field(ge=0.0)
+
+
+class LineageLink(LineageLinkCreate):
+    id: str = Field(min_length=1)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class UsageEventCreate(BaseModel):
+    source: str = Field(min_length=1)
+    metric: str = Field(min_length=1)
+    value: float = Field(ge=0.0)
+
+
+class UsageEvent(UsageEventCreate):
+    id: str = Field(min_length=1)
+    lineage_id: str = Field(min_length=1)
+    captured_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class LineageValuation(BaseModel):
+    lineage_id: str
+    idea_id: str
+    spec_id: str
+    measured_value_total: float = Field(ge=0.0)
+    estimated_cost: float = Field(ge=0.0)
+    roi_ratio: float = Field(ge=0.0)
+    event_count: int = Field(ge=0)
+
+
+class PayoutPreviewRequest(BaseModel):
+    payout_pool: float = Field(gt=0.0)
+
+
+class PayoutRow(BaseModel):
+    role: str
+    contributor: str
+    amount: float = Field(ge=0.0)
+
+
+class PayoutPreview(BaseModel):
+    lineage_id: str
+    payout_pool: float = Field(gt=0.0)
+    measured_value_total: float = Field(ge=0.0)
+    estimated_cost: float = Field(ge=0.0)
+    roi_ratio: float = Field(ge=0.0)
+    weights: dict[str, float]
+    payouts: list[PayoutRow]

--- a/api/app/routers/value_lineage.py
+++ b/api/app/routers/value_lineage.py
@@ -1,0 +1,59 @@
+"""API routes for value lineage and payout attribution."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.models.value_lineage import (
+    LineageLink,
+    LineageLinkCreate,
+    LineageValuation,
+    PayoutPreview,
+    PayoutPreviewRequest,
+    UsageEvent,
+    UsageEventCreate,
+)
+from app.services import value_lineage_service
+
+router = APIRouter()
+
+
+@router.post("/value-lineage/links", response_model=LineageLink, status_code=201)
+async def create_link(payload: LineageLinkCreate) -> LineageLink:
+    return value_lineage_service.create_link(payload)
+
+
+@router.get("/value-lineage/links/{lineage_id}", response_model=LineageLink)
+async def get_link(lineage_id: str) -> LineageLink:
+    link = value_lineage_service.get_link(lineage_id)
+    if link is None:
+        raise HTTPException(status_code=404, detail="Lineage link not found")
+    return link
+
+
+@router.post(
+    "/value-lineage/links/{lineage_id}/usage-events",
+    response_model=UsageEvent,
+    status_code=201,
+)
+async def add_usage_event(lineage_id: str, payload: UsageEventCreate) -> UsageEvent:
+    event = value_lineage_service.add_usage_event(lineage_id, payload)
+    if event is None:
+        raise HTTPException(status_code=404, detail="Lineage link not found")
+    return event
+
+
+@router.get("/value-lineage/links/{lineage_id}/valuation", response_model=LineageValuation)
+async def get_valuation(lineage_id: str) -> LineageValuation:
+    report = value_lineage_service.valuation(lineage_id)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Lineage link not found")
+    return report
+
+
+@router.post("/value-lineage/links/{lineage_id}/payout-preview", response_model=PayoutPreview)
+async def payout_preview(lineage_id: str, payload: PayoutPreviewRequest) -> PayoutPreview:
+    report = value_lineage_service.payout_preview(lineage_id, payload.payout_pool)
+    if report is None:
+        raise HTTPException(status_code=404, detail="Lineage link not found")
+    return report

--- a/api/app/services/value_lineage_service.py
+++ b/api/app/services/value_lineage_service.py
@@ -1,0 +1,186 @@
+"""Service for persistent value lineage and payout attribution previews."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+from app.models.value_lineage import (
+    LineageLink,
+    LineageLinkCreate,
+    LineageValuation,
+    PayoutPreview,
+    PayoutRow,
+    UsageEvent,
+    UsageEventCreate,
+)
+
+DEFAULT_ROLE_WEIGHTS: dict[str, float] = {
+    "idea": 0.1,
+    "spec": 0.2,
+    "implementation": 0.5,
+    "review": 0.2,
+}
+
+
+def _default_path() -> Path:
+    logs_dir = Path(__file__).resolve().parents[2] / "logs"
+    return logs_dir / "value_lineage.json"
+
+
+def _path() -> Path:
+    configured = os.getenv("VALUE_LINEAGE_PATH")
+    return Path(configured) if configured else _default_path()
+
+
+def _ensure_store() -> None:
+    path = _path()
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"links": [], "events": []}, indent=2), encoding="utf-8")
+
+
+def _read_store() -> dict:
+    _ensure_store()
+    path = _path()
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {"links": [], "events": []}
+    if not isinstance(data, dict):
+        return {"links": [], "events": []}
+    links = data.get("links") if isinstance(data.get("links"), list) else []
+    events = data.get("events") if isinstance(data.get("events"), list) else []
+    return {"links": links, "events": events}
+
+
+def _write_store(data: dict) -> None:
+    path = _path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def create_link(payload: LineageLinkCreate) -> LineageLink:
+    now = datetime.now(timezone.utc)
+    link = LineageLink(
+        id=f"lnk_{uuid4().hex[:12]}",
+        idea_id=payload.idea_id,
+        spec_id=payload.spec_id,
+        implementation_refs=payload.implementation_refs,
+        contributors=payload.contributors,
+        estimated_cost=round(float(payload.estimated_cost), 4),
+        created_at=now,
+        updated_at=now,
+    )
+    data = _read_store()
+    data["links"].append(link.model_dump(mode="json"))
+    _write_store(data)
+    return link
+
+
+def get_link(lineage_id: str) -> LineageLink | None:
+    data = _read_store()
+    for raw in data["links"]:
+        try:
+            link = LineageLink(**raw)
+        except Exception:
+            continue
+        if link.id == lineage_id:
+            return link
+    return None
+
+
+def add_usage_event(lineage_id: str, payload: UsageEventCreate) -> UsageEvent | None:
+    link = get_link(lineage_id)
+    if link is None:
+        return None
+    event = UsageEvent(
+        id=f"evt_{uuid4().hex[:12]}",
+        lineage_id=lineage_id,
+        source=payload.source,
+        metric=payload.metric,
+        value=round(float(payload.value), 4),
+        captured_at=datetime.now(timezone.utc),
+    )
+    data = _read_store()
+    updated_links = []
+    for raw in data["links"]:
+        if raw.get("id") == lineage_id:
+            raw["updated_at"] = datetime.now(timezone.utc).isoformat()
+        updated_links.append(raw)
+    data["links"] = updated_links
+    data["events"].append(event.model_dump(mode="json"))
+    _write_store(data)
+    return event
+
+
+def _lineage_events(lineage_id: str) -> list[UsageEvent]:
+    data = _read_store()
+    out: list[UsageEvent] = []
+    for raw in data["events"]:
+        try:
+            ev = UsageEvent(**raw)
+        except Exception:
+            continue
+        if ev.lineage_id == lineage_id:
+            out.append(ev)
+    return out
+
+
+def valuation(lineage_id: str) -> LineageValuation | None:
+    link = get_link(lineage_id)
+    if link is None:
+        return None
+    events = _lineage_events(lineage_id)
+    measured_value_total = round(sum(float(ev.value) for ev in events), 4)
+    estimated_cost = round(float(link.estimated_cost), 4)
+    roi = round((measured_value_total / estimated_cost), 4) if estimated_cost > 0 else 0.0
+    return LineageValuation(
+        lineage_id=lineage_id,
+        idea_id=link.idea_id,
+        spec_id=link.spec_id,
+        measured_value_total=measured_value_total,
+        estimated_cost=estimated_cost,
+        roi_ratio=roi,
+        event_count=len(events),
+    )
+
+
+def payout_preview(lineage_id: str, payout_pool: float) -> PayoutPreview | None:
+    link = get_link(lineage_id)
+    if link is None:
+        return None
+    summary = valuation(lineage_id)
+    if summary is None:
+        return None
+
+    contributors = {
+        "idea": link.contributors.idea,
+        "spec": link.contributors.spec,
+        "implementation": link.contributors.implementation,
+        "review": link.contributors.review,
+    }
+    active_roles = {role: who for role, who in contributors.items() if isinstance(who, str) and who}
+    weights = {role: DEFAULT_ROLE_WEIGHTS[role] for role in active_roles}
+    weight_total = sum(weights.values())
+    payouts: list[PayoutRow] = []
+    for role, contributor in active_roles.items():
+        normalized_weight = (weights[role] / weight_total) if weight_total > 0 else 0.0
+        amount = round(float(payout_pool) * normalized_weight, 4)
+        payouts.append(PayoutRow(role=role, contributor=contributor, amount=amount))
+
+    return PayoutPreview(
+        lineage_id=lineage_id,
+        payout_pool=round(float(payout_pool), 4),
+        measured_value_total=summary.measured_value_total,
+        estimated_cost=summary.estimated_cost,
+        roi_ratio=summary.roi_ratio,
+        weights=DEFAULT_ROLE_WEIGHTS,
+        payouts=payouts,
+    )

--- a/api/tests/test_value_lineage.py
+++ b/api/tests/test_value_lineage.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_lineage_link(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+
+    payload = {
+        "idea_id": "oss-interface-alignment",
+        "spec_id": "048-value-lineage-and-payout-attribution",
+        "implementation_refs": ["PR#26", "commit:e616516"],
+        "contributors": {
+            "idea": "alice",
+            "spec": "bob",
+            "implementation": "carol",
+            "review": "dave",
+        },
+        "estimated_cost": 120.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post("/api/value-lineage/links", json=payload)
+        assert created.status_code == 201
+        link = created.json()
+        assert link["idea_id"] == payload["idea_id"]
+        assert link["spec_id"] == payload["spec_id"]
+        assert link["contributors"]["implementation"] == "carol"
+
+        fetched = await client.get(f"/api/value-lineage/links/{link['id']}")
+        assert fetched.status_code == 200
+        assert fetched.json() == link
+
+
+@pytest.mark.asyncio
+async def test_usage_events_roll_up_to_valuation(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+
+    payload = {
+        "idea_id": "portfolio-governance",
+        "spec_id": "048-value-lineage-and-payout-attribution",
+        "implementation_refs": ["PR#27"],
+        "contributors": {"idea": "alice", "spec": "bob", "implementation": "carol"},
+        "estimated_cost": 50.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post("/api/value-lineage/links", json=payload)
+        lineage_id = created.json()["id"]
+
+        ev1 = await client.post(
+            f"/api/value-lineage/links/{lineage_id}/usage-events",
+            json={"source": "api", "metric": "adoption_events", "value": 40.0},
+        )
+        assert ev1.status_code == 201
+
+        ev2 = await client.post(
+            f"/api/value-lineage/links/{lineage_id}/usage-events",
+            json={"source": "web", "metric": "validated_flows", "value": 10.0},
+        )
+        assert ev2.status_code == 201
+
+        valuation = await client.get(f"/api/value-lineage/links/{lineage_id}/valuation")
+        assert valuation.status_code == 200
+        data = valuation.json()
+        assert data["measured_value_total"] == 50.0
+        assert data["estimated_cost"] == 50.0
+        assert data["roi_ratio"] == 1.0
+        assert data["event_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_payout_preview_uses_role_weights(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+
+    payload = {
+        "idea_id": "coherence-signal-depth",
+        "spec_id": "048-value-lineage-and-payout-attribution",
+        "implementation_refs": ["PR#28"],
+        "contributors": {
+            "idea": "alice",
+            "spec": "bob",
+            "implementation": "carol",
+            "review": "dave",
+        },
+        "estimated_cost": 80.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post("/api/value-lineage/links", json=payload)
+        lineage_id = created.json()["id"]
+
+        ev = await client.post(
+            f"/api/value-lineage/links/{lineage_id}/usage-events",
+            json={"source": "api", "metric": "adoption_events", "value": 100.0},
+        )
+        assert ev.status_code == 201
+
+        payout = await client.post(
+            f"/api/value-lineage/links/{lineage_id}/payout-preview",
+            json={"payout_pool": 1000.0},
+        )
+        assert payout.status_code == 200
+        data = payout.json()
+        assert data["weights"] == {
+            "idea": 0.1,
+            "spec": 0.2,
+            "implementation": 0.5,
+            "review": 0.2,
+        }
+        amounts = {row["role"]: row["amount"] for row in data["payouts"]}
+        assert amounts["idea"] == 100.0
+        assert amounts["spec"] == 200.0
+        assert amounts["implementation"] == 500.0
+        assert amounts["review"] == 200.0
+
+
+@pytest.mark.asyncio
+async def test_lineage_404_contract(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        missing = await client.get("/api/value-lineage/links/does-not-exist")
+        assert missing.status_code == 404
+        assert missing.json()["detail"] == "Lineage link not found"
+
+        missing_usage = await client.post(
+            "/api/value-lineage/links/does-not-exist/usage-events",
+            json={"source": "api", "metric": "x", "value": 1.0},
+        )
+        assert missing_usage.status_code == 404
+        assert missing_usage.json()["detail"] == "Lineage link not found"

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -59,6 +59,7 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 | 045 Effectiveness Plan Progress Phase 6  | ? | ? | ? | Pending |
 | 046 Agent Debugging Pipeline Stuck Task Hang | ? | ? | ? | Pending |
 | 047 Heal Completion Issue Resolutio | ? | ? | ? | Pending |
+| 048 Value Lineage and Payout Attribution | ✓ | ✓ | ✓ | idea->spec->impl->usage->payout preview trace API |
 **Present:** Implemented. **Missing:** Not implemented. **Shortcuts:** See below.
 
 ---
@@ -418,6 +419,21 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 | Indexer (deps.dev + pypi) | `index_pypi_packages`, `scripts/index_pypi.py` | Manual: `index_pypi.py --limit 3` |
 
 **Files:** `api/app/adapters/graph_store.py`, `api/app/models/project.py`, `api/app/routers/projects.py`, `api/app/services/indexer_service.py`, `api/scripts/index_npm.py`, `api/scripts/index_pypi.py`
+
+---
+
+## Spec 048: Value Lineage and Payout Attribution
+
+| Requirement | Implementation | Test |
+|-------------|----------------|------|
+| POST /api/value-lineage/links creates lineage link (idea/spec/implementation/contributors/cost) | `routers/value_lineage.py`, `services/value_lineage_service.py`, `models/value_lineage.py` | `test_create_and_get_lineage_link` |
+| GET /api/value-lineage/links/{id} fetches persisted lineage | same as above | `test_create_and_get_lineage_link` |
+| POST /api/value-lineage/links/{id}/usage-events appends measurable value signals | same as above | `test_usage_events_roll_up_to_valuation` |
+| GET /api/value-lineage/links/{id}/valuation returns measured value, estimated cost, ROI, event count | same as above | `test_usage_events_roll_up_to_valuation` |
+| POST /api/value-lineage/links/{id}/payout-preview returns role-weighted payouts | same as above | `test_payout_preview_uses_role_weights` |
+| Missing lineage returns 404 with exact detail | router raises HTTPException | `test_lineage_404_contract` |
+
+**Files:** `api/app/models/value_lineage.py`, `api/app/services/value_lineage_service.py`, `api/app/routers/value_lineage.py`, `api/app/main.py`, `api/tests/test_value_lineage.py`
 
 ---
 

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -10,8 +10,9 @@ Quick reference: spec status, test coverage, last verified.
 | 012–014 | ✓ | ✓ | ✓ |
 | 016–019 | ✓ | ✓ | ✓ |
 | 020–025 | ✓ | ✓ | ✓ |
+| 048 | ✓ | ✓ | ✓ |
 
-**Total:** 25 specs (001–025, excluding 006, 015); all implemented and covered.
+**Total:** 26 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048).
 
 ## Test Verification
 
@@ -39,6 +40,7 @@ cd web && npm run build      # 7 routes
 | 022, 025 | test_import_stack.py |
 | 024 | test_projects.py |
 | 027 (auto-update) | test_update_spec_coverage.py |
+| 048 | test_value_lineage.py |
 
 ## Last Updated
 

--- a/specs/048-value-lineage-and-payout-attribution.md
+++ b/specs/048-value-lineage-and-payout-attribution.md
@@ -1,0 +1,203 @@
+# Spec: Value Lineage and Payout Attribution
+
+## Purpose
+
+Create a verifiable, machine-readable chain from **idea -> spec -> implementation -> usage/value signals -> payout preview** so contributors can be rewarded based on measurable system value.
+
+## Requirements
+
+- [ ] API supports creating and fetching a lineage link that binds idea/spec/implementation references and contributor roles.
+- [ ] API supports appending usage/value events to a lineage link.
+- [ ] API exposes valuation summary for a lineage link (measured value, estimated cost, ROI ratio, event count).
+- [ ] API supports payout preview from valuation using explicit role weights and returns per-contributor attribution.
+- [ ] All artifacts are persisted in a durable local store for auditability.
+- [ ] Missing lineage id returns 404 with `{ "detail": "Lineage link not found" }`.
+
+## API Contract
+
+### `POST /api/value-lineage/links`
+
+Create a lineage link.
+
+**Request**
+```json
+{
+  "idea_id": "oss-interface-alignment",
+  "spec_id": "048-value-lineage-and-payout-attribution",
+  "implementation_refs": ["PR#26", "commit:e616516"],
+  "contributors": {
+    "idea": "alice",
+    "spec": "bob",
+    "implementation": "carol",
+    "review": "dave"
+  },
+  "estimated_cost": 120.0
+}
+```
+
+**Response 201**
+```json
+{
+  "id": "lnk_123",
+  "idea_id": "oss-interface-alignment",
+  "spec_id": "048-value-lineage-and-payout-attribution",
+  "implementation_refs": ["PR#26", "commit:e616516"],
+  "contributors": {
+    "idea": "alice",
+    "spec": "bob",
+    "implementation": "carol",
+    "review": "dave"
+  },
+  "estimated_cost": 120.0
+}
+```
+
+### `GET /api/value-lineage/links/{lineage_id}`
+
+Fetch lineage link.
+
+**Response 200**
+```json
+{
+  "id": "lnk_123",
+  "idea_id": "oss-interface-alignment",
+  "spec_id": "048-value-lineage-and-payout-attribution",
+  "implementation_refs": ["PR#26", "commit:e616516"],
+  "contributors": {
+    "idea": "alice",
+    "spec": "bob",
+    "implementation": "carol",
+    "review": "dave"
+  },
+  "estimated_cost": 120.0
+}
+```
+
+**Response 404**
+```json
+{ "detail": "Lineage link not found" }
+```
+
+### `POST /api/value-lineage/links/{lineage_id}/usage-events`
+
+Append measurable value signal to lineage link.
+
+**Request**
+```json
+{
+  "source": "api",
+  "metric": "adoption_events",
+  "value": 45.5
+}
+```
+
+**Response 201**
+```json
+{
+  "id": "evt_123",
+  "lineage_id": "lnk_123",
+  "source": "api",
+  "metric": "adoption_events",
+  "value": 45.5,
+  "captured_at": "2026-02-15T00:00:00Z"
+}
+```
+
+### `GET /api/value-lineage/links/{lineage_id}/valuation`
+
+Return summarized measured value and ROI.
+
+**Response 200**
+```json
+{
+  "lineage_id": "lnk_123",
+  "idea_id": "oss-interface-alignment",
+  "spec_id": "048-value-lineage-and-payout-attribution",
+  "measured_value_total": 100.0,
+  "estimated_cost": 120.0,
+  "roi_ratio": 0.8333,
+  "event_count": 2
+}
+```
+
+### `POST /api/value-lineage/links/{lineage_id}/payout-preview`
+
+Compute payout attribution for contributors.
+
+**Request**
+```json
+{
+  "payout_pool": 1000.0
+}
+```
+
+**Response 200**
+```json
+{
+  "lineage_id": "lnk_123",
+  "payout_pool": 1000.0,
+  "measured_value_total": 100.0,
+  "estimated_cost": 120.0,
+  "roi_ratio": 0.8333,
+  "weights": {
+    "idea": 0.1,
+    "spec": 0.2,
+    "implementation": 0.5,
+    "review": 0.2
+  },
+  "payouts": [
+    {"role": "idea", "contributor": "alice", "amount": 100.0},
+    {"role": "spec", "contributor": "bob", "amount": 200.0},
+    {"role": "implementation", "contributor": "carol", "amount": 500.0},
+    {"role": "review", "contributor": "dave", "amount": 200.0}
+  ]
+}
+```
+
+## Data Model
+
+```yaml
+LineageLink:
+  id: string
+  idea_id: string
+  spec_id: string
+  implementation_refs: string[]
+  contributors:
+    idea: string?
+    spec: string?
+    implementation: string?
+    review: string?
+  estimated_cost: number
+
+UsageEvent:
+  id: string
+  lineage_id: string
+  source: string
+  metric: string
+  value: number
+  captured_at: datetime
+```
+
+## Validation Contract
+
+- Tests define contract in `api/tests/test_value_lineage.py`.
+- Required behaviors:
+  - Create + fetch lineage link works with persistence.
+  - Usage events accumulate measured value.
+  - Valuation computes `roi_ratio = measured_value_total / estimated_cost` (0 when estimated_cost is 0).
+  - Payout preview allocates by role weights among present contributors.
+  - Missing lineage returns 404 exact detail message.
+
+## Files to Create/Modify
+
+- `api/app/models/value_lineage.py` — request/response models
+- `api/app/services/value_lineage_service.py` — persistence + valuation + payout logic
+- `api/app/routers/value_lineage.py` — API endpoints
+- `api/app/main.py` — router wiring
+- `api/tests/test_value_lineage.py` — contract tests
+
+## Out of Scope
+
+- On-chain payout execution
+- Fiat/crypto settlement integration
+- Dynamic weight governance beyond static defaults


### PR DESCRIPTION
## Summary
Implements end-to-end traceability and attribution from idea to payout preview:
- new spec: `specs/048-value-lineage-and-payout-attribution.md`
- new API surface:
  - `POST /api/value-lineage/links`
  - `GET /api/value-lineage/links/{lineage_id}`
  - `POST /api/value-lineage/links/{lineage_id}/usage-events`
  - `GET /api/value-lineage/links/{lineage_id}/valuation`
  - `POST /api/value-lineage/links/{lineage_id}/payout-preview`
- persistence-backed service in `api/logs/value_lineage.json` (or `VALUE_LINEAGE_PATH`)
- role-weighted payout preview contract (`idea/spec/implementation/review`)
- docs updated in `docs/SPEC-COVERAGE.md` and `docs/SPEC-TRACKING.md`

## Validation Contract
Defined in `api/tests/test_value_lineage.py` and spec 048:
- create/fetch lineage link
- usage events -> valuation rollup
- payout preview role allocation
- 404 contract for missing lineage

## Local Validation
- `cd api && .venv/bin/pytest -q tests/test_value_lineage.py` -> 4 passed
- `cd api && .venv/bin/pytest -q` -> 72 passed
