### PR TITLE
Use live no-store data fetch on automation page

### DIFF
--- a/docs/system_audit/commit_evidence_2026-03-03_automation-page-live-data-no-store.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_automation-page-live-data-no-store.json
@@ -1,0 +1,78 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/unify-native-provider-telemetry",
+  "commit_scope": "Switch automation page API fetches to no-store caching so production UI always reflects live provider telemetry instead of stale ISR cache snapshots.",
+  "files_owned": [
+    "web/app/automation/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_automation-page-live-data-no-store.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task-2026-03-03-automation-live-data-no-store"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && npm run -s build",
+    "https://coherence-web-production.up.railway.app/automation"
+  ],
+  "change_files": [
+    "web/app/automation/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm run -s build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting push/PR checks and production cache-refresh verification"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Automation page reflects live API values for usage/readiness/validation on each request.",
+    "public_endpoints": [
+      "https://coherence-web-production.up.railway.app/automation"
+    ],
+    "test_flows": [
+      "Load automation page and verify LLM cards mirror current API telemetry values without stale cache lag."
+    ]
+  }
+}

--- a/web/app/automation/page.tsx
+++ b/web/app/automation/page.tsx
@@ -347,7 +347,7 @@ function presentIssue(issue: string): string {
 
 async function fetchJsonOrDefault<T>(url: string, fallback: T): Promise<T> {
   try {
-    const response = await fetch(url, { cache: "force-cache" });
+    const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) {
       return fallback;
     }


### PR DESCRIPTION
## Summary
- switch `/automation` server fetches to `cache: "no-store"` so UI reflects current API telemetry immediately
- keep the existing unified provider telemetry contract, but remove stale page-cache lag that caused data disconnects

## Validation
- `cd web && npm run -s build`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
