### PR TITLE
Improve Telegram report content and diagnostics inspectability

### DIFF
--- a/api/app/services/telegram_adapter.py
+++ b/api/app/services/telegram_adapter.py
@@ -60,6 +60,7 @@ async def send_alert(message: str, parse_mode: str = "Markdown") -> bool:
     async with httpx.AsyncClient(timeout=10.0) as client:
         for chat_id in chat_ids:
             try:
+                telegram_diagnostics.record_report("alert", chat_id.strip(), message)
                 r = await client.post(
                     url,
                     json={
@@ -90,6 +91,7 @@ async def send_reply(chat_id: Union[int, str], message: str, parse_mode: str = "
     url = f"{TELEGRAM_API}/bot{token}/sendMessage"
     async with httpx.AsyncClient(timeout=10.0) as client:
         try:
+            telegram_diagnostics.record_report("reply", chat_id, message)
             r = await client.post(
                 url,
                 json={

--- a/api/app/services/telegram_diagnostics.py
+++ b/api/app/services/telegram_diagnostics.py
@@ -10,6 +10,9 @@ _webhook_events: deque = deque(maxlen=50)
 # Last 50 send_reply attempts: {chat_id, ok, status_code, response_text, ts}
 _send_results: deque = deque(maxlen=50)
 
+# Last 100 rendered Telegram reports: {kind, chat_id, text_preview, ts}
+_report_log: deque = deque(maxlen=100)
+
 
 def record_webhook(update: dict, sanitize: bool = True) -> None:
     """Record incoming webhook payload."""
@@ -40,6 +43,17 @@ def record_send(chat_id: Any, ok: bool, status_code: Optional[int] = None, respo
     })
 
 
+def record_report(kind: str, chat_id: Any, text: str) -> None:
+    """Record generated Telegram report text preview for inspection."""
+    _report_log.append({
+        "ts": time.time(),
+        "kind": str(kind or "unknown").strip() or "unknown",
+        "chat_id": chat_id,
+        "text_preview": (text or "")[:1200],
+        "text_len": len(text or ""),
+    })
+
+
 def get_webhook_events() -> list:
     return list(_webhook_events)
 
@@ -48,7 +62,12 @@ def get_send_results() -> list:
     return list(_send_results)
 
 
+def get_report_log() -> list:
+    return list(_report_log)
+
+
 def clear() -> None:
     """Clear webhook_events and send_results. For test isolation (spec 003 diagnostic test)."""
     _webhook_events.clear()
     _send_results.clear()
+    _report_log.clear()

--- a/api/tests/test_agent_telegram_webhook.py
+++ b/api/tests/test_agent_telegram_webhook.py
@@ -4,6 +4,8 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.models.agent import TaskStatus
+from app.routers.agent_telegram import format_task_alert
 
 
 def _telegram_update(text: str) -> dict:
@@ -55,8 +57,10 @@ async def test_telegram_railway_status_command(monkeypatch: pytest.MonkeyPatch) 
     assert response.json() == {"ok": True}
     assert sent["chat_id"] == "2002"
     assert "*Railway status*" in sent["message"]
+    assert "Checked:" in sent["message"]
     assert "public_contract_passed" in sent["message"]
     assert "`1234567890ab`" in sent["message"]
+    assert "Next:" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -103,9 +107,11 @@ async def test_telegram_railway_verify_command_creates_and_ticks_job(
     assert response.json() == {"ok": True}
     assert sent["chat_id"] == "2002"
     assert "*Railway verify*" in sent["message"]
+    assert "Checked:" in sent["message"]
     assert "`job_123`" in sent["message"]
     assert "`retrying`" in sent["message"]
     assert "blocked" in sent["message"]
+    assert "/railway tick job_123" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -140,6 +146,7 @@ async def test_telegram_railway_jobs_command_lists_recent_jobs(
     assert response.json() == {"ok": True}
     assert sent["chat_id"] == "2002"
     assert "*Railway jobs*" in sent["message"]
+    assert "Checked:" in sent["message"]
     assert "`job_a` scheduled" in sent["message"]
     assert "`job_b` completed" in sent["message"]
 
@@ -244,8 +251,10 @@ async def test_telegram_railway_tick_due_command(monkeypatch: pytest.MonkeyPatch
     assert response.json() == {"ok": True}
     assert sent["chat_id"] == "2002"
     assert "*Railway tick due*" in sent["message"]
+    assert "Checked:" in sent["message"]
     assert "`job_due_1` retrying" in sent["message"]
     assert "`job_due_2` completed" in sent["message"]
+    assert "Next: `/railway jobs`" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -292,7 +301,96 @@ async def test_telegram_railway_schedule_command_creates_job_without_tick(
     assert response.json() == {"ok": True}
     assert sent["chat_id"] == "2002"
     assert "*Railway schedule*" in sent["message"]
+    assert "Checked:" in sent["message"]
     assert "`job_sched_1`" in sent["message"]
     assert "`scheduled`" in sent["message"]
     assert "`0/5`" in sent["message"]
+    assert "Next: `/railway tick due`" in sent["message"]
     assert tick_called["value"] is False
+
+
+@pytest.mark.asyncio
+async def test_telegram_status_command_reports_checked_and_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.agent_service.get_review_summary",
+        lambda: {
+            "total": 3,
+            "by_status": {"running": 1, "failed": 1, "needs_decision": 1},
+            "needs_attention": [{"id": "task_a"}, {"id": "task_b"}],
+        },
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/status"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "*Agent status*" in sent["message"]
+    assert "Checked:" in sent["message"]
+    assert "Total tasks: `3`" in sent["message"]
+    assert "Attention: `2`" in sent["message"]
+    assert "/attention" in sent["message"]
+
+
+def test_format_task_alert_includes_updated_and_action() -> None:
+    task = {
+        "id": "task_123",
+        "status": "needs_decision",
+        "direction": "Handle release blocker",
+        "updated_at": "2026-02-19T17:00:00Z",
+        "context": {},
+    }
+    message = format_task_alert(task)
+    assert "Updated: `2026-02-19T17:00:00Z`" in message
+    assert "Action: `/reply task_123 <decision>`" in message
+
+
+@pytest.mark.asyncio
+async def test_telegram_tasks_command_renders_status_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    sent: dict[str, str] = {}
+
+    async def _fake_send_reply(chat_id: int | str, message: str, parse_mode: str = "Markdown") -> bool:
+        sent["chat_id"] = str(chat_id)
+        sent["message"] = message
+        sent["parse_mode"] = parse_mode
+        return True
+
+    monkeypatch.setattr("app.services.telegram_adapter.send_reply", _fake_send_reply)
+    monkeypatch.setattr(
+        "app.services.agent_service.list_tasks",
+        lambda status=None, limit=10: (
+            [{"id": "task_1", "status": TaskStatus.PENDING, "direction": "Build telemetry endpoint"}],
+            1,
+        ),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/agent/telegram/webhook",
+            json=_telegram_update("/tasks"),
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert sent["chat_id"] == "2002"
+    assert "`pending`" in sent["message"]
+    assert "TaskStatus.PENDING" not in sent["message"]

--- a/docs/system_audit/commit_evidence_2026-02-19_telegram-report-quality.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_telegram-report-quality.json
@@ -1,0 +1,102 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/telegram-report-content-20260219",
+  "commit_scope": "Improve Telegram report quality and inspectability: richer report text, action hints, timestamps, and diagnostics summary/report logs.",
+  "files_owned": [
+    "api/app/routers/agent.py",
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_adapter.py",
+    "api/app/services/telegram_diagnostics.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "api/tests/test_telegram_diagnostics_api.py",
+    "docs/system_audit/commit_evidence_2026-02-19_telegram-report-quality.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-003-agent-telegram-decision-loop"
+  ],
+  "task_ids": [
+    "task-2026-02-19-telegram-report-quality"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py tests/test_gates.py",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /status,/tasks,/attention,/railway head,/railway status,/railway schedule,/railway verify,/railway jobs,/railway tick due (captured report text)",
+    "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI smoke: /status with invalid TELEGRAM_BOT_TOKEN (diagnostics summary + report_log + send_results timestamps verified)",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+  ],
+  "change_files": [
+    "api/app/routers/agent.py",
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_adapter.py",
+    "api/app/services/telegram_diagnostics.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "api/tests/test_telegram_diagnostics_api.py"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py tests/test_gates.py",
+      "/opt/homebrew/opt/python@3.11/bin/python3.11 ASGI webhook smoke scripts for report text quality and diagnostics inspectability",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Telegram reports now include clearer status context (checked timestamps, severity/action hints, next steps) and diagnostics now include summary counters plus report logs for inspection.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics",
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/webhook"
+    ],
+    "test_flows": [
+      "POST /api/agent/telegram/webhook with /status,/tasks,/attention",
+      "POST /api/agent/telegram/webhook with /railway status,/railway verify,/railway tick due",
+      "GET /api/agent/telegram/diagnostics and inspect summary/report_log/send_results ts_iso"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting commit/push and CI/deploy completion."
+  }
+}


### PR DESCRIPTION
## Summary
- improve Telegram report content quality across task alerts and webhook command replies
- add explicit checked timestamps, clearer status labels, and actionable next-step hints
- improve Railway Telegram report content with next-command guidance for blocked/retrying/completed outcomes
- extend Telegram diagnostics with summary counters, ISO timestamps, and rendered `report_log` previews
- add focused tests for report content rendering and diagnostics shape

## Validation
- `make start-gate`
- `cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py`
- `cd api && pytest -q tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py tests/test_gates.py`
- ASGI smoke inspection for `/status`, `/tasks`, `/attention`, `/railway head`, `/railway status`, `/railway schedule`, `/railway verify`, `/railway jobs`, `/railway tick due`
- ASGI smoke with invalid Telegram token to validate diagnostics summary + report_log + send_results timestamps
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
