### PR TITLE
Simplify start-gate to minimal thread safety checks

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,6 +7,16 @@ Purpose: when a gate fails, the agent should self-unblock with concrete remediat
 - Do not stop at "gate blocked" as the final answer.
 - Fix the blocker first, rerun the gate, then continue commit/deploy flow.
 - Report exact failing command/output only after attempting remediation.
+- Start each prompt with:
+
+```bash
+make prompt-gate
+```
+
+- `make prompt-gate` is follow-up safe:
+  - clean worktree -> full `start-gate` + rebase + local guard,
+  - dirty worktree -> continuation mode (no re-bootstrap),
+  - detached `HEAD` -> fail fast with explicit `git switch` remediation.
 
 ## Gate-Specific Unblock Steps
 
@@ -15,19 +25,7 @@ Purpose: when a gate fails, the agent should self-unblock with concrete remediat
 This commonly happens mid-task after edits are already in progress.
 
 - Treat it as a continuation task, not a new thread bootstrap.
-- Re-run start-gate in continuation mode (now default in `auto` mode when dirty):
-
-```bash
-make start-gate
-```
-
-- If you need stash/rebase healing, use:
-
-```bash
-./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate
-```
-
-- `auto_heal_start_gate.sh` now auto-attaches detached `HEAD` to a `codex/...` branch before stash/rebase.
+- Prefer `make prompt-gate` for follow-up prompts instead of rerunning `make start-gate` directly.
 - Continue with targeted validation for changed files.
 - Before commit, run required pre-commit guards:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,19 +21,12 @@ Spec → Test → Implement → CI → Review → Merge
 1. Worktree-only execution
    - Never edit or run implementation commands in the primary workspace.
    - Every task must start in a new git worktree under `~/.claude-worktrees/...`.
-2. Start gate (required before any edits)
-   - Run: `make start-gate`
-   - `make start-gate` now runs in auto mode:
-     - clean tree => bootstrap,
-     - dirty tree => continuation (for follow-up prompts on same thread),
-     - detached `HEAD` => auto-attach to `codex/...` branch in linked worktrees.
-   - If it fails, fix blockers first.
-   - If stash/rebase healing is needed: `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`
-   - Main-workflow failure policy:
-     - Temporary waivers must be declared in `config/start_gate_main_workflow_waivers.json`.
-     - Each waiver must include `workflow`, `owner`, `reason`, `expires_at`, and should scope by `run_url_contains` when possible.
-     - Owner mappings for blocking workflows must exist in `config/start_gate_workflow_owners.json`.
-     - Waivers are short-lived and must be removed after root-cause repair.
+2. Prompt entry gate (required before any edits)
+   - Run: `make prompt-gate`
+   - Clean worktree: runs start-gate + rebase + local guard.
+   - Dirty worktree: continuation mode (skip re-bootstrap/start-gate and continue in-flight task).
+   - Detached `HEAD`: attach a branch first (`git switch -c codex/<thread-name>` or `git switch codex/<thread-name>`).
+   - If it fails, stop and fix blockers first.
 3. Pre-commit local gate (required)
    - Run: `git fetch origin main && git rebase origin/main` (must be cleanly rebased before push)
    - Run: `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
@@ -143,14 +136,14 @@ Spec → Test → Implement → CI → Review → Merge
 ## Commands
 
 ```bash
-# Mandatory first step for every thread
-make start-gate
+# Mandatory first step for every prompt (new thread + follow-up)
+make prompt-gate
 
 # Worktree setup for Codex thread start
 git fetch origin main
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
-make start-gate
+make prompt-gate
 
 # API
 cd api && uvicorn app.main:app --reload --port 8000
@@ -168,10 +161,8 @@ NPM_CACHE=/tmp/coherence-npm-cache ./scripts/verify_worktree_local_web.sh
 # Public production verify (required before merge/roll-forward)
 ./scripts/verify_web_api_deploy.sh
 
-# Start gate (required before starting a new task)
-make start-gate
-# For detached/stash/rebase recovery:
-./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate
+# Prompt entry gate (required before starting a new task)
+make prompt-gate
 
 # PR check failure prevention + tracking (default before commit/push)
 # Optional for n8n-backed automation flows:
@@ -277,12 +268,13 @@ Use these as design guidance for web changes. They are intended to keep the expe
 ### Worktree Stability Guidance
 
 - Before running stash/rebase helper flows, confirm the worktree is on a named branch (`git rev-parse --abbrev-ref HEAD` should not be `HEAD`).
-- If detached, `make start-gate` and `./scripts/auto_heal_start_gate.sh` now auto-attach to a `codex/...` branch in linked worktrees.
+- If detached, create or switch to a `codex/...` branch first. This avoids ambiguous stash restoration and preserves in-progress UI decisions.
 - During long UI iterations, capture screenshots in `.playwright-cli/` and keep a short decision summary in the task thread so visual intent can be restored quickly if recovery tooling resets files.
-- Observed failure mode: repeated stash+rebase while detached can make state recovery noisy and confusing; use the updated helper so branch attach is deterministic.
+- Observed failure mode: repeated use of stash+rebase helper scripts while detached can make state recovery noisy and confusing. The helper does not detach by itself; it assumes branch state is already valid.
 - Suggested preflight before any auto-heal command:
   - run `git rev-parse --abbrev-ref HEAD`
-  - if output is `HEAD`, either attach manually (`git switch -c codex/<topic>-<date>`) or let `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate` auto-attach
+  - if output is `HEAD`, attach first: `git switch -c codex/<topic>-<date>` (or `git switch codex/<existing-branch>`)
+  - only then run `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`
 - If `make start-gate` fails only because the worktree is dirty from active task work, prefer continuing the same task and running local validation gates directly rather than repeatedly stashing/restoring mid-task.
 - Suggested Codex thread start check (quick, lightweight): confirm branch name, run `git status --short`, and record if the worktree is intentionally dirty before running any recovery helpers.
 - For deploy-focused threads, prefer a clean dedicated branch/worktree for release scope. Keep unrelated in-progress edits in another branch/worktree so deploy evidence and PR diffs stay easy to verify.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Coherence Network — common targets
 
-.PHONY: test run setup lint web-worktree-validate spec-quality pr-preflight start-gate install-pre-push-hook
+.PHONY: test run setup lint web-worktree-validate spec-quality pr-preflight start-gate prompt-gate install-pre-push-hook
 
 test:
 	cd api && .venv/bin/pytest -v
@@ -28,3 +28,6 @@ install-pre-push-hook:
 
 start-gate:
 	@/usr/bin/python3 scripts/start_gate.py
+
+prompt-gate:
+	./scripts/prompt_entry_gate.sh

--- a/api/tests/test_start_gate.py
+++ b/api/tests/test_start_gate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "start_gate.py"
+    spec = importlib.util.spec_from_file_location("start_gate", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validate_thread_context_blocks_detached_head() -> None:
+    mod = _load_module()
+    with pytest.raises(SystemExit, match="detached HEAD"):
+        mod._validate_thread_context("HEAD", linked_worktree=True)
+
+
+def test_validate_thread_context_blocks_main_branch() -> None:
+    mod = _load_module()
+    with pytest.raises(SystemExit, match="direct work on main/master is blocked"):
+        mod._validate_thread_context("main", linked_worktree=True)
+
+
+def test_validate_thread_context_allows_linked_worktree_branch() -> None:
+    mod = _load_module()
+    mod._validate_thread_context("feature/my-branch", linked_worktree=True)
+
+
+def test_validate_thread_context_allows_codex_branch_without_worktree() -> None:
+    mod = _load_module()
+    mod._validate_thread_context("codex/thread-123", linked_worktree=False)
+
+
+def test_validate_thread_context_blocks_non_codex_branch_without_worktree() -> None:
+    mod = _load_module()
+    with pytest.raises(SystemExit, match="not in a linked worktree"):
+        mod._validate_thread_context("feature/my-branch", linked_worktree=False)

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -33,7 +33,7 @@ git fetch origin main
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
 git pull --ff-only origin main
-make start-gate
+make prompt-gate
 ```
 
 ### Phase 0: Start Gate (required before new task work)
@@ -41,21 +41,17 @@ make start-gate
 Run from the target worktree:
 
 ```bash
-make start-gate
+make prompt-gate
 ```
 
 Gate status:
-- PASS only when running from a linked worktree (`.git` points to a worktree gitdir, not the primary `.git` directory).
-- PASS in bootstrap mode when current worktree is clean.
-- PASS in continuation mode when current worktree is dirty from in-flight thread work.
-- PASS only when primary workspace is clean (prevents abandoned local changes in main workspace).
-- PASS only when current start-command checks succeed, including remote `main` workflow health and open `codex/*` PR checks.
-- PASS only when detached `HEAD` is resolved (start-gate now auto-attaches to a `codex/...` branch in linked worktrees).
+- PASS only when not detached (`HEAD` is attached to a named branch).
+- PASS only when not working directly on `main`/`master`.
+- PASS only when thread context is valid: linked worktree OR `codex/*` branch.
 
 Start command:
-- `make start-gate` in `auto` mode selects bootstrap/continuation automatically based on worktree cleanliness.
-- Continuation mode downgrades remote workflow failures to warnings by default so follow-up prompts on active threads do not deadlock.
-- `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate` remains the stash/rebase recovery path and now auto-attaches detached `HEAD` first.
+- `make prompt-gate` is the required prompt-entry command (clean tree runs start-gate + rebase + local guard; dirty tree enters continuation mode).
+- `make start-gate` is intentionally minimal and only validates branch/worktree safety.
 
 ### Phase A: Local Validation (required before commit)
 

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -28,31 +28,15 @@ git pull --ff-only origin main
 ## Mandatory Preflight (before edits)
 
 ```bash
-make start-gate
+make prompt-gate
 ```
 
-Default. `start-gate` now runs in `auto` mode:
-- clean worktree => bootstrap checks,
-- dirty worktree => continuation checks (no clean-start failure loop),
-- detached `HEAD` => auto-attach to a `codex/...` branch in linked worktrees.
+Mandatory for every prompt (new or follow-up). This command is continuation-safe:
+- clean worktree: runs full preflight (`start-gate`, rebase refresh, local guard),
+- dirty worktree: skips start-gate/rebase and treats the prompt as in-flight continuation,
+- detached HEAD: fails fast with exact branch attach commands.
 
-Use recovery flow only when you need stash/rebase healing:
-
-```bash
-./scripts/auto_heal_start_gate.sh --with-pr-gate --with-rebase
-```
-
-`auto_heal_start_gate.sh` now auto-attaches detached `HEAD` before stash/rebase and forces continuation-safe start-gate when stashing active work.
-
-## Follow-Up Prompt (same thread)
-
-When a later prompt continues the same branch and local edits already exist:
-
-```bash
-make start-gate
-```
-
-Do not treat this as a new-thread bootstrap. Continue task execution and close the same PR/deploy flow unless you explicitly record a blocker.
+Equivalent legacy flow (manual/clean tree): `make start-gate`.
 
 ## Mandatory Local Guard (before commit/push)
 

--- a/docs/system_audit/commit_evidence_2026-03-03_start-gate-minimal-thread-safety.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_start-gate-minimal-thread-safety.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/followup-gate-stability-20260303",
+  "commit_scope": "Simplify start-gate to minimal thread-safety checks (no main/master, no detached HEAD, valid branch/worktree context), add prompt-entry command wiring, and align docs/tests with the simplified workflow.",
+  "files_owned": [
+    "AGENT.md",
+    "AGENTS.md",
+    "Makefile",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/auto_heal_start_gate.sh",
+    "scripts/start_gate.py",
+    "scripts/prompt_entry_gate.sh",
+    "api/tests/test_start_gate.py",
+    "docs/system_audit/commit_evidence_2026-03-03_start-gate-minimal-thread-safety.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "make prompt-gate",
+      "python3 -m py_compile scripts/start_gate.py",
+      "cd api && pytest -q tests/test_start_gate.py",
+      "cd api && ruff check tests/test_start_gate.py"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Not a runtime feature; no deploy contract run required for this process change."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI validation pending until PR checks complete and merge is done."
+  },
+  "idea_ids": [
+    "thread-workflow-hardening"
+  ],
+  "spec_ids": [
+    "start-gate-minimal-thread-safety"
+  ],
+  "task_ids": [
+    "task_2026_03_03_start_gate_minimal_thread_safety"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "workflow-hardening"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/start_gate.py",
+    "api/tests/test_start_gate.py",
+    "scripts/prompt_entry_gate.sh"
+  ],
+  "change_files": [
+    "AGENT.md",
+    "AGENTS.md",
+    "Makefile",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/auto_heal_start_gate.sh",
+    "scripts/start_gate.py",
+    "scripts/prompt_entry_gate.sh",
+    "api/tests/test_start_gate.py",
+    "docs/system_audit/commit_evidence_2026-03-03_start-gate-minimal-thread-safety.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/auto_heal_start_gate.sh
+++ b/scripts/auto_heal_start_gate.sh
@@ -7,11 +7,8 @@ usage() {
   cat <<'USAGE'
 Usage: auto_heal_start_gate.sh [--with-pr-gate] [--with-rebase] [--skip-restore] [--start-command CMD]
 
-Run start-gate safely for active threads:
-- auto-attach detached HEAD to a named `codex/...` branch,
-- stash local changes when needed,
-- run start-gate (continuation mode when stashed),
-- restore local changes afterward.
+Run start-gate in a clean worktree, stashing local changes first and restoring them
+afterward.
 
 Options:
   --with-pr-gate     also run `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`.
@@ -27,7 +24,6 @@ run_rebase=0
 run_restore=1
 start_cmd="make start-gate"
 start_cmd_label="make start-gate"
-custom_start_cmd=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -51,7 +47,6 @@ while [[ $# -gt 0 ]]; do
       fi
       start_cmd="$1"
       start_cmd_label="$1"
-      custom_start_cmd=1
       shift
       ;;
     -h|--help)
@@ -71,40 +66,19 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-sanitize_branch_token() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//'
-}
-
-ensure_named_branch() {
-  local branch
-  branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
-  if [[ -n "$branch" ]]; then
-    echo "auto-heal-start-gate: active branch -> ${branch}."
-    return
-  fi
-
-  local candidate
-  while IFS= read -r candidate; do
-    [[ -z "$candidate" ]] && continue
-    if git switch "$candidate" >/dev/null 2>&1; then
-      echo "auto-heal-start-gate: detached HEAD reattached to existing branch ${candidate}."
-      return
-    fi
-  done < <(git for-each-ref --format='%(refname:short)' --points-at HEAD refs/heads/codex)
-
-  local hint
-  hint="$(basename "$(dirname "$PWD")")"
-  hint="$(sanitize_branch_token "$hint")"
-  if [[ -z "$hint" || "$hint" == "coherence-network" || "$hint" == "worktrees" || "$hint" == "codex" ]]; then
-    hint="resume"
-  fi
-  local short_sha
-  short_sha="$(git rev-parse --short HEAD 2>/dev/null || echo head)"
-  local new_branch
-  new_branch="codex/${hint}-resume-$(date +%Y%m%d-%H%M%S)-${short_sha}"
-  git switch -c "$new_branch" >/dev/null
-  echo "auto-heal-start-gate: detached HEAD reattached by creating ${new_branch}."
-}
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [[ -z "$current_branch" ]]; then
+  echo "auto-heal-start-gate: failed to detect current branch name."
+  exit 1
+fi
+if [[ "$current_branch" == "HEAD" ]]; then
+  echo "auto-heal-start-gate: detached HEAD detected; refusing stash/rebase in detached state."
+  echo "Attach this worktree first, then rerun:"
+  echo "  git switch -c codex/<thread-name>"
+  echo "  # or"
+  echo "  git switch codex/<thread-name>"
+  exit 1
+fi
 
 restore_stash_if_needed() {
   local stash_ref="$1"
@@ -127,7 +101,6 @@ restore_stash_if_needed() {
 }
 
 cd "$SCRIPT_DIR/.."
-ensure_named_branch
 
 initial_clean=0
 if [[ -z "$(git status --short --untracked-files=all)" ]]; then
@@ -138,10 +111,6 @@ stash_ref=""
 if [[ "$initial_clean" == "1" ]]; then
   echo "auto-heal-start-gate: worktree already clean."
 else
-  if [[ "$custom_start_cmd" == "0" ]]; then
-    start_cmd="START_GATE_MODE=continuation make start-gate"
-    start_cmd_label="$start_cmd (auto-applied for dirty continuation)"
-  fi
   stash_name="auto_heal_start_gate_$(date +%Y%m%dT%H%M%S)"
   echo "auto-heal-start-gate: stashing local changes as ${stash_name}."
   git stash push --include-untracked --message "$stash_name" >/dev/null

--- a/scripts/prompt_entry_gate.sh
+++ b/scripts/prompt_entry_gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+
+usage() {
+  cat <<'USAGE'
+Usage: prompt_entry_gate.sh [--force-full]
+
+Safe prompt-entry guard for Codex follow-up turns.
+
+Behavior:
+  - clean worktree: runs full preflight via auto_heal_start_gate.sh --with-pr-gate --with-rebase
+  - dirty worktree: continuation mode (skip start-gate/rebase) and print required pre-commit gates
+
+Options:
+  --force-full   run full preflight even when worktree is dirty (stashes/restores changes).
+  -h, --help     show this help text.
+USAGE
+}
+
+force_full=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-full)
+      force_full=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "prompt-entry-gate: unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "prompt-entry-gate: not inside a git worktree."
+  exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [[ -z "$branch" ]]; then
+  echo "prompt-entry-gate: failed to detect current branch name."
+  exit 1
+fi
+if [[ "$branch" == "HEAD" ]]; then
+  echo "prompt-entry-gate: detached HEAD detected."
+  echo "Attach this worktree first:"
+  echo "  git switch -c codex/<thread-name>"
+  echo "  # or"
+  echo "  git switch codex/<thread-name>"
+  exit 1
+fi
+
+if [[ "$force_full" == "1" ]]; then
+  echo "prompt-entry-gate: force-full enabled; running full preflight."
+  exec ./scripts/auto_heal_start_gate.sh --with-pr-gate --with-rebase
+fi
+
+if [[ -z "$(git status --short --untracked-files=all)" ]]; then
+  echo "prompt-entry-gate: clean worktree; running full preflight."
+  exec ./scripts/auto_heal_start_gate.sh --with-pr-gate --with-rebase
+fi
+
+echo "prompt-entry-gate: dirty worktree detected; continuation mode (skip start-gate/rebase)."
+echo "prompt-entry-gate: continue implementation in this thread and run required gates before commit:"
+echo "  git fetch origin main && git rebase origin/main"
+echo "  python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+echo "  python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+

--- a/scripts/start_gate.py
+++ b/scripts/start_gate.py
@@ -1,591 +1,83 @@
 from __future__ import annotations
 
-import argparse
-import json
-import re
-import shutil
 import subprocess
-import os
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-
-def env_flag(name: str, *, default: bool = True) -> bool:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    return str(value).strip().lower() not in {"0", "false", "no", "off"}
+MAIN_BRANCHES = {"main", "master"}
 
 
-def _workflow_name_set(value: str) -> set[str]:
-    names = set()
-    for raw in value.split(","):
-        normalized = raw.strip().lower()
-        if normalized:
-            names.add(normalized)
-    return names
-
-
-def _parse_iso8601_utc(value: str) -> datetime | None:
-    raw = str(value or "").strip()
-    if not raw:
-        return None
-    try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
-
-def _load_json_file(path: Path) -> dict | list | None:
-    if not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if isinstance(payload, (dict, list)):
-        return payload
-    return None
-
-
-def _load_workflow_owners(path: Path) -> dict[str, str]:
-    payload = _load_json_file(path)
-    if not isinstance(payload, dict):
-        return {}
-    mapping = payload.get("workflow_owners")
-    if not isinstance(mapping, dict):
-        return {}
-    out: dict[str, str] = {}
-    for key, value in mapping.items():
-        name = str(key or "").strip().lower()
-        owner = str(value or "").strip()
-        if name and owner:
-            out[name] = owner
-    return out
-
-
-def _load_active_waivers(path: Path, now: datetime) -> tuple[dict[str, list[dict]], list[str]]:
-    payload = _load_json_file(path)
-    if payload is None:
-        return {}, []
-    if not isinstance(payload, dict):
-        return {}, [f"start-gate: warning: invalid waiver payload in {path} (expected object)"]
-
-    rows = payload.get("waivers")
-    if not isinstance(rows, list):
-        return {}, [f"start-gate: warning: invalid waiver payload in {path} (missing waivers list)"]
-
-    warnings: list[str] = []
-    active_by_workflow: dict[str, list[dict]] = {}
-    for index, row in enumerate(rows):
-        if not isinstance(row, dict):
-            warnings.append(f"start-gate: warning: ignoring waiver[{index}] in {path} (expected object)")
-            continue
-        workflow = str(row.get("workflow") or "").strip().lower()
-        owner = str(row.get("owner") or "").strip()
-        reason = str(row.get("reason") or "").strip()
-        expires_at_raw = str(row.get("expires_at") or "").strip()
-        run_url_contains = str(row.get("run_url_contains") or "").strip()
-        expires_at = _parse_iso8601_utc(expires_at_raw)
-        if not workflow or not owner or not reason or expires_at is None:
-            warnings.append(
-                f"start-gate: warning: ignoring waiver[{index}] in {path} "
-                "(requires workflow, owner, reason, expires_at)"
-            )
-            continue
-        if expires_at <= now:
-            continue
-        waiver = {
-            "workflow": workflow,
-            "owner": owner,
-            "reason": reason,
-            "expires_at": expires_at,
-            "run_url_contains": run_url_contains,
-        }
-        active_by_workflow.setdefault(workflow, []).append(waiver)
-    return active_by_workflow, warnings
-
-
-def _match_waiver_for_failure(failure: dict, waivers: list[dict]) -> dict | None:
-    failure_url = str(failure.get("html_url") or "").strip()
-    for waiver in waivers:
-        run_url_contains = str(waiver.get("run_url_contains") or "").strip()
-        if run_url_contains and run_url_contains not in failure_url:
-            continue
-        return waiver
-    return None
-
-
-def _waiver_suggestion(failure: dict, owner: str, *, now: datetime) -> str:
-    workflow = str(failure.get("name") or "unknown").strip() or "unknown"
-    run_url = str(failure.get("html_url") or "").strip()
-    run_fragment = ""
-    match = re.search(r"actions/runs/\d+", run_url)
-    if match:
-        run_fragment = match.group(0)
-    expires_at = (now + timedelta(days=3)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    payload = {
-        "workflow": workflow,
-        "owner": owner or "unassigned",
-        "reason": (
-            "Temporary waiver while the latest main-workflow failure is actively remediated; "
-            "required to unblock start-gate for active thread completion."
-        ),
-        "expires_at": expires_at,
-    }
-    if run_fragment:
-        payload["run_url_contains"] = run_fragment
-    return json.dumps(payload, separators=(", ", ": "))
-
-
-def run_json(cmd: list[str], *, required: bool = True) -> dict | None:
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if proc.returncode != 0:
-        if required:
-            raise SystemExit(f"start-gate: command failed: {' '.join(cmd)}")
-        return None
-
-    output = proc.stdout.strip()
-    if not output:
-        raise SystemExit(f"start-gate: empty JSON output from {' '.join(cmd)}")
-
-    try:
-        payload = json.loads(output)
-    except json.JSONDecodeError as exc:
-        raise SystemExit(f"start-gate: invalid JSON from {' '.join(cmd)}: {exc}")
-
-    return payload
-
-
-def run_command(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if check and proc.returncode != 0:
-        stderr = (proc.stderr or "").strip()
-        stdout = (proc.stdout or "").strip()
-        raise SystemExit(
-            "start-gate: command failed: "
-            f"{' '.join(cmd)} ({stderr or stdout or 'unknown failure'})"
-        )
-
-    return proc
-
-
-def _normalized_mode(raw: str | None) -> str:
-    mode = str(raw or "").strip().lower()
-    if mode not in {"auto", "bootstrap", "continuation"}:
-        return "auto"
-    return mode
-
-
-def _sanitize_branch_token(value: str) -> str:
-    token = re.sub(r"[^a-z0-9._-]+", "-", str(value or "").strip().lower()).strip("-")
-    return token or "resume"
-
-
-def _current_branch_name() -> str | None:
+def _run_git(args: list[str]) -> str:
     proc = subprocess.run(
-        ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+        ["git", *args],
         capture_output=True,
         text=True,
         check=False,
     )
     if proc.returncode != 0:
-        return None
-    branch = (proc.stdout or "").strip()
-    return branch or None
+        detail = (proc.stderr or proc.stdout or "unknown failure").strip()
+        raise SystemExit(f"start-gate: git {' '.join(args)} failed ({detail})")
+    return (proc.stdout or "").strip()
 
 
-def _branches_pointing_at_head() -> list[str]:
-    proc = subprocess.run(
-        [
-            "git",
-            "for-each-ref",
-            "--format=%(refname:short)",
-            "--points-at",
-            "HEAD",
-            "refs/heads/codex",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return []
-    branches = [line.strip() for line in (proc.stdout or "").splitlines() if line.strip()]
-    return branches
+def _current_branch_name() -> str:
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+    if not branch:
+        raise SystemExit("start-gate: failed to detect current branch name")
+    return branch
 
 
-def _attach_detached_head(*, now: datetime) -> str:
-    for candidate in _branches_pointing_at_head():
-        proc = subprocess.run(
-            ["git", "switch", candidate],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if proc.returncode == 0:
-            return candidate
-
-    worktree_hint = Path.cwd().resolve().parent.name or Path.cwd().resolve().name
-    branch_hint = _sanitize_branch_token(worktree_hint)
-    if branch_hint in {"coherence-network", "worktrees", "codex"}:
-        branch_hint = "resume"
-    stamp = now.strftime("%Y%m%d-%H%M%S")
-    short_sha = (run_command(["git", "rev-parse", "--short", "HEAD"]).stdout or "").strip() or "head"
-    new_branch = f"codex/{branch_hint}-resume-{stamp}-{short_sha}"
-    proc = subprocess.run(
-        ["git", "switch", "-c", new_branch],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        stderr = (proc.stderr or "").strip()
-        stdout = (proc.stdout or "").strip()
-        raise SystemExit(
-            "start-gate: detached HEAD detected and automatic branch attach failed. "
-            "Attach manually with `git switch -c codex/<topic>-<date>` or `git switch codex/<existing-branch>` "
-            f"({stderr or stdout or 'unknown failure'})."
-        )
-    return new_branch
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Run start-gate checks for a worktree thread.")
-    parser.add_argument(
-        "--mode",
-        choices=("auto", "bootstrap", "continuation"),
-        default=_normalized_mode(os.environ.get("START_GATE_MODE")),
-        help="auto: bootstrap for clean trees, continuation for dirty trees.",
-    )
-    args = parser.parse_args()
-
-    if shutil.which("gh") is None:
-        raise SystemExit("start-gate: required command not found: gh")
-
-    require_gh_checks = env_flag("START_GATE_REQUIRE_GH", default=True)
-    enforce_remote_failures = env_flag("START_GATE_ENFORCE_REMOTE_FAILURES", default=True)
-    advisory_main_workflows = _workflow_name_set(
-        os.environ.get(
-            "START_GATE_ADVISORY_MAIN_WORKFLOWS",
-            "Maintainability Architecture Audit",
-        )
-    )
-    owners_file = Path(
-        os.environ.get(
-            "START_GATE_WORKFLOW_OWNERS_FILE",
-            "config/start_gate_workflow_owners.json",
-        )
-    )
-    waivers_file = Path(
-        os.environ.get(
-            "START_GATE_MAIN_FAILURE_WAIVERS_FILE",
-            "config/start_gate_main_workflow_waivers.json",
-        )
-    )
-    require_workflow_owner = env_flag("START_GATE_REQUIRE_WORKFLOW_OWNER", default=True)
-    now = datetime.now(timezone.utc)
-    workflow_owners = _load_workflow_owners(owners_file)
-    active_waivers, waiver_warnings = _load_active_waivers(waivers_file, now)
-    for warning in waiver_warnings:
-        print(warning)
-
-    if require_gh_checks:
-        run_command(["gh", "auth", "status"])
-    else:
-        print("start-gate: warning: skipping gh auth check because START_GATE_REQUIRE_GH=0")
-
+def _in_linked_worktree() -> bool:
     git_marker = Path(".git")
     if not git_marker.exists():
         raise SystemExit("start-gate: missing .git marker")
-
-    require_linked_worktree = env_flag("START_GATE_REQUIRE_LINKED_WORKTREE", default=True)
-    auto_attach_detached = env_flag("START_GATE_AUTO_ATTACH_DETACHED", default=True)
-    remote_failure_env_override = os.environ.get("START_GATE_ENFORCE_REMOTE_FAILURES")
-
-    in_worktree = False
-    if git_marker.is_file():
-        gitdir_line = git_marker.read_text(encoding="utf-8").strip()
-        if not gitdir_line.startswith("gitdir:"):
-            raise SystemExit("start-gate: expected .git to be a gitdir pointer file")
-
-        gitdir = gitdir_line.split(":", 1)[1].strip()
-        gitdir_path = Path(gitdir).resolve()
-        in_worktree = ".git/worktrees/" in gitdir_path.as_posix()
-        primary = gitdir_path.parent.parent.parent
-    elif git_marker.is_dir():
-        primary = Path.cwd().resolve()
-    else:
+    if git_marker.is_dir():
+        return False
+    if not git_marker.is_file():
         raise SystemExit("start-gate: unrecognized .git marker type")
 
-    if require_linked_worktree and not in_worktree:
+    gitdir_line = git_marker.read_text(encoding="utf-8").strip()
+    if not gitdir_line.startswith("gitdir:"):
+        raise SystemExit("start-gate: expected .git to be a gitdir pointer file")
+
+    gitdir = gitdir_line.split(":", 1)[1].strip()
+    gitdir_path = Path(gitdir).resolve().as_posix()
+    return "/.git/worktrees/" in gitdir_path
+
+
+def _validate_thread_context(branch_name: str, *, linked_worktree: bool) -> None:
+    if branch_name == "HEAD":
         raise SystemExit(
-            "start-gate: run this command from a linked worktree (for example ~/.claude-worktrees/... or ~/.codex/worktrees/...)."
+            "start-gate: detached HEAD detected. Attach to a branch first: "
+            "git switch -c codex/<thread-name> (new) or git switch codex/<thread-name> (existing)."
         )
 
-    active_branch = _current_branch_name()
-    if active_branch is None:
-        if not auto_attach_detached:
-            raise SystemExit(
-                "start-gate: detached HEAD detected. Attach first with `git switch -c codex/<topic>-<date>` "
-                "or `git switch codex/<existing-branch>`."
-            )
-        active_branch = _attach_detached_head(now=now)
-        print(f"start-gate: detached HEAD auto-attached to `{active_branch}`.")
-
-    proc = subprocess.run(["git", "status", "--short"], capture_output=True, text=True, check=False)
-    if proc.returncode != 0:
-        raise SystemExit("start-gate: failed to check current worktree state")
-    dirty_rows = [line for line in (proc.stdout or "").splitlines() if line.strip()]
-    dirty_worktree = bool(dirty_rows)
-    mode = args.mode
-    if mode == "auto":
-        mode = "continuation" if dirty_worktree else "bootstrap"
-
-    if dirty_worktree and mode == "bootstrap":
+    if branch_name in MAIN_BRANCHES:
         raise SystemExit(
-            "start-gate: current worktree has local changes. Do not abandon in-flight work: "
-            "finish merge/deploy (or record an explicit blocker), then rerun start-gate from a clean worktree. "
-            "For follow-up prompts on this thread, run continuation mode (`START_GATE_MODE=continuation make start-gate`) "
-            "or `./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate`."
+            "start-gate: direct work on main/master is blocked. "
+            "Create or switch to a thread branch (recommended: codex/<thread-name>)."
         )
 
-    if mode == "continuation":
-        if dirty_worktree:
-            print(
-                "start-gate: continuation mode detected active in-flight work "
-                f"({len(dirty_rows)} changed path(s)); clean-start invariant skipped."
-            )
-        else:
-            print("start-gate: continuation mode requested on a clean worktree.")
-        if enforce_remote_failures and remote_failure_env_override is None:
-            enforce_remote_failures = False
-            print(
-                "start-gate: continuation mode defaults remote workflow failures to non-blocking "
-                "(override with START_GATE_ENFORCE_REMOTE_FAILURES=1)."
-            )
+    if linked_worktree:
+        return
 
-    proc = subprocess.run(
-        ["git", "config", "--get", "remote.origin.url"],
-        capture_output=True,
-        text=True,
-        check=False,
+    if branch_name.startswith("codex/"):
+        return
+
+    raise SystemExit(
+        "start-gate: not in a linked worktree and not on a codex/* thread branch. "
+        "Use a linked worktree or switch to codex/<thread-name>."
     )
-    remote = (proc.stdout or "").strip()
-    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote)
-    if not match:
-        raise SystemExit(
-            "start-gate: could not detect github repo owner/name from git remote.origin.url"
-        )
-    repo_slug = f"{match.group('owner')}/{match.group('repo')}"
-    failed_conclusions = {
-        "failure",
-        "timed_out",
-        "cancelled",
-        "startup_failure",
-        "action_required",
-        "stale",
-    }
 
-    failed_prs: list[dict] = []
 
-    runs_payload = run_json(
-        ["gh", "api", f"repos/{repo_slug}/actions/runs?branch=main&per_page=20"],
-        required=require_gh_checks,
-    )
-    if runs_payload is None:
-        print("start-gate: warning: skipping workflow checks because gh is unavailable in current environment")
-    else:
-        runs = runs_payload.get("workflow_runs", []) if isinstance(runs_payload, dict) else []
-        completed = [
-            run for run in runs if isinstance(run, dict) and str(run.get("status") or "") == "completed"
-        ]
-        if not completed:
-            if enforce_remote_failures:
-                raise SystemExit("start-gate: no completed main workflow runs found")
-            print("start-gate: warning: no completed main workflow runs found")
+def main() -> None:
+    _run_git(["rev-parse", "--is-inside-work-tree"])
 
-        latest_by_workflow: dict[str, dict] = {}
-        for run in completed:
-            if not isinstance(run, dict):
-                continue
-            name = str(run.get("name") or "")
-            if name not in latest_by_workflow:
-                latest_by_workflow[name] = run
+    branch = _current_branch_name()
+    linked_worktree = _in_linked_worktree()
+    _validate_thread_context(branch, linked_worktree=linked_worktree)
 
-        failures = [
-            {
-                "name": row.get("name"),
-                "conclusion": row.get("conclusion"),
-                "html_url": row.get("html_url"),
-            }
-            for row in latest_by_workflow.values()
-            if str(row.get("conclusion") or "").strip().lower() in failed_conclusions
-        ]
-        advisory_failures = [
-            item
-            for item in failures
-            if str(item.get("name") or "").strip().lower() in advisory_main_workflows
-        ]
-        blocking_failures = [item for item in failures if item not in advisory_failures]
-        waived_failures: list[tuple[dict, dict]] = []
-        remaining_blocking: list[dict] = []
-        for failure in blocking_failures:
-            name_key = str(failure.get("name") or "").strip().lower()
-            waiver = _match_waiver_for_failure(failure, active_waivers.get(name_key, []))
-            if waiver is None:
-                remaining_blocking.append(failure)
-                continue
-            waived_failures.append((failure, waiver))
-        blocking_failures = remaining_blocking
-
-        if advisory_failures:
-            advisory_text = ", ".join(
-                f'{item["name"]}={item["conclusion"]} ({item["html_url"]})'
-                for item in advisory_failures
-            )
-            print(
-                "start-gate: warning: advisory main workflow failures detected: "
-                f"{advisory_text}"
-            )
-        if waived_failures:
-            waiver_text = ", ".join(
-                (
-                    f'{failure["name"]}={failure["conclusion"]} ({failure["html_url"]}) '
-                    f'waived_by={waiver["owner"]} until={waiver["expires_at"].isoformat()} '
-                    f'reason="{waiver["reason"]}"'
-                )
-                for failure, waiver in waived_failures
-            )
-            print(f"start-gate: warning: temporary workflow waivers applied: {waiver_text}")
-
-        if blocking_failures:
-            if require_workflow_owner:
-                missing_owner = [
-                    item for item in blocking_failures if str(item.get("name") or "").strip().lower() not in workflow_owners
-                ]
-                if missing_owner:
-                    missing_text = ", ".join(str(item.get("name") or "unknown") for item in missing_owner)
-                    raise SystemExit(
-                        "start-gate: blocking main workflow failures missing owner mapping: "
-                        f"{missing_text}. Update {owners_file}."
-                    )
-            failures_text = ", ".join(
-                (
-                    f'{item["name"]}={item["conclusion"]} ({item["html_url"]}) '
-                    f'owner={workflow_owners.get(str(item.get("name") or "").strip().lower(), "unassigned")}'
-                )
-                for item in blocking_failures
-            )
-            if enforce_remote_failures:
-                print(
-                    "start-gate: remediation: fix or rerun the failing main workflow(s), or add a short-lived waiver "
-                    f"in {waivers_file} with owner/reason/expires_at."
-                )
-                for item in blocking_failures:
-                    name_key = str(item.get("name") or "").strip().lower()
-                    owner = workflow_owners.get(name_key, "unassigned")
-                    print(
-                        "start-gate: remediation waiver example: "
-                        + _waiver_suggestion(item, owner, now=now)
-                    )
-                raise SystemExit(
-                    f"start-gate: latest main workflow failures detected: {failures_text}"
-                )
-            print(f"start-gate: warning: ignoring remote main workflow failures (non-blocking mode): {failures_text}")
-
-    pulls_payload = run_json(
-        ["gh", "api", f"repos/{repo_slug}/pulls?state=open&per_page=50"],
-        required=require_gh_checks,
-    )
-    if pulls_payload is not None:
-        pulls = pulls_payload if isinstance(pulls_payload, list) else []
-        for pr in (pulls if isinstance(pulls, list) else []):
-            if not isinstance(pr, dict):
-                continue
-
-            head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
-            branch = str((head or {}).get("ref") or "")
-            if not branch.startswith("codex/"):
-                continue
-
-            number = pr.get("number")
-            sha = str((head or {}).get("sha") or "")
-            if not number or not sha:
-                continue
-
-            checks_payload = run_json(
-                ["gh", "api", f"repos/{repo_slug}/commits/{sha}/check-runs?per_page=100"],
-                required=require_gh_checks,
-            )
-            if checks_payload is None:
-                continue
-            checks = checks_payload.get("check_runs", []) if isinstance(checks_payload, dict) else []
-            failed_checks = []
-            for check in checks:
-                if not isinstance(check, dict):
-                    continue
-                status = str(check.get("status") or "").strip().lower()
-                conclusion = str(check.get("conclusion") or "").strip().lower()
-                if status == "completed" and conclusion in failed_conclusions:
-                    failed_checks.append(
-                        {
-                            "name": check.get("name"),
-                            "conclusion": conclusion,
-                        }
-                    )
-            if failed_checks:
-                failed_prs.append(
-                    {
-                        "number": number,
-                        "title": pr.get("title"),
-                        "url": pr.get("html_url"),
-                        "failed_checks": failed_checks,
-                    }
-                )
-
-    if failed_prs:
-        first = failed_prs[0]
-        failure_text = (
-            "start-gate: open PR check failures detected. "
-            f"Example: PR #{first['number']} {first['title']} ({first['url']})"
-        )
-        if enforce_remote_failures:
-            raise SystemExit(failure_text)
-        print(f"start-gate: warning: {failure_text}")
-
-    require_primary_default = False if in_worktree else True
-    require_primary_clean = env_flag(
-        "START_GATE_REQUIRE_PRIMARY_CLEAN", default=require_primary_default
-    )
-    if require_primary_clean:
-        proc = subprocess.run(
-            ["git", "-C", str(primary), "status", "--short"],
-            capture_output=True,
-            text=True,
-        )
-        if proc.returncode != 0:
-            raise SystemExit("start-gate: failed to check primary workspace state")
-
-        if proc.stdout.strip():
-            raise SystemExit(
-                "start-gate: primary workspace has local changes. Do not abandon in-flight work: "
-                "finish merge/deploy (or record an explicit blocker), then rerun start-gate from a clean workspace. "
-                "If you must run gates without abandoning changes, use "
-                "./scripts/auto_heal_start_gate.sh --with-rebase --with-pr-gate."
-            )
-    elif in_worktree:
-        print(
-            "start-gate: skipping primary workspace cleanliness check in worktree mode "
-            "(START_GATE_REQUIRE_PRIMARY_CLEAN=0)."
-        )
-    else:
-        print("start-gate: skipping primary workspace cleanliness check (START_GATE_REQUIRE_PRIMARY_CLEAN=0)")
-
-    print(f"start-gate: passed (mode={mode}, branch={active_branch})")
+    location = "linked-worktree" if linked_worktree else "branch-only"
+    print(f"start-gate: passed ({location}, branch={branch})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rewrite `scripts/start_gate.py` to only enforce thread-safe git context
- block detached HEAD and direct work on main/master
- require linked worktree or `codex/*` branch when not in linked worktree
- keep `make prompt-gate` as prompt entry and align docs/tests/evidence

## Validation
- make start-gate
- make prompt-gate
- python3 -m py_compile scripts/start_gate.py
- cd api && pytest -q tests/test_start_gate.py
- cd api && ruff check tests/test_start_gate.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
