### PR TITLE
Add n8n security floor guards and ecosystem ROI specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,8 @@ NPM_CACHE=/tmp/coherence-npm-cache ./scripts/verify_worktree_local_web.sh
 make start-gate
 
 # PR check failure prevention + tracking (default before commit/push)
+# Optional for n8n-backed automation flows:
+# export N8N_VERSION=1.123.17
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 # Include remote PR check tracking (requires GH_TOKEN/GITHUB_TOKEN):
 python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)"

--- a/api/scripts/validate_pr_to_public.py
+++ b/api/scripts/validate_pr_to_public.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 
 from app.services import release_gate_service as gates
+
+_N8N_V1_MIN = (1, 123, 17)
+_N8N_V2_MIN = (2, 5, 2)
 
 
 def _default_endpoints(api_base: str, web_base: str) -> list[str]:
@@ -19,6 +23,54 @@ def _default_endpoints(api_base: str, web_base: str) -> list[str]:
         f"{web_base.rstrip('/')}/gates",
         f"{web_base.rstrip('/')}/api-health",
     ]
+
+
+def _format_semver(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _parse_semver(raw: str) -> tuple[int, int, int] | None:
+    text = raw.strip()
+    if text.startswith("v"):
+        text = text[1:]
+    parts = text.split(".")
+    if not parts:
+        return None
+    values: list[int] = []
+    for idx in range(3):
+        if idx >= len(parts):
+            values.append(0)
+            continue
+        match = re.match(r"^(\d+)", parts[idx])
+        if not match:
+            return None
+        values.append(int(match.group(1)))
+    return (values[0], values[1], values[2])
+
+
+def _evaluate_n8n_minimum(raw_version: str) -> dict[str, object]:
+    parsed = _parse_semver(raw_version)
+    if parsed is None:
+        return {
+            "input_version": raw_version,
+            "ok": False,
+            "reason": "invalid_n8n_version_format",
+            "minimum": "unknown",
+        }
+
+    major = parsed[0]
+    if major <= 1:
+        minimum = _N8N_V1_MIN
+    else:
+        minimum = _N8N_V2_MIN
+    ok = parsed >= minimum
+    return {
+        "input_version": raw_version,
+        "parsed_version": _format_semver(parsed),
+        "minimum": _format_semver(minimum),
+        "ok": ok,
+        "reason": "meets_minimum" if ok else "below minimum security floor",
+    }
 
 
 def main() -> None:
@@ -40,9 +92,18 @@ def main() -> None:
     parser.add_argument("--timeout-seconds", type=int, default=1200)
     parser.add_argument("--poll-seconds", type=int, default=30)
     parser.add_argument("--json", action="store_true", help="Output JSON only.")
+    parser.add_argument(
+        "--n8n-version",
+        default="",
+        help=(
+            "Optional deployed n8n version to validate against minimum security floor "
+            "(v1>=1.123.17 or v2>=2.5.2). Can also be provided via N8N_VERSION."
+        ),
+    )
     args = parser.parse_args()
 
     token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    n8n_version = args.n8n_version.strip() or os.getenv("N8N_VERSION", "").strip()
     endpoints = args.endpoint or _default_endpoints(args.api_base, args.web_base)
     report = gates.evaluate_pr_to_public_report(
         repository=args.repo,
@@ -56,6 +117,16 @@ def main() -> None:
         endpoint_urls=endpoints,
         github_token=token,
     )
+    if n8n_version:
+        n8n_gate = _evaluate_n8n_minimum(n8n_version)
+        report["n8n_gate"] = n8n_gate
+        if not bool(n8n_gate.get("ok")):
+            report["result"] = "blocked_n8n_version"
+            report["reason"] = (
+                "n8n security floor not met: "
+                f"found {n8n_gate.get('input_version')} "
+                f"minimum {n8n_gate.get('minimum')}"
+            )
     _emit(report, as_json=args.json)
     result = str(report.get("result"))
     if result in ("ready_for_merge", "public_validated"):
@@ -92,6 +163,15 @@ def _emit(payload: dict[str, object], as_json: bool) -> None:
         for check in public.get("checks", []):
             if isinstance(check, dict):
                 print(f"  - {check.get('url')} -> {check.get('status_code')} ok={check.get('ok')}")
+    n8n_gate = payload.get("n8n_gate")
+    if isinstance(n8n_gate, dict):
+        print(
+            "n8n gate:"
+            f" ok={n8n_gate.get('ok')}"
+            f" input={n8n_gate.get('input_version')}"
+            f" minimum={n8n_gate.get('minimum')}"
+            f" reason={n8n_gate.get('reason')}"
+        )
 
 
 if __name__ == "__main__":

--- a/api/tests/test_validate_pr_to_public.py
+++ b/api/tests/test_validate_pr_to_public.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    api_root = Path(__file__).resolve().parents[1]
+    script = api_root / "scripts" / "validate_pr_to_public.py"
+    spec = importlib.util.spec_from_file_location("validate_pr_to_public", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_semver_handles_common_inputs() -> None:
+    mod = _load_module()
+
+    assert mod._parse_semver("1.123.17") == (1, 123, 17)
+    assert mod._parse_semver("v2.5.2") == (2, 5, 2)
+    assert mod._parse_semver("2.5.2-beta.1") == (2, 5, 2)
+    assert mod._parse_semver("2.5") == (2, 5, 0)
+    assert mod._parse_semver("bad") is None
+
+
+def test_n8n_gate_blocks_old_v1() -> None:
+    mod = _load_module()
+
+    gate = mod._evaluate_n8n_minimum("1.123.16")
+    assert gate["ok"] is False
+    assert gate["minimum"] == "1.123.17"
+    assert "below minimum" in str(gate["reason"])
+
+
+def test_n8n_gate_allows_fixed_v1() -> None:
+    mod = _load_module()
+
+    gate = mod._evaluate_n8n_minimum("1.123.17")
+    assert gate["ok"] is True
+    assert gate["minimum"] == "1.123.17"
+
+
+def test_n8n_gate_blocks_old_v2() -> None:
+    mod = _load_module()
+
+    gate = mod._evaluate_n8n_minimum("2.5.1")
+    assert gate["ok"] is False
+    assert gate["minimum"] == "2.5.2"
+
+
+def test_n8n_gate_rejects_invalid_version() -> None:
+    mod = _load_module()
+
+    gate = mod._evaluate_n8n_minimum("version-unknown")
+    assert gate["ok"] is False
+    assert gate["reason"] == "invalid_n8n_version_format"

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -58,6 +58,7 @@ Start command:
 Run and record:
 
 ```bash
+# Optional for n8n-backed flows: export N8N_VERSION=<deployed-version>
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 python3 scripts/pr_check_failure_triage.py --repo seeker71/Coherence-Network --base main --head-prefix codex/ --fail-on-detected
 python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
@@ -86,6 +87,7 @@ Worktree notes:
 - It writes machine-readable artifacts under `docs/system_audit/pr_check_failures/`.
 - `thread-runtime.sh run-e2e` does runtime API smoke against the active local API and is cache-aware.
 - Remote/all mode also checks latest `Public Deploy Contract` health on `main` and blocks progression when deployment validation is failed or stale.
+- If `N8N_VERSION` is set (or `--n8n-version` is passed), the local guard enforces n8n security floor (`v1>=1.123.17`, `v2>=2.5.2`) and blocks push when below floor.
 - If running `./scripts/verify_worktree_local_web.sh` directly, npm cache defaults to per-worktree `<worktree>/.cache/npm` (override via `NPM_CACHE=...`).
 
 ### Phase B: CI Validation (required before merge)

--- a/docs/COMMUNITY-RESEARCH-PRIORITIES.md
+++ b/docs/COMMUNITY-RESEARCH-PRIORITIES.md
@@ -178,3 +178,15 @@
 - [PLAN.md](PLAN.md) — Product vision and roadmap
 - [AGENT-DEBUGGING.md](AGENT-DEBUGGING.md) — Debugging the pipeline
 - [REFERENCE-REPOS.md](REFERENCE-REPOS.md) — Source material and related work
+
+---
+
+## 7. Ecosystem Pulse Queue (2026-02-23)
+
+High-value items from latest framework/tooling scan, mapped to queued specs:
+
+| Priority | Spec | Improvement | ROI | Effort |
+|----------|------|-------------|-----|--------|
+| P0 | `108` | n8n security patch baseline + HITL hardening | Critical risk reduction | Low-Medium |
+| P1 | `109` | Open Responses-compatible provider normalization | High portability + routing resilience | Medium |
+| P2 | `110` | LangGraph-style StateSchema validation for orchestration state | Medium-High reliability | Medium |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -39,6 +39,26 @@ Web service (`coherence-web`):
 
 - `NEXT_PUBLIC_API_URL=https://coherence-network-production.up.railway.app`
 
+## n8n Security Baseline and HITL Contract
+
+When automation flows depend on n8n, deployment validation must enforce:
+
+1. Minimum secure n8n version:
+- v1 track: `>=1.123.17`
+- v2 track: `>=2.5.2`
+2. Human-in-the-loop (HITL) approval for destructive/external-impacting tool calls (for example delete/write/send actions).
+
+Optional pre-merge gate command (from `api/`):
+
+```bash
+.venv/bin/python scripts/validate_pr_to_public.py \
+  --branch codex/<thread-name> \
+  --wait-public \
+  --n8n-version "${N8N_VERSION}"
+```
+
+If the provided n8n version is below floor, the script returns non-zero with `result=blocked_n8n_version`.
+
 ## Railway Auto-Deploy Settings
 
 Set in both Railway services:

--- a/docs/PR-CHECK-FAILURE-TRIAGE.md
+++ b/docs/PR-CHECK-FAILURE-TRIAGE.md
@@ -55,6 +55,19 @@ Common mappings:
 - `Validate commit evidence` -> `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
 - `Validate spec quality` -> `python3 scripts/validate_spec_quality.py --base origin/main --head HEAD`
 - `Public Deploy Contract` -> `./scripts/verify_web_api_deploy.sh`
+- `n8n security floor/HITL readiness` -> `cd api && .venv/bin/python scripts/validate_pr_to_public.py --branch <branch> --wait-public --n8n-version \"${N8N_VERSION}\"`
+
+## n8n Blocker Pattern
+
+When deploy readiness reports `result=blocked_n8n_version`:
+
+1. Confirm deployed n8n runtime version.
+2. Upgrade to the minimum secure floor (`>=1.123.17` for v1 or `>=2.5.2` for v2).
+3. Re-run:
+   ```bash
+   cd api && .venv/bin/python scripts/validate_pr_to_public.py --branch <branch> --wait-public --n8n-version "${N8N_VERSION}"
+   ```
+4. Verify HITL approvals still block destructive/external-impact actions until explicit approval.
 
 ## Catch-Next-Time Automation
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -67,6 +67,29 @@ When the pipeline is stuck or the agent runner died:
 - Telegram: `/reply {task_id} yes` (or your decision)
 - API: `curl -X PATCH http://localhost:8000/api/agent/tasks/{id} -H "Content-Type: application/json" -d '{"decision":"yes"}'`
 
+## n8n Security and HITL Operations
+
+Use this when workflow runs involve n8n-powered automation.
+
+Security floor:
+- v1 deployments must be `>=1.123.17`
+- v2 deployments must be `>=2.5.2`
+
+Deploy gate check (from `api/`):
+
+```bash
+.venv/bin/python scripts/validate_pr_to_public.py --branch codex/<thread-name> --wait-public --n8n-version "${N8N_VERSION}"
+```
+
+Expected behavior:
+1. If n8n is below minimum, result is `blocked_n8n_version` and deploy should not proceed.
+2. If n8n is at/above minimum, gate result depends on normal PR/public checks.
+
+HITL contract:
+1. Mark destructive or external-impacting actions as approval-required.
+2. Verify a blocked action remains blocked until explicit approval event is recorded.
+3. If approvals fail to trigger, treat as a deploy blocker and roll back workflow changes enabling direct execution.
+
 ## Self-Improvement Thinking Loop
 
 When running plan/implement/verify cycles, enforce this thinking contract before coding:

--- a/docs/SPEC-TRACKING.md
+++ b/docs/SPEC-TRACKING.md
@@ -81,3 +81,6 @@ Run `pytest -v` and `npm run build` to verify before updating this doc.
 - `097` — `specs/097-openclaw-citation-and-allowed-file-guard.md`
 - `098` — `specs/098-openclaw-incremental-index-freshness.md`
 - `099` — `specs/099-openclaw-roi-benchmark-and-telemetry-loop.md`
+- `108` — `specs/108-n8n-security-and-hitl-hardening.md`
+- `109` — `specs/109-open-responses-interoperability-layer.md`
+- `110` — `specs/110-langgraph-stateschema-adoption.md`

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -55,6 +55,8 @@ git rebase origin/main
 ```
 
 ```bash
+# Optional: set deployed n8n version when automation flows depend on n8n
+# export N8N_VERSION=1.123.17
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 ./scripts/verify_worktree_local_web.sh
 # optional explicit startup (for manual end-to-end contract check)
@@ -66,6 +68,8 @@ THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
 Optional remote/deploy gate check:
 
 ```bash
+# Optional n8n security-floor enforcement in remote/deploy-aware mode:
+# N8N_VERSION=1.123.17 python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)"
 python3 scripts/worktree_pr_guard.py --mode all --branch "$(git rev-parse --abbrev-ref HEAD)"
 ```
 

--- a/docs/system_audit/commit_evidence_2026-02-23_n8n-premerge-guard-integration.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_n8n-premerge-guard-integration.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-02-23",
+  "thread_branch": "codex/n8n-premerge-guard-integration",
+  "commit_scope": "Implement n8n minimum-version security gate in pre-merge guard and deploy validation scripts, add unit tests, and document standard workflow wiring for deploy/triage/runbook.",
+  "files_owned": [
+    "scripts/worktree_pr_guard.py",
+    "api/scripts/validate_pr_to_public.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "api/tests/test_validate_pr_to_public.py",
+    "docs/DEPLOY.md",
+    "docs/RUNBOOK.md",
+    "docs/PR-CHECK-FAILURE-TRIAGE.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "specs/108-n8n-security-and-hitl-hardening.md"
+  ],
+  "idea_ids": [
+    "coherence-network-overall"
+  ],
+  "spec_ids": [
+    "108-n8n-security-and-hitl-hardening",
+    "109-open-responses-interoperability-layer",
+    "110-langgraph-stateschema-adoption"
+  ],
+  "task_ids": [
+    "task-2026-02-23-n8n-security-floor-guard-wiring"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260223T161417Z_codex-n8n-premerge-guard-integration.json"
+  ],
+  "change_files": [
+    "AGENTS.md",
+    "api/scripts/validate_pr_to_public.py",
+    "api/tests/test_validate_pr_to_public.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/COMMUNITY-RESEARCH-PRIORITIES.md",
+    "docs/DEPLOY.md",
+    "docs/PR-CHECK-FAILURE-TRIAGE.md",
+    "docs/RUNBOOK.md",
+    "docs/SPEC-TRACKING.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/worktree_pr_guard.py",
+    "specs/006-overnight-backlog.md",
+    "specs/108-n8n-security-and-hitl-hardening.md",
+    "specs/109-open-responses-interoperability-layer.md",
+    "specs/110-langgraph-stateschema-adoption.md",
+    "docs/system_audit/commit_evidence_2026-02-23_n8n-premerge-guard-integration.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -v tests/test_worktree_pr_guard.py tests/test_validate_pr_to_public.py",
+      "python3 scripts/validate_spec_quality.py --file specs/108-n8n-security-and-hitl-hardening.md",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting local guard re-run, push, PR checks, and deploy verification."
+  }
+}

--- a/specs/006-overnight-backlog.md
+++ b/specs/006-overnight-backlog.md
@@ -90,3 +90,8 @@ Use: `./scripts/run_overnight_pipeline.sh --backlog specs/006-overnight-backlog.
 72. Add smoke test script: curl health, pipeline-status, create minimal task
 73. Consolidate duplicate logic between project_manager and overnight_orchestrator if any
 74. Expand docs/AGENT-DEBUGGING.md and docs/MODEL-ROUTING.md per recent work
+
+## Phase 8: Ecosystem Research Pulse (2026-02-23) — PRIORITY
+75. Implement spec 108-n8n-security-and-hitl-hardening: patch baseline + HITL guardrails for destructive actions
+76. Implement spec 109-open-responses-interoperability-layer: normalize provider execution via Open Responses-compatible adapter
+77. Implement spec 110-langgraph-stateschema-adoption: enforce graph state schema checks and deterministic failure diagnostics

--- a/specs/108-n8n-security-and-hitl-hardening.md
+++ b/specs/108-n8n-security-and-hitl-hardening.md
@@ -1,0 +1,59 @@
+# Spec: n8n Security Patch and HITL Hardening
+
+## Purpose
+
+Protect automation workflows from known critical exposure and reduce high-impact execution risk by enforcing a patched n8n baseline plus Human-in-the-loop (HITL) approval gates for sensitive agent actions.
+
+## Requirements
+
+- [ ] Runtime docs and deployment checks define a minimum supported n8n version at or above fixed security releases (`1.123.17` for v1 or `2.5.2` for v2).
+- [ ] Automation workflows require explicit HITL approval before executing destructive or external-impacting actions (for example: delete/write/send).
+- [ ] Security and workflow-edit permissions are documented with operational validation steps and evidence hooks.
+
+## API Contract (if applicable)
+
+N/A - no Coherence API contract changes in this spec.
+
+## Data Model (if applicable)
+
+N/A - no model changes in this spec.
+
+## Files to Create/Modify
+
+- `docs/DEPLOY.md` - add minimum n8n version contract and verification checklist.
+- `docs/RUNBOOK.md` - add HITL enforcement and operational recovery steps.
+- `docs/PR-CHECK-FAILURE-TRIAGE.md` - add n8n version/HITL validation path for deployment blockers.
+- `api/scripts/validate_pr_to_public.py` - add optional n8n minimum-version gate check for deploy validation.
+- `api/tests/test_validate_pr_to_public.py` - cover n8n version floor parser and gate behavior.
+
+## Acceptance Tests
+
+- `cd api && pytest -v tests/test_validate_pr_to_public.py`
+- `python3 scripts/validate_spec_quality.py --file specs/108-n8n-security-and-hitl-hardening.md`
+- Manual validation:
+  - Verify runtime/deploy target version is `>=1.123.17` (v1) or `>=2.5.2` (v2).
+  - Verify at least one destructive tool action is blocked until HITL approval is provided.
+
+## Verification
+
+```bash
+python3 scripts/validate_spec_quality.py --file specs/108-n8n-security-and-hitl-hardening.md
+```
+
+## Out of Scope
+
+- Migrating all existing workflows to n8n v2.
+- Replacing n8n with another orchestration system.
+
+## Risks and Assumptions
+
+- Risk: HITL prompts can increase completion latency; mitigate by scoping approval only to high-risk actions.
+- Assumption: deployment/runtime surfaces can reliably expose active n8n version for checks.
+
+## Known Gaps and Follow-up Tasks
+
+- Follow-up task: `task_n8n_credentials_patch_rotation_001` to automate secret rotation via credentials PATCH API.
+
+## Decision Gates (if any)
+
+- Confirm high-risk action classes that must always require HITL in production.

--- a/specs/109-open-responses-interoperability-layer.md
+++ b/specs/109-open-responses-interoperability-layer.md
@@ -1,0 +1,64 @@
+# Spec: Open Responses Interoperability Layer
+
+## Purpose
+
+Reduce provider lock-in and simplify model routing by introducing a normalized Open Responses interface in the agent execution path, so task execution can move across providers without per-provider payload rewrites.
+
+## Requirements
+
+- [ ] Add a provider-agnostic request/response adapter that can map current task execution payloads to Open Responses-compatible structures.
+- [ ] Ensure at least two providers can execute through the same normalized interface without task-level prompt rewrites.
+- [ ] Persist route and model evidence for each normalized call so operator audits can verify actual execution path.
+
+## API Contract (if applicable)
+
+N/A - no external API route changes required for initial adapter rollout.
+
+## Data Model (if applicable)
+
+```yaml
+NormalizedResponseCall:
+  properties:
+    task_id: { type: string }
+    provider: { type: string }
+    model: { type: string }
+    request_schema: { type: string, enum: [open_responses_v1] }
+    output_text: { type: string }
+```
+
+## Files to Create/Modify
+
+- `api/app/services/agent_service.py` - insert normalization path before provider execution.
+- `api/app/services/provider_usage_service.py` - persist normalized request schema + route evidence.
+- `api/app/models/schemas.py` - add normalized response call model.
+- `api/tests/test_agent.py` - add provider-agnostic routing assertions.
+
+## Acceptance Tests
+
+- `cd api && pytest -v tests/test_agent.py -k \"route or provider\"`
+- `cd api && pytest -v tests/test_inventory_api.py -k endpoint_traceability`
+- Manual validation: create two tasks with different providers and confirm normalized schema markers in runtime evidence output.
+
+## Verification
+
+```bash
+python3 scripts/validate_spec_quality.py --file specs/109-open-responses-interoperability-layer.md
+```
+
+## Out of Scope
+
+- Full migration of every legacy provider integration in one pass.
+- Changes to UI rendering for task output display.
+
+## Risks and Assumptions
+
+- Risk: provider-specific capabilities may not map 1:1; mitigation is additive provider extension fields.
+- Assumption: current agent execution contracts can be wrapped without breaking existing endpoint behavior.
+
+## Known Gaps and Follow-up Tasks
+
+- Follow-up task: `task_open_responses_tool_schema_parity_001` to normalize tool-call schema parity across providers.
+
+## Decision Gates (if any)
+
+- Decide whether normalization is required for all task types (`spec`, `test`, `impl`, `review`, `heal`) or phased by task type.

--- a/specs/110-langgraph-stateschema-adoption.md
+++ b/specs/110-langgraph-stateschema-adoption.md
@@ -1,0 +1,67 @@
+# Spec: LangGraph StateSchema Contract Adoption
+
+## Purpose
+
+Improve determinism and validation quality in graph-based agent orchestration by adopting explicit StateSchema/JSON Schema contracts for runtime state transitions.
+
+## Requirements
+
+- [ ] Define a canonical StateSchema for agent graph state with explicit required/optional fields.
+- [ ] Validate graph state transitions against JSON Schema before and after critical nodes.
+- [ ] Emit actionable error context when schema validation fails so retries/heal paths can trigger with clear causes.
+
+## API Contract (if applicable)
+
+N/A - no public API route changes in this spec.
+
+## Data Model (if applicable)
+
+```yaml
+AgentGraphState:
+  required: [task_id, task_type, phase, direction]
+  properties:
+    task_id: { type: string }
+    task_type: { type: string }
+    phase: { type: string }
+    direction: { type: string }
+    attempt: { type: integer }
+    model: { type: string }
+    provider: { type: string }
+    route_decision: { type: object }
+```
+
+## Files to Create/Modify
+
+- `api/app/services/agent_service.py` - apply schema checkpoints in orchestration flow.
+- `api/app/models/schemas.py` - add StateSchema-aligned graph state model.
+- `api/tests/test_agent.py` - add schema validation pass/fail coverage.
+- `docs/AGENT-ARCHITECTURE.md` - document graph-state contract and failure handling.
+
+## Acceptance Tests
+
+- `cd api && pytest -v tests/test_agent.py -k \"schema or state\"`
+- Manual validation: execute one valid task and one intentionally malformed task context; verify deterministic schema-failure diagnostics.
+
+## Verification
+
+```bash
+python3 scripts/validate_spec_quality.py --file specs/110-langgraph-stateschema-adoption.md
+```
+
+## Out of Scope
+
+- Rewriting the full orchestration pipeline in LangGraph.
+- UI-level visualization of graph state transitions.
+
+## Risks and Assumptions
+
+- Risk: strict schema checks may reject currently tolerated loose payloads; mitigate with phased strictness and migration logging.
+- Assumption: existing task context fields can be normalized without loss of required behavior.
+
+## Known Gaps and Follow-up Tasks
+
+- Follow-up task: `task_graph_state_schema_versioning_001` for schema version migration support.
+
+## Decision Gates (if any)
+
+- Decide strict-fail vs warn-and-coerce behavior for non-critical schema mismatches in production.


### PR DESCRIPTION
## Summary\n- add n8n minimum-version security floor checks to pre-merge guards and deploy validation\n- add targeted tests for n8n semver gate behavior\n- queue new ecosystem ROI specs (108-110) and link backlog/tracking/docs\n\n## Validation\n- make start-gate (initially blocked by dirty tree; remediated via branch+rebase flow)\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence\n- cd api && pytest -v tests/test_worktree_pr_guard.py tests/test_validate_pr_to_public.py\n