### PR TITLE
feat(inventory): standing ROI question policy + next-task generation

### DIFF
--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -20,3 +20,8 @@ async def system_lineage_inventory(
 @router.get("/inventory/routes/canonical")
 async def canonical_routes() -> dict:
     return route_registry_service.get_canonical_routes()
+
+
+@router.post("/inventory/questions/next-highest-roi-task")
+async def next_highest_roi_task(create_task: bool = Query(False)) -> dict:
+    return inventory_service.next_highest_roi_task_from_answered_questions(create_task=create_task)

--- a/api/tests/test_inventory_api.py
+++ b/api/tests/test_inventory_api.py
@@ -58,6 +58,7 @@ async def test_system_lineage_inventory_includes_core_sections(
         assert data["implementation_usage"]["lineage_links_count"] >= 1
         assert data["implementation_usage"]["usage_events_count"] >= 1
         assert isinstance(data["runtime"]["ideas"], list)
+        assert all("question_roi" in row for row in data["questions"]["unanswered"])
 
 
 @pytest.mark.asyncio
@@ -86,3 +87,58 @@ async def test_canonical_routes_fallback_when_config_missing(
         assert resp.status_code == 200
         data = resp.json()
         assert any(route["path"] == "/api/runtime/events" for route in data["api_routes"])
+
+
+@pytest.mark.asyncio
+async def test_standing_question_exists_for_every_idea(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        listed = await client.get("/api/ideas")
+        assert listed.status_code == 200
+        ideas = listed.json()["ideas"]
+        for idea in ideas:
+            assert any(
+                "How can we improve this idea" in q["question"] for q in idea["open_questions"]
+            )
+
+
+@pytest.mark.asyncio
+async def test_next_highest_roi_task_generation_from_answered_questions(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        ideas = await client.get("/api/ideas")
+        first = ideas.json()["ideas"][0]
+        question = first["open_questions"][0]["question"]
+        answered = await client.post(
+            f"/api/ideas/{first['id']}/questions/answer",
+            json={
+                "question": question,
+                "answer": "Apply this answer to generate next implementation task.",
+                "measured_delta": 4.0,
+            },
+        )
+        assert answered.status_code == 200
+
+        suggest = await client.post("/api/inventory/questions/next-highest-roi-task")
+        assert suggest.status_code == 200
+        payload = suggest.json()
+        assert payload["result"] == "task_suggested"
+        assert payload["answer_roi"] >= 0
+
+        created = await client.post(
+            "/api/inventory/questions/next-highest-roi-task",
+            params={"create_task": True},
+        )
+        assert created.status_code == 200
+        created_payload = created.json()
+        assert created_payload["result"] == "task_suggested"
+        assert "created_task" in created_payload

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -486,6 +486,18 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 
 ---
 
+## Spec 053: Standing Questions, ROI Fields, and Next-Task Generation
+
+| Requirement | Implementation | Test |
+|-------------|----------------|------|
+| Every idea includes standing improvement/measurement question | `services/idea_service.py` | `test_standing_question_exists_for_every_idea` |
+| Inventory exposes question and answer ROI fields | `services/inventory_service.py` | `test_system_lineage_inventory_includes_core_sections` |
+| Next highest-ROI task suggestion and optional task creation | `routers/inventory.py`, `services/inventory_service.py` | `test_next_highest_roi_task_generation_from_answered_questions` |
+
+**Files:** `api/app/services/idea_service.py`, `api/app/services/inventory_service.py`, `api/app/routers/inventory.py`, `api/tests/test_inventory_api.py`
+
+---
+
 ## Files Not in Specs (Operational / Tooling)
 
 | File | Purpose |

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -15,13 +15,14 @@ Quick reference: spec status, test coverage, last verified.
 | 050 | ✓ | ✓ | ✓ |
 | 051 | ✓ | ✓ | ✓ |
 | 052 | ✓ | ✓ | ✓ |
+| 053 | ✓ | ✓ | ✓ |
 
-**Total:** 30 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–052).
+**Total:** 31 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–053).
 
 ## Test Verification
 
 ```bash
-cd api && pytest -v          # 83 tests
+cd api && pytest -v          # 85 tests
 cd web && npm run build      # 11 routes
 ```
 
@@ -49,6 +50,7 @@ cd web && npm run build      # 11 routes
 | 050 | test_runtime_api.py, test_inventory_api.py |
 | 051 | test_ideas.py, test_value_lineage.py |
 | 052 | web build + manual validation (`/portfolio`) |
+| 053 | test_inventory_api.py |
 
 ## Last Updated
 

--- a/specs/053-standing-questions-roi-and-next-task-generation.md
+++ b/specs/053-standing-questions-roi-and-next-task-generation.md
@@ -1,0 +1,35 @@
+# Spec: Standing Questions, ROI Fields, and Next-Task Generation
+
+## Purpose
+
+Enforce continuous ROI-driven discovery by ensuring each idea always has a standing improvement/measurement question, exposing ROI on questions and answers, and generating the next highest-ROI task from answered questions.
+
+## Requirements
+
+- [ ] Every idea includes the standing improvement/measurement question.
+- [ ] Inventory exposes `question_roi` and `answer_roi` for question rows.
+- [ ] API can suggest and optionally create the next highest-ROI task from answered questions.
+
+## API Contract
+
+### `POST /api/inventory/questions/next-highest-roi-task?create_task=false`
+
+Returns the highest-ROI answered question follow-up and task direction.
+
+### `POST /api/inventory/questions/next-highest-roi-task?create_task=true`
+
+Creates a task in the agent task store and returns task metadata.
+
+## Validation Contract
+
+- `api/tests/test_inventory_api.py::test_standing_question_exists_for_every_idea`
+- `api/tests/test_inventory_api.py::test_next_highest_roi_task_generation_from_answered_questions`
+- `api/tests/test_inventory_api.py::test_system_lineage_inventory_includes_core_sections` (ROI fields present)
+
+## Files
+
+- `api/app/services/idea_service.py`
+- `api/app/services/inventory_service.py`
+- `api/app/routers/inventory.py`
+- `api/tests/test_inventory_api.py`
+


### PR DESCRIPTION
## Summary
- enforce a standing question on every idea:
  - "How can we improve this idea, and if it cannot be measured yet how can it be measured, and if it is measured how can that measurement be improved?"
- add ROI fields for question rows in inventory output:
  - `question_roi = value_to_whole / estimated_cost`
  - `answer_roi = measured_delta / estimated_cost` (0 when not available)
- add next-task generation endpoint:
  - `POST /api/inventory/questions/next-highest-roi-task`
  - supports `create_task=true` to persist task in agent task store
- add spec 053 and tracking updates

## Validation
- `cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_ideas.py` (9 passed)
- `cd api && .venv/bin/pytest -q` (85 passed)
- `cd web && npm run build` (success)
