### PR TITLE
feat(ideas): question answering API + minimum e2e flow

### DIFF
--- a/api/app/models/idea.py
+++ b/api/app/models/idea.py
@@ -61,3 +61,9 @@ class IdeaUpdate(BaseModel):
     actual_cost: Optional[float] = Field(default=None, ge=0.0)
     confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     manifestation_status: Optional[ManifestationStatus] = None
+
+
+class IdeaQuestionAnswerUpdate(BaseModel):
+    question: str = Field(min_length=1)
+    answer: str = Field(min_length=1)
+    measured_delta: Optional[float] = None

--- a/api/app/models/value_lineage.py
+++ b/api/app/models/value_lineage.py
@@ -69,3 +69,11 @@ class PayoutPreview(BaseModel):
     roi_ratio: float = Field(ge=0.0)
     weights: dict[str, float]
     payouts: list[PayoutRow]
+
+
+class MinimumE2EFlowResponse(BaseModel):
+    lineage_id: str
+    usage_event_id: str
+    valuation: LineageValuation
+    payout_preview: PayoutPreview
+    checks: list[str]

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query
 
-from app.models.idea import IdeaPortfolioResponse, IdeaUpdate, IdeaWithScore
+from app.models.idea import (
+    IdeaPortfolioResponse,
+    IdeaQuestionAnswerUpdate,
+    IdeaUpdate,
+    IdeaWithScore,
+)
 from app.services import idea_service
 
 router = APIRouter()
@@ -47,4 +52,19 @@ async def update_idea(idea_id: str, data: IdeaUpdate) -> IdeaWithScore:
     )
     if updated is None:
         raise HTTPException(status_code=404, detail="Idea not found")
+    return updated
+
+
+@router.post("/ideas/{idea_id}/questions/answer", response_model=IdeaWithScore)
+async def answer_idea_question(idea_id: str, data: IdeaQuestionAnswerUpdate) -> IdeaWithScore:
+    updated, question_found = idea_service.answer_question(
+        idea_id=idea_id,
+        question=data.question,
+        answer=data.answer,
+        measured_delta=data.measured_delta,
+    )
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Idea not found")
+    if not question_found:
+        raise HTTPException(status_code=404, detail="Question not found for idea")
     return updated

--- a/api/app/routers/value_lineage.py
+++ b/api/app/routers/value_lineage.py
@@ -8,6 +8,7 @@ from app.models.value_lineage import (
     LineageLink,
     LineageLinkCreate,
     LineageValuation,
+    MinimumE2EFlowResponse,
     PayoutPreview,
     PayoutPreviewRequest,
     UsageEvent,
@@ -57,3 +58,8 @@ async def payout_preview(lineage_id: str, payload: PayoutPreviewRequest) -> Payo
     if report is None:
         raise HTTPException(status_code=404, detail="Lineage link not found")
     return report
+
+
+@router.post("/value-lineage/minimum-e2e-flow", response_model=MinimumE2EFlowResponse)
+async def run_minimum_e2e_flow() -> MinimumE2EFlowResponse:
+    return value_lineage_service.run_minimum_e2e_flow()

--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -191,3 +191,36 @@ def update_idea(
 
     _write_ideas(ideas)
     return _with_score(updated)
+
+
+def answer_question(
+    idea_id: str,
+    question: str,
+    answer: str,
+    measured_delta: float | None = None,
+) -> tuple[IdeaWithScore | None, bool]:
+    ideas = _read_ideas()
+    updated: Idea | None = None
+    question_found = False
+
+    for idx, idea in enumerate(ideas):
+        if idea.id != idea_id:
+            continue
+        for q in idea.open_questions:
+            if q.question == question:
+                q.answer = answer
+                if measured_delta is not None:
+                    q.measured_delta = measured_delta
+                question_found = True
+                break
+        ideas[idx] = idea
+        updated = idea
+        break
+
+    if updated is None:
+        return None, False
+    if not question_found:
+        return _with_score(updated), False
+
+    _write_ideas(ideas)
+    return _with_score(updated), True

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -463,6 +463,17 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 
 ---
 
+## Spec 051: Question Answering and Minimum E2E Flow
+
+| Requirement | Implementation | Test |
+|-------------|----------------|------|
+| POST /api/ideas/{idea_id}/questions/answer persists answer and measured delta | `models/idea.py`, `routers/ideas.py`, `services/idea_service.py` | `test_answer_idea_question_persists_answer` |
+| POST /api/value-lineage/minimum-e2e-flow runs minimum end-to-end lineage flow | `models/value_lineage.py`, `routers/value_lineage.py`, `services/value_lineage_service.py` | `test_minimum_e2e_flow_endpoint` |
+
+**Files:** `api/app/models/idea.py`, `api/app/services/idea_service.py`, `api/app/routers/ideas.py`, `api/app/models/value_lineage.py`, `api/app/services/value_lineage_service.py`, `api/app/routers/value_lineage.py`, `api/tests/test_ideas.py`, `api/tests/test_value_lineage.py`
+
+---
+
 ## Files Not in Specs (Operational / Tooling)
 
 | File | Purpose |

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -13,13 +13,14 @@ Quick reference: spec status, test coverage, last verified.
 | 048 | ✓ | ✓ | ✓ |
 | 049 | ✓ | ✓ | ✓ |
 | 050 | ✓ | ✓ | ✓ |
+| 051 | ✓ | ✓ | ✓ |
 
-**Total:** 28 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–050).
+**Total:** 29 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–051).
 
 ## Test Verification
 
 ```bash
-cd api && pytest -v          # 80 tests
+cd api && pytest -v          # 83 tests
 cd web && npm run build      # 11 routes
 ```
 
@@ -45,6 +46,7 @@ cd web && npm run build      # 11 routes
 | 048 | test_value_lineage.py |
 | 049 | test_runtime_api.py, test_inventory_api.py |
 | 050 | test_runtime_api.py, test_inventory_api.py |
+| 051 | test_ideas.py, test_value_lineage.py |
 
 ## Last Updated
 

--- a/specs/051-question-answering-and-minimum-e2e-flow.md
+++ b/specs/051-question-answering-and-minimum-e2e-flow.md
@@ -1,0 +1,45 @@
+# Spec: Question Answering and Minimum E2E Flow
+
+## Purpose
+
+Enable direct answering of idea questions in the portfolio and expose a runnable minimum E2E flow endpoint for interface-integrity validation.
+
+## Requirements
+
+- [ ] API supports answering a specific question for an idea and persisting answer/measured delta.
+- [ ] API returns 404 when question does not belong to the target idea.
+- [ ] API exposes a minimum value-lineage E2E flow endpoint that creates lineage, usage event, valuation, and payout preview in one call.
+
+## API Contract
+
+### `POST /api/ideas/{idea_id}/questions/answer`
+
+Request:
+```json
+{
+  "question": "Which route set is canonical for current milestone?",
+  "answer": "Canonical route set is exposed at /api/inventory/routes/canonical.",
+  "measured_delta": 3.5
+}
+```
+
+### `POST /api/value-lineage/minimum-e2e-flow`
+
+Runs a full minimum E2E flow and returns generated lineage id, usage event id, valuation, payout preview, and invariant checks.
+
+## Validation Contract
+
+- `api/tests/test_ideas.py::test_answer_idea_question_persists_answer`
+- `api/tests/test_value_lineage.py::test_minimum_e2e_flow_endpoint`
+
+## Files
+
+- `api/app/models/idea.py`
+- `api/app/services/idea_service.py`
+- `api/app/routers/ideas.py`
+- `api/app/models/value_lineage.py`
+- `api/app/services/value_lineage_service.py`
+- `api/app/routers/value_lineage.py`
+- `api/tests/test_ideas.py`
+- `api/tests/test_value_lineage.py`
+


### PR DESCRIPTION
## Summary
- add `POST /api/ideas/{idea_id}/questions/answer` to persist answer/measured delta for a specific idea question
- add `POST /api/value-lineage/minimum-e2e-flow` to run the minimum end-to-end lineage flow in one call
- add response model for minimum E2E flow results and checks
- add tests for both contracts
- add spec 051 and tracking updates

## Validation
- `cd api && .venv/bin/pytest -q tests/test_ideas.py tests/test_value_lineage.py` (9 passed)
- `cd api && .venv/bin/pytest -q` (83 passed)
- `cd web && npm run build` (success)
