### PR TITLE
Add runtime-intent and public E2E evidence CI gate

### DIFF
--- a/api/tests/test_commit_evidence_validation.py
+++ b/api/tests/test_commit_evidence_validation.py
@@ -29,6 +29,7 @@ def _base_payload() -> dict:
         "agent": {"name": "OpenAI Codex", "version": "gpt-5"},
         "evidence_refs": ["pytest api/tests/test_commit_evidence_validation.py -q"],
         "change_files": ["scripts/validate_commit_evidence.py"],
+        "change_intent": "process_only",
         "local_validation": {"status": "pass"},
         "ci_validation": {"status": "pending"},
         "deploy_validation": {"status": "pending"},
@@ -63,3 +64,52 @@ def test_validate_commit_evidence_fails_when_gate_true_without_ci_deploy_pass(tm
     )
     assert r.returncode == 1
     assert "requires ci_validation.status=pass" in (r.stdout + r.stderr)
+
+
+def test_validate_commit_evidence_fails_when_runtime_intent_has_no_runtime_changes(tmp_path: Path) -> None:
+    payload = _base_payload()
+    payload["change_intent"] = "runtime_feature"
+    payload["change_files"] = ["scripts/validate_commit_evidence.py"]
+    payload["e2e_validation"] = {
+        "status": "pending",
+        "expected_behavior_delta": "New endpoint returns enriched runtime data.",
+        "public_endpoints": ["https://coherence-network-production.up.railway.app/api/inventory/system-lineage"],
+        "test_flows": ["portfolio-load->api-summary->roi-render"],
+    }
+    evidence = tmp_path / "commit_evidence_runtime_missing_runtime_files.json"
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+
+    r = subprocess.run(
+        [
+            sys.executable,
+            str(_script_path()),
+            "--file",
+            str(evidence),
+            "--base",
+            "HEAD",
+            "--head",
+            "HEAD",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 1
+    assert "requires runtime changes" in (r.stdout + r.stderr)
+
+
+def test_validate_commit_evidence_fails_when_runtime_intent_missing_e2e_block(tmp_path: Path) -> None:
+    payload = _base_payload()
+    payload["change_intent"] = "runtime_fix"
+    payload["change_files"] = ["api/app/routers/inventory.py"]
+    evidence = tmp_path / "commit_evidence_runtime_missing_e2e.json"
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+
+    r = subprocess.run(
+        [sys.executable, str(_script_path()), "--file", str(evidence)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 1
+    assert "requires e2e_validation object" in (r.stdout + r.stderr)

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -85,10 +85,20 @@ It must include:
 - `agent` (`name`, `version`)
 - `evidence_refs` (non-empty list of verifiable references)
 - `change_files` (non-empty list of file paths changed by the commit)
+- `change_intent` (`runtime_feature` | `runtime_fix` | `process_only` | `docs_only` | `test_only`)
 - `local_validation` (commands + pass/fail)
 - `ci_validation` (pass/fail/pending + run URL when available)
 - `deploy_validation` (pass/fail/pending + environment checked)
 - `phase_gate` (can_move_next_phase: true/false)
+
+Runtime intent contract:
+- If `change_intent` is `runtime_feature` or `runtime_fix`, evidence must include `e2e_validation` with:
+  - `status` (`pass` | `pending` | `fail`)
+  - `expected_behavior_delta`
+  - `public_endpoints` (non-empty list)
+  - `test_flows` (non-empty list)
+- Runtime intents must include changed files under `api/app/`, `web/app/`, or `web/components/`.
+- Non-runtime intents cannot include runtime file changes.
 
 CI enforcement:
 - `python3 scripts/validate_commit_evidence.py --base <sha> --head <sha> --require-changed-evidence`

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -61,6 +61,7 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 | 047 Heal Completion Issue Resolutio | ? | ? | ? | Pending |
 | 048 Value Lineage and Payout Attribution | ✓ | ✓ | ✓ | idea->spec->impl->usage->payout preview trace API |
 | 054 Commit Provenance Contract Gate | ✓ | ✓ | ✓ | CI-enforced evidence schema + diff-range changed-file coverage gate |
+| 055 Runtime Intent and Public E2E Contract Gate | ✓ | ✓ | ✓ | runtime-intent classification + runtime-diff and E2E evidence requirements |
 **Present:** Implemented. **Missing:** Not implemented. **Shortcuts:** See below.
 
 ---

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -17,8 +17,9 @@ Quick reference: spec status, test coverage, last verified.
 | 052 | ✓ | ✓ | ✓ |
 | 053 | ✓ | ✓ | ✓ |
 | 054 | ✓ | ✓ | ✓ |
+| 055 | ✓ | ✓ | ✓ |
 
-**Total:** 32 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–054).
+**Total:** 33 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–055).
 
 ## Test Verification
 
@@ -53,6 +54,7 @@ cd web && npm run build      # 11 routes
 | 052 | web build + manual validation (`/portfolio`) |
 | 053 | test_inventory_api.py |
 | 054 | scripts/validate_commit_evidence.py (CLI validation), workflow gates |
+| 055 | test_commit_evidence_validation.py, scripts/validate_commit_evidence.py |
 
 ## Last Updated
 

--- a/docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json
@@ -1,0 +1,73 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-runtime-change-contract-gate",
+  "commit_scope": "enforce runtime-intent contract and public E2E evidence metadata",
+  "files_owned": [
+    "scripts/validate_commit_evidence.py",
+    "api/tests/test_commit_evidence_validation.py",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/SPEC-TRACKING.md",
+    "docs/SPEC-COVERAGE.md",
+    "specs/055-runtime-intent-and-public-e2e-contract-gate.md",
+    "docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "coherence-network-api-runtime"
+  ],
+  "spec_ids": [
+    "055"
+  ],
+  "task_ids": [
+    "runtime-intent-contract-gate"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && .venv/bin/pytest -q tests/test_commit_evidence_validation.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json"
+  ],
+  "change_files": [
+    "scripts/validate_commit_evidence.py",
+    "api/tests/test_commit_evidence_validation.py",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/SPEC-TRACKING.md",
+    "docs/SPEC-COVERAGE.md",
+    "specs/055-runtime-intent-and-public-e2e-contract-gate.md"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && .venv/bin/pytest -q tests/test_commit_evidence_validation.py",
+      "cd api && .venv/bin/pytest -q",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "n/a (process gate)"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting local+CI validation"
+  }
+}

--- a/specs/055-runtime-intent-and-public-e2e-contract-gate.md
+++ b/specs/055-runtime-intent-and-public-e2e-contract-gate.md
@@ -1,0 +1,27 @@
+# Spec 055: Runtime Intent and Public E2E Contract Gate
+
+## Goal
+Fail CI when a runtime feature/fix intent is declared without actual API/Web runtime changes and public E2E validation metadata.
+
+## Requirements
+1. Commit evidence must include `change_intent`.
+2. Runtime intents (`runtime_feature`, `runtime_fix`) require runtime code changes under:
+   - `api/app/`
+   - `web/app/`
+   - `web/components/`
+3. Runtime intents require `e2e_validation` block with:
+   - `status`
+   - `expected_behavior_delta`
+   - `public_endpoints`
+   - `test_flows`
+4. Non-runtime intents must not include runtime file changes.
+5. CI enforces these checks through commit evidence validator.
+
+## Implementation
+- `scripts/validate_commit_evidence.py`
+- `api/tests/test_commit_evidence_validation.py`
+- `docs/CODEX-THREAD-PROCESS.md`
+
+## Validation
+- `cd api && .venv/bin/pytest -q tests/test_commit_evidence_validation.py`
+- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json`


### PR DESCRIPTION
## Summary
- require `change_intent` in commit evidence
- enforce runtime intent contract:
  - runtime intents must include runtime code changes (`api/app`, `web/app`, `web/components`)
  - runtime intents must include `e2e_validation` with expected behavior delta, public endpoints, and test flows
  - non-runtime intents cannot include runtime code changes
- add tests for validator behavior and update process/spec docs

## Validation
- `cd api && .venv/bin/pytest -q tests/test_commit_evidence_validation.py`
- `cd api && .venv/bin/pytest -q`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_runtime-intent-gate.json`

## Worktree
- `/Users/ursmuff/source/coherence-worktrees/codex-20260215-runtime-change-contract-gate`
