### PR TITLE
runner: remap openrouter/free for codex-backed clawwork tasks

### DIFF
--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -218,6 +218,7 @@ PAID_CALL_COST_UNITS = max(0.0, PAID_CALL_COST_UNITS)
 
 TaskRunItem = tuple[str, str, str, str, dict[str, Any], str, bool]
 DEFAULT_CODEX_MODEL_ALIAS_MAP = (
+    "openrouter/free:gpt-5-codex,"
     "gpt-5.3-codex-spark:gpt-5-codex,"
     "gpt-5.3-codex:gpt-5-codex,"
     "gtp-5.3-codex-spark:gpt-5-codex,"

--- a/api/tests/test_agent_runner_tool_failure_telemetry.py
+++ b/api/tests/test_agent_runner_tool_failure_telemetry.py
@@ -223,6 +223,18 @@ def test_apply_codex_model_alias_supports_gtp_typo_default_map():
     assert "--model gtp-5.3-codex" not in remapped
 
 
+def test_apply_codex_model_alias_remaps_openrouter_free_default_map():
+    remapped, alias = agent_runner._apply_codex_model_alias(
+        'codex exec --model openrouter/free "Output exactly MODEL_OK."'
+    )
+    assert alias == {
+        "requested_model": "openrouter/free",
+        "effective_model": "gpt-5-codex",
+    }
+    assert "--model gpt-5-codex" in remapped
+    assert "--model openrouter/free" not in remapped
+
+
 def test_run_one_task_records_codex_model_alias_in_context_and_log(monkeypatch, tmp_path):
     t = [4000.0]
 

--- a/docs/system_audit/commit_evidence_2026-02-19_openclaw-codex-openrouter-alias.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_openclaw-codex-openrouter-alias.json
@@ -1,0 +1,78 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/railway-openclaw-runtime-fix",
+  "commit_scope": "Fix codex-runner clawwork/openclaw failures by remapping unsupported openrouter/free model requests to a codex-compatible fallback model and covering with regression tests.",
+  "files_owned": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "maintainability_audit_report.json",
+    "docs/system_audit/commit_evidence_2026-02-19_openclaw-codex-openrouter-alias.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-openclaw-clawwork-executor-alias"
+  ],
+  "task_ids": [
+    "task-2026-02-19-railway-openclaw-codex-openrouter-remap"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Railway runner logs show repeated codex failures for openclaw tasks with returncode=1 and output_len~=793 under worker_id=openai-codex:railway-runner-1.",
+    "Production runtime events show the same failure signature for task ids task_5bf765978f547728 and task_c61bd6e3b4e7d736.",
+    "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py",
+    "cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py -k 'clawwork or openclaw_openrouter_override_tracks_openrouter_provider'"
+  ],
+  "change_files": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "maintainability_audit_report.json",
+    "docs/system_audit/commit_evidence_2026-02-19_openclaw-codex-openrouter-alias.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py",
+      "cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py -k 'clawwork or openclaw_openrouter_override_tracks_openrouter_provider'",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_openclaw-codex-openrouter-alias.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting local guard re-run, CI, and production verification."
+  }
+}

--- a/maintainability_audit_report.json
+++ b/maintainability_audit_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-19T15:51:11.078115+00:00",
+  "generated_at": "2026-02-19T16:24:09.543184+00:00",
   "policy": {
     "large_module_lines": 600,
     "very_large_module_lines": 1000,


### PR DESCRIPTION
## Summary
- diagnose production clawwork/openclaw failures via Railway/runtime data (codex runner returned exit=1 with deterministic output length)
- add default codex model alias remap `openrouter/free -> gpt-5-codex` in runner execution path
- add regression test coverage for default alias map behavior

## Diagnosis Evidence
- Railway runner logs show failed tasks under `openai-codex:railway-runner-1` with `command_failed` and `returncode=1`
- Runtime events for failing tasks (`task_5bf765978f547728`, `task_c61bd6e3b4e7d736`) show `model=openclaw/openrouter/free` and codex tool failures
- Local codex invocation with `--model openrouter/free` reproduces unsupported model failure for codex account mode

## Validation
- `cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py`
- `cd api && pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_usage_tracking_api.py -k 'clawwork or openclaw_openrouter_override_tracks_openrouter_provider'`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
