### PR TITLE
feat: add opencode_enabled field to health response [opencode validation]

### DIFF
--- a/api/app/routers/health.py
+++ b/api/app/routers/health.py
@@ -106,6 +106,10 @@ class HealthResponse(_BaseHealthResponse):
         bool,
         Field(description="True if core tables (contributions, contributors, assets) exist"),
     ] = True
+    opencode_enabled: Annotated[
+        bool,
+        Field(description="True if opencode integration is enabled"),
+    ] = True
 
 
 class ReadyResponse(_BaseHealthResponse):


### PR DESCRIPTION
## OpenCode executor validation PR

This PR was generated end-to-end by **opencode v1.3.7** using `ollama/minimax-m2.7:cloud`.

**Validation result**: ✅ opencode correctly:
1. Read the target file (`api/app/routers/health.py`)
2. Made a precise code change (added `opencode_enabled: bool = True` to `HealthResponse`)
3. Committed with a clean message
4. Pushed and created this PR

The canary field itself is harmless and can be merged or closed.

🤖 Validated with [opencode](https://opencode.ai) v1.3.7 + minimax-m2.7:cloud via Ollama Cloud