### PR TITLE
Use OPENAI_ADMIN_API_KEY when OPENAI_API_KEY is missing

### DIFF
--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -2793,7 +2793,8 @@ def _configure_codex_cli_environment(
 
     openai_api_key = str(os.environ.get("OPENAI_API_KEY", "")).strip()
     openai_admin_key = str(os.environ.get("OPENAI_ADMIN_API_KEY", "")).strip()
-    api_key_present = bool(openai_api_key or openai_admin_key)
+    openai_primary_key = openai_api_key or openai_admin_key
+    api_key_present = bool(openai_primary_key)
     oauth_available_initial, oauth_source_initial = _codex_oauth_session_status(env)
     allow_oauth_fallback = _as_bool(os.environ.get("AGENT_CODEX_OAUTH_ALLOW_API_KEY_FALLBACK", "1"))
 
@@ -2803,7 +2804,7 @@ def _configure_codex_cli_environment(
 
     if effective_mode == "oauth":
         if allow_oauth_fallback:
-            env.setdefault("OPENAI_API_KEY", openai_api_key)
+            env.setdefault("OPENAI_API_KEY", openai_primary_key)
             env.setdefault("OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
             env.setdefault("OPENAI_BASE_URL", env.get("OPENAI_API_BASE"))
         else:
@@ -2815,7 +2816,7 @@ def _configure_codex_cli_environment(
         if _as_bool(os.environ.get("AGENT_CODEX_API_KEY_ISOLATE_HOME", "1")):
             _ensure_codex_api_key_isolated_home(env, task_id=task_id)
             env["AGENT_CODEX_OAUTH_SESSION_FILE"] = ""
-        env.setdefault("OPENAI_API_KEY", openai_api_key)
+        env.setdefault("OPENAI_API_KEY", openai_primary_key)
         env.setdefault("OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
         env.setdefault("OPENAI_BASE_URL", env.get("OPENAI_API_BASE"))
 

--- a/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-23",
   "thread_branch": "codex/self-improve-e2e-proof",
-  "commit_scope": "Unblock hosted self-improve execution by enabling Codex OAuth->API-key fallback by default, executing codex commands via argv (no shell expansion), and isolating Codex HOME/session in api_key mode so stale oauth sessions are not reused.",
+  "commit_scope": "Unblock hosted self-improve execution by enabling Codex OAuth->API-key fallback by default, executing codex commands via argv (no shell expansion), isolating Codex HOME/session in api_key mode, and mapping OPENAI_API_KEY from OPENAI_API_KEY or OPENAI_ADMIN_API_KEY to avoid missing-bearer failures.",
   "files_owned": [
     "api/scripts/agent_runner.py",
     "api/tests/test_agent_runner_tool_failure_telemetry.py",
@@ -16,7 +16,8 @@
   "task_ids": [
     "task-2026-02-23-self-improve-oauth-refresh-fallback",
     "task-2026-02-23-self-improve-codex-shell-expansion-fix",
-    "task-2026-02-23-self-improve-codex-api-key-home-isolation"
+    "task-2026-02-23-self-improve-codex-api-key-home-isolation",
+    "task-2026-02-23-self-improve-admin-key-fallback"
   ],
   "contributors": [
     {


### PR DESCRIPTION
## Summary
- set Codex runner `OPENAI_API_KEY` from `OPENAI_API_KEY` or fallback `OPENAI_ADMIN_API_KEY`
- keep api-key mode + isolated HOME/session behavior
- add regression test for admin-key fallback mapping

## Why
Latest hosted self-improve failures moved to explicit 401 "Missing bearer" after oauth/session isolation. This patch closes that gap.

## Validation
- `cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py`
- `cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json`
