### PR TITLE
Cap Change Contract runtime to avoid stuck validation step

### DIFF
--- a/.github/workflows/change-contract.yml
+++ b/.github/workflows/change-contract.yml
@@ -44,6 +44,8 @@ jobs:
               --sha "$TARGET_SHA" \
               --min-approvals "$MIN_APPROVALS" \
               --min-unique-approvers "$MIN_UNIQUE_APPROVERS" \
+              --timeout-seconds 300 \
+              --poll-seconds 15 \
               --json > ../contract_report.json
             code=$?
             cd ..

--- a/docs/system_audit/commit_evidence_2026-02-16_change-contract-timeout-cap.json
+++ b/docs/system_audit/commit_evidence_2026-02-16_change-contract-timeout-cap.json
@@ -1,0 +1,60 @@
+{
+  "date": "2026-02-16",
+  "thread_branch": "codex/change-contract-timeout-fix",
+  "commit_scope": "Cap Change Contract validation runtime to prevent long-running/stuck post-merge jobs",
+  "files_owned": [
+    ".github/workflows/change-contract.yml"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "074-tool-failure-awareness"
+  ],
+  "task_ids": [
+    "cap-change-contract-runtime"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "review"]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": ["idea", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/validate_workflow_references.py",
+    "gh run view 22080882110 --json status,conclusion,workflowName,createdAt,updatedAt,url,jobs"
+  ],
+  "change_files": [
+    ".github/workflows/change-contract.yml",
+    "docs/system_audit/commit_evidence_2026-02-16_change-contract-timeout-cap.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_workflow_references.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI/deploy pending"
+  }
+}


### PR DESCRIPTION
## Summary
- cap merged change contract script runtime in workflow to 5 minutes
- lower poll interval to 15s for faster completion signals
- retain existing logic, but prevent 20-minute long-running validation steps

## Validation
- `python3 scripts/validate_workflow_references.py`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
