### PR TITLE
Add external provider monitor and multi-strategy auto-heal

### DIFF
--- a/.github/workflows/provider-readiness-contract.yml
+++ b/.github/workflows/provider-readiness-contract.yml
@@ -57,6 +57,8 @@ jobs:
           fi
           python scripts/check_provider_readiness.py \
             --required-providers "$REQUIRED" \
+            --run-auto-heal \
+            --heal-rounds 2 \
             --run-probes \
             --json \
             --fail-on-blocking > ../provider_readiness_report.json

--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -80,6 +80,23 @@ async def run_provider_validation_probes(
     return report
 
 
+@router.post("/automation/usage/provider-heal/run")
+async def run_provider_auto_heal(
+    required_providers: str = Query("", description="Comma-separated provider ids to heal"),
+    max_rounds: int = Query(2, ge=1, le=6),
+    runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
+    min_execution_events: int = Query(1, ge=1, le=10),
+) -> dict:
+    requested = [item.strip().lower() for item in required_providers.split(",") if item.strip()]
+    report = automation_usage_service.run_provider_auto_heal(
+        required_providers=requested or None,
+        max_rounds=max_rounds,
+        runtime_window_seconds=runtime_window_seconds,
+        min_execution_events=min_execution_events,
+    )
+    return report
+
+
 @router.get("/automation/usage/provider-validation")
 async def get_provider_validation_report(
     required_providers: str = Query("", description="Comma-separated provider ids to validate"),

--- a/docs/API-KEYS-SETUP.md
+++ b/docs/API-KEYS-SETUP.md
@@ -176,10 +176,11 @@ See [AGENT-FRAMEWORKS.md](AGENT-FRAMEWORKS.md) for options.
 
 ## Provider Readiness Automation
 
-The provider readiness contract checks required provider configuration every 6 hours and raises an issue when blocking gaps exist.
+The provider readiness contract checks required provider configuration every 6 hours, runs multi-strategy auto-heal attempts for external providers, and raises an issue when blocking gaps remain.
 
 - API: `GET /api/automation/usage/readiness`
 - API: `POST /api/automation/usage/provider-validation/run`
+- API: `POST /api/automation/usage/provider-heal/run`
 - API: `GET /api/automation/usage/provider-validation`
 - CI workflow: `.github/workflows/provider-readiness-contract.yml`
 - Required providers variable: `AUTOMATION_REQUIRED_PROVIDERS` (comma-separated)

--- a/docs/system_audit/commit_evidence_2026-02-20_provider-health-auto-heal.json
+++ b/docs/system_audit/commit_evidence_2026-02-20_provider-health-auto-heal.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-02-20",
+  "thread_branch": "codex/provider-health-monitor-heal",
+  "commit_scope": "Add external provider health monitoring auto-heal with multi-strategy retries, API trigger endpoint, and scheduled contract execution so readiness is actively repaired multiple times daily.",
+  "files_owned": [
+    ".github/workflows/provider-readiness-contract.yml",
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/scripts/check_provider_readiness.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/API-KEYS-SETUP.md",
+    "docs/system_audit/commit_evidence_2026-02-20_provider-health-auto-heal.json"
+  ],
+  "local_validation": {
+    "status": "pass"
+  },
+  "ci_validation": {
+    "status": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "provider-readiness-contract"
+  ],
+  "spec_ids": [
+    "096",
+    "100"
+  ],
+  "task_ids": [
+    "provider-health-monitor-auto-heal",
+    "external-provider-health-recovery"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_automation_usage_api.py",
+    "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py scripts/check_provider_readiness.py tests/test_automation_usage_api.py",
+    "Scheduled workflow now runs auto-heal rounds before provider validation on each 6-hour contract cycle"
+  ],
+  "change_files": [
+    ".github/workflows/provider-readiness-contract.yml",
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/scripts/check_provider_readiness.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/API-KEYS-SETUP.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "External providers are monitored and auto-healed via multiple strategies (direct probe, refresh+reprobe, runtime validation) with configurable rounds; the scheduled readiness contract runs these heal attempts multiple times per day.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/provider-validation",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/provider-heal/run"
+    ],
+    "test_flows": [
+      "POST /api/automation/usage/provider-heal/run executes multi-strategy rounds and reports per-provider attempts",
+      "provider-readiness contract workflow runs auto-heal then validation every 6 hours",
+      "blocking readiness issues continue to raise/update issue when heal attempts do not recover provider health"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add external provider probe coverage for `openai` in automation usage validation
- add multi-strategy provider auto-heal service flow with multiple rounds per provider
- expose auto-heal run endpoint and wire readiness script/workflow to execute heal attempts multiple times per day

## Validation
- `cd api && pytest -q tests/test_automation_usage_api.py`
- `cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py scripts/check_provider_readiness.py tests/test_automation_usage_api.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-20_provider-health-auto-heal.json`
