### PR TITLE
fix: use snapshot fallback for readiness timeout

### DIFF
--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -95,9 +95,8 @@ async def get_provider_readiness(
             timeout=timeout_seconds,
         )
     except TimeoutError:
-        report = automation_usage_service.provider_readiness_report(
+        report = automation_usage_service.provider_readiness_report_from_snapshots(
             required_providers=requested or None,
-            force_refresh=False,
         )
     return report.model_dump(mode="json")
 

--- a/docs/system_audit/commit_evidence_2026-02-28_readiness-timeout-snapshot-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-02-28_readiness-timeout-snapshot-fallback.json
@@ -1,0 +1,86 @@
+{
+  "date": "2026-02-28",
+  "thread_branch": "codex/readiness-coalesce-no-degraded-20260228",
+  "commit_scope": "Fix readiness timeout fallback to use snapshot-based readiness reports, preserving family coalescing while preventing repeated slow live provider collection after timeout.",
+  "files_owned": [
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py",
+    "docs/system_audit/commit_evidence_2026-02-28_readiness-timeout-snapshot-fallback.json"
+  ],
+  "change_files": [
+    "api/app/routers/automation_usage.py",
+    "api/app/services/automation_usage_service.py",
+    "api/tests/test_automation_usage_api.py"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "requirements",
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && pytest -q tests/test_automation_usage_api.py",
+    "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py"
+  ],
+  "idea_ids": [
+    "automation-provider-usage-readiness-api"
+  ],
+  "spec_ids": [
+    "113-provider-usage-coalescing-timeout-resilience"
+  ],
+  "task_ids": [
+    "task-2026-02-28-readiness-timeout-snapshot-fallback"
+  ],
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocking_reason": "Pending commit/push/PR merge and post-deploy production verification for readiness timeout fallback behavior."
+  },
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_automation_usage_api.py",
+      "cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "expected": [
+      "Thread Gates",
+      "Test",
+      "Change Contract"
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Awaiting follow-up PR merge and production verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "If readiness live collection exceeds timeout, endpoint returns snapshot-based readiness quickly without re-running slow live provider probes, while still keeping provider-family coalescing and no degraded rows.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness"
+    ],
+    "test_flows": [
+      "Force readiness collection timeout and verify snapshot fallback path is used.",
+      "Confirm readiness response still has one row per provider family and no degraded rows."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a readiness-report builder that operates on a supplied overview payload
- add `provider_readiness_report_from_snapshots()` for bounded fallback execution
- update `/api/automation/usage/readiness` timeout fallback to use snapshot-based readiness instead of retrying live provider probes
- add regression coverage proving timeout fallback path uses snapshot readiness output
- add commit evidence for this follow-up fix

## Validation
- `cd api && pytest -q tests/test_automation_usage_api.py`
- `cd api && ruff check app/services/automation_usage_service.py app/routers/automation_usage.py tests/test_automation_usage_api.py`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
