### PR TITLE
fix: avoid GitHub rate-limit collapse in evidence fallback

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-16",
   "thread_branch": "codex/endpoint-traceability",
-  "commit_scope": "Add endpoint-level traceability inventory for idea/spec/process/validation coverage, expose it in gates UI, and make discovery robust in deployed packaged layouts via runtime route introspection",
+  "commit_scope": "Add endpoint-level traceability inventory for idea/spec/process/validation coverage, expose it in gates UI, and make deployed discovery robust via runtime introspection plus rate-safe GitHub evidence fallback",
   "files_owned": [
     "api/app/routers/inventory.py",
     "api/app/services/inventory_service.py",
@@ -52,6 +52,7 @@
     "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_ideas.py tests/test_gates.py tests/test_release_gate_service.py",
     "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_release_gate_service.py",
     "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_release_gate_service.py",
+    "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
     "cd web && npm run build",
     "cd api && .venv/bin/python -c \"from app.services import inventory_service; print(inventory_service.build_endpoint_traceability_inventory()['summary'])\"",
     "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-coverage.json"
@@ -83,7 +84,7 @@
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-16T10:51:19Z",
+    "ran_at": "2026-02-16T10:57:29Z",
     "environment": {
       "python": "3.14.3",
       "node": "v25.2.1",
@@ -92,6 +93,7 @@
     "commands": [
       "cd api && .venv/bin/pytest -q tests/test_inventory_api.py tests/test_ideas.py tests/test_gates.py tests/test_release_gate_service.py",
       "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_release_gate_service.py",
+      "cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
       "cd web && npm run build"
     ]
   },


### PR DESCRIPTION
Rebased replacement for #93.

## Summary
- cap remote commit-evidence downloads when GitHub token is unavailable (20 files)
- keep higher cap with token
- sort evidence files newest-first before fetch
- add regression test to enforce unauthenticated cap behavior

## Validation
- `cd api && .venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
