### PR TITLE
Fix deployed asset-modularity root detection

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_asset-modularity-root-detection.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_asset-modularity-root-detection.json
@@ -1,0 +1,60 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/asset-modularity-project-root-detection",
+  "commit_scope": "Fix deployed asset modularity root detection so implementation files are scanned in container layouts",
+  "files_owned": [
+    "api/app/services/inventory_service.py"
+  ],
+  "local_validation": { "status": "pass" },
+  "ci_validation": { "status": "pending" },
+  "deploy_validation": { "status": "pending" },
+  "phase_gate": { "can_move_next_phase": false },
+  "idea_ids": [
+    "portfolio-governance",
+    "coherence-network-api-runtime"
+  ],
+  "spec_ids": [
+    "089-endpoint-traceability-coverage",
+    "094"
+  ],
+  "task_ids": [
+    "asset-modularity-drift-daily-audit",
+    "asset-modularity-runtime-validation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    },
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "/Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q api/tests/test_inventory_api.py",
+    "/Users/ursmuff/source/Coherence-Network/api/.venv/bin/python api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
+    "/Users/ursmuff/source/Coherence-Network/api/.venv/bin/python api/scripts/run_asset_modularity_audit.py --json --max-implementation-files 1500"
+  ],
+  "change_files": [
+    "api/app/services/inventory_service.py",
+    "docs/system_audit/commit_evidence_2026-02-16_asset-modularity-root-detection.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Production inventory asset modularity endpoint scans real implementation files instead of returning zero due to incorrect project root assumptions.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/asset-modularity"
+    ],
+    "test_flows": [
+      "api:/api/inventory/asset-modularity -> summary.implementation_files_scanned > 0"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- fix inventory_service._project_root to support both monorepo and deployed API container layouts
- include app/components fallback scan directories for deployed runtime layouts
- keep modularity drift behavior unchanged while ensuring implementation files are actually scanned in production

## Validation
- /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q api/tests/test_inventory_api.py
- /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression
- /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python api/scripts/run_asset_modularity_audit.py --json --max-implementation-files 1500
