### PR TITLE
feat(monitor): add maintainability architecture regression gate

### DIFF
--- a/.github/workflows/maintainability-architecture-audit.yml
+++ b/.github/workflows/maintainability-architecture-audit.yml
@@ -1,0 +1,129 @@
+name: Maintainability Architecture Audit
+
+on:
+  schedule:
+    - cron: "0 11 * * 1,4"
+  workflow_dispatch:
+
+jobs:
+  audit-maintainability:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Run maintainability audit
+        id: audit
+        run: |
+          set +e
+          python api/scripts/run_maintainability_audit.py \
+            --json \
+            --output maintainability_audit_report.json \
+            --fail-on-regression \
+            --fail-on-blocking
+          code=$?
+          cat maintainability_audit_report.json
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload maintainability audit report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: maintainability_audit_report_${{ github.sha }}
+          path: maintainability_audit_report.json
+
+      - name: Create or update maintainability drift issue
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('maintainability_audit_report.json', 'utf8'));
+            const summary = report.summary || {};
+            const tasks = Array.isArray(report.recommended_tasks) ? report.recommended_tasks : [];
+            const title = 'Maintainability architecture drift detected';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'Automated maintainability audit detected blocking drift/regression.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              `- Severity: ${summary.severity || 'unknown'}`,
+              `- Risk score: ${summary.risk_score ?? 'n/a'}`,
+              `- Regression: ${summary.regression ? 'yes' : 'no'}`,
+              '',
+              'Counts:',
+              `- layer_violations: ${summary.layer_violation_count ?? 0}`,
+              `- large_modules: ${summary.large_module_count ?? 0}`,
+              `- very_large_modules: ${summary.very_large_module_count ?? 0}`,
+              `- long_functions: ${summary.long_function_count ?? 0}`,
+              `- placeholders: ${summary.placeholder_count ?? 0}`,
+              '',
+              'Recommended high-ROI tasks:',
+              ...(tasks.length
+                ? tasks.slice(0, 3).map((t) =>
+                    `- \`${t.task_id}\` (roi=${t.roi_estimate}, cost_h=${t.estimated_cost_hours}, value=${t.value_to_whole}): ${t.direction}`
+                  )
+                : ['- (none)']),
+              '',
+              'Raw report:',
+              '```json',
+              JSON.stringify(report, null, 2).slice(0, 6000),
+              '```',
+            ].join('\n');
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data.items[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
+
+      - name: Resolve maintainability drift issue when audit passes
+        if: ${{ steps.audit.outputs.exit_code == '0' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = 'Maintainability architecture drift detected';
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length === 0) {
+              return;
+            }
+            const issue = existing.data.items[0];
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Resolved by workflow run ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}. Maintainability audit is passing.`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+            });
+
+      - name: Fail when maintainability gate fails
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        run: |
+          echo "Maintainability architecture audit failed"
+          exit 1

--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -58,6 +58,13 @@ jobs:
         run: |
           python3 scripts/check_runtime_drift.py
 
+      - name: Check maintainability regression baseline
+        run: |
+          python3 api/scripts/run_maintainability_audit.py \
+            --output maintainability_audit_report.json \
+            --fail-on-regression
+          cat maintainability_audit_report.json
+
       - name: Run API tests
         run: |
           cd api && pytest -q

--- a/api/app/services/maintainability_audit_service.py
+++ b/api/app/services/maintainability_audit_service.py
@@ -1,0 +1,420 @@
+"""Maintainability audit service: architecture drift + runtime placeholder debt."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_POLICY: dict[str, int] = {
+    "large_module_lines": 600,
+    "very_large_module_lines": 1000,
+    "long_function_lines": 90,
+    "warning_risk_score": 40,
+    "blocking_risk_score": 90,
+}
+
+BASELINE_KEYS: tuple[str, ...] = (
+    "max_layer_violation_count",
+    "max_large_module_count",
+    "max_very_large_module_count",
+    "max_long_function_count",
+    "max_placeholder_count",
+    "max_risk_score",
+)
+
+PLACEHOLDER_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("todo_fixme", re.compile(r"(#|//)\s*(TODO|FIXME|XXX)\b", re.IGNORECASE)),
+    (
+        "fake_marker_constant",
+        re.compile(r"\b(MOCK|FAKE|DUMMY|STUB)_?[A-Z0-9_]*\b"),
+    ),
+    (
+        "literal_fake_data",
+        re.compile(r"""=\s*['"][^'"]*\b(fake|mock|dummy|stub|placeholder)\b[^'"]*['"]""", re.IGNORECASE),
+    ),
+    (
+        "return_fake_data",
+        re.compile(r"""return\s+.*['"][^'"]*\b(fake|mock|dummy|stub|placeholder)\b[^'"]*['"]""", re.IGNORECASE),
+    ),
+)
+
+RUNTIME_SCAN_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".jsx"}
+RUNTIME_SCAN_DIRS = ("api/app", "web/app", "web/components")
+IGNORED_PATH_PARTS = {"tests", "__tests__", "node_modules", ".next", "dist", "build", ".git"}
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _safe_read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _iter_runtime_files(project_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for rel in RUNTIME_SCAN_DIRS:
+        base = project_root / rel
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file() or path.suffix.lower() not in RUNTIME_SCAN_SUFFIXES:
+                continue
+            if any(part in IGNORED_PATH_PARTS for part in path.parts):
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _python_app_files(project_root: Path) -> list[Path]:
+    base = project_root / "api" / "app"
+    if not base.exists():
+        return []
+    return sorted(path for path in base.rglob("*.py") if path.is_file())
+
+
+def _module_layer(relative_path: str) -> str:
+    value = relative_path.replace("\\", "/")
+    if "/routers/" in value:
+        return "routers"
+    if "/services/" in value:
+        return "services"
+    if "/models/" in value:
+        return "models"
+    if "/adapters/" in value:
+        return "adapters"
+    return "other"
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if isinstance(alias.name, str) and alias.name.strip():
+                    out.append(alias.name.strip())
+        elif isinstance(node, ast.ImportFrom):
+            if isinstance(node.module, str) and node.module.strip():
+                out.append(node.module.strip())
+    return out
+
+
+def _scan_architecture(project_root: Path, policy: dict[str, int]) -> dict[str, Any]:
+    files = _python_app_files(project_root)
+    large_threshold = int(policy["large_module_lines"])
+    very_large_threshold = int(policy["very_large_module_lines"])
+    long_fn_threshold = int(policy["long_function_lines"])
+
+    layer_violations: list[dict[str, Any]] = []
+    large_modules: list[dict[str, Any]] = []
+    very_large_modules: list[dict[str, Any]] = []
+    long_functions: list[dict[str, Any]] = []
+    parse_errors: list[str] = []
+
+    for path in files:
+        rel = str(path.relative_to(project_root)).replace("\\", "/")
+        layer = _module_layer(rel)
+        source = _safe_read_text(path)
+        if not source:
+            continue
+        lines = source.splitlines()
+        line_count = len(lines)
+        if line_count >= large_threshold:
+            large_modules.append({"file": rel, "line_count": line_count})
+        if line_count >= very_large_threshold:
+            very_large_modules.append({"file": rel, "line_count": line_count})
+
+        try:
+            tree = ast.parse(source, filename=rel)
+        except SyntaxError:
+            parse_errors.append(rel)
+            continue
+
+        for module in _imported_modules(tree):
+            if layer == "models" and module.startswith(("app.services", "app.routers")):
+                layer_violations.append(
+                    {
+                        "file": rel,
+                        "layer": layer,
+                        "forbidden_import": module,
+                        "reason": "models should not depend on services/routers",
+                    }
+                )
+            elif layer == "services" and module.startswith("app.routers"):
+                layer_violations.append(
+                    {
+                        "file": rel,
+                        "layer": layer,
+                        "forbidden_import": module,
+                        "reason": "services should not depend on routers",
+                    }
+                )
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.end_lineno is None:
+                continue
+            span = int(node.end_lineno) - int(node.lineno) + 1
+            if span < long_fn_threshold:
+                continue
+            long_functions.append(
+                {
+                    "file": rel,
+                    "function": node.name,
+                    "line_count": span,
+                    "line_start": int(node.lineno),
+                }
+            )
+
+    large_modules.sort(key=lambda row: (int(row["line_count"]), row["file"]), reverse=True)
+    very_large_modules.sort(key=lambda row: (int(row["line_count"]), row["file"]), reverse=True)
+    long_functions.sort(key=lambda row: (int(row["line_count"]), row["file"]), reverse=True)
+
+    return {
+        "python_module_count": len(files),
+        "layer_violations": layer_violations,
+        "large_modules": large_modules,
+        "very_large_modules": very_large_modules,
+        "long_functions": long_functions,
+        "parse_errors": parse_errors,
+    }
+
+
+def _should_ignore_placeholder_line(path: Path, line: str) -> bool:
+    text = line.strip()
+    if not text:
+        return True
+    # UI placeholder attributes are UX text, not fake runtime payload.
+    if path.suffix.lower() in {".tsx", ".jsx"} and "placeholder=" in text.lower():
+        return True
+    if "placeholder:text-" in text.lower():
+        return True
+    if "command templates" in text.lower() and "placeholder" in text.lower():
+        return True
+    # Regex pattern declarations are scanner internals, not runtime placeholders.
+    if "re.compile(" in text:
+        return True
+    return False
+
+
+def _scan_runtime_placeholders(project_root: Path) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    scanned_files = _iter_runtime_files(project_root)
+
+    for path in scanned_files:
+        rel = str(path.relative_to(project_root)).replace("\\", "/")
+        source = _safe_read_text(path)
+        if not source:
+            continue
+        for idx, line in enumerate(source.splitlines(), start=1):
+            if _should_ignore_placeholder_line(path, line):
+                continue
+            for finding_type, pattern in PLACEHOLDER_PATTERNS:
+                if not pattern.search(line):
+                    continue
+                findings.append(
+                    {
+                        "file": rel,
+                        "line": idx,
+                        "type": finding_type,
+                        "snippet": line.strip()[:220],
+                    }
+                )
+                break
+
+    findings.sort(key=lambda row: (row["file"], int(row["line"]), row["type"]))
+    return {
+        "scanned_file_count": len(scanned_files),
+        "findings": findings,
+    }
+
+
+def evaluate_regression_against_baseline(summary: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    if not baseline:
+        return {"regression": False, "reasons": []}
+
+    expected = {
+        "max_layer_violation_count": int(summary.get("layer_violation_count", 0)),
+        "max_large_module_count": int(summary.get("large_module_count", 0)),
+        "max_very_large_module_count": int(summary.get("very_large_module_count", 0)),
+        "max_long_function_count": int(summary.get("long_function_count", 0)),
+        "max_placeholder_count": int(summary.get("placeholder_count", 0)),
+        "max_risk_score": int(summary.get("risk_score", 0)),
+    }
+
+    reasons: list[str] = []
+    for key, actual in expected.items():
+        limit = int(baseline.get(key, actual))
+        if actual > limit:
+            reasons.append(f"{key}: {actual} > baseline {limit}")
+
+    return {"regression": len(reasons) > 0, "reasons": reasons}
+
+
+def _severity_for_score(risk_score: int, policy: dict[str, int]) -> str:
+    if risk_score >= int(policy["blocking_risk_score"]):
+        return "high"
+    if risk_score >= int(policy["warning_risk_score"]):
+        return "medium"
+    return "low"
+
+
+def _task_roi(value_to_whole: float, estimated_cost_hours: float) -> float:
+    if estimated_cost_hours <= 0:
+        return 0.0
+    return round(float(value_to_whole) / float(estimated_cost_hours), 4)
+
+
+def _recommended_tasks(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    tasks: list[dict[str, Any]] = []
+    layer_violations = int(summary.get("layer_violation_count", 0))
+    large_modules = int(summary.get("large_module_count", 0))
+    very_large_modules = int(summary.get("very_large_module_count", 0))
+    long_functions = int(summary.get("long_function_count", 0))
+    placeholders = int(summary.get("placeholder_count", 0))
+    risk_score = int(summary.get("risk_score", 0))
+
+    if layer_violations > 0 or large_modules > 0 or very_large_modules > 0 or long_functions > 0:
+        estimated_cost = round(
+            1.5
+            + (layer_violations * 2.0)
+            + (very_large_modules * 1.25)
+            + (large_modules * 0.75)
+            + (long_functions * 0.1),
+            2,
+        )
+        value = round(min(100.0, 18.0 + risk_score * 0.85), 2)
+        tasks.append(
+            {
+                "task_id": "architecture-modularization-review",
+                "title": "Architecture modularization review",
+                "direction": (
+                    "Refactor high-risk modules and remove cross-layer dependencies. "
+                    "Split oversized files and long functions, then re-run maintainability audit."
+                ),
+                "estimated_cost_hours": estimated_cost,
+                "value_to_whole": value,
+                "roi_estimate": _task_roi(value, estimated_cost),
+                "priority": "high" if risk_score >= 90 else "medium",
+            }
+        )
+
+    if placeholders > 0:
+        estimated_cost = round(1.0 + placeholders * 0.4, 2)
+        value = round(min(100.0, 12.0 + placeholders * 8.0), 2)
+        tasks.append(
+            {
+                "task_id": "runtime-placeholder-elimination",
+                "title": "Runtime placeholder elimination",
+                "direction": (
+                    "Replace runtime mock/fake/placeholder markers with production-grade logic or tracked backlog tasks."
+                ),
+                "estimated_cost_hours": estimated_cost,
+                "value_to_whole": value,
+                "roi_estimate": _task_roi(value, estimated_cost),
+                "priority": "high",
+            }
+        )
+
+    tasks.sort(key=lambda row: float(row.get("roi_estimate", 0.0)), reverse=True)
+    return tasks
+
+
+def build_maintainability_audit(
+    *,
+    project_root: Path | None = None,
+    baseline: dict[str, Any] | None = None,
+    policy: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    root = project_root or _project_root()
+    merged_policy = dict(DEFAULT_POLICY)
+    if policy:
+        merged_policy.update({k: int(v) for k, v in policy.items() if k in merged_policy})
+
+    architecture = _scan_architecture(root, merged_policy)
+    placeholders = _scan_runtime_placeholders(root)
+
+    layer_violation_count = len(architecture["layer_violations"])
+    large_module_count = len(architecture["large_modules"])
+    very_large_module_count = len(architecture["very_large_modules"])
+    long_function_count = len(architecture["long_functions"])
+    placeholder_count = len(placeholders["findings"])
+
+    risk_score = (
+        layer_violation_count * 25
+        + very_large_module_count * 15
+        + large_module_count * 8
+        + long_function_count * 2
+        + placeholder_count * 10
+    )
+    severity = _severity_for_score(risk_score, merged_policy)
+    regression = evaluate_regression_against_baseline(
+        summary={
+            "layer_violation_count": layer_violation_count,
+            "large_module_count": large_module_count,
+            "very_large_module_count": very_large_module_count,
+            "long_function_count": long_function_count,
+            "placeholder_count": placeholder_count,
+            "risk_score": risk_score,
+        },
+        baseline=baseline or {},
+    )
+
+    summary = {
+        "python_module_count": int(architecture["python_module_count"]),
+        "runtime_file_count": int(placeholders["scanned_file_count"]),
+        "layer_violation_count": layer_violation_count,
+        "large_module_count": large_module_count,
+        "very_large_module_count": very_large_module_count,
+        "long_function_count": long_function_count,
+        "placeholder_count": placeholder_count,
+        "risk_score": int(risk_score),
+        "severity": severity,
+        "blocking_gap": severity == "high",
+        "regression": bool(regression["regression"]),
+        "regression_reasons": regression["reasons"],
+    }
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "policy": merged_policy,
+        "baseline": baseline or {},
+        "summary": summary,
+        "architecture": architecture,
+        "placeholder_scan": placeholders,
+        "recommended_tasks": _recommended_tasks(summary),
+    }
+
+
+def baseline_from_summary(summary: dict[str, Any]) -> dict[str, int]:
+    return {
+        "max_layer_violation_count": int(summary.get("layer_violation_count", 0)),
+        "max_large_module_count": int(summary.get("large_module_count", 0)),
+        "max_very_large_module_count": int(summary.get("very_large_module_count", 0)),
+        "max_long_function_count": int(summary.get("long_function_count", 0)),
+        "max_placeholder_count": int(summary.get("placeholder_count", 0)),
+        "max_risk_score": int(summary.get("risk_score", 0)),
+    }
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in BASELINE_KEYS:
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            out[key] = int(value)
+    return out

--- a/api/scripts/run_maintainability_audit.py
+++ b/api/scripts/run_maintainability_audit.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Run maintainability audit (architecture drift + runtime placeholder debt)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_api_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_api_dir))
+os.chdir(str(_api_dir.parent))
+
+from app.services import maintainability_audit_service
+
+
+def _default_baseline_path() -> Path:
+    return _api_dir.parent / "docs" / "system_audit" / "maintainability_baseline.json"
+
+
+def _print_human_summary(report: dict) -> None:
+    summary = report.get("summary", {})
+    print("Maintainability Audit")
+    print("====================")
+    print(f"severity: {summary.get('severity', 'unknown')}")
+    print(f"risk_score: {summary.get('risk_score', 0)}")
+    print(
+        "counts: "
+        f"layer_violations={summary.get('layer_violation_count', 0)}, "
+        f"large_modules={summary.get('large_module_count', 0)}, "
+        f"very_large_modules={summary.get('very_large_module_count', 0)}, "
+        f"long_functions={summary.get('long_function_count', 0)}, "
+        f"placeholders={summary.get('placeholder_count', 0)}"
+    )
+    if summary.get("regression"):
+        print("regression: yes")
+        for reason in summary.get("regression_reasons", []):
+            print(f"  - {reason}")
+    else:
+        print("regression: no")
+
+    tasks = report.get("recommended_tasks") or []
+    if tasks:
+        print("recommended_tasks:")
+        for task in tasks[:3]:
+            print(
+                f"  - {task.get('task_id')}: roi={task.get('roi_estimate')} "
+                f"cost_h={task.get('estimated_cost_hours')} value={task.get('value_to_whole')}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run maintainability architecture + placeholder audit")
+    parser.add_argument("--json", action="store_true", help="Print full JSON report")
+    parser.add_argument("--output", type=str, default="", help="Write full report JSON to path")
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default=str(_default_baseline_path()),
+        help="Baseline JSON path for regression check",
+    )
+    parser.add_argument("--write-baseline", action="store_true", help="Write baseline file from current report")
+    parser.add_argument("--fail-on-regression", action="store_true", help="Exit 1 when regression vs baseline is detected")
+    parser.add_argument("--fail-on-blocking", action="store_true", help="Exit 1 when severity is high")
+    args = parser.parse_args()
+
+    baseline_path = Path(args.baseline)
+    baseline = maintainability_audit_service.load_baseline(baseline_path)
+
+    report = maintainability_audit_service.build_maintainability_audit(baseline=baseline)
+    summary = report.get("summary", {})
+
+    if args.write_baseline:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = maintainability_audit_service.baseline_from_summary(summary)
+        baseline_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human_summary(report)
+
+    if args.fail_on_regression and bool(summary.get("regression")):
+        return 1
+    if args.fail_on_blocking and bool(summary.get("blocking_gap")):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/tests/test_maintainability_audit_service.py
+++ b/api/tests/test_maintainability_audit_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services import maintainability_audit_service
+
+
+def test_audit_detects_layer_violations_and_runtime_placeholders(tmp_path: Path) -> None:
+    (tmp_path / "api" / "app" / "services").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "api" / "app" / "models").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "web" / "app").mkdir(parents=True, exist_ok=True)
+
+    (tmp_path / "api" / "app" / "services" / "bad_service.py").write_text(
+        "from app.routers import agent\n\n\ndef run() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "api" / "app" / "models" / "bad_model.py").write_text(
+        "from app.services import idea_service\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "web" / "app" / "page.tsx").write_text(
+        "export default function Page(){ const value='fake runtime data'; return <div>{value}</div> }\n",
+        encoding="utf-8",
+    )
+
+    report = maintainability_audit_service.build_maintainability_audit(
+        project_root=tmp_path,
+        policy={
+            "large_module_lines": 200,
+            "very_large_module_lines": 400,
+            "long_function_lines": 80,
+            "warning_risk_score": 10,
+            "blocking_risk_score": 20,
+        },
+    )
+
+    summary = report["summary"]
+    assert summary["layer_violation_count"] == 2
+    assert summary["placeholder_count"] == 1
+    assert summary["risk_score"] > 0
+    assert summary["severity"] in {"medium", "high"}
+    assert report["recommended_tasks"]
+
+
+def test_audit_ignores_ui_placeholder_attributes(tmp_path: Path) -> None:
+    (tmp_path / "web" / "components").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "web" / "components" / "search.tsx").write_text(
+        'export function Search(){ return <input placeholder="Search projects..." /> }\n',
+        encoding="utf-8",
+    )
+
+    report = maintainability_audit_service.build_maintainability_audit(project_root=tmp_path)
+    assert report["summary"]["placeholder_count"] == 0
+
+
+def test_audit_detects_regressions_against_baseline(tmp_path: Path) -> None:
+    (tmp_path / "api" / "app" / "services").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "api" / "app" / "services" / "risk.py").write_text(
+        "from app.routers import inventory\n",
+        encoding="utf-8",
+    )
+
+    report = maintainability_audit_service.build_maintainability_audit(project_root=tmp_path)
+    summary = report["summary"]
+    regression = maintainability_audit_service.evaluate_regression_against_baseline(
+        summary=summary,
+        baseline={
+            "max_layer_violation_count": 0,
+            "max_large_module_count": 0,
+            "max_very_large_module_count": 0,
+            "max_long_function_count": 0,
+            "max_placeholder_count": 0,
+            "max_risk_score": 0,
+        },
+    )
+
+    assert regression["regression"] is True
+    assert regression["reasons"]

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -19,6 +19,7 @@ Quick reference: spec status, test coverage, last verified.
 | 054 | ✓ | ✓ | ✓ |
 | 055 | ✓ | ✓ | ✓ |
 | 056 | ✓ | ✓ | ✓ |
+| 090 | ✓ | ✓ | ✓ |
 
 **Total:** 34 tracked specs implemented and covered (001–025 excluding 006, 015, plus 048–056).
 
@@ -57,6 +58,7 @@ cd web && npm run build      # 11 routes
 | 054 | scripts/validate_commit_evidence.py (CLI validation), workflow gates |
 | 055 | test_commit_evidence_validation.py, scripts/validate_commit_evidence.py |
 | 056 | test_release_gate_service.py, test_gates.py |
+| 090 | test_maintainability_audit_service.py, workflow gates |
 
 ## Last Updated
 

--- a/docs/system_audit/commit_evidence_2026-02-16_maintainability-architecture-gate.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_maintainability-architecture-gate.json
@@ -1,0 +1,106 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/maintainability-architecture-gate",
+  "commit_scope": "Add scheduled maintainability architecture audit with regression gating, monitor integration, and runtime placeholder debt detection",
+  "files_owned": [
+    ".github/workflows/maintainability-architecture-audit.yml",
+    ".github/workflows/thread-gates.yml",
+    "api/app/services/maintainability_audit_service.py",
+    "api/scripts/monitor_pipeline.py",
+    "api/scripts/run_maintainability_audit.py",
+    "api/tests/test_maintainability_audit_service.py",
+    "docs/PIPELINE-MONITORING-AUTOMATED.md",
+    "docs/SPEC-TRACKING.md",
+    "docs/system_audit/maintainability_baseline.json",
+    "specs/090-maintainability-architecture-and-placeholder-gate.md",
+    "docs/system_audit/commit_evidence_2026-02-16_maintainability-architecture-gate.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "090"
+  ],
+  "task_ids": [
+    "maintainability-architecture-gate"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "spec",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && .venv/bin/python -m pytest -q tests/test_maintainability_audit_service.py tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
+    "python3 api/scripts/run_maintainability_audit.py --output /tmp/maintainability_audit_report.json --fail-on-regression",
+    "AGENT_API_BASE=http://127.0.0.1:9999 python3 api/scripts/monitor_pipeline.py --once",
+    "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+  ],
+  "change_files": [
+    ".github/workflows/maintainability-architecture-audit.yml",
+    ".github/workflows/thread-gates.yml",
+    "api/app/services/maintainability_audit_service.py",
+    "api/scripts/monitor_pipeline.py",
+    "api/scripts/run_maintainability_audit.py",
+    "api/tests/test_maintainability_audit_service.py",
+    "docs/PIPELINE-MONITORING-AUTOMATED.md",
+    "docs/SPEC-TRACKING.md",
+    "docs/system_audit/maintainability_baseline.json",
+    "specs/090-maintainability-architecture-and-placeholder-gate.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "System now runs scheduled architecture/placeholder audits, detects regression against baseline, and surfaces maintainability drift as monitor issues with high-ROI remediation tasks.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/monitor-issues",
+      "https://coherence-network-production.up.railway.app/api/agent/effectiveness"
+    ],
+    "test_flows": [
+      "api: monitor_pipeline -> maintainability audit report -> monitor issues include architecture_maintainability_drift/runtime_placeholder_debt when thresholds regress",
+      "ci: thread-gates fails when maintainability metrics regress against docs/system_audit/maintainability_baseline.json"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T11:23:30Z",
+    "environment": {
+      "python": "3.14.3"
+    },
+    "commands": [
+      "cd api && .venv/bin/python -m pytest -q tests/test_maintainability_audit_service.py tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
+      "python3 api/scripts/run_maintainability_audit.py --output /tmp/maintainability_audit_report.json --fail-on-regression",
+      "AGENT_API_BASE=http://127.0.0.1:9999 python3 api/scripts/monitor_pipeline.py --once"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-actions+railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deployment validation"
+  }
+}

--- a/docs/system_audit/maintainability_baseline.json
+++ b/docs/system_audit/maintainability_baseline.json
@@ -1,0 +1,8 @@
+{
+  "max_layer_violation_count": 0,
+  "max_large_module_count": 2,
+  "max_very_large_module_count": 2,
+  "max_long_function_count": 8,
+  "max_placeholder_count": 1,
+  "max_risk_score": 72
+}

--- a/specs/090-maintainability-architecture-and-placeholder-gate.md
+++ b/specs/090-maintainability-architecture-and-placeholder-gate.md
@@ -1,0 +1,19 @@
+# Spec 090: Maintainability Architecture and Placeholder Gate
+
+## Goal
+
+Add a recurring maintainability review that scans architecture quality from top-level to module-level and detects runtime mock/fake/placeholder debt before it compounds.
+
+## Requirements
+
+1. Provide a machine-readable maintainability audit report with architecture metrics (layer violations, large modules, long functions) and runtime placeholder findings.
+2. Include ROI-oriented recommended cleanup tasks in the report so remediation can be prioritized.
+3. Add a scheduled GitHub workflow that runs the audit at least twice per week and opens/updates an issue when drift becomes blocking or regresses against baseline.
+4. Add a PR gate that fails when maintainability metrics regress beyond baseline.
+5. Integrate audit into pipeline monitoring so conditions are visible in `/api/agent/monitor-issues`, and auto-fix can create a high-ROI heal task when configured.
+
+## Validation
+
+- `api/tests/test_maintainability_audit_service.py`
+- `python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
+- Workflow: `.github/workflows/maintainability-architecture-audit.yml`


### PR DESCRIPTION
## Summary
- add a maintainability audit service that scans architecture drift (layer violations, oversized modules, long functions) and runtime placeholder/mock debt
- add `api/scripts/run_maintainability_audit.py` with baseline regression checks and ROI-scored remediation tasks
- add monitor integration to run this audit every 12h and raise monitor issues (`architecture_maintainability_drift`, `runtime_placeholder_debt`) with auto-fix heal-task creation when enabled
- add scheduled workflow `.github/workflows/maintainability-architecture-audit.yml`
- add PR gate in `thread-gates.yml` that fails on maintainability regression against `docs/system_audit/maintainability_baseline.json`

## Why
- enforce recurring architecture reviews before debt compounds
- detect and contain mock/fake/placeholder runtime artifacts early
- prioritize cleanup via explicit ROI and monitor conditions

## Validation
- `cd api && .venv/bin/python -m pytest -q tests/test_maintainability_audit_service.py tests/test_inventory_discovery_sources.py tests/test_inventory_api.py`
- `python3 api/scripts/run_maintainability_audit.py --fail-on-regression --fail-on-blocking`
- `AGENT_API_BASE=http://127.0.0.1:9999 python3 api/scripts/monitor_pipeline.py --once`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
