### PR TITLE
Add infra preflight guardrails for self-improve cycle

### DIFF
--- a/.github/workflows/self-improve-cycle.yml
+++ b/.github/workflows/self-improve-cycle.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       SELF_IMPROVE_API_URL: ${{ vars.SELF_IMPROVE_API_URL || 'https://coherence-network-production.up.railway.app' }}
       SELF_IMPROVE_USAGE_THRESHOLD_RATIO: ${{ vars.SELF_IMPROVE_USAGE_THRESHOLD_RATIO || '0.15' }}
+      SELF_IMPROVE_INFRA_PREFLIGHT_ATTEMPTS: ${{ vars.SELF_IMPROVE_INFRA_PREFLIGHT_ATTEMPTS || '5' }}
+      SELF_IMPROVE_INFRA_PREFLIGHT_CONSECUTIVE_SUCCESSES: ${{ vars.SELF_IMPROVE_INFRA_PREFLIGHT_CONSECUTIVE_SUCCESSES || '2' }}
       AGENT_EXECUTE_TOKEN: ${{ secrets.AGENT_EXECUTE_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +36,8 @@ jobs:
           python api/scripts/run_self_improve_cycle.py \
             --base-url "${SELF_IMPROVE_API_URL}" \
             --usage-threshold-ratio "${SELF_IMPROVE_USAGE_THRESHOLD_RATIO}" \
+            --infra-preflight-attempts "${SELF_IMPROVE_INFRA_PREFLIGHT_ATTEMPTS}" \
+            --infra-preflight-consecutive-successes "${SELF_IMPROVE_INFRA_PREFLIGHT_CONSECUTIVE_SUCCESSES}" \
             --execute-pending \
             --json > self_improve_cycle_report.json
           code=$?
@@ -41,7 +45,18 @@ jobs:
             printf '%s\n' '{"status":"failed","failed_stage":"bootstrap","error":"self_improve_cycle_report_missing_or_empty"}' > self_improve_cycle_report.json
           fi
           cat self_improve_cycle_report.json
+          status=$(python - <<'PY'
+import json
+try:
+    with open("self_improve_cycle_report.json", "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(str(data.get("status") or "unknown"))
+except Exception:
+    print("unknown")
+PY
+)
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          echo "report_status=$status" >> "$GITHUB_OUTPUT"
           exit 0
 
       - name: Upload self-improve report
@@ -108,7 +123,7 @@ jobs:
             }
 
       - name: Resolve self-improve issue when cycle passes
-        if: ${{ steps.self_improve.outputs.exit_code == '0' }}
+        if: ${{ steps.self_improve.outputs.exit_code == '0' && steps.self_improve.outputs.report_status != 'infra_blocked' }}
         uses: actions/github-script@v8
         with:
           script: |
@@ -131,6 +146,58 @@ jobs:
               issue_number: issue.number,
               state: 'closed',
             });
+
+      - name: Create or update self-improve infra blocked issue
+        if: ${{ steps.self_improve.outputs.report_status == 'infra_blocked' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            let report = {};
+            try {
+              const raw = fs.readFileSync('self_improve_cycle_report.json', 'utf8');
+              report = JSON.parse(raw || '{}');
+            } catch (err) {
+              report = {
+                status: 'infra_blocked',
+                failed_stage: 'report_parse',
+                error: String(err || 'json_parse_error'),
+              };
+            }
+            const title = 'Self-improve infra blocked';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const history = Array.isArray(report?.infra_preflight?.history) ? report.infra_preflight.history : [];
+            const body = [
+              'Self-improve cycle skipped because infrastructure preflight failed.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              `- Status: ${report.status || 'unknown'}`,
+              `- Skip reason: ${report.skip_reason || 'unknown'}`,
+              `- Preflight error: ${report?.infra_preflight?.preflight_error || 'unknown'}`,
+              '',
+              'Preflight history:',
+              ...(history.length
+                ? history.map((row) => `- attempt=${row.attempt} ok=${row.ok} error=${row.error || 'none'}`)
+                : ['- (none)']),
+            ].join('\n');
+
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`;
+            const existing = await github.rest.search.issuesAndPullRequests({ q: query, per_page: 1 });
+            if (existing.data.items.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data.items[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
 
       - name: Fail when cycle is not successful
         if: ${{ steps.self_improve.outputs.exit_code != '0' }}

--- a/docs/system_audit/commit_evidence_2026-02-22_self-improve-infra-preflight-guard.json
+++ b/docs/system_audit/commit_evidence_2026-02-22_self-improve-infra-preflight-guard.json
@@ -1,0 +1,74 @@
+{
+  "date": "2026-02-22",
+  "thread_branch": "codex/codex-self-heal-preflight-guard-20260221-230012",
+  "commit_scope": "Add infrastructure preflight guards and infra_blocked handling for scheduled self-improve runs to stop repeated 502/timeout execution loops.",
+  "files_owned": [
+    ".github/workflows/self-improve-cycle.yml",
+    "api/scripts/run_self_improve_cycle.py",
+    "api/tests/test_run_self_improve_cycle.py"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "096-provider-readiness-contract-automation"
+  ],
+  "task_ids": [
+    "task-2026-02-22-self-improve-infra-preflight-guard"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["analysis", "implementation", "testing"]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/scripts/run_self_improve_cycle.py",
+    "api/tests/test_run_self_improve_cycle.py",
+    ".github/workflows/self-improve-cycle.yml"
+  ],
+  "change_files": [
+    ".github/workflows/self-improve-cycle.yml",
+    "api/scripts/run_self_improve_cycle.py",
+    "api/tests/test_run_self_improve_cycle.py",
+    "docs/system_audit/commit_evidence_2026-02-22_self-improve-infra-preflight-guard.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_run_self_improve_cycle.py",
+      "python3 scripts/validate_workflow_references.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting push, PR checks, merge, and hosted workflow verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Self-improve cycle now requires consecutive healthy infra preflight checks and returns infra_blocked without creating tasks when endpoints are unstable.",
+    "public_endpoints": [
+      "/api/health",
+      "/api/health/persistence",
+      "/api/automation/usage/alerts"
+    ],
+    "test_flows": [
+      "Run self-improve workflow during API instability and verify report_status=infra_blocked with preflight history.",
+      "Run self-improve workflow during healthy API and verify plan/execute/review tasks are created and executed."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add strict infrastructure preflight checks before creating self-improve tasks
- require consecutive healthy probes for /api/health, /api/health/persistence, and usage alerts endpoint
- return explicit `infra_blocked` status when infra is unstable to avoid repeated 502/timeout loops
- expose report status in workflow outputs and open/update dedicated infra-blocked issue
- add test coverage for infra-blocked and precheck-unavailable behavior

## Validation
- cd api && pytest -q tests/test_run_self_improve_cycle.py
- python3 scripts/validate_workflow_references.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-22_self-improve-infra-preflight-guard.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
