### PR TITLE
feat(inventory): auto-sync implementation-request questions into tasks

### DIFF
--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -31,3 +31,8 @@ async def page_lineage() -> dict:
 @router.post("/inventory/questions/next-highest-roi-task")
 async def next_highest_roi_task(create_task: bool = Query(False)) -> dict:
     return inventory_service.next_highest_roi_task_from_answered_questions(create_task=create_task)
+
+
+@router.post("/inventory/questions/sync-implementation-tasks")
+async def sync_implementation_request_tasks() -> dict:
+    return inventory_service.sync_implementation_request_question_tasks()

--- a/docs/system_audit/commit_evidence_2026-02-16_implementation-request-task-sync.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_implementation-request-task-sync.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/summary-sentence-guard",
+  "commit_scope": "auto-create impl tasks from implementation-request questions with dedup and API sync endpoint",
+  "files_owned": [
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_api.py",
+    "specs/081-implementation-request-question-task-sync.md",
+    "docs/system_audit/commit_evidence_2026-02-16_implementation-request-task-sync.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "081"
+  ],
+  "task_ids": [
+    "implementation-request-question-sync"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_inventory_api.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_implementation-request-task-sync.json"
+  ],
+  "change_files": [
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_api.py",
+    "specs/081-implementation-request-question-task-sync.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_inventory_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "api"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Implementation-request questions are converted into impl tasks before ROI suggestion flow, with dedup across repeated sync runs.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/questions/sync-implementation-tasks",
+      "https://coherence-network-production.up.railway.app/api/inventory/questions/next-highest-roi-task"
+    ],
+    "test_flows": [
+      "seed-implementation-question->POST-sync-implementation-tasks->task-created",
+      "rerun-sync->no-duplicate-task-created"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/081-implementation-request-question-task-sync.md
+++ b/specs/081-implementation-request-question-task-sync.md
@@ -1,0 +1,21 @@
+# Spec 081: Implementation Request Questions -> Task Sync
+
+## Goal
+Ensure implementation-request questions are never dropped by converting them into explicit `impl` tasks as soon as they are discovered. The sync must deduplicate by question fingerprint so repeated runs do not flood the task queue.
+
+## Requirements
+- [x] Add `POST /api/inventory/questions/sync-implementation-tasks` to scan inventory questions and create tasks for implementation-request questions.
+- [x] Mark synced tasks with machine-readable context (`source=implementation_request_question`, fingerprint, idea id, ROI fields).
+- [x] Deduplicate creation so rerunning sync does not create duplicate tasks for the same idea/question pair.
+- [x] Run this sync before `POST /api/inventory/questions/next-highest-roi-task` returns a suggestion.
+
+## Files To Modify (Allowed)
+- `specs/081-implementation-request-question-task-sync.md`
+- `api/app/routers/inventory.py`
+- `api/app/services/inventory_service.py`
+- `api/tests/test_inventory_api.py`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_inventory_api.py
+```


### PR DESCRIPTION
## Summary
- add `POST /api/inventory/questions/sync-implementation-tasks`
- detect implementation-request questions and create `impl` tasks automatically
- deduplicate by stable question fingerprint (`idea_id + question`)
- run sync before returning `/api/inventory/questions/next-highest-roi-task`
- add API tests and spec `081`

## Validation
- `cd api && pytest -q tests/test_inventory_api.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_implementation-request-task-sync.json`
