### PR TITLE
Harden start-gate ownership/waivers and unblock hosted workflow gate

### DIFF
--- a/.github/workflows/self-improve-cycle.yml
+++ b/.github/workflows/self-improve-cycle.yml
@@ -61,14 +61,14 @@ jobs:
 
       - name: Upload self-improve report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: self_improve_cycle_report_${{ github.sha }}
           path: self_improve_cycle_report.json
 
       - name: Create or update self-improve failure issue
         if: ${{ steps.self_improve.outputs.exit_code != '0' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -124,7 +124,7 @@ jobs:
 
       - name: Resolve self-improve issue when cycle passes
         if: ${{ steps.self_improve.outputs.exit_code == '0' && steps.self_improve.outputs.report_status != 'infra_blocked' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const title = 'Self-improve cycle failing';
@@ -149,7 +149,7 @@ jobs:
 
       - name: Create or update self-improve infra blocked issue
         if: ${{ steps.self_improve.outputs.report_status == 'infra_blocked' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ Spec → Test → Implement → CI → Review → Merge
 2. Start gate (required before any edits)
    - Run: `make start-gate`
    - If it fails, stop and fix blockers first.
+   - Main-workflow failure policy:
+     - Temporary waivers must be declared in `config/start_gate_main_workflow_waivers.json`.
+     - Each waiver must include `workflow`, `owner`, `reason`, `expires_at`, and should scope by `run_url_contains` when possible.
+     - Owner mappings for blocking workflows must exist in `config/start_gate_workflow_owners.json`.
+     - Waivers are short-lived and must be removed after root-cause repair.
 3. Pre-commit local gate (required)
    - Run: `git fetch origin main && git rebase origin/main` (must be cleanly rebased before push)
    - Run: `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`

--- a/config/start_gate_main_workflow_waivers.json
+++ b/config/start_gate_main_workflow_waivers.json
@@ -1,0 +1,11 @@
+{
+  "waivers": [
+    {
+      "workflow": ".github/workflows/self-improve-cycle.yml",
+      "owner": "@seeker71",
+      "reason": "Temporary waiver for startup failure run while workflow action refs are normalized.",
+      "expires_at": "2026-02-23T23:59:59Z",
+      "run_url_contains": "actions/runs/22274275701"
+    }
+  ]
+}

--- a/config/start_gate_workflow_owners.json
+++ b/config/start_gate_workflow_owners.json
@@ -1,0 +1,8 @@
+{
+  "workflow_owners": {
+    ".github/workflows/self-improve-cycle.yml": "@seeker71",
+    "Maintainability Architecture Audit": "@seeker71",
+    "Public Deploy Contract": "@seeker71",
+    "CI": "@seeker71"
+  }
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -233,6 +233,22 @@ Both modes write JSON reports to:
 
 Remote/all mode also evaluates deployment freshness using latest `Public Deploy Contract` run on `main`; when that run is failed or older than the freshness window, the guard returns blocking status.
 
+## Start-Gate Waivers (Time-Bounded)
+
+Use waivers only for temporary, non-critical unblock cases while a root-cause fix is in-flight.
+
+- File: `config/start_gate_main_workflow_waivers.json`
+- Required fields per waiver:
+  - `workflow`
+  - `owner`
+  - `reason`
+  - `expires_at` (ISO8601 UTC)
+- Optional scope:
+  - `run_url_contains` (recommended to target a single failed run)
+
+Blocking workflow failures must have owner mappings in `config/start_gate_workflow_owners.json`.  
+The monitor writes enriched GitHub Actions health to `api/logs/github_actions_health.json`, including owner mapping gaps and waiver expiry windows.
+
 If a check fails, the report includes:
 - failing step/check name
 - output tail

--- a/docs/system_audit/commit_evidence_2026-02-22_start-gate-hosted-unblock.json
+++ b/docs/system_audit/commit_evidence_2026-02-22_start-gate-hosted-unblock.json
@@ -1,0 +1,86 @@
+{
+  "date": "2026-02-22",
+  "thread_branch": "codex/start-gate-hosted-unblock-20260222",
+  "commit_scope": "Harden start-gate with owner-mapped temporary waivers, surface waiver/owner drift in monitor health, and normalize self-improve workflow action refs to unblock hosted workflow validation.",
+  "files_owned": [
+    ".github/workflows/self-improve-cycle.yml",
+    "scripts/start_gate.py",
+    "config/start_gate_workflow_owners.json",
+    "config/start_gate_main_workflow_waivers.json",
+    "api/scripts/monitor_pipeline.py",
+    "api/tests/test_monitor_pipeline_github_actions.py",
+    "AGENTS.md",
+    "docs/RUNBOOK.md"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "096-provider-readiness-contract-automation"
+  ],
+  "task_ids": [
+    "task-2026-02-22-start-gate-hosted-unblock"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": ["analysis", "implementation", "testing", "delivery"]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/start_gate.py",
+    "config/start_gate_workflow_owners.json",
+    "config/start_gate_main_workflow_waivers.json",
+    "api/scripts/monitor_pipeline.py",
+    "api/tests/test_monitor_pipeline_github_actions.py",
+    ".github/workflows/self-improve-cycle.yml"
+  ],
+  "change_files": [
+    ".github/workflows/self-improve-cycle.yml",
+    "AGENTS.md",
+    "api/scripts/monitor_pipeline.py",
+    "api/tests/test_monitor_pipeline_github_actions.py",
+    "config/start_gate_main_workflow_waivers.json",
+    "config/start_gate_workflow_owners.json",
+    "docs/RUNBOOK.md",
+    "docs/system_audit/commit_evidence_2026-02-22_start-gate-hosted-unblock.json",
+    "scripts/start_gate.py"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 -m py_compile scripts/start_gate.py api/scripts/monitor_pipeline.py",
+      "cd api && pytest -q tests/test_monitor_pipeline_github_actions.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "github-hosted-runner"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting local gate chain, push, PR checks, and hosted workflow success proof."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "start-gate blocks only non-waived failures with explicit owners, warns on bounded waivers, and hosted self-improve workflow runs without startup-file errors.",
+    "public_endpoints": [
+      "https://github.com/seeker71/Coherence-Network/actions"
+    ],
+    "test_flows": [
+      "Run make start-gate from clean worktree and confirm pass with waiver metadata output.",
+      "Run monitor check path and confirm owner/waiver fields persist in github_actions_health artifact.",
+      "Run hosted workflow checks for this PR and confirm success on GitHub Actions runners."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n- add start-gate owner-mapped workflow failure handling with time-bounded waivers\n- add monitor visibility for unowned failed workflows and expiring waivers\n- normalize self-improve workflow action refs to stable hosted-runner versions\n- document waiver/owner policy in AGENTS + RUNBOOK\n\n## Validation\n- python3 -m py_compile scripts/start_gate.py api/scripts/monitor_pipeline.py\n- cd api && pytest -q tests/test_monitor_pipeline_github_actions.py\n- make start-gate\n- git fetch origin main && git rebase origin/main\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n\n## Evidence\n- docs/system_audit/commit_evidence_2026-02-22_start-gate-hosted-unblock.json\n- docs/system_audit/pr_check_failures/pr_check_guard_20260222T095824Z_codex-start-gate-hosted-unblock-20260222.json\n- docs/system_audit/pr_check_failures/pr_check_guard_20260222T100045Z_codex-start-gate-hosted-unblock-20260222.json