### PR TITLE
Fix web health-proxy deployment resilience

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-19_remote-ops-web-health-proxy.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_remote-ops-web-health-proxy.json
@@ -1,0 +1,75 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/remote-ops-web-fix-20260219",
+  "commit_scope": "Make web API URL resolution resilient to legacy env values and increase health-proxy upstream timeout to avoid false failures under production latency.",
+  "files_owned": [
+    "web/lib/api.ts",
+    "web/app/api/health-proxy/route.ts"
+  ],
+  "idea_ids": [
+    "deployment-gate-reliability"
+  ],
+  "spec_ids": [
+    "054-commit-evidence-phase-gates"
+  ],
+  "task_ids": [
+    "task-remote-ops-web-health-proxy-2026-02-19"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "verification"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "./scripts/verify_web_api_deploy.sh",
+    "https://coherence-web-production.up.railway.app/api/health-proxy"
+  ],
+  "change_files": [
+    "web/lib/api.ts",
+    "web/app/api/health-proxy/route.ts"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pending",
+    "commands": [
+      "npm --prefix web run build",
+      "REMOTE_OPS_RUN_EXEC=1 REMOTE_OPS_CURL_TIMEOUT=90 ./scripts/verify_remote_ops_smoke.sh",
+      "./scripts/verify_web_api_deploy.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production",
+    "notes": "Needs successful GitHub deploy-to-production workflow after PR merge."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Legacy NEXT_PUBLIC_API_URL values (api.coherencycoin.com) are ignored in web API base resolution, and /api/health-proxy can tolerate slower upstream API responses up to 15s without returning false 502 states.",
+    "public_endpoints": [
+      "https://coherence-web-production.up.railway.app/api/health-proxy",
+      "https://coherence-web-production.up.railway.app/remote-ops",
+      "https://coherence-network-production.up.railway.app/api/health"
+    ],
+    "test_flows": [
+      "Call /api/health-proxy and verify it returns 200 with the API payload.",
+      "Use verify_web_api_deploy.sh to confirm web + API deployment contract passes."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Deployment and public verification pending."
+  }
+}

--- a/web/app/api/health-proxy/route.ts
+++ b/web/app/api/health-proxy/route.ts
@@ -5,6 +5,7 @@ import { fetchJsonOrNull } from "@/lib/fetch";
 const API_URL = getApiBase();
 const WEB_STARTED_AT = new Date();
 const WEB_UPDATED_AT = process.env.WEB_UPDATED_AT || process.env.VERCEL_GIT_COMMIT_SHA || "unknown";
+const UPSTREAM_TIMEOUT_MS = 15000;
 
 function uptimeSeconds() {
   return Math.max(0, Math.floor((Date.now() - WEB_STARTED_AT.getTime()) / 1000));
@@ -22,7 +23,11 @@ function uptimeHuman(seconds: number) {
 export async function GET() {
   const started = performance.now();
   try {
-    const upstreamJson = await fetchJsonOrNull<Record<string, unknown>>(`${API_URL}/api/health`, { cache: "no-store" }, 5000);
+    const upstreamJson = await fetchJsonOrNull<Record<string, unknown>>(
+      `${API_URL}/api/health`,
+      { cache: "no-store" },
+      UPSTREAM_TIMEOUT_MS,
+    );
     if (!upstreamJson) {
       throw new Error("Upstream health payload unavailable");
     }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,13 +1,42 @@
 export const PROD_API_URL = "https://coherence-network-production.up.railway.app";
 export const DEV_API_URL = "http://localhost:8000";
+const LEGACY_BLOCKED_API_HOSTS = ["api.coherencycoin.com"];
 
 function _stripTrailingSlash(url: string): string {
   return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
+function _isLocalhostHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+function _resolveApiEnvUrl(envValue: string): string | null {
+  const trimmed = envValue.trim();
+  if (!trimmed) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (LEGACY_BLOCKED_API_HOSTS.includes(hostname)) {
+    return null;
+  }
+
+  if (_isLocalhostHost(hostname) || parsed.protocol.startsWith("http")) {
+    return _stripTrailingSlash(trimmed);
+  }
+
+  return null;
+}
+
 export function getApiBase(): string {
   const env = process.env.NEXT_PUBLIC_API_URL;
-  if (env && env.trim()) return _stripTrailingSlash(env.trim());
+  const resolved = env ? _resolveApiEnvUrl(env) : null;
+  if (resolved) return resolved;
   if (process.env.NODE_ENV === "production") return PROD_API_URL;
   return DEV_API_URL;
 }


### PR DESCRIPTION
## Summary
- Ignore legacy NEXT_PUBLIC_API_URL values pointing to api.coherencycoin.com in web API base resolution.
- Increase web health-proxy upstream timeout from 5s to 15s to avoid false 502s.
- Add commit evidence artifact.