### PR TITLE
Reduce Auto Heal workflow noise and skipped runs

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -3,8 +3,7 @@ name: Auto Heal Deploy Gates
 on:
   workflow_run:
     workflows:
-      - Test
-      - Thread Gates
+      - Public Deploy Contract
       - Change Contract
     types: [completed]
     branches:
@@ -22,6 +21,9 @@ concurrency:
 
 jobs:
   heal-main-checks:
+    concurrency:
+      group: auto-heal-deploy-gates-job-${{ github.event.workflow_run.head_sha || github.sha }}
+      cancel-in-progress: true
     if: >
       github.event_name == 'workflow_dispatch' ||
       (


### PR DESCRIPTION
## Summary
- trigger auto-heal from deploy-contract workflows only (remove Test/Thread Gates triggers)
- add job-level concurrency keyed by SHA to avoid duplicate heal jobs running in parallel

## Why
- current setup generates many workflow_run auto-heal runs that immediately skip
- duplicate in-progress auto-heal jobs for the same SHA consume Actions capacity and create noise