### PR TITLE
Redeploy Railway web in public deploy contract

### DIFF
--- a/.github/workflows/public-deploy-contract.yml
+++ b/.github/workflows/public-deploy-contract.yml
@@ -22,6 +22,8 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
       RAILWAY_ENVIRONMENT: ${{ secrets.RAILWAY_ENVIRONMENT }}
+      RAILWAY_API_SERVICE: ${{ secrets.RAILWAY_API_SERVICE || secrets.RAILWAY_SERVICE }}
+      RAILWAY_WEB_SERVICE: ${{ secrets.RAILWAY_WEB_SERVICE }}
       RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
       PUBLIC_DEPLOY_REQUIRE_API_HEALTH_SHA: ${{ vars.PUBLIC_DEPLOY_REQUIRE_API_HEALTH_SHA || '1' }}
       PUBLIC_DEPLOY_REQUIRE_WEB_HEALTH_PROXY_SHA: ${{ vars.PUBLIC_DEPLOY_REQUIRE_WEB_HEALTH_PROXY_SHA || '1' }}
@@ -78,16 +80,95 @@ jobs:
         if: ${{ steps.validate.outputs.exit_code != '0' }}
         run: |
           set +e
-          if [ -z "${RAILWAY_TOKEN:-}" ] || [ -z "${RAILWAY_PROJECT_ID:-}" ] || [ -z "${RAILWAY_ENVIRONMENT:-}" ] || [ -z "${RAILWAY_SERVICE:-}" ]; then
+          if [ -z "${RAILWAY_TOKEN:-}" ] || [ -z "${RAILWAY_PROJECT_ID:-}" ] || [ -z "${RAILWAY_ENVIRONMENT:-}" ]; then
             echo "attempted=false" >> "$GITHUB_OUTPUT"
             echo "reason=missing_railway_context_secrets" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service "$RAILWAY_SERVICE" --json > railway_link.json
-          railway redeploy --service "$RAILWAY_SERVICE" --yes --json > railway_redeploy.json
+
+          api_service="${RAILWAY_API_SERVICE:-${RAILWAY_SERVICE:-}}"
+          web_service="${RAILWAY_WEB_SERVICE:-}"
+          attempted_any=0
+          failures=0
+          attempted_services=""
+          note=""
+
+          redeploy_one() {
+            label="$1"
+            service="$2"
+            link_file="railway_link_${label}.json"
+            redeploy_file="railway_redeploy_${label}.json"
+            if [ -z "$service" ]; then
+              return 0
+            fi
+            attempted_any=1
+            if [ -n "$attempted_services" ]; then
+              attempted_services="${attempted_services},${label}"
+            else
+              attempted_services="${label}"
+            fi
+            railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service "$service" --json > "$link_file"
+            link_code=$?
+            if [ "$link_code" -ne 0 ]; then
+              failures=$((failures + 1))
+              printf '{"error":"railway_link_failed","service":"%s","exit_code":%s}\n' "$service" "$link_code" > "$link_file"
+              return 0
+            fi
+            railway redeploy --service "$service" --yes --json > "$redeploy_file"
+            redeploy_code=$?
+            if [ "$redeploy_code" -ne 0 ]; then
+              failures=$((failures + 1))
+              printf '{"error":"railway_redeploy_failed","service":"%s","exit_code":%s}\n' "$service" "$redeploy_code" > "$redeploy_file"
+            fi
+            return 0
+          }
+
+          if [ -z "$api_service" ] && [ -z "$web_service" ]; then
+            echo "attempted=false" >> "$GITHUB_OUTPUT"
+            echo "reason=missing_railway_service_secret" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          redeploy_one "api" "$api_service"
+          if [ -n "$web_service" ] && [ "$web_service" != "$api_service" ]; then
+            redeploy_one "web" "$web_service"
+          elif [ -n "$web_service" ]; then
+            note="web_service_matches_api_service"
+          fi
+
+          reason="redeploy_triggered"
+          if [ "$attempted_any" -eq 0 ]; then
+            echo "attempted=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no_redeploy_attempted" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$failures" -gt 0 ]; then
+            reason="redeploy_triggered_with_failures"
+          fi
+
+          jq -n \
+            --arg reason "$reason" \
+            --arg services "$attempted_services" \
+            --arg note "$note" \
+            --arg api_service "$api_service" \
+            --arg web_service "$web_service" \
+            --argjson attempted true \
+            --argjson failures "$failures" \
+            '{
+              attempted: $attempted,
+              reason: $reason,
+              services: ($services | split(",") | map(select(length > 0))),
+              note: $note,
+              api_service: $api_service,
+              web_service: $web_service,
+              failures: $failures
+            }' > railway_redeploy.json
           cat railway_redeploy.json
+
           echo "attempted=true" >> "$GITHUB_OUTPUT"
-          echo "reason=redeploy_triggered" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
+          echo "services=${attempted_services}" >> "$GITHUB_OUTPUT"
+          echo "note=${note}" >> "$GITHUB_OUTPUT"
           exit 0
 
       - name: Re-validate after Railway redeploy
@@ -160,8 +241,9 @@ jobs:
         with:
           name: railway_redeploy_artifacts_${{ github.sha }}
           path: |
