### PR TITLE
Enforce mandatory codex remap for self-improve

### DIFF
--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -248,6 +248,12 @@ DEFAULT_CODEX_MODEL_ALIAS_MAP = (
     "gtp-5.3-codex:gpt-5-codex,"
     "gtp-5.3-codex-spark:gpt-5-codex"
 )
+MANDATORY_CODEX_MODEL_ALIAS_MAP = {
+    "gpt-5.3-codex": "gpt-5-codex",
+    "gpt-5.3-codex-spark": "gpt-5-codex",
+    "gtp-5.3-codex": "gpt-5-codex",
+    "gtp-5.3-codex-spark": "gpt-5-codex",
+}
 DEFAULT_CODEX_MODEL_NOT_FOUND_FALLBACK_MAP = (
     "gpt-5.3-codex:gpt-5-codex,"
     "gpt-5.3-codex-spark:gpt-5-codex,"
@@ -2976,7 +2982,10 @@ def _apply_codex_model_alias(command: str) -> tuple[str, dict[str, str] | None]:
     requested_model = _codex_command_model(command)
     if not requested_model:
         return command, None
-    target_model = _codex_model_alias_map().get(requested_model.lower(), "").strip()
+    requested_model_key = requested_model.lower()
+    target_model = MANDATORY_CODEX_MODEL_ALIAS_MAP.get(requested_model_key, "").strip()
+    if not target_model:
+        target_model = _codex_model_alias_map().get(requested_model_key, "").strip()
     if not target_model or target_model.lower() == requested_model.lower():
         return command, None
     match = CODEX_MODEL_ARG_RE.search(command or "")

--- a/docs/system_audit/commit_evidence_2026-02-24_self-improve-mandatory-model-remap.json
+++ b/docs/system_audit/commit_evidence_2026-02-24_self-improve-mandatory-model-remap.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-02-24",
+  "thread_branch": "codex/minimal-self-improve-unblock",
+  "commit_scope": "Enforce non-bypassable Codex model remap for gpt-5.3-codex variants to gpt-5-codex to prevent runtime fallback races from reusing unavailable model identifiers in self-improve tasks.",
+  "files_owned": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-mandatory-model-remap.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "096-provider-readiness-contract-automation"
+  ],
+  "task_ids": [
+    "task-2026-02-24-self-improve-mandatory-model-remap"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-mandatory-model-remap.json",
+    "https://github.com/seeker71/Coherence-Network/actions/runs/22339901527"
+  ],
+  "change_files": [
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "docs/system_audit/commit_evidence_2026-02-24_self-improve-mandatory-model-remap.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_runner_tool_failure_telemetry.py tests/test_run_self_improve_cycle.py",
+      "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting production self-improve run completion proof after mandatory remap deploy."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Self-improve Codex invocations cannot execute with unavailable gpt-5.3-codex variants even when environment alias configuration is stale or conflicting.",
+    "public_endpoints": [
+      "/api/agent/tasks",
+      "/api/health",
+      "/api/gates/main-head"
+    ],
+    "test_flows": [
+      "Submit self-improve-like task with model override gpt-5.3-codex and verify command remaps to gpt-5-codex path.",
+      "Confirm runner output/context no longer stalls at repeated gpt-5.3-codex missing-model failures without remap.",
+      "Run Self Improve Cycle on main and verify completed status with stage evidence."
+    ]
+  }
+}


### PR DESCRIPTION
Mandatory remap for unavailable gpt-5.3-codex variants to gpt-5-codex to prevent model-availability retry loops in self-improve production runs.