### PR TITLE
Harden start-gate continuation and detached-head recovery

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,19 @@ Purpose: when a gate fails, the agent should self-unblock with concrete remediat
 This commonly happens mid-task after edits are already in progress.
 
 - Treat it as a continuation task, not a new thread bootstrap.
+- Re-run start-gate in continuation mode (now default in `auto` mode when dirty):
+
+```bash
+make start-gate
+```
+
+- If you need stash/rebase healing, use:
+
+```bash
+./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate
+```
+
+- `auto_heal_start_gate.sh` now auto-attaches detached `HEAD` to a `codex/...` branch before stash/rebase.
 - Continue with targeted validation for changed files.
 - Before commit, run required pre-commit guards:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,12 @@ Spec → Test → Implement → CI → Review → Merge
    - Every task must start in a new git worktree under `~/.claude-worktrees/...`.
 2. Start gate (required before any edits)
    - Run: `make start-gate`
-   - If it fails, stop and fix blockers first.
+   - `make start-gate` now runs in auto mode:
+     - clean tree => bootstrap,
+     - dirty tree => continuation (for follow-up prompts on same thread),
+     - detached `HEAD` => auto-attach to `codex/...` branch in linked worktrees.
+   - If it fails, fix blockers first.
+   - If stash/rebase healing is needed: `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`
    - Main-workflow failure policy:
      - Temporary waivers must be declared in `config/start_gate_main_workflow_waivers.json`.
      - Each waiver must include `workflow`, `owner`, `reason`, `expires_at`, and should scope by `run_url_contains` when possible.
@@ -165,6 +170,8 @@ NPM_CACHE=/tmp/coherence-npm-cache ./scripts/verify_worktree_local_web.sh
 
 # Start gate (required before starting a new task)
 make start-gate
+# For detached/stash/rebase recovery:
+./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate
 
 # PR check failure prevention + tracking (default before commit/push)
 # Optional for n8n-backed automation flows:
@@ -270,13 +277,12 @@ Use these as design guidance for web changes. They are intended to keep the expe
 ### Worktree Stability Guidance
 
 - Before running stash/rebase helper flows, confirm the worktree is on a named branch (`git rev-parse --abbrev-ref HEAD` should not be `HEAD`).
-- If detached, create or switch to a `codex/...` branch first. This avoids ambiguous stash restoration and preserves in-progress UI decisions.
+- If detached, `make start-gate` and `./scripts/auto_heal_start_gate.sh` now auto-attach to a `codex/...` branch in linked worktrees.
 - During long UI iterations, capture screenshots in `.playwright-cli/` and keep a short decision summary in the task thread so visual intent can be restored quickly if recovery tooling resets files.
-- Observed failure mode: repeated use of stash+rebase helper scripts while detached can make state recovery noisy and confusing. The helper does not detach by itself; it assumes branch state is already valid.
+- Observed failure mode: repeated stash+rebase while detached can make state recovery noisy and confusing; use the updated helper so branch attach is deterministic.
 - Suggested preflight before any auto-heal command:
   - run `git rev-parse --abbrev-ref HEAD`
-  - if output is `HEAD`, attach first: `git switch -c codex/<topic>-<date>` (or `git switch codex/<existing-branch>`)
-  - only then run `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`
+  - if output is `HEAD`, either attach manually (`git switch -c codex/<topic>-<date>`) or let `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate` auto-attach
 - If `make start-gate` fails only because the worktree is dirty from active task work, prefer continuing the same task and running local validation gates directly rather than repeatedly stashing/restoring mid-task.
 - Suggested Codex thread start check (quick, lightweight): confirm branch name, run `git status --short`, and record if the worktree is intentionally dirty before running any recovery helpers.
 - For deploy-focused threads, prefer a clean dedicated branch/worktree for release scope. Keep unrelated in-progress edits in another branch/worktree so deploy evidence and PR diffs stay easy to verify.

--- a/api/tests/test_worktree_pr_guard.py
+++ b/api/tests/test_worktree_pr_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -108,3 +109,18 @@ def test_n8n_security_floor_step_allows_fixed_versions() -> None:
     v2 = mod._n8n_security_floor_step("2.5.2", False)
     assert v1 is not None and v1.ok is True
     assert v2 is not None and v2.ok is True
+
+
+def test_rebase_freshness_guard_blocks_detached_head(monkeypatch) -> None:
+    mod = _load_module()
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return subprocess.CompletedProcess(cmd, 0, "HEAD\n", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    step = mod._run_rebase_freshness_guard("origin/main")
+    assert step.ok is False
+    assert "detached HEAD detected" in step.output_tail
+    assert "git switch -c codex/" in step.output_tail

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -46,12 +46,16 @@ make start-gate
 
 Gate status:
 - PASS only when running from a linked worktree (`.git` points to a worktree gitdir, not the primary `.git` directory).
-- PASS only when current worktree has no local changes before starting the next task.
+- PASS in bootstrap mode when current worktree is clean.
+- PASS in continuation mode when current worktree is dirty from in-flight thread work.
 - PASS only when primary workspace is clean (prevents abandoned local changes in main workspace).
 - PASS only when current start-command checks succeed, including remote `main` workflow health and open `codex/*` PR checks.
+- PASS only when detached `HEAD` is resolved (start-gate now auto-attaches to a `codex/...` branch in linked worktrees).
 
 Start command:
-- `make start-gate` enforces worktree-only execution, current+primary clean checks, and remote guard checks via GitHub (`gh`).
+- `make start-gate` in `auto` mode selects bootstrap/continuation automatically based on worktree cleanliness.
+- Continuation mode downgrades remote workflow failures to warnings by default so follow-up prompts on active threads do not deadlock.
+- `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate` remains the stash/rebase recovery path and now auto-attaches detached `HEAD` first.
 
 ### Phase A: Local Validation (required before commit)
 

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -28,16 +28,31 @@ git pull --ff-only origin main
 ## Mandatory Preflight (before edits)
 
 ```bash
+make start-gate
+```
+
+Default. `start-gate` now runs in `auto` mode:
+- clean worktree => bootstrap checks,
+- dirty worktree => continuation checks (no clean-start failure loop),
+- detached `HEAD` => auto-attach to a `codex/...` branch in linked worktrees.
+
+Use recovery flow only when you need stash/rebase healing:
+
+```bash
 ./scripts/auto_heal_start_gate.sh --with-pr-gate --with-rebase
 ```
 
-Recommended. This command:
-- stashes local changes temporarily,
-- runs `make start-gate`,
-- refreshes `origin/main` with `git fetch/rebase` when requested,
-- runs local preflight guard.
+`auto_heal_start_gate.sh` now auto-attaches detached `HEAD` before stash/rebase and forces continuation-safe start-gate when stashing active work.
 
-Equivalent legacy flow (manual/clean tree): `make start-gate`.
+## Follow-Up Prompt (same thread)
+
+When a later prompt continues the same branch and local edits already exist:
+
+```bash
+make start-gate
+```
+
+Do not treat this as a new-thread bootstrap. Continue task execution and close the same PR/deploy flow unless you explicitly record a blocker.
 
 ## Mandatory Local Guard (before commit/push)
 

--- a/docs/system_audit/commit_evidence_2026-03-03_start-gate-continuation-detached-head-deploy.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_start-gate-continuation-detached-head-deploy.json
@@ -1,0 +1,88 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/64f7-resume-20260303-071418-a14dfa4",
+  "commit_scope": "Harden start-gate and worktree recovery for continuation-safe follow-up prompts, detached-HEAD auto-attach, and deterministic deploy-preflight behavior.",
+  "files_owned": [
+    "scripts/start_gate.py",
+    "scripts/auto_heal_start_gate.sh",
+    "scripts/worktree_pr_guard.py",
+    "api/tests/test_worktree_pr_guard.py",
+    "AGENT.md",
+    "AGENTS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/system_audit/commit_evidence_2026-03-03_start-gate-continuation-detached-head-deploy.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "python3 -m py_compile scripts/start_gate.py scripts/worktree_pr_guard.py",
+      "cd api && pytest -q tests/test_worktree_pr_guard.py",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Will verify deploy contract after CI/merge flow."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy checks pending."
+  },
+  "idea_ids": [
+    "workflow-stability"
+  ],
+  "spec_ids": [
+    "115-start-gate-continuation-and-hosted-worker-proof"
+  ],
+  "task_ids": [
+    "task_start_gate_continuation_detached_head_deploy_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "make start-gate",
+    "cd api && pytest -q tests/test_worktree_pr_guard.py",
+    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+  ],
+  "change_files": [
+    "AGENT.md",
+    "AGENTS.md",
+    "api/tests/test_worktree_pr_guard.py",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/auto_heal_start_gate.sh",
+    "scripts/start_gate.py",
+    "scripts/worktree_pr_guard.py",
+    "docs/system_audit/commit_evidence_2026-03-03_start-gate-continuation-detached-head-deploy.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/auto_heal_start_gate.sh
+++ b/scripts/auto_heal_start_gate.sh
@@ -7,8 +7,11 @@ usage() {
   cat <<'USAGE'
 Usage: auto_heal_start_gate.sh [--with-pr-gate] [--with-rebase] [--skip-restore] [--start-command CMD]
 
-Run start-gate in a clean worktree, stashing local changes first and restoring them
-afterward.
+Run start-gate safely for active threads:
+- auto-attach detached HEAD to a named `codex/...` branch,
+- stash local changes when needed,
+- run start-gate (continuation mode when stashed),
+- restore local changes afterward.
 
 Options:
   --with-pr-gate     also run `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`.
@@ -24,6 +27,7 @@ run_rebase=0
 run_restore=1
 start_cmd="make start-gate"
 start_cmd_label="make start-gate"
+custom_start_cmd=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -47,6 +51,7 @@ while [[ $# -gt 0 ]]; do
       fi
       start_cmd="$1"
       start_cmd_label="$1"
+      custom_start_cmd=1
       shift
       ;;
     -h|--help)
@@ -65,6 +70,41 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "auto-heal-start-gate: not inside a git worktree."
   exit 1
 fi
+
+sanitize_branch_token() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//'
+}
+
+ensure_named_branch() {
+  local branch
+  branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [[ -n "$branch" ]]; then
+    echo "auto-heal-start-gate: active branch -> ${branch}."
+    return
+  fi
+
+  local candidate
+  while IFS= read -r candidate; do
+    [[ -z "$candidate" ]] && continue
+    if git switch "$candidate" >/dev/null 2>&1; then
+      echo "auto-heal-start-gate: detached HEAD reattached to existing branch ${candidate}."
+      return
+    fi
+  done < <(git for-each-ref --format='%(refname:short)' --points-at HEAD refs/heads/codex)
+
+  local hint
+  hint="$(basename "$(dirname "$PWD")")"
+  hint="$(sanitize_branch_token "$hint")"
+  if [[ -z "$hint" || "$hint" == "coherence-network" || "$hint" == "worktrees" || "$hint" == "codex" ]]; then
+    hint="resume"
+  fi
+  local short_sha
+  short_sha="$(git rev-parse --short HEAD 2>/dev/null || echo head)"
+  local new_branch
+  new_branch="codex/${hint}-resume-$(date +%Y%m%d-%H%M%S)-${short_sha}"
+  git switch -c "$new_branch" >/dev/null
+  echo "auto-heal-start-gate: detached HEAD reattached by creating ${new_branch}."
+}
 
 restore_stash_if_needed() {
   local stash_ref="$1"
@@ -87,6 +127,7 @@ restore_stash_if_needed() {
 }
 
 cd "$SCRIPT_DIR/.."
+ensure_named_branch
 
 initial_clean=0
 if [[ -z "$(git status --short --untracked-files=all)" ]]; then
@@ -97,6 +138,10 @@ stash_ref=""
 if [[ "$initial_clean" == "1" ]]; then
   echo "auto-heal-start-gate: worktree already clean."
 else
+  if [[ "$custom_start_cmd" == "0" ]]; then
+    start_cmd="START_GATE_MODE=continuation make start-gate"
+    start_cmd_label="$start_cmd (auto-applied for dirty continuation)"
+  fi
   stash_name="auto_heal_start_gate_$(date +%Y%m%dT%H%M%S)"
   echo "auto-heal-start-gate: stashing local changes as ${stash_name}."
   git stash push --include-untracked --message "$stash_name" >/dev/null

--- a/scripts/start_gate.py
+++ b/scripts/start_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import shutil
@@ -172,7 +173,96 @@ def run_command(cmd: list[str], *, check: bool = True) -> subprocess.CompletedPr
     return proc
 
 
+def _normalized_mode(raw: str | None) -> str:
+    mode = str(raw or "").strip().lower()
+    if mode not in {"auto", "bootstrap", "continuation"}:
+        return "auto"
+    return mode
+
+
+def _sanitize_branch_token(value: str) -> str:
+    token = re.sub(r"[^a-z0-9._-]+", "-", str(value or "").strip().lower()).strip("-")
+    return token or "resume"
+
+
+def _current_branch_name() -> str | None:
+    proc = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    branch = (proc.stdout or "").strip()
+    return branch or None
+
+
+def _branches_pointing_at_head() -> list[str]:
+    proc = subprocess.run(
+        [
+            "git",
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "--points-at",
+            "HEAD",
+            "refs/heads/codex",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    branches = [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
+    return branches
+
+
+def _attach_detached_head(*, now: datetime) -> str:
+    for candidate in _branches_pointing_at_head():
+        proc = subprocess.run(
+            ["git", "switch", candidate],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            return candidate
+
+    worktree_hint = Path.cwd().resolve().parent.name or Path.cwd().resolve().name
+    branch_hint = _sanitize_branch_token(worktree_hint)
+    if branch_hint in {"coherence-network", "worktrees", "codex"}:
+        branch_hint = "resume"
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    short_sha = (run_command(["git", "rev-parse", "--short", "HEAD"]).stdout or "").strip() or "head"
+    new_branch = f"codex/{branch_hint}-resume-{stamp}-{short_sha}"
+    proc = subprocess.run(
+        ["git", "switch", "-c", new_branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        stdout = (proc.stdout or "").strip()
+        raise SystemExit(
+            "start-gate: detached HEAD detected and automatic branch attach failed. "
+            "Attach manually with `git switch -c codex/<topic>-<date>` or `git switch codex/<existing-branch>` "
+            f"({stderr or stdout or 'unknown failure'})."
+        )
+    return new_branch
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Run start-gate checks for a worktree thread.")
+    parser.add_argument(
+        "--mode",
+        choices=("auto", "bootstrap", "continuation"),
+        default=_normalized_mode(os.environ.get("START_GATE_MODE")),
+        help="auto: bootstrap for clean trees, continuation for dirty trees.",
+    )
+    args = parser.parse_args()
+
     if shutil.which("gh") is None:
         raise SystemExit("start-gate: required command not found: gh")
 
@@ -212,6 +302,10 @@ def main() -> None:
     if not git_marker.exists():
         raise SystemExit("start-gate: missing .git marker")
 
+    require_linked_worktree = env_flag("START_GATE_REQUIRE_LINKED_WORKTREE", default=True)
+    auto_attach_detached = env_flag("START_GATE_AUTO_ATTACH_DETACHED", default=True)
+    remote_failure_env_override = os.environ.get("START_GATE_ENFORCE_REMOTE_FAILURES")
+
     in_worktree = False
     if git_marker.is_file():
         gitdir_line = git_marker.read_text(encoding="utf-8").strip()
@@ -227,16 +321,52 @@ def main() -> None:
     else:
         raise SystemExit("start-gate: unrecognized .git marker type")
 
+    if require_linked_worktree and not in_worktree:
+        raise SystemExit(
+            "start-gate: run this command from a linked worktree (for example ~/.claude-worktrees/... or ~/.codex/worktrees/...)."
+        )
+
+    active_branch = _current_branch_name()
+    if active_branch is None:
+        if not auto_attach_detached:
+            raise SystemExit(
+                "start-gate: detached HEAD detected. Attach first with `git switch -c codex/<topic>-<date>` "
+                "or `git switch codex/<existing-branch>`."
+            )
+        active_branch = _attach_detached_head(now=now)
+        print(f"start-gate: detached HEAD auto-attached to `{active_branch}`.")
+
     proc = subprocess.run(["git", "status", "--short"], capture_output=True, text=True, check=False)
     if proc.returncode != 0:
         raise SystemExit("start-gate: failed to check current worktree state")
-    if proc.stdout.strip():
+    dirty_rows = [line for line in (proc.stdout or "").splitlines() if line.strip()]
+    dirty_worktree = bool(dirty_rows)
+    mode = args.mode
+    if mode == "auto":
+        mode = "continuation" if dirty_worktree else "bootstrap"
+
+    if dirty_worktree and mode == "bootstrap":
         raise SystemExit(
             "start-gate: current worktree has local changes. Do not abandon in-flight work: "
             "finish merge/deploy (or record an explicit blocker), then rerun start-gate from a clean worktree. "
-            "If you must run gates without abandoning changes, use "
-            "./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate."
+            "For follow-up prompts on this thread, run continuation mode (`START_GATE_MODE=continuation make start-gate`) "
+            "or `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`."
         )
+
+    if mode == "continuation":
+        if dirty_worktree:
+            print(
+                "start-gate: continuation mode detected active in-flight work "
+                f"({len(dirty_rows)} changed path(s)); clean-start invariant skipped."
+            )
+        else:
+            print("start-gate: continuation mode requested on a clean worktree.")
+        if enforce_remote_failures and remote_failure_env_override is None:
+            enforce_remote_failures = False
+            print(
+                "start-gate: continuation mode defaults remote workflow failures to non-blocking "
+                "(override with START_GATE_ENFORCE_REMOTE_FAILURES=1)."
+            )
 
     proc = subprocess.run(
         ["git", "config", "--get", "remote.origin.url"],
@@ -455,7 +585,7 @@ def main() -> None:
     else:
         print("start-gate: skipping primary workspace cleanliness check (START_GATE_REQUIRE_PRIMARY_CLEAN=0)")
 
-    print("start-gate: passed")
+    print(f"start-gate: passed (mode={mode}, branch={active_branch})")
 
 
 if __name__ == "__main__":

--- a/scripts/worktree_pr_guard.py
+++ b/scripts/worktree_pr_guard.py
@@ -257,6 +257,19 @@ def _run_rebase_freshness_guard(base_ref: str) -> StepResult:
         text=True,
     )
     branch = (branch_proc.stdout or "").strip() or "unknown-branch"
+    if branch == "HEAD":
+        return StepResult(
+            name="rebase-freshness-guard",
+            command=f"git fetch origin main && git rebase {base_ref}",
+            ok=False,
+            exit_code=1,
+            duration_seconds=round(time.monotonic() - start, 2),
+            output_tail=(
+                "ERROR: detached HEAD detected. Attach this worktree to a named branch before rebase.\n"
+                "Run: git switch -c codex/<topic>-<date> (or git switch codex/<existing-branch>)"
+            ),
+            hint="Attach a codex/* branch before rebase and rerun guard.",
+        )
 
     # Keep base ref current when it points to a remote tracking branch.
     if "/" in base_ref:


### PR DESCRIPTION
## Summary\n- add start-gate auto mode that distinguishes bootstrap vs continuation and avoids dirty follow-up prompt deadlocks\n- auto-attach detached HEAD to a codex branch in start-gate and auto-heal flows\n- harden worktree rebase freshness guard and update docs/playbooks for continuation-safe deploy flow\n\n## Validation\n- make start-gate\n- python3 -m py_compile scripts/start_gate.py scripts/worktree_pr_guard.py\n- cd api && pytest -q tests/test_worktree_pr_guard.py\n- git fetch origin main && git rebase origin/main\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict