### PR TITLE
Reduce flow/usage endpoint DB egress with compact payload controls

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,7 +5,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 
-from fastapi import FastAPI, HTTPException, Header, Request
+from fastapi import FastAPI, HTTPException, Header, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from sqlalchemy import text
@@ -451,9 +451,9 @@ async def _prime_hot_caches() -> None:
         contribution_payload_rows: list[dict] = []
         asset_payload_rows: list[dict] = []
         if store is not None:
-            contributor_payload_rows = [item.model_dump(mode="json") for item in store.list_contributors(limit=2000)]
-            contribution_payload_rows = [item.model_dump(mode="json") for item in store.list_contributions(limit=2000)]
-            asset_payload_rows = [item.model_dump(mode="json") for item in store.list_assets(limit=2000)]
+            contributor_payload_rows = [item.model_dump(mode="json") for item in store.list_contributors(limit=300)]
+            contribution_payload_rows = [item.model_dump(mode="json") for item in store.list_contributions(limit=600)]
+            asset_payload_rows = [item.model_dump(mode="json") for item in store.list_assets(limit=300)]
             contributor_rows = len(contributor_payload_rows)
             contribution_rows = len(contribution_payload_rows)
             asset_rows = len(asset_payload_rows)
@@ -464,11 +464,12 @@ async def _prime_hot_caches() -> None:
                 contributor_rows=contributor_payload_rows,
                 contribution_rows=contribution_payload_rows,
                 asset_rows=asset_payload_rows,
-                spec_registry_limit=200,
-                lineage_link_limit=300,
-                usage_event_limit=1200,
-                commit_evidence_limit=500,
-                runtime_event_limit=2000,
+                spec_registry_limit=160,
+                lineage_link_limit=180,
+                usage_event_limit=350,
+                commit_evidence_limit=200,
+                runtime_event_limit=600,
+                list_item_limit=12,
             )
             if not isinstance(flow_payload, dict):
                 flow_payload = {}

--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -10,8 +10,17 @@ router = APIRouter()
 
 
 @router.get("/automation/usage")
-async def get_automation_usage(force_refresh: bool = Query(False)) -> dict:
+async def get_automation_usage(
+    force_refresh: bool = Query(False),
+    compact: bool = Query(False, description="Return a trimmed payload for lower-bandwidth clients"),
+    include_raw: bool = Query(False, description="Include provider raw payload in compact mode"),
+) -> dict:
     overview = automation_usage_service.collect_usage_overview(force_refresh=force_refresh)
+    if compact:
+        return automation_usage_service.compact_usage_overview_payload(
+            overview,
+            include_raw=include_raw,
+        )
     return overview.model_dump(mode="json")
 
 

--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -249,14 +249,15 @@ def spec_process_implementation_validation_flow(
     request: Request,
     idea_id: str | None = Query(default=None),
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
-    contributor_limit: int = Query(500, ge=1, le=10000),
-    contribution_limit: int = Query(2000, ge=1, le=20000),
-    asset_limit: int = Query(500, ge=1, le=10000),
-    spec_limit: int = Query(200, ge=1, le=2000),
-    lineage_link_limit: int = Query(300, ge=1, le=1000),
-    usage_event_limit: int = Query(1200, ge=1, le=5000),
-    commit_evidence_limit: int = Query(500, ge=1, le=3000),
-    runtime_event_limit: int = Query(2000, ge=1, le=5000),
+    contributor_limit: int = Query(120, ge=1, le=10000),
+    contribution_limit: int = Query(300, ge=1, le=20000),
+    asset_limit: int = Query(120, ge=1, le=10000),
+    spec_limit: int = Query(160, ge=1, le=2000),
+    lineage_link_limit: int = Query(180, ge=1, le=1000),
+    usage_event_limit: int = Query(350, ge=1, le=5000),
+    commit_evidence_limit: int = Query(200, ge=1, le=3000),
+    runtime_event_limit: int = Query(600, ge=1, le=5000),
+    list_item_limit: int = Query(12, ge=1, le=200),
 ) -> dict:
     store = get_store(request)
     contributor_rows = [item.model_dump(mode="json") for item in store.list_contributors(limit=contributor_limit)]
@@ -273,6 +274,7 @@ def spec_process_implementation_validation_flow(
         usage_event_limit=usage_event_limit,
         commit_evidence_limit=commit_evidence_limit,
         runtime_event_limit=runtime_event_limit,
+        list_item_limit=list_item_limit,
     )
 
 

--- a/docs/system_audit/commit_evidence_2026-02-24_flow-usage-egress-efficiency.json
+++ b/docs/system_audit/commit_evidence_2026-02-24_flow-usage-egress-efficiency.json
@@ -1,0 +1,92 @@
+{
+  "date": "2026-02-24",
+  "thread_branch": "codex/db-endpoint-efficiency-20260224-clean",
+  "commit_scope": "Reduce DB egress pressure from flow and automation-usage endpoints by adding bounded payload controls, smaller default scan limits, compact client requests, and stronger cache behavior.",
+  "files_owned": [
+    "api/app/main.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/routers/inventory.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/automation/page.tsx",
+    "web/lib/egress.ts"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "088-flow-endpoint-lineage-and-tracking",
+    "100-provider-usage-readiness-hard-data"
+  ],
+  "task_ids": [
+    "task-2026-02-24-flow-usage-egress-efficiency"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260224T082642Z_codex-db-endpoint-efficiency-20260224-clean.json"
+  ],
+  "change_files": [
+    "api/app/main.py",
+    "api/app/routers/automation_usage.py",
+    "api/app/routers/inventory.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/inventory_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "api/tests/test_inventory_api.py",
+    "web/app/automation/page.tsx",
+    "web/lib/egress.ts",
+    "docs/system_audit/commit_evidence_2026-02-24_flow-usage-egress-efficiency.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_automation_usage_api.py -k \"automation_usage_endpoint_returns_normalized_providers or automation_usage_endpoint_compact_mode_trims_payload\"",
+      "cd api && pytest -q tests/test_inventory_api.py -k \"flow_endpoint_forwards_list_item_limit or flow_inventory_includes_end_to_end_tracking_chain\"",
+      "cd api && ruff check app/main.py app/routers/inventory.py app/services/automation_usage_service.py app/services/inventory_service.py tests/test_automation_usage_api.py tests/test_inventory_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit/push, PR checks, deploy, and post-deploy egress measurements for flow and usage endpoints."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Flow and automation usage responses return materially smaller payloads by default and for compact clients, while retaining required operational metrics.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/inventory/flow",
+      "https://coherence-network-production.up.railway.app/api/automation/usage",
+      "https://coherence-network-production.up.railway.app/api/automation/usage?compact=true"
+    ],
+    "test_flows": [
+      "Measure response size and latency for /api/inventory/flow with default and explicit list_item_limit values.",
+      "Measure response size and payload composition for /api/automation/usage baseline vs compact=true.",
+      "Verify flow and automation web pages render correctly with reduced endpoint payloads."
+    ]
+  }
+}

--- a/web/app/automation/page.tsx
+++ b/web/app/automation/page.tsx
@@ -148,7 +148,7 @@ const DEFAULT_VALIDATION: ProviderValidationResponse = {
 
 async function fetchJsonOrDefault<T>(url: string, fallback: T): Promise<T> {
   try {
-    const response = await fetch(url, { cache: "no-store" });
+    const response = await fetch(url, { cache: "force-cache" });
     if (!response.ok) {
       return fallback;
     }
@@ -170,7 +170,7 @@ async function loadAutomationData(): Promise<{
     min_execution_events: "1",
   });
   const [usage, alerts, readiness, validation] = await Promise.all([
-    fetchJsonOrDefault<AutomationUsageResponse>(`${api}/api/automation/usage`, DEFAULT_USAGE),
+    fetchJsonOrDefault<AutomationUsageResponse>(`${api}/api/automation/usage?compact=true`, DEFAULT_USAGE),
     fetchJsonOrDefault<UsageAlertResponse>(`${api}/api/automation/usage/alerts?threshold_ratio=0.2`, DEFAULT_ALERTS),
     fetchJsonOrDefault<ProviderReadinessResponse>(`${api}/api/automation/usage/readiness`, DEFAULT_READINESS),
     fetchJsonOrDefault<ProviderValidationResponse>(

--- a/web/lib/egress.ts
+++ b/web/lib/egress.ts
@@ -6,14 +6,15 @@ const UI_SYSTEM_LINEAGE_LIMITS = {
   runtime_event_limit: 300,
 } as const;
 const UI_FLOW_LIMITS = {
-  contributor_limit: 150,
-  contribution_limit: 400,
-  asset_limit: 200,
-  spec_limit: 120,
-  lineage_link_limit: 120,
-  usage_event_limit: 300,
-  commit_evidence_limit: 120,
-  runtime_event_limit: 300,
+  contributor_limit: 80,
+  contribution_limit: 160,
+  asset_limit: 80,
+  spec_limit: 160,
+  lineage_link_limit: 160,
+  usage_event_limit: 220,
+  commit_evidence_limit: 80,
+  runtime_event_limit: 220,
+  list_item_limit: 10,
 } as const;
 
 export const UI_CONTRIBUTOR_LIMIT = 150;


### PR DESCRIPTION
## Summary
- add compact-mode support to `/api/automation/usage` and use compact mode from web automation page
- bound expensive flow payload lists via `list_item_limit`, lower flow aggregation defaults, and forward limit controls in router/UI params
- reduce automation runtime-event scan volume with bounded cached windows and configurable scan caps
- tighten startup flow-cache warm limits to avoid oversized cold-start reads
- add regression tests for compact usage payload trimming and flow `list_item_limit` forwarding

## Validation
- `cd api && pytest -q tests/test_automation_usage_api.py -k "automation_usage_endpoint_returns_normalized_providers or automation_usage_endpoint_compact_mode_trims_payload"`
- `cd api && pytest -q tests/test_inventory_api.py -k "flow_endpoint_forwards_list_item_limit or flow_inventory_includes_end_to_end_tracking_chain"`
- `cd api && ruff check app/main.py app/routers/inventory.py app/services/automation_usage_service.py app/services/inventory_service.py tests/test_automation_usage_api.py tests/test_inventory_api.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
