### PR TITLE
Enforce real-data presence for route evidence

### DIFF
--- a/api/scripts/run_route_evidence_probe.py
+++ b/api/scripts/run_route_evidence_probe.py
@@ -27,15 +27,60 @@ def _materialize_path(path_template: str) -> str:
     return path
 
 
-def _request(client: httpx.Client, method: str, url: str, timeout_seconds: float) -> tuple[int | None, float, str | None]:
+def _json_non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, dict):
+        return len(value) > 0
+    if isinstance(value, list):
+        return len(value) > 0
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _data_present_for_response(response: httpx.Response, probe_method: str) -> bool | None:
+    method = str(probe_method or "").upper()
+    if method != "GET":
+        return None
+
+    body_text = response.text or ""
+    if not body_text.strip():
+        return False
+
+    content_type = str(response.headers.get("content-type") or "").lower()
+    if "json" in content_type:
+        try:
+            payload = response.json()
+        except ValueError:
+            return False
+        return _json_non_empty(payload)
+    return True
+
+
+def _probe_ok(status_code: int | None, probe_method: str, data_present: bool | None) -> bool:
+    if status_code is None:
+        return False
+    method = str(probe_method or "").upper()
+    if method == "GET":
+        return int(status_code) < 400 and bool(data_present)
+    return int(status_code) in {200, 204, 405}
+
+
+def _request(
+    client: httpx.Client, method: str, url: str, timeout_seconds: float
+) -> tuple[int | None, float, str | None, str | None, int | None, bool | None]:
     started = time.perf_counter()
     try:
         response = client.request(method, url, timeout=timeout_seconds, follow_redirects=True)
         elapsed = round((time.perf_counter() - started) * 1000.0, 3)
-        return int(response.status_code), elapsed, None
+        content_type = str(response.headers.get("content-type") or "").strip() or None
+        body_bytes = len(response.content) if response.content is not None else 0
+        data_present = _data_present_for_response(response, method)
+        return int(response.status_code), elapsed, None, content_type, body_bytes, data_present
     except Exception as exc:  # noqa: BLE001
         elapsed = round((time.perf_counter() - started) * 1000.0, 3)
-        return None, elapsed, str(exc)
+        return None, elapsed, str(exc), None, None, None
 
 
 def run_probe(api_base_url: str, web_base_url: str, timeout_seconds: float) -> dict[str, Any]:
@@ -62,7 +107,9 @@ def run_probe(api_base_url: str, web_base_url: str, timeout_seconds: float) -> d
             for method in methods:
                 probe_method = "GET" if method == "GET" else "OPTIONS"
                 url = f"{api_base_url.rstrip('/')}{path}"
-                status_code, elapsed_ms, error = _request(client, probe_method, url, timeout_seconds)
+                status_code, elapsed_ms, error, content_type, body_bytes, data_present = _request(
+                    client, probe_method, url, timeout_seconds
+                )
                 api_rows.append(
                     {
                         "path_template": path_template,
@@ -71,7 +118,11 @@ def run_probe(api_base_url: str, web_base_url: str, timeout_seconds: float) -> d
                         "probe_method": probe_method,
                         "url": url,
                         "status_code": status_code,
-                        "probe_ok": (status_code is not None and int(status_code) < 500),
+                        "probe_ok": _probe_ok(status_code, probe_method, data_present),
+                        "expects_real_data": method == "GET",
+                        "data_present": data_present,
+                        "content_type": content_type,
+                        "body_bytes": body_bytes,
                         "runtime_ms": elapsed_ms,
                         "error": error,
                     }
@@ -85,14 +136,20 @@ def run_probe(api_base_url: str, web_base_url: str, timeout_seconds: float) -> d
                 continue
             path = _materialize_path(path_template)
             url = f"{web_base_url.rstrip('/')}{path}"
-            status_code, elapsed_ms, error = _request(client, "GET", url, timeout_seconds)
+            status_code, elapsed_ms, error, content_type, body_bytes, data_present = _request(
+                client, "GET", url, timeout_seconds
+            )
             web_rows.append(
                 {
                     "path_template": path_template,
                     "path": path,
                     "url": url,
                     "status_code": status_code,
-                    "probe_ok": (status_code is not None and int(status_code) < 500),
+                    "probe_ok": _probe_ok(status_code, "GET", data_present),
+                    "expects_real_data": True,
+                    "data_present": data_present,
+                    "content_type": content_type,
+                    "body_bytes": body_bytes,
                     "runtime_ms": elapsed_ms,
                     "error": error,
                 }
@@ -108,8 +165,10 @@ def run_probe(api_base_url: str, web_base_url: str, timeout_seconds: float) -> d
         "summary": {
             "api_total": len(api_rows),
             "api_probe_ok": sum(1 for row in api_rows if bool(row.get("probe_ok"))),
+            "api_probe_data_present": sum(1 for row in api_rows if bool(row.get("data_present"))),
             "web_total": len(web_rows),
             "web_probe_ok": sum(1 for row in web_rows if bool(row.get("probe_ok"))),
+            "web_probe_data_present": sum(1 for row in web_rows if bool(row.get("data_present"))),
         },
     }
 

--- a/docs/system_audit/commit_evidence_2026-02-16_route-evidence-real-data-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_route-evidence-real-data-guard.json
@@ -1,0 +1,65 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/real-data-presence-guard",
+  "commit_scope": "Enforce real-data presence for route evidence probes so empty payloads do not count as valid evidence",
+  "files_owned": [
+    "api/app/services/inventory_service.py",
+    "api/scripts/run_route_evidence_probe.py",
+    "api/tests/test_inventory_api.py",
+    "docs/system_audit/route_evidence_probe_2026-02-16_public.json"
+  ],
+  "local_validation": { "status": "pass" },
+  "ci_validation": { "status": "pending" },
+  "deploy_validation": { "status": "pending" },
+  "phase_gate": { "can_move_next_phase": false },
+  "idea_ids": [
+    "oss-interface-alignment",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "089-endpoint-traceability-coverage",
+    "094"
+  ],
+  "task_ids": [
+    "route-evidence-real-data-guard"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    },
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_inventory_api.py tests/test_inventory_discovery_sources.py",
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && PYTHONPATH=/Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_route_evidence_probe.py --api-base-url https://coherence-network-production.up.railway.app --web-base-url https://coherence-network.vercel.app --output ../docs/system_audit/route_evidence_probe_2026-02-16_public.json"
+  ],
+  "change_files": [
+    "api/app/services/inventory_service.py",
+    "api/scripts/run_route_evidence_probe.py",
+    "api/tests/test_inventory_api.py",
+    "docs/system_audit/route_evidence_probe_2026-02-16_public.json",
+    "docs/system_audit/commit_evidence_2026-02-16_route-evidence-real-data-guard.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Route evidence no longer counts GET probes as valid when payload is empty; expected-real-data routes require non-empty payload evidence.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/route-evidence"
+    ],
+    "test_flows": [
+      "api:/api/inventory/route-evidence exposes api_missing_real_data and web_missing_real_data and blocks empty-data probes from passing"
+    ]
+  }
+}

--- a/docs/system_audit/route_evidence_probe_2026-02-16_public.json
+++ b/docs/system_audit/route_evidence_probe_2026-02-16_public.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-16T18:07:16.728821+00:00",
+  "generated_at": "2026-02-16T18:26:14.662284+00:00",
   "api_base_url": "https://coherence-network-production.up.railway.app",
   "web_base_url": "https://coherence-network.vercel.app",
   "registry_version": "2026-02-15",
@@ -12,7 +12,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 5187.277,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 27516,
+      "runtime_ms": 5465.809,
       "error": null
     },
     {
@@ -23,7 +27,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/routes/canonical",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 40.089,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 6767,
+      "runtime_ms": 37.043,
       "error": null
     },
     {
@@ -34,7 +42,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/events",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.804,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.654,
       "error": null
     },
     {
@@ -45,7 +57,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/events",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 62.451,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 35257,
+      "runtime_ms": 72.779,
       "error": null
     },
     {
@@ -56,7 +72,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/ideas/summary",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 58.964,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 563,
+      "runtime_ms": 42.862,
       "error": null
     },
     {
@@ -67,7 +87,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/endpoints/summary",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 59.25,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 3901,
+      "runtime_ms": 46.84,
       "error": null
     },
     {
@@ -78,7 +102,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/exerciser/run",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.89,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 34.259,
       "error": null
     },
     {
@@ -89,7 +117,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.302,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.272,
       "error": null
     },
     {
@@ -100,7 +132,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/usage-events",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.164,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.958,
       "error": null
     },
     {
@@ -110,8 +146,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/valuation",
       "status_code": 404,
-      "probe_ok": true,
-      "runtime_ms": 37.498,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 35,
+      "runtime_ms": 36.745,
       "error": null
     },
     {
@@ -122,7 +162,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/payout-preview",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.048,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.676,
       "error": null
     },
     {
@@ -133,7 +177,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/flow",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2030.538,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 107391,
+      "runtime_ms": 2582.76,
       "error": null
     },
     {
@@ -144,7 +192,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/endpoint-traceability",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 1135.998,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 101265,
+      "runtime_ms": 1237.309,
       "error": null
     },
     {
@@ -153,9 +205,13 @@
       "method": "GET",
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/inventory/route-evidence",
-      "status_code": 404,
+      "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 38.343,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 14427,
+      "runtime_ms": 233.288,
       "error": null
     },
     {
@@ -166,7 +222,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-traceability",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.559,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 34.897,
       "error": null
     },
     {
@@ -177,7 +237,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/process-completeness",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 4361.625,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 12069,
+      "runtime_ms": 4703.259,
       "error": null
     },
     {
@@ -188,7 +252,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-process-tasks",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 45.81,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 39.198,
       "error": null
     },
     {
@@ -199,7 +267,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/asset-modularity",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2176.973,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 6121,
+      "runtime_ms": 2417.694,
       "error": null
     },
     {
@@ -210,7 +282,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-asset-modularity-tasks",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.956,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.556,
       "error": null
     },
     {
@@ -221,7 +297,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/questions/proactive",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 1091.497,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 20320,
+      "runtime_ms": 1197.172,
       "error": null
     },
     {
@@ -232,7 +312,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/questions/sync-proactive",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 46.095,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 34.507,
       "error": null
     },
     {
@@ -243,7 +327,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/flow/next-unblock-task",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.294,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.838,
       "error": null
     },
     {
@@ -254,7 +342,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas/storage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 678.641,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 230,
+      "runtime_ms": 739.101,
       "error": null
     },
     {
@@ -265,7 +357,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 67.787,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.862,
       "error": null
     },
     {
@@ -276,7 +372,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas/sample/questions",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 47.938,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 39.132,
       "error": null
     },
     {
@@ -286,8 +386,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry",
       "status_code": 200,
-      "probe_ok": true,
-      "runtime_ms": 40.47,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": "application/json",
+      "body_bytes": 2,
+      "runtime_ms": 41.692,
       "error": null
     },
     {
@@ -298,7 +402,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 45.902,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 38.828,
       "error": null
     },
     {
@@ -308,8 +416,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry/sample",
       "status_code": 404,
-      "probe_ok": true,
-      "runtime_ms": 43.85,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 27,
+      "runtime_ms": 333.894,
       "error": null
     },
     {
@@ -320,7 +432,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry/sample",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.419,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 39.309,
       "error": null
     },
     {
@@ -330,8 +446,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests",
       "status_code": 200,
-      "probe_ok": true,
-      "runtime_ms": 41.291,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": "application/json",
+      "body_bytes": 2,
+      "runtime_ms": 60.317,
       "error": null
     },
     {
@@ -342,7 +462,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.405,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.047,
       "error": null
     },
     {
@@ -353,7 +477,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests/sample/votes",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.959,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 36.862,
       "error": null
     },
     {
@@ -364,7 +492,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/agent/tasks/upsert-active",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.96,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 36.725,
       "error": null
     },
     {
@@ -375,7 +507,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/agent/visibility",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 63.243,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 850,
+      "runtime_ms": 62.335,
       "error": null
     },
     {
@@ -386,7 +522,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 39.251,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 1669,
+      "runtime_ms": 44.807,
       "error": null
     },
     {
@@ -397,7 +537,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage/alerts",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 70.001,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 541,
+      "runtime_ms": 52.042,
       "error": null
     },
     {
@@ -408,7 +552,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage/snapshots",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 52.596,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 41687,
+      "runtime_ms": 52.601,
       "error": null
     }
   ],
