### PR TITLE
Add automatic provider quota guard for paid execution

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -33,6 +33,15 @@ PUBLIC_DEPLOY_CONTRACT_BLOCK_THRESHOLD_SECONDS=600
 PAID_TOOL_8H_LIMIT=300
 PAID_TOOL_WEEK_LIMIT=2200
 PAID_TOOL_WINDOW_BUDGET_FRACTION=0.333
+# Provider quota guard (automatic per-provider hourly/weekly/monthly remaining checks)
+AUTOMATION_PROVIDER_WINDOW_GUARD_ENABLED=1
+AUTOMATION_PROVIDER_MIN_REMAINING_RATIO_HOURLY=0.1
+AUTOMATION_PROVIDER_MIN_REMAINING_RATIO_WEEKLY=0.1
+AUTOMATION_PROVIDER_MIN_REMAINING_RATIO_MONTHLY=0.1
+# Optional strict mode: block paid execution when required/active providers have no remaining telemetry.
+# AUTOMATION_PROVIDER_WINDOW_GUARD_BLOCK_ON_MISSING_LIMITS=1
+# Optional provider-specific overrides (JSON). Example:
+# AUTOMATION_PROVIDER_WINDOW_GUARD_POLICY_JSON={"default":{"hourly":0.1,"weekly":0.1,"monthly":0.1},"openai":{"weekly":0.05},"github":{"monthly":0.2}}
 
 # Database
 # NEO4J_URI=bolt://localhost:7687

--- a/api/tests/test_agent_execute_endpoint.py
+++ b/api/tests/test_agent_execute_endpoint.py
@@ -624,6 +624,67 @@ async def test_execute_endpoint_blocks_paid_provider_when_usage_window_budget_ex
 
 
 @pytest.mark.asyncio
+async def test_execute_endpoint_blocks_paid_provider_when_provider_quota_guard_blocks(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.setenv("FRICTION_EVENTS_PATH", str(tmp_path / "friction_events.jsonl"))
+    monkeypatch.setenv("AGENT_ALLOW_PAID_PROVIDERS", "1")
+    monkeypatch.delenv("PAID_TOOL_8H_LIMIT", raising=False)
+    monkeypatch.delenv("PAID_TOOL_WEEK_LIMIT", raising=False)
+    monkeypatch.delenv("AGENT_EXECUTE_TOKEN", raising=False)
+    _reset_agent_store()
+
+    from app.services import agent_execution_service
+
+    monkeypatch.setattr(
+        agent_execution_service.automation_usage_service,
+        "provider_limit_guard_decision",
+        lambda provider, force_refresh=False: {
+            "allowed": False,
+            "provider": provider,
+            "reason": "monthly::credits remaining=4.0/100.0 ratio=0.04<=threshold=0.1",
+            "blocked_metrics": [
+                {
+                    "metric_id": "credits",
+                    "window": "monthly",
+                    "remaining_ratio": 0.04,
+                    "threshold_ratio": 0.1,
+                }
+            ],
+            "evaluated_metrics": [],
+        },
+    )
+
+    task = agent_service.create_task(
+        AgentTaskCreate(
+            direction="Assess codex route with provider quota guard",
+            task_type=TaskType.IMPL,
+            context={"executor": "openclaw", "model_override": "gpt-5.3-codex"},
+        )
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.post(f"/api/agent/tasks/{task['id']}/execute")
+        blocked = await client.get(f"/api/agent/tasks/{task['id']}")
+        assert blocked.status_code == 200
+        payload = blocked.json()
+        assert payload["status"] == "failed"
+        assert payload["output"].startswith("Paid-provider usage blocked by provider quota policy")
+
+        friction = await client.get("/api/friction/events?status=open")
+        assert friction.status_code == 200
+        assert any(
+            item.get("block_type") == "provider_usage_limit_exceeded"
+            and "provider quota policy" in item.get("notes", "")
+            for item in friction.json()
+        )
+
+
+@pytest.mark.asyncio
 async def test_review_task_can_return_confidence_with_paid_override(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/docs/system_audit/commit_evidence_2026-02-20_provider-window-quota-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-20_provider-window-quota-guard.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-02-20",
+  "thread_branch": "codex/provider-quota-awareness",
+  "commit_scope": "Add automatic provider quota awareness and execution guardrails so paid tasks are blocked when hourly/weekly/monthly remaining usage crosses configured thresholds.",
+  "files_owned": [
+    "api/.env.example",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_agent_execute_endpoint.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/system_audit/commit_evidence_2026-02-20_provider-window-quota-guard.json"
+  ],
+  "local_validation": {
+    "status": "pass"
+  },
+  "ci_validation": {
+    "status": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "coherence-network-agent-pipeline",
+    "provider-readiness-contract"
+  ],
+  "spec_ids": [
+    "100"
+  ],
+  "task_ids": [
+    "provider-quota-awareness-window-guard"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && .venv/bin/ruff check app/services/automation_usage_service.py app/services/agent_execution_service.py tests/test_automation_usage_api.py tests/test_agent_execute_endpoint.py",
+    "cd api && .venv/bin/pytest -q tests/test_automation_usage_api.py::test_provider_limit_guard_decision_blocks_low_monthly_remaining tests/test_agent_execute_endpoint.py::test_execute_endpoint_blocks_paid_provider_when_provider_quota_guard_blocks",
+    "cd api && .venv/bin/pytest -q tests/test_agent_execute_endpoint.py::test_execute_endpoint_blocks_paid_provider_when_usage_window_budget_exceeded tests/test_automation_usage_api.py::test_evaluate_usage_alerts_flags_remaining_tracking_gap_for_required_provider tests/test_automation_usage_api.py::test_evaluate_usage_alerts_suppresses_openai_permission_only_degraded"
+  ],
+  "change_files": [
+    "api/.env.example",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_agent_execute_endpoint.py",
+    "api/tests/test_automation_usage_api.py"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Paid provider execution now consults provider quota telemetry and blocks automatically when remaining ratio in hourly/weekly/monthly windows is below configured policy thresholds.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/alerts",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks/{task_id}/execute"
+    ],
+    "test_flows": [
+      "provider_limit_guard_decision returns blocked decision for low monthly remaining quota",
+      "execute endpoint fails paid task with provider_usage_limit_exceeded friction when guard blocks",
+      "legacy paid window policy blocking remains active as fallback"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add provider quota guard policy using hourly/weekly/monthly remaining ratios
- enforce guard in paid execution path with provider_usage_limit_exceeded friction events
- add tests for guard decision and execution block path
- document env configuration knobs in api/.env.example

## Validation
- cd api && .venv/bin/ruff check app/services/automation_usage_service.py app/services/agent_execution_service.py tests/test_automation_usage_api.py tests/test_agent_execute_endpoint.py
- cd api && .venv/bin/pytest -q tests/test_automation_usage_api.py::test_provider_limit_guard_decision_blocks_low_monthly_remaining tests/test_agent_execute_endpoint.py::test_execute_endpoint_blocks_paid_provider_when_provider_quota_guard_blocks
- cd api && .venv/bin/pytest -q tests/test_agent_execute_endpoint.py::test_execute_endpoint_blocks_paid_provider_when_usage_window_budget_exceeded tests/test_automation_usage_api.py::test_evaluate_usage_alerts_flags_remaining_tracking_gap_for_required_provider tests/test_automation_usage_api.py::test_evaluate_usage_alerts_suppresses_openai_permission_only_degraded
