### PR TITLE
Fix Codex api-key env injection for hosted self-improve

### DIFF
--- a/api/tests/test_agent_runner_tool_failure_telemetry.py
+++ b/api/tests/test_agent_runner_tool_failure_telemetry.py
@@ -432,6 +432,28 @@ def test_configure_codex_cli_environment_uses_admin_key_when_primary_missing(mon
     assert env.get("OPENAI_API_KEY") == "admin-only-key"
 
 
+def test_configure_codex_cli_environment_overrides_blank_api_key_env(monkeypatch):
+    monkeypatch.setenv("AGENT_CODEX_AUTH_MODE", "api_key")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-non-empty")
+
+    env = {
+        "OPENAI_API_KEY": "",
+        "OPENAI_API_BASE": "",
+        "OPENAI_BASE_URL": "",
+    }
+    auth = agent_runner._configure_codex_cli_environment(
+        env=env,
+        task_id="task_blank_api_key_env",
+        log=agent_runner._setup_logging(verbose=False),
+    )
+
+    assert auth["effective_mode"] == "api_key"
+    assert auth["api_key_present"] is True
+    assert env.get("OPENAI_API_KEY") == "sk-non-empty"
+    assert env.get("OPENAI_API_BASE") == "https://api.openai.com/v1"
+    assert env.get("OPENAI_BASE_URL") == "https://api.openai.com/v1"
+
+
 def test_configure_codex_cli_environment_respects_task_auth_override(monkeypatch, tmp_path):
     session_file = tmp_path / "codex-auth.json"
     session_file.write_text('{"token":"test"}', encoding="utf-8")

--- a/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-02-23",
   "thread_branch": "codex/self-improve-e2e-proof",
-  "commit_scope": "Unblock hosted self-improve execution by forcing self-improve task payloads to request runner_codex_auth_mode=api_key, while preserving prior Codex fallback/argv/home-isolation/admin-key fixes.",
+  "commit_scope": "Unblock hosted self-improve execution by forcing self-improve task payloads to request runner_codex_auth_mode=api_key and ensuring agent runner overwrites blank OPENAI_API_KEY env values when API-key auth is selected.",
   "files_owned": [
     "api/scripts/run_self_improve_cycle.py",
     "api/tests/test_run_self_improve_cycle.py",
@@ -20,7 +20,8 @@
     "task-2026-02-23-self-improve-codex-shell-expansion-fix",
     "task-2026-02-23-self-improve-codex-api-key-home-isolation",
     "task-2026-02-23-self-improve-admin-key-fallback",
-    "task-2026-02-23-self-improve-force-api-key-context"
+    "task-2026-02-23-self-improve-force-api-key-context",
+    "task-2026-02-23-self-improve-blank-openai-key-env-fix"
   ],
   "contributors": [
     {


### PR DESCRIPTION
## Summary
- force non-empty `OPENAI_API_KEY` injection when runner selects Codex `api_key` auth mode
- stop preserving blank `OPENAI_API_KEY` values that caused `401 Missing bearer`
- add regression test for blank inherited env values

## Validation
- cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py
- cd api && pytest -q tests/test_run_self_improve_cycle.py
- cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py scripts/run_self_improve_cycle.py tests/test_run_self_improve_cycle.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-23_self-improve-codex-auth-fallback.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
