### PR TITLE
runner: emit per-agent AGENT.md manifestation provenance

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json
@@ -1,0 +1,76 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/b480",
+  "commit_scope": "Add runner-managed AGENT.md manifestation provenance so generated code blocks are linked to line ranges, idea links, and source document references.",
+  "files_owned": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "030-task-runner-reliability"
+  ],
+  "task_ids": [
+    "task_agent-manifest-provenance"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex:railway-runner-1",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "Runner writes api/logs/agent_manifests/<agent>/AGENT.md entries with file:line, read range, manifestation range, idea link, and source reference",
+    "Task context now includes agent_manifest metadata for UI/system lookup"
+  ],
+  "change_files": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting CI and deploy verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "PR-mode runs produce append-only per-agent AGENT.md provenance and task context manifestation metadata tied to idea/system links.",
+    "public_endpoints": [
+      "/api/agent/tasks/{task_id}",
+      "/api/ideas/{idea_id}"
+    ],
+    "test_flows": [
+      "runner parses git diff hunks into manifestation ranges",
+      "runner appends AGENT.md entry under api/logs/agent_manifests/<agent>",
+      "runner patches task context with agent_manifest block metadata"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add runner-managed per-agent AGENT.md provenance output under api/logs/agent_manifests/<agent>/AGENT.md
- capture code manifestation blocks from git diff hunks with file:line, read range, and manifestation range
- include idea link + API link + source document references in each AGENT.md task entry
- patch task context with agent_manifest metadata so the web/API can inspect the same block-level provenance

## Tests
- add parser coverage for diff hunk -> manifestation block extraction
- add manifest writer coverage for AGENT.md output + task context payload

## Validation
- make start-gate
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_agent-manifest-provenance.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict