### PR TITLE
Minimal unblock: self-improve auth/payload/escaping hardening

### DIFF
--- a/api/app/services/agent_service.py
+++ b/api/app/services/agent_service.py
@@ -795,8 +795,13 @@ def _build_command(
         template = _openclaw_command_template(task_type)
     else:
         template = COMMAND_TEMPLATES[task_type]
-    # Escape direction for shell (double-quoted string)
-    escaped = direction.replace("\\", "\\\\").replace('"', '\\"')
+    # Escape direction for shell in a double-quoted template placeholder.
+    escaped = (
+        direction.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("`", "\\`")
+        .replace("$", "\\$")
+    )
     return template.replace("{{direction}}", escaped)
 
 

--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -2695,6 +2695,14 @@ def _abs_expanded_path(path: str) -> str:
     return os.path.abspath(os.path.expanduser(value))
 
 
+def _set_env_if_blank(env: dict[str, str], key: str, value: str) -> None:
+    if not str(value or "").strip():
+        return
+    if str(env.get(key, "")).strip():
+        return
+    env[key] = value
+
+
 def _codex_oauth_session_candidates(env: dict[str, str]) -> list[str]:
     candidates: list[str] = []
     seen: set[str] = set()
@@ -2804,9 +2812,9 @@ def _configure_codex_cli_environment(
 
     if effective_mode == "oauth":
         if allow_oauth_fallback:
-            env.setdefault("OPENAI_API_KEY", openai_primary_key)
-            env.setdefault("OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
-            env.setdefault("OPENAI_BASE_URL", env.get("OPENAI_API_BASE"))
+            _set_env_if_blank(env, "OPENAI_API_KEY", openai_primary_key)
+            _set_env_if_blank(env, "OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
+            _set_env_if_blank(env, "OPENAI_BASE_URL", str(env.get("OPENAI_API_BASE") or ""))
         else:
             env.pop("OPENAI_API_KEY", None)
             env.pop("OPENAI_ADMIN_API_KEY", None)
@@ -2816,9 +2824,9 @@ def _configure_codex_cli_environment(
         if _as_bool(os.environ.get("AGENT_CODEX_API_KEY_ISOLATE_HOME", "1")):
             _ensure_codex_api_key_isolated_home(env, task_id=task_id)
             env["AGENT_CODEX_OAUTH_SESSION_FILE"] = ""
-        env.setdefault("OPENAI_API_KEY", openai_primary_key)
-        env.setdefault("OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
-        env.setdefault("OPENAI_BASE_URL", env.get("OPENAI_API_BASE"))
+        _set_env_if_blank(env, "OPENAI_API_KEY", openai_primary_key)
+        _set_env_if_blank(env, "OPENAI_API_BASE", os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"))
+        _set_env_if_blank(env, "OPENAI_BASE_URL", str(env.get("OPENAI_API_BASE") or ""))
 
     oauth_available, oauth_source = _codex_oauth_session_status(env)
     oauth_missing = bool(effective_mode == "oauth" and not oauth_available and not allow_oauth_fallback)

--- a/api/tests/test_agent_integration_api.py
+++ b/api/tests/test_agent_integration_api.py
@@ -65,3 +65,14 @@ def test_task_target_state_contract_is_persisted(monkeypatch: pytest.MonkeyPatch
     assert context.get("abort_evidence") == ["fatal error", "abort now"]
     assert context.get("observation_window_sec") == 180
     assert isinstance(context.get("target_state_contract"), dict)
+
+
+def test_build_command_escapes_shell_sensitive_direction_tokens() -> None:
+    command = agent_service._build_command(
+        'Check `uname -a` and "$HOME" value',
+        TaskType.IMPL,
+        executor="openclaw",
+    )
+
+    assert "\\`uname -a\\`" in command
+    assert '\\"\\$HOME\\"' in command

--- a/api/tests/test_agent_runner_tool_failure_telemetry.py
+++ b/api/tests/test_agent_runner_tool_failure_telemetry.py
@@ -432,6 +432,23 @@ def test_configure_codex_cli_environment_uses_admin_key_when_primary_missing(mon
     assert env.get("OPENAI_API_KEY") == "admin-only-key"
 
 
+def test_configure_codex_cli_environment_overwrites_blank_primary_with_admin_key(monkeypatch):
+    monkeypatch.setenv("AGENT_CODEX_AUTH_MODE", "api_key")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+    monkeypatch.setenv("OPENAI_ADMIN_API_KEY", "admin-only-key")
+
+    env = {"OPENAI_API_KEY": ""}
+    auth = agent_runner._configure_codex_cli_environment(
+        env=env,
+        task_id="task_admin_key_blank_primary",
+        log=agent_runner._setup_logging(verbose=False),
+    )
+
+    assert auth["effective_mode"] == "api_key"
+    assert auth["api_key_present"] is True
+    assert env.get("OPENAI_API_KEY") == "admin-only-key"
+
+
 def test_configure_codex_cli_environment_respects_task_auth_override(monkeypatch, tmp_path):
     session_file = tmp_path / "codex-auth.json"
     session_file.write_text('{"token":"test"}', encoding="utf-8")

--- a/api/tests/test_run_self_improve_cycle.py
+++ b/api/tests/test_run_self_improve_cycle.py
@@ -38,12 +38,17 @@ class _FakeClient:
         execute_status_code: int = 200,
         pending_polls_before_complete: int = 0,
         post_error_plan: list[Exception] | None = None,
+        task_post_status_plan: list[int] | None = None,
+        stage_output_overrides: dict[int, str] | None = None,
     ) -> None:
         self.created_payloads: list[dict] = []
+        self.submitted_payloads: list[dict] = []
         self._task_counter = 0
         self._task_order: list[str] = []
         self._task_outputs: dict[str, str] = {}
         self._post_error_plan = list(post_error_plan or [])
+        self._task_post_status_plan = list(task_post_status_plan or [])
+        self._stage_output_overrides = dict(stage_output_overrides or {})
         self.usage_payload = usage_payload
         self.tasks_payload = tasks_payload if tasks_payload is not None else []
         self.needs_decision_payload = needs_decision_payload if needs_decision_payload is not None else []
@@ -81,9 +86,13 @@ class _FakeClient:
             raise self._post_error_plan.pop(0)
 
         if url.endswith("/api/agent/tasks"):
+            payload = dict(json or {})
+            self.submitted_payloads.append(payload)
+            status_code = self._task_post_status_plan.pop(0) if self._task_post_status_plan else 201
+            if status_code >= 400:
+                return _FakeResponse(status_code, {"error": f"forced status {status_code}"})
             self._task_counter += 1
             task_id = f"task-{self._task_counter}"
-            payload = dict(json or {})
             payload["_task_id"] = task_id
             self.created_payloads.append(payload)
             self._task_order.append(task_id)
@@ -159,7 +168,7 @@ class _FakeClient:
                         },
                     )
                 idx = int(task_id.split("-")[-1])
-                output = f"stage-{idx}-output"
+                output = self._stage_output_overrides.get(idx, f"stage-{idx}-output")
                 self._task_outputs[task_id] = output
                 payload = self.created_payloads[idx - 1]
                 context = payload.get("context") if isinstance(payload.get("context"), dict) else {}
@@ -581,3 +590,65 @@ def test_infra_preflight_allows_degraded_observability_when_core_is_healthy() ->
     assert preflight["history"][0]["runtime_ok"] is False
     assert preflight["history"][0]["health_ok"] is True
     assert preflight["history"][0]["gates_ok"] is True
+
+
+def test_run_cycle_caps_review_direction_below_agent_task_limit() -> None:
+    client = _FakeClient(
+        usage_payload=_default_usage_payload(),
+        stage_output_overrides={
+            1: "PLAN-" + ("A" * 4000),
+            2: "EXEC-" + ("B" * 4000),
+        },
+    )
+
+    report = run_self_improve_cycle.run_cycle(
+        client=client,
+        base_url="https://example.test",
+        poll_interval_seconds=0,
+        timeout_seconds=5,
+        execute_pending=False,
+        execute_token="",
+        usage_threshold_ratio=0.15,
+        usage_cache_path="/tmp/self_improve_cache_direction_cap.json",
+    )
+
+    assert report["status"] == "completed"
+    assert len(client.created_payloads) == 3
+    review_payload = client.created_payloads[2]
+    assert review_payload["task_type"] == "review"
+    assert len(review_payload["direction"]) <= run_self_improve_cycle.AGENT_TASK_DIRECTION_SAFE_CHARS
+    assert "Original plan:" in review_payload["direction"]
+    assert "Execution output:" in review_payload["direction"]
+
+
+def test_run_cycle_recovers_from_422_with_compacted_direction_retry() -> None:
+    client = _FakeClient(
+        usage_payload=_default_usage_payload(),
+        stage_output_overrides={
+            1: "PLAN-" + ("A" * 4000),
+            2: "EXEC-" + ("B" * 4000),
+        },
+        # plan success, execute success, review submit 422, review submit retry success
+        task_post_status_plan=[201, 201, 422, 201],
+    )
+
+    report = run_self_improve_cycle.run_cycle(
+        client=client,
+        base_url="https://example.test",
+        poll_interval_seconds=0,
+        timeout_seconds=5,
+        execute_pending=False,
+        execute_token="",
+        usage_threshold_ratio=0.15,
+        usage_cache_path="/tmp/self_improve_cache_review_422_retry.json",
+    )
+
+    assert report["status"] == "completed"
+    assert len(client.created_payloads) == 3
+    # Four submit attempts total with one failed review submit.
+    assert len(client.submitted_payloads) == 4
+    failed_review_submit = client.submitted_payloads[2]
+    retried_review_submit = client.submitted_payloads[3]
+    assert failed_review_submit["task_type"] == "review"
+    assert retried_review_submit["task_type"] == "review"
+    assert len(retried_review_submit["direction"]) <= len(failed_review_submit["direction"])


### PR DESCRIPTION
## Summary
- harden self-improve stage submit payload sizing with bounded direction and compact retry on HTTP 422
- tighten review/execute prompt clipping to keep task direction under API limits
- fix runner codex api-key fallback when OPENAI_API_KEY is present but blank (admin key fallback)
- escape backticks and dollar signs in shell command direction interpolation
- add focused regression tests for these failure modes

## Scope
Minimal unblock patch only (no broad refactors).

## Verification (focused)
- cd api && pytest -q tests/test_run_self_improve_cycle.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_agent_integration_api.py
- cd api && ruff check scripts/run_self_improve_cycle.py scripts/agent_runner.py app/services/agent_service.py tests/test_run_self_improve_cycle.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_agent_integration_api.py

## Note
Per temporary grace-period instruction, full local gate chain was not run for this push.