### PR TITLE
Refactor agent routing, diagnostics, and paid/free provider attribution

### DIFF
--- a/api/app/models/agent.py
+++ b/api/app/models/agent.py
@@ -151,3 +151,6 @@ class RouteResponse(BaseModel):
     command_template: str
     tier: str
     executor: Optional[str] = None  # "claude", "cursor", or "openclaw"
+    provider: Optional[str] = None
+    billing_provider: Optional[str] = None
+    is_paid_provider: Optional[bool] = None

--- a/api/app/services/agent_routing_service.py
+++ b/api/app/services/agent_routing_service.py
@@ -1,0 +1,247 @@
+"""Deterministic agent routing and provider classification utilities."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from typing import Any
+
+from app.models.agent import TaskType
+
+# Routing defaults (see docs/MODEL-ROUTING.md)
+_OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "openrouter/free")
+_OLLAMA_CLOUD_MODEL = os.environ.get("OLLAMA_CLOUD_MODEL", "openrouter/free")
+_CLAUDE_MODEL = os.environ.get("CLAUDE_FALLBACK_MODEL", "openrouter/free")
+
+_CURSOR_MODEL_DEFAULT = os.environ.get("CURSOR_CLI_MODEL", "openrouter/free")
+_CURSOR_MODEL_REVIEW = os.environ.get("CURSOR_CLI_REVIEW_MODEL", "openrouter/free")
+
+_OPENCLAW_MODEL_DEFAULT = os.environ.get("OPENCLAW_MODEL", "gpt-5.1-codex")
+_OPENCLAW_MODEL_REVIEW = os.environ.get("OPENCLAW_REVIEW_MODEL", _OPENCLAW_MODEL_DEFAULT)
+
+ROUTING: dict[TaskType, tuple[str, str]] = {
+    TaskType.SPEC: (_OLLAMA_MODEL, "openrouter"),
+    TaskType.TEST: (_OLLAMA_CLOUD_MODEL, "openrouter"),
+    TaskType.IMPL: (_OLLAMA_CLOUD_MODEL, "openrouter"),
+    TaskType.REVIEW: (_CLAUDE_MODEL, "openrouter"),
+    TaskType.HEAL: (_CLAUDE_MODEL, "openrouter"),
+}
+
+CURSOR_MODEL_BY_TYPE: dict[TaskType, str] = {
+    TaskType.SPEC: _CURSOR_MODEL_DEFAULT,
+    TaskType.TEST: _CURSOR_MODEL_DEFAULT,
+    TaskType.IMPL: _CURSOR_MODEL_DEFAULT,
+    TaskType.REVIEW: _CURSOR_MODEL_REVIEW,
+    TaskType.HEAL: _CURSOR_MODEL_REVIEW,
+}
+
+OPENCLAW_MODEL_BY_TYPE: dict[TaskType, str] = {
+    TaskType.SPEC: _OPENCLAW_MODEL_DEFAULT,
+    TaskType.TEST: _OPENCLAW_MODEL_DEFAULT,
+    TaskType.IMPL: _OPENCLAW_MODEL_DEFAULT,
+    TaskType.REVIEW: _OPENCLAW_MODEL_REVIEW,
+    TaskType.HEAL: _OPENCLAW_MODEL_REVIEW,
+}
+
+EXECUTOR_VALUES = ("claude", "cursor", "openclaw")
+
+REPO_SCOPE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bthis repo\b", re.IGNORECASE),
+    re.compile(r"\bthis repository\b", re.IGNORECASE),
+    re.compile(r"\bcodebase\b", re.IGNORECASE),
+    re.compile(r"\bin (?:the )?repo\b", re.IGNORECASE),
+    re.compile(r"\bAGENTS\.md\b", re.IGNORECASE),
+    re.compile(r"\bCLAUDE\.md\b", re.IGNORECASE),
+    re.compile(r"\bdocs/[A-Za-z0-9_.\-\/]+\b", re.IGNORECASE),
+    re.compile(r"\bapi/[A-Za-z0-9_.\-\/]+\b", re.IGNORECASE),
+    re.compile(r"\bweb/[A-Za-z0-9_.\-\/]+\b", re.IGNORECASE),
+    re.compile(r"`[^`]+\.(?:py|ts|tsx|js|jsx|md|json|toml|yaml|yml)`", re.IGNORECASE),
+    re.compile(r"\b[A-Za-z0-9_.\-]+\.(?:py|ts|tsx|js|jsx|md|json|toml|yaml|yml)\b", re.IGNORECASE),
+)
+
+
+def int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except ValueError:
+        return default
+    return max(0, value)
+
+
+def executor_policy_enabled() -> bool:
+    raw = os.environ.get("AGENT_EXECUTOR_POLICY_ENABLED", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def normalize_executor(value: str | None, default: str = "claude") -> str:
+    candidate = (value or "").strip().lower()
+    if candidate in EXECUTOR_VALUES:
+        return candidate
+    return default
+
+
+def cheap_executor_default() -> str:
+    configured = os.environ.get("AGENT_EXECUTOR_CHEAP_DEFAULT")
+    if configured:
+        return normalize_executor(configured, default="cursor")
+    fallback = os.environ.get("AGENT_EXECUTOR_DEFAULT", "cursor")
+    return normalize_executor(fallback, default="cursor")
+
+
+def escalation_executor_default() -> str:
+    configured = os.environ.get("AGENT_EXECUTOR_ESCALATE_TO")
+    if configured:
+        return normalize_executor(configured, default="claude")
+    cheap = cheap_executor_default()
+    return "claude" if cheap != "claude" else "openclaw"
+
+
+def executor_binary_name(executor: str) -> str:
+    if executor == "cursor":
+        return "agent"
+    if executor == "openclaw":
+        return "openclaw"
+    return "aider"
+
+
+def executor_available(executor: str) -> bool:
+    return shutil.which(executor_binary_name(executor)) is not None
+
+
+def first_available_executor(preferred: list[str]) -> str:
+    for executor in preferred:
+        candidate = normalize_executor(executor, default="")
+        if candidate and executor_available(candidate):
+            return candidate
+    return normalize_executor(os.environ.get("AGENT_EXECUTOR_DEFAULT"), default="claude")
+
+
+def is_repo_scoped_question(direction: str, context: dict[str, Any]) -> bool:
+    scope_hint = str(context.get("question_scope") or context.get("scope") or "").strip().lower()
+    if scope_hint in {"repo", "repository", "codebase"}:
+        return True
+    if scope_hint in {"open", "general"}:
+        return False
+
+    text = direction.strip()
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in REPO_SCOPE_PATTERNS)
+
+
+def repo_question_executor_default() -> str:
+    configured = os.environ.get("AGENT_EXECUTOR_REPO_DEFAULT")
+    if configured:
+        return normalize_executor(configured, default="cursor")
+    return "cursor"
+
+
+def open_question_executor_default() -> str:
+    configured = os.environ.get("AGENT_EXECUTOR_OPEN_QUESTION_DEFAULT")
+    if configured:
+        return normalize_executor(configured, default="openclaw")
+    return "openclaw"
+
+
+def cursor_command_template(task_type: TaskType) -> str:
+    model = CURSOR_MODEL_BY_TYPE[task_type]
+    return f'agent "{{{{direction}}}}" --model {model}'
+
+
+def openclaw_command_template(task_type: TaskType) -> str:
+    model = OPENCLAW_MODEL_BY_TYPE[task_type]
+    template = os.environ.get(
+        "OPENCLAW_COMMAND_TEMPLATE",
+        'codex exec "{{direction}}" --model {{model}} --skip-git-repo-check --json',
+    )
+    if "{{direction}}" not in template:
+        template = template.strip() + ' "{{direction}}"'
+    return template.replace("{{model}}", model)
+
+
+def route_for_executor(task_type: TaskType, executor: str, default_command_template: str) -> dict[str, Any]:
+    normalized = normalize_executor(executor, default="claude")
+    if normalized == "cursor":
+        model = f"cursor/{CURSOR_MODEL_BY_TYPE[task_type]}"
+        template = cursor_command_template(task_type)
+        tier = "cursor"
+    elif normalized == "openclaw":
+        model = f"openclaw/{OPENCLAW_MODEL_BY_TYPE[task_type]}"
+        template = openclaw_command_template(task_type)
+        tier = "openclaw"
+    else:
+        model, tier = ROUTING[task_type]
+        template = default_command_template
+
+    provider, billing_provider, is_paid_provider = classify_provider(
+        executor=normalized,
+        model=model,
+        command=template,
+        worker_id=None,
+    )
+    return {
+        "task_type": task_type.value,
+        "model": model,
+        "command_template": template,
+        "tier": tier,
+        "executor": normalized,
+        "provider": provider,
+        "billing_provider": billing_provider,
+        "is_paid_provider": is_paid_provider,
+    }
+
+
+def apply_model_override(command: str, override: str) -> tuple[str, str]:
+    cleaned = override.strip()
+    if not cleaned:
+        return command, ""
+    if re.search(r"--model\s+\S+", command):
+        return re.sub(r"--model\s+\S+", f"--model {cleaned}", command), cleaned
+    return command.rstrip() + f" --model {cleaned}", cleaned
+
+
+def classify_provider(*, executor: str, model: str, command: str, worker_id: str | None) -> tuple[str, str, bool]:
+    lower_model = (model or "").strip().lower()
+    lower_command = (command or "").strip().lower()
+    normalized_worker = (worker_id or "").strip().lower()
+    command_model_match = re.search(r"--model\s+([^\s]+)", lower_command)
+    command_model = command_model_match.group(1).strip().lower() if command_model_match else ""
+
+    provider = "unknown"
+    if normalized_worker == "openai-codex" or normalized_worker.startswith("openai-codex:"):
+        provider = "openai-codex"
+    elif "openrouter" in command_model or "openrouter" in lower_model:
+        provider = "openrouter"
+    elif command_model.startswith("openai/") or command_model.startswith(("gpt", "o1", "o3", "o4")):
+        provider = "openai-codex" if "codex" in command_model else "openai"
+    elif "codex" in lower_model:
+        provider = "openai-codex"
+    elif lower_model.startswith("openai/") or lower_model.startswith(("gpt", "o1", "o3", "o4")):
+        provider = "openai"
+    elif lower_command.startswith("codex "):
+        provider = "openai-codex"
+    elif executor == "openclaw":
+        provider = "openclaw"
+    elif executor == "cursor":
+        provider = "cursor"
+    elif executor in {"claude", "aider"}:
+        provider = "claude"
+
+    billing_provider = provider
+    is_paid_provider = is_paid_model(provider=provider, model=lower_model, command_model=command_model)
+    return provider, billing_provider, is_paid_provider
+
+
+def is_paid_model(*, provider: str, model: str, command_model: str) -> bool:
+    if provider == "openrouter":
+        ref = command_model or model
+        if "openrouter/free" in ref or ref.endswith("/free"):
+            return False
+        return True
+    if provider in {"openai", "openai-codex", "claude", "cursor"}:
+        return True
+    return False

--- a/api/tests/test_agent_executor_policy.py
+++ b/api/tests/test_agent_executor_policy.py
@@ -33,6 +33,10 @@ def test_policy_uses_cheap_executor_by_default(monkeypatch: pytest.MonkeyPatch) 
     assert str(task["command"]).startswith("agent ")
     context = task.get("context") or {}
     assert context.get("executor") == "cursor"
+    route_decision = context.get("route_decision") or {}
+    assert route_decision.get("executor") == "cursor"
+    assert route_decision.get("provider") in {"cursor", "openrouter", "openai-codex"}
+    assert "is_paid_provider" in route_decision
     policy = context.get("executor_policy") or {}
     assert policy.get("policy_applied") is True
     assert policy.get("reason") == "cheap_default"

--- a/api/tests/test_agent_usage_tracking_api.py
+++ b/api/tests/test_agent_usage_tracking_api.py
@@ -249,3 +249,4 @@ async def test_openclaw_openrouter_override_tracks_openrouter_provider(
         metadata = completion_events[0]["metadata"]
         assert metadata["provider"] == "openrouter"
         assert metadata["billing_provider"] == "openrouter"
+        assert metadata["is_paid_provider"] is False

--- a/api/tests/test_openclaw_executor_integration.py
+++ b/api/tests/test_openclaw_executor_integration.py
@@ -34,8 +34,8 @@ def test_create_task_openclaw_default_template_includes_model(monkeypatch: pytes
     monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
     monkeypatch.delenv("OPENCLAW_COMMAND_TEMPLATE", raising=False)
     monkeypatch.setattr(
-        agent_service,
-        "_OPENCLAW_MODEL_BY_TYPE",
+        agent_service.routing_service,
+        "OPENCLAW_MODEL_BY_TYPE",
         {task_type: "openrouter/free" for task_type in TaskType},
     )
     agent_service._store.clear()
@@ -83,6 +83,8 @@ async def test_agent_route_endpoint_accepts_openclaw_executor() -> None:
         assert payload["executor"] == "openclaw"
         assert payload["tier"] == "openclaw"
         assert str(payload["model"]).startswith("openclaw/")
+        assert payload["provider"] in {"openrouter", "openclaw", "openai-codex"}
+        assert isinstance(payload["is_paid_provider"], bool)
         template = str(payload["command_template"])
         assert "{{direction}}" in template
         assert template.startswith("openclaw ") or template.startswith("codex exec ")

--- a/docs/system_audit/commit_evidence_2026-02-17_openclaw-paid-usage-validation.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_openclaw-paid-usage-validation.json
@@ -1,17 +1,14 @@
 {
   "date": "2026-02-17",
   "thread_branch": "codex/openclaw-proof-20260216-220156",
-  "commit_scope": "Enable OpenClaw provider validation on Codex-backed execution and enforce paid-provider usage attribution in runtime completion telemetry.",
+  "commit_scope": "Refactor agent routing into a dedicated service with explicit executor/model/provider decisions, add route diagnostics, and enforce free-vs-paid provider classification for completion telemetry.",
   "files_owned": [
+    "api/app/services/agent_routing_service.py",
     "api/app/services/agent_service.py",
-    "api/app/services/automation_usage_service.py",
-    "api/app/services/inventory_service.py",
-    "api/app/services/release_gate_service.py",
+    "api/app/models/agent.py",
+    "api/tests/test_agent_executor_policy.py",
     "api/tests/test_agent_usage_tracking_api.py",
-    "api/tests/test_automation_usage_api.py",
     "api/tests/test_openclaw_executor_integration.py",
-    "scripts/worktree_pr_guard.py",
-    "scripts/pr_check_failure_triage.py",
     "docs/system_audit/commit_evidence_2026-02-17_openclaw-paid-usage-validation.json"
   ],
   "idea_ids": [
@@ -22,7 +19,7 @@
     "100"
   ],
   "task_ids": [
-    "openclaw-paid-usage-validation"
+    "openclaw-routing-refactor"
   ],
   "contributors": [
     {
@@ -47,40 +44,39 @@
     "version": "gpt-5"
   },
   "evidence_refs": [
-    "cd api && pytest -q tests/test_agent_usage_tracking_api.py tests/test_automation_usage_api.py",
-    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_openclaw-paid-usage-validation.json"
+    "cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py tests/test_agent_executor_policy.py",
+    "cd api && pytest -q",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
   ],
   "change_files": [
+    "api/app/services/agent_routing_service.py",
     "api/app/services/agent_service.py",
-    "api/app/services/automation_usage_service.py",
-    "api/app/services/inventory_service.py",
-    "api/app/services/release_gate_service.py",
+    "api/app/models/agent.py",
+    "api/tests/test_agent_executor_policy.py",
     "api/tests/test_agent_usage_tracking_api.py",
-    "api/tests/test_automation_usage_api.py",
-    "api/tests/test_openclaw_executor_integration.py",
-    "scripts/worktree_pr_guard.py",
-    "scripts/pr_check_failure_triage.py"
+    "api/tests/test_openclaw_executor_integration.py"
   ],
   "change_intent": "runtime_fix",
   "e2e_validation": {
     "status": "pending",
-    "expected_behavior_delta": "OpenClaw validation supports Codex/OpenAI-backed execution; runtime completion events include provider attribution so paid-provider usage is measurable and enforceable. PR guard/triage treats Vercel status context as optional by default so Railway deployment remains primary merge gate.",
+    "expected_behavior_delta": "Task and route outputs include explicit executor/model/provider/billing/paid decision data. Completion tracking marks openrouter/free as non-paid while preserving provider attribution.",
     "public_endpoints": [
-      "https://coherence-network-production.up.railway.app/api/automation/usage/provider-validation",
-      "https://coherence-network-production.up.railway.app/api/agent/usage",
+      "https://coherence-network-production.up.railway.app/api/agent/route?task_type=impl&executor=openclaw",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
       "https://coherence-network-production.up.railway.app/api/runtime/events"
     ],
     "test_flows": [
-      "api: POST /api/automation/usage/provider-validation/run?required_providers=openclaw,openai-codex then GET provider-validation and confirm required providers validate",
-      "api: execute openclaw task lifecycle and confirm runtime completion event metadata includes provider/billing_provider"
+      "api: create openclaw task with model_override=openrouter/free and verify context.route_decision fields",
+      "api: complete task and verify runtime completion event metadata contains provider/billing_provider/is_paid_provider=false for openrouter/free"
     ]
   },
   "local_validation": {
     "status": "pass",
-    "ran_at": "2026-02-17T05:50:00Z",
+    "ran_at": "2026-02-17T06:36:30Z",
     "commands": [
-      "cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py tests/test_automation_usage_api.py",
-      "python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --json"
+      "cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py tests/test_agent_executor_policy.py",
+      "cd api && pytest -q"
     ]
   },
   "ci_validation": {
@@ -93,6 +89,6 @@
   },
   "phase_gate": {
     "can_move_next_phase": false,
-    "reason": "Awaiting CI and deployment validation on public Railway instance."
+    "reason": "Awaiting PR checks and production verification after refactor deploy."
   }
 }


### PR DESCRIPTION
## Summary
- extract executor/model/provider routing logic into dedicated `agent_routing_service`
- add explicit route diagnostics (provider, billing_provider, is_paid_provider) to route responses and task context
- standardize completion telemetry provider classification, including `openrouter/free` as non-paid
- keep OpenClaw command model override behavior deterministic and test-covered

## Validation
- `cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py tests/test_agent_executor_policy.py`
- `cd api && pytest -q`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
