### PR TITLE
feat: Implement GitHub contributor/organization indexing (spec 029)

### DIFF
--- a/api/app/adapters/graph_store.py
+++ b/api/app/adapters/graph_store.py
@@ -19,6 +19,8 @@ from uuid import UUID
 from app.models.asset import Asset
 from app.models.contribution import Contribution
 from app.models.contributor import Contributor
+from app.models.github_contributor import GitHubContributor
+from app.models.github_organization import GitHubOrganization
 from app.models.project import Project, ProjectSummary
 
 
@@ -97,6 +99,35 @@ class GraphStore(Protocol):
         """Get all contributions by a contributor."""
         ...
 
+    # ---- GitHub integration API (spec 029) ----
+    def upsert_github_contributor(self, github_contributor: GitHubContributor) -> GitHubContributor:
+        """Upsert GitHub contributor node."""
+        ...
+
+    def get_github_contributor(self, contributor_id: str) -> GitHubContributor | None:
+        """Get GitHub contributor by ID (github:login)."""
+        ...
+
+    def list_github_contributors(self, limit: int = 100) -> list[GitHubContributor]:
+        """List all GitHub contributors."""
+        ...
+
+    def upsert_github_organization(self, organization: GitHubOrganization) -> GitHubOrganization:
+        """Upsert GitHub organization node."""
+        ...
+
+    def get_github_organization(self, organization_id: str) -> GitHubOrganization | None:
+        """Get GitHub organization by ID (github:login)."""
+        ...
+
+    def add_github_contributes_to(self, contributor_id: str, ecosystem: str, project_name: str) -> None:
+        """Add CONTRIBUTES_TO edge from GitHub contributor to project."""
+        ...
+
+    def get_project_github_contributors(self, ecosystem: str, project_name: str) -> list[GitHubContributor]:
+        """Get all GitHub contributors for a project."""
+        ...
+
 
 class InMemoryGraphStore:
     """In-memory GraphStore. Optional JSON persistence for restart."""
@@ -110,6 +141,11 @@ class InMemoryGraphStore:
         self._contributors: dict[UUID, Contributor] = {}
         self._assets: dict[UUID, Asset] = {}
         self._contributions: dict[UUID, Contribution] = {}
+
+        # GitHub integration data (spec 029)
+        self._github_contributors: dict[str, GitHubContributor] = {}  # key: github:login
+        self._github_organizations: dict[str, GitHubOrganization] = {}  # key: github:login
+        self._github_contributes_to: list[tuple[str, tuple[str, str]]] = []  # (contributor_id, project_key)
 
         self._persist_path = persist_path
         if persist_path and os.path.isfile(persist_path):
@@ -142,6 +178,17 @@ class InMemoryGraphStore:
                 contribn = Contribution(**cn)
                 self._contributions[contribn.id] = contribn
 
+            # GitHub integration (spec 029)
+            for gc in data.get("github_contributors", []):
+                ghc = GitHubContributor(**gc)
+                self._github_contributors[ghc.id] = ghc
+            for go in data.get("github_organizations", []):
+                gho = GitHubOrganization(**go)
+                self._github_organizations[gho.id] = gho
+            for edge in data.get("github_contributes_to", []):
+                if len(edge) >= 2 and isinstance(edge[1], list) and len(edge[1]) >= 2:
+                    self._github_contributes_to.append((edge[0], (edge[1][0], edge[1][1])))
+
         except (json.JSONDecodeError, IOError, KeyError, ValueError):
             pass
 
@@ -159,11 +206,14 @@ class InMemoryGraphStore:
             return
         os.makedirs(os.path.dirname(self._persist_path) or ".", exist_ok=True)
         data = {
-            "projects": [p.model_dump() for p in self._projects.values()],
+            "projects": [p.model_dump(mode="json") for p in self._projects.values()],
             "edges": [[list(from_k), list(to_k)] for from_k, to_k in self._edges],
-            "contributors": [c.model_dump() for c in self._contributors.values()],
-            "assets": [a.model_dump() for a in self._assets.values()],
-            "contributions": [c.model_dump() for c in self._contributions.values()],
+            "contributors": [c.model_dump(mode="json") for c in self._contributors.values()],
+            "assets": [a.model_dump(mode="json") for a in self._assets.values()],
+            "contributions": [c.model_dump(mode="json") for c in self._contributions.values()],
+            "github_contributors": [gc.model_dump(mode="json") for gc in self._github_contributors.values()],
+            "github_organizations": [go.model_dump(mode="json") for go in self._github_organizations.values()],
+            "github_contributes_to": [[contrib_id, list(proj_k)] for contrib_id, proj_k in self._github_contributes_to],
         }
         with open(self._persist_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=0)
@@ -271,3 +321,42 @@ class InMemoryGraphStore:
         out = [c for c in self._contributions.values() if c.contributor_id == contributor_id]
         out.sort(key=lambda c: c.timestamp)
         return out
+
+    # ----------------------------
+    # GitHub integration API (spec 029)
+    # ----------------------------
+    def upsert_github_contributor(self, github_contributor: GitHubContributor) -> GitHubContributor:
+        """Upsert GitHub contributor. ID format: github:login."""
+        self._github_contributors[github_contributor.id] = github_contributor
+        return github_contributor
+
+    def get_github_contributor(self, contributor_id: str) -> GitHubContributor | None:
+        """Get GitHub contributor by ID (github:login)."""
+        return self._github_contributors.get(contributor_id)
+
+    def list_github_contributors(self, limit: int = 100) -> list[GitHubContributor]:
+        """List all GitHub contributors."""
+        items = sorted(self._github_contributors.values(), key=lambda c: c.created_at, reverse=True)
+        return items[: max(0, int(limit))]
+
+    def upsert_github_organization(self, organization: GitHubOrganization) -> GitHubOrganization:
+        """Upsert GitHub organization. ID format: github:login."""
+        self._github_organizations[organization.id] = organization
+        return organization
+
+    def get_github_organization(self, organization_id: str) -> GitHubOrganization | None:
+        """Get GitHub organization by ID (github:login)."""
+        return self._github_organizations.get(organization_id)
+
+    def add_github_contributes_to(self, contributor_id: str, ecosystem: str, project_name: str) -> None:
+        """Add CONTRIBUTES_TO edge from GitHub contributor to project."""
+        proj_key = _key(ecosystem, project_name)
+        edge = (contributor_id, proj_key)
+        if edge not in self._github_contributes_to:
+            self._github_contributes_to.append(edge)
+
+    def get_project_github_contributors(self, ecosystem: str, project_name: str) -> list[GitHubContributor]:
+        """Get all GitHub contributors for a project."""
+        proj_key = _key(ecosystem, project_name)
+        contributor_ids = [cid for cid, pk in self._github_contributes_to if pk == proj_key]
+        return [self._github_contributors[cid] for cid in contributor_ids if cid in self._github_contributors]

--- a/api/app/models/github_contributor.py
+++ b/api/app/models/github_contributor.py
@@ -1,0 +1,34 @@
+"""GitHub Contributor model — spec 029.
+
+Represents contributors fetched from GitHub API for coherence score calculation.
+Separate from contribution network Contributor (wallet, hourly_rate).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class GitHubContributor(BaseModel):
+    """GitHub contributor node for coherence analysis."""
+
+    id: str  # format: "github:login"
+    source: str = "github"
+    login: str
+    name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    contributions_count: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: Optional[datetime] = None
+
+
+class GitHubContributorCreate(BaseModel):
+    """Request body for creating GitHub contributor."""
+
+    login: str
+    name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    contributions_count: int = 0

--- a/api/app/models/github_organization.py
+++ b/api/app/models/github_organization.py
@@ -1,0 +1,32 @@
+"""GitHub Organization model — spec 029.
+
+Represents organizations fetched from GitHub API for coherence analysis.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class GitHubOrganization(BaseModel):
+    """GitHub organization node for coherence analysis."""
+
+    id: str  # format: "github:login"
+    login: str
+    type: str  # "Organization" or "User"
+    name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: Optional[datetime] = None
+
+
+class GitHubOrganizationCreate(BaseModel):
+    """Request body for creating GitHub organization."""
+
+    login: str
+    type: str  # "Organization" or "User"
+    name: Optional[str] = None
+    avatar_url: Optional[str] = None

--- a/api/tests/test_github_indexing.py
+++ b/api/tests/test_github_indexing.py
@@ -1,0 +1,352 @@
+"""Tests for GitHub contributor/organization indexing (spec 029).
+
+Validates GraphStore GitHub methods, GitHubContributor/GitHubOrganization models,
+and index_github.py script integration.
+"""
+
+import tempfile
+from datetime import datetime
+
+import pytest
+
+from app.adapters.graph_store import InMemoryGraphStore
+from app.models.github_contributor import GitHubContributor, GitHubContributorCreate
+from app.models.github_organization import GitHubOrganization, GitHubOrganizationCreate
+from app.models.project import Project
+
+
+def test_github_contributor_model():
+    """GitHubContributor model should have required fields."""
+    contrib = GitHubContributor(
+        id="github:octocat",
+        login="octocat",
+        name="The Octocat",
+        avatar_url="https://github.com/images/octocat.png",
+        contributions_count=42,
+    )
+
+    assert contrib.id == "github:octocat"
+    assert contrib.source == "github"
+    assert contrib.login == "octocat"
+    assert contrib.name == "The Octocat"
+    assert contrib.contributions_count == 42
+    assert contrib.created_at is not None
+
+
+def test_github_contributor_create_model():
+    """GitHubContributorCreate should validate input."""
+    contrib = GitHubContributorCreate(
+        login="octocat",
+        name="The Octocat",
+        contributions_count=10,
+    )
+
+    assert contrib.login == "octocat"
+    assert contrib.name == "The Octocat"
+    assert contrib.contributions_count == 10
+
+
+def test_github_organization_model():
+    """GitHubOrganization model should have required fields."""
+    org = GitHubOrganization(
+        id="github:facebook",
+        login="facebook",
+        type="Organization",
+        name="Facebook",
+    )
+
+    assert org.id == "github:facebook"
+    assert org.login == "facebook"
+    assert org.type == "Organization"
+    assert org.name == "Facebook"
+
+
+def test_graphstore_upsert_github_contributor():
+    """GraphStore should upsert GitHub contributors."""
+    store = InMemoryGraphStore()
+
+    contrib = GitHubContributor(
+        id="github:alice",
+        login="alice",
+        name="Alice",
+        contributions_count=10,
+    )
+
+    result = store.upsert_github_contributor(contrib)
+
+    assert result.id == "github:alice"
+    assert result.login == "alice"
+
+
+def test_graphstore_get_github_contributor():
+    """GraphStore should retrieve GitHub contributors by ID."""
+    store = InMemoryGraphStore()
+
+    contrib = GitHubContributor(
+        id="github:bob",
+        login="bob",
+        contributions_count=5,
+    )
+    store.upsert_github_contributor(contrib)
+
+    retrieved = store.get_github_contributor("github:bob")
+
+    assert retrieved is not None
+    assert retrieved.login == "bob"
+    assert retrieved.contributions_count == 5
+
+
+def test_graphstore_get_github_contributor_not_found():
+    """GraphStore should return None for non-existent contributors."""
+    store = InMemoryGraphStore()
+
+    result = store.get_github_contributor("github:nonexistent")
+
+    assert result is None
+
+
+def test_graphstore_list_github_contributors():
+    """GraphStore should list all GitHub contributors."""
+    store = InMemoryGraphStore()
+
+    contrib1 = GitHubContributor(id="github:alice", login="alice", contributions_count=10)
+    contrib2 = GitHubContributor(id="github:bob", login="bob", contributions_count=5)
+
+    store.upsert_github_contributor(contrib1)
+    store.upsert_github_contributor(contrib2)
+
+    contributors = store.list_github_contributors(limit=100)
+
+    assert len(contributors) == 2
+    logins = {c.login for c in contributors}
+    assert "alice" in logins
+    assert "bob" in logins
+
+
+def test_graphstore_list_github_contributors_limit():
+    """GraphStore should respect limit parameter."""
+    store = InMemoryGraphStore()
+
+    for i in range(10):
+        contrib = GitHubContributor(id=f"github:user{i}", login=f"user{i}", contributions_count=i)
+        store.upsert_github_contributor(contrib)
+
+    contributors = store.list_github_contributors(limit=3)
+
+    assert len(contributors) == 3
+
+
+def test_graphstore_upsert_github_organization():
+    """GraphStore should upsert GitHub organizations."""
+    store = InMemoryGraphStore()
+
+    org = GitHubOrganization(
+        id="github:facebook",
+        login="facebook",
+        type="Organization",
+        name="Facebook",
+    )
+
+    result = store.upsert_github_organization(org)
+
+    assert result.id == "github:facebook"
+    assert result.login == "facebook"
+
+
+def test_graphstore_get_github_organization():
+    """GraphStore should retrieve GitHub organizations by ID."""
+    store = InMemoryGraphStore()
+
+    org = GitHubOrganization(
+        id="github:google",
+        login="google",
+        type="Organization",
+    )
+    store.upsert_github_organization(org)
+
+    retrieved = store.get_github_organization("github:google")
+
+    assert retrieved is not None
+    assert retrieved.login == "google"
+
+
+def test_graphstore_add_github_contributes_to():
+    """GraphStore should create CONTRIBUTES_TO edges."""
+    store = InMemoryGraphStore()
+
+    # Create project
+    project = Project(
+        ecosystem="npm",
+        name="react",
+        version="18.2.0",
+        description="React library",
+        repository_url="https://github.com/facebook/react",
+    )
+    store.upsert_project(project)
+
+    # Create contributor
+    contrib = GitHubContributor(id="github:gaearon", login="gaearon", contributions_count=1000)
+    store.upsert_github_contributor(contrib)
+
+    # Add edge
+    store.add_github_contributes_to("github:gaearon", "npm", "react")
+
+    # Verify edge exists
+    contributors = store.get_project_github_contributors("npm", "react")
+    assert len(contributors) == 1
+    assert contributors[0].login == "gaearon"
+
+
+def test_graphstore_get_project_github_contributors():
+    """GraphStore should retrieve all contributors for a project."""
+    store = InMemoryGraphStore()
+
+    # Create project
+    project = Project(ecosystem="npm", name="lodash", version="4.17.21", description="Lodash utility library")
+    store.upsert_project(project)
+
+    # Create multiple contributors
+    contrib1 = GitHubContributor(id="github:jdalton", login="jdalton", contributions_count=500)
+    contrib2 = GitHubContributor(id="github:bnjmnt4n", login="bnjmnt4n", contributions_count=100)
+
+    store.upsert_github_contributor(contrib1)
+    store.upsert_github_contributor(contrib2)
+
+    store.add_github_contributes_to("github:jdalton", "npm", "lodash")
+    store.add_github_contributes_to("github:bnjmnt4n", "npm", "lodash")
+
+    # Retrieve contributors
+    contributors = store.get_project_github_contributors("npm", "lodash")
+
+    assert len(contributors) == 2
+    logins = {c.login for c in contributors}
+    assert "jdalton" in logins
+    assert "bnjmnt4n" in logins
+
+
+def test_graphstore_get_project_github_contributors_empty():
+    """GraphStore should return empty list for project with no contributors."""
+    store = InMemoryGraphStore()
+
+    project = Project(ecosystem="pypi", name="requests", version="2.31.0", description="HTTP library")
+    store.upsert_project(project)
+
+    contributors = store.get_project_github_contributors("pypi", "requests")
+
+    assert contributors == []
+
+
+def test_graphstore_persist_github_data():
+    """GraphStore should persist GitHub data to JSON."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+        persist_path = f.name
+
+    try:
+        # Create store and add GitHub data
+        store = InMemoryGraphStore(persist_path=persist_path)
+
+        contrib = GitHubContributor(id="github:test", login="test", contributions_count=1)
+        org = GitHubOrganization(id="github:testorg", login="testorg", type="Organization")
+
+        store.upsert_github_contributor(contrib)
+        store.upsert_github_organization(org)
+
+        project = Project(ecosystem="npm", name="test-pkg", version="1.0.0", description="Test package")
+        store.upsert_project(project)
+        store.add_github_contributes_to("github:test", "npm", "test-pkg")
+
+        store.save()
+
+        # Load into new store
+        store2 = InMemoryGraphStore(persist_path=persist_path)
+
+        # Verify data persisted
+        loaded_contrib = store2.get_github_contributor("github:test")
+        assert loaded_contrib is not None
+        assert loaded_contrib.login == "test"
+
+        loaded_org = store2.get_github_organization("github:testorg")
+        assert loaded_org is not None
+        assert loaded_org.login == "testorg"
+
+        contributors = store2.get_project_github_contributors("npm", "test-pkg")
+        assert len(contributors) == 1
+        assert contributors[0].login == "test"
+
+    finally:
+        import os
+
+        if os.path.exists(persist_path):
+            os.unlink(persist_path)
+
+
+def test_graphstore_upsert_github_contributor_updates_existing():
+    """GraphStore should update existing GitHub contributors on upsert."""
+    store = InMemoryGraphStore()
+
+    # Create initial contributor
+    contrib = GitHubContributor(id="github:alice", login="alice", contributions_count=10)
+    store.upsert_github_contributor(contrib)
+
+    # Update with new data
+    updated = GitHubContributor(id="github:alice", login="alice", contributions_count=20, name="Alice Smith")
+    store.upsert_github_contributor(updated)
+
+    # Verify update
+    retrieved = store.get_github_contributor("github:alice")
+    assert retrieved.contributions_count == 20
+    assert retrieved.name == "Alice Smith"
+
+
+def test_graphstore_add_github_contributes_to_no_duplicates():
+    """GraphStore should not create duplicate CONTRIBUTES_TO edges."""
+    store = InMemoryGraphStore()
+
+    project = Project(ecosystem="npm", name="react", version="18.2.0", description="React library")
+    store.upsert_project(project)
+
+    contrib = GitHubContributor(id="github:gaearon", login="gaearon", contributions_count=1000)
+    store.upsert_github_contributor(contrib)
+
+    # Add edge twice
+    store.add_github_contributes_to("github:gaearon", "npm", "react")
+    store.add_github_contributes_to("github:gaearon", "npm", "react")
+
+    # Should only have one contributor
+    contributors = store.get_project_github_contributors("npm", "react")
+    assert len(contributors) == 1
+
+
+def test_index_github_script_imports():
+    """index_github.py should have correct imports."""
+    import sys
+    import os
+
+    _api_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script_path = os.path.join(_api_dir, "scripts", "index_github.py")
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # Verify correct imports
+    assert "from app.models.github_contributor import GitHubContributor" in content
+    assert "from app.models.github_organization import GitHubOrganization" in content
+    assert "from app.adapters.graph_store import InMemoryGraphStore" in content
+    assert "from app.services.github_client import GitHubClient" in content
+
+
+def test_index_github_script_uses_correct_methods():
+    """index_github.py should use GitHub-specific methods."""
+    import sys
+    import os
+
+    _api_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script_path = os.path.join(_api_dir, "scripts", "index_github.py")
+
+    with open(script_path, "r") as f:
+        content = f.read()
+
+    # Verify correct method calls
+    assert "store.upsert_github_contributor" in content
+    assert "store.upsert_github_organization" in content
+    assert "store.add_github_contributes_to" in content


### PR DESCRIPTION
## Summary
- Implement GitHub contributor/organization indexing (spec 029)
- **P0 blocker** for coherence accuracy — enables real contributor_diversity, activity_cadence scores
- All functionality tested with 18 new tests, no regressions

## New Models

### GitHubContributor
```python
GitHubContributor(
    id="github:login",           # Unique ID format
    source="github",              # Always "github"
    login="octocat",              # GitHub username
    name="The Octocat",           # Display name (optional)
    avatar_url="https://...",     # Profile image (optional)
    contributions_count=42,       # Number of contributions
    created_at=datetime,          # When indexed
    updated_at=datetime|None      # Last update
)
```

### GitHubOrganization
```python
GitHubOrganization(
    id="github:facebook",         # Unique ID format
    login="facebook",              # Organization name
    type="Organization",           # "Organization" or "User"
    name="Facebook",               # Display name (optional)
    avatar_url="https://...",      # Logo (optional)
    created_at=datetime,
    updated_at=datetime|None
)
```

## GraphStore Extensions

**New Protocol Methods**:
- `upsert_github_contributor(contrib: GitHubContributor) -> GitHubContributor`
- `get_github_contributor(id: str) -> GitHubContributor | None`
- `list_github_contributors(limit: int = 100) -> list[GitHubContributor]`
- `upsert_github_organization(org: GitHubOrganization) -> GitHubOrganization`
- `get_github_organization(id: str) -> GitHubOrganization | None`
- `add_github_contributes_to(contributor_id: str, ecosystem: str, project_name: str)`
- `get_project_github_contributors(ecosystem: str, project_name: str) -> list[GitHubContributor]`

**Persistence**:
- GitHub data saved/loaded from JSON alongside existing graph data
- Fixed datetime serialization using `model_dump(mode="json")`

## Script Updates

### api/scripts/index_github.py
Updated to use new models and methods:
- Creates `GitHubContributor` instances from GitHub API data
- Creates `GitHubOrganization` instances for repo owners
- Calls `store.upsert_github_contributor()` instead of old `upsert_contributor()`
- Calls `store.add_github_contributes_to()` to create edges

**Usage**:
```bash
# Index specific repo
python api/scripts/index_github.py --owner facebook --repo react --ecosystem npm

# Index all projects with repository_url
python api/scripts/index_github.py --all -v
```

## Tests (18 new, all passing)

### Model Tests (3 tests):
- `test_github_contributor_model` — Validates required fields
- `test_github_contributor_create_model` — Validates input model
- `test_github_organization_model` — Validates organization fields

### GraphStore CRUD Tests (7 tests):
- `test_graphstore_upsert_github_contributor` — Create/update contributors
- `test_graphstore_get_github_contributor` — Retrieve by ID
- `test_graphstore_get_github_contributor_not_found` — 404 behavior
- `test_graphstore_list_github_contributors` — List all
- `test_graphstore_list_github_contributors_limit` — Pagination
- `test_graphstore_upsert_github_organization` — Create/update orgs
- `test_graphstore_get_github_organization` — Retrieve by ID

### Edge Tests (5 tests):
- `test_graphstore_add_github_contributes_to` — Create CONTRIBUTES_TO edges
- `test_graphstore_get_project_github_contributors` — Query contributors for project
- `test_graphstore_get_project_github_contributors_empty` — Empty results
- `test_graphstore_add_github_contributes_to_no_duplicates` — Prevent duplicates
- `test_graphstore_upsert_github_contributor_updates_existing` — Upsert behavior

### Integration Tests (3 tests):
- `test_graphstore_persist_github_data` — Save/load JSON persistence
- `test_index_github_script_imports` — Verify correct imports
- `test_index_github_script_uses_correct_methods` — Verify method calls

## Test Results

✅ **All 96 tests passing** (78 existing + 18 new)
```
============================== 96 passed, 46 warnings in 0.56s ==============================
```

No regressions in existing tests.

## Files Changed

- ✨ `api/app/models/github_contributor.py` (36 lines) — New model
- ✨ `api/app/models/github_organization.py` (32 lines) — New model
- 🔧 `api/app/adapters/graph_store.py` (+67 lines) — Extended with GitHub methods
- 🔧 `api/scripts/index_github.py` (~15 lines changed) — Updated to use new models
- ✨ `api/tests/test_github_indexing.py` (360 lines) — 18 new tests

## Spec 029 Requirements Status

- [x] GraphStore: add Contributor and Organization node types
- [x] GraphStore: edges CONTRIBUTES_TO (MAINTAINS, MEMBER_OF deferred)
- [x] GitHub API client: already implemented (spec 029, PR #45)
- [x] Indexer: resolve GitHub repo URL, fetch contributors
- [x] Store: persist Contributor (login, name, avatar_url, contributions_count)
- [x] Store: persist Organization (login, type)
- [x] Env: GITHUB_TOKEN support (via GitHubClient)
- [ ] **Deferred**: Wire contributor_diversity, activity_cadence into coherence API (future PR)

## Next Steps (Future PRs)

1. **Wire into coherence calculation** — Use contributor count and diversity in coherence scores
2. **Add MAINTAINS edges** — Mark top 3 contributors as maintainers
3. **Add MEMBER_OF edges** — Link contributors to their organizations
4. **Activity cadence** — Use last_contribution_date for recency scoring

## Impact

- **Unblocks coherence accuracy** — Real contributor data instead of stubs
- **Enables contributor_diversity component** — Count unique contributors
- **Enables activity_cadence component** — Track recent activity (data structure ready)
- **Foundation for community metrics** — Maintainer identification, org membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)