### PR TITLE
Fix public walkable flow runtime mismatches

### DIFF
--- a/api/app/adapters/graph_store.py
+++ b/api/app/adapters/graph_store.py
@@ -89,6 +89,10 @@ class GraphStore(Protocol):
         """Get contribution by ID."""
         ...
 
+    def list_contributions(self, limit: int = 100) -> list[Contribution]:
+        """List all contributions."""
+        ...
+
     def get_asset_contributions(self, asset_id: UUID) -> list[Contribution]:
         """Get all contributions to an asset."""
         ...
@@ -261,6 +265,10 @@ class InMemoryGraphStore:
 
     def get_contribution(self, contribution_id: UUID) -> Contribution | None:
         return self._contributions.get(contribution_id)
+
+    def list_contributions(self, limit: int = 100) -> list[Contribution]:
+        items = sorted(self._contributions.values(), key=lambda c: c.timestamp, reverse=True)
+        return items[: max(0, int(limit))]
 
     def get_asset_contributions(self, asset_id: UUID) -> list[Contribution]:
         out = [c for c in self._contributions.values() if c.asset_id == asset_id]

--- a/api/app/adapters/postgres_store.py
+++ b/api/app/adapters/postgres_store.py
@@ -264,6 +264,27 @@ class PostgresGraphStore:
                 metadata=model.meta or {},
             )
 
