### PR TITLE
Refresh latest route-evidence probe artifact

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-16_route-evidence-latest-refresh.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_route-evidence-latest-refresh.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/refresh-route-evidence-latest",
+  "commit_scope": "Refresh route_evidence_probe_latest artifact with strict data-presence fields so production evidence guard uses non-empty payload validation",
+  "files_owned": [
+    "docs/system_audit/route_evidence_probe_latest.json"
+  ],
+  "local_validation": { "status": "pass" },
+  "ci_validation": { "status": "pending" },
+  "deploy_validation": { "status": "pending" },
+  "phase_gate": { "can_move_next_phase": false },
+  "idea_ids": [
+    "oss-interface-alignment",
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "089-endpoint-traceability-coverage",
+    "094"
+  ],
+  "task_ids": [
+    "route-evidence-latest-artifact-refresh"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    },
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api && PYTHONPATH=/Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_route_evidence_probe.py --api-base-url https://coherence-network-production.up.railway.app --web-base-url https://coherence-network.vercel.app --output ../docs/system_audit/route_evidence_probe_latest.json"
+  ],
+  "change_files": [
+    "docs/system_audit/route_evidence_probe_latest.json",
+    "docs/system_audit/commit_evidence_2026-02-16_route-evidence-latest-refresh.json"
+  ],
+  "change_intent": "docs_only"
+}

--- a/docs/system_audit/route_evidence_probe_latest.json
+++ b/docs/system_audit/route_evidence_probe_latest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-16T18:07:16.728821+00:00",
+  "generated_at": "2026-02-16T18:31:09.401883+00:00",
   "api_base_url": "https://coherence-network-production.up.railway.app",
   "web_base_url": "https://coherence-network.vercel.app",
   "registry_version": "2026-02-15",
@@ -12,7 +12,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/system-lineage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 5187.277,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 28729,
+      "runtime_ms": 1291.688,
       "error": null
     },
     {
@@ -23,7 +27,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/routes/canonical",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 40.089,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 6767,
+      "runtime_ms": 211.5,
       "error": null
     },
     {
@@ -34,7 +42,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/events",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.804,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.648,
       "error": null
     },
     {
@@ -45,7 +57,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/events",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 62.451,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 35618,
+      "runtime_ms": 313.921,
       "error": null
     },
     {
@@ -56,7 +72,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/ideas/summary",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 58.964,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 569,
+      "runtime_ms": 60.911,
       "error": null
     },
     {
@@ -67,7 +87,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/endpoints/summary",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 59.25,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 11402,
+      "runtime_ms": 70.368,
       "error": null
     },
     {
@@ -78,7 +102,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/runtime/exerciser/run",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.89,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 40.095,
       "error": null
     },
     {
@@ -89,7 +117,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.302,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 41.307,
       "error": null
     },
     {
@@ -100,7 +132,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/usage-events",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 39.164,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 44.101,
       "error": null
     },
     {
@@ -110,8 +146,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/valuation",
       "status_code": 404,
-      "probe_ok": true,
-      "runtime_ms": 37.498,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 35,
+      "runtime_ms": 41.095,
       "error": null
     },
     {
@@ -122,7 +162,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/value-lineage/links/sample/payout-preview",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.048,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 41.584,
       "error": null
     },
     {
@@ -133,7 +177,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/flow",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2030.538,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 110551,
+      "runtime_ms": 2019.498,
       "error": null
     },
     {
@@ -144,7 +192,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/endpoint-traceability",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 1135.998,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 98454,
+      "runtime_ms": 1200.901,
       "error": null
     },
     {
@@ -153,9 +205,13 @@
       "method": "GET",
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/inventory/route-evidence",
-      "status_code": 404,
+      "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 38.343,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 21127,
+      "runtime_ms": 90.743,
       "error": null
     },
     {
@@ -166,7 +222,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-traceability",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.559,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 39.291,
       "error": null
     },
     {
@@ -177,7 +237,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/process-completeness",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 4361.625,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 12045,
+      "runtime_ms": 4776.124,
       "error": null
     },
     {
@@ -188,7 +252,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-process-tasks",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 45.81,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 288.499,
       "error": null
     },
     {
@@ -199,7 +267,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/asset-modularity",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2176.973,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 6097,
+      "runtime_ms": 2286.807,
       "error": null
     },
     {
@@ -210,7 +282,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/gaps/sync-asset-modularity-tasks",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.956,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 43.444,
       "error": null
     },
     {
@@ -221,7 +297,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/questions/proactive",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 1091.497,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 20814,
+      "runtime_ms": 1172.539,
       "error": null
     },
     {
@@ -232,7 +312,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/questions/sync-proactive",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 46.095,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 43.311,
       "error": null
     },
     {
@@ -243,7 +327,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/inventory/flow/next-unblock-task",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.294,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 43.597,
       "error": null
     },
     {
@@ -254,7 +342,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas/storage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 678.641,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 230,
+      "runtime_ms": 730.01,
       "error": null
     },
     {
@@ -265,7 +357,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 67.787,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 42.747,
       "error": null
     },
     {
@@ -276,7 +372,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/ideas/sample/questions",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 47.938,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 41.926,
       "error": null
     },
     {
@@ -286,8 +386,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry",
       "status_code": 200,
-      "probe_ok": true,
-      "runtime_ms": 40.47,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": "application/json",
+      "body_bytes": 2,
+      "runtime_ms": 42.987,
       "error": null
     },
     {
@@ -298,7 +402,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 45.902,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 40.893,
       "error": null
     },
     {
@@ -308,8 +416,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry/sample",
       "status_code": 404,
-      "probe_ok": true,
-      "runtime_ms": 43.85,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 27,
+      "runtime_ms": 42.434,
       "error": null
     },
     {
@@ -320,7 +432,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/spec-registry/sample",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.419,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 43.78,
       "error": null
     },
     {
@@ -330,8 +446,12 @@
       "probe_method": "GET",
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests",
       "status_code": 200,
-      "probe_ok": true,
-      "runtime_ms": 41.291,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": "application/json",
+      "body_bytes": 2,
+      "runtime_ms": 49.903,
       "error": null
     },
     {
@@ -342,7 +462,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 41.405,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 44.211,
       "error": null
     },
     {
@@ -353,7 +477,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/governance/change-requests/sample/votes",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 37.959,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 46.192,
       "error": null
     },
     {
@@ -364,7 +492,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/agent/tasks/upsert-active",
       "status_code": 405,
       "probe_ok": true,
-      "runtime_ms": 38.96,
+      "expects_real_data": false,
+      "data_present": null,
+      "content_type": "application/json",
+      "body_bytes": 31,
+      "runtime_ms": 37.705,
       "error": null
     },
     {
@@ -375,7 +507,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/agent/visibility",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 63.243,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 850,
+      "runtime_ms": 61.372,
       "error": null
     },
     {
@@ -386,7 +522,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 39.251,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 1669,
+      "runtime_ms": 48.01,
       "error": null
     },
     {
@@ -397,7 +537,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage/alerts",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 70.001,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 541,
+      "runtime_ms": 78.975,
       "error": null
     },
     {
@@ -408,7 +552,11 @@
       "url": "https://coherence-network-production.up.railway.app/api/automation/usage/snapshots",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 52.596,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "application/json",
+      "body_bytes": 40144,
+      "runtime_ms": 45.658,
       "error": null
     }
   ],
