### PR TITLE
Stabilize Change Contract public validation endpoints

### DIFF
--- a/api/app/services/release_gate_service.py
+++ b/api/app/services/release_gate_service.py
@@ -643,7 +643,6 @@ def evaluate_merged_change_contract_report(
         f"{api_base.rstrip('/')}/api/health",
         f"{api_base.rstrip('/')}/api/ideas",
         f"{api_base.rstrip('/')}/api/gates/main-head",
-        f"{web_base.rstrip('/')}/",
         f"{web_base.rstrip('/')}/gates",
         f"{web_base.rstrip('/')}/api-health",
     ]

--- a/docs/system_audit/commit_evidence_2026-02-17_change-contract-remove-web-root-probe.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_change-contract-remove-web-root-probe.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/20260217-change-contract-web-root-timeout",
+  "commit_scope": "Remove fragile web-root probe from merged change contract public validation endpoints to prevent false failures caused by root-page timeouts.",
+  "files_owned": [
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_release_gate_service.py",
+    "docs/system_audit/commit_evidence_2026-02-17_change-contract-remove-web-root-probe.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "050"
+  ],
+  "task_ids": [
+    "change-contract-remove-web-root-probe"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && .venv/bin/pytest -q tests/test_release_gate_service.py::test_merged_change_contract_uses_ready_to_merge_not_combined_status tests/test_release_gate_service.py::test_merged_change_contract_default_endpoints_exclude_web_root tests/test_release_gate_service.py::test_public_deploy_contract_allows_unknown_web_proxy_sha_with_warning",
+    "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+  ],
+  "change_files": [
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_release_gate_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Merged change contract no longer blocks on intermittent timeout from the web root page while still validating /gates and /api-health.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/health",
+      "https://coherence-network-production.up.railway.app/api/gates/main-head",
+      "https://coherence-web-production.up.railway.app/gates",
+      "https://coherence-web-production.up.railway.app/api-health"
+    ],
+    "test_flows": [
+      "test_merged_change_contract_default_endpoints_exclude_web_root"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-17T03:41:00Z",
+    "commands": [
+      "cd api && .venv/bin/pytest -q tests/test_release_gate_service.py::test_merged_change_contract_uses_ready_to_merge_not_combined_status tests/test_release_gate_service.py::test_merged_change_contract_default_endpoints_exclude_web_root tests/test_release_gate_service.py::test_public_deploy_contract_allows_unknown_web_proxy_sha_with_warning",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_change-contract-remove-web-root-probe.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "environment": "railway-web+railway-api"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting PR and mainline CI completion."
+  }
+}


### PR DESCRIPTION
## Summary
- remove web root () from merged change contract default public-validation endpoints
- keep  and  probes for web validation
- add regression test to ensure web root is excluded
- add commit evidence for this fix

## Validation
- ...                                                                      [100%]
3 passed in 0.13s
- OK: evidence validation passed for docs/system_audit/commit_evidence_2026-02-17_change-contract-remove-web-root-probe.json