### PR TITLE
Server execute agent tasks via OpenRouter free model

### DIFF
--- a/api/app/services/agent_execution_service.py
+++ b/api/app/services/agent_execution_service.py
@@ -1,0 +1,327 @@
+"""Server-side execution for agent tasks.
+
+This is intentionally conservative:
+- default-deny for paid providers (can be overridden via env for emergencies)
+- records runtime events for diagnostics and usage visibility
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+from app.models.agent import TaskStatus
+from app.models.runtime import RuntimeEventCreate
+from app.services import agent_service, metrics_service, runtime_service
+from app.services.openrouter_client import OpenRouterError, chat_completion
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _paid_providers_allowed() -> bool:
+    # Default: paid providers NOT allowed.
+    return _truthy(os.getenv("AGENT_ALLOW_PAID_PROVIDERS", "0"))
+
+
+def _extract_underlying_model(task_model: str) -> str:
+    cleaned = (task_model or "").strip()
+    if cleaned.startswith("openclaw/"):
+        return cleaned.split("/", 1)[1].strip()
+    if cleaned.startswith("cursor/"):
+        return cleaned.split("/", 1)[1].strip()
+    return cleaned
+
+
+def _write_task_log(task_id: str, lines: list[str]) -> None:
+    try:
+        api_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        logs_dir = os.path.join(api_dir, "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+        path = os.path.join(logs_dir, f"task_{task_id}.log")
+        with open(path, "a", encoding="utf-8") as f:
+            for ln in lines:
+                f.write(ln.rstrip() + "\n")
+    except Exception:
+        # Logging must never break execution.
+        return
+
+
+def _claim_task(task_id: str, worker_id: str) -> tuple[bool, str | None]:
+    try:
+        agent_service.update_task(task_id, status=TaskStatus.RUNNING, worker_id=worker_id)
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _task_route_is_paid(task: dict[str, Any]) -> bool:
+    ctx = task.get("context") if isinstance(task.get("context"), dict) else {}
+    route_decision = ctx.get("route_decision") if isinstance(ctx.get("route_decision"), dict) else {}
+    return bool(route_decision.get("is_paid_provider"))
+
+
+def _finish_task(
+    *,
+    task_id: str,
+    task: dict[str, Any],
+    worker_id: str,
+    status: TaskStatus,
+    output: str,
+    model_for_metrics: str,
+    elapsed_ms: int,
+) -> None:
+    agent_service.update_task(task_id, status=status, output=output, worker_id=worker_id)
+    metrics_service.record_task(
+        task_id=task_id,
+        task_type=str(task.get("task_type") or "unknown"),
+        model=model_for_metrics,
+        duration_seconds=max(0.0, float(elapsed_ms) / 1000.0),
+        status="completed" if status == TaskStatus.COMPLETED else "failed",
+    )
+
+
+def _record_openrouter_tool_event(
+    *,
+    task_id: str,
+    model: str,
+    elapsed_ms: int,
+    ok: bool,
+    provider_request_id: str | None = None,
+    response_id: str | None = None,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    total_tokens: int = 0,
+    usage_json: str = "{}",
+    error: str | None = None,
+) -> None:
+    status_code = 200 if ok else 500
+    metadata: dict[str, str | float | int | bool] = {
+        "tracking_kind": "agent_tool_call",
+        "task_id": task_id,
+        "model": model,
+        "provider": "openrouter",
+        "is_paid_provider": False,
+    }
+    if ok:
+        metadata.update(
+            {
+                "usage_prompt_tokens": int(prompt_tokens),
+                "usage_completion_tokens": int(completion_tokens),
+                "usage_total_tokens": int(total_tokens),
+                "usage_json": str(usage_json)[:2000],
+                "provider_request_id": (provider_request_id or "")[:200],
+                "response_id": (response_id or "")[:200],
+            }
+        )
+    else:
+        metadata["error"] = (error or "unknown")[:800]
+
+    runtime_service.record_event(
+        RuntimeEventCreate(
+            source="worker",
+            endpoint="tool:openrouter.chat_completion",
+            method="RUN",
+            status_code=status_code,
+            runtime_ms=float(max(1, int(elapsed_ms))),
+            idea_id="coherence-network-agent-pipeline",
+            metadata=metadata,
+        )
+    )
+
+
+def _run_openrouter(
+    *,
+    task_id: str,
+    model: str,
+    prompt: str,
+    started_perf: float,
+) -> dict[str, Any]:
+    try:
+        content, usage, meta = chat_completion(model=model, prompt=prompt)
+        elapsed_ms = max(1, int(meta.get("elapsed_ms") or int(round((time.perf_counter() - started_perf) * 1000))))
+        usage_dict = usage if isinstance(usage, dict) else {}
+        prompt_tokens = int(usage_dict.get("prompt_tokens") or usage_dict.get("input_tokens") or 0)
+        completion_tokens = int(usage_dict.get("completion_tokens") or usage_dict.get("output_tokens") or 0)
+        total_tokens = int(usage_dict.get("total_tokens") or (prompt_tokens + completion_tokens))
+        usage_json = json.dumps(usage_dict, sort_keys=True)[:2000]
+        _record_openrouter_tool_event(
+            task_id=task_id,
+            model=model,
+            elapsed_ms=elapsed_ms,
+            ok=True,
+            provider_request_id=str(meta.get("provider_request_id") or ""),
+            response_id=str(meta.get("response_id") or ""),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            usage_json=usage_json,
+        )
+        return {
+            "ok": True,
+            "elapsed_ms": elapsed_ms,
+            "content": content,
+            "usage_json": usage_json,
+            "provider_request_id": str(meta.get("provider_request_id") or ""),
+        }
+    except OpenRouterError as exc:
+        elapsed_ms = max(1, int(round((time.perf_counter() - started_perf) * 1000)))
+        _record_openrouter_tool_event(task_id=task_id, model=model, elapsed_ms=elapsed_ms, ok=False, error=str(exc))
+        return {"ok": False, "elapsed_ms": elapsed_ms, "error": f"Execution failed (OpenRouter): {exc}"}
+
+
+def _resolve_openrouter_model(task: dict[str, Any], default: str) -> str:
+    model = _extract_underlying_model(str(task.get("model") or ""))
+    return model or default
+
+
+def _resolve_prompt(task: dict[str, Any]) -> str:
+    return str(task.get("direction") or "").strip()
+
+
+def _complete_success(
+    *,
+    task_id: str,
+    task: dict[str, Any],
+    worker_id: str,
+    model: str,
+    elapsed_ms: int,
+    content: str,
+    usage_json: str,
+    request_id: str,
+) -> dict[str, Any]:
+    _write_task_log(
+        task_id,
+        [
+            f"[openrouter] status=200 elapsed_ms={elapsed_ms} request_id={request_id}",
+            f"[usage] {usage_json}",
+            "[output]",
+            content,
+        ],
+    )
+    _finish_task(
+        task_id=task_id,
+        task=task,
+        worker_id=worker_id,
+        status=TaskStatus.COMPLETED,
+        output=content,
+        model_for_metrics=str(task.get("model") or model or "unknown"),
+        elapsed_ms=elapsed_ms,
+    )
+    return {"ok": True, "status": "completed", "elapsed_ms": elapsed_ms, "model": model}
+
+
+def _complete_failure(
+    *,
+    task_id: str,
+    task: dict[str, Any],
+    worker_id: str,
+    model: str,
+    elapsed_ms: int,
+    msg: str,
+) -> dict[str, Any]:
+    _write_task_log(task_id, [msg])
+    _finish_task(
+        task_id=task_id,
+        task=task,
+        worker_id=worker_id,
+        status=TaskStatus.FAILED,
+        output=msg,
+        model_for_metrics=str(task.get("model") or model or "unknown"),
+        elapsed_ms=elapsed_ms,
+    )
+    return {"ok": False, "status": "failed", "elapsed_ms": elapsed_ms, "model": model}
+
+
+def execute_task(
+    task_id: str,
+    *,
+    worker_id: str = "openclaw-worker:server",
+) -> dict[str, Any]:
+    """Execute a task using OpenRouter (free model by default).
+
+    Returns a small summary dict (also useful for unit tests). This is safe to
+    call from FastAPI BackgroundTasks.
+    """
+    task = agent_service.get_task(task_id)
+    if task is None:
+        return {"ok": False, "error": "task_not_found"}
+
+    claimed, claim_error = _claim_task(task_id, worker_id)
+    if not claimed:
+        return {"ok": False, "error": f"claim_failed:{claim_error}"}
+
+    task = agent_service.get_task(task_id) or {}
+
+    if _task_route_is_paid(task) and not _paid_providers_allowed():
+        msg = "Blocked: task routes to a paid provider and AGENT_ALLOW_PAID_PROVIDERS is disabled."
+        _write_task_log(task_id, [msg])
+        _finish_task(
+            task_id=task_id,
+            task=task,
+            worker_id=worker_id,
+            status=TaskStatus.FAILED,
+            output=msg,
+            model_for_metrics=str(task.get("model") or "unknown"),
+            elapsed_ms=1,
+        )
+        return {"ok": False, "error": "paid_provider_blocked"}
+
+    default_model = os.getenv("OPENROUTER_FREE_MODEL", "openrouter/free").strip() or "openrouter/free"
+    model = _resolve_openrouter_model(task, default_model)
+
+    prompt = _resolve_prompt(task)
+    if not prompt:
+        return _complete_failure(
+            task_id=task_id,
+            task=task,
+            worker_id=worker_id,
+            model=model,
+            elapsed_ms=1,
+            msg="Empty direction",
+        )
+
+    started = time.perf_counter()
+    _write_task_log(task_id, [f"[execute] worker_id={worker_id} model={model}", f"[prompt]\n{prompt}"])
+
+    try:
+        result = _run_openrouter(task_id=task_id, model=model, prompt=prompt, started_perf=started)
+        elapsed_ms = int(result.get("elapsed_ms") or 1)
+        if result.get("ok") is True:
+            content = str(result.get("content") or "")
+            usage_json = str(result.get("usage_json") or "{}")
+            request_id = str(result.get("provider_request_id") or "")
+            return _complete_success(
+                task_id=task_id,
+                task=task,
+                worker_id=worker_id,
+                model=model,
+                elapsed_ms=elapsed_ms,
+                content=content,
+                usage_json=usage_json,
+                request_id=request_id,
+            )
+
+        msg = str(result.get("error") or "Execution failed (OpenRouter)")
+        return _complete_failure(
+            task_id=task_id,
+            task=task,
+            worker_id=worker_id,
+            model=model,
+            elapsed_ms=elapsed_ms,
+            msg=msg,
+        )
+    except Exception as exc:
+        elapsed_ms = max(1, int(round((time.perf_counter() - started) * 1000)))
+        msg = f"Execution failed: {exc}"
+        return _complete_failure(
+            task_id=task_id,
+            task=task,
+            worker_id=worker_id,
+            model=model,
+            elapsed_ms=elapsed_ms,
+            msg=msg,
+        )

--- a/api/app/services/openrouter_client.py
+++ b/api/app/services/openrouter_client.py
@@ -1,0 +1,102 @@
+"""Minimal OpenRouter client for server-side task execution.
+
+This is intentionally small and dependency-free (httpx only), so it can be used
+from background workers in production.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+
+
+class OpenRouterError(RuntimeError):
+    pass
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def chat_completion(
+    *,
+    model: str,
+    prompt: str,
+    timeout_s: float = 45.0,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Return (content, usage, meta).
+
+    meta includes: status_code, elapsed_ms, provider_request_id, response_id.
+    """
+    api_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        raise OpenRouterError("OPENROUTER_API_KEY is not configured")
+
+    url = os.getenv("OPENROUTER_CHAT_URL", "https://openrouter.ai/api/v1/chat/completions").strip()
+    if not url:
+        raise OpenRouterError("OPENROUTER_CHAT_URL is empty")
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    # Optional, but recommended by OpenRouter to attribute traffic.
+    referer = (os.getenv("OPENROUTER_HTTP_REFERER") or os.getenv("PUBLIC_APP_URL") or "").strip()
+    title = (os.getenv("OPENROUTER_X_TITLE") or "Coherence-Network").strip()
+    if referer:
+        headers["HTTP-Referer"] = referer
+    if title:
+        headers["X-Title"] = title
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": float(os.getenv("OPENROUTER_TEMPERATURE", "0.2") or 0.2),
+    }
+    if _truthy(os.getenv("OPENROUTER_DISABLE_STREAM", "1")):
+        payload["stream"] = False
+
+    started = time.perf_counter()
+    with httpx.Client(timeout=timeout_s, headers=headers) as client:
+        resp = client.post(url, json=payload)
+    elapsed_ms = int(round((time.perf_counter() - started) * 1000))
+
+    status = int(resp.status_code)
+    provider_request_id = (resp.headers.get("x-request-id") or resp.headers.get("x-openrouter-request-id") or "").strip()
+
+    try:
+        data = resp.json()
+    except Exception:
+        body_preview = (resp.text or "")[:500]
+        raise OpenRouterError(f"OpenRouter response was not JSON (status={status}): {body_preview}")
+
+    if status >= 400:
+        err = data.get("error") if isinstance(data, dict) else None
+        raise OpenRouterError(f"OpenRouter error (status={status}): {err or data}")
+
+    if not isinstance(data, dict):
+        raise OpenRouterError(f"Unexpected OpenRouter payload type: {type(data).__name__}")
+
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise OpenRouterError("OpenRouter payload missing choices")
+
+    msg = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = (msg or {}).get("content") if isinstance(msg, dict) else None
+    if not isinstance(content, str):
+        raise OpenRouterError("OpenRouter payload missing message.content")
+
+    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+    response_id = str(data.get("id") or "")
+
+    meta = {
+        "status_code": status,
+        "elapsed_ms": elapsed_ms,
+        "provider_request_id": provider_request_id,
+        "response_id": response_id,
+    }
+    return content, usage, meta
+

--- a/api/tests/test_agent_execute_endpoint.py
+++ b/api/tests/test_agent_execute_endpoint.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.agent import AgentTaskCreate, TaskType
+from app.services import agent_service
+
+
+def _reset_agent_store() -> None:
+    agent_service._store.clear()
+    agent_service._store_loaded = False
+    agent_service._store_loaded_path = None
+
+
+@pytest.mark.asyncio
+async def test_execute_endpoint_requires_token_when_configured(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
+    monkeypatch.setenv("AGENT_EXECUTE_TOKEN", "secret")
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    _reset_agent_store()
+
+    task = agent_service.create_task(
+        AgentTaskCreate(
+            direction="Return ok",
+            task_type=TaskType.IMPL,
+            context={"executor": "openclaw", "model_override": "openrouter/free"},
+        )
+    )
+
+    from app.services import agent_execution_service
+
+    monkeypatch.setattr(
+        agent_execution_service,
+        "chat_completion",
+        lambda **_: (
+            "ok",
+            {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            {"elapsed_ms": 5, "provider_request_id": "req_test", "response_id": "resp_test"},
+        ),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(f"/api/agent/tasks/{task['id']}/execute")
+        assert res.status_code == 403
+
+        res2 = await client.post(
+            f"/api/agent/tasks/{task['id']}/execute",
+            headers={"X-Agent-Execute-Token": "secret"},
+        )
+        assert res2.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_execute_endpoint_completes_task_when_openrouter_is_stubbed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.delenv("AGENT_EXECUTE_TOKEN", raising=False)
+    _reset_agent_store()
+
+    from app.services import agent_execution_service
+
+    monkeypatch.setattr(
+        agent_execution_service,
+        "chat_completion",
+        lambda **_: (
+            "ok",
+            {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            {"elapsed_ms": 5, "provider_request_id": "req_test", "response_id": "resp_test"},
+        ),
+    )
+
+    task = agent_service.create_task(
+        AgentTaskCreate(
+            direction="Return ok",
+            task_type=TaskType.IMPL,
+            context={"executor": "openclaw", "model_override": "openrouter/free"},
+        )
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(f"/api/agent/tasks/{task['id']}/execute")
+        assert res.status_code == 200
+
+        fetched = await client.get(f"/api/agent/tasks/{task['id']}")
+        assert fetched.status_code == 200
+        payload = fetched.json()
+        assert payload["status"] == "completed"
+        assert payload["output"] == "ok"

--- a/docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json
@@ -1,0 +1,92 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/openclaw-server-exec",
+  "commit_scope": "Add server-side agent task execution using OpenRouter free model (\"openclaw\" executor), with paid-provider enforcement, runtime event diagnostics, and optional auto-execute on task creation for the public deployed instance.",
+  "files_owned": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/openrouter_client.py",
+    "api/tests/test_agent_execute_endpoint.py",
+    "docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "2",
+    "26"
+  ],
+  "task_ids": [
+    "openclaw-server-exec-openrouter"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_agent_execute_endpoint.py tests/test_openclaw_executor_integration.py tests/test_agent_task_persistence.py tests/test_agent_tasks_runtime_fallback.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/openrouter_client.py",
+    "api/tests/test_agent_execute_endpoint.py"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Production can execute an agent task server-side using the OpenRouter free model, track completion/usage events, and render tasks in the Vercel /tasks UI.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/tasks",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
+      "https://coherence-network-production.up.railway.app/api/agent/metrics",
+      "https://coherence-network-production.up.railway.app/api/runtime/events"
+    ],
+    "test_flows": [
+      "POST /api/agent/tasks with AGENT_AUTO_EXECUTE=1 set in production; confirm it completes and is visible in /tasks UI",
+      "GET /api/runtime/events and confirm tool + completion events include task_id, model, and token usage fields"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-17T09:17:50Z",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_execute_endpoint.py tests/test_openclaw_executor_integration.py tests/test_agent_task_persistence.py tests/test_agent_tasks_runtime_fallback.py",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting local gates, CI, deployment, and public verification."
+  }
+}


### PR DESCRIPTION
## What\n- Adds server-side task execution () using OpenRouter chat completions.\n- Optional auto-execute on task creation when .\n- Adds explicit execute endpoint  (token-guarded via ).\n- Enforces no paid providers by default ().\n- Records runtime tool-call events (with token usage fields) plus existing completion tracking events for Tasks UI backfill.\n\n## Why\n- Production  was empty because tasks were never executed on the deployed instance and completions were not persisted across restarts.\n\n## Local Validation\n- cd api && pytest -q tests/test_agent_execute_endpoint.py tests/test_openclaw_executor_integration.py tests/test_agent_task_persistence.py tests/test_agent_tasks_runtime_fallback.py\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n\n## Evidence\n- docs/system_audit/commit_evidence_2026-02-17_openclaw-server-exec-openrouter.json\n