### PR TITLE
Harden Telegram alerts and enforce OAuth-only paid providers

### DIFF
--- a/api/app/services/agent_service.py
+++ b/api/app/services/agent_service.py
@@ -1261,6 +1261,9 @@ def _apply_runner_auth_mode_defaults(ctx: dict[str, Any], executor: str) -> None
         return
     if executor == "cursor":
         ctx["runner_cursor_auth_mode"] = "oauth"
+        return
+    if executor == "claude":
+        ctx["runner_claude_auth_mode"] = "oauth"
 
 
 def _enforce_openrouter_executor_policy(ctx: dict[str, Any], executor: str) -> str:

--- a/api/tests/test_telegram_adapter.py
+++ b/api/tests/test_telegram_adapter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import telegram_adapter
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, text: str = '{"ok": true}') -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_send_alert_rate_limits_repeated_failed_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_IDS", "111")
+    monkeypatch.setenv("TELEGRAM_FAILED_ALERT_WINDOW_SECONDS", "3600")
+    monkeypatch.setenv("TELEGRAM_FAILED_ALERT_MAX_PER_WINDOW", "1")
+    telegram_adapter._FAILED_ALERT_TIMESTAMPS.clear()
+
+    sent_payloads: list[dict] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url: str, json: dict) -> _FakeResponse:
+            sent_payloads.append(json)
+            return _FakeResponse()
+
+    monkeypatch.setattr("app.services.telegram_adapter.httpx.AsyncClient", _FakeAsyncClient)
+
+    failed_message = "Status: `failed`\nTask: test"
+    first = await telegram_adapter.send_alert(failed_message)
+    second = await telegram_adapter.send_alert(failed_message)
+
+    assert first is True
+    assert second is True
+    assert len(sent_payloads) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_alert_does_not_rate_limit_non_failed_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_IDS", "111")
+    monkeypatch.setenv("TELEGRAM_FAILED_ALERT_WINDOW_SECONDS", "3600")
+    monkeypatch.setenv("TELEGRAM_FAILED_ALERT_MAX_PER_WINDOW", "1")
+    telegram_adapter._FAILED_ALERT_TIMESTAMPS.clear()
+
+    sent_payloads: list[dict] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url: str, json: dict) -> _FakeResponse:
+            sent_payloads.append(json)
+            return _FakeResponse()
+
+    monkeypatch.setattr("app.services.telegram_adapter.httpx.AsyncClient", _FakeAsyncClient)
+
+    message = "Status: `needs_decision`\nTask: test"
+    first = await telegram_adapter.send_alert(message)
+    second = await telegram_adapter.send_alert(message)
+
+    assert first is True
+    assert second is True
+    assert len(sent_payloads) == 2