-            railway_link.json
             railway_redeploy.json
+            railway_link_*.json
+            railway_redeploy_*.json
 
       - name: Create or update deploy drift issue
         if: ${{ steps.outcome.outputs.exit_code != '0' }}
@@ -183,6 +265,8 @@ jobs:
               `- Revalidated exit code: \`${"${{ steps.outcome.outputs.revalidated_exit_code }}"}\``,
               `- Railway redeploy attempted: \`${"${{ steps.railway_redeploy.outputs.attempted || 'false' }}"}\``,
               `- Railway redeploy note: \`${"${{ steps.railway_redeploy.outputs.reason || 'n/a' }}"}\``,
+              `- Railway redeploy services: \`${"${{ steps.railway_redeploy.outputs.services || 'none' }}"}\``,
+              `- Railway redeploy detail: \`${"${{ steps.railway_redeploy.outputs.note || 'n/a' }}"}\``,
               '',
               'Failing checks:',
               ...(Array.isArray(report.failing_checks) && report.failing_checks.length

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -85,14 +85,16 @@ VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA=1 \
 ## CI/CD Validation
 
 - `.github/workflows/public-deploy-contract.yml` validates Railway API + Railway web.
-- If contract fails and Railway CLI secrets are present, workflow triggers Railway redeploy and revalidates.
+- If contract fails and Railway CLI secrets are present, workflow triggers Railway redeploy (API + web when both service secrets are set) and revalidates.
 
 Required repo secrets for automated redeploy:
 
 - `RAILWAY_TOKEN`
- - `RAILWAY_PROJECT_ID`
- - `RAILWAY_ENVIRONMENT`
- - `RAILWAY_SERVICE`
+- `RAILWAY_PROJECT_ID`
+- `RAILWAY_ENVIRONMENT`
+- `RAILWAY_API_SERVICE` (preferred; falls back to legacy `RAILWAY_SERVICE` if unset)
+- `RAILWAY_WEB_SERVICE` (required to auto-heal web SHA drift checks)
+- `RAILWAY_SERVICE` (legacy fallback for API service)
 
 Optional repo variables to override deploy de-risk defaults:
 

--- a/docs/system_audit/commit_evidence_2026-03-03_public-deploy-web-service-redeploy.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_public-deploy-web-service-redeploy.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/unify-native-provider-telemetry",
+  "commit_scope": "Update public deploy contract workflow to redeploy both Railway API and Railway web services (with backward-compatible API fallback), then revalidate contract checks and attach multi-service redeploy artifacts.",
+  "files_owned": [
+    ".github/workflows/public-deploy-contract.yml",
+    "docs/DEPLOY.md",
+    "docs/system_audit/commit_evidence_2026-03-03_public-deploy-web-service-redeploy.json"
+  ],
+  "idea_ids": [
+    "coherence-network-agent-pipeline"
+  ],
+  "spec_ids": [
+    "111-greenfield-autonomous-intelligence-system"
+  ],
+  "task_ids": [
+    "task-2026-03-03-public-deploy-contract-web-service-redeploy"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "python3 scripts/validate_workflow_references.py",
+    "python3 - <<'PY' (yaml.safe_load) parse check for .github/workflows/public-deploy-contract.yml",
+    "./scripts/verify_web_api_deploy.sh (production contract verification before/after merge)"
+  ],
+  "change_files": [
+    ".github/workflows/public-deploy-contract.yml",
+    "docs/DEPLOY.md"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/validate_workflow_references.py",
+      "python3 - <<'PY'\\nimport yaml\\nfrom pathlib import Path\\nyaml.safe_load(Path('.github/workflows/public-deploy-contract.yml').read_text())\\nprint('OK yaml parse')\\nPY"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": "pending"
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "railway-production"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Awaiting merge and rerun of Public Deploy Contract with RAILWAY_WEB_SERVICE configured."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public Deploy Contract auto-remediation can redeploy both API and web services so web SHA parity can self-heal when API and web drift.",
+    "public_endpoints": [
+      "https://coherence-network-production.up.railway.app/api/health",
+      "https://coherence-web-production.up.railway.app/api/health-proxy"
+    ],
+    "test_flows": [
+      "Trigger public deploy contract on main and confirm Railway redeploy artifacts include api and web service outputs.",
+      "Verify /api/health and /api/health-proxy report matching deployed_sha for main."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- update public deploy contract workflow to redeploy Railway API and web services separately
- keep backward compatibility by falling back to legacy `RAILWAY_SERVICE` for API
- publish per-service redeploy artifacts and include attempted services in deploy drift issue details
- document new secrets in DEPLOY guide (`RAILWAY_API_SERVICE`, `RAILWAY_WEB_SERVICE`)

## Why
- production drift issue #406 shows API rolled to main SHA while web remained on old SHA
- previous workflow only redeployed one Railway service, so web SHA parity could not self-heal

## Validation
- `python3 scripts/validate_workflow_references.py`
- `python3 - <<'PY'\nimport yaml\nfrom pathlib import Path\nyaml.safe_load(Path('.github/workflows/public-deploy-contract.yml').read_text())\nprint('OK yaml parse')\nPY`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
