### PR TITLE
Unify inventory commit-evidence source with DATABASE_URL DB path

### DIFF
--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -2156,7 +2156,9 @@ def _read_commit_evidence_records_from_github(limit: int) -> list[dict[str, Any]
 
 
 def _read_commit_evidence_records(limit: int = 400) -> list[dict[str, Any]]:
-    db_url_configured = bool(os.getenv("COMMIT_EVIDENCE_DATABASE_URL", "").strip())
+    commit_evidence_db_url = str(os.getenv("COMMIT_EVIDENCE_DATABASE_URL", "")).strip()
+    shared_database_url = str(os.getenv("DATABASE_URL", "")).strip()
+    db_url_configured = bool(commit_evidence_db_url or shared_database_url)
     use_db_raw = str(os.getenv("COMMIT_EVIDENCE_USE_DB", "auto")).strip().lower()
     use_db = use_db_raw in {"1", "true", "yes", "on"}
     if use_db_raw not in {"1", "true", "yes", "on", "0", "false", "no", "off"}:
@@ -2172,7 +2174,7 @@ def _read_commit_evidence_records(limit: int = 400) -> list[dict[str, Any]]:
             backend_url = os.getenv("DATABASE_URL", "").strip().lower()
             use_db = required and ("postgresql" in backend_url)
     if use_db:
-        source_key = f"db:{os.getenv('COMMIT_EVIDENCE_DATABASE_URL', '').strip()}|{os.getenv('DATABASE_URL', '').strip()}"
+        source_key = f"db:{commit_evidence_db_url}|{shared_database_url}"
         now = time.time()
         cached_source = str(_DB_EVIDENCE_CACHE.get("source_key", ""))
         if (

--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -213,10 +213,49 @@ def test_inventory_reads_commit_evidence_from_store(
     assert str(records[0]["_evidence_file"]) == "memory:remote"
 
 
+def test_inventory_reads_commit_evidence_from_store_when_database_url_configured(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("COMMIT_EVIDENCE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
+    commit_evidence_service.upsert_record(
+        {
+            "idea_ids": ["database-url-evidence"],
+            "spec_ids": ["091"],
+        },
+        "memory:database-url",
+    )
+
+    records = inventory_service._read_commit_evidence_records(limit=20)
+
+    assert len(records) == 1
+    assert records[0]["idea_ids"] == ["database-url-evidence"]
+    assert records[0]["spec_ids"] == ["091"]
+    assert str(records[0]["_evidence_file"]) == "memory:database-url"
+
+
 def test_inventory_commit_evidence_returns_empty_when_store_has_no_rows(
     monkeypatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("COMMIT_EVIDENCE_DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence-empty.db'}")
+
+    records = inventory_service._read_commit_evidence_records(limit=1000)
+
+    assert records == []
+
+
+def test_inventory_commit_evidence_database_source_does_not_fallback_to_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("COMMIT_EVIDENCE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence-empty.db'}")
+    evidence_dir = tmp_path / "system_audit"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    (evidence_dir / "commit_evidence_2026-03-03_fake.json").write_text(
+        '{"idea_ids": ["legacy-file-only"], "spec_ids": ["999"]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("IDEA_COMMIT_EVIDENCE_DIR", str(evidence_dir))
 
     records = inventory_service._read_commit_evidence_records(limit=1000)
 

--- a/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
@@ -1,9 +1,10 @@
 {
   "date": "2026-03-03",
   "thread_branch": "codex/ideas-registry-backfill-20260303",
-  "commit_scope": "Keep idea domain discovery enabled in production by default so /api/ideas includes DB-backed internal and registry-derived ideas even when IDEA_PORTFOLIO_PATH is customized.",
+  "commit_scope": "Keep idea domain discovery enabled in production and force inventory commit-evidence reads to the same DB source when DATABASE_URL is configured, eliminating mixed DB/file idea-source drift.",
   "files_owned": [
     "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
     "api/tests/test_inventory_discovery_sources.py",
     "docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json"
   ],
@@ -11,9 +12,9 @@
     "status": "pass",
     "commands": [
       "make start-gate",
-      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured\"",
+      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"reads_commit_evidence_from_store_when_database_url_configured or database_source_does_not_fallback_to_files or inventory_reads_commit_evidence_from_store or inventory_commit_evidence_returns_empty_when_store_has_no_rows or database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured\"",
       "cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q",
-      "cd api && ruff check app/services/idea_service.py tests/test_inventory_discovery_sources.py"
+      "cd api && ruff check app/services/idea_service.py app/services/inventory_service.py tests/test_inventory_discovery_sources.py"
     ]
   },
   "ci_validation": {
@@ -68,6 +69,7 @@
   ],
   "change_files": [
     "api/app/services/idea_service.py",
+    "api/app/services/inventory_service.py",
     "api/tests/test_inventory_discovery_sources.py",
     "docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json"
   ],


### PR DESCRIPTION
## Summary
- treat `DATABASE_URL` as DB source configuration in inventory commit-evidence reads
- avoid fallback to file/github commit-evidence when DB source is configured
- add regression tests for DATABASE_URL-backed reads and no-fallback behavior

## Validation
- make start-gate
- cd api && pytest -q tests/test_inventory_discovery_sources.py -k "reads_commit_evidence_from_store_when_database_url_configured or database_source_does_not_fallback_to_files or inventory_reads_commit_evidence_from_store or inventory_commit_evidence_returns_empty_when_store_has_no_rows or database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured"
- cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q
- cd api && ruff check app/services/idea_service.py app/services/inventory_service.py tests/test_inventory_discovery_sources.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict