### PR TITLE
restore missing ensure_worktree_start_clean.py

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-18_restore-worktree-start-script.json
+++ b/docs/system_audit/commit_evidence_2026-02-18_restore-worktree-start-script.json
@@ -1,0 +1,62 @@
+{
+  "date": "2026-02-18",
+  "thread_branch": "codex/fix-worktree-start-script",
+  "commit_scope": "Restore ensure_worktree_start_clean compatibility script and allow primary worktree gate checks",
+  "files_owned": [
+    "scripts/start_gate.py",
+    "scripts/ensure_worktree_start_clean.py"
+  ],
+  "idea_ids": ["public-e2e-flow-gate-automation"],
+  "spec_ids": ["095-public-e2e-flow-gate-automation"],
+  "task_ids": ["task_2026_02_18_start_gate_fix"],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "validation",
+        "decision"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/ensure_worktree_start_clean.py --json",
+    "make start-gate",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-18_restore-worktree-start-script.json"
+  ],
+  "change_files": [
+    "scripts/start_gate.py",
+    "scripts/ensure_worktree_start_clean.py",
+    "docs/system_audit/commit_evidence_2026-02-18_restore-worktree-start-script.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/ensure_worktree_start_clean.py --json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI/deploy pending"
+  }
+}

--- a/scripts/ensure_worktree_start_clean.py
+++ b/scripts/ensure_worktree_start_clean.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Backward-compatible start gate entrypoint used by Codex worktree docs and scripts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Emit JSON status")
+    args = parser.parse_args()
+
+    script_path = Path(__file__).with_name("start_gate.py")
+    proc = subprocess.run(
+        [sys.executable, str(script_path)],
+        capture_output=bool(args.json),
+        text=True,
+        check=False,
+    )
+
+    if args.json:
+        payload = {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "script": "scripts/start_gate.py",
+        }
+        if proc.returncode != 0:
+            payload["error"] = (proc.stderr or proc.stdout or "start-gate failed").strip()
+            print(json.dumps(payload))
+            return proc.returncode
+
+        print(json.dumps(payload))
+        return 0
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Restore compatibility script removed in prior start-gate migration and allow primary-worktree gate checks.