### PR TITLE
Automate PR check failure triage and remediation

### DIFF
--- a/.github/workflows/pr-check-failure-triage.yml
+++ b/.github/workflows/pr-check-failure-triage.yml
@@ -1,0 +1,53 @@
+name: PR Check Failure Triage
+
+on:
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: pr-check-failure-triage
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install API dependencies
+        run: |
+          cd api && pip install -e ".[dev]"
+
+      - name: Run PR check failure triage
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/pr_check_failure_triage.py \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --head-prefix codex/ \
+            --rerun-failed-actions \
+            --rerun-settle-seconds 180 \
+            --poll-seconds 20 \
+            --fail-on-detected \
+            --json > pr-check-triage-report.json
+
+      - name: Upload triage report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-check-triage-report
+          path: |
+            pr-check-triage-report.json
+            docs/system_audit/pr_check_failures/pr_failure_triage_*.json
+          if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Spec → Test → Implement → CI → Review → Merge
 - `docs/PIPELINE-MONITORING-AUTOMATED.md` — Automated monitor: check issues, react, improve
 - `docs/META-QUESTIONS.md` — Questions to validate setup, monitoring, effectiveness; catch misconfigurations
 - `docs/RUNBOOK.md` — Log locations, restart, pipeline recovery
+- `docs/PR-CHECK-FAILURE-TRIAGE.md` — PR check failure detection, auto-retry, remediation mapping
 - `docs/DEPLOY.md` — Deploy checklist
 - `docs/GLOSSARY.md` — Terms (coherence, backlog, pipeline)
 - `specs/TEMPLATE.md` — Spec format
@@ -59,6 +60,9 @@ python3 scripts/ensure_worktree_start_clean.py --json
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 # Include remote PR check tracking (requires GH_TOKEN/GITHUB_TOKEN):
 python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)"
+# Dedicated triage for open PR check failures (+ optional auto-rerun for flaky GitHub Actions checks):
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --fail-on-detected
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --rerun-failed-actions --fail-on-detected
 # Tighten deploy freshness requirement if needed (default 6h):
 python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)" --deploy-success-max-age-hours 2
 

