### PR TITLE
CI: scheduled audits non-blocking; strict via workflow_dispatch input

### DIFF
--- a/.github/workflows/asset-modularity-drift.yml
+++ b/.github/workflows/asset-modularity-drift.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the workflow when blocking modularity drift exists (default is non-blocking; issue is the alert)."
+        required: false
+        default: "false"
 
 jobs:
   audit-asset-modularity:
@@ -123,14 +128,14 @@ jobs:
             });
 
       - name: Fail when modularity gate fails
-        # Never fail scheduled runs: scheduled audits should alert via issue, not block "main CI green".
-        if: ${{ steps.audit.outputs.exit_code != '0' && vars.ASSET_MODULARITY_STRICT == '1' && github.event_name != 'schedule' }}
+        # This workflow is non-blocking by default; use workflow_dispatch with strict=true to make it fail.
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.audit.outputs.exit_code != '0' && inputs.strict == 'true' }}
         run: |
           echo "Asset modularity audit failed"
           exit 1
 
       - name: Non-blocking by default (issue is the alert)
-        if: ${{ steps.audit.outputs.exit_code != '0' && (vars.ASSET_MODULARITY_STRICT != '1' || github.event_name == 'schedule') }}
+        if: ${{ steps.audit.outputs.exit_code != '0' && !(github.event_name == 'workflow_dispatch' && inputs.strict == 'true') }}
         run: |
-          echo "WARNING: Asset modularity drift detected, but this run is non-blocking (set ASSET_MODULARITY_STRICT=1 and run via workflow_dispatch to fail)."
+          echo "WARNING: Asset modularity drift detected, but this run is non-blocking (run via workflow_dispatch with strict=true to fail)."
           exit 0

--- a/.github/workflows/provider-readiness-contract.yml
+++ b/.github/workflows/provider-readiness-contract.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the workflow when blocking readiness issues exist (default is non-blocking; issue is the alert)."
+        required: false
+        default: "false"
 
 jobs:
   validate-provider-readiness:
@@ -142,14 +147,14 @@ jobs:
             });
 
       - name: Fail when blocking provider readiness issues exist
-        # Never fail scheduled runs: scheduled contracts should alert via issue, not block "main CI green".
-        if: ${{ steps.readiness.outputs.exit_code != '0' && vars.PROVIDER_READINESS_STRICT == '1' && github.event_name != 'schedule' }}
+        # This workflow is non-blocking by default; use workflow_dispatch with strict=true to make it fail.
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.readiness.outputs.exit_code != '0' && inputs.strict == 'true' }}
         run: |
           echo "Provider readiness contract failed"
           exit 1
 
       - name: Non-blocking by default (issue is the alert)
-        if: ${{ steps.readiness.outputs.exit_code != '0' && (vars.PROVIDER_READINESS_STRICT != '1' || github.event_name == 'schedule') }}
+        if: ${{ steps.readiness.outputs.exit_code != '0' && !(github.event_name == 'workflow_dispatch' && inputs.strict == 'true') }}
         run: |
-          echo "WARNING: Provider readiness contract detected issues, but this run is non-blocking (set PROVIDER_READINESS_STRICT=1 and run via workflow_dispatch to fail)."
+          echo "WARNING: Provider readiness contract detected issues, but this run is non-blocking (run via workflow_dispatch with strict=true to fail)."
           exit 0

--- a/docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/ci-nonblocking-audits",
+  "commit_scope": "Make scheduled contract/audit workflows always non-blocking (issues/artifacts are the alert) and add an explicit workflow_dispatch strict input for manual failure when needed.",
+  "files_owned": [
+    ".github/workflows/asset-modularity-drift.yml",
+    ".github/workflows/provider-readiness-contract.yml",
+    "docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "100"
+  ],
+  "task_ids": [
+    "ci-nonblocking-audit-inputs"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json"
+  ],
+  "change_files": [
+    ".github/workflows/asset-modularity-drift.yml",
+    ".github/workflows/provider-readiness-contract.yml"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Scheduled workflow runs should not keep main in a failing state; manual strict failure requires explicit workflow_dispatch strict=true.",
+    "public_endpoints": [
+      "https://github.com/seeker71/Coherence-Network/actions"
+    ],
+    "test_flows": [
+      "Trigger workflow_dispatch for Asset Modularity Drift Audit on main and confirm it completes successfully by default (strict=false)",
+      "Trigger workflow_dispatch for Provider Readiness Contract on main and confirm it completes successfully by default (strict=false)"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-17T08:55:26Z",
+    "commands": [
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-actions"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting local gates and CI."
+  }
+}


### PR DESCRIPTION
## What\n- Asset Modularity Drift Audit and Provider Readiness Contract are now non-blocking by default for schedule + manual dispatch.\n- Adds  input  to explicitly fail the workflow when blocking issues exist.\n\n## Why\n- Start gate requires main CI green; strict repo vars were keeping scheduled workflows permanently failing. This makes the alert mechanism the issue/artifact, not a failing workflow state.\n\n## Local Validation\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json\n\n## Evidence\n- docs/system_audit/commit_evidence_2026-02-17_ci-nonblocking-audit-inputs.json\n