### PR TITLE
fix: normalize inflated commit cost estimates

### DIFF
--- a/.github/workflows/auto_track_contributions.yml
+++ b/.github/workflows/auto_track_contributions.yml
@@ -36,8 +36,14 @@ jobs:
           FILES=${{ steps.commit_info.outputs.files_changed }}
           LINES=${{ steps.commit_info.outputs.lines_added }}
 
-          # Base cost: $10 per file + $0.50 per line
-          COST=$(echo "($FILES * 10) + ($LINES * 0.5)" | bc)
+          # Normalized v2 estimator:
+          # base 0.10 + 0.15/file + 0.002/line, clamped to [0.05, 10.00]
+          COST=$(awk -v files="$FILES" -v lines="$LINES" 'BEGIN {
+            c = 0.10 + (files * 0.15) + (lines * 0.002);
+            if (c < 0.05) c = 0.05;
+            if (c > 10.00) c = 10.00;
+            printf "%.2f", c
+          }')
 
           echo "cost=$COST" >> $GITHUB_OUTPUT
 

--- a/api/app/services/contribution_cost_service.py
+++ b/api/app/services/contribution_cost_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
+# Cost model v2 (normalized):
+# - keep commit costs comparable and bounded
+# - avoid line-count explosions from large commits
+BASE_COST = Decimal("0.10")
+PER_FILE_COST = Decimal("0.15")
+PER_LINE_COST = Decimal("0.002")
+MIN_COMMIT_COST = Decimal("0.05")
+MAX_COMMIT_COST = Decimal("10.00")
+ESTIMATOR_VERSION = "v2_normalized"
+
+
+def _to_non_negative_int(value: Any) -> int:
+    try:
+        out = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, out)
+
+
+def _clamp_cost(value: Decimal) -> Decimal:
+    clamped = max(MIN_COMMIT_COST, min(MAX_COMMIT_COST, value))
+    return clamped.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def estimate_commit_cost(
+    *,
+    files_changed: Any,
+    lines_added: Any,
+    submitted_cost: Decimal | None = None,
+) -> Decimal:
+    """Return normalized cost for a commit.
+
+    Preference order:
+    1. If commit-shape metadata exists, use normalized formula from files/lines.
+    2. Otherwise, fallback to submitted cost (clamped).
+    3. If no usable inputs, return minimum cost.
+    """
+    files = _to_non_negative_int(files_changed)
+    lines = _to_non_negative_int(lines_added)
+
+    if files > 0 or lines > 0:
+        estimated = BASE_COST + (Decimal(files) * PER_FILE_COST) + (Decimal(lines) * PER_LINE_COST)
+        return _clamp_cost(estimated)
+
+    if submitted_cost is not None:
+        return _clamp_cost(Decimal(submitted_cost))
+
+    return _clamp_cost(MIN_COMMIT_COST)

--- a/api/tests/test_contribution_cost_service.py
+++ b/api/tests/test_contribution_cost_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.contribution_cost_service import estimate_commit_cost
+
+
+def test_estimate_commit_cost_uses_metadata_formula() -> None:
+    cost = estimate_commit_cost(files_changed=3, lines_added=120, submitted_cost=Decimal("342.50"))
+    assert cost == Decimal("0.79")
+
+
+def test_estimate_commit_cost_clamps_large_metadata() -> None:
+    cost = estimate_commit_cost(files_changed=200, lines_added=50000, submitted_cost=Decimal("1.00"))
+    assert cost == Decimal("10.00")
+
+
+def test_estimate_commit_cost_falls_back_to_submitted_when_metadata_missing() -> None:
+    cost = estimate_commit_cost(files_changed=0, lines_added=0, submitted_cost=Decimal("7.25"))
+    assert cost == Decimal("7.25")
+
+
+def test_estimate_commit_cost_clamps_submitted_when_metadata_missing() -> None:
+    cost = estimate_commit_cost(files_changed=None, lines_added=None, submitted_cost=Decimal("342.50"))
+    assert cost == Decimal("10.00")

