### PR TITLE
test: replace mocked gate tests with live integration checks

### DIFF
--- a/api/tests/test_gates.py
+++ b/api/tests/test_gates.py
@@ -1,85 +1,105 @@
 from __future__ import annotations
 
+import re
+import uuid
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
-from app.services import release_gate_service as gates
+
+SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+async def _get_main_head_sha(client: AsyncClient) -> str:
+    resp = await client.get("/api/gates/main-head")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data.get("repo"), str)
+    assert data.get("branch") == "main"
+    sha = data.get("sha")
+    assert isinstance(sha, str)
+    assert SHA40_RE.fullmatch(sha)
+    return sha
 
 
 @pytest.mark.asyncio
-async def test_gate_pr_to_public_endpoint_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_report(**_kwargs):
-        return {"result": "ready_for_merge", "pr_gate": {"ready_to_merge": True}}
-
-    monkeypatch.setattr(gates, "evaluate_pr_to_public_report", fake_report)
-
+async def test_gate_main_head_returns_live_sha() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/gates/pr-to-public", params={"branch": "codex/test"})
+        _ = await _get_main_head_sha(client)
+
+
+@pytest.mark.asyncio
+async def test_gate_pr_to_public_blocks_for_unknown_branch() -> None:
+    unknown_branch = f"codex/nonexistent-{uuid.uuid4().hex}"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/gates/pr-to-public", params={"branch": unknown_branch})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["result"] == "ready_for_merge"
-        assert data["pr_gate"]["ready_to_merge"] is True
+        assert data["result"] == "blocked"
+        assert data["reason"] == "No open PR found for branch"
+        assert data["open_pr_count"] == 0
+        assert data["branch"] == unknown_branch
 
 
 @pytest.mark.asyncio
-async def test_gate_merged_contract_endpoint_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_report(**_kwargs):
-        return {"result": "contract_passed", "contributor_ack": {"eligible": True}}
-
-    monkeypatch.setattr(gates, "evaluate_merged_change_contract_report", fake_report)
-
+async def test_gate_merged_contract_returns_real_report_shape() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/gates/merged-contract", params={"sha": "abc1234"})
+        sha = await _get_main_head_sha(client)
+        resp = await client.get(
+            "/api/gates/merged-contract",
+            params={
+                "sha": sha,
+                "min_approvals": 10,
+                "min_unique_approvers": 10,
+                "timeout_seconds": 10,
+                "poll_seconds": 1,
+            },
+        )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["result"] == "contract_passed"
-        assert data["contributor_ack"]["eligible"] is True
+        assert data["repo"] == "seeker71/Coherence-Network"
+        assert data["sha"] == sha
+        assert data["result"] == "blocked"
+        assert isinstance(data.get("reason"), str)
 
 
 @pytest.mark.asyncio
