### PR TITLE
fix(api): prevent test contributors in persistent stores

### DIFF
--- a/api/app/routers/contributions.py
+++ b/api/app/routers/contributions.py
@@ -121,7 +121,10 @@ async def track_github_contribution(payload: GitHubContribution, store: GraphSto
             name=contributor_name,
             email=payload.contributor_email
         )
-        contributor = store.create_contributor(contributor)
+        try:
+            contributor = store.create_contributor(contributor)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     # Find or create asset for repository
     asset = None

--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -19,7 +19,10 @@ def get_store(request: Request) -> GraphStore:
 async def create_contributor(contributor: ContributorCreate, store: GraphStore = Depends(get_store)) -> Contributor:
     """Create a new contributor."""
     contrib = Contributor(**contributor.model_dump())
-    return store.create_contributor(contrib)
+    try:
+        return store.create_contributor(contrib)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.get(

--- a/api/app/services/contributor_hygiene.py
+++ b/api/app/services/contributor_hygiene.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+
+DEFAULT_TEST_EMAIL_DOMAINS = {
+    "example.com",
+    "example.org",
+    "example.net",
+    "invalid",
+    "invalid.local",
+    "localhost",
+    "test",
+    "test.local",
+}
+
+
+def _configured_test_domains() -> set[str]:
+    raw = os.getenv("TEST_CONTRIBUTOR_EMAIL_DOMAINS", "").strip()
+    if not raw:
+        return set(DEFAULT_TEST_EMAIL_DOMAINS)
+    domains = {chunk.strip().lower() for chunk in raw.split(",") if chunk.strip()}
+    return domains or set(DEFAULT_TEST_EMAIL_DOMAINS)
+
+
+def is_test_contributor_email(email: str | None) -> bool:
+    if not email:
+        return False
+    value = str(email).strip().lower()
+    if "@" not in value:
+        return False
+    domain = value.rsplit("@", 1)[1]
+    return domain in _configured_test_domains()

--- a/api/tests/test_contributor_hygiene.py
+++ b/api/tests/test_contributor_hygiene.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.adapters.graph_store import InMemoryGraphStore
+from app.main import app
+from app.models.asset import Asset, AssetType
+from app.models.contribution import Contribution
+from app.models.contributor import Contributor, ContributorType
+from app.services.contributor_hygiene import is_test_contributor_email
+
+
+def test_is_test_contributor_email_recognizes_reserved_domains() -> None:
+    assert is_test_contributor_email("test@example.com") is True
+    assert is_test_contributor_email("alice@example.org") is True
+    assert is_test_contributor_email("dev@example.net") is True
+    assert is_test_contributor_email("alice@coherence.network") is False
+
+
+@pytest.mark.asyncio
+async def test_persistent_store_rejects_test_email_contributor(tmp_path: Path) -> None:
+    app.state.graph_store = InMemoryGraphStore(persist_path=str(tmp_path / "graph_store.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        blocked = await client.post(
+            "/v1/contributors",
+            json={"type": "HUMAN", "name": "Test User", "email": "test@example.com"},
+        )
+        assert blocked.status_code == 422
+
+        allowed = await client.post(
+            "/v1/contributors",
+            json={"type": "HUMAN", "name": "Real User", "email": "real@coherence.network"},
+        )
+        assert allowed.status_code == 201
+
+
+def test_persistent_load_purges_test_contributors_and_their_contributions(tmp_path: Path) -> None:
+    path = tmp_path / "graph_store.json"
+
+    test_contributor = Contributor(
+        type=ContributorType.HUMAN,
+        name="Test User",
+        email="test@example.com",
+    )
+    real_contributor = Contributor(
+        type=ContributorType.HUMAN,
+        name="Real User",
+        email="real@coherence.network",
+    )
+    asset = Asset(type=AssetType.CODE, description="Repo")
+    test_contribution = Contribution(
+        contributor_id=test_contributor.id,
+        asset_id=asset.id,
+        cost_amount=Decimal("1.00"),
+        coherence_score=0.5,
+        metadata={},
+    )
+    real_contribution = Contribution(
+        contributor_id=real_contributor.id,
+        asset_id=asset.id,
+        cost_amount=Decimal("2.00"),
+        coherence_score=0.8,
+        metadata={},
+    )
+
+    payload = {
+        "projects": [],
+        "edges": [],
+        "contributors": [
+            test_contributor.model_dump(mode="json"),
+            real_contributor.model_dump(mode="json"),
+        ],
+        "assets": [asset.model_dump(mode="json")],
+        "contributions": [
+            test_contribution.model_dump(mode="json"),
+            real_contribution.model_dump(mode="json"),
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    store = InMemoryGraphStore(persist_path=str(path))
+
+    contributors = store.list_contributors(limit=10)
+    contributions = store.list_contributions(limit=10)
+
+    assert {c.email for c in contributors} == {"real@coherence.network"}
+    assert all(c.contributor_id != test_contributor.id for c in contributions)
+    assert any(c.contributor_id == real_contributor.id for c in contributions)

--- a/specs/080-persistent-store-test-contributor-guard.md
+++ b/specs/080-persistent-store-test-contributor-guard.md
@@ -1,0 +1,25 @@
+# Spec 080: Persistent Store Test Contributor Guard
+
+## Goal
+Prevent test contributors from polluting persistent contributor data.
+
+## Requirements
+- [x] Persistent stores reject contributor creation for test emails.
+- [x] Persistent stores purge previously stored test contributors at load/startup.
+- [x] Any contributions linked to purged test contributors are removed.
+- [x] API returns `422` when persistent store rejects a test contributor.
+- [x] Existing non-persistent test flows remain unaffected.
+
+## Files To Modify (Allowed)
+- `specs/080-persistent-store-test-contributor-guard.md`
+- `api/app/services/contributor_hygiene.py`
+- `api/app/adapters/graph_store.py`
+- `api/app/adapters/postgres_store.py`
+- `api/app/routers/contributors.py`
+- `api/app/routers/contributions.py`
+- `api/tests/test_contributor_hygiene.py`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_contributor_hygiene.py tests/test_contributors.py tests/test_contributions.py
+```


### PR DESCRIPTION
## Summary\n- add contributor hygiene rules to identify test emails (reserved test domains)\n- block test contributor creation in persistent stores\n- purge existing test contributors and linked contributions at persistent store load/startup\n- return HTTP 422 when persistent store rejects test contributor creation\n\n## Why\nTest contributors should not pollute persistent contributor/contribution data in production-like stores.\n\n## Validation\n- cd api && pytest -q tests/test_contributor_hygiene.py tests/test_contributors.py tests/test_contributions.py