--- a/docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/commit-cost-normalization",
+  "commit_scope": "normalize github contribution cost-per-commit estimation and prevent inflated values in API/workflow/UI",
+  "files_owned": [
+    "api/app/services/contribution_cost_service.py",
+    "api/app/routers/contributions.py",
+    "api/tests/test_contribution_cost_service.py",
+    "api/tests/test_contributions.py",
+    ".github/workflows/auto_track_contributions.yml",
+    "web/app/contributions/page.tsx",
+    "specs/086-normalize-github-commit-cost-estimation.md",
+    "docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json"
+  ],
+  "idea_ids": [
+    "coherence-network-value-attribution",
+    "portfolio-governance",
+    "deployment-gate-reliability"
+  ],
+  "spec_ids": [
+    "086"
+  ],
+  "task_ids": [
+    "normalize-commit-cost-estimator"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_contribution_cost_service.py tests/test_contributions.py",
+    "cd web && npm ci --cache .npm-cache && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json"
+  ],
+  "change_files": [
+    "api/app/services/contribution_cost_service.py",
+    "api/app/routers/contributions.py",
+    "api/tests/test_contribution_cost_service.py",
+    "api/tests/test_contributions.py",
+    ".github/workflows/auto_track_contributions.yml",
+    "web/app/contributions/page.tsx",
+    "specs/086-normalize-github-commit-cost-estimation.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_contribution_cost_service.py tests/test_contributions.py",
+      "cd web && npm ci --cache .npm-cache && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "api+web"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "GitHub auto-tracked contribution costs are normalized and capped; web UI shows effective normalized cost with raw-to-normalized traceability.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/v1/contributions",
+      "https://coherence-network-production.up.railway.app/v1/contributions/github",
+      "https://coherence-network.vercel.app/contributions"
+    ],
+    "test_flows": [
+      "github-payload->api-normalizes-cost->stored-cost-bounded",
+      "api-list-contributions->metadata-contains-raw-and-normalized-cost",
+      "web-contributions-page->effective-cost-renders-and-adjustment-visible"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/086-normalize-github-commit-cost-estimation.md
+++ b/specs/086-normalize-github-commit-cost-estimation.md
@@ -1,0 +1,31 @@
+# Spec 086: Normalize GitHub Commit Cost Estimation
+
+## Goal
+Fix inflated per-commit contribution cost values by replacing the high-multiplier estimator with a bounded normalized model and enforcing normalization server-side.
+
+## Requirements
+- [x] GitHub contribution ingestion computes normalized commit cost from metadata (`files_changed`, `lines_added`) with bounded range.
+- [x] Submitted raw cost is retained in metadata for auditability while normalized cost is stored as the effective contribution cost.
+- [x] Auto-track GitHub workflow uses the same normalized estimator model to reduce inflated payload values.
+- [x] Contributions web page displays effective normalized cost and highlights raw-to-normalized adjustment when present.
+- [x] Tests cover estimator behavior and GitHub contribution route normalization.
+
+## Files To Modify (Allowed)
+- `specs/086-normalize-github-commit-cost-estimation.md`
+- `api/app/services/contribution_cost_service.py`
+- `api/app/routers/contributions.py`
+- `api/tests/test_contribution_cost_service.py`
+- `api/tests/test_contributions.py`
+- `.github/workflows/auto_track_contributions.yml`
+- `web/app/contributions/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json`
+
+## Validation
+```bash
+cd api && pytest -q tests/test_contribution_cost_service.py tests/test_contributions.py
+cd web && npm ci --cache .npm-cache && npm run build
+```
+
+## Out of Scope
+- Backfilling historical contribution records already persisted with inflated cost values.
+- Redesigning payout/distribution weighting formulas.


### PR DESCRIPTION
## Summary
- replace inflated commit-cost estimator with normalized bounded v2 model
- enforce normalization in `/v1/contributions/github` so API does not trust inflated submitted cost
- keep raw and normalized values in metadata for traceability
- update contributions web UI to render effective normalized cost and show raw->normalized adjustment
- align auto-track workflow estimator with API model

## Validation
- `cd api && pytest -q tests/test_contribution_cost_service.py tests/test_contributions.py`
- `cd web && npm ci --cache .npm-cache && npm run build`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_normalized-commit-cost-estimator.json`
