### PR TITLE
Add DB-backed ideas cards feed API and change polling

### DIFF
--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -13,7 +13,7 @@ from app.models.idea import (
     IdeaUpdate,
     IdeaWithScore,
 )
-from app.services import idea_service
+from app.services import idea_service, inventory_service
 
 router = APIRouter()
 
@@ -36,6 +36,57 @@ async def list_ideas(
 @router.get("/ideas/storage", response_model=IdeaStorageInfo)
 async def get_idea_storage_info() -> IdeaStorageInfo:
     return idea_service.storage_info()
+
+
+@router.get("/ideas/cards")
+async def list_idea_cards(
+    q: str = Query("", description="Free-text search across idea title/description/spec IDs."),
+    state: str = Query(
+        "all",
+        description="One of: all, none, spec, implemented, validated, measured.",
+    ),
+    attention: str = Query(
+        "all",
+        description="One of: all, none, low, medium, high.",
+    ),
+    sort: str = Query(
+        "attention_desc",
+        description="One of: attention_desc, roi_desc, gap_desc, state_desc, name_asc.",
+    ),
+    cursor: str | None = Query(default=None, description="Offset cursor returned by previous page."),
+    limit: int = Query(50, ge=1, le=200),
+    include_internal_ideas: bool = Query(True),
+    only_actionable: bool = Query(False),
+    min_roi: float | None = Query(default=None),
+    min_value_gap: float | None = Query(default=None),
+    runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
+) -> dict:
+    return inventory_service.build_idea_cards_feed(
+        q=q,
+        state=state,
+        attention=attention,
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
+        include_internal_ideas=include_internal_ideas,
+        only_actionable=only_actionable,
+        min_roi=min_roi,
+        min_value_gap=min_value_gap,
+        runtime_window_seconds=runtime_window_seconds,
+    )
+
+
+@router.get("/ideas/cards/changes")
+async def list_idea_card_changes(
+    since_token: str | None = Query(default=None),
+    include_internal_ideas: bool = Query(True),
+    runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
+) -> dict:
+    return inventory_service.build_idea_cards_changes(
+        since_token=since_token,
+        include_internal_ideas=include_internal_ideas,
+        runtime_window_seconds=runtime_window_seconds,
+    )
 
 
 @router.get("/ideas/{idea_id}", response_model=IdeaWithScore)

--- a/api/app/services/commit_evidence_service.py
+++ b/api/app/services/commit_evidence_service.py
@@ -159,6 +159,19 @@ def backend_info() -> dict[str, Any]:
     }
 
 
+def checkpoint() -> dict[str, Any]:
+    ensure_schema()
+    with _session() as session:
+        count, max_updated_at = session.query(
+            func.count(CommitEvidenceRecord.id),
+            func.max(CommitEvidenceRecord.updated_at),
+        ).one()
+    return {
+        "record_count": int(count or 0),
+        "max_updated_at": max_updated_at.isoformat() if max_updated_at is not None else None,
+    }
+
+
 def _fingerprint_from_payload(payload: dict[str, Any], source_file: str) -> str:
     digest_source = {
         "source_file": source_file,

--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -261,7 +261,11 @@ def _tracked_idea_ids_from_store(max_files: int = 400) -> list[str]:
 def _should_include_default_tracked_ideas() -> bool:
     # When callers isolate ideas into a custom portfolio path (common in tests),
     # avoid implicitly pulling repo-global tracked ids unless explicitly requested.
-    if os.getenv("IDEA_COMMIT_EVIDENCE_DIR") or os.getenv("COMMIT_EVIDENCE_DATABASE_URL"):
+    if (
+        os.getenv("IDEA_COMMIT_EVIDENCE_DIR")
+        or os.getenv("COMMIT_EVIDENCE_DATABASE_URL")
+        or os.getenv("DATABASE_URL")
+    ):
         return True
     return os.getenv("IDEA_PORTFOLIO_PATH") in {None, ""}
 
@@ -285,7 +289,9 @@ def _ideas_cache_key() -> str:
         f"{os.getenv('IDEA_REGISTRY_DB_URL','')}|"
         f"{os.getenv('DATABASE_URL','')}|"
         f"{os.getenv('COMMIT_EVIDENCE_DATABASE_URL','')}|"
-        f"{os.getenv('IDEA_COMMIT_EVIDENCE_DIR','')}"
+        f"{os.getenv('IDEA_COMMIT_EVIDENCE_DIR','')}|"
+        f"{os.getenv('IDEA_SYNC_RUNTIME_WINDOW_SECONDS','')}|"
+        f"{os.getenv('IDEA_SYNC_RUNTIME_EVENT_LIMIT','')}"
     )
 
 
