### PR TITLE
fix(ideas): normalize internal ids to contributor-facing ideas

### DIFF
--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -186,6 +187,15 @@ DEFAULT_INTERNAL_IDEA_PREFIXES = (
     "e2e-idea-",
 )
 DEFAULT_INTERNAL_IDEA_INTERFACE_TAGS = {"machine:commit-evidence"}
+TRANSIENT_INTERNAL_ID_PATTERNS = (
+    re.compile(r"^public-e2e-[0-9a-f]{8}$"),
+)
+DISCOVERED_INTERNAL_ID_ALIASES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^public-e2e-"), "deployment-gate-reliability"),
+    (re.compile(r"^e2e-idea-"), "deployment-gate-reliability"),
+    (re.compile(r"^spec-origin-"), "portfolio-governance"),
+    (re.compile(r"^endpoint-lineage-"), "oss-interface-alignment"),
+)
 
 
 def _default_portfolio_path() -> str:
@@ -235,6 +245,29 @@ def is_internal_idea_id(idea_id: str, interfaces: list[str] | None = None) -> bo
         if tags.intersection(_configured_internal_idea_interface_tags()):
             return True
     return False
+
+
+def _is_transient_internal_idea_id(idea_id: str) -> bool:
+    normalized_id = str(idea_id or "").strip().lower()
+    if not normalized_id:
+        return False
+    return any(pattern.match(normalized_id) for pattern in TRANSIENT_INTERNAL_ID_PATTERNS)
+
+
+def _canonical_discovered_idea_id(idea_id: str) -> str | None:
+    normalized_id = str(idea_id or "").strip().lower()
+    if not normalized_id or normalized_id == "unmapped":
+        return None
+    for pattern, target_id in DISCOVERED_INTERNAL_ID_ALIASES:
+        if pattern.match(normalized_id):
+            return target_id
+    if _is_transient_internal_idea_id(normalized_id):
+        return None
+    return normalized_id
+
+
+def _should_track_discovered_idea_id(idea_id: str) -> bool:
+    return _canonical_discovered_idea_id(idea_id) is not None
 
 
 def _idea_ids_from_payload(payload: dict[str, Any]) -> list[str]:
@@ -359,7 +392,11 @@ def _discover_registry_domain_idea_ids() -> list[str]:
     if not _should_discover_registry_domain_ideas():
         return []
 
-    discovered: set[str] = set(_tracked_idea_ids())
+    discovered: set[str] = {
+        idea_id
+        for idea_id in _tracked_idea_ids()
+        if _should_track_discovered_idea_id(idea_id)
+    }
 
     try:
         spec_rows = spec_registry_service.list_specs(limit=2000, offset=0)
@@ -367,8 +404,9 @@ def _discover_registry_domain_idea_ids() -> list[str]:
         spec_rows = []
     for row in spec_rows:
         idea_id = str(getattr(row, "idea_id", "") or "").strip()
-        if idea_id:
-            discovered.add(idea_id)
+        canonical_id = _canonical_discovered_idea_id(idea_id)
+        if canonical_id:
+            discovered.add(canonical_id)
 
     try:
         lineage_rows = value_lineage_service.list_links(limit=2000)
@@ -376,8 +414,9 @@ def _discover_registry_domain_idea_ids() -> list[str]:
         lineage_rows = []
     for row in lineage_rows:
         idea_id = str(getattr(row, "idea_id", "") or "").strip()
-        if idea_id:
-            discovered.add(idea_id)
+        canonical_id = _canonical_discovered_idea_id(idea_id)
+        if canonical_id:
+            discovered.add(canonical_id)
 
     try:
         runtime_window_raw = int(str(os.getenv("IDEA_SYNC_RUNTIME_WINDOW_SECONDS", "86400")).strip() or "86400")
@@ -401,10 +440,13 @@ def _discover_registry_domain_idea_ids() -> list[str]:
         runtime_rows = []
     for row in runtime_rows:
         idea_id = str(getattr(row, "idea_id", "") or "").strip()
-        if idea_id and idea_id != "unmapped":
-            discovered.add(idea_id)
-
-    discovered.update(_contribution_metadata_idea_ids())
+        canonical_id = _canonical_discovered_idea_id(idea_id)
+        if canonical_id:
+            discovered.add(canonical_id)
+    for idea_id in _contribution_metadata_idea_ids():
+        canonical_id = _canonical_discovered_idea_id(idea_id)
+        if canonical_id:
+            discovered.add(canonical_id)
 
     return sorted(discovered)
 
@@ -478,12 +520,29 @@ def _ensure_registry_domain_idea_entries(ideas: list[Idea]) -> tuple[list[Idea],
     existing = {idea.id for idea in ideas}
     changed = False
     for idea_id in discovered_ids:
+        if not _should_track_discovered_idea_id(idea_id):
+            continue
         if idea_id in existing:
             continue
         ideas.append(_derived_idea_for_id(idea_id))
         existing.add(idea_id)
         changed = True
     return ideas, changed
+
+
+def _prune_transient_internal_ideas(ideas: list[Idea]) -> tuple[list[Idea], bool]:
+    kept: list[Idea] = []
+    changed = False
+    for idea in ideas:
+        canonical_id = _canonical_discovered_idea_id(idea.id)
+        if canonical_id is not None and canonical_id != str(idea.id).strip().lower():
+            changed = True
+            continue
+        if _is_transient_internal_idea_id(idea.id):
+            changed = True
+            continue
+        kept.append(idea)
+    return kept, changed
 
 
 def _humanize_idea_id(idea_id: str) -> str:
@@ -621,6 +680,7 @@ def _read_ideas() -> list[Idea]:
         ideas, required_changed = _ensure_required_system_ideas(ideas)
         ideas, tracked_changed = _ensure_tracked_idea_entries(ideas)
         ideas, domain_discovered_changed = _ensure_registry_domain_idea_entries(ideas)
+        ideas, transient_pruned_changed = _prune_transient_internal_ideas(ideas)
         ideas, pruned_changed = _prune_internal_standing_questions(ideas)
         ideas, standing_changed = _ensure_standing_questions(ideas)
         bootstrap_source = source
@@ -630,7 +690,7 @@ def _read_ideas() -> list[Idea]:
             bootstrap_source = f"{bootstrap_source}+derived"
         if domain_discovered_changed:
             bootstrap_source = f"{bootstrap_source}+domain_discovery"
-        if standing_changed or pruned_changed:
+        if standing_changed or pruned_changed or transient_pruned_changed:
             bootstrap_source = f"{bootstrap_source}+standing_question"
         idea_registry_service.save_ideas(ideas, bootstrap_source=bootstrap_source)
         _write_snapshot_file(ideas)
@@ -640,9 +700,17 @@ def _read_ideas() -> list[Idea]:
     ideas, required_changed = _ensure_required_system_ideas(ideas)
     ideas, tracked_changed = _ensure_tracked_idea_entries(ideas)
     ideas, domain_discovered_changed = _ensure_registry_domain_idea_entries(ideas)
+    ideas, transient_pruned_changed = _prune_transient_internal_ideas(ideas)
     ideas, pruned_changed = _prune_internal_standing_questions(ideas)
     ideas, standing_changed = _ensure_standing_questions(ideas)
-    if required_changed or tracked_changed or domain_discovered_changed or standing_changed or pruned_changed:
+    if (
+        required_changed
+        or tracked_changed
+        or domain_discovered_changed
+        or standing_changed
+        or pruned_changed
+        or transient_pruned_changed
+    ):
         _write_ideas(ideas)
     else:
         path = _portfolio_path()

--- a/api/app/services/release_gate_service.py
+++ b/api/app/services/release_gate_service.py
@@ -1028,7 +1028,7 @@ def check_value_lineage_e2e_flow(api_base: str, timeout: float = 8.0) -> dict[st
     base = api_base.rstrip("/")
     marker = uuid.uuid4().hex[:8]
     create_payload = {
-        "idea_id": f"public-e2e-{marker}",
+        "idea_id": "deployment-gate-reliability",
         "spec_id": "048-value-lineage-and-payout-attribution",
         "implementation_refs": [f"contract:{marker}"],
         "contributors": {

--- a/api/tests/test_ideas.py
+++ b/api/tests/test_ideas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -76,7 +77,7 @@ async def test_list_ideas_can_hide_internal_system_generated_ideas(
         created = await client.post(
             "/api/ideas",
             json={
-                "id": "spec-origin-cleanup-seed-1234abcd",
+                "id": "internal-cleanup-seed-1234abcd",
                 "name": "Internal seed",
                 "description": "System-generated idea should be hidden from actionable lists.",
                 "potential_value": 10.0,
@@ -91,11 +92,45 @@ async def test_list_ideas_can_hide_internal_system_generated_ideas(
 
         include_all = await client.get("/api/ideas?include_internal=true")
         assert include_all.status_code == 200
-        assert any(row["id"] == "spec-origin-cleanup-seed-1234abcd" for row in include_all.json()["ideas"])
+        assert any(row["id"] == "internal-cleanup-seed-1234abcd" for row in include_all.json()["ideas"])
 
         actionable_only = await client.get("/api/ideas?include_internal=false")
         assert actionable_only.status_code == 200
-        assert all(row["id"] != "spec-origin-cleanup-seed-1234abcd" for row in actionable_only.json()["ideas"])
+        assert all(row["id"] != "internal-cleanup-seed-1234abcd" for row in actionable_only.json()["ideas"])
+
+
+@pytest.mark.asyncio
+async def test_list_ideas_prunes_transient_public_e2e_idea_ids_from_discovery(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    portfolio_path = tmp_path / "idea_portfolio.json"
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(portfolio_path))
+    monkeypatch.setenv("IDEA_SYNC_ENABLE_DOMAIN_DISCOVERY", "true")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'ideas.db'}")
+    monkeypatch.setattr("app.services.spec_registry_service.list_specs", lambda *args, **kwargs: [])
+    monkeypatch.setattr("app.services.runtime_service.summarize_by_idea", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "app.services.value_lineage_service.list_links",
+        lambda *args, **kwargs: [
+            SimpleNamespace(idea_id="public-e2e-deadbeef"),
+            SimpleNamespace(idea_id="spec-origin-cleanup-seed-1234abcd"),
+            SimpleNamespace(idea_id="endpoint-lineage-health-check-1234abcd"),
+            SimpleNamespace(idea_id="discovered-non-transient"),
+        ],
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        listed = await client.get("/api/ideas?include_internal=true&limit=500")
+
+    assert listed.status_code == 200
+    ids = {row["id"] for row in listed.json()["ideas"]}
+    assert "public-e2e-deadbeef" not in ids
+    assert "spec-origin-cleanup-seed-1234abcd" not in ids
+    assert "endpoint-lineage-health-check-1234abcd" not in ids
+    assert "deployment-gate-reliability" in ids
+    assert "portfolio-governance" in ids
+    assert "oss-interface-alignment" in ids
+    assert "discovered-non-transient" in ids
 
 
 @pytest.mark.asyncio
@@ -398,7 +433,7 @@ async def test_ideas_cards_defaults_include_internal_and_allow_actionable_filter
     monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
     monkeypatch.setenv("COMMIT_EVIDENCE_DATABASE_URL", f"sqlite+pysqlite:///{tmp_path / 'commit_evidence.db'}")
 
-    internal_id = "spec-origin-cards-hidden-example"
+    internal_id = "internal-cards-hidden-example"
     external_id = "cards-visible-example"
     base_payload = {
         "name": "Cards Example",
@@ -411,7 +446,14 @@ async def test_ideas_cards_defaults_include_internal_and_allow_actionable_filter
     }
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        create_internal = await client.post("/api/ideas", json={"id": internal_id, **base_payload})
+        create_internal = await client.post(
+            "/api/ideas",
+            json={
+                "id": internal_id,
+                **base_payload,
+                "interfaces": ["machine:commit-evidence"],
+            },
+        )
         assert create_internal.status_code == 201
         create_external = await client.post("/api/ideas", json={"id": external_id, **base_payload})
         assert create_external.status_code == 201

--- a/api/tests/test_inventory_api.py
+++ b/api/tests/test_inventory_api.py
@@ -1103,7 +1103,7 @@ async def test_next_unblock_task_defaults_to_actionable_ideas_only(
             {
                 "ideas": [
                     {
-                        "id": "spec-origin-internal-1234abcd",
+                        "id": "internal-derived-1234abcd",
                         "name": "Internal derived idea",
                         "description": "Should not be first unblock target in actionable mode.",
                         "potential_value": 120.0,
@@ -1142,16 +1142,16 @@ async def test_next_unblock_task_defaults_to_actionable_ideas_only(
         assert default_resp.status_code == 200
         default_payload = default_resp.json()
         assert default_payload["result"] == "task_suggested"
-        assert default_payload["idea_id"] != "spec-origin-internal-1234abcd"
+        assert default_payload["idea_id"] != "internal-derived-1234abcd"
 
         include_internal = await client.post(
             "/api/inventory/flow/next-unblock-task",
-            params={"include_internal_ideas": True, "idea_id": "spec-origin-internal-1234abcd"},
+            params={"include_internal_ideas": True, "idea_id": "internal-derived-1234abcd"},
         )
         assert include_internal.status_code == 200
         include_payload = include_internal.json()
         assert include_payload["result"] == "task_suggested"
-        assert include_payload["idea_id"] == "spec-origin-internal-1234abcd"
+        assert include_payload["idea_id"] == "internal-derived-1234abcd"
 
 
 @pytest.mark.asyncio
@@ -1214,8 +1214,8 @@ async def test_flow_inventory_counts_spec_registry_specs_for_idea(
     monkeypatch.setenv("RUNTIME_EVENTS_PATH", str(tmp_path / "runtime_events.json"))
     monkeypatch.setenv("RUNTIME_IDEA_MAP_PATH", str(tmp_path / "runtime_idea_map.json"))
 
-    idea_id = "public-e2e-flow-gate-automation"
-    spec_id = "095-public-e2e-flow-gate-automation-test"
+    idea_id = "deployment-gate-reliability"
+    spec_id = "095-deployment-gate-reliability-test"
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         create_spec = await client.post(

--- a/api/tests/test_release_gate_service.py
+++ b/api/tests/test_release_gate_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from typing import Any
 
 import httpx
@@ -336,6 +337,43 @@ def test_evaluate_public_deploy_contract_report_live_shape() -> None:
     assert out["result"] in {"public_contract_passed", "blocked"}
     assert isinstance(out.get("failing_checks"), list)
     assert isinstance(out.get("warnings"), list)
+
+
+@respx.mock
+def test_check_value_lineage_e2e_flow_uses_stable_idea_id() -> None:
+    base_url = "https://example.test"
+    lineage_id = "lnk_test123"
+    captured_payload: dict[str, Any] = {}
+
+    def _capture_create(request: httpx.Request) -> httpx.Response:
+        captured_payload.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(201, json={"id": lineage_id})
+
+    respx.post(f"{base_url}/api/value-lineage/links").mock(side_effect=_capture_create)
+    respx.post(f"{base_url}/api/value-lineage/links/{lineage_id}/usage-events").mock(
+        return_value=httpx.Response(201, json={"id": "evt_1"})
+    )
+    respx.get(f"{base_url}/api/value-lineage/links/{lineage_id}/valuation").mock(
+        return_value=httpx.Response(200, json={"measured_value_total": 5.0, "event_count": 1})
+    )
+    respx.post(f"{base_url}/api/value-lineage/links/{lineage_id}/payout-preview").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "payouts": [
+                    {"role": "idea", "amount": 10.0},
+                    {"role": "spec", "amount": 20.0},
+                    {"role": "implementation", "amount": 50.0},
+                    {"role": "review", "amount": 20.0},
+                ]
+            },
+        )
+    )
+
+    result = gates.check_value_lineage_e2e_flow(base_url, timeout=1.0)
+
+    assert result["ok"] is True
+    assert captured_payload["idea_id"] == "deployment-gate-reliability"
 
 
 def test_evaluate_public_deploy_contract_report_fails_without_paid_override_header(monkeypatch) -> None:

--- a/docs/system_audit/commit_evidence_2026-03-03_ideas-relevance-normalization.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_ideas-relevance-normalization.json
@@ -1,0 +1,99 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/ideas-registry-backfill-20260303",
+  "commit_scope": "Normalize internal/system-generated idea identifiers to contributor-facing canonical ideas, stop random deploy-check idea proliferation, and default ideas UI to contributor-actionable scope.",
+  "files_owned": [
+    "api/app/services/idea_service.py",
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_ideas.py",
+    "api/tests/test_inventory_api.py",
+    "api/tests/test_release_gate_service.py",
+    "web/app/ideas/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_ideas-relevance-normalization.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && pytest -q tests/test_ideas.py::test_list_ideas_can_hide_internal_system_generated_ideas tests/test_ideas.py::test_list_ideas_prunes_transient_public_e2e_idea_ids_from_discovery tests/test_ideas.py::test_ideas_cards_defaults_include_internal_and_allow_actionable_filter tests/test_release_gate_service.py::test_check_value_lineage_e2e_flow_uses_stable_idea_id tests/test_inventory_api.py::test_next_unblock_task_defaults_to_actionable_ideas_only tests/test_inventory_api.py::test_flow_inventory_counts_spec_registry_specs_for_idea",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Awaiting PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Will run deploy verification after publish."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Contributor-facing ideas are default scope; internal/generated traces are mapped to canonical portfolio ideas and no longer create random non-human cards.",
+    "public_endpoints": [
+      "/ideas",
+      "/api/ideas",
+      "/api/ideas/cards",
+      "/api/value-lineage/links"
+    ],
+    "test_flows": [
+      "ideas-default-contributor-scope",
+      "idea-domain-discovery-alias-normalization",
+      "public-deploy-value-lineage-e2e-stable-idea-id"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy checks pending."
+  },
+  "idea_ids": [
+    "deployment-gate-reliability",
+    "portfolio-governance",
+    "oss-interface-alignment",
+    "coherence-network-web-interface"
+  ],
+  "spec_ids": [
+    "111-greenfield-autonomous-intelligence-system",
+    "048-value-lineage-and-payout-attribution"
+  ],
+  "task_ids": [
+    "task_ideas_relevance_normalization_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing",
+        "delivery"
+      ]
+    },
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "approval"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "output/playwright/ideas-production-verify/ideas-prod-desktop-top.png",
+    "output/playwright/ideas-production-verify/ideas-prod-desktop-deep-scroll-sticky.png",
+    "output/playwright/ideas-production-verify/ideas-prod-mobile-idea-card.png"
+  ],
+  "change_files": [
+    "api/app/services/idea_service.py",
+    "api/app/services/release_gate_service.py",
+    "api/tests/test_ideas.py",
+    "api/tests/test_inventory_api.py",
+    "api/tests/test_release_gate_service.py",
+    "web/app/ideas/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_ideas-relevance-normalization.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/web/app/ideas/page.tsx
+++ b/web/app/ideas/page.tsx
@@ -61,6 +61,7 @@ type IdeaCardsResponse = {
     cursor: string;
     limit: number;
     include_internal_ideas: boolean;
+    only_actionable: boolean;
     min_roi: number | null;
     min_value_gap: number | null;
   };
@@ -75,6 +76,7 @@ const FILTER_STATES = ["all", "spec", "implemented", "validated", "measured"] as
 const ATTENTION_LEVELS = ["all", "none", "low", "medium", "high"] as const;
 const SORT_OPTIONS = ["attention_desc", "roi_desc", "gap_desc", "state_desc", "name_asc"] as const;
 const VIEW_OPTIONS = ["list", "focus"] as const;
+const SCOPE_OPTIONS = ["contributors", "all"] as const;
 const LIMIT_OPTIONS = [25, 50, 100, 200] as const;
 
 const SORT_LABEL: Record<(typeof SORT_OPTIONS)[number], string> = {
@@ -219,6 +221,7 @@ async function loadIdeaCards(params: {
   minRoi: number | null;
   minValueGap: number | null;
   includeInternalIdeas: boolean;
+  onlyActionable: boolean;
 }): Promise<IdeaCardsResponse> {
   const API = getApiBase();
   const search = new URLSearchParams({
@@ -229,6 +232,7 @@ async function loadIdeaCards(params: {
     cursor: String(params.cursor),
     limit: String(params.limit),
     include_internal_ideas: params.includeInternalIdeas ? "true" : "false",
+    only_actionable: params.onlyActionable ? "true" : "false",
     runtime_window_seconds: String(UI_RUNTIME_SUMMARY_WINDOW),
   });
   if (params.minRoi !== null) search.set("min_roi", String(params.minRoi));
@@ -250,10 +254,13 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
   const attention = parseEnum(readParam(resolved.attention, "all"), ATTENTION_LEVELS, "all");
   const sort = parseEnum(readParam(resolved.sort, "attention_desc"), SORT_OPTIONS, "attention_desc");
   const view = parseEnum(readParam(resolved.view, "list"), VIEW_OPTIONS, "list");
+  const scope = parseEnum(readParam(resolved.scope, "contributors"), SCOPE_OPTIONS, "contributors");
   const cursor = parseCursor(readParam(resolved.cursor, "0"));
   const limit = parseLimit(readParam(resolved.limit, String(DEFAULT_LIMIT)));
   const minRoi = parseOptionalNumber(readParam(resolved.min_roi));
   const minValueGap = parseOptionalNumber(readParam(resolved.min_value_gap));
+  const includeInternalIdeas = scope === "all";
+  const onlyActionable = scope !== "all";
 
   const currentParams = new URLSearchParams();
   if (q) currentParams.set("q", q);
@@ -261,6 +268,7 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
   if (attention !== "all") currentParams.set("attention", attention);
   if (sort !== "attention_desc") currentParams.set("sort", sort);
   if (view !== "list") currentParams.set("view", view);
+  if (scope !== "contributors") currentParams.set("scope", scope);
   if (cursor > 0) currentParams.set("cursor", String(cursor));
   if (limit !== DEFAULT_LIMIT) currentParams.set("limit", String(limit));
   if (minRoi !== null) currentParams.set("min_roi", String(minRoi));
@@ -275,7 +283,8 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
     limit,
     minRoi,
     minValueGap,
-    includeInternalIdeas: true,
+    includeInternalIdeas,
+    onlyActionable,
   });
 
   const items = payload.items;
@@ -307,6 +316,9 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
           <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Ideas In Motion</h1>
           <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
             A global community bringing ideas to life with care, coherence, and measurable impact.
+          </p>
+          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            {scope === "all" ? "Showing all ideas (including system/internal)." : "Showing contributor-actionable ideas."}
           </p>
         </section>
 
@@ -357,6 +369,7 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
             <input type="hidden" name="attention" value={attention} />
             <input type="hidden" name="sort" value={sort} />
             <input type="hidden" name="view" value={view} />
+            <input type="hidden" name="scope" value={scope} />
             <input type="hidden" name="limit" value={String(limit)} />
             {minRoi !== null ? <input type="hidden" name="min_roi" value={String(minRoi)} /> : null}
             {minValueGap !== null ? <input type="hidden" name="min_value_gap" value={String(minValueGap)} /> : null}
@@ -393,6 +406,26 @@ export default async function IdeasPage({ searchParams }: { searchParams: IdeaSe
 
         <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
           <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href={buildHref(currentParams, { scope: "contributors", ...clearCursor })}
+              className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition ${
+                scope === "contributors"
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-border/70 bg-background/55 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Contributor Ideas
+            </Link>
+            <Link
+              href={buildHref(currentParams, { scope: "all", ...clearCursor })}
+              className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition ${
+                scope === "all"
+                  ? "border-primary/50 bg-primary/15 text-primary"
+                  : "border-border/70 bg-background/55 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              All Ideas
+            </Link>
             {[
               {
                 label: "All",


### PR DESCRIPTION
## Summary
- map system-generated idea-id families to stable canonical portfolio ideas instead of creating new noisy records
- stop public deploy E2E checks from generating random  idea ids
- default  UI scope to contributor-actionable ideas, with explicit All Ideas toggle
- add regression tests for ID normalization and stable deploy-gate idea usage

## Validation
- cd api && pytest -q tests/test_ideas.py::test_list_ideas_can_hide_internal_system_generated_ideas tests/test_ideas.py::test_list_ideas_prunes_transient_public_e2e_idea_ids_from_discovery tests/test_ideas.py::test_ideas_cards_defaults_include_internal_and_allow_actionable_filter tests/test_release_gate_service.py::test_check_value_lineage_e2e_flow_uses_stable_idea_id tests/test_inventory_api.py::test_next_unblock_task_defaults_to_actionable_ideas_only tests/test_inventory_api.py::test_flow_inventory_counts_spec_registry_specs_for_idea
- cd web && npm run build
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