@@ -419,7 +567,11 @@
       "url": "https://coherence-network.vercel.app/gates",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 196.049,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 28636,
+      "runtime_ms": 159.683,
       "error": null
     },
     {
@@ -428,7 +580,11 @@
       "url": "https://coherence-network.vercel.app/search",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 54.684,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 24958,
+      "runtime_ms": 58.886,
       "error": null
     },
     {
@@ -436,8 +592,12 @@
       "path": "/api/runtime-beacon",
       "url": "https://coherence-network.vercel.app/api/runtime-beacon",
       "status_code": 405,
-      "probe_ok": true,
-      "runtime_ms": 143.592,
+      "probe_ok": false,
+      "expects_real_data": true,
+      "data_present": false,
+      "content_type": null,
+      "body_bytes": 0,
+      "runtime_ms": 144.244,
       "error": null
     },
     {
@@ -446,7 +606,11 @@
       "url": "https://coherence-network.vercel.app/flow",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 2607.352,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 349073,
+      "runtime_ms": 2967.83,
       "error": null
     },
     {
@@ -455,7 +619,11 @@
       "url": "https://coherence-network.vercel.app/contribute",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 48.351,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 31913,
+      "runtime_ms": 59.678,
       "error": null
     },
     {
@@ -464,7 +632,11 @@
       "url": "https://coherence-network.vercel.app/specs/sample",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 3244.908,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 35296,
+      "runtime_ms": 3593.265,
       "error": null
     },
     {
@@ -473,7 +645,11 @@
       "url": "https://coherence-network.vercel.app/agent",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 237.159,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 31553,
+      "runtime_ms": 226.997,
       "error": null
     },
     {
@@ -482,14 +658,20 @@
       "url": "https://coherence-network.vercel.app/automation",
       "status_code": 200,
       "probe_ok": true,
-      "runtime_ms": 352.883,
+      "expects_real_data": true,
+      "data_present": true,
+      "content_type": "text/html; charset=utf-8",
+      "body_bytes": 32145,
+      "runtime_ms": 286.836,
       "error": null
     }
   ],
   "summary": {
     "api_total": 37,
-    "api_probe_ok": 37,
+    "api_probe_ok": 33,
+    "api_probe_data_present": 18,
     "web_total": 8,
-    "web_probe_ok": 8
+    "web_probe_ok": 7,
+    "web_probe_data_present": 7
   }
 }


### PR DESCRIPTION
## Summary
- refresh `docs/system_audit/route_evidence_probe_latest.json` using strict probe semantics (includes `data_present`, `content_type`, `body_bytes`)
- ensure production route-evidence fallback consumes up-to-date probe artifact format

## Validation
- `cd api && PYTHONPATH=/Users/ursmuff/.claude-worktrees/Coherence-Network/asset-modularity-drift-daily/api /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/run_route_evidence_probe.py --api-base-url https://coherence-network-production.up.railway.app --web-base-url https://coherence-network.vercel.app --output ../docs/system_audit/route_evidence_probe_latest.json`
