### PR TITLE
Enforce DB-backed commit-evidence tracking and remove fallback

### DIFF
--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -187,3 +187,10 @@ async def route_evidence_inventory(
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
 ) -> dict:
     return inventory_service.build_route_evidence_inventory(runtime_window_seconds=runtime_window_seconds)
+
+
+@router.get("/inventory/commit-evidence")
+async def commit_evidence_inventory(
+    limit: int = Query(50, ge=1, le=500),
+) -> dict:
+    return inventory_service.build_commit_evidence_inventory(limit=limit)

--- a/api/app/services/commit_evidence_service.py
+++ b/api/app/services/commit_evidence_service.py
@@ -1,0 +1,199 @@
+"""Persistence service for commit evidence records."""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import DateTime, Integer, String, Text, create_engine, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
+from sqlalchemy.pool import NullPool
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class CommitEvidenceRecord(Base):
+    __tablename__ = "commit_evidence_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    source_file: Mapped[str] = mapped_column(String, nullable=False, default="", index=True)
+    record_fingerprint: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+_ENGINE_CACHE: dict[str, Any] = {"url": "", "engine": None, "sessionmaker": None}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _default_sqlite_path() -> Path:
+    return _repo_root() / "api" / "logs" / "commit_evidence_store.db"
+
+
+def database_url() -> str:
+    configured = os.getenv("COMMIT_EVIDENCE_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if configured:
+        return str(configured).strip()
+    sqlite_path = _default_sqlite_path()
+    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite+pysqlite:///{sqlite_path}"
+
+
+def _create_engine(url: str):
+    kwargs: dict[str, Any] = {"pool_pre_ping": True}
+    if url.startswith("sqlite"):
+        kwargs["connect_args"] = {"check_same_thread": False}
+        kwargs["poolclass"] = NullPool
+    return create_engine(url, **kwargs)
+
+
+def _engine():
+    url = database_url()
+    if _ENGINE_CACHE["engine"] is not None and _ENGINE_CACHE["url"] == url:
+        return _ENGINE_CACHE["engine"]
+    engine = _create_engine(url)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+    _ENGINE_CACHE["url"] = url
+    _ENGINE_CACHE["engine"] = engine
+    _ENGINE_CACHE["sessionmaker"] = SessionLocal
+    return engine
+
+
+def _sessionmaker():
+    _engine()
+    return _ENGINE_CACHE["sessionmaker"]
+
+
+@contextmanager
+def _session() -> Session:
+    SessionLocal = _sessionmaker()
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def ensure_schema() -> None:
+    engine = _engine()
+    Base.metadata.create_all(bind=engine)
+
+
+def _redact_database_url(url: str) -> str:
+    if "@" not in url or "://" not in url:
+        return url
+    scheme, remainder = url.split("://", 1)
+    if "@" not in remainder:
+        return url
+    credentials, host = remainder.split("@", 1)
+    if ":" in credentials:
+        user = credentials.split(":", 1)[0]
+        credentials = f"{user}:***"
+    else:
+        credentials = "***"
+    return f"{scheme}://{credentials}@{host}"
+
+
+def backend_info() -> dict[str, Any]:
+    ensure_schema()
+    url = database_url()
+    backend = "postgresql" if "postgres" in url else "sqlite"
+    with _session() as session:
+        rows = int(session.query(func.count(CommitEvidenceRecord.id)).scalar() or 0)
+    return {
+        "backend": backend,
+        "database_url": _redact_database_url(url),
+        "record_rows": rows,
+    }
+
+
+def _fingerprint_from_payload(payload: dict[str, Any], source_file: str) -> str:
+    digest_source = {
+        "source_file": source_file,
+        "date": payload.get("date"),
+        "thread_branch": payload.get("thread_branch"),
+        "commit_scope": payload.get("commit_scope"),
+        "idea_ids": payload.get("idea_ids"),
+        "spec_ids": payload.get("spec_ids"),
+        "task_ids": payload.get("task_ids"),
+        "change_files": payload.get("change_files"),
+    }
+    return json.dumps(digest_source, sort_keys=True, default=str)
+
+
+def upsert_record(payload: dict[str, Any], source_file: str = "") -> None:
+    if not isinstance(payload, dict):
+        return
+    ensure_schema()
+    normalized_source = str(source_file or payload.get("_evidence_file") or "").strip()
+    fingerprint = _fingerprint_from_payload(payload, normalized_source)
+    body = dict(payload)
+    body["_evidence_file"] = normalized_source
+    serialized = json.dumps(body, default=str, sort_keys=True)
+    now = datetime.utcnow()
+    with _session() as session:
+        row = (
+            session.query(CommitEvidenceRecord)
+            .filter(CommitEvidenceRecord.record_fingerprint == fingerprint)
+            .first()
+        )
+        if row is None:
+            session.add(
+                CommitEvidenceRecord(
+                    source_file=normalized_source,
+                    record_fingerprint=fingerprint,
+                    payload_json=serialized,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        else:
+            row.source_file = normalized_source
+            row.payload_json = serialized
+            row.updated_at = now
+            session.add(row)
+
+
+def bulk_upsert(records: list[dict[str, Any]]) -> int:
+    imported = 0
+    for row in records:
+        if not isinstance(row, dict):
+            continue
+        upsert_record(row, str(row.get("_evidence_file") or ""))
+        imported += 1
+    return imported
+
+
+def list_records(limit: int = 400) -> list[dict[str, Any]]:
+    ensure_schema()
+    with _session() as session:
+        rows = (
+            session.query(CommitEvidenceRecord)
+            .order_by(CommitEvidenceRecord.updated_at.desc(), CommitEvidenceRecord.id.desc())
+            .limit(max(1, min(limit, 5000)))
+            .all()
+        )
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            payload = json.loads(row.payload_json)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payload["_evidence_file"] = str(payload.get("_evidence_file") or row.source_file or "")
+            out.append(payload)
+    return out

--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-import time
-from pathlib import Path
 from typing import Any
-
-import httpx
 
 from app.models.idea import (
     Idea,
@@ -21,6 +17,7 @@ from app.models.idea import (
     ManifestationStatus,
 )
 from app.services import idea_registry_service
+from app.services import commit_evidence_service
 
 
 DEFAULT_IDEAS: list[dict[str, Any]] = [
@@ -181,36 +178,6 @@ def _portfolio_path() -> str:
     return os.getenv("IDEA_PORTFOLIO_PATH", _default_portfolio_path())
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[3]
-
-
-def _tracking_repository() -> str:
-    return os.getenv("TRACKING_REPOSITORY", "seeker71/Coherence-Network")
-
-
-def _tracking_ref() -> str:
-    return os.getenv("TRACKING_REPOSITORY_REF", "main")
-
-
-def _github_headers() -> dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    token = os.getenv("GITHUB_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
-def _commit_evidence_dir() -> Path:
-    custom = os.getenv("IDEA_COMMIT_EVIDENCE_DIR")
-    if custom:
-        return Path(custom)
-    return _repo_root() / "docs" / "system_audit"
-
-
 def _idea_ids_from_payload(payload: dict[str, Any]) -> list[str]:
     raw = payload.get("idea_ids")
     if not isinstance(raw, list):
@@ -225,78 +192,23 @@ def _idea_ids_from_payload(payload: dict[str, Any]) -> list[str]:
     return out
 
 
-def _tracked_idea_ids_from_local(max_files: int = 400) -> list[str]:
-    evidence_dir = _commit_evidence_dir()
-    if not evidence_dir.exists():
-        return []
-    out: set[str] = set()
-    files = sorted(evidence_dir.glob("commit_evidence_*.json"))[: max(1, max_files)]
-    for path in files:
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if isinstance(payload, dict):
-            out.update(_idea_ids_from_payload(payload))
-    return sorted(out)
-
-
-def _tracked_idea_ids_from_github(max_files: int = 80, timeout: float = 8.0) -> list[str]:
-    now = time.time()
-    cache_key = f"{_tracking_repository()}::{_tracking_ref()}"
-    cached_ids = _TRACKED_IDEA_CACHE.get("idea_ids")
-    if (
-        isinstance(cached_ids, list)
-        and _TRACKED_IDEA_CACHE.get("cache_key") == cache_key
-        and _TRACKED_IDEA_CACHE.get("expires_at", 0.0) > now
-    ):
-        return [x for x in cached_ids if isinstance(x, str) and x.strip()]
-
-    repository = _tracking_repository()
-    ref = _tracking_ref()
-    url = f"https://api.github.com/repos/{repository}/contents/docs/system_audit"
-    out: set[str] = set()
-
+def _tracked_idea_ids_from_store(max_files: int = 400) -> list[str]:
     try:
-        with httpx.Client(timeout=timeout, headers=_github_headers()) as client:
-            response = client.get(url, params={"ref": ref})
-            response.raise_for_status()
-            rows = response.json()
-            if not isinstance(rows, list):
-                return []
-            evidence_rows = [
-                row
-                for row in rows
-                if isinstance(row, dict)
-                and isinstance(row.get("name"), str)
-                and row["name"].startswith("commit_evidence_")
-                and row["name"].endswith(".json")
-            ][: max(1, max_files)]
-
-            for row in evidence_rows:
-                download_url = row.get("download_url")
-                if not isinstance(download_url, str) or not download_url:
-                    continue
-                payload_resp = client.get(download_url)
-                if payload_resp.status_code != 200:
-                    continue
-                payload = payload_resp.json()
-                if isinstance(payload, dict):
-                    out.update(_idea_ids_from_payload(payload))
-    except (httpx.HTTPError, ValueError, TypeError):
-        return []
-
-    result = sorted(out)
-    _TRACKED_IDEA_CACHE["cache_key"] = cache_key
-    _TRACKED_IDEA_CACHE["idea_ids"] = result
-    _TRACKED_IDEA_CACHE["expires_at"] = now + _TRACKED_IDEA_CACHE_TTL_SECONDS
-    return result
+        db_rows = commit_evidence_service.list_records(limit=max(1, max_files))
+    except Exception:
+        db_rows = []
+    out: set[str] = set()
+    for row in db_rows:
+        if not isinstance(row, dict):
+            continue
+        out.update(_idea_ids_from_payload(row))
+    return sorted(out)
 
 
 def _should_include_default_tracked_ideas() -> bool:
     # When callers isolate ideas into a custom portfolio path (common in tests),
     # avoid implicitly pulling repo-global tracked ids unless explicitly requested.
-    if os.getenv("IDEA_COMMIT_EVIDENCE_DIR"):
+    if os.getenv("IDEA_COMMIT_EVIDENCE_DIR") or os.getenv("COMMIT_EVIDENCE_DATABASE_URL"):
         return True
     return os.getenv("IDEA_PORTFOLIO_PATH") in {None, ""}
 
@@ -304,10 +216,7 @@ def _should_include_default_tracked_ideas() -> bool:
 def _tracked_idea_ids() -> list[str]:
     if not _should_include_default_tracked_ideas():
         return []
-    local = _tracked_idea_ids_from_local()
-    if local:
-        return local
-    return _tracked_idea_ids_from_github()
+    return _tracked_idea_ids_from_store()
 
 
 def _humanize_idea_id(idea_id: str) -> str:

--- a/api/app/services/persistence_contract_service.py
+++ b/api/app/services/persistence_contract_service.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from app.adapters.postgres_store import PostgresGraphStore
 from app.services import (
+    commit_evidence_service,
     idea_registry_service,
     runtime_event_store,
     spec_registry_service,
@@ -84,6 +85,15 @@ def evaluate(app: Any) -> dict[str, Any]:
     if required and usage_provider_info["snapshots_path_override"]:
         failures.append("provider_usage_file_override_enabled")
 
+    commit_evidence_info = commit_evidence_service.backend_info()
+    commit_evidence_tracking = {
+        "ok": commit_evidence_info.get("backend") == "postgresql",
+        "backend": commit_evidence_info.get("backend"),
+        "note": "commit evidence tracking backend",
+    }
+    if required and not commit_evidence_tracking["ok"]:
+        failures.append("commit_evidence_not_postgresql")
+
     report = {
         "required": required,
         "pass_contract": len(failures) == 0,
@@ -94,6 +104,7 @@ def evaluate(app: Any) -> dict[str, Any]:
             "specs_and_pseudocode": specs_and_pseudocode,
             "usage_runtime_metrics": usage_runtime,
             "usage_provider_info": usage_provider_info,
+            "commit_evidence_tracking": commit_evidence_tracking,
         },
         "failures": failures,
     }

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -72,3 +72,4 @@ async def test_persistence_contract_endpoint_returns_domain_report(monkeypatch: 
         assert "domains" in payload
         assert "ideas" in payload["domains"]
         assert "specs_and_pseudocode" in payload["domains"]
+        assert "commit_evidence_tracking" in payload["domains"]

--- a/docs/system_audit/commit_evidence_2026-02-17_api-web-endpoint-linkage-evidence.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_api-web-endpoint-linkage-evidence.json
@@ -1,0 +1,94 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/api-web-gap-analysis",
+  "commit_scope": "Endpoint-to-web linkage evidence and PostgreSQL-backed commit evidence tracking migration",
+  "files_owned": [
+    "api/app/routers/inventory.py",
+    "api/app/services/commit_evidence_service.py",
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/persistence_contract_service.py",
+    "api/tests/conftest.py",
+    "api/tests/test_health.py",
+    "api/tests/test_inventory_api.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "web/app/api-coverage/page.tsx"
+  ],
+  "idea_ids": [
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "089-endpoint-traceability-coverage"
+  ],
+  "task_ids": [
+    "api-web-gap-analysis"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["implementation", "validation"]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": ["idea", "review"]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_health.py tests/test_inventory_discovery_sources.py tests/test_inventory_api.py",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+  ],
+  "change_files": [
+    "api/app/routers/inventory.py",
+    "api/app/services/commit_evidence_service.py",
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/persistence_contract_service.py",
+    "api/tests/conftest.py",
+    "api/tests/test_health.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/api-coverage/page.tsx",
+    "docs/system_audit/endpoint_web_link_matrix_2026-02-17.json",
+    "docs/system_audit/commit_evidence_2026-02-17_api-web-endpoint-linkage-evidence.json"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_health.py tests/test_inventory_discovery_sources.py tests/test_inventory_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy validation pending"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Commit evidence tracking resolves through DB-backed API services (PostgreSQL in production) with fallback backfill from legacy artifacts; endpoint traceability still exposes web linkage evidence.",
+    "public_endpoints": [
+      "/api/inventory/commit-evidence",
+      "/api/inventory/endpoint-traceability",
+      "/api-coverage"
+    ],
+    "test_flows": [
+      "Call /api/inventory/commit-evidence and verify storage backend plus persisted records are returned even after legacy file removal.",
+      "Open /api-coverage and verify each endpoint row includes a clickable API/docs link.",
+      "Call /api/inventory/endpoint-traceability and verify summary includes with_web_link and missing_web_link."
+    ]
+  }
+}

--- a/docs/system_audit/endpoint_web_link_matrix_2026-02-17.json
+++ b/docs/system_audit/endpoint_web_link_matrix_2026-02-17.json
@@ -1,0 +1,2027 @@
+{
+  "generated_at": "2026-02-17T06:25:33.496167+00:00",
+  "summary": {
+    "total_endpoints": 98,
+    "canonical_registered": 36,
+    "with_idea": 98,
+    "with_origin_idea": 98,
+    "with_usage_events": 52,
+    "with_spec": 85,
+    "with_process": 85,
+    "with_validation": 85,
+    "with_web_link": 98,
+    "with_explicit_web_link": 42,
+    "fully_traced": 85,
+    "missing_idea": 0,
+    "missing_spec": 13,
+    "missing_process": 13,
+    "missing_validation": 13,
+    "missing_web_link": 0
+  },
+  "endpoint_web_link_matrix": [
+    {
+      "path": "/api/admin/reset-database",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/effectiveness",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 161,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 171,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/fatal-issues",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/integration",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/metrics",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/monitor-issues",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/pipeline-status",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 160,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 170,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/route",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/status-report",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/tasks",
+          "source_file": "web/app/tasks/page.tsx",
+          "line": 34,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/tasks",
+          "source_file": "web/app/tasks/page.tsx",
+          "line": 80,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 159,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks/attention",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks/count",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks/upsert-active",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks/{task_id}",
+      "methods": [
+        "GET",
+        "PATCH"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/tasks/{task_id}/log",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/telegram/diagnostics",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/telegram/test-send",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/telegram/webhook",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/usage",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 169,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/agent/visibility",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/agent",
+          "source_file": "web/app/agent/page.tsx",
+          "line": 54,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 168,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/assets",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/assets",
+          "source_file": "web/app/assets/page.tsx",
+          "line": 31,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/assets",
+          "source_file": "web/app/assets/page.tsx",
+          "line": 70,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 151,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/assets/{asset_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/assets/{asset_id}/contributions",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/automation",
+          "source_file": "web/app/automation/page.tsx",
+          "line": 114,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 113,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/alerts",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/automation",
+          "source_file": "web/app/automation/page.tsx",
+          "line": 115,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 114,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/provider-validation",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/automation",
+          "source_file": "web/app/automation/page.tsx",
+          "line": 117,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 117,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/provider-validation/run",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 118,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/readiness",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/automation",
+          "source_file": "web/app/automation/page.tsx",
+          "line": 116,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 116,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/snapshots",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 115,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/automation/usage/subscription-estimator",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/usage",
+          "source_file": "web/app/usage/page.tsx",
+          "line": 68,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributions",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 7,
+      "evidence": [
+        {
+          "web_route": "/contributions",
+          "source_file": "web/app/contributions/page.tsx",
+          "line": 50,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/contributions",
+          "source_file": "web/app/contributions/page.tsx",
+          "line": 124,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": "/flow",
+          "source_file": "web/app/flow/page.tsx",
+          "line": 165,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributions/github",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributions/github/debug",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributions/{contribution_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributors",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 8,
+      "evidence": [
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 128,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 194,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/contributors",
+          "source_file": "web/app/contributors/page.tsx",
+          "line": 54,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributors/{contributor_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/contributors/{contributor_id}/contributions",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/distributions",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 144,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/friction/entry-points",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/friction",
+          "source_file": "web/app/friction/page.tsx",
+          "line": 73,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/friction/events",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/friction",
+          "source_file": "web/app/friction/page.tsx",
+          "line": 72,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 188,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/friction/report",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 4,
+      "evidence": [
+        {
+          "web_route": "/friction",
+          "source_file": "web/app/friction/page.tsx",
+          "line": 71,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/usage",
+          "source_file": "web/app/usage/page.tsx",
+          "line": 67,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 106,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/commit-traceability",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 180,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/main-contract",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 27,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 74,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 178,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/main-head",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/merged-contract",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 92,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/pr-to-public",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 57,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/gates/public-deploy-contract",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 28,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 109,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 179,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/governance/change-requests",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 131,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 233,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 134,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/governance/change-requests/{change_request_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/governance/change-requests/{change_request_id}/votes",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 263,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/health",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 212,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 219,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/ideas",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 9,
+      "evidence": [
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 129,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/ideas",
+          "source_file": "web/app/ideas/page.tsx",
+          "line": 44,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/ideas",
+          "source_file": "web/app/ideas/page.tsx",
+          "line": 90,
+          "evidence_type": "literal"
+        }
+      ]
+    },
+    {
+      "path": "/api/ideas/storage",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/portfolio",
+          "source_file": "web/app/portfolio/page.tsx",
+          "line": 86,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/ideas/{idea_id}",
+      "methods": [
+        "GET",
+        "PATCH"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/ideas/[idea_id]",
+          "source_file": "web/app/ideas/[idea_id]/page.tsx",
+          "line": 68,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/ideas/[idea_id]",
+          "source_file": "web/app/ideas/[idea_id]/page.tsx",
+          "line": 264,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 275,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/ideas/{idea_id}/questions",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/ideas/{idea_id}/questions/answer",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": "/portfolio",
+          "source_file": "web/app/portfolio/page.tsx",
+          "line": 120,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/asset-modularity",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/endpoint-traceability",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": 140,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 29,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/gates",
+          "source_file": "web/app/gates/page.tsx",
+          "line": 124,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/flow",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 9,
+      "evidence": [
+        {
+          "web_route": "/contributors",
+          "source_file": "web/app/contributors/page.tsx",
+          "line": 55,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/flow",
+          "source_file": "web/app/flow/page.tsx",
+          "line": 163,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/ideas/[idea_id]",
+          "source_file": "web/app/ideas/[idea_id]/page.tsx",
+          "line": 80,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/flow/next-unblock-task",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/gaps/sync-asset-modularity-tasks",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/gaps/sync-process-tasks",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/gaps/sync-traceability",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/page-lineage",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 45,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 54,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 204,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/process-completeness",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/questions/next-highest-roi-task",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/questions/proactive",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/questions/sync-implementation-tasks",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/questions/sync-proactive",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/route-evidence",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/routes/canonical",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 3,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": 141,
+          "evidence_type": "literal"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 89,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 196,
+          "evidence_type": "link"
+        }
+      ]
+    },
+    {
+      "path": "/api/inventory/system-lineage",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 14,
+      "evidence": [
+        {
+          "web_route": "/ideas/[idea_id]",
+          "source_file": "web/app/ideas/[idea_id]/page.tsx",
+          "line": 284,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/page.tsx",
+          "source_file": "web/app/page.tsx",
+          "line": 164,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/portfolio",
+          "source_file": "web/app/portfolio/page.tsx",
+          "line": 83,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/ready",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 220,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/runtime/endpoints/summary",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/runtime/events",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/runtime/exerciser/run",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/runtime/ideas/summary",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 4,
+      "evidence": [
+        {
+          "web_route": "/ideas/[idea_id]",
+          "source_file": "web/app/ideas/[idea_id]/page.tsx",
+          "line": 279,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/page.tsx",
+          "source_file": "web/app/page.tsx",
+          "line": 176,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/usage",
+          "source_file": "web/app/usage/page.tsx",
+          "line": 66,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/runtime/usage/verification",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/spec-registry",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 5,
+      "evidence": [
+        {
+          "web_route": "/contribute",
+          "source_file": "web/app/contribute/page.tsx",
+          "line": 130,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/specs/[spec_id]",
+          "source_file": "web/app/specs/[spec_id]/page.tsx",
+          "line": 87,
+          "evidence_type": "fetch"
+        },
+        {
+          "web_route": "/specs",
+          "source_file": "web/app/specs/page.tsx",
+          "line": 94,
+          "evidence_type": "fetch"
+        }
+      ]
+    },
+    {
+      "path": "/api/spec-registry/{spec_id}",
+      "methods": [
+        "GET",
+        "PATCH"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/specs/[spec_id]",
+          "source_file": "web/app/specs/[spec_id]/page.tsx",
+          "line": 400,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 281,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/links",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/links/{lineage_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 2,
+      "evidence": [
+        {
+          "web_route": "/flow",
+          "source_file": "web/app/flow/page.tsx",
+          "line": 485,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/specs/[spec_id]",
+          "source_file": "web/app/specs/[spec_id]/page.tsx",
+          "line": 362,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/links/{lineage_id}/payout-preview",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/links/{lineage_id}/usage-events",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/links/{lineage_id}/valuation",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/value-lineage/minimum-e2e-flow",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/api/version",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 1,
+      "evidence": [
+        {
+          "web_route": null,
+          "source_file": "web/components/page_context_links.tsx",
+          "line": 221,
+          "evidence_type": "link"
+        },
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/assets",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/assets/{asset_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/assets/{asset_id}/contributions",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributions",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributions/github",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributions/github/debug",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributions/{contribution_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributors",
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributors/{contributor_id}",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/contributors/{contributor_id}/contributions",
+      "methods": [
+        "GET"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    },
+    {
+      "path": "/v1/distributions",
+      "methods": [
+        "POST"
+      ],
+      "web_link_tracked": true,
+      "explicit_count": 0,
+      "evidence": [
+        {
+          "web_route": "/api-coverage",
+          "source_file": "web/app/api-coverage/page.tsx",
+          "line": null,
+          "evidence_type": "catalog"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add persistent commit-evidence storage service and inventory endpoint
- switch idea/inventory commit-evidence consumers to DB-only reads
- remove local/GitHub commit-evidence fallback paths
- keep endpoint-to-web link traceability coverage updates and evidence matrix

## Validation
- cd api && pytest -q tests/test_inventory_discovery_sources.py tests/test_inventory_api.py tests/test_health.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_api-web-endpoint-linkage-evidence.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
