### PR TITLE
feat(web): portfolio cockpit for ROI-first question triage

### DIFF
--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -474,6 +474,18 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 
 ---
 
+## Spec 052: Portfolio Cockpit UI
+
+| Requirement | Implementation | Test |
+|-------------|----------------|------|
+| `/portfolio` page presents ROI-prioritized unanswered questions and runtime-by-idea summary | `web/app/portfolio/page.tsx` | `npm run build` |
+| Home page links to Portfolio Cockpit | `web/app/page.tsx` | `npm run build` |
+| Answer action posts to question-answer API | `web/app/portfolio/page.tsx` | Manual public validation |
+
+**Files:** `web/app/portfolio/page.tsx`, `web/app/page.tsx`
+
+---
+
 ## Files Not in Specs (Operational / Tooling)
 
 | File | Purpose |

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -14,8 +14,9 @@ Quick reference: spec status, test coverage, last verified.
 | 049 | ✓ | ✓ | ✓ |
 | 050 | ✓ | ✓ | ✓ |
 | 051 | ✓ | ✓ | ✓ |
+| 052 | ✓ | ✓ | ✓ |
 
-**Total:** 29 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–051).
+**Total:** 30 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–052).
 
 ## Test Verification
 
@@ -47,6 +48,7 @@ cd web && npm run build      # 11 routes
 | 049 | test_runtime_api.py, test_inventory_api.py |
 | 050 | test_runtime_api.py, test_inventory_api.py |
 | 051 | test_ideas.py, test_value_lineage.py |
+| 052 | web build + manual validation (`/portfolio`) |
 
 ## Last Updated
 

