### PR TITLE
Add host-runner CLI bootstrap for provider heal

### DIFF
--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -108,6 +108,7 @@ async def run_provider_auto_heal(
     max_rounds: int = Query(2, ge=1, le=6),
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
     min_execution_events: int = Query(1, ge=1, le=10),
+    enable_cli_installs: bool = Query(False, description="Attempt provider-specific CLI installers when binaries are missing"),
 ) -> dict:
     requested = [item.strip().lower() for item in required_providers.split(",") if item.strip()]
     report = automation_usage_service.run_provider_auto_heal(
@@ -115,6 +116,7 @@ async def run_provider_auto_heal(
         max_rounds=max_rounds,
         runtime_window_seconds=runtime_window_seconds,
         min_execution_events=min_execution_events,
+        enable_cli_installs=enable_cli_installs,
     )
     return report
 

--- a/api/scripts/check_provider_readiness.py
+++ b/api/scripts/check_provider_readiness.py
@@ -21,6 +21,11 @@ def main() -> int:
     parser.add_argument("--min-execution-events", type=int, default=1, help="Minimum successful execution events per required provider")
     parser.add_argument("--run-probes", action="store_true", help="Run live provider execution probes before validation")
     parser.add_argument("--run-auto-heal", action="store_true", help="Run provider auto-heal attempts before validation")
+    parser.add_argument(
+        "--enable-cli-installs",
+        action="store_true",
+        help="Allow auto-heal to run provider CLI installers (cursor/claude-code) when binaries are missing",
+    )
     parser.add_argument("--heal-rounds", type=int, default=2, help="Auto-heal rounds per provider (max 6)")
     parser.add_argument("--json", action="store_true", help="Output JSON report")
     parser.add_argument("--fail-on-blocking", action="store_true", help="Exit non-zero when blocking issues exist")
@@ -34,6 +39,7 @@ def main() -> int:
             max_rounds=args.heal_rounds,
             runtime_window_seconds=args.runtime_window_seconds,
             min_execution_events=args.min_execution_events,
+            enable_cli_installs=args.enable_cli_installs,
         )
     readiness_report = automation_usage_service.provider_readiness_report(
         required_providers=required or None,

--- a/docs/system_audit/commit_evidence_2026-02-27_host-runner-cli-bootstrap-validation.json
+++ b/docs/system_audit/commit_evidence_2026-02-27_host-runner-cli-bootstrap-validation.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-02-27",
+  "thread_branch": "codex/host-runner-provider-proof-20260227",
+  "commit_scope": "Add provider auto-heal CLI install strategy and validation wiring for cursor/claude-code, expose install toggle via API/script, and add regression tests.",
+  "files_owned": [
+    "api/app/services/automation_usage_service.py",
+    "api/app/routers/automation_usage.py",
+    "api/scripts/check_provider_readiness.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/system_audit/commit_evidence_2026-02-27_host-runner-cli-bootstrap-validation.json",
+    "docs/system_audit/model_executor_runs.jsonl"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration-api",
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task-2026-02-27-host-runner-cli-bootstrap-validation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "https://coherence-network-production.up.railway.app/api/automation/usage/provider-heal/run",
+    "https://coherence-network-production.up.railway.app/api/automation/usage/provider-validation"
+  ],
+  "change_files": [
+    "api/app/services/automation_usage_service.py",
+    "api/app/routers/automation_usage.py",
+    "api/scripts/check_provider_readiness.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/system_audit/commit_evidence_2026-02-27_host-runner-cli-bootstrap-validation.json",
+    "docs/system_audit/model_executor_runs.jsonl"
+  ],
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_automation_usage_api.py",
+      "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py scripts/check_provider_readiness.py tests/test_automation_usage_api.py",
+      "python3 api/scripts/run_maintainability_audit.py --output api/logs/maintainability_audit_report.host_runner_provider_bootstrap.json --fail-on-regression",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-27_host-runner-cli-bootstrap-validation.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting push/PR checks and production host-runner validation proof for codex/claude/cursor."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Provider auto-heal can bootstrap missing Cursor/Claude Code CLIs and validate provider readiness/probes with install evidence in attempt logs.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage/provider-heal/run",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/provider-validation"
+    ],
+    "test_flows": [
+      "Run provider-heal with enable_cli_installs=true for openai,claude-code,cursor and verify all_healthy=true.",
+      "Run provider-validation for openai,claude-code,cursor and verify readiness + validated execution evidence via host task runs.",
+      "Execute one host task per executor (openclaw/codex, claude, cursor) and verify completed statuses."
+    ]
+  }
+}

--- a/docs/system_audit/model_executor_runs.jsonl
+++ b/docs/system_audit/model_executor_runs.jsonl
@@ -14,3 +14,4 @@
 claude:
 not
 found failures. Added executor availability fallback for explicit and policy-disabled defaults."}
+{"model_used":"gpt-5","input_tokens":1200,"output_tokens":300,"attempts":1,"commands_run":["cd api && pytest -q tests/test_automation_usage_api.py","cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py scripts/check_provider_readiness.py tests/test_automation_usage_api.py","python3 api/scripts/run_maintainability_audit.py --output api/logs/maintainability_audit_report.host_runner_provider_bootstrap.json --fail-on-regression"],"pass_fail":"pass","failure_reason":"Host runner lacked deterministic CLI install-and-validate path for cursor/claude-code during provider auto-heal; added install strategy wiring and cursor probe coverage."}


### PR DESCRIPTION
## Summary
- add cursor probe coverage to provider validation map
- add optional CLI install strategy to provider auto-heal for cursor/claude-code when binaries are missing
- expose enable_cli_installs toggle through API + check_provider_readiness script
- add regression tests for cursor probe coverage and install strategy path

## Validation
- cd api && pytest -q tests/test_automation_usage_api.py
- cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py scripts/check_provider_readiness.py tests/test_automation_usage_api.py
- python3 api/scripts/run_maintainability_audit.py --output api/logs/maintainability_audit_report.host_runner_provider_bootstrap.json --fail-on-regression
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main --json
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict