### PR TITLE
ship: portfolio-summary, auto-tag-all, smart-reap fix, dev quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,10 @@ __pycache__/
 .task-*
 data/coherence.db
 .codex*
+
+# Runtime artifacts that pollute worktrees (don't commit)
+api/data/*.db
+**/tsconfig.tsbuildinfo
+test-results/
+web/test-results/
+.claude/plans/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 # Coherence Network — common targets
 
-.PHONY: test run setup lint web-worktree-validate spec-quality pr-preflight start-gate prompt-gate install-pre-push-hook
+.PHONY: test test-quick run setup dev-setup lint seed web-dev api-dev build web-worktree-validate spec-quality pr-preflight start-gate prompt-gate install-pre-push-hook
 
 test:
 	cd api && .venv/bin/pytest -v
+
+test-quick:
+	cd api && .venv/bin/pytest -x -q
 
 run:
 	cd api && uvicorn app.main:app --reload --port 8000
@@ -11,8 +14,23 @@ run:
 setup:
 	cd api && python -m venv .venv && .venv/bin/pip install -e ".[dev]"
 
+dev-setup: setup
+	cd web && npm install
+
 lint:
 	cd api && .venv/bin/ruff check . 2>/dev/null || true
+
+seed:
+	api/.venv/bin/python scripts/seed_db.py
+
+api-dev:
+	cd api && .venv/bin/uvicorn app.main:app --reload --port 8000
+
+web-dev:
+	cd web && npm run dev
+
+build:
+	cd web && npm run build
 
 web-worktree-validate:
 	THREAD_RUNTIME_AUTO_HEAL=1 ./scripts/verify_worktree_local_web.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Idea → Research → Spec → Implementation → Review → Usage → Payout
 
 Every stage is scored for **coherence** (0.0–1.0) — measuring test coverage, documentation quality, and implementation simplicity. Contributors are paid proportionally to the energy they invested and the coherence they achieved.
 
+## Quickstart (< 15 minutes)
+
+```bash
+git clone https://github.com/seeker71/Coherence-Network.git
+cd Coherence-Network
+make dev-setup        # api venv + web npm install
+make test             # ~8s flow-centric suite
+make api-dev          # http://localhost:8000
+make web-dev          # http://localhost:3000
+```
+
 ## Your first 5 minutes
 
 **Option A — no install, just browse:**

--- a/README.template.md
+++ b/README.template.md
@@ -6,6 +6,17 @@ An open intelligence platform that traces every idea from inception to payout â€
 
 <!-- include: docs/shared/lifecycle-diagram.md -->
 
+## Quickstart (< 15 minutes)
+
+```bash
+git clone https://github.com/seeker71/Coherence-Network.git
+cd Coherence-Network
+make dev-setup        # api venv + web npm install
+make test             # ~8s flow-centric suite
+make api-dev          # http://localhost:8000
+make web-dev          # http://localhost:3000
+```
+
 ## Your first 5 minutes
 
 **Option A â€” no install, just browse:**

