### PR TITLE
Merge remaining local worktree branches and stash history

### DIFF
--- a/docs/system_audit/commit_evidence_2026-03-03_merge-local-worktrees-stashes-admin.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_merge-local-worktrees-stashes-admin.json
@@ -44,7 +44,9 @@
     "gh pr list --state open",
     "gh pr create --base main --head codex/merge-all-local-worktrees-stashes-admin-20260303"
   ],
-  "change_files": [],
+  "change_files": [
+    "docs/system_audit/commit_evidence_2026-03-03_merge-local-worktrees-stashes-admin.json"
+  ],
   "change_intent": "process_only",
   "local_validation": {
     "status": "pass",


### PR DESCRIPTION
Administrative merge pass to ensure remaining local worktree branches and stash commits are merged into main history without reintroducing stale payload files.\n\n- merges outstanding local worktree branches via merge commits\n- merges remaining stash commits into main history and clears stash backlog\n- no open PR backlog remains