-async def test_gate_main_head_502_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(gates, "get_branch_head_sha", lambda *args, **kwargs: None)
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/gates/main-head")
-        assert resp.status_code == 502
-        assert resp.json()["detail"] == "Could not resolve branch head SHA"
-
-
-@pytest.mark.asyncio
-async def test_gate_public_deploy_contract_endpoint_returns_report(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fake_report(**_kwargs):
-        return {"result": "public_contract_passed", "failing_checks": []}
-
-    monkeypatch.setattr(gates, "evaluate_public_deploy_contract_report", fake_report)
-
+async def test_gate_public_deploy_contract_returns_real_checks() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/api/gates/public-deploy-contract")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["result"] == "public_contract_passed"
-        assert data["failing_checks"] == []
+        assert data["repository"] == "seeker71/Coherence-Network"
+        assert data["branch"] == "main"
+        assert isinstance(data.get("expected_sha"), str)
+        checks = data.get("checks")
+        assert isinstance(checks, list)
+        check_names = {
+            row.get("name")
+            for row in checks
+            if isinstance(row, dict) and isinstance(row.get("name"), str)
+        }
+        assert "railway_health" in check_names
+        assert "vercel_gates_page" in check_names
+        assert "vercel_health_proxy" in check_names
+        assert "railway_value_lineage_e2e" in check_names
+        assert data["result"] in {"public_contract_passed", "blocked"}
 
 
 @pytest.mark.asyncio
-async def test_gate_commit_traceability_endpoint_returns_report(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fake_report(**_kwargs):
-        return {
-            "result": "traceability_ready",
-            "traceability": {"ideas": [{"idea_id": "portfolio-governance"}]},
-            "missing_answers": [],
-        }
-
-    monkeypatch.setattr(gates, "evaluate_commit_traceability_report", fake_report)
-
+async def test_gate_commit_traceability_returns_real_report_shape() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        resp = await client.get("/api/gates/commit-traceability", params={"sha": "abc1234"})
+        sha = await _get_main_head_sha(client)
+        resp = await client.get("/api/gates/commit-traceability", params={"sha": sha})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["result"] == "traceability_ready"
-        assert data["traceability"]["ideas"][0]["idea_id"] == "portfolio-governance"
+        assert data["repository"] == "seeker71/Coherence-Network"
+        assert data["sha"] == sha
+        assert isinstance(data.get("traceability"), dict)
+        traceability = data["traceability"]
+        assert isinstance(traceability.get("ideas"), list)
+        assert isinstance(traceability.get("specs"), list)
+        assert isinstance(traceability.get("implementations"), list)
+        assert isinstance(traceability.get("evidence_files"), list)
+        assert data["result"] in {"traceability_ready", "traceability_incomplete"}

--- a/docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json
@@ -1,0 +1,71 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/real-gates-tests",
+  "commit_scope": "replace mocked gate endpoint and release-gate report tests with live integration checks",
+  "files_owned": [
+    "api/tests/test_gates.py",
+    "api/tests/test_release_gate_service.py",
+    "specs/084-live-gate-tests-without-mocks.md",
+    "docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "084"
+  ],
+  "task_ids": [
+    "live-gate-tests-no-mocks"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_gates.py tests/test_release_gate_service.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json"
+  ],
+  "change_files": [
+    "api/tests/test_gates.py",
+    "api/tests/test_release_gate_service.py",
+    "specs/084-live-gate-tests-without-mocks.md"
+  ],
+  "change_intent": "test_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_gates.py tests/test_release_gate_service.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "api"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/084-live-gate-tests-without-mocks.md
+++ b/specs/084-live-gate-tests-without-mocks.md
@@ -1,0 +1,26 @@
+# Spec 084: Live Gate Tests Without Mock API Responses
+
+## Goal
+Replace fake/mocked gate endpoint tests with real integration checks that execute actual gate logic against live GitHub/public deployment data. This removes false confidence from monkeypatched endpoint tests.
+
+## Requirements
+- [x] `api/tests/test_gates.py` no longer monkeypatches gate service functions.
+- [x] Gate route tests assert real response shape and contract behavior from live calls.
+- [x] `api/tests/test_release_gate_service.py` no longer monkeypatches public deploy and traceability report fetch paths.
+- [x] Release gate service tests for public deploy and traceability use real external data and validate response structure.
+- [x] Updated tests pass locally.
+
+## Files To Modify (Allowed)
+- `specs/084-live-gate-tests-without-mocks.md`
+- `api/tests/test_gates.py`
+- `api/tests/test_release_gate_service.py`
+- `docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_gates.py tests/test_release_gate_service.py
+```
+
+## Out of Scope
+- Rewriting every unit test that uses local monkeypatch for pure-function behavior.
+- Refactoring release gate implementation logic.


### PR DESCRIPTION
## Summary\n- replace mocked gate API route tests with live gate-service behavior assertions\n- replace mocked release-gate public/traceability tests with live-shape checks\n- add spec 084 and commit evidence for this cleanup slice\n\n## Validation\n- cd api && pytest -q tests/test_gates.py tests/test_release_gate_service.py\n- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_live-gate-tests-no-mocks.json