### PR TITLE
Hotfix v2: further reduce agent task DB egress

### DIFF
--- a/api/app/services/agent_service.py
+++ b/api/app/services/agent_service.py
@@ -458,20 +458,20 @@ def _persistence_enabled() -> bool:
 
 
 def _db_store_reload_ttl_seconds() -> float:
-    raw = os.getenv("AGENT_TASKS_DB_RELOAD_TTL_SECONDS", "15").strip()
+    raw = os.getenv("AGENT_TASKS_DB_RELOAD_TTL_SECONDS", "30").strip()
     try:
         value = float(raw)
     except ValueError:
-        value = 15.0
+        value = 30.0
     return max(0.0, min(value, 300.0))
 
 
 def _max_task_output_chars() -> int:
-    raw = os.getenv("AGENT_TASK_OUTPUT_MAX_CHARS", "20000").strip()
+    raw = os.getenv("AGENT_TASK_OUTPUT_MAX_CHARS", "4000").strip()
     try:
         value = int(raw)
     except ValueError:
-        value = 20000
+        value = 4000
     return max(500, min(value, 200000))
 
 
@@ -1114,7 +1114,7 @@ def _runtime_fallback_events_for_tasks(existing_count: int) -> list[Any]:
 
         runtime_fallback_limit = max(
             50,
-            min(int(os.getenv("AGENT_TASKS_RUNTIME_FALLBACK_LIMIT", "500")), 5000),
+            min(int(os.getenv("AGENT_TASKS_RUNTIME_FALLBACK_LIMIT", "200")), 5000),
         )
         return runtime_service.list_events(limit=runtime_fallback_limit)
     except Exception:

--- a/docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix-v2.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix-v2.json
@@ -1,0 +1,73 @@
+{
+  "date": "2026-02-23",
+  "thread_branch": "codex/db-egress-hotfix-20260223",
+  "commit_scope": "Second-pass DB egress reduction by lowering default task output retention and increasing DB task-store reload cache TTL to reduce repeated read amplification under polling.",
+  "files_owned": [
+    "api/app/services/agent_service.py"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "003-agent-task-orchestration"
+  ],
+  "task_ids": [
+    "task-2026-02-23-db-egress-hotfix-2"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260223T163214Z_codex-db-egress-hotfix-20260223.json"
+  ],
+  "change_files": [
+    "api/app/services/agent_service.py",
+    "docs/system_audit/commit_evidence_2026-02-23_db-egress-hotfix-v2.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && ruff check app/services/agent_service.py",
+      "cd api && pytest -q tests/test_agent_task_persistence.py tests/test_agent_usage_tracking_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit/push, PR checks, and production measurements for second-pass egress reduction."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Task-store DB read cadence drops via longer TTL and new large outputs are retained at a smaller bounded size, reducing ongoing DB egress pressure.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/tasks?limit=20",
+      "https://coherence-network-production.up.railway.app/api/agent/usage"
+    ],
+    "test_flows": [
+      "Verify task list endpoint remains healthy under repeated polling.",
+      "Verify task detail endpoint still returns output for completed tasks.",
+      "Observe post-deploy task endpoint payload/time trends for reduced DB pressure."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n- increase DB task-store reload cache TTL default from 15s to 30s\n- reduce default retained task output cap from 20k chars to 4k\n- lower runtime fallback event scan default from 500 to 200\n\n## Validation\n- cd api && ruff check app/services/agent_service.py\n- cd api && pytest -q tests/test_agent_task_persistence.py tests/test_agent_usage_tracking_api.py\n- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence\n- git push (pre-push hook ran full worktree_pr_guard local preflight incl. pytest -q)\n