### PR TITLE
Default-enable Codex auth fallback and safe argv execution

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-23",
   "thread_branch": "codex/self-improve-e2e-proof",
-  "commit_scope": "Unblock hosted self-improve execution by auto-falling back from Codex OAuth to API-key auth on refresh_token_reused failures, with per-task auth override support and regression tests for fallback scheduling.",
+  "commit_scope": "Unblock hosted self-improve execution by enabling Codex OAuth->API-key fallback by default, preserving opt-out, and executing codex commands via argv (no shell expansion) so plan text with backticks cannot break impl command execution.",
   "files_owned": [
     "api/scripts/agent_runner.py",
     "api/tests/test_agent_runner_tool_failure_telemetry.py",
@@ -14,7 +14,8 @@
     "096-provider-readiness-contract-automation"
   ],
   "task_ids": [
-    "task-2026-02-23-self-improve-oauth-refresh-fallback"
+    "task-2026-02-23-self-improve-oauth-refresh-fallback",
+    "task-2026-02-23-self-improve-codex-shell-expansion-fix"
   ],
   "contributors": [
     {
@@ -49,7 +50,7 @@
   "local_validation": {
     "status": "pass",
     "commands": [
-      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k \"codex_oauth or auth_override or model_not_found_fallback\"",
+      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k \"codex_oauth or auth_override or oauth_fallback or argv or model_not_found_fallback\"",
       "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py"
     ]
   },


### PR DESCRIPTION
## Summary
- default `AGENT_CODEX_OAUTH_ALLOW_API_KEY_FALLBACK` to enabled unless explicitly turned off
- execute `codex ...` commands via argv (shell disabled) to prevent backtick expansion from task plan text
- add regression tests for default fallback behavior and codex argv execution mode

## Validation
- `cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k "codex_oauth or auth_override or oauth_fallback or argv or model_not_found_fallback"`
- `cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json`
