### PR TITLE
Unblock self-improve by remapping codex model aliases

### DIFF
--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -243,9 +243,10 @@ _last_idle_task_generation_ts = 0.0
 TaskRunItem = tuple[str, str, str, str, dict[str, Any], str, bool]
 DEFAULT_CODEX_MODEL_ALIAS_MAP = (
     "openrouter/free:gpt-5-codex,"
-    "gpt-5.3-codex-spark:gpt-5.3-codex,"
-    "gtp-5.3-codex-spark:gpt-5.3-codex,"
-    "gtp-5.3-codex:gpt-5.3-codex"
+    "gpt-5.3-codex:gpt-5-codex,"
+    "gpt-5.3-codex-spark:gpt-5-codex,"
+    "gtp-5.3-codex:gpt-5-codex,"
+    "gtp-5.3-codex-spark:gpt-5-codex"
 )
 DEFAULT_CODEX_MODEL_NOT_FOUND_FALLBACK_MAP = (
     "gpt-5.3-codex:gpt-5-codex,"

--- a/api/tests/test_agent_runner_tool_failure_telemetry.py
+++ b/api/tests/test_agent_runner_tool_failure_telemetry.py
@@ -219,9 +219,9 @@ def test_apply_codex_model_alias_supports_gtp_typo_default_map():
     )
     assert alias == {
         "requested_model": "gtp-5.3-codex",
-        "effective_model": "gpt-5.3-codex",
+        "effective_model": "gpt-5-codex",
     }
-    assert "--model gpt-5.3-codex" in remapped
+    assert "--model gpt-5-codex" in remapped
     assert "--model gtp-5.3-codex" not in remapped
 
 
@@ -244,9 +244,9 @@ def test_apply_codex_model_alias_merges_defaults_with_partial_env_map(monkeypatc
     )
     assert alias == {
         "requested_model": "gtp-5.3-codex",
-        "effective_model": "gpt-5.3-codex",
+        "effective_model": "gpt-5-codex",
     }
-    assert "--model gpt-5.3-codex" in remapped
+    assert "--model gpt-5-codex" in remapped
     assert "--model gtp-5.3-codex" not in remapped
 
 
@@ -283,6 +283,8 @@ def test_run_one_task_schedules_model_not_found_fallback_retry(monkeypatch, tmp_
     monkeypatch.setenv("AGENT_WORKER_ID", "openai-codex:test-runner")
     monkeypatch.delenv("AGENT_CODEX_MODEL_ALIAS_MAP", raising=False)
     monkeypatch.delenv("AGENT_CODEX_MODEL_NOT_FOUND_FALLBACK_MAP", raising=False)
+    # Force model-not-found path to exercise retry fallback logic (bypass default alias remap).
+    monkeypatch.setattr(agent_runner, "_codex_model_alias_map", lambda: {})
 
     def _popen(*args, **kwargs):
         return _Proc(

--- a/docs/system_audit/commit_evidence_2026-02-24_self-improve-model-alias-unblock.json
+++ b/docs/system_audit/commit_evidence_2026-02-24_self-improve-model-alias-unblock.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-02-24",
+  "thread_branch": "codex/minimal-self-improve-unblock",
+  "commit_scope": "Unblock production self-improve Codex execution by remapping gpt-5.3-codex model aliases directly to gpt-5-codex and preserving fallback retry test coverage.",
+  "files_owned": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-model-alias-unblock.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "096-provider-readiness-contract-automation"
+  ],
+  "task_ids": [
+    "task-2026-02-24-self-improve-model-alias-unblock"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-model-alias-unblock.json",
+    "https://github.com/seeker71/Coherence-Network/actions/runs/22339734149"
+  ],
+  "change_files": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-model-alias-unblock.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py tests/test_run_self_improve_cycle.py",
+      "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting production self-improve run artifact showing completed cycle with stage evidence after alias fix deploy."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Production runner no longer attempts unavailable gpt-5.3-codex for self-improve tasks and instead executes with gpt-5-codex-compatible alias path.",
+    "public_endpoints": [
+      "/api/agent/tasks",
+      "/api/health",
+      "/api/gates/main-head"
+    ],
+    "test_flows": [
+      "Submit self-improve-like spec task with model_override gpt-5.3-codex and confirm no missing-bearer signature.",
+      "Confirm runner context shows api-key bootstrap auth and task progresses past initial model availability failure path.",
+      "Run Self Improve Cycle on main and confirm report status completed with stage entries."
+    ]
+  }
+}


### PR DESCRIPTION
## Goal
Finish unblocking self-improve in production after auth-path fix deploy.

## Change
- Default Codex alias map now routes `gpt-5.3-codex*` and typo variants directly to `gpt-5-codex`.
- Keeps model-not-found fallback logic, but avoids first-attempt hard fail on unavailable model names.
- Updates alias/fallback tests accordingly.

## Why
Production auth failures are resolved; current blocker is model availability (`gpt-5.3-codex` unavailable). This patch removes that blocker in the default execution path.
