### PR TITLE
CI: soften main post-merge maintainability gate

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -81,6 +81,13 @@ jobs:
             echo "No runtime code changes detected in diff range; skipping maintainability regression gate."
             exit 0
           fi
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            python3 api/scripts/run_maintainability_audit.py \
+              --output maintainability_audit_report.json || true
+            cat maintainability_audit_report.json
+            echo "WARNING: maintainability regression detected on main; follow-up remediation required, but post-merge thread gate will not hard-fail."
+            exit 0
+          fi
           python3 api/scripts/run_maintainability_audit.py \
             --output maintainability_audit_report.json \
             --fail-on-regression

--- a/docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json
@@ -1,0 +1,66 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/main-thread-gate-maintainability-fix",
+  "commit_scope": "prevent post-merge main thread-gates hard-fail on maintainability regression while keeping strict pre-merge enforcement on PRs",
+  "files_owned": [
+    ".github/workflows/thread-gates.yml",
+    "docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json"
+  ],
+  "idea_ids": [
+    "idea-mainline-gate-stability-with-strict-pr-enforcement"
+  ],
+  "spec_ids": [
+    "spec-thread-gate-main-postmerge-softfail-maintainability"
+  ],
+  "task_ids": [
+    "task-fix-main-thread-gates-maintainability-postmerge-failure"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "ci-gating",
+        "release-stability"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    ".github/workflows/thread-gates.yml"
+  ],
+  "change_files": [
+    ".github/workflows/thread-gates.yml",
+    "docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json"
+    ],
+    "notes": [
+      "PR events remain strict with --fail-on-regression; push-to-main records maintainability report without hard-failing post-merge."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "checks": [
+      "thread-gates",
+      "test"
+    ],
+    "notes": "Pending after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "main",
+    "notes": "Pending post-merge contract runs."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI/deploy pending"
+  }
+}


### PR DESCRIPTION
## Summary\n- keep maintainability regression strict on pull_request runs\n- avoid hard-failing thread-gates on push to main post-merge\n- still emit maintainability report/warning on main for follow-up remediation\n\n## Validation\n- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-16_main-thread-gate-maintainability-postmerge-softfail.json\n