### PR TITLE
fix(inventory): map deployed app/app source paths to evidence

### DIFF
--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -618,6 +618,13 @@ def _extract_decorated_routes(module_path: Path, decorator_owner: str) -> list[t
 
 def _source_path_aliases(file_path: str) -> set[str]:
     value = str(file_path or "").replace("\\", "/").strip().lstrip("/")
+    # Deployed runtime stacks can resolve modules under duplicated segments (e.g. app/app/routers/*).
+    while value.startswith("api/app/app/"):
+        value = value.replace("api/app/app/", "api/app/", 1)
+    while value.startswith("app/app/"):
+        value = value.replace("app/app/", "app/", 1)
+    value = value.replace("/api/app/app/", "/api/app/")
+    value = value.replace("/app/app/", "/app/")
     if not value:
         return set()
     out = {value}

--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -181,3 +181,10 @@ def test_inventory_limits_remote_commit_evidence_fetch_without_token(
 
     assert len(records) == 20
     assert fake_client.download_calls == 20
+
+
+def test_source_aliases_normalize_deployed_double_app_prefix() -> None:
+    aliases = inventory_service._source_path_aliases("/app/app/routers/inventory.py")
+
+    assert "app/routers/inventory.py" in aliases
+    assert "api/app/routers/inventory.py" in aliases

--- a/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json
@@ -1,9 +1,10 @@
 {
   "date": "2026-02-16",
   "thread_branch": "codex/evidence-parse-guard",
-  "commit_scope": "Harden remote commit-evidence discovery by skipping malformed GitHub JSON payloads per file instead of dropping the full evidence batch",
+  "commit_scope": "Normalize deployed app/app source-path aliases and harden remote commit-evidence parsing so endpoint traceability maps evidence/spec/process data in production",
   "files_owned": [
     "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
     "docs/system_audit/commit_evidence_2026-02-16_endpoint-traceability-parse-guard.json"
   ],
   "idea_ids": [
@@ -43,12 +44,13 @@
     "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
   ],
   "change_files": [
-    "api/app/services/inventory_service.py"
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py"
   ],
   "change_intent": "runtime_fix",
   "e2e_validation": {
     "status": "pending",
-    "expected_behavior_delta": "Public endpoint traceability inventory no longer collapses coverage counts to zero when one remote evidence payload is malformed.",
+    "expected_behavior_delta": "Public endpoint traceability inventory maps commit evidence to deployed route source files and no longer collapses spec/process coverage to zero.",
     "public_endpoints": [
       "https://coherence-network-production.up.railway.app/api/inventory/endpoint-traceability"
     ],
@@ -58,7 +60,7 @@
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-16T11:06:06Z",
+    "ran_at": "2026-02-16T11:09:58Z",
     "environment": {
       "python": "3.14.3"
     },


### PR DESCRIPTION
## Summary
- normalize duplicated deployed source path prefixes (, ) in endpoint traceability alias mapping
- keep commit evidence matching functional for production runtime filename layouts
- add regression test for deployed double-prefix aliasing and update commit evidence record

## Validation
- cd api && .venv/bin/python -m pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence