### PR TITLE
fix: normalize legacy commit costs in contributions UI

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json
@@ -1,0 +1,75 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/commit-cost-normalization",
+  "commit_scope": "normalize displayed commit costs for legacy contribution rows by deriving effective cost from metadata in web UI",
+  "files_owned": [
+    "web/app/contributions/page.tsx",
+    "specs/087-legacy-commit-cost-ui-normalization.md",
+    "docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json"
+  ],
+  "idea_ids": [
+    "coherence-network-value-attribution",
+    "coherence-network-web-interface"
+  ],
+  "spec_ids": [
+    "087"
+  ],
+  "task_ids": [
+    "legacy-commit-cost-ui-normalization"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json"
+  ],
+  "change_files": [
+    "web/app/contributions/page.tsx",
+    "specs/087-legacy-commit-cost-ui-normalization.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "web"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Contributions page shows normalized effective cost for legacy and new rows, with raw-to-normalized transparency.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/contributions",
+      "https://coherence-network-production.up.railway.app/v1/contributions"
+    ],
+    "test_flows": [
+      "api-legacy-row->web-derived-normalized-cost-display",
+      "api-new-row-with-normalized-metadata->web-normalized-cost-display"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation"
+  }
+}

--- a/specs/087-legacy-commit-cost-ui-normalization.md
+++ b/specs/087-legacy-commit-cost-ui-normalization.md
@@ -1,0 +1,23 @@
+# Spec 087: Legacy Commit Cost UI Normalization
+
+## Goal
+Prevent legacy contribution rows from showing inflated historical cost values by deriving normalized effective cost from available metadata when normalized values are missing.
+
+## Requirements
+- [x] Contributions UI computes normalized effective cost from legacy metadata (`files_changed`, `lines_added`) when `normalized_cost_amount` is absent.
+- [x] UI displays raw-to-normalized adjustment for both current normalized rows and legacy-derived rows.
+- [x] Web build passes with the updated contributions UI.
+
+## Files To Modify (Allowed)
+- `specs/087-legacy-commit-cost-ui-normalization.md`
+- `web/app/contributions/page.tsx`
+- `docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json`
+
+## Validation
+```bash
+cd web && npm run build
+```
+
+## Out of Scope
+- Rewriting historical stored contribution records.
+- Changing API contribution schemas in this follow-up slice.


### PR DESCRIPTION
## Summary
- derive normalized effective cost for legacy contribution rows when `normalized_cost_amount` is missing
- keep raw-to-normalized transparency in UI for both new and legacy records
- add spec 087 + commit evidence for this focused UI correction

## Validation
- `cd web && npm run build`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_legacy-commit-cost-ui-normalization.json`
