### PR TITLE
Fix provider_wrapper: Windows output capture + pipe hang

### DIFF
--- a/api/scripts/provider_wrapper.py
+++ b/api/scripts/provider_wrapper.py
@@ -114,11 +114,24 @@ class ProviderWrapper:
         with self._output_lock:
             output = "\n".join(self._output_lines)
 
-        # Also capture stderr
-        try:
-            stderr = self._proc.stderr.read() if self._proc.stderr else ""
-        except Exception:
-            stderr = ""
+        # Also capture stderr (with timeout to avoid pipe hang on Windows)
+        stderr = ""
+        if self._proc.stderr:
+            def _read_stderr():
+                nonlocal stderr
+                try:
+                    stderr = self._proc.stderr.read()
+                except Exception:
+                    pass
+            t = threading.Thread(target=_read_stderr, daemon=True)
+            t.start()
+            t.join(timeout=5)
+            if t.is_alive():
+                log.warning("WRAPPER stderr read hung — pipe held by orphan child")
+                try:
+                    self._proc.stderr.close()
+                except Exception:
+                    pass
 
         if not output and stderr:
             output = stderr
@@ -127,16 +140,36 @@ class ProviderWrapper:
             output = "(no output)"
 
         success = self._proc.returncode == 0 and not self._aborted
+        log.info(
+            "WRAPPER finished: rc=%s output=%d chars duration=%.1fs aborted=%s",
+            self._proc.returncode, len(output), duration, self._aborted,
+        )
+        if not success and len(output) < 100:
+            log.warning(
+                "WRAPPER low-output failure: rc=%s stderr=%s",
+                self._proc.returncode, (stderr or "")[:500],
+            )
         return success, output, duration
 
     def _read_stdout(self) -> None:
-        """Read provider stdout line by line."""
+        """Read provider stdout line by line.
+
+        Uses readline() instead of iterator to avoid Python's internal
+        buffering which can block on Windows until the buffer fills.
+        Logs exceptions instead of silently swallowing them.
+        """
         try:
-            for line in self._proc.stdout:
+            while not self._stop_event.is_set():
+                line = self._proc.stdout.readline()
+                if not line:  # EOF — process closed stdout
+                    break
                 with self._output_lock:
                     self._output_lines.append(line.rstrip("\n"))
-        except Exception:
+        except ValueError:
+            # Pipe closed — expected after kill
             pass
+        except Exception as exc:
+            log.warning("WRAPPER stdout reader error: %s", exc)
 
     def _control_monitor(self) -> None:
         """Monitor .task-control for commands. Process-level control — no agent cooperation needed."""


### PR DESCRIPTION
## Summary
- Fix silent stdout reader exception swallowing in `provider_wrapper.py` — previously any pipe error was caught and ignored, causing 0-char output on Windows
- Switch from `for line in proc.stdout` iterator to `readline()` loop to avoid Python's 8KB buffer blocking on Windows
- Add stderr read timeout to prevent pipe hang after `taskkill /F /T` when orphan processes hold handles
- Add diagnostic logging for low-output failures

## Context
The-Seeker node was showing 0% health (`failing`) with all tasks producing 0 chars of output across all providers (claude, codex, cursor). Root cause: the `_read_stdout()` thread was silently swallowing exceptions, and Python's iterator-based stdout reading blocks on Windows until the internal buffer fills.

## Test plan
- [x] Verified codex connectivity works on The-Seeker
- [ ] Monitor The-Seeker node health after deploy — should recover from `failing` to `healthy`
- [ ] Verify new logging shows in worker_service.log on failure
- [ ] Confirm stderr pipe hang protection activates on timeout kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)