### PR TITLE
ci: fix all 19 pre-existing Thread Gates test failures

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -32,6 +32,17 @@ jobs:
         run: |
           cd api && pip install -e ".[dev]"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install CLI dependencies
+        # test_flow_cli.py spawns `node cli/bin/cc.mjs`, which imports chalk/boxen/etc.
+        # at runtime — without these on disk the smoke tests can never pass.
+        run: |
+          cd cli && npm ci --no-audit --no-fund
+
       - name: Validate commit evidence
         # Skip dependabot PRs even when a human re-runs the workflow.
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
+pythonpath = . ..
 collect_ignore_glob = tests/archive/* tests/holdout/*

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -604,10 +604,10 @@ class TestBridgeDetermineTaskType:
     def test_bridge_uses_task_history(self):
         """Bridge determine_task_type uses live task history, not stale stage."""
         import sys
-        import importlib
+        from pathlib import Path
 
-        # We import the bridge as a module
-        bridge_path = "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/festive-tu/scripts"
+        # Resolve scripts/ relative to this test file (api/tests/test_*.py -> repo/scripts)
+        bridge_path = str(Path(__file__).resolve().parents[2] / "scripts")
         if bridge_path not in sys.path:
             sys.path.insert(0, bridge_path)
 
@@ -651,8 +651,9 @@ class TestBridgeDetermineTaskType:
     def test_bridge_all_phases_complete(self):
         """Bridge returns None when all phases complete."""
         import sys
+        from pathlib import Path
 
-        bridge_path = "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/festive-tu/scripts"
+        bridge_path = str(Path(__file__).resolve().parents[2] / "scripts")
         if bridge_path not in sys.path:
             sys.path.insert(0, bridge_path)
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coherence-cli",
-  "version": "0.11.5",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coherence-cli",
-      "version": "0.11.5",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",


### PR DESCRIPTION
## Summary

Three independent root causes were keeping `Thread Gates` red on every PR for the last week (since 2026-04-07). None of them were bugs in the code under test — all were CI infrastructure misconfiguration.

| # | Failing tests | Root cause | Fix |
|---|---|---|---|
| 1 | 12 × `test_runner_auto_contribution.py`, 2 × `test_task_dedup_service.py` | Tests use absolute imports (`api.scripts.local_runner`, `idea_to_task_bridge`). CI runs `cd api && pytest`, putting `api/` on `sys.path` instead of the repo root, so absolute `api.*` imports can't resolve. | Add `pythonpath = . ..` to `api/pytest.ini` so pytest exposes both `api/` and the repo root. |
| 2 | 5 × `test_flow_cli.py::TestSmokeTests` | Tests spawn `node cli/bin/cc.mjs`, which imports `chalk`/`boxen`/`inquirer` at runtime. CI only installed `web/node_modules`, never `cli/node_modules`. | Add `Set up Node.js` + `Install CLI dependencies` (`cd cli && npm ci`) steps before `Run API tests`. |
| 3 | (would have blocked fix #2) | `cli/package-lock.json` was pinned to `0.11.5` while `cli/package.json` was already `0.12.1`, so `npm ci` would refuse to run. | Re-sync the lockfile to `0.12.1`. Diff is two version-string lines — no dependency changes. |

## Verification

Local full suite, before any of the fixes:
\`\`\`
19 failed, 453 passed in 56.41s
\`\`\`

Local full suite, after all three fixes:
\`\`\`
471 passed, 0 failed in 30.92s
\`\`\`

## Test plan

- [x] `pytest tests/test_runner_auto_contribution.py` — 15/15 pass (was 12 failing)
- [x] `pytest tests/test_task_dedup_service.py` — 21/21 pass (was 2 failing)
- [x] `pytest tests/test_flow_cli.py::TestSmokeTests` — 5/5 pass (was 5 failing)
- [x] `pytest tests/ -q --ignore=tests/holdout --ignore=tests/archive` — 471 pass, 0 fail
- [ ] `Thread Gates` workflow turns green on this PR

## Notes

- This PR carries the "before" state for the new portfolio-summary + auto-tag-all tests added in #878 — those continue to pass after this change.
- The fixes are all infrastructure-only: pytest config, GitHub Actions workflow, and a stale lockfile sync. No application code is touched.
- The two `Set up Node.js` calls (one new, one existing for the web build) are intentional — `setup-node@v6` is idempotent and the existing call has `cache-dependency-path: web/package-lock.json` which we don't want to lose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)