### PR TITLE
feat: fix idea/spec count parity from tracked sources

### DIFF
--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.services import idea_service, inventory_service
+
+
+def test_idea_service_derives_missing_ideas_from_commit_evidence(
+    monkeypatch, tmp_path: Path
+) -> None:
+    portfolio_path = tmp_path / "idea_portfolio.json"
+    evidence_dir = tmp_path / "system_audit"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    (evidence_dir / "commit_evidence_2026-02-16_test.json").write_text(
+        json.dumps({"idea_ids": ["derived-runtime-observability"]}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(portfolio_path))
+    monkeypatch.setenv("IDEA_COMMIT_EVIDENCE_DIR", str(evidence_dir))
+
+    listed = idea_service.list_ideas()
+    idea_ids = [item.id for item in listed.ideas]
+
+    assert "derived-runtime-observability" in idea_ids
+    assert portfolio_path.exists()
+    assert "derived-runtime-observability" in idea_service.list_tracked_idea_ids()
+
+
+def test_inventory_uses_github_spec_discovery_when_local_specs_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+
+    monkeypatch.setattr(inventory_service, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        inventory_service,
+        "_discover_specs_from_github",
+        lambda limit=300, timeout=8.0: [
+            {
+                "spec_id": "900",
+                "title": "remote inventory source",
+                "path": "specs/900-remote-inventory-source.md",
+            }
+        ],
+    )
+    monkeypatch.setattr(idea_service, "list_tracked_idea_ids", lambda: ["portfolio-governance"])
+
+    inventory = inventory_service.build_system_lineage_inventory(runtime_window_seconds=60)
+
+    assert inventory["specs"]["count"] == 1
+    assert inventory["specs"]["source"] == "github"
+    assert inventory["specs"]["items"][0]["spec_id"] == "900"

--- a/docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/idea-count-parity",
+  "commit_scope": "fix idea/spec count parity by discovering tracked ideas/specs from commit evidence and repository sources with source-aware inventory telemetry",
+  "files_owned": [
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "web/app/portfolio/page.tsx",
+    "web/app/specs/page.tsx",
+    "specs/085-tracked-count-parity-and-source-discovery.md",
+    "docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "oss-interface-alignment",
+    "coherence-network-api-runtime"
+  ],
+  "spec_ids": [
+    "085"
+  ],
+  "task_ids": [
+    "tracked-count-parity-source-discovery"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_ideas.py tests/test_inventory_api.py tests/test_inventory_discovery_sources.py",
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json"
+  ],
+  "change_files": [
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "web/app/portfolio/page.tsx",
+    "web/app/specs/page.tsx",
+    "specs/085-tracked-count-parity-and-source-discovery.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_ideas.py tests/test_inventory_api.py tests/test_inventory_discovery_sources.py",
+      "cd web && npm ci --cache .npm-cache && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "api+web"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public inventory/spec pages report tracked counts from source-of-truth discovery instead of sparse fallback counts.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/ideas",
+      "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
+      "https://coherence-network.vercel.app/portfolio",
+      "https://coherence-network.vercel.app/specs"
+    ],
+    "test_flows": [
+      "api:/ideas->derived_commit_evidence_idea_ids_included",
+      "api:/inventory/system-lineage->spec_source_and_count_reflect_repository_tracking",
+      "web:/portfolio->counts_show_portfolio_vs_tracked_ids_vs_specs",
+      "web:/specs->source_and_spec_total_render"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deployed public validation"
+  }
+}

--- a/specs/085-tracked-count-parity-and-source-discovery.md
+++ b/specs/085-tracked-count-parity-and-source-discovery.md
@@ -1,0 +1,30 @@
+# Spec 085: Tracked Count Parity and Source Discovery
+
+## Goal
+Ensure public API and web UI show idea/spec/usage counts that match tracked system artifacts, even when deployment packages do not include full repository files.
+
+## Requirements
+- [x] Idea portfolio auto-discovers missing tracked idea IDs from commit-evidence artifacts and adds them as derived ideas.
+- [x] Inventory spec discovery falls back to GitHub repository `specs/` listing when local specs are sparse or missing.
+- [x] Inventory response exposes discovery source and tracked-count telemetry for machine inspection.
+- [x] Portfolio and Specs web pages display source-aware counts so human users can verify parity.
+- [x] Add deterministic tests for derived idea discovery and spec-source fallback behavior.
+
+## Files To Modify (Allowed)
+- `specs/085-tracked-count-parity-and-source-discovery.md`
+- `api/app/services/idea_service.py`
+- `api/app/services/inventory_service.py`
+- `api/tests/test_inventory_discovery_sources.py`
+- `web/app/portfolio/page.tsx`
+- `web/app/specs/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_ideas.py tests/test_inventory_api.py tests/test_inventory_discovery_sources.py
+cd web && npm run build
+```
+
+## Out of Scope
+- Backfilling historical usage events that were never recorded.
+- Replacing all runtime storage backends in this change.

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -34,6 +34,10 @@ interface InventoryResponse {
       total_value_gap: number;
     };
   };
+  specs: {
+    count: number;
+    source: string;
+  };
   questions: {
     answered_count: number;
     unanswered_count: number;
@@ -45,6 +49,11 @@ interface InventoryResponse {
   implementation_usage: {
     lineage_links_count: number;
     usage_events_count: number;
+  };
+  tracking: {
+    tracked_idea_ids_count: number;
+    runtime_events_count: number;
+    spec_discovery_source: string;
   };
 }
 
@@ -156,22 +165,27 @@ export default function PortfolioPage() {
         <>
           <section className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
             <div className="rounded border p-3">
-              <p className="text-muted-foreground">Ideas</p>
+              <p className="text-muted-foreground">Ideas in portfolio</p>
               <p className="text-lg font-semibold">{inventory.ideas.summary.total_ideas}</p>
             </div>
             <div className="rounded border p-3">
-              <p className="text-muted-foreground">Value gap</p>
-              <p className="text-lg font-semibold">{inventory.ideas.summary.total_value_gap}</p>
+              <p className="text-muted-foreground">Tracked idea ids</p>
+              <p className="text-lg font-semibold">{inventory.tracking.tracked_idea_ids_count}</p>
             </div>
             <div className="rounded border p-3">
-              <p className="text-muted-foreground">Questions unanswered</p>
-              <p className="text-lg font-semibold">{inventory.questions.unanswered_count}</p>
+              <p className="text-muted-foreground">Specs discovered</p>
+              <p className="text-lg font-semibold">{inventory.specs.count}</p>
             </div>
             <div className="rounded border p-3">
-              <p className="text-muted-foreground">Lineage links</p>
-              <p className="text-lg font-semibold">{inventory.implementation_usage.lineage_links_count}</p>
+              <p className="text-muted-foreground">Usage events</p>
+              <p className="text-lg font-semibold">{inventory.implementation_usage.usage_events_count}</p>
             </div>
           </section>
+
+          <p className="text-xs text-muted-foreground">
+            spec source {inventory.specs.source} | runtime_events {inventory.tracking.runtime_events_count} | unanswered_questions{" "}
+            {inventory.questions.unanswered_count} | value_gap {inventory.ideas.summary.total_value_gap}
+          </p>
 
           <section className="rounded border p-4 space-y-3">
             <h2 className="font-semibold">Top Unanswered Questions (ROI-ordered)</h2>


### PR DESCRIPTION
## Summary\n- derive missing idea entries from tracked commit-evidence idea ids\n- add source-aware spec discovery fallback (GitHub repo listing when local specs are sparse)\n- expose tracking telemetry in inventory and surface counts/source in portfolio + specs pages\n- add tests for derived idea discovery and spec source fallback\n\n## Validation\n- cd api && pytest -q tests/test_ideas.py tests/test_inventory_api.py tests/test_inventory_discovery_sources.py\n- cd web && npm ci --cache .npm-cache && npm run build\n- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_tracked-count-parity-source-discovery.json