### PR TITLE
Enforce key-backed usage tracking for active providers

### DIFF
--- a/api/app/models/automation_usage.py
+++ b/api/app/models/automation_usage.py
@@ -82,3 +82,23 @@ class SubscriptionUpgradeEstimatorReport(BaseModel):
     estimated_current_monthly_cost_usd: float = Field(ge=0.0)
     estimated_next_monthly_cost_usd: float = Field(ge=0.0)
     estimated_monthly_upgrade_delta_usd: float = Field(ge=0.0)
+
+
+class ProviderReadinessRow(BaseModel):
+    provider: str = Field(min_length=1, max_length=120)
+    kind: str = Field(min_length=1, max_length=120)
+    status: ProviderStatus
+    required: bool = False
+    configured: bool = False
+    severity: AlertSeverity
+    missing_env: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class ProviderReadinessReport(BaseModel):
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    required_providers: list[str] = Field(default_factory=list)
+    all_required_ready: bool = False
+    blocking_issues: list[str] = Field(default_factory=list)
+    recommendations: list[str] = Field(default_factory=list)
+    providers: list[ProviderReadinessRow] = Field(default_factory=list)

--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -34,3 +34,16 @@ async def get_automation_usage_alerts(threshold_ratio: float = Query(0.2, ge=0.0
 async def get_subscription_upgrade_estimator() -> dict:
     report = automation_usage_service.estimate_subscription_upgrades()
     return report.model_dump(mode="json")
+
+
+@router.get("/automation/usage/readiness")
+async def get_provider_readiness(
+    required_providers: str = Query("", description="Comma-separated provider ids to require"),
+    force_refresh: bool = Query(True),
+) -> dict:
+    requested = [item.strip().lower() for item in required_providers.split(",") if item.strip()]
+    report = automation_usage_service.provider_readiness_report(
+        required_providers=requested or None,
+        force_refresh=force_refresh,
+    )
+    return report.model_dump(mode="json")

--- a/docs/API-KEYS-SETUP.md
+++ b/docs/API-KEYS-SETUP.md
@@ -171,3 +171,40 @@ When OpenClaw, Agent Zero, or another framework is chosen:
 4. Use Cursor as manual override unless framework has a superior interface
 
 See [AGENT-FRAMEWORKS.md](AGENT-FRAMEWORKS.md) for options.
+
+---
+
+## Provider Readiness Automation
+
+The provider readiness contract checks required provider configuration every 6 hours and raises an issue when blocking gaps exist.
+
+- API: `GET /api/automation/usage/readiness`
+- CI workflow: `.github/workflows/provider-readiness-contract.yml`
+- Required providers variable: `AUTOMATION_REQUIRED_PROVIDERS` (comma-separated)
+- Active-provider key policy: `AUTOMATION_REQUIRE_KEYS_FOR_ACTIVE_PROVIDERS=1` (default)
+  - Any provider observed in runtime usage is treated as required and must have its API key/config present.
+
+Recommended secrets/vars for full readiness:
+
+```bash
+# OpenAI usage/cost
+OPENAI_ADMIN_API_KEY=
+
+# GitHub billing usage
+GITHUB_TOKEN=
+GITHUB_BILLING_OWNER=
+GITHUB_BILLING_SCOPE=org
+
+# Railway deploy health automation
+RAILWAY_TOKEN=
+RAILWAY_PROJECT_ID=
+RAILWAY_ENVIRONMENT=
+RAILWAY_SERVICE=
+
+# Vercel deploy health automation
+VERCEL_TOKEN=
+VERCEL_PROJECT_ID=
+
+# OpenClaw usage tracking
+OPENCLAW_API_KEY=
+```

--- a/docs/PIPELINE-MONITORING-AUTOMATED.md
+++ b/docs/PIPELINE-MONITORING-AUTOMATED.md
@@ -202,7 +202,7 @@ including value-lineage E2E, to pass.
 If contract fails:
 - Workflow uploads `public_deploy_contract_report.json`.
 - Workflow opens or updates issue: `Public deployment contract failing on main`.
-- If Railway secrets are configured (`RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT`, `RAILWAY_SERVICE`), workflow triggers `railway redeploy` and re-validates for up to 20 minutes before deciding pass/fail.
+- If Railway secrets are configured (`RAILWAY_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT`, `RAILWAY_SERVICE`), workflow triggers `railway redeploy` and re-validates with bounded retries (`PUBLIC_DEPLOY_REVALIDATE_MAX_ATTEMPTS`, default `12`) and sleep (`PUBLIC_DEPLOY_REVALIDATE_SLEEP_SECONDS`, default `15`) plus fail-fast conditions.
 
 Machine and human access:
 - Machine API: `GET /api/gates/public-deploy-contract`
@@ -218,20 +218,6 @@ To track newly added external tools and keep upgrade cadence:
 - Registry: `docs/system_audit/external_tools_registry.json`
 - Trigger:
   - Tuesdays + Fridays (`cron`)
-  - Manual run (`workflow_dispatch`)
-
-Behavior:
-1. Discover external GitHub Actions, workflow CLI tools, and dependency ecosystems.
-2. Compare discovered set against tracked registry.
-3. Upload `external_tools_audit_report.json`.
-4. Open/update issue `External tools registry drift detected` if new tools appear.
-5. Close the issue automatically once registry is updated and audit passes.
-
-Dependency update cadence:
-- Dependabot config in `.github/dependabot.yml` runs daily for:
-  - GitHub Actions
-  - Python (`/api`)
-  - npm (`/web`)
 
 ## Workflow Reference Guard (Per PR/Push)
 
@@ -257,6 +243,7 @@ To ensure provider configuration is continuously validated and failures are surf
 Contract behavior:
 1. Collect provider usage/readiness snapshots.
 2. Evaluate required providers from `AUTOMATION_REQUIRED_PROVIDERS` (repo variable, comma-separated).
+   - Providers observed in runtime usage are also required by default (`AUTOMATION_REQUIRE_KEYS_FOR_ACTIVE_PROVIDERS=1`).
 3. Fail when any required provider is not configured or not healthy.
 4. Upload `provider_readiness_report.json` artifact.
 5. Open/update issue `Provider readiness contract failing` when blocking issues exist; close it when healthy.
@@ -271,6 +258,20 @@ Required provider defaults:
 Machine and human access:
 - Machine API: `GET /api/automation/usage/readiness`
 - Human UI: `/automation` page, section **Provider Readiness**
+  - Manual run (`workflow_dispatch`)
+
+Behavior:
+1. Discover external GitHub Actions, workflow CLI tools, and dependency ecosystems.
+2. Compare discovered set against tracked registry.
+3. Upload `external_tools_audit_report.json`.
+4. Open/update issue `External tools registry drift detected` if new tools appear.
+5. Close the issue automatically once registry is updated and audit passes.
+
+Dependency update cadence:
+- Dependabot config in `.github/dependabot.yml` runs daily for:
+  - GitHub Actions
+  - Python (`/api`)
+  - npm (`/web`)
 
 ## Maintainability Architecture Monitor (Twice Weekly + PR Gate)
 

--- a/docs/system_audit/commit_evidence_2026-02-16_provider-key-usage-tracking.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_provider-key-usage-tracking.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/provider-key-usage-tracking",
+  "commit_scope": "Enforce API-key readiness for providers observed in runtime usage and enrich automation usage tracking with active-provider runtime metrics.",
+  "files_owned": [
+    "api/app/models/automation_usage.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/API-KEYS-SETUP.md",
+    "docs/PIPELINE-MONITORING-AUTOMATED.md",
+    "docs/system_audit/commit_evidence_2026-02-16_provider-key-usage-tracking.json"
+  ],
+  "idea_ids": [
+    "automation-provider-usage-governance"
+  ],
+  "spec_ids": [
+    "002"
+  ],
+  "task_ids": [
+    "provider-key-usage-tracking"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_automation_usage_api.py",
+    "python3 scripts/validate_workflow_references.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_provider-key-usage-tracking.json"
+  ],
+  "change_files": [
+    "api/app/models/automation_usage.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/API-KEYS-SETUP.md",
+    "docs/PIPELINE-MONITORING-AUTOMATED.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Providers observed in runtime execution are automatically treated as required for readiness and must have API key/config; usage snapshots now include runtime_task_runs for active providers.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness",
+      "https://coherence-network.vercel.app/automation"
+    ],
+    "test_flows": [
+      "API usage endpoint returns runtime_task_runs metric for active providers",
+      "Readiness endpoint marks active providers without key/config as required and blocking",
+      "Automation web page reflects provider readiness and usage from API"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T20:20:00Z",
+    "environment": {
+      "python": "3.11"
+    },
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_automation_usage_api.py",
+      "python3 scripts/validate_workflow_references.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway+vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deployment validation"
+  }
+}


### PR DESCRIPTION
## Summary
- require provider key/config readiness for providers observed in runtime usage
- add runtime provider inference and runtime_task_runs usage metric for active providers
- add OpenClaw provider key rule and readiness policy docs

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_automation_usage_api.py
- python3 scripts/validate_workflow_references.py
- python3 scripts/validate_commit_evidence.py --base HEAD~1 --head HEAD --require-changed-evidence