### PR TITLE
fix: enable production evidence fallback for endpoint traceability

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
@@ -8,6 +8,7 @@
     "api/app/services/release_gate_service.py",
     "api/app/services/route_registry_service.py",
     "api/tests/test_inventory_api.py",
+    "api/tests/test_inventory_discovery_sources.py",
     "api/tests/test_release_gate_service.py",
     "config/canonical_routes.json",
     "web/app/gates/page.tsx",
@@ -49,6 +50,7 @@
   },
   "evidence_refs": [
     "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_ideas.py tests/test_gates.py tests/test_release_gate_service.py",
+    "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_release_gate_service.py",
     "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_release_gate_service.py",
     "cd web && npm run build",
     "cd api && .venv/bin/python -c \"from app.services import inventory_service; print(inventory_service.build_endpoint_traceability_inventory()['summary'])\"",
@@ -60,6 +62,7 @@
     "api/app/services/release_gate_service.py",
     "api/app/services/route_registry_service.py",
     "api/tests/test_inventory_api.py",
+    "api/tests/test_inventory_discovery_sources.py",
     "api/tests/test_release_gate_service.py",
     "config/canonical_routes.json",
     "web/app/gates/page.tsx",
@@ -80,7 +83,7 @@
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-16T10:45:12Z",
+    "ran_at": "2026-02-16T10:51:19Z",
     "environment": {
       "python": "3.14.3",
       "node": "v25.2.1",
@@ -88,6 +91,7 @@
     },
     "commands": [
       "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_ideas.py tests/test_gates.py tests/test_release_gate_service.py",
+      "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_release_gate_service.py",
       "cd web && npm run build"
     ]
   },


### PR DESCRIPTION
## Summary
- add GitHub fallback for commit evidence discovery in inventory service when local `docs/system_audit` is unavailable
- cache discovered evidence payloads to avoid repeated remote fetches
- add regression test for remote evidence fallback

## Why
Production deployment currently had endpoint traceability summary with `with_spec=0` and `with_process=0` because local evidence files were not present in runtime package.

## Validation
- `cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_release_gate_service.py`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
