### PR TITLE
Force Codex api-key mode to ignore stale OAuth sessions

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-23",
   "thread_branch": "codex/self-improve-e2e-proof",
-  "commit_scope": "Unblock hosted self-improve execution by enabling Codex OAuth->API-key fallback by default, preserving opt-out, and executing codex commands via argv (no shell expansion) so plan text with backticks cannot break impl command execution.",
+  "commit_scope": "Unblock hosted self-improve execution by enabling Codex OAuth->API-key fallback by default, executing codex commands via argv (no shell expansion), and isolating Codex HOME/session in api_key mode so stale oauth sessions are not reused.",
   "files_owned": [
     "api/scripts/agent_runner.py",
     "api/tests/test_agent_runner_tool_failure_telemetry.py",
@@ -15,7 +15,8 @@
   ],
   "task_ids": [
     "task-2026-02-23-self-improve-oauth-refresh-fallback",
-    "task-2026-02-23-self-improve-codex-shell-expansion-fix"
+    "task-2026-02-23-self-improve-codex-shell-expansion-fix",
+    "task-2026-02-23-self-improve-codex-api-key-home-isolation"
   ],
   "contributors": [
     {
@@ -50,7 +51,7 @@
   "local_validation": {
     "status": "pass",
     "commands": [
-      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k \"codex_oauth or auth_override or oauth_fallback or argv or model_not_found_fallback\"",
+      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py",
       "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py"
     ]
   },


### PR DESCRIPTION
## Summary
- isolate `HOME`/`CODEX_HOME` for Codex runs when `effective_mode=api_key`
- clear `AGENT_CODEX_OAUTH_SESSION_FILE` in subprocess env for api-key mode
- teach oauth session candidate lookup to honor env overrides first
- add regression test for api-key home isolation and no oauth session detection

## Why
Post-fix production run still showed refresh-token OAuth failures in `api_key` mode due stale `/root/.codex/auth.json` being reused.

## Validation
- `cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py`
- `cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json`
