### PR TITLE
Fix public web reliability for tasks, idea detail, runtime, and API health

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-19_public-ui-reliability-fix.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_public-ui-reliability-fix.json
@@ -1,0 +1,120 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/public-ui-reliability-fix-20260219",
+  "commit_scope": "Fix public web reliability regressions by routing browser API calls through same-origin proxy routes, hardening idea detail loading against upstream failures, adding /runtime route handling, and preventing API health page indefinite loading on stalled requests.",
+  "files_owned": [
+    "maintainability_audit_report.json",
+    "web/lib/api.ts",
+    "web/app/api/[...path]/",
+    "web/app/api/[...path]/route.ts",
+    "web/app/tasks/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/api-health/page.tsx",
+    "web/app/runtime/",
+    "web/app/runtime/page.tsx",
+    "docs/system_audit/commit_evidence_2026-02-19_public-ui-reliability-fix.json"
+  ],
+  "idea_ids": [
+    "portfolio-governance",
+    "coherence-network-agent-pipeline",
+    "coherence-network-api-runtime"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration-api",
+    "054-commit-evidence-phase-gates"
+  ],
+  "task_ids": [
+    "task_b4c49be570ad0e28",
+    "task_68e7eb1a555be31b",
+    "task_bc95e91205261492",
+    "task_906faef73e031cb2",
+    "task_be620c1831b88ad7",
+    "task_53111a59c7b4015c"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "deployment"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
+    "cd web && npm run build",
+    "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+    "Playwright local UI verification artifacts: /tmp/coherence_local_playwright and /tmp/coherence_local_playwright_artifacts",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_public-ui-reliability-fix.json",
+    "Public verification report: /tmp/coherence_public_verify/public_verification_report_2026-02-19.md"
+  ],
+  "change_files": [
+    "maintainability_audit_report.json",
+    "web/lib/api.ts",
+    "web/app/api/[...path]/",
+    "web/app/api/[...path]/route.ts",
+    "web/app/tasks/page.tsx",
+    "web/app/ideas/[idea_id]/page.tsx",
+    "web/app/api-health/page.tsx",
+    "web/app/runtime/",
+    "web/app/runtime/page.tsx"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public web routes no longer fail due cross-origin browser fetches, /ideas/{id} no longer crashes on transient upstream failures, /runtime is no longer a 404, and /api-health no longer remains indefinitely in first-load waiting state.",
+    "public_endpoints": [
+      "https://coherence-network.vercel.app/tasks",
+      "https://coherence-network.vercel.app/tasks?task_id=task_b4c49be570ad0e28",
+      "https://coherence-network.vercel.app/ideas/portfolio-governance",
+      "https://coherence-network.vercel.app/runtime",
+      "https://coherence-network.vercel.app/api-health",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks"
+    ],
+    "test_flows": [
+      "web: open /tasks and confirm data renders (not stuck loading)",
+      "web: open /tasks?task_id=<id> and confirm evidence panel renders instead of hanging",
+      "web: open /ideas/portfolio-governance and confirm no server-side application error",
+      "web: open /runtime and confirm route resolves (redirect to /usage)",
+      "web: open /api-health and confirm status resolves to ok/error state without indefinite waiting"
+    ]
+  },
+  "local_validation": {
+    "status": "pass",
+    "ran_at": "2026-02-19T20:30:00Z",
+    "commands": [
+      "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression",
+      "cd web && npm run build",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "Local Playwright check: /tasks, /tasks?task_id=..., /ideas/portfolio-governance, /runtime, /api-health"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "https://github.com/seeker71/Coherence-Network/actions"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and public deploy verification for this branch."
+  }
+}

