### PR TITLE
Guard public deploy auto-heal dispatch behind opt-in

### DIFF
--- a/.github/workflows/public-deploy-contract.yml
+++ b/.github/workflows/public-deploy-contract.yml
@@ -232,7 +232,7 @@ jobs:
             });
 
       - name: Dispatch auto-heal workflow
-        if: ${{ steps.outcome.outputs.exit_code != '0' && github.event_name != 'schedule' }}
+        if: ${{ steps.outcome.outputs.exit_code != '0' && github.event_name == 'push' && vars.AUTO_HEAL_DEPLOY_GATES_ENABLED == '1' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/docs/system_audit/commit_evidence_2026-02-17_public-deploy-autoheal-dispatch-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_public-deploy-autoheal-dispatch-guard.json
@@ -1,0 +1,67 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/20260217-public-deploy-autoheal-guard",
+  "commit_scope": "Stop recursive public-deploy auto-heal dispatch loops by gating auto-heal dispatch behind an explicit repository variable.",
+  "files_owned": [
+    ".github/workflows/public-deploy-contract.yml",
+    "docs/system_audit/commit_evidence_2026-02-17_public-deploy-autoheal-dispatch-guard.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "050"
+  ],
+  "task_ids": [
+    "public-deploy-autoheal-dispatch-guard"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+  ],
+  "change_files": [
+    ".github/workflows/public-deploy-contract.yml"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-17T03:15:00Z",
+    "commands": [
+      "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy-contract validation."
+  }
+}


### PR DESCRIPTION
## Summary
- gate `Public Deploy Contract` auto-heal dispatch behind `AUTO_HEAL_DEPLOY_GATES_ENABLED=1`
- prevent recursive dispatch loops from continuously canceling deploy-contract runs

## Validation
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
