### PR TITLE
Close auto-heal skip loop with failure-only dispatch

### DIFF
--- a/.github/workflows/auto-heal-deploy-gates.yml
+++ b/.github/workflows/auto-heal-deploy-gates.yml
@@ -1,13 +1,6 @@
 name: Auto Heal Deploy Gates
 
 on:
-  workflow_run:
-    workflows:
-      - Public Deploy Contract
-      - Change Contract
-    types: [completed]
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       sha:
@@ -15,23 +8,11 @@ on:
         required: false
         type: string
 
-concurrency:
-  group: auto-heal-deploy-gates-${{ github.event.workflow_run.head_sha || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   heal-main-checks:
     concurrency:
-      group: auto-heal-deploy-gates-job-${{ github.event.workflow_run.head_sha || github.sha }}
+      group: auto-heal-deploy-gates-job-${{ github.event.inputs.sha || github.sha }}
       cancel-in-progress: true
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.run_attempt == 1 &&
-        github.event.workflow_run.actor.login != 'github-actions[bot]' &&
-        contains(fromJSON('["failure","cancelled","timed_out","action_required","startup_failure"]'), github.event.workflow_run.conclusion)
-      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,7 +32,7 @@ jobs:
       - name: Auto-heal failed required checks
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.event.workflow_run.head_sha }}
+          TARGET_SHA: ${{ github.event.inputs.sha || github.sha }}
         run: |
           cd api
           python scripts/auto_heal_deploy_gates.py \

--- a/.github/workflows/public-deploy-contract.yml
+++ b/.github/workflows/public-deploy-contract.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: write
     env:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -229,6 +230,18 @@ jobs:
               issue_number: issue.number,
               state: 'closed',
             });
+
+      - name: Dispatch auto-heal workflow
+        if: ${{ steps.outcome.outputs.exit_code != '0' && github.event_name != 'schedule' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          curl -sS -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/auto-heal-deploy-gates.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"sha":"${{ github.sha }}"}}'
 
       - name: Fail when contract is not satisfied
         if: ${{ steps.outcome.outputs.exit_code != '0' && github.event_name != 'schedule' }}


### PR DESCRIPTION
## Summary
- remove workflow_run trigger from Auto Heal Deploy Gates
- keep Auto Heal as workflow_dispatch only
- dispatch Auto Heal from Public Deploy Contract only when deploy contract fails (non-schedule)
- grant actions:write permission to dispatch workflow

## Result
- no more periodic workflow_run skip/cancel noise from Auto Heal
- Auto Heal runs only when there is an actual deploy contract failure