--- a/maintainability_audit_report.json
+++ b/maintainability_audit_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-19T18:07:38.545490+00:00",
+  "generated_at": "2026-02-19T20:32:52.878239+00:00",
   "policy": {
     "large_module_lines": 600,
     "very_large_module_lines": 1000,
@@ -17,7 +17,7 @@
   },
   "summary": {
     "python_module_count": 81,
-    "runtime_file_count": 113,
+    "runtime_file_count": 115,
     "layer_violation_count": 0,
     "large_module_count": 7,
     "very_large_module_count": 4,
@@ -55,7 +55,7 @@
       },
       {
         "file": "api/app/routers/agent.py",
-        "line_count": 911
+        "line_count": 965
       },
       {
         "file": "api/app/services/idea_service.py",
@@ -142,12 +142,6 @@
         "line_start": 1310
       },
       {
-        "file": "api/app/routers/agent_telegram.py",
-        "function": "telegram_webhook",
-        "line_count": 125,
-        "line_start": 232
-      },
-      {
         "file": "api/app/services/inventory_service.py",
         "function": "build_system_lineage_inventory",
         "line_count": 110,
@@ -158,6 +152,12 @@
         "function": "_build_github_snapshot",
         "line_count": 110,
         "line_start": 791
+      },
+      {
+        "file": "api/app/routers/agent_telegram.py",
+        "function": "telegram_webhook",
+        "line_count": 109,
+        "line_start": 382
       },
       {
         "file": "api/app/services/automation_usage_service.py",
@@ -181,7 +181,7 @@
     "parse_errors": []
   },
   "placeholder_scan": {
-    "scanned_file_count": 113,
+    "scanned_file_count": 115,
     "findings": [
       {
         "file": "api/app/models/coherence.py",

--- a/web/app/api/[...path]/route.ts
+++ b/web/app/api/[...path]/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApiBase } from "@/lib/api";
+
+const API_URL = getApiBase();
+const UPSTREAM_TIMEOUT_MS = 15000;
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{
+    path: string[];
+  }>;
+};
+
+function buildUpstreamUrl(pathSegments: string[], search: string): string {
+  const path = pathSegments.map((segment) => encodeURIComponent(segment)).join("/");
+  return `${API_URL}/api/${path}${search}`;
+}
+
+function copyRequestHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return;
+    headers.set(key, value);
+  });
+  return headers;
+}
+
+function copyResponseHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) return;
+    headers.set(key, value);
+  });
+  headers.set("cache-control", "no-store");
+  return headers;
+}
+
+async function proxyRequest(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { path } = await context.params;
+  if (!Array.isArray(path) || path.length === 0) {
+    return NextResponse.json({ error: "invalid_api_path" }, { status: 400 });
+  }
+
+  const upstreamUrl = buildUpstreamUrl(path, request.nextUrl.search);
+  const method = request.method.toUpperCase();
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new DOMException("Request timed out", "TimeoutError")),
+    UPSTREAM_TIMEOUT_MS,
+  );
+
+  try {
+    const body = method === "GET" || method === "HEAD" ? undefined : await request.arrayBuffer();
+    const upstream = await fetch(upstreamUrl, {
+      method,
+      headers: copyRequestHeaders(request),
+      body,
+      cache: "no-store",
+      redirect: "manual",
+      signal: controller.signal,
+    });
+
+    const headers = copyResponseHeaders(upstream);
+    const responseBody = method === "HEAD" ? null : await upstream.arrayBuffer();
+    return new NextResponse(responseBody, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: "error",
+        code: 502,
+        message: "Upstream API unavailable",
+        upstream_url: upstreamUrl,
+        details: String(error),
+      },
+      { status: 502 },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function HEAD(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function OPTIONS(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function POST(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function PUT(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  return proxyRequest(request, context);
+}

--- a/web/app/runtime/page.tsx
+++ b/web/app/runtime/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RuntimePage() {
+  redirect("/usage");
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -34,6 +34,9 @@ function _resolveApiEnvUrl(envValue: string): string | null {
 }
 
 export function getApiBase(): string {
+  // Browser callers should use same-origin `/api/...` routes so they do not depend on cross-origin CORS behavior.
+  if (typeof window !== "undefined") return "";
+
   const env = process.env.NEXT_PUBLIC_API_URL;
   const resolved = env ? _resolveApiEnvUrl(env) : null;
   if (resolved) return resolved;


### PR DESCRIPTION
## Summary
- route browser-side web API calls through a same-origin catch-all proxy (`web/app/api/[...path]/route.ts`)
- make browser clients use relative `/api/...` base to avoid cross-origin CORS failures (`web/lib/api.ts`)
- harden `tasks` client fetch paths with timeout handling and schema-flexible parsing
- harden `ideas/[idea_id]` server page with retries and graceful upstream-failure UI (instead of application crash)
- add `/runtime` route (redirects to `/usage`) to remove 404
- add timeout + abort handling in `/api-health` polling so it does not stay in indefinite waiting state

## Validation
- `cd web && npm run build`
- `THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh`
- local playwright route checks for `/tasks`, `/tasks?task_id=...`, `/ideas/portfolio-governance`, `/runtime`, `/api-health`
- `python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_public-ui-reliability-fix.json`