@@ -419,7 +567,11 @@
       "url": "https://coherence-network.vercel.app/gates",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 196.049,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 28636,
+      "runtime_ms": 204.831,
       "error": null
     },
     {
@@ -428,7 +580,11 @@
       "url": "https://coherence-network.vercel.app/search",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 54.684,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 24958,
+      "runtime_ms": 326.951,
       "error": null
     },
     {
@@ -436,8 +592,12 @@
       "path": "/api/runtime-beacon",
       "url": "https://coherence-network.vercel.app/api/runtime-beacon",
       "status_code": 405,
-      "probe_ok": true,
-      "runtime_ms": 143.592,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": null,
+      "body_bytes": 0,
+      "runtime_ms": 124.973,
       "error": null
     },
     {
@@ -446,7 +606,11 @@
       "url": "https://coherence-network.vercel.app/flow",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2607.352,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 318213,
+      "runtime_ms": 3085.48,
       "error": null
     },
     {
@@ -455,7 +619,11 @@
       "url": "https://coherence-network.vercel.app/contribute",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 48.351,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 31913,
+      "runtime_ms": 319.402,
       "error": null
     },
     {
@@ -464,7 +632,11 @@
       "url": "https://coherence-network.vercel.app/specs/sample",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 3244.908,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 35296,
+      "runtime_ms": 3628.71,
       "error": null
     },
     {
@@ -473,7 +645,11 @@
       "url": "https://coherence-network.vercel.app/agent",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 237.159,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 31553,
+      "runtime_ms": 494.512,
       "error": null
     },
     {
@@ -482,14 +658,20 @@
       "url": "https://coherence-network.vercel.app/automation",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 352.883,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 32145,
+      "runtime_ms": 373.886,
       "error": null
     }
   ],
   "summary": {
     "api_total": 37,
-    "api_probe_ok": 37,
+    "api_probe_ok": 33,
+    "api_probe_data_present": 18,
     "web_total": 8,
-    "web_probe_ok": 8
+    "web_probe_ok": 7,
+    "web_probe_data_present": 7
   }
 }


### PR DESCRIPTION
## Summary
- enforce strict real-data presence for route-evidence probes: GET probes now require successful status and non-empty payload
- add explicit summary fields `api_missing_real_data` and `web_missing_real_data`
- add regression test proving empty GET payload does not pass as actual evidence
- refresh public probe artifact with new data presence fields

## Validation
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_inventory_api.py tests/test_inventory_discovery_sources.py`
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
- `cd api && PYTHONPATH=/Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_route_evidence_probe.py --api-base-url https://coherence-network-production.up.railway.app --web-base-url https://coherence-network.vercel.app --output ../docs/system_audit/route_evidence_probe_2026-02-16_public.json`
