### PR TITLE
Improve runner update card links and title formatting

### DIFF
--- a/api/tests/test_agent_telegram_webhook.py
+++ b/api/tests/test_agent_telegram_webhook.py
@@ -376,6 +376,20 @@ def test_format_task_alert_includes_updated_and_action() -> None:
     assert "[all tasks](https://coherence-web-production.up.railway.app/tasks)" in message
 
 
+def test_format_runner_update_card_uses_clean_title_and_links() -> None:
+    task = {
+        "id": "taskrunner123",
+        "status": "running",
+        "direction": "Stream runner progress",
+        "context": {},
+    }
+    message = format_task_alert(task, runner_update=True)
+    assert "*runner update*" in message
+    assert "runner\\_update" not in message
+    assert "Task ID: [taskrunner123](https://coherence-web-production.up.railway.app/tasks?task_id=taskrunner123)" in message
+    assert "Railway logs: [open logs](https://coherence-network-production.up.railway.app/api/agent/tasks/taskrunner123/log)" in message
+
+
 @pytest.mark.asyncio
 async def test_telegram_tasks_command_renders_status_values(
     monkeypatch: pytest.MonkeyPatch,

--- a/docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json
@@ -1,0 +1,88 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/runner-update-card-links-20260219",
+  "commit_scope": "Improve Telegram runner update card UX: remove escaped underscore title artifact, link Task ID directly to task context, and add Railway logs link for rapid debugging.",
+  "files_owned": [
+    "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-003-agent-telegram-decision-loop"
+  ],
+  "task_ids": [
+    "task-2026-02-19-runner-update-card-links"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+    "cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+  ],
+  "change_files": [
+    "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_telegram_webhook.py"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+      "cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Runner update Telegram cards now show a clean title (`runner update`), a clickable task-id link to task context, and a direct Railway logs link for task-level debugging.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/webhook",
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks/{task_id}/log"
+    ],
+    "test_flows": [
+      "Emit runner_update message and verify title text has no escaped underscore",
+      "Verify Task ID is rendered as clickable link to /tasks?task_id=...",
+      "Verify Railway logs link resolves to /api/agent/tasks/{task_id}/log"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting commit/push/CI and production verification."
+  }
+}


### PR DESCRIPTION
## Summary
- remove underscore title artifact in runner update cards (`runner update` instead of `runner_update`)
- make `Task ID` clickable to the task detail page
- add a `Railway logs` link on runner update cards (task log endpoint)
- add tests + commit evidence

## Validation
- make start-gate
- cd api && pytest -q tests/test_agent_telegram_webhook.py
- cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json
- WORKTREE_PR_GUARD_MAINTAINABILITY_REPORT=/tmp/maint_runner_update_card_links.json python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict