### PR TITLE
feat(web): route-level loading skeletons + proper 404s on detail pages

### DIFF
--- a/web/app/assets/[asset_id]/page.tsx
+++ b/web/app/assets/[asset_id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { getApiBase } from "@/lib/api";
 
@@ -87,18 +88,11 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
   const assetId = decodeURIComponent(resolved.asset_id);
   const { asset, contributions, contributorsById } = await loadAssetPage(assetId);
 
+  // Return a proper 404 status instead of rendering a 200 with "not found"
+  // copy. Next.js will fall through to app/not-found.tsx (or the root
+  // loading boundary) and set `Cache-Control: private, no-cache, no-store`.
   if (!asset) {
-    return (
-      <main className="min-h-screen p-8 max-w-5xl mx-auto space-y-4">
-        <Link href="/assets" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Assets
-        </Link>
-        <h1 className="text-2xl font-bold">Asset not found</h1>
-        <p className="text-muted-foreground">
-          There is no asset record for <span className="font-mono">{assetId}</span>.
-        </p>
-      </main>
-    );
+    notFound();
   }
 
   const totalContributionCost = contributions.reduce((sum, item) => sum + (Number(item.cost_amount) || 0), 0);

--- a/web/app/assets/loading.tsx
+++ b/web/app/assets/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading assets" />;
+}

--- a/web/app/concepts/loading.tsx
+++ b/web/app/concepts/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading concepts" />;
+}

--- a/web/app/contributors/[id]/loading.tsx
+++ b/web/app/contributors/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DetailSkeleton label="Loading contributor" />;
+}

--- a/web/app/contributors/loading.tsx
+++ b/web/app/contributors/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading contributors" />;
+}

--- a/web/app/dashboard/loading.tsx
+++ b/web/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading dashboard" />;
+}

--- a/web/app/discover/loading.tsx
+++ b/web/app/discover/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading discover" />;
+}

--- a/web/app/flow/loading.tsx
+++ b/web/app/flow/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading flow" />;
+}

--- a/web/app/governance/loading.tsx
+++ b/web/app/governance/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading governance" />;
+}

--- a/web/app/ideas/[idea_id]/loading.tsx
+++ b/web/app/ideas/[idea_id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DetailSkeleton label="Loading idea" />;
+}

--- a/web/app/ideas/loading.tsx
+++ b/web/app/ideas/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading ideas" />;
+}

--- a/web/app/invest/loading.tsx
+++ b/web/app/invest/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading invest" />;
+}

--- a/web/app/marketplace/loading.tsx
+++ b/web/app/marketplace/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading marketplace" />;
+}

--- a/web/app/pipeline/loading.tsx
+++ b/web/app/pipeline/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading pipeline" />;
+}

--- a/web/app/portfolio/loading.tsx
+++ b/web/app/portfolio/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading portfolio" />;
+}

--- a/web/app/projects/loading.tsx
+++ b/web/app/projects/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading projects" />;
+}

--- a/web/app/specs/[spec_id]/loading.tsx
+++ b/web/app/specs/[spec_id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DetailSkeleton label="Loading spec" />;
+}

--- a/web/app/specs/[spec_id]/page.tsx
+++ b/web/app/specs/[spec_id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { getApiBase } from "@/lib/api";
 import {
@@ -122,6 +123,14 @@ export default async function SpecDetailPage({ params }: { params: Promise<{ spe
   const resolved = await params;
   const specId = decodeURIComponent(resolved.spec_id);
   const { source, inventoryItem, registryItem, relatedFlow } = await loadSpecContext(specId);
+
+  // If neither the inventory nor the registry knows about this spec, return a
+  // proper 404 instead of rendering an empty shell. Previously the page would
+  // render headings referencing the missing spec with "(title not yet registered)",
+  // which looked broken and returned a 200 status to crawlers.
+  if (!inventoryItem && !registryItem && relatedFlow.length === 0) {
+    notFound();
+  }
 
   const ideaIds = new Set<string>();
   const contributorByRole = new Map<string, Set<string>>();

--- a/web/app/specs/loading.tsx
+++ b/web/app/specs/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading specs" />;
+}

--- a/web/app/tasks/[task_id]/loading.tsx
+++ b/web/app/tasks/[task_id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DetailSkeleton label="Loading task" />;
+}

--- a/web/app/tasks/loading.tsx
+++ b/web/app/tasks/loading.tsx
@@ -1,0 +1,5 @@
+import { ListSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <ListSkeleton label="Loading tasks" />;
+}

--- a/web/app/today/loading.tsx
+++ b/web/app/today/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/components/loading/Skeletons";
+
+export default function Loading() {
+  return <DashboardSkeleton label="Loading today" />;
+}

--- a/web/components/loading/Skeletons.tsx
+++ b/web/components/loading/Skeletons.tsx
@@ -1,0 +1,116 @@
+/**
+ * Shared loading-state skeletons.
+ *
+ * Next.js App Router mounts a `loading.tsx` at any route-segment boundary
+ * as a React Suspense fallback while the server component fetches its
+ * data. Historically all 71 pages shared a single root-level skeleton
+ * (`app/loading.tsx`), so users saw the same generic placeholder
+ * regardless of whether they were on a list, a detail view, or a
+ * multi-panel dashboard.
+ *
+ * This module exports three tailored variants. Segment-level
+ * `loading.tsx` files import and render the appropriate one.
+ */
+
+import type { ReactNode } from "react";
+
+function Bar({ className }: { className?: string }) {
+  return <div className={`rounded bg-muted ${className || ""}`} />;
+}
+
+function ShellWrap({ children, label }: { children: ReactNode; label: string }) {
+  return (
+    <main
+      className="mx-auto max-w-6xl px-4 md:px-8 py-12 animate-pulse"
+      aria-busy="true"
+      aria-label={label}
+    >
+      {children}
+    </main>
+  );
+}
+
+/** Row-based skeleton for list pages (/ideas, /specs, /contributors, /tasks). */
+export function ListSkeleton({ label = "Loading list" }: { label?: string }) {
+  return (
+    <ShellWrap label={label}>
+      <div className="space-y-6">
+        <Bar className="h-8 w-48" />
+        <Bar className="h-5 w-72" />
+        <div className="space-y-3 mt-8">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4">
+              <Bar className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Bar className="h-5 w-3/4" />
+                <Bar className="h-4 w-1/2" />
+              </div>
+              <Bar className="h-8 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </ShellWrap>
+  );
+}
+
+/** Detail skeleton for `[id]` pages (/ideas/[id], /specs/[id], /contributors/[id]). */
+export function DetailSkeleton({ label = "Loading details" }: { label?: string }) {
+  return (
+    <ShellWrap label={label}>
+      <div className="space-y-8">
+        <div className="space-y-3">
+          <Bar className="h-4 w-32" />
+          <Bar className="h-10 w-3/4" />
+          <Bar className="h-5 w-1/2" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-2 p-4 rounded-lg border border-border/40">
+              <Bar className="h-4 w-20" />
+              <Bar className="h-8 w-24" />
+            </div>
+          ))}
+        </div>
+        <div className="space-y-3">
+          <Bar className="h-6 w-40" />
+          <Bar className="h-24 w-full" />
+          <Bar className="h-24 w-full" />
+        </div>
+      </div>
+    </ShellWrap>
+  );
+}
+
+/** Dashboard skeleton for multi-panel pages (/dashboard, /pipeline, /today, /marketplace). */
+export function DashboardSkeleton({ label = "Loading dashboard" }: { label?: string }) {
+  return (
+    <ShellWrap label={label}>
+      <div className="space-y-8">
+        <div className="flex items-center justify-between">
+          <Bar className="h-9 w-64" />
+          <Bar className="h-8 w-32" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="space-y-2 p-4 rounded-lg border border-border/40">
+              <Bar className="h-4 w-16" />
+              <Bar className="h-10 w-20" />
+              <Bar className="h-3 w-24" />
+            </div>
+          ))}
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-3 p-4 rounded-lg border border-border/40">
+            <Bar className="h-5 w-40" />
+            <Bar className="h-48 w-full" />
+          </div>
+          <div className="space-y-3 p-4 rounded-lg border border-border/40">
+            <Bar className="h-5 w-40" />
+            <Bar className="h-48 w-full" />
+          </div>
+        </div>
+      </div>
+    </ShellWrap>
+  );
+}


### PR DESCRIPTION
Fifth PR in the review-and-improve series. Closes gaps in the **Clarity** and **Functionality** lenses on the web surface.

## Problem

- 71 pages, only **2** loading/error boundaries (both at root). Every page showed the same generic skeleton regardless of what was loading. Users couldn't tell a list was loading from a dashboard.
- Detail pages (\`[id]\` dynamic segments) that couldn't find their record rendered a **200 response** with \"not found\" copy. Broken HTTP semantics, bad for crawlers and Cache-Control.

## Fix

### Shared skeleton component
\`web/components/loading/Skeletons.tsx\` exports:
- \`ListSkeleton\` — 8 rows, avatar + two-line text + action chip
- \`DetailSkeleton\` — breadcrumb + title + 3 stat cards + 2 content blocks
- \`DashboardSkeleton\` — heading + 4 stat cards + 2 chart panels

All set \`aria-busy\` + \`aria-label\` for screen readers.

### 20 new \`loading.tsx\` files
Each 4 lines — import the right variant, render with a labeled aria message. Coverage:

| Variant | Segments |
|---|---|
| List | /ideas, /specs, /contributors, /tasks, /assets, /concepts, /projects, /governance |
| Detail | /ideas/[idea_id], /specs/[spec_id], /contributors/[id], /tasks/[task_id] |
| Dashboard | /dashboard, /pipeline, /today, /marketplace, /invest, /portfolio, /discover, /flow |

### Proper 404s
- \`/specs/[spec_id]\` → \`notFound()\` when absent from inventory AND registry AND flow
- \`/assets/[asset_id]\` → \`notFound()\` when asset API returns 404

Both fall through to the existing \`web/app/not-found.tsx\` which sets proper 404 HTTP status.

## Not touched
- Client-side detail pages (\`/tasks/[task_id]\` is \"use client\") can't use \`notFound()\`; they handle errors via UI state.
- Already-correct pages (\`/ideas/[idea_id]\`, \`/concepts/[id]\`) left alone.

## Verification

\`\`\`
$ tsc --noEmit --skipLibCheck   # exit 0
\`\`\`

## Risks

- **None.** Additive: new files + two small \`notFound()\` insertions replacing inline \"not found\" rendering. No breaking changes to existing routes or public API contracts.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>