### PR TITLE
Add GitHub fallback for route-evidence probe discovery

### DIFF
--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -211,3 +211,68 @@ def test_source_aliases_normalize_deployed_double_app_prefix() -> None:
 
     assert "app/routers/inventory.py" in aliases
     assert "api/app/routers/inventory.py" in aliases
+
+
+def test_route_evidence_probe_uses_github_when_local_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(inventory_service, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(inventory_service, "_tracking_repository", lambda: "seeker71/Coherence-Network")
+    monkeypatch.setattr(inventory_service, "_tracking_ref", lambda: "main")
+    inventory_service._ROUTE_PROBE_DISCOVERY_CACHE["expires_at"] = 0.0
+    inventory_service._ROUTE_PROBE_DISCOVERY_CACHE["item"] = None
+
+    class FakeResponse:
+        def __init__(self, status_code: int, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError("http error")
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, params=None):
+            if url.endswith("/contents/docs/system_audit"):
+                return FakeResponse(
+                    200,
+                    [
+                        {
+                            "name": "route_evidence_probe_2026-02-16_public.json",
+                            "path": "docs/system_audit/route_evidence_probe_2026-02-16_public.json",
+                            "download_url": "https://example.test/route_probe.json",
+                        }
+                    ],
+                )
+            if url == "https://example.test/route_probe.json":
+                return FakeResponse(
+                    200,
+                    {
+                        "generated_at": "2026-02-16T00:00:00+00:00",
+                        "api": [
+                            {"path_template": "/api/inventory/system-lineage", "method": "GET", "status_code": 200}
+                        ],
+                        "web": [{"path_template": "/flow", "status_code": 200}],
+                    },
+                )
+            return FakeResponse(404, {"detail": "not found"})
+
+    monkeypatch.setattr(inventory_service.httpx, "Client", FakeClient)
+
+    payload = inventory_service._read_latest_route_evidence_probe()
+
+    assert isinstance(payload, dict)
+    assert payload["api"][0]["path_template"] == "/api/inventory/system-lineage"
+    assert str(payload["_probe_file"]).endswith("route_evidence_probe_2026-02-16_public.json")

--- a/docs/system_audit/commit_evidence_2026-02-16_route-evidence-github-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_route-evidence-github-fallback.json
@@ -1,0 +1,60 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/route-evidence-probe-discovery",
+  "commit_scope": "Enable route-evidence probe discovery from GitHub when local docs artifacts are unavailable in deployment layout",
+  "files_owned": [
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py"
+  ],
+  "local_validation": { "status": "pass" },
+  "ci_validation": { "status": "pending" },
+  "deploy_validation": { "status": "pending" },
+  "phase_gate": { "can_move_next_phase": false },
+  "idea_ids": [
+    "oss-interface-alignment",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "089-endpoint-traceability-coverage",
+    "094"
+  ],
+  "task_ids": [
+    "route-evidence-deploy-fallback"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    },
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression"
+  ],
+  "change_files": [
+    "api/app/services/inventory_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "docs/system_audit/commit_evidence_2026-02-16_route-evidence-github-fallback.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public /api/inventory/route-evidence can use committed route probe artifacts from GitHub when local docs path is unavailable in runtime container layout.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/route-evidence"
+    ],
+    "test_flows": [
+      "api:/api/inventory/route-evidence returns probe.available=true with source_file from docs/system_audit/route_evidence_probe_*.json"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add GitHub fallback in route-evidence probe discovery when local `docs/system_audit` probe artifacts are unavailable in runtime layout
- cache remote probe discovery to avoid repeated GitHub calls
- add test coverage for GitHub fallback probe loading

## Validation
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py`
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
