### PR TITLE
fix(ci): retry change-contract on transient main-check race

### DIFF
--- a/.github/workflows/change-contract.yml
+++ b/.github/workflows/change-contract.yml
@@ -38,14 +38,36 @@ jobs:
           MIN_UNIQUE_APPROVERS: ${{ vars.CHANGE_CONTRACT_MIN_UNIQUE_APPROVERS || '0' }}
         run: |
           set +e
-          cd api
-          python scripts/validate_merged_change_contract.py \
-            --sha "$TARGET_SHA" \
-            --min-approvals "$MIN_APPROVALS" \
-            --min-unique-approvers "$MIN_UNIQUE_APPROVERS" \
-            --json > ../contract_report.json
-          exit_code=$?
-          cd ..
+          run_validate() {
+            cd api
+            python scripts/validate_merged_change_contract.py \
+              --sha "$TARGET_SHA" \
+              --min-approvals "$MIN_APPROVALS" \
+              --min-unique-approvers "$MIN_UNIQUE_APPROVERS" \
+              --json > ../contract_report.json
+            code=$?
+            cd ..
+            echo "$code"
+          }
+
+          exit_code=$(run_validate)
+          reason=$(jq -r '.reason // ""' contract_report.json)
+
+          # Avoid false negatives when workflow runs before main checks are fully green.
+          if [ "$exit_code" -ne 0 ] && [ "$reason" = "Commit checks are not green on main" ]; then
+            for i in $(seq 1 20); do
+              sleep 15
+              exit_code=$(run_validate)
+              reason=$(jq -r '.reason // ""' contract_report.json)
+              if [ "$exit_code" -eq 0 ]; then
+                break
+              fi
+              if [ "$reason" != "Commit checks are not green on main" ]; then
+                break
+              fi
+            done
+          fi
+
           cat contract_report.json
           echo "pr_number=$(jq -r '.pr.number' contract_report.json)" >> "$GITHUB_OUTPUT"
           echo "contributor=$(jq -r '.contributor_ack.contributor' contract_report.json)" >> "$GITHUB_OUTPUT"
@@ -54,6 +76,7 @@ jobs:
           echo "collective_review_passed=$(jq -r '.collective_review.collective_review_passed // false' contract_report.json)" >> "$GITHUB_OUTPUT"
           echo "min_approvals_required=$(jq -r '.collective_review.min_approvals_required // 0' contract_report.json)" >> "$GITHUB_OUTPUT"
           echo "min_unique_approvers_required=$(jq -r '.collective_review.min_unique_approvers_required // 0' contract_report.json)" >> "$GITHUB_OUTPUT"
+          echo "reason=$(jq -r '.reason // \"\"' contract_report.json)" >> "$GITHUB_OUTPUT"
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           exit 0
 

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -166,6 +166,8 @@ Behavior:
 - `CHANGE_CONTRACT_MIN_UNIQUE_APPROVERS` (repo variable, default `0`)
 Raise these values when collective review coverage is strong enough to enforce stricter payout/ack gates.
 
+To avoid race conditions right after merge, `Change Contract` now re-validates for up to 5 minutes when the only failure reason is `Commit checks are not green on main`.
+
 ## Public Deploy Drift Monitor (Main + Schedule)
 
 To detect production drift even when CI checks are green:


### PR DESCRIPTION
## Summary
- update `Change Contract` workflow to retry validation (up to 5 minutes) when failure reason is only `Commit checks are not green on main`
- prevents false-red runs caused by timing race immediately after merge
- keep hard-fail behavior for all other reasons
- document the behavior in pipeline monitoring docs

## Validation
- workflow logic reviewed with existing run failure mode (`Commit checks are not green on main`)
