### PR TITLE
Fix External Tools Audit drift

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-17_external-tools-audit-fix.json
+++ b/docs/system_audit/commit_evidence_2026-02-17_external-tools-audit-fix.json
@@ -1,0 +1,72 @@
+{
+  "date": "2026-02-17",
+  "thread_branch": "codex/external-tools-audit-fix",
+  "commit_scope": "Fix External Tools Audit false positives (heredocs and multi-line quoted literals) and update the tracked GitHub Actions versions to match current workflows.",
+  "files_owned": [
+    "scripts/audit_external_tools.py",
+    "docs/system_audit/external_tools_registry.json",
+    "docs/system_audit/commit_evidence_2026-02-17_external-tools-audit-fix.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "100"
+  ],
+  "task_ids": [
+    "external-tools-audit-fix"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/audit_external_tools.py --json --fail-on-untracked",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_external-tools-audit-fix.json"
+  ],
+  "change_files": [
+    "scripts/audit_external_tools.py",
+    "docs/system_audit/external_tools_registry.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-17T09:53:28Z",
+    "commands": [
+      "python3 scripts/audit_external_tools.py --json --fail-on-untracked",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-17_external-tools-audit-fix.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-actions"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting local gates and CI."
+  }
+}

--- a/docs/system_audit/external_tools_registry.json
+++ b/docs/system_audit/external_tools_registry.json
@@ -5,10 +5,10 @@
   },
   "github_actions": [
     "actions/checkout@v4",
-    "actions/github-script@v7",
-    "actions/setup-node@v4",
+    "actions/github-script@v8",
+    "actions/setup-node@v6",
     "actions/setup-python@v5",
-    "actions/upload-artifact@v4"
+    "actions/upload-artifact@v6"
   ],
   "workflow_cli_tools": [
     "bc",


### PR DESCRIPTION
Fixes false positives in external tools audit (heredocs + multi-line single-quoted literals) and updates the tracked GitHub Actions versions in the registry.