### PR TITLE
fix: make endpoint traceability audit work in production runtime

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-16",
   "thread_branch": "codex/endpoint-traceability",
-  "commit_scope": "Add endpoint-level traceability inventory for idea/spec/process/validation coverage, expose it in gates UI, and handle deployed source-layout fallback",
+  "commit_scope": "Add endpoint-level traceability inventory for idea/spec/process/validation coverage, expose it in gates UI, and make discovery robust in deployed packaged layouts via runtime route introspection",
   "files_owned": [
     "api/app/routers/inventory.py",
     "api/app/services/inventory_service.py",
@@ -80,7 +80,7 @@
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-16T10:37:06Z",
+    "ran_at": "2026-02-16T10:45:12Z",
     "environment": {
       "python": "3.14.3",
       "node": "v25.2.1",


### PR DESCRIPTION
## Summary
- fix production endpoint-traceability report returning `total_endpoints=0`
- switch endpoint discovery to runtime FastAPI route introspection first
- keep source parsing fallback for non-runtime contexts
- normalize source-file aliases so commit evidence maps across `api/app/...` and `app/...`

## Validation
- `cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_release_gate_service.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json`
