### PR TITLE
Web: unify ideas page with flow-stage filtering

### DIFF
--- a/docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json
@@ -1,0 +1,78 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/stash-ideas-followup-20260303",
+  "commit_scope": "Unify /ideas page around flow-stage coverage with clearer filtering, sorting, and pagination for first-time navigation without overwhelming detail.",
+  "files_owned": [
+    "web/app/ideas/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Will verify public endpoints after merge."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Ideas page shows a cleaner stage-driven view (spec/implementation/validation/measurement) with concise controls and clearer progression context.",
+    "public_endpoints": [
+      "/ideas"
+    ],
+    "test_flows": [
+      "ideas-stage-filters-and-pagination"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy checks pending."
+  },
+  "idea_ids": [
+    "coherence-network-web-interface"
+  ],
+  "spec_ids": [
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task_ideas_page_flow_unification_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cd web && npm run build",
+    "docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json"
+  ],
+  "change_files": [
+    "web/app/ideas/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/web/app/ideas/page.tsx
+++ b/web/app/ideas/page.tsx
@@ -1,59 +1,114 @@
 import Link from "next/link";
 
 import { getApiBase } from "@/lib/api";
-
-type IdeaQuestion = {
-  question: string;
-  value_to_whole: number;
-  estimated_cost: number;
-  answer?: string | null;
-  measured_delta?: number | null;
-};
+import { buildFlowSearchParams } from "@/lib/egress";
+import { fetchJsonOrNull } from "@/lib/fetch";
 
 type IdeaWithScore = {
   id: string;
   name: string;
   description: string;
-  potential_value: number;
-  actual_value: number;
-  estimated_cost: number;
-  actual_cost: number;
-  confidence: number;
-  resistance_risk: number;
   manifestation_status: string;
-  interfaces: string[];
-  open_questions: IdeaQuestion[];
   free_energy_score: number;
   value_gap: number;
-};
-
-type PaginationInfo = {
-  total: number;
-  limit: number;
-  offset: number;
-  returned: number;
-  has_more: boolean;
 };
 
 type IdeasResponse = {
   ideas: IdeaWithScore[];
   summary: {
     total_ideas: number;
-    unvalidated_ideas: number;
     validated_ideas: number;
+    unvalidated_ideas: number;
     total_potential_value: number;
     total_actual_value: number;
     total_value_gap: number;
   };
-  pagination?: PaginationInfo;
+};
+
+type ValidationCounts = {
+  pass: number;
+  fail: number;
+  pending: number;
+};
+
+type FlowItem = {
+  idea_id: string;
+  idea_name: string;
+  idea_classification?: {
+    internal?: boolean;
+    actionable?: boolean;
+  };
+  spec: {
+    tracked: boolean;
+    count: number;
+    spec_ids: string[];
+  };
+  implementation: {
+    tracked: boolean;
+    lineage_link_count: number;
+    runtime_events_count: number;
+    runtime_cost_estimate: number;
+  };
+  validation: {
+    tracked: boolean;
+    local: ValidationCounts;
+    ci: ValidationCounts;
+    deploy: ValidationCounts;
+    e2e: ValidationCounts;
+  };
+  contributions: {
+    tracked: boolean;
+    measured_value_total: number;
+    usage_events_count: number;
+  };
+  interdependencies: {
+    blocked: boolean;
+    blocking_stage: string | null;
+    unblock_priority_score: number;
+  };
+  idea_signals: {
+    value_gap: number;
+    potential_value: number;
+    actual_value: number;
+    estimated_cost: number;
+    confidence: number;
+  };
+};
+
+type FlowResponse = {
+  summary: {
+    ideas: number;
+    with_spec: number;
+    with_implementation: number;
+    with_validation: number;
+    with_contributions: number;
+    blocked_ideas: number;
+  };
+  items: FlowItem[];
 };
 
 type IdeasSearchParams = Promise<{
   page?: string | string[];
   page_size?: string | string[];
+  q?: string | string[];
+  stage?: string | string[];
+  manifestation?: string | string[];
+  sort?: string | string[];
+  actionable_only?: string | string[];
 }>;
 
-const DEFAULT_PAGE_SIZE = 25;
+type DisplayRow = {
+  id: string;
+  name: string;
+  description: string;
+  manifestation: string;
+  freeEnergyScore: number | null;
+  valueGap: number;
+  isInIdeaRegistry: boolean;
+  flow: FlowItem;
+};
+
+const DEFAULT_PAGE_SIZE = 24;
 const MAX_PAGE_SIZE = 100;
 
 export const revalidate = 90;
@@ -65,40 +120,220 @@ function parsePositiveInt(raw: string | string[] | undefined, fallback: number):
   return parsed;
 }
 
-async function loadIdeas(limit: number, offset: number): Promise<IdeasResponse> {
+function parseSingle(raw: string | string[] | undefined, fallback = ""): string {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const text = String(value || "").trim();
+  return text || fallback;
+}
+
+function parseBool(raw: string | string[] | undefined): boolean {
+  const value = parseSingle(raw).toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+function humanizeMachineText(value: string): string {
+  const normalized = value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!normalized) return value;
+  return normalized
+    .split(" ")
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(" ");
+}
+
+function formatNumber(value: number | null | undefined, digits = 2): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "0";
+  return Number(value).toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function inferManifestation(flow: FlowItem): string {
+  const hasValidationPass =
+    (flow.validation.local.pass || 0) +
+      (flow.validation.ci.pass || 0) +
+      (flow.validation.deploy.pass || 0) +
+      (flow.validation.e2e.pass || 0) >
+    0;
+  if (flow.validation.tracked && hasValidationPass) return "validated";
+  if (flow.implementation.tracked || flow.spec.tracked) return "partial";
+  return "none";
+}
+
+function isMeasured(flow: FlowItem): boolean {
+  return (
+    flow.contributions.tracked ||
+    flow.contributions.measured_value_total > 0 ||
+    flow.implementation.runtime_events_count > 0
+  );
+}
+
+function stageMatches(stage: string, row: DisplayRow): boolean {
+  const flow = row.flow;
+  if (!stage || stage === "all") return true;
+  if (stage === "needs_spec") return !flow.spec.tracked;
+  if (stage === "spec") return flow.spec.tracked;
+  if (stage === "implementation") return flow.implementation.tracked;
+  if (stage === "validation") return flow.validation.tracked;
+  if (stage === "measurement") return isMeasured(flow);
+  if (stage === "blocked") return flow.interdependencies.blocked;
+  return true;
+}
+
+function compareRows(sort: string, a: DisplayRow, b: DisplayRow): number {
+  if (sort === "name_asc") return a.name.localeCompare(b.name);
+  if (sort === "value_gap_desc") return b.valueGap - a.valueGap;
+  if (sort === "roi_desc") return b.flow.contributions.measured_value_total - a.flow.contributions.measured_value_total;
+  if (sort === "energy_desc") return (b.freeEnergyScore || 0) - (a.freeEnergyScore || 0);
+  return b.flow.interdependencies.unblock_priority_score - a.flow.interdependencies.unblock_priority_score;
+}
+
+function buildIdeasHref(input: {
+  page: number;
+  pageSize: number;
+  q: string;
+  stage: string;
+  manifestation: string;
+  sort: string;
+  actionableOnly: boolean;
+}): string {
+  const params = new URLSearchParams();
+  params.set("page", String(Math.max(1, input.page)));
+  params.set("page_size", String(Math.max(1, Math.min(input.pageSize, MAX_PAGE_SIZE))));
+  if (input.q) params.set("q", input.q);
+  if (input.stage && input.stage !== "all") params.set("stage", input.stage);
+  if (input.manifestation && input.manifestation !== "all") params.set("manifestation", input.manifestation);
+  if (input.sort && input.sort !== "priority_desc") params.set("sort", input.sort);
+  if (input.actionableOnly) params.set("actionable_only", "1");
+  return `/ideas?${params.toString()}`;
+}
+
+async function loadIdeas(): Promise<IdeasResponse> {
   const API = getApiBase();
   const params = new URLSearchParams({
-    limit: String(Math.max(1, Math.min(limit, MAX_PAGE_SIZE))),
-    offset: String(Math.max(0, offset)),
+    limit: "500",
+    offset: "0",
+    include_internal: "true",
   });
-  const res = await fetch(`${API}/api/ideas?${params.toString()}`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return (await res.json()) as IdeasResponse;
+  const payload = await fetchJsonOrNull<IdeasResponse>(`${API}/api/ideas?${params.toString()}`, {}, 7000);
+  return (
+    payload || {
+      ideas: [],
+      summary: {
+        total_ideas: 0,
+        validated_ideas: 0,
+        unvalidated_ideas: 0,
+        total_potential_value: 0,
+        total_actual_value: 0,
+        total_value_gap: 0,
+      },
+    }
+  );
+}
+
+async function loadFlow(): Promise<FlowResponse> {
+  const API = getApiBase();
+  const params = buildFlowSearchParams();
+  params.set("include_internal_ideas", "true");
+  const payload = await fetchJsonOrNull<FlowResponse>(`${API}/api/inventory/flow?${params.toString()}`, {}, 9000);
+  return (
+    payload || {
+      summary: {
+        ideas: 0,
+        with_spec: 0,
+        with_implementation: 0,
+        with_validation: 0,
+        with_contributions: 0,
+        blocked_ideas: 0,
+      },
+      items: [],
+    }
+  );
 }
 
 export default async function IdeasPage({ searchParams }: { searchParams: IdeasSearchParams }) {
   const resolved = await searchParams;
+  const currentPage = parsePositiveInt(resolved.page, 1);
   const requestedPageSize = parsePositiveInt(resolved.page_size, DEFAULT_PAGE_SIZE);
   const pageSize = Math.max(1, Math.min(requestedPageSize, MAX_PAGE_SIZE));
-  const requestedPage = parsePositiveInt(resolved.page, 1);
-  const offset = (requestedPage - 1) * pageSize;
+  const query = parseSingle(resolved.q).toLowerCase();
+  const stage = parseSingle(resolved.stage, "all");
+  const manifestation = parseSingle(resolved.manifestation, "all").toLowerCase();
+  const sort = parseSingle(resolved.sort, "priority_desc");
+  const actionableOnly = parseBool(resolved.actionable_only);
 
-  const data = await loadIdeas(pageSize, offset);
-  const ideas = [...data.ideas].sort((a, b) => b.free_energy_score - a.free_energy_score);
-  const pagination = data.pagination;
-  const currentPage = Math.max(1, Math.floor((pagination?.offset ?? offset) / (pagination?.limit || pageSize)) + 1);
-  const hasPrevious = currentPage > 1;
-  const hasNext = Boolean(pagination?.has_more) || ideas.length >= pageSize;
-  const pageStart = (pagination?.offset ?? offset) + 1;
-  const pageEnd = (pagination?.offset ?? offset) + ideas.length;
+  const [ideasData, flowData] = await Promise.all([loadIdeas(), loadFlow()]);
+  const byIdeaId = new Map(ideasData.ideas.map((idea) => [idea.id, idea]));
 
-  const prevHref = hasPrevious
-    ? `/ideas?page=${currentPage - 1}&page_size=${pagination?.limit || pageSize}`
-    : "/ideas";
-  const nextHref = `/ideas?page=${currentPage + 1}&page_size=${pagination?.limit || pageSize}`;
+  const merged: DisplayRow[] = flowData.items.map((flowItem) => {
+    const idea = byIdeaId.get(flowItem.idea_id);
+    const rawName = idea?.name || flowItem.idea_name || flowItem.idea_id;
+    const friendlyName = rawName.includes("_") ? humanizeMachineText(rawName) : rawName;
+    const rawDescription = idea?.description || "";
+    return {
+      id: flowItem.idea_id,
+      name: friendlyName,
+      description: rawDescription,
+      manifestation: String(idea?.manifestation_status || inferManifestation(flowItem)).toLowerCase(),
+      freeEnergyScore: typeof idea?.free_energy_score === "number" ? idea.free_energy_score : null,
+      valueGap: typeof idea?.value_gap === "number" ? idea.value_gap : flowItem.idea_signals.value_gap,
+      isInIdeaRegistry: Boolean(idea),
+      flow: flowItem,
+    };
+  });
+
+  const filtered = merged
+    .filter((row) => {
+      if (actionableOnly && row.flow.idea_classification?.actionable === false) return false;
+      if (query) {
+        const haystack = `${row.id} ${row.name} ${row.description}`.toLowerCase();
+        if (!haystack.includes(query)) return false;
+      }
+      if (manifestation !== "all" && row.manifestation !== manifestation) return false;
+      return stageMatches(stage, row);
+    })
+    .sort((a, b) => compareRows(sort, a, b));
+
+  const totalFiltered = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(totalFiltered / pageSize));
+  const clampedPage = Math.min(currentPage, totalPages);
+  const startIndex = (clampedPage - 1) * pageSize;
+  const pageItems = filtered.slice(startIndex, startIndex + pageSize);
+  const pageStart = totalFiltered === 0 ? 0 : startIndex + 1;
+  const pageEnd = startIndex + pageItems.length;
+
+  const counted = filtered.reduce(
+    (acc, row) => {
+      if (row.flow.spec.tracked) acc.spec += 1;
+      if (row.flow.implementation.tracked) acc.implementation += 1;
+      if (row.flow.validation.tracked) acc.validation += 1;
+      if (isMeasured(row.flow)) acc.measured += 1;
+      return acc;
+    },
+    { spec: 0, implementation: 0, validation: 0, measured: 0 },
+  );
+
+  const prevHref = buildIdeasHref({
+    page: Math.max(1, clampedPage - 1),
+    pageSize,
+    q: parseSingle(resolved.q),
+    stage,
+    manifestation,
+    sort,
+    actionableOnly,
+  });
+  const nextHref = buildIdeasHref({
+    page: clampedPage + 1,
+    pageSize,
+    q: parseSingle(resolved.q),
+    stage,
+    manifestation,
+    sort,
+    actionableOnly,
+  });
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
+    <main className="min-h-screen p-8 max-w-6xl mx-auto space-y-6">
       <div className="flex flex-wrap gap-3 text-sm">
         <Link href="/" className="text-muted-foreground hover:text-foreground">
           ← Home
@@ -106,66 +341,133 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeasS
         <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
           Portfolio
         </Link>
+        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
+          Flow
+        </Link>
         <Link href="/specs" className="text-muted-foreground hover:text-foreground">
           Specs
         </Link>
         <Link href="/usage" className="text-muted-foreground hover:text-foreground">
           Usage
         </Link>
-        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
-          Flow
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-        <Link href="/gates" className="text-muted-foreground hover:text-foreground">
-          Gates
-        </Link>
       </div>
 
-      <h1 className="text-2xl font-bold">Ideas</h1>
-      <p className="text-muted-foreground">Paginated `GET /api/ideas` with direct links to full idea detail.</p>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">Ideas</h1>
+        <p className="text-muted-foreground">
+          Unified view of idea stage coverage: spec, implementation, validation, and measurement.
+        </p>
+      </div>
 
-      <section className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+      <section className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
         <div className="rounded border p-3">
-          <p className="text-muted-foreground">Total ideas</p>
-          <p className="text-lg font-semibold">{data.summary.total_ideas}</p>
+          <p className="text-muted-foreground">Ideas visible</p>
+          <p className="text-lg font-semibold">
+            {totalFiltered} / {flowData.summary.ideas}
+          </p>
         </div>
         <div className="rounded border p-3">
-          <p className="text-muted-foreground">Actual value</p>
-          <p className="text-lg font-semibold">{data.summary.total_actual_value}</p>
+          <p className="text-muted-foreground">With spec</p>
+          <p className="text-lg font-semibold">{counted.spec}</p>
         </div>
         <div className="rounded border p-3">
-          <p className="text-muted-foreground">Value gap</p>
-          <p className="text-lg font-semibold">{data.summary.total_value_gap}</p>
+          <p className="text-muted-foreground">Implemented</p>
+          <p className="text-lg font-semibold">{counted.implementation}</p>
         </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Validated</p>
+          <p className="text-lg font-semibold">{counted.validation}</p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="text-muted-foreground">Measured</p>
+          <p className="text-lg font-semibold">{counted.measured}</p>
+        </div>
+      </section>
+
+      <section className="rounded border p-4 space-y-2 text-sm">
+        <p className="font-medium">Manifestation status meanings</p>
+        <p className="text-muted-foreground">
+          <span className="font-medium text-foreground">none</span>: no material implementation evidence yet.
+        </p>
+        <p className="text-muted-foreground">
+          <span className="font-medium text-foreground">partial</span>: some spec or implementation progress exists, but end-to-end validation is incomplete.
+        </p>
+        <p className="text-muted-foreground">
+          <span className="font-medium text-foreground">validated</span>: validated through passing validation signals and tracked as validated in the idea registry.
+        </p>
+      </section>
+
+      <section className="rounded border p-4 space-y-3">
+        <form className="grid gap-3 md:grid-cols-6" method="GET">
+          <input
+            type="text"
+            name="q"
+            defaultValue={parseSingle(resolved.q)}
+            placeholder="Search idea name or id"
+            className="md:col-span-2 rounded border px-3 py-2 bg-background"
+          />
+          <select name="stage" defaultValue={stage} className="rounded border px-3 py-2 bg-background">
+            <option value="all">All stages</option>
+            <option value="needs_spec">Needs spec</option>
+            <option value="spec">Has spec</option>
+            <option value="implementation">Implemented</option>
+            <option value="validation">Validated</option>
+            <option value="measurement">Measured</option>
+            <option value="blocked">Blocked</option>
+          </select>
+          <select name="manifestation" defaultValue={manifestation} className="rounded border px-3 py-2 bg-background">
+            <option value="all">All manifestation states</option>
+            <option value="none">none</option>
+            <option value="partial">partial</option>
+            <option value="validated">validated</option>
+          </select>
+          <select name="sort" defaultValue={sort} className="rounded border px-3 py-2 bg-background">
+            <option value="priority_desc">Sort by unblock priority</option>
+            <option value="value_gap_desc">Sort by value gap</option>
+            <option value="roi_desc">Sort by measured ROI</option>
+            <option value="energy_desc">Sort by free energy</option>
+            <option value="name_asc">Sort by name</option>
+          </select>
+          <select
+            name="page_size"
+            defaultValue={String(pageSize)}
+            className="rounded border px-3 py-2 bg-background"
+          >
+            <option value="12">12 / page</option>
+            <option value="24">24 / page</option>
+            <option value="48">48 / page</option>
+            <option value="96">96 / page</option>
+          </select>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="actionable_only" value="1" defaultChecked={actionableOnly} />
+            Actionable only
+          </label>
+          <div className="flex gap-3 items-center">
+            <button type="submit" className="rounded border px-3 py-2 hover:bg-muted">
+              Apply
+            </button>
+            <Link href="/ideas" className="text-muted-foreground hover:text-foreground underline">
+              Reset
+            </Link>
+          </div>
+        </form>
       </section>
 
       <section className="rounded border p-4 space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
           <p>
-            Showing {ideas.length > 0 ? `${pageStart}-${pageEnd}` : "0"} of {pagination?.total ?? data.summary.total_ideas}
-            {" | "}
-            page {currentPage}
+            Showing {pageStart > 0 ? `${pageStart}-${pageEnd}` : "0"} of {totalFiltered}
+            {" | "}page {clampedPage} / {totalPages}
           </p>
           <div className="flex gap-3">
-            {hasPrevious ? (
+            {clampedPage > 1 ? (
               <Link href={prevHref} className="underline hover:text-foreground">
                 Previous
               </Link>
             ) : (
               <span className="opacity-50">Previous</span>
             )}
-            {hasNext ? (
+            {clampedPage < totalPages ? (
               <Link href={nextHref} className="underline hover:text-foreground">
                 Next
               </Link>
@@ -176,22 +478,47 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeasS
         </div>
 
         <ul className="space-y-2">
-          {ideas.map((idea) => (
-            <li key={idea.id} className="rounded border p-3 space-y-1">
-              <div className="flex justify-between gap-3">
-                <Link href={`/ideas/${encodeURIComponent(idea.id)}`} className="font-medium hover:underline">
-                  {idea.name}
-                </Link>
-                <span className="text-muted-foreground">{idea.manifestation_status}</span>
-              </div>
-              <p className="text-sm text-muted-foreground">{idea.id}</p>
-              <p className="text-sm">{idea.description}</p>
-              <p className="text-sm text-muted-foreground">
-                free_energy {idea.free_energy_score.toFixed(2)} | value_gap {idea.value_gap.toFixed(2)} | cost_est {idea.estimated_cost}
-              </p>
-            </li>
-          ))}
-          {ideas.length === 0 ? <li className="text-muted-foreground">No ideas found for this page.</li> : null}
+          {pageItems.map((row) => {
+            const measured = isMeasured(row.flow);
+            return (
+              <li key={row.id} className="rounded border p-3 space-y-2">
+                <div className="flex flex-wrap justify-between gap-3">
+                  {row.isInIdeaRegistry ? (
+                    <Link href={`/ideas/${encodeURIComponent(row.id)}`} className="font-medium hover:underline">
+                      {row.name}
+                    </Link>
+                  ) : (
+                    <p className="font-medium">{row.name}</p>
+                  )}
+                  <div className="flex gap-2 text-xs">
+                    <span className="rounded border px-2 py-1">{row.manifestation}</span>
+                    <span className="rounded border px-2 py-1">{row.flow.interdependencies.blocked ? "blocked" : "ready"}</span>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">{row.id}</p>
+                {row.description ? <p className="text-sm">{row.description}</p> : null}
+                <p className="text-sm text-muted-foreground">
+                  Spec {row.flow.spec.tracked ? "yes" : "no"} | Implementation {row.flow.implementation.tracked ? "yes" : "no"} | Validation{" "}
+                  {row.flow.validation.tracked ? "yes" : "no"} | Measurement {measured ? "yes" : "no"}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Blocking stage {row.flow.interdependencies.blocking_stage || "none"} | Unblock priority{" "}
+                  {formatNumber(row.flow.interdependencies.unblock_priority_score)} | Specs {row.flow.spec.count}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Measured ROI {formatNumber(row.flow.contributions.measured_value_total)} | Runtime events{" "}
+                  {row.flow.implementation.runtime_events_count} | Value gap {formatNumber(row.valueGap)} | Free energy{" "}
+                  {formatNumber(row.freeEnergyScore)}
+                </p>
+                {!row.isInIdeaRegistry ? (
+                  <p className="text-xs text-muted-foreground">
+                    This idea is derived from traceability evidence and is not yet represented in the idea registry.
+                  </p>
+                ) : null}
+              </li>
+            );
+          })}
+          {pageItems.length === 0 ? <li className="text-muted-foreground">No ideas found for this filter set.</li> : null}
         </ul>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- apply remaining undeployed stash change to `web/app/ideas/page.tsx`
- unify Ideas UI around flow stage coverage (spec/implementation/validation/measurement)
- add filtering/sorting/pagination controls and stage summary counters
- include commit evidence file for this deploy unit

## Validation
- make start-gate
- cd web && npm run build
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-03-03_ideas-page-flow-unification.json
