### PR TITLE
feat(gates): enforce public value-lineage e2e contract

### DIFF
--- a/api/app/routers/gates.py
+++ b/api/app/routers/gates.py
@@ -87,3 +87,21 @@ async def gates_main_contract(
     )
     report["branch"] = branch
     return report
+
+
+@router.get("/gates/public-deploy-contract")
+async def gates_public_deploy_contract(
+    repo: str = Query("seeker71/Coherence-Network"),
+    branch: str = Query("main"),
+    api_base: str = Query("https://coherence-network-production.up.railway.app"),
+    web_base: str = Query("https://coherence-network.vercel.app"),
+    timeout: float = Query(8.0, ge=1.0, le=60.0),
+) -> dict:
+    return gates.evaluate_public_deploy_contract_report(
+        repository=repo,
+        branch=branch,
+        api_base=api_base,
+        web_base=web_base,
+        timeout=timeout,
+        github_token=os.getenv("GITHUB_TOKEN"),
+    )

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -177,11 +177,26 @@ Contract checks:
 2. Railway `/api/gates/main-head` responds `200` and returns SHA equal to GitHub `main` head.
 3. Vercel `/gates` page responds `200`.
 4. Vercel `/api/health-proxy` responds `200`, reports `api.status=ok`, and `web.updated_at` equals GitHub `main` head.
+5. Railway value-lineage E2E transaction passes:
+   - `POST /api/value-lineage/links`
+   - `POST /api/value-lineage/links/{id}/usage-events`
+   - `GET /api/value-lineage/links/{id}/valuation`
+   - `POST /api/value-lineage/links/{id}/payout-preview`
+   - invariants validated (`measured_value_total`, payout weights/amounts).
+
+Note: if `/api/gates/main-head` is unavailable due missing GitHub auth in public runtime (401/403/502),
+the contract records a warning (`railway_gates_main_head_unavailable`) but still requires all other checks,
+including value-lineage E2E, to pass.
 
 If contract fails:
 - Workflow uploads `public_deploy_contract_report.json`.
 - Workflow opens or updates issue: `Public deployment contract failing on main`.
 - If Railway secrets are configured (`RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT`, `RAILWAY_SERVICE`), workflow triggers `railway redeploy` and re-validates for up to 20 minutes before deciding pass/fail.
+
+Machine and human access:
+- Machine API: `GET /api/gates/public-deploy-contract`
+- Human UI: `/gates` page, section **Public Deploy Contract**
+- CI artifact: `public_deploy_contract_report.json`
 
 ## External Tool Drift Monitor (Twice Weekly)
 

--- a/specs/048-value-lineage-and-payout-attribution.md
+++ b/specs/048-value-lineage-and-payout-attribution.md
@@ -187,6 +187,7 @@ UsageEvent:
   - Valuation computes `roi_ratio = measured_value_total / estimated_cost` (0 when estimated_cost is 0).
   - Payout preview allocates by role weights among present contributors.
   - Missing lineage returns 404 exact detail message.
+- Public deploy gate must include a live E2E transaction check for this flow and fail deployment contract when invariants break.
 
 ## Files to Create/Modify
 
@@ -195,6 +196,10 @@ UsageEvent:
 - `api/app/routers/value_lineage.py` — API endpoints
 - `api/app/main.py` — router wiring
 - `api/tests/test_value_lineage.py` — contract tests
+- `api/app/services/release_gate_service.py` — public E2E transaction gate check
+- `api/tests/test_release_gate_service.py` — deploy contract coverage for value-lineage E2E
+- `api/app/routers/gates.py` — machine-access endpoint for public deploy contract report
+- `web/app/gates/page.tsx` — human-access report viewer for public deploy contract
 
 ## Out of Scope
 

--- a/web/app/gates/page.tsx
+++ b/web/app/gates/page.tsx
@@ -12,6 +12,7 @@ export default function GatesPage() {
   const [sha, setSha] = useState("");
   const [prReport, setPrReport] = useState<Record<string, unknown> | null>(null);
   const [contractReport, setContractReport] = useState<Record<string, unknown> | null>(null);
+  const [publicDeployReport, setPublicDeployReport] = useState<Record<string, unknown> | null>(null);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
 
@@ -66,6 +67,21 @@ export default function GatesPage() {
     }
   }
 
+  async function runPublicDeployContract() {
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch(`${API_URL}/api/gates/public-deploy-contract`);
+      const json = await res.json();
+      if (!res.ok) throw new Error(JSON.stringify(json));
+      setPublicDeployReport(json);
+      setStatus("idle");
+    } catch (e) {
+      setStatus("error");
+      setError(String(e));
+    }
+  }
+
   return (
     <main className="min-h-screen p-8 max-w-4xl mx-auto space-y-6">
       <div>
@@ -110,6 +126,13 @@ export default function GatesPage() {
         </div>
       </section>
 
+      <section className="space-y-3 border border-border rounded-md p-4">
+        <h2 className="text-lg font-semibold">Public Deploy Contract</h2>
+        <Button variant="outline" onClick={runPublicDeployContract} disabled={status === "loading"}>
+          Check Public Deploy Contract
+        </Button>
+      </section>
+
       {status === "error" && error && (
         <p className="text-destructive">Error: {error}</p>
       )}
@@ -128,6 +151,15 @@ export default function GatesPage() {
           <h3 className="font-medium">Change Contract Report</h3>
           <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
             {JSON.stringify(contractReport, null, 2)}
+          </pre>
+        </section>
+      )}
+
+      {publicDeployReport && (
+        <section className="space-y-2">
+          <h3 className="font-medium">Public Deploy Report</h3>
+          <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
+            {JSON.stringify(publicDeployReport, null, 2)}
           </pre>
         </section>
       )}


### PR DESCRIPTION
## Summary
- add a real public E2E validation step for value-lineage contract behavior in `evaluate_public_deploy_contract_report`
- treat `railway_gates_main_head` auth/unavailable (401/403/502) as a warning instead of a hard blocker, while still hard-failing on all functional checks
- add machine endpoint `GET /api/gates/public-deploy-contract` and expose it in web `/gates`
- update spec 048 and pipeline monitoring docs with the contract and access paths

## Validation
- `cd api && .venv/bin/pytest -q` (74 passed)
- `cd web && npm run build` (success)
- `cd api && .venv/bin/python scripts/validate_public_deploy_contract.py --repo seeker71/Coherence-Network --branch main --json` (result: `public_contract_passed`, includes `railway_value_lineage_e2e`)
