### PR TITLE
Retry self-improve stage submission on transient API timeouts

### DIFF
--- a/api/scripts/run_self_improve_cycle.py
+++ b/api/scripts/run_self_improve_cycle.py
@@ -24,6 +24,8 @@ INPUT_ENDPOINT_TIMEOUT_SECONDS = float(os.environ.get("SELF_IMPROVE_INPUT_TIMEOU
 HTTP_RETRY_ATTEMPTS = int(os.environ.get("SELF_IMPROVE_HTTP_RETRY_ATTEMPTS", "3"))
 HTTP_RETRY_BASE_SECONDS = float(os.environ.get("SELF_IMPROVE_HTTP_RETRY_BASE_SECONDS", "0.75"))
 HTTP_TIMEOUT_SECONDS = float(os.environ.get("SELF_IMPROVE_HTTP_TIMEOUT_SECONDS", "20.0"))
+STAGE_SUBMIT_ATTEMPTS = int(os.environ.get("SELF_IMPROVE_STAGE_SUBMIT_ATTEMPTS", "4"))
+STAGE_SUBMIT_RETRY_BASE_SECONDS = float(os.environ.get("SELF_IMPROVE_STAGE_SUBMIT_RETRY_BASE_SECONDS", "2.0"))
 CHECKPOINT_FILE = Path(".cache/self_improve_cycle_checkpoint.json")
 CHECKPOINT_MAX_AGE_SECONDS = int(os.environ.get("SELF_IMPROVE_CHECKPOINT_MAX_AGE_SECONDS", "172800"))
 INFRA_PREFLIGHT_SLEEP_SECONDS = int(os.environ.get("SELF_IMPROVE_INFRA_PREFLIGHT_SLEEP_SECONDS", "20"))
@@ -621,6 +623,28 @@ def _submit_task(client: Any, base_url: str, payload: dict[str, Any]) -> str:
     return task_id
 
 
+def _submit_task_with_retry(
+    client: Any,
+    *,
+    base_url: str,
+    payload: dict[str, Any],
+    attempts: int = STAGE_SUBMIT_ATTEMPTS,
+) -> str:
+    safe_attempts = max(1, attempts)
+    last_error: Exception | None = None
+    for attempt in range(1, safe_attempts + 1):
+        try:
+            return _submit_task(client, base_url, payload)
+        except Exception as exc:
+            last_error = exc
+            if attempt >= safe_attempts or not _is_infra_error(str(exc)):
+                raise
+            time.sleep(STAGE_SUBMIT_RETRY_BASE_SECONDS * attempt)
+    if last_error is not None:
+        raise RuntimeError(f"task submit failed after {safe_attempts} attempts: {last_error}")
+    raise RuntimeError(f"task submit failed after {safe_attempts} attempts")
+
+
 def _request_execute(client: Any, base_url: str, task_id: str, execute_token: str) -> bool:
     headers = {}
     if execute_token:
@@ -700,7 +724,7 @@ def _run_stage(
         task_type=task_type,
         model_override=model_override,
     )
-    task_id = _submit_task(client, base_url, payload)
+    task_id = _submit_task_with_retry(client, base_url=base_url, payload=payload)
     task = _wait_for_terminal(
         client,
         base_url=base_url,

--- a/docs/system_audit/commit_evidence_2026-02-23_self-improve-hosted-stage-unblock.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_self-improve-hosted-stage-unblock.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-23",
   "thread_branch": "codex/self-improve-e2e-proof",
-  "commit_scope": "Unblock hosted self-improve execution by making infra preflight tolerant to degraded observability probes, avoiding forced execute calls in hosted workflow, and adding tests for execute/auth fallback and degraded preflight behavior.",
+  "commit_scope": "Unblock hosted self-improve execution by making infra preflight tolerant to degraded observability probes, adding stage-level task submit retries for transient production timeouts, avoiding forced execute calls in hosted workflow, and extending tests for execute/auth fallback and degraded preflight behavior.",
   "files_owned": [
     "api/scripts/run_self_improve_cycle.py",
     "api/tests/test_run_self_improve_cycle.py",
@@ -16,7 +16,8 @@
   ],
   "task_ids": [
     "task-2026-02-23-self-improve-hosted-stage-unblock",
-    "task-2026-02-23-self-improve-preflight-degraded-tolerance"
+    "task-2026-02-23-self-improve-preflight-degraded-tolerance",
+    "task-2026-02-23-self-improve-stage-submit-retry-hardening"
   ],
   "contributors": [
     {


### PR DESCRIPTION
## Summary
- add stage-level task submit retries in self-improve cycle to survive transient API task-create timeouts
- keep infra-only failures classified as infra_blocked while increasing recovery chance before declaring blocked
- update self-improve tests to validate multi-outage submit recovery and exhaustion behavior

## Validation
- cd api && pytest -q tests/test_run_self_improve_cycle.py
- cd api && ruff check scripts/run_self_improve_cycle.py tests/test_run_self_improve_cycle.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict