### PR TITLE
Make Telegram links clickable with absolute context URLs

### DIFF
--- a/api/tests/test_agent_telegram_webhook.py
+++ b/api/tests/test_agent_telegram_webhook.py
@@ -61,6 +61,8 @@ async def test_telegram_railway_status_command(monkeypatch: pytest.MonkeyPatch) 
     assert "public_contract_passed" in sent["message"]
     assert "`1234567890ab`" in sent["message"]
     assert "Next:" in sent["message"]
+    assert "[main head](https://coherence-network-production.up.railway.app/api/gates/main-head)" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -112,6 +114,8 @@ async def test_telegram_railway_verify_command_creates_and_ticks_job(
     assert "`retrying`" in sent["message"]
     assert "blocked" in sent["message"]
     assert "/railway tick job_123" in sent["message"]
+    assert "[main head](https://coherence-network-production.up.railway.app/api/gates/main-head)" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -149,6 +153,8 @@ async def test_telegram_railway_jobs_command_lists_recent_jobs(
     assert "Checked:" in sent["message"]
     assert "`job_a` scheduled" in sent["message"]
     assert "`job_b` completed" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
+    assert "[telegram diagnostics](https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics)" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -204,6 +210,8 @@ async def test_telegram_railway_head_command(monkeypatch: pytest.MonkeyPatch) ->
     assert sent["chat_id"] == "2002"
     assert "*Railway head*" in sent["message"]
     assert "`abcdef123456`" in sent["message"]
+    assert "[main head](https://coherence-network-production.up.railway.app/api/gates/main-head)" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -255,6 +263,8 @@ async def test_telegram_railway_tick_due_command(monkeypatch: pytest.MonkeyPatch
     assert "`job_due_1` retrying" in sent["message"]
     assert "`job_due_2` completed" in sent["message"]
     assert "Next: `/railway jobs`" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
+    assert "[telegram diagnostics](https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics)" in sent["message"]
 
 
 @pytest.mark.asyncio
@@ -306,6 +316,8 @@ async def test_telegram_railway_schedule_command_creates_job_without_tick(
     assert "`scheduled`" in sent["message"]
     assert "`0/5`" in sent["message"]
     assert "Next: `/railway tick due`" in sent["message"]
+    assert "[tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
+    assert "[telegram diagnostics](https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics)" in sent["message"]
     assert tick_called["value"] is False
 
 
@@ -346,6 +358,7 @@ async def test_telegram_status_command_reports_checked_and_attention(
     assert "Total tasks: `3`" in sent["message"]
     assert "Attention: `2`" in sent["message"]
     assert "/attention" in sent["message"]
+    assert "Web UI: [open tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]
 
 
 def test_format_task_alert_includes_updated_and_action() -> None:
@@ -359,6 +372,8 @@ def test_format_task_alert_includes_updated_and_action() -> None:
     message = format_task_alert(task)
     assert "Updated: `2026-02-19T17:00:00Z`" in message
     assert "Action: `/reply task_123 <decision>`" in message
+    assert "[open task](https://coherence-web-production.up.railway.app/tasks?task_id=task_123)" in message
+    assert "[all tasks](https://coherence-web-production.up.railway.app/tasks)" in message
 
 
 @pytest.mark.asyncio
@@ -394,3 +409,5 @@ async def test_telegram_tasks_command_renders_status_values(
     assert sent["chat_id"] == "2002"
     assert "`pending`" in sent["message"]
     assert "TaskStatus.PENDING" not in sent["message"]
+    assert "[open](https://coherence-web-production.up.railway.app/tasks?task_id=task_1)" in sent["message"]
+    assert "Web UI: [open tasks](https://coherence-web-production.up.railway.app/tasks)" in sent["message"]

--- a/docs/system_audit/commit_evidence_2026-02-19_telegram-clickable-links.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_telegram-clickable-links.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/telegram-clickable-links-20260219",
+  "commit_scope": "Make Telegram report links explicitly clickable with absolute URLs and add high-context links across task and Railway command replies.",
+  "files_owned": [
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "docs/system_audit/commit_evidence_2026-02-19_telegram-clickable-links.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-003-agent-telegram-decision-loop"
+  ],
+  "task_ids": [
+    "task-2026-02-19-telegram-clickable-links"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+    "cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+  ],
+  "change_files": [
+    "api/app/routers/agent_telegram.py",
+    "api/app/services/telegram_railway_service.py",
+    "api/tests/test_agent_telegram_webhook.py"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+      "cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Telegram messages include absolute clickable links for tasks and Railway context links so users can jump directly from alert text to relevant web/API context.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/webhook",
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics",
+      "https://coherence-web-production.up.railway.app/tasks"
+    ],
+    "test_flows": [
+      "POST webhook commands and verify report_log contains markdown links with absolute URLs",
+      "Extract links from report_log and verify each resolves HTTP 200"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting commit, CI, merge, and production verification."
+  }
+}


### PR DESCRIPTION
## Summary
- make task links absolute so Telegram renders clickable links consistently
- add contextual links to task/status/attention replies and Railway management replies
- add/update tests to lock link behavior and Railway link coverage
- add commit evidence for this thread

## Validation
- make start-gate
- cd api && pytest -q tests/test_agent_telegram_webhook.py
- cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main (passed in manual run)
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict