### PR TITLE
Return task log snapshot fallback when log file missing

### DIFF
--- a/api/tests/test_agent_task_log_endpoint.py
+++ b/api/tests/test_agent_task_log_endpoint.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_task_log_endpoint_returns_snapshot_when_log_file_missing() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post(
+            "/api/agent/tasks",
+            json={"direction": "task log fallback coverage", "task_type": "impl"},
+        )
+        assert created.status_code == 201
+        task_id = created.json()["id"]
+
+        await client.patch(
+            f"/api/agent/tasks/{task_id}",
+            json={"current_step": "running fallback check", "output": "snapshot output text"},
+        )
+
+        log_path = Path(__file__).resolve().parents[1] / "logs" / f"task_{task_id}.log"
+        if log_path.exists():
+            log_path.unlink()
+
+        response = await client.get(f"/api/agent/tasks/{task_id}/log")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["task_id"] == task_id
+        assert body["log_source"] == "task_snapshot"
+        assert "running fallback check" in body["log"]
+        assert "snapshot output text" in body["log"]
+
+
+@pytest.mark.asyncio
+async def test_task_log_endpoint_prefers_file_when_available() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        created = await client.post(
+            "/api/agent/tasks",
+            json={"direction": "task log file coverage", "task_type": "impl"},
+        )
+        assert created.status_code == 201
+        task_id = created.json()["id"]
+
+        log_path = Path(__file__).resolve().parents[1] / "logs" / f"task_{task_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("line-1\nline-2\n", encoding="utf-8")
+
+        try:
+            response = await client.get(f"/api/agent/tasks/{task_id}/log")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["task_id"] == task_id
+            assert body["log_source"] == "file"
+            assert body["log"] == "line-1\nline-2\n"
+        finally:
+            if log_path.exists():
+                log_path.unlink()

--- a/docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json
@@ -1,9 +1,11 @@
 {
   "date": "2026-02-19",
   "thread_branch": "codex/runner-update-card-links-20260219",
-  "commit_scope": "Improve Telegram runner update card UX: remove escaped underscore title artifact, link Task ID directly to task context, and add Railway logs link for rapid debugging.",
+  "commit_scope": "Improve Telegram runner update card UX and make Railway log links reliable by returning task-snapshot fallback content when per-task log files are unavailable.",
   "files_owned": [
+    "api/app/routers/agent.py",
     "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_task_log_endpoint.py",
     "api/tests/test_agent_telegram_webhook.py",
     "docs/system_audit/commit_evidence_2026-02-19_runner-update-card-links.json"
   ],
@@ -43,12 +45,16 @@
     "make start-gate",
     "cd api && pytest -q tests/test_agent_telegram_webhook.py",
     "cd api && pytest -q tests/test_telegram_diagnostics_api.py tests/test_agent_telegram_webhook.py",
+    "cd api && pytest -q tests/test_agent_task_log_endpoint.py tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py",
     "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
     "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
-    "PR #245 created from rebased commit 297c7ad to retrigger CI on current origin/main base"
+    "PR #245 merged to main at dc1b52b",
+    "https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics live alert preview and send-status validation"
   ],
   "change_files": [
+    "api/app/routers/agent.py",
     "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_task_log_endpoint.py",
     "api/tests/test_agent_telegram_webhook.py"
   ],
   "change_intent": "runtime_feature",
@@ -79,7 +85,8 @@
     "test_flows": [
       "Emit runner_update message and verify title text has no escaped underscore",
       "Verify Task ID is rendered as clickable link to /tasks?task_id=...",
-      "Verify Railway logs link resolves to /api/agent/tasks/{task_id}/log"
+      "Verify Railway logs link resolves to /api/agent/tasks/{task_id}/log",
+      "Verify /api/agent/tasks/{task_id}/log returns task_snapshot fallback when no file log exists"
     ]
   },
   "phase_gate": {


### PR DESCRIPTION
## Summary
- keep `/api/agent/tasks/{task_id}/log` usable when file logs are missing by returning a task-snapshot fallback payload
- preserve file-log behavior when a streamed log file exists (`log_source: file`)
- add API tests covering both fallback and file-backed task log responses

## Why
- Telegram runner update cards now include a Railway log link per task
- in production, many tasks do not have a persisted `task_{id}.log` file, which previously caused 404 links
- this change keeps the link context-aware and non-broken for every task

## Validation
- `cd api && pytest -q tests/test_agent_task_log_endpoint.py tests/test_agent_telegram_webhook.py tests/test_telegram_diagnostics_api.py`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main` (`ready_for_push=True`)
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
