### PR TITLE
feat(flow): track spec-process-implementation-validation in API and UI

### DIFF
--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -36,3 +36,14 @@ async def next_highest_roi_task(create_task: bool = Query(False)) -> dict:
 @router.post("/inventory/questions/sync-implementation-tasks")
 async def sync_implementation_request_tasks() -> dict:
     return inventory_service.sync_implementation_request_question_tasks()
+
+
+@router.get("/inventory/flow")
+async def spec_process_implementation_validation_flow(
+    idea_id: str | None = Query(default=None),
+    runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
+) -> dict:
+    return inventory_service.build_spec_process_implementation_validation_flow(
+        idea_id=idea_id,
+        runtime_window_seconds=runtime_window_seconds,
+    )

--- a/api/app/services/page_lineage_service.py
+++ b/api/app/services/page_lineage_service.py
@@ -19,6 +19,7 @@ def _config_path() -> Path:
 FALLBACK_PAGES: list[dict[str, str]] = [
     {"path": "/", "idea_id": "portfolio-governance"},
     {"path": "/portfolio", "idea_id": "portfolio-governance"},
+    {"path": "/flow", "idea_id": "portfolio-governance"},
     {"path": "/ideas", "idea_id": "portfolio-governance"},
     {"path": "/ideas/[idea_id]", "idea_id": "portfolio-governance"},
     {"path": "/specs", "idea_id": "coherence-network-api-runtime"},

--- a/api/app/services/route_registry_service.py
+++ b/api/app/services/route_registry_service.py
@@ -60,6 +60,12 @@ def _default_registry() -> dict:
                 "purpose": "Role-weight payout attribution preview",
                 "idea_id": "portfolio-governance",
             },
+            {
+                "path": "/api/inventory/flow",
+                "methods": ["GET"],
+                "purpose": "Unified idea->spec->process->implementation->validation flow inventory",
+                "idea_id": "portfolio-governance",
+            },
         ],
         "web_routes": [
             {
@@ -76,6 +82,11 @@ def _default_registry() -> dict:
                 "path": "/api/runtime-beacon",
                 "purpose": "Web runtime telemetry forwarder",
                 "idea_id": "oss-interface-alignment",
+            },
+            {
+                "path": "/flow",
+                "purpose": "Human flow visualization for spec-process-implementation-validation tracking",
+                "idea_id": "portfolio-governance",
             },
         ],
     }

--- a/config/canonical_routes.json
+++ b/config/canonical_routes.json
@@ -49,6 +49,12 @@
       "methods": ["POST"],
       "purpose": "Role-weight payout attribution preview",
       "idea_id": "portfolio-governance"
+    },
+    {
+      "path": "/api/inventory/flow",
+      "methods": ["GET"],
+      "purpose": "Unified idea->spec->process->implementation->validation flow inventory",
+      "idea_id": "portfolio-governance"
     }
   ],
   "web_routes": [
@@ -66,7 +72,11 @@
       "path": "/api/runtime-beacon",
       "purpose": "Web runtime telemetry forwarder",
       "idea_id": "oss-interface-alignment"
+    },
+    {
+      "path": "/flow",
+      "purpose": "Human flow visualization for spec-process-implementation-validation tracking",
+      "idea_id": "portfolio-governance"
     }
   ]
 }
-

--- a/config/page_lineage.json
+++ b/config/page_lineage.json
@@ -2,6 +2,7 @@
   "pages": [
     { "path": "/", "idea_id": "portfolio-governance" },
     { "path": "/portfolio", "idea_id": "portfolio-governance" },
+    { "path": "/flow", "idea_id": "portfolio-governance" },
     { "path": "/ideas", "idea_id": "portfolio-governance" },
     { "path": "/ideas/[idea_id]", "idea_id": "portfolio-governance" },
     { "path": "/specs", "idea_id": "coherence-network-api-runtime" },

--- a/docs/system_audit/commit_evidence_2026-02-16_flow-visibility.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_flow-visibility.json
@@ -1,0 +1,111 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/spec-process-flow",
+  "commit_scope": "Add unified spec->process->implementation->validation flow API and UI with contributor/contribution visibility",
+  "files_owned": [
+    "specs/088-spec-process-implementation-validation-flow.md",
+    "api/app/services/inventory_service.py",
+    "api/app/routers/inventory.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/flow/page.tsx",
+    "web/components/site_header.tsx",
+    "web/components/page_context_links.tsx",
+    "config/page_lineage.json",
+    "api/app/services/page_lineage_service.py",
+    "config/canonical_routes.json",
+    "api/app/services/route_registry_service.py",
+    "docs/system_audit/commit_evidence_2026-02-16_flow-visibility.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "coherence-network-web-interface"
+  ],
+  "spec_ids": [
+    "088"
+  ],
+  "task_ids": [
+    "spec-process-implementation-validation-flow"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "spec",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_inventory_api.py",
+    "cd web && npm ci --cache .npm-cache",
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_flow-visibility.json"
+  ],
+  "change_files": [
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/page_lineage_service.py",
+    "api/app/services/route_registry_service.py",
+    "api/tests/test_inventory_api.py",
+    "config/canonical_routes.json",
+    "config/page_lineage.json",
+    "specs/088-spec-process-implementation-validation-flow.md",
+    "web/app/flow/page.tsx",
+    "web/components/page_context_links.tsx",
+    "web/components/site_header.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public API and UI now expose per-idea chain tracking for spec, process, implementation, validation, contributors, and contributions.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/flow",
+      "https://coherence-network-production.up.railway.app/api/inventory/flow"
+    ],
+    "test_flows": [
+      "web:/flow -> inspect idea chain statuses and contributor/contribution sections",
+      "api:/api/inventory/flow -> filter by idea_id and verify spec/process/implementation/validation fields",
+      "web navigation -> reach /flow from global header and context links"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T10:05:27Z",
+    "environment": {
+      "python": "3.14.3",
+      "node": "v25.2.1",
+      "npm": "11.6.2"
+    },
+    "commands": [
+      "cd api && pytest -q tests/test_inventory_api.py",
+      "cd web && npm ci --cache .npm-cache",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "vercel+railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deployment validation"
+  }
+}

--- a/specs/088-spec-process-implementation-validation-flow.md
+++ b/specs/088-spec-process-implementation-validation-flow.md
@@ -1,0 +1,53 @@
+# 088 — Spec-Process-Implementation-Validation Flow Visibility
+
+## Summary
+
+Expose a first-class machine and human view of the tracked delivery chain:
+
+`idea -> spec -> process -> implementation -> validation -> contributors -> contributions`.
+
+The API must aggregate existing evidence and runtime signals; the web UI must render that aggregate so humans can inspect what is tracked versus missing.
+
+## Problem
+
+Current endpoints expose parts of the system independently (`ideas`, `specs`, `value-lineage`, `runtime`, contributor registries), but there is no single contract that shows whether each idea has:
+
+1. Spec tracking
+2. Process tracking
+3. Implementation tracking
+4. Validation tracking
+5. Contributor attribution
+6. Contribution/value evidence
+
+## Requirements
+
+1. Add `GET /api/inventory/flow` under the inventory router.
+2. Support optional `idea_id` filter and runtime window parameter.
+3. Build flow rows per idea by joining:
+   - `ideas` portfolio
+   - `value_lineage` links and usage events
+   - runtime summaries
+   - commit evidence (`docs/system_audit/commit_evidence_*.json`)
+4. Each row must include sections:
+   - `spec`
+   - `process`
+   - `implementation`
+   - `validation`
+   - `contributors`
+   - `contributions`
+   - `chain` statuses
+5. Add a human page `/flow` that renders these sections clearly.
+6. Ensure navigation and page lineage include `/flow`.
+7. Add automated tests for the API contract and page lineage route coverage.
+
+## Non-goals
+
+1. Replacing existing `ideas`, `specs`, `usage`, or contributor endpoints.
+2. Reworking graph-store schemas.
+3. Defining payout policy changes.
+
+## Validation
+
+1. `cd api && pytest -q tests/test_inventory_api.py`
+2. `cd web && npm run build`
+

--- a/web/app/flow/page.tsx
+++ b/web/app/flow/page.tsx
@@ -1,0 +1,253 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+type ValidationCounts = {
+  pass: number;
+  fail: number;
+  pending: number;
+};
+
+type FlowItem = {
+  idea_id: string;
+  idea_name: string;
+  spec: { tracked: boolean; count: number; spec_ids: string[] };
+  process: {
+    tracked: boolean;
+    evidence_count: number;
+    task_ids: string[];
+    thread_branches: string[];
+    change_intents: string[];
+    source_files: string[];
+  };
+  implementation: {
+    tracked: boolean;
+    lineage_link_count: number;
+    implementation_refs: string[];
+    runtime_events_count: number;
+    runtime_total_ms: number;
+    runtime_cost_estimate: number;
+  };
+  validation: {
+    tracked: boolean;
+    local: ValidationCounts;
+    ci: ValidationCounts;
+    deploy: ValidationCounts;
+    e2e: ValidationCounts;
+    phase_gate: { pass_count: number; blocked_count: number };
+    public_endpoints: string[];
+  };
+  contributors: {
+    tracked: boolean;
+    total_unique: number;
+    by_role: Record<string, string[]>;
+  };
+  contributions: {
+    tracked: boolean;
+    usage_events_count: number;
+    measured_value_total: number;
+  };
+  chain: {
+    spec: string;
+    process: string;
+    implementation: string;
+    validation: string;
+    contributors: string;
+    contributions: string;
+  };
+};
+
+type FlowResponse = {
+  summary: {
+    ideas: number;
+    with_spec: number;
+    with_process: number;
+    with_implementation: number;
+    with_validation: number;
+    with_contributors: number;
+    with_contributions: number;
+  };
+  items: FlowItem[];
+};
+
+type Contributor = { id: string; name: string; type: string };
+type Contribution = { id: string; contributor_id: string; asset_id: string; timestamp: string };
+
+async function loadData(): Promise<{
+  flow: FlowResponse;
+  contributors: Contributor[];
+  contributions: Contribution[];
+}> {
+  const API = getApiBase();
+  const [flowRes, contributorsRes, contributionsRes] = await Promise.all([
+    fetch(`${API}/api/inventory/flow?runtime_window_seconds=86400`, { cache: "no-store" }),
+    fetch(`${API}/v1/contributors`, { cache: "no-store" }),
+    fetch(`${API}/v1/contributions`, { cache: "no-store" }),
+  ]);
+  if (!flowRes.ok) throw new Error(`flow HTTP ${flowRes.status}`);
+  if (!contributorsRes.ok) throw new Error(`contributors HTTP ${contributorsRes.status}`);
+  if (!contributionsRes.ok) throw new Error(`contributions HTTP ${contributionsRes.status}`);
+
+  return {
+    flow: (await flowRes.json()) as FlowResponse,
+    contributors: ((await contributorsRes.json()) as Contributor[]).slice(0, 500),
+    contributions: ((await contributionsRes.json()) as Contribution[]).slice(0, 2000),
+  };
+}
+
+function statLabel(value: boolean): string {
+  return value ? "tracked" : "missing";
+}
+
+export default async function FlowPage() {
+  const { flow, contributors, contributions } = await loadData();
+  const contributorsById = new Map(contributors.map((c) => [c.id, c]));
+
+  const topContributors = [...contributions]
+    .reduce<Map<string, number>>((acc, row) => {
+      acc.set(row.contributor_id, (acc.get(row.contributor_id) ?? 0) + 1);
+      return acc;
+    }, new Map())
+    .entries();
+  const topContributorsRows = [...topContributors]
+    .map(([contributorId, count]) => ({
+      contributorId,
+      count,
+      name: contributorsById.get(contributorId)?.name ?? contributorId,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8);
+
+  return (
+    <main className="min-h-screen p-8 max-w-6xl mx-auto space-y-6">
+      <div className="flex flex-wrap gap-3 text-sm">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
+          Portfolio
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
+          Ideas
+        </Link>
+        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
+          Specs
+        </Link>
+        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
+          Usage
+        </Link>
+      </div>
+
+      <h1 className="text-2xl font-bold">Flow</h1>
+      <p className="text-muted-foreground">
+        Unified tracking of <code>idea -&gt; spec -&gt; process -&gt; implementation -&gt; validation</code> with contributor and contribution visibility.
+      </p>
+
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Ideas tracked</p>
+          <p className="text-lg font-semibold">{flow.summary.ideas}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Flow complete (spec+process+impl+validation)</p>
+          <p className="text-lg font-semibold">
+            {flow.items.filter((row) => row.spec.tracked && row.process.tracked && row.implementation.tracked && row.validation.tracked).length}
+          </p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Contributors in registry</p>
+          <p className="text-lg font-semibold">{contributors.length}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Contributions in registry</p>
+          <p className="text-lg font-semibold">{contributions.length}</p>
+        </div>
+      </section>
+
+      <section className="rounded border p-4 space-y-2">
+        <h2 className="font-semibold">Top Contributors by Contribution Count</h2>
+        <ul className="space-y-1 text-sm">
+          {topContributorsRows.map((row) => (
+            <li key={row.contributorId} className="flex justify-between">
+              <span>{row.name}</span>
+              <span className="text-muted-foreground">{row.count}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        {flow.items.map((item) => (
+          <article key={item.idea_id} className="rounded border p-4 space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="font-semibold">{item.idea_name}</h2>
+              <span className="text-xs text-muted-foreground">{item.idea_id}</span>
+            </div>
+
+            <div className="flex flex-wrap gap-2 text-xs">
+              <span className="rounded border px-2 py-1">spec: {item.chain.spec}</span>
+              <span className="rounded border px-2 py-1">process: {item.chain.process}</span>
+              <span className="rounded border px-2 py-1">implementation: {item.chain.implementation}</span>
+              <span className="rounded border px-2 py-1">validation: {item.chain.validation}</span>
+              <span className="rounded border px-2 py-1">contributors: {item.chain.contributors}</span>
+              <span className="rounded border px-2 py-1">contributions: {item.chain.contributions}</span>
+            </div>
+
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-3 text-sm">
+              <div className="rounded border p-3 space-y-1">
+                <p className="font-medium">Spec + Process</p>
+                <p className="text-muted-foreground">
+                  specs {item.spec.count} ({statLabel(item.spec.tracked)}) | evidence {item.process.evidence_count} ({statLabel(item.process.tracked)})
+                </p>
+                <p className="text-muted-foreground">spec_ids {item.spec.spec_ids.slice(0, 8).join(", ") || "-"}</p>
+                <p className="text-muted-foreground">task_ids {item.process.task_ids.slice(0, 8).join(", ") || "-"}</p>
+                <p className="text-muted-foreground">threads {item.process.thread_branches.slice(0, 4).join(", ") || "-"}</p>
+              </div>
+
+              <div className="rounded border p-3 space-y-1">
+                <p className="font-medium">Implementation + Contribution</p>
+                <p className="text-muted-foreground">
+                  lineage_links {item.implementation.lineage_link_count} ({statLabel(item.implementation.tracked)}) | runtime_events {item.implementation.runtime_events_count}
+                </p>
+                <p className="text-muted-foreground">
+                  runtime_ms {item.implementation.runtime_total_ms.toFixed(2)} | runtime_cost {item.implementation.runtime_cost_estimate.toFixed(6)}
+                </p>
+                <p className="text-muted-foreground">
+                  usage_events {item.contributions.usage_events_count} | measured_value {item.contributions.measured_value_total.toFixed(2)}
+                </p>
+              </div>
+
+              <div className="rounded border p-3 space-y-1">
+                <p className="font-medium">Validation</p>
+                <p className="text-muted-foreground">
+                  local pass {item.validation.local.pass} | ci pass {item.validation.ci.pass} | deploy pass {item.validation.deploy.pass} | e2e pass {item.validation.e2e.pass}
+                </p>
+                <p className="text-muted-foreground">
+                  phase_gate pass {item.validation.phase_gate.pass_count} | blocked {item.validation.phase_gate.blocked_count}
+                </p>
+                <p className="text-muted-foreground">public_endpoints {item.validation.public_endpoints.length}</p>
+              </div>
+
+              <div className="rounded border p-3 space-y-1">
+                <p className="font-medium">Contributors</p>
+                <p className="text-muted-foreground">
+                  unique {item.contributors.total_unique} ({statLabel(item.contributors.tracked)})
+                </p>
+                <ul className="space-y-1 text-muted-foreground">
+                  {Object.entries(item.contributors.by_role)
+                    .slice(0, 8)
+                    .map(([role, ids]) => (
+                      <li key={role}>
+                        {role}: {ids.slice(0, 5).join(", ") || "-"}
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}
+

--- a/web/components/page_context_links.tsx
+++ b/web/components/page_context_links.tsx
@@ -18,6 +18,7 @@ type ContextDef = {
 
 const SHARED_RELATED: LinkItem[] = [
   { href: "/portfolio", label: "Portfolio" },
+  { href: "/flow", label: "Flow" },
   { href: "/ideas", label: "Ideas" },
   { href: "/specs", label: "Specs" },
   { href: "/usage", label: "Usage" },
@@ -45,6 +46,16 @@ const CONTEXTS: Record<string, ContextDef> = {
       { href: "/api/inventory/system-lineage", label: "System lineage" },
       { href: "/api/inventory/page-lineage", label: "Page lineage" },
       { href: "/api/ideas", label: "Ideas API" },
+    ],
+  },
+  "/flow": {
+    ideaId: "portfolio-governance",
+    related: SHARED_RELATED,
+    machinePaths: [
+      { href: "/api/inventory/flow", label: "Flow inventory" },
+      { href: "/api/inventory/system-lineage", label: "System lineage" },
+      { href: "/v1/contributors", label: "Contributors API" },
+      { href: "/v1/contributions", label: "Contributions API" },
     ],
   },
   "/ideas": {

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -7,6 +7,7 @@ import { getApiBase } from "@/lib/api";
 const NAV = [
   { href: "/search", label: "Search" },
   { href: "/portfolio", label: "Portfolio" },
+  { href: "/flow", label: "Flow" },
   { href: "/ideas", label: "Ideas" },
   { href: "/specs", label: "Specs" },
   { href: "/usage", label: "Usage" },


### PR DESCRIPTION
## Summary
- add `GET /api/inventory/flow` to expose per-idea `spec -> process -> implementation -> validation` tracking
- aggregate flow data from idea portfolio, value lineage links/events, runtime summaries, and commit evidence files
- add `/flow` page to visualize chain status, validation state, contributors, and contributions for humans
- wire `/flow` into header navigation, context links, page-lineage mapping, and canonical routes
- add spec `088` and API tests for flow contract coverage

## Validation
- `cd api && pytest -q tests/test_inventory_api.py`
- `cd web && npm ci --cache .npm-cache`
- `cd web && npm run build`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
