### PR TITLE
feat(web): contributor-first landing page with value highlights

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json
@@ -1,0 +1,78 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/landing-contributor-focus",
+  "commit_scope": "redesign landing page for contributor onboarding with main-idea framing and ROI/achievement highlights",
+  "files_owned": [
+    "web/app/page.tsx",
+    "specs/082-landing-page-contributor-onboarding.md",
+    "docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "082"
+  ],
+  "task_ids": [
+    "landing-page-contributor-onboarding"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && npm_config_cache=/Users/ursmuff/.claude-worktrees/Coherence-Network/landing-contributor-focus/.npm-cache npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json"
+  ],
+  "change_files": [
+    "web/app/page.tsx",
+    "specs/082-landing-page-contributor-onboarding.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm_config_cache=/Users/ursmuff/.claude-worktrees/Coherence-Network/landing-contributor-focus/.npm-cache npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "vercel"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Landing page now orients new contributors, highlights the main idea chain, and surfaces top estimated-upside ideas plus measurable achievements.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/",
+      "https://coherence-network-production.up.railway.app/api/ideas",
+      "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
+      "https://coherence-network-production.up.railway.app/api/runtime/ideas/summary"
+    ],
+    "test_flows": [
+      "open-root-page->see-contributor-cta-and-main-idea-section",
+      "open-root-page->see-highest-estimated-benefit-ideas-section",
+      "open-root-page->see-recent-achievements-section"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/082-landing-page-contributor-onboarding.md
+++ b/specs/082-landing-page-contributor-onboarding.md
@@ -1,0 +1,21 @@
+# Spec 082: Landing Page Contributor Onboarding + Value Highlights
+
+## Goal
+Make the root web page inviting for new contributors while clearly explaining the core system idea and showing high-value opportunities. The page should surface top estimated-benefit ideas and recent measurable achievements so contributors can pick impact-first work quickly.
+
+## Requirements
+- [x] Landing page includes a contributor-focused hero with clear calls to action.
+- [x] Landing page explains the main idea chain from idea to measured value.
+- [x] Landing page shows top ideas ranked by estimated collective upside.
+- [x] Landing page shows measurable recent achievements from lineage valuation data.
+- [x] Landing page remains machine-friendly with links to API docs and existing web routes.
+
+## Files To Modify (Allowed)
+- `specs/082-landing-page-contributor-onboarding.md`
+- `web/app/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json`
+
+## Validation
+```bash
+cd web && npm run build
+```

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,115 +2,365 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { getApiBase } from "@/lib/api";
 
-const CARDS: Array<{ href: string; title: string; description: string }> = [
+type IdeaQuestion = {
+  question: string;
+  value_to_whole: number;
+  estimated_cost: number;
+  answer?: string | null;
+  measured_delta?: number | null;
+};
+
+type IdeaWithScore = {
+  id: string;
+  name: string;
+  description: string;
+  potential_value: number;
+  actual_value: number;
+  estimated_cost: number;
+  confidence: number;
+  manifestation_status: string;
+  open_questions: IdeaQuestion[];
+  free_energy_score: number;
+  value_gap: number;
+};
+
+type IdeasResponse = {
+  ideas: IdeaWithScore[];
+  summary: {
+    total_ideas: number;
+    total_potential_value: number;
+    total_actual_value: number;
+    total_value_gap: number;
+  };
+};
+
+type LineageValuation = {
+  measured_value_total: number;
+  estimated_cost: number;
+  roi_ratio: number;
+  event_count: number;
+};
+
+type InventoryResponse = {
+  implementation_usage?: {
+    lineage_links?: Array<{
+      lineage_id: string;
+      idea_id: string;
+      spec_id: string;
+      valuation?: LineageValuation | null;
+    }>;
+  };
+};
+
+type RuntimeSummaryResponse = {
+  ideas: Array<{
+    idea_id: string;
+    event_count: number;
+    average_runtime_ms: number;
+  }>;
+};
+
+type OpportunityIdea = IdeaWithScore & {
+  estimated_collective_upside: number;
+};
+
+const API_NAV_CARDS: Array<{ href: string; title: string; description: string }> = [
   {
     href: "/portfolio",
     title: "Portfolio",
-    description: "ROI-first governance: questions, cost signals, and next actions.",
+    description: "ROI-first governance: questions, costs, signals, and next actions.",
   },
   {
     href: "/ideas",
     title: "Ideas",
-    description: "Browse the idea graph: value gap, confidence, and open questions.",
+    description: "Browse high-upside ideas and unresolved questions.",
   },
   {
     href: "/specs",
     title: "Specs",
-    description: "Specs discovered from system lineage inventory (what exists, what’s missing).",
+    description: "Specs discovered from system lineage inventory.",
   },
   {
     href: "/usage",
     title: "Usage",
-    description: "Runtime telemetry and friction signals rendered for human inspection.",
-  },
-  {
-    href: "/import",
-    title: "Import Stack",
-    description: "Upload a lockfile and inspect risk/coherence of your dependency tree.",
-  },
-  {
-    href: "/gates",
-    title: "Gates",
-    description: "Deployment validation contracts and PR-to-public checks.",
-  },
-  {
-    href: "/friction",
-    title: "Friction",
-    description: "Cost-without-gain ledger: blockers, tool failures, and energy loss estimates.",
+    description: "Runtime telemetry and friction signals.",
   },
   {
     href: "/contributors",
     title: "Contributors",
-    description: "People and agents registered as value-producing entities in the system.",
+    description: "Register contributors and track who created value.",
   },
   {
     href: "/assets",
     title: "Assets",
-    description: "Trackable artifacts with cost and contribution attribution (code, docs, endpoints).",
+    description: "Track code/docs/endpoints as measurable system assets.",
   },
 ];
 
-export default function Home() {
+async function loadIdeas(): Promise<IdeasResponse | null> {
+  try {
+    const res = await fetch(`${getApiBase()}/api/ideas`, { cache: "no-store" });
+    if (!res.ok) return null;
+    return (await res.json()) as IdeasResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function loadInventory(): Promise<InventoryResponse | null> {
+  try {
+    const res = await fetch(`${getApiBase()}/api/inventory/system-lineage?runtime_window_seconds=86400`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as InventoryResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function loadRuntimeSummary(): Promise<RuntimeSummaryResponse | null> {
+  try {
+    const res = await fetch(`${getApiBase()}/api/runtime/ideas/summary?seconds=86400`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as RuntimeSummaryResponse;
+  } catch {
+    return null;
+  }
+}
+
+function formatNumber(value: number | undefined): string {
+  if (typeof value !== "number" || Number.isNaN(value)) return "0";
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value);
+}
+
+export default async function Home() {
+  const [ideasData, inventoryData, runtimeData] = await Promise.all([
+    loadIdeas(),
+    loadInventory(),
+    loadRuntimeSummary(),
+  ]);
+
+  const topOpportunityIdeas: OpportunityIdea[] = (ideasData?.ideas ?? [])
+    .map((idea) => {
+      const cost = Math.max(idea.estimated_cost, 0.0001);
+      return {
+        ...idea,
+        estimated_collective_upside: (Math.max(idea.potential_value - idea.actual_value, 0) * idea.confidence) / cost,
+      };
+    })
+    .sort((a, b) => b.estimated_collective_upside - a.estimated_collective_upside)
+    .slice(0, 5);
+
+  const topAchievements = (inventoryData?.implementation_usage?.lineage_links ?? [])
+    .filter((row) => row.valuation && row.valuation.event_count > 0)
+    .sort((a, b) => {
+      const aValue = (a.valuation?.measured_value_total ?? 0) + (a.valuation?.roi_ratio ?? 0);
+      const bValue = (b.valuation?.measured_value_total ?? 0) + (b.valuation?.roi_ratio ?? 0);
+      return bValue - aValue;
+    })
+    .slice(0, 5);
+
+  const topRuntimeActivity = (runtimeData?.ideas ?? [])
+    .sort((a, b) => b.event_count - a.event_count)
+    .slice(0, 5);
+
+  const summary = ideasData?.summary;
+
   return (
     <main className="min-h-[calc(100vh-3.5rem)] px-4 md:px-8 py-10">
-      <section className="mx-auto max-w-6xl grid gap-10">
-        <div className="grid gap-4">
-          <p className="text-sm text-muted-foreground">
-            Open source intelligence graph
-          </p>
-          <h1 className="text-4xl md:text-5xl font-semibold leading-tight tracking-tight">
-            Search, measure, and attribute value across the OSS ecosystem.
-          </h1>
-          <p className="text-muted-foreground max-w-3xl">
-            Coherence Network connects projects, ideas, specs, implementations, usage, and contributors into one
-            inspectable operating model.
-          </p>
-        </div>
+      <section className="mx-auto max-w-6xl grid gap-8">
+        <section className="relative overflow-hidden rounded-2xl border bg-gradient-to-br from-background via-background to-muted/40 p-6 md:p-10">
+          <div className="absolute -right-16 -top-16 h-44 w-44 rounded-full bg-primary/10 blur-2xl" />
+          <div className="absolute -left-10 bottom-0 h-36 w-36 rounded-full bg-emerald-400/15 blur-2xl" />
 
-        <section className="rounded-lg border bg-background/60 p-4 md:p-6 grid gap-4">
-          <div className="flex items-center justify-between gap-3 flex-wrap">
-            <h2 className="font-semibold">Search packages</h2>
+          <div className="relative grid gap-5">
+            <p className="text-sm text-muted-foreground">Collective intelligence operating system</p>
+            <h1 className="text-3xl md:text-5xl font-semibold leading-tight tracking-tight max-w-4xl">
+              Turn ideas into measurable collective value.
+            </h1>
+            <p className="max-w-3xl text-muted-foreground">
+              Coherence Network links ideas to specs, implementations, runtime usage, and contributor attribution so new
+              contributors can see where help is needed and where impact is highest.
+            </p>
+
+            <div className="flex flex-wrap gap-3 pt-1">
+              <Button asChild>
+                <Link href="/contributors">Start Contributing</Link>
+              </Button>
+              <Button asChild variant="secondary">
+                <Link href="/ideas">Pick a High-Upside Idea</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <a href={`${getApiBase()}/docs`} target="_blank" rel="noopener noreferrer">
+                  API For Machines
+                </a>
+              </Button>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2 text-sm">
+              <div className="rounded-lg border bg-background/80 p-3">
+                <p className="text-muted-foreground">Ideas tracked</p>
+                <p className="text-xl font-semibold">{formatNumber(summary?.total_ideas)}</p>
+              </div>
+              <div className="rounded-lg border bg-background/80 p-3">
+                <p className="text-muted-foreground">Estimated total potential value</p>
+                <p className="text-xl font-semibold">{formatNumber(summary?.total_potential_value)}</p>
+              </div>
+              <div className="rounded-lg border bg-background/80 p-3">
+                <p className="text-muted-foreground">Remaining value gap</p>
+                <p className="text-xl font-semibold">{formatNumber(summary?.total_value_gap)}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <article className="rounded-xl border p-5 space-y-3">
+            <p className="text-sm text-muted-foreground">Main Idea</p>
+            <h2 className="text-xl font-semibold">One walkable chain from idea to realized value</h2>
             <p className="text-sm text-muted-foreground">
-              Examples: <code className="rounded bg-muted px-1 py-0.5">react</code>,{" "}
+              Every contribution should be traceable through the same chain: idea to spec to process to implementation
+              to usage to measurable value.
+            </p>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {[
+                "Idea",
+                "Spec",
+                "Process",
+                "Implementation",
+                "Runtime Usage",
+                "Value Attribution",
+              ].map((step) => (
+                <span key={step} className="rounded-full border px-2 py-1 bg-muted/40">
+                  {step}
+                </span>
+              ))}
+            </div>
+          </article>
+
+          <article className="rounded-xl border p-5 space-y-3">
+            <p className="text-sm text-muted-foreground">Contributor Onboarding</p>
+            <h2 className="text-xl font-semibold">Best first path for a new contributor</h2>
+            <ol className="space-y-2 text-sm text-muted-foreground list-decimal list-inside">
+              <li>Register in the contributor registry and declare your role.</li>
+              <li>Pick one high-upside idea or unanswered question.</li>
+              <li>Create a spec/task link so your implementation is attributable.</li>
+            </ol>
+            <div className="flex gap-2 flex-wrap">
+              <Link href="/contributors" className="text-sm underline text-muted-foreground hover:text-foreground">
+                Open contributors
+              </Link>
+              <Link href="/portfolio" className="text-sm underline text-muted-foreground hover:text-foreground">
+                Open portfolio
+              </Link>
+              <Link href="/tasks" className="text-sm underline text-muted-foreground hover:text-foreground">
+                Open tasks
+              </Link>
+            </div>
+          </article>
+        </section>
+
+        <section className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+          <article className="rounded-xl border p-5 xl:col-span-2 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold">Highest Estimated Collective Benefit</h2>
+              <Link href="/ideas" className="text-sm text-muted-foreground hover:text-foreground underline">
+                View all ideas
+              </Link>
+            </div>
+            {topOpportunityIdeas.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No idea data available right now.</p>
+            ) : (
+              <ul className="space-y-2">
+                {topOpportunityIdeas.map((idea) => (
+                  <li key={idea.id} className="rounded-lg border p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <Link href={`/ideas/${encodeURIComponent(idea.id)}`} className="font-medium hover:underline">
+                        {idea.name}
+                      </Link>
+                      <span className="text-xs rounded-full border px-2 py-1 bg-muted/40">{idea.manifestation_status}</span>
+                    </div>
+                    <p className="text-sm text-muted-foreground mt-1">{idea.description}</p>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      upside score {idea.estimated_collective_upside.toFixed(2)} | value gap {idea.value_gap.toFixed(2)} |
+                      cost est {idea.estimated_cost.toFixed(2)}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+
+          <article className="rounded-xl border p-5 space-y-3">
+            <h2 className="text-lg font-semibold">Recent Achievements</h2>
+            {topAchievements.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No measured usage achievements yet.</p>
+            ) : (
+              <ul className="space-y-2 text-sm">
+                {topAchievements.map((row) => (
+                  <li key={row.lineage_id} className="rounded-lg border p-3">
+                    <p className="font-medium">{row.idea_id}</p>
+                    <p className="text-xs text-muted-foreground">spec {row.spec_id}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      value {formatNumber(row.valuation?.measured_value_total)} | ROI {formatNumber(row.valuation?.roi_ratio)} |
+                      events {formatNumber(row.valuation?.event_count)}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </section>
+
+        <section className="rounded-xl border bg-background/60 p-5 space-y-4">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <h2 className="text-lg font-semibold">Search Projects</h2>
+            <p className="text-sm text-muted-foreground">
+              Try <code className="rounded bg-muted px-1 py-0.5">react</code>,{" "}
               <code className="rounded bg-muted px-1 py-0.5">fastapi</code>,{" "}
               <code className="rounded bg-muted px-1 py-0.5">neo4j</code>
             </p>
           </div>
           <form action="/search" method="GET" className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-2">
-            <Input name="q" placeholder="Search projects…" autoComplete="off" className="h-11 bg-background" />
+            <Input name="q" placeholder="Search projects..." autoComplete="off" className="h-11 bg-background" />
             <Button type="submit" className="h-11">
               Search
             </Button>
           </form>
-          <p className="text-sm text-muted-foreground">
-            If you already know the project path, open a project page directly:{" "}
-            <code className="rounded bg-muted px-1 py-0.5">/project/npm/react</code>.
-          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 text-sm">
+            {topRuntimeActivity.map((row) => (
+              <div key={row.idea_id} className="rounded border p-2">
+                <p className="font-medium">{row.idea_id}</p>
+                <p className="text-xs text-muted-foreground">
+                  24h events {formatNumber(row.event_count)} | avg runtime {formatNumber(row.average_runtime_ms)}ms
+                </p>
+              </div>
+            ))}
+            {topRuntimeActivity.length === 0 && (
+              <p className="text-sm text-muted-foreground">No runtime activity captured in the last 24 hours.</p>
+            )}
+          </div>
         </section>
 
-        <section className="grid gap-4">
-          <div className="flex items-end justify-between gap-3 flex-wrap">
-            <h2 className="text-xl font-semibold">Console</h2>
-            <Link href="/portfolio" className="text-sm text-muted-foreground hover:text-foreground underline">
-              Open operating cockpit
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {API_NAV_CARDS.map((card) => (
+            <Link
+              key={card.href}
+              href={card.href}
+              className="rounded-lg border bg-background/60 p-4 hover:bg-background/80 transition-colors"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="font-semibold">{card.title}</h3>
+                <span className="text-muted-foreground text-sm">→</span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-2">{card.description}</p>
             </Link>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {CARDS.map((c) => (
-              <Link
-                key={c.href}
-                href={c.href}
-                className="rounded-lg border bg-background/60 p-4 hover:bg-background/80 transition-colors"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="font-semibold">{c.title}</h3>
-                  <span className="text-muted-foreground text-sm">→</span>
-                </div>
-                <p className="text-sm text-muted-foreground mt-2">{c.description}</p>
-              </Link>
-            ))}
-          </div>
+          ))}
         </section>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- redesign `/` to be inviting for new contributors
- highlight the main idea chain from idea -> spec -> process -> implementation -> usage -> value
- surface top estimated-benefit ideas using live `/api/ideas` signals
- surface measurable achievements from `/api/inventory/system-lineage` valuation data
- keep machine/human entry points visible (API docs + contributor/task/portfolio links)

## Validation
- `cd web && npm_config_cache=/Users/ursmuff/.claude-worktrees/Coherence-Network/landing-contributor-focus/.npm-cache npm run build`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_landing-page-contributor-onboarding.json`
