### PR TITLE
Fix start-gate owner mapping for External Tools Audit

### DIFF
--- a/config/start_gate_workflow_owners.json
+++ b/config/start_gate_workflow_owners.json
@@ -1,7 +1,9 @@
 {
   "workflow_owners": {
     ".github/workflows/self-improve-cycle.yml": "@seeker71",
+    ".github/workflows/external-tools-audit.yml": "@seeker71",
     "Self Improve Cycle": "@seeker71",
+    "External Tools Audit": "@seeker71",
     "Maintainability Architecture Audit": "@seeker71",
     "Public Deploy Contract": "@seeker71",
     "Auto Heal Deploy Gates": "@seeker71",

--- a/docs/system_audit/commit_evidence_2026-02-24_start-gate-external-tools-owner-fix.json
+++ b/docs/system_audit/commit_evidence_2026-02-24_start-gate-external-tools-owner-fix.json
@@ -1,0 +1,64 @@
+{
+  "date": "2026-02-24",
+  "thread_branch": "codex/start-gate-external-tools-owner-20260224-f489",
+  "commit_scope": "Unblock worktree initialization by adding missing owner mapping for External Tools Audit in start-gate workflow owners config.",
+  "files_owned": [
+    "config/start_gate_workflow_owners.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "006-overnight-backlog"
+  ],
+  "task_ids": [
+    "task-2026-02-24-start-gate-owner-fix"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "https://github.com/seeker71/Coherence-Network/actions/runs/22345229221"
+  ],
+  "change_files": [
+    "config/start_gate_workflow_owners.json",
+    "docs/system_audit/commit_evidence_2026-02-24_start-gate-external-tools-owner-fix.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "START_GATE_ENFORCE_REMOTE_FAILURES=0 START_GATE_REQUIRE_PRIMARY_CLEAN=0 make start-gate"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit and propagation of owner mapping to main."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "start-gate no longer blocks worktree init on missing owner mapping for External Tools Audit.",
+    "public_endpoints": [],
+    "test_flows": []
+  }
+}


### PR DESCRIPTION
## Summary
- add missing owner mapping for `External Tools Audit` in `config/start_gate_workflow_owners.json`
- add commit evidence record for the unblock change

## Why
Fresh worktree init failed at `make start-gate` with:
`blocking main workflow failures missing owner mapping: External Tools Audit`

## Validation
- `START_GATE_ENFORCE_REMOTE_FAILURES=0 START_GATE_REQUIRE_PRIMARY_CLEAN=0 make start-gate`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
