### PR TITLE
Document GitHub auth + add agent preflight scripts

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-15_gh-auth-preflight.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_gh-auth-preflight.json
@@ -1,0 +1,68 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-auth-preflight",
+  "commit_scope": "document GH auth expectations for agents and add preflight script to verify gh + GH_TOKEN availability",
+  "files_owned": [
+    "docs/AGENT-DEBUGGING.md",
+    "scripts/check_dev_auth.py",
+    "scripts/source_gh_token.sh",
+    "docs/system_audit/commit_evidence_2026-02-15_gh-auth-preflight.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "054",
+    "056"
+  ],
+  "task_ids": [
+    "dev-auth-preflight"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/check_dev_auth.py",
+    "python3 scripts/check_dev_auth.py --json",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_gh-auth-preflight.json"
+  ],
+  "change_files": [
+    "docs/AGENT-DEBUGGING.md",
+    "scripts/check_dev_auth.py",
+    "scripts/source_gh_token.sh"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/check_dev_auth.py",
+      "python3 scripts/check_dev_auth.py --json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "n/a (docs+scripts only)"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI validation"
+  }
+}

--- a/scripts/check_dev_auth.py
+++ b/scripts/check_dev_auth.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Preflight: verify local GitHub auth is usable for Codex automation.
+
+This script is safe to run in CI or locally. It never prints token values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from shutil import which
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str | None = None
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _gh_auth_status() -> CheckResult:
+    if which("gh") is None:
+        return CheckResult(name="gh_installed", ok=False, detail="gh not found on PATH")
+    r = _run(["gh", "auth", "status"])
+    ok = r.returncode == 0
+    # Keep detail short and non-sensitive.
+    detail = None
+    if not ok:
+        detail = (r.stderr or r.stdout or "").strip().splitlines()[-1:] or None
+        detail = detail[0] if isinstance(detail, list) and detail else "gh auth status failed"
+    return CheckResult(name="gh_auth", ok=ok, detail=detail)
+
+
+def _gh_token_env() -> CheckResult:
+    token = os.getenv("GH_TOKEN", "")
+    ok = bool(token)
+    return CheckResult(
+        name="gh_token_env",
+        ok=ok,
+        detail=f"len={len(token)}" if ok else "GH_TOKEN is empty",
+    )
+
+
+def _gh_token_login_shell() -> CheckResult:
+    if which("zsh") is None:
+        return CheckResult(name="gh_token_login_shell", ok=False, detail="zsh not found on PATH")
+    # Do not echo token. Only print length.
+    r = _run(["zsh", "-lc", "echo ${#GH_TOKEN}"])
+    if r.returncode != 0:
+        return CheckResult(name="gh_token_login_shell", ok=False, detail="zsh -lc failed")
+    value = (r.stdout or "").strip()
+    try:
+        length = int(value)
+    except ValueError:
+        length = 0
+    ok = length > 0
+    return CheckResult(
+        name="gh_token_login_shell",
+        ok=ok,
+        detail=f"len={length}" if ok else "GH_TOKEN not set in login shell",
+    )
+
+
+def _api_env_has_github_token(repo_root: Path) -> CheckResult:
+    env_path = repo_root / "api" / ".env"
+    if not env_path.exists():
+        return CheckResult(name="api_env_github_token", ok=True, detail="api/.env missing (ok)")
+    try:
+        keys = {
+            line.split("=", 1)[0].strip()
+            for line in env_path.read_text(encoding="utf-8").splitlines()
+            if "=" in line and not line.lstrip().startswith("#")
+        }
+    except OSError as exc:
+        return CheckResult(name="api_env_github_token", ok=False, detail=str(exc))
+    ok = "GITHUB_TOKEN" in keys
+    return CheckResult(
+        name="api_env_github_token",
+        ok=ok,
+        detail="present" if ok else "missing GITHUB_TOKEN key",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    gh_auth = _gh_auth_status()
+    token_env = _gh_token_env()
+    token_login = _gh_token_login_shell()
+    api_env = _api_env_has_github_token(repo_root)
+
+    gh_token_ok = token_env.ok or token_login.ok
+    derived = [
+        CheckResult(
+            name="gh_token_available",
+            ok=gh_token_ok,
+            detail="env_or_login_shell" if gh_token_ok else "missing",
+        )
+    ]
+
+    checks = [gh_auth, token_env, token_login, api_env, *derived]
+    ok = bool(gh_auth.ok and gh_token_ok and api_env.ok)
+    payload = {"ok": ok, "checks": [asdict(c) for c in checks]}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        for c in checks:
+            status = "OK" if c.ok else "FAIL"
+            detail = f" ({c.detail})" if c.detail else ""
+            print(f"{status}: {c.name}{detail}")
+        print(f"overall_ok={payload['ok']}")
+
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/source_gh_token.sh
+++ b/scripts/source_gh_token.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh not found on PATH" >&2
+  exit 1
+fi
+
+token="$(gh auth token 2>/dev/null || true)"
+if [ -z "$token" ]; then
+  echo "ERROR: gh auth token unavailable. Run: gh auth login -h github.com" >&2
+  exit 1
+fi
+
+export GH_TOKEN="$token"
+echo "OK: exported GH_TOKEN (len=${#GH_TOKEN})"


### PR DESCRIPTION
## Summary
- document GitHub auth expectations for Codex threads in `docs/AGENT-DEBUGGING.md`
- add `scripts/check_dev_auth.py` preflight (safe: never prints token) to verify:
  - `gh auth status` is valid
  - `GH_TOKEN` is available in env or login shell (`zsh -lc`)
- add `scripts/source_gh_token.sh` helper to export `GH_TOKEN` into the current shell
- add commit evidence artifact for thread gates

## Local validation
- `python3 scripts/check_dev_auth.py`
- `python3 scripts/check_dev_auth.py --json`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_gh-auth-preflight.json`
