### PR TITLE
Hotfix: reduce agent task DB egress

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-02-23",
+  "thread_branch": "codex/db-egress-hotfix-20260223",
+  "commit_scope": "Reduce database egress from agent task APIs by avoiding full output blob reloads, adding DB reload TTL caching, and capping stored task output size.",
+  "files_owned": [
+    "api/app/services/agent_service.py",
+    "api/app/services/agent_task_store_service.py",
+    "api/tests/test_agent_task_persistence.py"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "003-agent-task-orchestration"
+  ],
+  "task_ids": [
+    "task-2026-02-23-db-egress-hotfix-1"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260223T160818Z_codex-db-egress-hotfix-20260223.json"
+  ],
+  "change_files": [
+    "api/app/services/agent_service.py",
+    "api/app/services/agent_task_store_service.py",
+    "api/tests/test_agent_task_persistence.py",
+    "docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && ruff check app/services/agent_service.py app/services/agent_task_store_service.py tests/test_agent_task_persistence.py",
+      "cd api && pytest -q tests/test_agent_task_persistence.py tests/test_agent_visibility_api.py tests/test_agent_usage_tracking_api.py tests/test_agent_runner_registry_api.py",
+      "cd api && pytest -q tests/test_agent_execute_endpoint.py",
+      "/opt/homebrew/bin/python3.14 scripts/worktree_pr_guard.py --mode local --base-ref origin/main --skip-api-tests --skip-web-build",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit/push, PR checks, and production verification of reduced DB egress."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Task list and usage endpoints avoid repeated full-table output blob hydration, reducing DB read bytes while preserving task detail retrieval.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/tasks?limit=20",
+      "https://coherence-network-production.up.railway.app/api/agent/usage",
+      "https://coherence-network-production.up.railway.app/api/agent/visibility"
+    ],
+    "test_flows": [
+      "Call task list/usage/visibility endpoints repeatedly and verify responses remain correct.",
+      "Verify GET /api/agent/tasks/{task_id} still returns output for completed tasks.",
+      "Compare post-deploy DB egress trend versus pre-deploy spike window."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n- avoid hydrating agent task output blobs on hot list/count/usage paths\n- add targeted single-task loading for detail routes\n- add bounded task output truncation and regression tests\n\n## Validation\n- make start-gate\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence\n- git push (pre-push hook ran full worktree_pr_guard local preflight incl. pytest -q)\n