### PR TITLE
Enable Gemini CLI executor path for Railway host runner

### DIFF
--- a/api/app/models/agent.py
+++ b/api/app/models/agent.py
@@ -219,7 +219,7 @@ class RouteResponse(BaseModel):
     model: str
     command_template: str
     tier: str
-    executor: Optional[str] = None  # "claude", "cursor", or "openclaw" (accepts "clawwork" alias)
+    executor: Optional[str] = None  # "claude", "cursor", "codex"/"openclaw", "gemini", or "openrouter"
     provider: Optional[str] = None
     billing_provider: Optional[str] = None
     is_paid_provider: Optional[bool] = None

--- a/api/app/routers/agent.py
+++ b/api/app/routers/agent.py
@@ -1407,10 +1407,10 @@ async def route(
     task_type: TaskType = Query(...),
     executor: Optional[str] = Query(
         "auto",
-        description="Executor: auto (default policy), claude, cursor, codex, openrouter, openclaw (alias), or clawwork (alias).",
+        description="Executor: auto (default policy), claude, cursor, codex, gemini, openrouter, openclaw (alias), or clawwork (alias).",
     ),
 ) -> RouteResponse:
-    """Get routing for a task type (no persistence). Use executor=cursor|codex|openrouter (openclaw/clawwork alias to codex)."""
+    """Get routing for a task type (no persistence). Use executor=cursor|codex|gemini|openrouter (openclaw/clawwork alias to codex)."""
     return RouteResponse(**agent_service.get_route(task_type, executor=executor or "auto"))
 
 

--- a/api/app/services/agent_execution_service.py
+++ b/api/app/services/agent_execution_service.py
@@ -84,6 +84,8 @@ def _extract_underlying_model(task_model: str) -> str:
         return cleaned.split("/", 1)[1].strip()
     if cleaned.startswith("cursor/"):
         return cleaned.split("/", 1)[1].strip()
+    if cleaned.startswith("gemini/"):
+        return cleaned.split("/", 1)[1].strip()
     return cleaned
 
 
@@ -133,6 +135,8 @@ def _task_route_provider(task: dict[str, Any]) -> str:
         return "openai-codex"
     if "claude" in model:
         return "claude"
+    if "gemini" in model:
+        return "gemini"
     if model.startswith(("gpt", "o1", "o3", "o4", "openai/")):
         return "openai"
     return "unknown"

--- a/api/app/services/agent_routing_service.py
+++ b/api/app/services/agent_routing_service.py
@@ -16,6 +16,8 @@ _CLAUDE_MODEL = os.environ.get("CLAUDE_FALLBACK_MODEL", "openrouter/free")
 
 _CURSOR_MODEL_DEFAULT = os.environ.get("CURSOR_CLI_MODEL", "auto")
 _CURSOR_MODEL_REVIEW = os.environ.get("CURSOR_CLI_REVIEW_MODEL", "auto")
+_GEMINI_MODEL_DEFAULT = os.environ.get("GEMINI_CLI_MODEL", "gemini-2.5-pro")
+_GEMINI_MODEL_REVIEW = os.environ.get("GEMINI_CLI_REVIEW_MODEL", _GEMINI_MODEL_DEFAULT)
 
 DEFAULT_MODEL_ALIAS_MAP = (
     "gtp-5.3-codex-spark:gpt-5.3-codex-spark,"
@@ -100,6 +102,14 @@ OPENCLAW_MODEL_BY_TYPE: dict[TaskType, str] = {
 }
 CODEX_MODEL_BY_TYPE = OPENCLAW_MODEL_BY_TYPE
 
+GEMINI_MODEL_BY_TYPE: dict[TaskType, str] = {
+    TaskType.SPEC: _GEMINI_MODEL_DEFAULT,
+    TaskType.TEST: _GEMINI_MODEL_DEFAULT,
+    TaskType.IMPL: _GEMINI_MODEL_DEFAULT,
+    TaskType.REVIEW: _GEMINI_MODEL_REVIEW,
+    TaskType.HEAL: _GEMINI_MODEL_REVIEW,
+}
+
 CLAUDE_CODE_MODEL_BY_TYPE: dict[TaskType, str] = {
     TaskType.SPEC: _CLAUDE_CODE_MODEL_DEFAULT,
     TaskType.TEST: _CLAUDE_CODE_MODEL_DEFAULT,
@@ -108,7 +118,7 @@ CLAUDE_CODE_MODEL_BY_TYPE: dict[TaskType, str] = {
     TaskType.HEAL: _CLAUDE_CODE_MODEL_REVIEW,
 }
 
-_CANONICAL_EXECUTOR_VALUES = ("claude", "cursor", "codex", "openrouter")
+_CANONICAL_EXECUTOR_VALUES = ("claude", "cursor", "codex", "gemini", "openrouter")
 _EXECUTOR_ALIASES = {"clawwork": "codex", "openclaw": "codex"}
 _OPENROUTER_FREE_MODEL = normalize_model_name(
     os.environ.get("OPENROUTER_FREE_MODEL", "openrouter/free")
@@ -167,6 +177,8 @@ def escalation_executor_default() -> str:
     if configured:
         return normalize_executor(configured, default="claude")
     cheap = cheap_executor_default()
+    if cheap == "gemini":
+        return "gemini"
     return "claude" if cheap != "claude" else "codex"
 
 
@@ -179,6 +191,11 @@ def executor_binary_name(executor: str) -> str:
         if configured:
             return configured
         return "codex"
+    if normalized == "gemini":
+        configured = os.environ.get("GEMINI_EXECUTABLE", "").strip()
+        if configured:
+            return configured
+        return "gemini"
     if normalized == "openrouter":
         return "server-executor"
     return "claude"
@@ -265,6 +282,17 @@ def openrouter_command_template(task_type: TaskType) -> str:
     return template.replace("{{model}}", resolved_model)
 
 
+def gemini_command_template(task_type: TaskType) -> str:
+    model = GEMINI_MODEL_BY_TYPE[task_type]
+    template = (
+        os.environ.get("GEMINI_COMMAND_TEMPLATE", "").strip()
+        or 'gemini -p "{{direction}}" --model {{model}}'
+    )
+    if "{{direction}}" not in template:
+        template = template.strip() + ' "{{direction}}"'
+    return template.replace("{{model}}", model)
+
+
 def enforce_openrouter_free_model(model: str | None) -> str:
     """OpenRouter execution policy: force free-tier model usage."""
     cleaned = normalize_model_name(str(model or "").strip())
@@ -322,6 +350,10 @@ def route_for_executor(task_type: TaskType, executor: str, default_command_templ
         model = enforce_openrouter_free_model(resolved_model)
         template = openrouter_command_template(task_type)
         tier = "openrouter"
+    elif normalized == "gemini":
+        model = f"gemini/{GEMINI_MODEL_BY_TYPE[task_type]}"
+        template = gemini_command_template(task_type)
+        tier = "gemini"
     elif normalized == "claude":
         cc_model = CLAUDE_CODE_MODEL_BY_TYPE[task_type]
         model = f"claude/{cc_model}" if cc_model else "claude/default"
@@ -369,7 +401,7 @@ def normalize_open_responses_model(model: str) -> str:
     cleaned = str(model or "").strip()
     if "/" in cleaned:
         prefix, _, suffix = cleaned.partition("/")
-        if prefix in {"codex", "openclaw", "clawwork", "cursor"} and suffix.strip():
+        if prefix in {"codex", "openclaw", "clawwork", "cursor", "gemini"} and suffix.strip():
             return suffix.strip()
     return cleaned
 
@@ -413,16 +445,24 @@ def classify_provider(*, executor: str, model: str, command: str, worker_id: str
         provider = "openai-codex"
     elif normalized_executor == "codex":
         provider = "openai-codex"
+    elif normalized_executor == "gemini":
+        provider = "gemini"
     elif normalized_executor == "openrouter":
         provider = "openrouter"
     elif "openrouter" in command_model or "openrouter" in lower_model:
         provider = "openrouter"
+    elif command_model.startswith(("gemini", "google/gemini")):
+        provider = "gemini"
     elif command_model.startswith("openai/") or command_model.startswith(("gpt", "o1", "o3", "o4")):
         provider = "openai-codex" if "codex" in command_model else "openai"
+    elif lower_model.startswith("gemini/") or lower_model.startswith("google/gemini"):
+        provider = "gemini"
     elif "codex" in lower_model:
         provider = "openai-codex"
     elif lower_model.startswith("openai/") or lower_model.startswith(("gpt", "o1", "o3", "o4")):
         provider = "openai"
+    elif lower_command.startswith("gemini "):
+        provider = "gemini"
     elif lower_command.startswith("codex "):
         provider = "openai-codex"
     elif normalized_executor == "cursor":
@@ -441,6 +481,6 @@ def is_paid_model(*, provider: str, model: str, command_model: str) -> bool:
         if "openrouter/free" in ref or ref.endswith("/free"):
             return False
         return True
-    if provider in {"openai", "openai-codex", "claude", "cursor"}:
+    if provider in {"openai", "openai-codex", "claude", "cursor", "gemini"}:
         return True
     return False

--- a/api/app/services/agent_service.py
+++ b/api/app/services/agent_service.py
@@ -116,15 +116,15 @@ def _escalation_executor_default() -> str:
     if configured:
         return _normalize_executor(configured, default="claude")
     cheap = _cheap_executor_default()
+    if cheap == "gemini":
+        return "gemini"
     return "claude" if cheap != "claude" else "codex"
 
 
 def _executor_binary_name(executor: str) -> str:
     if executor == "cursor":
         return "agent"
-    if executor == "codex":
-        return routing_service.executor_binary_name(executor)
-    if executor == "openrouter":
+    if executor in {"codex", "openrouter", "gemini"}:
         return routing_service.executor_binary_name(executor)
     return "claude"
 
@@ -149,7 +149,7 @@ def _first_available_executor(preferred: list[str]) -> str:
     if configured_default and _executor_available(configured_default):
         return configured_default
     # Final deterministic safety net: prefer codex when available.
-    for candidate in ("codex", "cursor", "claude"):
+    for candidate in ("codex", "gemini", "cursor", "claude"):
         if _executor_available(candidate):
             return candidate
     return _normalize_executor(os.environ.get("AGENT_EXECUTOR_DEFAULT"), default="codex")
@@ -160,6 +160,7 @@ def _executor_fallback_candidates() -> list[str]:
         _cheap_executor_default(),
         _escalation_executor_default(),
         "codex",
+        "gemini",
         "openrouter",
         "cursor",
         "claude",
@@ -176,7 +177,10 @@ def _select_executor_with_retry_policy(
     cheap = _cheap_executor_default()
     escalate_to = _escalation_executor_default()
     if escalate_to == cheap:
-        escalate_to = "claude" if cheap != "claude" else "codex"
+        if cheap == "gemini":
+            escalate_to = "gemini"
+        else:
+            escalate_to = "claude" if cheap != "claude" else "codex"
 
     stats = _prior_attempt_stats(task_fingerprint)
     retry_hint = _task_retry_hint(context)
@@ -187,7 +191,7 @@ def _select_executor_with_retry_policy(
         "failure_threshold" if should_escalate else "cheap_default"
     )
     if not _executor_available(selected):
-        fallback = _first_available_executor([cheap, escalate_to, "cursor", "claude", "codex", "openrouter"])
+        fallback = _first_available_executor([cheap, escalate_to, "cursor", "claude", "codex", "gemini", "openrouter"])
         return fallback, {
             "policy_applied": True,
             "reason": "selected_executor_unavailable",
@@ -364,6 +368,7 @@ def _select_executor(task_type: TaskType, direction: str, context: dict[str, Any
             "cursor",
             "claude",
             "codex",
+            "gemini",
         ])
         return selected, {
             "policy_applied": True,
@@ -375,6 +380,7 @@ def _select_executor(task_type: TaskType, direction: str, context: dict[str, Any
     selected_open = _first_available_executor([
         _open_question_executor_default(),
         "codex",
+        "gemini",
         "cursor",
         "claude",
     ])
@@ -463,6 +469,7 @@ def _integration_gaps() -> dict[str, Any]:
         "claude": _executor_available("claude"),
         "agent": _executor_available("cursor"),
         "codex": _executor_available("codex"),
+        "gemini": _executor_available("gemini"),
         "openrouter": _executor_available("openrouter"),
     }
 
@@ -786,6 +793,8 @@ def _derive_task_executor(task: dict[str, Any]) -> str:
     command = str(task.get("command") or "").strip()
     if model.startswith("cursor/") or command.startswith("agent "):
         return "cursor"
+    if model.startswith("gemini/") or command.startswith("gemini "):
+        return "gemini"
     if model.startswith("openrouter/") or command.startswith("openrouter-exec "):
         return "openrouter"
     if model.startswith("codex/") or command.startswith("codex "):
@@ -1162,11 +1171,13 @@ def _claim_running_task(task: dict[str, Any], worker_id: str | None) -> None:
 def _build_command(
     direction: str, task_type: TaskType, executor: str = "claude"
 ) -> str:
-    """Build command for task. executor: 'claude' (default), 'cursor', 'codex', or 'openrouter'."""
+    """Build command for task. executor: 'claude' (default), 'cursor', 'codex', 'gemini', or 'openrouter'."""
     if executor == "cursor":
         template = _cursor_command_template(task_type)
     elif executor == "codex":
         template = _openclaw_command_template(task_type)
+    elif executor == "gemini":
+        template = routing_service.gemini_command_template(task_type)
     elif executor == "openrouter":
         template = _openrouter_command_template(task_type)
     elif executor == "claude":
@@ -1222,6 +1233,8 @@ def _resolve_task_route(
                     model = f"codex/{applied_override}"
                 elif executor == "cursor":
                     model = f"cursor/{applied_override}"
+                elif executor == "gemini":
+                    model = f"gemini/{applied_override}"
                 elif executor == "openrouter":
                     model = routing_service.enforce_openrouter_free_model(applied_override)
                 else:
@@ -1261,6 +1274,9 @@ def _apply_runner_auth_mode_defaults(ctx: dict[str, Any], executor: str) -> None
         return
     if executor == "cursor":
         ctx["runner_cursor_auth_mode"] = "oauth"
+        return
+    if executor == "gemini":
+        ctx["runner_gemini_auth_mode"] = "oauth"
         return
     if executor == "claude":
         ctx["runner_claude_auth_mode"] = "oauth"
@@ -1736,7 +1752,7 @@ def get_review_summary() -> dict[str, Any]:
 
 
 def get_route(task_type: TaskType, executor: str = "claude") -> dict[str, Any]:
-    """Return routing info for a task type (no persistence). executor: auto|claude|cursor|codex|openrouter|openclaw|clawwork."""
+    """Return routing info for a task type (no persistence). executor: auto|claude|cursor|codex|gemini|openrouter|openclaw|clawwork."""
     executor = (executor or "auto").strip().lower()
     if executor == "auto":
         executor = _cheap_executor_default()

--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -294,6 +294,7 @@ CODEX_MODEL_ARG_RE = re.compile(r"(?P<prefix>--model\s+)(?P<model>[^\s]+)")
 CODEX_AUTH_MODE_VALUES = {"oauth"}
 CURSOR_AUTH_MODE_VALUES = {"oauth"}
 CLAUDE_AUTH_MODE_VALUES = {"oauth"}
+GEMINI_AUTH_MODE_VALUES = {"oauth"}
 
 
 def _tool_token(command: str) -> str:
@@ -3079,6 +3080,11 @@ def _uses_cursor_cli(command: str) -> bool:
     return command.strip().startswith("agent ")
 
 
+def _uses_gemini_cli(command: str) -> bool:
+    """True if command uses Gemini CLI."""
+    return command.strip().startswith("gemini ")
+
+
 def _uses_openclaw_cli(command: str) -> bool:
     """True if command uses OpenClaw CLI."""
     stripped = command.strip()
@@ -3305,6 +3311,8 @@ def _cli_install_provider_for_command(command: str) -> str:
         return "cursor"
     if _uses_claude_cli(command):
         return "claude"
+    if _uses_gemini_cli(command):
+        return "gemini"
     if _uses_codex_cli(command):
         return "codex"
     return ""
@@ -3314,6 +3322,7 @@ def _cli_binary_for_provider(provider: str) -> str:
     mapping = {
         "cursor": "agent",
         "claude": "claude",
+        "gemini": "gemini",
         "codex": "codex",
     }
     return mapping.get(provider, "")
@@ -3349,6 +3358,7 @@ def _cli_install_commands(provider: str) -> list[str]:
     env_overrides = {
         "cursor": "AGENT_RUNNER_CURSOR_INSTALL_COMMANDS",
         "claude": "AGENT_RUNNER_CLAUDE_INSTALL_COMMANDS",
+        "gemini": "AGENT_RUNNER_GEMINI_INSTALL_COMMANDS",
         "codex": "AGENT_RUNNER_CODEX_INSTALL_COMMANDS",
     }
     default_commands = {
@@ -3361,6 +3371,10 @@ def _cli_install_commands(provider: str) -> list[str]:
             ensure_node_cmd,
             "curl -fsSL https://claude.ai/install.sh | bash",
             "npm install -g @anthropic-ai/claude-code",
+        ],
+        "gemini": [
+            ensure_node_cmd,
+            "npm install -g @google/gemini-cli",
         ],
         "codex": [
             ensure_node_cmd,
@@ -3757,7 +3771,13 @@ def _ensure_cli_for_command(
 def _prepare_cli_command_for_exec(command: str) -> tuple[str | list[str], bool, str]:
     """Run supported CLI commands via argv to avoid shell expansion in prompt text."""
     cmd = str(command or "")
-    if not (_uses_codex_cli(cmd) or _uses_cursor_cli(cmd) or _uses_openclaw_cli(cmd) or _uses_claude_cli(cmd)):
+    if not (
+        _uses_codex_cli(cmd)
+        or _uses_cursor_cli(cmd)
+        or _uses_gemini_cli(cmd)
+        or _uses_openclaw_cli(cmd)
+        or _uses_claude_cli(cmd)
+    ):
         return cmd, True, "shell"
     try:
         argv = shlex.split(cmd, posix=True)
@@ -4385,6 +4405,250 @@ def _configure_cursor_cli_environment(
     return auth_state
 
 
+def _configure_gemini_cli_environment(
+    *,
+    env: dict[str, str],
+    task_id: str,
+    log: logging.Logger,
+    task_ctx: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    requested_mode_raw = str((task_ctx or {}).get("runner_gemini_auth_mode") or "").strip().lower()
+    requested_mode = _normalize_oauth_only_auth_mode(
+        requested_mode_raw or str(os.environ.get("AGENT_GEMINI_AUTH_MODE", "oauth")),
+        default="oauth",
+        allowed=GEMINI_AUTH_MODE_VALUES,
+    )
+    effective_mode = "oauth"
+    if requested_mode_raw and requested_mode_raw != "oauth":
+        log.info(
+            "task=%s forcing gemini auth mode to oauth; ignoring requested=%s",
+            task_id,
+            requested_mode_raw,
+        )
+    gemini_config_override = str(os.environ.get("AGENT_GEMINI_CONFIG_DIR", "")).strip()
+    if gemini_config_override:
+        env["AGENT_GEMINI_CONFIG_DIR"] = _abs_expanded_path(gemini_config_override)
+
+    oauth_session_bootstrapped, oauth_session_bootstrap_detail = _bootstrap_gemini_oauth_session_from_env(
+        env=env,
+        task_id=task_id,
+        log=log,
+        task_ctx=task_ctx,
+    )
+    settings_configured, settings_config_detail = _ensure_gemini_oauth_settings(
+        env=env,
+        task_id=task_id,
+        log=log,
+    )
+
+    env.pop("GEMINI_API_KEY", None)
+    env.pop("GOOGLE_API_KEY", None)
+
+    target_oauth_path = _gemini_oauth_creds_target_path(env)
+    if target_oauth_path:
+        env["AGENT_GEMINI_OAUTH_CREDS_FILE"] = target_oauth_path
+    config_dir = _gemini_config_dir(env)
+    if config_dir:
+        env["AGENT_GEMINI_CONFIG_DIR"] = config_dir
+
+    oauth_available, oauth_source = _gemini_oauth_session_status(env)
+    oauth_missing = bool(not oauth_available)
+    auth_state = {
+        "requested_mode": requested_mode,
+        "effective_mode": effective_mode,
+        "oauth_session": bool(oauth_available),
+        "oauth_source": oauth_source,
+        "api_key_present": False,
+        "oauth_missing": oauth_missing,
+        "oauth_session_bootstrapped": bool(oauth_session_bootstrapped),
+        "oauth_session_bootstrap_detail": oauth_session_bootstrap_detail,
+        "oauth_settings_configured": bool(settings_configured),
+        "oauth_settings_config_detail": settings_config_detail,
+    }
+    if oauth_missing:
+        log.warning(
+            "task=%s gemini oauth mode requested but no session detected source=%s",
+            task_id,
+            oauth_source,
+        )
+    log.info(
+        "task=%s using gemini CLI auth requested=%s effective=%s oauth_session=%s source=%s oauth_bootstrap=%s settings=%s",
+        task_id,
+        requested_mode,
+        effective_mode,
+        bool(oauth_available),
+        oauth_source,
+        oauth_session_bootstrap_detail or "none",
+        settings_config_detail or "none",
+    )
+    return auth_state
+
+
+def _gemini_config_dir(env: dict[str, str]) -> str:
+    config_dir = (
+        str(env.get("AGENT_GEMINI_CONFIG_DIR", "")).strip()
+        or str(os.environ.get("AGENT_GEMINI_CONFIG_DIR", "")).strip()
+        or str(env.get("GEMINI_CONFIG_DIR", "")).strip()
+        or str(os.environ.get("GEMINI_CONFIG_DIR", "")).strip()
+    )
+    if config_dir:
+        return _abs_expanded_path(config_dir)
+    home = str(env.get("HOME", "")).strip() or str(os.environ.get("HOME", "")).strip()
+    if home:
+        return _abs_expanded_path(os.path.join(home, ".gemini"))
+    return ""
+
+
+def _gemini_oauth_creds_target_path(env: dict[str, str]) -> str:
+    explicit = str(env.get("AGENT_GEMINI_OAUTH_CREDS_FILE", "")).strip()
+    if not explicit:
+        explicit = str(os.environ.get("AGENT_GEMINI_OAUTH_CREDS_FILE", "")).strip()
+    if explicit:
+        return _abs_expanded_path(explicit)
+    config_dir = _gemini_config_dir(env)
+    if config_dir:
+        return _abs_expanded_path(os.path.join(config_dir, "oauth_creds.json"))
+    return ""
+
+
+def _gemini_settings_target_path(env: dict[str, str]) -> str:
+    explicit = str(env.get("AGENT_GEMINI_SETTINGS_FILE", "")).strip()
+    if not explicit:
+        explicit = str(os.environ.get("AGENT_GEMINI_SETTINGS_FILE", "")).strip()
+    if explicit:
+        return _abs_expanded_path(explicit)
+    config_dir = _gemini_config_dir(env)
+    if config_dir:
+        return _abs_expanded_path(os.path.join(config_dir, "settings.json"))
+    return ""
+
+
+def _extract_gemini_oauth_tokens(payload: Any) -> tuple[str, str]:
+    access_token = _find_first_nested_token_value(payload, ("accessToken", "access_token", "oauth_token"))
+    refresh_token = _find_first_nested_token_value(payload, ("refreshToken", "refresh_token"))
+    return access_token, refresh_token
+
+
+def _gemini_oauth_session_status(env: dict[str, str]) -> tuple[bool, str]:
+    target = _gemini_oauth_creds_target_path(env)
+    if not target:
+        return False, "missing_gemini_oauth_session"
+    payload = _read_json_object_file(target)
+    if payload:
+        access_token, refresh_token = _extract_gemini_oauth_tokens(payload)
+        if refresh_token or access_token:
+            return True, f"session_file:{target}"
+    return False, f"missing_session_file:{target}"
+
+
+def _bootstrap_gemini_oauth_session_from_env(
+    *,
+    env: dict[str, str],
+    task_id: str,
+    log: logging.Logger,
+    task_ctx: dict[str, Any] | None = None,
+    overwrite_existing: bool = False,
+) -> tuple[bool, str]:
+    encoded = _oauth_session_b64_from_task_or_env(
+        task_ctx=task_ctx,
+        task_ctx_key="runner_gemini_oauth_session_b64",
+        env=env,
+        env_key="AGENT_GEMINI_OAUTH_SESSION_B64",
+    )
+    if not encoded:
+        return False, ""
+    target_path = _gemini_oauth_creds_target_path(env)
+    if not target_path:
+        return False, "oauth_session_target_missing"
+
+    existing_payload = _read_json_object_file(target_path)
+    existing_access_token, existing_refresh_token = _extract_gemini_oauth_tokens(existing_payload)
+    if existing_refresh_token or existing_access_token:
+        if overwrite_existing:
+            log.info("task=%s replacing existing gemini oauth session at %s", task_id, target_path)
+        else:
+            env["AGENT_GEMINI_OAUTH_CREDS_FILE"] = target_path
+            return False, f"oauth_session_preserved_existing:{target_path}"
+
+    payload, decode_detail = _decode_oauth_session_b64_payload(
+        encoded=encoded,
+        task_id=task_id,
+        log=log,
+        env_key="AGENT_GEMINI_OAUTH_SESSION_B64",
+    )
+    if not payload:
+        return False, decode_detail or "oauth_session_b64_decode_failed"
+
+    access_token, refresh_token = _extract_gemini_oauth_tokens(payload)
+    if not refresh_token:
+        return False, "oauth_session_missing_refresh_token"
+    if access_token:
+        payload["access_token"] = access_token
+    payload["refresh_token"] = refresh_token
+    payload.pop("apiKey", None)
+    payload.pop("api_key", None)
+
+    try:
+        os.makedirs(os.path.dirname(target_path) or ".", exist_ok=True)
+        with open(target_path, "w", encoding="utf-8") as file:
+            file.write(json.dumps(payload, separators=(",", ":"), ensure_ascii=False))
+        os.chmod(target_path, 0o600)
+    except Exception as exc:
+        return False, f"oauth_session_write_failed:{type(exc).__name__}"
+
+    env["AGENT_GEMINI_OAUTH_CREDS_FILE"] = target_path
+    if existing_refresh_token or existing_access_token:
+        return True, f"oauth_session_overwritten:{target_path}"
+    return True, f"oauth_session_bootstrapped:{target_path}"
+
+
+def _ensure_gemini_oauth_settings(
+    *,
+    env: dict[str, str],
+    task_id: str,
+    log: logging.Logger,
+) -> tuple[bool, str]:
+    settings_path = _gemini_settings_target_path(env)
+    if not settings_path:
+        return False, "oauth_settings_target_missing"
+    payload = _read_json_object_file(settings_path)
+    if not payload:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    security = payload.get("security")
+    if not isinstance(security, dict):
+        security = {}
+    auth = security.get("auth")
+    if not isinstance(auth, dict):
+        auth = {}
+
+    selected = str(auth.get("selectedType") or "").strip().lower()
+    enforced = str(auth.get("enforcedType") or "").strip().lower()
+    desired = "oauth-personal"
+    if selected == desired and enforced == desired:
+        env["AGENT_GEMINI_SETTINGS_FILE"] = settings_path
+        return False, f"oauth_settings_preserved_existing:{settings_path}"
+
+    auth["selectedType"] = desired
+    auth["enforcedType"] = desired
+    security["auth"] = auth
+    payload["security"] = security
+
+    try:
+        os.makedirs(os.path.dirname(settings_path) or ".", exist_ok=True)
+        with open(settings_path, "w", encoding="utf-8") as file:
+            file.write(json.dumps(payload, separators=(",", ":"), ensure_ascii=False))
+        os.chmod(settings_path, 0o600)
+    except Exception as exc:
+        log.warning("task=%s failed to configure gemini oauth settings detail=%s", task_id, type(exc).__name__)
+        return False, f"oauth_settings_write_failed:{type(exc).__name__}"
+
+    env["AGENT_GEMINI_SETTINGS_FILE"] = settings_path
+    return True, f"oauth_settings_bootstrapped:{settings_path}"
+
+
 def _claude_oauth_session_target_path(env: dict[str, str]) -> str:
     explicit_session_file = str(env.get("AGENT_CLAUDE_OAUTH_SESSION_FILE", "")).strip()
     if not explicit_session_file:
@@ -4809,6 +5073,8 @@ def _infer_executor(command: str, model: str) -> str:
     model_value = (model or "").strip().lower()
     if _uses_cursor_cli(command) or model_value.startswith("cursor/"):
         return "cursor"
+    if _uses_gemini_cli(command) or model_value.startswith("gemini/"):
+        return "gemini"
     if _uses_openrouter_executor_command(command) or model_value.startswith("openrouter/"):
         return "openrouter"
     if _uses_codex_cli(command):
@@ -5472,6 +5738,14 @@ def run_one_task(
             task_ctx=task_ctx,
         )
         log.info("task=%s using Cursor CLI (OAuth/session)", task_id)
+    elif _uses_gemini_cli(command):
+        _configure_gemini_cli_environment(
+            env=env,
+            task_id=task_id,
+            log=log,
+            task_ctx=task_ctx,
+        )
+        log.info("task=%s using Gemini CLI (OAuth/session)", task_id)
     elif _uses_codex_cli(command):
         codex_auth_state = _configure_codex_cli_environment(env=env, task_id=task_id, log=log, task_ctx=task_ctx)
         command, codex_model_alias = _apply_codex_model_alias(command)

--- a/api/tests/test_agent_executor_policy.py
+++ b/api/tests/test_agent_executor_policy.py
@@ -257,6 +257,36 @@ def test_open_question_prefers_codex(monkeypatch: pytest.MonkeyPatch) -> None:
     assert str(task["model"]).startswith("codex/")
 
 
+def test_policy_does_not_escalate_away_from_gemini_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
+    monkeypatch.setenv("AGENT_EXECUTOR_POLICY_ENABLED", "1")
+    monkeypatch.setenv("AGENT_EXECUTOR_CHEAP_DEFAULT", "gemini")
+    monkeypatch.delenv("AGENT_EXECUTOR_ESCALATE_TO", raising=False)
+    monkeypatch.setenv("AGENT_EXECUTOR_ESCALATE_FAILURE_THRESHOLD", "1")
+    monkeypatch.setenv("AGENT_EXECUTOR_ESCALATE_RETRY_THRESHOLD", "10")
+    _which = {"agent": None, "claude": "/usr/bin/claude", "codex": None, "gemini": "/usr/bin/gemini"}
+    monkeypatch.setattr(agent_service.shutil, "which", lambda name: _which.get(name))
+    _reset_agent_store()
+
+    first = agent_service.create_task(
+        AgentTaskCreate(direction="Investigate repository drift signal", task_type=TaskType.IMPL)
+    )
+    assert (first.get("context") or {}).get("executor") == "gemini"
+    agent_service.update_task(first["id"], status=TaskStatus.FAILED, output="failed attempt")
+
+    second = agent_service.create_task(
+        AgentTaskCreate(direction="Investigate repository drift signal", task_type=TaskType.IMPL)
+    )
+
+    assert str(second["model"]).startswith("gemini/")
+    assert str(second["command"]).startswith("gemini ")
+    context = second.get("context") or {}
+    assert context.get("executor") == "gemini"
+    policy = context.get("executor_policy") or {}
+    assert policy.get("reason") == "failure_threshold"
+    assert policy.get("escalation_executor") == "gemini"
+
+
 def test_open_responses_normalization_is_shared_across_executors(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
     _which = {"agent": "/usr/bin/agent", "aider": "/usr/bin/aider", "codex": "/usr/bin/codex"}

--- a/api/tests/test_agent_runner_tool_failure_telemetry.py
+++ b/api/tests/test_agent_runner_tool_failure_telemetry.py
@@ -210,6 +210,10 @@ def test_infer_executor_detects_openrouter_model():
     assert agent_runner._infer_executor('echo "task"', "openrouter/free") == "openrouter"
 
 
+def test_infer_executor_detects_gemini():
+    assert agent_runner._infer_executor('gemini -p "task"', "gemini/gemini-2.5-pro") == "gemini"
+
+
 def test_run_one_task_dispatches_openrouter_server_executor(monkeypatch, tmp_path):
     monkeypatch.setattr(agent_runner, "LOG_DIR", str(tmp_path))
     monkeypatch.setenv("AGENT_WORKER_ID", "runner:test")
@@ -294,6 +298,44 @@ def test_run_one_task_cursor_oauth_mode_strips_api_key_env(monkeypatch, tmp_path
     assert captured_env.get("OPENAI_ADMIN_API_KEY", "") == ""
     assert captured_env.get("OPENAI_API_BASE", "") == ""
     assert captured_env.get("OPENAI_BASE_URL", "") == ""
+
+
+def test_run_one_task_gemini_forces_oauth_mode_and_strips_api_key_env(monkeypatch, tmp_path):
+    t = [1300.0]
+
+    def _mono():
+        t[0] += 0.25
+        return t[0]
+
+    captured_env: dict[str, str] = {}
+
+    def _popen(*args, **kwargs):
+        env = kwargs.get("env") or {}
+        captured_env.clear()
+        captured_env.update({str(k): str(v) for k, v in env.items()})
+        return _Proc(returncode=0, stdout_text='{"result":"ok"}\n')
+
+    monkeypatch.setattr(agent_runner.time, "monotonic", _mono)
+    monkeypatch.setattr(agent_runner, "LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(agent_runner.subprocess, "Popen", _popen)
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key-should-not-be-used")
+    monkeypatch.setenv("GOOGLE_API_KEY", "google-key-should-not-be-used")
+
+    client = _Client()
+    log = agent_runner._setup_logging(verbose=False)
+    done = agent_runner.run_one_task(
+        client=client,
+        task_id="task_gemini_oauth_mode",
+        command='gemini -p "Return ok" --model gemini-2.5-pro',
+        log=log,
+        verbose=False,
+        task_type="impl",
+        model="gemini/gemini-2.5-pro",
+        task_context={"runner_gemini_auth_mode": "api_key"},
+    )
+    assert done is True
+    assert captured_env.get("GEMINI_API_KEY", "") == ""
+    assert captured_env.get("GOOGLE_API_KEY", "") == ""
 
 
 def test_run_one_task_claude_oauth_mode_strips_api_key_env(monkeypatch, tmp_path):
@@ -541,6 +583,7 @@ def test_cli_install_provider_for_command_detects_supported_providers():
     assert agent_runner._cli_install_provider_for_command('agent "run" --model auto') == "cursor"
     assert agent_runner._cli_install_provider_for_command('claude -p "run"') == "claude"
     assert agent_runner._cli_install_provider_for_command('codex exec "run" --json') == "codex"
+    assert agent_runner._cli_install_provider_for_command('gemini -p "run" --model gemini-2.5-pro') == "gemini"
     assert agent_runner._cli_install_provider_for_command("pytest -q") == ""
 
 
@@ -1109,6 +1152,54 @@ def test_configure_claude_cli_environment_bootstraps_oauth_session_from_b64(monk
     assert loaded.get("refreshToken") == "claude-refresh-token"
     assert loaded.get("accessToken") == "claude-access-token"
     assert "apiKey" not in loaded
+
+
+def test_configure_gemini_cli_environment_bootstraps_oauth_session_from_b64(monkeypatch, tmp_path):
+    session_payload = {
+        "access_token": "gemini-access-token",
+        "refresh_token": "gemini-refresh-token",
+        "apiKey": "should-be-removed",
+    }
+    encoded = base64.b64encode(json.dumps(session_payload).encode("utf-8")).decode("utf-8")
+    monkeypatch.setenv("AGENT_GEMINI_AUTH_MODE", "oauth")
+    monkeypatch.setenv("AGENT_GEMINI_OAUTH_SESSION_B64", encoded)
+    monkeypatch.delenv("AGENT_GEMINI_OAUTH_CREDS_FILE", raising=False)
+    monkeypatch.delenv("AGENT_GEMINI_SETTINGS_FILE", raising=False)
+
+    env = {
+        "HOME": str(tmp_path),
+        "GEMINI_API_KEY": "gemini-key",
+        "GOOGLE_API_KEY": "google-key",
+    }
+    auth = agent_runner._configure_gemini_cli_environment(
+        env=env,
+        task_id="task_gemini_auth_bootstrap_b64",
+        log=agent_runner._setup_logging(verbose=False),
+    )
+
+    assert auth["requested_mode"] == "oauth"
+    assert auth["effective_mode"] == "oauth"
+    assert auth["oauth_session_bootstrapped"] is True
+    assert auth["oauth_session"] is True
+    assert str(auth.get("oauth_session_bootstrap_detail") or "").startswith("oauth_session_bootstrapped:")
+    assert str(auth.get("oauth_settings_config_detail") or "").startswith(
+        ("oauth_settings_bootstrapped:", "oauth_settings_preserved_existing:")
+    )
+    assert "GEMINI_API_KEY" not in env
+    assert "GOOGLE_API_KEY" not in env
+    target = env.get("AGENT_GEMINI_OAUTH_CREDS_FILE") or ""
+    assert target.endswith("/.gemini/oauth_creds.json")
+    loaded = json.loads(Path(target).read_text(encoding="utf-8"))
+    assert loaded.get("refresh_token") == "gemini-refresh-token"
+    assert loaded.get("access_token") == "gemini-access-token"
+    assert "apiKey" not in loaded
+    settings_target = env.get("AGENT_GEMINI_SETTINGS_FILE") or ""
+    assert settings_target.endswith("/.gemini/settings.json")
+    settings = json.loads(Path(settings_target).read_text(encoding="utf-8"))
+    security = settings.get("security") if isinstance(settings, dict) else {}
+    auth_settings = security.get("auth") if isinstance(security, dict) else {}
+    assert auth_settings.get("selectedType") == "oauth-personal"
+    assert auth_settings.get("enforcedType") == "oauth-personal"
 
 
 def test_configure_codex_cli_environment_uses_oauth_mode_and_strips_api_env(monkeypatch, tmp_path):

--- a/api/tests/test_openclaw_executor_integration.py
+++ b/api/tests/test_openclaw_executor_integration.py
@@ -49,6 +49,29 @@ def test_create_task_supports_openrouter_executor(monkeypatch: pytest.MonkeyPatc
     assert task["command"].startswith("openrouter-exec ")
 
 
+def test_create_task_supports_gemini_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
+    monkeypatch.setenv("GEMINI_CLI_MODEL", "gemini-2.5-pro")
+    monkeypatch.setenv("GEMINI_COMMAND_TEMPLATE", 'gemini -p "{{direction}}" --model {{model}} --format json')
+    agent_service._store.clear()
+    agent_service._store_loaded = False
+    agent_service._store_loaded_path = None
+
+    task = agent_service.create_task(
+        AgentTaskCreate(
+            direction="Implement gemini executor support",
+            task_type=TaskType.IMPL,
+            context={"executor": "gemini"},
+        )
+    )
+
+    assert task["model"].startswith("gemini/")
+    assert task["tier"] == "gemini"
+    assert task["command"].startswith("gemini -p ")
+    context = task.get("context") or {}
+    assert context.get("executor") == "gemini"
+
+
 def test_create_task_supports_clawwork_executor_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_TASKS_PERSIST", "0")
     monkeypatch.setenv("OPENCLAW_MODEL", "openclaw/test-model")
@@ -392,3 +415,19 @@ async def test_agent_route_endpoint_accepts_openrouter_executor() -> None:
         template = str(payload["command_template"])
         assert "{{direction}}" in template
         assert template.startswith("openrouter-exec ")
+
+
+@pytest.mark.asyncio
+async def test_agent_route_endpoint_accepts_gemini_executor() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/agent/route", params={"task_type": "impl", "executor": "gemini"})
+        assert res.status_code == 200
+        payload = res.json()
+        assert payload["executor"] == "gemini"
+        assert payload["tier"] == "gemini"
+        assert str(payload["model"]).startswith("gemini/")
+        assert payload["provider"] == "gemini"
+        assert isinstance(payload["is_paid_provider"], bool)
+        template = str(payload["command_template"])
+        assert "{{direction}}" in template
+        assert template.startswith("gemini ")

--- a/docs/CURSOR-CLI.md
+++ b/docs/CURSOR-CLI.md
@@ -124,3 +124,43 @@ curl "http://localhost:8000/api/agent/route?task_type=impl&executor=clawwork"
 Notes:
 - `OPENCLAW_COMMAND_TEMPLATE` must include `{{direction}}`; `{{model}}` is optional and replaced automatically.
 - Runner telemetry classifies OpenClaw runs under `executor=openclaw` for usage/success-rate reporting.
+
+## Gemini CLI Integration
+
+Gemini CLI is supported through `context.executor=gemini` with OAuth-only auth mode (no API keys).
+
+### Required env (Railway/hosted runner)
+
+Set in `api/.env` (or Railway service variables):
+
+```bash
+AGENT_EXECUTOR_DEFAULT=gemini
+GEMINI_CLI_MODEL=gemini-2.5-pro
+GEMINI_CLI_REVIEW_MODEL=gemini-2.5-pro
+AGENT_GEMINI_AUTH_MODE=oauth
+AGENT_GEMINI_OAUTH_SESSION_B64=...    # base64 of oauth_creds.json
+```
+
+Optional:
+
+```bash
+AGENT_GEMINI_CONFIG_DIR=/root/.gemini
+```
+
+The runner always strips `GEMINI_API_KEY` and `GOOGLE_API_KEY` for Gemini tasks and enforces:
+- `settings.json -> security.auth.selectedType = oauth-personal`
+- `settings.json -> security.auth.enforcedType = oauth-personal`
+
+### API usage
+
+```bash
+curl -X POST http://localhost:8000/api/agent/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"direction":"Implement GET /api/foo","task_type":"impl","context":{"executor":"gemini"}}'
+```
+
+### Routing check
+
+```bash
+curl "http://localhost:8000/api/agent/route?task_type=impl&executor=gemini"
+```

--- a/docs/system_audit/commit_evidence_2026-03-02_gemini-railway-cli-paths.json
+++ b/docs/system_audit/commit_evidence_2026-03-02_gemini-railway-cli-paths.json
@@ -1,0 +1,112 @@
+{
+  "date": "2026-03-02",
+  "thread_branch": "codex/gemini-cli-task-engine",
+  "commit_scope": "Add Gemini CLI as a first-class executor with OAuth-only host-runner auth bootstrap, enforce keyless Gemini execution, and prove Railway hosted-runner CLI path coverage for claude/cursor/codex plus Gemini readiness hardening.",
+  "files_owned": [
+    "api/app/models/agent.py",
+    "api/app/routers/agent.py",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/agent_routing_service.py",
+    "api/app/services/agent_service.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_executor_policy.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_openclaw_executor_integration.py",
+    "docs/CURSOR-CLI.md",
+    "docs/system_audit/commit_evidence_2026-03-02_gemini-railway-cli-paths.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "002-agent-orchestration-api",
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task-2026-03-02-gemini-railway-cli-host-runner"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_executor_policy.py",
+    "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k 'gemini or configure_gemini_cli_environment_bootstraps_oauth_session_from_b64'",
+    "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py",
+    "python3 -m py_compile api/scripts/agent_runner.py",
+    "railway production probes: task_5336cc70d0e2cecb, task_f9ed37268e560477, task_a9fe75ed38dc08a6, task_2ca9b6932c7472c6, task_98dc2b06644470d7",
+    "https://coherence-network-production.up.railway.app/api/agent/tasks",
+    "https://coherence-network-production.up.railway.app/api/agent/runners",
+    "https://coherence-network-production.up.railway.app/api/agent/integration"
+  ],
+  "change_files": [
+    "api/app/models/agent.py",
+    "api/app/routers/agent.py",
+    "api/app/services/agent_execution_service.py",
+    "api/app/services/agent_routing_service.py",
+    "api/app/services/agent_service.py",
+    "api/scripts/agent_runner.py",
+    "api/tests/test_agent_executor_policy.py",
+    "api/tests/test_agent_runner_tool_failure_telemetry.py",
+    "api/tests/test_openclaw_executor_integration.py",
+    "docs/CURSOR-CLI.md"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_executor_policy.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k 'gemini or configure_gemini_cli_environment_bootstraps_oauth_session_from_b64'",
+      "cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py",
+      "python3 -m py_compile api/scripts/agent_runner.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting PR checks and Railway deployment verification on updated SHA"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Railway hosted runner supports claude/cursor/codex/gemini CLI executor paths with OAuth/session auth and Gemini keyless bootstrap support.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/agent/tasks",
+      "https://coherence-network-production.up.railway.app/api/agent/tasks/{task_id}",
+      "https://coherence-network-production.up.railway.app/api/agent/runners",
+      "https://coherence-network-production.up.railway.app/api/agent/integration"
+    ],
+    "test_flows": [
+      "Create and execute Railway task with context.executor=claude and verify status=completed.",
+      "Create and execute Railway task with context.executor=cursor and verify status=completed.",
+      "Create and execute Railway task with context.executor=codex and verify status=completed.",
+      "Create and execute Railway task with context.executor=gemini and verify status=completed after deploy and runner env bootstrap."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add Gemini CLI executor routing/model support in agent service + route endpoint
- add host-runner Gemini CLI install + OAuth-only auth bootstrap in api/scripts/agent_runner.py (keyless, no API key mode)
- add tests for Gemini executor policy, routing, and runner auth/env handling
- document Gemini executor setup for hosted runners
- include commit evidence artifact for this runtime feature

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_openclaw_executor_integration.py tests/test_agent_executor_policy.py
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_agent_runner_tool_failure_telemetry.py -k "gemini or configure_gemini_cli_environment_bootstraps_oauth_session_from_b64"
- cd api && ruff check scripts/agent_runner.py tests/test_agent_runner_tool_failure_telemetry.py
- python3 -m py_compile api/scripts/agent_runner.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Railway verification target
After merge/deploy, verify hosted runner execution for claude, cursor, codex, gemini via production /api/agent/tasks smoke tasks.