--- a/docs/system_audit/commit_evidence_2026-03-01_oauth-paid-provider-telegram-noise.json
+++ b/docs/system_audit/commit_evidence_2026-03-01_oauth-paid-provider-telegram-noise.json
@@ -1,0 +1,104 @@
+{
+  "date": "2026-03-01",
+  "thread_branch": "codex/telegram-alert-noise-20260228",
+  "commit_scope": "Suppress noisy duplicate Telegram task alerts and enforce OAuth-only paid-provider execution (codex/cursor/claude) with refresh-token-backed session bootstrap and API-key removal from runner execution paths.",
+  "files_owned": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/app/services/telegram_adapter.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_registry_api.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_telegram_adapter.py",
+    "docs/system_audit/commit_evidence_2026-03-01_oauth-paid-provider-telegram-noise.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent.py",
+    "api/app/services/agent_service.py",
+    "api/app/services/telegram_adapter.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_runner_registry_api.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_telegram_adapter.py",
+    "docs/system_audit/commit_evidence_2026-03-01_oauth-paid-provider-telegram-noise.json"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "requirements",
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && ruff check app/routers/agent.py app/services/agent_service.py app/services/telegram_adapter.py scripts/agent_runner.py tests/test_agent_runner_registry_api.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_telegram_adapter.py",
+    "cd api && pytest -q tests/test_telegram_adapter.py tests/test_agent_runner_registry_api.py tests/test_agent_runner_tool_failure_telemetry.py",
+    "cd api && pytest -q tests/test_openclaw_executor_integration.py -k \"defaults_runner_codex_auth_mode_oauth or defaults_runner_cursor_auth_mode_oauth or forces_oauth_runner_codex_auth_mode\"",
+    "./scripts/verify_worktree_local_web.sh --start",
+    "./scripts/verify_web_api_deploy.sh"
+  ],
+  "idea_ids": [
+    "telegram-failed-alert-dedup",
+    "oauth-only-paid-provider-runner",
+    "refresh-token-session-bootstrap-for-paid-providers"
+  ],
+  "spec_ids": [
+    "006-overnight-backlog"
+  ],
+  "task_ids": [
+    "task-2026-03-01-telegram-noise-and-oauth-paid-providers"
+  ],
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocking_reason": "Pending commit/push/PR checks and post-push CI completion."
+  },
+  "change_intent": "runtime_fix",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && ruff check app/routers/agent.py app/services/agent_service.py app/services/telegram_adapter.py scripts/agent_runner.py tests/test_agent_runner_registry_api.py tests/test_agent_runner_tool_failure_telemetry.py tests/test_telegram_adapter.py",
+      "cd api && pytest -q tests/test_telegram_adapter.py tests/test_agent_runner_registry_api.py tests/test_agent_runner_tool_failure_telemetry.py",
+      "./scripts/verify_worktree_local_web.sh --start",
+      "./scripts/verify_web_api_deploy.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "expected": [
+      "Thread Gates",
+      "Test",
+      "Change Contract"
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Awaiting branch deploy/push and CI-linked deploy confirmation."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Task failure/needs_decision Telegram alerts are deduplicated and no longer spam repeated failed sends; paid-provider runner execution for codex/cursor/claude enforces OAuth session auth only, strips API-key env usage, and supports refresh-token session bootstrap payloads.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/health",
+      "https://coherence-network-production.up.railway.app/api/automation/usage/readiness",
+      "https://coherence-network-production.up.railway.app/api/runtime/endpoints/summary"
+    ],
+    "test_flows": [
+      "Run a paid codex/cursor/claude task and confirm runner uses OAuth/session path without API-key injection.",
+      "Trigger repeated task failure transitions and confirm Telegram alert emission remains deduplicated rather than spammed."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary\n- dedupe/suppress repeated Telegram failed/needs_decision task alerts to reduce noise\n- enforce OAuth-only paid-provider runner auth for codex/cursor/claude (refresh-token session bootstrap; no API-key execution path)\n- add regression tests for Telegram adapter and paid-provider runner OAuth behavior\n\n## Validation\n- All checks passed!\n- ........................................................................ [ 93%]
.....                                                                    [100%]
=============================== warnings summary ===============================
app/main.py:426
  /Users/ursmuff/.claude-worktrees/Coherence-Network/telegram-alert-noise-20260228/api/app/main.py:426: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

../../../../../../opt/homebrew/lib/python3.14/site-packages/fastapi/applications.py:4599
  /opt/homebrew/lib/python3.14/site-packages/fastapi/applications.py:4599: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

tests/test_agent_runner_registry_api.py::test_runner_idle_heartbeat_reaps_orphaned_running_tasks
tests/test_agent_runner_registry_api.py::test_task_failed_alert_emits_once_per_status_transition
  /opt/homebrew/lib/python3.14/site-packages/sqlalchemy/sql/schema.py:3624: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    return util.wrap_callable(lambda ctx: fn(), fn)  # type: ignore

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
77 passed, 4 warnings in 1.53s\n- Using repo root: /Users/ursmuff/.claude-worktrees/Coherence-Network/telegram-alert-noise-20260228
Using API base: http://127.0.0.1:18121
Using web base: http://127.0.0.1:3221
Thread runtime key: telegram-alert-noise-20260228-ec9b35ae85116778
Starting API on http://127.0.0.1:18121 with /opt/homebrew/bin/python3.11
API ready.
Building web app...

> coherence-web@0.1.0 build
> next build

   ▲ Next.js 15.5.12

   Creating an optimized production build ...
 ✓ Compiled successfully in 841ms
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/27) ...
   Generating static pages (6/27) 
   Generating static pages (13/27) 
   Generating static pages (20/27) 
 ✓ Generating static pages (27/27)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS  Revalidate  Expire
┌ ○ /                                      183 B         106 kB         ≈2m      1y
├ ○ /_not-found                            999 B         103 kB
├ ƒ /agent                                 183 B         106 kB
├ ○ /api-coverage                        4.35 kB         119 kB
├ ○ /api-health                          1.35 kB         107 kB
├ ƒ /api/[...path]                         134 B         102 kB
├ ƒ /api/health-proxy                      134 B         102 kB
├ ƒ /api/runtime-beacon                    134 B         102 kB
├ ƒ /api/web-version                       134 B         102 kB
├ ○ /assets                              1.72 kB         107 kB
├ ○ /automation                            183 B         106 kB          2m      1y
├ ○ /contribute                          4.52 kB         110 kB
├ ○ /contributions                       2.36 kB         108 kB
├ ○ /contributors                        2.39 kB         108 kB
├ ƒ /flow                                  183 B         106 kB
├ ○ /friction                            2.17 kB         108 kB
├ ○ /gates                               2.71 kB         118 kB
├ ƒ /ideas                                 183 B         106 kB
├ ƒ /ideas/[idea_id]                       183 B         106 kB
├ ○ /import                               2.4 kB         117 kB
├ ○ /portfolio                           3.29 kB         118 kB
├ ƒ /project/[ecosystem]/[name]           1.7 kB         107 kB
├ ○ /remote-ops                          4.64 kB         120 kB
├ ○ /runtime                               134 B         102 kB
├ ○ /search                              2.29 kB         117 kB
├ ƒ /specs                                 183 B         106 kB
├ ƒ /specs/[spec_id]                       183 B         106 kB
├ ○ /tasks                               3.81 kB         109 kB
└ ƒ /usage                                 183 B         106 kB
+ First Load JS shared by all             102 kB
  ├ chunks/255-ebd51be49873d76c.js         46 kB
  ├ chunks/4bd1b696-c023c6e3521b1417.js  54.2 kB
  └ other shared chunks (total)          1.92 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

Web ready.
==> API health: http://127.0.0.1:18121/api/health
HTTP status: 200
PASS
==> API ideas: http://127.0.0.1:18121/api/ideas
HTTP status: 200
PASS
==> API tasks: http://127.0.0.1:18121/api/agent/tasks
HTTP status: 200
PASS
==> API system lineage: http://127.0.0.1:18121/api/inventory/system-lineage
HTTP status: 200
PASS
==> API endpoint runtime summary: http://127.0.0.1:18121/api/runtime/endpoints/summary
HTTP status: 200
PASS
==> Web root: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web root nav flow: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web root nav specs: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web root nav tasks: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web root nav contribute: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web root nav gates: http://127.0.0.1:3221/
HTTP status: 200
PASS
==> Web ideas: http://127.0.0.1:3221/ideas
HTTP status: 200
PASS
==> Web specs: http://127.0.0.1:3221/specs
HTTP status: 200
PASS
==> Web flow: http://127.0.0.1:3221/flow
HTTP status: 200
PASS
==> Web tasks: http://127.0.0.1:3221/tasks
HTTP status: 200
PASS
==> Web gates: http://127.0.0.1:3221/gates
HTTP status: 200
PASS
==> Web contribute: http://127.0.0.1:3221/contribute
HTTP status: 200
PASS
==> Web API health page: http://127.0.0.1:3221/api-health
HTTP status: 200
PASS

Local worktree web validation passed.\n- 
==> Railway API health: https://coherence-network-production.up.railway.app/api/health
HTTP status: 200
Server: railway-edge
PASS

==> Railway gates main head: https://coherence-network-production.up.railway.app/api/gates/main-head
HTTP status: 200
Server: railway-edge
PASS

==> API runtime SHA parity: https://coherence-network-production.up.railway.app/api/health vs https://coherence-network-production.up.railway.app/api/gates/main-head (required=0)
health status: 200 | main-head status: 200
expected_sha: 160ef981e956805b83dfa7127933e0b924f009f7
observed_sha: 160ef981e956805b83dfa7127933e0b924f009f7
PASS

==> Persistence contract: https://coherence-network-production.up.railway.app/api/health/persistence
HTTP status: 200
required: true | pass_contract: true
PASS

==> Provider readiness: https://coherence-network-production.up.railway.app/api/automation/usage/readiness (required=0)
HTTP status: 200
all_required_ready: true | blocking_issues: 0
PASS

==> Railway web root: https://coherence-web-production.up.railway.app/
HTTP status: 200
Server: railway-edge
PASS

==> Railway web gates page: https://coherence-web-production.up.railway.app/gates
HTTP status: 200
Server: railway-edge
PASS

==> Railway web API health page: https://coherence-web-production.up.railway.app/api-health
HTTP status: 200
Server: railway-edge
PASS

==> Railway web API health proxy: https://coherence-web-production.up.railway.app/api/health-proxy
HTTP status: 200
Server: railway-edge
PASS

==> Web runtime SHA parity: https://coherence-web-production.up.railway.app/api/health-proxy vs https://coherence-network-production.up.railway.app/api/gates/main-head (required=0)
proxy status: 200 | main-head status: 200
expected_sha: 160ef981e956805b83dfa7127933e0b924f009f7
observed_sha: 160ef981e956805b83dfa7127933e0b924f009f7
api_status: ok
PASS

==> CORS check: https://coherence-network-production.up.railway.app/api/health with Origin https://coherence-web-production.up.railway.app
HTTP status: 200
Access-Control-Allow-Origin: https://coherence-web-production.up.railway.app
PASS

==> Skipping Telegram alert config gate (VERIFY_REQUIRE_TELEGRAM_ALERTS=0)

Deployment verification passed: Railway API and Railway web are reachable and CORS is aligned.\n- OK: evidence validation passed for /Users/ursmuff/.claude-worktrees/Coherence-Network/telegram-alert-noise-20260228/docs/system_audit/commit_evidence_2026-03-01_oauth-paid-provider-telegram-noise.json\n- PR guard report: /Users/ursmuff/.claude-worktrees/Coherence-Network/telegram-alert-noise-20260228/docs/system_audit/pr_check_failures/pr_check_guard_20260301T113129Z_codex-telegram-alert-noise-20260228.json
ready_for_push=True
All selected checks passed.
local_preflight=pass
remote_pr_checks=skipped
n8n_security_floor=skipped\n- repo=seeker71/Coherence-Network
codex_open_prs=0
stale_threshold_minutes=90.0
stale_codex_prs=0