### PR TITLE
Enable production default domain discovery for /api/ideas parity

### DIFF
--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -344,9 +344,11 @@ def _should_discover_registry_domain_ideas() -> bool:
         return True
     if explicit in {"0", "false", "no", "off"}:
         return False
-    # In isolated test runs, IDEA_PORTFOLIO_PATH is often pointed at tmp files.
-    # Default to off there unless explicitly enabled.
-    return os.getenv("IDEA_PORTFOLIO_PATH") in {None, ""}
+    # Keep isolated pytest runs deterministic unless explicitly enabled.
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return False
+    # In runtime/deploy environments, always discover registry-domain ideas.
+    return True
 
 
 def _discover_registry_domain_idea_ids() -> list[str]:

--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -108,6 +108,38 @@ def test_idea_service_derives_missing_ideas_from_other_registry_domains(
     assert "derived-from-runtime" in idea_ids
 
 
+def test_idea_service_domain_discovery_default_on_outside_pytest(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("COMMIT_EVIDENCE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'shared.db'}")
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.delenv("IDEA_SYNC_ENABLE_DOMAIN_DISCOVERY", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("IDEA_COMMIT_EVIDENCE_DIR", raising=False)
+
+    monkeypatch.setattr(
+        spec_registry_service,
+        "list_specs",
+        lambda limit=200, offset=0: [SimpleNamespace(idea_id="derived-prod-default")],
+    )
+    monkeypatch.setattr(
+        value_lineage_service,
+        "list_links",
+        lambda limit=200: [],
+    )
+    monkeypatch.setattr(
+        runtime_service,
+        "summarize_by_idea",
+        lambda seconds=3600, event_limit=2000, summary_limit=500, summary_offset=0, event_rows=None: [],
+    )
+
+    listed = idea_service.list_ideas(include_internal=True)
+    idea_ids = {item.id for item in listed.ideas}
+
+    assert "derived-prod-default" in idea_ids
+
+
 def test_inventory_uses_github_spec_discovery_when_local_specs_missing(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
@@ -1,0 +1,75 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/ideas-registry-backfill-20260303",
+  "commit_scope": "Keep idea domain discovery enabled in production by default so /api/ideas includes DB-backed internal and registry-derived ideas even when IDEA_PORTFOLIO_PATH is customized.",
+  "files_owned": [
+    "api/app/services/idea_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured\"",
+      "cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q",
+      "cd api && ruff check app/services/idea_service.py tests/test_inventory_discovery_sources.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting follow-up PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Will verify after merge/redeploy and include API parity proof."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Production /api/ideas should include internal and registry-derived ideas by default, matching inventory flow idea population from the same database domains.",
+    "public_endpoints": [
+      "/api/ideas",
+      "/api/inventory/flow"
+    ],
+    "test_flows": [
+      "ideas-count-parity-internal-included"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI/deploy checks pending for follow-up hotfix commit."
+  },
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "085-tracked-count-parity-and-source-discovery"
+  ],
+  "task_ids": [
+    "task_ideas_domain_discovery_prod_default_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "deploy-verification"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/commit_evidence_2026-03-03_idea-registry-domain-backfill.json"
+  ],
+  "change_files": [
+    "api/app/services/idea_service.py",
+    "api/tests/test_inventory_discovery_sources.py",
+    "docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- keep registry domain discovery default-on outside pytest
- preserve isolated test behavior unless `IDEA_SYNC_ENABLE_DOMAIN_DISCOVERY=1`
- add regression test for production-like custom portfolio path

## Validation
- make start-gate
- cd api && pytest -q tests/test_inventory_discovery_sources.py -k "database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured"
- cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q
- cd api && ruff check app/services/idea_service.py tests/test_inventory_discovery_sources.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict