### PR TITLE
Add runtime metrics for /api/runtime-beacon endpoint

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-17_runtime-beacon-usage-metrics.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_runtime-beacon-usage-metrics.json
@@ -61,7 +61,7 @@
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-17T02:50:00Z",
+    "ran_at": "2026-02-17T03:02:00Z",
     "environment": {
       "python": "3.11",
       "node": "v25.2.1",

--- a/web/app/api/runtime-beacon/route.ts
+++ b/web/app/api/runtime-beacon/route.ts
@@ -5,6 +5,7 @@ const API_URL = getApiBase();
 
 async function recordBeaconRuntime(statusCode: number, runtimeMs: number): Promise<void> {
   try {
+    // Track beacon endpoint usage itself so web API routes are visible in runtime coverage.
     await fetch(`${API_URL}/api/runtime/events`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- record runtime usage metrics for `POST /api/runtime-beacon` in both success and failure paths
- keep telemetry non-blocking so endpoint behavior is unchanged on metrics failures

## Validation
- `./scripts/verify_worktree_local_web.sh`
- `cd api && python3.11 -m pytest -q tests/test_runtime_api.py`
- local persistence check confirms `/api/ideas` and `/api/runtime-beacon` runtime events are written
