### PR TITLE
feat(web): align main pages with ideas/specs layout and interactions

### DIFF
--- a/docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json
+++ b/docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json
@@ -1,0 +1,93 @@
+{
+  "date": "2026-03-03",
+  "thread_branch": "codex/main-pages-style-parity-20260304",
+  "commit_scope": "Apply ideas/specs style system to core operational pages (flow, usage, tasks, gates, contributors, contributions, assets) with consistent responsive shell, chip navigation, and card treatment while preserving behavior.",
+  "files_owned": [
+    "web/app/flow/page.tsx",
+    "web/app/usage/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/app/gates/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/assets/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make start-gate",
+      "cd web && npm run build"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge to main and public deploy verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Main operational pages now share ideas/specs visual shell and card hierarchy with responsive chip navigation and consistent panel styling.",
+    "public_endpoints": [
+      "/flow",
+      "/usage",
+      "/tasks",
+      "/gates",
+      "/contributors",
+      "/contributions",
+      "/assets"
+    ],
+    "test_flows": [
+      "flow-page-style-parity",
+      "usage-page-style-parity",
+      "tasks-page-style-parity",
+      "gates-page-style-parity",
+      "contributors-page-style-parity",
+      "contributions-page-style-parity",
+      "assets-page-style-parity"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Awaiting CI and deploy verification."
+  },
+  "idea_ids": [
+    "portfolio-governance"
+  ],
+  "spec_ids": [
+    "075-web-ideas-specs-usage-pages"
+  ],
+  "task_ids": [
+    "task_main_pages_style_parity_2026_03_03"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex-gpt5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json"
+  ],
+  "change_files": [
+    "web/app/assets/page.tsx",
+    "web/app/contributions/page.tsx",
+    "web/app/contributors/page.tsx",
+    "web/app/flow/page.tsx",
+    "web/app/gates/page.tsx",
+    "web/app/tasks/page.tsx",
+    "web/app/usage/page.tsx",
+    "docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/web/app/assets/page.tsx
+++ b/web/app/assets/page.tsx
@@ -47,40 +47,45 @@ function AssetsPageContent() {
   }, [rows, selectedAssetId]);
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-      </div>
-      <h1 className="text-2xl font-bold">Assets</h1>
-      <p className="text-muted-foreground">
-        Human interface for `GET /api/assets`.
-        {selectedAssetId ? (
-          <>
-            {" "}
-            Filtered by asset <code>{selectedAssetId}</code>.
-          </>
-        ) : null}
-      </p>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Assets In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Human interface for <code>GET /api/assets</code> with linked contribution pathways.
+          </p>
+          {selectedAssetId ? (
+            <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              Filtered by asset <code>{selectedAssetId}</code>.
+            </p>
+          ) : null}
+        </section>
 
-      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
-      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/contributors", label: "Contributors" },
+              { href: "/contributions", label: "Contributions" },
+              { href: "/tasks", label: "Tasks" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      {status === "ok" && (
-        <section className="rounded border p-4 space-y-3">
+        {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+        {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+        {status === "ok" && (
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3">
           <p className="text-sm text-muted-foreground">
             Total: {filteredRows.length}
             {selectedAssetId ? (
@@ -92,7 +97,7 @@ function AssetsPageContent() {
           </p>
           <ul className="space-y-2 text-sm">
             {filteredRows.slice(0, 100).map((a) => (
-              <li key={a.id} className="rounded border p-2 flex justify-between gap-3">
+              <li key={a.id} className="rounded-lg border border-border/70 bg-background/45 p-2 flex justify-between gap-3">
                 <span className="font-medium">
                   <Link href={`/assets?asset_id=${encodeURIComponent(a.id)}`} className="hover:underline">
                     {a.id}
@@ -112,14 +117,15 @@ function AssetsPageContent() {
             ))}
           </ul>
         </section>
-      )}
+        )}
+      </div>
     </main>
   );
 }
 
 export default function AssetsPage() {
   return (
-    <Suspense fallback={<main className="min-h-screen p-8 max-w-5xl mx-auto"><p className="text-muted-foreground">Loading assets…</p></main>}>
+    <Suspense fallback={<main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8"><div className="mx-auto w-full max-w-7xl"><p className="text-muted-foreground">Loading assets…</p></div></main>}>
       <AssetsPageContent />
     </Suspense>
   );

--- a/web/app/contributions/page.tsx
+++ b/web/app/contributions/page.tsx
@@ -101,46 +101,46 @@ function ContributionsPageContent() {
   };
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-      </div>
-      <h1 className="text-2xl font-bold">Contributions</h1>
-      <p className="text-muted-foreground">
-        Human interface for `GET /api/contributions`.
-        {contributorFilter ? (
-          <>
-            {" "}
-            Filter contributor <code>{contributorFilter}</code>.
-          </>
-        ) : null}
-        {assetFilter ? (
-          <>
-            {" "}
-            Filter asset <code>{assetFilter}</code>.
-          </>
-        ) : null}
-      </p>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Contributions In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Human interface for <code>GET /api/contributions</code> with normalized cost evidence and attribution.
+          </p>
+          {(contributorFilter || assetFilter) ? (
+            <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              {contributorFilter ? <>Contributor <code>{contributorFilter}</code>. </> : null}
+              {assetFilter ? <>Asset <code>{assetFilter}</code>.</> : null}
+            </p>
+          ) : null}
+        </section>
 
-      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
-      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/contributors", label: "Contributors" },
+              { href: "/assets", label: "Assets" },
+              { href: "/tasks", label: "Tasks" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      {status === "ok" && (
-        <section className="rounded border p-4 space-y-3">
+        {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+        {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+        {status === "ok" && (
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3">
           <p className="text-sm text-muted-foreground">
             Total: {filteredRows.length}
             {(contributorFilter || assetFilter) ? (
@@ -152,7 +152,7 @@ function ContributionsPageContent() {
           </p>
           <ul className="space-y-2 text-sm">
             {filteredRows.slice(0, 100).map((c) => (
-              <li key={c.id} className="rounded border p-2 space-y-1">
+              <li key={c.id} className="rounded-lg border border-border/70 bg-background/45 p-2 space-y-1">
                 {(() => {
                   const cost = effectiveCost(c);
                   const commitHash = c.metadata?.commit_hash;
@@ -208,14 +208,15 @@ function ContributionsPageContent() {
             ))}
           </ul>
         </section>
-      )}
+        )}
+      </div>
     </main>
   );
 }
 
 export default function ContributionsPage() {
   return (
-    <Suspense fallback={<main className="min-h-screen p-8 max-w-5xl mx-auto"><p className="text-muted-foreground">Loading contributions…</p></main>}>
+    <Suspense fallback={<main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8"><div className="mx-auto w-full max-w-7xl"><p className="text-muted-foreground">Loading contributions…</p></div></main>}>
       <ContributionsPageContent />
     </Suspense>
   );

--- a/web/app/contributors/page.tsx
+++ b/web/app/contributors/page.tsx
@@ -110,47 +110,51 @@ function ContributorsPageContent() {
   }, [flowRows]);
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/contribute" className="text-muted-foreground hover:text-foreground">
-          Contribute
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-      </div>
-      <h1 className="text-2xl font-bold">Contributors</h1>
-      <p className="text-muted-foreground">
-        Human interface for `GET /api/contributors`.
-        {selectedContributorId ? (
-          <>
-            {" "}
-            Filtered by contributor <code>{selectedContributorId}</code>.
-          </>
-        ) : null}
-      </p>
-      <p className="text-sm text-muted-foreground">
-        To register a new contributor and submit idea/spec/question changes, use the{" "}
-        <Link href="/contribute" className="underline hover:text-foreground">Contribution Console</Link>.
-      </p>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Contributors In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Human interface for <code>GET /api/contributors</code> with idea/spec/process relation visibility.
+          </p>
+          {selectedContributorId ? (
+            <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              Filtered by contributor <code>{selectedContributorId}</code>.
+            </p>
+          ) : null}
+        </section>
 
-      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
-      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/contribute", label: "Contribute" },
+              { href: "/contributions", label: "Contributions" },
+              { href: "/assets", label: "Assets" },
+              { href: "/tasks", label: "Tasks" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      {status === "ok" && (
-        <section className="rounded border p-4 space-y-3">
+        <p className="px-1 text-sm text-muted-foreground">
+          To register a new contributor and submit idea/spec/question changes, use the{" "}
+          <Link href="/contribute" className="underline hover:text-foreground">Contribution Console</Link>.
+        </p>
+
+        {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+        {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+        {status === "ok" && (
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3">
           <p className="text-sm text-muted-foreground">
             Total: {filteredRows.length}
             {selectedContributorId ? (
@@ -162,7 +166,7 @@ function ContributorsPageContent() {
           </p>
           <ul className="space-y-2 text-sm">
             {filteredRows.slice(0, 100).map((c) => (
-              <li key={c.id} className="rounded border p-2 flex justify-between gap-3">
+              <li key={c.id} className="rounded-lg border border-border/70 bg-background/45 p-2 flex justify-between gap-3">
                 <span className="font-medium">
                   <Link href={`/contributors?contributor_id=${encodeURIComponent(c.id)}`} className="hover:underline">
                     {c.name}
@@ -185,7 +189,7 @@ function ContributorsPageContent() {
             {filteredRows.slice(0, 100).map((c) => {
               const rel = relationsByContributor.get(c.id);
               return (
-                <li key={`${c.id}-relations`} className="rounded border p-2 text-muted-foreground">
+                <li key={`${c.id}-relations`} className="rounded-lg border border-border/70 bg-background/45 p-2 text-muted-foreground">
                   idea{" "}
                   {rel && rel.ideaIds.length > 0
                     ? rel.ideaIds.slice(0, 6).map((ideaId, idx) => (
@@ -251,14 +255,15 @@ function ContributorsPageContent() {
             })}
           </ul>
         </section>
-      )}
+        )}
+      </div>
     </main>
   );
 }
 
 export default function ContributorsPage() {
   return (
-    <Suspense fallback={<main className="min-h-screen p-8 max-w-5xl mx-auto"><p className="text-muted-foreground">Loading contributors…</p></main>}>
+    <Suspense fallback={<main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8"><div className="mx-auto w-full max-w-7xl"><p className="text-muted-foreground">Loading contributors…</p></div></main>}>
       <ContributorsPageContent />
     </Suspense>
   );

--- a/web/app/flow/page.tsx
+++ b/web/app/flow/page.tsx
@@ -234,102 +234,98 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
     .slice(0, 8);
 
   return (
-    <main className="min-h-screen p-8 max-w-6xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
-          Ideas
-        </Link>
-        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
-          Specs
-        </Link>
-        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
-          Usage
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-        <Link href="/gates" className="text-muted-foreground hover:text-foreground">
-          Gates
-        </Link>
-      </div>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Flow In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Unified tracking of <code>idea -&gt; spec -&gt; process -&gt; implementation -&gt; validation</code> with contributor and contribution visibility.
+          </p>
+        </section>
 
-      <h1 className="text-2xl font-bold">Flow</h1>
-      <p className="text-muted-foreground">
-        Unified tracking of <code>idea -&gt; spec -&gt; process -&gt; implementation -&gt; validation</code> with contributor and contribution visibility.
-      </p>
-      {(ideaFilter || specFilter || contributorFilter) && (
-        <p className="text-sm text-muted-foreground">
-          Filters:
-          {ideaFilter ? (
-            <>
-              {" "}
-              idea <code>{ideaFilter}</code>
-            </>
-          ) : null}
-          {specFilter ? (
-            <>
-              {" "}
-              spec <code>{specFilter}</code>
-            </>
-          ) : null}
-          {contributorFilter ? (
-            <>
-              {" "}
-              contributor <code>{contributorFilter}</code>
-            </>
-          ) : null}
-          {" | "}
-          <Link href="/flow" className="underline hover:text-foreground">
-            Clear filters
-          </Link>
-        </p>
-      )}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/ideas", label: "Ideas" },
+              { href: "/specs", label: "Specs" },
+              { href: "/usage", label: "Usage" },
+              { href: "/contributors", label: "Contributors" },
+              { href: "/contributions", label: "Contributions" },
+              { href: "/assets", label: "Assets" },
+              { href: "/tasks", label: "Tasks" },
+              { href: "/gates", label: "Gates" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-        <div className="rounded border p-3">
+        {(ideaFilter || specFilter || contributorFilter) && (
+          <p className="px-1 text-sm text-muted-foreground">
+            Filters:
+            {ideaFilter ? (
+              <>
+                {" "}
+                idea <code>{ideaFilter}</code>
+              </>
+            ) : null}
+            {specFilter ? (
+              <>
+                {" "}
+                spec <code>{specFilter}</code>
+              </>
+            ) : null}
+            {contributorFilter ? (
+              <>
+                {" "}
+                contributor <code>{contributorFilter}</code>
+              </>
+            ) : null}
+            {" | "}
+            <Link href="/flow" className="underline hover:text-foreground">
+              Clear filters
+            </Link>
+          </p>
+        )}
+
+        <section className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Ideas tracked</p>
           <p className="text-lg font-semibold">{filteredItems.length}</p>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Flow complete (spec+process+impl+validation)</p>
           <p className="text-lg font-semibold">
             {filteredItems.filter((row) => row.spec.tracked && row.process.tracked && row.implementation.tracked && row.validation.tracked).length}
           </p>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Contributors in registry</p>
           <p className="text-lg font-semibold">{contributors.length}</p>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Contributions in registry</p>
           <p className="text-lg font-semibold">{contributions.length}</p>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Blocked ideas</p>
           <p className="text-lg font-semibold">{flow.summary.blocked_ideas}</p>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="text-muted-foreground">Unblock queue items</p>
           <p className="text-lg font-semibold">{flow.summary.queue_items}</p>
         </div>
-      </section>
+        </section>
 
-      <section className="rounded border p-4 space-y-2">
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2">
         <h2 className="font-semibold">Top Contributors by Contribution Count</h2>
         <ul className="space-y-1 text-sm">
           {topContributorsRows.map((row) => (
@@ -346,16 +342,16 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
             </li>
           ))}
         </ul>
-      </section>
+        </section>
 
-      <section className="rounded border p-4 space-y-2">
+        <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2">
         <h2 className="font-semibold">Unblock Priority Queue</h2>
         <p className="text-sm text-muted-foreground">
           Ordered by estimated unlock value per cost. Work top-down to unblock more downstream tasks.
         </p>
         <ul className="space-y-2 text-sm">
           {flow.unblock_queue.slice(0, 12).map((row) => (
-            <li key={row.task_fingerprint} className="rounded border p-2 space-y-1">
+            <li key={row.task_fingerprint} className="rounded-lg border border-border/70 bg-background/45 p-2 space-y-1">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <Link href={`/flow?idea_id=${encodeURIComponent(row.idea_id)}`} className="font-medium underline hover:text-foreground">
                   {row.idea_name}
@@ -385,11 +381,11 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
             <li className="text-muted-foreground">No blockers detected in current flow scope.</li>
           )}
         </ul>
-      </section>
+        </section>
 
-      <section className="space-y-4">
+        <section className="space-y-4">
         {filteredItems.map((item) => (
-          <article key={item.idea_id} className="rounded border p-4 space-y-3">
+          <article key={item.idea_id} className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <h2 className="font-semibold">
                 <Link href={`/ideas/${encodeURIComponent(item.idea_id)}`} className="hover:underline">
@@ -400,13 +396,13 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
             </div>
 
             <div className="flex flex-wrap gap-2 text-xs">
-              <span className="rounded border px-2 py-1">spec: {item.chain.spec}</span>
-              <span className="rounded border px-2 py-1">process: {item.chain.process}</span>
-              <span className="rounded border px-2 py-1">implementation: {item.chain.implementation}</span>
-              <span className="rounded border px-2 py-1">validation: {item.chain.validation}</span>
-              <span className="rounded border px-2 py-1">contributors: {item.chain.contributors}</span>
-              <span className="rounded border px-2 py-1">contributions: {item.chain.contributions}</span>
-              <span className="rounded border px-2 py-1">assets: {item.chain.assets}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">spec: {item.chain.spec}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">process: {item.chain.process}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">implementation: {item.chain.implementation}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">validation: {item.chain.validation}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">contributors: {item.chain.contributors}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">contributions: {item.chain.contributions}</span>
+              <span className="rounded-lg border border-border/70 bg-background/45 px-2 py-1">assets: {item.chain.assets}</span>
             </div>
             <p className="text-xs text-muted-foreground">
               blocker {item.interdependencies.blocking_stage ?? "none"} | unblock priority{" "}
@@ -415,7 +411,7 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
             </p>
 
             <div className="grid grid-cols-1 xl:grid-cols-2 gap-3 text-sm">
-              <div className="rounded border p-3 space-y-1">
+              <div className="rounded-xl border border-border/70 bg-background/45 p-3 space-y-1">
                 <p className="font-medium">Spec + Process</p>
                 <p className="text-muted-foreground">
                   specs {item.spec.count} ({statLabel(item.spec.tracked)}) | evidence {item.process.evidence_count} ({statLabel(item.process.tracked)})
@@ -479,7 +475,7 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
                 </p>
               </div>
 
-              <div className="rounded border p-3 space-y-1">
+              <div className="rounded-xl border border-border/70 bg-background/45 p-3 space-y-1">
                 <p className="font-medium">Implementation + Contribution</p>
                 <p className="text-muted-foreground">
                   lineage_links {item.implementation.lineage_link_count} ({statLabel(item.implementation.tracked)}) | runtime_events {item.implementation.runtime_events_count}
@@ -529,7 +525,7 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
                 </p>
               </div>
 
-              <div className="rounded border p-3 space-y-1">
+              <div className="rounded-xl border border-border/70 bg-background/45 p-3 space-y-1">
                 <p className="font-medium">Validation</p>
                 <p className="text-muted-foreground">
                   local pass {item.validation.local.pass} | ci pass {item.validation.ci.pass} | deploy pass {item.validation.deploy.pass} | e2e pass {item.validation.e2e.pass}
@@ -552,7 +548,7 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
                 </p>
               </div>
 
-              <div className="rounded border p-3 space-y-1">
+              <div className="rounded-xl border border-border/70 bg-background/45 p-3 space-y-1">
                 <p className="font-medium">Contributors</p>
                 <p className="text-muted-foreground">
                   unique {item.contributors.total_unique} ({statLabel(item.contributors.tracked)})
@@ -585,11 +581,12 @@ export default async function FlowPage({ searchParams }: { searchParams: FlowSea
           </article>
         ))}
         {filteredItems.length === 0 && (
-          <article className="rounded border p-4 text-sm text-muted-foreground">
+          <article className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm text-sm text-muted-foreground">
             No flow rows match current filters.
           </article>
         )}
-      </section>
+        </section>
+      </div>
     </main>
   );
 }

--- a/web/app/gates/page.tsx
+++ b/web/app/gates/page.tsx
@@ -133,28 +133,35 @@ export default function GatesPage() {
   }
 
   return (
-    <main className="min-h-screen p-8 max-w-4xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Coherence Network
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
-          Flow
-        </Link>
-        <Link href="/usage" className="text-muted-foreground hover:text-foreground">
-          Usage
-        </Link>
-      </div>
-      <h1 className="text-2xl font-bold">Gate Status</h1>
-      <p className="text-muted-foreground">
-        Human interface for release/public gate inspection. Machine clients should use the
-        `/api/gates/*` endpoints directly.
-      </p>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Gate Status In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Live release/public gate inspection. Machine clients should continue using <code>/api/gates/*</code> directly.
+          </p>
+        </section>
 
-      <section className="space-y-3 border border-border rounded-md p-4">
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/tasks", label: "Tasks" },
+              { href: "/flow", label: "Flow" },
+              { href: "/usage", label: "Usage" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
         <h2 className="text-lg font-semibold">PR → Public Readiness</h2>
         <div className="flex gap-2">
           <Input
@@ -168,7 +175,7 @@ export default function GatesPage() {
         </div>
       </section>
 
-      <section className="space-y-3 border border-border rounded-md p-4">
+      <section className="space-y-3 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
         <h2 className="text-lg font-semibold">Merged Change Contract</h2>
         <div className="flex gap-2">
           <Input
@@ -185,7 +192,7 @@ export default function GatesPage() {
         </div>
       </section>
 
-      <section className="space-y-3 border border-border rounded-md p-4">
+      <section className="space-y-3 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
         <h2 className="text-lg font-semibold">Public Deploy Contract</h2>
         <Button variant="outline" onClick={runPublicDeployContract} disabled={status === "loading"}>
           Check Public Deploy Contract
@@ -195,7 +202,7 @@ export default function GatesPage() {
         </Button>
       </section>
 
-      <section className="space-y-3 border border-border rounded-md p-4">
+      <section className="space-y-3 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
         <h2 className="text-lg font-semibold">Endpoint Traceability Coverage</h2>
         <p className="text-sm text-muted-foreground">
           Verify every endpoint is mapped to idea, spec, process, and validation signals.
@@ -210,7 +217,7 @@ export default function GatesPage() {
       )}
 
       {prReport && (
-        <section className="space-y-2">
+        <section className="space-y-2 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
           <h3 className="font-medium">PR Gate Report</h3>
           <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
             {JSON.stringify(prReport, null, 2)}
@@ -219,7 +226,7 @@ export default function GatesPage() {
       )}
 
       {contractReport && (
-        <section className="space-y-2">
+        <section className="space-y-2 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
           <h3 className="font-medium">Change Contract Report</h3>
           <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
             {JSON.stringify(contractReport, null, 2)}
@@ -228,7 +235,7 @@ export default function GatesPage() {
       )}
 
       {publicDeployReport && (
-        <section className="space-y-2">
+        <section className="space-y-2 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
           <h3 className="font-medium">Public Deploy Report</h3>
           <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
             {JSON.stringify(publicDeployReport, null, 2)}
@@ -237,13 +244,14 @@ export default function GatesPage() {
       )}
 
       {traceabilityReport && (
-        <section className="space-y-2">
+        <section className="space-y-2 rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm">
           <h3 className="font-medium">Endpoint Traceability Report</h3>
           <pre className="text-xs bg-muted p-3 rounded-md overflow-auto">
             {JSON.stringify(traceabilityReport, null, 2)}
           </pre>
         </section>
       )}
+      </div>
     </main>
   );
 }

--- a/web/app/tasks/page.tsx
+++ b/web/app/tasks/page.tsx
@@ -263,56 +263,45 @@ function TasksPageContent() {
   }, [selectedTaskEvents]);
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/gates" className="text-muted-foreground hover:text-foreground">
-          Gates
-        </Link>
-        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
-          Flow
-        </Link>
-        <Link href="/agent" className="text-muted-foreground hover:text-foreground">
-          Agent
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-      </div>
-      <h1 className="text-2xl font-bold">Tasks</h1>
-      <p className="text-muted-foreground">
-        Human interface for `GET /api/agent/tasks`.
-        {statusFilter ? (
-          <>
-            {" "}
-            status <code>{statusFilter}</code>.
-          </>
-        ) : null}
-        {typeFilter ? (
-          <>
-            {" "}
-            task type <code>{typeFilter}</code>.
-          </>
-        ) : null}
-        {taskIdFilter ? (
-          <>
-            {" "}
-            task id <code>{taskIdFilter}</code>.
-          </>
-        ) : null}
-      </p>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Tasks In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Human interface for <code>GET /api/agent/tasks</code> with live execution proof and runtime evidence.
+          </p>
+          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+            {statusFilter || typeFilter || taskIdFilter ? "Filtered task stream." : "All active and historical tasks."}
+          </p>
+        </section>
 
-      {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
-      {status === "error" && <p className="text-destructive">Error: {error}</p>}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/gates", label: "Gates" },
+              { href: "/flow", label: "Flow" },
+              { href: "/agent", label: "Agent" },
+              { href: "/contributors", label: "Contributors" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      {status === "ok" && (
+        {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
+        {status === "error" && <p className="text-destructive">Error: {error}</p>}
+
+        {status === "ok" && (
         <>
-          <section className="rounded border p-4 space-y-3">
+          <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3">
             <p className="text-sm text-muted-foreground">
               Showing {pageStart}-{pageEnd} of {totalTasks} | page {page}
               {(statusFilter || typeFilter || taskIdFilter) ? (
@@ -345,7 +334,7 @@ function TasksPageContent() {
             ) : null}
             <ul className="space-y-2 text-sm">
               {filteredRows.map((t) => (
-                <li key={t.id} className="rounded border p-2 space-y-1">
+                <li key={t.id} className="rounded-lg border border-border/70 bg-background/45 p-2 space-y-1">
                   <div className="flex justify-between gap-3">
                     <span className="font-medium">
                       <Link href={`/tasks?task_id=${encodeURIComponent(t.id)}`} className="underline hover:text-foreground">
@@ -369,7 +358,7 @@ function TasksPageContent() {
           </section>
 
           {taskIdFilter && (
-            <section className="rounded border p-4 space-y-3 text-sm">
+            <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-3 text-sm">
               <h2 className="font-semibold">Evidence Trail</h2>
               {selectedTask ? (
                 <>
@@ -478,7 +467,8 @@ function TasksPageContent() {
             </section>
           )}
         </>
-      )}
+        )}
+      </div>
     </main>
   );
 }
@@ -487,8 +477,10 @@ export default function TasksPage() {
   return (
     <Suspense
       fallback={
-        <main className="min-h-screen p-8 max-w-5xl mx-auto">
-          <p className="text-muted-foreground">Loading tasks…</p>
+        <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+          <div className="mx-auto w-full max-w-7xl">
+            <p className="text-muted-foreground">Loading tasks…</p>
+          </div>
         </main>
       }
     >

--- a/web/app/usage/page.tsx
+++ b/web/app/usage/page.tsx
@@ -521,54 +521,51 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
   const nextHref = `/usage?page=${page + 1}&page_size=${pageSize}`;
 
   return (
-    <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-6">
-      <div className="flex flex-wrap gap-3 text-sm">
-        <Link href="/" className="text-muted-foreground hover:text-foreground">
-          ← Home
-        </Link>
-        <Link href="/portfolio" className="text-muted-foreground hover:text-foreground">
-          Portfolio
-        </Link>
-        <Link href="/ideas" className="text-muted-foreground hover:text-foreground">
-          Ideas
-        </Link>
-        <Link href="/specs" className="text-muted-foreground hover:text-foreground">
-          Specs
-        </Link>
-        <Link href="/flow" className="text-muted-foreground hover:text-foreground">
-          Flow
-        </Link>
-        <Link href="/contributors" className="text-muted-foreground hover:text-foreground">
-          Contributors
-        </Link>
-        <Link href="/contributions" className="text-muted-foreground hover:text-foreground">
-          Contributions
-        </Link>
-        <Link href="/assets" className="text-muted-foreground hover:text-foreground">
-          Assets
-        </Link>
-        <Link href="/tasks" className="text-muted-foreground hover:text-foreground">
-          Tasks
-        </Link>
-        <Link href="/agent" className="text-muted-foreground hover:text-foreground">
-          Agent
-        </Link>
-        <Link href="/gates" className="text-muted-foreground hover:text-foreground">
-          Gates
-        </Link>
-      </div>
+    <main className="min-h-screen px-4 pb-8 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-7xl space-y-4">
+        <section className="space-y-1 px-1">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Usage In Motion</h1>
+          <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+            Runtime telemetry + friction summary, rendered with operational context for fast triage.
+          </p>
+          {warnings.length > 0 ? (
+            <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              Partial data mode: unavailable {warnings.join(", ")}.
+            </p>
+          ) : null}
+        </section>
 
-      <h1 className="text-2xl font-bold">Usage</h1>
-      <p className="text-muted-foreground">Runtime telemetry + friction summary (machine data rendered for humans).</p>
-      {warnings.length > 0 ? (
-        <p className="text-sm text-muted-foreground">Partial data mode: unavailable {warnings.join(", ")}.</p>
-      ) : null}
+        <section className="rounded-xl border border-border/70 bg-card/50 px-3 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            {[
+              { href: "/", label: "Home" },
+              { href: "/portfolio", label: "Portfolio" },
+              { href: "/ideas", label: "Ideas" },
+              { href: "/specs", label: "Specs" },
+              { href: "/flow", label: "Flow" },
+              { href: "/contributors", label: "Contributors" },
+              { href: "/contributions", label: "Contributions" },
+              { href: "/assets", label: "Assets" },
+              { href: "/tasks", label: "Tasks" },
+              { href: "/agent", label: "Agent" },
+              { href: "/gates", label: "Gates" },
+            ].map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="inline-flex items-center rounded-full border border-border/70 bg-background/55 px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Friction (24h)</h2>
         <p className="text-muted-foreground">total_events {friction.total_events} | open {friction.open_events}</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Top block types</p>
             <ul className="space-y-1">
               {friction.top_block_types.slice(0, 8).map((row) => (
@@ -581,7 +578,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
               ))}
             </ul>
           </div>
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Top stages</p>
             <ul className="space-y-1">
               {friction.top_stages.slice(0, 8).map((row) => (
@@ -593,7 +590,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
             </ul>
           </div>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="font-medium mb-2">Top entry points</p>
           <ul className="space-y-1">
             {friction.entry_points.slice(0, 8).map((row) => (
@@ -611,7 +608,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </div>
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Host Runner (24h)</h2>
         <p className="text-muted-foreground">
           runs {dailySummary.host_runner.total_runs} | failed {dailySummary.host_runner.failed_runs} | completed{" "}
@@ -620,7 +617,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </p>
         <ul className="space-y-2">
           {hostTaskTypeRows.map(([taskType, counts]) => (
-            <li key={taskType} className="rounded border p-2 flex flex-wrap justify-between gap-2">
+            <li key={taskType} className="rounded-lg border border-border/70 bg-background/45 p-2 flex flex-wrap justify-between gap-2">
               <span className="font-medium">{taskType}</span>
               <span className="text-muted-foreground">
                 total {Number(counts.total || 0)} | completed {Number(counts.completed || 0)} | failed{" "}
@@ -631,7 +628,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
           {hostTaskTypeRows.length === 0 ? <li className="text-muted-foreground">No host-runner task-type data yet.</li> : null}
         </ul>
         {dailySummary.contract_gaps.length > 0 ? (
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-1">Telemetry Contract Gaps</p>
             <ul className="list-disc pl-5 space-y-1 text-muted-foreground">
               {dailySummary.contract_gaps.map((gap) => (
@@ -642,7 +639,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         ) : null}
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Code Quality Awareness (Guidance)</h2>
         <p className="text-muted-foreground">
           intent {qualityAwareness.intent_focus.join(", ")} | severity {qualityAwareness.summary.severity} | risk score{" "}
@@ -654,7 +651,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
           {qualityAwareness.summary.very_large_modules} | long functions {qualityAwareness.summary.long_functions}
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Hotspots</p>
             <ul className="space-y-1">
               {qualityAwareness.hotspots.slice(0, 6).map((row, idx) => (
@@ -675,7 +672,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
               ) : null}
             </ul>
           </div>
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Guidance</p>
             <ul className="space-y-1">
               {qualityAwareness.guidance.map((row) => (
@@ -689,7 +686,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
             </ul>
           </div>
         </div>
-        <div className="rounded border p-3">
+        <div className="rounded-xl border border-border/70 bg-background/45 p-3">
           <p className="font-medium mb-2">Recommended self-improvement tasks</p>
           <ul className="space-y-1">
             {qualityAwareness.recommended_tasks.slice(0, 3).map((task) => (
@@ -707,11 +704,11 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </div>
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Providers + Limits</h2>
         <ul className="space-y-2">
           {providerRows.map((row) => (
-            <li key={row.provider} className="rounded border p-2">
+            <li key={row.provider} className="rounded-lg border border-border/70 bg-background/45 p-2">
               <div className="flex flex-wrap justify-between gap-2">
                 <span className="font-medium">
                   {row.provider} ({row.status})
@@ -737,10 +734,10 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </ul>
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Top Tool Usage + Attention (24h)</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Top tools</p>
             <ul className="space-y-1">
               {topTools.map((tool) => (
@@ -754,7 +751,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
               {topTools.length === 0 ? <li className="text-muted-foreground">No worker tool events in window.</li> : null}
             </ul>
           </div>
-          <div className="rounded border p-3">
+          <div className="rounded-xl border border-border/70 bg-background/45 p-3">
             <p className="font-medium mb-2">Top attention areas</p>
             <ul className="space-y-1">
               {topAttentionRows.map((row) => (
@@ -771,7 +768,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </div>
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Runtime Cost by Idea</h2>
         <p className="text-muted-foreground">window_seconds {runtime.window_seconds} | page {page}</p>
         <div className="flex gap-3 text-muted-foreground">
@@ -792,7 +789,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </div>
         <ul className="space-y-2">
           {ideas.map((row) => (
-            <li key={row.idea_id} className="flex justify-between rounded border p-2">
+            <li key={row.idea_id} className="flex justify-between rounded-lg border border-border/70 bg-background/45 p-2">
               <Link href={`/ideas/${encodeURIComponent(row.idea_id)}`} className="underline hover:text-foreground">
                 {row.idea_id}
               </Link>
@@ -805,14 +802,14 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </ul>
       </section>
 
-      <section className="rounded border p-4 space-y-2 text-sm">
+      <section className="rounded-2xl border border-border/70 bg-card/60 p-4 shadow-sm space-y-2 text-sm">
         <h2 className="font-semibold">Full View Render + API Cost</h2>
         <p className="text-muted-foreground">
           Measured after data is loaded (`web_view_complete` beacon): render time and summed API runtime/cost per route.
         </p>
         <ul className="space-y-2">
           {viewRows.map((row) => (
-            <li key={row.route} className="rounded border p-2 flex flex-wrap justify-between gap-2">
+            <li key={row.route} className="rounded-lg border border-border/70 bg-background/45 p-2 flex flex-wrap justify-between gap-2">
               <Link href={row.route} className="underline hover:text-foreground">
                 {row.route}
               </Link>
@@ -826,6 +823,7 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
           ) : null}
         </ul>
       </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- align main operational pages to the same responsive shell, card, and panel system used by ideas/specs
- preserve existing page behavior while standardizing spacing, structure, and visual hierarchy
- update suspense fallbacks for client-rendered pages to match the same layout language

## Files
- web/app/flow/page.tsx
- web/app/usage/page.tsx
- web/app/tasks/page.tsx
- web/app/gates/page.tsx
- web/app/contributors/page.tsx
- web/app/contributions/page.tsx
- web/app/assets/page.tsx
- docs/system_audit/commit_evidence_2026-03-03_main-pages-style-parity.json

## Validation
- make start-gate
- npm run build (web)
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict