### PR TITLE
Include DB contribution metadata ideas in /api/ideas discovery

### DIFF
--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -8,6 +8,9 @@ import time
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
 from app.models.idea import (
     Idea,
     PaginationInfo,
@@ -294,7 +297,8 @@ def _ideas_cache_key() -> str:
         f"{os.getenv('COMMIT_EVIDENCE_DATABASE_URL','')}|"
         f"{os.getenv('IDEA_COMMIT_EVIDENCE_DIR','')}|"
         f"{os.getenv('IDEA_SYNC_RUNTIME_WINDOW_SECONDS','')}|"
-        f"{os.getenv('IDEA_SYNC_RUNTIME_EVENT_LIMIT','')}"
+        f"{os.getenv('IDEA_SYNC_RUNTIME_EVENT_LIMIT','')}|"
+        f"{os.getenv('IDEA_SYNC_CONTRIBUTION_LIMIT','')}"
     )
 
 
@@ -400,6 +404,70 @@ def _discover_registry_domain_idea_ids() -> list[str]:
         if idea_id and idea_id != "unmapped":
             discovered.add(idea_id)
 
+    discovered.update(_contribution_metadata_idea_ids())
+
+    return sorted(discovered)
+
+
+def _contribution_metadata_idea_ids() -> list[str]:
+    database_url = str(os.getenv("DATABASE_URL", "")).strip()
+    if not database_url:
+        return []
+
+    try:
+        contribution_limit_raw = int(str(os.getenv("IDEA_SYNC_CONTRIBUTION_LIMIT", "3000")).strip() or "3000")
+    except ValueError:
+        contribution_limit_raw = 3000
+    contribution_limit = max(1, min(contribution_limit_raw, 20000))
+
+    engine_kwargs: dict[str, Any] = {"pool_pre_ping": True}
+    if database_url.startswith("sqlite"):
+        engine_kwargs["connect_args"] = {"check_same_thread": False}
+        engine_kwargs["poolclass"] = NullPool
+
+    rows: list[Any] = []
+    try:
+        engine = create_engine(database_url, **engine_kwargs)
+        with engine.connect() as conn:
+            rows = list(
+                conn.execute(
+                    text("SELECT meta FROM contributions ORDER BY timestamp DESC LIMIT :limit"),
+                    {"limit": contribution_limit},
+                )
+            )
+    except Exception:
+        return []
+    finally:
+        try:
+            engine.dispose()
+        except Exception:
+            pass
+
+    discovered: set[str] = set()
+    for row in rows:
+        metadata: Any = None
+        try:
+            metadata = row[0] if isinstance(row, tuple) else row.meta  # type: ignore[attr-defined]
+        except Exception:
+            try:
+                metadata = row[0]
+            except Exception:
+                metadata = None
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except ValueError:
+                metadata = None
+        if not isinstance(metadata, dict):
+            continue
+        raw_single = metadata.get("idea_id")
+        if isinstance(raw_single, str) and raw_single.strip():
+            discovered.add(raw_single.strip())
+        raw_multi = metadata.get("idea_ids")
+        if isinstance(raw_multi, list):
+            for item in raw_multi:
+                if isinstance(item, str) and item.strip():
+                    discovered.add(item.strip())
     return sorted(discovered)
 
 

--- a/api/tests/test_inventory_discovery_sources.py
+++ b/api/tests/test_inventory_discovery_sources.py
@@ -140,6 +140,34 @@ def test_idea_service_domain_discovery_default_on_outside_pytest(
     assert "derived-prod-default" in idea_ids
 
 
+def test_idea_service_derives_missing_ideas_from_contribution_metadata_domain(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("COMMIT_EVIDENCE_DATABASE_URL", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'shared.db'}")
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "idea_portfolio.json"))
+    monkeypatch.setenv("IDEA_SYNC_ENABLE_DOMAIN_DISCOVERY", "1")
+    monkeypatch.delenv("IDEA_COMMIT_EVIDENCE_DIR", raising=False)
+
+    monkeypatch.setattr(spec_registry_service, "list_specs", lambda limit=200, offset=0: [])
+    monkeypatch.setattr(value_lineage_service, "list_links", lambda limit=200: [])
+    monkeypatch.setattr(
+        runtime_service,
+        "summarize_by_idea",
+        lambda seconds=3600, event_limit=2000, summary_limit=500, summary_offset=0, event_rows=None: [],
+    )
+    monkeypatch.setattr(
+        idea_service,
+        "_contribution_metadata_idea_ids",
+        lambda: ["derived-from-contribution-meta"],
+    )
+
+    listed = idea_service.list_ideas(include_internal=True)
+    idea_ids = {item.id for item in listed.ideas}
+
+    assert "derived-from-contribution-meta" in idea_ids
+
+
 def test_inventory_uses_github_spec_discovery_when_local_specs_missing(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_idea-domain-discovery-prod-default.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-03-03",
   "thread_branch": "codex/ideas-registry-backfill-20260303",
-  "commit_scope": "Keep idea domain discovery enabled in production and force inventory commit-evidence reads to the same DB source when DATABASE_URL is configured, eliminating mixed DB/file idea-source drift.",
+  "commit_scope": "Keep idea domain discovery enabled in production, force inventory commit-evidence reads to the same DB source when DATABASE_URL is configured, and include contribution-metadata idea IDs from the DB to close ideas vs flow parity gaps.",
   "files_owned": [
     "api/app/services/idea_service.py",
     "api/app/services/inventory_service.py",
@@ -12,7 +12,7 @@
     "status": "pass",
     "commands": [
       "make start-gate",
-      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"reads_commit_evidence_from_store_when_database_url_configured or database_source_does_not_fallback_to_files or inventory_reads_commit_evidence_from_store or inventory_commit_evidence_returns_empty_when_store_has_no_rows or database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured\"",
+      "cd api && pytest -q tests/test_inventory_discovery_sources.py -k \"derives_missing_ideas_from_contribution_metadata_domain or reads_commit_evidence_from_store_when_database_url_configured or database_source_does_not_fallback_to_files or inventory_reads_commit_evidence_from_store or inventory_commit_evidence_returns_empty_when_store_has_no_rows or database_url_is_configured or derives_missing_ideas_from_other_registry_domains or domain_discovery_default_on_outside_pytest or db_is_configured\"",
       "cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q",
       "cd api && ruff check app/services/idea_service.py app/services/inventory_service.py tests/test_inventory_discovery_sources.py"
     ]


### PR DESCRIPTION
## Summary
- derive additional idea IDs from contribution metadata in the shared DB (`contributions.meta.idea_id/idea_ids`)
- include this domain in `/api/ideas` discovery cache key + sync flow
- add regression coverage for contribution-metadata discovery

## Validation
- make start-gate
- cd api && pytest -q tests/test_inventory_discovery_sources.py -k "derives_missing_ideas_from_contribution_metadata_domain or reads_commit_evidence_from_store_when_database_url_configured or database_source_does_not_fallback_to_files or domain_discovery_default_on_outside_pytest or derives_missing_ideas_from_other_registry_domains or database_url_is_configured or db_is_configured"
- cd api && pytest -q tests/test_inventory_api.py::test_standing_question_exists_for_every_idea -q
- cd api && ruff check app/services/idea_service.py app/services/inventory_service.py tests/test_inventory_discovery_sources.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict