### PR TITLE
Add mandatory delivery contract to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,28 @@ Spec → Test → Implement → CI → Review → Merge
 - Do NOT modify tests to make implementation pass
 - Only modify files listed in spec/issue
 
+## Mandatory Delivery Contract (No Exceptions)
+
+1. Worktree-only execution
+   - Never edit or run implementation commands in the primary workspace.
+   - Every task must start in a new git worktree under `~/.claude-worktrees/...`.
+2. Start gate (required before any edits)
+   - Run: `python3 scripts/ensure_worktree_start_clean.py --json`
+   - If it fails, stop and fix blockers first.
+3. Pre-commit local gate (required)
+   - Run: `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
+   - Run: `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
+   - If either fails, do not commit.
+4. Evidence contract (required per commit)
+   - Add/update `docs/system_audit/commit_evidence_<date>_<topic>.json`.
+   - Validate it: `python3 scripts/validate_commit_evidence.py --file <path>`.
+5. PR + CI contract
+   - Open PR immediately after push.
+   - Monitor checks until green, or report blocker with failing check links and remediation command.
+6. Finish contract
+   - No partial/abandoned work. If incomplete, leave explicit blocking status and next exact command.
+   - Do not start a new task while previous task has unresolved blocking checks.
+
 ## Key Files
 
 - `CLAUDE.md` — Project config, conventions, guardrails

--- a/docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json
@@ -1,0 +1,62 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/mandatory-delivery-contract",
+  "commit_scope": "Add mandatory delivery contract to AGENTS.md so all threads consistently use worktree-only execution, required start/pre-commit gates, PR/CI follow-through, and no-abandonment rules.",
+  "files_owned": [
+    "AGENTS.md",
+    "docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration"
+  ],
+  "task_ids": [
+    "task-mandatory-delivery-contract-instructions"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "documentation",
+        "process-hardening",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "AGENTS.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "scripts/ensure_worktree_start_clean.py",
+    "scripts/worktree_pr_guard.py"
+  ],
+  "change_files": [
+    "AGENTS.md",
+    "docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-actions"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting PR checks and merge."
+  }
+}


### PR DESCRIPTION
## Summary
- add a Mandatory Delivery Contract section to `AGENTS.md`
- enforce worktree-only execution and required start/pre-commit gates
- enforce commit evidence + PR/CI follow-through + no-abandonment rule

## Validation
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_mandatory-delivery-contract-agents.json`
