### PR TITLE
Fix usage provider duplication, remaining quota selection, and timeout fallback

### DIFF
--- a/docs/system_audit/commit_evidence_2026-02-28_provider-usage-coalescing-timeout.json
+++ b/docs/system_audit/commit_evidence_2026-02-28_provider-usage-coalescing-timeout.json
@@ -1,0 +1,94 @@
+{
+  "date": "2026-02-28",
+  "thread_branch": "codex/usage-provider-fix-timeout-20260228",
+  "commit_scope": "Fix automation usage provider-family duplication (openai/claude aliases), use quota-aware summary metrics for usage_remaining, and add timeout fallback for /api/automation/usage.",
+  "files_owned": [
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "specs/113-provider-usage-coalescing-timeout-resilience.md",
+    "docs/system_audit/commit_evidence_2026-02-28_provider-usage-coalescing-timeout.json"
+  ],
+  "change_files": [
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "specs/113-provider-usage-coalescing-timeout-resilience.md"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "requirements",
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_automation_usage_api.py -k \"finalize_snapshot_uses_summary_metric_for_usage_remaining or coalesces_provider_families or times_out_to_snapshot_fallback\"",
+    "cd api && pytest -q tests/test_automation_usage_api.py",
+    "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py",
+    "python3 scripts/validate_spec_quality.py --base origin/main --head HEAD"
+  ],
+  "idea_ids": [
+    "automation-provider-usage-readiness-api"
+  ],
+  "spec_ids": [
+    "113-provider-usage-coalescing-timeout-resilience"
+  ],
+  "task_ids": [
+    "task-2026-02-28-provider-usage-family-coalescing-timeout-fallback"
+  ],
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocking_reason": "Pending commit/push/PR and public deployment verification for timeout behavior on production endpoints."
+  },
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_automation_usage_api.py -k \"finalize_snapshot_uses_summary_metric_for_usage_remaining or coalesces_provider_families or times_out_to_snapshot_fallback\"",
+      "cd api && pytest -q tests/test_automation_usage_api.py",
+      "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "expected": [
+      "Thread Gates",
+      "Test",
+      "Change Contract"
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR merge and public API verification in production."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Automation usage endpoint responds within configured timeout by serving snapshot fallback instead of hanging, and provider families are coalesced to one openai and one claude row with improved usage_remaining values when quota metrics exist.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/daily-summary?window_hours=24&top_n=8"
+    ],
+    "test_flows": [
+      "Call /api/automation/usage and verify provider rows are coalesced by family (single openai, single claude).",
+      "Call /api/automation/usage and verify usage_remaining is populated when summary quota metrics include remaining values.",
+      "Force a slow provider collection path and verify /api/automation/usage still returns fallback payload before client timeout."
+    ]
+  }
+}

--- a/specs/113-provider-usage-coalescing-timeout-resilience.md
+++ b/specs/113-provider-usage-coalescing-timeout-resilience.md
@@ -1,0 +1,82 @@
+# Spec: Provider Usage Coalescing + Timeout Resilience
+
+## Purpose
+
+Automation usage responses currently expose provider-family duplicates (for example `openai` with `openai-codex`, and `claude` with `claude-code`), often show `usage_remaining` as null even when quota metrics exist, and can timeout under slow provider probes. This spec unifies family-level provider reporting, improves remaining-quota selection, and guarantees fast fallback behavior when live collection exceeds endpoint latency budgets.
+
+## Requirements
+
+- [ ] `GET /api/automation/usage` returns one row per provider family (`openai`, `claude`) instead of duplicate family variants.
+- [ ] Provider snapshots set `usage_remaining` from the best quota-bearing summary metric when available, even if the primary usage metric is runtime-only.
+- [ ] `GET /api/automation/usage` avoids long hangs by returning a valid fallback payload when live collection exceeds a configurable timeout.
+
+## API Contract (if applicable)
+
+### `GET /api/automation/usage`
+
+**Request**
+- `force_refresh`: boolean (query, optional)
+- `compact`: boolean (query, optional)
+- `include_raw`: boolean (query, optional)
+
+**Response 200**
+```json
+{
+  "generated_at": "2026-02-28T00:00:00Z",
+  "providers": [
+    {
+      "provider": "openai",
+      "status": "ok",
+      "actual_current_usage": 120.0,
+      "usage_remaining": 880.0
+    }
+  ],
+  "tracked_providers": 1,
+  "unavailable_providers": []
+}
+```
+
+Behavioral updates:
+- Provider-family aliases are coalesced in usage output.
+- Endpoint may serve a snapshot-based fallback payload on live-collection timeout.
+
+## Data Model (if applicable)
+
+N/A - no model schema changes.
+
+## Files to Create/Modify
+
+- `api/app/services/automation_usage_service.py` - provider-family coalescing, summary metric remaining selection, snapshot fallback builder.
+- `api/app/routers/automation_usage.py` - timeout-guarded usage endpoint flow with fallback.
+- `api/tests/test_automation_usage_api.py` - regression tests for coalescing, remaining metric selection, and timeout fallback behavior.
+
+## Acceptance Tests
+
+- `api/tests/test_automation_usage_api.py::test_finalize_snapshot_uses_summary_metric_for_usage_remaining`
+- `api/tests/test_automation_usage_api.py::test_automation_usage_endpoint_coalesces_provider_families`
+- `api/tests/test_automation_usage_api.py::test_automation_usage_endpoint_times_out_to_snapshot_fallback`
+
+## Verification
+
+```bash
+cd api && pytest -q tests/test_automation_usage_api.py -k "finalize_snapshot_uses_summary_metric_for_usage_remaining or coalesces_provider_families or times_out_to_snapshot_fallback"
+cd api && pytest -q tests/test_automation_usage_api.py -k "automation_usage_endpoint_returns_normalized_providers or daily_summary"
+```
+
+## Out of Scope
+
+- Changing provider-validation probe semantics for `claude-code` and `openai-codex`.
+- Reworking upstream provider APIs or transport-level network reliability.
+
+## Risks and Assumptions
+
+- Risk: Coalescing could hide useful sub-provider details. Mitigation: preserve merged notes/metrics in coalesced rows.
+- Assumption: Snapshot fallback data exists in store for degraded timeout paths.
+
+## Known Gaps and Follow-up Tasks
+
+- None at spec time.
+
+## Decision Gates (if any)
+
+- None.


### PR DESCRIPTION
## Summary
- coalesce provider families in usage output (`openai-codex` -> `openai`, `claude-code` -> `claude`)
- derive `usage_remaining` from summary quota metrics instead of runtime-only primary metric
- add timeout guard + snapshot fallback for `/api/automation/usage`
- normalize usage-row statuses so API output no longer emits `degraded`
- add regression tests and spec/evidence artifacts

## Validation
- cd api && pytest -q tests/test_automation_usage_api.py
- cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-02-28_provider-usage-coalescing-timeout.json
