### PR TITLE
feat(agent): track task claims and prevent ROI duplicate pickups

### DIFF
--- a/api/app/models/agent.py
+++ b/api/app/models/agent.py
@@ -60,6 +60,7 @@ class AgentTaskUpdate(BaseModel):
     current_step: Optional[str] = None
     decision_prompt: Optional[str] = None
     decision: Optional[str] = None  # user reply; when present and status is needs_decision, set status→running
+    worker_id: Optional[str] = Field(default=None, min_length=1, max_length=200)
 
     @field_validator("progress_pct", mode="before")
     @classmethod
@@ -87,6 +88,8 @@ class AgentTask(BaseModel):
     current_step: Optional[str] = None
     decision_prompt: Optional[str] = None
     decision: Optional[str] = None
+    claimed_by: Optional[str] = None
+    claimed_at: Optional[datetime] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
 
@@ -103,6 +106,8 @@ class AgentTaskListItem(BaseModel):
     current_step: Optional[str] = None
     decision_prompt: Optional[str] = None
     decision: Optional[str] = None
+    claimed_by: Optional[str] = None
+    claimed_at: Optional[datetime] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
 

--- a/api/tests/test_agent_task_claims.py
+++ b/api/tests/test_agent_task_claims.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services import agent_service
+
+
+@pytest.mark.asyncio
+async def test_task_start_tracks_claim_owner_and_blocks_other_workers() -> None:
+    agent_service._store.clear()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post(
+            "/api/agent/tasks",
+            json={
+                "direction": "Implement claim ownership tracking",
+                "task_type": "impl",
+            },
+        )
+        assert created.status_code == 201
+        task_id = created.json()["id"]
+
+        first_claim = await client.patch(
+            f"/api/agent/tasks/{task_id}",
+            json={"status": "running", "worker_id": "bot-a"},
+        )
+        assert first_claim.status_code == 200
+        first_payload = first_claim.json()
+        assert first_payload["status"] == "running"
+        assert first_payload["claimed_by"] == "bot-a"
+        assert first_payload["claimed_at"] is not None
+
+        conflicting_claim = await client.patch(
+            f"/api/agent/tasks/{task_id}",
+            json={"status": "running", "worker_id": "bot-b"},
+        )
+        assert conflicting_claim.status_code == 409
+
+        idempotent_claim = await client.patch(
+            f"/api/agent/tasks/{task_id}",
+            json={"status": "running", "worker_id": "bot-a"},
+        )
+        assert idempotent_claim.status_code == 200
+        assert idempotent_claim.json()["claimed_by"] == "bot-a"

--- a/docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json
@@ -1,0 +1,89 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/task-claim-dedupe",
+  "commit_scope": "track task claim ownership and prevent ROI auto-pick duplicate work across parallel contributors",
+  "files_owned": [
+    "api/app/models/agent.py",
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/app/services/inventory_service.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_task_claims.py",
+    "api/tests/test_inventory_api.py",
+    "specs/083-task-claim-tracking-and-roi-dedupe.md",
+    "docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "083"
+  ],
+  "task_ids": [
+    "task-claim-tracking-roi-dedupe"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_agent_task_claims.py tests/test_inventory_api.py tests/test_contributions.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json"
+  ],
+  "change_files": [
+    "api/app/models/agent.py",
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/app/services/inventory_service.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_task_claims.py",
+    "api/tests/test_inventory_api.py",
+    "specs/083-task-claim-tracking-and-roi-dedupe.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_task_claims.py tests/test_inventory_api.py tests/test_contributions.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "api"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Task starts record worker ownership and conflicting claims return 409. ROI task generation returns task_already_active when matching active work exists.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
+      "https://coherence-network-production.up.railway.app/api/inventory/questions/next-highest-roi-task",
+      "https://coherence-network-production.up.railway.app/api/inventory/questions/sync-implementation-tasks"
+    ],
+    "test_flows": [
+      "create-task->patch-running-with-worker_id->claimed_by-recorded",
+      "same-task-second-worker-patch-running->409-conflict",
+      "answered-question-create_task-true->task_already_active-when-active-fingerprint-exists"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/083-task-claim-tracking-and-roi-dedupe.md
+++ b/specs/083-task-claim-tracking-and-roi-dedupe.md
@@ -1,0 +1,27 @@
+# Spec 083: Task Claim Tracking and ROI Auto-Pick De-duplication
+
+## Goal
+Prevent parallel contributors/agents from working the same ROI-ranked task at the same time. Track who started a task and ensure automatic ROI task generation skips work already in progress.
+
+## Requirements
+- [x] Task updates to `running` record claim ownership (`claimed_by`, `claimed_at`).
+- [x] Starting a task already claimed by another worker returns `409` conflict.
+- [x] Agent runner sends a stable worker identifier when claiming tasks.
+- [x] ROI auto-pick flow detects active fingerprint-matched tasks and returns `task_already_active` instead of creating duplicates.
+- [x] Implementation-request question sync uses active-task deduplication and task fingerprints.
+
+## Files To Modify (Allowed)
+- `specs/083-task-claim-tracking-and-roi-dedupe.md`
+- `api/app/models/agent.py`
+- `api/app/routers/agent.py`
+- `api/app/services/agent_service.py`
+- `api/app/services/inventory_service.py`
+- `api/scripts/agent_runner.py`
+- `api/tests/test_agent_task_claims.py`
+- `api/tests/test_inventory_api.py`
+- `docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_agent_task_claims.py tests/test_inventory_api.py tests/test_contributions.py
+```


### PR DESCRIPTION
## Summary
- add task claim ownership tracking (`claimed_by`, `claimed_at`) when task moves to `running`
- return `409` when another worker tries to claim an already-running task
- include worker id from `agent_runner` when claiming
- prevent ROI duplicate work by fingerprinting tasks and returning `task_already_active`
- keep implementation-request sync dedupe focused on active tasks

## Validation
- `cd api && pytest -q tests/test_agent_task_claims.py tests/test_inventory_api.py tests/test_contributions.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_task-claim-tracking-roi-dedupe.json`
