### PR TITLE
Harden npm installs and add agent code reference provenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 
+      - name: Upgrade npm for install hardening support
+        run: npm install -g npm@11.10.0
+
       - name: Build web
         run: |
-          cd web && npm ci && npm run build
+          cd web && npm ci --allow-git=none && npm run build

--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -106,9 +106,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 
+      - name: Upgrade npm for install hardening support
+        run: npm install -g npm@11.10.0
+
       - name: Build web
         run: |
-          cd web && npm ci && npm run build
+          cd web && npm ci --allow-git=none && npm run build
 
       - name: Check open PR failures (PRs only)
         if: github.event_name == 'pull_request'

--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -769,6 +769,33 @@ def _task_source_references(context: dict[str, Any]) -> list[str]:
     return deduped
 
 
+def _task_code_references(context: dict[str, Any]) -> list[dict[str, str]]:
+    raw = context.get("code_references")
+    if not isinstance(raw, list):
+        return []
+
+    references: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in raw:
+        url = ""
+        license_name = ""
+        note = ""
+        if isinstance(item, str):
+            url = item.strip()
+        elif isinstance(item, dict):
+            url = str(item.get("url") or item.get("source") or "").strip()
+            license_name = str(item.get("license") or item.get("license_id") or "").strip()
+            note = str(item.get("note") or item.get("repository") or item.get("match_reason") or "").strip()
+        if not url:
+            continue
+        key = (url, license_name, note)
+        if key in seen:
+            continue
+        seen.add(key)
+        references.append({"url": url, "license": license_name, "note": note})
+    return references
+
+
 def _idea_links(idea_id: str) -> tuple[str, str]:
     if not idea_id:
         return "", ""
@@ -864,7 +891,9 @@ def _append_agent_manifest_entry(
         idea_id = _task_idea_id(task_ctx)
         idea_url, idea_api_url = _idea_links(idea_id)
         source_refs = _task_source_references(task_ctx)
+        code_refs = _task_code_references(task_ctx)
         primary_source_ref = source_refs[0] if source_refs else ""
+        primary_code_ref = code_refs[0]["url"] if code_refs else ""
 
         manifest_dir = os.path.join(AGENT_MANIFESTS_DIR, _safe_agent_slug(agent_name))
         manifest_path = os.path.join(manifest_dir, "AGENT.md")
@@ -893,6 +922,18 @@ def _append_agent_manifest_entry(
                         handle.write(f"  - [{ref}]({ref})\n")
                 else:
                     handle.write("- Source references: none\n")
+                if code_refs:
+                    handle.write("- Code references:\n")
+                    for ref in code_refs:
+                        detail_parts: list[str] = []
+                        if ref["license"]:
+                            detail_parts.append(f"license `{ref['license']}`")
+                        if ref["note"]:
+                            detail_parts.append(ref["note"])
+                        detail = f" ({'; '.join(detail_parts)})" if detail_parts else ""
+                        handle.write(f"  - [{ref['url']}]({ref['url']}){detail}\n")
+                else:
+                    handle.write("- Code references: none\n")
                 handle.write("- Manifestation blocks:\n")
                 for block in blocks:
                     file_line_ref = str(block.get("file_line_ref") or "")
@@ -905,6 +946,8 @@ def _append_agent_manifest_entry(
                         line += f" | idea [{idea_id}]({idea_url})"
                     if primary_source_ref:
                         line += f" | source [{primary_source_ref}]({primary_source_ref})"
+                    if primary_code_ref:
+                        line += f" | code_ref [{primary_code_ref}]({primary_code_ref})"
                     handle.write(line + "\n")
                 handle.write("\n")
 
@@ -928,6 +971,7 @@ def _append_agent_manifest_entry(
                 "idea_url": idea_url or None,
                 "idea_api_url": idea_api_url or None,
                 "source_refs": source_refs,
+                "code_refs": code_refs,
                 "manifestation_blocks": context_blocks,
                 "manifestation_block_count": len(blocks),
             }

--- a/api/tests/test_pr_check_failure_triage.py
+++ b/api/tests/test_pr_check_failure_triage.py
@@ -20,6 +20,7 @@ def test_hint_mapping_known_checks() -> None:
     assert "pytest -q" in mod._hint_for_check("Test")
     assert "validate_spec_quality.py" in mod._hint_for_check("Validate spec quality contract")
     assert "worktree_pr_guard.py" in mod._hint_for_check("Thread Gates")
+    assert "--allow-git=none" in mod._hint_for_check("Build web")
 
 
 def test_blocking_failures_detection() -> None:

--- a/api/tests/test_worktree_pr_guard.py
+++ b/api/tests/test_worktree_pr_guard.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "worktree_pr_guard.py"
+    spec = importlib.util.spec_from_file_location("worktree_pr_guard", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_steps_web_build_is_hardened(monkeypatch) -> None:
+    mod = _load_module()
+    monkeypatch.setattr(mod, "_worktree_has_runtime_changes", lambda _base_ref: True)
+
+    steps = mod._local_steps(
+        base_ref="origin/main",
+        skip_api_tests=True,
+        skip_web_build=False,
+        require_gh_auth=False,
+    )
+    web_step = next((step for step in steps if step[0] == "web-build"), None)
+    assert web_step is not None
+    assert "--allow-git=none" in web_step[1]
+
+
+def test_check_run_hint_build_web_is_hardened() -> None:
+    mod = _load_module()
+    assert "--allow-git=none" in mod._check_run_hint("build web")

--- a/docs/system_audit/commit_evidence_2026-02-19_npm-hardening-telegram-proof.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_npm-hardening-telegram-proof.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/telegram-deploy-proof",
+  "commit_scope": "Harden npm install flows with --allow-git=none and extend agent manifest provenance with code references; validate deploy and Telegram reporting paths.",
+  "files_owned": [
+    ".github/workflows/test.yml",
+    ".github/workflows/thread-gates.yml",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_pr_check_failure_triage.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "scripts/pr_check_failure_triage.py",
+    "scripts/verify_worktree_local_web.sh",
+    "scripts/worktree_pr_guard.py",
+    "docs/system_audit/commit_evidence_2026-02-19_npm-hardening-telegram-proof.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "003-agent-telegram-decision-loop",
+    "054-commit-provenance-contract-gate"
+  ],
+  "task_ids": [
+    "task_npm-hardening-telegram-proof"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex:gpt-5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "deployment"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "pytest -q tests/test_pr_check_failure_triage.py tests/test_worktree_pr_guard.py tests/test_agent_runner_tool_failure_telemetry.py",
+    "python3 scripts/validate_workflow_references.py",
+    "API_PORT=18100 WEB_PORT=3110 ./scripts/verify_worktree_local_web.sh --start",
+    "./scripts/verify_web_api_deploy.sh"
+  ],
+  "change_files": [
+    ".github/workflows/test.yml",
+    ".github/workflows/thread-gates.yml",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_pr_check_failure_triage.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "scripts/pr_check_failure_triage.py",
+    "scripts/verify_worktree_local_web.sh",
+    "scripts/worktree_pr_guard.py"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "pytest -q tests/test_pr_check_failure_triage.py tests/test_worktree_pr_guard.py tests/test_agent_runner_tool_failure_telemetry.py",
+      "python3 scripts/validate_workflow_references.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting PR CI and public deploy + Telegram verification on main."
+  }
+}

--- a/scripts/pr_check_failure_triage.py
+++ b/scripts/pr_check_failure_triage.py
@@ -72,7 +72,7 @@ def _hint_for_check(name: str) -> str:
             "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
         ),
         ("test", "cd api && pytest -q"),
-        ("build web", "cd web && npm ci && npm run build"),
+        ("build web", "cd web && npm ci --allow-git=none && npm run build"),
         ("thread gates", "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"),
         ("public deploy contract", "./scripts/verify_web_api_deploy.sh"),
         ("change contract", "python3 scripts/worktree_pr_guard.py --mode all --base-ref origin/main"),

--- a/scripts/verify_worktree_local_web.sh
+++ b/scripts/verify_worktree_local_web.sh
@@ -83,6 +83,15 @@ ensure_npm_cache() {
   export NPM_CONFIG_CACHE="${NPM_CACHE}"
 }
 
+npm_ci_hardened() {
+  if npm help install 2>/dev/null | grep -q -- "--allow-git"; then
+    npm ci --allow-git=none
+  else
+    echo "Warning: npm version lacks --allow-git; running npm ci without that hardening flag."
+    npm ci
+  fi
+}
+
 select_python() {
   local candidate
   for candidate in "${API_DIR}/.venv/bin/python" "${API_DIR}/.venv/bin/python3" "$(command -v python3.11 || true)" "$(command -v python3 || true)"; do
@@ -241,7 +250,7 @@ start_web_if_needed() {
   pushd "${WEB_DIR}" >/dev/null
   if [[ ! -d node_modules || ! -x node_modules/.bin/next ]]; then
     echo "Installing web dependencies (node_modules missing)..."
-    npm ci
+    npm_ci_hardened
   fi
 
   echo "Building web app..."

--- a/scripts/worktree_pr_guard.py
+++ b/scripts/worktree_pr_guard.py
@@ -111,7 +111,7 @@ def _hint_for_step(name: str, command: str, output: str) -> str:
     if "pytest" in lower:
         return "Reproduce locally with failing test subset, fix implementation, re-run full api pytest."
     if "npm run build" in lower:
-        return "Fix web build/type/runtime issues and re-run npm ci && npm run build in web/."
+        return "Fix web build/type/runtime issues and re-run npm ci --allow-git=none && npm run build in web/."
     if "verify_worktree_local_web" in lower:
         return "Inspect API/web runtime logs emitted by verify_worktree_local_web.sh and fix failing route/runtime errors."
     return "Review command output tail, fix root cause, and re-run this guard before push."
@@ -490,7 +490,7 @@ def _local_steps(
     if not skip_api_tests:
         steps.append(("api-tests", "cd api && pytest -q"))
     if not skip_web_build:
-        steps.append(("web-build", "cd web && npm ci && npm run build"))
+        steps.append(("web-build", "cd web && npm ci --allow-git=none && npm run build"))
     steps.append(("worktree-runtime-web-guard", "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh"))
     return steps
 
@@ -504,7 +504,7 @@ def _check_run_hint(name: str) -> str:
         ("maintainability", "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression"),
         ("run api tests", "cd api && pytest -q"),
         ("test", "cd api && pytest -q"),
-        ("build web", "cd web && npm ci && npm run build"),
+        ("build web", "cd web && npm ci --allow-git=none && npm run build"),
         ("thread gates", "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"),
     ]
     for key, cmd in mapping:


### PR DESCRIPTION
## Summary
- enforce `npm ci --allow-git=none` in web build guard paths
- upgrade npm to 11.10.0 in CI workflows before hardened install
- add local fallback in worktree verify script when npm lacks `--allow-git`
- extend agent manifest provenance with task `code_references` and expose `agent_manifest.code_refs`
- add tests for hardening hints/steps and code-reference manifest output

## Validation
- `pytest -q tests/test_pr_check_failure_triage.py tests/test_worktree_pr_guard.py tests/test_agent_runner_tool_failure_telemetry.py`
- `python3 scripts/validate_workflow_references.py`
- `THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
