### PR TITLE
Harden deploy verification with retry/backoff

### DIFF
--- a/docs/system_audit/commit_evidence_2026-03-01_web-api-deploy-retry-resilience.json
+++ b/docs/system_audit/commit_evidence_2026-03-01_web-api-deploy-retry-resilience.json
@@ -1,0 +1,62 @@
+{
+  "date": "2026-03-01",
+  "thread_branch": "codex/open-questions-unblock-20260228",
+  "commit_scope": "Harden public web/API deploy verification with retry/backoff so transient Railway/API reachability blips do not produce false deploy failures.",
+  "files_owned": [
+    "scripts/verify_web_api_deploy.sh",
+    "docs/system_audit/commit_evidence_2026-03-01_web-api-deploy-retry-resilience.json"
+  ],
+  "idea_ids": [
+    "deployment-gate-reliability"
+  ],
+  "spec_ids": [
+    "056-release-gates"
+  ],
+  "task_ids": [
+    "task-2026-03-01-web-api-deploy-retry-resilience"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "bash -n scripts/verify_web_api_deploy.sh",
+    "./scripts/verify_web_api_deploy.sh"
+  ],
+  "change_files": [
+    "scripts/verify_web_api_deploy.sh",
+    "docs/system_audit/commit_evidence_2026-03-01_web-api-deploy-retry-resilience.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n scripts/verify_web_api_deploy.sh",
+      "./scripts/verify_web_api_deploy.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting push, PR checks, and merge/deploy follow-through evidence."
+  }
+}


### PR DESCRIPTION
## Summary
- add retry/backoff wrappers to deploy verification curl probes
- apply retries to API/web health, SHA parity, persistence, readiness, and CORS checks
- add commit evidence for this deployment-contract hardening

## Validation
- bash -n scripts/verify_web_api_deploy.sh
- ./scripts/verify_web_api_deploy.sh