--- a/specs/052-portfolio-cockpit-ui.md
+++ b/specs/052-portfolio-cockpit-ui.md
@@ -1,0 +1,22 @@
+# Spec: Portfolio Cockpit UI
+
+## Purpose
+
+Provide a human interface to prioritize unanswered questions by ROI, submit answers directly, and view runtime cost by idea.
+
+## Requirements
+
+- [ ] Web page `/portfolio` exists and is linked from home.
+- [ ] Page fetches `GET /api/inventory/system-lineage` and displays question + runtime sections.
+- [ ] Page allows answering unanswered questions via `POST /api/ideas/{idea_id}/questions/answer`.
+
+## Validation Contract
+
+- `web` build succeeds with the new route.
+- Manual check: `/portfolio` renders and answer action posts successfully.
+
+## Files
+
+- `web/app/portfolio/page.tsx`
+- `web/app/page.tsx`
+

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -35,6 +35,9 @@ export default function Home() {
         <Button asChild variant="outline">
           <Link href="/gates">Gate Status</Link>
         </Button>
+        <Button asChild variant="outline">
+          <Link href="/portfolio">Portfolio Cockpit</Link>
+        </Button>
       </div>
     </main>
   );

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+interface IdeaQuestionRow {
+  idea_id: string;
+  idea_name: string;
+  question: string;
+  value_to_whole: number;
+  estimated_cost: number;
+  answer: string | null;
+  measured_delta: number | null;
+}
+
+interface RuntimeIdeaRow {
+  idea_id: string;
+  event_count: number;
+  total_runtime_ms: number;
+  runtime_cost_estimate: number;
+}
+
+interface InventoryResponse {
+  ideas: {
+    summary: {
+      total_ideas: number;
+      total_potential_value: number;
+      total_actual_value: number;
+      total_value_gap: number;
+    };
+  };
+  questions: {
+    answered_count: number;
+    unanswered_count: number;
+    unanswered: IdeaQuestionRow[];
+  };
+  runtime: {
+    ideas: RuntimeIdeaRow[];
+  };
+  implementation_usage: {
+    lineage_links_count: number;
+    usage_events_count: number;
+  };
+}
+
+export default function PortfolioPage() {
+  const [inventory, setInventory] = useState<InventoryResponse | null>(null);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [draftAnswers, setDraftAnswers] = useState<Record<string, string>>({});
+  const [draftDeltas, setDraftDeltas] = useState<Record<string, string>>({});
+  const [submittingKey, setSubmittingKey] = useState<string | null>(null);
+
+  async function loadInventory() {
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch(`${API_URL}/api/inventory/system-lineage?runtime_window_seconds=86400`, {
+        cache: "no-store",
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(JSON.stringify(json));
+      setInventory(json);
+      setStatus("ok");
+    } catch (e) {
+      setStatus("error");
+      setError(String(e));
+    }
+  }
+
+  useEffect(() => {
+    void loadInventory();
+  }, []);
+
+  const topRuntime = useMemo(() => {
+    if (!inventory) return [];
+    return [...inventory.runtime.ideas]
+      .sort((a, b) => b.runtime_cost_estimate - a.runtime_cost_estimate)
+      .slice(0, 5);
+  }, [inventory]);
+
+  async function submitAnswer(question: IdeaQuestionRow) {
+    const key = `${question.idea_id}::${question.question}`;
+    const answer = (draftAnswers[key] || "").trim();
+    if (!answer) return;
+    const deltaRaw = (draftDeltas[key] || "").trim();
+    const measuredDelta = deltaRaw ? Number(deltaRaw) : undefined;
+    setSubmittingKey(key);
+    try {
+      const res = await fetch(`${API_URL}/api/ideas/${encodeURIComponent(question.idea_id)}/questions/answer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          question: question.question,
+          answer,
+          measured_delta: Number.isFinite(measuredDelta) ? measuredDelta : undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(JSON.stringify(json));
+      setDraftAnswers((prev) => ({ ...prev, [key]: "" }));
+      setDraftDeltas((prev) => ({ ...prev, [key]: "" }));
+      await loadInventory();
+    } catch (e) {
+      setStatus("error");
+      setError(String(e));
+    } finally {
+      setSubmittingKey(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div>
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Coherence Network
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold">Portfolio Cockpit</h1>
+      <p className="text-muted-foreground">
+        Human interface for ROI-first idea governance: unanswered questions, runtime cost, and value gap.
+      </p>
+
+      {status === "loading" && <p className="text-muted-foreground">Loading portfolio data…</p>}
+      {status === "error" && error && <p className="text-destructive">Error: {error}</p>}
+
+      {status === "ok" && inventory && (
+        <>
+          <section className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+            <div className="rounded border p-3">
+              <p className="text-muted-foreground">Ideas</p>
+              <p className="text-lg font-semibold">{inventory.ideas.summary.total_ideas}</p>
+            </div>
+            <div className="rounded border p-3">
+              <p className="text-muted-foreground">Value gap</p>
+              <p className="text-lg font-semibold">{inventory.ideas.summary.total_value_gap}</p>
+            </div>
+            <div className="rounded border p-3">
+              <p className="text-muted-foreground">Questions unanswered</p>
+              <p className="text-lg font-semibold">{inventory.questions.unanswered_count}</p>
+            </div>
+            <div className="rounded border p-3">
+              <p className="text-muted-foreground">Lineage links</p>
+              <p className="text-lg font-semibold">{inventory.implementation_usage.lineage_links_count}</p>
+            </div>
+          </section>
+
+          <section className="rounded border p-4 space-y-3">
+            <h2 className="font-semibold">Top Unanswered Questions (ROI-ordered)</h2>
+            {inventory.questions.unanswered.length === 0 && (
+              <p className="text-sm text-muted-foreground">No open questions. Add new high-value questions.</p>
+            )}
+            <ul className="space-y-3">
+              {inventory.questions.unanswered.map((q) => {
+                const key = `${q.idea_id}::${q.question}`;
+                const roi = q.estimated_cost > 0 ? q.value_to_whole / q.estimated_cost : 0;
+                return (
+                  <li key={key} className="rounded border p-3 space-y-2">
+                    <p className="font-medium">{q.question}</p>
+                    <p className="text-sm text-muted-foreground">
+                      idea: {q.idea_id} | value: {q.value_to_whole} | cost: {q.estimated_cost} | ROI:{" "}
+                      {roi.toFixed(2)}
+                    </p>
+                    <div className="flex flex-col md:flex-row gap-2">
+                      <Input
+                        placeholder="Answer"
+                        value={draftAnswers[key] || ""}
+                        onChange={(e) => setDraftAnswers((prev) => ({ ...prev, [key]: e.target.value }))}
+                      />
+                      <Input
+                        placeholder="Measured delta (optional)"
+                        value={draftDeltas[key] || ""}
+                        onChange={(e) => setDraftDeltas((prev) => ({ ...prev, [key]: e.target.value }))}
+                      />
+                      <Button
+                        disabled={submittingKey === key || !(draftAnswers[key] || "").trim()}
+                        onClick={() => void submitAnswer(q)}
+                      >
+                        {submittingKey === key ? "Saving…" : "Answer"}
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          <section className="rounded border p-4 space-y-2">
+            <h2 className="font-semibold">Runtime Cost by Idea (24h)</h2>
+            <ul className="space-y-2 text-sm">
+              {topRuntime.map((row) => (
+                <li key={row.idea_id} className="flex justify-between rounded border p-2">
+                  <span>{row.idea_id}</span>
+                  <span className="text-muted-foreground">
+                    events {row.event_count} | runtime {row.total_runtime_ms.toFixed(2)}ms | cost $
+                    {row.runtime_cost_estimate.toFixed(6)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
+      )}
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add new human interface page: `/portfolio`
- show portfolio summary, ROI-ordered unanswered questions, and runtime cost by idea
- enable inline question answering via `POST /api/ideas/{idea_id}/questions/answer`
- link cockpit from home page
- add spec 052 + spec tracking updates

## Validation
- `cd web && npm run build` (success)
- `cd api && .venv/bin/pytest -q` (83 passed)
- manual public validation: answer actions via `/portfolio` should update inventory counts