@@ -308,6 +314,7 @@ def _tracked_idea_ids() -> list[str]:
     now = time.time()
     cache_key = (
         f"{os.getenv('COMMIT_EVIDENCE_DATABASE_URL','')}"
+        f"|{os.getenv('DATABASE_URL','')}"
         f"|{os.getenv('COMMIT_EVIDENCE_USE_DB','')}"
         f"|{os.getenv('GLOBAL_PERSISTENCE_REQUIRED','')}"
         f"|{os.getenv('IDEA_COMMIT_EVIDENCE_DIR','')}"

--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -117,6 +117,7 @@ logger = logging.getLogger("coherence.inventory")
 _INVENTORY_CACHE: dict[str, dict[str, Any]] = {
     "system_lineage": {"expires_at": 0.0, "items": {}},
     "flow": {"expires_at": 0.0, "items": {}},
+    "idea_cards": {"expires_at": 0.0, "items": {}},
 }
 
 
@@ -5326,3 +5327,518 @@ def next_unblock_task_from_flow(
         ),
     }
     return report
+
+
+_IDEA_CARD_STATE_ORDER: dict[str, int] = {
+    "none": 0,
+    "spec": 1,
+    "implemented": 2,
+    "validated": 3,
+    "measured": 4,
+}
+_IDEA_CARD_STATE_ICON: dict[str, str] = {
+    "none": "sparkle",
+    "spec": "file-text",
+    "implemented": "box",
+    "validated": "shield-check",
+    "measured": "chart-line",
+}
+_IDEA_CARD_ATTENTION_ORDER: dict[str, int] = {
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _normalize_card_enum(value: str | None, allowed: set[str], default: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return default
+    return normalized if normalized in allowed else default
+
+
+def _friendly_card_title(name: str, fallback_idea_id: str) -> str:
+    raw = str(name or "").strip() or str(fallback_idea_id or "").strip()
+    if not raw:
+        return "Idea"
+    if "_" not in raw and raw.lower() != str(fallback_idea_id or "").strip().lower():
+        return raw
+    words = [part for part in re.split(r"[_\\-]+", raw) if part]
+    if not words:
+        return raw
+    return " ".join(word.capitalize() for word in words)
+
+
+def _idea_card_state(flow_row: dict[str, Any]) -> str:
+    spec = bool((flow_row.get("spec") or {}).get("tracked"))
+    implementation = bool((flow_row.get("implementation") or {}).get("tracked"))
+    validation = bool((flow_row.get("validation") or {}).get("tracked"))
+    contributions = flow_row.get("contributions") or {}
+    measured = (
+        bool(contributions.get("tracked"))
+        or _safe_float(contributions.get("measured_value_total")) > 0.0
+        or _safe_int((flow_row.get("implementation") or {}).get("runtime_events_count")) > 0
+    )
+    if measured:
+        return "measured"
+    if validation:
+        return "validated"
+    if implementation:
+        return "implemented"
+    if spec:
+        return "spec"
+    return "none"
+
+
+def _idea_card_state_from_manifestation(status: str | None) -> str:
+    normalized = str(status or "").strip().lower()
+    if normalized == "validated":
+        return "validated"
+    if normalized == "partial":
+        return "implemented"
+    return "none"
+
+
+def _idea_card_attention(flow_row: dict[str, Any], state: str, value_gap: float) -> tuple[str, float, str]:
+    interdependencies = flow_row.get("interdependencies") or {}
+    blocked = bool(interdependencies.get("blocked"))
+    blocking_stage = str(interdependencies.get("blocking_stage") or "").strip()
+    unblock_priority = _safe_float(interdependencies.get("unblock_priority_score"))
+    score = round(
+        unblock_priority
+        + (12.0 if blocked else 0.0)
+        + (_IDEA_CARD_STATE_ORDER.get("measured", 4) - _IDEA_CARD_STATE_ORDER.get(state, 0)) * 2.0
+        + min(max(value_gap, 0.0) * 0.15, 20.0),
+        4,
+    )
+
+    if blocked and (unblock_priority >= 25.0 or state in {"none", "spec"}):
+        return "high", score, f"blocked:{blocking_stage or 'unknown'}"
+    if blocked or unblock_priority >= 12.0 or (state in {"none", "spec"} and value_gap >= 20.0):
+        return "medium", score, (f"blocked:{blocking_stage}" if blocked else "focus-upstream")
+    if value_gap > 0.0:
+        return "low", score, "improvement-opportunity"
+    return "none", score, "healthy"
+
+
+def _idea_cards_flow_index(include_internal_ideas: bool, runtime_window_seconds: int) -> dict[str, dict[str, Any]]:
+    flow = build_spec_process_implementation_validation_flow(
+        include_internal_ideas=include_internal_ideas,
+        runtime_window_seconds=runtime_window_seconds,
+        contributor_rows=[],
+        contribution_rows=[],
+        asset_rows=[],
+        spec_registry_limit=500,
+        lineage_link_limit=800,
+        usage_event_limit=3000,
+        commit_evidence_limit=2000,
+        runtime_event_limit=3000,
+        list_item_limit=8,
+    )
+    flow_items = flow.get("items") if isinstance(flow.get("items"), list) else []
+    flow_by_idea: dict[str, dict[str, Any]] = {}
+    for row in flow_items:
+        if not isinstance(row, dict):
+            continue
+        idea_id = str(row.get("idea_id") or "").strip()
+        if idea_id and idea_id not in flow_by_idea:
+            flow_by_idea[idea_id] = row
+    return flow_by_idea
+
+
+def _idea_card_metrics(idea_model: Any, flow_row: dict[str, Any]) -> dict[str, Any]:
+    manifestation_raw = getattr(idea_model, "manifestation_status", "none")
+    manifestation_value = manifestation_raw.value if hasattr(manifestation_raw, "value") else str(manifestation_raw)
+    flow_state = _idea_card_state(flow_row) if flow_row else "none"
+    manifestation_state = _idea_card_state_from_manifestation(manifestation_value)
+    state_value = manifestation_state if _IDEA_CARD_STATE_ORDER.get(manifestation_state, 0) > _IDEA_CARD_STATE_ORDER.get(flow_state, 0) else flow_state
+
+    idea_signals = flow_row.get("idea_signals") if isinstance(flow_row, dict) else {}
+    potential_value = _safe_float(getattr(idea_model, "potential_value", None), _safe_float(idea_signals.get("potential_value")))
+    actual_value = _safe_float(getattr(idea_model, "actual_value", None), _safe_float(idea_signals.get("actual_value")))
+    value_gap = round(max(_safe_float(idea_signals.get("value_gap")), max(potential_value - actual_value, 0.0)), 4)
+    measured_contribution = _safe_float((flow_row.get("contributions") or {}).get("measured_value_total"))
+    measured_value = round(max(measured_contribution, actual_value), 4)
+    estimated_cost = max(_safe_float(getattr(idea_model, "estimated_cost", None), _safe_float(idea_signals.get("estimated_cost"))), 0.0)
+    measured_roi = round((measured_value / estimated_cost), 4) if estimated_cost > 0 else round(measured_value, 4)
+    if state_value != "measured" and measured_value > 0.0:
+        state_value = "measured"
+
+    attention_level, attention_score, attention_reason = _idea_card_attention(flow_row, state_value, value_gap)
+    return {
+        "manifestation_status": manifestation_value,
+        "state": state_value,
+        "state_icon": _IDEA_CARD_STATE_ICON.get(state_value, "sparkle"),
+        "value_gap": value_gap,
+        "measured_value": measured_value,
+        "measured_roi": measured_roi,
+        "attention_level": attention_level,
+        "attention_score": attention_score,
+        "attention_reason": attention_reason,
+    }
+
+
+def _idea_card_row_from_sources(
+    idea_model: Any,
+    flow_row: dict[str, Any],
+    *,
+    include_internal_ideas: bool,
+    only_actionable: bool,
+) -> dict[str, Any] | None:
+    idea_id = str(getattr(idea_model, "id", "")).strip()
+    if not idea_id:
+        return None
+
+    classification = flow_row.get("idea_classification") if isinstance(flow_row, dict) else {}
+    if not isinstance(classification, dict):
+        classification = {}
+    interfaces = [item for item in getattr(idea_model, "interfaces", []) if isinstance(item, str)]
+    inferred_internal = idea_service.is_internal_idea_id(idea_id, interfaces)
+    internal = bool(classification.get("internal", inferred_internal))
+    actionable = bool(classification.get("actionable", not internal))
+    if (not include_internal_ideas and internal) or (only_actionable and not actionable):
+        return None
+
+    title = _friendly_card_title(
+        str(getattr(idea_model, "name", "") or flow_row.get("idea_name") or idea_id),
+        fallback_idea_id=idea_id,
+    )
+    spec_ids = [str(item).strip() for item in ((flow_row.get("spec") or {}).get("spec_ids") or []) if str(item).strip()]
+    top_spec_id = spec_ids[0] if spec_ids else ""
+    metrics = _idea_card_metrics(idea_model, flow_row)
+    return {
+        "idea_id": idea_id,
+        "title": title,
+        "subtitle": str(getattr(idea_model, "description", "") or "").strip(),
+        "interfaces": interfaces,
+        "manifestation_status": metrics["manifestation_status"],
+        "spec_ids": spec_ids,
+        "spec_count": _safe_int((flow_row.get("spec") or {}).get("count")),
+        "implementation_ref_count": _safe_int((flow_row.get("implementation") or {}).get("lineage_link_count")),
+        "state": metrics["state"],
+        "state_icon": metrics["state_icon"],
+        "attention_level": metrics["attention_level"],
+        "attention_score": metrics["attention_score"],
+        "attention_reason": metrics["attention_reason"],
+        "blocked": bool((flow_row.get("interdependencies") or {}).get("blocked")),
+        "blocking_stage": str((flow_row.get("interdependencies") or {}).get("blocking_stage") or "") or None,
+        "value_gap": metrics["value_gap"],
+        "measured_roi": metrics["measured_roi"],
+        "measured_value": metrics["measured_value"],
+        "actionable": actionable,
+        "internal": internal,
+        "links": {
+            "web_detail_path": f"/ideas/{quote(idea_id, safe='')}",
+            "api_detail_path": f"/api/ideas/{quote(idea_id, safe='')}",
+            "web_usage_path": f"/usage?idea_id={quote(idea_id, safe='')}",
+            "web_spec_path": f"/specs/{quote(top_spec_id, safe='')}" if top_spec_id else None,
+        },
+    }
+
+
+def _idea_card_matches_filters(
+    row: dict[str, Any],
+    *,
+    normalized_query: str,
+    normalized_state: str,
+    normalized_attention: str,
+    min_roi_value: float | None,
+    min_gap_value: float | None,
+) -> bool:
+    if normalized_query:
+        haystack = " ".join(
+            [
+                str(row.get("idea_id") or ""),
+                str(row.get("title") or ""),
+                str(row.get("subtitle") or ""),
+                str(row.get("manifestation_status") or ""),
+                " ".join(str(item) for item in row.get("spec_ids", []) if isinstance(item, str)),
+                " ".join(str(item) for item in row.get("interfaces", []) if isinstance(item, str)),
+                str(row.get("attention_reason") or ""),
+            ]
+        ).lower()
+        if normalized_query not in haystack:
+            return False
+
+    if normalized_state != "all" and str(row.get("state") or "") != normalized_state:
+        return False
+    if normalized_attention != "all" and str(row.get("attention_level") or "") != normalized_attention:
+        return False
+    if min_roi_value is not None and _safe_float(row.get("measured_roi")) < min_roi_value:
+        return False
+    if min_gap_value is not None and _safe_float(row.get("value_gap")) < min_gap_value:
+        return False
+    return True
+
+
+def _sort_idea_card_rows(candidates: list[dict[str, Any]], normalized_sort: str) -> None:
+    if normalized_sort == "name_asc":
+        candidates.sort(key=lambda row: (str(row.get("title") or "").lower(), str(row.get("idea_id") or "")))
+        return
+    if normalized_sort == "roi_desc":
+        candidates.sort(key=lambda row: (-_safe_float(row.get("measured_roi")), -_safe_float(row.get("value_gap")), str(row.get("title") or "").lower()))
+        return
+    if normalized_sort == "gap_desc":
+        candidates.sort(key=lambda row: (-_safe_float(row.get("value_gap")), -_safe_float(row.get("measured_roi")), str(row.get("title") or "").lower()))
+        return
+    if normalized_sort == "state_desc":
+        candidates.sort(key=lambda row: (-_IDEA_CARD_STATE_ORDER.get(str(row.get("state") or "none"), 0), -_safe_float(row.get("value_gap")), str(row.get("title") or "").lower()))
+        return
+    candidates.sort(
+        key=lambda row: (
+            -_IDEA_CARD_ATTENTION_ORDER.get(str(row.get("attention_level") or "none"), 0),
+            -_safe_float(row.get("attention_score")),
+            -_safe_float(row.get("value_gap")),
+            -_safe_float(row.get("measured_roi")),
+            str(row.get("title") or "").lower(),
+        )
+    )
+
+
+def _idea_card_facet_counts(candidates: list[dict[str, Any]]) -> tuple[dict[str, int], dict[str, int]]:
+    state_counts: dict[str, int] = {key: 0 for key in _IDEA_CARD_STATE_ORDER}
+    attention_counts: dict[str, int] = {key: 0 for key in _IDEA_CARD_ATTENTION_ORDER}
+    for row in candidates:
+        state_key = str(row.get("state") or "none")
+        attention_key = str(row.get("attention_level") or "none")
+        state_counts[state_key] = state_counts.get(state_key, 0) + 1
+        attention_counts[attention_key] = attention_counts.get(attention_key, 0) + 1
+    return state_counts, attention_counts
+
+
+def _build_idea_cards_payload(
+    *,
+    query_text: str,
+    normalized_state: str,
+    normalized_attention: str,
+    normalized_sort: str,
+    safe_offset: int,
+    safe_limit: int,
+    include_internal_ideas: bool,
+    only_actionable: bool,
+    min_roi_value: float | None,
+    min_gap_value: float | None,
+    bounded_runtime_window: int,
+    filtered_total: int,
+    returned: int,
+    state_counts: dict[str, int],
+    attention_counts: dict[str, int],
+    next_cursor: str | None,
+    has_more: bool,
+    change_token: str | None,
+    page_items: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "query": {
+            "q": query_text,
+            "state": normalized_state,
+            "attention": normalized_attention,
+            "sort": normalized_sort,
+            "cursor": str(safe_offset),
+            "limit": safe_limit,
+            "include_internal_ideas": include_internal_ideas,
+            "only_actionable": only_actionable,
+            "min_roi": min_roi_value,
+            "min_value_gap": min_gap_value,
+            "runtime_window_seconds": bounded_runtime_window,
+        },
+        "summary": {
+            "total": filtered_total,
+            "returned": returned,
+            "state_counts": state_counts,
+            "attention_counts": attention_counts,
+            "needs_attention": attention_counts.get("high", 0) + attention_counts.get("medium", 0),
+        },
+        "pagination": {
+            "cursor": str(safe_offset),
+            "next_cursor": next_cursor,
+            "limit": safe_limit,
+            "returned": returned,
+            "has_more": has_more,
+        },
+        "change_token": change_token,
+        "items": page_items,
+    }
+
+
+def build_idea_cards_feed(
+    q: str = "",
+    state: str = "all",
+    attention: str = "all",
+    sort: str = "attention_desc",
+    cursor: str | None = None,
+    limit: int = 50,
+    include_internal_ideas: bool = True,
+    only_actionable: bool = False,
+    min_roi: float | None = None,
+    min_value_gap: float | None = None,
+    runtime_window_seconds: int = 86400,
+) -> dict[str, Any]:
+    query_text = str(q or "").strip()
+    normalized_query = query_text.lower()
+    normalized_state = _normalize_card_enum(state, {"all", "none", "spec", "implemented", "validated", "measured"}, "all")
+    normalized_attention = _normalize_card_enum(attention, {"all", "none", "low", "medium", "high"}, "all")
+    normalized_sort = _normalize_card_enum(sort, {"attention_desc", "roi_desc", "gap_desc", "name_asc", "state_desc"}, "attention_desc")
+    safe_limit = max(1, min(int(limit), 200))
+    try:
+        safe_offset = max(0, int(str(cursor or "0").strip() or "0"))
+    except ValueError:
+        safe_offset = 0
+    bounded_runtime_window = max(60, min(int(runtime_window_seconds), 60 * 60 * 24 * 30))
+    min_roi_value = None if min_roi is None else _safe_float(min_roi)
+    min_gap_value = None if min_value_gap is None else _safe_float(min_value_gap)
+
+    cache_key = _cache_key("cards", normalized_query, normalized_state, normalized_attention, normalized_sort, safe_limit, safe_offset, include_internal_ideas, only_actionable, min_roi_value, min_gap_value, bounded_runtime_window, _inventory_environment_cache_key())
+    cached = _read_inventory_cache("idea_cards", cache_key)
+    if cached is not None:
+        return cached
+
+    flow_by_idea = _idea_cards_flow_index(include_internal_ideas, bounded_runtime_window)
+    portfolio = idea_service.list_ideas(include_internal=True, limit=None, offset=0)
+
+    candidates: list[dict[str, Any]] = []
+    for idea_model in portfolio.ideas:
+        row = _idea_card_row_from_sources(
+            idea_model,
+            flow_by_idea.get(str(idea_model.id).strip(), {}),
+            include_internal_ideas=include_internal_ideas,
+            only_actionable=only_actionable,
+        )
+        if row is None:
+            continue
+        if _idea_card_matches_filters(
+            row,
+            normalized_query=normalized_query,
+            normalized_state=normalized_state,
+            normalized_attention=normalized_attention,
+            min_roi_value=min_roi_value,
+            min_gap_value=min_gap_value,
+        ):
+            candidates.append(row)
+
+    state_counts, attention_counts = _idea_card_facet_counts(candidates)
+    _sort_idea_card_rows(candidates, normalized_sort)
+
+    filtered_total = len(candidates)
+    page_items = candidates[safe_offset:safe_offset + safe_limit]
+    returned = len(page_items)
+    has_more = (safe_offset + returned) < filtered_total
+    next_cursor = str(safe_offset + returned) if has_more else None
+    change_token_payload = build_idea_cards_change_token(include_internal_ideas=include_internal_ideas, runtime_window_seconds=bounded_runtime_window)
+
+    payload = _build_idea_cards_payload(
+        query_text=query_text,
+        normalized_state=normalized_state,
+        normalized_attention=normalized_attention,
+        normalized_sort=normalized_sort,
+        safe_offset=safe_offset,
+        safe_limit=safe_limit,
+        include_internal_ideas=include_internal_ideas,
+        only_actionable=only_actionable,
+        min_roi_value=min_roi_value,
+        min_gap_value=min_gap_value,
+        bounded_runtime_window=bounded_runtime_window,
+        filtered_total=filtered_total,
+        returned=returned,
+        state_counts=state_counts,
+        attention_counts=attention_counts,
+        next_cursor=next_cursor,
+        has_more=has_more,
+        change_token=change_token_payload.get("token"),
+        page_items=page_items,
+    )
+    _write_inventory_cache("idea_cards", cache_key, payload)
+    return payload
+
+
+def build_idea_cards_change_token(
+    include_internal_ideas: bool = True,
+    runtime_window_seconds: int = 86400,
+) -> dict[str, Any]:
+    runtime_payload = runtime_service.live_change_token(force_refresh=False)
+    runtime_token = str(runtime_payload.get("token") or "")
+
+    ideas = idea_service.list_ideas(include_internal=True, limit=None, offset=0).ideas
+    idea_digest = hashlib.sha256()
+    idea_count = 0
+    for idea in sorted(ideas, key=lambda row: row.id):
+        if (not include_internal_ideas) and idea_service.is_internal_idea_id(idea.id, idea.interfaces):
+            continue
+        idea_count += 1
+        idea_digest.update(
+            (
+                f"{idea.id}|{idea.manifestation_status.value}|"
+                f"{float(idea.actual_value):.4f}|{float(idea.potential_value):.4f}|"
+                f"{float(idea.estimated_cost):.4f}|{float(idea.confidence):.4f}|"
+                f"{len(idea.open_questions)};"
+            ).encode("utf-8")
+        )
+
+    spec_summary = spec_registry_service.summary()
+    latest_specs = spec_registry_service.list_specs(limit=1, offset=0)
+    latest_spec = latest_specs[0].updated_at.isoformat() if latest_specs else None
+
+    try:
+        commit_checkpoint = commit_evidence_service.checkpoint()
+    except Exception:
+        commit_checkpoint = {}
+    try:
+        lineage_checkpoint = value_lineage_service.checkpoint()
+    except Exception:
+        lineage_checkpoint = {}
+
+    components = {
+        "runtime_token": runtime_token,
+        "runtime_window_seconds": max(60, min(int(runtime_window_seconds), 60 * 60 * 24 * 30)),
+        "idea_count": idea_count,
+        "idea_digest": idea_digest.hexdigest()[:24],
+        "spec_count": int(spec_summary.get("count") or 0),
+        "spec_latest_updated_at": latest_spec,
+        "commit_evidence": commit_checkpoint,
+        "value_lineage": lineage_checkpoint,
+        "include_internal_ideas": include_internal_ideas,
+    }
+    token_basis = json.dumps(components, sort_keys=True, default=str)
+    token = hashlib.sha256(token_basis.encode("utf-8")).hexdigest()[:24]
+    return {
+        "token": token,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "components": components,
+    }
+
+
+def build_idea_cards_changes(
+    since_token: str | None = None,
+    include_internal_ideas: bool = True,
+    runtime_window_seconds: int = 86400,
+) -> dict[str, Any]:
+    current = build_idea_cards_change_token(
+        include_internal_ideas=include_internal_ideas,
+        runtime_window_seconds=runtime_window_seconds,
+    )
+    current_token = str(current.get("token") or "")
+    previous = str(since_token or "").strip()
+    changed = (not previous) or (previous != current_token)
+    return {
+        "changed": changed,
+        "since_token": previous or None,
+        "token": current_token,
+        "generated_at": current.get("generated_at"),
+        "poll_after_ms": 5000,
+    }

--- a/api/app/services/value_lineage_service.py
+++ b/api/app/services/value_lineage_service.py
@@ -255,6 +255,49 @@ def _write_store(data: dict) -> None:
         json.dump(data, f, indent=2)
 
 
+def checkpoint() -> dict[str, object]:
+    path = _path()
+    data = _read_store()
+    links_raw = data.get("links") if isinstance(data.get("links"), list) else []
+    events_raw = data.get("events") if isinstance(data.get("events"), list) else []
+    max_link_updated_at: datetime | None = None
+    max_event_captured_at: datetime | None = None
+
+    for raw in links_raw:
+        try:
+            link = LineageLink(**raw)
+        except Exception:
+            continue
+        if max_link_updated_at is None or link.updated_at > max_link_updated_at:
+            max_link_updated_at = link.updated_at
+
+    for raw in events_raw:
+        try:
+            event = UsageEvent(**raw)
+        except Exception:
+            continue
+        if max_event_captured_at is None or event.captured_at > max_event_captured_at:
+            max_event_captured_at = event.captured_at
+
+    try:
+        stat = path.stat()
+        size = int(stat.st_size)
+        mtime_ns = int(stat.st_mtime_ns)
+    except OSError:
+        size = 0
+        mtime_ns = 0
+
+    return {
+        "path": str(path),
+        "link_count": len(links_raw),
+        "event_count": len(events_raw),
+        "max_link_updated_at": max_link_updated_at.isoformat() if max_link_updated_at else None,
+        "max_event_captured_at": max_event_captured_at.isoformat() if max_event_captured_at else None,
+        "file_size": size,
+        "file_mtime_ns": mtime_ns,
+    }
+
+
 def create_link(payload: LineageLinkCreate) -> LineageLink:
     now = datetime.now(timezone.utc)
     link = LineageLink(

--- a/api/tests/test_ideas.py
+++ b/api/tests/test_ideas.py
@@ -328,3 +328,105 @@ async def test_required_federation_idea_is_backfilled_for_existing_portfolio(
         assert federation["manifestation_status"] == "none"
         assert federation["potential_value"] >= 100.0
         assert any("federation contract" in q["question"].lower() for q in federation["open_questions"])
+
+
+@pytest.mark.asyncio
+async def test_ideas_cards_endpoint_returns_paginated_card_feed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.setenv("COMMIT_EVIDENCE_DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/ideas/cards",
+            params={"limit": 10, "state": "all", "sort": "attention_desc"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload.get("items"), list)
+    assert payload["pagination"]["limit"] == 10
+    assert payload["summary"]["total"] >= len(payload["items"])
+    assert isinstance(payload.get("change_token"), str) and payload["change_token"]
+    assert len(payload["items"]) >= 1
+    first = payload["items"][0]
+    assert "idea_id" in first
+    assert "state" in first
+    assert "state_icon" in first
+    assert "attention_level" in first
+    assert isinstance(first.get("links"), dict)
+
+
+@pytest.mark.asyncio
+async def test_ideas_cards_changes_endpoint_detects_no_change_for_same_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.setenv("COMMIT_EVIDENCE_DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        cards = await client.get("/api/ideas/cards", params={"limit": 5})
+        assert cards.status_code == 200
+        token = cards.json().get("change_token")
+        assert isinstance(token, str) and token
+
+        unchanged = await client.get("/api/ideas/cards/changes", params={"since_token": token})
+        assert unchanged.status_code == 200
+        unchanged_payload = unchanged.json()
+        assert unchanged_payload["changed"] is False
+        assert unchanged_payload["token"] == token
+
+        initial = await client.get("/api/ideas/cards/changes")
+        assert initial.status_code == 200
+        assert initial.json()["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_ideas_cards_defaults_include_internal_and_allow_actionable_filter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.setenv("VALUE_LINEAGE_PATH", str(tmp_path / "value_lineage.json"))
+    monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
+    monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
+    monkeypatch.setenv("COMMIT_EVIDENCE_DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
+
+    internal_id = "spec-origin-cards-hidden-example"
+    external_id = "cards-visible-example"
+    base_payload = {
+        "name": "Cards Example",
+        "description": "Cards endpoint visibility test.",
+        "potential_value": 14.0,
+        "estimated_cost": 2.0,
+        "confidence": 0.6,
+        "interfaces": ["machine:api"],
+        "open_questions": [],
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_internal = await client.post("/api/ideas", json={"id": internal_id, **base_payload})
+        assert create_internal.status_code == 201
+        create_external = await client.post("/api/ideas", json={"id": external_id, **base_payload})
+        assert create_external.status_code == 201
+
+        defaults = await client.get("/api/ideas/cards", params={"limit": 200})
+        assert defaults.status_code == 200
+        default_ids = {row["idea_id"] for row in defaults.json().get("items", [])}
+        assert internal_id in default_ids
+        assert external_id in default_ids
+
+        actionable_only = await client.get(
+            "/api/ideas/cards",
+            params={"limit": 200, "only_actionable": "true", "include_internal_ideas": "false"},
+        )
+        assert actionable_only.status_code == 200
+        actionable_ids = {row["idea_id"] for row in actionable_only.json().get("items", [])}
+        assert external_id in actionable_ids
+        assert internal_id not in actionable_ids

--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from app.services import commit_evidence_service, idea_service, inventory_service
@@ -37,6 +36,21 @@ def test_idea_service_includes_store_tracked_ids_when_db_is_configured(
     monkeypatch.delenv("IDEA_COMMIT_EVIDENCE_DIR", raising=False)
 
     assert idea_service.list_tracked_idea_ids() == ["unexpected-local"]
+
+
+def test_idea_service_includes_store_tracked_ids_when_database_url_is_configured(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("COMMIT_EVIDENCE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
+    commit_evidence_service.upsert_record(
+        {"idea_ids": ["database-url-tracked"], "thread_branch": "codex/test"},
+        "memory:test",
+    )
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.delenv("IDEA_COMMIT_EVIDENCE_DIR", raising=False)
+
+    assert idea_service.list_tracked_idea_ids() == ["database-url-tracked"]
 
 
 def test_idea_service_reads_tracked_ids_from_commit_evidence_store(

--- a/docs/system_audit/commit_evidence_2026-03-02_ideas-cards-api-feed.json
+++ b/docs/system_audit/commit_evidence_2026-03-02_ideas-cards-api-feed.json
@@ -1,0 +1,89 @@
+{
+  "date": "2026-03-02",
+  "thread_branch": "codex/ideas-cards-api-sync-20260302",
+  "commit_scope": "Add single-feed ideas cards API endpoints backed by DB idea set with search/filter/sort, cursor pagination, and change-token polling.",
+  "files_owned": [
+    "api/app/routers/ideas.py",
+    "api/app/services/commit_evidence_service.py",
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/value_lineage_service.py",
+    "api/tests/test_ideas.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "docs/system_audit/commit_evidence_2026-03-02_ideas-cards-api-feed.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "cd api && pytest -q tests/test_ideas.py -k \"cards or list_ideas_returns_ranked_scores_and_summary\"",
+      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"database_url_is_configured or db_is_configured\"",
+      "cd api && ruff check app/routers/ideas.py app/services/idea_service.py app/services/inventory_service.py app/services/commit_evidence_service.py app/services/value_lineage_service.py tests/test_ideas.py tests/test_inventory_discovery_sources.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR creation and GitHub Actions checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Deploy verification runs after push/PR."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Ideas cards endpoint returns all DB-backed ideas by default and supports cursor paging + change-token polling.",
+    "public_endpoints": [
+      "/api/ideas/cards",
+      "/api/ideas/cards/changes",
+      "/api/ideas"
+    ],
+    "test_flows": [
+      "ideas-cards-default-feed",
+      "ideas-cards-change-token",
+      "ideas-cards-actionable-filter"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy validation completion."
+  },
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "088-spec-process-implementation-validation-flow"
+  ],
+  "task_ids": [
+    "task_ideas_cards_api_feed_2026_03_02"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260303T000610Z_codex-ideas-cards-api-sync-20260302.json",
+    "docs/system_audit/commit_evidence_2026-03-02_ideas-cards-api-feed.json"
+  ],
+  "change_files": [
+    "api/app/routers/ideas.py",
+    "api/app/services/commit_evidence_service.py",
+    "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
+    "api/app/services/value_lineage_service.py",
+    "api/tests/test_ideas.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "docs/system_audit/commit_evidence_2026-03-02_ideas-cards-api-feed.json"
+  ],
+  "change_intent": "runtime_feature"
+}


### PR DESCRIPTION
## Summary\n- add  with search/filter/sort/cursor pagination from the DB-backed idea set\n- add  token-based lightweight polling endpoint\n- add change-token checkpoints for commit evidence and value lineage\n- add API tests for cards feed defaults and changes endpoint\n\n## Validation\n- auto-heal-start-gate: worktree already clean.
start-gate: skipping primary workspace cleanliness check in worktree mode (START_GATE_REQUIRE_PRIMARY_CLEAN=0).
start-gate: passed
auto-heal-start-gate: running git fetch/rebase refresh.
Current branch codex/ideas-cards-api-sync-20260302 is up to date.
auto-heal-start-gate: running worktree-pr-guard (local).
PR guard report: /Users/ursmuff/.codex/worktrees/0c36/Coherence-Network/docs/system_audit/pr_check_failures/pr_check_guard_20260303T001656Z_codex-ideas-cards-api-sync-20260302.json
ready_for_push=True
All selected checks passed.
local_preflight=pass
remote_pr_checks=skipped
n8n_security_floor=skipped
auto-heal-start-gate: completed.
auto-heal-start-gate: command used -> make start-gate
auto-heal-start-gate: git fetch/rebase executed.
auto-heal-start-gate: local worktree gate executed.
auto-heal-start-gate: no changes to restore.\n- repo=seeker71/Coherence-Network
codex_open_prs=0
stale_threshold_minutes=90.0
stale_codex_prs=0\n- All checks passed!\n- ....                                                                     [100%]
=============================== warnings summary ===============================
app/main.py:426
  /Users/ursmuff/.codex/worktrees/0c36/Coherence-Network/api/app/main.py:426: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("startup")

../../../../../../../opt/homebrew/lib/python3.14/site-packages/fastapi/applications.py:4599
  /opt/homebrew/lib/python3.14/site-packages/fastapi/applications.py:4599: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
4 passed, 9 deselected, 2 warnings in 0.50s\n- ..                                                                       [100%]
=============================== warnings summary ===============================
tests/test_inventory_discovery_sources.py::test_idea_service_includes_store_tracked_ids_when_db_is_configured
tests/test_inventory_discovery_sources.py::test_idea_service_includes_store_tracked_ids_when_database_url_is_configured
  /Users/ursmuff/.codex/worktrees/0c36/Coherence-Network/api/app/services/commit_evidence_service.py:198: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2 passed, 9 deselected, 2 warnings in 0.22s