### PR TITLE
Expose API deployed SHA and harden deploy freshness checks

### DIFF
--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -33,6 +33,17 @@ async def test_health_returns_ok():
 
 
 @pytest.mark.asyncio
+async def test_health_exposes_deployed_sha_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123sha")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/api/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deployed_sha"] == "abc123sha"
+        assert data["deployed_sha_source"] == "RAILWAY_GIT_COMMIT_SHA"
+
+
+@pytest.mark.asyncio
 async def test_ready_returns_ready_when_store_exists(monkeypatch: pytest.MonkeyPatch):
     """GET /api/ready returns 200 when graph_store is set."""
     # Keep this baseline readiness check independent of caller environment variables.

--- a/api/tests/test_release_gate_service.py
+++ b/api/tests/test_release_gate_service.py
@@ -867,6 +867,151 @@ def test_public_deploy_contract_allows_unknown_web_proxy_sha_with_warning(monkey
     assert "railway_web_health_proxy_unknown_sha" in report.get("warnings", [])
 
 
+def test_public_deploy_contract_warns_when_api_health_sha_unknown(monkeypatch) -> None:
+    expected_sha = "h" * 40
+    monkeypatch.delenv("PUBLIC_DEPLOY_REQUIRE_API_HEALTH_SHA", raising=False)
+    monkeypatch.setattr(gates, "get_branch_head_sha", lambda *args, **kwargs: expected_sha)
+
+    def _check_http_json(url: str, timeout: float = 8.0) -> dict[str, object]:
+        if url.endswith("/api/health"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"status": "ok"},
+            }
+        if url.endswith("/api/gates/main-head"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"sha": expected_sha},
+            }
+        if url.endswith("/api/health-proxy"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"api": {"status": "ok"}, "web": {"updated_at": expected_sha}},
+            }
+        if url.endswith("/openapi.json"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {
+                    "paths": {
+                        "/api/agent/tasks/{task_id}/execute": {
+                            "post": {
+                                "parameters": [
+                                    {"name": "X-Force-Paid-Providers", "in": "header"},
+                                    {"name": "X-Agent-Execute-Token", "in": "header"},
+                                ]
+                            }
+                        }
+                    }
+                },
+            }
+        return {"url": url, "ok": True, "status_code": 200, "json": {}}
+
+    monkeypatch.setattr(gates, "check_http_json_endpoint", _check_http_json)
+    monkeypatch.setattr(
+        gates,
+        "check_http_endpoint",
+        lambda url, timeout=8.0: {"url": url, "ok": True, "status_code": 200},
+    )
+    monkeypatch.setattr(
+        gates,
+        "check_value_lineage_e2e_flow",
+        lambda api_base, timeout=8.0: {
+            "url": f"{api_base}/api/value-lineage/links/x",
+            "ok": True,
+            "status_code": 200,
+        },
+    )
+
+    report = evaluate_public_deploy_contract_report(
+        repository="seeker71/Coherence-Network",
+        branch="main",
+    )
+
+    assert report["result"] == "public_contract_passed"
+    assert "railway_health" not in report.get("failing_checks", [])
+    assert "railway_health_unknown_sha" in report.get("warnings", [])
+
+
+def test_public_deploy_contract_blocks_when_api_health_sha_required_and_missing(monkeypatch) -> None:
+    expected_sha = "j" * 40
+    monkeypatch.setenv("PUBLIC_DEPLOY_REQUIRE_API_HEALTH_SHA", "1")
+    monkeypatch.setattr(gates, "get_branch_head_sha", lambda *args, **kwargs: expected_sha)
+
+    def _check_http_json(url: str, timeout: float = 8.0) -> dict[str, object]:
+        if url.endswith("/api/health"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"status": "ok"},
+            }
+        if url.endswith("/api/gates/main-head"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"sha": expected_sha},
+            }
+        if url.endswith("/api/health-proxy"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {"api": {"status": "ok"}, "web": {"updated_at": expected_sha}},
+            }
+        if url.endswith("/openapi.json"):
+            return {
+                "url": url,
+                "ok": True,
+                "status_code": 200,
+                "json": {
+                    "paths": {
+                        "/api/agent/tasks/{task_id}/execute": {
+                            "post": {
+                                "parameters": [
+                                    {"name": "X-Force-Paid-Providers", "in": "header"},
+                                    {"name": "X-Agent-Execute-Token", "in": "header"},
+                                ]
+                            }
+                        }
+                    }
+                },
+            }
+        return {"url": url, "ok": True, "status_code": 200, "json": {}}
+
+    monkeypatch.setattr(gates, "check_http_json_endpoint", _check_http_json)
+    monkeypatch.setattr(
+        gates,
+        "check_http_endpoint",
+        lambda url, timeout=8.0: {"url": url, "ok": True, "status_code": 200},
+    )
+    monkeypatch.setattr(
+        gates,
+        "check_value_lineage_e2e_flow",
+        lambda api_base, timeout=8.0: {
+            "url": f"{api_base}/api/value-lineage/links/x",
+            "ok": True,
+            "status_code": 200,
+        },
+    )
+
+    report = evaluate_public_deploy_contract_report(
+        repository="seeker71/Coherence-Network",
+        branch="main",
+    )
+
+    assert report["result"] == "blocked"
+    assert "railway_health" in report.get("failing_checks", [])
+
+
 def test_evaluate_commit_traceability_report_live_shape() -> None:
     sha = get_branch_head_sha("seeker71/Coherence-Network", "main")
     assert isinstance(sha, str) and len(sha) == 40

--- a/docs/system_audit/commit_evidence_2026-02-25_api-health-sha-freshness-contract.json
+++ b/docs/system_audit/commit_evidence_2026-02-25_api-health-sha-freshness-contract.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-02-25",
+  "thread_branch": "codex/api-health-sha-freshness-20260225",
+  "commit_scope": "Add API deployed SHA visibility to health endpoints and enforce deploy-contract/runtime verification paths so stale API runtimes cannot silently pass parity checks.",
+  "files_owned": [
+    "api/app/routers/health.py",
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_health.py",
+    "api/tests/test_release_gate_service.py",
+    "scripts/verify_web_api_deploy.sh"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "095-public-e2e-flow-gate-automation",
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task-2026-02-25-api-health-sha-freshness"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260225T183627Z_codex-24h-gap-closure-20260225.json"
+  ],
+  "change_files": [
+    "api/app/routers/health.py",
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_health.py",
+    "api/tests/test_release_gate_service.py",
+    "scripts/verify_web_api_deploy.sh",
+    "docs/system_audit/commit_evidence_2026-02-25_api-health-sha-freshness-contract.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_health.py tests/test_release_gate_service.py -k \"api_health_sha or unknown_web_proxy_sha or provider_readiness_required or warns_when_provider_readiness_blocked_if_not_required or evaluate_public_deploy_contract_report_live_shape\"",
+      "cd api && ruff check app/routers/health.py app/services/release_gate_service.py tests/test_health.py tests/test_release_gate_service.py",
+      "bash -n scripts/verify_web_api_deploy.sh",
+      "./scripts/verify_web_api_deploy.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit/push, PR checks, merge, and production rollout of API health deployed SHA fields."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public deploy contract and deploy verification scripts now surface API runtime SHA parity (with optional strict mode) using /api/health deployed SHA metadata, reducing false-green stale-runtime outcomes.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/health",
+      "https://coherence-network-production.up.railway.app/api/gates/main-head",
+      "https://coherence-network-production.up.railway.app/api/gates/public-deploy/verify",
+      "https://coherence-web-production.up.railway.app/api/health-proxy"
+    ],
+    "test_flows": [
+      "Query /api/health and confirm deployed_sha/deployed_sha_source are present when runtime env exposes commit SHA.",
+      "Run public deploy contract and verify railway_health parity uses observed deployed SHA when available.",
+      "Run scripts/verify_web_api_deploy.sh and verify API runtime SHA parity output warns or fails according to VERIFY_REQUIRE_API_HEALTH_SHA.",
+      "Confirm web health proxy SHA parity remains enforced against expected main-head SHA."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- expose deployed git SHA (and source env key) via  and 
- harden public deploy contract evaluation to compare expected main SHA with API health SHA when available
- add strict/optional toggles for missing API runtime SHA in deploy checks
- update deploy verification script to validate API SHA parity against 

## Validation
- ......                                                                   [100%]
=============================== warnings summary ===============================
app/main.py:426
  /Users/ursmuff/.codex/worktrees/02f0/Coherence-Network/api/app/main.py:426: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

../../../../../../../opt/homebrew/lib/python3.11/site-packages/fastapi/applications.py:4573
  /opt/homebrew/lib/python3.11/site-packages/fastapi/applications.py:4573: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
6 passed, 29 deselected, 2 warnings in 4.62s
- All checks passed!
- 
- 
==> Railway API health: https://coherence-network-production.up.railway.app/api/health
HTTP status: 200
Server: railway-edge
PASS

==> Railway gates main head: https://coherence-network-production.up.railway.app/api/gates/main-head
HTTP status: 200
Server: railway-edge
PASS

==> API runtime SHA parity: https://coherence-network-production.up.railway.app/api/health vs https://coherence-network-production.up.railway.app/api/gates/main-head (required=0)
health status: 200 | main-head status: 200
expected_sha: 230407b80b91b6b28899ee79a672db3c373005a3
observed_sha: <missing>
WARN: API health does not expose deployed SHA (non-blocking)

==> Persistence contract: https://coherence-network-production.up.railway.app/api/health/persistence
HTTP status: 200
required: true | pass_contract: true
PASS

==> Provider readiness: https://coherence-network-production.up.railway.app/api/automation/usage/readiness (required=0)
HTTP status: 200
all_required_ready: false | blocking_issues: 3
WARN: provider readiness has blocking issues (non-blocking)

==> Railway web root: https://coherence-web-production.up.railway.app/
HTTP status: 200
Server: railway-edge
PASS

==> Railway web gates page: https://coherence-web-production.up.railway.app/gates
HTTP status: 200
Server: railway-edge
PASS

==> Railway web API health page: https://coherence-web-production.up.railway.app/api-health
HTTP status: 200
Server: railway-edge
PASS

==> Railway web API health proxy: https://coherence-web-production.up.railway.app/api/health-proxy
HTTP status: 200
Server: railway-edge
PASS

==> CORS check: https://coherence-network-production.up.railway.app/api/health with Origin https://coherence-web-production.up.railway.app
HTTP status: 200
Access-Control-Allow-Origin: https://coherence-web-production.up.railway.app
PASS

==> Skipping Telegram alert config gate (VERIFY_REQUIRE_TELEGRAM_ALERTS=0)

Deployment verification passed: Railway API and Railway web are reachable and CORS is aligned.
- OK: evidence validation passed for docs/system_audit/commit_evidence_2026-02-25_api-health-sha-freshness-contract.json

## Evidence
- 