### PR TITLE
Harden mandatory worktree-only quickstart process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Spec → Test → Implement → CI → Review → Merge
 ## Key Files
 
 - `CLAUDE.md` — Project config, conventions, guardrails
+- `docs/WORKTREE-QUICKSTART.md` — Mandatory worktree-only startup flow and failure recovery
 - `docs/STATUS.md` — Current implementation status, sprint progress
 - `docs/SPEC-COVERAGE.md` — Spec → implementation → test mapping
 - `docs/SPEC-TRACKING.md` — Quick reference: spec status, test mapping, verification
@@ -41,6 +42,9 @@ Spec → Test → Implement → CI → Review → Merge
 ## Commands
 
 ```bash
+# Mandatory first step for every thread
+python3 scripts/ensure_worktree_start_clean.py --json
+
 # API
 cd api && uvicorn app.main:app --reload --port 8000
 

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -4,6 +4,9 @@ Date: 2026-02-14
 
 Purpose: ensure each Codex thread can work independently, commit only its own scope, and advance phases only when validation gates pass.
 
+Canonical setup reference:
+- `docs/WORKTREE-QUICKSTART.md` (mandatory for every new thread)
+
 ## Core Rules
 
 1. Scope isolation
@@ -16,6 +19,22 @@ Purpose: ensure each Codex thread can work independently, commit only its own sc
    - Do not move to next phase until current phase gates pass.
 
 ## Required Phase Gates
+
+### Phase -1: Worktree Setup Gate (required before Phase 0)
+
+Non-negotiable:
+- All implementation work happens in a linked worktree branch (`codex/*`).
+- Never start implementation from the primary workspace.
+
+Minimum startup sequence:
+
+```bash
+git fetch origin main
+git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
+cd ~/.claude-worktrees/Coherence-Network/<thread-name>
+git pull --ff-only origin main
+python3 scripts/ensure_worktree_start_clean.py --json
+```
 
 ### Phase 0: Start Gate (required before new task work)
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -254,6 +254,9 @@ This gate fails when:
 - current worktree has uncommitted local changes,
 - primary workspace still has leftover local changes from unfinished tasks.
 
+For the full one-page startup flow, use:
+- `docs/WORKTREE-QUICKSTART.md`
+
 ## Telemetry Migration To DB
 
 Migrate local telemetry files (`automation_usage_snapshots.json`, `friction_events.jsonl`) into DB-backed telemetry tables:

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -1,0 +1,89 @@
+# Worktree Quickstart (Mandatory)
+
+Date: 2026-02-17
+
+Purpose: remove repeated setup mistakes by making every Codex/Claude thread follow one exact worktree startup flow.
+
+## Rule 0
+
+- Never implement from the primary repo workspace.
+- Always create/use a linked worktree under `~/.claude-worktrees/Coherence-Network/`.
+
+## Start New Thread (copy/paste)
+
+From primary workspace:
+
+```bash
+git fetch origin main
+git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
+```
+
+Enter worktree:
+
+```bash
+cd ~/.claude-worktrees/Coherence-Network/<thread-name>
+git pull --ff-only origin main
+```
+
+## Mandatory Preflight (before edits)
+
+```bash
+python3 scripts/ensure_worktree_start_clean.py --json
+```
+
+Must pass all:
+- running in linked worktree (not primary workspace),
+- current worktree clean,
+- primary workspace clean,
+- latest `main` CI green,
+- no open PRs with failing checks.
+
+## Mandatory Local Guard (before commit/push)
+
+```bash
+python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
+./scripts/verify_worktree_local_web.sh
+```
+
+Optional remote/deploy gate check:
+
+```bash
+python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)"
+```
+
+## Commit + PR
+
+```bash
+git add <files>
+git commit -m "<message>"
+git push -u origin codex/<thread-name>
+gh pr create --base main --head codex/<thread-name> --title "<title>" --body "<body>"
+```
+
+## Merge (after checks)
+
+Use rebase merge:
+
+```bash
+gh api -X PUT repos/seeker71/Coherence-Network/pulls/<pr_number>/merge -f merge_method=rebase
+gh api -X DELETE repos/seeker71/Coherence-Network/git/refs/heads/codex/<thread-name>
+```
+
+## Recover Common Failures
+
+- `next: command not found`: run `cd web && npm ci --cache /tmp/npm-codex-cache`.
+- missing pytest in worktree: use repo venv path for validation:
+  - `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q`.
+- maintainability gate fail: run
+  - `python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
+  and refactor before re-push.
+
+## Close Thread
+
+After merge and deploy validation:
+
+```bash
+cd /Users/ursmuff/source/Coherence-Network
+git worktree remove ~/.claude-worktrees/Coherence-Network/<thread-name>
+git branch -D codex/<thread-name> 2>/dev/null || true
+```

--- a/docs/system_audit/commit_evidence_2026-02-17_worktree-quickstart-mandatory.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_worktree-quickstart-mandatory.json
@@ -1,0 +1,67 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/worktree-mode-doc",
+  "commit_scope": "Harden worktree-only operating process with mandatory quickstart and gate references",
+  "files_owned": [
+    "AGENTS.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/RUNBOOK.md",
+    "docs/WORKTREE-QUICKSTART.md"
+  ],
+  "idea_ids": [
+    "public-e2e-flow-gate-automation"
+  ],
+  "spec_ids": [
+    "095-public-e2e-flow-gate-automation"
+  ],
+  "task_ids": [
+    "task_da4d52b6325e004f"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "review"]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": ["idea", "validation"]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/ensure_worktree_start_clean.py --json",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "./scripts/verify_worktree_local_web.sh"
+  ],
+  "change_files": [
+    "AGENTS.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/RUNBOOK.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/system_audit/commit_evidence_2026-02-17_worktree-quickstart-mandatory.json"
+  ],
+  "change_intent": "docs_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_worktree-quickstart-mandatory.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI/deploy pending"
+  }
+}


### PR DESCRIPTION
## Summary
- add `docs/WORKTREE-QUICKSTART.md` as canonical mandatory startup flow
- add mandatory references in `AGENTS.md` and `docs/CODEX-THREAD-PROCESS.md`
- link runbook worktree start gate to quickstart doc

## Validation
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_worktree-quickstart-mandatory.json`
