### PR TITLE
feat(specs): mirror ideas sorting/filter UX and cards feed

### DIFF
--- a/api/app/routers/spec_registry.py
+++ b/api/app/routers/spec_registry.py
@@ -20,6 +20,40 @@ async def list_specs(
     return spec_registry_service.list_specs(limit=limit, offset=offset)
 
 
+@router.get("/spec-registry/cards")
+async def list_spec_cards(
+    q: str = Query("", description="Free-text search across spec title/summary/ids/contributors."),
+    state: str = Query(
+        "all",
+        description="One of: all, unlinked, linked, in_progress, implemented, measured.",
+    ),
+    attention: str = Query(
+        "all",
+        description="One of: all, none, low, medium, high.",
+    ),
+    sort: str = Query(
+        "attention_desc",
+        description="One of: attention_desc, roi_desc, gap_desc, state_desc, updated_desc, name_asc.",
+    ),
+    cursor: str | None = Query(default=None, description="Offset cursor returned by previous page."),
+    limit: int = Query(50, ge=1, le=200),
+    linked: str = Query("all", description="One of: all, linked, unlinked."),
+    min_roi: float | None = Query(default=None),
+    min_value_gap: float | None = Query(default=None),
+) -> dict:
+    return spec_registry_service.build_spec_cards_feed(
+        q=q,
+        state=state,
+        attention=attention,
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
+        linked=linked,
+        min_roi=min_roi,
+        min_value_gap=min_value_gap,
+    )
+
+
 @router.get("/spec-registry/{spec_id}", response_model=SpecRegistryEntry)
 async def get_spec(spec_id: str) -> SpecRegistryEntry:
     found = spec_registry_service.get_spec(spec_id)

--- a/api/app/services/spec_cards_service.py
+++ b/api/app/services/spec_cards_service.py
@@ -1,0 +1,428 @@
+"""Specs cards feed builder for /api/spec-registry/cards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Callable
+from urllib.parse import quote
+
+from app.models.spec_registry import SpecRegistryEntry
+
+_CARD_ALLOWED_STATES = {"all", "unlinked", "linked", "in_progress", "implemented", "measured"}
+_CARD_ALLOWED_ATTENTION = {"all", "none", "low", "medium", "high"}
+_CARD_ALLOWED_SORTS = {
+    "attention_desc",
+    "roi_desc",
+    "gap_desc",
+    "state_desc",
+    "updated_desc",
+    "name_asc",
+}
+_CARD_DEFAULT_LIMIT = 50
+_CARD_MAX_LIMIT = 200
+_CARD_STATE_RANK = {
+    "unlinked": 4,
+    "linked": 3,
+    "in_progress": 2,
+    "implemented": 1,
+    "measured": 0,
+}
+
+
+@dataclass
+class EnrichedSpecRow:
+    spec: SpecRegistryEntry
+    state: str
+    attention_level: str
+    attention_score: int
+    attention_reason: str | None
+    links_count: int
+    search_blob: str
+
+
+@dataclass
+class SpecCardsQuery:
+    q: str
+    state: str
+    attention: str
+    sort: str
+    cursor: int
+    limit: int
+    linked: str
+    min_roi: float | None
+    min_value_gap: float | None
+
+
+def _normalize_enum(value: str, *, allowed: set[str], fallback: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in allowed:
+        return normalized
+    return fallback
+
+
+def _normalize_cursor(value: str | None) -> int:
+    if value is None:
+        return 0
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
+def _normalize_limit(value: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return _CARD_DEFAULT_LIMIT
+    if parsed < 1:
+        return _CARD_DEFAULT_LIMIT
+    return max(1, min(parsed, _CARD_MAX_LIMIT))
+
+
+def _normalize_optional_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not parsed == parsed:  # NaN check
+        return None
+    return parsed
+
+
+def normalize_query(
+    *,
+    q: str = "",
+    state: str = "all",
+    attention: str = "all",
+    sort: str = "attention_desc",
+    cursor: str | None = None,
+    limit: int = _CARD_DEFAULT_LIMIT,
+    linked: str = "all",
+    min_roi: float | None = None,
+    min_value_gap: float | None = None,
+) -> SpecCardsQuery:
+    return SpecCardsQuery(
+        q=str(q or "").strip().lower(),
+        state=_normalize_enum(state, allowed=_CARD_ALLOWED_STATES, fallback="all"),
+        attention=_normalize_enum(attention, allowed=_CARD_ALLOWED_ATTENTION, fallback="all"),
+        sort=_normalize_enum(sort, allowed=_CARD_ALLOWED_SORTS, fallback="attention_desc"),
+        cursor=_normalize_cursor(cursor),
+        limit=_normalize_limit(limit),
+        linked=_normalize_enum(linked, allowed={"all", "linked", "unlinked"}, fallback="all"),
+        min_roi=_normalize_optional_float(min_roi),
+        min_value_gap=_normalize_optional_float(min_value_gap),
+    )
+
+
+def _derive_spec_state(spec: SpecRegistryEntry) -> str:
+    has_idea = bool((spec.idea_id or "").strip())
+    has_process = bool((spec.process_summary or "").strip() or (spec.pseudocode_summary or "").strip())
+    has_implementation = bool((spec.implementation_summary or "").strip())
+    has_measurement = float(spec.actual_value or 0.0) > 0.0 or float(spec.actual_cost or 0.0) > 0.0
+
+    if not has_idea:
+        return "unlinked"
+    if has_measurement:
+        return "measured"
+    if has_implementation:
+        return "implemented"
+    if has_process:
+        return "in_progress"
+    return "linked"
+
+
+def _derive_attention(spec: SpecRegistryEntry, *, state: str) -> tuple[str, int, str | None]:
+    score = 0
+    reasons: list[str] = []
+
+    if state == "unlinked":
+        score += 3
+        reasons.append("missing idea link")
+
+    value_gap = float(spec.value_gap or 0.0)
+    if value_gap >= 10:
+        score += 2
+        reasons.append("large value gap")
+    elif value_gap >= 5:
+        score += 1
+        reasons.append("value gap rising")
+
+    actual_roi = float(spec.actual_roi or 0.0)
+    estimated_roi = float(spec.estimated_roi or 0.0)
+    if estimated_roi >= 3 and actual_roi < 1:
+        score += 1
+        reasons.append("actual roi below plan")
+
+    missing_process = not bool((spec.process_summary or "").strip())
+    missing_implementation = not bool((spec.implementation_summary or "").strip())
+    if state in {"linked", "in_progress"} and missing_process:
+        score += 1
+        reasons.append("missing process summary")
+    if state in {"linked", "in_progress", "implemented"} and missing_implementation:
+        score += 1
+        reasons.append("missing implementation notes")
+
+    now_utc_naive = datetime.now(UTC).replace(tzinfo=None)
+    age_days = (now_utc_naive - spec.updated_at.replace(tzinfo=None)).total_seconds() / 86400.0
+    if age_days > 45:
+        score += 1
+        reasons.append("stale updates")
+
+    if score >= 4:
+        level = "high"
+    elif score >= 2:
+        level = "medium"
+    elif score >= 1:
+        level = "low"
+    else:
+        level = "none"
+
+    reason = ", ".join(reasons[:2]) if reasons else None
+    return level, score, reason
+
+
+def _build_search_blob(spec: SpecRegistryEntry) -> str:
+    fields = [
+        spec.spec_id,
+        spec.title,
+        spec.summary,
+        spec.idea_id or "",
+        spec.created_by_contributor_id or "",
+        spec.updated_by_contributor_id or "",
+        spec.process_summary or "",
+        spec.pseudocode_summary or "",
+        spec.implementation_summary or "",
+    ]
+    return " ".join(fields).lower()
+
+
+def _list_all_specs(list_specs_fn: Callable[[int, int], list[SpecRegistryEntry]]) -> list[SpecRegistryEntry]:
+    rows: list[SpecRegistryEntry] = []
+    offset = 0
+    page_size = 1000
+    while True:
+        page = list_specs_fn(page_size, offset)
+        if not page:
+            break
+        rows.extend(page)
+        if len(page) < page_size:
+            break
+        offset += len(page)
+    return rows
+
+
+def _enrich_specs(specs: list[SpecRegistryEntry]) -> list[EnrichedSpecRow]:
+    rows: list[EnrichedSpecRow] = []
+    for spec in specs:
+        state = _derive_spec_state(spec)
+        attention_level, attention_score, attention_reason = _derive_attention(spec, state=state)
+        links_count = sum(
+            1
+            for value in (
+                spec.idea_id,
+                spec.process_summary,
+                spec.pseudocode_summary,
+                spec.implementation_summary,
+                spec.created_by_contributor_id,
+                spec.updated_by_contributor_id,
+            )
+            if bool(str(value or "").strip())
+        )
+        rows.append(
+            EnrichedSpecRow(
+                spec=spec,
+                state=state,
+                attention_level=attention_level,
+                attention_score=attention_score,
+                attention_reason=attention_reason,
+                links_count=links_count,
+                search_blob=_build_search_blob(spec),
+            )
+        )
+    return rows
+
+
+def _matches_filters(row: EnrichedSpecRow, query: SpecCardsQuery) -> bool:
+    if query.q and query.q not in row.search_blob:
+        return False
+    if query.state != "all" and row.state != query.state:
+        return False
+    if query.attention != "all" and row.attention_level != query.attention:
+        return False
+    if query.linked == "linked" and not bool((row.spec.idea_id or "").strip()):
+        return False
+    if query.linked == "unlinked" and bool((row.spec.idea_id or "").strip()):
+        return False
+    if query.min_roi is not None and float(row.spec.actual_roi or 0.0) < query.min_roi:
+        return False
+    if query.min_value_gap is not None and float(row.spec.value_gap or 0.0) < query.min_value_gap:
+        return False
+    return True
+
+
+def _sort_rows(rows: list[EnrichedSpecRow], sort: str) -> None:
+    if sort == "name_asc":
+        rows.sort(key=lambda row: (str(row.spec.title).lower(), row.spec.spec_id))
+        return
+    if sort == "roi_desc":
+        rows.sort(
+            key=lambda row: (
+                -float(row.spec.actual_roi or 0.0),
+                -float(row.spec.estimated_roi or 0.0),
+                -float(row.spec.value_gap or 0.0),
+                str(row.spec.title).lower(),
+            )
+        )
+        return
+    if sort == "gap_desc":
+        rows.sort(
+            key=lambda row: (
+                -float(row.spec.value_gap or 0.0),
+                -row.attention_score,
+                str(row.spec.title).lower(),
+            )
+        )
+        return
+    if sort == "state_desc":
+        rows.sort(
+            key=lambda row: (
+                -_CARD_STATE_RANK.get(row.state, 0),
+                -row.attention_score,
+                str(row.spec.title).lower(),
+            )
+        )
+        return
+    if sort == "updated_desc":
+        rows.sort(
+            key=lambda row: (
+                -row.spec.updated_at.timestamp(),
+                str(row.spec.title).lower(),
+            )
+        )
+        return
+    rows.sort(
+        key=lambda row: (
+            -row.attention_score,
+            -float(row.spec.value_gap or 0.0),
+            -float(row.spec.actual_roi or 0.0),
+            -row.spec.updated_at.timestamp(),
+            str(row.spec.title).lower(),
+        )
+    )
+
+
+def _build_counts(rows: list[EnrichedSpecRow]) -> tuple[dict[str, int], dict[str, int]]:
+    state_counts = {key: 0 for key in ("unlinked", "linked", "in_progress", "implemented", "measured")}
+    attention_counts = {key: 0 for key in ("none", "low", "medium", "high")}
+    for row in rows:
+        state_counts[row.state] = int(state_counts.get(row.state, 0)) + 1
+        attention_counts[row.attention_level] = int(attention_counts.get(row.attention_level, 0)) + 1
+    return state_counts, attention_counts
+
+
+def _build_items(page_rows: list[EnrichedSpecRow]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for row in page_rows:
+        spec = row.spec
+        encoded_spec_id = quote(spec.spec_id, safe="")
+        encoded_idea_id = quote(spec.idea_id, safe="") if spec.idea_id else None
+        items.append(
+            {
+                "spec_id": spec.spec_id,
+                "title": spec.title,
+                "summary": spec.summary,
+                "state": row.state,
+                "attention_level": row.attention_level,
+                "attention_score": row.attention_score,
+                "attention_reason": row.attention_reason,
+                "value_gap": float(spec.value_gap or 0.0),
+                "actual_roi": float(spec.actual_roi or 0.0),
+                "estimated_roi": float(spec.estimated_roi or 0.0),
+                "potential_value": float(spec.potential_value or 0.0),
+                "actual_value": float(spec.actual_value or 0.0),
+                "estimated_cost": float(spec.estimated_cost or 0.0),
+                "actual_cost": float(spec.actual_cost or 0.0),
+                "links_count": row.links_count,
+                "idea_id": spec.idea_id,
+                "created_by_contributor_id": spec.created_by_contributor_id,
+                "updated_by_contributor_id": spec.updated_by_contributor_id,
+                "updated_at": spec.updated_at.isoformat(),
+                "links": {
+                    "web_detail_path": f"/specs/{encoded_spec_id}",
+                    "web_idea_path": f"/ideas/{encoded_idea_id}" if encoded_idea_id else None,
+                    "api_path": f"/api/spec-registry/{encoded_spec_id}",
+                },
+            }
+        )
+    return items
+
+
+def build_spec_cards_feed_payload(
+    *,
+    list_specs_fn: Callable[[int, int], list[SpecRegistryEntry]],
+    q: str = "",
+    state: str = "all",
+    attention: str = "all",
+    sort: str = "attention_desc",
+    cursor: str | None = None,
+    limit: int = _CARD_DEFAULT_LIMIT,
+    linked: str = "all",
+    min_roi: float | None = None,
+    min_value_gap: float | None = None,
+) -> dict[str, Any]:
+    query = normalize_query(
+        q=q,
+        state=state,
+        attention=attention,
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
+        linked=linked,
+        min_roi=min_roi,
+        min_value_gap=min_value_gap,
+    )
+    rows = _enrich_specs(_list_all_specs(list_specs_fn))
+    filtered = [row for row in rows if _matches_filters(row, query)]
+    _sort_rows(filtered, query.sort)
+
+    state_counts, attention_counts = _build_counts(filtered)
+    total = len(filtered)
+    page_start = min(query.cursor, total)
+    page_end = min(page_start + query.limit, total)
+    page_rows = filtered[page_start:page_end]
+    has_more = page_end < total
+    next_cursor = str(page_end) if has_more else None
+    items = _build_items(page_rows)
+
+    return {
+        "summary": {
+            "total": total,
+            "returned": len(items),
+            "state_counts": state_counts,
+            "attention_counts": attention_counts,
+            "needs_attention": attention_counts["high"],
+        },
+        "pagination": {
+            "cursor": str(page_start),
+            "next_cursor": next_cursor,
+            "limit": query.limit,
+            "returned": len(items),
+            "has_more": has_more,
+        },
+        "query": {
+            "q": query.q,
+            "state": query.state,
+            "attention": query.attention,
+            "sort": query.sort,
+            "cursor": page_start,
+            "limit": query.limit,
+            "linked": query.linked,
+            "min_roi": query.min_roi,
+            "min_value_gap": query.min_value_gap,
+        },
+        "items": items,
+    }

--- a/api/app/services/spec_registry_service.py
+++ b/api/app/services/spec_registry_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sess
 from sqlalchemy.pool import NullPool
 
 from app.models.spec_registry import SpecRegistryCreate, SpecRegistryEntry, SpecRegistryUpdate
+from app.services.spec_cards_service import build_spec_cards_feed_payload
 
 
 class Base(DeclarativeBase):
@@ -317,6 +318,32 @@ def update_spec(spec_id: str, data: SpecRegistryUpdate) -> SpecRegistryEntry | N
         session.refresh(row)
     _invalidate_spec_cache()
     return _to_model(row)
+
+
+def build_spec_cards_feed(
+    *,
+    q: str = "",
+    state: str = "all",
+    attention: str = "all",
+    sort: str = "attention_desc",
+    cursor: str | None = None,
+    limit: int = 50,
+    linked: str = "all",
+    min_roi: float | None = None,
+    min_value_gap: float | None = None,
+) -> dict[str, Any]:
+    return build_spec_cards_feed_payload(
+        list_specs_fn=lambda limit_arg, offset_arg: list_specs(limit=limit_arg, offset=offset_arg),
+        q=q,
+        state=state,
+        attention=attention,
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
+        linked=linked,
+        min_roi=min_roi,
+        min_value_gap=min_value_gap,
+    )
 
 
 def summary() -> dict[str, Any]:

--- a/api/tests/test_spec_registry_api.py
+++ b/api/tests/test_spec_registry_api.py
@@ -97,3 +97,111 @@ async def test_spec_registry_uses_database_url_fallback(
         listed = await client.get("/api/spec-registry")
         assert listed.status_code == 200
         assert any(row["spec_id"] == "spec-db-fallback" for row in listed.json())
+
+
+@pytest.mark.asyncio
+async def test_spec_registry_cards_endpoint_supports_filters_and_sort(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for payload in (
+            {
+                "spec_id": "spec-alpha",
+                "title": "Alpha Unlinked",
+                "summary": "No idea linked yet.",
+                "potential_value": 20.0,
+                "estimated_cost": 4.0,
+                "actual_value": 0.0,
+                "actual_cost": 0.0,
+            },
+            {
+                "spec_id": "spec-beta",
+                "title": "Beta In Progress",
+                "summary": "Implementation pending.",
+                "idea_id": "idea-beta",
+                "process_summary": "Draft process exists.",
+                "potential_value": 30.0,
+                "estimated_cost": 6.0,
+                "actual_value": 0.0,
+                "actual_cost": 0.0,
+            },
+            {
+                "spec_id": "spec-gamma",
+                "title": "Gamma Measured",
+                "summary": "Measured results available.",
+                "idea_id": "idea-gamma",
+                "implementation_summary": "Shipped rollout complete.",
+                "potential_value": 50.0,
+                "estimated_cost": 10.0,
+                "actual_value": 40.0,
+                "actual_cost": 5.0,
+            },
+        ):
+            created = await client.post("/api/spec-registry", json=payload)
+            assert created.status_code == 201
+
+        linked = await client.get("/api/spec-registry/cards", params={"linked": "linked", "sort": "roi_desc", "limit": 10})
+        assert linked.status_code == 200
+        linked_payload = linked.json()
+        assert linked_payload["summary"]["total"] == 2
+        assert linked_payload["items"][0]["spec_id"] == "spec-gamma"
+        assert linked_payload["items"][0]["state"] == "measured"
+        assert linked_payload["items"][0]["attention_level"] in {"none", "low", "medium", "high"}
+        assert linked_payload["items"][0]["links"]["web_detail_path"] == "/specs/spec-gamma"
+        assert linked_payload["items"][0]["links"]["web_idea_path"] == "/ideas/idea-gamma"
+
+        unlinked = await client.get("/api/spec-registry/cards", params={"state": "unlinked", "limit": 10})
+        assert unlinked.status_code == 200
+        unlinked_payload = unlinked.json()
+        assert unlinked_payload["summary"]["total"] == 1
+        assert unlinked_payload["items"][0]["spec_id"] == "spec-alpha"
+        assert unlinked_payload["items"][0]["state"] == "unlinked"
+        assert unlinked_payload["items"][0]["attention_level"] == "high"
+
+        min_roi = await client.get("/api/spec-registry/cards", params={"min_roi": 6, "limit": 10})
+        assert min_roi.status_code == 200
+        min_roi_payload = min_roi.json()
+        assert min_roi_payload["summary"]["total"] == 1
+        assert min_roi_payload["items"][0]["spec_id"] == "spec-gamma"
+
+
+@pytest.mark.asyncio
+async def test_spec_registry_cards_endpoint_uses_cursor_pagination(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", str(tmp_path / "ideas.json"))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for index in range(1, 5):
+            created = await client.post(
+                "/api/spec-registry",
+                json={
+                    "spec_id": f"spec-{index}",
+                    "title": f"Spec {index}",
+                    "summary": "Cursor pagination sample.",
+                    "idea_id": f"idea-{index}",
+                    "potential_value": float(10 + index),
+                    "estimated_cost": 2.0,
+                    "actual_value": 0.0,
+                    "actual_cost": 0.0,
+                },
+            )
+            assert created.status_code == 201
+
+        first = await client.get("/api/spec-registry/cards", params={"sort": "name_asc", "limit": 2})
+        assert first.status_code == 200
+        first_payload = first.json()
+        assert first_payload["pagination"]["returned"] == 2
+        assert first_payload["pagination"]["has_more"] is True
+        next_cursor = first_payload["pagination"]["next_cursor"]
+        assert isinstance(next_cursor, str) and next_cursor
+        first_ids = [row["spec_id"] for row in first_payload["items"]]
+
+        second = await client.get("/api/spec-registry/cards", params={"sort": "name_asc", "limit": 2, "cursor": next_cursor})
+        assert second.status_code == 200
+        second_payload = second.json()
+        second_ids = [row["spec_id"] for row in second_payload["items"]]
+        assert len(set(first_ids).intersection(set(second_ids))) == 0
+        assert second_payload["query"]["cursor"] == 2

--- a/docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/specs-page-parity-20260303",
+  "commit_scope": "Mirror latest ideas sorting/filtering UX improvements on specs page, including explicit filter controls, header sorting links, and per-row links dropdowns; add specs cards API feed + tests.",
+  "files_owned": [
+    "api/app/routers/spec_registry.py",
+    "api/app/services/spec_cards_service.py",
+    "api/app/services/spec_registry_service.py",
+    "api/tests/test_spec_registry_api.py",
+    "web/app/specs/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd api && pytest -q tests/test_spec_registry_api.py",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge to main and production verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Specs table now has explicit filter/sort controls, direct header sorting interactions, and per-row links dropdown behavior aligned with ideas.",
+    "public_endpoints": [
+      "/specs",
+      "/api/spec-registry/cards"
+    ],
+    "test_flows": [
+      "specs-filter-controls",
+      "specs-table-header-sort",
+      "specs-row-links-dropdown"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy verification."
+  },
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "085-tracked-count-parity-and-source-discovery"
+  ],
+  "task_ids": [
+    "task_specs_filter_sort_links_dropdown_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "testing"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json"
+  ],
+  "change_files": [
+    "api/app/routers/spec_registry.py",
+    "api/app/services/spec_cards_service.py",
+    "api/app/services/spec_registry_service.py",
+    "api/tests/test_spec_registry_api.py",
+    "web/app/specs/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/web/app/specs/page.tsx
+++ b/web/app/specs/page.tsx
@@ -1,257 +1,956 @@
+import {
+  Activity,
+  ArrowUpDown,
+  BadgeCheck,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Cog,
+  GitBranch,
+  Link2,
+  Search,
+  Sparkles,
+  TrendingUp,
+  Unlink2,
+  type LucideIcon,
+} from "lucide-react";
 import Link from "next/link";
 
 import { getApiBase } from "@/lib/api";
 
-type SpecRegistryEntry = {
+type SpecCardState = "unlinked" | "linked" | "in_progress" | "implemented" | "measured";
+type SpecAttentionLevel = "none" | "low" | "medium" | "high";
+
+type SpecCardItem = {
   spec_id: string;
   title: string;
   summary: string;
+  state: SpecCardState;
+  attention_level: SpecAttentionLevel;
+  attention_score: number;
+  attention_reason?: string | null;
+  value_gap: number;
+  actual_roi: number;
+  estimated_roi: number;
   potential_value: number;
   actual_value: number;
   estimated_cost: number;
   actual_cost: number;
-  value_gap: number;
-  cost_gap: number;
-  estimated_roi: number;
-  actual_roi: number;
+  links_count: number;
   idea_id?: string | null;
-  process_summary?: string | null;
-  pseudocode_summary?: string | null;
-  implementation_summary?: string | null;
   created_by_contributor_id?: string | null;
   updated_by_contributor_id?: string | null;
   updated_at: string;
+  links: {
+    web_detail_path: string;
+    web_idea_path?: string | null;
+    api_path: string;
+  };
 };
 
-type SpecsSearchParams = Promise<{
-  spec_id?: string | string[];
-  page?: string | string[];
-  page_size?: string | string[];
-}>;
+type SpecCardsResponse = {
+  summary: {
+    total: number;
+    returned: number;
+    state_counts: Record<string, number>;
+    attention_counts: Record<string, number>;
+    needs_attention: number;
+  };
+  pagination: {
+    cursor: string;
+    next_cursor: string | null;
+    limit: number;
+    returned: number;
+    has_more: boolean;
+  };
+  query: {
+    q: string;
+    state: string;
+    attention: string;
+    sort: string;
+    cursor: number;
+    limit: number;
+    linked: string;
+    min_roi: number | null;
+    min_value_gap: number | null;
+  };
+  items: SpecCardItem[];
+};
 
-const DEFAULT_PAGE_SIZE = 25;
-const MAX_PAGE_SIZE = 100;
+type SpecsSearchParams = Promise<Record<string, string | string[] | undefined>>;
 
-export const revalidate = 90;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const FILTER_STATES = ["all", "unlinked", "linked", "in_progress", "implemented", "measured"] as const;
+const ATTENTION_LEVELS = ["all", "none", "low", "medium", "high"] as const;
+const SORT_OPTIONS = ["attention_desc", "roi_desc", "gap_desc", "state_desc", "updated_desc", "name_asc"] as const;
+const VIEW_OPTIONS = ["list", "focus"] as const;
+const LINKED_OPTIONS = ["all", "linked", "unlinked"] as const;
+const LIMIT_OPTIONS = [25, 50, 100, 200] as const;
 
-function normalizeValue(raw: string | string[] | undefined): string {
-  if (Array.isArray(raw)) return (raw[0] || "").trim();
-  return (raw || "").trim();
+const SORT_LABEL: Record<(typeof SORT_OPTIONS)[number], string> = {
+  attention_desc: "attention (high to low)",
+  roi_desc: "ROI (high to low)",
+  gap_desc: "value gap (high to low)",
+  state_desc: "state progress",
+  updated_desc: "updated (newest first)",
+  name_asc: "name (A to Z)",
+};
+
+const STATE_FILTER_LABEL: Record<(typeof FILTER_STATES)[number], string> = {
+  all: "All states",
+  unlinked: "Unlinked",
+  linked: "Linked",
+  in_progress: "In progress",
+  implemented: "Implemented",
+  measured: "Measured",
+};
+
+const ATTENTION_FILTER_LABEL: Record<(typeof ATTENTION_LEVELS)[number], string> = {
+  all: "All attention levels",
+  none: "On track",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+};
+
+const VIEW_LABEL: Record<(typeof VIEW_OPTIONS)[number], string> = {
+  list: "List + side insights",
+  focus: "Focus list only",
+};
+
+const LINKED_LABEL: Record<(typeof LINKED_OPTIONS)[number], string> = {
+  all: "All specs",
+  linked: "Linked to ideas",
+  unlinked: "Unlinked specs",
+};
+
+const STATE_META: Record<SpecCardState, { label: string; icon: LucideIcon; tone: string; subtleTone: string }> = {
+  unlinked: {
+    label: "unlinked",
+    icon: Unlink2,
+    tone: "border-destructive/45 text-destructive bg-destructive/10",
+    subtleTone: "text-destructive",
+  },
+  linked: {
+    label: "linked",
+    icon: Link2,
+    tone: "border-chart-5/45 text-chart-5 bg-chart-5/10",
+    subtleTone: "text-chart-5",
+  },
+  in_progress: {
+    label: "in progress",
+    icon: GitBranch,
+    tone: "border-chart-3/45 text-chart-3 bg-chart-3/10",
+    subtleTone: "text-chart-3",
+  },
+  implemented: {
+    label: "implemented",
+    icon: Cog,
+    tone: "border-chart-4/45 text-chart-4 bg-chart-4/10",
+    subtleTone: "text-chart-4",
+  },
+  measured: {
+    label: "measured",
+    icon: BadgeCheck,
+    tone: "border-chart-2/45 text-chart-2 bg-chart-2/10",
+    subtleTone: "text-chart-2",
+  },
+};
+
+const ATTENTION_META: Record<SpecAttentionLevel, { label: string; dot: string }> = {
+  none: { label: "on track", dot: "bg-chart-2" },
+  low: { label: "low", dot: "bg-chart-5" },
+  medium: { label: "medium", dot: "bg-chart-3" },
+  high: { label: "high", dot: "bg-destructive" },
+};
+
+export const revalidate = 30;
+
+function readParam(value: string | string[] | undefined, fallback = ""): string {
+  if (Array.isArray(value)) return String(value[0] || fallback);
+  return String(value || fallback);
 }
 
-function parsePositiveInt(raw: string | string[] | undefined, fallback: number): number {
-  const value = normalizeValue(raw);
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+function parseCursor(value: string): number {
+  const parsed = Number.parseInt(value.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
   return parsed;
 }
 
-async function loadSpecPage(limit: number, offset: number): Promise<{ items: SpecRegistryEntry[]; total: number }> {
+function parseLimit(value: string): number {
+  const parsed = Number.parseInt(value.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(parsed, MAX_LIMIT));
+}
+
+function parseEnum<T extends readonly string[]>(value: string, allowed: T, fallback: T[number]): T[number] {
+  return (allowed as readonly string[]).includes(value) ? (value as T[number]) : fallback;
+}
+
+function parseOptionalNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseFloat(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+}
+
+function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(Math.max(0, Math.round(value)));
+}
+
+function formatMetric(value: number, fractionDigits = 1): string {
+  if (!Number.isFinite(value)) return "0.0";
+  return value.toFixed(fractionDigits);
+}
+
+function formatAttentionReason(value?: string | null): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const cleaned = raw.replace(/[_:-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!cleaned) return null;
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+function buildHref(
+  base: URLSearchParams,
+  updates: Record<string, string | number | null | undefined>,
+): string {
+  const next = new URLSearchParams(base.toString());
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === null || value === undefined || String(value).trim() === "") {
+      next.delete(key);
+    } else {
+      next.set(key, String(value));
+    }
+  }
+  const query = next.toString();
+  return query ? `/specs?${query}` : "/specs";
+}
+
+function buildSparklinePath(values: number[]): string {
+  const points = values.length > 1 ? values : [0.2, 0.45, 0.75, 0.55, 0.95, 1.2, 1.35];
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const span = Math.max(max - min, 0.0001);
+  const width = 260;
+  const height = 72;
+
+  return points
+    .map((value, index) => {
+      const x = (index / Math.max(points.length - 1, 1)) * width;
+      const y = height - ((value - min) / span) * height;
+      return `${index === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+async function loadSpecCards(params: {
+  q: string;
+  state: string;
+  attention: string;
+  sort: string;
+  cursor: number;
+  limit: number;
+  linked: string;
+  minRoi: number | null;
+  minValueGap: number | null;
+}): Promise<SpecCardsResponse> {
   const API = getApiBase();
-  const params = new URLSearchParams({
-    limit: String(Math.max(1, Math.min(limit, MAX_PAGE_SIZE))),
-    offset: String(Math.max(0, offset)),
+  const search = new URLSearchParams({
+    q: params.q,
+    state: params.state,
+    attention: params.attention,
+    sort: params.sort,
+    cursor: String(params.cursor),
+    limit: String(params.limit),
+    linked: params.linked,
   });
-  const response = await fetch(`${API}/api/spec-registry?${params.toString()}`);
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-  const totalHeader = Number.parseInt(response.headers.get("x-total-count") || "0", 10);
-  const items = (await response.json()) as SpecRegistryEntry[];
-  return {
-    items: Array.isArray(items) ? items : [],
-    total: Number.isFinite(totalHeader) ? Math.max(0, totalHeader) : Array.isArray(items) ? items.length : 0,
-  };
-}
+  if (params.minRoi !== null) search.set("min_roi", String(params.minRoi));
+  if (params.minValueGap !== null) search.set("min_value_gap", String(params.minValueGap));
 
-async function loadSingleSpec(specId: string): Promise<SpecRegistryEntry | null> {
-  const API = getApiBase();
-  const response = await fetch(`${API}/api/spec-registry/${encodeURIComponent(specId)}`);
-  if (response.status === 404) return null;
+  const response = await fetch(`${API}/api/spec-registry/cards?${search.toString()}`, {
+    cache: "no-store",
+  });
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
+    throw new Error(`Failed to load spec cards (${response.status})`);
   }
-  return (await response.json()) as SpecRegistryEntry;
-}
-
-function paginationHref(page: number, pageSize: number): string {
-  const safePage = Math.max(1, page);
-  return `/specs?page=${safePage}&page_size=${pageSize}`;
+  return (await response.json()) as SpecCardsResponse;
 }
 
 export default async function SpecsPage({ searchParams }: { searchParams: SpecsSearchParams }) {
   const resolved = await searchParams;
-  const specFilter = normalizeValue(resolved.spec_id);
-  const requestedPageSize = parsePositiveInt(resolved.page_size, DEFAULT_PAGE_SIZE);
-  const pageSize = Math.max(1, Math.min(requestedPageSize, MAX_PAGE_SIZE));
-  const requestedPage = parsePositiveInt(resolved.page, 1);
-  const offset = (requestedPage - 1) * pageSize;
+  const q = readParam(resolved.q);
+  const state = parseEnum(readParam(resolved.state, "all"), FILTER_STATES, "all");
+  const attention = parseEnum(readParam(resolved.attention, "all"), ATTENTION_LEVELS, "all");
+  const sort = parseEnum(readParam(resolved.sort, "attention_desc"), SORT_OPTIONS, "attention_desc");
+  const view = parseEnum(readParam(resolved.view, "list"), VIEW_OPTIONS, "list");
+  const linked = parseEnum(readParam(resolved.linked, "all"), LINKED_OPTIONS, "all");
+  const cursor = parseCursor(readParam(resolved.cursor, "0"));
+  const limit = parseLimit(readParam(resolved.limit, String(DEFAULT_LIMIT)));
+  const minRoi = parseOptionalNumber(readParam(resolved.min_roi));
+  const minValueGap = parseOptionalNumber(readParam(resolved.min_value_gap));
 
-  let items: SpecRegistryEntry[] = [];
-  let total = 0;
+  const currentParams = new URLSearchParams();
+  if (q) currentParams.set("q", q);
+  if (state !== "all") currentParams.set("state", state);
+  if (attention !== "all") currentParams.set("attention", attention);
+  if (sort !== "attention_desc") currentParams.set("sort", sort);
+  if (view !== "list") currentParams.set("view", view);
+  if (linked !== "all") currentParams.set("linked", linked);
+  if (cursor > 0) currentParams.set("cursor", String(cursor));
+  if (limit !== DEFAULT_LIMIT) currentParams.set("limit", String(limit));
+  if (minRoi !== null) currentParams.set("min_roi", String(minRoi));
+  if (minValueGap !== null) currentParams.set("min_value_gap", String(minValueGap));
 
-  if (specFilter) {
-    const single = await loadSingleSpec(specFilter);
-    if (single) {
-      items = [single];
-      total = 1;
-    }
-  } else {
-    const paged = await loadSpecPage(pageSize, offset);
-    items = paged.items;
-    total = paged.total;
-  }
+  const payload = await loadSpecCards({
+    q,
+    state,
+    attention,
+    sort,
+    cursor,
+    limit,
+    linked,
+    minRoi,
+    minValueGap,
+  });
 
-  const currentPage = specFilter ? 1 : requestedPage;
-  const pageStart = specFilter ? (items.length > 0 ? 1 : 0) : offset + (items.length > 0 ? 1 : 0);
-  const pageEnd = specFilter ? items.length : offset + items.length;
-  const hasPrevious = !specFilter && currentPage > 1;
-  const hasNext = !specFilter && pageEnd < total;
+  const items = payload.items;
+  const summary = payload.summary;
+  const pagination = payload.pagination;
+
+  const unlinkedCount = Number(summary.state_counts.unlinked || 0);
+  const linkedCount = Math.max(summary.total - unlinkedCount, 0);
+  const measuredCount = Number(summary.state_counts.measured || 0);
+  const needsAttentionCount = Number(summary.needs_attention || 0);
+
+  const startIndex = summary.total === 0 ? 0 : cursor + 1;
+  const endIndex = summary.total === 0 ? 0 : Math.min(cursor + pagination.returned, summary.total);
+
+  const focusSpecs = [...items].sort((a, b) => b.attention_score - a.attention_score).slice(0, 3);
+  const pulsePath = buildSparklinePath(items.slice(0, 7).map((item) => Math.max(item.attention_score, item.value_gap, item.actual_roi)));
+
+  const clearCursor = { cursor: null } as const;
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/contribute" className="text-muted-foreground hover:text-foreground">
-          Contribute
-        </Link>
-        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
-          Ideas
-        </Link>
-        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
-          Usage
-        </Link>
-        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
-          Flow
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-        <Link href="/gates" className="text-muted-foreground hover:text-foreground">
-          Gates
-        </Link>
-      </div>
-
-      <h1 className="text-2xl font-bold">Specs</h1>
-      <p className="text-muted-foreground">Paginated registry view with direct links to spec detail, idea context, and contributor ownership.</p>
-      {specFilter ? (
-        <p className="text-sm text-muted-foreground">
-          Filter spec <code>{specFilter}</code> |{" "}
-          <Link href="/specs" className="underline hover:text-foreground">
-            Clear filter
-          </Link>
-        </p>
-      ) : null}
-
-      <section className="rounded border p-4 space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
-          <p>
-            Showing {items.length > 0 ? `${pageStart}-${pageEnd}` : "0"} of {total}
-            {specFilter ? "" : ` | page ${currentPage}`}
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Specs In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Contributor-written specs moving from draft intent to measurable outcomes.
           </p>
-          {!specFilter ? (
-            <div className="flex gap-3">
-              {hasPrevious ? (
-                <Link href={paginationHref(currentPage - 1, pageSize)} className="underline hover:text-foreground">
-                  Previous
-                </Link>
-              ) : (
-                <span className="opacity-50">Previous</span>
-              )}
-              {hasNext ? (
-                <Link href={paginationHref(currentPage + 1, pageSize)} className="underline hover:text-foreground">
-                  Next
-                </Link>
-              ) : (
-                <span className="opacity-50">Next</span>
-              )}
-            </div>
-          ) : null}
-        </div>
+          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            {linked === "all" ? "Showing all specs in registry." : linked === "linked" ? "Showing specs linked to ideas." : "Showing specs missing idea links."}
+          </p>
+        </section>
 
-        <ul className="space-y-2 text-sm">
-          {items.map((spec) => (
-            <li key={spec.spec_id} className="rounded border p-3 space-y-1">
-              <div className="flex justify-between gap-3">
-                <Link href={`/specs/${encodeURIComponent(spec.spec_id)}`} className="font-medium underline hover:text-foreground">
-                  Spec {spec.spec_id}
+        <section className="rounded-2xl border border-border/70 bg-card/70 p-4 shadow-sm sm:p-5">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-[repeat(4,minmax(0,1fr))_1.8fr]">
+            <div className="rounded-xl border border-border/70 bg-background/45 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Specs in registry</p>
+              <p className="mt-1 text-2xl font-semibold">{formatCompactNumber(summary.total)}</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background/45 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Linked to ideas</p>
+              <p className="mt-1 text-2xl font-semibold">{formatCompactNumber(linkedCount)}</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background/45 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Measured</p>
+              <p className="mt-1 text-2xl font-semibold">{formatCompactNumber(measuredCount)}</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background/45 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Needs attention</p>
+              <p className="mt-1 text-2xl font-semibold">{formatCompactNumber(needsAttentionCount)}</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-background/45 p-4">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Collective focus</p>
+              <p className="mt-2 text-sm font-medium text-foreground sm:text-base">
+                {focusSpecs[0]
+                  ? `Resolve ${focusSpecs[0].title} gaps with linked ownership and implementation clarity.`
+                  : "Lift under-specified specs toward measurable outcomes."}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm sm:p-5">
+          <form action="/specs" method="get" className="space-y-3">
+            <div className="flex items-center gap-2 rounded-xl border border-border/70 bg-background/50 px-3 py-3">
+              <Search className="h-4 w-4 text-muted-foreground" aria-hidden />
+              <input
+                type="text"
+                name="q"
+                defaultValue={q}
+                placeholder="Search specs, ideas, contributors, or implementation notes"
+                className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              />
+              <button
+                type="submit"
+                className="rounded-lg border border-border/70 bg-background/70 px-3 py-1.5 text-sm font-medium hover:bg-muted/60"
+              >
+                Apply
+              </button>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">State</span>
+                <select
+                  name="state"
+                  defaultValue={state}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {FILTER_STATES.map((stateOption) => (
+                    <option key={stateOption} value={stateOption}>
+                      {STATE_FILTER_LABEL[stateOption]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Attention</span>
+                <select
+                  name="attention"
+                  defaultValue={attention}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {ATTENTION_LEVELS.map((attentionOption) => (
+                    <option key={attentionOption} value={attentionOption}>
+                      {ATTENTION_FILTER_LABEL[attentionOption]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+                  Sort (table header)
+                </span>
+                <select
+                  name="sort"
+                  defaultValue={sort}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {SORT_OPTIONS.map((sortOption) => (
+                    <option key={sortOption} value={sortOption}>
+                      {SORT_LABEL[sortOption]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">View</span>
+                <select
+                  name="view"
+                  defaultValue={view}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {VIEW_OPTIONS.map((viewOption) => (
+                    <option key={viewOption} value={viewOption}>
+                      {VIEW_LABEL[viewOption]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Link status</span>
+                <select
+                  name="linked"
+                  defaultValue={linked}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {LINKED_OPTIONS.map((linkedOption) => (
+                    <option key={linkedOption} value={linkedOption}>
+                      {LINKED_LABEL[linkedOption]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Rows per page</span>
+                <select
+                  name="limit"
+                  defaultValue={String(limit)}
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                >
+                  {LIMIT_OPTIONS.map((pageLimit) => (
+                    <option key={pageLimit} value={String(pageLimit)}>
+                      {pageLimit}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Min ROI</span>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="min_roi"
+                  defaultValue={minRoi ?? ""}
+                  placeholder="Any"
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                />
+              </label>
+              <label className="space-y-1.5 rounded-xl border border-border/70 bg-background/45 px-3 py-2.5">
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">Min Value Gap</span>
+                <input
+                  type="number"
+                  step="0.1"
+                  name="min_value_gap"
+                  defaultValue={minValueGap ?? ""}
+                  placeholder="Any"
+                  className="w-full rounded-md border border-border/70 bg-background/90 px-2.5 py-1.5 text-sm"
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground">
+                State, link status, and attention narrow results. Click table headers to sort; this dropdown is a fallback. View only changes layout.
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="submit"
+                  className="rounded-lg border border-border/70 bg-background/70 px-3 py-1.5 text-sm font-medium hover:bg-muted/60"
+                >
+                  Apply filters
+                </button>
+                <Link
+                  href="/specs"
+                  className="rounded-lg border border-border/70 bg-background/70 px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                >
+                  Reset
                 </Link>
-                <span className="text-muted-foreground">updated {spec.updated_at}</span>
               </div>
-              <p>{spec.title}</p>
-              <p className="text-muted-foreground">{spec.summary}</p>
-              <p className="text-xs text-muted-foreground">
-                value potential {spec.potential_value.toFixed(2)} | value actual {spec.actual_value.toFixed(2)} | value_gap {spec.value_gap.toFixed(2)}
-                {" | "}
-                cost est {spec.estimated_cost.toFixed(2)} | cost actual {spec.actual_cost.toFixed(2)} | cost_gap {spec.cost_gap.toFixed(2)}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                idea{" "}
-                {spec.idea_id ? (
-                  <Link href={`/ideas/${encodeURIComponent(spec.idea_id)}`} className="underline hover:text-foreground">
-                    {spec.idea_id}
-                  </Link>
-                ) : (
-                  <Link href="/ideas" className="underline hover:text-foreground">
-                    missing
-                  </Link>
-                )}
-                {" | "}
-                created_by{" "}
-                {spec.created_by_contributor_id ? (
-                  <Link
-                    href={`/contributors?contributor_id=${encodeURIComponent(spec.created_by_contributor_id)}`}
-                    className="underline hover:text-foreground"
-                  >
-                    {spec.created_by_contributor_id}
-                  </Link>
-                ) : (
-                  <Link href="/contributors" className="underline hover:text-foreground">
-                    missing
-                  </Link>
-                )}
-                {" | "}
-                updated_by{" "}
-                {spec.updated_by_contributor_id ? (
-                  <Link
-                    href={`/contributors?contributor_id=${encodeURIComponent(spec.updated_by_contributor_id)}`}
-                    className="underline hover:text-foreground"
-                  >
-                    {spec.updated_by_contributor_id}
-                  </Link>
-                ) : (
-                  <Link href="/contributors" className="underline hover:text-foreground">
-                    missing
-                  </Link>
-                )}
-                {" | "}
-                <Link href={`/specs/${encodeURIComponent(spec.spec_id)}`} className="underline hover:text-foreground">
-                  full detail
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              {
+                label: "All",
+                href: buildHref(currentParams, {
+                  state: "all",
+                  attention: "all",
+                  linked: "all",
+                  min_roi: null,
+                  min_value_gap: null,
+                  ...clearCursor,
+                }),
+                active: state === "all" && attention === "all" && linked === "all" && minRoi === null && minValueGap === null,
+              },
+              { label: "Linked Ideas", href: buildHref(currentParams, { linked: "linked", ...clearCursor }), active: linked === "linked" },
+              { label: "Unlinked", href: buildHref(currentParams, { linked: "unlinked", ...clearCursor }), active: linked === "unlinked" },
+              {
+                label: "In Progress",
+                href: buildHref(currentParams, { state: "in_progress", ...clearCursor }),
+                active: state === "in_progress",
+              },
+              {
+                label: "Implemented",
+                href: buildHref(currentParams, { state: "implemented", ...clearCursor }),
+                active: state === "implemented",
+              },
+              {
+                label: "Measured",
+                href: buildHref(currentParams, { state: "measured", ...clearCursor }),
+                active: state === "measured",
+              },
+              {
+                label: "Needs Attention",
+                href: buildHref(currentParams, { attention: "high", ...clearCursor }),
+                active: attention === "high",
+              },
+              {
+                label: "ROI > 5",
+                href: buildHref(currentParams, { min_roi: 5, ...clearCursor }),
+                active: minRoi !== null && minRoi >= 5,
+              },
+              {
+                label: "Gap > 5",
+                href: buildHref(currentParams, { min_value_gap: 5, ...clearCursor }),
+                active: minValueGap !== null && minValueGap >= 5,
+              },
+            ].map((chip) => (
+              <Link
+                key={chip.label}
+                href={chip.href}
+                className={`inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition ${
+                  chip.active
+                    ? "border-primary/50 bg-primary/15 text-primary"
+                    : "border-border/70 bg-background/55 text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {chip.label}
+              </Link>
+            ))}
+
+            <div className="ml-auto flex flex-wrap items-center gap-2">
+              {LIMIT_OPTIONS.map((pageLimit) => (
+                <Link
+                  key={pageLimit}
+                  href={buildHref(currentParams, { limit: pageLimit, ...clearCursor })}
+                  className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs transition ${
+                    limit === pageLimit
+                      ? "border-primary/50 bg-primary/15 text-primary"
+                      : "border-border/70 text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {pageLimit}
                 </Link>
-              </p>
-            </li>
-          ))}
-          {items.length === 0 ? (
-            <li className="text-muted-foreground">
-              {specFilter ? "Spec not found in registry." : "No specs found for this page."}
-            </li>
-          ) : null}
-        </ul>
-      </section>
+              ))}
+              <span className="text-xs text-muted-foreground">
+                {startIndex}-{endIndex} of {formatCompactNumber(summary.total)}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className={view === "focus" ? "space-y-4" : "grid gap-4 xl:grid-cols-[2fr_1fr]"}>
+          <article className="rounded-2xl border border-border/70 bg-card/60 p-4 sm:p-5">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-xl font-semibold tracking-tight">Active Specs</h2>
+              <p className="text-xs text-muted-foreground">sorted by {SORT_LABEL[sort]}</p>
+            </div>
+            <div className="sticky top-[56px] z-30 mb-3 hidden grid-cols-[minmax(0,1fr)_128px_76px_76px_120px] items-center rounded-lg border border-border/70 bg-background/95 px-3 py-2 text-xs text-muted-foreground shadow-sm backdrop-blur-sm md:grid">
+              <Link
+                href={buildHref(currentParams, { sort: "name_asc", ...clearCursor })}
+                className={`inline-flex items-center gap-1.5 transition ${
+                  sort === "name_asc" ? "font-semibold text-primary" : "hover:text-foreground"
+                }`}
+                aria-label="Sort by spec name"
+              >
+                <Circle className="h-3.5 w-3.5" aria-hidden />
+                spec
+                <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+              </Link>
+              <span className="inline-flex items-center justify-end gap-1" title="Links column is not sortable yet.">
+                <Link2 className="h-3.5 w-3.5" aria-hidden />
+                links
+              </span>
+              <Link
+                href={buildHref(currentParams, { sort: "gap_desc", ...clearCursor })}
+                className={`inline-flex items-center justify-end gap-1 transition ${
+                  sort === "gap_desc" ? "font-semibold text-primary" : "hover:text-foreground"
+                }`}
+                aria-label="Sort by value gap"
+              >
+                <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                gap
+                <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+              </Link>
+              <Link
+                href={buildHref(currentParams, { sort: "roi_desc", ...clearCursor })}
+                className={`inline-flex items-center justify-end gap-1 transition ${
+                  sort === "roi_desc" ? "font-semibold text-primary" : "hover:text-foreground"
+                }`}
+                aria-label="Sort by ROI"
+              >
+                <TrendingUp className="h-3.5 w-3.5" aria-hidden />
+                roi
+                <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+              </Link>
+              <Link
+                href={buildHref(currentParams, { sort: "attention_desc", ...clearCursor })}
+                className={`inline-flex items-center justify-end gap-1 transition ${
+                  sort === "attention_desc" ? "font-semibold text-primary" : "hover:text-foreground"
+                }`}
+                aria-label="Sort by attention"
+              >
+                <Activity className="h-3.5 w-3.5" aria-hidden />
+                attention
+                <ArrowUpDown className="h-3.5 w-3.5" aria-hidden />
+              </Link>
+            </div>
+            <div className="sticky top-[56px] z-30 mb-2 flex items-center justify-between gap-2 rounded-lg border border-border/70 bg-background/95 px-2.5 py-1.5 text-[11px] text-muted-foreground shadow-sm backdrop-blur-sm md:hidden">
+              <span className="inline-flex items-center gap-1">
+                <Link2 className="h-3 w-3" aria-hidden />
+                links
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Sparkles className="h-3 w-3" aria-hidden />
+                gap
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <TrendingUp className="h-3 w-3" aria-hidden />
+                roi
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Activity className="h-3 w-3" aria-hidden />
+                attention
+              </span>
+            </div>
+            <div className="mb-2 flex flex-wrap items-center gap-1.5 md:hidden">
+              {[
+                { label: "spec", value: "name_asc" },
+                { label: "gap", value: "gap_desc" },
+                { label: "roi", value: "roi_desc" },
+                { label: "attention", value: "attention_desc" },
+              ].map((option) => (
+                <Link
+                  key={option.value}
+                  href={buildHref(currentParams, { sort: option.value, ...clearCursor })}
+                  className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] transition ${
+                    sort === option.value
+                      ? "border-primary/50 bg-primary/15 text-primary"
+                      : "border-border/70 text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {option.label}
+                </Link>
+              ))}
+            </div>
+
+            <ul className="space-y-2.5">
+              {items.map((item) => {
+                const stateMeta = STATE_META[item.state];
+                const attentionMeta = ATTENTION_META[item.attention_level];
+                const StateIcon = stateMeta.icon;
+                const reason = formatAttentionReason(item.attention_reason);
+                const linkTargets = [
+                  { label: "Spec detail", href: item.links.web_detail_path },
+                  ...(item.links.web_idea_path ? [{ label: "Idea", href: item.links.web_idea_path }] : []),
+                  ...(item.created_by_contributor_id
+                    ? [
+                        {
+                          label: "Created by",
+                          href: `/contributors?contributor_id=${encodeURIComponent(item.created_by_contributor_id)}`,
+                        },
+                      ]
+                    : []),
+                  ...(item.updated_by_contributor_id
+                    ? [
+                        {
+                          label: "Updated by",
+                          href: `/contributors?contributor_id=${encodeURIComponent(item.updated_by_contributor_id)}`,
+                        },
+                      ]
+                    : []),
+                  { label: "API record", href: item.links.api_path },
+                ];
+                const linksCount = linkTargets.length;
+
+                return (
+                  <li key={item.spec_id} className="rounded-xl border border-border/70 bg-background/45 p-2.5 shadow-sm sm:p-3.5">
+                    <div className="grid gap-2.5 md:grid-cols-[minmax(0,1fr)_128px_76px_76px_120px] md:items-center">
+                      <div className="min-w-0">
+                        <div className="flex items-start gap-3">
+                          <span
+                            title={stateMeta.label}
+                            className={`mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border ${stateMeta.tone}`}
+                          >
+                            <StateIcon className="h-4 w-4" aria-hidden />
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="truncate text-base font-semibold">
+                                <Link href={item.links.web_detail_path} className="underline-offset-2 hover:underline">
+                                  {item.title}
+                                </Link>
+                              </h3>
+                              <span className="text-xs text-muted-foreground">{item.spec_id}</span>
+                              {item.links.web_idea_path ? (
+                                <Link
+                                  href={item.links.web_idea_path}
+                                  className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                                >
+                                  idea
+                                </Link>
+                              ) : null}
+                            </div>
+                            <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground md:line-clamp-1">
+                              {item.summary || "No summary provided yet. Add process context and implementation notes to improve execution quality."}
+                            </p>
+                            {reason ? <p className="mt-0.5 text-xs text-muted-foreground">{reason}</p> : null}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="hidden justify-end md:flex">
+                        <details className="group relative">
+                          <summary className="inline-flex list-none cursor-pointer items-center gap-1 rounded-md border border-border/70 bg-background/70 px-2 py-1 text-xs text-foreground transition hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+                            {formatCompactNumber(linksCount)} links
+                            <ChevronDown className="h-3 w-3 transition group-open:rotate-180" aria-hidden />
+                          </summary>
+                          <div className="absolute right-0 top-full z-30 mt-1 w-44 rounded-md border border-border/70 bg-popover p-1 shadow-md">
+                            {linkTargets.map((target) => (
+                              <Link
+                                key={`${item.spec_id}-${target.label}`}
+                                href={target.href}
+                                className="block rounded px-2 py-1.5 text-xs text-foreground hover:bg-muted/60"
+                              >
+                                {target.label}
+                              </Link>
+                            ))}
+                          </div>
+                        </details>
+                      </div>
+                      <div className="hidden text-right text-sm font-medium tabular-nums text-foreground md:block">
+                        {formatMetric(item.value_gap)}
+                      </div>
+                      <div className="hidden text-right text-sm font-medium tabular-nums text-foreground md:block">
+                        {formatMetric(item.actual_roi)}
+                      </div>
+                      <div className="hidden items-center justify-end gap-2 text-sm text-muted-foreground md:flex">
+                        <span className={`inline-block h-2.5 w-2.5 rounded-full ${attentionMeta.dot}`} />
+                        {attentionMeta.label}
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-2 text-xs md:hidden">
+                        <div className="rounded-lg border border-border/60 bg-muted/30 px-2 py-1.5">
+                          <p className="text-muted-foreground">links</p>
+                          <p className="tabular-nums text-foreground">{formatCompactNumber(linksCount)}</p>
+                        </div>
+                        <div className="rounded-lg border border-border/60 bg-muted/30 px-2 py-1.5">
+                          <p className="text-muted-foreground">gap</p>
+                          <p className="tabular-nums text-foreground">{formatMetric(item.value_gap)}</p>
+                        </div>
+                        <div className="rounded-lg border border-border/60 bg-muted/30 px-2 py-1.5">
+                          <p className="text-muted-foreground">roi</p>
+                          <p className="tabular-nums text-foreground">{formatMetric(item.actual_roi)}</p>
+                        </div>
+                        <div className="rounded-lg border border-border/60 bg-muted/30 px-2 py-1.5">
+                          <p className="text-muted-foreground">value</p>
+                          <p className="tabular-nums text-foreground">{formatMetric(item.actual_value)}</p>
+                        </div>
+                      </div>
+                      <div className="space-y-1.5 md:hidden">
+                        <details className="group relative">
+                          <summary className="inline-flex list-none cursor-pointer items-center gap-1 rounded-md border border-border/70 bg-background/70 px-2 py-1 text-xs text-foreground transition hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+                            Links
+                            <ChevronDown className="h-3 w-3 transition group-open:rotate-180" aria-hidden />
+                          </summary>
+                          <div className="absolute left-0 top-full z-30 mt-1 w-44 rounded-md border border-border/70 bg-popover p-1 shadow-md">
+                            {linkTargets.map((target) => (
+                              <Link
+                                key={`${item.spec_id}-mobile-${target.label}`}
+                                href={target.href}
+                                className="block rounded px-2 py-1.5 text-xs text-foreground hover:bg-muted/60"
+                              >
+                                {target.label}
+                              </Link>
+                            ))}
+                          </div>
+                        </details>
+                        <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                          <span className={`inline-block h-2 w-2 rounded-full ${attentionMeta.dot}`} />
+                          {attentionMeta.label}
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+              {items.length === 0 ? (
+                <li className="rounded-xl border border-border/70 bg-background/45 p-6 text-sm text-muted-foreground">
+                  No specs matched this query yet. Try widening filters or clearing search.
+                </li>
+              ) : null}
+            </ul>
+
+            <div className="mt-4 flex items-center justify-between gap-3">
+              <Link
+                href={buildHref(currentParams, { cursor: Math.max(cursor - limit, 0) })}
+                className={`rounded-full border px-4 py-2 text-sm ${
+                  cursor > 0
+                    ? "border-border/70 text-foreground hover:bg-muted/50"
+                    : "pointer-events-none border-border/40 text-muted-foreground/50"
+                }`}
+              >
+                Previous
+              </Link>
+              <span className="text-xs text-muted-foreground">
+                showing {formatCompactNumber(pagination.returned)} of {formatCompactNumber(summary.total)}
+              </span>
+              <Link
+                href={buildHref(currentParams, { cursor: pagination.next_cursor })}
+                className={`rounded-full border px-4 py-2 text-sm ${
+                  pagination.has_more && pagination.next_cursor
+                    ? "border-border/70 text-foreground hover:bg-muted/50"
+                    : "pointer-events-none border-border/40 text-muted-foreground/50"
+                }`}
+              >
+                Next
+              </Link>
+            </div>
+          </article>
+
+          {view === "focus" ? null : (
+            <aside className="space-y-4">
+              <section className="rounded-2xl border border-border/70 bg-card/60 p-5">
+                <h2 className="text-lg font-semibold">Where Spec Attention Helps Most</h2>
+                <div className="mt-3 space-y-3">
+                  {focusSpecs.map((item) => {
+                    const lift = Math.max(item.value_gap, item.attention_score);
+                    return (
+                      <div key={item.spec_id} className="rounded-xl border border-border/70 bg-background/45 p-3">
+                        <p className="text-base font-semibold">{item.title}</p>
+                        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                          {item.summary || "Expected lift from clearer implementation and contributor ownership."}
+                        </p>
+                        <div className="mt-2 flex items-center justify-between text-sm">
+                          <p className="font-medium text-primary">+{formatMetric(lift)} potential lift</p>
+                          <Link
+                            href={item.links.web_detail_path}
+                            className="inline-flex items-center gap-1 text-foreground underline-offset-2 hover:underline"
+                          >
+                            Focus
+                            <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+                          </Link>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {focusSpecs.length === 0 ? (
+                    <p className="rounded-xl border border-border/70 bg-background/45 p-3 text-sm text-muted-foreground">
+                      No focus specs yet. Try removing filters.
+                    </p>
+                  ) : null}
+                </div>
+              </section>
+
+              <section className="rounded-2xl border border-border/70 bg-card/60 p-5">
+                <h2 className="text-lg font-semibold">Registry Pulse</h2>
+                <p className="mt-1 text-sm text-muted-foreground">Activity trend from current spec feed</p>
+                <div className="mt-3 rounded-xl border border-border/70 bg-background/45 p-3">
+                  <svg viewBox="0 0 260 72" className="h-20 w-full" preserveAspectRatio="none" aria-hidden>
+                    <path d={pulsePath} fill="none" stroke="hsl(var(--primary))" strokeWidth="2.5" strokeLinecap="round" />
+                  </svg>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {formatCompactNumber(summary.total)} specs • {formatCompactNumber(linkedCount)} linked •{" "}
+                    {formatCompactNumber(measuredCount)} measured
+                  </p>
+                </div>
+              </section>
+            </aside>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-border/70 bg-card/50 px-4 py-3 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-4">
+            {Object.entries(STATE_META).map(([key, meta]) => {
+              const Icon = meta.icon;
+              return (
+                <span key={key} className="inline-flex items-center gap-1.5">
+                  <Icon className={`h-3.5 w-3.5 ${meta.subtleTone}`} aria-hidden />
+                  {meta.label}
+                </span>
+              );
+            })}
+          </div>
+        </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- mirror /ideas sorting/filtering layout and controls on /specs
- add specs cards API endpoint with cursor pagination and filters/sort
- include specs API tests and evidence updates

## Validation
- make start-gate
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- cd api && pytest -q tests/test_spec_registry_api.py
- cd web && npm run build
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-03-03_specs-filter-sort-links-dropdown.json