### PR TITLE
start-gate: enforce workflow owner coverage and resilient fetch/deploy checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Spec → Test → Implement → CI → Review → Merge
      - Owner mappings for blocking workflows must exist in `config/start_gate_workflow_owners.json`.
      - Waivers are short-lived and must be removed after root-cause repair.
 3. Pre-commit local gate (required)
-   - Run: `git fetch origin main && git rebase origin/main` (must be cleanly rebased before push)
+   - Run: `./scripts/fetch_origin_main.sh && git rebase origin/main` (must be cleanly rebased before push)
    - Run: `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
    - Run: `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
    - If either fails, do not commit.
@@ -142,7 +142,7 @@ Spec → Test → Implement → CI → Review → Merge
 make start-gate
 
 # Worktree setup for Codex thread start
-git fetch origin main
+./scripts/fetch_origin_main.sh
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
 make start-gate

--- a/config/start_gate_workflow_owners.json
+++ b/config/start_gate_workflow_owners.json
@@ -11,7 +11,10 @@
     "Test": "@seeker71",
     "CI": "@seeker71",
     "Change Contract": "@seeker71",
-    "Thread Gates": "@seeker71",
-    "Test": "@seeker71"
+    "PR Check Failure Triage": "@seeker71",
+    "Asset Modularity Drift Audit": "@seeker71",
+    "Update External Asset Values": "@seeker71",
+    "Provider Readiness Contract": "@seeker71",
+    "Auto-Track Contributions": "@seeker71"
   }
 }

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -29,7 +29,7 @@ Non-negotiable:
 Minimum startup sequence:
 
 ```bash
-git fetch origin main
+./scripts/fetch_origin_main.sh
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
 git pull --ff-only origin main

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -14,7 +14,7 @@ Purpose: remove repeated setup mistakes by making every Codex/Claude thread foll
 From primary workspace:
 
 ```bash
-git fetch origin main
+./scripts/fetch_origin_main.sh
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 ```
 
@@ -50,7 +50,7 @@ make install-pre-push-hook
 Always rebase to latest main first:
 
 ```bash
-git fetch origin main
+./scripts/fetch_origin_main.sh
 git rebase origin/main
 ```
 

--- a/docs/system_audit/commit_evidence_2026-02-25_start-gate-deploy-resilience.json
+++ b/docs/system_audit/commit_evidence_2026-02-25_start-gate-deploy-resilience.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-02-25",
+  "thread_branch": "codex/start-gate-deploy-resilience-20260225",
+  "commit_scope": "Harden thread start/deploy verification reliability: add network-aware fetch preflight, enforce declared workflow owner mappings in start-gate, and add transient HTTP retry/backoff to deploy verification.",
+  "files_owned": [
+    "AGENTS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "scripts/fetch_origin_main.sh",
+    "scripts/start_gate.py",
+    "config/start_gate_workflow_owners.json",
+    "scripts/verify_web_api_deploy.sh",
+    "docs/system_audit/commit_evidence_2026-02-25_start-gate-deploy-resilience.json"
+  ],
+  "local_validation": {
+    "status": "pass"
+  },
+  "ci_validation": {
+    "status": "pending"
+  },
+  "deploy_validation": {
+    "status": "pass"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "start-gate-network-resilience",
+    "workflow-owner-map-completeness",
+    "deploy-verify-transient-retry"
+  ],
+  "spec_ids": [
+    "014"
+  ],
+  "task_ids": [
+    "task_start_gate_owner_coverage",
+    "task_fetch_preflight_network_guard",
+    "task_deploy_verify_retry_hardening"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "requester",
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "git fetch origin main && git rebase origin/main",
+    "./scripts/fetch_origin_main.sh",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+    "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+    "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-25_start-gate-deploy-resilience.json",
+    "./scripts/verify_web_api_deploy.sh"
+  ],
+  "change_files": [
+    "AGENTS.md",
+    "config/start_gate_workflow_owners.json",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/start_gate.py",
+    "scripts/verify_web_api_deploy.sh",
+    "scripts/fetch_origin_main.sh"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/fetch_origin_main.sh
+++ b/scripts/fetch_origin_main.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FETCH_ALLOW_STALE_MAIN="${FETCH_ALLOW_STALE_MAIN:-0}"
+
+has_cached_origin_main() {
+  git show-ref --verify --quiet "refs/remotes/origin/main"
+}
+
+network_preflight() {
+  python3 - <<'PY'
+import socket
+import sys
+
+host = "github.com"
+port = 443
+
+try:
+    socket.getaddrinfo(host, port)
+except Exception as exc:
+    print(f"fetch-origin-main: network preflight failed (dns): {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(5.0)
+try:
+    sock.connect((host, port))
+except Exception as exc:
+    print(f"fetch-origin-main: network preflight failed (tcp): {exc}", file=sys.stderr)
+    raise SystemExit(3)
+finally:
+    sock.close()
+PY
+}
+
+is_network_error() {
+  local text="$1"
+  [[ "$text" == *"Could not resolve host"* ]] || \
+    [[ "$text" == *"Failed to connect"* ]] || \
+    [[ "$text" == *"Connection timed out"* ]] || \
+    [[ "$text" == *"No route to host"* ]] || \
+    [[ "$text" == *"Name or service not known"* ]]
+}
+
+if ! network_preflight; then
+  if [[ "$FETCH_ALLOW_STALE_MAIN" == "1" ]] && has_cached_origin_main; then
+    echo "fetch-origin-main: warning: network unavailable; using cached refs/remotes/origin/main"
+    exit 0
+  fi
+  echo "fetch-origin-main: ERROR: cannot reach GitHub; aborting fetch."
+  echo "fetch-origin-main: hint: restore network or rerun with FETCH_ALLOW_STALE_MAIN=1 to proceed with cached origin/main."
+  exit 1
+fi
+
+fetch_output=""
+if ! fetch_output="$(git fetch origin main 2>&1)"; then
+  echo "$fetch_output" >&2
+  if is_network_error "$fetch_output"; then
+    if [[ "$FETCH_ALLOW_STALE_MAIN" == "1" ]] && has_cached_origin_main; then
+      echo "fetch-origin-main: warning: git fetch failed due to network; using cached refs/remotes/origin/main"
+      exit 0
+    fi
+    echo "fetch-origin-main: ERROR: git fetch failed due to network."
+    echo "fetch-origin-main: hint: restore network or rerun with FETCH_ALLOW_STALE_MAIN=1."
+  fi
+  exit 1
+fi
+
+echo "$fetch_output"
+echo "fetch-origin-main: ok"


### PR DESCRIPTION
## Summary
- add `scripts/fetch_origin_main.sh` with network preflight and stale-ref fallback option
- update docs and AGENTS pre-commit guidance to use the fetch helper
- enforce owner mappings for declared GitHub workflow names in `scripts/start_gate.py`
- harden `scripts/verify_web_api_deploy.sh` with retry/backoff for transient HTTP/request failures
- add commit evidence JSON for this change

## Validation
- `make start-gate`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-25_start-gate-deploy-resilience.json`
- `python3 -m py_compile scripts/start_gate.py`
- `bash -n scripts/verify_web_api_deploy.sh`
- `bash -n scripts/fetch_origin_main.sh`