--- a/api/tests/test_pr_check_failure_triage.py
+++ b/api/tests/test_pr_check_failure_triage.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "pr_check_failure_triage.py"
+    spec = importlib.util.spec_from_file_location("pr_check_failure_triage", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_hint_mapping_known_checks() -> None:
+    mod = _load_module()
+
+    assert "pytest -q" in mod._hint_for_check("Test")
+    assert "validate_spec_quality.py" in mod._hint_for_check("Validate spec quality contract")
+    assert "worktree_pr_guard.py" in mod._hint_for_check("Thread Gates")
+
+
+def test_blocking_failures_detection() -> None:
+    mod = _load_module()
+
+    assert mod._has_blocking_failures([]) is False
+    assert (
+        mod._has_blocking_failures(
+            [
+                {
+                    "failing_check_runs": [],
+                    "failing_status_contexts": [],
+                    "missing_required_contexts": [],
+                    "failing_required_contexts": [],
+                }
+            ]
+        )
+        is False
+    )
+    assert (
+        mod._has_blocking_failures(
+            [
+                {
+                    "failing_check_runs": [{"name": "Thread Gates"}],
+                    "failing_status_contexts": [],
+                    "missing_required_contexts": [],
+                    "failing_required_contexts": [],
+                }
+            ]
+        )
+        is True
+    )

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -42,6 +42,7 @@ Run and record:
 
 ```bash
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --fail-on-detected
 python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
 ```
 
@@ -49,6 +50,7 @@ Gate status:
 - PASS only if tests/build succeed for the thread’s touched surface.
 - PASS only if changed specs pass the spec quality contract (when any feature spec changed).
 - PASS only if no stale open `codex/*` PR is left unattended.
+- PASS only if open `codex/*` PR checks are green (or auto-rerun has healed flaky failures).
 - PASS only if guard does not detect evidence/workflow/reference contract failures.
 
 Worktree notes:

--- a/docs/PR-CHECK-FAILURE-TRIAGE.md
+++ b/docs/PR-CHECK-FAILURE-TRIAGE.md
@@ -1,0 +1,60 @@
+# PR Check Failure Triage
+
+Date: 2026-02-17
+
+Purpose: detect PR check failures early, auto-retry flaky GitHub Actions failures, and provide deterministic local remediation commands.
+
+## Commands
+
+Detect and report failures for open `codex/*` PRs:
+
+```bash
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/
+```
+
+Detect and fail local/CI step if failures exist:
+
+```bash
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --fail-on-detected
+```
+
+Detect, auto-rerun failed GitHub Actions jobs, wait for settlement, then fail only if still blocked:
+
+```bash
+python3 scripts/pr_check_failure_triage.py \
+  --repo seeker71/Coherence-Network \
+  --base main \
+  --head-prefix codex/ \
+  --rerun-failed-actions \
+  --rerun-settle-seconds 180 \
+  --poll-seconds 20 \
+  --fail-on-detected
+```
+
+All runs write JSON artifacts under:
+- `docs/system_audit/pr_check_failures/`
+
+## Failure Resolution Contract
+
+For each failed check/context, the triage report includes `suggested_local_preflight`.
+
+Common mappings:
+- `Thread Gates` -> `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
+- `Test` / API checks -> `cd api && pytest -q`
+- `Build web` -> `cd web && npm ci && npm run build`
+- `Validate commit evidence` -> `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
+- `Validate spec quality` -> `python3 scripts/validate_spec_quality.py --base origin/main --head HEAD`
+- `Public Deploy Contract` -> `./scripts/verify_web_api_deploy.sh`
+
+## Catch-Next-Time Automation
+
+GitHub Actions workflow:
+- `.github/workflows/pr-check-failure-triage.yml`
+
+Behavior:
+1. Runs every 6 hours and on manual dispatch.
+2. Executes `pr_check_failure_triage.py` with auto-rerun enabled.
+3. Uploads machine-readable triage artifacts.
+4. Fails when blocking PR check failures remain after retry window.
+
+This catches regressions even when no new local development command is run.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -235,6 +235,33 @@ If a check fails, the report includes:
 - output tail
 - suggested local remediation command
 
+### PR Failure Triage Automation
+
+Run dedicated PR failure triage across open `codex/*` PRs:
+
+```bash
+python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --fail-on-detected
+```
+
+Auto-rerun failed GitHub Actions jobs and fail only if still blocked after retry window:
+
+```bash
+python3 scripts/pr_check_failure_triage.py \
+  --repo seeker71/Coherence-Network \
+  --base main \
+  --head-prefix codex/ \
+  --rerun-failed-actions \
+  --rerun-settle-seconds 180 \
+  --poll-seconds 20 \
+  --fail-on-detected
+```
+
+Scheduled automation runs in:
+- `.github/workflows/pr-check-failure-triage.yml`
+
+Reference:
+- `docs/PR-CHECK-FAILURE-TRIAGE.md`
+
 ## Worktree Start Gate
 
 Before starting a new task, enforce worktree-only + clean-state:

--- a/docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json
@@ -1,0 +1,76 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/pr-check-failure-guard-2",
+  "commit_scope": "Document and automate PR check failure detection with remediation mapping and scheduled triage workflow that retries flaky failed actions checks.",
+  "files_owned": [
+    ".github/workflows/pr-check-failure-triage.yml",
+    "scripts/pr_check_failure_triage.py",
+    "api/tests/test_pr_check_failure_triage.py",
+    "docs/PR-CHECK-FAILURE-TRIAGE.md",
+    "docs/RUNBOOK.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "AGENTS.md",
+    "docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration"
+  ],
+  "task_ids": [
+    "task-pr-check-failure-triage-automation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "documentation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/pr_check_failure_triage.py",
+    ".github/workflows/pr-check-failure-triage.yml",
+    "docs/PR-CHECK-FAILURE-TRIAGE.md"
+  ],
+  "change_files": [
+    ".github/workflows/pr-check-failure-triage.yml",
+    "scripts/pr_check_failure_triage.py",
+    "api/tests/test_pr_check_failure_triage.py",
+    "docs/PR-CHECK-FAILURE-TRIAGE.md",
+    "docs/RUNBOOK.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "AGENTS.md",
+    "docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/pr_check_failure_triage.py --help",
+      "cd api && pytest -q tests/test_pr_check_failure_triage.py",
+      "python3 scripts/validate_workflow_references.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-actions"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting PR checks and merge."
+  }
+}

--- a/scripts/pr_check_failure_triage.py
+++ b/scripts/pr_check_failure_triage.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Detect, summarize, and optionally auto-rerun failing PR checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_ROOT = REPO_ROOT / "api"
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+from app.services import release_gate_service as gates  # noqa: E402
+
+
+def _now_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hint_for_check(name: str) -> str:
+    value = name.lower()
+    mapping: list[tuple[str, str]] = [
+        (
+            "validate commit evidence",
+            "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence",
+        ),
+        ("spec quality", "python3 scripts/validate_spec_quality.py --base origin/main --head HEAD"),
+        ("workflow file references", "python3 scripts/validate_workflow_references.py"),
+        (
+            "maintainability",
+            "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
+        ),
+        ("test", "cd api && pytest -q"),
+        ("build web", "cd web && npm ci && npm run build"),
+        ("thread gates", "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"),
+        ("public deploy contract", "./scripts/verify_web_api_deploy.sh"),
+        ("change contract", "python3 scripts/worktree_pr_guard.py --mode all --base-ref origin/main"),
+    ]
+    for key, command in mapping:
+        if key in value:
+            return command
+    return "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+
+
+def _check_run_to_item(run: dict[str, Any]) -> dict[str, Any]:
+    name = str(run.get("name") or "unknown")
+    details_url = run.get("details_url")
+    run_id = gates.extract_actions_run_id(details_url) if isinstance(details_url, str) else None
+    return {
+        "name": name,
+        "status": str(run.get("status") or ""),
+        "conclusion": str(run.get("conclusion") or ""),
+        "details_url": details_url,
+        "html_url": run.get("html_url"),
+        "actions_run_id": run_id,
+        "suggested_local_preflight": _hint_for_check(name),
+    }
+
+
+def _status_to_item(status: dict[str, Any]) -> dict[str, Any]:
+    context = str(status.get("context") or "unknown")
+    return {
+        "context": context,
+        "state": str(status.get("state") or "unknown"),
+        "description": status.get("description"),
+        "target_url": status.get("target_url"),
+        "suggested_local_preflight": _hint_for_check(context),
+    }
+
+
+def _open_pr_payload(
+    repo: str,
+    base: str,
+    head_prefix: str,
+    token: str,
+) -> list[dict[str, Any]]:
+    pulls = gates.get_open_prs(repo, github_token=token)
+    required_contexts = gates.get_required_contexts(repo, base, github_token=token) or []
+    failed_conclusions = {"failure", "timed_out", "cancelled", "startup_failure", "action_required", "stale"}
+
+    rows: list[dict[str, Any]] = []
+    for pr in pulls:
+        head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+        branch = str(head.get("ref") or "")
+        if head_prefix and not branch.startswith(head_prefix):
+            continue
+        sha = str(head.get("sha") or "")
+        if not sha:
+            continue
+        commit_status = gates.get_commit_status(repo, sha, github_token=token)
+        check_runs = gates.get_check_runs(repo, sha, github_token=token)
+        eval_result = gates.evaluate_pr_gates(pr, commit_status, check_runs, required_contexts)
+
+        failing_check_runs = []
+        for run in check_runs:
+            conclusion = str(run.get("conclusion") or "").lower()
+            status = str(run.get("status") or "").lower()
+            if status == "completed" and conclusion in failed_conclusions:
+                failing_check_runs.append(_check_run_to_item(run))
+
+        failing_status_contexts = []
+        statuses = commit_status.get("statuses")
+        if isinstance(statuses, list):
+            for status in statuses:
+                if not isinstance(status, dict):
+                    continue
+                state = str(status.get("state") or "").lower()
+                if state not in {"success", "expected"}:
+                    failing_status_contexts.append(_status_to_item(status))
+
+        rows.append(
+            {
+                "pr_number": pr.get("number"),
+                "pr_url": pr.get("html_url"),
+                "title": pr.get("title"),
+                "head_branch": branch,
+                "head_sha": sha,
+                "combined_status_state": commit_status.get("state"),
+                "ready_to_merge": eval_result.get("ready_to_merge"),
+                "missing_required_contexts": eval_result.get("missing_required_contexts"),
+                "failing_required_contexts": eval_result.get("failing_required_contexts"),
+                "failing_check_runs": failing_check_runs,
+                "failing_status_contexts": failing_status_contexts,
+            }
+        )
+    return rows
+
+
+def _rerun_failed_actions(repo: str, rows: list[dict[str, Any]], token: str) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    seen_run_ids: set[int] = set()
+    for row in rows:
+        checks = row.get("failing_check_runs")
+        if not isinstance(checks, list):
+            continue
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            run_id = check.get("actions_run_id")
+            if not isinstance(run_id, int) or run_id in seen_run_ids:
+                continue
+            seen_run_ids.add(run_id)
+            result = gates.rerun_actions_failed_jobs(repo, run_id, token)
+            actions.append(
+                {
+                    "run_id": run_id,
+                    "accepted": bool(result.get("accepted")),
+                    "status_code": result.get("status_code"),
+                    "response_text": result.get("response_text"),
+                    "check_name": check.get("name"),
+                }
+            )
+    return actions
+
+
+def _has_blocking_failures(rows: list[dict[str, Any]]) -> bool:
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if row.get("failing_check_runs"):
+            return True
+        if row.get("failing_status_contexts"):
+            return True
+        if row.get("missing_required_contexts"):
+            return True
+        if row.get("failing_required_contexts"):
+            return True
+    return False
+
+
+def _short_summary(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return "No matching open PRs found."
+    failures = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if (
+            row.get("failing_check_runs")
+            or row.get("failing_status_contexts")
+            or row.get("missing_required_contexts")
+            or row.get("failing_required_contexts")
+        ):
+            failures += 1
+    if failures == 0:
+        return f"Checked {len(rows)} PR(s); no blocking failures."
+    return f"Checked {len(rows)} PR(s); blocking failures in {failures} PR(s)."
+
+
+def _safe_slug(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]+", "-", value).strip("-") or "report"
+
+
+def _write_report(output_dir: Path, report: dict[str, Any], branch_filter: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"pr_failure_triage_{stamp}_{_safe_slug(branch_filter)}.json"
+    path = output_dir / filename
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect and triage open PR check failures.")
+    parser.add_argument("--repo", default="seeker71/Coherence-Network")
+    parser.add_argument("--base", default="main")
+    parser.add_argument("--head-prefix", default="codex/")
+    parser.add_argument("--output-dir", default=str(REPO_ROOT / "docs" / "system_audit" / "pr_check_failures"))
+    parser.add_argument("--fail-on-detected", action="store_true")
+    parser.add_argument("--rerun-failed-actions", action="store_true")
+    parser.add_argument("--rerun-settle-seconds", type=int, default=120)
+    parser.add_argument("--poll-seconds", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if not token:
+        payload = {
+            "generated_at": _now_utc(),
+            "repo": args.repo,
+            "base": args.base,
+            "head_prefix": args.head_prefix,
+            "status": "blocked_no_token",
+            "summary": "Set GITHUB_TOKEN or GH_TOKEN.",
+            "open_prs": [],
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(payload["summary"])
+        return 2
+
+    open_prs = _open_pr_payload(args.repo, args.base, args.head_prefix, token)
+    report: dict[str, Any] = {
+        "generated_at": _now_utc(),
+        "tool": "scripts/pr_check_failure_triage.py",
+        "repo": args.repo,
+        "base": args.base,
+        "head_prefix": args.head_prefix,
+        "status": "ok",
+        "open_prs": open_prs,
+        "summary": _short_summary(open_prs),
+        "auto_rerun_actions": [],
+    }
+
+    if args.rerun_failed_actions and _has_blocking_failures(open_prs):
+        report["auto_rerun_actions"] = _rerun_failed_actions(args.repo, open_prs, token)
+        deadline = time.time() + max(0, args.rerun_settle_seconds)
+        while time.time() < deadline:
+            refreshed = _open_pr_payload(args.repo, args.base, args.head_prefix, token)
+            if not _has_blocking_failures(refreshed):
+                open_prs = refreshed
+                report["open_prs"] = refreshed
+                break
+            time.sleep(max(1, args.poll_seconds))
+        report["summary_after_rerun"] = _short_summary(report["open_prs"])
+
+    report["has_blocking_failures"] = _has_blocking_failures(report["open_prs"])
+    report_path = _write_report(Path(args.output_dir), report, args.head_prefix)
+    report["report_path"] = str(report_path)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"PR check triage report: {report_path}")
+        print(report["summary"])
+        if report.get("summary_after_rerun"):
+            print(f"After auto-rerun: {report['summary_after_rerun']}")
+
+    if args.fail_on_detected and report["has_blocking_failures"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/pr_check_failure_triage.py` to detect open PR check failures and map each failure to a local remediation command
- support optional auto-rerun of failed GitHub Actions checks and settlement polling
- add scheduled workflow `.github/workflows/pr-check-failure-triage.yml` to catch failures every 6 hours
- document operator workflow in `docs/PR-CHECK-FAILURE-TRIAGE.md` and wire command references into runbook/process docs

## Validation
- `python3 scripts/pr_check_failure_triage.py --help`
- `cd api && pytest -q tests/test_pr_check_failure_triage.py`
- `python3 scripts/validate_workflow_references.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_pr-check-failure-triage-automation.json`
