### PR TITLE
Add proactive paid-usage monitoring and smart runtime refresh gating

### DIFF
--- a/api/app/models/automation_usage.py
+++ b/api/app/models/automation_usage.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 
 ProviderKind = Literal["internal", "github", "openai", "custom"]
 ProviderStatus = Literal["ok", "degraded", "unavailable"]
-UnitType = Literal["tokens", "requests", "minutes", "usd", "tasks", "hours"]
+UnitType = Literal["tokens", "requests", "minutes", "usd", "tasks", "hours", "gb"]
 AlertSeverity = Literal["info", "warning", "critical"]
 DataSource = Literal["provider_api", "provider_cli", "runtime_events", "configuration_only", "unknown"]
 

--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -39,8 +39,14 @@ async def get_external_tool_usage_events(
 
 
 @router.get("/automation/usage/alerts")
-async def get_automation_usage_alerts(threshold_ratio: float = Query(0.2, ge=0.0, le=1.0)) -> dict:
-    report = automation_usage_service.evaluate_usage_alerts(threshold_ratio=threshold_ratio)
+async def get_automation_usage_alerts(
+    threshold_ratio: float = Query(0.2, ge=0.0, le=1.0),
+    force_refresh: bool = Query(False),
+) -> dict:
+    report = automation_usage_service.evaluate_usage_alerts(
+        threshold_ratio=threshold_ratio,
+        force_refresh=force_refresh,
+    )
     return report.model_dump(mode="json")
 
 
@@ -53,7 +59,7 @@ async def get_subscription_upgrade_estimator() -> dict:
 @router.get("/automation/usage/readiness")
 async def get_provider_readiness(
     required_providers: str = Query("", description="Comma-separated provider ids to require"),
-    force_refresh: bool = Query(True),
+    force_refresh: bool = Query(False),
 ) -> dict:
     requested = [item.strip().lower() for item in required_providers.split(",") if item.strip()]
     report = automation_usage_service.provider_readiness_report(
@@ -79,7 +85,7 @@ async def get_provider_validation_report(
     required_providers: str = Query("", description="Comma-separated provider ids to validate"),
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
     min_execution_events: int = Query(1, ge=1, le=50),
-    force_refresh: bool = Query(True),
+    force_refresh: bool = Query(False),
 ) -> dict:
     requested = [item.strip().lower() for item in required_providers.split(",") if item.strip()]
     report = automation_usage_service.provider_validation_report(

--- a/api/app/routers/runtime.py
+++ b/api/app/routers/runtime.py
@@ -20,6 +20,11 @@ async def list_runtime_events(limit: int = Query(100, ge=1, le=2000)) -> list[Ru
     return runtime_service.list_events(limit=limit)
 
 
+@router.get("/runtime/change-token")
+async def runtime_change_token(force_refresh: bool = Query(False)) -> dict:
+    return runtime_service.live_change_token(force_refresh=force_refresh)
+
+
 @router.get("/runtime/ideas/summary")
 async def runtime_summary_by_idea(seconds: int = Query(3600, ge=60, le=2592000)) -> dict:
     rows = runtime_service.summarize_by_idea(seconds=seconds)

--- a/api/app/services/runtime_exerciser_service.py
+++ b/api/app/services/runtime_exerciser_service.py
@@ -1,0 +1,219 @@
+"""Runtime endpoint exerciser implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from fastapi.routing import APIRoute
+
+from app.services import value_lineage_service
+
+
+_EXERCISER_QUERY_DEFAULTS: dict[str, dict[str, str]] = {
+    "/api/agent/route": {"task_type": "impl"},
+    "/api/agent/tasks": {"limit": "20", "offset": "0"},
+    "/api/agent/tasks/attention": {"limit": "20"},
+    "/api/agent/tasks/count": {},
+    "/api/runtime/events": {"limit": "100"},
+    "/api/runtime/ideas/summary": {"seconds": "3600"},
+    "/api/runtime/endpoints/summary": {"seconds": "3600"},
+    "/api/runtime/endpoints/attention": {
+        "seconds": "3600",
+        "min_event_count": "1",
+        "attention_threshold": "0.0",
+    },
+    "/api/inventory/process-completeness": {"runtime_window_seconds": "86400"},
+    "/api/inventory/questions/proactive": {"limit": "20", "top": "20"},
+    "/api/inventory/endpoint-traceability": {"runtime_window_seconds": "86400"},
+    "/api/inventory/system-lineage": {"runtime_window_seconds": "3600"},
+    "/api/automation/usage/snapshots": {"limit": "200"},
+    "/api/automation/usage/provider-validation": {
+        "runtime_window_seconds": "86400",
+        "min_execution_events": "1",
+    },
+}
+
+
+def _sample_path_value(param_name: str) -> str:
+    key = (param_name or "").strip().lower()
+    if key == "task_id":
+        try:
+            from app.services import agent_service
+
+            rows, total = agent_service.list_tasks(limit=1)
+            if total > 0 and rows:
+                value = str(rows[0].get("id") or "").strip()
+                if value:
+                    return value
+        except Exception:
+            pass
+        return "task_missing"
+    if key == "lineage_id":
+        try:
+            rows = value_lineage_service.list_links(limit=1)
+            if rows:
+                return rows[0].id
+        except Exception:
+            pass
+        return "lineage_missing"
+    if key == "spec_id":
+        try:
+            from app.services import spec_registry_service
+
+            rows = spec_registry_service.list_specs(limit=1)
+            if rows:
+                return rows[0].spec_id
+        except Exception:
+            pass
+        return "spec_missing"
+    if key == "idea_id":
+        return "portfolio-governance"
+    return f"{key}_sample"
+
+
+def _materialize_route_path(path_template: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        return _sample_path_value(match.group(1))
+
+    return re.sub(r"\{([^{}]+)\}", _replace, path_template)
+
+
+def _discover_get_api_paths(app) -> list[str]:
+    paths: list[str] = []
+    for route in getattr(app, "routes", []):
+        if not isinstance(route, APIRoute):
+            continue
+        methods = {m.upper() for m in (route.methods or set())}
+        if "GET" not in methods:
+            continue
+        path = str(getattr(route, "path", "") or "").strip()
+        if not path.startswith("/api/"):
+            continue
+        if path.startswith("/api/runtime/exerciser"):
+            continue
+        paths.append(path)
+    return sorted(set(paths))
+
+
+def _exerciser_inventory_snapshot(runtime_window_seconds: int) -> tuple[int, int]:
+    from app.services import inventory_service
+
+    snapshot = inventory_service.build_endpoint_traceability_inventory(
+        runtime_window_seconds=runtime_window_seconds
+    )
+    with_usage = int((snapshot.get("summary") or {}).get("with_usage_events") or 0)
+    total = int((snapshot.get("summary") or {}).get("total_endpoints") or 0)
+    return with_usage, total
+
+
+async def _run_get_endpoint_exerciser_calls(
+    *,
+    app,
+    base_url: str,
+    paths: list[str],
+    total_cycles: int,
+    per_call_delay: int,
+    timeout: float,
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    results: list[dict[str, object]] = []
+    by_status: dict[str, int] = {}
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url=base_url.rstrip("/"),
+        timeout=timeout,
+        follow_redirects=True,
+    ) as client:
+        for cycle in range(1, total_cycles + 1):
+            for path_template in paths:
+                path = _materialize_route_path(path_template)
+                params = dict(_EXERCISER_QUERY_DEFAULTS.get(path_template, {}))
+                started = time.perf_counter()
+                status_code = 599
+                error = None
+                try:
+                    response = await client.get(path, params=params, headers={"x-endpoint-exerciser": "1"})
+                    status_code = int(response.status_code)
+                except Exception as exc:
+                    error = str(exc)
+                elapsed_ms = round(max(0.1, (time.perf_counter() - started) * 1000.0), 4)
+                status_key = str(status_code)
+                by_status[status_key] = by_status.get(status_key, 0) + 1
+                row: dict[str, object] = {
+                    "cycle": cycle,
+                    "path_template": path_template,
+                    "path_called": path,
+                    "query_params": params,
+                    "status_code": status_code,
+                    "runtime_ms": elapsed_ms,
+                }
+                if error:
+                    row["error"] = error
+                results.append(row)
+                if per_call_delay > 0:
+                    await asyncio.sleep(per_call_delay / 1000.0)
+    return results, by_status
+
+
+async def run_get_endpoint_exerciser(
+    *,
+    app,
+    base_url: str,
+    cycles: int = 1,
+    max_endpoints: int = 250,
+    delay_ms: int = 0,
+    timeout_seconds: float = 8.0,
+    runtime_window_seconds: int = 86400,
+) -> dict[str, Any]:
+    total_cycles = max(1, min(int(cycles), 200))
+    endpoint_limit = max(1, min(int(max_endpoints), 2000))
+    per_call_delay = max(0, min(int(delay_ms), 30000))
+    timeout = max(1.0, min(float(timeout_seconds), 60.0))
+    paths = _discover_get_api_paths(app)[:endpoint_limit]
+
+    before_with_usage, before_total = _exerciser_inventory_snapshot(
+        runtime_window_seconds=runtime_window_seconds
+    )
+    results, by_status = await _run_get_endpoint_exerciser_calls(
+        app=app,
+        base_url=base_url,
+        paths=paths,
+        total_cycles=total_cycles,
+        per_call_delay=per_call_delay,
+        timeout=timeout,
+    )
+    after_with_usage, after_total = _exerciser_inventory_snapshot(
+        runtime_window_seconds=runtime_window_seconds
+    )
+
+    return {
+        "result": "runtime_get_endpoint_exerciser_completed",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "config": {
+            "cycles": total_cycles,
+            "max_endpoints": endpoint_limit,
+            "delay_ms": per_call_delay,
+            "timeout_seconds": timeout,
+            "runtime_window_seconds": runtime_window_seconds,
+        },
+        "coverage": {
+            "before_with_usage_events": before_with_usage,
+            "after_with_usage_events": after_with_usage,
+            "delta_with_usage_events": after_with_usage - before_with_usage,
+            "before_total_endpoints": before_total,
+            "after_total_endpoints": after_total,
+        },
+        "summary": {
+            "discovered_get_endpoints": len(paths),
+            "total_calls": len(results),
+            "status_counts": by_status,
+            "successful_calls": sum(1 for row in results if int(row["status_code"]) < 400),
+            "failed_calls": sum(1 for row in results if int(row["status_code"]) >= 400),
+        },
+        "calls": results[:500],
+    }

--- a/docs/system_audit/commit_evidence_2026-02-20_paid-observability-smart-refresh.json
+++ b/docs/system_audit/commit_evidence_2026-02-20_paid-observability-smart-refresh.json
@@ -1,0 +1,128 @@
+{
+  "date": "2026-02-20",
+  "thread_branch": "codex/paid-observability",
+  "commit_scope": "Add paid-provider observability and proactive monitor alerts (OpenAI/OpenRouter/Railway/Supabase), reduce high-frequency refresh pressure, and introduce a runtime change-token gate so expensive UI refreshes only run when data changes.",
+  "files_owned": [
+    "api/app/main.py",
+    "api/app/models/automation_usage.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/routers/runtime.py",
+    "api/app/services/agent_task_store_service.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/runtime_event_store.py",
+    "api/app/services/runtime_exerciser_service.py",
+    "api/app/services/runtime_service.py",
+    "api/app/services/telemetry_persistence_service.py",
+    "api/scripts/monitor_pipeline.py",
+    "api/tests/test_automation_usage_api.py",
+    "api/tests/test_monitor_pipeline_stale_running.py",
+    "api/tests/test_runtime_api.py",
+    "web/app/automation/page.tsx",
+    "web/components/live_updates_controller.tsx",
+    "maintainability_audit_report.json",
+    "docs/system_audit/commit_evidence_2026-02-20_paid-observability-smart-refresh.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "oss-interface-alignment"
+  ],
+  "spec_ids": [
+    "027-fully-automated-pipeline",
+    "049-system-lineage-inventory-and-runtime-telemetry",
+    "050-canonical-route-registry-and-runtime-mapping",
+    "100-automation-provider-usage-and-readiness-api"
+  ],
+  "task_ids": [
+    "task_paid_observability_and_smart_refresh_20260220"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Added OpenRouter and Supabase provider snapshot/probe coverage and included them in required readiness/validation defaults",
+    "Added proactive paid-service monitor issue detection and Telegram monitor alert push with dedupe state",
+    "Added runtime change-token endpoint and lightweight checkpoint aggregation to gate heavy UI refreshes",
+    "Updated live updates controller to poll change token and skip expensive reloads when no change",
+    "cd api && pytest -q tests/test_runtime_api.py tests/test_automation_usage_api.py tests/test_monitor_pipeline_stale_running.py tests/test_monitor_pipeline_github_actions.py",
+    "cd api && ruff check app/main.py app/routers/runtime.py app/services/runtime_service.py app/services/runtime_exerciser_service.py app/services/runtime_event_store.py app/services/agent_task_store_service.py app/services/telemetry_persistence_service.py app/services/automation_usage_service.py app/models/automation_usage.py app/routers/automation_usage.py scripts/monitor_pipeline.py tests/test_runtime_api.py tests/test_automation_usage_api.py tests/test_monitor_pipeline_stale_running.py",
+    "python3 api/scripts/run_maintainability_audit.py --json --output maintainability_audit_report.json",
+    "git fetch origin main && git rebase origin/main",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-20_paid-observability-smart-refresh.json"
+  ],
+  "change_files": [
+    "api/app/main.py",
+    "api/app/models/automation_usage.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/routers/runtime.py",
+    "api/app/services/agent_task_store_service.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/runtime_event_store.py",
+    "api/app/services/runtime_exerciser_service.py",
+    "api/app/services/runtime_service.py",
+    "api/app/services/telemetry_persistence_service.py",
+    "api/scripts/monitor_pipeline.py",
+    "api/tests/test_automation_usage_api.py",
+    "api/tests/test_monitor_pipeline_stale_running.py",
+    "api/tests/test_runtime_api.py",
+    "web/app/automation/page.tsx",
+    "web/components/live_updates_controller.tsx",
+    "maintainability_audit_report.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_runtime_api.py tests/test_automation_usage_api.py tests/test_monitor_pipeline_stale_running.py tests/test_monitor_pipeline_github_actions.py",
+      "cd api && ruff check app/main.py app/routers/runtime.py app/services/runtime_service.py app/services/runtime_exerciser_service.py app/services/runtime_event_store.py app/services/agent_task_store_service.py app/services/telemetry_persistence_service.py app/services/automation_usage_service.py app/models/automation_usage.py app/routers/automation_usage.py scripts/monitor_pipeline.py tests/test_runtime_api.py tests/test_automation_usage_api.py tests/test_monitor_pipeline_stale_running.py",
+      "python3 api/scripts/run_maintainability_audit.py --json --output maintainability_audit_report.json",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-20_paid-observability-smart-refresh.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting PR checks, merge to main, and Railway production deployment verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Live updates now perform a lightweight change-token check first, triggering expensive refresh/data reload only when underlying runtime/tasks/telemetry state changes; paid-provider readiness/alerts become proactive across monitor and Telegram paths.",
+    "public_endpoints": [
+      "/api/runtime/change-token",
+      "/api/automation/usage",
+      "/api/automation/usage/alerts",
+      "/api/automation/usage/readiness",
+      "/api/automation/usage/provider-validation",
+      "/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Call /api/runtime/change-token twice without state change and verify token stability; write runtime event and verify token changes",
+      "Open /automation and verify backend refresh traffic drops when token unchanged",
+      "Trigger paid-provider degradation and verify monitor issues + Telegram monitor alert publication"
+    ]
+  }
+}

--- a/maintainability_audit_report.json
+++ b/maintainability_audit_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-02-19T21:01:47.489375+00:00",
+  "generated_at": "2026-02-20T08:21:23.870137+00:00",
   "policy": {
     "large_module_lines": 600,
     "very_large_module_lines": 1000,
@@ -16,21 +16,21 @@
     "max_risk_score": 158
   },
   "summary": {
-    "python_module_count": 82,
-    "runtime_file_count": 116,
+    "python_module_count": 83,
+    "runtime_file_count": 117,
     "layer_violation_count": 0,
     "large_module_count": 7,
     "very_large_module_count": 4,
-    "long_function_count": 16,
+    "long_function_count": 15,
     "placeholder_count": 1,
-    "risk_score": 158,
+    "risk_score": 156,
     "severity": "high",
     "blocking_gap": true,
     "regression": false,
     "regression_reasons": []
   },
   "architecture": {
-    "python_module_count": 82,
+    "python_module_count": 83,
     "layer_violations": [],
     "large_modules": [
       {
@@ -39,7 +39,7 @@
       },
       {
         "file": "api/app/services/automation_usage_service.py",
-        "line_count": 1953
+        "line_count": 2489
       },
       {
         "file": "api/app/services/release_gate_service.py",
@@ -50,12 +50,12 @@
         "line_count": 1797
       },
       {
-        "file": "api/app/services/runtime_service.py",
-        "line_count": 994
+        "file": "api/app/routers/agent.py",
+        "line_count": 996
       },
       {
-        "file": "api/app/routers/agent.py",
-        "line_count": 965
+        "file": "api/app/services/runtime_service.py",
+        "line_count": 914
       },
       {
         "file": "api/app/services/idea_service.py",
@@ -69,7 +69,7 @@
       },
       {
         "file": "api/app/services/automation_usage_service.py",
-        "line_count": 1953
+        "line_count": 2489
       },
       {
         "file": "api/app/services/release_gate_service.py",
@@ -112,6 +112,12 @@
         "line_start": 2010
       },
       {
+        "file": "api/app/services/automation_usage_service.py",
+        "function": "_build_openai_snapshot",
+        "line_count": 198,
+        "line_start": 1483
+      },
+      {
         "file": "api/app/services/release_gate_service.py",
         "function": "evaluate_public_deploy_contract_report",
         "line_count": 144,
@@ -124,16 +130,10 @@
         "line_start": 1756
       },
       {
-        "file": "api/app/services/automation_usage_service.py",
-        "function": "_build_openai_snapshot",
-        "line_count": 138,
-        "line_start": 1132
-      },
-      {
         "file": "api/app/routers/agent_telegram.py",
         "function": "telegram_webhook",
         "line_count": 134,
-        "line_start": 409
+        "line_start": 453
       },
       {
         "file": "api/app/services/release_gate_service.py",
@@ -157,31 +157,25 @@
         "file": "api/app/services/automation_usage_service.py",
         "function": "_build_github_snapshot",
         "line_count": 110,
-        "line_start": 791
+        "line_start": 845
       },
       {
         "file": "api/app/services/automation_usage_service.py",
         "function": "_subscription_plans",
         "line_count": 104,
-        "line_start": 1835
+        "line_start": 2371
       },
       {
         "file": "api/app/services/inventory_service.py",
         "function": "next_unblock_task_from_flow",
         "line_count": 96,
         "line_start": 3887
-      },
-      {
-        "file": "api/app/main.py",
-        "function": "capture_runtime_metrics",
-        "line_count": 91,
-        "line_start": 337
       }
     ],
     "parse_errors": []
   },
   "placeholder_scan": {
-    "scanned_file_count": 116,
+    "scanned_file_count": 117,
     "findings": [
       {
         "file": "api/app/models/coherence.py",
@@ -205,9 +199,9 @@
       "task_id": "architecture-modularization-review",
       "title": "Architecture modularization review",
       "direction": "Refactor high-risk modules and remove cross-layer dependencies. Split oversized files and long functions, then re-run maintainability audit.",
-      "estimated_cost_hours": 13.35,
+      "estimated_cost_hours": 13.25,
       "value_to_whole": 100.0,
-      "roi_estimate": 7.4906,
+      "roi_estimate": 7.5472,
       "priority": "high"
     }
   ]

--- a/web/app/automation/page.tsx
+++ b/web/app/automation/page.tsx
@@ -111,10 +111,10 @@ async function loadAutomationData(): Promise<{
 }> {
   const api = getApiBase();
   const [usageRes, alertsRes, readinessRes, validationRes] = await Promise.all([
-    fetch(`${api}/api/automation/usage?force_refresh=true`, { cache: "no-store" }),
+    fetch(`${api}/api/automation/usage`, { cache: "no-store" }),
     fetch(`${api}/api/automation/usage/alerts?threshold_ratio=0.2`, { cache: "no-store" }),
-    fetch(`${api}/api/automation/usage/readiness?force_refresh=true`, { cache: "no-store" }),
-    fetch(`${api}/api/automation/usage/provider-validation?runtime_window_seconds=86400&min_execution_events=1&force_refresh=true`, {
+    fetch(`${api}/api/automation/usage/readiness`, { cache: "no-store" }),
+    fetch(`${api}/api/automation/usage/provider-validation?runtime_window_seconds=86400&min_execution_events=1`, {
       cache: "no-store",
     }),
   ]);


### PR DESCRIPTION
## Summary
- add paid-provider observability snapshots and proactive usage/readiness alerting across OpenAI, OpenRouter, Supabase, and Railway
- add runtime change-token endpoint and smarter web auto-refresh flow that avoids expensive full refresh when nothing changed
- add monitor pipeline issue detection and Telegram alert hooks for paid-provider degradation and low-remaining coverage gaps

## Validation
- pytest -q api/tests/test_runtime_api.py api/tests/test_automation_usage_api.py api/tests/test_monitor_pipeline_stale_running.py api/tests/test_monitor_pipeline_github_actions.py
- cd api && ruff check app/main.py app/services/runtime_service.py app/services/runtime_exerciser_service.py app/services/automation_usage_service.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict