### PR TITLE
Add commit-derived traceability gate (spec 056)

### DIFF
--- a/api/app/routers/gates.py
+++ b/api/app/routers/gates.py
@@ -110,3 +110,22 @@ async def gates_public_deploy_contract(
         timeout=timeout,
         github_token=os.getenv("GITHUB_TOKEN"),
     )
+
+
+@router.get("/gates/commit-traceability")
+async def gates_commit_traceability(
+    sha: str = Query(..., min_length=7, description="Commit SHA to derive traceability from"),
+    repo: str = Query("seeker71/Coherence-Network"),
+    api_base: str = Query("https://coherence-network-production.up.railway.app"),
+    web_base: str = Query("https://coherence-network.vercel.app"),
+    timeout: float = Query(10.0, ge=1.0, le=60.0),
+) -> dict:
+    return await asyncio.to_thread(
+        gates.evaluate_commit_traceability_report,
+        repository=repo,
+        sha=sha,
+        api_base=api_base,
+        web_base=web_base,
+        timeout=timeout,
+        github_token=os.getenv("GITHUB_TOKEN"),
+    )

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -62,6 +62,7 @@ Audit of spec → implementation → test mapping. All implementations are spec-
 | 048 Value Lineage and Payout Attribution | ✓ | ✓ | ✓ | idea->spec->impl->usage->payout preview trace API |
 | 054 Commit Provenance Contract Gate | ✓ | ✓ | ✓ | CI-enforced evidence schema + diff-range changed-file coverage gate |
 | 055 Runtime Intent and Public E2E Contract Gate | ✓ | ✓ | ✓ | runtime-intent classification + runtime-diff and E2E evidence requirements |
+| 056 Commit-Derived Traceability Report | ✓ | ✓ | ✓ | derives idea/spec/implementation references from commit evidence + SHA |
 **Present:** Implemented. **Missing:** Not implemented. **Shortcuts:** See below.
 
 ---

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -18,8 +18,9 @@ Quick reference: spec status, test coverage, last verified.
 | 053 | ✓ | ✓ | ✓ |
 | 054 | ✓ | ✓ | ✓ |
 | 055 | ✓ | ✓ | ✓ |
+| 056 | ✓ | ✓ | ✓ |
 
-**Total:** 33 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–055).
+**Total:** 34 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–056).
 
 ## Test Verification
 
@@ -55,6 +56,7 @@ cd web && npm run build      # 11 routes
 | 053 | test_inventory_api.py |
 | 054 | scripts/validate_commit_evidence.py (CLI validation), workflow gates |
 | 055 | test_commit_evidence_validation.py, scripts/validate_commit_evidence.py |
+| 056 | test_release_gate_service.py, test_gates.py |
 
 ## Last Updated
 

--- a/docs/system_audit/commit_evidence_2026-02-15_commit-traceability-derivation.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_commit-traceability-derivation.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-derive-traceability-from-commit",
+  "commit_scope": "derive idea/spec/implementation traceability from commit SHA and expose it via gate API",
+  "files_owned": [
+    "api/app/services/release_gate_service.py",
+    "api/app/routers/gates.py",
+    "api/tests/test_release_gate_service.py",
+    "api/tests/test_gates.py",
+    "docs/SPEC-TRACKING.md",
+    "docs/SPEC-COVERAGE.md",
+    "specs/056-commit-derived-traceability-report.md",
+    "docs/system_audit/commit_evidence_2026-02-15_commit-traceability-derivation.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "coherence-network-api-runtime"
+  ],
+  "spec_ids": [
+    "056"
+  ],
+  "task_ids": [
+    "commit-traceability-derivation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_release_gate_service.py tests/test_gates.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_commit-traceability-derivation.json"
+  ],
+  "change_files": [
+    "api/app/services/release_gate_service.py",
+    "api/app/routers/gates.py",
+    "api/tests/test_release_gate_service.py",
+    "api/tests/test_gates.py",
+    "docs/SPEC-TRACKING.md",
+    "docs/SPEC-COVERAGE.md",
+    "specs/056-commit-derived-traceability-report.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Commit SHA can be queried to derive idea/spec/implementation references without manually provided public links.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/gates/commit-traceability?sha=<commit>",
+      "https://coherence-network.vercel.app/gates"
+    ],
+    "test_flows": [
+      "commit-sha->gate-traceability-api->derived-idea-spec-implementation-links",
+      "gates-ui->traceability-query->inspect-derived-contract"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_release_gate_service.py tests/test_gates.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway + vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deploy validation"
+  }
+}

--- a/specs/056-commit-derived-traceability-report.md
+++ b/specs/056-commit-derived-traceability-report.md
@@ -1,0 +1,22 @@
+# Spec 056: Commit-Derived Traceability Report
+
+## Goal
+Allow the system to derive idea/spec/implementation traceability from a commit SHA without manually entering public links.
+
+## Requirements
+1. Add API endpoint `GET /api/gates/commit-traceability`.
+2. Endpoint must accept `sha` and `repo` and return:
+   - derived idea API references from commit evidence `idea_ids`
+   - derived spec references from commit evidence `spec_ids`
+   - derived implementation references from commit evidence `change_files` or commit file diff
+3. Traceability derivation must read changed `docs/system_audit/commit_evidence_*.json` files in the commit.
+4. Response must include machine/human access pointers and explicit unanswered items when derivation is incomplete.
+
+## Implementation
+- `api/app/services/release_gate_service.py`
+- `api/app/routers/gates.py`
+- `api/tests/test_release_gate_service.py`
+- `api/tests/test_gates.py`
+
+## Validation
+- `cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_release_gate_service.py tests/test_gates.py`


### PR DESCRIPTION
## Summary
- add `GET /api/gates/commit-traceability` to derive idea/spec/implementation references from commit SHA
- parse changed `docs/system_audit/commit_evidence_*.json` to map `idea_ids`, `spec_ids`, and implementation paths
- add spec 056 and spec tracking/coverage updates
- add commit evidence artifact for this thread

## Local validation
- `cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_release_gate_service.py tests/test_gates.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_commit-traceability-derivation.json`
