### PR TITLE
Add fully public walkable flow (API/web parity)

### DIFF
--- a/api/app/models/value_lineage.py
+++ b/api/app/models/value_lineage.py
@@ -77,3 +77,7 @@ class MinimumE2EFlowResponse(BaseModel):
     valuation: LineageValuation
     payout_preview: PayoutPreview
     checks: list[str]
+
+
+class LineageLinksResponse(BaseModel):
+    links: list[LineageLink]

--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Query
 
 from app.services import inventory_service
+from app.services import page_lineage_service
 from app.services import route_registry_service
 
 router = APIRouter()
@@ -20,6 +21,11 @@ async def system_lineage_inventory(
 @router.get("/inventory/routes/canonical")
 async def canonical_routes() -> dict:
     return route_registry_service.get_canonical_routes()
+
+
+@router.get("/inventory/page-lineage")
+async def page_lineage() -> dict:
+    return page_lineage_service.get_page_lineage()
 
 
 @router.post("/inventory/questions/next-highest-roi-task")

--- a/api/app/routers/value_lineage.py
+++ b/api/app/routers/value_lineage.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException
 from app.models.value_lineage import (
     LineageLink,
     LineageLinkCreate,
+    LineageLinksResponse,
     LineageValuation,
     MinimumE2EFlowResponse,
     PayoutPreview,
@@ -22,6 +23,12 @@ router = APIRouter()
 @router.post("/value-lineage/links", response_model=LineageLink, status_code=201)
 async def create_link(payload: LineageLinkCreate) -> LineageLink:
     return value_lineage_service.create_link(payload)
+
+
+@router.get("/value-lineage/links", response_model=LineageLinksResponse)
+async def list_links(limit: int = 200) -> LineageLinksResponse:
+    links = value_lineage_service.list_links(limit=limit)
+    return LineageLinksResponse(links=links)
 
 
 @router.get("/value-lineage/links/{lineage_id}", response_model=LineageLink)

--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -47,11 +47,18 @@ def _discover_specs(limit: int = 300) -> list[dict]:
         stem = path.stem
         spec_id = stem.split("-", 1)[0] if "-" in stem else stem
         title = stem.replace("-", " ")
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines()[:8]:
+                if line.lstrip().startswith("#"):
+                    title = line.lstrip("#").strip()
+                    break
+        except OSError:
+            pass
         out.append(
             {
                 "spec_id": spec_id,
                 "title": title,
-                "path": str(path),
+                "path": f"specs/{path.name}",
             }
         )
     return out or FALLBACK_SPECS[: max(1, min(limit, 2000))]

--- a/api/app/services/page_lineage_service.py
+++ b/api/app/services/page_lineage_service.py
@@ -1,0 +1,55 @@
+"""Public mapping of human web pages to idea ids (for ontology traversal)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _config_path() -> Path:
+    return _project_root() / "config" / "page_lineage.json"
+
+
+FALLBACK_PAGES: list[dict[str, str]] = [
+    {"path": "/portfolio", "idea_id": "portfolio-governance"},
+    {"path": "/gates", "idea_id": "oss-interface-alignment"},
+    {"path": "/search", "idea_id": "coherence-signal-depth"},
+    {"path": "/api-health", "idea_id": "oss-interface-alignment"},
+    {"path": "/contributors", "idea_id": "portfolio-governance"},
+    {"path": "/contributions", "idea_id": "portfolio-governance"},
+    {"path": "/assets", "idea_id": "portfolio-governance"},
+    {"path": "/tasks", "idea_id": "coherence-network-agent-pipeline"},
+]
+
+
+def get_page_lineage() -> dict[str, Any]:
+    """Return page->idea mapping for public traversal."""
+    path = _config_path()
+    pages = None
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict) and isinstance(raw.get("pages"), list):
+                pages = [
+                    row
+                    for row in raw["pages"]
+                    if isinstance(row, dict)
+                    and isinstance(row.get("path"), str)
+                    and isinstance(row.get("idea_id"), str)
+                ]
+        except (OSError, ValueError):
+            pages = None
+
+    items = pages if pages else FALLBACK_PAGES
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "pages": items,
+        "source": "config/page_lineage.json" if pages else "fallback",
+    }
+

--- a/config/page_lineage.json
+++ b/config/page_lineage.json
@@ -1,0 +1,12 @@
+{
+  "pages": [
+    { "path": "/portfolio", "idea_id": "portfolio-governance" },
+    { "path": "/gates", "idea_id": "oss-interface-alignment" },
+    { "path": "/search", "idea_id": "coherence-signal-depth" },
+    { "path": "/api-health", "idea_id": "oss-interface-alignment" },
+    { "path": "/contributors", "idea_id": "portfolio-governance" },
+    { "path": "/contributions", "idea_id": "portfolio-governance" },
+    { "path": "/assets", "idea_id": "portfolio-governance" },
+    { "path": "/tasks", "idea_id": "coherence-network-agent-pipeline" }
+  ]
+}

--- a/docs/system_audit/commit_evidence_2026-02-15_public-walkable-flow-parity.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_public-walkable-flow-parity.json
@@ -1,0 +1,112 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-public-walkable-flow",
+  "commit_scope": "add public-walkable flow parity: page-lineage, value-lineage listing, and web UI pages for contributors/contributions/assets/tasks",
+  "files_owned": [
+    "specs/072-public-walkable-flow-parity.md",
+    "api/app/models/value_lineage.py",
+    "api/app/routers/value_lineage.py",
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/page_lineage_service.py",
+    "config/page_lineage.json",
+    "api/tests/test_value_lineage.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/portfolio/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/tasks/page.tsx",
+    "docs/system_audit/commit_evidence_2026-02-15_public-walkable-flow-parity.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "oss-interface-alignment",
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "072"
+  ],
+  "task_ids": [
+    "public-walkable-flow-parity"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_value_lineage.py tests/test_inventory_api.py",
+    "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit",
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_public-walkable-flow-parity.json"
+  ],
+  "change_files": [
+    "api/app/models/value_lineage.py",
+    "api/app/routers/value_lineage.py",
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/page_lineage_service.py",
+    "config/page_lineage.json",
+    "api/tests/test_value_lineage.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/portfolio/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/tasks/page.tsx",
+    "specs/072-public-walkable-flow-parity.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public web UI can navigate from portfolio to contributors/contributions/assets/tasks; API exposes page-lineage and value-lineage listing for full public walk traversal.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
+      "https://coherence-network-production.up.railway.app/api/inventory/page-lineage",
+      "https://coherence-network-production.up.railway.app/api/value-lineage/links",
+      "https://coherence-network.vercel.app/portfolio",
+      "https://coherence-network.vercel.app/contributors",
+      "https://coherence-network.vercel.app/contributions",
+      "https://coherence-network.vercel.app/assets",
+      "https://coherence-network.vercel.app/tasks"
+    ],
+    "test_flows": [
+      "web:/portfolio->navigate->/contributors,/contributions,/assets,/tasks",
+      "api:/inventory/system-lineage->specs(items repo-relative)->routes(canonical)->runtime(ideas)->implementation_usage(lineage_links)",
+      "api:/inventory/page-lineage->page->idea_id mapping",
+      "api:/value-lineage/links->list lineage links"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_value_lineage.py tests/test_inventory_api.py",
+      "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway + vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deploy validation"
+  }
+}

--- a/specs/072-public-walkable-flow-parity.md
+++ b/specs/072-public-walkable-flow-parity.md
@@ -1,0 +1,45 @@
+# Spec 072: Fully Public Walkable Flow (API/Web Parity)
+
+## Goal
+Provide a fully public, verifiable flow that lets a human or machine start at the system portfolio and walk to:
+ideas -> specs -> processes/routes -> implementations -> contributors/contributions/assets/tasks -> runtime usage/value usage.
+
+## Requirements
+### API
+1. Add `GET /api/value-lineage/links` to list lineage links (read-only, sorted newest-first).
+2. Add `GET /api/inventory/page-lineage` to return a public mapping of web pages to `idea_id`.
+3. Ensure `/api/inventory/system-lineage` spec inventory:
+   - enumerates all `specs/*.md`
+   - returns `path` as repo-relative (e.g. `specs/049-...md`), never absolute server paths.
+
+### Web
+4. Add public pages:
+   - `/contributors` (reads `GET /v1/contributors`)
+   - `/contributions` (reads `GET /v1/contributions`)
+   - `/assets` (reads `GET /v1/assets`)
+   - `/tasks` (reads `GET /api/agent/tasks`)
+5. Add navigation links from `/portfolio` to those pages.
+
+## Implementation (Allowed Files)
+- `api/app/models/value_lineage.py`
+- `api/app/routers/value_lineage.py`
+- `api/app/routers/inventory.py`
+- `api/app/services/inventory_service.py`
+- `api/app/services/page_lineage_service.py` (new)
+- `config/page_lineage.json` (new)
+- `api/tests/test_value_lineage.py`
+- `api/tests/test_inventory_api.py`
+- `web/app/portfolio/page.tsx`
+- `web/app/contributors/page.tsx` (new)
+- `web/app/contributions/page.tsx` (new)
+- `web/app/assets/page.tsx` (new)
+- `web/app/tasks/page.tsx` (new)
+
+## Validation
+- `cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_value_lineage.py tests/test_inventory_api.py`
+- `cd web && npm run build`
+- Public smoke (post-deploy):
+  - `GET https://coherence-network-production.up.railway.app/api/inventory/system-lineage`
+  - `GET https://coherence-network-production.up.railway.app/api/inventory/page-lineage`
+  - `GET https://coherence-network-production.up.railway.app/api/value-lineage/links`
+  - `GET https://coherence-network.vercel.app/portfolio` and links to the new pages return 200

--- a/web/app/assets/page.tsx
+++ b/web/app/assets/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+type Asset = {
+  id: string;
+  name: string;
+  type: string;
+  created_at: string;
+};
+
+export default function AssetsPage() {
+  const [rows, setRows] = useState<Asset[]>([]);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/v1/assets`, { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(JSON.stringify(json));
+        setRows(Array.isArray(json.assets) ? json.assets : []);
+        setStatus("ok");
+      } catch (e) {
+        setStatus("error");
+        setError(String(e));
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold">Assets</h1>
+      <p className="text-muted-foreground">Human interface for `GET /v1/assets`.</p>
+
+      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+      {status === "ok" && (
+        <section className="rounded border p-4 space-y-3">
+          <p className="text-sm text-muted-foreground">Total: {rows.length}</p>
+          <ul className="space-y-2 text-sm">
+            {rows.slice(0, 100).map((a) => (
+              <li key={a.id} className="rounded border p-2 flex justify-between gap-3">
+                <span className="font-medium">{a.id}</span>
+                <span className="text-muted-foreground">
+                  {a.type} | {a.name} | {a.created_at}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}
+

--- a/web/app/contributions/page.tsx
+++ b/web/app/contributions/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+type Contribution = {
+  id: string;
+  contributor_id: string;
+  asset_id: string;
+  value: number;
+  timestamp: string;
+};
+
+export default function ContributionsPage() {
+  const [rows, setRows] = useState<Contribution[]>([]);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/v1/contributions`, { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(JSON.stringify(json));
+        setRows(Array.isArray(json.contributions) ? json.contributions : []);
+        setStatus("ok");
+      } catch (e) {
+        setStatus("error");
+        setError(String(e));
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold">Contributions</h1>
+      <p className="text-muted-foreground">Human interface for `GET /v1/contributions`.</p>
+
+      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+      {status === "ok" && (
+        <section className="rounded border p-4 space-y-3">
+          <p className="text-sm text-muted-foreground">Total: {rows.length}</p>
+          <ul className="space-y-2 text-sm">
+            {rows.slice(0, 100).map((c) => (
+              <li key={c.id} className="rounded border p-2 space-y-1">
+                <div className="flex justify-between gap-3">
+                  <span className="font-medium">{c.id}</span>
+                  <span className="text-muted-foreground">{c.timestamp}</span>
+                </div>
+                <div className="text-muted-foreground">
+                  contributor {c.contributor_id} | asset {c.asset_id} | value {c.value}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}
+

--- a/web/app/contributors/page.tsx
+++ b/web/app/contributors/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+type Contributor = {
+  id: string;
+  name: string;
+  type: string;
+  total_contributions: number;
+  total_value: number;
+};
+
+export default function ContributorsPage() {
+  const [rows, setRows] = useState<Contributor[]>([]);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/v1/contributors`, { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(JSON.stringify(json));
+        setRows(Array.isArray(json.contributors) ? json.contributors : []);
+        setStatus("ok");
+      } catch (e) {
+        setStatus("error");
+        setError(String(e));
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold">Contributors</h1>
+      <p className="text-muted-foreground">Human interface for `GET /v1/contributors`.</p>
+
+      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+      {status === "ok" && (
+        <section className="rounded border p-4 space-y-3">
+          <p className="text-sm text-muted-foreground">Total: {rows.length}</p>
+          <ul className="space-y-2 text-sm">
+            {rows.slice(0, 100).map((c) => (
+              <li key={c.id} className="rounded border p-2 flex justify-between gap-3">
+                <span className="font-medium">{c.id}</span>
+                <span className="text-muted-foreground">
+                  {c.type} | contributions {c.total_contributions} | value {c.total_value}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}
+

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -124,6 +124,20 @@ export default function PortfolioPage() {
       <p className="text-muted-foreground">
         Human interface for ROI-first idea governance: unanswered questions, runtime cost, and value gap.
       </p>
+      <div className="flex flex-wrap gap-2 text-sm">
+        <Link href="/contributors" className="text-muted-foreground hover:text-foreground underline">
+          Contributors
+        </Link>
+        <Link href="/contributions" className="text-muted-foreground hover:text-foreground underline">
+          Contributions
+        </Link>
+        <Link href="/assets" className="text-muted-foreground hover:text-foreground underline">
+          Assets
+        </Link>
+        <Link href="/tasks" className="text-muted-foreground hover:text-foreground underline">
+          Tasks
+        </Link>
+      </div>
 
       {status === "loading" && <p className="text-muted-foreground">Loading portfolio data…</p>}
       {status === "error" && error && <p className="text-destructive">Error: {error}</p>}
@@ -208,4 +222,3 @@ export default function PortfolioPage() {
     </main>
   );
 }
-

--- a/web/app/tasks/page.tsx
+++ b/web/app/tasks/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+type AgentTask = {
+  id: string;
+  status: string;
+  task_type: string;
+  direction: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export default function TasksPage() {
+  const [rows, setRows] = useState<AgentTask[]>([]);
+  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/api/agent/tasks`, { cache: "no-store" });
+        const json = await res.json();
+        if (!res.ok) throw new Error(JSON.stringify(json));
+        setRows(Array.isArray(json.tasks) ? json.tasks : []);
+        setStatus("ok");
+      } catch (e) {
+        setStatus("error");
+        setError(String(e));
+      }
+    })();
+  }, []);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+      </div>
+      <h1 className="text-2xl font-bold">Tasks</h1>
+      <p className="text-muted-foreground">Human interface for `GET /api/agent/tasks`.</p>
+
+      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+      {status === "ok" && (
+        <section className="rounded border p-4 space-y-3">
+          <p className="text-sm text-muted-foreground">Total: {rows.length}</p>
+          <ul className="space-y-2 text-sm">
+            {rows.slice(0, 50).map((t) => (
+              <li key={t.id} className="rounded border p-2 space-y-1">
+                <div className="flex justify-between gap-3">
+                  <span className="font-medium">{t.id}</span>
+                  <span className="text-muted-foreground">
+                    {t.task_type} | {t.status}
+                  </span>
+                </div>
+                <div className="text-muted-foreground">{t.direction}</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
Close public walkability gaps so humans and machines can traverse the system end-to-end.

### API
- add `GET /api/value-lineage/links` (list lineage links)
- add `GET /api/inventory/page-lineage` (page -> idea_id mapping)
- ensure `system-lineage.specs.items[].path` is repo-relative (no absolute server paths)

### Web
- add pages: `/contributors`, `/contributions`, `/assets`, `/tasks`
- add navigation links from `/portfolio`

## Spec
- `specs/072-public-walkable-flow-parity.md`

## Local validation
- `cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_value_lineage.py tests/test_inventory_api.py`
- `cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit`
- `cd web && npm run build`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_public-walkable-flow-parity.json`
