### PR TITLE
Auto-generate spec-gap tasks and self-heal PR guard artifacts

### DIFF
--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -51,6 +51,17 @@ async def sync_implementation_request_tasks() -> dict:
     return inventory_service.sync_implementation_request_question_tasks()
 
 
+@router.post("/inventory/specs/sync-implementation-tasks")
+async def sync_spec_implementation_gap_tasks(
+    create_task: bool = Query(False),
+    limit: int = Query(200, ge=1, le=500),
+) -> dict:
+    return inventory_service.sync_spec_implementation_gap_tasks(
+        create_task=create_task,
+        limit=limit,
+    )
+
+
 @router.get("/inventory/questions/proactive")
 async def proactive_questions(
     limit: int = Query(20, ge=1, le=200),

--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -449,6 +449,16 @@ def _project_root() -> Path:
     return source_path.parents[3]
 
 
+_SPEC_COVERAGE_FILE = "docs/SPEC-COVERAGE.md"
+_SPEC_COVERAGE_SKIP_HINTS = (
+    "backlog",
+    "placeholder",
+    "template",
+    "test-backlog",
+    "sprint0-graph-foundation-indexer-api",
+)
+
+
 def _tracking_repository() -> str:
     return os.getenv("TRACKING_REPOSITORY", "seeker71/Coherence-Network")
 
@@ -602,6 +612,245 @@ def _discover_specs(limit: int = 300) -> tuple[list[dict], str]:
     if local:
         return local, "local"
     return [], "none"
+
+
+def _spec_registry_roi_by_prefix(limit: int = 5000) -> dict[str, float]:
+    roi_by_prefix: dict[str, float] = {}
+    try:
+        rows = spec_registry_service.list_specs(limit=max(1, min(limit, 10000)))
+    except Exception:
+        return roi_by_prefix
+
+    for row in rows:
+        raw_spec_id = str(getattr(row, "spec_id", "") or "").strip()
+        match = re.match(r"^(\d{3})", raw_spec_id)
+        if not match:
+            continue
+        prefix = match.group(1)
+        try:
+            estimated_roi = float(getattr(row, "estimated_roi", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            estimated_roi = 0.0
+        previous = roi_by_prefix.get(prefix)
+        if previous is None or estimated_roi > previous:
+            roi_by_prefix[prefix] = round(estimated_roi, 4)
+    return roi_by_prefix
+
+
+def _spec_source_path_for_id(spec_id: str) -> str:
+    root = _project_root()
+    specs_dir = root / "specs"
+    if not specs_dir.exists():
+        return ""
+    matches = sorted(specs_dir.glob(f"{spec_id}-*.md"))
+    if not matches:
+        return ""
+    try:
+        return matches[0].relative_to(root).as_posix()
+    except ValueError:
+        return matches[0].as_posix()
+
+
+def _parse_spec_coverage_status_summary(limit: int = 500) -> list[dict[str, Any]]:
+    root = _project_root()
+    coverage_path = root / _SPEC_COVERAGE_FILE
+    if not coverage_path.exists():
+        return []
+
+    try:
+        lines = coverage_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    in_status_summary = False
+    in_table = False
+    rows: list[dict[str, Any]] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not in_status_summary:
+            if line.startswith("## Status Summary"):
+                in_status_summary = True
+            continue
+
+        if line.startswith("## ") and not line.startswith("## Status Summary"):
+            break
+
+        if line.startswith("| Spec |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+
+        if not line.startswith("|"):
+            if rows:
+                break
+            continue
+
+        parts = [part.strip() for part in raw_line.split("|")[1:-1]]
+        if len(parts) < 4:
+            continue
+        if parts[0].lower() == "spec" or set(parts[0]) == {"-"}:
+            continue
+
+        spec_cell = parts[0]
+        match = re.match(r"^(\d{3})\s+(.+)$", spec_cell)
+        if not match:
+            continue
+
+        spec_id = match.group(1)
+        title = match.group(2).strip()
+        present = parts[1] if len(parts) > 1 else ""
+        specd = parts[2] if len(parts) > 2 else ""
+        tested = parts[3] if len(parts) > 3 else ""
+        notes = parts[4] if len(parts) > 4 else ""
+        source_path = _spec_source_path_for_id(spec_id)
+
+        rows.append(
+            {
+                "spec_id": spec_id,
+                "title": title,
+                "present": present,
+                "specd": specd,
+                "tested": tested,
+                "notes": notes,
+                "source_path": source_path,
+            }
+        )
+        if len(rows) >= max(1, min(limit, 5000)):
+            break
+
+    return rows
+
+
+def _should_skip_spec_gap_task(row: dict[str, Any]) -> bool:
+    present = str(row.get("present") or "")
+    if "—" in present:
+        return True
+    source_path = str(row.get("source_path") or "").lower()
+    title = str(row.get("title") or "").lower()
+    check = f"{source_path} {title}"
+    return any(hint in check for hint in _SPEC_COVERAGE_SKIP_HINTS)
+
+
+def _spec_implementation_gap_candidates(limit: int = 200) -> list[dict[str, Any]]:
+    rows = _parse_spec_coverage_status_summary(limit=max(limit * 3, 200))
+    roi_by_prefix = _spec_registry_roi_by_prefix(limit=5000)
+    candidates: list[dict[str, Any]] = []
+
+    for row in rows:
+        present = str(row.get("present") or "")
+        specd = str(row.get("specd") or "")
+        if "✓" in present:
+            continue
+        if "✓" not in specd:
+            continue
+        if _should_skip_spec_gap_task(row):
+            continue
+
+        spec_id = str(row.get("spec_id") or "").strip()
+        if not spec_id:
+            continue
+        estimated_roi = round(float(roi_by_prefix.get(spec_id, 0.0) or 0.0), 4)
+        source_path = str(row.get("source_path") or "").strip()
+        candidates.append(
+            {
+                "spec_id": spec_id,
+                "title": str(row.get("title") or "").strip(),
+                "source_path": source_path,
+                "present": present,
+                "specd": specd,
+                "tested": str(row.get("tested") or ""),
+                "notes": str(row.get("notes") or ""),
+                "estimated_roi": estimated_roi,
+                "roi_source": "spec_registry.estimated_roi" if estimated_roi > 0 else "default_zero",
+                "task_fingerprint": f"spec_implementation_gap::{spec_id}",
+            }
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            -float(item.get("estimated_roi") or 0.0),
+            str(item.get("spec_id") or ""),
+        )
+    )
+    return candidates[: max(1, min(limit, 500))]
+
+
+def sync_spec_implementation_gap_tasks(create_task: bool = False, limit: int = 200) -> dict[str, Any]:
+    candidates = _spec_implementation_gap_candidates(limit=max(1, min(limit, 500)))
+    if not candidates:
+        return {
+            "result": "no_spec_implementation_gaps",
+            "gaps_count": 0,
+            "created_count": 0,
+            "skipped_existing_count": 0,
+            "ordered_gaps": [],
+            "created_tasks": [],
+        }
+
+    ordered_gaps: list[dict[str, Any]] = []
+    created_tasks: list[dict[str, Any]] = []
+    skipped_existing_count = 0
+
+    for candidate in candidates:
+        row = dict(candidate)
+        fingerprint = str(row.get("task_fingerprint") or "").strip()
+        active = agent_service.find_active_task_by_fingerprint(fingerprint) if fingerprint else None
+        if isinstance(active, dict):
+            row["active_task"] = {
+                "id": active.get("id"),
+                "status": (
+                    active["status"].value
+                    if hasattr(active.get("status"), "value")
+                    else str(active.get("status"))
+                ),
+                "claimed_by": active.get("claimed_by"),
+            }
+            if create_task:
+                skipped_existing_count += 1
+        ordered_gaps.append(row)
+
+        if not create_task or isinstance(active, dict):
+            continue
+
+        spec_id = str(row.get("spec_id") or "").strip()
+        title = str(row.get("title") or "").strip()
+        source_path = str(row.get("source_path") or "").strip()
+        direction = (
+            f"Implement spec {spec_id} ({title}) from {source_path or 'spec file'}. "
+            "Follow the spec verification contract, add/update tests for behavior, and run local validation. "
+            "Do not modify tests only to force pass."
+        )
+        task = agent_service.create_task(
+            AgentTaskCreate(
+                direction=direction,
+                task_type=TaskType.IMPL,
+                context={
+                    "source": "spec_implementation_gap",
+                    "spec_id": spec_id,
+                    "spec_title": title,
+                    "spec_path": source_path,
+                    "estimated_roi": float(row.get("estimated_roi") or 0.0),
+                    "task_fingerprint": fingerprint,
+                },
+            )
+        )
+        created_tasks.append(
+            {
+                "task_id": task["id"],
+                "spec_id": spec_id,
+                "estimated_roi": float(row.get("estimated_roi") or 0.0),
+            }
+        )
+
+    return {
+        "result": "spec_implementation_gap_tasks_synced",
+        "gaps_count": len(ordered_gaps),
+        "created_count": len(created_tasks),
+        "skipped_existing_count": skipped_existing_count,
+        "ordered_gaps": ordered_gaps,
+        "created_tasks": created_tasks,
+    }
 
 
 def _build_lineage_idea_items(ideas_response: Any) -> list[dict[str, Any]]:

--- a/api/tests/test_worktree_pr_guard.py
+++ b/api/tests/test_worktree_pr_guard.py
@@ -25,6 +25,7 @@ def test_local_steps_web_build_is_hardened(monkeypatch) -> None:
         skip_api_tests=True,
         skip_web_build=False,
         require_gh_auth=False,
+        maintainability_output=mod.DEFAULT_MAINTAINABILITY_OUTPUT,
     )
     web_step = next((step for step in steps if step[0] == "web-build"), None)
     assert web_step is not None
@@ -34,3 +35,46 @@ def test_local_steps_web_build_is_hardened(monkeypatch) -> None:
 def test_check_run_hint_build_web_is_hardened() -> None:
     mod = _load_module()
     assert "--allow-git=none" in mod._check_run_hint("build web")
+
+
+def test_local_steps_uses_non_repo_default_maintainability_output(monkeypatch) -> None:
+    mod = _load_module()
+    monkeypatch.setattr(mod, "_worktree_has_runtime_changes", lambda _base_ref: True)
+
+    steps = mod._local_steps(
+        base_ref="origin/main",
+        skip_api_tests=True,
+        skip_web_build=True,
+        require_gh_auth=False,
+        maintainability_output=mod.DEFAULT_MAINTAINABILITY_OUTPUT,
+    )
+    maintainability_step = next(
+        (step for step in steps if step[0] == "maintainability-regression-guard"),
+        None,
+    )
+    assert maintainability_step is not None
+    assert mod.DEFAULT_MAINTAINABILITY_OUTPUT in maintainability_step[1]
+    assert "maintainability_audit_report.json" not in maintainability_step[1]
+
+
+def test_auto_heal_generated_artifact_restores_snapshot(monkeypatch, tmp_path) -> None:
+    mod = _load_module()
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    target = tmp_path / "maintainability_audit_report.json"
+    target.write_text("before\n", encoding="utf-8")
+    snapshots = mod._snapshot_files({"maintainability_audit_report.json"})
+
+    target.write_text("after\n", encoding="utf-8")
+    monkeypatch.setattr(
+        mod,
+        "_changed_paths_worktree",
+        lambda: ["maintainability_audit_report.json"],
+    )
+
+    healed = mod._auto_heal_generated_artifacts(
+        preexisting_changed_paths=set(),
+        snapshots=snapshots,
+    )
+    assert healed == ["maintainability_audit_report.json"]
+    assert target.read_text(encoding="utf-8") == "before\n"

--- a/docs/system_audit/commit_evidence_2026-02-20_spec-gap-idle-task-generation.json
+++ b/docs/system_audit/commit_evidence_2026-02-20_spec-gap-idle-task-generation.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-02-20",
+  "thread_branch": "codex/spec-gap-idle-task-generation",
+  "commit_scope": "Add ROI-ordered spec implementation gap task generation, idle queue auto task creation, and PR-guard self-healing for generated maintainability artifacts.",
+  "files_owned": [
+    "api/app/services/inventory_service.py",
+    "api/app/routers/inventory.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_inventory_api.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "scripts/worktree_pr_guard.py",
+    "api/tests/test_worktree_pr_guard.py"
+  ],
+  "local_validation": {
+    "status": "pass"
+  },
+  "ci_validation": {
+    "status": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "005",
+    "053",
+    "083"
+  ],
+  "task_ids": [
+    "spec-implementation-gap-sync",
+    "runner-idle-auto-generate"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_worktree_pr_guard.py tests/test_inventory_api.py tests/test_agent_runner_tool_failure_telemetry.py",
+    "cd api && ruff check app/services/inventory_service.py app/routers/inventory.py scripts/agent_runner.py tests/test_inventory_api.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_worktree_pr_guard.py",
+    "cd api && python3 scripts/update_spec_coverage.py --validate"
+  ],
+  "change_files": [
+    "api/app/routers/inventory.py",
+    "api/app/services/inventory_service.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_inventory_api.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "scripts/worktree_pr_guard.py"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "When the queue is idle, the runner can auto-create ROI-ordered spec implementation tasks from coverage gaps instead of stalling.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/specs/sync-implementation-tasks"
+    ],
+    "test_flows": [
+      "api:/api/inventory/specs/sync-implementation-tasks returns ordered gaps and create_task dedupe",
+      "runner idle path calls spec-gap sync endpoint when no open tasks"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add ROI-ordered spec implementation gap sync endpoint: `POST /api/inventory/specs/sync-implementation-tasks`
- auto-create spec-gap tasks from `agent_runner` whenever there are no open tasks
- make `worktree_pr_guard.py` self-heal generated maintainability artifacts and avoid mutating tracked `maintainability_audit_report.json`
- add regression tests for inventory sync, runner idle generation, and guard auto-heal

## Validation
- cd api && pytest -q tests/test_worktree_pr_guard.py tests/test_inventory_api.py tests/test_agent_runner_tool_failure_telemetry.py
- cd api && ruff check app/services/inventory_service.py app/routers/inventory.py scripts/agent_runner.py tests/test_inventory_api.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_worktree_pr_guard.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- ./scripts/verify_web_api_deploy.sh