### PR TITLE
Add guidance-first orchestration awareness endpoint

### DIFF
--- a/api/app/routers/agent.py
+++ b/api/app/routers/agent.py
@@ -677,6 +677,15 @@ async def get_visibility() -> dict:
     return agent_service.get_visibility_summary()
 
 
+@router.get("/agent/orchestration/guidance")
+async def get_orchestration_guidance(
+    seconds: int = Query(21600, ge=300, le=2592000),
+    limit: int = Query(500, ge=1, le=5000),
+) -> dict:
+    """Guidance-first routing and awareness summary (advisory, non-blocking)."""
+    return agent_service.get_orchestration_guidance_summary(seconds=seconds, limit=limit)
+
+
 @router.get("/agent/integration")
 async def get_agent_integration() -> dict:
     """Role-agent integration coverage and remaining gaps."""

--- a/docs/system_audit/commit_evidence_2026-02-26_orchestration-guidance-awareness.json
+++ b/docs/system_audit/commit_evidence_2026-02-26_orchestration-guidance-awareness.json
@@ -1,0 +1,80 @@
+{
+  "date": "2026-02-26",
+  "thread_branch": "codex/guidance-coherence-20260226",
+  "commit_scope": "Add guidance-first orchestration awareness summary with advisory model/tool routing recommendations and telemetry-backed awareness signals.",
+  "files_owned": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/tests/test_agent_visibility_api.py",
+    "specs/112-orchestration-guidance-awareness.md"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "112-orchestration-guidance-awareness"
+  ],
+  "task_ids": [
+    "task-2026-02-26-orchestration-guidance-awareness"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "specs/112-orchestration-guidance-awareness.md"
+  ],
+  "change_files": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/tests/test_agent_visibility_api.py",
+    "specs/112-orchestration-guidance-awareness.md",
+    "docs/system_audit/commit_evidence_2026-02-26_orchestration-guidance-awareness.json"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_spec_quality.py --file specs/112-orchestration-guidance-awareness.md",
+      "cd api && pytest -q tests/test_agent_visibility_api.py -k \"orchestration_guidance\"",
+      "cd api && pytest -q tests/test_agent_visibility_api.py",
+      "cd api && ruff check app/services/agent_service.py app/routers/agent.py tests/test_agent_visibility_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting guard chain, commit/push, PR checks, and deploy verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Advisory orchestration guidance endpoint returns route matrix, awareness metrics, and actionable guidance without introducing hard-blocking execution rules.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/orchestration/guidance",
+      "https://coherence-network-production.up.railway.app/api/agent/visibility"
+    ],
+    "test_flows": [
+      "Call /api/agent/orchestration/guidance and verify mode/enforcement/advisory payload keys.",
+      "Generate a failed runtime tool event and verify execution-success guidance appears."
+    ]
+  }
+}

--- a/specs/112-orchestration-guidance-awareness.md
+++ b/specs/112-orchestration-guidance-awareness.md
@@ -1,0 +1,63 @@
+# Spec: Orchestration Guidance Awareness
+
+## Purpose
+
+Add a guidance-first orchestration summary that makes model/tool routing decisions easier to understand and apply without introducing new hard-blocking behavior.
+
+## Requirements
+
+- [ ] Add an API endpoint that returns orchestration guidance as advisory output.
+- [ ] Include default executor policy (cheap, escalation, repo-question, open-question).
+- [ ] Include per-task-type route recommendations for cheap and escalation paths.
+- [ ] Include awareness metrics from runtime/lifecycle/friction signals.
+- [ ] Include actionable guidance items that prioritize alignment/coherence over force.
+- [ ] Keep enforcement explicitly non-blocking (`mode=guidance`, advisory semantics).
+
+## API Contract (if applicable)
+
+`GET /api/agent/orchestration/guidance`
+
+Response must include:
+
+- `generated_at`
+- `mode` (`guidance`)
+- `enforcement` (`advisory`)
+- `defaults`
+- `recommended_routes`
+- `awareness`
+- `guidance`
+
+## Files to Create/Modify
+
+- `api/app/services/agent_service.py` - build orchestration guidance summary payload.
+- `api/app/routers/agent.py` - expose orchestration guidance endpoint.
+- `api/tests/test_agent_visibility_api.py` - endpoint shape and awareness guidance tests.
+
+## Acceptance Tests
+
+- `cd api && pytest -q tests/test_agent_visibility_api.py -k "orchestration_guidance"`
+- `cd api && ruff check app/services/agent_service.py app/routers/agent.py tests/test_agent_visibility_api.py`
+
+## Verification
+
+```bash
+python3 scripts/validate_spec_quality.py --file specs/112-orchestration-guidance-awareness.md
+cd api && pytest -q tests/test_agent_visibility_api.py -k "orchestration_guidance"
+cd api && ruff check app/services/agent_service.py app/routers/agent.py tests/test_agent_visibility_api.py
+```
+
+## Out of Scope
+
+- Any new task-execution hard gates or blocking enforcement.
+- Model/provider billing policy changes.
+- UI/dashboard rendering changes.
+
+## Risks and Assumptions
+
+- Risk: Guidance output can become noisy if too many hints are emitted; mitigate with short prioritized lists.
+- Assumption: Existing runtime/lifecycle/friction telemetry is available often enough to produce useful guidance.
+
+## Known Gaps and Follow-up Tasks
+
+- Gap: Guidance currently uses internal telemetry only; it does not yet include UI-facing recommendation ordering by business impact.
+- Follow-up task: add optional weighting that prioritizes guidance items by recent repeat-frequency and energy-loss impact.


### PR DESCRIPTION
## Summary
- add `/api/agent/orchestration/guidance` as an advisory orchestration summary endpoint
- include cheap/escalation route matrix by task type plus awareness signals from lifecycle/runtime/friction telemetry
- add spec and tests to keep the change guidance-first and non-blocking

## Validation
- `python3 scripts/validate_spec_quality.py --file specs/112-orchestration-guidance-awareness.md`
- `cd api && pytest -q tests/test_agent_visibility_api.py -k "orchestration_guidance"`
- `cd api && pytest -q tests/test_agent_visibility_api.py`
- `cd api && ruff check app/services/agent_service.py app/routers/agent.py tests/test_agent_visibility_api.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
