### PR TITLE
test: Playwright e2e suite (47 tests) + fix /specs broken links + jargon

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -75,6 +75,7 @@ from app.routers import pipeline_policies
 from app.routers import ui_preferences as ui_preferences_router
 from app.routers import memberships as memberships_router
 from app.routers import activity as activity_router
+from app.routers import messages as messages_router
 from app.routers import workspaces as workspaces_router
 from app.routers import workspace_projects as workspace_projects_router
 from app.routers import provider_stats
@@ -607,6 +608,7 @@ app.include_router(agent.router, prefix="/api", tags=["agent"])
 app.include_router(automation_usage.router, prefix="/api", tags=["automation-usage"])
 app.include_router(ideas.router, prefix="/api", tags=["ideas"])
 app.include_router(workspaces_router.router, prefix="/api", tags=["workspaces"])
+app.include_router(messages_router.router, prefix="/api", tags=["messages"])
 app.include_router(activity_router.router, prefix="/api", tags=["activity"])
 app.include_router(workspace_projects_router.router, prefix="/api", tags=["projects"])
 app.include_router(memberships_router.router, prefix="/api", tags=["memberships"])

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -74,7 +74,9 @@ from app.routers import pipeline
 from app.routers import pipeline_policies
 from app.routers import ui_preferences as ui_preferences_router
 from app.routers import memberships as memberships_router
+from app.routers import activity as activity_router
 from app.routers import workspaces as workspaces_router
+from app.routers import workspace_projects as workspace_projects_router
 from app.routers import provider_stats
 from app.routers import service_registry_router
 from app.routers import constellation as constellation_router
@@ -605,6 +607,8 @@ app.include_router(agent.router, prefix="/api", tags=["agent"])
 app.include_router(automation_usage.router, prefix="/api", tags=["automation-usage"])
 app.include_router(ideas.router, prefix="/api", tags=["ideas"])
 app.include_router(workspaces_router.router, prefix="/api", tags=["workspaces"])
+app.include_router(activity_router.router, prefix="/api", tags=["activity"])
+app.include_router(workspace_projects_router.router, prefix="/api", tags=["projects"])
 app.include_router(memberships_router.router, prefix="/api", tags=["memberships"])
 app.include_router(lenses.router, prefix="/api", tags=["lenses"])
 app.include_router(spec_registry.router, prefix="/api", tags=["spec-registry"])

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -74,10 +74,7 @@ from app.routers import pipeline
 from app.routers import pipeline_policies
 from app.routers import ui_preferences as ui_preferences_router
 from app.routers import memberships as memberships_router
-from app.routers import activity as activity_router
-from app.routers import messages as messages_router
 from app.routers import workspaces as workspaces_router
-from app.routers import workspace_projects as workspace_projects_router
 from app.routers import provider_stats
 from app.routers import service_registry_router
 from app.routers import constellation as constellation_router
@@ -608,9 +605,6 @@ app.include_router(agent.router, prefix="/api", tags=["agent"])
 app.include_router(automation_usage.router, prefix="/api", tags=["automation-usage"])
 app.include_router(ideas.router, prefix="/api", tags=["ideas"])
 app.include_router(workspaces_router.router, prefix="/api", tags=["workspaces"])
-app.include_router(messages_router.router, prefix="/api", tags=["messages"])
-app.include_router(activity_router.router, prefix="/api", tags=["activity"])
-app.include_router(workspace_projects_router.router, prefix="/api", tags=["projects"])
 app.include_router(memberships_router.router, prefix="/api", tags=["memberships"])
 app.include_router(lenses.router, prefix="/api", tags=["lenses"])
 app.include_router(spec_registry.router, prefix="/api", tags=["spec-registry"])

--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -629,7 +629,10 @@ def _discover_specs_local(limit: int = 300) -> list[dict]:
     out: list[dict] = []
     for path in files[: max(1, min(limit, 2000))]:
         stem = path.stem
-        spec_id = stem.split("-", 1)[0] if "-" in stem else stem
+        if stem.upper() in ("INDEX", "TEMPLATE"):
+            continue
+        # Full stem is the spec_id — slugs are plain, no numeric prefix to strip
+        spec_id = stem
         title = stem.replace("-", " ")
         try:
             for line in path.read_text(encoding="utf-8").splitlines()[:8]:
@@ -675,7 +678,10 @@ def _discover_specs_from_github(limit: int = 300, timeout: float = 8.0) -> list[
                 continue
             name = row.get("name") if isinstance(row.get("name"), str) else Path(path).name
             stem = Path(name).stem
-            spec_id = stem.split("-", 1)[0] if "-" in stem else stem
+            if stem.upper() in ("INDEX", "TEMPLATE"):
+                continue
+            # Full stem is the spec_id — slugs are plain, no numeric prefix to strip
+            spec_id = stem
             title = stem.replace("-", " ")
             out.append(
                 _normalize_spec_item(

--- a/web/app/contribute/page.tsx
+++ b/web/app/contribute/page.tsx
@@ -699,14 +699,14 @@ export default function ContributePage() {
         </ul>
       </section>
 
-      <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-2 text-sm">
-        <h2 className="text-xl font-semibold">Machine API</h2>
-        <p className="text-sm text-muted-foreground">All actions above are also available via the API for automated workflows.</p>
+      <details className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-2 text-sm">
+        <summary className="text-xl font-semibold cursor-pointer">For developers and scripts</summary>
+        <p className="text-sm text-muted-foreground mt-2">All the actions above can also be done programmatically — useful for bots, scripts, or AI agents.</p>
         <p>Register contributor: <code>POST /api/contributors</code></p>
         <p>Submit change request: <code>POST /api/governance/change-requests</code></p>
         <p>Vote yes/no: <code>POST /api/governance/change-requests/&lt;id&gt;/votes</code></p>
         <p>List specs: <code>GET /api/spec-registry</code> | list queue: <code>GET /api/governance/change-requests</code></p>
-      </section>
+      </details>
 
       {status === "loading" && <p className="text-muted-foreground">Loading…</p>}
       {status === "error" && <p className="text-destructive">Error: {error}</p>}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -320,13 +320,16 @@ export default async function Home() {
           <Link href="/invest" className="hover:text-foreground transition-colors">Invest</Link>
           <Link href="/contribute" className="hover:text-foreground transition-colors">Contribute</Link>
         </div>
-        <div className="flex flex-wrap justify-center gap-4 text-xs text-foreground/85 mb-4">
-          <a href="https://github.com/seeker71/Coherence-Network" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">GitHub</a>
-          <a href="https://www.npmjs.com/package/coherence-cli" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">CLI (npm)</a>
-          <a href="https://www.npmjs.com/package/coherence-mcp-server" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">MCP Server</a>
-          <a href="https://api.coherencycoin.com/docs" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">API Docs</a>
-          <a href="https://clawhub.ai/skills/coherence-network" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">OpenClaw Skill</a>
-        </div>
+        <details className="text-xs text-foreground/60 mb-4">
+          <summary className="cursor-pointer hover:text-foreground/85 transition-colors">For developers</summary>
+          <div className="flex flex-wrap justify-center gap-4 mt-2">
+            <a href="https://github.com/seeker71/Coherence-Network" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">GitHub</a>
+            <a href="https://www.npmjs.com/package/coherence-cli" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Command line tool</a>
+            <a href="https://www.npmjs.com/package/coherence-mcp-server" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">AI assistant integration</a>
+            <a href="https://api.coherencycoin.com/docs" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">Developer documentation</a>
+            <a href="https://clawhub.ai/skills/coherence-network" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">OpenClaw Skill</a>
+          </div>
+        </details>
         <p className="text-xs text-foreground/85 leading-relaxed">
           Ideas into realization — through attention, curiosity, and collaboration.
         </p>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.2.1",
         "@types/node": "^25",
         "@types/react": "^19",
@@ -1238,6 +1239,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -5819,6 +5836,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
@@ -21,12 +24,13 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^10",
     "eslint-config-next": "^16.2.1",
-    "@tailwindcss/postcss": "^4.2.1",
     "postcss": "^8",
     "tailwindcss": "^4.2.1",
     "typescript": "^5",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30000,
+  expect: { timeout: 10000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : 4,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://coherencycoin.com',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/web/tests/e2e/content-rendering.spec.ts
+++ b/web/tests/e2e/content-rendering.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// Use domcontentloaded (not 'load') because pages stream resources and fonts
+// that keep 'load' pending beyond the test timeout while the DOM is ready.
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' as const, timeout: 60_000 };
+
+// Extra headroom for pages that are slow under parallel test load.
+test.describe.configure({ timeout: 90_000 });
+
+test('home page shows navigation', async ({ page }) => {
+  await page.goto('/', GOTO_OPTS);
+  const links = await page.locator('a[href^="/"]').count();
+  expect(links).toBeGreaterThan(3);
+});
+
+test('ideas page lists ideas or shows empty state', async ({ page }) => {
+  await page.goto('/ideas', GOTO_OPTS);
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText.length).toBeGreaterThan(100);
+});
+
+test('vitality page shows score', async ({ page }) => {
+  await page.goto('/vitality', GOTO_OPTS);
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText).toMatch(/vitality|health|diversity|resonance|flow/i);
+});
+
+test('discover page shows resonance content', async ({ page }) => {
+  await page.goto('/discover', GOTO_OPTS);
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText).toMatch(/resonan|discover|idea/i);
+});
+
+test('constellation page has visualization elements', async ({ page }) => {
+  await page.goto('/constellation', GOTO_OPTS);
+  const visualElements = await page.locator('svg, [style*="position: absolute"]').count();
+  expect(visualElements).toBeGreaterThan(0);
+});
+
+test('breath page shows gas/water/ice', async ({ page }) => {
+  await page.goto('/breath', GOTO_OPTS);
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText).toMatch(/gas|water|ice|breath/i);
+});
+
+test('cc page shows coherence credit info', async ({ page }) => {
+  await page.goto('/cc', GOTO_OPTS);
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText).toMatch(/cc|coherence credit|supply|minted/i);
+});

--- a/web/tests/e2e/links.spec.ts
+++ b/web/tests/e2e/links.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+const PAGES_TO_CHECK = [
+  '/',
+  '/ideas',
+  '/specs',
+  '/contributors',
+  '/teams',
+  '/discover',
+  '/vitality',
+  '/governance',
+  '/cc',
+];
+
+// Allow generous time: each page may link to 20+ routes and the app is SSR,
+// so each request can take several seconds to stream the full body.
+test.describe.configure({ timeout: 300_000 });
+
+// Limit how many link checks run in parallel so the SSR server isn't swamped.
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+type CheckResult = { link: string; status: number; error: string | null };
+
+for (const path of PAGES_TO_CHECK) {
+  test(`${path} - all internal links resolve`, async ({ page, request }) => {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    const hrefs = await page.locator('a[href]').evaluateAll((els) =>
+      els.map((el) => (el as HTMLAnchorElement).getAttribute('href') || '')
+    );
+
+    const internalLinks = new Set<string>();
+    for (const href of hrefs) {
+      if (!href) continue;
+      if (href.startsWith('http://') || href.startsWith('https://')) continue;
+      if (href.startsWith('#') || href.startsWith('mailto:')) continue;
+      if (href.startsWith('javascript:') || href.startsWith('tel:')) continue;
+      if (href.startsWith('data:')) continue;
+      const clean = href.split('#')[0].split('?')[0];
+      if (!clean) continue;
+      if (!clean.startsWith('/')) continue;
+      internalLinks.add(clean);
+    }
+
+    const links = Array.from(internalLinks);
+
+    // Try HEAD first (fast, no body); fall back to GET if HEAD is unsupported
+    // or returns an unexpected status. SSR apps sometimes only answer GET.
+    const check = async (link: string): Promise<CheckResult> => {
+      try {
+        const head = await request.fetch(link, {
+          method: 'HEAD',
+          timeout: 20_000,
+        });
+        if (head.status() < 400) {
+          return { link, status: head.status(), error: null };
+        }
+        // HEAD said error — try GET as a fallback (some frameworks 405 on HEAD)
+        if (head.status() === 405 || head.status() === 501) {
+          const get = await request.get(link, { timeout: 30_000 });
+          return { link, status: get.status(), error: null };
+        }
+        return { link, status: head.status(), error: null };
+      } catch (e) {
+        // On network error, retry once with GET
+        try {
+          const get = await request.get(link, { timeout: 30_000 });
+          return { link, status: get.status(), error: null };
+        } catch (e2) {
+          return { link, status: 0, error: String(e2) };
+        }
+      }
+    };
+
+    const results = await mapLimit(links, 3, check);
+
+    // Rate-limit responses (429) mean the server is alive and protecting
+    // itself under our test burst, not that the link is broken. Only treat
+    // true 4xx (excluding 429) and 5xx as broken.
+    const isBroken = (r: CheckResult) => {
+      if (r.error) return true;
+      if (r.status === 429) return false;
+      return r.status >= 400;
+    };
+
+    const broken = results
+      .filter(isBroken)
+      .map((r) => `${r.link} -> ${r.error ?? r.status}`);
+
+    expect(
+      broken,
+      `Broken links on ${path} (${links.length} checked):\n  ${broken.join('\n  ')}`
+    ).toHaveLength(0);
+  });
+}

--- a/web/tests/e2e/non-technical-audit.spec.ts
+++ b/web/tests/e2e/non-technical-audit.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+// Terms that non-technical users won't understand without explanation
+const TECHNICAL_JARGON = [
+  'api', 'endpoint', 'payload', 'schema', 'http', 'json', 'sdk',
+  'oauth', 'uuid', 'mcp', 'stdio', 'sse', 'cdn', 'ssr',
+  'sqlite', 'postgres', 'neo4j', 'graphql',
+  'idempotency', 'deduplication', 'fingerprint', 'hash',
+  'gini coefficient', 'jaccard', 'cosine similarity', 'shannon entropy',
+  'harmonic kernel', 'optimal transport', 'crk', 'ot-phi',
+  'proprioception',
+];
+
+const PUBLIC_PAGES = [
+  { path: '/', name: 'Home' },
+  { path: '/ideas', name: 'Ideas' },
+  { path: '/discover', name: 'Discover' },
+  { path: '/vitality', name: 'Vitality' },
+  { path: '/teams', name: 'Teams' },
+  { path: '/contribute', name: 'Contribute' },
+];
+
+// Pages may be slow under parallel test load — give them extra headroom.
+test.describe.configure({ timeout: 90_000 });
+
+for (const { path, name } of PUBLIC_PAGES) {
+  test(`${name} - jargon audit`, async ({ page }) => {
+    await page.goto(path, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    const text = (await page.locator('body').innerText()).toLowerCase();
+
+    const foundJargon: string[] = [];
+    for (const term of TECHNICAL_JARGON) {
+      const regex = new RegExp(`\\b${term}\\b`, 'i');
+      if (regex.test(text)) {
+        foundJargon.push(term);
+      }
+    }
+
+    if (foundJargon.length > 0) {
+      console.warn(`[jargon] ${path}: ${foundJargon.join(', ')}`);
+    }
+
+    expect(
+      foundJargon.length,
+      `${path} has too much jargon for non-technical users: ${foundJargon.join(', ')}`
+    ).toBeLessThanOrEqual(5);
+  });
+}

--- a/web/tests/e2e/page-loads.spec.ts
+++ b/web/tests/e2e/page-loads.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const PAGES = [
+  { path: '/', name: 'Home' },
+  { path: '/ideas', name: 'Ideas' },
+  { path: '/specs', name: 'Specs' },
+  { path: '/tasks', name: 'Tasks' },
+  { path: '/contributors', name: 'Contributors' },
+  { path: '/concepts', name: 'Concepts' },
+  { path: '/teams', name: 'Teams' },
+  { path: '/messages', name: 'Messages' },
+  { path: '/activity', name: 'Activity' },
+  { path: '/projects', name: 'Projects' },
+  { path: '/discover', name: 'Discover' },
+  { path: '/constellation', name: 'Constellation' },
+  { path: '/vitality', name: 'Vitality' },
+  { path: '/governance', name: 'Governance' },
+  { path: '/news', name: 'News' },
+  { path: '/federation', name: 'Federation' },
+  { path: '/beliefs', name: 'Beliefs' },
+  { path: '/peers', name: 'Peers' },
+  { path: '/coherence', name: 'Coherence' },
+  { path: '/cc', name: 'CC Economics' },
+  { path: '/breath', name: 'Breath' },
+  { path: '/identity', name: 'Identity' },
+  { path: '/contribute', name: 'Contribute' },
+  { path: '/dashboard', name: 'Dashboard' },
+  { path: '/resonance', name: 'Resonance' },
+  { path: '/pipeline', name: 'Pipeline' },
+];
+
+// Extra headroom for pages that are slow under parallel test load.
+test.describe.configure({ timeout: 90_000 });
+
+for (const { path, name } of PAGES) {
+  test(`${name} page loads`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    const response = await page.goto(path, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+    expect(response?.status(), `HTTP status for ${path}`).toBeLessThan(400);
+
+    // Wait for body to have content
+    await expect(page.locator('body')).not.toBeEmpty();
+
+    // No JavaScript errors
+    expect(errors, `JS errors on ${path}: ${errors.join(', ')}`).toHaveLength(0);
+
+    // Page has a title
+    const title = await page.title();
+    expect(title.length, `Empty title on ${path}`).toBeGreaterThan(0);
+  });
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["tests/e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
Comprehensive Playwright test suite covering all web pages, plus fixes for bugs the tests found.

### Tests (47 total)
- **Page loads (26)**: every page returns 2xx, renders body, has title, zero JS errors
- **Link crawls (9)**: every internal link resolves (HEAD+GET fallback)
- **Content rendering (7)**: key sections visible on home, ideas, vitality, discover, constellation, breath, cc
- **Jargon audit (6)**: flag technical terms on public pages

### Bugs Found and Fixed

**1. /specs page: 50+ broken links (HIGH)**
The inventory service was splitting spec stems on `-` and taking only the first word (`ideas-prioritization` → `ideas`). Broken links: `/api/spec-registry/agent`, `/api/spec-registry/knowledge`, etc. Also returned `INDEX.md` and `TEMPLATE.md` as spec items.

Root cause: legacy numbered-prefix handling in `_discover_specs_local()` and `_discover_specs_from_github()`.

Fix: use full stem as spec_id, skip INDEX/TEMPLATE.

**2. Jargon on home + contribute (MEDIUM)**
Home page exposed "MCP Server", "API Docs" to all visitors. Contribute page had a "Machine API" section.

Fix: collapsed both into "For developers" disclosures with plain-English labels ("Command line tool", "AI assistant integration", "Developer documentation").

### How to run
```bash
cd web
PLAYWRIGHT_BASE_URL=https://coherencycoin.com npx playwright test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)