### PR TITLE
Add slow API telemetry and speed up inventory flow reads

### DIFF
--- a/api/app/routers/contributions.py
+++ b/api/app/routers/contributions.py
@@ -108,7 +108,7 @@ async def get_contribution(contribution_id: UUID, store: GraphStore = Depends(ge
 
 
 @router.get("/contributions", response_model=list[Contribution])
-async def list_contributions(limit: int = 100, store: GraphStore = Depends(get_store)) -> list[Contribution]:
+def list_contributions(limit: int = 100, store: GraphStore = Depends(get_store)) -> list[Contribution]:
     """List all contributions (read-only)."""
     return store.list_contributions(limit=limit)
 

--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -16,7 +16,7 @@ def get_store(request: Request) -> GraphStore:
 
 
 @router.post("/contributors", response_model=Contributor, status_code=201)
-async def create_contributor(contributor: ContributorCreate, store: GraphStore = Depends(get_store)) -> Contributor:
+def create_contributor(contributor: ContributorCreate, store: GraphStore = Depends(get_store)) -> Contributor:
     """Create a new contributor."""
     contrib = Contributor(**contributor.model_dump())
     try:
@@ -30,7 +30,7 @@ async def create_contributor(contributor: ContributorCreate, store: GraphStore =
     response_model=Contributor,
     responses={404: {"model": ErrorDetail}},
 )
-async def get_contributor(contributor_id: UUID, store: GraphStore = Depends(get_store)) -> Contributor:
+def get_contributor(contributor_id: UUID, store: GraphStore = Depends(get_store)) -> Contributor:
     """Get contributor by ID."""
     contrib = store.get_contributor(contributor_id)
     if not contrib:
@@ -39,6 +39,6 @@ async def get_contributor(contributor_id: UUID, store: GraphStore = Depends(get_
 
 
 @router.get("/contributors", response_model=list[Contributor])
-async def list_contributors(limit: int = 100, store: GraphStore = Depends(get_store)) -> list[Contributor]:
+def list_contributors(limit: int = 100, store: GraphStore = Depends(get_store)) -> list[Contributor]:
     """List all contributors."""
     return store.list_contributors(limit=limit)

--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -142,7 +142,7 @@ async def sync_asset_modularity_tasks(
 
 
 @router.get("/inventory/flow")
-async def spec_process_implementation_validation_flow(
+def spec_process_implementation_validation_flow(
     request: Request,
     idea_id: str | None = Query(default=None),
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),

--- a/docs/system_audit/commit_evidence_2026-02-18_api-inventory-flow-latency.json
+++ b/docs/system_audit/commit_evidence_2026-02-18_api-inventory-flow-latency.json
@@ -1,0 +1,91 @@
+{
+  "date": "2026-02-18",
+  "thread_branch": "codex/api-slow-fix",
+  "commit_scope": "Add request-time slow-endpoint telemetry and optimize synchronous read endpoints to reduce event-loop blocking for flow/inventory and contributor endpoints.",
+  "files_owned": [
+    "api/app/main.py",
+    "api/app/routers/contributors.py",
+    "api/app/routers/contributions.py",
+    "api/app/routers/inventory.py",
+    "docs/system_audit/commit_evidence_2026-02-18_api-inventory-flow-latency.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "006"
+  ],
+  "task_ids": [
+    "api-flow-latency-debug"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5.3-codex"
+  },
+  "evidence_refs": [
+    "python3 - <<'PY'\nimport time, urllib.request\n\n# local\nfor i in range(1, 6):\n    start = time.perf_counter()\n    urllib.request.urlopen('http://127.0.0.1:18130/api/inventory/flow', timeout=20)\n    print('local_flow_ms', (time.perf_counter()-start)*1000)\nPY",
+    "python3 - <<'PY'\nimport time, urllib.request\n\n# production\nfor i in range(1, 3):\n    start = time.perf_counter()\n    urllib.request.urlopen('https://coherence-network-production.up.railway.app/api/inventory/flow', timeout=40)\n    print('prod_flow_ms', (time.perf_counter()-start)*1000)\nPY",
+    "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+  ],
+  "change_files": [
+    "api/app/main.py",
+    "api/app/routers/contributors.py",
+    "api/app/routers/contributions.py",
+    "api/app/routers/inventory.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Slow request telemetry identifies API endpoints above threshold, and inventory flow endpoint no longer blocks the asyncio loop; production latency regressions are reduced by avoiding slow synchronous handling on key read routes.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/flow",
+      "https://coherence-network-production.up.railway.app/api/contributors?limit=5000",
+      "https://coherence-network-production.up.railway.app/api/contributions?limit=10000"
+    ],
+    "test_flows": [
+      "run local timing probe against /api/inventory/flow and contributor/contribution read endpoints and compare P95 to baseline",
+      "verify slow_endpoint logs emit for /api/inventory/flow when threshold is exceeded",
+      "run production endpoint timing probe and capture delta after deploy"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-18T11:20:00Z",
+    "environment": {
+      "python": "3.11"
+    },
+    "commands": [
+      "python3 - <<'PY'\nimport time, urllib.request\nfor i in range(1, 6):\n    start=time.perf_counter(); urllib.request.urlopen('http://127.0.0.1:18130/api/inventory/flow', timeout=20); print((time.perf_counter()-start)*1000)\nPY"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and production deploy re-verification before opening next phase."
+  }
+}


### PR DESCRIPTION
Track slow API endpoints and convert inventory/contributor/contribution read routes to sync handlers to avoid blocking the event loop on production PostgreSQL workloads.