+    def list_contributions(self, limit: int = 100) -> list[Contribution]:
+        with self._session() as session:
+            models = (
+                session.query(ContributionModel)
+                .order_by(ContributionModel.timestamp.desc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                Contribution(
+                    id=m.id,
+                    contributor_id=m.contributor_id,
+                    asset_id=m.asset_id,
+                    cost_amount=Decimal(str(m.cost_amount)),
+                    coherence_score=float(m.coherence_score),
+                    timestamp=m.timestamp,
+                    metadata=m.meta or {},
+                )
+                for m in models
+            ]
+
     def get_asset_contributions(self, asset_id: UUID) -> list[Contribution]:
         with self._session() as session:
             models = (

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 from app.adapters.graph_store import InMemoryGraphStore
 from app.adapters.postgres_store import PostgresGraphStore, Base
 from app.routers import (
+    agent,
     assets,
     contributions,
     contributors,
@@ -91,6 +92,7 @@ app.include_router(contributors.router, prefix="/v1", tags=["contributors"])
 app.include_router(assets.router, prefix="/v1", tags=["assets"])
 app.include_router(contributions.router, prefix="/v1", tags=["contributions"])
 app.include_router(distributions.router, prefix="/v1", tags=["distributions"])
+app.include_router(agent.router, prefix="/api", tags=["agent"])
 app.include_router(ideas.router, prefix="/api", tags=["ideas"])
 app.include_router(friction.router, prefix="/api", tags=["friction"])
 app.include_router(gates.router, prefix="/api", tags=["gates"])

--- a/api/app/routers/contributions.py
+++ b/api/app/routers/contributions.py
@@ -78,6 +78,12 @@ async def get_contribution(contribution_id: UUID, store: GraphStore = Depends(ge
     return contrib
 
 
+@router.get("/contributions", response_model=list[Contribution])
+async def list_contributions(limit: int = 100, store: GraphStore = Depends(get_store)) -> list[Contribution]:
+    """List all contributions (read-only)."""
+    return store.list_contributions(limit=limit)
+
+
 @router.get("/assets/{asset_id}/contributions", response_model=list[Contribution])
 async def get_asset_contributions(asset_id: UUID, store: GraphStore = Depends(get_store)) -> list[Contribution]:
     """Get all contributions to an asset."""

--- a/docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json
@@ -1,0 +1,107 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-walkable-flow-fixes",
+  "commit_scope": "fix public walkability runtime mismatches: expose agent router, add GET /v1/contributions, align web pages with array schemas",
+  "files_owned": [
+    "specs/073-walkable-flow-runtime-mismatch-fixes.md",
+    "api/app/main.py",
+    "api/app/routers/contributions.py",
+    "api/app/adapters/graph_store.py",
+    "api/app/adapters/postgres_store.py",
+    "api/tests/test_contributions.py",
+    "web/app/contributors/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/contributions/page.tsx",
+    "docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "oss-interface-alignment",
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "073"
+  ],
+  "task_ids": [
+    "walkable-flow-runtime-mismatch-fixes"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_contributions.py",
+    "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit",
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json"
+  ],
+  "change_files": [
+    "specs/073-walkable-flow-runtime-mismatch-fixes.md",
+    "api/app/main.py",
+    "api/app/routers/contributions.py",
+    "api/app/adapters/graph_store.py",
+    "api/app/adapters/postgres_store.py",
+    "api/tests/test_contributions.py",
+    "web/app/contributors/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/contributions/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public web UI pages load without schema mismatch; tasks page successfully reads /api/agent/tasks; contributions page successfully reads list of contributions from GET /v1/contributions.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
+      "https://coherence-network-production.up.railway.app/v1/contributors",
+      "https://coherence-network-production.up.railway.app/v1/assets",
+      "https://coherence-network-production.up.railway.app/v1/contributions",
+      "https://coherence-network.vercel.app/contributors",
+      "https://coherence-network.vercel.app/assets",
+      "https://coherence-network.vercel.app/contributions",
+      "https://coherence-network.vercel.app/tasks"
+    ],
+    "test_flows": [
+      "web:/portfolio->navigate->/contributors,/assets,/contributions,/tasks->observe non-error render",
+      "api:/api/agent/tasks->200->body.tasks array",
+      "api:/v1/contributions->200->array payload"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_contributions.py",
+      "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway + vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deploy validation"
+  }
+}

--- a/specs/073-walkable-flow-runtime-mismatch-fixes.md
+++ b/specs/073-walkable-flow-runtime-mismatch-fixes.md
@@ -1,0 +1,33 @@
+# Spec 073: Walkable Flow Runtime Mismatch Fixes
+
+## Goal
+Fix public walkability mismatches discovered post-deploy:
+- tasks UI requires `/api/agent/tasks` but agent router is not exposed publicly
+- contributors/assets web pages assumed object-wrapped responses, but API returns arrays
+- contributions web page requires a list endpoint, but API only supports POST
+
+## Requirements
+### API
+1. Expose agent router under `/api` so `GET /api/agent/tasks` is publicly available.
+2. Add `GET /v1/contributions` to list contributions (read-only).
+3. Ensure stores implement listing contributions (in-memory + postgres).
+
+### Web
+4. Update `/contributors`, `/assets` to accept array responses from `/v1/*`.
+5. Update `/contributions` to use the new `GET /v1/contributions`.
+
+## Implementation (Allowed Files)
+- `api/app/main.py`
+- `api/app/routers/contributions.py`
+- `api/app/adapters/graph_store.py`
+- `api/app/adapters/postgres_store.py`
+- `api/tests/test_contributions.py`
+- `web/app/contributors/page.tsx`
+- `web/app/assets/page.tsx`
+- `web/app/contributions/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json`
+
+## Validation
+- `cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_contributions.py`
+- `cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit && npm run build`
+- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_walkable-flow-runtime-mismatch-fixes.json`

--- a/web/app/assets/page.tsx
+++ b/web/app/assets/page.tsx
@@ -7,8 +7,9 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 type Asset = {
   id: string;
-  name: string;
   type: string;
+  description: string;
+  total_cost: string;
   created_at: string;
 };
 
@@ -25,7 +26,7 @@ export default function AssetsPage() {
         const res = await fetch(`${API_URL}/v1/assets`, { cache: "no-store" });
         const json = await res.json();
         if (!res.ok) throw new Error(JSON.stringify(json));
-        setRows(Array.isArray(json.assets) ? json.assets : []);
+        setRows(Array.isArray(json) ? json : []);
         setStatus("ok");
       } catch (e) {
         setStatus("error");
@@ -58,7 +59,7 @@ export default function AssetsPage() {
               <li key={a.id} className="rounded border p-2 flex justify-between gap-3">
                 <span className="font-medium">{a.id}</span>
                 <span className="text-muted-foreground">
-                  {a.type} | {a.name} | {a.created_at}
+                  {a.type} | {a.description} | cost {a.total_cost} | {a.created_at}
                 </span>
               </li>
             ))}
@@ -68,4 +69,3 @@ export default function AssetsPage() {
     </main>
   );
 }
-

--- a/web/app/contributions/page.tsx
+++ b/web/app/contributions/page.tsx
@@ -9,7 +9,8 @@ type Contribution = {
   id: string;
   contributor_id: string;
   asset_id: string;
-  value: number;
+  cost_amount: string;
+  coherence_score: number;
   timestamp: string;
 };
 
@@ -26,7 +27,7 @@ export default function ContributionsPage() {
         const res = await fetch(`${API_URL}/v1/contributions`, { cache: "no-store" });
         const json = await res.json();
         if (!res.ok) throw new Error(JSON.stringify(json));
-        setRows(Array.isArray(json.contributions) ? json.contributions : []);
+        setRows(Array.isArray(json) ? json : []);
         setStatus("ok");
       } catch (e) {
         setStatus("error");
@@ -62,7 +63,7 @@ export default function ContributionsPage() {
                   <span className="text-muted-foreground">{c.timestamp}</span>
                 </div>
                 <div className="text-muted-foreground">
-                  contributor {c.contributor_id} | asset {c.asset_id} | value {c.value}
+                  contributor {c.contributor_id} | asset {c.asset_id} | cost {c.cost_amount} | coherence {c.coherence_score}
                 </div>
               </li>
             ))}
@@ -72,4 +73,3 @@ export default function ContributionsPage() {
     </main>
   );
 }
-

--- a/web/app/contributors/page.tsx
+++ b/web/app/contributors/page.tsx
@@ -9,8 +9,8 @@ type Contributor = {
   id: string;
   name: string;
   type: string;
-  total_contributions: number;
-  total_value: number;
+  email: string;
+  created_at: string;
 };
 
 export default function ContributorsPage() {
@@ -26,7 +26,7 @@ export default function ContributorsPage() {
         const res = await fetch(`${API_URL}/v1/contributors`, { cache: "no-store" });
         const json = await res.json();
         if (!res.ok) throw new Error(JSON.stringify(json));
-        setRows(Array.isArray(json.contributors) ? json.contributors : []);
+        setRows(Array.isArray(json) ? json : []);
         setStatus("ok");
       } catch (e) {
         setStatus("error");
@@ -57,9 +57,9 @@ export default function ContributorsPage() {
           <ul className="space-y-2 text-sm">
             {rows.slice(0, 100).map((c) => (
               <li key={c.id} className="rounded border p-2 flex justify-between gap-3">
-                <span className="font-medium">{c.id}</span>
+                <span className="font-medium">{c.name}</span>
                 <span className="text-muted-foreground">
-                  {c.type} | contributions {c.total_contributions} | value {c.total_value}
+                  {c.type} | {c.email} | {c.created_at}
                 </span>
               </li>
             ))}
@@ -69,4 +69,3 @@ export default function ContributorsPage() {
     </main>
   );
 }
-


### PR DESCRIPTION
Spec: specs/073-walkable-flow-runtime-mismatch-fixes.md

Changes:
- Mount agent router at /api so /api/agent/tasks is available
- Add GET /v1/contributions (store-backed list)
- Align web pages /contributors, /assets, /contributions with actual array response schemas

Local validation:
- cd api && /opt/homebrew/bin/python3.11 -m pytest -q tests/test_contributions.py
- cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit && npm run build
- /opt/homebrew/bin/python3.11 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence

Public validation targets after deploy:
- https://coherence-network-production.up.railway.app/api/agent/tasks
- https://coherence-network-production.up.railway.app/v1/contributions
- https://coherence-network.vercel.app/tasks
- https://coherence-network.vercel.app/contributions
