### PR TITLE
Remove visible backslash from runner Task ID link label

### DIFF
--- a/api/app/routers/agent_telegram.py
+++ b/api/app/routers/agent_telegram.py
@@ -69,6 +69,12 @@ def _escape_markdown(text: str) -> str:
     return out
 
 
+def _task_id_link_label(task_id: str) -> str:
+    # Task ids are generated internally and should already be safe; do not escape "_" here
+    # because Telegram clients can display the escape character in markdown link labels.
+    return str(task_id or "").strip()
+
+
 def _normalize_base_url(raw_value: Any) -> str:
     value = str(raw_value or "").strip()
     if not value:
@@ -327,7 +333,7 @@ def format_task_alert(task: dict, *, runner_update: bool = False) -> str:
     elif status_norm == TaskStatus.NEEDS_DECISION.value:
         icon = "🟡"
     title = "runner update" if runner_update else status_norm
-    task_id_label = _escape_markdown(task_id)
+    task_id_label = _task_id_link_label(task_id)
     msg = (
         f"{icon} *{_escape_markdown(title)}*\n"
         f"Task: {direction}\n"

--- a/api/tests/test_agent_telegram_webhook.py
+++ b/api/tests/test_agent_telegram_webhook.py
@@ -508,7 +508,7 @@ def test_format_task_alert_defaults_to_public_web_ui_link() -> None:
 
 def test_format_runner_update_card_uses_clean_title_and_links() -> None:
     task = {
-        "id": "taskrunner123",
+        "id": "task_runner_123",
         "status": "running",
         "direction": "Stream runner progress",
         "context": {},
@@ -516,8 +516,9 @@ def test_format_runner_update_card_uses_clean_title_and_links() -> None:
     message = format_task_alert(task, runner_update=True)
     assert "*runner update*" in message
     assert "runner\\_update" not in message
-    assert "Task ID: [taskrunner123](https://coherence-web-production.up.railway.app/tasks?task_id=taskrunner123)" in message
-    assert "Railway logs: [open logs](https://coherence-network-production.up.railway.app/api/agent/tasks/taskrunner123/log)" in message
+    assert "task\\_runner_123" not in message
+    assert "Task ID: [task_runner_123](https://coherence-web-production.up.railway.app/tasks?task_id=task_runner_123)" in message
+    assert "Railway logs: [open logs](https://coherence-network-production.up.railway.app/api/agent/tasks/task_runner_123/log)" in message
 
 
 @pytest.mark.asyncio

--- a/docs/system_audit/commit_evidence_2026-02-19_taskid-link-no-backslash.json
+++ b/docs/system_audit/commit_evidence_2026-02-19_taskid-link-no-backslash.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-02-19",
+  "thread_branch": "codex/remove-taskid-backslash-20260219",
+  "commit_scope": "Remove visible backslash from Telegram runner update Task ID link label while keeping the ID clickable and preserving runner card links.",
+  "files_owned": [
+    "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_telegram_webhook.py",
+    "docs/system_audit/commit_evidence_2026-02-19_taskid-link-no-backslash.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "spec-003-agent-telegram-decision-loop"
+  ],
+  "task_ids": [
+    "task-2026-02-19-taskid-link-no-backslash"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_agent_telegram_webhook.py",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_taskid-link-no-backslash.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent_telegram.py",
+    "api/tests/test_agent_telegram_webhook.py"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_agent_telegram_webhook.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Runner update cards show Task ID link text without a visible backslash escape while keeping the link clickable and preserving Railway log links.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/telegram/diagnostics",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
+      "https://coherence-web-production.up.railway.app/tasks"
+    ],
+    "test_flows": [
+      "Render runner update card with underscore task id and verify link label has no backslash escape",
+      "Verify Task ID and Railway logs links remain present in runner update card"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting commit, PR CI, and production verification."
+  }
+}


### PR DESCRIPTION
## Summary
- remove markdown escaping from runner-update Task ID link label so Telegram cards no longer show a visible `\`
- keep Task ID clickable to the task page and keep Railway logs link behavior unchanged
- add regression test using underscore task id to ensure no escaped label regression

## Validation
- `make start-gate`
- `cd api && pytest -q tests/test_agent_telegram_webhook.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-19_taskid-link-no-backslash.json`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
