### PR TITLE
docs: add specs for 6 previously unspecified API implementations

### DIFF
--- a/specs/048-contributions-api.md
+++ b/specs/048-contributions-api.md
@@ -1,0 +1,330 @@
+# Spec: Contributions API
+
+## Purpose
+
+Track contributions (time, effort, code) from contributors to assets with automatic coherence scoring. Enables fair value distribution based on contribution history. Supports manual contribution tracking and automated GitHub webhook ingestion.
+
+## Requirements
+
+- [x] POST /api/contributions — Create contribution with contributor_id, asset_id, cost_amount
+- [x] GET /api/contributions/{id} — Retrieve contribution by ID (404 if not found)
+- [x] GET /api/assets/{asset_id}/contributions — List all contributions to an asset
+- [x] GET /api/contributors/{contributor_id}/contributions — List all contributions by a contributor
+- [x] POST /api/contributions/github — Track contribution from GitHub webhook (auto-create contributor/asset)
+- [x] Coherence score auto-calculated from metadata (has_tests, has_docs, complexity)
+- [x] Contributions update asset.total_cost automatically
+- [x] All endpoints return 404 when contributor or asset not found
+- [x] All responses are Pydantic models (JSON-serialized)
+
+## API Contract
+
+### `POST /api/contributions`
+
+**Purpose**: Manually record a contribution
+
+**Request**
+```json
+{
+  "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "cost_amount": 150.00,
+  "metadata": {
+    "has_tests": true,
+    "has_docs": true,
+    "complexity": "low"
+  }
+}
+```
+
+- `contributor_id`: UUID (required) — Must exist in GraphStore
+- `asset_id`: UUID (required) — Must exist in GraphStore
+- `cost_amount`: Decimal (required) — Cost in currency units (≥ 0)
+- `metadata`: Object (optional) — Additional contribution metadata
+
+**Response 201**
+```json
+{
+  "id": "770e8400-e29b-41d4-a716-446655440000",
+  "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "cost_amount": 150.00,
+  "coherence_score": 1.0,
+  "metadata": {
+    "has_tests": true,
+    "has_docs": true,
+    "complexity": "low"
+  },
+  "timestamp": "2026-02-15T10:30:00Z"
+}
+```
+
+- `coherence_score`: Float (0.0–1.0) — Auto-calculated from metadata
+  - Baseline: 0.5
+  - +0.2 if `has_tests=true`
+  - +0.2 if `has_docs=true`
+  - +0.1 if `complexity="low"`
+  - Capped at 1.0
+
+**Response 404**
+```json
+{
+  "detail": "Contributor not found"
+}
+```
+or
+```json
+{
+  "detail": "Asset not found"
+}
+```
+
+**Response 422**
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "cost_amount"],
+      "msg": "Field required",
+      "type": "missing"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/contributions/{contribution_id}`
+
+**Purpose**: Retrieve a specific contribution by ID
+
+**Request**
+- `contribution_id`: UUID (path)
+
+**Response 200**
+```json
+{
+  "id": "770e8400-e29b-41d4-a716-446655440000",
+  "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "cost_amount": 150.00,
+  "coherence_score": 1.0,
+  "metadata": {},
+  "timestamp": "2026-02-15T10:30:00Z"
+}
+```
+
+**Response 404**
+```json
+{
+  "detail": "Contribution not found"
+}
+```
+
+---
+
+### `GET /api/assets/{asset_id}/contributions`
+
+**Purpose**: List all contributions to an asset (for rollup calculations)
+
+**Request**
+- `asset_id`: UUID (path)
+
+**Response 200**
+```json
+[
+  {
+    "id": "770e8400-e29b-41d4-a716-446655440000",
+    "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+    "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+    "cost_amount": 150.00,
+    "coherence_score": 1.0,
+    "metadata": {},
+    "timestamp": "2026-02-15T10:30:00Z"
+  },
+  {
+    "id": "880e8400-e29b-41d4-a716-446655440000",
+    "contributor_id": "990e8400-e29b-41d4-a716-446655440000",
+    "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+    "cost_amount": 200.00,
+    "coherence_score": 0.8,
+    "metadata": {},
+    "timestamp": "2026-02-15T11:00:00Z"
+  }
+]
+```
+
+**Response 404**
+```json
+{
+  "detail": "Asset not found"
+}
+```
+
+---
+
+### `GET /api/contributors/{contributor_id}/contributions`
+
+**Purpose**: List all contributions by a contributor (for contributor analytics)
+
+**Request**
+- `contributor_id`: UUID (path)
+
+**Response 200**
+```json
+[
+  {
+    "id": "770e8400-e29b-41d4-a716-446655440000",
+    "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+    "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+    "cost_amount": 150.00,
+    "coherence_score": 1.0,
+    "metadata": {},
+    "timestamp": "2026-02-15T10:30:00Z"
+  }
+]
+```
+
+**Response 404**
+```json
+{
+  "detail": "Contributor not found"
+}
+```
+
+---
+
+### `POST /api/contributions/github`
+
+**Purpose**: Track contribution from GitHub webhook (auto-creates contributor/asset if needed)
+
+**Request**
+```json
+{
+  "contributor_email": "alice@example.com",
+  "repository": "org/repo",
+  "commit_hash": "abc123def456",
+  "cost_amount": 100.00,
+  "metadata": {
+    "files_changed": 3,
+    "lines_added": 50,
+    "lines_deleted": 10
+  }
+}
+```
+
+- `contributor_email`: String (required) — Auto-creates contributor if not found
+- `repository`: String (required) — Auto-creates asset if not found
+- `commit_hash`: String (required) — Stored in metadata
+- `cost_amount`: Decimal (required) — Contribution value
+- `metadata`: Object (optional) — GitHub commit metadata
+
+**Response 201**
+```json
+{
+  "id": "770e8400-e29b-41d4-a716-446655440000",
+  "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "cost_amount": 100.00,
+  "coherence_score": 0.8,
+  "metadata": {
+    "files_changed": 3,
+    "lines_added": 50,
+    "lines_deleted": 10,
+    "commit_hash": "abc123def456",
+    "repository": "org/repo",
+    "contributor_email": "alice@example.com"
+  },
+  "timestamp": "2026-02-15T12:00:00Z"
+}
+```
+
+**Coherence Calculation (GitHub)**:
+- Baseline: 0.5
+- +0.1 if `files_changed > 0`
+- +0.2 if `lines_added > 0 && lines_added < 100` (well-scoped)
+- +0.1 if `lines_added >= 100` (large changes)
+- Capped at 1.0
+
+---
+
+### `POST /api/contributions/github/debug`
+
+**Purpose**: Debug version of GitHub webhook (returns errors instead of raising)
+
+**Request**: Same as `/api/contributions/github`
+
+**Response 200** (success)
+```json
+{
+  "success": true,
+  "contribution_id": "770e8400-e29b-41d4-a716-446655440000",
+  "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Response 200** (error)
+```json
+{
+  "success": false,
+  "error": "Database connection failed",
+  "error_type": "ConnectionError",
+  "traceback": "..."
+}
+```
+
+## Data Model
+
+```yaml
+Contribution:
+  id: UUID
+  contributor_id: UUID (FK → Contributor)
+  asset_id: UUID (FK → Asset)
+  cost_amount: Decimal (≥ 0)
+  coherence_score: Float (0.0–1.0)
+  metadata: Object
+  timestamp: DateTime (ISO 8601 UTC)
+
+ContributionCreate:
+  contributor_id: UUID
+  asset_id: UUID
+  cost_amount: Decimal
+  metadata: Object (optional)
+
+GitHubContribution:
+  contributor_email: String
+  repository: String
+  commit_hash: String
+  cost_amount: Decimal
+  metadata: Object (optional)
+```
+
+## Files to Create/Modify
+
+- `api/app/routers/contributions.py` — Route handlers (implemented)
+- `api/app/models/contribution.py` — Pydantic models (implemented)
+- `api/app/adapters/graph_store.py` — Storage methods (implemented)
+- `api/tests/test_contributions.py` — Test suite (implemented)
+- `specs/048-contributions-api.md` — This spec
+
+## Acceptance Tests
+
+See `api/tests/test_contributions.py`:
+- [x] `test_create_get_contribution_and_asset_rollup_cost` — Create contribution, verify asset.total_cost updates
+- [x] `test_create_contribution_404s` — 404 when contributor or asset not found
+- [x] `test_get_asset_and_contributor_contributions` — List contributions by asset and contributor
+- [x] `test_create_contribution_422` — 422 validation errors for invalid input
+
+All 4 tests passing.
+
+## Out of Scope
+
+- OAuth GitHub authentication (uses webhook payload)
+- Contribution approval workflow (contributions are immediately recorded)
+- Contribution editing or deletion (immutable audit trail)
+- Contribution aggregation by time period (analytics endpoint deferred)
+- Advanced coherence algorithms (ML-based scoring deferred)
+
+## Decision Gates
+
+None — implementation already complete and tested.

--- a/specs/049-distribution-engine.md
+++ b/specs/049-distribution-engine.md
@@ -1,0 +1,136 @@
+# Spec: Distribution Engine
+
+## Purpose
+
+Calculate fair value distribution among contributors based on their contributions weighted by coherence scores. Enables automated payouts proportional to contribution quality and effort.
+
+## Requirements
+
+- [x] POST /api/distributions — Trigger distribution for an asset
+- [x] Distribution algorithm: proportional to (cost_amount × (0.5 + coherence_score))
+- [x] Coherence weighting: higher coherence = higher payout multiplier
+- [x] Handles zero contributions (empty payout list)
+- [x] Handles zero weighted cost (empty payout list)
+- [x] Payout amounts rounded to 2 decimal places (ROUND_HALF_UP)
+- [x] Returns 404 when asset not found
+- [x] Async execution for future scaling
+
+## API Contract
+
+### `POST /api/distributions`
+
+**Purpose**: Calculate value distribution for an asset
+
+**Request**
+```json
+{
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "value_amount": 1000.00
+}
+```
+
+- `asset_id`: UUID (required) — Asset to distribute value for
+- `value_amount`: Decimal (required) — Total value to distribute
+
+**Response 201**
+```json
+{
+  "asset_id": "660e8400-e29b-41d4-a716-446655440000",
+  "value_amount": 1000.00,
+  "payouts": [
+    {
+      "contributor_id": "550e8400-e29b-41d4-a716-446655440000",
+      "amount": 600.00
+    },
+    {
+      "contributor_id": "660e8400-e29b-41d4-a716-446655440001",
+      "amount": 400.00
+    }
+  ]
+}
+```
+
+- `payouts`: List of contributor payouts (sorted by contributor_id)
+- `amount`: Decimal — Payout amount rounded to 2 decimals
+
+**Distribution Algorithm**:
+1. For each contribution: `weighted_cost = cost_amount × (0.5 + coherence_score)`
+2. Sum weighted costs per contributor
+3. Calculate proportion: `payout = (contributor_weighted / total_weighted) × value_amount`
+4. Round to 2 decimals (ROUND_HALF_UP)
+
+**Example**:
+- Contributor A: 100 cost × (0.5 + 1.0) = 150 weighted
+- Contributor B: 100 cost × (0.5 + 0.5) = 100 weighted
+- Total weighted: 250
+- Value to distribute: 1000
+- Payout A: (150/250) × 1000 = 600.00
+- Payout B: (100/250) × 1000 = 400.00
+
+**Response 404**
+```json
+{
+  "detail": "Asset not found"
+}
+```
+
+**Response 422**
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "value_amount"],
+      "msg": "Field required",
+      "type": "missing"
+    }
+  ]
+}
+```
+
+## Data Model
+
+```yaml
+Distribution:
+  asset_id: UUID
+  value_amount: Decimal
+  payouts: List[Payout]
+
+DistributionCreate:
+  asset_id: UUID
+  value_amount: Decimal
+
+Payout:
+  contributor_id: UUID
+  amount: Decimal
+```
+
+## Files to Create/Modify
+
+- `api/app/routers/distributions.py` — Route handler (implemented)
+- `api/app/services/distribution_engine.py` — Distribution algorithm (implemented)
+- `api/app/models/distribution.py` — Pydantic models (implemented)
+- `api/tests/test_distributions.py` — Test suite (implemented)
+- `specs/049-distribution-engine.md` — This spec
+
+## Acceptance Tests
+
+See `api/tests/test_distributions.py`:
+- [x] `test_distribution_weighted_by_coherence` — Verify coherence weighting
+- [x] `test_distribution_asset_not_found_404` — 404 for nonexistent asset
+- [x] `test_distribution_no_contributions_returns_empty_payouts` — Empty payout list when no contributions
+- [x] `test_distribution_422` — 422 validation errors
+
+All 4 tests passing.
+
+## Out of Scope
+
+- Payout execution (bank transfers, crypto) — distribution calculation only
+- Tax handling or withholding
+- Multi-currency distributions
+- Historical distribution records (ephemeral calculation)
+- Minimum payout thresholds
+- Payout approval workflow
+
+## Decision Gates
+
+None — implementation already complete and tested.

--- a/specs/050-friction-analysis.md
+++ b/specs/050-friction-analysis.md
@@ -1,0 +1,80 @@
+# Spec: Friction Analysis API
+
+## Purpose
+
+Track and analyze friction events (bugs, blockers, bottlenecks) to identify systemic issues and measure effectiveness. Enables data-driven process improvements.
+
+## Requirements
+
+- [x] GET /api/friction/events — List friction events with optional status filter
+- [x] POST /api/friction/events — Record new friction event
+- [x] GET /api/friction/report — Aggregated friction report with time window
+- [x] Events stored in append-only log (api/logs/friction.jsonl)
+- [x] Supports filtering by status (pending, resolved, ignored)
+- [x] Report includes: total_events, by_status, by_category, ignored_lines
+
+## API Contract
+
+### `GET /api/friction/events`
+
+**Request**:
+- `limit`: Integer (query, 1-1000, default: 100)
+- `status`: String (query, optional) — Filter by status
+
+**Response 200**:
+```json
+[
+  {
+    "timestamp": "2026-02-15T10:00:00Z",
+    "category": "bug",
+    "description": "API timeout on /distributions",
+    "status": "pending",
+    "metadata": {}
+  }
+]
+```
+
+### `POST /api/friction/events`
+
+**Request**:
+```json
+{
+  "timestamp": "2026-02-15T10:00:00Z",
+  "category": "blocker",
+  "description": "Database migration failed",
+  "status": "pending",
+  "metadata": {"severity": "high"}
+}
+```
+
+**Response 201**: Returns created event
+
+### `GET /api/friction/report`
+
+**Request**:
+- `window_days`: Integer (query, 1-365, default: 7)
+
+**Response 200**:
+```json
+{
+  "total_events": 42,
+  "by_status": {"pending": 10, "resolved": 30, "ignored": 2},
+  "by_category": {"bug": 20, "blocker": 12, "bottleneck": 10},
+  "source_file": "api/logs/friction.jsonl",
+  "ignored_lines": 0
+}
+```
+
+## Files
+
+- `api/app/routers/friction.py` (implemented)
+- `api/app/services/friction_service.py` (implemented)
+- `api/tests/test_friction_api.py` (implemented)
+- `specs/050-friction-analysis.md` (this spec)
+
+## Acceptance Tests
+
+- [x] `test_friction_events_create_list_and_filter` — Create and filter events
+- [x] `test_friction_report_aggregates` — Verify report aggregation
+
+All tests passing.

--- a/specs/051-release-gates.md
+++ b/specs/051-release-gates.md
@@ -1,0 +1,94 @@
+# Spec: Release Gates API
+
+## Purpose
+
+Automated checks for deployment readiness. Validates that PRs meet quality gates (CI passing, approvals, deploy contract) before merging to production.
+
+## Requirements
+
+- [x] GET /api/gates/pr-to-public — Check if PR is ready for merge to production
+- [x] GET /api/gates/merged-contract — Verify merged change meets contract (CI, approvals, deploy)
+- [x] GET /api/gates/main-head — Get current main branch status
+- [x] Integrates with GitHub API for PR status, checks, approvals
+- [x] Supports polling with timeout for async CI completion
+- [x] Returns detailed reports with pass/fail reasons
+
+## API Contract
+
+### `GET /api/gates/pr-to-public`
+
+**Purpose**: Check if PR is ready for production merge
+
+**Request**:
+- `branch`: String (query, required) — PR head branch
+- `repo`: String (query, default: "seeker71/Coherence-Network")
+- `base`: String (query, default: "main")
+- `wait_public`: Boolean (query, default: false) — Poll until ready or timeout
+- `timeout_seconds`: Integer (query, 10-7200, default: 1200)
+- `poll_seconds`: Integer (query, 1-300, default: 30)
+
+**Response 200**:
+```json
+{
+  "ready": true,
+  "pr_number": 123,
+  "checks_passed": true,
+  "approvals_met": true,
+  "required_checks": ["CI", "tests"],
+  "failed_checks": [],
+  "rerunnable_run_ids": []
+}
+```
+
+### `GET /api/gates/merged-contract`
+
+**Purpose**: Verify merged commit meets deployment contract
+
+**Request**:
+- `sha`: String (query, required, min 7 chars) — Merged commit SHA
+- `repo`: String (query, default: "seeker71/Coherence-Network")
+- `min_approvals`: Integer (query, 0-10, default: 1)
+- `min_unique_approvers`: Integer (query, 0-10, default: 1)
+- `timeout_seconds`: Integer (query, 10-7200, default: 1200)
+- `poll_seconds`: Integer (query, 1-300, default: 30)
+
+**Response 200**:
+```json
+{
+  "contract_met": true,
+  "ci_passed": true,
+  "approvals": 2,
+  "unique_approvers": 2,
+  "deploy_sha_match": true
+}
+```
+
+### `GET /api/gates/main-head`
+
+**Purpose**: Get current main branch HEAD status
+
+**Response 200**:
+```json
+{
+  "sha": "abc123def456",
+  "ci_status": "success",
+  "deploy_status": "deployed"
+}
+```
+
+**Response 502**: When GitHub API unavailable
+
+## Files
+
+- `api/app/routers/gates.py` (implemented)
+- `api/app/services/release_gate_service.py` (implemented)
+- `api/tests/test_gates.py` (implemented)
+- `specs/051-release-gates.md` (this spec)
+
+## Acceptance Tests
+
+- [x] `test_gate_pr_to_public_endpoint_returns_report`
+- [x] `test_gate_merged_contract_endpoint_returns_report`
+- [x] `test_gate_main_head_502_when_unavailable`
+
+All tests passing.

--- a/specs/052-assets-api.md
+++ b/specs/052-assets-api.md
@@ -1,0 +1,168 @@
+# Spec: Assets API
+
+## Purpose
+
+Manage assets (code, models, content, data) that receive contributions. Assets accumulate total_cost as contributions are recorded. Core entity in the value distribution system.
+
+## Requirements
+
+- [x] POST /api/assets — Create new asset
+- [x] GET /api/assets/{id} — Retrieve asset by ID (404 if not found)
+- [x] GET /api/assets — List all assets with pagination (limit parameter)
+- [x] Asset types: CODE, MODEL, CONTENT, DATA
+- [x] total_cost auto-updates when contributions are recorded
+- [x] All responses are Pydantic models (JSON-serialized)
+- [x] Assets have unique UUID identifiers
+
+## API Contract
+
+### `POST /api/assets`
+
+**Purpose**: Create a new asset
+
+**Request**
+```json
+{
+  "type": "CODE",
+  "description": "API server for Coherence Network"
+}
+```
+
+- `type`: String enum (required) — One of: CODE, MODEL, CONTENT, DATA
+- `description`: String (required) — Asset description
+
+**Response 201**
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440000",
+  "type": "CODE",
+  "description": "API server for Coherence Network",
+  "total_cost": 0.00,
+  "created_at": "2026-02-15T10:00:00Z"
+}
+```
+
+- `id`: UUID — Auto-generated unique identifier
+- `total_cost`: Decimal — Initialized to 0.00, updated as contributions recorded
+- `created_at`: DateTime — ISO 8601 UTC timestamp
+
+**Response 422**
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "type"],
+      "msg": "Input should be 'CODE', 'MODEL', 'CONTENT' or 'DATA'",
+      "type": "enum"
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/assets/{asset_id}`
+
+**Purpose**: Retrieve a specific asset by ID
+
+**Request**
+- `asset_id`: UUID (path)
+
+**Response 200**
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440000",
+  "type": "CODE",
+  "description": "API server for Coherence Network",
+  "total_cost": 350.00,
+  "created_at": "2026-02-15T10:00:00Z"
+}
+```
+
+**Response 404**
+```json
+{
+  "detail": "Asset not found"
+}
+```
+
+---
+
+### `GET /api/assets`
+
+**Purpose**: List all assets with pagination
+
+**Request**
+- `limit`: Integer (query, optional, default: 100) — Max assets to return
+
+**Response 200**
+```json
+[
+  {
+    "id": "660e8400-e29b-41d4-a716-446655440000",
+    "type": "CODE",
+    "description": "API server for Coherence Network",
+    "total_cost": 350.00,
+    "created_at": "2026-02-15T10:00:00Z"
+  },
+  {
+    "id": "770e8400-e29b-41d4-a716-446655440000",
+    "type": "MODEL",
+    "description": "Coherence scoring model",
+    "total_cost": 500.00,
+    "created_at": "2026-02-15T11:00:00Z"
+  }
+]
+```
+
+Results sorted by `created_at` descending (newest first).
+
+## Data Model
+
+```yaml
+AssetType: enum
+  - CODE      # Source code, applications
+  - MODEL     # ML models, algorithms
+  - CONTENT   # Documentation, designs
+  - DATA      # Datasets, training data
+
+Asset:
+  id: UUID
+  type: AssetType
+  description: String
+  total_cost: Decimal (≥ 0.00, updated by contributions)
+  created_at: DateTime (ISO 8601 UTC)
+
+AssetCreate:
+  type: AssetType
+  description: String
+```
+
+## Files to Create/Modify
+
+- `api/app/routers/assets.py` — Route handlers (implemented)
+- `api/app/models/asset.py` — Pydantic models (implemented)
+- `api/app/adapters/graph_store.py` — Storage methods (implemented)
+- `api/tests/test_assets.py` — Test suite (implemented)
+- `specs/052-assets-api.md` — This spec
+
+## Acceptance Tests
+
+See `api/tests/test_assets.py`:
+- [x] `test_create_get_list_assets` — Create asset, retrieve by ID, list all
+- [x] `test_get_asset_404` — 404 when asset not found
+- [x] `test_create_asset_422` — 422 validation errors for invalid type
+
+All 3 tests passing.
+
+## Out of Scope
+
+- Asset editing or deletion (immutable once created)
+- Asset versioning (single version per asset)
+- Asset ownership or permissions (open system)
+- Asset search or filtering (simple list only)
+- Asset archival or soft delete
+
+## Decision Gates
+
+None — implementation already complete and tested.

--- a/specs/053-ideas-prioritization.md
+++ b/specs/053-ideas-prioritization.md
@@ -1,0 +1,295 @@
+# Spec: Ideas Prioritization API
+
+## Purpose
+
+Portfolio-based idea tracking and prioritization using free energy scoring. Enables data-driven decision making by ranking ideas based on potential value, confidence, cost, and resistance risk.
+
+## Requirements
+
+- [x] GET /api/ideas — List ideas ranked by free energy score with portfolio summary
+- [x] GET /api/ideas/{id} — Retrieve individual idea with score (404 if not found)
+- [x] PATCH /api/ideas/{id} — Update idea validation fields (404 if not found)
+- [x] Filter support for unvalidated ideas only
+- [x] Free energy scoring: (potential_value × confidence) / (estimated_cost + resistance_risk)
+- [x] Value gap tracking: potential_value - actual_value
+- [x] Manifestation status: none, partial, validated
+- [x] Ideas stored in JSON file (api/logs/idea_portfolio.json)
+- [x] Portfolio summary with aggregated metrics
+
+## API Contract
+
+### `GET /api/ideas`
+
+**Purpose**: List all ideas ranked by free energy score with portfolio summary
+
+**Request**:
+- `only_unvalidated`: Boolean (query, default: false) — Filter to exclude validated ideas
+
+**Response 200**:
+```json
+{
+  "ideas": [
+    {
+      "id": "oss-interface-alignment",
+      "name": "Align OSS intelligence interfaces with runtime",
+      "description": "Expose and validate declared API routes used by web and scripts.",
+      "potential_value": 90.0,
+      "actual_value": 10.0,
+      "estimated_cost": 18.0,
+      "actual_cost": 0.0,
+      "resistance_risk": 4.0,
+      "confidence": 0.7,
+      "manifestation_status": "partial",
+      "interfaces": ["machine:api", "human:web", "ai:automation"],
+      "open_questions": [
+        {
+          "question": "Which route set is canonical for current milestone?",
+          "value_to_whole": 30.0,
+          "estimated_cost": 1.0,
+          "answer": null,
+          "measured_delta": null
+        }
+      ],
+      "free_energy_score": 2.8636,
+      "value_gap": 80.0
+    }
+  ],
+  "summary": {
+    "total_ideas": 3,
+    "unvalidated_ideas": 2,
+    "validated_ideas": 1,
+    "total_potential_value": 250.0,
+    "total_actual_value": 30.0,
+    "total_value_gap": 220.0
+  }
+}
+```
+
+- `ideas`: List sorted by `free_energy_score` descending (highest value first)
+- `free_energy_score`: Float — Calculated as (potential_value × confidence) / (estimated_cost + resistance_risk)
+- `value_gap`: Float — Calculated as max(potential_value - actual_value, 0.0)
+- `summary`: Portfolio-wide aggregated metrics
+
+---
+
+### `GET /api/ideas/{idea_id}`
+
+**Purpose**: Retrieve a specific idea by ID with score
+
+**Request**:
+- `idea_id`: String (path, required) — Unique idea identifier
+
+**Response 200**:
+```json
+{
+  "id": "oss-interface-alignment",
+  "name": "Align OSS intelligence interfaces with runtime",
+  "description": "Expose and validate declared API routes used by web and scripts.",
+  "potential_value": 90.0,
+  "actual_value": 10.0,
+  "estimated_cost": 18.0,
+  "actual_cost": 0.0,
+  "resistance_risk": 4.0,
+  "confidence": 0.7,
+  "manifestation_status": "partial",
+  "interfaces": ["machine:api", "human:web", "ai:automation"],
+  "open_questions": [],
+  "free_energy_score": 2.8636,
+  "value_gap": 80.0
+}
+```
+
+**Response 404**:
+```json
+{
+  "detail": "Idea not found"
+}
+```
+
+---
+
+### `PATCH /api/ideas/{idea_id}`
+
+**Purpose**: Update idea validation fields after implementation or measurement
+
+**Request**:
+- `idea_id`: String (path, required) — Unique idea identifier
+
+**Body** (at least one field required):
+```json
+{
+  "actual_value": 34.5,
+  "actual_cost": 8.0,
+  "confidence": 0.75,
+  "manifestation_status": "validated"
+}
+```
+
+- `actual_value`: Float (optional, ≥ 0.0) — Measured value delivered
+- `actual_cost`: Float (optional, ≥ 0.0) — Actual cost incurred
+- `confidence`: Float (optional, 0.0–1.0) — Confidence level in estimates
+- `manifestation_status`: String (optional) — One of: "none", "partial", "validated"
+
+**Response 200**:
+```json
+{
+  "id": "oss-interface-alignment",
+  "name": "Align OSS intelligence interfaces with runtime",
+  "description": "Expose and validate declared API routes used by web and scripts.",
+  "potential_value": 90.0,
+  "actual_value": 34.5,
+  "estimated_cost": 18.0,
+  "actual_cost": 8.0,
+  "resistance_risk": 4.0,
+  "confidence": 0.75,
+  "manifestation_status": "validated",
+  "interfaces": ["machine:api", "human:web", "ai:automation"],
+  "open_questions": [],
+  "free_energy_score": 3.0682,
+  "value_gap": 55.5
+}
+```
+
+**Response 400**:
+```json
+{
+  "detail": "At least one field required"
+}
+```
+
+**Response 404**:
+```json
+{
+  "detail": "Idea not found"
+}
+```
+
+**Response 422**:
+```json
+{
+  "detail": [
+    {
+      "loc": ["body", "confidence"],
+      "msg": "Input should be less than or equal to 1.0",
+      "type": "less_than_equal"
+    }
+  ]
+}
+```
+
+## Scoring Algorithm
+
+### Free Energy Score
+
+Prioritizes ideas with high potential value and confidence, low cost and resistance:
+
+```
+free_energy_score = (potential_value × confidence) / (estimated_cost + resistance_risk)
+```
+
+- Higher scores indicate better value-to-cost ratio
+- Confidence weights potential value (0.0–1.0)
+- Denominator minimum 0.0001 to prevent division by zero
+- Rounded to 4 decimal places
+
+### Value Gap
+
+Tracks unrealized potential:
+
+```
+value_gap = max(potential_value - actual_value, 0.0)
+```
+
+- Indicates how much value remains to be captured
+- Never negative (capped at 0.0)
+- Rounded to 4 decimal places
+
+## Data Model
+
+```yaml
+ManifestationStatus: enum
+  - none       # Not yet implemented
+  - partial    # In progress or partially implemented
+  - validated  # Fully implemented and validated
+
+IdeaQuestion:
+  question: String (min 1 char)
+  value_to_whole: Float (≥ 0.0)
+  estimated_cost: Float (≥ 0.0)
+  answer: String | null
+  measured_delta: Float | null
+
+Idea:
+  id: String (min 1 char, unique)
+  name: String (min 1 char)
+  description: String (min 1 char)
+  potential_value: Float (≥ 0.0)
+  actual_value: Float (≥ 0.0, default: 0.0)
+  estimated_cost: Float (≥ 0.0)
+  actual_cost: Float (≥ 0.0, default: 0.0)
+  resistance_risk: Float (≥ 0.0, default: 1.0)
+  confidence: Float (0.0–1.0, default: 0.5)
+  manifestation_status: ManifestationStatus (default: none)
+  interfaces: List[String] (default: [])
+  open_questions: List[IdeaQuestion] (default: [])
+
+IdeaWithScore: Idea + computed fields
+  free_energy_score: Float (≥ 0.0)
+  value_gap: Float (≥ 0.0)
+
+IdeaSummary:
+  total_ideas: Integer (≥ 0)
+  unvalidated_ideas: Integer (≥ 0)
+  validated_ideas: Integer (≥ 0)
+  total_potential_value: Float (≥ 0.0)
+  total_actual_value: Float (≥ 0.0)
+  total_value_gap: Float (≥ 0.0)
+
+IdeaPortfolioResponse:
+  ideas: List[IdeaWithScore]
+  summary: IdeaSummary
+
+IdeaUpdate:
+  actual_value: Float | null (≥ 0.0)
+  actual_cost: Float | null (≥ 0.0)
+  confidence: Float | null (0.0–1.0)
+  manifestation_status: ManifestationStatus | null
+```
+
+## Storage
+
+- **Location**: `api/logs/idea_portfolio.json`
+- **Format**: JSON with `{"ideas": [...]}` structure
+- **Initialization**: Auto-creates with default ideas if file missing
+- **Environment**: Path configurable via `IDEA_PORTFOLIO_PATH` env var
+
+## Files
+
+- `api/app/routers/ideas.py` — Route handlers (implemented)
+- `api/app/services/idea_service.py` — Portfolio service (implemented)
+- `api/app/models/idea.py` — Pydantic models (implemented)
+- `api/tests/test_ideas.py` — Test suite (implemented)
+- `specs/053-ideas-prioritization.md` — This spec
+
+## Acceptance Tests
+
+See `api/tests/test_ideas.py`:
+- [x] `test_list_ideas_returns_ranked_scores_and_summary` — List endpoint with ranking and summary
+- [x] `test_get_idea_by_id_and_404` — Get endpoint with 404 handling
+- [x] `test_patch_idea_updates_fields` — Update endpoint with persistence
+
+All 3 tests passing.
+
+## Out of Scope
+
+- Multi-user portfolio isolation (single shared portfolio)
+- Idea creation or deletion via API (manual JSON editing only)
+- Idea versioning or history tracking
+- Idea dependencies or relationships
+- Real-time collaboration or locking
+- Idea search or filtering beyond manifestation status
+- Authentication or authorization
+
+## Decision Gates
+
+None — implementation already complete and tested.


### PR DESCRIPTION
## Summary

Document 6 existing API implementations that lacked formal specifications:
- **048-contributions-api.md**: Contribution tracking with coherence scoring (manual + GitHub webhooks)
- **052-assets-api.md**: Asset CRUD operations for CODE, MODEL, CONTENT, DATA types
- **049-distribution-engine.md**: Fair value distribution weighted by coherence scores
- **050-friction-analysis.md**: Friction event tracking and aggregated reporting
- **051-release-gates.md**: PR readiness checks and deployment contract validation
- **053-ideas-prioritization.md**: Portfolio-based idea ranking with free energy scoring

All implementations are already tested and working. These specs formalize the API contracts, data models, and acceptance tests for documentation and compliance purposes.

## Test plan

- [x] All referenced acceptance tests already passing
- [x] Specs match actual implementation behavior
- [x] API contracts document all endpoints and response formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)