### PR TITLE
docs(api): add OpenAPI summary= to 384 endpoints (100% coverage)

### DIFF
--- a/api/app/routers/accessible_ontology.py
+++ b/api/app/routers/accessible_ontology.py
@@ -171,7 +171,7 @@ def _legacy_response(record: dict, *, index: int = 0) -> AccessibleConceptRespon
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ontology/contribute", status_code=201, tags=["ontology"])
+@router.post("/ontology/contribute", status_code=201, tags=["ontology"], summary="Contribute Concept")
 async def contribute_concept(body: PlainLanguageContribution) -> AccessibleConceptResponse:
     record = svc.create_concept(
         title=_legacy_title(body.plain_text, body.title),
@@ -182,7 +182,7 @@ async def contribute_concept(body: PlainLanguageContribution) -> AccessibleConce
     return _legacy_response(record)
 
 
-@router.get("/ontology/contributions", tags=["ontology"])
+@router.get("/ontology/contributions", tags=["ontology"], summary="List Contributions")
 async def list_contributions(
     domain: str | None = Query(default=None),
     status: str | None = Query(default=None),
@@ -194,7 +194,7 @@ async def list_contributions(
     return {"items": payload, "total": len(payload)}
 
 
-@router.get("/ontology/contributions/{concept_id}", tags=["ontology"])
+@router.get("/ontology/contributions/{concept_id}", tags=["ontology"], summary="Get Contribution")
 async def get_contribution(concept_id: str) -> AccessibleConceptResponse:
     record = svc.get_concept(concept_id)
     if not record:
@@ -202,7 +202,7 @@ async def get_contribution(concept_id: str) -> AccessibleConceptResponse:
     return _legacy_response(record)
 
 
-@router.patch("/ontology/contributions/{concept_id}", tags=["ontology"])
+@router.patch("/ontology/contributions/{concept_id}", tags=["ontology"], summary="Patch Contribution")
 async def patch_contribution(concept_id: str, body: OntologyConceptPatch) -> AccessibleConceptResponse:
     record = svc.patch_concept(
         concept_id,
@@ -216,13 +216,13 @@ async def patch_contribution(concept_id: str, body: OntologyConceptPatch) -> Acc
     return _legacy_response(record)
 
 
-@router.delete("/ontology/contributions/{concept_id}", status_code=204, tags=["ontology"])
+@router.delete("/ontology/contributions/{concept_id}", status_code=204, tags=["ontology"], summary="Delete Contribution")
 async def delete_contribution(concept_id: str) -> None:
     if not svc.delete_concept(concept_id):
         raise HTTPException(status_code=404, detail=f"Concept '{concept_id}' not found")
 
 
-@router.get("/ontology/edges", tags=["ontology"])
+@router.get("/ontology/edges", tags=["ontology"], summary="List Ontology Edges")
 async def list_ontology_edges() -> dict[str, list[dict[str, object]]]:
     edges: list[dict[str, object]] = []
     for concept in svc.list_concepts(domain=None, status=None, search=None):
@@ -233,12 +233,12 @@ async def list_ontology_edges() -> dict[str, list[dict[str, object]]]:
     return {"edges": edges}
 
 
-@router.get("/ontology/garden", tags=["ontology"])
+@router.get("/ontology/garden", tags=["ontology"], summary="Get Ontology Garden")
 async def get_ontology_garden(limit: int = Query(default=200, ge=1, le=500)) -> GardenView:
     return GardenView(**svc.get_garden_payload(limit=limit))
 
 
-@router.get("/ontology/stats", tags=["ontology"])
+@router.get("/ontology/stats", tags=["ontology"], summary="Get Ontology Stats")
 async def get_ontology_stats() -> OntologyContributionStats:
     return OntologyContributionStats(**svc.get_stats())
 
@@ -248,7 +248,7 @@ async def get_ontology_stats() -> OntologyContributionStats:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ontology/suggest", status_code=201, tags=["ontology"])
+@router.post("/ontology/suggest", status_code=201, tags=["ontology"], summary="Suggest a new concept in plain language. No technical knowledge needed")
 async def suggest_concept(body: SuggestConceptRequest):
     """Suggest a new concept in plain language. No technical knowledge needed.
 
@@ -264,7 +264,7 @@ async def suggest_concept(body: SuggestConceptRequest):
     )
 
 
-@router.get("/ontology/suggestions", tags=["ontology"])
+@router.get("/ontology/suggestions", tags=["ontology"], summary="List concept suggestions. Filter by status to see the review queue")
 async def list_concept_suggestions(
     status: str | None = Query(default=None, description="Filter by status: pending, approved, rejected"),
     limit: int = Query(default=50, ge=1, le=200),
@@ -276,7 +276,7 @@ async def list_concept_suggestions(
     return svc.list_concept_suggestions(status=status, limit=limit, offset=offset)
 
 
-@router.get("/ontology/suggestions/{suggestion_id}", tags=["ontology"])
+@router.get("/ontology/suggestions/{suggestion_id}", tags=["ontology"], summary="Get a single concept suggestion by ID")
 async def get_concept_suggestion(suggestion_id: str):
     """Get a single concept suggestion by ID."""
     record = svc.get_concept_suggestion(suggestion_id)
@@ -285,7 +285,7 @@ async def get_concept_suggestion(suggestion_id: str):
     return record
 
 
-@router.post("/ontology/suggestions/{suggestion_id}/approve", tags=["ontology"])
+@router.post("/ontology/suggestions/{suggestion_id}/approve", tags=["ontology"], summary="Approve a concept suggestion and promote it to the live ontology")
 async def approve_concept_suggestion(suggestion_id: str, body: ApproveConceptRequest):
     """Approve a concept suggestion and promote it to the live ontology.
 
@@ -305,7 +305,7 @@ async def approve_concept_suggestion(suggestion_id: str, body: ApproveConceptReq
         raise HTTPException(status_code=409, detail=str(e))
 
 
-@router.post("/ontology/suggestions/{suggestion_id}/reject", tags=["ontology"])
+@router.post("/ontology/suggestions/{suggestion_id}/reject", tags=["ontology"], summary="Reject a concept suggestion with an optional explanatory note")
 async def reject_concept_suggestion(suggestion_id: str, body: RejectRequest):
     """Reject a concept suggestion with an optional explanatory note."""
     try:
@@ -325,7 +325,7 @@ async def reject_concept_suggestion(suggestion_id: str, body: RejectRequest):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ontology/suggest-relationship", status_code=201, tags=["ontology"])
+@router.post("/ontology/suggest-relationship", status_code=201, tags=["ontology"], summary="Suggest a relationship between two concepts in plain language")
 async def suggest_relationship(body: SuggestRelationshipRequest):
     """Suggest a relationship between two concepts in plain language.
 
@@ -341,7 +341,7 @@ async def suggest_relationship(body: SuggestRelationshipRequest):
     )
 
 
-@router.get("/ontology/relationship-suggestions", tags=["ontology"])
+@router.get("/ontology/relationship-suggestions", tags=["ontology"], summary="List relationship suggestions pending review")
 async def list_relationship_suggestions(
     status: str | None = Query(default=None, description="Filter: pending, approved, rejected"),
     limit: int = Query(default=50, ge=1, le=200),
@@ -356,6 +356,7 @@ async def list_relationship_suggestions(
 @router.post(
     "/ontology/relationship-suggestions/{suggestion_id}/review",
     tags=["ontology"],
+    summary="Approve or reject a relationship suggestion",
 )
 async def review_relationship_suggestion(suggestion_id: str, body: ReviewRelationshipRequest):
     """Approve or reject a relationship suggestion."""
@@ -377,7 +378,7 @@ async def review_relationship_suggestion(suggestion_id: str, body: ReviewRelatio
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ontology/endorse/{concept_id}", status_code=200, tags=["ontology"])
+@router.post("/ontology/endorse/{concept_id}", status_code=200, tags=["ontology"], summary="Endorse (upvote) a concept to signal its importance to the community")
 async def endorse_concept(concept_id: str, body: EndorseRequest):
     """Endorse (upvote) a concept to signal its importance to the community.
 
@@ -390,7 +391,7 @@ async def endorse_concept(concept_id: str, body: EndorseRequest):
         raise HTTPException(status_code=404, detail=str(e))
 
 
-@router.get("/ontology/endorse/{concept_id}", tags=["ontology"])
+@router.get("/ontology/endorse/{concept_id}", tags=["ontology"], summary="Get the endorsement count and list of endorsers for a concept")
 async def get_endorsements(concept_id: str):
     """Get the endorsement count and list of endorsers for a concept."""
     try:
@@ -399,7 +400,7 @@ async def get_endorsements(concept_id: str):
         raise HTTPException(status_code=404, detail=str(e))
 
 
-@router.get("/ontology/top-endorsed", tags=["ontology"])
+@router.get("/ontology/top-endorsed", tags=["ontology"], summary="List concepts ranked by number of endorsements")
 async def top_endorsed(limit: int = Query(default=20, ge=1, le=100)):
     """List concepts ranked by number of endorsements.
 

--- a/api/app/routers/activity.py
+++ b/api/app/routers/activity.py
@@ -19,6 +19,7 @@ router = APIRouter()
 @router.get(
     "/workspaces/{workspace_id}/activity",
     response_model=ActivityFeedResponse,
+    summary="List activity events for a workspace",
 )
 async def list_activity(
     workspace_id: str,
@@ -53,6 +54,7 @@ async def list_activity(
 @router.get(
     "/workspaces/{workspace_id}/activity/summary",
     response_model=ActivitySummaryResponse,
+    summary="Get activity event counts by type for a workspace",
 )
 async def activity_summary(
     workspace_id: str,

--- a/api/app/routers/agent_auto_heal_routes.py
+++ b/api/app/routers/agent_auto_heal_routes.py
@@ -9,7 +9,7 @@ from app.services.agent_service import list_tasks
 router = APIRouter()
 
 
-@router.get("/auto-heal/stats")
+@router.get("/auto-heal/stats", summary="Auto-heal statistics: heals created, rates, by-category breakdown")
 async def get_auto_heal_stats() -> dict:
     """Auto-heal statistics: heals created, rates, by-category breakdown."""
     items, _total, _runtime_backfill = list_tasks()

--- a/api/app/routers/agent_diagnostics_routes.py
+++ b/api/app/routers/agent_diagnostics_routes.py
@@ -328,7 +328,7 @@ def _diagnostics_runner_payload(runner_rows: list[dict[str, Any]]) -> dict[str, 
     }
 
 
-@router.get("/diagnostics/overview")
+@router.get("/diagnostics/overview", summary="Get Diagnostics Overview")
 async def get_diagnostics_overview(
     request: Request,
     _admin_key: str = Depends(require_admin_key),
@@ -379,7 +379,7 @@ async def get_diagnostics_overview(
     }
 
 
-@router.get("/diagnostics/config-editor", response_model=DiagnosticsConfigEditorResponse)
+@router.get("/diagnostics/config-editor", response_model=DiagnosticsConfigEditorResponse, summary="Get Diagnostics Config Editor")
 async def get_diagnostics_config_editor(_admin_key: str = Depends(require_admin_key)) -> DiagnosticsConfigEditorResponse:
     return DiagnosticsConfigEditorResponse(
         generated_at=_iso_utc_now(),
@@ -388,7 +388,7 @@ async def get_diagnostics_config_editor(_admin_key: str = Depends(require_admin_
     )
 
 
-@router.patch("/diagnostics/config-editor", response_model=DiagnosticsConfigEditorResponse)
+@router.patch("/diagnostics/config-editor", response_model=DiagnosticsConfigEditorResponse, summary="Update Diagnostics Config Editor")
 async def update_diagnostics_config_editor(
     payload: DiagnosticsConfigEditorUpdate,
     _admin_key: str = Depends(require_admin_key),
@@ -493,7 +493,7 @@ async def update_diagnostics_config_editor(
     )
 
 
-@router.get("/diagnostics-completeness")
+@router.get("/diagnostics-completeness", summary="Diagnostics completeness across all failed tasks")
 async def get_diagnostics_completeness() -> dict:
     """Diagnostics completeness across all failed tasks."""
     items, _total, _runtime_backfill = list_tasks()

--- a/api/app/routers/agent_execute_routes.py
+++ b/api/app/routers/agent_execute_routes.py
@@ -27,6 +27,7 @@ router = APIRouter()
         404: {"description": "No pending task found", "model": ErrorDetail},
         409: {"description": "Task already claimed/running by another worker", "model": ErrorDetail},
     },
+    summary="Pick a pending task (oldest-first fallback) and execute it via Codex/API worker flow",
 )
 async def pickup_and_execute_task(
     request: Request,
@@ -111,6 +112,7 @@ async def pickup_and_execute_task(
         403: {"description": "Forbidden (missing or invalid execute token)", "model": ErrorDetail},
         404: {"description": "Task not found", "model": ErrorDetail},
     },
+    summary="Execute a task server-side (background)",
 )
 async def execute_task(
     task_id: str,

--- a/api/app/routers/agent_grounded_metrics_routes.py
+++ b/api/app/routers/agent_grounded_metrics_routes.py
@@ -11,7 +11,7 @@ from app.services import idea_service
 router = APIRouter(tags=["ideas"])
 
 
-@router.get("/ideas/grounded-metrics")
+@router.get("/ideas/grounded-metrics", summary="Return grounded metrics for all tracked ideas")
 async def get_all_grounded_metrics() -> dict:
     """Return grounded metrics for all tracked ideas."""
     data = grounded_idea_metrics_service.collect_all_data()
@@ -22,14 +22,14 @@ async def get_all_grounded_metrics() -> dict:
     return {"ideas": results, "count": len(results)}
 
 
-@router.get("/ideas/{idea_id}/grounded-metrics")
+@router.get("/ideas/{idea_id}/grounded-metrics", summary="Return grounded metrics for a single idea")
 async def get_idea_grounded_metrics(idea_id: str) -> dict:
     """Return grounded metrics for a single idea."""
     data = grounded_idea_metrics_service.collect_all_data()
     return grounded_idea_metrics_service.compute_idea_metrics(idea_id, **data)
 
 
-@router.post("/ideas/{idea_id}/grounded-metrics/sync")
+@router.post("/ideas/{idea_id}/grounded-metrics/sync", summary="Compute grounded metrics and write them back to the idea")
 async def sync_grounded_metrics(idea_id: str, _key: str = Depends(require_api_key)) -> dict:
     """Compute grounded metrics and write them back to the idea."""
     data = grounded_idea_metrics_service.collect_all_data()
@@ -66,7 +66,7 @@ async def sync_grounded_metrics(idea_id: str, _key: str = Depends(require_api_ke
     }
 
 
-@router.post("/ideas/grounded-metrics/sync")
+@router.post("/ideas/grounded-metrics/sync", summary="Compute and write back grounded metrics for all ideas")
 async def sync_all_grounded_metrics(_key: str = Depends(require_api_key)) -> dict:
     """Compute and write back grounded metrics for all ideas."""
     data = grounded_idea_metrics_service.collect_all_data()

--- a/api/app/routers/agent_issues_routes.py
+++ b/api/app/routers/agent_issues_routes.py
@@ -14,7 +14,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.get("/fatal-issues")
+@router.get("/fatal-issues", summary="Unrecoverable failures. Check when autonomous; no user interaction needed until fatal")
 async def get_fatal_issues() -> dict:
     """Unrecoverable failures. Check when autonomous; no user interaction needed until fatal."""
     logs_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")
@@ -30,7 +30,7 @@ async def get_fatal_issues() -> dict:
         return {"fatal": False}
 
 
-@router.get("/monitor-issues")
+@router.get("/monitor-issues", summary="Monitor issues from automated pipeline check. Checkable; use to react and improve. Spec 0…")
 async def get_monitor_issues() -> dict:
     """Monitor issues from automated pipeline check. Checkable; use to react and improve. Spec 027."""
     logs_dir = agent_monitor_helpers.agent_logs_dir()
@@ -77,7 +77,7 @@ async def get_metrics(
     return data
 
 
-@router.get("/effectiveness")
+@router.get("/effectiveness", summary="Pipeline effectiveness: throughput, success rate, issue tracking, progress, goal proximity")
 async def get_effectiveness() -> dict:
     """Pipeline effectiveness: throughput, success rate, issue tracking, progress, goal proximity."""
     try:
@@ -97,7 +97,7 @@ async def get_effectiveness() -> dict:
         }
 
 
-@router.get("/collective-health")
+@router.get("/collective-health", summary="Collective health scorecard focused on coherence, resonance, flow, and friction")
 async def get_collective_health(
     window_days: int = Query(7, ge=1, le=30),
 ) -> dict:

--- a/api/app/routers/agent_prompt_ab_routes.py
+++ b/api/app/routers/agent_prompt_ab_routes.py
@@ -7,7 +7,7 @@ from app.services import prompt_ab_roi_service
 router = APIRouter()
 
 
-@router.get("/prompt-ab/stats")
+@router.get("/prompt-ab/stats", summary="Per-variant ROI stats with Thompson Sampling selection probabilities")
 async def get_prompt_ab_stats() -> dict:
     """Per-variant ROI stats with Thompson Sampling selection probabilities."""
     return prompt_ab_roi_service.get_variant_stats()

--- a/api/app/routers/agent_route_telegram_routes.py
+++ b/api/app/routers/agent_route_telegram_routes.py
@@ -38,7 +38,7 @@ def _get_telegram_config() -> dict:
     }
 
 
-@router.get("/route", response_model=RouteResponse)
+@router.get("/route", response_model=RouteResponse, summary="Get routing for a task type (no persistence). Canonical executors only")
 async def route(
     task_type: TaskType = Query(...),
     executor: Optional[str] = Query(
@@ -50,7 +50,7 @@ async def route(
     return RouteResponse(**agent_service.get_route(task_type, executor=executor or "auto"))
 
 
-@router.get("/telegram/diagnostics")
+@router.get("/telegram/diagnostics", summary="Diagnostics: last webhook events, send results, config (masked). For debugging")
 async def telegram_diagnostics() -> dict:
     """Diagnostics: last webhook events, send results, config (masked). For debugging."""
     from app.services import telegram_adapter
@@ -125,7 +125,7 @@ async def telegram_diagnostics() -> dict:
     }
 
 
-@router.post("/telegram/test-send")
+@router.post("/telegram/test-send", summary="Send a test message to configured chat IDs. Returns raw Telegram API response for debuggi…")
 async def telegram_test_send(
     text: Optional[str] = Query(None, description="Optional message text"),
 ) -> dict:

--- a/api/app/routers/agent_run_state_routes.py
+++ b/api/app/routers/agent_run_state_routes.py
@@ -24,7 +24,7 @@ from app.services import (
 router = APIRouter()
 
 
-@router.post("/run-state/claim", response_model=AgentRunStateSnapshot)
+@router.post("/run-state/claim", response_model=AgentRunStateSnapshot, summary="Claim or refresh an execution lease for task-level run ownership")
 async def claim_run_state(data: AgentRunStateClaim) -> dict:
     """Claim or refresh an execution lease for task-level run ownership."""
     return agent_run_state_service.claim_run_state(
@@ -39,7 +39,7 @@ async def claim_run_state(data: AgentRunStateClaim) -> dict:
     )
 
 
-@router.post("/run-state/heartbeat", response_model=AgentRunStateSnapshot)
+@router.post("/run-state/heartbeat", response_model=AgentRunStateSnapshot, summary="Heartbeat Run State")
 async def heartbeat_run_state(data: AgentRunStateHeartbeat) -> dict:
     return agent_run_state_service.heartbeat_run_state(
         task_id=data.task_id,
@@ -49,7 +49,7 @@ async def heartbeat_run_state(data: AgentRunStateHeartbeat) -> dict:
     )
 
 
-@router.post("/run-state/update", response_model=AgentRunStateSnapshot)
+@router.post("/run-state/update", response_model=AgentRunStateSnapshot, summary="Update Run State")
 async def update_run_state(data: AgentRunStateUpdate) -> dict:
     return agent_run_state_service.update_run_state(
         task_id=data.task_id,
@@ -61,7 +61,7 @@ async def update_run_state(data: AgentRunStateUpdate) -> dict:
     )
 
 
-@router.get("/run-state/{task_id}", response_model=AgentRunStateSnapshot)
+@router.get("/run-state/{task_id}", response_model=AgentRunStateSnapshot, summary="Get Run State")
 async def get_run_state(task_id: str) -> dict:
     state = agent_run_state_service.get_run_state(task_id)
     if state is None:
@@ -69,7 +69,7 @@ async def get_run_state(task_id: str) -> dict:
     return state
 
 
-@router.post("/runners/heartbeat", response_model=AgentRunnerSnapshot)
+@router.post("/runners/heartbeat", response_model=AgentRunnerSnapshot, summary="Heartbeat Runner")
 async def heartbeat_runner(data: AgentRunnerHeartbeat, background_tasks: BackgroundTasks) -> dict:
     snapshot = agent_runner_registry_service.heartbeat_runner(
         runner_id=data.runner_id,
@@ -92,7 +92,7 @@ async def heartbeat_runner(data: AgentRunnerHeartbeat, background_tasks: Backgro
     return snapshot
 
 
-@router.get("/runners", response_model=AgentRunnerList)
+@router.get("/runners", response_model=AgentRunnerList, summary="List Runners")
 async def list_runners(
     include_stale: bool = Query(False),
     limit: int = Query(100, ge=1, le=500),
@@ -104,7 +104,7 @@ async def list_runners(
     )
 
 
-@router.get("/lifecycle/summary")
+@router.get("/lifecycle/summary", summary="Agent Lifecycle Summary")
 async def agent_lifecycle_summary(
     seconds: int = Query(3600, ge=60, le=2592000),
     limit: int = Query(500, ge=1, le=5000),

--- a/api/app/routers/agent_smart_reap_routes.py
+++ b/api/app/routers/agent_smart_reap_routes.py
@@ -210,7 +210,7 @@ def _run_smart_reap(
     }
 
 
-@router.get("/smart-reap/preview")
+@router.get("/smart-reap/preview", summary="Preview which stuck tasks would be reaped or extended — no state changes")
 async def smart_reap_preview(
     max_age_minutes: int | None = Query(None, ge=0, le=1440),
 ) -> dict:
@@ -218,7 +218,7 @@ async def smart_reap_preview(
     return _run_smart_reap(max_age_minutes=max_age_minutes, dry_run=True)
 
 
-@router.post("/smart-reap/run")
+@router.post("/smart-reap/run", summary="Diagnose stuck running tasks and reap or extend them")
 async def smart_reap_run(
     max_age_minutes: int | None = Query(None, ge=0, le=1440),
 ) -> dict:

--- a/api/app/routers/agent_status_routes.py
+++ b/api/app/routers/agent_status_routes.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/status-report")
+@router.get("/status-report", summary="Hierarchical pipeline status (Layer 0 Goal → 1 Orchestration → 2 Execution → 3 Attention)")
 async def get_status_report() -> dict:
     """Hierarchical pipeline status (Layer 0 Goal → 1 Orchestration → 2 Execution → 3 Attention).
     Machine and human readable. Written by monitor each check. Includes meta_questions (unanswered/failed) when present."""
@@ -71,7 +71,7 @@ async def get_status_report() -> dict:
     return merge_meta_questions_into_report(fallback_report, logs_dir)
 
 
-@router.get("/pipeline-status")
+@router.get("/pipeline-status", summary="Pipeline visibility: running task, pending with wait times, recent completed with duration")
 async def get_pipeline_status() -> dict:
     """Pipeline visibility: running task, pending with wait times, recent completed with duration.
     Includes project manager state when available. For running tasks, includes live_tail (last 20 lines of streamed log).

--- a/api/app/routers/agent_task_log_routes.py
+++ b/api/app/routers/agent_task_log_routes.py
@@ -13,6 +13,7 @@ router = APIRouter()
 @router.get(
     "/tasks/{task_id}/log",
     responses={404: {"description": "Task not found or task log not found", "model": ErrorDetail}},
+    summary="Full task log (prompt, command, output). File is streamed during execution, complete on f…",
 )
 async def get_task_log(task_id: str) -> dict:
     """Full task log (prompt, command, output). File is streamed during execution, complete on finish."""

--- a/api/app/routers/agent_tasks_routes.py
+++ b/api/app/routers/agent_tasks_routes.py
@@ -49,6 +49,7 @@ def _route_side_effects_enabled_in_tests() -> bool:
     "/tasks",
     status_code=201,
     responses={422: {"description": "Invalid task_type, empty direction, or validation error (detail: list of {loc, msg, type})"}},
+    summary="Submit a task. Execution is handled by federation node runners, not server-side",
 )
 async def create_task(data: AgentTaskCreate, background_tasks: BackgroundTasks) -> AgentTask:
     """Submit a task. Execution is handled by federation node runners, not server-side.
@@ -66,6 +67,7 @@ async def create_task(data: AgentTaskCreate, background_tasks: BackgroundTasks) 
     responses={
         409: {"description": "Task already claimed/running by another worker", "model": ErrorDetail},
     },
+    summary="Ensure an external work session is represented as a running task",
 )
 async def upsert_active_task(data: AgentTaskUpsertActive) -> dict:
     """Ensure an external work session is represented as a running task."""
@@ -91,6 +93,7 @@ async def upsert_active_task(data: AgentTaskUpsertActive) -> dict:
     "/tasks",
     status_code=204,
     responses={400: {"description": "Missing confirm=clear query parameter"}},
+    summary="Clear the entire task queue (in-memory and persistence). Use before a fresh pipeline run",
 )
 async def clear_all_tasks(confirm: Optional[str] = Query(None)) -> None:
     """Clear the entire task queue (in-memory and persistence). Use before a fresh pipeline run.
@@ -103,7 +106,7 @@ async def clear_all_tasks(confirm: Optional[str] = Query(None)) -> None:
     agent_service.clear_store()
 
 
-@router.get("/tasks")
+@router.get("/tasks", summary="List tasks with optional filters. Pagination: limit, offset")
 async def list_tasks(
     status: Optional[TaskStatus] = Query(None),
     task_type: Optional[TaskType] = Query(None),
@@ -124,7 +127,7 @@ async def list_tasks(
     )
 
 
-@router.get("/reap-history")
+@router.get("/reap-history", summary="Return per-idea reap summary for the last 30 days (Spec 169 R7)")
 async def get_reap_history(
     idea_id: Optional[str] = Query(None),
     needs_attention: Optional[bool] = Query(None),
@@ -166,6 +169,7 @@ async def get_reap_history(
 @router.get(
     "/tasks/{task_id}/reap-diagnosis",
     responses={404: {"description": "Task not reaped or not found", "model": ErrorDetail}},
+    summary="Return the reap_diagnosis sub-object for a reaped task (Spec 169 R9)",
 )
 async def get_reap_diagnosis(task_id: str) -> dict:
     """Return the reap_diagnosis sub-object for a reaped task (Spec 169 R9).
@@ -188,7 +192,7 @@ async def get_reap_diagnosis(task_id: str) -> dict:
     return {"task_id": task_id, **diagnosis}
 
 
-@router.get("/tasks/attention")
+@router.get("/tasks/attention", summary="List tasks with status needs_decision or failed only (spec 003: includes output, decision…")
 async def get_attention_tasks(limit: int = Query(20, ge=1, le=100)) -> dict:
     """List tasks with status needs_decision or failed only (spec 003: includes output, decision_prompt)."""
     items, total = agent_service.get_attention_tasks(limit=limit)
@@ -198,13 +202,13 @@ async def get_attention_tasks(limit: int = Query(20, ge=1, le=100)) -> dict:
     }
 
 
-@router.get("/tasks/count")
+@router.get("/tasks/count", summary="Lightweight task counts for dashboards (total, by_status)")
 async def get_task_count() -> dict:
     """Lightweight task counts for dashboards (total, by_status)."""
     return agent_service.get_task_count()
 
 
-@router.get("/skills")
+@router.get("/skills", summary="Return all procedural skills ingested via the Hermes Learning Loop")
 async def list_skills(limit: int = Query(50, ge=1, le=200)) -> dict:
     """Return all procedural skills ingested via the Hermes Learning Loop."""
     from app.services import graph_service
@@ -218,6 +222,7 @@ async def list_skills(limit: int = Query(50, ge=1, le=200)) -> dict:
 @router.get(
     "/tasks/{task_id}",
     responses={404: {"description": "Task not found", "model": ErrorDetail}},
+    summary="Get task by id",
 )
 async def get_task(task_id: str) -> AgentTask:
     """Get task by id."""
@@ -234,6 +239,7 @@ async def get_task(task_id: str) -> AgentTask:
         404: {"description": "Task not found", "model": ErrorDetail},
         409: {"description": "Task already claimed/running by another worker", "model": ErrorDetail},
     },
+    summary="Update task. Supports status, output, progress_pct, current_step, decision_prompt, decisi…",
 )
 async def update_task(
     task_id: str,

--- a/api/app/routers/agent_telegram.py
+++ b/api/app/routers/agent_telegram.py
@@ -464,7 +464,7 @@ def _format_attention_reply(
 def _extract_status_filter(arg: str) -> str | None:
     return telegram_report_formatter.extract_status_filter(arg)
 
-@router.post("/agent/telegram/webhook")
+@router.post("/agent/telegram/webhook", summary="Receive Telegram updates and run command handlers")
 async def telegram_webhook(update: dict = Body(...)) -> dict:
     """Receive Telegram updates and run command handlers.
 

--- a/api/app/routers/agent_usage_routes.py
+++ b/api/app/routers/agent_usage_routes.py
@@ -7,19 +7,19 @@ from app.services import agent_service
 router = APIRouter()
 
 
-@router.get("/usage")
+@router.get("/usage", summary="Per-model usage and routing. For /usage bot command and dashboards")
 async def get_usage() -> dict:
     """Per-model usage and routing. For /usage bot command and dashboards."""
     return agent_service.get_usage_summary()
 
 
-@router.get("/visibility")
+@router.get("/visibility", summary="Unified visibility for pipeline execution, usage telemetry, and remaining tracking gaps")
 async def get_visibility() -> dict:
     """Unified visibility for pipeline execution, usage telemetry, and remaining tracking gaps."""
     return agent_service.get_visibility_summary()
 
 
-@router.get("/orchestration/guidance")
+@router.get("/orchestration/guidance", summary="Guidance-first routing and awareness summary (advisory, non-blocking)")
 async def get_orchestration_guidance(
     seconds: int = Query(21600, ge=300, le=2592000),
     limit: int = Query(500, ge=1, le=5000),
@@ -28,7 +28,7 @@ async def get_orchestration_guidance(
     return agent_service.get_orchestration_guidance_summary(seconds=seconds, limit=limit)
 
 
-@router.get("/integration")
+@router.get("/integration", summary="Role-agent integration coverage and remaining gaps")
 async def get_agent_integration() -> dict:
     """Role-agent integration coverage and remaining gaps."""
     return agent_service.get_agent_integration_status()

--- a/api/app/routers/audit.py
+++ b/api/app/routers/audit.py
@@ -21,7 +21,7 @@ from app.services import audit_ledger_service
 router = APIRouter(prefix="/audit", tags=["Audit"])
 
 
-@router.get("/transactions", response_model=AuditTransactionResponse)
+@router.get("/transactions", response_model=AuditTransactionResponse, summary="Query CC transaction audit entries")
 async def get_audit_transactions(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=500),
@@ -62,7 +62,7 @@ async def get_audit_transactions(
     )
 
 
-@router.get("/governance", response_model=AuditGovernanceResponse)
+@router.get("/governance", response_model=AuditGovernanceResponse, summary="Query governance audit entries")
 async def get_audit_governance(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=500),
@@ -93,7 +93,7 @@ async def get_audit_governance(
     )
 
 
-@router.get("/treasury", response_model=AuditTreasuryResponse)
+@router.get("/treasury", response_model=AuditTreasuryResponse, summary="Query treasury audit entries")
 async def get_audit_treasury(
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=500),
@@ -130,7 +130,7 @@ async def get_audit_treasury(
     )
 
 
-@router.get("/verify", response_model=VerificationResult)
+@router.get("/verify", response_model=VerificationResult, summary="Verify hash chain integrity")
 async def verify_audit_chain(
     from_entry_id: Optional[str] = None,
     to_entry_id: Optional[str] = None,
@@ -139,7 +139,7 @@ async def verify_audit_chain(
     return audit_ledger_service.verify_chain(from_entry_id, to_entry_id)
 
 
-@router.get("/snapshots", response_model=AuditSnapshotResponse)
+@router.get("/snapshots", response_model=AuditSnapshotResponse, summary="List signed audit snapshots")
 async def get_audit_snapshots(
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=50),
@@ -154,7 +154,7 @@ async def get_audit_snapshots(
     )
 
 
-@router.get("/export")
+@router.get("/export", summary="Export ledger as newline-delimited JSON")
 async def export_audit_ledger(
     from_date: Optional[datetime] = None,
     to_date: Optional[datetime] = None,

--- a/api/app/routers/auth_keys.py
+++ b/api/app/routers/auth_keys.py
@@ -46,7 +46,7 @@ def verify_contributor_key(api_key: str) -> dict | None:
     return _KEY_STORE.get(h)
 
 
-@router.post("/auth/keys", status_code=201)
+@router.post("/auth/keys", status_code=201, summary="Generate a personal API key for a contributor")
 @traces_to(spec="identity-driven-onboarding", idea="identity-driven-onboarding")
 async def generate_api_key(body: KeyRequest) -> KeyResponse:
     """Generate a personal API key for a contributor.
@@ -123,7 +123,7 @@ class VerifyProof(BaseModel):
 _CHALLENGES: dict[str, dict] = {}
 
 
-@router.post("/auth/verify/challenge")
+@router.post("/auth/verify/challenge", summary="Create a verification challenge for an identity provider")
 @traces_to(spec="identity-driven-onboarding", idea="identity-driven-onboarding")
 async def create_verification_challenge(body: VerifyChallenge) -> dict:
     """Create a verification challenge for an identity provider.
@@ -166,7 +166,7 @@ async def create_verification_challenge(body: VerifyChallenge) -> dict:
     }
 
 
-@router.post("/auth/verify/proof")
+@router.post("/auth/verify/proof", summary="Submit proof of identity ownership. Marks the identity as verified")
 @traces_to(spec="identity-driven-onboarding", idea="identity-driven-onboarding")
 async def submit_verification_proof(body: VerifyProof) -> dict:
     """Submit proof of identity ownership. Marks the identity as verified."""
@@ -228,7 +228,7 @@ class OnboardRequest(BaseModel):
     display_name: str | None = None
 
 
-@router.post("/onboard", status_code=201)
+@router.post("/onboard", status_code=201, summary="One-shot onboarding: create contributor + link identity + generate API key")
 @traces_to(spec="identity-driven-onboarding", idea="identity-driven-onboarding")
 async def onboard_contributor(body: OnboardRequest) -> dict:
     """One-shot onboarding: create contributor + link identity + generate API key.
@@ -303,7 +303,7 @@ async def onboard_contributor(body: OnboardRequest) -> dict:
     }
 
 
-@router.get("/auth/whoami")
+@router.get("/auth/whoami", summary="Check who the current API key belongs to")
 async def whoami(
     x_api_key: str | None = Header(None, alias="X-API-Key"),
     api_key_query: str | None = None,

--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -12,7 +12,7 @@ from app.services import automation_usage_service
 router = APIRouter()
 
 
-@router.get("/automation/usage")
+@router.get("/automation/usage", summary="Get Automation Usage")
 async def get_automation_usage(
     force_refresh: bool = Query(False),
     compact: bool = Query(False, description="Return a trimmed payload for lower-bandwidth clients"),
@@ -60,7 +60,7 @@ async def get_automation_usage(
         return payload
 
 
-@router.get("/automation/usage/snapshots")
+@router.get("/automation/usage/snapshots", summary="Get Automation Usage Snapshots")
 async def get_automation_usage_snapshots(limit: int = Query(200, ge=1, le=2000)) -> dict:
     rows = automation_usage_service.list_usage_snapshots(limit=limit)
     return {
@@ -69,7 +69,7 @@ async def get_automation_usage_snapshots(limit: int = Query(200, ge=1, le=2000))
     }
 
 
-@router.get("/automation/usage/external-tools")
+@router.get("/automation/usage/external-tools", summary="Get External Tool Usage Events")
 async def get_external_tool_usage_events(
     limit: int = Query(200, ge=1, le=5000),
     provider: str = Query("", description="Optional provider filter (e.g. github-actions)"),
@@ -83,7 +83,7 @@ async def get_external_tool_usage_events(
     return {"count": len(rows), "events": rows}
 
 
-@router.get("/automation/usage/alerts")
+@router.get("/automation/usage/alerts", summary="Get Automation Usage Alerts")
 async def get_automation_usage_alerts(
     threshold_ratio: float = Query(0.2, ge=0.0, le=1.0),
     force_refresh: bool = Query(False),
@@ -111,13 +111,13 @@ async def get_automation_usage_alerts(
         return payload
 
 
-@router.get("/automation/usage/subscription-estimator")
+@router.get("/automation/usage/subscription-estimator", summary="Get Subscription Upgrade Estimator")
 async def get_subscription_upgrade_estimator() -> dict:
     report = automation_usage_service.estimate_subscription_upgrades()
     return report.model_dump(mode="json")
 
 
-@router.get("/automation/usage/readiness")
+@router.get("/automation/usage/readiness", summary="Get Provider Readiness")
 async def get_provider_readiness(
     required_providers: str = Query("", description="Comma-separated provider ids to require"),
     force_refresh: bool = Query(False),
@@ -161,7 +161,7 @@ async def get_provider_readiness(
         return payload
 
 
-@router.get("/automation/usage/daily-summary")
+@router.get("/automation/usage/daily-summary", summary="Get Automation Usage Daily Summary")
 async def get_automation_usage_daily_summary(
     window_hours: int = Query(24, ge=1, le=24 * 30),
     top_n: int = Query(3, ge=1, le=20),
@@ -268,7 +268,7 @@ async def get_automation_usage_daily_summary(
         }
 
 
-@router.post("/automation/usage/provider-validation/run")
+@router.post("/automation/usage/provider-validation/run", summary="Run Provider Validation Probes")
 async def run_provider_validation_probes(
     required_providers: str = Query("", description="Comma-separated provider ids to probe"),
 ) -> dict:
@@ -279,7 +279,7 @@ async def run_provider_validation_probes(
     return report
 
 
-@router.post("/automation/usage/provider-heal/run")
+@router.post("/automation/usage/provider-heal/run", summary="Run Provider Auto Heal")
 async def run_provider_auto_heal(
     required_providers: str = Query("", description="Comma-separated provider ids to heal"),
     max_rounds: int = Query(2, ge=1, le=6),
@@ -298,7 +298,7 @@ async def run_provider_auto_heal(
     return report
 
 
-@router.get("/automation/usage/provider-validation")
+@router.get("/automation/usage/provider-validation", summary="Get Provider Validation Report")
 async def get_provider_validation_report(
     required_providers: str = Query("", description="Comma-separated provider ids to validate"),
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),

--- a/api/app/routers/blueprints.py
+++ b/api/app/routers/blueprints.py
@@ -38,7 +38,7 @@ class Blueprint(BaseModel):
     ideas: List[dict]
     edges: List[dict]
 
-@router.get("/blueprints")
+@router.get("/blueprints", summary="List available project roadmap blueprints")
 def list_blueprints() -> List[dict]:
     """List available project roadmap blueprints."""
     if not os.path.exists(BLUEPRINTS_DIR):
@@ -58,7 +58,7 @@ def list_blueprints() -> List[dict]:
                 })
     return blueprints
 
-@router.post("/blueprints/{blueprint_id}/apply")
+@router.post("/blueprints/{blueprint_id}/apply", summary="Apply a blueprint by creating its ideas and edges in the network")
 def apply_blueprint(blueprint_id: str, prefix: str = "", applicant_id: str | None = None) -> dict:
     """Apply a blueprint by creating its ideas and edges in the network."""
     path = os.path.join(BLUEPRINTS_DIR, f"{blueprint_id}.json")

--- a/api/app/routers/brief.py
+++ b/api/app/routers/brief.py
@@ -49,7 +49,7 @@ class BriefFeedbackRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.get("/daily")
+@router.get("/daily", summary="Generate and return a daily brief")
 async def get_daily_brief(
     response: Response,
     contributor_id: Optional[str] = Query(default=None),
@@ -70,7 +70,7 @@ async def get_daily_brief(
     return brief
 
 
-@router.post("/feedback", status_code=201)
+@router.post("/feedback", status_code=201, summary="Record that a brief card led to an action")
 async def post_feedback(body: BriefFeedbackRequest) -> dict:
     """Record that a brief card led to an action."""
     try:
@@ -85,7 +85,7 @@ async def post_feedback(body: BriefFeedbackRequest) -> dict:
     return feedback
 
 
-@router.get("/engagement-metrics")
+@router.get("/engagement-metrics", summary="Return aggregate engagement metrics")
 async def get_engagement_metrics(
     window_days: int = Query(default=30, ge=1, le=365),
 ) -> dict:

--- a/api/app/routers/cc_economics.py
+++ b/api/app/routers/cc_economics.py
@@ -27,7 +27,7 @@ from app.services import cc_economics_service
 router = APIRouter(prefix="/cc", tags=["cc-economics"])
 
 
-@router.get("/supply", response_model=CCSupply)
+@router.get("/supply", response_model=CCSupply, summary="Return current CC supply metrics with coherence score")
 async def get_supply():
     """Return current CC supply metrics with coherence score."""
     result = cc_economics_service.supply()
@@ -36,7 +36,7 @@ async def get_supply():
     return result
 
 
-@router.get("/exchange-rate", response_model=CCExchangeRate)
+@router.get("/exchange-rate", response_model=CCExchangeRate, summary="Return current exchange rate with spread and cache metadata")
 async def get_exchange_rate():
     """Return current exchange rate with spread and cache metadata."""
     result = cc_economics_service.exchange_rate()
@@ -45,7 +45,7 @@ async def get_exchange_rate():
     return result
 
 
-@router.post("/stake", response_model=StakePosition, status_code=201)
+@router.post("/stake", response_model=StakePosition, status_code=201, summary="Stake CC into an idea")
 async def stake_cc(request: StakeRequest):
     """Stake CC into an idea."""
     try:
@@ -56,7 +56,7 @@ async def stake_cc(request: StakeRequest):
         raise HTTPException(status_code=400, detail=str(exc))
 
 
-@router.post("/unstake", response_model=UnstakeResponse)
+@router.post("/unstake", response_model=UnstakeResponse, summary="Unstake a position with cooldown")
 async def unstake_cc(request: UnstakeRequest):
     """Unstake a position with cooldown."""
     try:
@@ -67,7 +67,7 @@ async def unstake_cc(request: UnstakeRequest):
         raise HTTPException(status_code=400, detail=str(exc))
 
 
-@router.get("/staking/{user_id}", response_model=UserStakingSummary)
+@router.get("/staking/{user_id}", response_model=UserStakingSummary, summary="Return all staking positions for a user")
 async def get_staking_positions(user_id: str):
     """Return all staking positions for a user."""
     return cc_economics_service.get_staking_positions(user_id)

--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -70,7 +70,7 @@ class PlainConceptSubmit(BaseModel):
 # Core CRUD endpoints
 # ---------------------------------------------------------------------------
 
-@router.get("/concepts")
+@router.get("/concepts", summary="List concepts from the ontology (paged)")
 async def list_concepts(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
@@ -79,7 +79,7 @@ async def list_concepts(
     return concept_service.list_concepts(limit=limit, offset=offset)
 
 
-@router.post("/concepts", status_code=201)
+@router.post("/concepts", status_code=201, summary="Create a new user-defined concept (extends the ontology)")
 async def create_concept(body: ConceptCreate):
     """Create a new user-defined concept (extends the ontology)."""
     if concept_service.get_concept(body.id):
@@ -87,7 +87,7 @@ async def create_concept(body: ConceptCreate):
     return concept_service.create_concept(body.model_dump())
 
 
-@router.get("/concepts/search")
+@router.get("/concepts/search", summary="Full-text search concepts by name or description")
 async def search_concepts(
     q: str = Query(..., min_length=1),
     limit: int = Query(default=20, ge=1, le=100),
@@ -96,13 +96,13 @@ async def search_concepts(
     return concept_service.search_concepts(query=q, limit=limit)
 
 
-@router.get("/concepts/stats")
+@router.get("/concepts/stats", summary="Get ontology statistics: concept count, relationship types, axes, user edges")
 async def concept_stats():
     """Get ontology statistics: concept count, relationship types, axes, user edges."""
     return concept_service.get_stats()
 
 
-@router.post("/concepts/auto-tag-all")
+@router.post("/concepts/auto-tag-all", summary="Run concept auto-tagging on every non-internal idea in the portfolio")
 async def auto_tag_all_ideas() -> dict[str, Any]:
     """Run concept auto-tagging on every non-internal idea in the portfolio.
 
@@ -112,19 +112,19 @@ async def auto_tag_all_ideas() -> dict[str, Any]:
     return concept_auto_tagger.tag_all_ideas()
 
 
-@router.get("/concepts/relationships")
+@router.get("/concepts/relationships", summary="List all 46 relationship types from the Living Codex ontology")
 async def list_relationships():
     """List all 46 relationship types from the Living Codex ontology."""
     return concept_service.list_relationship_types()
 
 
-@router.get("/concepts/axes")
+@router.get("/concepts/axes", summary="List all 53 ontology axes")
 async def list_axes():
     """List all 53 ontology axes."""
     return concept_service.list_axes()
 
 
-@router.get("/concepts/{concept_id}/translate")
+@router.get("/concepts/{concept_id}/translate", summary="Translate a concept from one worldview lens framing to another")
 async def translate_concept_view(
     concept_id: str,
     from_lens: TranslateLens = Query(..., alias="from", description="Source worldview lens"),
@@ -150,7 +150,7 @@ async def translate_concept_view(
     )
 
 
-@router.get("/concepts/{concept_id}")
+@router.get("/concepts/{concept_id}", summary="Get a single concept by ID with full metadata")
 async def get_concept(concept_id: str):
     """Get a single concept by ID with full metadata."""
     concept = concept_service.get_concept(concept_id)
@@ -159,7 +159,7 @@ async def get_concept(concept_id: str):
     return concept
 
 
-@router.patch("/concepts/{concept_id}")
+@router.patch("/concepts/{concept_id}", summary="Patch mutable fields of a concept (name, description, keywords, axes)")
 async def patch_concept(concept_id: str, body: ConceptPatch):
     """Patch mutable fields of a concept (name, description, keywords, axes)."""
     if not concept_service.get_concept(concept_id):
@@ -167,7 +167,7 @@ async def patch_concept(concept_id: str, body: ConceptPatch):
     return concept_service.patch_concept(concept_id, body.model_dump(exclude_none=True))
 
 
-@router.delete("/concepts/{concept_id}", status_code=204)
+@router.delete("/concepts/{concept_id}", status_code=204, summary="Delete a user-created concept. Core ontology concepts cannot be deleted")
 async def delete_concept(concept_id: str):
     """Delete a user-created concept. Core ontology concepts cannot be deleted."""
     concept = concept_service.get_concept(concept_id)
@@ -182,7 +182,7 @@ async def delete_concept(concept_id: str):
 # Edge endpoints
 # ---------------------------------------------------------------------------
 
-@router.get("/concepts/{concept_id}/edges")
+@router.get("/concepts/{concept_id}/edges", summary="Get all user-defined edges for a concept (incoming and outgoing)")
 async def get_concept_edges(concept_id: str):
     """Get all user-defined edges for a concept (incoming and outgoing)."""
     if not concept_service.get_concept(concept_id):
@@ -190,7 +190,7 @@ async def get_concept_edges(concept_id: str):
     return concept_service.get_concept_edges(concept_id)
 
 
-@router.post("/concepts/{concept_id}/edges", status_code=200)
+@router.post("/concepts/{concept_id}/edges", status_code=200, summary="Create a typed relationship edge from this concept to another")
 async def create_edge(concept_id: str, body: EdgeCreate, response: Response):
     """Create a typed relationship edge from this concept to another."""
     source = concept_service.get_concept(concept_id)
@@ -213,7 +213,7 @@ async def create_edge(concept_id: str, body: EdgeCreate, response: Response):
 # Tagging: attach concepts to ideas / specs
 # ---------------------------------------------------------------------------
 
-@router.get("/concepts/{concept_id}/related")
+@router.get("/concepts/{concept_id}/related", summary="Get ideas and specs tagged with this concept")
 async def get_related_items(concept_id: str):
     """Get ideas and specs tagged with this concept."""
     if not concept_service.get_concept(concept_id):
@@ -221,7 +221,7 @@ async def get_related_items(concept_id: str):
     return concept_service.get_related_items(concept_id)
 
 
-@router.post("/ideas/{idea_id}/concepts")
+@router.post("/ideas/{idea_id}/concepts", summary="Tag an idea with one or more concepts")
 async def tag_idea_with_concepts(idea_id: str, body: ConceptTagBody):
     """Tag an idea with one or more concepts."""
     missing = [cid for cid in body.concept_ids if not concept_service.get_concept(cid)]
@@ -230,13 +230,13 @@ async def tag_idea_with_concepts(idea_id: str, body: ConceptTagBody):
     return concept_service.tag_entity(entity_type="idea", entity_id=idea_id, concept_ids=body.concept_ids)
 
 
-@router.get("/ideas/{idea_id}/concepts")
+@router.get("/ideas/{idea_id}/concepts", summary="Get concepts tagged on an idea")
 async def get_idea_concepts(idea_id: str):
     """Get concepts tagged on an idea."""
     return concept_service.get_entity_concepts(entity_type="idea", entity_id=idea_id)
 
 
-@router.post("/specs/{spec_id}/concepts")
+@router.post("/specs/{spec_id}/concepts", summary="Tag a spec with one or more concepts")
 async def tag_spec_with_concepts(spec_id: str, body: ConceptTagBody):
     """Tag a spec with one or more concepts."""
     missing = [cid for cid in body.concept_ids if not concept_service.get_concept(cid)]
@@ -245,7 +245,7 @@ async def tag_spec_with_concepts(spec_id: str, body: ConceptTagBody):
     return concept_service.tag_entity(entity_type="spec", entity_id=spec_id, concept_ids=body.concept_ids)
 
 
-@router.get("/specs/{spec_id}/concepts")
+@router.get("/specs/{spec_id}/concepts", summary="Get concepts tagged on a spec")
 async def get_spec_concepts(spec_id: str):
     """Get concepts tagged on a spec."""
     return concept_service.get_entity_concepts(entity_type="spec", entity_id=spec_id)
@@ -255,7 +255,7 @@ async def get_spec_concepts(spec_id: str):
 # Accessible ontology: plain-language contribution endpoints (POST only — GETs above)
 # ---------------------------------------------------------------------------
 
-@router.post("/concepts/suggest")
+@router.post("/concepts/suggest", summary="Accessible ontology entry point for non-technical contributors")
 async def suggest_concept(body: PlainConceptSuggest):
     """
     Accessible ontology entry point for non-technical contributors.
@@ -274,7 +274,7 @@ async def suggest_concept(body: PlainConceptSuggest):
     )
 
 
-@router.post("/concepts/submit", status_code=201)
+@router.post("/concepts/submit", status_code=201, summary="Commit a plain-language concept to the ontology")
 async def submit_plain_concept(body: PlainConceptSubmit):
     """
     Commit a plain-language concept to the ontology.

--- a/api/app/routers/constellation.py
+++ b/api/app/routers/constellation.py
@@ -12,7 +12,7 @@ from app.services import constellation_service
 router = APIRouter()
 
 
-@router.get("/constellation")
+@router.get("/constellation", summary="Return network graph data optimized for constellation/force-directed visualization")
 async def get_constellation(
     workspace_id: str = Query("coherence-network", description="Workspace to visualize"),
     max_nodes: int = Query(100, ge=10, le=500, description="Maximum number of nodes to return"),

--- a/api/app/routers/credentials.py
+++ b/api/app/routers/credentials.py
@@ -14,7 +14,7 @@ from app.services import repo_credential_service as service
 router = APIRouter(tags=["credentials"])
 
 
-@router.post("", response_model=RepoCredentialResponse)
+@router.post("", response_model=RepoCredentialResponse, summary="Add or update a repo-specific credential (hashed)")
 async def add_credential(req: RepoCredentialCreate):
     """Add or update a repo-specific credential (hashed)."""
     # Hash the raw credential before passing it to the service
@@ -42,7 +42,7 @@ async def add_credential(req: RepoCredentialCreate):
     return full_recs[0]
 
 
-@router.get("", response_model=RepoCredentialList)
+@router.get("", response_model=RepoCredentialList, summary="List registered credentials, filtered by contributor or repo")
 async def list_credentials(
     contributor_id: Optional[str] = Query(None),
     repo_url: Optional[str] = Query(None)
@@ -52,7 +52,7 @@ async def list_credentials(
     return {"credentials": recs}
 
 
-@router.delete("/{credential_id}")
+@router.delete("/{credential_id}", summary="Remove a credential record")
 async def delete_credential(credential_id: str):
 
     """Remove a credential record."""

--- a/api/app/routers/data_retention.py
+++ b/api/app/routers/data_retention.py
@@ -16,19 +16,19 @@ from app.services import data_retention_service
 router = APIRouter()
 
 
-@router.get("/data-retention/policy")
+@router.get("/data-retention/policy", summary="Return the active tiered retention policy")
 async def get_retention_policy() -> dict:
     """Return the active tiered retention policy."""
     return data_retention_service.get_policy()
 
 
-@router.get("/data-retention/status")
+@router.get("/data-retention/status", summary="Return current row counts, backup sizes, and last-run metadata")
 async def get_retention_status() -> dict:
     """Return current row counts, backup sizes, and last-run metadata."""
     return data_retention_service.get_status()
 
 
-@router.post("/data-retention/run")
+@router.post("/data-retention/run", summary="Execute a retention pass: summarize, export backup, then trim stale rows")
 async def run_retention_pass(
     dry_run: bool = Query(False, description="Preview only -- do not delete or export"),
 ) -> dict:
@@ -36,7 +36,7 @@ async def run_retention_pass(
     return data_retention_service.run_retention_pass(dry_run=dry_run)
 
 
-@router.get("/data-retention/summaries/daily")
+@router.get("/data-retention/summaries/daily", summary="Return pre-computed daily aggregate summaries for runtime_events")
 async def get_daily_summaries(
     days_back: int = Query(
         7, ge=1, le=90, description="How many days of daily summaries to return"

--- a/api/app/routers/debug.py
+++ b/api/app/routers/debug.py
@@ -44,13 +44,13 @@ class DebugStatusUpdate(BaseModel):
 # ── Endpoints ───────────────────────────────────────────────────────
 
 
-@router.get("/status")
+@router.get("/status", summary="Return current debug configuration")
 async def get_debug_status() -> DebugStatusResponse:
     """Return current debug configuration."""
     return DebugStatusResponse(**_debug_state)
 
 
-@router.patch("/status")
+@router.patch("/status", summary="Update debug configuration at runtime")
 async def update_debug_status(body: DebugStatusUpdate) -> DebugStatusResponse:
     """Update debug configuration at runtime.
 

--- a/api/app/routers/dif_feedback.py
+++ b/api/app/routers/dif_feedback.py
@@ -29,19 +29,19 @@ class DifOutcomeUpdate(BaseModel):
     outcome: str  # success | failure | timeout
 
 
-@router.get("/dif/stats")
+@router.get("/dif/stats", summary="DIF accuracy statistics — true/false positive rates, accuracy by language")
 async def dif_stats():
     """DIF accuracy statistics — true/false positive rates, accuracy by language."""
     return dif_feedback_service.get_stats()
 
 
-@router.get("/dif/recent")
+@router.get("/dif/recent", summary="Recent DIF verification entries with scores and outcomes")
 async def dif_recent(limit: int = Query(default=20, ge=1, le=100)):
     """Recent DIF verification entries with scores and outcomes."""
     return dif_feedback_service.get_recent(limit=limit)
 
 
-@router.post("/dif/record", status_code=201)
+@router.post("/dif/record", status_code=201, summary="Record a DIF verification result for accuracy tracking")
 async def record_verification(body: DifVerificationRecord):
     """Record a DIF verification result for accuracy tracking."""
     return dif_feedback_service.record_verification(
@@ -56,14 +56,14 @@ async def record_verification(body: DifVerificationRecord):
     )
 
 
-@router.post("/dif/outcome")
+@router.post("/dif/outcome", summary="Update all DIF feedback entries for a task with the final outcome")
 async def update_outcome(body: DifOutcomeUpdate):
     """Update all DIF feedback entries for a task with the final outcome."""
     updated = dif_feedback_service.update_outcome(body.task_id, body.outcome)
     return {"task_id": body.task_id, "outcome": body.outcome, "entries_updated": updated}
 
 
-@router.post("/dif/flush")
+@router.post("/dif/flush", summary="Flush DIF feedback buffer to graph_nodes for persistent storage")
 async def flush_to_graph():
     """Flush DIF feedback buffer to graph_nodes for persistent storage."""
     flushed = dif_feedback_service.flush_to_api()

--- a/api/app/routers/discord_votes.py
+++ b/api/app/routers/discord_votes.py
@@ -20,6 +20,7 @@ router = APIRouter()
     "/ideas/{idea_id}/questions/{question_index}/vote",
     response_model=QuestionVoteResponse,
     status_code=200,
+    summary="Record a Discord reaction vote on an idea open question",
 )
 async def vote_on_question(
     idea_id: str,

--- a/api/app/routers/distributions.py
+++ b/api/app/routers/distributions.py
@@ -16,6 +16,7 @@ router = APIRouter()
     response_model=Distribution,
     status_code=201,
     responses={404: {"model": ErrorDetail}},
+    summary="Trigger value distribution for an asset",
 )
 async def create_distribution(distribution: DistributionCreate) -> Distribution:
     """Trigger value distribution for an asset."""

--- a/api/app/routers/edges.py
+++ b/api/app/routers/edges.py
@@ -29,7 +29,7 @@ class EdgeCreateRequest(BaseModel):
 # ── Type Registry ─────────────────────────────────────────────────────
 
 
-@router.get("/edges/types")
+@router.get("/edges/types", summary="Return all 46 canonical edge types grouped by family")
 async def get_edge_types(family: str | None = None):
     """Return all 46 canonical edge types grouped by family.
 
@@ -50,7 +50,7 @@ async def get_edge_types(family: str | None = None):
 # ── Edge CRUD ─────────────────────────────────────────────────────────
 
 
-@router.get("/edges")
+@router.get("/edges", summary="List edges with optional filters. Responses include from_node and to_node stubs")
 async def list_edges(
     type: str | None = None,
     from_id: str | None = None,
@@ -64,7 +64,7 @@ async def list_edges(
     )
 
 
-@router.get("/edges/{edge_id}")
+@router.get("/edges/{edge_id}", summary="Get a single edge by ID with node stubs")
 async def get_edge(edge_id: str):
     """Get a single edge by ID with node stubs."""
     edge = graph_service.get_edge_by_id(edge_id)
@@ -73,7 +73,7 @@ async def get_edge(edge_id: str):
     return edge
 
 
-@router.post("/edges", status_code=201)
+@router.post("/edges", status_code=201, summary="Create a typed edge between two entities")
 async def create_edge(body: EdgeCreateRequest, strict: bool = False):
     """Create a typed edge between two entities.
 
@@ -119,7 +119,7 @@ async def create_edge(body: EdgeCreateRequest, strict: bool = False):
     return result
 
 
-@router.delete("/edges/{edge_id}")
+@router.delete("/edges/{edge_id}", summary="Delete an edge by ID")
 async def delete_edge(edge_id: str):
     """Delete an edge by ID."""
     if not graph_service.delete_edge(edge_id):
@@ -130,7 +130,7 @@ async def delete_edge(edge_id: str):
 # ── Entity-scoped edge endpoints ───────────────────────────────────────
 
 
-@router.get("/entities/{entity_id}/edges")
+@router.get("/entities/{entity_id}/edges", summary="List all edges for any entity regardless of node type")
 async def get_entity_edges(
     entity_id: str,
     type: str | None = None,
@@ -156,7 +156,7 @@ async def get_entity_edges(
     )
 
 
-@router.get("/entities/{entity_id}/neighbors")
+@router.get("/entities/{entity_id}/neighbors", summary="Return neighboring node objects reachable via 1 hop from entity_id")
 async def get_entity_neighbors(
     entity_id: str,
     type: str | None = None,

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -40,19 +40,19 @@ from app.services import openclaw_node_bridge_service
 router = APIRouter()
 
 
-@router.post("/federation/instances", response_model=FederatedInstance, status_code=201)
+@router.post("/federation/instances", response_model=FederatedInstance, status_code=201, summary="Register a remote Coherence instance")
 async def register_instance(instance: FederatedInstance) -> FederatedInstance:
     """Register a remote Coherence instance."""
     return federation_service.register_instance(instance)
 
 
-@router.get("/federation/instances", response_model=list[FederatedInstance])
+@router.get("/federation/instances", response_model=list[FederatedInstance], summary="List all registered remote instances")
 async def list_instances() -> list[FederatedInstance]:
     """List all registered remote instances."""
     return federation_service.list_instances()
 
 
-@router.get("/federation/instances/{instance_id}", response_model=FederatedInstance)
+@router.get("/federation/instances/{instance_id}", response_model=FederatedInstance, summary="Get a single registered instance by ID")
 async def get_instance(instance_id: str) -> FederatedInstance:
     """Get a single registered instance by ID."""
     found = federation_service.get_instance(instance_id)
@@ -61,13 +61,13 @@ async def get_instance(instance_id: str) -> FederatedInstance:
     return found
 
 
-@router.post("/federation/sync", response_model=FederationSyncResult)
+@router.post("/federation/sync", response_model=FederationSyncResult, summary="Receive a federated payload from a remote instance")
 async def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
     """Receive a federated payload from a remote instance."""
     return federation_service.receive_payload(payload)
 
 
-@router.get("/federation/sync/history")
+@router.get("/federation/sync/history", summary="List past sync operations")
 async def sync_history(limit: int = Query(200, ge=1, le=1000)) -> list[dict]:
     """List past sync operations."""
     return federation_service.list_sync_history(limit=limit)
@@ -77,7 +77,7 @@ async def sync_history(limit: int = Query(200, ge=1, le=1000)) -> list[dict]:
 # Node registration / heartbeat (Spec 132)
 # ---------------------------------------------------------------------------
 
-@router.post("/federation/nodes", response_model=FederationNodeRegisterResponse)
+@router.post("/federation/nodes", response_model=FederationNodeRegisterResponse, summary="Register or update a federation node")
 @traces_to(spec="132", idea="federation-node-identity", description="Register a federation node")
 async def register_node(body: FederationNodeRegisterRequest):
     """Register or update a federation node."""
@@ -87,7 +87,7 @@ async def register_node(body: FederationNodeRegisterRequest):
     return JSONResponse(content=resp.model_dump(mode="json"), status_code=status_code)
 
 
-@router.post("/federation/nodes/{node_id}/heartbeat", response_model=FederationNodeHeartbeatResponse)
+@router.post("/federation/nodes/{node_id}/heartbeat", response_model=FederationNodeHeartbeatResponse, summary="Refresh liveness for a previously registered node")
 async def heartbeat_node(
     node_id: str,
     body: FederationNodeHeartbeatRequest,
@@ -114,13 +114,13 @@ async def heartbeat_node(
     return result
 
 
-@router.get("/federation/nodes")
+@router.get("/federation/nodes", summary="List all registered federation nodes")
 async def list_nodes():
     """List all registered federation nodes."""
     return federation_service.list_nodes()
 
 
-@router.delete("/federation/nodes/{node_id}", status_code=204)
+@router.delete("/federation/nodes/{node_id}", status_code=204, summary="Remove a stale or duplicate federation node")
 async def delete_node(node_id: str):
     """Remove a stale or duplicate federation node."""
     ok = federation_service.delete_node(node_id)
@@ -129,7 +129,7 @@ async def delete_node(node_id: str):
     return None
 
 
-@router.get("/federation/nodes/capabilities", response_model=FleetCapabilitySummary)
+@router.get("/federation/nodes/capabilities", response_model=FleetCapabilitySummary, summary="Return aggregated fleet capability coverage")
 async def get_fleet_capabilities():
     """Return aggregated fleet capability coverage."""
     return federation_service.get_fleet_capability_summary()
@@ -139,7 +139,7 @@ async def get_fleet_capabilities():
 # Aggregated node stats (Spec 133)
 # ---------------------------------------------------------------------------
 
-@router.get("/federation/nodes/stats")
+@router.get("/federation/nodes/stats", summary="Return aggregated provider stats across all federation nodes")
 async def get_aggregated_node_stats(window_days: int | None = Query(default=None, ge=1, le=365)):
     """Return aggregated provider stats across all federation nodes."""
     return federation_service.get_aggregated_node_stats(window_days=window_days)
@@ -153,6 +153,7 @@ async def get_aggregated_node_stats(window_days: int | None = Query(default=None
     "/federation/nodes/{node_id}/measurements",
     response_model=MeasurementPushResponse,
     status_code=201,
+    summary="Accept a batch of measurement summaries from a node",
 )
 async def post_measurement_summaries(node_id: str, body: MeasurementPushRequest):
     """Accept a batch of measurement summaries from a node."""
@@ -182,6 +183,7 @@ async def post_measurement_summaries(node_id: str, body: MeasurementPushRequest)
 
 @router.get(
     "/federation/nodes/{node_id}/measurements",
+    summary="Return stored measurement summaries for a node",
 )
 async def get_measurement_summaries(
     node_id: str,
@@ -212,6 +214,7 @@ async def get_measurement_summaries(
 @router.get(
     "/federation/strategies",
     response_model=FederationStrategyListResponse,
+    summary="Return active (non-expired) federation strategy broadcasts",
 )
 async def get_strategies(
     strategy_type: str | None = Query(None),
@@ -240,7 +243,7 @@ async def get_strategies(
     )
 
 
-@router.post("/federation/strategies/compute", status_code=200)
+@router.post("/federation/strategies/compute", status_code=200, summary="Trigger computation of new strategy broadcasts from current data")
 async def compute_strategies():
     """Trigger computation of new strategy broadcasts from current data."""
     new_strategies = federation_service.compute_and_store_strategies()
@@ -251,6 +254,7 @@ async def compute_strategies():
     "/federation/strategies/{strategy_id}/effectiveness",
     response_model=FederationStrategyEffectivenessReportResponse,
     status_code=201,
+    summary="Record whether acting on a strategy improved outcome metrics",
 )
 async def report_strategy_effectiveness(
     strategy_id: int,
@@ -272,6 +276,7 @@ async def report_strategy_effectiveness(
     "/federation/instances/{node_id}/aggregate",
     response_model=FederatedAggregationResponse,
     status_code=202,
+    summary="Submit partner instance aggregation payload for trust-gated merge",
 )
 async def post_federated_aggregation(node_id: str, body: FederatedAggregationRequest):
     """Submit partner instance aggregation payload for trust-gated merge."""
@@ -292,7 +297,7 @@ async def post_federated_aggregation(node_id: str, body: FederatedAggregationReq
     return result
 
 
-@router.get("/federation/aggregates", response_model=FederatedAggregationListResponse)
+@router.get("/federation/aggregates", response_model=FederatedAggregationListResponse, summary="Return merged federated aggregation results")
 async def get_federated_aggregates(strategy_type: str | None = Query(None)):
     """Return merged federated aggregation results."""
     aggregates = federation_service.list_federated_aggregates(strategy_type=strategy_type)
@@ -404,7 +409,7 @@ def _mark_messages_read(node_id: str, msg_ids: set[str]) -> None:
         _msg_log.warning("Failed to mark messages read for %s: %s", node_id, e)
 
 
-@router.post("/federation/nodes/{node_id}/messages", status_code=201)
+@router.post("/federation/nodes/{node_id}/messages", status_code=201, summary="Send a message from this node. Set to_node=null to broadcast")
 async def send_message(node_id: str, body: NodeMessage):
     """Send a message from this node. Set to_node=null to broadcast."""
     msg = {
@@ -425,7 +430,7 @@ async def send_message(node_id: str, body: NodeMessage):
     return msg
 
 
-@router.get("/federation/nodes/{node_id}/messages")
+@router.get("/federation/nodes/{node_id}/messages", summary="Get messages for this node (direct + broadcasts). Marks them as read")
 async def get_messages(
     node_id: str,
     since: str | None = Query(None, description="ISO timestamp — only messages after this time"),
@@ -442,7 +447,7 @@ async def get_messages(
     return {"node_id": node_id, "messages": results, "count": len(results)}
 
 
-@router.post("/federation/broadcast", status_code=201)
+@router.post("/federation/broadcast", status_code=201, summary="Broadcast a message to all nodes")
 async def broadcast_message(body: NodeMessage):
     """Broadcast a message to all nodes."""
     msg = {
@@ -492,7 +497,7 @@ def _notify_sse_subscribers(target_node_id: str | None, event: dict) -> None:
             pass  # Drop if subscriber is too slow
 
 
-@router.get("/federation/nodes/{node_id}/stream")
+@router.get("/federation/nodes/{node_id}/stream", summary="SSE stream for a node. Pushes: messages, deploys, task events, status changes")
 async def node_event_stream(node_id: str):
     """SSE stream for a node. Pushes: messages, deploys, task events, status changes.
 
@@ -578,7 +583,7 @@ _diag_subscribers: dict[str, list[asyncio.Queue]] = {}  # node_id → queues
 _diag_lock = asyncio.Lock()
 
 
-@router.post("/federation/nodes/{node_id}/diag", status_code=201)
+@router.post("/federation/nodes/{node_id}/diag", status_code=201, summary="Publish a diagnostic event from a node. High-frequency, ephemeral")
 async def publish_diagnostic(node_id: str, body: dict = {}):
     """Publish a diagnostic event from a node. High-frequency, ephemeral.
 
@@ -607,7 +612,7 @@ async def publish_diagnostic(node_id: str, body: dict = {}):
     return {"ok": True}
 
 
-@router.get("/federation/nodes/{node_id}/diag/stream")
+@router.get("/federation/nodes/{node_id}/diag/stream", summary="SSE stream for diagnostic events from a node. Use node_id='*' for all nodes")
 async def subscribe_diagnostics(node_id: str):
     """SSE stream for diagnostic events from a node. Use node_id='*' for all nodes.
 

--- a/api/app/routers/friction.py
+++ b/api/app/routers/friction.py
@@ -17,7 +17,7 @@ from app.services import friction_service
 router = APIRouter()
 
 
-@router.get("/friction/events", response_model=list[FrictionEvent])
+@router.get("/friction/events", response_model=list[FrictionEvent], summary="List Events")
 async def list_events(
     limit: int = Query(100, ge=1, le=1000),
     status: Optional[str] = Query(None),
@@ -28,13 +28,13 @@ async def list_events(
     return events[:limit]
 
 
-@router.post("/friction/events", response_model=FrictionEvent, status_code=201)
+@router.post("/friction/events", response_model=FrictionEvent, status_code=201, summary="Create Event")
 async def create_event(event: FrictionEvent) -> FrictionEvent:
     friction_service.append_event(event)
     return event
 
 
-@router.get("/friction/report", response_model=FrictionReport)
+@router.get("/friction/report", response_model=FrictionReport, summary="Report")
 async def report(
     window_days: int = Query(7, ge=1),
     limit: int = Query(500, ge=1, le=5000, description="Max events to scan"),
@@ -54,7 +54,7 @@ async def report(
     return FrictionReport(**data)
 
 
-@router.get("/friction/entry-points", response_model=FrictionEntryPointReport)
+@router.get("/friction/entry-points", response_model=FrictionEntryPointReport, summary="Entry Points")
 async def entry_points(
     window_days: int = Query(7, ge=1, le=365),
     limit: int = Query(20, ge=1, le=200),
@@ -63,7 +63,7 @@ async def entry_points(
     return FrictionEntryPointReport(**data)
 
 
-@router.get("/friction/categories", response_model=FrictionCategoryReport)
+@router.get("/friction/categories", response_model=FrictionCategoryReport, summary="Categories")
 async def categories(
     window_days: int = Query(7, ge=1, le=365),
     limit: int = Query(20, ge=1, le=200),

--- a/api/app/routers/gates.py
+++ b/api/app/routers/gates.py
@@ -17,7 +17,7 @@ def _github_token() -> str | None:
     return get_github_token()
 
 
-@router.get("/gates/pr-to-public")
+@router.get("/gates/pr-to-public", summary="Gate Pr To Public")
 async def gate_pr_to_public(
     branch: str = Query(..., min_length=1, description="PR head branch"),
     repo: str = Query("seeker71/Coherence-Network"),
@@ -39,7 +39,7 @@ async def gate_pr_to_public(
     return report
 
 
-@router.get("/gates/merged-contract")
+@router.get("/gates/merged-contract", summary="Gate Merged Contract")
 async def gate_merged_contract(
     sha: str = Query(..., min_length=7, description="Merged commit SHA on main"),
     repo: str = Query("seeker71/Coherence-Network"),
@@ -61,7 +61,7 @@ async def gate_merged_contract(
     return report
 
 
-@router.get("/gates/main-head")
+@router.get("/gates/main-head", summary="Gates Main Head")
 async def gates_main_head(
     repo: str = Query("seeker71/Coherence-Network"),
     branch: str = Query("main"),
@@ -81,7 +81,7 @@ async def gates_main_head(
     return {"repo": repo, "branch": branch, "sha": sha}
 
 
-@router.get("/gates/main-contract")
+@router.get("/gates/main-contract", summary="Gates Main Contract")
 async def gates_main_contract(
     repo: str = Query("seeker71/Coherence-Network"),
     branch: str = Query("main"),
@@ -112,7 +112,7 @@ async def gates_main_contract(
     return report
 
 
-@router.get("/gates/public-deploy-contract")
+@router.get("/gates/public-deploy-contract", summary="Gates Public Deploy Contract")
 async def gates_public_deploy_contract(
     repo: str = Query("seeker71/Coherence-Network"),
     branch: str = Query("main"),
@@ -131,7 +131,7 @@ async def gates_public_deploy_contract(
     )
 
 
-@router.post("/gates/public-deploy-verification-jobs")
+@router.post("/gates/public-deploy-verification-jobs", summary="Create Public Deploy Verification Job")
 async def create_public_deploy_verification_job(
     repo: str = Query("seeker71/Coherence-Network"),
     branch: str = Query("main"),
@@ -156,12 +156,12 @@ async def create_public_deploy_verification_job(
     )
 
 
-@router.get("/gates/public-deploy-verification-jobs")
+@router.get("/gates/public-deploy-verification-jobs", summary="List Public Deploy Verification Jobs")
 async def list_public_deploy_verification_jobs() -> list[dict]:
     return await asyncio.to_thread(gates.list_public_deploy_verification_jobs)
 
 
-@router.post("/gates/public-deploy-verification-jobs/{job_id}/tick")
+@router.post("/gates/public-deploy-verification-jobs/{job_id}/tick", summary="Tick Public Deploy Verification Job")
 async def tick_public_deploy_verification_job(job_id: str) -> dict:
     return await asyncio.to_thread(
         gates.tick_public_deploy_verification_job,
@@ -170,7 +170,7 @@ async def tick_public_deploy_verification_job(job_id: str) -> dict:
     )
 
 
-@router.post("/gates/public-deploy-verification-jobs/tick")
+@router.post("/gates/public-deploy-verification-jobs/tick", summary="Tick Public Deploy Verification Jobs")
 async def tick_public_deploy_verification_jobs(
     due_only: bool = Query(True),
 ) -> dict:
@@ -181,7 +181,7 @@ async def tick_public_deploy_verification_jobs(
     )
 
 
-@router.get("/gates/commit-traceability")
+@router.get("/gates/commit-traceability", summary="Gates Commit Traceability")
 async def gates_commit_traceability(
     sha: str = Query(..., min_length=7, description="Commit SHA to derive traceability from"),
     repo: str = Query("seeker71/Coherence-Network"),

--- a/api/app/routers/governance.py
+++ b/api/app/routers/governance.py
@@ -12,12 +12,12 @@ from app.services import governance_service
 router = APIRouter()
 
 
-@router.get("/governance/change-requests", response_model=list[ChangeRequest])
+@router.get("/governance/change-requests", response_model=list[ChangeRequest], summary="List Change Requests")
 async def list_change_requests(limit: int = Query(200, ge=1, le=1000)) -> list[ChangeRequest]:
     return governance_service.list_change_requests(limit=limit)
 
 
-@router.get("/governance/change-requests/{change_request_id}", response_model=ChangeRequest)
+@router.get("/governance/change-requests/{change_request_id}", response_model=ChangeRequest, summary="Get Change Request")
 async def get_change_request(change_request_id: str) -> ChangeRequest:
     found = governance_service.get_change_request(change_request_id)
     if found is None:
@@ -25,12 +25,12 @@ async def get_change_request(change_request_id: str) -> ChangeRequest:
     return found
 
 
-@router.post("/governance/change-requests", response_model=ChangeRequest, status_code=201)
+@router.post("/governance/change-requests", response_model=ChangeRequest, status_code=201, summary="Create Change Request")
 async def create_change_request(data: ChangeRequestCreate, _key: str = Depends(require_api_key)) -> ChangeRequest:
     return governance_service.create_change_request(data)
 
 
-@router.post("/governance/change-requests/{change_request_id}/votes", response_model=ChangeRequest)
+@router.post("/governance/change-requests/{change_request_id}/votes", response_model=ChangeRequest, summary="Cast Vote")
 async def cast_vote(change_request_id: str, data: ChangeRequestVoteCreate, _key: str = Depends(require_api_key)) -> ChangeRequest:
     try:
         updated = governance_service.cast_vote(change_request_id, data)

--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -51,7 +51,7 @@ class EdgeCreate(BaseModel):
 # ── Node endpoints ──────────────────────────────────────────────────
 
 
-@router.get("/graph/nodes")
+@router.get("/graph/nodes", summary="List nodes with optional type, phase, and search filters")
 async def list_nodes(
     type: str | None = None,
     phase: str | None = None,
@@ -65,7 +65,7 @@ async def list_nodes(
     )
 
 
-@router.post("/graph/nodes")
+@router.post("/graph/nodes", summary="Create a new node. Reject unknown graph node types while preserving canonical semantics")
 async def create_node(body: NodeCreate):
     """Create a new node. Reject unknown graph node types while preserving canonical semantics."""
     if body.type not in NODE_TYPE_SET:
@@ -93,19 +93,19 @@ async def create_node(body: NodeCreate):
         raise HTTPException(status_code=422, detail=str(exc))
 
 
-@router.get("/graph/nodes/count")
+@router.get("/graph/nodes/count", summary="Count nodes, optionally filtered by type")
 async def count_nodes(type: str | None = None):
     """Count nodes, optionally filtered by type."""
     return graph_service.count_nodes(type=type)
 
 
-@router.get("/graph/stats")
+@router.get("/graph/stats", summary="Get graph-wide statistics")
 async def graph_stats():
     """Get graph-wide statistics."""
     return graph_service.get_stats()
 
 
-@router.get("/graph/nodes/{node_id}")
+@router.get("/graph/nodes/{node_id}", summary="Get a single node")
 async def get_node(node_id: str):
     """Get a single node."""
     node = graph_service.get_node(node_id)
@@ -114,7 +114,7 @@ async def get_node(node_id: str):
     return node
 
 
-@router.patch("/graph/nodes/{node_id}")
+@router.patch("/graph/nodes/{node_id}", summary="Update a node")
 async def update_node(node_id: str, body: NodeUpdate):
     """Update a node."""
     result = graph_service.update_node(node_id, **body.model_dump(exclude_none=True))
@@ -123,7 +123,7 @@ async def update_node(node_id: str, body: NodeUpdate):
     return result
 
 
-@router.delete("/graph/nodes/{node_id}")
+@router.delete("/graph/nodes/{node_id}", summary="Delete a node and all its edges")
 async def delete_node(node_id: str):
     """Delete a node and all its edges."""
     if not graph_service.delete_node(node_id):
@@ -134,7 +134,7 @@ async def delete_node(node_id: str):
 # ── Edge endpoints ──────────────────────────────────────────────────
 
 
-@router.get("/graph/nodes/{node_id}/edges")
+@router.get("/graph/nodes/{node_id}/edges", summary="Get edges for a node")
 async def get_edges(
     node_id: str,
     direction: str = Query(default="both", pattern="^(both|outgoing|incoming)$"),
@@ -144,7 +144,7 @@ async def get_edges(
     return graph_service.get_edges(node_id, direction=direction, edge_type=type)
 
 
-@router.post("/graph/edges")
+@router.post("/graph/edges", summary="Create an edge between two nodes. Validates edge_type and prevents self-loops (Spec 169)")
 async def create_edge(body: EdgeCreate):
     """Create an edge between two nodes. Validates edge_type and prevents self-loops (Spec 169)."""
     # Canonical edge type validation
@@ -173,7 +173,7 @@ async def create_edge(body: EdgeCreate):
         raise HTTPException(status_code=422, detail=str(exc))
 
 
-@router.delete("/graph/edges/{edge_id}")
+@router.delete("/graph/edges/{edge_id}", summary="Delete an edge")
 async def delete_edge(edge_id: str):
     """Delete an edge."""
     if not graph_service.delete_edge(edge_id):
@@ -184,7 +184,7 @@ async def delete_edge(edge_id: str):
 # ── Graph query endpoints ───────────────────────────────────────────
 
 
-@router.get("/graph/nodes/{node_id}/neighbors")
+@router.get("/graph/nodes/{node_id}/neighbors", summary="Get neighboring nodes (1–2 hops)")
 async def get_neighbors(
     node_id: str,
     edge_type: str | None = None,
@@ -217,7 +217,7 @@ async def get_neighbors(
     )
 
 
-@router.get("/graph/nodes/{node_id}/subgraph")
+@router.get("/graph/nodes/{node_id}/subgraph", summary="Get a subgraph centered on a node")
 async def get_subgraph(
     node_id: str,
     depth: int = Query(default=1, ge=1, le=5),
@@ -228,7 +228,7 @@ async def get_subgraph(
     return graph_service.get_subgraph(node_id, depth=depth, edge_types=types)
 
 
-@router.get("/graph/path")
+@router.get("/graph/path", summary="Find shortest path between two nodes")
 async def find_path(
     from_id: str = Query(...),
     to_id: str = Query(...),
@@ -244,7 +244,7 @@ async def find_path(
 # ── Spec 169: Registry + Proof endpoints ────────────────────────────
 
 
-@router.get("/graph/node-types")
+@router.get("/graph/node-types", summary="Return the canonical 10-type node registry (Spec 169)")
 async def get_node_types():
     """Return the canonical 10-type node registry (Spec 169).
 
@@ -254,7 +254,7 @@ async def get_node_types():
     return graph_service.get_node_type_registry()
 
 
-@router.get("/graph/edge-types")
+@router.get("/graph/edge-types", summary="Return the canonical 7-type edge registry (Spec 169)")
 async def get_edge_types():
     """Return the canonical 7-type edge registry (Spec 169).
 
@@ -263,7 +263,7 @@ async def get_edge_types():
     return graph_service.get_edge_type_registry()
 
 
-@router.get("/graph/proof")
+@router.get("/graph/proof", summary="Return aggregate proof that the graph is the fractal data layer (Spec 169)")
 async def get_graph_proof():
     """Return aggregate proof that the graph is the fractal data layer (Spec 169).
 
@@ -275,21 +275,21 @@ async def get_graph_proof():
 
 # ── DIF Feedback endpoints ───────────────────────────────────────────
 
-@router.get("/dif/feedback/stats")
+@router.get("/dif/feedback/stats", summary="Get DIF feedback statistics — true/false positive rates, accuracy")
 async def dif_feedback_stats():
     """Get DIF feedback statistics — true/false positive rates, accuracy."""
     from app.services import dif_feedback_service
     return dif_feedback_service.get_stats()
 
 
-@router.get("/dif/feedback/recent")
+@router.get("/dif/feedback/recent", summary="Get recent DIF feedback entries")
 async def dif_feedback_recent(limit: int = Query(default=20, ge=1, le=100)):
     """Get recent DIF feedback entries."""
     from app.services import dif_feedback_service
     return dif_feedback_service.get_recent(limit=limit)
 
 
-@router.post("/dif/feedback")
+@router.post("/dif/feedback", summary="Record a DIF verification result for accuracy tracking")
 async def record_dif_feedback(body: dict):
     """Record a DIF verification result for accuracy tracking."""
     from app.services import dif_feedback_service

--- a/api/app/routers/graph_health.py
+++ b/api/app/routers/graph_health.py
@@ -11,19 +11,19 @@ from app.services import graph_health_service as svc
 router = APIRouter()
 
 
-@router.get("/graph/health")
+@router.get("/graph/health", summary="Get Graph Health")
 async def get_graph_health():
     snap = svc.get_latest_or_baseline()
     return snap.model_dump(mode="json")
 
 
-@router.post("/graph/health/compute")
+@router.post("/graph/health/compute", summary="Compute Graph Health")
 async def compute_graph_health():
     snap = svc.compute_snapshot()
     return snap.model_dump(mode="json")
 
 
-@router.post("/graph/concepts/{concept_id}/convergence-guard")
+@router.post("/graph/concepts/{concept_id}/convergence-guard", summary="Set Convergence Guard")
 async def set_convergence_guard(concept_id: str, body: ConvergenceGuardBody):
     graph_health_repo.set_guard(concept_id, body.reason, body.set_by)
     return ConvergenceGuardResponse(
@@ -34,7 +34,7 @@ async def set_convergence_guard(concept_id: str, body: ConvergenceGuardBody):
     ).model_dump(mode="json")
 
 
-@router.delete("/graph/concepts/{concept_id}/convergence-guard")
+@router.delete("/graph/concepts/{concept_id}/convergence-guard", summary="Delete Convergence Guard")
 async def delete_convergence_guard(concept_id: str):
     graph_health_repo.remove_guard(concept_id)
     return ConvergenceGuardResponse(
@@ -43,6 +43,6 @@ async def delete_convergence_guard(concept_id: str):
     ).model_dump(mode="json")
 
 
-@router.get("/graph/health/roi")
+@router.get("/graph/health/roi", summary="Graph Health Roi")
 async def graph_health_roi():
     return svc.roi_snapshot()

--- a/api/app/routers/graph_questions.py
+++ b/api/app/routers/graph_questions.py
@@ -18,6 +18,7 @@ router = APIRouter()
     response_model=QuestionResponse,
     status_code=201,
     tags=["graph"],
+    summary="Add an open question to a node",
 )
 async def add_question(node_id: str, body: AddQuestionRequest):
     """Add an open question to a node."""
@@ -35,6 +36,7 @@ async def add_question(node_id: str, body: AddQuestionRequest):
     "/graph/nodes/{node_id}/questions/{question_id}",
     response_model=QuestionResponse,
     tags=["graph"],
+    summary="Resolve or re-open an open question on a node",
 )
 async def patch_question(node_id: str, question_id: str, body: PatchQuestionRequest):
     """Resolve or re-open an open question on a node."""

--- a/api/app/routers/graph_zoom.py
+++ b/api/app/routers/graph_zoom.py
@@ -12,13 +12,13 @@ from app.services import zoom_service
 router = APIRouter()
 
 
-@router.get("/graph/pillars", response_model=PillarListResponse, tags=["graph"])
+@router.get("/graph/pillars", response_model=PillarListResponse, tags=["graph"], summary="Return all root-level pillar nodes: traceability, trust, freedom, uniqueness, collaborati…")
 async def get_pillars():
     """Return all root-level pillar nodes: traceability, trust, freedom, uniqueness, collaboration."""
     return zoom_service.get_pillars()
 
 
-@router.get("/graph/zoom/{node_id}", response_model=ZoomResponse, tags=["graph"])
+@router.get("/graph/zoom/{node_id}", response_model=ZoomResponse, tags=["graph"], summary="Return a fractal subtree rooted at node_id")
 async def zoom_node(
     node_id: str,
     depth: int = Query(default=1, ge=0),

--- a/api/app/routers/health.py
+++ b/api/app/routers/health.py
@@ -139,20 +139,20 @@ class PingResponse(BaseModel):
     timestamp: Annotated[str, Field(description="ISO8601 UTC")]
 
 
-@router.get("/version")
+@router.get("/version", summary="Return API version (lightweight, for dashboards)")
 async def version():
     """Return API version (lightweight, for dashboards)."""
     return {"version": HEALTH_VERSION}
 
 
-@router.get("/ping", response_model=PingResponse)
+@router.get("/ping", response_model=PingResponse, summary="Lightweight liveness ping with current UTC timestamp")
 async def ping():
     """Lightweight liveness ping with current UTC timestamp."""
     now = datetime.now(timezone.utc)
     return PingResponse(pong=True, timestamp=_iso_utc(now))
 
 
-@router.get("/ready", response_model=ReadyResponse)
+@router.get("/ready", response_model=ReadyResponse, summary="Readiness probe for k8s/deploy. Returns 200 when API can serve traffic")
 async def ready(request: Request):
     """Readiness probe for k8s/deploy. Returns 200 when API can serve traffic."""
     is_ready = getattr(request.app.state, "graph_store", None) is not None
@@ -204,7 +204,7 @@ async def ready(request: Request):
     )
 
 
-@router.get("/health/persistence")
+@router.get("/health/persistence", summary="Return global persistence contract status for core domain data")
 async def persistence_contract(request: Request):
     """Return global persistence contract status for core domain data."""
     return persistence_contract_service.evaluate(request.app)
@@ -223,7 +223,7 @@ def _check_schema() -> bool:
         return False
 
 
-@router.get("/health", response_model=HealthResponse)
+@router.get("/health", response_model=HealthResponse, summary="Return API health status")
 async def health():
     """Return API health status."""
     now = datetime.now(timezone.utc)

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -54,7 +54,7 @@ from app.models.lens_translation import TranslationRegenerateBody
 router = APIRouter()
 
 
-@router.get("/ideas", response_model=IdeaPortfolioResponse)
+@router.get("/ideas", response_model=IdeaPortfolioResponse, summary="List Ideas")
 @traces_to(spec="053", idea="portfolio-governance", description="Browse the idea portfolio ranked by ROI")
 async def list_ideas(
     only_unvalidated: bool = Query(False, description="When true, only return ideas not yet validated."),
@@ -84,18 +84,18 @@ async def list_ideas(
     )
 
 
-@router.get("/ideas/tags", response_model=IdeaTagCatalogResponse)
+@router.get("/ideas/tags", response_model=IdeaTagCatalogResponse, summary="Return the normalized idea tag catalog with idea counts (spec 129)")
 async def get_idea_tags_catalog() -> IdeaTagCatalogResponse:
     """Return the normalized idea tag catalog with idea counts (spec 129)."""
     return idea_service.get_tag_catalog()
 
 
-@router.get("/ideas/storage", response_model=IdeaStorageInfo)
+@router.get("/ideas/storage", response_model=IdeaStorageInfo, summary="Get Idea Storage Info")
 async def get_idea_storage_info() -> IdeaStorageInfo:
     return idea_service.storage_info()
 
 
-@router.get("/ideas/cards")
+@router.get("/ideas/cards", summary="List Idea Cards")
 async def list_idea_cards(
     q: str = Query("", description="Free-text search across idea title/description/spec IDs."),
     state: str = Query(
@@ -151,7 +151,7 @@ async def list_idea_cards(
         return {"items": items, "total": result.get("total", len(items)), "cursor": None}
 
 
-@router.get("/ideas/cards/changes")
+@router.get("/ideas/cards/changes", summary="List Idea Card Changes")
 async def list_idea_card_changes(
     since_token: str | None = Query(default=None),
     include_internal_ideas: bool = Query(True),
@@ -164,7 +164,7 @@ async def list_idea_card_changes(
     )
 
 
-@router.get("/ideas/health", response_model=GovernanceHealth)
+@router.get("/ideas/health", response_model=GovernanceHealth, summary="Portfolio governance effectiveness snapshot (spec 126)")
 async def get_governance_health(
     window_days: int = Query(30, ge=1, le=365, description="Lookback window in days"),
 ) -> GovernanceHealth:
@@ -175,14 +175,14 @@ async def get_governance_health(
 # ── Right-sizing endpoints (spec 158) ────────────────────────────────────────
 
 
-@router.get("/ideas/right-sizing", response_model=RightSizingReport)
+@router.get("/ideas/right-sizing", response_model=RightSizingReport, summary="Portfolio right-sizing report with health counts and suggestions (spec 158)")
 async def get_right_sizing_report() -> RightSizingReport:
     """Portfolio right-sizing report with health counts and suggestions (spec 158)."""
     from app.services import right_sizing_service
     return right_sizing_service.build_report()
 
 
-@router.post("/ideas/right-sizing/apply", response_model=RightSizingApplyResponse)
+@router.post("/ideas/right-sizing/apply", response_model=RightSizingApplyResponse, summary="Execute a split or merge suggestion, with dry_run support (spec 158)")
 async def apply_right_sizing(
     body: RightSizingApplyRequest,
     _key: str = Depends(require_api_key),
@@ -209,7 +209,7 @@ async def apply_right_sizing(
         raise HTTPException(status_code=422, detail=str(exc))
 
 
-@router.get("/ideas/right-sizing/history", response_model=RightSizingHistoryResponse)
+@router.get("/ideas/right-sizing/history", response_model=RightSizingHistoryResponse, summary="Time-series health snapshots for the portfolio (spec 158)")
 async def get_right_sizing_history(
     days: int = Query(7, ge=1, le=365, description="Lookback window in days"),
 ) -> RightSizingHistoryResponse:
@@ -218,13 +218,13 @@ async def get_right_sizing_history(
     return right_sizing_service.get_history(days=days)
 
 
-@router.get("/ideas/showcase", response_model=IdeaShowcaseResponse)
+@router.get("/ideas/showcase", response_model=IdeaShowcaseResponse, summary="Funder-facing idea summaries with ask, budget, proof, and status")
 async def list_ideas_showcase() -> IdeaShowcaseResponse:
     """Funder-facing idea summaries with ask, budget, proof, and status."""
     return idea_service.list_showcase_ideas()
 
 
-@router.get("/ideas/resonance")
+@router.get("/ideas/resonance", summary="Return ideas with recent activity, sorted by most-recent-activity-first")
 async def get_resonance(
     window_hours: int = Query(24, ge=1, le=720),
     limit: int = Query(20, ge=1, le=100),
@@ -233,7 +233,7 @@ async def get_resonance(
     return idea_service.get_resonance_feed(window_hours=window_hours, limit=limit)
 
 
-@router.get("/ideas/{idea_id}/concept-resonance", response_model=IdeaConceptResonanceResponse)
+@router.get("/ideas/{idea_id}/concept-resonance", response_model=IdeaConceptResonanceResponse, summary="Return conceptually related ideas, preferring matches from different domains")
 async def get_idea_concept_resonance(
     idea_id: str,
     limit: int = Query(5, ge=1, le=25),
@@ -250,7 +250,7 @@ async def get_idea_concept_resonance(
     return result
 
 
-@router.get("/ideas/{idea_id}/translate", response_model=IdeaTranslationResponse)
+@router.get("/ideas/{idea_id}/translate", response_model=IdeaTranslationResponse, summary="Reframe an idea through a worldview using the ontology graph and resonance edges")
 async def translate_idea_view(
     idea_id: str,
     view: TranslationLens = Query(..., description="Worldview lens (conceptual framing, not MT)."),
@@ -287,12 +287,12 @@ async def translate_idea_view(
     )
 
 
-@router.get("/ideas/selection-ab/stats")
+@router.get("/ideas/selection-ab/stats", summary="Get Selection Ab Stats")
 async def get_selection_ab_stats() -> dict:
     return idea_selection_ab_service.get_comparison()
 
 
-@router.post("/ideas/select", response_model=IdeaSelectionResult)
+@router.post("/ideas/select", response_model=IdeaSelectionResult, summary="Weighted stochastic idea selection")
 async def select_idea(
     method: str = Query("marginal_cc", description="Score method: free_energy | marginal_cc"),
     temperature: float = Query(1.0, ge=0.0, le=5.0, description="0=deterministic, 1=proportional, 2+=explore"),
@@ -319,24 +319,24 @@ async def select_idea(
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/ideas/count", response_model=IdeaCountResponse)
+@router.get("/ideas/count", response_model=IdeaCountResponse, summary="Count Ideas")
 async def count_ideas() -> IdeaCountResponse:
     return idea_service.count_ideas()
 
 
-@router.get("/ideas/progress", response_model=ProgressDashboard)
+@router.get("/ideas/progress", response_model=ProgressDashboard, summary="Per-stage idea counts and completion percentage (spec 138)")
 async def get_progress_dashboard() -> ProgressDashboard:
     """Per-stage idea counts and completion percentage (spec 138)."""
     return idea_service.compute_progress_dashboard()
 
 
-@router.get("/ideas/portfolio-summary")
+@router.get("/ideas/portfolio-summary", summary="Summary of curated super-ideas with spec counts, pillar grouping, and red/yellow/green he…")
 async def get_portfolio_summary() -> dict:
     """Summary of curated super-ideas with spec counts, pillar grouping, and red/yellow/green health."""
     return idea_service.get_portfolio_summary()
 
 
-@router.post("/ideas/{idea_id}/advance", response_model=IdeaWithScore)
+@router.post("/ideas/{idea_id}/advance", response_model=IdeaWithScore, summary="Advance an idea to the next sequential stage (spec 138)")
 async def advance_idea_stage(idea_id: str, _key: str = Depends(require_api_key)) -> IdeaWithScore:
     """Advance an idea to the next sequential stage (spec 138)."""
     result, error = idea_service.advance_idea_stage(idea_id)
@@ -347,7 +347,7 @@ async def advance_idea_stage(idea_id: str, _key: str = Depends(require_api_key))
     return result
 
 
-@router.post("/ideas/{idea_id}/stage", response_model=IdeaWithScore)
+@router.post("/ideas/{idea_id}/stage", response_model=IdeaWithScore, summary="Set an explicit stage for an idea (admin override, spec 138)")
 async def set_idea_stage(idea_id: str, body: StageSetRequest, _key: str = Depends(require_api_key)) -> IdeaWithScore:
     """Set an explicit stage for an idea (admin override, spec 138)."""
     try:
@@ -360,7 +360,7 @@ async def set_idea_stage(idea_id: str, body: StageSetRequest, _key: str = Depend
     return result
 
 
-@router.post("/ideas/{idea_id}/fork", status_code=201)
+@router.post("/ideas/{idea_id}/fork", status_code=201, summary="Fork an existing idea. Identify by forker_id or provider+provider_id")
 async def fork_idea_endpoint(
     idea_id: str,
     forker_id: str | None = Query(default=None, min_length=1),
@@ -407,7 +407,7 @@ def _resolve_contributor(contributor_id: str | None, provider: str | None, provi
     raise HTTPException(status_code=422, detail="Provide contributor_id OR provider+provider_id")
 
 
-@router.post("/ideas/{idea_id}/stake")
+@router.post("/ideas/{idea_id}/stake", summary="Stake CC on an idea. Identify by contributor_id or provider+provider_id")
 async def stake_on_idea(idea_id: str, body: StakeRequest) -> dict:
     """Stake CC on an idea. Identify by contributor_id or provider+provider_id."""
     staker_id = _resolve_contributor(body.contributor_id, body.provider, body.provider_id)
@@ -422,7 +422,7 @@ async def stake_on_idea(idea_id: str, body: StakeRequest) -> dict:
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/ideas/{idea_id}/progress")
+@router.get("/ideas/{idea_id}/progress", summary="Show idea progress: stage, tasks by phase, CC staked/spent, contributors")
 async def get_idea_progress(idea_id: str) -> dict:
     """Show idea progress: stage, tasks by phase, CC staked/spent, contributors."""
     result = stake_compute_service.get_idea_progress(idea_id)
@@ -431,7 +431,7 @@ async def get_idea_progress(idea_id: str) -> dict:
     return result
 
 
-@router.get("/ideas/{idea_id}/activity")
+@router.get("/ideas/{idea_id}/activity", summary="Return activity events for an idea")
 async def get_idea_activity_endpoint(
     idea_id: str,
     limit: int = Query(20, ge=1, le=100),
@@ -443,7 +443,7 @@ async def get_idea_activity_endpoint(
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/ideas/{idea_id}/tasks", response_model=IdeaTasksResponse)
+@router.get("/ideas/{idea_id}/tasks", response_model=IdeaTasksResponse, summary="Return all tasks linked to an idea, grouped by type with status counts")
 async def list_idea_tasks(idea_id: str) -> IdeaTasksResponse:
     """Return all tasks linked to an idea, grouped by type with status counts."""
     idea = idea_service.get_idea(idea_id)
@@ -452,7 +452,7 @@ async def list_idea_tasks(idea_id: str) -> IdeaTasksResponse:
     return agent_service.list_tasks_for_idea(idea_id)
 
 
-@router.put("/ideas/{idea_id}/tags", response_model=IdeaTagUpdateResponse)
+@router.put("/ideas/{idea_id}/tags", response_model=IdeaTagUpdateResponse, summary="Replace the full tag set for an idea after normalization (spec 129)")
 async def put_idea_tags(idea_id: str, body: IdeaTagUpdateRequest) -> IdeaTagUpdateResponse:
     """Replace the full tag set for an idea after normalization (spec 129)."""
     normalized, valid = idea_service.validate_raw_tags(body.tags)
@@ -464,7 +464,7 @@ async def put_idea_tags(idea_id: str, body: IdeaTagUpdateRequest) -> IdeaTagUpda
     return result
 
 
-@router.get("/ideas/{idea_id}/translations")
+@router.get("/ideas/{idea_id}/translations", summary="All worldview translations for an idea (spec-181 batch)")
 async def list_idea_translations_all(idea_id: str) -> dict:
     """All worldview translations for an idea (spec-181 batch)."""
     out = lens_translation_service.list_translations_for_idea(idea_id)
@@ -473,7 +473,7 @@ async def list_idea_translations_all(idea_id: str) -> dict:
     return out
 
 
-@router.get("/ideas/{idea_id}/translations/{lens_id}")
+@router.get("/ideas/{idea_id}/translations/{lens_id}", summary="Single lens translation with optional belief resonance (spec-181)")
 async def get_idea_translation_spec181(
     idea_id: str,
     lens_id: str,
@@ -493,7 +493,7 @@ async def get_idea_translation_spec181(
     return result
 
 
-@router.post("/ideas/{idea_id}/translations/{lens_id}")
+@router.post("/ideas/{idea_id}/translations/{lens_id}", summary="Force-regenerate cached translation (spec-181)")
 async def post_idea_translation_regenerate(
     idea_id: str,
     lens_id: str,
@@ -514,7 +514,7 @@ async def post_idea_translation_regenerate(
     return result
 
 
-@router.get("/ideas/{idea_id}/translate")
+@router.get("/ideas/{idea_id}/translate", summary="Translate an idea's conceptual framing through a worldview lens")
 async def translate_idea_view(
     idea_id: str,
     view: TranslateLens = Query(..., description="Target worldview lens"),
@@ -555,7 +555,7 @@ async def translate_idea_view(
     )
 
 
-@router.get("/ideas/{idea_id}/children", response_model=list[IdeaWithScore])
+@router.get("/ideas/{idea_id}/children", response_model=list[IdeaWithScore], summary="Return all child ideas whose parent_idea_id equals {idea_id}")
 async def list_idea_children(idea_id: str) -> list[IdeaWithScore]:
     """Return all child ideas whose parent_idea_id equals {idea_id}.
 
@@ -567,7 +567,7 @@ async def list_idea_children(idea_id: str) -> list[IdeaWithScore]:
     return idea_service.list_children_of(idea_id)
 
 
-@router.get("/ideas/{idea_id}/specs")
+@router.get("/ideas/{idea_id}/specs", summary="Return all specs linked to {idea_id} via their frontmatter idea_id")
 async def list_idea_specs(idea_id: str) -> list[dict]:
     """Return all specs linked to {idea_id} via their frontmatter idea_id."""
     from app.services import spec_registry_service
@@ -577,7 +577,7 @@ async def list_idea_specs(idea_id: str) -> list[dict]:
     return [s.model_dump(mode="json") for s in specs]
 
 
-@router.get("/ideas/{idea_id}/lifecycle")
+@router.get("/ideas/{idea_id}/lifecycle", summary="Return lifecycle closure state and blockers for an idea")
 async def get_idea_lifecycle(idea_id: str) -> dict:
     """Return lifecycle closure state and blockers for an idea."""
     result = idea_service.get_idea_lifecycle(idea_id)
@@ -586,7 +586,7 @@ async def get_idea_lifecycle(idea_id: str) -> dict:
     return result
 
 
-@router.get("/ideas/{idea_id}/rollup", response_model=RollupProgress)
+@router.get("/ideas/{idea_id}/rollup", response_model=RollupProgress, summary="Return rollup progress for a super-idea: children validated / total children (R4)")
 @traces_to(spec="super-idea-rollup-criteria", idea="idea-realization-engine", description="Rollup progress for a super-idea")
 async def get_idea_rollup(idea_id: str) -> RollupProgress:
     """Return rollup progress for a super-idea: children validated / total children (R4)."""
@@ -596,7 +596,7 @@ async def get_idea_rollup(idea_id: str) -> RollupProgress:
     return progress
 
 
-@router.post("/ideas/{idea_id}/validate-rollup", response_model=RollupProgress)
+@router.post("/ideas/{idea_id}/validate-rollup", response_model=RollupProgress, summary="Check rollup criteria for a super-idea and auto-update manifestation_status (R2, R3)")
 @traces_to(spec="super-idea-rollup-criteria", idea="idea-realization-engine", description="Validate super-idea rollup criteria and auto-update status")
 async def validate_super_idea_rollup(idea_id: str, _key: str = Depends(require_api_key)) -> RollupProgress:
     """Check rollup criteria for a super-idea and auto-update manifestation_status (R2, R3)."""
@@ -608,14 +608,14 @@ async def validate_super_idea_rollup(idea_id: str, _key: str = Depends(require_a
     return progress
 
 
-@router.get("/ideas/breath-overview")
+@router.get("/ideas/breath-overview", summary="Portfolio breath overview — gas/water/ice phase distribution for all curated super-ideas")
 async def get_breath_overview() -> dict:
     """Portfolio breath overview — gas/water/ice phase distribution for all curated super-ideas."""
     from app.services import breath_service
     return breath_service.compute_breath_overview()
 
 
-@router.get("/ideas/{idea_id}/resonance")
+@router.get("/ideas/{idea_id}/resonance", summary="Return top resonant ideas for a given idea, with coherence scores and cross-domain flags")
 async def get_idea_resonance(
     idea_id: str,
     limit: int = Query(10, ge=1, le=50),
@@ -669,7 +669,7 @@ async def get_idea_resonance(
         return []
 
 
-@router.get("/ideas/{idea_id}/breath")
+@router.get("/ideas/{idea_id}/breath", summary="Return breath analysis (gas/water/ice phase distribution) for an idea")
 async def get_idea_breath(idea_id: str) -> dict:
     """Return breath analysis (gas/water/ice phase distribution) for an idea."""
     from app.services import breath_service
@@ -679,7 +679,7 @@ async def get_idea_breath(idea_id: str) -> dict:
     return breath_service.compute_idea_breath(idea_id)
 
 
-@router.get("/ideas/{idea_id}", response_model=IdeaWithScore)
+@router.get("/ideas/{idea_id}", response_model=IdeaWithScore, summary="Get Idea")
 async def get_idea(idea_id: str) -> IdeaWithScore:
     idea = idea_service.get_idea(idea_id)
     if idea is None:
@@ -687,7 +687,7 @@ async def get_idea(idea_id: str) -> IdeaWithScore:
     return idea
 
 
-@router.post("/ideas", response_model=IdeaWithScore, status_code=201)
+@router.post("/ideas", response_model=IdeaWithScore, status_code=201, summary="Create Idea")
 async def create_idea(data: IdeaCreate) -> IdeaWithScore:
     # Layer 1 guardrails — universal across all agent provider CLIs.
     try:
@@ -731,7 +731,7 @@ async def create_idea(data: IdeaCreate) -> IdeaWithScore:
     return created
 
 
-@router.patch("/ideas/{idea_id}", response_model=IdeaWithScore)
+@router.patch("/ideas/{idea_id}", response_model=IdeaWithScore, summary="Update Idea")
 async def update_idea(idea_id: str, data: IdeaUpdate, _key: str = Depends(require_api_key)) -> IdeaWithScore:
     if all(
         field is None
@@ -784,7 +784,7 @@ async def update_idea(idea_id: str, data: IdeaUpdate, _key: str = Depends(requir
     return updated
 
 
-@router.patch("/ideas/{idea_id}/slug", response_model=SlugUpdateResponse)
+@router.patch("/ideas/{idea_id}/slug", response_model=SlugUpdateResponse, summary="Rename an idea's slug. Old slug is kept in slug_history for permanent redirect")
 async def update_idea_slug(
     idea_id: str,
     body: SlugUpdateRequest,
@@ -804,7 +804,7 @@ async def update_idea_slug(
     )
 
 
-@router.post("/ideas/{idea_id}/questions", response_model=IdeaWithScore)
+@router.post("/ideas/{idea_id}/questions", response_model=IdeaWithScore, summary="Add Idea Question")
 async def add_idea_question(idea_id: str, data: IdeaQuestionCreate) -> IdeaWithScore:
     updated, added = idea_service.add_question(
         idea_id=idea_id,
@@ -819,7 +819,7 @@ async def add_idea_question(idea_id: str, data: IdeaQuestionCreate) -> IdeaWithS
     return updated
 
 
-@router.post("/ideas/{idea_id}/questions/answer", response_model=IdeaWithScore)
+@router.post("/ideas/{idea_id}/questions/answer", response_model=IdeaWithScore, summary="Answer Idea Question")
 async def answer_idea_question(idea_id: str, data: IdeaQuestionAnswerUpdate) -> IdeaWithScore:
     updated, question_found = idea_service.answer_question(
         idea_id=idea_id,

--- a/api/app/routers/inventory.py
+++ b/api/app/routers/inventory.py
@@ -57,7 +57,7 @@ def _queue_inventory_auto_execute(payload: dict, background_tasks: BackgroundTas
         background_tasks.add_task(agent_execution_service.execute_task, task_id)
 
 
-@router.get("/inventory/system-lineage")
+@router.get("/inventory/system-lineage", summary="System Lineage Inventory")
 async def system_lineage_inventory(
     runtime_window_seconds: int = Query(3600, ge=60, le=2592000),
     lineage_link_limit: int = Query(300, ge=1, le=1000),
@@ -72,17 +72,17 @@ async def system_lineage_inventory(
     )
 
 
-@router.get("/inventory/routes/canonical")
+@router.get("/inventory/routes/canonical", summary="Canonical Routes")
 async def canonical_routes() -> dict:
     return route_registry_service.get_canonical_routes()
 
 
-@router.get("/inventory/page-lineage")
+@router.get("/inventory/page-lineage", summary="Page Lineage")
 async def page_lineage() -> dict:
     return page_lineage_service.get_page_lineage()
 
 
-@router.post("/inventory/questions/next-highest-roi-task")
+@router.post("/inventory/questions/next-highest-roi-task", summary="Next Highest Roi Task")
 async def next_highest_roi_task(
     background_tasks: BackgroundTasks,
     create_task: bool = Query(False),
@@ -93,14 +93,14 @@ async def next_highest_roi_task(
     return payload
 
 
-@router.post("/inventory/questions/sync-implementation-tasks")
+@router.post("/inventory/questions/sync-implementation-tasks", summary="Sync Implementation Request Tasks")
 async def sync_implementation_request_tasks(background_tasks: BackgroundTasks) -> dict:
     payload = inventory_service.sync_implementation_request_question_tasks()
     _queue_inventory_auto_execute(payload, background_tasks)
     return payload
 
 
-@router.post("/inventory/specs/sync-implementation-tasks")
+@router.post("/inventory/specs/sync-implementation-tasks", summary="Sync Spec Implementation Gap Tasks")
 async def sync_spec_implementation_gap_tasks(
     background_tasks: BackgroundTasks,
     create_task: bool = Query(False),
@@ -115,7 +115,7 @@ async def sync_spec_implementation_gap_tasks(
     return payload
 
 
-@router.post("/inventory/roi/sync-progress")
+@router.post("/inventory/roi/sync-progress", summary="Sync Roi Progress Tasks")
 async def sync_roi_progress_tasks(
     background_tasks: BackgroundTasks,
     create_task: bool = Query(False),
@@ -136,7 +136,7 @@ async def sync_roi_progress_tasks(
     return payload
 
 
-@router.get("/inventory/questions/proactive")
+@router.get("/inventory/questions/proactive", summary="Proactive Questions")
 async def proactive_questions(
     limit: int = Query(20, ge=1, le=200),
     top: int = Query(20, ge=1, le=200),
@@ -149,7 +149,7 @@ async def proactive_questions(
     )
 
 
-@router.post("/inventory/questions/sync-proactive")
+@router.post("/inventory/questions/sync-proactive", summary="Sync Proactive Questions")
 async def sync_proactive_questions(
     limit: int = Query(20, ge=1, le=200),
     max_add: int = Query(20, ge=1, le=200),
@@ -162,7 +162,7 @@ async def sync_proactive_questions(
     )
 
 
-@router.post("/inventory/gaps/sync-traceability")
+@router.post("/inventory/gaps/sync-traceability", summary="Sync Traceability Gap Artifacts")
 async def sync_traceability_gap_artifacts(
     background_tasks: BackgroundTasks,
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
@@ -182,7 +182,7 @@ async def sync_traceability_gap_artifacts(
     return payload
 
 
-@router.get("/pipeline/pulse")
+@router.get("/pipeline/pulse", summary="Pipeline self-awareness digest: what's working, what's stuck, what to do next")
 async def pipeline_pulse(
     window_days: int = Query(7, ge=1, le=90),
     task_limit: int = Query(500, ge=10, le=5000),
@@ -195,7 +195,7 @@ async def pipeline_pulse(
     )
 
 
-@router.post("/pipeline/fix-hollow-completions")
+@router.post("/pipeline/fix-hollow-completions", summary="Reclassify hollow completions as broken_provider. Fixes Thompson Sampling data")
 async def fix_hollow_completions(
     min_output_chars: int = Query(30, ge=1),
     batch_size: int = Query(200, ge=1, le=1000),
@@ -272,7 +272,7 @@ async def fix_hollow_completions(
     }
 
 
-@router.post("/inventory/gaps/bootstrap-specs")
+@router.post("/inventory/gaps/bootstrap-specs", summary="Create spec tasks for the highest-ROI ideas that don't have a spec yet")
 async def bootstrap_spec_tasks(
     max_tasks: int = Query(20, ge=1, le=100),
     min_value_gap: float = Query(10.0, ge=0),
@@ -284,7 +284,7 @@ async def bootstrap_spec_tasks(
     )
 
 
-@router.get("/inventory/process-completeness")
+@router.get("/inventory/process-completeness", summary="Process Completeness")
 async def process_completeness(
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
     auto_sync: bool = Query(False),
@@ -303,7 +303,7 @@ async def process_completeness(
     )
 
 
-@router.post("/inventory/gaps/sync-process-tasks")
+@router.post("/inventory/gaps/sync-process-tasks", summary="Sync Process Gap Tasks")
 async def sync_process_gap_tasks(
     background_tasks: BackgroundTasks,
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
@@ -327,7 +327,7 @@ async def sync_process_gap_tasks(
     return payload
 
 
-@router.get("/inventory/asset-modularity")
+@router.get("/inventory/asset-modularity", summary="Asset Modularity")
 async def asset_modularity(
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
     max_implementation_files: int = Query(5000, ge=100, le=20000),
@@ -338,7 +338,7 @@ async def asset_modularity(
     )
 
 
-@router.post("/inventory/gaps/sync-asset-modularity-tasks")
+@router.post("/inventory/gaps/sync-asset-modularity-tasks", summary="Sync Asset Modularity Tasks")
 async def sync_asset_modularity_tasks(
     background_tasks: BackgroundTasks,
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
@@ -352,7 +352,7 @@ async def sync_asset_modularity_tasks(
     return payload
 
 
-@router.get("/inventory/flow")
+@router.get("/inventory/flow", summary="Spec Process Implementation Validation Flow")
 def spec_process_implementation_validation_flow(
     request: Request,
     idea_id: str | None = Query(default=None),
@@ -413,7 +413,7 @@ def spec_process_implementation_validation_flow(
     )
 
 
-@router.post("/inventory/flow/next-unblock-task")
+@router.post("/inventory/flow/next-unblock-task", summary="Next Unblock Task")
 async def next_unblock_task(
     background_tasks: BackgroundTasks,
     create_task: bool = Query(False),
@@ -432,7 +432,7 @@ async def next_unblock_task(
     return payload
 
 
-@router.get("/inventory/endpoint-traceability")
+@router.get("/inventory/endpoint-traceability", summary="Endpoint Traceability Inventory")
 async def endpoint_traceability_inventory(
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
 ) -> dict:
@@ -441,21 +441,21 @@ async def endpoint_traceability_inventory(
     )
 
 
-@router.get("/inventory/route-evidence")
+@router.get("/inventory/route-evidence", summary="Route Evidence Inventory")
 async def route_evidence_inventory(
     runtime_window_seconds: int = Query(86400, ge=60, le=2592000),
 ) -> dict:
     return inventory_service.build_route_evidence_inventory(runtime_window_seconds=runtime_window_seconds)
 
 
-@router.get("/inventory/commit-evidence")
+@router.get("/inventory/commit-evidence", summary="Commit Evidence Inventory")
 async def commit_evidence_inventory(
     limit: int = Query(50, ge=1, le=500),
 ) -> dict:
     return inventory_service.build_commit_evidence_inventory(limit=limit)
 
 
-@router.post("/inventory/commit-evidence")
+@router.post("/inventory/commit-evidence", summary="Accept a batch of commit records from external tools")
 async def post_commit_evidence(
     body: dict = Body(...),
 ) -> dict:

--- a/api/app/routers/lenses.py
+++ b/api/app/routers/lenses.py
@@ -12,13 +12,13 @@ from app.services import lens_translation_service
 router = APIRouter()
 
 
-@router.get("/lenses/roi")
+@router.get("/lenses/roi", summary="Aggregate lens engagement metrics")
 def lenses_roi() -> dict:
     """Aggregate lens engagement metrics."""
     return lens_translation_service.get_roi_payload()
 
 
-@router.get("/lenses")
+@router.get("/lenses", summary="List all registered worldview and discipline lenses")
 def list_lenses() -> dict:
     """List all registered worldview and discipline lenses."""
     lenses = []
@@ -30,7 +30,7 @@ def list_lenses() -> dict:
     return {"lenses": lenses, "total": len(lenses)}
 
 
-@router.get("/lenses/{lens_id}")
+@router.get("/lenses/{lens_id}", summary="Get Lens")
 def get_lens(lens_id: str) -> dict:
     meta = translate_service.get_lens_meta(lens_id)
     if not meta:
@@ -38,7 +38,7 @@ def get_lens(lens_id: str) -> dict:
     return lens_public_dict(lens_id, meta)
 
 
-@router.post("/lenses", status_code=201)
+@router.post("/lenses", status_code=201, summary="Create Lens")
 def create_lens(body: WorldviewLensCreate, _key: str = Depends(require_api_key)) -> dict:
     if translate_service.get_lens_meta(body.lens_id):
         raise HTTPException(status_code=409, detail=f"Lens '{body.lens_id}' already exists")

--- a/api/app/routers/memberships.py
+++ b/api/app/routers/memberships.py
@@ -24,6 +24,7 @@ router = APIRouter()
 @router.get(
     "/workspaces/{workspace_id}/members",
     response_model=WorkspaceMembersResponse,
+    summary="List all members of a workspace",
 )
 async def list_members(workspace_id: str) -> WorkspaceMembersResponse:
     """List all members of a workspace."""
@@ -42,6 +43,7 @@ async def list_members(workspace_id: str) -> WorkspaceMembersResponse:
     "/workspaces/{workspace_id}/members",
     response_model=WorkspaceMember,
     status_code=201,
+    summary="Add a contributor directly as a member of a workspace",
 )
 async def add_member(
     workspace_id: str,
@@ -64,6 +66,7 @@ async def add_member(
     "/workspaces/{workspace_id}/invite",
     response_model=InviteResponse,
     status_code=201,
+    summary="Invite a contributor to a workspace (status=pending)",
 )
 async def invite_member(
     workspace_id: str,
@@ -85,6 +88,7 @@ async def invite_member(
 @router.post(
     "/workspaces/{workspace_id}/invite/{contributor_id}/accept",
     response_model=WorkspaceMember,
+    summary="Accept a pending invite to a workspace",
 )
 async def accept_invite(
     workspace_id: str,
@@ -108,6 +112,7 @@ async def accept_invite(
 @router.delete(
     "/workspaces/{workspace_id}/members/{contributor_id}",
     status_code=204,
+    summary="Remove a contributor from a workspace",
 )
 async def remove_member(
     workspace_id: str,
@@ -124,6 +129,7 @@ async def remove_member(
 @router.get(
     "/contributors/{contributor_id}/workspaces",
     response_model=MyWorkspacesResponse,
+    summary="List all workspaces a contributor belongs to",
 )
 async def list_workspaces_for_contributor(
     contributor_id: str,
@@ -138,6 +144,7 @@ async def list_workspaces_for_contributor(
 
 @router.get(
     "/workspaces/{workspace_id}/members/{contributor_id}",
+    summary="Get a contributor's role in a workspace",
 )
 async def get_member_role(workspace_id: str, contributor_id: str):
     """Get a contributor's role in a workspace."""

--- a/api/app/routers/messages.py
+++ b/api/app/routers/messages.py
@@ -20,7 +20,7 @@ class MarkReadBody(BaseModel):
     contributor_id: str = Field(min_length=1)
 
 
-@router.post("/messages", response_model=Message, status_code=201)
+@router.post("/messages", response_model=Message, status_code=201, summary="Send a direct or workspace message")
 async def send_message(
     data: MessageCreate,
     _api_key: str = Depends(require_api_key),
@@ -50,7 +50,7 @@ async def send_message(
     )
 
 
-@router.get("/messages/inbox/{contributor_id}", response_model=InboxResponse)
+@router.get("/messages/inbox/{contributor_id}", response_model=InboxResponse, summary="Get a contributor's inbox")
 async def get_inbox(
     contributor_id: str,
     limit: int = Query(50, ge=1, le=200),
@@ -72,7 +72,7 @@ async def get_inbox(
     )
 
 
-@router.get("/messages/thread/{contributor_a}/{contributor_b}", response_model=list[Message])
+@router.get("/messages/thread/{contributor_a}/{contributor_b}", response_model=list[Message], summary="Get the message thread between two contributors")
 async def get_thread(
     contributor_a: str,
     contributor_b: str,
@@ -87,7 +87,7 @@ async def get_thread(
     return [Message(**m) for m in messages]
 
 
-@router.patch("/messages/{message_id}/read", response_model=Message)
+@router.patch("/messages/{message_id}/read", response_model=Message, summary="Mark a message as read")
 async def mark_read(
     message_id: str,
     body: MarkReadBody,
@@ -110,7 +110,7 @@ async def mark_read(
     )
 
 
-@router.get("/workspaces/{workspace_id}/messages", response_model=list[Message])
+@router.get("/workspaces/{workspace_id}/messages", response_model=list[Message], summary="Get messages sent to a workspace")
 async def get_workspace_messages(
     workspace_id: str,
     limit: int = Query(50, ge=1, le=200),

--- a/api/app/routers/models.py
+++ b/api/app/routers/models.py
@@ -70,7 +70,7 @@ def _save_routing(config: dict) -> None:
 # ── Endpoints ───────────────────────────────────────────────────────
 
 
-@router.get("")
+@router.get("", summary="List all configured models grouped by executor with tier info")
 async def list_models() -> ModelsListResponse:
     """List all configured models grouped by executor with tier info."""
     config = _load_routing()
@@ -112,7 +112,7 @@ async def list_models() -> ModelsListResponse:
     return ModelsListResponse(executors=result, total=total)
 
 
-@router.get("/routing")
+@router.get("/routing", summary="Return current task-type → model routing configuration")
 async def get_routing_config() -> RoutingConfigResponse:
     """Return current task-type → model routing configuration."""
     config = _load_routing()
@@ -124,7 +124,7 @@ async def get_routing_config() -> RoutingConfigResponse:
     )
 
 
-@router.patch("/routing")
+@router.patch("/routing", summary="Update model routing configuration at runtime")
 async def update_routing_config(body: RoutingUpdateRequest) -> RoutingConfigResponse:
     """Update model routing configuration at runtime.
 

--- a/api/app/routers/news.py
+++ b/api/app/routers/news.py
@@ -46,7 +46,7 @@ class NewsSourceUpdate(BaseModel):
     priority: int | None = None
 
 
-@router.get("/news/sources")
+@router.get("/news/sources", summary="List all configured news sources")
 @traces_to(spec="151", idea="configurable-news-sources", description="List all configured news sources")
 async def list_news_sources(active_only: bool = Query(False)):
     """List all configured news sources."""
@@ -54,7 +54,7 @@ async def list_news_sources(active_only: bool = Query(False)):
     return {"count": len(sources), "sources": sources}
 
 
-@router.get("/news/sources/{source_id}")
+@router.get("/news/sources/{source_id}", summary="Get a single news source by ID")
 async def get_news_source(source_id: str):
     """Get a single news source by ID."""
     source = news_ingestion_service.get_source(source_id)
@@ -63,7 +63,7 @@ async def get_news_source(source_id: str):
     return source
 
 
-@router.post("/news/sources", status_code=201)
+@router.post("/news/sources", status_code=201, summary="Add a new news source")
 async def add_news_source(body: NewsSourceCreate, _key: str = Depends(require_api_key)):
     """Add a new news source."""
     try:
@@ -72,7 +72,7 @@ async def add_news_source(body: NewsSourceCreate, _key: str = Depends(require_ap
         raise HTTPException(400, str(e))
 
 
-@router.patch("/news/sources/{source_id}")
+@router.patch("/news/sources/{source_id}", summary="Update a news source")
 async def update_news_source(source_id: str, body: NewsSourceUpdate, _key: str = Depends(require_api_key)):
     """Update a news source."""
     updates = {k: v for k, v in body.model_dump().items() if v is not None}
@@ -82,7 +82,7 @@ async def update_news_source(source_id: str, body: NewsSourceUpdate, _key: str =
     return result
 
 
-@router.delete("/news/sources/{source_id}")
+@router.delete("/news/sources/{source_id}", summary="Remove a news source")
 async def remove_news_source(source_id: str, _key: str = Depends(require_api_key)):
     """Remove a news source."""
     if not news_ingestion_service.remove_source(source_id):
@@ -103,7 +103,7 @@ def _ideas_as_dicts(ideas) -> list[dict]:
     ]
 
 
-@router.get("/news/feed")
+@router.get("/news/feed", summary="Latest news items from RSS feeds")
 @traces_to(spec="151", idea="configurable-news-sources", description="Fetch news from configured RSS sources")
 async def get_news_feed(
     limit: int = Query(50, ge=1, le=200),
@@ -143,7 +143,7 @@ async def get_news_feed(
     return payload
 
 
-@router.get("/news/resonance")
+@router.get("/news/resonance", summary="News items matched to ideas with resonance scores and explanations")
 async def get_news_resonance(
     top_n: int = Query(5, ge=1, le=20, description="Top N matches per idea"),
     limit: int = Query(100, ge=1, le=500, description="Max news items to consider"),
@@ -165,7 +165,7 @@ async def get_news_resonance(
     }
 
 
-@router.get("/news/resonance/{contributor_id}")
+@router.get("/news/resonance/{contributor_id}", summary="News resonance filtered to a contributor's staked ideas")
 async def get_personalized_resonance(
     contributor_id: str,
     top_n: int = Query(5, ge=1, le=20),
@@ -207,7 +207,7 @@ async def get_personalized_resonance(
     }
 
 
-@router.get("/news/trending")
+@router.get("/news/trending", summary="Trending keywords extracted from recent news items")
 async def get_trending_keywords(
     top_n: int = Query(20, ge=1, le=100),
     refresh: bool = Query(False),

--- a/api/app/routers/pipeline.py
+++ b/api/app/routers/pipeline.py
@@ -10,7 +10,7 @@ from app.services import pipeline_service
 router = APIRouter()
 
 
-@router.get("/pipeline/status")
+@router.get("/pipeline/status", summary="Get Pipeline Status")
 async def get_pipeline_status() -> JSONResponse:
     status = pipeline_service.get_status()
     if not status.get("running"):
@@ -18,7 +18,7 @@ async def get_pipeline_status() -> JSONResponse:
     return JSONResponse(status_code=200, content=status)
 
 
-@router.get("/pipeline/summary")
+@router.get("/pipeline/summary", summary="Lightweight summary for the live dashboard — never returns 503")
 async def get_pipeline_summary() -> JSONResponse:
     """Lightweight summary for the live dashboard — never returns 503."""
     status = pipeline_service.get_status()

--- a/api/app/routers/provider_stats.py
+++ b/api/app/routers/provider_stats.py
@@ -62,7 +62,7 @@ def _error_breakdown(records: list[dict]) -> dict[str, int]:
     return counts
 
 
-@router.get("/stats")
+@router.get("/stats", summary="Per-provider stats across all task types")
 async def get_provider_stats() -> dict:
     """Per-provider stats across all task types."""
     # Collect all measurements grouped by provider
@@ -197,7 +197,7 @@ async def get_provider_stats() -> dict:
     }
 
 
-@router.get("/stats/network")
+@router.get("/stats/network", summary="Network-wide provider stats from federation nodes")
 async def get_network_provider_stats(window_days: int | None = None) -> dict:
     """Network-wide provider stats from federation nodes.
 

--- a/api/app/routers/providers.py
+++ b/api/app/routers/providers.py
@@ -8,7 +8,7 @@ from app.services import agent_service
 router = APIRouter()
 
 
-@router.get("/providers", response_model=TaskExecutionProviderList)
+@router.get("/providers", response_model=TaskExecutionProviderList, summary="Get Providers")
 async def get_providers() -> TaskExecutionProviderList:
     providers = agent_service.list_available_task_execution_providers()
     return TaskExecutionProviderList(

--- a/api/app/routers/registry_discovery.py
+++ b/api/app/routers/registry_discovery.py
@@ -19,12 +19,12 @@ from app.services import registry_discovery_service, registry_stats_service
 router = APIRouter()
 
 
-@router.get("/discovery/registry-submissions", tags=["discovery"], response_model=RegistrySubmissionInventory)
+@router.get("/discovery/registry-submissions", tags=["discovery"], response_model=RegistrySubmissionInventory, summary="List Registry Submissions")
 async def list_registry_submissions() -> RegistrySubmissionInventory:
     return registry_discovery_service.build_registry_submission_inventory()
 
 
-@router.get("/discovery/registry-stats", tags=["discovery"], response_model=RegistryStatsList)
+@router.get("/discovery/registry-stats", tags=["discovery"], response_model=RegistryStatsList, summary="List Registry Stats")
 async def list_registry_stats(
     refresh: bool = Query(default=False, description="Bypass cache and fetch live data"),
     registry_id: Optional[str] = Query(default=None, description="Filter to one registry"),
@@ -35,7 +35,7 @@ async def list_registry_stats(
     )
 
 
-@router.get("/discovery/registry-dashboard", tags=["discovery"], response_model=RegistryDashboard)
+@router.get("/discovery/registry-dashboard", tags=["discovery"], response_model=RegistryDashboard, summary="Get Registry Dashboard")
 async def get_registry_dashboard() -> RegistryDashboard:
     inventory = registry_discovery_service.build_registry_submission_inventory()
     try:

--- a/api/app/routers/resonance.py
+++ b/api/app/routers/resonance.py
@@ -119,7 +119,7 @@ def _all_ideas_as_dicts() -> list[dict]:
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
-@router.get("/resonance/cross-domain", response_model=CrossDomainResponse)
+@router.get("/resonance/cross-domain", response_model=CrossDomainResponse, summary="Return top cross-domain idea pairs ranked by CRK coherence")
 async def get_cross_domain_resonances(
     limit: int = Query(20, ge=1, le=100, description="Max pairs to return"),
     min_coherence: float = Query(0.0, ge=0.0, le=1.0, description="Minimum CRK coherence filter"),
@@ -146,7 +146,7 @@ async def get_cross_domain_resonances(
     )
 
 
-@router.get("/resonance/ideas/{idea_id}", response_model=ResonanceForIdeaResponse)
+@router.get("/resonance/ideas/{idea_id}", response_model=ResonanceForIdeaResponse, summary="Return ideas that resonate structurally with the given idea")
 async def get_resonance_for_idea(
     idea_id: str,
     limit: int = Query(10, ge=1, le=50),
@@ -188,7 +188,7 @@ async def get_resonance_for_idea(
     )
 
 
-@router.get("/resonance/proof", response_model=ResonanceProofOut)
+@router.get("/resonance/proof", response_model=ResonanceProofOut, summary="Return evidence that structural cross-domain resonance is working")
 async def get_resonance_proof() -> ResonanceProofOut:
     """Return evidence that structural cross-domain resonance is working.
 
@@ -222,7 +222,7 @@ async def get_resonance_proof() -> ResonanceProofOut:
     )
 
 
-@router.get("/resonance/events")
+@router.get("/resonance/events", summary="Return the resonance discovery event log (most recent first)")
 async def get_resonance_events(
     limit: int = Query(50, ge=1, le=200),
 ) -> list[dict]:
@@ -234,7 +234,7 @@ async def get_resonance_events(
     return resonance_svc.get_event_log(limit=limit)
 
 
-@router.post("/resonance/scan", response_model=ScanResult)
+@router.post("/resonance/scan", response_model=ScanResult, summary="Trigger a full cross-domain resonance scan of the idea portfolio")
 async def trigger_resonance_scan(
     min_coherence: float = Query(0.0, ge=0.0, le=1.0),
     max_ideas: int = Query(100, ge=1, le=500, description="Cap ideas to scan (prevents timeout)"),

--- a/api/app/routers/runtime.py
+++ b/api/app/routers/runtime.py
@@ -24,12 +24,12 @@ class RuntimeExerciserRunRequest(BaseModel):
     runtime_window_seconds: int | None = None
 
 
-@router.post("/runtime/events", response_model=RuntimeEvent, status_code=201)
+@router.post("/runtime/events", response_model=RuntimeEvent, status_code=201, summary="Create Runtime Event")
 async def create_runtime_event(payload: RuntimeEventCreate) -> RuntimeEvent:
     return runtime_service.record_event(payload)
 
 
-@router.get("/runtime/events", response_model=list[RuntimeEvent])
+@router.get("/runtime/events", response_model=list[RuntimeEvent], summary="List Runtime Events")
 async def list_runtime_events(
     limit: int = Query(100, ge=1, le=2000),
     source: str | None = Query(default=None, max_length=64),
@@ -38,12 +38,12 @@ async def list_runtime_events(
     return runtime_service.cached_runtime_events(limit=limit, source=source, force_refresh=force_refresh)
 
 
-@router.get("/runtime/change-token")
+@router.get("/runtime/change-token", summary="Runtime Change Token")
 async def runtime_change_token(force_refresh: bool = Query(False)) -> dict:
     return runtime_service.live_change_token(force_refresh=force_refresh)
 
 
-@router.get("/runtime/ideas/summary")
+@router.get("/runtime/ideas/summary", summary="Runtime Summary By Idea")
 async def runtime_summary_by_idea(
     seconds: int = Query(3600, ge=60, le=2592000),
     limit: int = Query(200, ge=1, le=2000),
@@ -62,7 +62,7 @@ async def runtime_summary_by_idea(
     )
 
 
-@router.get("/runtime/endpoints/summary")
+@router.get("/runtime/endpoints/summary", summary="Runtime Summary By Endpoint")
 async def runtime_summary_by_endpoint(
     seconds: int = Query(3600, ge=60, le=2592000),
     limit: int = Query(200, ge=1, le=2000),
@@ -74,7 +74,7 @@ async def runtime_summary_by_endpoint(
     }
 
 
-@router.get("/runtime/web/views/summary", response_model=WebViewPerformanceReport)
+@router.get("/runtime/web/views/summary", response_model=WebViewPerformanceReport, summary="Runtime Web View Summary")
 async def runtime_web_view_summary(
     seconds: int = Query(21600, ge=60, le=2592000),
     limit: int = Query(100, ge=1, le=500),
@@ -92,7 +92,7 @@ async def runtime_web_view_summary(
     return WebViewPerformanceReport.model_validate(payload)
 
 
-@router.get("/runtime/endpoints/attention", response_model=EndpointAttentionReport)
+@router.get("/runtime/endpoints/attention", response_model=EndpointAttentionReport, summary="Runtime Endpoint Attention")
 async def runtime_endpoint_attention(
     seconds: int = Query(3600, ge=60, le=2592000),
     min_event_count: int = Query(1, ge=1, le=5000),
@@ -107,7 +107,7 @@ async def runtime_endpoint_attention(
     )
 
 
-@router.post("/runtime/exerciser/run")
+@router.post("/runtime/exerciser/run", summary="Run Runtime Get Endpoint Exerciser")
 async def run_runtime_get_endpoint_exerciser(
     request: Request,
     payload: RuntimeExerciserRunRequest | None = Body(default=None),
@@ -129,7 +129,7 @@ async def run_runtime_get_endpoint_exerciser(
     )
 
 
-@router.get("/runtime/usage/verification")
+@router.get("/runtime/usage/verification", summary="Verify Runtime Usage Internal Vs Public")
 async def verify_runtime_usage_internal_vs_public(
     public_api_base: str = Query(
         "https://api.coherencycoin.com",
@@ -145,7 +145,7 @@ async def verify_runtime_usage_internal_vs_public(
     )
 
 
-@router.get("/runtime/mvp/acceptance-summary")
+@router.get("/runtime/mvp/acceptance-summary", summary="Runtime Mvp Acceptance Summary")
 async def runtime_mvp_acceptance_summary(
     seconds: int = Query(86400, ge=60, le=2592000),
     limit: int = Query(2000, ge=100, le=5000),
@@ -153,7 +153,7 @@ async def runtime_mvp_acceptance_summary(
     return runtime_service.summarize_mvp_acceptance(seconds=seconds, event_limit=limit)
 
 
-@router.get("/runtime/mvp/acceptance-judge")
+@router.get("/runtime/mvp/acceptance-judge", summary="Runtime Mvp Acceptance Judge")
 async def runtime_mvp_acceptance_judge(
     seconds: int = Query(86400, ge=60, le=2592000),
     limit: int = Query(2000, ge=100, le=5000),
@@ -161,7 +161,7 @@ async def runtime_mvp_acceptance_judge(
     return runtime_service.evaluate_mvp_acceptance_judge(seconds=seconds, event_limit=limit)
 
 
-@router.get("/runtime/mvp/local-baselines")
+@router.get("/runtime/mvp/local-baselines", summary="Runtime Mvp Local Baselines")
 async def runtime_mvp_local_baselines(
     limit: int = Query(20, ge=1, le=100),
 ) -> dict:

--- a/api/app/routers/service_registry_router.py
+++ b/api/app/routers/service_registry_router.py
@@ -16,21 +16,21 @@ def _get_registry(request: Request):
     return registry
 
 
-@router.get("/services/health")
+@router.get("/services/health", summary="Full health report for all registered services")
 async def services_health(request: Request) -> dict:
     """Full health report for all registered services."""
     registry = _get_registry(request)
     return registry.health_report()
 
 
-@router.get("/services/dependencies")
+@router.get("/services/dependencies", summary="Dependency graph across all registered services")
 async def services_dependencies(request: Request) -> dict:
     """Dependency graph across all registered services."""
     registry = _get_registry(request)
     return registry.dependency_graph()
 
 
-@router.get("/services/{service_id}/health")
+@router.get("/services/{service_id}/health", summary="Health check for a single service")
 async def service_health(service_id: str, request: Request) -> dict:
     """Health check for a single service."""
     registry = _get_registry(request)
@@ -44,7 +44,7 @@ async def service_health(service_id: str, request: Request) -> dict:
         return {"error": False, "detail": str(exc)}
 
 
-@router.get("/services/{service_id}")
+@router.get("/services/{service_id}", summary="Get spec for a single service")
 async def get_service(service_id: str, request: Request) -> dict:
     """Get spec for a single service."""
     registry = _get_registry(request)
@@ -55,7 +55,7 @@ async def get_service(service_id: str, request: Request) -> dict:
     return asdict(spec)
 
 
-@router.get("/services")
+@router.get("/services", summary="List all registered service specs")
 async def list_services(request: Request) -> list[dict]:
     """List all registered service specs."""
     registry = _get_registry(request)

--- a/api/app/routers/spec_registry.py
+++ b/api/app/routers/spec_registry.py
@@ -16,7 +16,7 @@ from app.services.workspace_scoped_validation import (
 router = APIRouter()
 
 
-@router.get("/spec-registry", response_model=list[SpecRegistryEntry])
+@router.get("/spec-registry", response_model=list[SpecRegistryEntry], summary="List Specs")
 async def list_specs(
     response: Response,
     limit: int = Query(200, ge=1, le=1000),
@@ -27,7 +27,7 @@ async def list_specs(
     return spec_registry_service.list_specs(limit=limit, offset=offset, workspace_id=workspace_id)
 
 
-@router.get("/spec-registry/cards")
+@router.get("/spec-registry/cards", summary="List Spec Cards")
 async def list_spec_cards(
     q: str = Query("", description="Free-text search across spec title/summary/ids/contributors."),
     state: str = Query(
@@ -61,7 +61,7 @@ async def list_spec_cards(
     )
 
 
-@router.get("/spec-registry/{spec_id}", response_model=SpecRegistryEntry)
+@router.get("/spec-registry/{spec_id}", response_model=SpecRegistryEntry, summary="Get Spec")
 async def get_spec(spec_id: str) -> SpecRegistryEntry:
     found = spec_registry_service.get_spec(spec_id)
     if found is None:
@@ -69,7 +69,7 @@ async def get_spec(spec_id: str) -> SpecRegistryEntry:
     return found
 
 
-@router.post("/spec-registry", response_model=SpecRegistryEntry, status_code=201)
+@router.post("/spec-registry", response_model=SpecRegistryEntry, status_code=201, summary="Create Spec")
 async def create_spec(data: SpecRegistryCreate, _key: str = Depends(require_api_key)) -> SpecRegistryEntry:
     # Layer 1 guardrails — universal across all agent provider CLIs.
     try:
@@ -86,7 +86,7 @@ async def create_spec(data: SpecRegistryCreate, _key: str = Depends(require_api_
     return created
 
 
-@router.delete("/spec-registry/{spec_id}", status_code=204)
+@router.delete("/spec-registry/{spec_id}", status_code=204, summary="Delete Spec")
 async def delete_spec(spec_id: str, _key: str = Depends(require_api_key)) -> None:
     deleted = spec_registry_service.delete_spec(spec_id)
     if not deleted:
@@ -94,7 +94,7 @@ async def delete_spec(spec_id: str, _key: str = Depends(require_api_key)) -> Non
     return None
 
 
-@router.patch("/spec-registry/{spec_id}", response_model=SpecRegistryEntry)
+@router.patch("/spec-registry/{spec_id}", response_model=SpecRegistryEntry, summary="Update Spec")
 async def update_spec(spec_id: str, data: SpecRegistryUpdate, _key: str = Depends(require_api_key)) -> SpecRegistryEntry:
     if all(
         value is None

--- a/api/app/routers/task_activity_routes.py
+++ b/api/app/routers/task_activity_routes.py
@@ -28,7 +28,7 @@ class ActivityEvent(BaseModel):
     data: dict = {}
 
 
-@router.get("/tasks/activity")
+@router.get("/tasks/activity", summary="Recent activity across all tasks")
 async def recent_activity(
     limit: int = Query(50, ge=1, le=200),
     task_id: str | None = Query(None),
@@ -38,19 +38,19 @@ async def recent_activity(
     return get_activity(limit=limit, task_id=task_id, node_id=node_id)
 
 
-@router.get("/tasks/active")
+@router.get("/tasks/active", summary="Currently executing tasks across all nodes")
 async def active_tasks() -> list[dict]:
     """Currently executing tasks across all nodes."""
     return get_active_tasks()
 
 
-@router.get("/tasks/{task_id}/stream")
+@router.get("/tasks/{task_id}/stream", summary="All events for one task")
 async def task_stream(task_id: str) -> list[dict]:
     """All events for one task."""
     return get_task_stream(task_id)
 
 
-@router.post("/tasks/{task_id}/activity", status_code=201)
+@router.post("/tasks/{task_id}/activity", status_code=201, summary="Log an activity event (from runners)")
 async def post_activity(task_id: str, body: ActivityEvent) -> dict:
     """Log an activity event (from runners)."""
     event = log_activity(
@@ -66,7 +66,7 @@ async def post_activity(task_id: str, body: ActivityEvent) -> dict:
     return event
 
 
-@router.get("/tasks/{task_id}/events")
+@router.get("/tasks/{task_id}/events", summary="Server-Sent Events stream for live task updates")
 async def task_events_sse(task_id: str):
     """Server-Sent Events stream for live task updates."""
 

--- a/api/app/routers/traceability.py
+++ b/api/app/routers/traceability.py
@@ -36,7 +36,7 @@ router = APIRouter()
 # ---- Legacy endpoints (keep backward compat) ---------------------------------
 
 
-@router.get("/traceability")
+@router.get("/traceability", summary="List all runtime-traced functions with their spec and idea links")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability")
 async def list_all_traces(
     limit: int = Query(100, ge=1, le=500),
@@ -49,7 +49,7 @@ async def list_all_traces(
     }
 
 
-@router.get("/traceability/coverage")
+@router.get("/traceability/coverage", summary="Report legacy traceability coverage from @traces_to decorator")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability")
 async def traceability_coverage():
     """Report legacy traceability coverage from @traces_to decorator."""
@@ -68,7 +68,7 @@ async def traceability_coverage():
 # ---- Phase 1 endpoints -------------------------------------------------------
 
 
-@router.get("/traceability/report")
+@router.get("/traceability/report", summary="Return current traceability state across all dimensions")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability",
              description="Full traceability report across all dimensions")
 async def traceability_report():
@@ -81,7 +81,7 @@ async def traceability_report():
     return report.model_dump()
 
 
-@router.post("/traceability/backfill", status_code=202)
+@router.post("/traceability/backfill", status_code=202, summary="Trigger background backfill of all Phase 1 scripts")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability",
              description="Trigger background backfill of spec->idea and code->spec links")
 async def trigger_backfill(body: BackfillRequest = BackfillRequest()):
@@ -97,7 +97,7 @@ async def trigger_backfill(body: BackfillRequest = BackfillRequest()):
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
-@router.get("/traceability/backfill/status")
+@router.get("/traceability/backfill/status", summary="Check the status of the most recent backfill job")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability")
 async def backfill_status():
     """Check the status of the most recent backfill job."""
@@ -110,7 +110,7 @@ async def backfill_status():
 # ---- Phase 3 endpoints -------------------------------------------------------
 
 
-@router.get("/traceability/functions")
+@router.get("/traceability/functions", summary="Return all functions annotated with @spec_traced, with coverage stats")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability",
              description="List all functions with @spec_traced decorator")
 async def function_registry(
@@ -126,7 +126,7 @@ async def function_registry(
     return result.model_dump()
 
 
-@router.get("/traceability/lineage/{idea_id}")
+@router.get("/traceability/lineage/{idea_id}", summary="Return the complete lineage chain from an idea to its specs, files, and functions")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability",
              description="Full lineage chain: idea to specs to files to functions")
 async def idea_lineage(idea_id: str):
@@ -141,7 +141,7 @@ async def idea_lineage(idea_id: str):
     return lineage.model_dump()
 
 
-@router.get("/traceability/spec/{spec_id}")
+@router.get("/traceability/spec/{spec_id}", summary="Return all files and functions that implement a given spec")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability",
              description="Forward trace from spec to all implementing files and functions")
 async def spec_forward_trace(spec_id: str):
@@ -156,7 +156,7 @@ async def spec_forward_trace(spec_id: str):
     return trace.model_dump()
 
 
-@router.get("/traceability/idea/{idea_id}")
+@router.get("/traceability/idea/{idea_id}", summary="Find all @traces_to-decorated functions that trace back to a specific idea")
 @spec_traced("full-code-traceability", idea_id="full-code-traceability")
 async def traces_for_idea(idea_id: str):
     """Find all @traces_to-decorated functions that trace back to a specific idea."""

--- a/api/app/routers/value_lineage.py
+++ b/api/app/routers/value_lineage.py
@@ -21,18 +21,18 @@ from app.services import value_lineage_service
 router = APIRouter()
 
 
-@router.post("/value-lineage/links", response_model=LineageLink, status_code=201)
+@router.post("/value-lineage/links", response_model=LineageLink, status_code=201, summary="Create Link")
 async def create_link(payload: LineageLinkCreate, _key: str = Depends(require_api_key)) -> LineageLink:
     return value_lineage_service.create_link(payload)
 
 
-@router.get("/value-lineage/links", response_model=LineageLinksResponse)
+@router.get("/value-lineage/links", response_model=LineageLinksResponse, summary="List Links")
 async def list_links(limit: int = 200) -> LineageLinksResponse:
     links = value_lineage_service.list_links(limit=limit)
     return LineageLinksResponse(links=links)
 
 
-@router.get("/value-lineage/links/{lineage_id}", response_model=LineageLink)
+@router.get("/value-lineage/links/{lineage_id}", response_model=LineageLink, summary="Get Link")
 async def get_link(lineage_id: str) -> LineageLink:
     link = value_lineage_service.get_link(lineage_id)
     if link is None:
@@ -44,6 +44,7 @@ async def get_link(lineage_id: str) -> LineageLink:
     "/value-lineage/links/{lineage_id}/usage-events",
     response_model=UsageEvent,
     status_code=201,
+    summary="Add Usage Event",
 )
 async def add_usage_event(lineage_id: str, payload: UsageEventCreate, _key: str = Depends(require_api_key)) -> UsageEvent:
     event = value_lineage_service.add_usage_event(lineage_id, payload)
@@ -52,7 +53,7 @@ async def add_usage_event(lineage_id: str, payload: UsageEventCreate, _key: str 
     return event
 
 
-@router.get("/value-lineage/links/{lineage_id}/valuation", response_model=LineageValuation)
+@router.get("/value-lineage/links/{lineage_id}/valuation", response_model=LineageValuation, summary="Get Valuation")
 async def get_valuation(lineage_id: str) -> LineageValuation:
     report = value_lineage_service.valuation(lineage_id)
     if report is None:
@@ -60,7 +61,7 @@ async def get_valuation(lineage_id: str) -> LineageValuation:
     return report
 
 
-@router.post("/value-lineage/links/{lineage_id}/payout-preview", response_model=PayoutPreview)
+@router.post("/value-lineage/links/{lineage_id}/payout-preview", response_model=PayoutPreview, summary="Payout Preview")
 async def payout_preview(lineage_id: str, payload: PayoutPreviewRequest, _key: str = Depends(require_api_key)) -> PayoutPreview:
     report = value_lineage_service.payout_preview(lineage_id, payload.payout_pool)
     if report is None:
@@ -68,6 +69,6 @@ async def payout_preview(lineage_id: str, payload: PayoutPreviewRequest, _key: s
     return report
 
 
-@router.post("/value-lineage/minimum-e2e-flow", response_model=MinimumE2EFlowResponse)
+@router.post("/value-lineage/minimum-e2e-flow", response_model=MinimumE2EFlowResponse, summary="Run Minimum E2e Flow")
 async def run_minimum_e2e_flow(_key: str = Depends(require_api_key)) -> MinimumE2EFlowResponse:
     return value_lineage_service.run_minimum_e2e_flow()

--- a/api/app/routers/vitality.py
+++ b/api/app/routers/vitality.py
@@ -12,7 +12,7 @@ from app.services import vitality_service
 router = APIRouter()
 
 
-@router.get("/workspaces/{workspace_id}/vitality")
+@router.get("/workspaces/{workspace_id}/vitality", summary="Return living-system health metrics for a workspace")
 async def get_vitality(workspace_id: str) -> dict:
     """Return living-system health metrics for a workspace."""
     return vitality_service.compute_vitality(workspace_id=workspace_id)

--- a/api/app/routers/workspace_projects.py
+++ b/api/app/routers/workspace_projects.py
@@ -25,6 +25,7 @@ router = APIRouter()
     "/workspaces/{workspace_id}/projects",
     response_model=WorkspaceProject,
     status_code=201,
+    summary="Create Project",
 )
 async def create_project(
     workspace_id: str,
@@ -47,6 +48,7 @@ async def create_project(
 @router.get(
     "/workspaces/{workspace_id}/projects",
     response_model=ProjectListResponse,
+    summary="List Projects",
 )
 async def list_projects(workspace_id: str) -> ProjectListResponse:
     projects = workspace_project_service.list_projects(workspace_id)
@@ -59,6 +61,7 @@ async def list_projects(workspace_id: str) -> ProjectListResponse:
 @router.get(
     "/projects/{project_id}",
     response_model=WorkspaceProjectDetail,
+    summary="Get Project",
 )
 async def get_project(project_id: str) -> WorkspaceProjectDetail:
     proj = workspace_project_service.get_project(project_id)
@@ -67,7 +70,7 @@ async def get_project(project_id: str) -> WorkspaceProjectDetail:
     return WorkspaceProjectDetail(**proj)
 
 
-@router.delete("/projects/{project_id}", status_code=204)
+@router.delete("/projects/{project_id}", status_code=204, summary="Delete Project")
 async def delete_project(
     project_id: str,
     _key: str = Depends(require_api_key),
@@ -80,6 +83,7 @@ async def delete_project(
 @router.post(
     "/projects/{project_id}/ideas",
     status_code=201,
+    summary="Add Idea To Project",
 )
 async def add_idea_to_project(
     project_id: str,
@@ -97,7 +101,7 @@ async def add_idea_to_project(
     return edge
 
 
-@router.delete("/projects/{project_id}/ideas/{idea_id}", status_code=204)
+@router.delete("/projects/{project_id}/ideas/{idea_id}", status_code=204, summary="Remove Idea From Project")
 async def remove_idea_from_project(
     project_id: str,
     idea_id: str,
@@ -108,7 +112,7 @@ async def remove_idea_from_project(
         raise HTTPException(status_code=404, detail="Edge not found")
 
 
-@router.get("/ideas/{idea_id}/projects", response_model=ProjectListResponse)
+@router.get("/ideas/{idea_id}/projects", response_model=ProjectListResponse, summary="List Projects For Idea")
 async def list_projects_for_idea(idea_id: str) -> ProjectListResponse:
     projects = workspace_project_service.list_projects_for_idea(idea_id)
     return ProjectListResponse(

--- a/api/app/routers/workspaces.py
+++ b/api/app/routers/workspaces.py
@@ -15,12 +15,12 @@ from app.services import workspace_service
 router = APIRouter()
 
 
-@router.get("/workspaces", response_model=list[Workspace])
+@router.get("/workspaces", response_model=list[Workspace], summary="List Workspaces")
 async def list_workspaces() -> list[Workspace]:
     return workspace_service.list_workspaces()
 
 
-@router.get("/workspaces/{workspace_id}", response_model=Workspace)
+@router.get("/workspaces/{workspace_id}", response_model=Workspace, summary="Get Workspace")
 async def get_workspace(workspace_id: str) -> Workspace:
     ws = workspace_service.get_workspace(workspace_id)
     if ws is None:
@@ -28,7 +28,7 @@ async def get_workspace(workspace_id: str) -> Workspace:
     return ws
 
 
-@router.post("/workspaces", response_model=Workspace, status_code=201)
+@router.post("/workspaces", response_model=Workspace, status_code=201, summary="Create Workspace")
 async def create_workspace(data: WorkspaceCreate) -> Workspace:
     created = workspace_service.create_workspace(data)
     if created is None:
@@ -36,7 +36,7 @@ async def create_workspace(data: WorkspaceCreate) -> Workspace:
     return created
 
 
-@router.patch("/workspaces/{workspace_id}", response_model=Workspace)
+@router.patch("/workspaces/{workspace_id}", response_model=Workspace, summary="Update Workspace")
 async def update_workspace(workspace_id: str, data: WorkspaceUpdate) -> Workspace:
     if all(
         field is None
@@ -52,7 +52,7 @@ async def update_workspace(workspace_id: str, data: WorkspaceUpdate) -> Workspac
     return updated
 
 
-@router.get("/workspaces/{workspace_id}/pillars", response_model=list[str])
+@router.get("/workspaces/{workspace_id}/pillars", response_model=list[str], summary="Return the pillar taxonomy declared by this workspace")
 async def get_workspace_pillars(workspace_id: str) -> list[str]:
     """Return the pillar taxonomy declared by this workspace."""
     if workspace_service.get_workspace(workspace_id) is None:


### PR DESCRIPTION
Third PR in the review-and-improve series. Closes the biggest finding from the **Clarity** lens on the API surface: 94% of endpoints had no OpenAPI summary, so autodoc and generated clients were effectively empty.

## Before / after

| | Endpoints with \`summary=\` |
|---|---|
| Before | 29 / 482 (6%) |
| After  | 481 / 481 (100%) |

61/87 router files touched. 384 new summaries added; 98 pre-existing summaries left alone.

## Method

AST-based script (not committed) that:

1. Walks every \`api/app/routers/*.py\` finding \`@router.<method>(...)\` decorators
2. Skips any that already have a \`summary=\` kwarg (idempotent)
3. Derives summary from:
   - Function's docstring first line (stripped, trailing period removed, truncated at 90 chars)
   - Fallback to Title-Case-from-function-name if no docstring
4. String-inserts \`summary=\"...\"\` handling 5 decorator shapes (single-line, multi-line, with/without trailing comma, empty args)
5. Preserves existing formatting — no reformat, no import changes

## Verification

- \`ast.parse\` clean on all 87 routers
- \`pytest tests/\` 471/471 pass
- \`app.openapi()\` reports 481/481 paths have summaries
- Spot-checks on multi-line + single-line + trailing-comma cases all render cleanly

## Sample output

Single-line, inline:
\`\`\`python
@router.get(\"/concepts\", summary=\"List concepts from the ontology (paged)\")
\`\`\`

Multi-line with response_model, trailing comma preserved:
\`\`\`python
@router.get(
    \"/workspaces/{workspace_id}/activity\",
    response_model=ActivityFeedResponse,
    summary=\"List activity events for a workspace\",
)
\`\`\`

## Side-effect surfaced (NOT from this PR)

\`\`\`
UserWarning: Duplicate Operation ID translate_idea_view_api_ideas__idea_id__translate_get
\`\`\`

Long-standing duplicate operation ID flagged by FastAPI's OpenAPI generator. Pre-existed this PR; noting for a follow-up.

## Risks

- **None to runtime.** \`summary=\` is OpenAPI metadata only; it doesn't affect request handling, validation, response shapes, or permissions.
- **Pure documentation win.** Swagger UI at \`/docs\` becomes usable for the first time. Client SDK generators (openapi-generator, swagger-codegen) will now produce methods with named intent rather than generated identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)