### PR TITLE
Guard Vercel preview deployments to prevent rate-limit failures

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -216,6 +216,7 @@ Fix:
 
 Repository guardrail added:
 - `web/vercel.json` now pins `"framework": "nextjs"` so Vercel does not expect a static `public/` output.
+- `web/vercel.json` includes `"ignoreCommand": "./scripts/vercel-ignore.sh"` to skip preview deployments for non-web-only commits and reduce rate-limit pressure.
 
 ### Interpreting Vercel build logs
 

--- a/docs/system_audit/commit_evidence_2026-02-16_vercel-rate-limit-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_vercel-rate-limit-guard.json
@@ -1,0 +1,73 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/vercel-rate-limit-guard",
+  "commit_scope": "Reduce recurring Vercel deployment rate-limit failures by skipping preview deployments for non-web changes via vercel ignoreCommand.",
+  "files_owned": [
+    "web/vercel.json",
+    "web/scripts/vercel-ignore.sh",
+    "docs/DEPLOY.md",
+    "docs/system_audit/commit_evidence_2026-02-16_vercel-rate-limit-guard.json"
+  ],
+  "idea_ids": [
+    "deployment-gate-reliability"
+  ],
+  "spec_ids": [
+    "014"
+  ],
+  "task_ids": [
+    "vercel-rate-limit-guard"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": ["direction", "review"]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && VERCEL_GIT_COMMIT_REF=main ./scripts/vercel-ignore.sh",
+    "cd web && VERCEL_GIT_COMMIT_REF=feature/vercel ./scripts/vercel-ignore.sh",
+    "python3 scripts/validate_workflow_references.py",
+    "python3 api/scripts/run_maintainability_audit.py --fail-on-regression"
+  ],
+  "change_files": [
+    "web/vercel.json",
+    "web/scripts/vercel-ignore.sh",
+    "docs/DEPLOY.md"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-16T20:30:00Z",
+    "environment": {
+      "python": "3.11"
+    },
+    "commands": [
+      "cd web && VERCEL_GIT_COMMIT_REF=main ./scripts/vercel-ignore.sh",
+      "cd web && VERCEL_GIT_COMMIT_REF=feature/vercel ./scripts/vercel-ignore.sh",
+      "python3 scripts/validate_workflow_references.py",
+      "python3 api/scripts/run_maintainability_audit.py --fail-on-regression"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and Vercel deployment validation"
+  }
+}

--- a/web/scripts/vercel-ignore.sh
+++ b/web/scripts/vercel-ignore.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Vercel ignoreCommand contract:
+# - Exit 0 => skip deployment
+# - Exit 1 => continue deployment
+#
+# Strategy:
+# - Always deploy production branch commits.
+# - For preview branches, deploy only when web-relevant files changed.
+
+branch="${VERCEL_GIT_COMMIT_REF:-}"
+if [ "$branch" = "main" ]; then
+  echo "Production branch; do not skip."
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+if ! git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+  echo "No parent commit available; do not skip."
+  exit 1
+fi
+
+changed_files="$(git diff --name-only HEAD^ HEAD || true)"
+if [ -z "$changed_files" ]; then
+  echo "No changed files detected; skip deployment."
+  exit 0
+fi
+
+web_changed=0
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  case "$path" in
+    web/*|package.json|package-lock.json|pnpm-lock.yaml|yarn.lock)
+      web_changed=1
+      break
+      ;;
+  esac
+done <<EOF
+$changed_files
+EOF
+
+if [ "$web_changed" -eq 1 ]; then
+  echo "Web-relevant changes detected; do not skip."
+  exit 1
+fi
+
+echo "No web-relevant changes on preview branch; skip deployment."
+exit 0

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "./scripts/vercel-ignore.sh"
 }


### PR DESCRIPTION
## Summary
- add ignoreCommand in web/vercel.json
- add web/scripts/vercel-ignore.sh to skip preview deployments when commits do not change web-relevant files
- keep production branch (main) deployments always enabled
- document the guard in deploy docs

## Validation
- cd web && VERCEL_GIT_COMMIT_REF=main ./scripts/vercel-ignore.sh
- cd web && VERCEL_GIT_COMMIT_REF=feature/vercel ./scripts/vercel-ignore.sh
- python3 scripts/validate_workflow_references.py
- python3 api/scripts/run_maintainability_audit.py --fail-on-regression
- python3 scripts/validate_commit_evidence.py --base HEAD~1 --head HEAD --require-changed-evidence