### PR TITLE
Fix provider usage tracking: rate-limit header parsing + GitHub billing fallback

### DIFF
--- a/api/app/services/automation_usage_service.py
+++ b/api/app/services/automation_usage_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -163,10 +164,24 @@ def _header_float(headers: httpx.Headers, *keys: str) -> float | None:
         raw = str(headers.get(key, "")).strip()
         if not raw:
             continue
-        try:
-            return float(raw)
-        except ValueError:
-            continue
+        # Support standard rate-limit header formats like:
+        # - "1000"
+        # - "1000;w=3600" (RFC 9233)
+        # - "1000, 2000;w=60" (multiple policies; take first numeric)
+        for part in raw.split(","):
+            token = part.strip()
+            if not token:
+                continue
+            token = token.split(";", 1)[0].strip()
+            if not token:
+                continue
+            match = re.search(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)", token)
+            if not match:
+                continue
+            try:
+                return float(match.group(0))
+            except ValueError:
+                continue
     return None
 
 
@@ -700,65 +715,62 @@ def _github_billing_url(owner: str, scope: str) -> str:
     return f"https://api.github.com/orgs/{owner}/settings/billing/actions"
 
 
-def _build_github_snapshot() -> ProviderUsageSnapshot:
-    token = os.getenv("GITHUB_TOKEN", "").strip() or os.getenv("GH_TOKEN", "").strip()
-    owner = os.getenv("GITHUB_BILLING_OWNER", "").strip()
-    scope = os.getenv("GITHUB_BILLING_SCOPE", "org").strip().lower()
-    if not token:
-        return ProviderUsageSnapshot(
-            id=f"provider_github_{int(time.time())}",
-            provider="github",
-            kind="github",
-            status="unavailable",
-            data_source="configuration_only",
-            notes=["Set GITHUB_TOKEN (or GH_TOKEN) to enable GitHub usage data."],
-        )
+def _github_billing_urls(*, owner: str, scope: str) -> list[str]:
+    urls: list[str] = []
+    normalized_scope = scope.strip().lower()
+    if owner and normalized_scope in {"org", "user"}:
+        urls.append(_github_billing_url(owner=owner, scope=normalized_scope))
+        # If scope is wrong for the owner (or token can't access billing), GitHub often returns 404.
+        urls.append(_github_billing_url(owner=owner, scope=("org" if normalized_scope == "user" else "user")))
+    # Fallback: authenticated user's billing endpoint (works when the token belongs to the billing account).
+    urls.append("https://api.github.com/user/settings/billing/actions")
+    return list(dict.fromkeys(urls))
 
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    billing_payload: dict[str, Any] = {}
-    rate_payload: dict[str, Any] = {}
-    billing_error = None
-    rate_error = None
-    billing_url = ""
 
-    if owner and scope in {"org", "user"}:
-        billing_url = _github_billing_url(owner=owner, scope=scope)
+def _github_fetch_billing_payload(
+    *,
+    client: httpx.Client,
+    owner: str,
+    scope: str,
+) -> tuple[dict[str, Any], str, str | None]:
+    payload: dict[str, Any] = {}
+    url_used = ""
+    last_error: str | None = None
+
+    for url in _github_billing_urls(owner=owner, scope=scope):
         try:
-            with httpx.Client(timeout=8.0, headers=headers) as client:
-                response = client.get(billing_url)
-                response.raise_for_status()
-                billing_payload = response.json()
-        except Exception as exc:
-            billing_error = str(exc)
-    else:
-        billing_error = "billing_owner_or_scope_not_configured"
-
-    try:
-        with httpx.Client(timeout=8.0, headers=headers) as client:
-            response = client.get("https://api.github.com/rate_limit")
+            response = client.get(url)
             response.raise_for_status()
-            rate_payload = response.json() if isinstance(response.json(), dict) else {}
-    except Exception as exc:
-        rate_error = str(exc)
+            raw = response.json()
+            if isinstance(raw, dict):
+                payload = raw
+                url_used = url
+                last_error = None
+                break
+        except httpx.HTTPStatusError as exc:
+            status = int(getattr(exc.response, "status_code", 0) or 0)
+            if status in {403, 404}:
+                last_error = f"http_{status}"
+                continue
+            last_error = str(exc)
+        except Exception as exc:
+            last_error = str(exc)
 
-    if rate_error:
-        return ProviderUsageSnapshot(
-            id=f"provider_github_{int(time.time())}",
-            provider="github",
-            kind="github",
-            status="degraded",
-            data_source="provider_api",
-            notes=[f"GitHub rate-limit probe failed: {rate_error}"],
-            raw={"rate_limit_url": "https://api.github.com/rate_limit", "billing_url": billing_url},
-        )
+    if not payload and not owner:
+        last_error = last_error or "billing_owner_or_scope_not_configured"
+    return payload, url_used, last_error
 
+
+def _github_usage_metrics_and_raw(
+    *,
+    billing_payload: dict[str, Any],
+    rate_payload: dict[str, Any],
+    billing_url: str,
+) -> tuple[list[UsageMetric], dict[str, Any]]:
     included = float(billing_payload.get("included_minutes") or 0.0)
     used = float(billing_payload.get("total_minutes_used") or 0.0)
     remaining = max(0.0, included - used) if included > 0 else None
+
     resources = rate_payload.get("resources") if isinstance(rate_payload.get("resources"), dict) else {}
     core = resources.get("core") if isinstance(resources.get("core"), dict) else {}
     core_limit = float(core.get("limit") or 0.0)
@@ -789,9 +801,82 @@ def _build_github_snapshot() -> ProviderUsageSnapshot:
             )
         )
 
+    raw = {
+        "included_minutes": included,
+        "total_minutes_used": used,
+        "minutes_used_breakdown": billing_payload.get("minutes_used_breakdown"),
+        "rate_limit": resources,
+        "rate_limit_url": "https://api.github.com/rate_limit",
+        "billing_url": billing_url,
+    }
+    return metrics, raw
+
+
+def _build_github_snapshot() -> ProviderUsageSnapshot:
+    token = os.getenv("GITHUB_TOKEN", "").strip() or os.getenv("GH_TOKEN", "").strip()
+    owner = os.getenv("GITHUB_BILLING_OWNER", "").strip()
+    scope = os.getenv("GITHUB_BILLING_SCOPE", "org").strip().lower()
+    if not token:
+        return ProviderUsageSnapshot(
+            id=f"provider_github_{int(time.time())}",
+            provider="github",
+            kind="github",
+            status="unavailable",
+            data_source="configuration_only",
+            notes=["Set GITHUB_TOKEN (or GH_TOKEN) to enable GitHub usage data."],
+        )
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    billing_payload: dict[str, Any] = {}
+    rate_payload: dict[str, Any] = {}
+    billing_error = None
+    rate_error = None
+    billing_url = ""
+
+    with httpx.Client(timeout=8.0, headers=headers) as client:
+        billing_payload, billing_url, billing_error = _github_fetch_billing_payload(
+            client=client,
+            owner=owner,
+            scope=scope,
+        )
+
+    try:
+        with httpx.Client(timeout=8.0, headers=headers) as client:
+            response = client.get("https://api.github.com/rate_limit")
+            response.raise_for_status()
+            rate_payload = response.json() if isinstance(response.json(), dict) else {}
+    except Exception as exc:
+        rate_error = str(exc)
+
+    if rate_error:
+        return ProviderUsageSnapshot(
+            id=f"provider_github_{int(time.time())}",
+            provider="github",
+            kind="github",
+            status="degraded",
+            data_source="provider_api",
+            notes=[f"GitHub rate-limit probe failed: {rate_error}"],
+            raw={"rate_limit_url": "https://api.github.com/rate_limit", "billing_url": billing_url},
+        )
+
+    metrics, raw = _github_usage_metrics_and_raw(
+        billing_payload=billing_payload,
+        rate_payload=rate_payload,
+        billing_url=billing_url,
+    )
+
     notes: list[str] = []
     if billing_error:
         notes.append(f"GitHub billing data unavailable: {billing_error}")
+        if billing_error.startswith("http_404") or "404" in billing_error:
+            notes.append(
+                "GitHub billing endpoints often return 404 when the token lacks billing access for the configured owner/scope. "
+                "Set GITHUB_BILLING_OWNER + GITHUB_BILLING_SCOPE (org|user), or use a token for the billing account."
+            )
 
     return ProviderUsageSnapshot(
         id=f"provider_github_{int(time.time())}",
@@ -801,14 +886,7 @@ def _build_github_snapshot() -> ProviderUsageSnapshot:
         data_source="provider_api",
         metrics=metrics,
         notes=notes,
-        raw={
-            "included_minutes": included,
-            "total_minutes_used": used,
-            "minutes_used_breakdown": billing_payload.get("minutes_used_breakdown"),
-            "rate_limit": resources,
-            "rate_limit_url": "https://api.github.com/rate_limit",
-            "billing_url": billing_url,
-        },
+        raw=raw,
     )
 
 
@@ -857,12 +935,12 @@ def _build_openai_codex_snapshot() -> ProviderUsageSnapshot:
         models_url=models_url,
         rows=rows,
         headers=response.headers,
-        request_limit_keys=("x-ratelimit-limit-requests",),
-        request_remaining_keys=("x-ratelimit-remaining-requests",),
+        request_limit_keys=("x-ratelimit-limit-requests", "ratelimit-limit-requests", "ratelimit-limit"),
+        request_remaining_keys=("x-ratelimit-remaining-requests", "ratelimit-remaining-requests", "ratelimit-remaining"),
         request_window="minute",
         request_label="OpenAI request quota",
-        token_limit_keys=("x-ratelimit-limit-tokens",),
-        token_remaining_keys=("x-ratelimit-remaining-tokens",),
+        token_limit_keys=("x-ratelimit-limit-tokens", "ratelimit-limit-tokens"),
+        token_remaining_keys=("x-ratelimit-remaining-tokens", "ratelimit-remaining-tokens"),
         token_window="minute",
         token_label="OpenAI token quota",
         rate_header_keys=(
@@ -870,6 +948,12 @@ def _build_openai_codex_snapshot() -> ProviderUsageSnapshot:
             "x-ratelimit-remaining-requests",
             "x-ratelimit-limit-tokens",
             "x-ratelimit-remaining-tokens",
+            "ratelimit-limit",
+            "ratelimit-remaining",
+            "ratelimit-limit-requests",
+            "ratelimit-remaining-requests",
+            "ratelimit-limit-tokens",
+            "ratelimit-remaining-tokens",
         ),
         no_header_note="OpenAI models probe succeeded, but no request/token remaining headers were returned.",
     )
@@ -937,12 +1021,30 @@ def _build_claude_snapshot() -> ProviderUsageSnapshot:
         models_url=models_url,
         rows=rows,
         headers=response.headers,
-        request_limit_keys=("anthropic-ratelimit-requests-limit", "x-ratelimit-limit-requests"),
-        request_remaining_keys=("anthropic-ratelimit-requests-remaining", "x-ratelimit-remaining-requests"),
+        request_limit_keys=(
+            "anthropic-ratelimit-requests-limit",
+            "x-ratelimit-limit-requests",
+            "ratelimit-limit-requests",
+            "ratelimit-limit",
+        ),
+        request_remaining_keys=(
+            "anthropic-ratelimit-requests-remaining",
+            "x-ratelimit-remaining-requests",
+            "ratelimit-remaining-requests",
+            "ratelimit-remaining",
+        ),
         request_window="minute",
         request_label="Claude request quota",
-        token_limit_keys=("anthropic-ratelimit-tokens-limit", "x-ratelimit-limit-tokens"),
-        token_remaining_keys=("anthropic-ratelimit-tokens-remaining", "x-ratelimit-remaining-tokens"),
+        token_limit_keys=(
+            "anthropic-ratelimit-tokens-limit",
+            "x-ratelimit-limit-tokens",
+            "ratelimit-limit-tokens",
+        ),
+        token_remaining_keys=(
+            "anthropic-ratelimit-tokens-remaining",
+            "x-ratelimit-remaining-tokens",
+            "ratelimit-remaining-tokens",
+        ),
         token_window="minute",
         token_label="Claude token quota",
         rate_header_keys=(
@@ -950,6 +1052,16 @@ def _build_claude_snapshot() -> ProviderUsageSnapshot:
             "anthropic-ratelimit-requests-remaining",
             "anthropic-ratelimit-tokens-limit",
             "anthropic-ratelimit-tokens-remaining",
+            "x-ratelimit-limit-requests",
+            "x-ratelimit-remaining-requests",
+            "x-ratelimit-limit-tokens",
+            "x-ratelimit-remaining-tokens",
+            "ratelimit-limit",
+            "ratelimit-remaining",
+            "ratelimit-limit-requests",
+            "ratelimit-remaining-requests",
+            "ratelimit-limit-tokens",
+            "ratelimit-remaining-tokens",
         ),
         no_header_note="Claude models probe succeeded, but no request/token remaining headers were returned.",
     )
