### PR TITLE
fix(inventory): tolerate malformed remote evidence payloads

### DIFF
--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -518,12 +518,15 @@ def _read_commit_evidence_records(limit: int = 400) -> list[dict[str, Any]]:
                     payload_resp = client.get(download_url)
                     if payload_resp.status_code != 200:
                         continue
-                    payload = payload_resp.json()
+                    try:
+                        payload = payload_resp.json()
+                    except ValueError:
+                        continue
                     if not isinstance(payload, dict):
                         continue
                     payload["_evidence_file"] = str(row.get("path") or row.get("name") or "github")
                     remote_out.append(payload)
-    except (httpx.HTTPError, ValueError, TypeError):
+    except (httpx.HTTPError, TypeError):
         remote_out = []
 
     _EVIDENCE_DISCOVERY_CACHE["items"] = remote_out

--- a/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/evidence-parse-guard",
+  "commit_scope": "Harden remote commit-evidence discovery by skipping malformed GitHub JSON payloads per file instead of dropping the full evidence batch",
+  "files_owned": [
+    "api/app/services/inventory_service.py",
+    "docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "089"
+  ],
+  "task_ids": [
+    "endpoint-traceability-coverage"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && .venv/bin/python -m pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
+    "cd api && .venv/bin/python -c \"from app.services.inventory_service import build_endpoint_traceability_inventory; print(build_endpoint_traceability_inventory()['summary'])\"",
+    "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+  ],
+  "change_files": [
+    "api/app/services/inventory_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public endpoint traceability inventory no longer collapses coverage counts to zero when one remote evidence payload is malformed.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/endpoint-traceability"
+    ],
+    "test_flows": [
+      "api:/api/inventory/endpoint-traceability -> confirm with_spec and with_process are non-zero"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T11:06:06Z",
+    "environment": {
+      "python": "3.14.3"
+    },
+    "commands": [
+      "cd api && .venv/bin/python -m pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deployment verification"
+  }
+}


### PR DESCRIPTION
## Summary
- skip malformed JSON per remote evidence file instead of dropping all evidence discovery
- keep endpoint traceability inventory resilient under mixed-quality GitHub evidence responses
- add commit evidence artifact for this runtime fix

## Validation
- cd api && .venv/bin/python -m pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence