### PR TITLE
fix(news)+feat(scripts): stop tests polluting worktree + agent_status JSON upgrade

### DIFF
--- a/api/app/services/news_ingestion_service.py
+++ b/api/app/services/news_ingestion_service.py
@@ -25,10 +25,17 @@ logger = logging.getLogger(__name__)
 # Source configuration — loaded from config file, editable via API
 # ---------------------------------------------------------------------------
 
-_CONFIG_PATH = Path(os.environ.get(
-    "NEWS_SOURCES_CONFIG",
-    str(Path(__file__).resolve().parent.parent.parent.parent / "config" / "news-sources.json"),
-))
+# Default location of the on-disk source list. Resolved lazily so that tests
+# (and any other consumer that wants isolation) can point NEWS_SOURCES_CONFIG
+# at a temp file at runtime — the previous module-level constant captured the
+# value at import time, so per-test env-var overrides were silently ignored
+# and the in-tree config/news-sources.json got polluted on every test run.
+_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent.parent.parent / "config" / "news-sources.json"
+
+
+def _config_path() -> Path:
+    return Path(os.environ.get("NEWS_SOURCES_CONFIG", str(_DEFAULT_CONFIG_PATH)))
+
 
 _DEFAULT_SOURCES: list[dict] = [
     {"id": "hackernews", "name": "Hacker News", "type": "rss", "url": "https://news.ycombinator.com/rss", "categories": ["technology", "programming"], "is_active": True, "update_interval_minutes": 60, "priority": 1},
@@ -39,22 +46,24 @@ _DEFAULT_SOURCES: list[dict] = [
 
 def _load_sources() -> list[dict]:
     """Load news sources from config file, falling back to defaults."""
-    if _CONFIG_PATH.exists():
+    cfg = _config_path()
+    if cfg.exists():
         try:
-            sources = json.loads(_CONFIG_PATH.read_text())
+            sources = json.loads(cfg.read_text())
             active = [s for s in sources if s.get("is_active", True)]
-            logger.info("Loaded %d news sources (%d active) from %s", len(sources), len(active), _CONFIG_PATH)
+            logger.info("Loaded %d news sources (%d active) from %s", len(sources), len(active), cfg)
             return sources
         except Exception as e:
-            logger.warning("Failed to load %s: %s — using defaults", _CONFIG_PATH, e)
+            logger.warning("Failed to load %s: %s — using defaults", cfg, e)
     return list(_DEFAULT_SOURCES)
 
 
 def _save_sources(sources: list[dict]) -> None:
     """Persist news sources to config file."""
-    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _CONFIG_PATH.write_text(json.dumps(sources, indent=2))
-    logger.info("Saved %d news sources to %s", len(sources), _CONFIG_PATH)
+    cfg = _config_path()
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps(sources, indent=2))
+    logger.info("Saved %d news sources to %s", len(sources), cfg)
 
 
 # Module-level source list — reloaded on mutation

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -231,6 +231,15 @@ def _reset_service_caches_between_tests(tmp_path: Path) -> None:
     # Ideas now live in graph_nodes (unified DB) — don't set file-based portfolio path
     os.environ.pop("IDEA_PORTFOLIO_PATH", None)
     os.environ["AGENT_TASKS_USE_DB"] = "0"
+    # Point news ingestion at a per-test config file. The service used to
+    # cache the path at import time, so this env var was silently ignored
+    # and tests dirtied the in-tree config/news-sources.json.
+    os.environ["NEWS_SOURCES_CONFIG"] = str(tmp_path / "news_sources.json")
+    try:
+        from app.services import news_ingestion_service
+        news_ingestion_service._sources = news_ingestion_service._load_sources()
+    except Exception:
+        pass
 
     # Reset config to its baseline first, then apply per-test overrides to the
     # loaded config so later cache invalidations preserve those defaults.

--- a/scripts/agent_status.py
+++ b/scripts/agent_status.py
@@ -1,131 +1,385 @@
 #!/usr/bin/env python3
-"""Show active worktrees, their branches, and potential conflicts.
+"""Show active work across all coding agents (worktrees + tasks).
 
 Usage:
-    python3 scripts/agent_status.py          # summary view
-    python3 scripts/agent_status.py --diff   # include changed-file overlap detection
+    python3 scripts/agent_status.py          # human-readable output
+    python3 scripts/agent_status.py --json   # machine-readable output
+
+Cross-references git worktrees with running tasks from the API to show:
+- Which worktrees exist and their git state (branch, dirty, ahead/behind)
+- Which tasks are claimed/running and by whom
+- File-level conflict warnings when two worktrees touch the same files
 """
+
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import re
 import subprocess
 import sys
-from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 
-def run(cmd: list[str], cwd: str | None = None) -> str:
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd)
-    return result.stdout.strip()
+API = os.environ.get("COHERENCE_API_URL", "https://api.coherencycoin.com")
 
 
-def get_worktrees(repo_root: str) -> list[dict[str, str]]:
-    raw = run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
-    worktrees: list[dict[str, str]] = []
+# ── Git helpers (reused from worktree_continuity_guard.py patterns) ──
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def _repo_root() -> Path:
+    proc = _run_git(["rev-parse", "--show-toplevel"], Path.cwd())
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "not a git repository")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _parse_worktrees(repo_root: Path) -> list[dict[str, str]]:
+    proc = _run_git(["worktree", "list", "--porcelain"], repo_root)
+    if proc.returncode != 0:
+        return []
+    rows: list[dict[str, str]] = []
     current: dict[str, str] = {}
-    for line in raw.splitlines():
-        if line.startswith("worktree "):
+    for raw in proc.stdout.splitlines():
+        line = raw.strip()
+        if not line:
             if current:
-                worktrees.append(current)
-            current = {"path": line.split(" ", 1)[1]}
-        elif line.startswith("HEAD "):
-            current["head"] = line.split(" ", 1)[1]
-        elif line.startswith("branch "):
-            current["branch"] = line.split(" ", 1)[1].replace("refs/heads/", "")
-        elif line == "detached":
-            current["branch"] = "(detached)"
+                rows.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value.strip()
     if current:
-        worktrees.append(current)
-    return worktrees
+        rows.append(current)
+    return rows
 
 
-def get_changed_files(worktree_path: str) -> list[str]:
-    """Return files changed vs main (staged + unstaged + untracked)."""
-    diff_vs_main = run(
-        ["git", "diff", "--name-only", "main...HEAD"],
-        cwd=worktree_path,
-    )
-    diff_local = run(
-        ["git", "diff", "--name-only"],
-        cwd=worktree_path,
-    )
-    staged = run(
-        ["git", "diff", "--name-only", "--cached"],
-        cwd=worktree_path,
-    )
-    files = set()
-    for output in (diff_vs_main, diff_local, staged):
-        for f in output.splitlines():
-            if f.strip():
-                files.add(f.strip())
-    return sorted(files)
+def _branch_name(wt_path: Path, branch_ref: str) -> str:
+    if branch_ref.startswith("refs/heads/"):
+        return branch_ref.replace("refs/heads/", "", 1)
+    proc = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], wt_path)
+    return proc.stdout.strip() if proc.returncode == 0 else "(detached)"
 
 
-def detect_conflicts(worktrees: list[dict[str, str]]) -> list[str]:
-    """Find files modified in more than one worktree."""
-    file_to_worktrees: dict[str, list[str]] = defaultdict(list)
-    for wt in worktrees:
-        path = wt["path"]
-        branch = wt.get("branch", "?")
-        for f in get_changed_files(path):
-            file_to_worktrees[f].append(branch)
-
-    conflicts = []
-    for filepath, branches in sorted(file_to_worktrees.items()):
-        if len(branches) > 1:
-            conflicts.append(f"  {filepath}  ({', '.join(branches)})")
-    return conflicts
+def _ahead_behind(wt_path: Path) -> tuple[int, int]:
+    proc = _run_git(["rev-list", "--left-right", "--count", "origin/main...HEAD"], wt_path)
+    if proc.returncode != 0:
+        return 0, 0
+    parts = proc.stdout.strip().split()
+    if len(parts) != 2:
+        return 0, 0
+    try:
+        return int(parts[1]), int(parts[0])  # ahead, behind
+    except ValueError:
+        return 0, 0
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Show active agent worktrees and conflict warnings")
-    parser.add_argument("--diff", action="store_true", help="Check for file-level conflicts across worktrees")
+def _dirty_files(wt_path: Path) -> list[str]:
+    proc = _run_git(["status", "--short", "--untracked-files=all"], wt_path)
+    if proc.returncode != 0:
+        return []
+    paths: list[str] = []
+    for raw in proc.stdout.splitlines():
+        if not raw.strip():
+            continue
+        payload = raw[3:] if len(raw) >= 4 else ""
+        if " -> " in payload:
+            payload = payload.split(" -> ", 1)[1]
+        payload = payload.strip()
+        if payload:
+            paths.append(payload)
+    return paths
+
+
+def _worktree_name(wt_path: str) -> str:
+    """Extract a short name from a worktree path."""
+    p = Path(wt_path)
+    # .claude/worktrees/{name} pattern
+    if ".claude" in p.parts and "worktrees" in p.parts:
+        return p.name
+    # .codex/worktrees/{hash}/RepoName pattern
+    if ".codex" in p.parts and "worktrees" in p.parts:
+        parts = list(p.parts)
+        try:
+            idx = parts.index("worktrees")
+            return f"codex-{parts[idx + 1][:6]}"
+        except (ValueError, IndexError):
+            pass
+    # Main repo
+    return p.name
+
+
+# ── API helpers ──
+
+
+def _api_get(path: str) -> Any:
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "--max-time", "5", f"{API}{path}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return []
+
+
+def _fetch_running_tasks() -> list[dict]:
+    """Fetch tasks with status=running from the API."""
+    data = _api_get("/api/agent/tasks?status=running&limit=50")
+    if isinstance(data, dict):
+        return data.get("items", data.get("tasks", []))
+    if isinstance(data, list):
+        return data
+    return []
+
+
+# ── Spec source map ──
+
+
+def _spec_source_files(spec_slug: str, repo_root: Path) -> list[str]:
+    """Read a spec's frontmatter source: map to get files it touches."""
+    specs_dir = repo_root / "specs"
+    # Try with slug directly, then with common prefixes
+    candidates = [specs_dir / f"{spec_slug}.md"]
+    if not candidates[0].exists():
+        # Try finding by suffix match
+        for f in specs_dir.glob("*.md"):
+            if f.stem.endswith(spec_slug) or spec_slug in f.stem:
+                candidates.append(f)
+
+    for spec_path in candidates:
+        if not spec_path.exists():
+            continue
+        try:
+            text = spec_path.read_text()
+        except OSError:
+            continue
+        # Extract file: entries from frontmatter source: block
+        in_frontmatter = False
+        in_source = False
+        files: list[str] = []
+        for line in text.splitlines():
+            if line.strip() == "---":
+                if in_frontmatter:
+                    break
+                in_frontmatter = True
+                continue
+            if not in_frontmatter:
+                continue
+            if line.startswith("source:"):
+                in_source = True
+                continue
+            if in_source:
+                if line.startswith("  - file:"):
+                    files.append(line.split("file:", 1)[1].strip())
+                elif not line.startswith("  "):
+                    in_source = False
+        if files:
+            return files
+    return []
+
+
+# ── Data model ──
+
+
+@dataclass
+class WorktreeInfo:
+    path: str
+    name: str
+    branch: str
+    ahead: int = 0
+    behind: int = 0
+    dirty_files: list[str] = field(default_factory=list)
+    matched_task: dict | None = None
+    is_main: bool = False
+
+
+def _match_task_to_worktree(task: dict, worktree_names: list[str]) -> str | None:
+    """Try to match a task to a worktree by claimed_by/session_key/worker_id."""
+    for field_name in ("claimed_by", "session_key", "worker_id"):
+        val = task.get(field_name, "") or ""
+        for name in worktree_names:
+            if name in val:
+                return name
+    return None
+
+
+# ── Main ──
+
+
+def collect(repo_root: Path) -> tuple[list[WorktreeInfo], list[dict], list[str]]:
+    """Collect worktree info, running tasks, and conflict warnings."""
+    raw_worktrees = _parse_worktrees(repo_root)
+    tasks = _fetch_running_tasks()
+    worktrees: list[WorktreeInfo] = []
+
+    for row in raw_worktrees:
+        wt_path = row.get("worktree", "").strip()
+        if not wt_path or not Path(wt_path).exists():
+            continue
+
+        p = Path(wt_path)
+        branch = _branch_name(p, row.get("branch", ""))
+        ahead, behind = _ahead_behind(p)
+        dirty = _dirty_files(p)
+        name = _worktree_name(wt_path)
+        is_main = (p == repo_root)
+
+        worktrees.append(WorktreeInfo(
+            path=wt_path,
+            name=name,
+            branch=branch,
+            ahead=ahead,
+            behind=behind,
+            dirty_files=dirty,
+            is_main=is_main,
+        ))
+
+    # Match tasks to worktrees
+    wt_names = [w.name for w in worktrees]
+    unmatched_tasks: list[dict] = []
+    for task in tasks:
+        matched_name = _match_task_to_worktree(task, wt_names)
+        if matched_name:
+            for w in worktrees:
+                if w.name == matched_name:
+                    w.matched_task = task
+                    break
+        else:
+            unmatched_tasks.append(task)
+
+    # Detect file-level conflicts
+    warnings: list[str] = []
+    wt_files: dict[str, set[str]] = {}
+    for w in worktrees:
+        if w.is_main:
+            continue
+        files = set(w.dirty_files)
+        # Also include files from matched task's spec source map
+        if w.matched_task:
+            spec_id = w.matched_task.get("spec_id") or ""
+            idea_id = w.matched_task.get("idea_id") or ""
+            direction = w.matched_task.get("direction") or ""
+            # Try to extract spec slug from task context
+            for slug_candidate in [spec_id, idea_id]:
+                if slug_candidate:
+                    files.update(_spec_source_files(slug_candidate, repo_root))
+        if files:
+            wt_files[w.name] = files
+
+    # Cross-check for overlaps
+    names = list(wt_files.keys())
+    for i, name_a in enumerate(names):
+        for name_b in names[i + 1:]:
+            overlap = wt_files[name_a] & wt_files[name_b]
+            if overlap:
+                file_list = ", ".join(sorted(overlap)[:5])
+                extra = f" (+{len(overlap) - 5} more)" if len(overlap) > 5 else ""
+                warnings.append(
+                    f"CONFLICT RISK: {name_a} and {name_b} both touch: {file_list}{extra}"
+                )
+
+    return worktrees, unmatched_tasks, warnings
+
+
+def print_human(worktrees: list[WorktreeInfo], unmatched: list[dict], warnings: list[str]) -> None:
+    print()
+    print("ACTIVE WORK ACROSS AGENTS")
+    print("\u2501" * 50)
+
+    for w in worktrees:
+        status_parts: list[str] = []
+        if w.dirty_files:
+            status_parts.append(f"dirty ({len(w.dirty_files)} files)")
+        else:
+            status_parts.append("clean")
+        if w.ahead:
+            status_parts.append(f"{w.ahead} ahead")
+        if w.behind:
+            status_parts.append(f"{w.behind} behind")
+        status_str = ", ".join(status_parts)
+
+        label = "(main)" if w.is_main else ""
+        task_str = "(no task)"
+        if w.matched_task:
+            direction = w.matched_task.get("direction", "")[:60]
+            task_id = w.matched_task.get("id", "")
+            task_str = f"task {task_id}: {direction}"
+
+        print(f"\n  {w.name} {label}")
+        print(f"    Branch:  {w.branch}")
+        print(f"    Status:  {status_str}")
+        print(f"    Task:    {task_str}")
+
+    if unmatched:
+        print(f"\n  Unmatched running tasks:")
+        for t in unmatched:
+            tid = t.get("id", "?")
+            direction = (t.get("direction") or "")[:60]
+            claimed = t.get("claimed_by", "?")
+            print(f"    - task {tid}: {direction} (claimed_by: {claimed})")
+
+    print()
+    if warnings:
+        for w in warnings:
+            print(f"  \u26a0  {w}")
+    else:
+        print("  No conflicts detected")
+    print()
+
+
+def print_json(worktrees: list[WorktreeInfo], unmatched: list[dict], warnings: list[str]) -> None:
+    data = {
+        "worktrees": [
+            {
+                "name": w.name,
+                "path": w.path,
+                "branch": w.branch,
+                "ahead": w.ahead,
+                "behind": w.behind,
+                "dirty_files": w.dirty_files,
+                "is_main": w.is_main,
+                "task": w.matched_task,
+            }
+            for w in worktrees
+        ],
+        "unmatched_tasks": unmatched,
+        "warnings": warnings,
+    }
+    print(json.dumps(data, indent=2, default=str))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Show active work across all coding agents.")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
     args = parser.parse_args()
 
-    # Find repo root
-    repo_root = run(["git", "rev-parse", "--show-toplevel"])
-    if not repo_root:
-        print("Not in a git repository", file=sys.stderr)
-        sys.exit(1)
+    repo_root = _repo_root()
+    worktrees, unmatched, warnings = collect(repo_root)
 
-    # If we're in a worktree, go to the main working tree
-    common_dir = run(["git", "rev-parse", "--git-common-dir"])
-    if common_dir and not common_dir.endswith("/.git"):
-        repo_root = str(Path(common_dir).parent)
+    if args.json:
+        print_json(worktrees, unmatched, warnings)
+    else:
+        print_human(worktrees, unmatched, warnings)
 
-    worktrees = get_worktrees(repo_root)
-
-    print(f"Active worktrees: {len(worktrees)}\n")
-    for wt in worktrees:
-        path = wt["path"]
-        branch = wt.get("branch", "(detached)")
-        head = wt.get("head", "?")[:8]
-        is_main = "main" in branch or path == repo_root
-        label = " [main]" if is_main else ""
-        print(f"  {branch}{label}")
-        print(f"    path: {path}")
-        print(f"    HEAD: {head}")
-        if args.diff and not is_main:
-            changed = get_changed_files(path)
-            if changed:
-                print(f"    changed: {len(changed)} files")
-            else:
-                print("    changed: (clean)")
-        print()
-
-    if args.diff:
-        non_main = [wt for wt in worktrees if "main" not in wt.get("branch", "") and wt["path"] != repo_root]
-        if len(non_main) >= 2:
-            conflicts = detect_conflicts(non_main)
-            if conflicts:
-                print("CONFLICT WARNING — files modified in multiple worktrees:")
-                for c in conflicts:
-                    print(c)
-            else:
-                print("No file conflicts detected across worktrees.")
-        else:
-            print("Only one active worktree branch — no conflict check needed.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two related changes that came out of triaging the dirty sibling worktrees:

1. **`fix(news)`** — `news_ingestion_service` was capturing `_CONFIG_PATH` at import time, so the existing `NEWS_SOURCES_CONFIG` env var override was silently ignored and every test that touched `/api/news/sources` wrote back to the in-tree `config/news-sources.json`. Now resolved lazily, with the test fixture redirecting to a per-test tmp file.
2. **`chore`** — `git rm --cached data/coherence.db` (production uses Postgres, this file is purely a local-dev artifact and was already documented as "NOT committed to git" in `scripts/seed_db.py`).
3. **`feat(scripts)`** — replace `scripts/agent_status.py` with the 385-line rewrite from `lucid-pascal`: adds `--json` output, live API task cross-reference, and always-on per-worktree conflict detection.

## Why this matters

Every sibling worktree (`festive-tu`, `wizardly-hopper`, `lucid-pascal`, `nostalgic-montalcini`, plus the main repo checkout) was showing dirty after a single `pytest` run because of #1 above. The triage I did earlier this session needed `git checkout HEAD -- config/news-sources.json` and `git checkout HEAD -- data/coherence.db` after every test invocation just to keep the worktree merge-able. With this PR, that workaround is no longer needed.

## Verification

\`\`\`
$ pytest tests/ -q --ignore=tests/holdout --ignore=tests/archive
471 passed, 6 warnings in 19.07s

$ git status -s
 M api/app/services/news_ingestion_service.py
 M api/tests/conftest.py
D  data/coherence.db
 M scripts/agent_status.py
\`\`\`

That is, the working tree shows **only** the four intentional changes — zero test side effects. Before: a full suite added pollution to `config/news-sources.json` (and historically `data/coherence.db` until the conftest DB redirect landed earlier).

## Notes

- The news fix preserves production behavior: `_config_path()` returns the same default location as before when `NEWS_SOURCES_CONFIG` is unset. Only test runs (which now set the env var) get redirected.
- Untracking `data/coherence.db` is safe for deploys: production uses `DATABASE_URL=postgresql://...` (verified via the VPS docker-compose), and `scripts/seed_db.py` regenerates the local SQLite file from spec markdown for fresh checkouts.
- The agent_status.py rewrite was salvaged from `lucid-pascal` where it was sitting untracked. The old 131-line version was a pure developer tool with no public-API contract — no callers to migrate.

## Test plan

- [x] `pytest tests/` — 471 passed, working tree clean afterward
- [x] `python3 scripts/agent_status.py --json` returns valid JSON listing 10 worktrees
- [x] `pytest tests/ -k news` — 5 passed (news fixture works)
- [ ] CI green on this PR
- [ ] After deploy: `curl https://api.coherencycoin.com/api/health` still healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)