@@ -1128,12 +1240,12 @@ def _build_openai_snapshot() -> ProviderUsageSnapshot:
             has_model_limits = _append_rate_limit_metrics(
                 metrics=metrics,
                 headers=model_response.headers,
-                request_limit_keys=("x-ratelimit-limit-requests",),
-                request_remaining_keys=("x-ratelimit-remaining-requests",),
+                request_limit_keys=("x-ratelimit-limit-requests", "ratelimit-limit-requests", "ratelimit-limit"),
+                request_remaining_keys=("x-ratelimit-remaining-requests", "ratelimit-remaining-requests", "ratelimit-remaining"),
                 request_window="minute",
                 request_label="OpenAI request quota",
-                token_limit_keys=("x-ratelimit-limit-tokens",),
-                token_remaining_keys=("x-ratelimit-remaining-tokens",),
+                token_limit_keys=("x-ratelimit-limit-tokens", "ratelimit-limit-tokens"),
+                token_remaining_keys=("x-ratelimit-remaining-tokens", "ratelimit-remaining-tokens"),
                 token_window="minute",
                 token_label="OpenAI token quota",
             )
@@ -1321,8 +1433,8 @@ def evaluate_usage_alerts(threshold_ratio: float = 0.2) -> UsageAlertReport:
 
 def provider_readiness_report(*, required_providers: list[str] | None = None, force_refresh: bool = True) -> ProviderReadinessReport:
     required = [item.strip().lower() for item in (required_providers or _required_providers_from_env()) if item.strip()]
+    active_counts = _active_provider_usage_counts()
     if _env_truthy("AUTOMATION_REQUIRE_KEYS_FOR_ACTIVE_PROVIDERS", default=True):
-        active_counts = _active_provider_usage_counts()
         for provider_name, count in active_counts.items():
             if count > 0:
                 required.append(provider_name)
@@ -1340,6 +1452,8 @@ def provider_readiness_report(*, required_providers: list[str] | None = None, fo
         kind = snapshot.kind if snapshot is not None else str(_PROVIDER_CONFIG_RULES.get(provider, {}).get("kind", "custom"))
         status = snapshot.status if snapshot is not None else ("ok" if configured else "unavailable")
         is_required = provider in required_set
+        active_count = int(active_counts.get(provider, 0))
+        has_runtime_usage = active_count > 0 or bool((snapshot.raw if snapshot is not None else {}).get("runtime_task_runs"))
 
         if is_required and (not configured or status != "ok"):
             severity = "critical"
@@ -1348,7 +1462,11 @@ def provider_readiness_report(*, required_providers: list[str] | None = None, fo
             recommendations.append(
                 f"Configure provider '{provider}' ({', '.join(missing) if missing else 'connectivity/runtime checks'}) and re-run /api/automation/usage/readiness."
             )
-        elif (not configured) or status != "ok":
+        elif has_runtime_usage and ((not configured) or status != "ok"):
+            # Provider observed in runtime usage but not ready.
+            severity = "warning"
+        elif configured and status != "ok":
+            # Provider configured but failing provider probe.
             severity = "warning"
         else:
             severity = "info"

--- a/api/tests/test_automation_usage_api.py
+++ b/api/tests/test_automation_usage_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -553,3 +554,56 @@ async def test_automation_usage_endpoints_trace_back_to_spec_100(
     for row in rows:
         assert row["spec"]["tracked"] is True
         assert "100" in row["spec"]["spec_ids"]
+
+
+def test_rate_limit_header_parsing_supports_rfc9233_semicolon_params() -> None:
+    metrics = []
+    headers = httpx.Headers(
+        {
+            "ratelimit-limit": "1000;w=3600",
+            "ratelimit-remaining": "999",
+        }
+    )
+    ok = automation_usage_service._append_rate_limit_metrics(  # type: ignore[attr-defined]
+        metrics=metrics,
+        headers=headers,
+        request_limit_keys=("ratelimit-limit",),
+        request_remaining_keys=("ratelimit-remaining",),
+        request_window="hourly",
+        request_label="Test quota",
+    )
+    assert ok is True
+    assert any(row.id == "requests_quota" for row in metrics)
+
+
+def test_optional_unconfigured_provider_is_info_not_warning(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTOMATION_USAGE_SNAPSHOTS_PATH", str(tmp_path / "automation_usage.json"))
+    monkeypatch.setenv("GITHUB_TOKEN", "")
+    monkeypatch.setenv("GH_TOKEN", "")
+    monkeypatch.setenv("OPENAI_ADMIN_API_KEY", "")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "")
+    monkeypatch.setenv("OPENCLAW_API_KEY", "")
+    monkeypatch.setenv("RAILWAY_TOKEN", "")
+    monkeypatch.setenv("RAILWAY_PROJECT_ID", "")
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT", "")
+    monkeypatch.setenv("RAILWAY_SERVICE", "")
+    monkeypatch.setattr(automation_usage_service, "_railway_auth_available", lambda: False)  # type: ignore[attr-defined]
+
+    agent_service._store.clear()
+    agent_service._store_loaded = False
+    agent_service._store_loaded_path = None
+
+    report = automation_usage_service.provider_readiness_report(
+        required_providers=["coherence-internal"],
+        force_refresh=True,
+    )
+    rows = {row.provider: row for row in report.providers}
+    assert "openclaw" in rows
+    assert rows["openclaw"].required is False
+    assert rows["openclaw"].configured is False
+    assert rows["openclaw"].severity == "info"

--- a/docs/system_audit/commit_evidence_2026-02-17_provider-usage-tracking.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_provider-usage-tracking.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/provider-usage-tracking",
+  "commit_scope": "Harden provider usage/readiness probes: parse RFC9233 rate-limit headers (e.g. ratelimit-limit: 1000;w=3600), broaden recognized rate-limit header keys for OpenAI/Claude probes, add GitHub billing endpoint fallbacks to reduce 404 noise, and downgrade optional unconfigured providers (e.g. openclaw) from warning to info unless observed in runtime usage.",
+  "files_owned": [
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/system_audit/commit_evidence_2026-02-17_provider-usage-tracking.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "100"
+  ],
+  "task_ids": [
+    "provider-usage-tracking"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_automation_usage_api.py",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_provider-usage-tracking.json"
+  ],
+  "change_files": [
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Provider usage/readiness should show fewer false warnings (optional unconfigured providers are info), and more providers should surface request remaining/limit metrics when servers emit RFC9233-style ratelimit headers or provider-specific ratelimit keys; GitHub billing minutes should populate when accessible via configured owner/scope or authenticated user fallback.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness"
+    ],
+    "test_flows": [
+      "api:/api/automation/usage -> verify Railway/OpenAI/Claude rate-limit metrics appear when headers are present; ensure no 'no request remaining headers' note when RFC9233 headers are returned",
+      "api:/api/automation/usage/readiness -> verify optional unconfigured providers (e.g. openclaw) severity=info unless observed in runtime usage",
+      "api:/api/automation/usage -> verify GitHub billing minutes appear when token has billing access (owner/scope or /user fallback)"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_automation_usage_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway+vercel"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and (optional) production endpoint verification for provider probes"
+  }
+}
+


### PR DESCRIPTION
Addresses provider usage/readiness noise and improves quota tracking:

- Parse RFC9233-style rate-limit headers (e.g. ratelimit-limit: 1000;w=3600).
- Recognize additional ratelimit header keys for OpenAI/Claude probes.
- Add GitHub billing endpoint fallbacks (owner/scope + /user) to reduce 404 noise.
- Downgrade optional unconfigured providers (e.g. openclaw) to severity=info unless observed in runtime usage.

Verification:
- cd api && pytest -q tests/test_automation_usage_api.py