### PR TITLE
feat(inventory): unified lineage inventory and runtime telemetry

### DIFF
--- a/api/app/models/runtime.py
+++ b/api/app/models/runtime.py
@@ -1,0 +1,37 @@
+"""Runtime telemetry models for endpoint-level tracking."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+RuntimeSource = Literal["api", "web", "web_api", "worker"]
+
+
+class RuntimeEventCreate(BaseModel):
+    source: RuntimeSource
+    endpoint: str = Field(min_length=1)
+    method: str = Field(default="GET", min_length=1)
+    status_code: int = Field(default=200, ge=100, le=599)
+    runtime_ms: float = Field(gt=0.0)
+    idea_id: Optional[str] = None
+    metadata: dict[str, str | float | int | bool] = Field(default_factory=dict)
+
+
+class RuntimeEvent(RuntimeEventCreate):
+    id: str = Field(min_length=1)
+    recorded_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    runtime_cost_estimate: float = Field(ge=0.0)
+
+
+class IdeaRuntimeSummary(BaseModel):
+    idea_id: str
+    event_count: int = Field(ge=0)
+    total_runtime_ms: float = Field(ge=0.0)
+    average_runtime_ms: float = Field(ge=0.0)
+    runtime_cost_estimate: float = Field(ge=0.0)
+    by_source: dict[str, int] = Field(default_factory=dict)
+

--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -1,0 +1,17 @@
+"""Unified system inventory routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.services import inventory_service
+
+router = APIRouter()
+
+
+@router.get("/inventory/system-lineage")
+async def system_lineage_inventory(
+    runtime_window_seconds: int = Query(3600, ge=60, le=2592000),
+) -> dict:
+    return inventory_service.build_system_lineage_inventory(runtime_window_seconds=runtime_window_seconds)
+

--- a/api/app/routers/runtime.py
+++ b/api/app/routers/runtime.py
@@ -1,0 +1,30 @@
+"""Runtime telemetry API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+
+from app.models.runtime import RuntimeEvent, RuntimeEventCreate
+from app.services import runtime_service
+
+router = APIRouter()
+
+
+@router.post("/runtime/events", response_model=RuntimeEvent, status_code=201)
+async def create_runtime_event(payload: RuntimeEventCreate) -> RuntimeEvent:
+    return runtime_service.record_event(payload)
+
+
+@router.get("/runtime/events", response_model=list[RuntimeEvent])
+async def list_runtime_events(limit: int = Query(100, ge=1, le=2000)) -> list[RuntimeEvent]:
+    return runtime_service.list_events(limit=limit)
+
+
+@router.get("/runtime/ideas/summary")
+async def runtime_summary_by_idea(seconds: int = Query(3600, ge=60, le=2592000)) -> dict:
+    rows = runtime_service.summarize_by_idea(seconds=seconds)
+    return {
+        "window_seconds": seconds,
+        "ideas": [row.model_dump(mode="json") for row in rows],
+    }
+

--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -1,0 +1,107 @@
+"""Unified inventory service for ideas, questions, specs, implementations, and usage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.services import idea_service, runtime_service, value_lineage_service
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _discover_specs(limit: int = 300) -> list[dict]:
+    specs_dir = _project_root() / "specs"
+    if not specs_dir.exists():
+        return []
+    files = sorted(specs_dir.glob("*.md"))
+    out: list[dict] = []
+    for path in files[: max(1, min(limit, 2000))]:
+        stem = path.stem
+        spec_id = stem.split("-", 1)[0] if "-" in stem else stem
+        title = stem.replace("-", " ")
+        out.append(
+            {
+                "spec_id": spec_id,
+                "title": title,
+                "path": str(path),
+            }
+        )
+    return out
+
+
+def build_system_lineage_inventory(runtime_window_seconds: int = 3600) -> dict:
+    ideas_response = idea_service.list_ideas()
+    ideas = [item.model_dump(mode="json") for item in ideas_response.ideas]
+
+    answered_questions: list[dict] = []
+    unanswered_questions: list[dict] = []
+    for idea in ideas_response.ideas:
+        for q in idea.open_questions:
+            row = {
+                "idea_id": idea.id,
+                "idea_name": idea.name,
+                "question": q.question,
+                "value_to_whole": q.value_to_whole,
+                "estimated_cost": q.estimated_cost,
+                "answer": q.answer,
+                "measured_delta": q.measured_delta,
+            }
+            if q.answer:
+                answered_questions.append(row)
+            else:
+                unanswered_questions.append(row)
+
+    unanswered_questions.sort(
+        key=lambda x: ((x["estimated_cost"] / max(x["value_to_whole"], 0.0001)), -x["value_to_whole"])
+    )
+    answered_questions.sort(key=lambda x: -float(x.get("measured_delta") or 0.0))
+
+    links = value_lineage_service.list_links(limit=300)
+    events = value_lineage_service.list_usage_events(limit=1000)
+    link_rows = []
+    for link in links:
+        valuation = value_lineage_service.valuation(link.id)
+        link_rows.append(
+            {
+                "lineage_id": link.id,
+                "idea_id": link.idea_id,
+                "spec_id": link.spec_id,
+                "implementation_refs": link.implementation_refs,
+                "estimated_cost": link.estimated_cost,
+                "valuation": valuation.model_dump(mode="json") if valuation else None,
+            }
+        )
+
+    runtime_summary = [x.model_dump(mode="json") for x in runtime_service.summarize_by_idea(runtime_window_seconds)]
+    spec_items = _discover_specs()
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ideas": {
+            "summary": ideas_response.summary.model_dump(mode="json"),
+            "items": ideas,
+        },
+        "questions": {
+            "total": len(answered_questions) + len(unanswered_questions),
+            "answered_count": len(answered_questions),
+            "unanswered_count": len(unanswered_questions),
+            "answered": answered_questions,
+            "unanswered": unanswered_questions,
+        },
+        "specs": {
+            "count": len(spec_items),
+            "items": spec_items,
+        },
+        "implementation_usage": {
+            "lineage_links_count": len(link_rows),
+            "usage_events_count": len(events),
+            "lineage_links": link_rows,
+        },
+        "runtime": {
+            "window_seconds": runtime_window_seconds,
+            "ideas": runtime_summary,
+        },
+    }

--- a/api/app/services/runtime_service.py
+++ b/api/app/services/runtime_service.py
@@ -1,0 +1,177 @@
+"""Runtime telemetry persistence and aggregation service."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+from app.models.runtime import IdeaRuntimeSummary, RuntimeEvent, RuntimeEventCreate
+from app.services import value_lineage_service
+
+
+def _default_events_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "logs" / "runtime_events.json"
+
+
+def _events_path() -> Path:
+    configured = os.getenv("RUNTIME_EVENTS_PATH")
+    return Path(configured) if configured else _default_events_path()
+
+
+def _default_idea_map_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "logs" / "runtime_idea_map.json"
+
+
+def _idea_map_path() -> Path:
+    configured = os.getenv("RUNTIME_IDEA_MAP_PATH")
+    return Path(configured) if configured else _default_idea_map_path()
+
+
+def _runtime_cost_per_second() -> float:
+    return float(os.getenv("RUNTIME_COST_PER_SECOND", "0.002"))
+
+
+def _ensure_events_store() -> None:
+    path = _events_path()
+    if path.exists():
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"events": []}, indent=2), encoding="utf-8")
+
+
+def _read_store() -> dict:
+    _ensure_events_store()
+    path = _events_path()
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {"events": []}
+    if not isinstance(data, dict):
+        return {"events": []}
+    events = data.get("events") if isinstance(data.get("events"), list) else []
+    return {"events": events}
+
+
+def _write_store(data: dict) -> None:
+    path = _events_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def _default_idea_map() -> dict:
+    return {
+        "prefix_map": {
+            "/api/ideas": "portfolio-governance",
+            "/api/value-lineage": "portfolio-governance",
+            "/api/gates": "oss-interface-alignment",
+            "/api/runtime": "oss-interface-alignment",
+            "/gates": "oss-interface-alignment",
+            "/search": "coherence-signal-depth",
+        }
+    }
+
+
+def _load_idea_map() -> dict:
+    path = _idea_map_path()
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(_default_idea_map(), indent=2), encoding="utf-8")
+        return _default_idea_map()
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return _default_idea_map()
+    if not isinstance(data, dict):
+        return _default_idea_map()
+    return data
+
+
+def resolve_idea_id(endpoint: str, explicit_idea_id: str | None = None) -> str:
+    if explicit_idea_id:
+        return explicit_idea_id
+
+    map_data = _load_idea_map()
+    prefix_map = map_data.get("prefix_map") if isinstance(map_data.get("prefix_map"), dict) else {}
+    for prefix, idea_id in prefix_map.items():
+        if isinstance(prefix, str) and isinstance(idea_id, str) and endpoint.startswith(prefix):
+            return idea_id
+
+    # Derive idea from lineage endpoint references where possible.
+    marker = "/api/value-lineage/links/"
+    if marker in endpoint:
+        tail = endpoint.split(marker, 1)[1]
+        lineage_id = tail.split("/", 1)[0]
+        link = value_lineage_service.get_link(lineage_id)
+        if link:
+            return link.idea_id
+
+    return "unmapped"
+
+
+def record_event(payload: RuntimeEventCreate) -> RuntimeEvent:
+    idea_id = resolve_idea_id(payload.endpoint, payload.idea_id)
+    runtime_cost = round((float(payload.runtime_ms) / 1000.0) * _runtime_cost_per_second(), 8)
+    event = RuntimeEvent(
+        id=f"rt_{uuid4().hex[:12]}",
+        source=payload.source,
+        endpoint=payload.endpoint,
+        method=payload.method.upper(),
+        status_code=payload.status_code,
+        runtime_ms=round(float(payload.runtime_ms), 4),
+        idea_id=idea_id,
+        metadata=payload.metadata,
+        runtime_cost_estimate=runtime_cost,
+    )
+    data = _read_store()
+    data["events"].append(event.model_dump(mode="json"))
+    _write_store(data)
+    return event
+
+
+def list_events(limit: int = 100) -> list[RuntimeEvent]:
+    data = _read_store()
+    out: list[RuntimeEvent] = []
+    for raw in data["events"]:
+        try:
+            out.append(RuntimeEvent(**raw))
+        except Exception:
+            continue
+    out.sort(key=lambda x: x.recorded_at, reverse=True)
+    return out[: max(1, min(limit, 2000))]
+
+
+def summarize_by_idea(seconds: int = 3600) -> list[IdeaRuntimeSummary]:
+    window_seconds = max(60, min(seconds, 60 * 60 * 24 * 30))
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
+    rows = [e for e in list_events(limit=2000) if e.recorded_at >= cutoff]
+
+    grouped: dict[str, list[RuntimeEvent]] = {}
+    for event in rows:
+        grouped.setdefault(event.idea_id or "unmapped", []).append(event)
+
+    summaries: list[IdeaRuntimeSummary] = []
+    for idea_id, events in grouped.items():
+        total_runtime = round(sum(e.runtime_ms for e in events), 4)
+        total_cost = round(sum(e.runtime_cost_estimate for e in events), 8)
+        by_source: dict[str, int] = {}
+        for event in events:
+            by_source[event.source] = by_source.get(event.source, 0) + 1
+        summaries.append(
+            IdeaRuntimeSummary(
+                idea_id=idea_id,
+                event_count=len(events),
+                total_runtime_ms=total_runtime,
+                average_runtime_ms=round(total_runtime / len(events), 4),
+                runtime_cost_estimate=total_cost,
+                by_source=by_source,
+            )
+        )
+    summaries.sort(key=lambda x: x.runtime_cost_estimate, reverse=True)
+    return summaries
+

--- a/api/app/services/value_lineage_service.py
+++ b/api/app/services/value_lineage_service.py
@@ -96,6 +96,18 @@ def get_link(lineage_id: str) -> LineageLink | None:
     return None
 
 
+def list_links(limit: int = 200) -> list[LineageLink]:
+    data = _read_store()
+    out: list[LineageLink] = []
+    for raw in data["links"]:
+        try:
+            out.append(LineageLink(**raw))
+        except Exception:
+            continue
+    out.sort(key=lambda x: x.updated_at, reverse=True)
+    return out[: max(1, min(limit, 2000))]
+
+
 def add_usage_event(lineage_id: str, payload: UsageEventCreate) -> UsageEvent | None:
     link = get_link(lineage_id)
     if link is None:
@@ -131,6 +143,18 @@ def _lineage_events(lineage_id: str) -> list[UsageEvent]:
         if ev.lineage_id == lineage_id:
             out.append(ev)
     return out
+
+
+def list_usage_events(limit: int = 500) -> list[UsageEvent]:
+    data = _read_store()
+    out: list[UsageEvent] = []
+    for raw in data["events"]:
+        try:
+            out.append(UsageEvent(**raw))
+        except Exception:
+            continue
+    out.sort(key=lambda x: x.captured_at, reverse=True)
+    return out[: max(1, min(limit, 5000))]
 
 
 def valuation(lineage_id: str) -> LineageValuation | None:

--- a/api/tests/test_inventory_api.py
+++ b/api/tests/test_inventory_api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_system_lineage_inventory_includes_core_sections(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+
+    link_payload = {
+        "idea_id": "portfolio-governance",
+        "spec_id": "049-system-lineage-inventory-and-runtime-telemetry",
+        "implementation_refs": ["PR#inventory"],
+        "contributors": {
+            "idea": "alice",
+            "spec": "bob",
+            "implementation": "carol",
+            "review": "dave",
+        },
+        "estimated_cost": 10.0,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post("/api/value-lineage/links", json=link_payload)
+        assert created.status_code == 201
+        lineage_id = created.json()["id"]
+
+        usage = await client.post(
+            f"/api/value-lineage/links/{lineage_id}/usage-events",
+            json={"source": "api", "metric": "validated_flow", "value": 3.0},
+        )
+        assert usage.status_code == 201
+
+        inventory = await client.get("/api/inventory/system-lineage", params={"runtime_window_seconds": 3600})
+        assert inventory.status_code == 200
+        data = inventory.json()
+
+        assert "ideas" in data
+        assert "questions" in data
+        assert "specs" in data
+        assert "implementation_usage" in data
+        assert "runtime" in data
+
+        assert data["ideas"]["summary"]["total_ideas"] >= 1
+        assert data["questions"]["total"] >= 1
+        assert data["specs"]["count"] >= 1
+        assert data["implementation_usage"]["lineage_links_count"] >= 1
+        assert data["implementation_usage"]["usage_events_count"] >= 1
+        assert isinstance(data["runtime"]["ideas"], list)
+

--- a/api/tests/test_runtime_api.py
+++ b/api/tests/test_runtime_api.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_runtime_event_ingest_and_summary(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post(
+            "/api/runtime/events",
+            json={
+                "source": "web",
+                "endpoint": "/gates",
+                "method": "GET",
+                "status_code": 200,
+                "runtime_ms": 84.2,
+            },
+        )
+        assert created.status_code == 201
+        row = created.json()
+        assert row["source"] == "web"
+        assert row["idea_id"] == "oss-interface-alignment"
+        assert row["runtime_cost_estimate"] > 0
+
+        summary = await client.get("/api/runtime/ideas/summary", params={"seconds": 3600})
+        assert summary.status_code == 200
+        data = summary.json()
+        assert data["window_seconds"] == 3600
+        assert isinstance(data["ideas"], list)
+        assert any(item["idea_id"] == "oss-interface-alignment" for item in data["ideas"])
+
+
+@pytest.mark.asyncio
+async def test_runtime_middleware_records_api_calls(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/ideas")
+        assert resp.status_code == 200
+
+        events = await client.get("/api/runtime/events", params={"limit": 200})
+        assert events.status_code == 200
+        rows = events.json()
+        assert any(row["source"] == "api" and row["endpoint"] == "/api/ideas" for row in rows)
+

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -437,6 +437,21 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 
 ---
 
+## Spec 049: System Lineage Inventory and Runtime Telemetry
+
+| Requirement | Implementation | Test |
+|-------------|----------------|------|
+| GET /api/inventory/system-lineage returns unified ideas/questions/specs/implementation usage | `routers/inventory.py`, `services/inventory_service.py` | `test_system_lineage_inventory_includes_core_sections` |
+| POST /api/runtime/events ingests runtime telemetry with idea mapping | `routers/runtime.py`, `services/runtime_service.py`, `models/runtime.py` | `test_runtime_event_ingest_and_summary` |
+| GET /api/runtime/events returns recent runtime events | same as above | `test_runtime_middleware_records_api_calls` |
+| GET /api/runtime/ideas/summary aggregates runtime and estimated cost by idea | same as above | `test_runtime_event_ingest_and_summary` |
+| API middleware auto-captures endpoint runtime to telemetry store | `app/main.py` middleware + `services/runtime_service.py` | `test_runtime_middleware_records_api_calls` |
+| Web runtime beacon forwards route/runtime telemetry to API | `web/app/api/runtime-beacon/route.ts`, `web/components/runtime-beacon.tsx`, `web/app/layout.tsx` | Web build validation (`npm run build`) |
+
+**Files:** `api/app/models/runtime.py`, `api/app/services/runtime_service.py`, `api/app/services/inventory_service.py`, `api/app/routers/runtime.py`, `api/app/routers/inventory.py`, `api/app/main.py`, `api/tests/test_runtime_api.py`, `api/tests/test_inventory_api.py`, `web/app/api/runtime-beacon/route.ts`, `web/components/runtime-beacon.tsx`, `web/app/layout.tsx`
+
+---
+
 ## Files Not in Specs (Operational / Tooling)
 
 | File | Purpose |

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -11,14 +11,15 @@ Quick reference: spec status, test coverage, last verified.
 | 016–019 | ✓ | ✓ | ✓ |
 | 020–025 | ✓ | ✓ | ✓ |
 | 048 | ✓ | ✓ | ✓ |
+| 049 | ✓ | ✓ | ✓ |
 
-**Total:** 26 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048).
+**Total:** 27 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–049).
 
 ## Test Verification
 
 ```bash
-cd api && pytest -v          # 74 tests
-cd web && npm run build      # 7 routes
+cd api && pytest -v          # 78 tests
+cd web && npm run build      # 11 routes
 ```
 
 **CI:** `.github/workflows/test.yml` runs full suite on push/PR.
@@ -41,6 +42,7 @@ cd web && npm run build      # 7 routes
 | 024 | test_projects.py |
 | 027 (auto-update) | test_update_spec_coverage.py |
 | 048 | test_value_lineage.py |
+| 049 | test_runtime_api.py, test_inventory_api.py |
 
 ## Last Updated
 

--- a/specs/049-system-lineage-inventory-and-runtime-telemetry.md
+++ b/specs/049-system-lineage-inventory-and-runtime-telemetry.md
@@ -1,0 +1,69 @@
+# Spec: System Lineage Inventory and Runtime Telemetry
+
+## Purpose
+
+Provide one API to inspect all core planning/execution artifacts (questions, ideas, specs, implementation usage) and add real-time runtime telemetry linked to ideas so cost/value can be measured continuously across API and web surfaces.
+
+## Requirements
+
+- [ ] API exposes a unified inventory endpoint for questions, ideas, specs, and implementation usage.
+- [ ] API records runtime telemetry for API endpoints automatically.
+- [ ] API accepts runtime telemetry events from web clients/routes.
+- [ ] Runtime telemetry links each event to an idea id (explicitly or via endpoint mapping).
+- [ ] API exposes runtime summaries by idea (event count, runtime totals, estimated runtime cost).
+- [ ] Inventory endpoint includes answered vs unanswered question inventory.
+
+## API Contract
+
+### `GET /api/inventory/system-lineage`
+
+Returns a machine-readable inventory of:
+- idea portfolio and question status
+- discovered specs from `specs/`
+- value-lineage implementation usage
+- runtime telemetry summary by idea
+
+### `POST /api/runtime/events`
+
+Ingest a runtime event (typically web-side beacon).
+
+**Request**
+```json
+{
+  "source": "web",
+  "endpoint": "/gates",
+  "method": "GET",
+  "status_code": 200,
+  "runtime_ms": 82.5,
+  "idea_id": "oss-interface-alignment"
+}
+```
+
+### `GET /api/runtime/events?limit=100`
+
+List recent runtime events.
+
+### `GET /api/runtime/ideas/summary?seconds=3600`
+
+Return per-idea runtime aggregates for recent events.
+
+## Validation Contract
+
+- Tests cover unified inventory endpoint structure and non-empty ideas/specs.
+- Tests cover runtime event ingestion and runtime-by-idea aggregation.
+- Tests verify automatic API runtime capture records events for API requests.
+
+## Files to Create/Modify
+
+- `api/app/models/runtime.py`
+- `api/app/services/runtime_service.py`
+- `api/app/services/inventory_service.py`
+- `api/app/routers/runtime.py`
+- `api/app/routers/inventory.py`
+- `api/app/main.py`
+- `api/tests/test_runtime_api.py`
+- `api/tests/test_inventory_api.py`
+- `web/app/api/runtime-beacon/route.ts`
+- `web/components/runtime-beacon.tsx`
+- `web/app/layout.tsx`
+

--- a/web/app/api/runtime-beacon/route.ts
+++ b/web/app/api/runtime-beacon/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await request.json();
+    const upstream = await fetch(`${API_URL}/api/runtime/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    });
+    const body = await upstream.json();
+    return NextResponse.json(body, { status: upstream.status });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "runtime_beacon_failed",
+        details: String(error),
+      },
+      { status: 502 },
+    );
+  }
+}
+

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import RuntimeBeacon from "@/components/runtime-beacon";
 
 export const metadata: Metadata = {
   title: "Coherence Network",
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <RuntimeBeacon />
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/components/runtime-beacon.tsx
+++ b/web/components/runtime-beacon.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+function emitRuntime(endpoint: string, runtimeMs: number) {
+  const payload = {
+    source: "web",
+    endpoint,
+    method: "GET",
+    status_code: 200,
+    runtime_ms: Math.max(0.1, Number(runtimeMs.toFixed(4))),
+  };
+  const body = JSON.stringify(payload);
+  if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+    const blob = new Blob([body], { type: "application/json" });
+    navigator.sendBeacon("/api/runtime-beacon", blob);
+    return;
+  }
+  void fetch("/api/runtime-beacon", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: true,
+  });
+}
+
+export default function RuntimeBeacon() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const start = performance.now();
+
+    const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+    if (nav && pathname) {
+      emitRuntime(pathname, nav.duration);
+    }
+
+    return () => {
+      if (!pathname) return;
+      const duration = performance.now() - start;
+      emitRuntime(pathname, duration);
+    };
+  }, [pathname]);
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add unified inventory endpoint `GET /api/inventory/system-lineage` to expose questions, ideas, specs, implementation usage, and runtime aggregation in one response
- add runtime telemetry API:
  - `POST /api/runtime/events`
  - `GET /api/runtime/events`
  - `GET /api/runtime/ideas/summary`
- add API middleware to auto-capture runtime for `/api/*` and `/v1/*` endpoints and map telemetry to idea IDs
- add runtime idea mapping and runtime cost estimation (`runtime_ms` -> estimated cost)
- extend value-lineage service with list helpers used by inventory
- add web runtime telemetry path:
  - client runtime beacon component (`web/components/runtime-beacon.tsx`)
  - forwarding route (`web/app/api/runtime-beacon/route.ts`)
  - health-proxy runtime emission (`web/app/api/health-proxy/route.ts`)
- add spec + tracking docs for spec 049

## Validation
- `cd api && .venv/bin/pytest -q tests/test_runtime_api.py tests/test_inventory_api.py` (3 passed)
- `cd api && .venv/bin/pytest -q` (78 passed)
- `cd web && npm run build` (success)
