### PR TITLE
Unblock codex spark execution + manual rerun flow

### DIFF
--- a/api/app/services/agent_execution_codex_service.py
+++ b/api/app/services/agent_execution_codex_service.py
@@ -1,0 +1,231 @@
+"""Codex execution fallback helpers for agent task execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+from app.models.runtime import RuntimeEventCreate
+from app.services import runtime_service
+
+
+def _extract_underlying_model(task_model: str) -> str:
+    cleaned = (task_model or "").strip()
+    if cleaned.startswith("openclaw/") or cleaned.startswith("clawwork/"):
+        return cleaned.split("/", 1)[1].strip()
+    if cleaned.startswith("cursor/"):
+        return cleaned.split("/", 1)[1].strip()
+    return cleaned
+
+
+def _runtime_cost_per_second() -> float:
+    raw = os.getenv("RUNTIME_COST_PER_SECOND", "0.002").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        value = 0.002
+    return value if value > 0.0 else 0.002
+
+
+def _runtime_cost_usd(runtime_ms: int) -> float:
+    return max(0.0, float(runtime_ms)) / 1000.0 * _runtime_cost_per_second()
+
+
+def _record_codex_tool_event(
+    *,
+    task_id: str,
+    model: str,
+    is_paid_provider: bool,
+    elapsed_ms: int,
+    ok: bool,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    total_tokens: int = 0,
+    usage_json: str = "{}",
+    error: str | None = None,
+    actual_cost_usd: float | None = None,
+) -> None:
+    status_code = 200 if ok else 500
+    metadata: dict[str, str | float | int | bool] = {
+        "tracking_kind": "agent_tool_call",
+        "task_id": task_id,
+        "model": model,
+        "provider": "openai-codex",
+        "is_openai_codex": True,
+        "is_paid_provider": bool(is_paid_provider),
+    }
+    if actual_cost_usd is not None:
+        metadata["runtime_cost_usd"] = round(float(actual_cost_usd), 6)
+    if ok:
+        metadata.update(
+            {
+                "usage_prompt_tokens": int(prompt_tokens),
+                "usage_completion_tokens": int(completion_tokens),
+                "usage_total_tokens": int(total_tokens),
+                "usage_json": str(usage_json)[:2000],
+            }
+        )
+    else:
+        metadata["error"] = (error or "unknown")[:800]
+
+    runtime_service.record_event(
+        RuntimeEventCreate(
+            source="worker",
+            endpoint="tool:codex.exec",
+            method="RUN",
+            status_code=status_code,
+            runtime_ms=float(max(1, int(elapsed_ms))),
+            idea_id="coherence-network-agent-pipeline",
+            metadata=metadata,
+        )
+    )
+
+
+def _extract_usage_from_codex_jsonl(output: str) -> dict[str, int]:
+    for raw_line in (output or "").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except Exception:
+            continue
+        if str(payload.get("type") or "").strip() != "turn.completed":
+            continue
+        usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+        prompt_tokens = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
+        completion_tokens = int(usage.get("output_tokens") or usage.get("completion_tokens") or 0)
+        total_tokens = int(usage.get("total_tokens") or (prompt_tokens + completion_tokens))
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        }
+    return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+def should_fallback_to_codex_exec(model: str, error: str) -> bool:
+    underlying = _extract_underlying_model(model).strip().lower()
+    if "codex" not in underlying:
+        return False
+    return "OPENROUTER_API_KEY is not configured" in error
+
+
+def _failure_result(
+    *,
+    task_id: str,
+    model: str,
+    route_is_paid: bool,
+    elapsed_ms: int,
+    error: str,
+) -> dict[str, Any]:
+    _record_codex_tool_event(
+        task_id=task_id,
+        model=model,
+        is_paid_provider=route_is_paid,
+        elapsed_ms=elapsed_ms,
+        ok=False,
+        error=error,
+        actual_cost_usd=_runtime_cost_usd(elapsed_ms),
+    )
+    return {"ok": False, "elapsed_ms": elapsed_ms, "error": error}
+
+
+def _read_output_file(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except Exception:
+        return ""
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def run_codex_exec(
+    *,
+    task_id: str,
+    model: str,
+    prompt: str,
+    route_is_paid: bool,
+    started_perf: float,
+    cost_budget: dict[str, float | None],
+) -> dict[str, Any]:
+    resolved_model = _extract_underlying_model(model).strip() or "gpt-5.3-codex-spark"
+    with tempfile.NamedTemporaryFile(prefix="codex_exec_", suffix=".txt", delete=False) as tmp_out:
+        out_path = tmp_out.name
+
+    cmd = [
+        "codex",
+        "exec",
+        prompt,
+        "--model",
+        resolved_model,
+        "--skip-git-repo-check",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+        "-o",
+        out_path,
+    ]
+    try:
+        completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except Exception as exc:
+        elapsed_ms = max(1, int(round((time.perf_counter() - started_perf) * 1000)))
+        return _failure_result(
+            task_id=task_id,
+            model=model,
+            route_is_paid=route_is_paid,
+            elapsed_ms=elapsed_ms,
+            error=f"Execution failed (Codex): {exc}",
+        )
+
+    elapsed_ms = max(1, int(round((time.perf_counter() - started_perf) * 1000)))
+    content = _read_output_file(out_path)
+
+    if completed.returncode != 0:
+        err = (completed.stderr or completed.stdout or "codex exec failed").strip()
+        return _failure_result(
+            task_id=task_id,
+            model=model,
+            route_is_paid=route_is_paid,
+            elapsed_ms=elapsed_ms,
+            error=f"Execution failed (Codex): {err[:1000]}",
+        )
+
+    if not content:
+        content = (completed.stdout or "").strip() or "Codex execution completed with no output."
+
+    usage = _extract_usage_from_codex_jsonl(completed.stdout or "")
+    usage_json = json.dumps(usage, sort_keys=True)[:2000]
+    prompt_tokens = int(usage.get("prompt_tokens") or 0)
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    total_tokens = int(usage.get("total_tokens") or (prompt_tokens + completion_tokens))
+    cost_usd = _runtime_cost_usd(elapsed_ms)
+    _record_codex_tool_event(
+        task_id=task_id,
+        model=model,
+        is_paid_provider=route_is_paid,
+        elapsed_ms=elapsed_ms,
+        ok=True,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        usage_json=usage_json,
+        actual_cost_usd=cost_usd,
+    )
+    return {
+        "ok": True,
+        "elapsed_ms": elapsed_ms,
+        "content": content,
+        "usage_json": usage_json,
+        "provider_request_id": "",
+        "actual_cost_usd": cost_usd,
+        "max_cost_usd": cost_budget.get("max_cost_usd"),
+        "cost_slack_ratio": cost_budget.get("cost_slack_ratio"),
+    }

--- a/docs/system_audit/commit_evidence_2026-02-26_codex-spark-execution-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-26_codex-spark-execution-fallback.json
@@ -1,0 +1,91 @@
+{
+  "date": "2026-02-26",
+  "thread_branch": "codex/actual-progress-20260226",
+  "commit_scope": "Unblock server-side task execution for Codex Spark routes by falling back from OpenRouter-key errors to local codex exec, and allow explicit manual re-execution of failed/completed tasks.",
+  "files_owned": [
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/agent_execution_codex_service.py",
+    "api/app/routers/agent.py",
+    "api/tests/test_agent_execute_endpoint.py",
+    "docs/system_audit/commit_evidence_2026-02-26_codex-spark-execution-fallback.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration-api",
+    "003-task-status-and-attention"
+  ],
+  "task_ids": [
+    "task_a4eb8599bf4d67fe",
+    "task_380be33944346917"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "verification"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "./scripts/auto_heal_start_gate.sh",
+    "cd api && pytest -q tests/test_agent_execute_endpoint.py -k \"blocks_paid_provider_until_forced or falls_back_to_codex_when_openrouter_key_missing_for_codex_model or requeues_failed_task_for_manual_rerun\"",
+    "cd api && ruff check app/services/agent_execution_service.py tests/test_agent_execute_endpoint.py app/routers/agent.py",
+    "AGENT_EXECUTE_TOKEN_ALLOW_UNAUTH=1 /Users/ursmuff/source/Coherence-Network/api/.venv/bin/uvicorn app.main:app --port 18112 --host 127.0.0.1",
+    "POST /api/agent/tasks/{task_id}/execute?force_paid_providers=true on openclaw/gpt-5.3-codex-spark task",
+    "GET /api/runtime/events?limit=80 (verified tool:codex.exec success event)",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260226T104034Z_codex-actual-progress-20260226.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/agent_execution_codex_service.py",
+    "api/tests/test_agent_execute_endpoint.py",
+    "docs/system_audit/commit_evidence_2026-02-26_codex-spark-execution-fallback.json"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_agent_execute_endpoint.py -k \"blocks_paid_provider_until_forced or falls_back_to_codex_when_openrouter_key_missing_for_codex_model or requeues_failed_task_for_manual_rerun\"",
+      "cd api && ruff check app/services/agent_execution_service.py tests/test_agent_execute_endpoint.py app/routers/agent.py",
+      "POST /api/agent/tasks/{task_id}/execute?force_paid_providers=true (local uvicorn on :18112, spark task)",
+      "GET /api/runtime/events?limit=80 (confirmed /tool:codex.exec status_code=200)"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting commit/push and CI verification."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Codex Spark tasks now complete via codex CLI fallback when OpenRouter key is absent, and runtime telemetry includes a successful tool:codex.exec event for those executions.",
+    "public_endpoints": [
+      "http://127.0.0.1:18112/api/agent/tasks/{task_id}",
+      "http://127.0.0.1:18112/api/runtime/events?limit=80",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks/{task_id}"
+    ],
+    "test_flows": [
+      "Create task with context.executor=openclaw and model_override=gpt-5.3-codex-spark, then execute with force_paid_providers=true and verify status=completed.",
+      "Confirm runtime events include endpoint /tool:codex.exec with provider openai-codex and status_code 200 for that task.",
+      "Re-execute a failed task through POST /api/agent/tasks/{task_id}/execute and verify rerun is attempted (manual_reexecute_requested=true)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add manual requeue path so `POST /api/agent/tasks/{id}/execute` can rerun failed/completed tasks
- add Codex Spark fallback for server-side execution when OpenRouter key is missing on codex models
- add/extend execute endpoint tests and commit evidence

## Verification
- make start-gate (via auto-heal in dirty worktree mode)
- cd api && pytest -q tests/test_agent_execute_endpoint.py -k 'blocks_paid_provider_until_forced or falls_back_to_codex_when_openrouter_key_missing_for_codex_model or requeues_failed_task_for_manual_rerun'
- cd api && ruff check app/services/agent_execution_service.py app/services/agent_execution_codex_service.py tests/test_agent_execute_endpoint.py app/routers/agent.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- live local API verification on openclaw/gpt-5.3-codex-spark with force_paid_providers=true -> completed output + /tool:codex.exec event
