### PR TITLE
Web: Ideas/Specs/Usage pages + production API default

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json
+++ b/docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json
@@ -1,0 +1,126 @@
+{
+  "date": "2026-02-15",
+  "thread_branch": "codex/20260215-web-ideas-specs-usage",
+  "commit_scope": "add web pages for ideas/specs/usage and default API base to production when NEXT_PUBLIC_API_URL is unset",
+  "files_owned": [
+    "specs/075-web-ideas-specs-usage-pages.md",
+    "web/lib/api.ts",
+    "web/app/page.tsx",
+    "web/app/portfolio/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/app/import/page.tsx",
+    "web/app/search/page.tsx",
+    "web/app/project/[ecosystem]/[name]/page.tsx",
+    "web/app/friction/page.tsx",
+    "web/app/gates/page.tsx",
+    "web/app/api-health/page.tsx",
+    "web/app/api/health-proxy/route.ts",
+    "web/app/api/runtime-beacon/route.ts",
+    "web/app/ideas/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/specs/page.tsx",
+    "web/app/usage/page.tsx",
+    "docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json"
+  ],
+  "idea_ids": [
+    "coherence-network-web-interface",
+    "oss-interface-alignment",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "075"
+  ],
+  "task_ids": [
+    "web-ideas-specs-usage-pages"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json"
+  ],
+  "change_files": [
+    "specs/075-web-ideas-specs-usage-pages.md",
+    "web/lib/api.ts",
+    "web/app/page.tsx",
+    "web/app/portfolio/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/assets/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/app/import/page.tsx",
+    "web/app/search/page.tsx",
+    "web/app/project/[ecosystem]/[name]/page.tsx",
+    "web/app/friction/page.tsx",
+    "web/app/gates/page.tsx",
+    "web/app/api-health/page.tsx",
+    "web/app/api/health-proxy/route.ts",
+    "web/app/api/runtime-beacon/route.ts",
+    "web/app/ideas/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/specs/page.tsx",
+    "web/app/usage/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Vercel UI exposes dedicated pages for ideas/specs/usage; all UI pages fetch production API by default without requiring NEXT_PUBLIC_API_URL.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/ideas",
+      "https://coherence-network.vercel.app/specs",
+      "https://coherence-network.vercel.app/usage",
+      "https://coherence-network.vercel.app/portfolio",
+      "https://coherence-network-production.up.railway.app/api/ideas",
+      "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
+      "https://coherence-network-production.up.railway.app/api/runtime/ideas/summary",
+      "https://coherence-network-production.up.railway.app/api/friction/report"
+    ],
+    "test_flows": [
+      "web:/ -> click Ideas/Specs/Usage -> pages render data",
+      "web:/portfolio -> loads inventory from production API even if NEXT_PUBLIC_API_URL is unset",
+      "web:/ideas/{idea_id} -> idea detail renders questions",
+      "web:/usage -> runtime + friction summaries render"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deploy validation"
+  }
+}

--- a/specs/075-web-ideas-specs-usage-pages.md
+++ b/specs/075-web-ideas-specs-usage-pages.md
@@ -1,0 +1,61 @@
+# Spec 075: Web Pages For Ideas, Specs, Usage (Human Parity)
+
+## Goal
+On `https://coherence-network.vercel.app/`, provide human-browsable pages for:
+- ideas
+- specs
+- usage (runtime + friction)
+
+Also ensure web pages that fetch the API work in production even when `NEXT_PUBLIC_API_URL` is not configured.
+
+## Requirements
+### Navigation
+1. Home page must link to:
+   - `/portfolio`
+   - `/ideas`
+   - `/specs`
+   - `/usage`
+
+### API Base Default
+2. Client pages must default API base to production Railway when `NEXT_PUBLIC_API_URL` is unset.
+   - Production default: `https://coherence-network-production.up.railway.app`
+   - Dev default: `http://localhost:8000`
+
+### New Pages
+3. `/ideas` lists ideas from `GET /api/ideas`.
+4. `/ideas/[idea_id]` shows idea details, open questions, and links to relevant APIs.
+5. `/specs` lists specs from `GET /api/inventory/system-lineage` (`specs.items`).
+6. `/usage` shows:
+   - runtime summary by idea from `GET /api/runtime/ideas/summary`
+   - friction report from `GET /api/friction/report`
+
+## Non-Goals
+- Full editing UI (create/update ideas) in web.
+- Complex visualizations.
+
+## Implementation (Allowed Files)
+- `specs/075-web-ideas-specs-usage-pages.md`
+- `web/lib/api.ts`
+- `web/app/page.tsx`
+- `web/app/portfolio/page.tsx`
+- `web/app/contributors/page.tsx`
+- `web/app/assets/page.tsx`
+- `web/app/contributions/page.tsx`
+- `web/app/tasks/page.tsx`
+- `web/app/import/page.tsx`
+- `web/app/search/page.tsx`
+- `web/app/project/[ecosystem]/[name]/page.tsx`
+- `web/app/friction/page.tsx`
+- `web/app/gates/page.tsx`
+- `web/app/api-health/page.tsx`
+- `web/app/api/health-proxy/route.ts`
+- `web/app/api/runtime-beacon/route.ts`
+- `web/app/ideas/page.tsx`
+- `web/app/ideas/[idea_id]/page.tsx`
+- `web/app/specs/page.tsx`
+- `web/app/usage/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json`
+
+## Validation
+- `cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit && npm run build`
+- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-15_web-ideas-specs-usage-pages.json`

--- a/web/app/api-health/page.tsx
+++ b/web/app/api-health/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
 
 export default function ApiHealthPage() {
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const apiUrl = getApiBase();
   const proxyUrl = "/api/health-proxy";
   const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
   const [data, setData] = useState<Record<string, unknown> | null>(null);

--- a/web/app/api/health-proxy/route.ts
+++ b/web/app/api/health-proxy/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 const WEB_STARTED_AT = new Date();
 const WEB_UPDATED_AT = process.env.WEB_UPDATED_AT || process.env.VERCEL_GIT_COMMIT_SHA || "unknown";
 

--- a/web/app/api/runtime-beacon/route.ts
+++ b/web/app/api/runtime-beacon/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 export async function POST(request: NextRequest) {
   try {
@@ -23,4 +24,3 @@ export async function POST(request: NextRequest) {
     );
   }
 }
-

--- a/web/app/assets/page.tsx
+++ b/web/app/assets/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 type Asset = {
   id: string;

--- a/web/app/contributions/page.tsx
+++ b/web/app/contributions/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 type Contribution = {
   id: string;

--- a/web/app/contributors/page.tsx
+++ b/web/app/contributors/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 type Contributor = {
   id: string;

--- a/web/app/friction/page.tsx
+++ b/web/app/friction/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 interface ReportRow {
   key: string;

--- a/web/app/gates/page.tsx
+++ b/web/app/gates/page.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 export default function GatesPage() {
   const [branch, setBranch] = useState("main");

--- a/web/app/ideas/[idea_id]/page.tsx
+++ b/web/app/ideas/[idea_id]/page.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+type IdeaQuestion = {
+  question: string;
+  value_to_whole: number;
+  estimated_cost: number;
+  answer?: string | null;
+  measured_delta?: number | null;
+};
+
+type IdeaWithScore = {
+  id: string;
+  name: string;
+  description: string;
+  potential_value: number;
+  actual_value: number;
+  estimated_cost: number;
+  actual_cost: number;
+  confidence: number;
+  resistance_risk: number;
+  manifestation_status: string;
+  interfaces: string[];
+  open_questions: IdeaQuestion[];
+  free_energy_score: number;
+  value_gap: number;
+};
+
+async function loadIdea(ideaId: string): Promise<IdeaWithScore> {
+  const API = getApiBase();
+  const res = await fetch(`${API}/api/ideas/${encodeURIComponent(ideaId)}`, { cache: "no-store" });
+  if (res.status === 404) throw new Error("Idea not found");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as IdeaWithScore;
+}
+
+export default async function IdeaDetailPage({ params }: { params: Promise<{ idea_id: string }> }) {
+  const resolved = await params;
+  const ideaId = decodeURIComponent(resolved.idea_id);
+  const idea = await loadIdea(ideaId);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
+          Ideas
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold">{idea.name}</h1>
+        <p className="text-muted-foreground">{idea.id}</p>
+      </div>
+
+      <p>{idea.description}</p>
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Manifestation</p>
+          <p className="text-lg font-semibold">{idea.manifestation_status}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Free energy</p>
+          <p className="text-lg font-semibold">{idea.free_energy_score.toFixed(2)}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Value gap</p>
+          <p className="text-lg font-semibold">{idea.value_gap.toFixed(2)}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Confidence</p>
+          <p className="text-lg font-semibold">{idea.confidence.toFixed(2)}</p>
+        </div>
+      </section>
+
+      <section className="rounded border p-4 space-y-3">
+        <h2 className="font-semibold">Open Questions</h2>
+        {idea.open_questions.length === 0 && <p className="text-sm text-muted-foreground">None</p>}
+        <ul className="space-y-2 text-sm">
+          {idea.open_questions.map((q) => {
+            const roi = q.estimated_cost > 0 ? q.value_to_whole / q.estimated_cost : 0;
+            return (
+              <li key={q.question} className="rounded border p-3 space-y-1">
+                <p className="font-medium">{q.question}</p>
+                <p className="text-muted-foreground">
+                  value {q.value_to_whole} | cost {q.estimated_cost} | ROI {roi.toFixed(2)}
+                </p>
+                {q.answer ? (
+                  <p className="text-muted-foreground">answer: {q.answer}</p>
+                ) : (
+                  <p className="text-muted-foreground">answer: (unanswered)</p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">API Links</h2>
+        <p className="text-muted-foreground">Use these for machine inspection and automation.</p>
+        <ul className="space-y-1">
+          <li>
+            <code>/api/ideas/{idea.id}</code>
+          </li>
+          <li>
+            <code>/api/runtime/ideas/summary</code> (filter by <code>{idea.id}</code>)
+          </li>
+          <li>
+            <code>/api/inventory/system-lineage</code>
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/app/ideas/page.tsx
+++ b/web/app/ideas/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+type IdeaQuestion = {
+  question: string;
+  value_to_whole: number;
+  estimated_cost: number;
+  answer?: string | null;
+  measured_delta?: number | null;
+};
+
+type IdeaWithScore = {
+  id: string;
+  name: string;
+  description: string;
+  potential_value: number;
+  actual_value: number;
+  estimated_cost: number;
+  actual_cost: number;
+  confidence: number;
+  resistance_risk: number;
+  manifestation_status: string;
+  interfaces: string[];
+  open_questions: IdeaQuestion[];
+  free_energy_score: number;
+  value_gap: number;
+};
+
+type IdeasResponse = {
+  ideas: IdeaWithScore[];
+  summary: {
+    total_ideas: number;
+    unvalidated_ideas: number;
+    validated_ideas: number;
+    total_potential_value: number;
+    total_actual_value: number;
+    total_value_gap: number;
+  };
+};
+
+async function loadIdeas(): Promise<IdeasResponse> {
+  const API = getApiBase();
+  const res = await fetch(`${API}/api/ideas`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as IdeasResponse;
+}
+
+export default async function IdeasPage() {
+  const data = await loadIdeas();
+
+  const ideas = [...data.ideas].sort((a, b) => b.free_energy_score - a.free_energy_score);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
+          Specs
+        </Link>
+        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
+          Usage
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">Ideas</h1>
+      <p className="text-muted-foreground">Human interface for `GET /api/ideas`.</p>
+
+      <section className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Total ideas</p>
+          <p className="text-lg font-semibold">{data.summary.total_ideas}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Actual value</p>
+          <p className="text-lg font-semibold">{data.summary.total_actual_value}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Value gap</p>
+          <p className="text-lg font-semibold">{data.summary.total_value_gap}</p>
+        </div>
+      </section>
+
+      <section className="rounded border p-4 space-y-3">
+        <p className="text-sm text-muted-foreground">Sorted by free energy score (higher first).</p>
+        <ul className="space-y-2">
+          {ideas.map((idea) => (
+            <li key={idea.id} className="rounded border p-3 space-y-1">
+              <div className="flex justify-between gap-3">
+                <Link href={`/ideas/${encodeURIComponent(idea.id)}`} className="font-medium hover:underline">
+                  {idea.name}
+                </Link>
+                <span className="text-muted-foreground">{idea.manifestation_status}</span>
+              </div>
+              <p className="text-sm text-muted-foreground">{idea.id}</p>
+              <p className="text-sm">{idea.description}</p>
+              <p className="text-sm text-muted-foreground">
+                free_energy {idea.free_energy_score.toFixed(2)} | value_gap {idea.value_gap.toFixed(2)} | cost_est {idea.estimated_cost}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/app/import/page.tsx
+++ b/web/app/import/page.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 interface ImportPackage {
   name: string;

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { getApiBase } from "@/lib/api";
 
 export default function Home() {
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const apiUrl = getApiBase();
   return (
     <main className="min-h-screen flex flex-col items-center justify-center p-8">
       <h1 className="text-3xl font-bold mb-4">Coherence Network</h1>
@@ -37,6 +37,15 @@ export default function Home() {
         </Button>
         <Button asChild variant="outline">
           <Link href="/portfolio">Portfolio Cockpit</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/ideas">Ideas</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/specs">Specs</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/usage">Usage</Link>
         </Button>
       </div>
     </main>

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 interface IdeaQuestionRow {
   idea_id: string;
@@ -136,6 +137,15 @@ export default function PortfolioPage() {
         </Link>
         <Link href="/tasks" className="text-muted-foreground hover:text-foreground underline">
           Tasks
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground underline">
+          Ideas
+        </Link>
+        <Link href="/specs" className="text-muted-foreground hover:text-foreground underline">
+          Specs
+        </Link>
+        <Link href="/usage" className="text-muted-foreground hover:text-foreground underline">
+          Usage
         </Link>
       </div>
 

--- a/web/app/project/[ecosystem]/[name]/page.tsx
+++ b/web/app/project/[ecosystem]/[name]/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 interface Project {
   name: string;

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 interface ProjectSummary {
   name: string;

--- a/web/app/specs/page.tsx
+++ b/web/app/specs/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+type SpecItem = {
+  spec_id: string;
+  title: string;
+  path: string;
+};
+
+type InventoryResponse = {
+  specs?: {
+    items?: SpecItem[];
+  };
+};
+
+async function loadSpecs(): Promise<SpecItem[]> {
+  const API = getApiBase();
+  const res = await fetch(`${API}/api/inventory/system-lineage?runtime_window_seconds=86400`, { cache: "no-store" });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = (await res.json()) as InventoryResponse;
+  return (json.specs?.items ?? []).filter((s) => Boolean(s?.spec_id));
+}
+
+export default async function SpecsPage() {
+  const specs = await loadSpecs();
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
+          Ideas
+        </Link>
+        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
+          Usage
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">Specs</h1>
+      <p className="text-muted-foreground">Human interface for specs discovered via `GET /api/inventory/system-lineage`.</p>
+
+      <section className="rounded border p-4 space-y-3">
+        <p className="text-sm text-muted-foreground">Total: {specs.length}</p>
+        <ul className="space-y-2 text-sm">
+          {specs.map((s) => (
+            <li key={s.spec_id} className="rounded border p-3">
+              <div className="flex justify-between gap-3">
+                <span className="font-medium">Spec {s.spec_id}</span>
+                <span className="text-muted-foreground">{s.path}</span>
+              </div>
+              <p>{s.title}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/app/tasks/page.tsx
+++ b/web/app/tasks/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { getApiBase } from "@/lib/api";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = getApiBase();
 
 type AgentTask = {
   id: string;
@@ -73,4 +74,3 @@ export default function TasksPage() {
     </main>
   );
 }
-

--- a/web/app/usage/page.tsx
+++ b/web/app/usage/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+type RuntimeIdeaRow = {
+  idea_id: string;
+  event_count: number;
+  total_runtime_ms: number;
+  average_runtime_ms: number;
+  runtime_cost_estimate: number;
+  by_source: Record<string, number>;
+};
+
+type RuntimeSummaryResponse = {
+  window_seconds: number;
+  ideas: RuntimeIdeaRow[];
+};
+
+type FrictionReportRow = {
+  key: string;
+  count: number;
+  energy_loss: number;
+  cost_of_delay?: number;
+};
+
+type FrictionReport = {
+  window_days: number;
+  total_events: number;
+  open_events: number;
+  total_energy_loss: number;
+  total_cost_of_delay: number;
+  top_block_types: FrictionReportRow[];
+  top_stages: FrictionReportRow[];
+};
+
+async function loadUsage(): Promise<{ runtime: RuntimeSummaryResponse; friction: FrictionReport }> {
+  const API = getApiBase();
+  const [rtRes, frRes] = await Promise.all([
+    fetch(`${API}/api/runtime/ideas/summary?seconds=86400`, { cache: "no-store" }),
+    fetch(`${API}/api/friction/report?window_days=7`, { cache: "no-store" }),
+  ]);
+  if (!rtRes.ok) throw new Error(`runtime HTTP ${rtRes.status}`);
+  if (!frRes.ok) throw new Error(`friction HTTP ${frRes.status}`);
+  return {
+    runtime: (await rtRes.json()) as RuntimeSummaryResponse,
+    friction: (await frRes.json()) as FrictionReport,
+  };
+}
+
+export default async function UsagePage() {
+  const { runtime, friction } = await loadUsage();
+  const ideas = [...runtime.ideas].sort((a, b) => b.runtime_cost_estimate - a.runtime_cost_estimate).slice(0, 20);
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex gap-3">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
+          Ideas
+        </Link>
+        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
+          Specs
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">Usage</h1>
+      <p className="text-muted-foreground">Runtime telemetry + friction summary (machine data rendered for humans).</p>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Friction (7d)</h2>
+        <p className="text-muted-foreground">
+          total_events {friction.total_events} | open {friction.open_events} | energy_loss {friction.total_energy_loss}
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="rounded border p-3">
+            <p className="font-medium mb-2">Top block types</p>
+            <ul className="space-y-1">
+              {friction.top_block_types.slice(0, 8).map((r) => (
+                <li key={r.key} className="flex justify-between">
+                  <span>{r.key}</span>
+                  <span className="text-muted-foreground">{r.count}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded border p-3">
+            <p className="font-medium mb-2">Top stages</p>
+            <ul className="space-y-1">
+              {friction.top_stages.slice(0, 8).map((r) => (
+                <li key={r.key} className="flex justify-between">
+                  <span>{r.key}</span>
+                  <span className="text-muted-foreground">{r.count}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Runtime Cost by Idea (24h)</h2>
+        <p className="text-muted-foreground">window_seconds {runtime.window_seconds}</p>
+        <ul className="space-y-2">
+          {ideas.map((row) => (
+            <li key={row.idea_id} className="flex justify-between rounded border p-2">
+              <span>{row.idea_id}</span>
+              <span className="text-muted-foreground">
+                events {row.event_count} | runtime {row.total_runtime_ms.toFixed(2)}ms | cost ${row.runtime_cost_estimate.toFixed(6)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,13 @@
+export const PROD_API_URL = "https://coherence-network-production.up.railway.app";
+export const DEV_API_URL = "http://localhost:8000";
+
+function _stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+export function getApiBase(): string {
+  const env = process.env.NEXT_PUBLIC_API_URL;
+  if (env && env.trim()) return _stripTrailingSlash(env.trim());
+  if (process.env.NODE_ENV === "production") return PROD_API_URL;
+  return DEV_API_URL;
+}


### PR DESCRIPTION
Spec: specs/075-web-ideas-specs-usage-pages.md

Fixes:
- Adds web pages: /ideas, /ideas/[idea_id], /specs, /usage
- Ensures web pages default API base to production Railway when NEXT_PUBLIC_API_URL is unset (prevents 'localhost' fetch failures on Vercel)
- Adds navigation links from / (Home) and /portfolio

Local validation:
- cd web && npm ci --cache ./tmp-npm-cache --no-fund --no-audit --prefer-offline --fetch-retries 5 --fetch-retry-mintimeout 20000 --fetch-retry-maxtimeout 120000
- cd web && npm run build
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence

Public validation targets after deploy:
- https://coherence-network.vercel.app/ideas
- https://coherence-network.vercel.app/specs
- https://coherence-network.vercel.app/usage
- https://coherence-network.vercel.app/portfolio (should load data without NEXT_PUBLIC_API_URL)