--- a/api/app/routers/agent_smart_reap_routes.py
+++ b/api/app/routers/agent_smart_reap_routes.py
@@ -212,7 +212,7 @@ def _run_smart_reap(
 
 @router.get("/smart-reap/preview")
 async def smart_reap_preview(
-    max_age_minutes: int | None = Query(None, ge=1, le=1440),
+    max_age_minutes: int | None = Query(None, ge=0, le=1440),
 ) -> dict:
     """Preview which stuck tasks would be reaped or extended — no state changes."""
     return _run_smart_reap(max_age_minutes=max_age_minutes, dry_run=True)
@@ -220,7 +220,7 @@ async def smart_reap_preview(
 
 @router.post("/smart-reap/run")
 async def smart_reap_run(
-    max_age_minutes: int | None = Query(None, ge=1, le=1440),
+    max_age_minutes: int | None = Query(None, ge=0, le=1440),
 ) -> dict:
     """Diagnose stuck running tasks and reap or extend them.
 

--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 from typing import Any
 
-from app.services import concept_service, translate_service
+from app.services import concept_auto_tagger, concept_service, translate_service
 from app.services.translate_service import TranslateLens
 
 router = APIRouter()
@@ -100,6 +100,16 @@ async def search_concepts(
 async def concept_stats():
     """Get ontology statistics: concept count, relationship types, axes, user edges."""
     return concept_service.get_stats()
+
+
+@router.post("/concepts/auto-tag-all")
+async def auto_tag_all_ideas() -> dict[str, Any]:
+    """Run concept auto-tagging on every non-internal idea in the portfolio.
+
+    Matches each idea's name + description against the Living Codex concepts
+    via keyword overlap scoring and tags each idea with its top matches.
+    """
+    return concept_auto_tagger.tag_all_ideas()
 
 
 @router.get("/concepts/relationships")

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -330,6 +330,12 @@ async def get_progress_dashboard() -> ProgressDashboard:
     return idea_service.compute_progress_dashboard()
 
 
+@router.get("/ideas/portfolio-summary")
+async def get_portfolio_summary() -> dict:
+    """Summary of curated super-ideas with spec counts, pillar grouping, and red/yellow/green health."""
+    return idea_service.get_portfolio_summary()
+
+
 @router.post("/ideas/{idea_id}/advance", response_model=IdeaWithScore)
 async def advance_idea_stage(idea_id: str, _key: str = Depends(require_api_key)) -> IdeaWithScore:
     """Advance an idea to the next sequential stage (spec 138)."""

--- a/api/app/services/concept_auto_tagger.py
+++ b/api/app/services/concept_auto_tagger.py
@@ -1,0 +1,192 @@
+"""Concept auto-tagger -- matches ideas against the Living Codex ontology.
+
+Extracts keywords from idea name + description, scores them against all
+184 concepts (name, description, keywords), and tags each idea with the
+top-scoring concepts.  No external models -- pure keyword overlap.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from app.services import concept_service, idea_service
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stopword set (mirrors concept_service._extract_keywords)
+# ---------------------------------------------------------------------------
+
+_STOPWORDS: set[str] = {
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "up", "about", "into", "through", "is",
+    "are", "was", "were", "be", "been", "being", "have", "has", "had",
+    "do", "does", "did", "will", "would", "could", "should", "may", "might",
+    "can", "that", "this", "it", "its", "they", "their", "we", "our", "you",
+    "your", "i", "my", "he", "she", "his", "her", "which", "who", "what",
+    "when", "where", "how", "not", "no", "so", "as", "if", "then",
+}
+
+# Minimum score to count as a match (0.0-1.0)
+_MIN_SCORE = 0.05
+
+# Maximum concepts to tag per idea
+_MAX_TAGS = 5
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _extract_keywords(text: str) -> list[str]:
+    """Extract meaningful keywords from text (stopword-free, deduplicated)."""
+    words = re.findall(r"\b[a-zA-Z]{3,}\b", text.lower())
+    seen: set[str] = set()
+    keywords: list[str] = []
+    for w in words:
+        if w not in _STOPWORDS and w not in seen:
+            seen.add(w)
+            keywords.append(w)
+    return keywords
+
+
+def _score_concept(concept: dict[str, Any], keywords: list[str]) -> float:
+    """Score how well a concept matches a bag of keywords (0.0-1.0).
+
+    Uses bidirectional matching:
+    - Forward: fraction of idea keywords found in concept text
+    - Reverse: fraction of concept keywords found in idea text
+    The final score is the weighted combination, biased toward forward.
+    """
+    if not keywords:
+        return 0.0
+
+    concept_text = " ".join([
+        concept.get("name", ""),
+        concept.get("description", ""),
+        " ".join(concept.get("keywords", [])),
+    ]).lower()
+
+    idea_text = " ".join(keywords)
+
+    # Forward: how many idea keywords appear in concept text
+    forward_hits = sum(1 for kw in keywords if kw in concept_text)
+    forward_score = forward_hits / len(keywords) if keywords else 0.0
+
+    # Reverse: how many concept keywords appear in idea text
+    concept_kws = concept.get("keywords", [])
+    if concept_kws:
+        reverse_hits = sum(1 for ckw in concept_kws if ckw.lower() in idea_text)
+        reverse_score = reverse_hits / len(concept_kws)
+    else:
+        reverse_score = 0.0
+
+    # Exact name match bonus
+    name_lower = concept.get("name", "").lower()
+    name_bonus = 0.3 if name_lower in idea_text else 0.0
+
+    score = (0.5 * forward_score) + (0.3 * reverse_score) + name_bonus
+    return round(min(score, 1.0), 4)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def match_concepts(
+    idea_name: str,
+    idea_description: str,
+    max_results: int = _MAX_TAGS,
+) -> list[dict[str, Any]]:
+    """Return top matching concepts for the given idea text.
+
+    Each result dict: {"concept_id": str, "concept_name": str, "score": float}
+    """
+    text = f"{idea_name} {idea_description}"
+    keywords = _extract_keywords(text)
+    if not keywords:
+        return []
+
+    all_concepts = concept_service.list_concepts(limit=9999, offset=0).get("items", [])
+
+    scored: list[tuple[float, dict[str, Any]]] = []
+    for c in all_concepts:
+        score = _score_concept(c, keywords)
+        if score >= _MIN_SCORE:
+            scored.append((score, c))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    results: list[dict[str, Any]] = []
+    for score, c in scored[:max_results]:
+        results.append({
+            "concept_id": c["id"],
+            "concept_name": c.get("name", c["id"]),
+            "score": score,
+        })
+    return results
+
+
+def tag_idea(
+    idea_id: str,
+    idea_name: str,
+    idea_description: str,
+) -> dict[str, Any]:
+    """Match concepts for an idea and create concept-idea tags.
+
+    Returns summary with idea_id, matched concepts, and count.
+    """
+    matches = match_concepts(idea_name, idea_description)
+    if not matches:
+        return {
+            "idea_id": idea_id,
+            "concepts_tagged": [],
+            "count": 0,
+        }
+
+    concept_ids = [m["concept_id"] for m in matches]
+    concept_service.tag_entity(
+        entity_type="idea",
+        entity_id=idea_id,
+        concept_ids=concept_ids,
+    )
+
+    log.info("Auto-tagged idea %s with %d concepts: %s", idea_id, len(concept_ids), concept_ids)
+    return {
+        "idea_id": idea_id,
+        "concepts_tagged": matches,
+        "count": len(matches),
+    }
+
+
+def tag_all_ideas() -> dict[str, Any]:
+    """Iterate all ideas in the portfolio and auto-tag each one.
+
+    Returns aggregate stats: total ideas processed, total tags created,
+    and per-idea results.
+    """
+    portfolio = idea_service.list_ideas(limit=9999, include_internal=False)
+    ideas = portfolio.ideas
+
+    total_tagged = 0
+    results: list[dict[str, Any]] = []
+
+    for idea in ideas:
+        result = tag_idea(
+            idea_id=idea.id,
+            idea_name=idea.name,
+            idea_description=idea.description,
+        )
+        if result["count"] > 0:
+            total_tagged += 1
+            results.append(result)
+
+    log.info("Auto-tag-all complete: %d/%d ideas tagged", total_tagged, len(ideas))
+    return {
+        "ideas_processed": len(ideas),
+        "ideas_tagged": total_tagged,
+        "total_concept_links": sum(r["count"] for r in results),
+        "results": results,
+    }

--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -2310,6 +2310,92 @@ def get_idea_activity(idea_id: str, limit: int = 20) -> list[dict]:
     return events[:max(1, limit)]
 
 
+def get_portfolio_summary() -> dict:
+    """Return a summary of curated super-ideas grouped by pillar with health status.
+
+    Health logic:
+      - "red":    no specs linked at all
+      - "green":  has specs AND (actual_value > 0 OR activity within 30 days OR any active spec)
+      - "yellow": has specs but all done, no recorded value, no recent activity
+    """
+    from datetime import datetime, timedelta, timezone
+
+    ideas = _read_ideas(persist_ensures=False)
+    curated = [i for i in ideas if i.is_curated]
+
+    # Pre-fetch all specs once to avoid N+1
+    all_specs = spec_registry_service.list_specs(limit=1000, offset=0)
+    specs_by_idea: dict[str, list] = {}
+    for spec in all_specs:
+        if spec.idea_id:
+            specs_by_idea.setdefault(spec.idea_id, []).append(spec)
+
+    children_by_parent: dict[str, int] = {}
+    for idea in ideas:
+        if idea.parent_idea_id:
+            children_by_parent[idea.parent_idea_id] = children_by_parent.get(idea.parent_idea_id, 0) + 1
+
+    recent_threshold = datetime.now(timezone.utc) - timedelta(days=30)
+    items: list[dict] = []
+    pillar_stats: dict[str, dict] = {}
+
+    for idea in curated:
+        idea_specs = specs_by_idea.get(idea.id, [])
+        spec_count = len(idea_specs)
+        done_spec_count = sum(1 for s in idea_specs if s.actual_value > 0)
+        active_spec_count = spec_count - done_spec_count
+        child_count = children_by_parent.get(idea.id, 0)
+
+        if spec_count == 0:
+            health = "red"
+        else:
+            has_value = idea.actual_value > 0
+            has_recent_activity = False
+            if idea.last_activity_at:
+                try:
+                    activity_dt = datetime.fromisoformat(idea.last_activity_at.replace("Z", "+00:00"))
+                    has_recent_activity = activity_dt > recent_threshold
+                except (ValueError, TypeError):
+                    pass
+            health = "green" if (has_value or has_recent_activity or active_spec_count > 0) else "yellow"
+
+        pillar = idea.pillar or "unknown"
+        items.append({
+            "idea_id": idea.id,
+            "name": idea.name,
+            "stage": idea.stage.value if idea.stage else "none",
+            "pillar": pillar,
+            "spec_count": spec_count,
+            "done_spec_count": done_spec_count,
+            "active_spec_count": active_spec_count,
+            "child_idea_count": child_count,
+            "health_status": health,
+        })
+
+        stats = pillar_stats.setdefault(pillar, {
+            "pillar": pillar,
+            "idea_count": 0,
+            "total_specs": 0,
+            "done_specs": 0,
+            "active_specs": 0,
+        })
+        stats["idea_count"] += 1
+        stats["total_specs"] += spec_count
+        stats["done_specs"] += done_spec_count
+        stats["active_specs"] += active_spec_count
+
+    items.sort(key=lambda x: (x["pillar"], x["name"]))
+
+    return {
+        "total_ideas": len(items),
+        "total_specs": sum(e["spec_count"] for e in items),
+        "total_done_specs": sum(e["done_spec_count"] for e in items),
+        "pillars": sorted(pillar_stats.values(), key=lambda p: p["pillar"]),
+        "ideas": items,
+        "snapshot_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def compute_progress_dashboard() -> ProgressDashboard:
     """Compute per-stage idea counts and completion percentage."""
     ideas = _read_ideas(persist_ensures=False)

--- a/api/tests/test_knowledge_resonance.py
+++ b/api/tests/test_knowledge_resonance.py
@@ -196,3 +196,90 @@ async def test_discovery_feed_item_structure():
             assert "entity_id" in item
             assert isinstance(item["score"], (int, float))
             assert 0.0 <= item["score"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# 6. POST /api/concepts/auto-tag-all maps ideas to ontology concepts
+# ---------------------------------------------------------------------------
+
+
+async def _create_concept(c: AsyncClient, concept_id: str, name: str, keywords: list[str]) -> None:
+    """Create a concept via the public API."""
+    r = await c.post("/api/concepts", json={
+        "id": concept_id,
+        "name": name,
+        "description": f"Concept {name} about {' '.join(keywords)}",
+        "type_id": "codex.ucore.user",
+        "level": 0,
+        "keywords": keywords,
+    })
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_match_concepts_returns_top_matches():
+    """match_concepts ranks concepts by keyword overlap."""
+    from app.services import concept_auto_tagger
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _create_concept(c, _uid("c-resonance"), "Resonance Engine", ["resonance", "coherence", "ontology"])
+        await _create_concept(c, _uid("c-payments"), "Payment Gateway", ["payment", "billing", "stripe"])
+
+    matches = concept_auto_tagger.match_concepts(
+        idea_name="Resonance discovery",
+        idea_description="Build a resonance-driven coherence engine for the ontology layer.",
+        max_results=5,
+    )
+    assert isinstance(matches, list)
+    assert len(matches) >= 1
+    # The resonance concept should rank above the payments concept (and the payments concept may not appear at all).
+    names = [m["concept_name"].lower() for m in matches]
+    assert any("resonance" in n for n in names), f"resonance concept missing from matches: {names}"
+    for m in matches:
+        assert "concept_id" in m
+        assert "score" in m
+        assert 0.0 <= m["score"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_auto_tag_all_endpoint_returns_aggregate_stats():
+    """POST /api/concepts/auto-tag-all returns processed/tagged counts and per-idea results."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _create_concept(c, _uid("c-software"), "Software Engineering", ["software", "engineering", "code"])
+        await _create_idea(c)
+        await _create_idea(c)
+
+        r = await c.post("/api/concepts/auto-tag-all")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        for key in ("ideas_processed", "ideas_tagged", "total_concept_links", "results"):
+            assert key in body, f"missing key: {key}"
+        assert isinstance(body["ideas_processed"], int)
+        assert isinstance(body["ideas_tagged"], int)
+        assert body["ideas_processed"] >= 2
+        assert body["ideas_tagged"] >= 0
+        assert body["total_concept_links"] >= 0
+        assert isinstance(body["results"], list)
+
+
+@pytest.mark.asyncio
+async def test_auto_tag_all_results_have_per_idea_breakdown():
+    """Each entry in `results` exposes the idea_id and the concepts attached to it."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _create_concept(c, _uid("c-onto"), "Ontology Layer", ["ontology", "resonance", "software"])
+        await _create_idea(c)
+
+        r = await c.post("/api/concepts/auto-tag-all")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        for entry in body["results"]:
+            assert "idea_id" in entry
+            assert "concepts_tagged" in entry
+            assert "count" in entry
+            assert isinstance(entry["concepts_tagged"], list)
+            assert entry["count"] == len(entry["concepts_tagged"])
+            for tag in entry["concepts_tagged"]:
+                assert "concept_id" in tag
+                assert "concept_name" in tag
+                assert "score" in tag
+                assert 0.0 <= tag["score"] <= 1.0

--- a/api/tests/test_portfolio_governance.py
+++ b/api/tests/test_portfolio_governance.py
@@ -173,3 +173,152 @@ async def test_stake_creates_position():
         assert data["idea_id"] == idea_id
         assert data["amount_cc"] == 500.0
         assert data["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# 6. GET /api/ideas/portfolio-summary returns curated super-idea rollup
+# ---------------------------------------------------------------------------
+
+
+def _seed_curated_idea(
+    *,
+    idea_id: str,
+    pillar: str,
+    actual_value: float = 0.0,
+    last_activity_at: str | None = None,
+) -> None:
+    """Seed a curated super-idea node directly via graph_service.
+
+    The public POST /api/ideas does not expose is_curated, so curated fixtures
+    must be created at the graph layer.
+    """
+    from app.services import graph_service, unified_db
+    unified_db.ensure_schema()
+    graph_service.create_node(
+        id=idea_id,
+        type="idea",
+        name=f"Curated {idea_id}",
+        description=f"Curated super-idea {idea_id} for portfolio summary tests",
+        phase="gas",
+        properties={
+            "potential_value": 100.0,
+            "estimated_cost": 10.0,
+            "actual_value": actual_value,
+            "actual_cost": 0.5,
+            "confidence": 0.8,
+            "manifestation_status": "none",
+            "stage": "active",
+            "idea_type": "standalone",
+            "interfaces": [],
+            "open_questions": [],
+            "is_curated": True,
+            "pillar": pillar,
+            "last_activity_at": last_activity_at,
+        },
+    )
+
+
+def _seed_spec_for_idea(spec_id: str, idea_id: str, *, actual_value: float = 0.0) -> None:
+    """Seed a spec node linked to the given idea via idea_id property."""
+    from app.services import graph_service
+    graph_service.create_node(
+        id=spec_id,
+        type="spec",
+        name=spec_id,
+        description=f"Spec {spec_id} for idea {idea_id}",
+        phase="gas",
+        properties={
+            "idea_id": idea_id,
+            "actual_value": actual_value,
+            "potential_value": 50.0,
+            "estimated_cost": 5.0,
+            "status": "done" if actual_value > 0 else "active",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_returns_envelope():
+    """Endpoint returns the canonical envelope shape even when no curated ideas exist."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/ideas/portfolio-summary")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        for key in ("total_ideas", "total_specs", "total_done_specs", "pillars", "ideas", "snapshot_at"):
+            assert key in body, f"missing key: {key}"
+        assert isinstance(body["pillars"], list)
+        assert isinstance(body["ideas"], list)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_red_when_no_specs_linked():
+    """A curated idea with no linked specs reports health=red."""
+    iid = _uid("curated-red")
+    _seed_curated_idea(idea_id=iid, pillar="realization")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/ideas/portfolio-summary")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        match = next((i for i in body["ideas"] if i["idea_id"] == iid), None)
+        assert match is not None, f"seeded idea {iid} not in summary"
+        assert match["pillar"] == "realization"
+        assert match["spec_count"] == 0
+        assert match["health_status"] == "red"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_green_when_active_specs_present():
+    """A curated idea with at least one undelivered spec reports health=green."""
+    iid = _uid("curated-green")
+    _seed_curated_idea(idea_id=iid, pillar="pipeline")
+    _seed_spec_for_idea(_uid("spec-active"), iid, actual_value=0.0)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/ideas/portfolio-summary")
+        body = r.json()
+        match = next((i for i in body["ideas"] if i["idea_id"] == iid), None)
+        assert match is not None
+        assert match["spec_count"] == 1
+        assert match["active_spec_count"] == 1
+        assert match["done_spec_count"] == 0
+        assert match["health_status"] == "green"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_yellow_when_all_specs_done_no_value():
+    """A curated idea whose specs are all delivered but with no recorded value or recent activity is yellow."""
+    iid = _uid("curated-yellow")
+    _seed_curated_idea(idea_id=iid, pillar="economics", actual_value=0.0, last_activity_at=None)
+    _seed_spec_for_idea(_uid("spec-done"), iid, actual_value=42.0)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/ideas/portfolio-summary")
+        body = r.json()
+        match = next((i for i in body["ideas"] if i["idea_id"] == iid), None)
+        assert match is not None
+        assert match["done_spec_count"] == 1
+        assert match["active_spec_count"] == 0
+        assert match["health_status"] == "yellow"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_summary_pillar_grouping_aggregates():
+    """Per-pillar stats correctly aggregate spec counts across multiple curated ideas."""
+    iid_a = _uid("curated-pillar-a")
+    iid_b = _uid("curated-pillar-b")
+    _seed_curated_idea(idea_id=iid_a, pillar="surfaces")
+    _seed_curated_idea(idea_id=iid_b, pillar="surfaces")
+    _seed_spec_for_idea(_uid("spec-a1"), iid_a, actual_value=0.0)
+    _seed_spec_for_idea(_uid("spec-b1"), iid_b, actual_value=10.0)
+    _seed_spec_for_idea(_uid("spec-b2"), iid_b, actual_value=0.0)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/ideas/portfolio-summary")
+        body = r.json()
+        surfaces = next((p for p in body["pillars"] if p["pillar"] == "surfaces"), None)
+        assert surfaces is not None, "surfaces pillar missing from rollup"
+        assert surfaces["idea_count"] >= 2
+        assert surfaces["total_specs"] >= 3
+        assert surfaces["done_specs"] >= 1
+        assert surfaces["active_specs"] >= 2


### PR DESCRIPTION
## Summary

Consolidated ship of work salvaged from three sibling worktrees (`festive-tu`, `wizardly-hopper`, `lucid-pascal`) plus a `.gitignore` cleanup. Each commit is independently revertable.

- **`fix(smart-reap)`** — `max_age_minutes` lower bound relaxed from `ge=1` to `ge=0` on `/smart-reap/preview` and `/smart-reap/run`. Lets callers force an immediate sweep.
- **`feat(ideas,concepts)`** — Two new endpoints with full test coverage:
  - `GET /api/ideas/portfolio-summary` — curated super-idea rollup with spec counts, child counts, pillar grouping, and red/yellow/green health logic.
  - `POST /api/concepts/auto-tag-all` — iterates the public idea portfolio and tags each idea with up to 5 Living Codex concepts via bidirectional keyword overlap (no external models).
- **`docs/make`** — README Quickstart (< 15 minutes) and new Makefile targets (`dev-setup`, `test-quick`, `seed`, `api-dev`, `web-dev`, `build`) that satisfy the open `developer-quick-start` spec without disturbing the existing `test`/`setup`/`lint` targets.
- **`chore: gitignore`** — adds `api/data/*.db`, `**/tsconfig.tsbuildinfo`, `test-results/`, `web/test-results/`, `.claude/plans/` so worktrees stop showing dirty after test runs.

## What was deliberately dropped

- 6 modified + 9 new numbered spec files from `wizardly-hopper` — main has normalized to slug-only spec filenames (commit `4ced5384`); the numbered versions would create duplicates. At least spec 201 was a literal duplicate of the existing `developer-quick-start.md`.
- `wizardly-hopper`'s `Makefile` regression that swapped `.venv/bin/pytest` for `python3 -m pytest` and `ruff` for `flake8` — only the additive new targets are kept.
- `ULTRAPLAN.md` and `scripts/cleanup_specs.py` from `wizardly-hopper` — local planning + one-shot migration already superseded on main.
- `config/news-sources.json` test fixture pollution from `festive-tu`.
- `lucid-pascal`'s 385-line `scripts/agent_status.py` rewrite — represents a real upgrade over main's 131-line version but needs its own follow-up PR (would conflict with the tracked file otherwise).
- `.claude/plans/` session artifacts.

## Test plan

- [x] `pytest tests/test_portfolio_governance.py` — 5 new portfolio-summary cases pass (envelope shape, red/green/yellow health, pillar aggregation)
- [x] `pytest tests/test_knowledge_resonance.py` — 3 new auto-tag-all cases pass (match ranking, aggregate envelope, per-idea breakdown)
- [x] `pytest tests/test_flow_core_api.py` — baseline 50 tests still pass
- [x] Full suite excluding env-broken-in-worktree files: 436 passed
- [x] Smoke test of `/api/ideas/portfolio-summary` against fresh test DB returns 200 with the canonical envelope shape
- [ ] After deploy: `curl https://api.coherencycoin.com/api/ideas/portfolio-summary` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)