### PR TITLE
Add complete Railway Telegram management commands

### DIFF
--- a/api/app/routers/agent_telegram.py
+++ b/api/app/routers/agent_telegram.py
@@ -233,7 +233,7 @@ async def telegram_webhook(update: dict = Body(...)) -> dict:
     """Receive Telegram updates and run command handlers.
 
     Commands: /status, /tasks [status], /task {id}, /reply {id} {decision},
-    /attention, /usage, /direction \"...\" or plain text.
+    /attention, /usage, /direction \"...\", /railway ..., or plain text.
     """
     from app.services import telegram_adapter
     from app.services import telegram_diagnostics
@@ -328,6 +328,10 @@ async def telegram_webhook(update: dict = Body(...)) -> dict:
             reply += f"\n`{t['id']}` {t['status']} — {str(t.get('direction', ''))[:40]}..."
             if t.get("decision_prompt"):
                 reply += f"\n  _{t['decision_prompt'][:60]}_"
+    elif cmd in {"railway", "deploy"}:
+        from app.services import telegram_railway_service
+
+        reply = await telegram_railway_service.handle_railway_command(arg)
     elif cmd == "direction" or (not cmd and text):
         direction = arg if cmd == "direction" else text
         if not direction:
@@ -340,7 +344,7 @@ async def telegram_webhook(update: dict = Body(...)) -> dict:
     else:
         reply = (
             "Commands: /status, /tasks [status], /task {id}, /reply {id} {decision}, "
-            "/attention, /usage, /direction \"...\" or just type your direction"
+            "/attention, /usage, /direction \"...\", /railway ..., or just type your direction"
         )
 
     if reply:

--- a/api/app/services/telegram_railway_service.py
+++ b/api/app/services/telegram_railway_service.py
@@ -1,0 +1,330 @@
+"""Railway management command handlers for Telegram webhook."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from app.services import release_gate_service
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REPOSITORY = "seeker71/Coherence-Network"
+_DEFAULT_BRANCH = "main"
+_DEFAULT_API_BASE = "https://coherence-network-production.up.railway.app"
+_DEFAULT_WEB_BASE = "https://coherence-web-production.up.railway.app"
+_JOB_LIST_LIMIT = 8
+
+
+def _escape_markdown(text: str) -> str:
+    out = text or ""
+    for ch in ("\\", "`", "*", "_", "[", "]"):
+        out = out.replace(ch, f"\\{ch}")
+    return out
+
+
+def _github_token() -> str | None:
+    token = (os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN") or "").strip()
+    return token or None
+
+
+def _short_sha(value: Any) -> str:
+    raw = str(value or "").strip()
+    return raw[:12] if raw else "unknown"
+
+
+def _inline_code_list(values: list[Any], *, limit: int = 6) -> str:
+    items = [str(value).strip() for value in values if str(value).strip()]
+    if not items:
+        return "none"
+    shown = items[:limit]
+    out = ", ".join(f"`{item}`" for item in shown)
+    if len(items) > limit:
+        out += f", +{len(items) - limit} more"
+    return out
+
+
+def railway_help_reply() -> str:
+    return (
+        "*Railway commands*\n"
+        "`/railway head`\n"
+        "`/railway status`\n"
+        "`/railway jobs`\n"
+        "`/railway schedule [max_attempts]`\n"
+        "`/railway verify`\n"
+        "`/railway tick due`\n"
+        "`/railway tick all`\n"
+        "`/railway tick {job_id}`"
+    )
+
+
+def _format_status_reply(report: dict[str, Any]) -> str:
+    result = str(report.get("result") or "unknown")
+    reason = str(report.get("reason") or "").strip()
+    failing = report.get("failing_checks")
+    warnings = report.get("warnings")
+    reply = (
+        "*Railway status*\n"
+        f"Repository: `{report.get('repository', _DEFAULT_REPOSITORY)}`\n"
+        f"Branch: `{report.get('branch', _DEFAULT_BRANCH)}`\n"
+        f"Result: `{result}`\n"
+        f"Expected SHA: `{_short_sha(report.get('expected_sha'))}`"
+    )
+    if isinstance(failing, list):
+        reply += f"\nFailing: {_inline_code_list(failing)}"
+    if isinstance(warnings, list) and warnings:
+        reply += f"\nWarnings: {_inline_code_list(warnings)}"
+    if reason:
+        reply += f"\nReason: {_escape_markdown(reason[:200])}"
+    return reply
+
+
+def _format_jobs_reply(jobs: list[dict[str, Any]]) -> str:
+    if not jobs:
+        return "*Railway jobs*\nNo verification jobs found."
+    reply = f"*Railway jobs* ({len(jobs)} total)\n"
+    latest = list(reversed(jobs))[:_JOB_LIST_LIMIT]
+    for job in latest:
+        job_id = str(job.get("job_id") or "?")
+        status = str(job.get("status") or "unknown")
+        attempts = int(job.get("attempts") or 0)
+        max_attempts = int(job.get("max_attempts") or 0)
+        if max_attempts > 0:
+            reply += f"\n`{job_id}` {status} ({attempts}/{max_attempts})"
+        else:
+            reply += f"\n`{job_id}` {status} ({attempts})"
+    return reply
+
+
+def _format_verify_reply(created: dict[str, Any], ticked: dict[str, Any]) -> str:
+    job_id = str(ticked.get("job_id") or created.get("job_id") or "?")
+    status = str(ticked.get("status") or created.get("status") or "unknown")
+    attempts = int(ticked.get("attempts") or created.get("attempts") or 0)
+    max_attempts = int(ticked.get("max_attempts") or created.get("max_attempts") or 0)
+    last_result = ticked.get("last_result")
+    result = (
+        str(last_result.get("result") or "unknown")
+        if isinstance(last_result, dict)
+        else "unknown"
+    )
+    reason = (
+        str(last_result.get("reason") or "").strip()
+        if isinstance(last_result, dict)
+        else ""
+    )
+    reply = (
+        "*Railway verify*\n"
+        f"Job: `{job_id}`\n"
+        f"Status: `{status}`\n"
+        f"Attempts: `{attempts}/{max_attempts or '?'}`\n"
+        f"Result: `{result}`"
+    )
+    if reason:
+        reply += f"\nReason: {_escape_markdown(reason[:200])}"
+    return reply
+
+
+def _format_tick_reply(job: dict[str, Any]) -> str:
+    status = str(job.get("status") or "unknown")
+    job_id = str(job.get("job_id") or "?")
+    if status == "not_found":
+        return f"Railway job `{job_id}` not found"
+    attempts = int(job.get("attempts") or 0)
+    max_attempts = int(job.get("max_attempts") or 0)
+    last_result = job.get("last_result")
+    result = (
+        str(last_result.get("result") or "unknown")
+        if isinstance(last_result, dict)
+        else "unknown"
+    )
+    reason = (
+        str(last_result.get("reason") or "").strip()
+        if isinstance(last_result, dict)
+        else str(job.get("last_error") or "").strip()
+    )
+    reply = (
+        "*Railway tick*\n"
+        f"Job: `{job_id}`\n"
+        f"Status: `{status}`\n"
+        f"Attempts: `{attempts}/{max_attempts or '?'}`\n"
+        f"Result: `{result}`"
+    )
+    if reason:
+        reply += f"\nReason: {_escape_markdown(reason[:200])}"
+    return reply
+
+
+def _format_tick_many_reply(result: dict[str, Any], *, due_only: bool) -> str:
+    jobs = result.get("jobs") if isinstance(result.get("jobs"), list) else []
+    mode = "due" if due_only else "all"
+    if not jobs:
+        return f"*Railway tick {mode}*\nNo jobs were updated."
+    reply = f"*Railway tick {mode}* ({len(jobs)} updated)\n"
+    for job in jobs[:_JOB_LIST_LIMIT]:
+        job_id = str(job.get("job_id") or "?")
+        status = str(job.get("status") or "unknown")
+        attempts = int(job.get("attempts") or 0)
+        max_attempts = int(job.get("max_attempts") or 0)
+        result_obj = job.get("last_result")
+        result_name = (
+            str(result_obj.get("result") or "unknown")
+            if isinstance(result_obj, dict)
+            else "unknown"
+        )
+        reply += f"\n`{job_id}` {status} ({attempts}/{max_attempts or '?'}) `{result_name}`"
+    return reply
+
+
+def _format_schedule_reply(created: dict[str, Any]) -> str:
+    job_id = str(created.get("job_id") or "?")
+    status = str(created.get("status") or "unknown")
+    attempts = int(created.get("attempts") or 0)
+    max_attempts = int(created.get("max_attempts") or 0)
+    return (
+        "*Railway schedule*\n"
+        f"Job: `{job_id}`\n"
+        f"Status: `{status}`\n"
+        f"Attempts: `{attempts}/{max_attempts or '?'}`"
+    )
+
+
+def _parse_max_attempts(rest: list[str]) -> int | None:
+    if not rest:
+        return None
+    raw = rest[0].strip()
+    if not raw.isdigit():
+        return None
+    return max(1, min(200, int(raw)))
+
+
+async def _command_head(token: str | None) -> str:
+    sha = await asyncio.to_thread(
+        release_gate_service.get_branch_head_sha,
+        _DEFAULT_REPOSITORY,
+        _DEFAULT_BRANCH,
+        token,
+        8.0,
+    )
+    if not sha:
+        return (
+            "*Railway head*\n"
+            f"Repository: `{_DEFAULT_REPOSITORY}`\n"
+            f"Branch: `{_DEFAULT_BRANCH}`\n"
+            "SHA: `unavailable`"
+        )
+    return (
+        "*Railway head*\n"
+        f"Repository: `{_DEFAULT_REPOSITORY}`\n"
+        f"Branch: `{_DEFAULT_BRANCH}`\n"
+        f"SHA: `{_short_sha(sha)}`"
+    )
+
+
+async def _command_status(token: str | None) -> str:
+    report = await asyncio.to_thread(
+        release_gate_service.evaluate_public_deploy_contract_report,
+        repository=_DEFAULT_REPOSITORY,
+        branch=_DEFAULT_BRANCH,
+        api_base=_DEFAULT_API_BASE,
+        web_base=_DEFAULT_WEB_BASE,
+        timeout=8.0,
+        github_token=token,
+    )
+    return _format_status_reply(report if isinstance(report, dict) else {})
+
+
+async def _command_jobs() -> str:
+    jobs = await asyncio.to_thread(release_gate_service.list_public_deploy_verification_jobs)
+    return _format_jobs_reply(jobs if isinstance(jobs, list) else [])
+
+
+async def _create_job(token: str | None, *, max_attempts: int | None) -> dict[str, Any]:
+    created = await asyncio.to_thread(
+        release_gate_service.create_public_deploy_verification_job,
+        repository=_DEFAULT_REPOSITORY,
+        branch=_DEFAULT_BRANCH,
+        api_base=_DEFAULT_API_BASE,
+        web_base=_DEFAULT_WEB_BASE,
+        max_attempts=max_attempts,
+        timeout=8.0,
+        poll_seconds=30.0,
+        github_token=token,
+    )
+    return created if isinstance(created, dict) else {}
+
+
+async def _command_schedule(token: str | None, rest: list[str]) -> str:
+    created = await _create_job(token, max_attempts=_parse_max_attempts(rest))
+    if not created:
+        return "Railway schedule failed: unable to create verification job"
+    return _format_schedule_reply(created)
+
+
+async def _command_verify(token: str | None, rest: list[str]) -> str:
+    created = await _create_job(token, max_attempts=_parse_max_attempts(rest))
+    if not created:
+        return "Railway verify failed: unable to create verification job"
+    job_id = str(created.get("job_id") or "").strip()
+    if not job_id:
+        return "Railway verify failed: missing job id"
+    ticked = await asyncio.to_thread(
+        release_gate_service.tick_public_deploy_verification_job,
+        job_id=job_id,
+        github_token=token,
+    )
+    return _format_verify_reply(created, ticked if isinstance(ticked, dict) else {})
+
+
+async def _command_tick(token: str | None, rest: list[str]) -> str:
+    if not rest:
+        return "Usage: /railway tick {job_id}"
+    target = rest[0].strip().lower()
+    if target in {"due", "all"}:
+        due_only = target != "all"
+        ticked_many = await asyncio.to_thread(
+            release_gate_service.tick_public_deploy_verification_jobs,
+            github_token=token,
+            due_only=due_only,
+        )
+        if not isinstance(ticked_many, dict):
+            return "Railway tick failed: unable to update verification jobs"
+        return _format_tick_many_reply(ticked_many, due_only=due_only)
+
+    job_id = rest[0].strip()
+    if not job_id:
+        return "Usage: /railway tick {job_id}"
+    ticked = await asyncio.to_thread(
+        release_gate_service.tick_public_deploy_verification_job,
+        job_id=job_id,
+        github_token=token,
+    )
+    return _format_tick_reply(ticked if isinstance(ticked, dict) else {})
+
+
+async def handle_railway_command(arg: str) -> str:
+    args = (arg or "").split()
+    action = args[0].lower() if args else "help"
+    rest = args[1:] if len(args) > 1 else []
+    token = _github_token()
+    handlers = {
+        "head": lambda: _command_head(token),
+        "status": lambda: _command_status(token),
+        "jobs": _command_jobs,
+        "schedule": lambda: _command_schedule(token, rest),
+        "create": lambda: _command_schedule(token, rest),
+        "verify": lambda: _command_verify(token, rest),
+        "tick": lambda: _command_tick(token, rest),
+    }
+    if action in {"help", "h", "?"}:
+        return railway_help_reply()
+    if action not in handlers:
+        return railway_help_reply()
+
+    try:
+        return await handlers[action]()
+    except Exception as exc:
+        logger.exception("Telegram railway command failed: action=%s", action)
+        msg = str(exc).strip() or "unknown error"
+        return f"Railway command failed: {_escape_markdown(msg[:240])}"

--- a/api/tests/test_agent_telegram_webhook.py
+++ b/api/tests/test_agent_telegram_webhook.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+def _telegram_update(text: str) -> dict:
+    return {
+        "update_id": 1,
+        "message": {
+            "message_id": 1,
+            "date": 0,
+            "text": text,
+            "from": {"id": 1001, "is_bot": False, "first_name": "tester"},
+            "chat": {"id": 2002, "type": "private"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_status_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.evaluate_public_deploy_contract_report",
+        lambda **kwargs: {
+            "repository": kwargs.get("repository", "seeker71/Coherence-Network"),
+            "branch": kwargs.get("branch", "main"),
+            "expected_sha": "1234567890abcdef1234567890abcdef12345678",
+            "result": "public_contract_passed",
+            "failing_checks": [],
+            "warnings": [],
+            "reason": "",
+        },
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway status"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway status*" in sent["message"]
+    assert "public_contract_passed" in sent["message"]
+    assert "`1234567890ab`" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_verify_command_creates_and_ticks_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.create_public_deploy_verification_job",
+        lambda **kwargs: {
+            "job_id": "job_123",
+            "status": "scheduled",
+            "attempts": 0,
+            "max_attempts": kwargs.get("max_attempts") or 8,
+        },
+    )
+    monkeypatch.setattr(
+        "app.services.release_gate_service.tick_public_deploy_verification_job",
+        lambda **kwargs: {
+            "job_id": kwargs.get("job_id", "job_123"),
+            "status": "retrying",
+            "attempts": 1,
+            "max_attempts": 8,
+            "last_result": {"result": "blocked", "reason": "railway_health"},
+        },
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway verify"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway verify*" in sent["message"]
+    assert "`job_123`" in sent["message"]
+    assert "`retrying`" in sent["message"]
+    assert "blocked" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_jobs_command_lists_recent_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.list_public_deploy_verification_jobs",
+        lambda: [
+            {"job_id": "job_a", "status": "scheduled", "attempts": 0, "max_attempts": 8},
+            {"job_id": "job_b", "status": "completed", "attempts": 1, "max_attempts": 8},
+        ],
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway jobs"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway jobs*" in sent["message"]
+    assert "`job_a` scheduled" in sent["message"]
+    assert "`job_b` completed" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_tick_requires_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway tick"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "Usage: /railway tick {job_id}" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_head_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.get_branch_head_sha",
+        lambda repository, branch, github_token=None, timeout=10.0: "abcdef1234567890abcdef1234567890abcdef12",
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway head"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway head*" in sent["message"]
+    assert "`abcdef123456`" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_tick_due_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.tick_public_deploy_verification_jobs",
+        lambda **kwargs: {
+            "ok": True,
+            "jobs": [
+                {
+                    "job_id": "job_due_1",
+                    "status": "retrying",
+                    "attempts": 1,
+                    "max_attempts": 8,
+                    "last_result": {"result": "blocked"},
+                },
+                {
+                    "job_id": "job_due_2",
+                    "status": "completed",
+                    "attempts": 2,
+                    "max_attempts": 8,
+                    "last_result": {"result": "public_contract_passed"},
+                },
+            ],
+        },
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway tick due"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway tick due*" in sent["message"]
+    assert "`job_due_1` retrying" in sent["message"]
+    assert "`job_due_2` completed" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_railway_schedule_command_creates_job_without_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+    tick_called = {"value": False}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.release_gate_service.create_public_deploy_verification_job",
+        lambda **kwargs: {
+            "job_id": "job_sched_1",
+            "status": "scheduled",
+            "attempts": 0,
+            "max_attempts": kwargs.get("max_attempts") or 8,
+        },
+    )
+
+    def _fail_if_ticked(**kwargs):
+        tick_called["value"] = True
+        return {"job_id": kwargs.get("job_id", ""), "status": "completed"}
+
+    monkeypatch.setattr(
+        "app.services.release_gate_service.tick_public_deploy_verification_job",
+        _fail_if_ticked,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/railway schedule 5"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Railway schedule*" in sent["message"]
+    assert "`job_sched_1`" in sent["message"]
+    assert "`scheduled`" in sent["message"]
+    assert "`0/5`" in sent["message"]
+    assert tick_called["value"] is False

--- a/docs/system_audit/commit_evidence_2026-02-19_railway-telegram-management.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_railway-telegram-management.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/railway-telegram-management-20260219",
+  "commit_scope": "Map Railway deploy-management calls into Telegram commands (head, status, schedule, verify, jobs, tick due/all/by-id) with validated webhook responses.",
+  "files_owned": [
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "docs/system_audit/commit_evidence_2026-02-19_railway-telegram-management.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-003-agent-telegram-decision-loop"
+  ],
+  "task_ids": [
+    "task-2026-02-19-railway-telegram-management"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py (red before implementation: 4 failed)",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py (green after implementation: 7 passed)",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_gates.py (13 passed)",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway head -> SHA 4e0242e854c3",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway status -> public_contract_passed (warnings included)",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway schedule 3 -> job 65fc290d30624ce2 scheduled",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway verify 2 -> job 0ff95eeedf954988 completed",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway jobs -> listed scheduled+completed jobs",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway tick due -> updated due job to completed",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway tick all -> no jobs updated",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /railway tick {job_id} -> explicit per-job tick path exercised",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+  ],
+  "change_files": [
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_gates.py",
+      "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI webhook smoke scripts for /railway head|status|schedule|verify|jobs|tick due|tick all|tick {job_id}",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Telegram webhook now exposes all Railway deploy-management operations in command form and returns deploy/job state to the requesting Telegram chat.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/gates/public-deploy-contract",
+      "https://coherence-network-production.up.railway.app/api/gates/public-deploy-verification-jobs"
+    ],
+    "test_flows": [
+      "POST /api/agent/telegram/webhook with /railway head and /railway status",
+      "POST /api/agent/telegram/webhook with /railway schedule 3 then /railway jobs",
+      "POST /api/agent/telegram/webhook with /railway verify 2",
+      "POST /api/agent/telegram/webhook with /railway tick due and /railway tick all",
+      "POST /api/agent/telegram/webhook with /railway tick {job_id}"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting commit/push and CI/deploy completion."
+  }
+}


### PR DESCRIPTION
## Summary
- add full Telegram Railway command coverage for deploy management operations
- map `/railway` (and `/deploy`) to: `head`, `status`, `schedule`, `verify`, `jobs`, `tick due|all|{job_id}`
- move Railway Telegram command logic into `api/app/services/telegram_railway_service.py` to satisfy maintainability guardrails
- add focused webhook tests for all Railway command paths
- add commit evidence artifact for this change

## Validation
- `make start-gate`
- `cd api && pytest -q tests/test_agent_telegram_webhook.py`
- `cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_gates.py`
- Live ASGI webhook smoke with captured Telegram replies for:
  - `/railway head`
  - `/railway status`
  - `/railway schedule 3`
  - `/railway verify 2`
  - `/railway jobs`
  - `/railway tick due`
  - `/railway tick all`
  - `/railway tick {job_id}`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
