### PR TITLE
feat(web): enforce full concept cross-linking across specs and flow

### DIFF
--- a/api/tests/test_inventory_api.py
+++ b/api/tests/test_inventory_api.py
@@ -168,6 +168,7 @@ async def test_page_lineage_inventory_endpoint_returns_page_to_idea_mapping() ->
             "/ideas",
             "/ideas/[idea_id]",
             "/specs",
+            "/specs/[spec_id]",
             "/usage",
             "/contribute",
             "/friction",

--- a/config/canonical_routes.json
+++ b/config/canonical_routes.json
@@ -130,6 +130,11 @@
       "path": "/contribute",
       "purpose": "Human contributor onboarding and review console",
       "idea_id": "portfolio-governance"
+    },
+    {
+      "path": "/specs/[spec_id]",
+      "purpose": "Human spec detail with explicit links to idea, contributors, process, and implementation",
+      "idea_id": "coherence-network-api-runtime"
     }
   ]
 }

--- a/config/page_lineage.json
+++ b/config/page_lineage.json
@@ -6,6 +6,7 @@
     { "path": "/ideas", "idea_id": "portfolio-governance" },
     { "path": "/ideas/[idea_id]", "idea_id": "portfolio-governance" },
     { "path": "/specs", "idea_id": "coherence-network-api-runtime" },
+    { "path": "/specs/[spec_id]", "idea_id": "coherence-network-api-runtime" },
     { "path": "/usage", "idea_id": "coherence-network-value-attribution" },
     { "path": "/contribute", "idea_id": "portfolio-governance" },
     { "path": "/friction", "idea_id": "coherence-network-agent-pipeline" },

--- a/docs/system_audit/commit_evidence_2026-02-16_spec-link-ontology-completeness.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_spec-link-ontology-completeness.json
@@ -1,0 +1,105 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/spec-link-ontology",
+  "commit_scope": "Close cross-linkage gaps so spec, idea, contributor, process, and implementation views all link to related concepts without silent dead-ends",
+  "files_owned": [
+    "api/tests/test_inventory_api.py",
+    "config/canonical_routes.json",
+    "config/page_lineage.json",
+    "docs/system_audit/commit_evidence_2026-02-16_spec-link-ontology-completeness.json",
+    "web/app/contributors/page.tsx",
+    "web/app/flow/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/specs/page.tsx",
+    "web/app/specs/[spec_id]/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/components/page_context_links.tsx"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "coherence-network-api-runtime",
+    "coherence-network-web-interface"
+  ],
+  "spec_ids": [
+    "094"
+  ],
+  "task_ids": [
+    "spec-link-ontology-completeness"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_inventory_api.py",
+    "cd web && npm run build",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_spec-link-ontology-completeness.json"
+  ],
+  "change_files": [
+    "api/tests/test_inventory_api.py",
+    "config/canonical_routes.json",
+    "config/page_lineage.json",
+    "web/app/contributors/page.tsx",
+    "web/app/flow/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/specs/page.tsx",
+    "web/app/specs/[spec_id]/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/components/page_context_links.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Humans can navigate from any spec/idea/contributor/process/implementation surface to all directly related components with explicit links and missing-link fallback paths.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/specs",
+      "https://coherence-network.vercel.app/specs/094",
+      "https://coherence-network.vercel.app/ideas/portfolio-governance",
+      "https://coherence-network.vercel.app/flow?spec_id=094",
+      "https://coherence-network.vercel.app/contributors",
+      "https://coherence-network-production.up.railway.app/api/inventory/flow"
+    ],
+    "test_flows": [
+      "web: open /specs and navigate to /specs/{spec_id}, then follow idea/contributor/process/implementation links",
+      "web: open /ideas/{idea_id} and follow spec/process/implementation/contributor links",
+      "web: open /contributors and follow linked idea/spec/process/implementation paths",
+      "api: inspect /api/inventory/flow to verify process and implementation references are present for linked entities"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T12:40:00Z",
+    "environment": {
+      "node": "v25.2.1",
+      "npm": "11.6.2"
+    },
+    "commands": [
+      "cd api && pytest -q tests/test_inventory_api.py",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "vercel+railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deployment validation"
+  }
+}

--- a/web/app/specs/[spec_id]/page.tsx
+++ b/web/app/specs/[spec_id]/page.tsx
@@ -1,0 +1,386 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+const REPO_BLOB_MAIN = "https://github.com/seeker71/Coherence-Network/blob/main";
+const REPO_TREE = "https://github.com/seeker71/Coherence-Network/tree";
+
+type SpecItem = {
+  spec_id: string;
+  title: string;
+  path: string;
+};
+
+type InventoryResponse = {
+  specs?: {
+    source?: string;
+    items?: SpecItem[];
+  };
+};
+
+type SpecRegistryEntry = {
+  spec_id: string;
+  title: string;
+  summary: string;
+  idea_id?: string | null;
+  process_summary?: string | null;
+  pseudocode_summary?: string | null;
+  implementation_summary?: string | null;
+  created_by_contributor_id?: string | null;
+  updated_by_contributor_id?: string | null;
+  updated_at: string;
+};
+
+type FlowItem = {
+  idea_id: string;
+  idea_name: string;
+  spec: { spec_ids: string[] };
+  process: {
+    task_ids: string[];
+    thread_branches: string[];
+    evidence_refs: string[];
+    source_files: string[];
+  };
+  implementation: {
+    lineage_ids: string[];
+    implementation_refs: string[];
+  };
+  validation: {
+    public_endpoints: string[];
+  };
+  contributors: {
+    all: string[];
+    by_role: Record<string, string[]>;
+  };
+};
+
+type FlowResponse = {
+  items: FlowItem[];
+};
+
+function toRepoHref(pathOrUrl: string): string {
+  if (/^https?:\/\//.test(pathOrUrl)) return pathOrUrl;
+  return `${REPO_BLOB_MAIN}/${pathOrUrl.replace(/^\/+/, "")}`;
+}
+
+function toBranchHref(branch: string): string {
+  return `${REPO_TREE}/${encodeURIComponent(branch)}`;
+}
+
+async function loadSpecContext(specId: string): Promise<{
+  source: string;
+  inventoryItem: SpecItem | null;
+  registryItem: SpecRegistryEntry | null;
+  relatedFlow: FlowItem[];
+}> {
+  const API = getApiBase();
+  const [inventoryRes, registryRes, flowRes] = await Promise.all([
+    fetch(`${API}/api/inventory/system-lineage?runtime_window_seconds=86400`, { cache: "no-store" }),
+    fetch(`${API}/api/spec-registry`, { cache: "no-store" }),
+    fetch(`${API}/api/inventory/flow?runtime_window_seconds=86400`, { cache: "no-store" }),
+  ]);
+  if (!inventoryRes.ok || !registryRes.ok || !flowRes.ok) {
+    throw new Error(`HTTP ${inventoryRes.status}/${registryRes.status}/${flowRes.status}`);
+  }
+
+  const inventoryJson = (await inventoryRes.json()) as InventoryResponse;
+  const registryJson = (await registryRes.json()) as SpecRegistryEntry[];
+  const flowJson = (await flowRes.json()) as FlowResponse;
+
+  const inventoryItems = inventoryJson.specs?.items ?? [];
+  const inventoryItem = inventoryItems.find((item) => item.spec_id === specId) ?? null;
+  const registryItem = (Array.isArray(registryJson) ? registryJson : []).find((item) => item.spec_id === specId) ?? null;
+  const relatedFlow = (Array.isArray(flowJson?.items) ? flowJson.items : []).filter((item) => item.spec.spec_ids.includes(specId));
+
+  return {
+    source: inventoryJson.specs?.source ?? "unknown",
+    inventoryItem,
+    registryItem,
+    relatedFlow,
+  };
+}
+
+export default async function SpecDetailPage({ params }: { params: Promise<{ spec_id: string }> }) {
+  const resolved = await params;
+  const specId = decodeURIComponent(resolved.spec_id);
+  const apiBase = getApiBase();
+  const { source, inventoryItem, registryItem, relatedFlow } = await loadSpecContext(specId);
+
+  const ideaIds = new Set<string>();
+  const contributorByRole = new Map<string, Set<string>>();
+  const taskIds = new Set<string>();
+  const threadBranches = new Set<string>();
+  const sourceFiles = new Set<string>();
+  const evidenceRefs = new Set<string>();
+  const implementationRefs = new Set<string>();
+  const lineageIds = new Set<string>();
+  const publicEndpoints = new Set<string>();
+
+  if (registryItem?.idea_id) ideaIds.add(registryItem.idea_id);
+  for (const flow of relatedFlow) {
+    ideaIds.add(flow.idea_id);
+    for (const taskId of flow.process.task_ids) taskIds.add(taskId);
+    for (const branch of flow.process.thread_branches) threadBranches.add(branch);
+    for (const sourceFile of flow.process.source_files) sourceFiles.add(sourceFile);
+    for (const evidenceRef of flow.process.evidence_refs) evidenceRefs.add(evidenceRef);
+    for (const implementationRef of flow.implementation.implementation_refs) implementationRefs.add(implementationRef);
+    for (const lineageId of flow.implementation.lineage_ids) lineageIds.add(lineageId);
+    for (const endpoint of flow.validation.public_endpoints) publicEndpoints.add(endpoint);
+    for (const [role, contributorIds] of Object.entries(flow.contributors.by_role)) {
+      if (!contributorByRole.has(role)) contributorByRole.set(role, new Set<string>());
+      const bucket = contributorByRole.get(role);
+      if (!bucket) continue;
+      for (const contributorId of contributorIds) bucket.add(contributorId);
+    }
+  }
+  if (registryItem?.created_by_contributor_id) {
+    if (!contributorByRole.has("spec_created_by")) contributorByRole.set("spec_created_by", new Set<string>());
+    contributorByRole.get("spec_created_by")?.add(registryItem.created_by_contributor_id);
+  }
+  if (registryItem?.updated_by_contributor_id) {
+    if (!contributorByRole.has("spec_updated_by")) contributorByRole.set("spec_updated_by", new Set<string>());
+    contributorByRole.get("spec_updated_by")?.add(registryItem.updated_by_contributor_id);
+  }
+
+  const allContributors = [...new Set([...contributorByRole.values()].flatMap((ids) => [...ids]))].sort();
+
+  return (
+    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+      <div className="flex flex-wrap gap-3 text-sm">
+        <Link href="/" className="text-muted-foreground hover:text-foreground">
+          ← Home
+        </Link>
+        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
+          Specs
+        </Link>
+        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
+          Ideas
+        </Link>
+        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
+          Contributors
+        </Link>
+        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
+          Flow
+        </Link>
+        <Link href="/contribute" className="text-muted-foreground hover:text-foreground">
+          Contribute
+        </Link>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold">Spec {specId}</h1>
+        <p className="text-muted-foreground">{registryItem?.title || inventoryItem?.title || "(title not yet registered)"}</p>
+      </div>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Spec Source</h2>
+        <p className="text-muted-foreground">
+          inventory_source {source} | inventory_path {inventoryItem?.path || "-"} | registry_updated {registryItem?.updated_at || "-"}
+        </p>
+        {inventoryItem?.path ? (
+          <p>
+            <a href={toRepoHref(inventoryItem.path)} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+              Open spec file
+            </a>
+          </p>
+        ) : (
+          <p className="text-muted-foreground">
+            Spec file path missing.{" "}
+            <Link href="/contribute" className="underline hover:text-foreground">
+              Add/update registry metadata
+            </Link>
+            .
+          </p>
+        )}
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Linked Ideas</h2>
+        {[...ideaIds].sort().length > 0 ? (
+          <ul className="space-y-1">
+            {[...ideaIds].sort().map((ideaId) => (
+              <li key={ideaId}>
+                <Link href={`/ideas/${encodeURIComponent(ideaId)}`} className="underline hover:text-foreground">
+                  {ideaId}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground">
+            Missing idea linkage.{" "}
+            <Link href="/contribute" className="underline hover:text-foreground">
+              Add idea_id to this spec
+            </Link>
+            .
+          </p>
+        )}
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Linked Contributors</h2>
+        {allContributors.length > 0 ? (
+          <ul className="space-y-1">
+            {[...contributorByRole.entries()]
+              .sort((a, b) => a[0].localeCompare(b[0]))
+              .map(([role, ids]) => (
+                <li key={role}>
+                  {role}:{" "}
+                  {[...ids].sort().map((contributorId, idx) => (
+                    <span key={`${role}-${contributorId}`}>
+                      {idx > 0 ? ", " : ""}
+                      <Link
+                        href={`/contributors?contributor_id=${encodeURIComponent(contributorId)}`}
+                        className="underline hover:text-foreground"
+                      >
+                        {contributorId}
+                      </Link>
+                    </span>
+                  ))}
+                </li>
+              ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground">
+            Missing contributor linkage.{" "}
+            <Link href="/contribute" className="underline hover:text-foreground">
+              Submit a change request with contributor attribution
+            </Link>
+            .
+          </p>
+        )}
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Linked Process</h2>
+        <p>
+          <Link href={`/flow?spec_id=${encodeURIComponent(specId)}`} className="underline hover:text-foreground">
+            Open process view for this spec
+          </Link>
+        </p>
+        <p className="text-muted-foreground">
+          task_ids{" "}
+          {[...taskIds].sort().length > 0
+            ? [...taskIds].sort().map((taskId, idx) => (
+                <span key={taskId}>
+                  {idx > 0 ? ", " : ""}
+                  <Link href={`/tasks?task_id=${encodeURIComponent(taskId)}`} className="underline hover:text-foreground">
+                    {taskId}
+                  </Link>
+                </span>
+              ))
+            : "-"}
+        </p>
+        <p className="text-muted-foreground">
+          branches{" "}
+          {[...threadBranches].sort().length > 0
+            ? [...threadBranches].sort().map((branch, idx) => (
+                <span key={branch}>
+                  {idx > 0 ? ", " : ""}
+                  <a href={toBranchHref(branch)} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+                    {branch}
+                  </a>
+                </span>
+              ))
+            : "-"}
+        </p>
+        <p className="text-muted-foreground">
+          source_files{" "}
+          {[...sourceFiles].sort().length > 0
+            ? [...sourceFiles].sort().slice(0, 8).map((filePath, idx) => (
+                <span key={filePath}>
+                  {idx > 0 ? ", " : ""}
+                  <a href={toRepoHref(filePath)} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+                    {filePath}
+                  </a>
+                </span>
+              ))
+            : "-"}
+        </p>
+        <p className="text-muted-foreground">evidence_refs {[...evidenceRefs].sort().slice(0, 5).join(" | ") || "-"}</p>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Linked Implementation</h2>
+        <p>
+          <Link href={`/flow?spec_id=${encodeURIComponent(specId)}`} className="underline hover:text-foreground">
+            Open implementation view for this spec
+          </Link>
+        </p>
+        <p className="text-muted-foreground">
+          implementation_refs{" "}
+          {[...implementationRefs].sort().length > 0
+            ? [...implementationRefs].sort().slice(0, 8).map((ref, idx) => (
+                <span key={ref}>
+                  {idx > 0 ? ", " : ""}
+                  <a href={toRepoHref(ref)} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+                    {ref}
+                  </a>
+                </span>
+              ))
+            : "-"}
+        </p>
+        <p className="text-muted-foreground">
+          lineage_ids{" "}
+          {[...lineageIds].sort().length > 0
+            ? [...lineageIds].sort().slice(0, 8).map((lineageId, idx) => (
+                <span key={lineageId}>
+                  {idx > 0 ? ", " : ""}
+                  <a
+                    href={`${apiBase}/api/value-lineage/links/${encodeURIComponent(lineageId)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
+                  >
+                    {lineageId}
+                  </a>
+                </span>
+              ))
+            : "-"}
+        </p>
+        <p className="text-muted-foreground">
+          public_endpoints{" "}
+          {[...publicEndpoints].sort().length > 0
+            ? [...publicEndpoints].sort().slice(0, 6).map((endpoint, idx) => (
+                <span key={endpoint}>
+                  {idx > 0 ? ", " : ""}
+                  <a href={endpoint} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+                    {endpoint}
+                  </a>
+                </span>
+              ))
+            : "-"}
+        </p>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">Spec Summary + Process + Pseudocode + Implementation Notes</h2>
+        <p className="text-muted-foreground">summary {registryItem?.summary || "-"}</p>
+        <p className="text-muted-foreground">process_summary {registryItem?.process_summary || "-"}</p>
+        <p className="text-muted-foreground">pseudocode_summary {registryItem?.pseudocode_summary || "-"}</p>
+        <p className="text-muted-foreground">implementation_summary {registryItem?.implementation_summary || "-"}</p>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <h2 className="font-semibold">API Links</h2>
+        <ul className="space-y-1 text-muted-foreground">
+          <li>
+            <a href={`${apiBase}/api/spec-registry/${encodeURIComponent(specId)}`} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+              /api/spec-registry/{specId}
+            </a>
+          </li>
+          <li>
+            <a href={`${apiBase}/api/inventory/flow?runtime_window_seconds=86400`} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+              /api/inventory/flow
+            </a>
+          </li>
+          <li>
+            <a href={`${apiBase}/api/inventory/system-lineage?runtime_window_seconds=86400`} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
+              /api/inventory/system-lineage
+            </a>
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/app/specs/page.tsx
+++ b/web/app/specs/page.tsx
@@ -20,29 +20,93 @@ type SpecRegistryEntry = {
   title: string;
   summary: string;
   idea_id?: string | null;
+  process_summary?: string | null;
+  pseudocode_summary?: string | null;
+  implementation_summary?: string | null;
   created_by_contributor_id?: string | null;
   updated_by_contributor_id?: string | null;
   updated_at: string;
 };
 
-async function loadSpecs(): Promise<{ source: string; items: SpecItem[]; registry: SpecRegistryEntry[] }> {
+type FlowItem = {
+  idea_id: string;
+  spec: { spec_ids: string[] };
+  process: { task_ids: string[] };
+  implementation: { implementation_refs: string[] };
+  contributors: { all: string[] };
+};
+
+type FlowResponse = {
+  items: FlowItem[];
+};
+
+type SpecRelations = {
+  ideaIds: Set<string>;
+  contributorIds: Set<string>;
+  taskIds: Set<string>;
+  implementationRefs: Set<string>;
+};
+
+type SpecsSearchParams = Promise<{
+  spec_id?: string | string[];
+}>;
+
+function normalizeFilter(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return (value[0] || "").trim();
+  return (value || "").trim();
+}
+
+function collectSpecRelations(flowItems: FlowItem[]): Map<string, SpecRelations> {
+  const map = new Map<string, SpecRelations>();
+  for (const item of flowItems) {
+    for (const specId of item.spec.spec_ids) {
+      if (!map.has(specId)) {
+        map.set(specId, {
+          ideaIds: new Set<string>(),
+          contributorIds: new Set<string>(),
+          taskIds: new Set<string>(),
+          implementationRefs: new Set<string>(),
+        });
+      }
+      const rel = map.get(specId);
+      if (!rel) continue;
+      rel.ideaIds.add(item.idea_id);
+      for (const contributorId of item.contributors.all) rel.contributorIds.add(contributorId);
+      for (const taskId of item.process.task_ids) rel.taskIds.add(taskId);
+      for (const ref of item.implementation.implementation_refs) rel.implementationRefs.add(ref);
+    }
+  }
+  return map;
+}
+
+async function loadSpecs(): Promise<{ source: string; items: SpecItem[]; registry: SpecRegistryEntry[]; flowItems: FlowItem[] }> {
   const API = getApiBase();
-  const [inventoryRes, registryRes] = await Promise.all([
+  const [inventoryRes, registryRes, flowRes] = await Promise.all([
     fetch(`${API}/api/inventory/system-lineage?runtime_window_seconds=86400`, { cache: "no-store" }),
     fetch(`${API}/api/spec-registry`, { cache: "no-store" }),
+    fetch(`${API}/api/inventory/flow?runtime_window_seconds=86400`, { cache: "no-store" }),
   ]);
-  if (!inventoryRes.ok || !registryRes.ok) throw new Error(`HTTP ${inventoryRes.status}/${registryRes.status}`);
+  if (!inventoryRes.ok || !registryRes.ok || !flowRes.ok) {
+    throw new Error(`HTTP ${inventoryRes.status}/${registryRes.status}/${flowRes.status}`);
+  }
   const json = (await inventoryRes.json()) as InventoryResponse;
   const registryJson = (await registryRes.json()) as SpecRegistryEntry[];
+  const flowJson = (await flowRes.json()) as FlowResponse;
   return {
     source: json.specs?.source ?? "unknown",
     items: (json.specs?.items ?? []).filter((s) => Boolean(s?.spec_id)),
     registry: Array.isArray(registryJson) ? registryJson : [],
+    flowItems: Array.isArray(flowJson?.items) ? flowJson.items : [],
   };
 }
 
-export default async function SpecsPage() {
-  const { source, items: specs, registry } = await loadSpecs();
+export default async function SpecsPage({ searchParams }: { searchParams: SpecsSearchParams }) {
+  const resolvedSearchParams = await searchParams;
+  const specFilter = normalizeFilter(resolvedSearchParams.spec_id);
+  const { source, items: specs, registry, flowItems } = await loadSpecs();
+  const relationsBySpec = collectSpecRelations(flowItems);
+  const filteredSpecs = specFilter ? specs.filter((s) => s.spec_id === specFilter) : specs;
+  const filteredRegistry = specFilter ? registry.filter((s) => s.spec_id === specFilter) : registry;
 
   return (
     <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
@@ -84,48 +148,157 @@ export default async function SpecsPage() {
 
       <h1 className="text-2xl font-bold">Specs</h1>
       <p className="text-muted-foreground">
-        Human interface for specs discovered via `GET /api/inventory/system-lineage` plus contributor-authored registry via `GET /api/spec-registry`.
+        Spec index with direct links to idea, contributor, process, and implementation relations.
       </p>
+      {specFilter ? (
+        <p className="text-sm text-muted-foreground">
+          Filter spec <code>{specFilter}</code> |{" "}
+          <Link href="/specs" className="underline hover:text-foreground">
+            Clear filter
+          </Link>
+        </p>
+      ) : null}
 
       <section className="rounded border p-4 space-y-3">
         <p className="text-sm text-muted-foreground">
-          Total: {specs.length} | source: {source}
+          Total discovered specs: {filteredSpecs.length} | source: {source}
         </p>
         <ul className="space-y-2 text-sm">
-          {specs.map((s) => (
-            <li key={s.spec_id} className="rounded border p-3">
-              <div className="flex justify-between gap-3">
-                <span className="font-medium">Spec {s.spec_id}</span>
-                <span className="text-muted-foreground">{s.path}</span>
-              </div>
-              <p>{s.title}</p>
-            </li>
-          ))}
+          {filteredSpecs.map((s) => {
+            const relations = relationsBySpec.get(s.spec_id);
+            const ideaIds = relations ? [...relations.ideaIds].sort() : [];
+            const contributorIds = relations ? [...relations.contributorIds].sort() : [];
+            return (
+              <li key={s.spec_id} className="rounded border p-3 space-y-1">
+                <div className="flex justify-between gap-3">
+                  <Link href={`/specs/${encodeURIComponent(s.spec_id)}`} className="font-medium underline hover:text-foreground">
+                    Spec {s.spec_id}
+                  </Link>
+                  <span className="text-muted-foreground">{s.path}</span>
+                </div>
+                <p>{s.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  idea{" "}
+                  {ideaIds.length > 0
+                    ? ideaIds.map((ideaId, idx) => (
+                        <span key={`${s.spec_id}-idea-${ideaId}`}>
+                          {idx > 0 ? ", " : ""}
+                          <Link href={`/ideas/${encodeURIComponent(ideaId)}`} className="underline hover:text-foreground">
+                            {ideaId}
+                          </Link>
+                        </span>
+                      ))
+                    : (
+                      <Link href="/ideas" className="underline hover:text-foreground">
+                        missing
+                      </Link>
+                    )}{" "}
+                  | contributors{" "}
+                  {contributorIds.length > 0
+                    ? contributorIds.slice(0, 6).map((contributorId, idx) => (
+                        <span key={`${s.spec_id}-contributor-${contributorId}`}>
+                          {idx > 0 ? ", " : ""}
+                          <Link
+                            href={`/contributors?contributor_id=${encodeURIComponent(contributorId)}`}
+                            className="underline hover:text-foreground"
+                          >
+                            {contributorId}
+                          </Link>
+                        </span>
+                      ))
+                    : (
+                      <Link href="/contributors" className="underline hover:text-foreground">
+                        missing
+                      </Link>
+                    )}{" "}
+                  |{" "}
+                  <Link href={`/flow?spec_id=${encodeURIComponent(s.spec_id)}`} className="underline hover:text-foreground">
+                    process
+                  </Link>{" "}
+                  |{" "}
+                  <Link href={`/flow?spec_id=${encodeURIComponent(s.spec_id)}`} className="underline hover:text-foreground">
+                    implementation
+                  </Link>
+                </p>
+              </li>
+            );
+          })}
+          {filteredSpecs.length === 0 && <li className="text-muted-foreground">No discovered specs match current filter.</li>}
         </ul>
       </section>
 
       <section className="rounded border p-4 space-y-3">
         <p className="text-sm text-muted-foreground">
-          Registry specs: {registry.length} | create/update via{" "}
-          <Link href="/contribute" className="underline hover:text-foreground">Contribution Console</Link>
+          Registry specs: {filteredRegistry.length} | create/update via{" "}
+          <Link href="/contribute" className="underline hover:text-foreground">
+            Contribution Console
+          </Link>
         </p>
         <ul className="space-y-2 text-sm">
-          {registry.map((s) => (
-            <li key={s.spec_id} className="rounded border p-3">
+          {filteredRegistry.map((s) => (
+            <li key={s.spec_id} className="rounded border p-3 space-y-1">
               <div className="flex justify-between gap-3">
-                <span className="font-medium">Spec {s.spec_id}</span>
+                <Link href={`/specs/${encodeURIComponent(s.spec_id)}`} className="font-medium underline hover:text-foreground">
+                  Spec {s.spec_id}
+                </Link>
                 <span className="text-muted-foreground">updated {s.updated_at}</span>
               </div>
               <p>{s.title}</p>
               <p className="text-muted-foreground">{s.summary}</p>
               <p className="text-xs text-muted-foreground">
-                idea {s.idea_id || "-"} | created_by {s.created_by_contributor_id || "-"} | updated_by{" "}
-                {s.updated_by_contributor_id || "-"}
+                idea{" "}
+                {s.idea_id ? (
+                  <Link href={`/ideas/${encodeURIComponent(s.idea_id)}`} className="underline hover:text-foreground">
+                    {s.idea_id}
+                  </Link>
+                ) : (
+                  <Link href="/ideas" className="underline hover:text-foreground">
+                    missing
+                  </Link>
+                )}{" "}
+                | created_by{" "}
+                {s.created_by_contributor_id ? (
+                  <Link
+                    href={`/contributors?contributor_id=${encodeURIComponent(s.created_by_contributor_id)}`}
+                    className="underline hover:text-foreground"
+                  >
+                    {s.created_by_contributor_id}
+                  </Link>
+                ) : (
+                  <Link href="/contributors" className="underline hover:text-foreground">
+                    missing
+                  </Link>
+                )}{" "}
+                | updated_by{" "}
+                {s.updated_by_contributor_id ? (
+                  <Link
+                    href={`/contributors?contributor_id=${encodeURIComponent(s.updated_by_contributor_id)}`}
+                    className="underline hover:text-foreground"
+                  >
+                    {s.updated_by_contributor_id}
+                  </Link>
+                ) : (
+                  <Link href="/contributors" className="underline hover:text-foreground">
+                    missing
+                  </Link>
+                )}{" "}
+                |{" "}
+                <Link href={`/flow?spec_id=${encodeURIComponent(s.spec_id)}`} className="underline hover:text-foreground">
+                  process
+                </Link>{" "}
+                |{" "}
+                <Link href={`/flow?spec_id=${encodeURIComponent(s.spec_id)}`} className="underline hover:text-foreground">
+                  implementation
+                </Link>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                process_summary {s.process_summary || "-"} | pseudocode_summary {s.pseudocode_summary || "-"} | implementation_summary{" "}
+                {s.implementation_summary || "-"}
               </p>
             </li>
           ))}
-          {registry.length === 0 && (
-            <li className="text-muted-foreground">No contributor-authored registry specs yet.</li>
+          {filteredRegistry.length === 0 && (
+            <li className="text-muted-foreground">No contributor-authored registry specs match current filter.</li>
           )}
         </ul>
       </section>

--- a/web/app/tasks/page.tsx
+++ b/web/app/tasks/page.tsx
@@ -25,6 +25,7 @@ function TasksPageContent() {
 
   const statusFilter = useMemo(() => (searchParams.get("status") || "").trim(), [searchParams]);
   const typeFilter = useMemo(() => (searchParams.get("task_type") || "").trim(), [searchParams]);
+  const taskIdFilter = useMemo(() => (searchParams.get("task_id") || "").trim(), [searchParams]);
 
   const loadRows = useCallback(async () => {
     setStatus((prev) => (prev === "ok" ? "ok" : "loading"));
@@ -47,9 +48,10 @@ function TasksPageContent() {
     return rows.filter((row) => {
       if (statusFilter && row.status !== statusFilter) return false;
       if (typeFilter && row.task_type !== typeFilter) return false;
+      if (taskIdFilter && row.id !== taskIdFilter) return false;
       return true;
     });
-  }, [rows, statusFilter, typeFilter]);
+  }, [rows, statusFilter, typeFilter, taskIdFilter]);
 
   return (
     <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
@@ -85,6 +87,12 @@ function TasksPageContent() {
             task type <code>{typeFilter}</code>.
           </>
         ) : null}
+        {taskIdFilter ? (
+          <>
+            {" "}
+            task id <code>{taskIdFilter}</code>.
+          </>
+        ) : null}
       </p>
 
       {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
@@ -94,7 +102,7 @@ function TasksPageContent() {
         <section className="rounded border p-4 space-y-3">
           <p className="text-sm text-muted-foreground">
             Total: {filteredRows.length}
-            {(statusFilter || typeFilter) ? (
+            {(statusFilter || typeFilter || taskIdFilter) ? (
               <>
                 {" "}
                 | <Link href="/tasks" className="underline hover:text-foreground">Clear filters</Link>
@@ -105,7 +113,11 @@ function TasksPageContent() {
             {filteredRows.slice(0, 50).map((t) => (
               <li key={t.id} className="rounded border p-2 space-y-1">
                 <div className="flex justify-between gap-3">
-                  <span className="font-medium">{t.id}</span>
+                  <span className="font-medium">
+                    <Link href={`/tasks?task_id=${encodeURIComponent(t.id)}`} className="underline hover:text-foreground">
+                      {t.id}
+                    </Link>
+                  </span>
                   <span className="text-muted-foreground text-right">
                     <Link
                       href={`/tasks?task_type=${encodeURIComponent(t.task_type)}`}

--- a/web/components/page_context_links.tsx
+++ b/web/components/page_context_links.tsx
@@ -87,6 +87,15 @@ const CONTEXTS: Record<string, ContextDef> = {
       { href: "/api/inventory/routes/canonical", label: "Canonical routes" },
     ],
   },
+  "/specs/[spec_id]": {
+    ideaId: "coherence-network-api-runtime",
+    related: SHARED_RELATED,
+    machinePaths: [
+      { href: "/api/spec-registry", label: "Spec registry API" },
+      { href: "/api/inventory/flow", label: "Flow inventory" },
+      { href: "/api/inventory/system-lineage", label: "System lineage" },
+    ],
+  },
   "/usage": {
     ideaId: "coherence-network-value-attribution",
     related: SHARED_RELATED,
@@ -192,6 +201,7 @@ const CONTEXTS: Record<string, ContextDef> = {
 
 function normalizePath(pathname: string): string {
   if (pathname.startsWith("/ideas/")) return "/ideas/[idea_id]";
+  if (pathname.startsWith("/specs/")) return "/specs/[spec_id]";
   if (pathname.startsWith("/project/")) return "/project/[ecosystem]/[name]";
   return pathname;
 }
@@ -214,6 +224,8 @@ export default function PageContextLinks() {
 
   const dynamicIdeaId =
     key === "/ideas/[idea_id]" ? decodeURIComponent(pathname.split("/")[2] || "") : "";
+  const dynamicSpecId =
+    key === "/specs/[spec_id]" ? decodeURIComponent(pathname.split("/")[2] || "") : "";
   const dynamicProjectEcosystem =
     key === "/project/[ecosystem]/[name]" ? decodeURIComponent(pathname.split("/")[2] || "") : "";
   const dynamicProjectName =
@@ -238,6 +250,12 @@ export default function PageContextLinks() {
     machine.unshift({
       href: `/api/ideas/${encodeURIComponent(dynamicIdeaId)}`,
       label: "Idea detail API",
+    });
+  }
+  if (key === "/specs/[spec_id]" && dynamicSpecId) {
+    machine.unshift({
+      href: `/api/spec-registry/${encodeURIComponent(dynamicSpecId)}`,
+      label: "Spec detail API",
     });
   }
   if (key === "/project/[ecosystem]/[name]" && dynamicProjectEcosystem && dynamicProjectName) {


### PR DESCRIPTION
## Summary
- add `/specs/[spec_id]` detail page with explicit links to related idea, contributors, process, and implementation
- upgrade `/specs`, `/ideas/[idea_id]`, `/contributors`, and `/flow` to render clickable relation links instead of plain text IDs
- add flow/task filters (`idea_id`, `spec_id`, `contributor_id`, `task_id`) so process and implementation paths are directly navigable
- update page lineage and context mappings so dynamic spec detail pages expose machine and human navigation links

## Validation
- `cd api && pytest -q tests/test_inventory_api.py`
- `cd web && npm run build`
- `python3 scripts/validate_commit_evidence.py --base HEAD~1 --head HEAD --require-changed-evidence`

## Evidence
- `docs/system_audit/commit_evidence_2026-02-16_spec-link-ontology-completeness.json`
