### PR TITLE
feat(cli): shared --json output + auto-TTY detection on the core commands

### DIFF
--- a/cli/bin/cc.mjs
+++ b/cli/bin/cc.mjs
@@ -163,7 +163,7 @@ const COMMANDS = {
   spec:          () => showSpec(args),
   contribute:    () => contribute(args),
   ontology:      () => ontology(args),
-  status:        () => showStatus(),
+  status:        () => showStatus(args),
   resonance:     () => showResonance(),
   identity:      () => handleIdentity(args),
   nodes:         () => listNodes(),
@@ -773,6 +773,19 @@ function showHelp() {
    onboarding register     Register a new contributor (Trust-on-First-Use)
    onboarding session      Get contributor profile from session token
    onboarding upgrade      Upgrade trust level to verified (stub)
+
+\x1b[1mGlobal flags:\x1b[0m
+  --workspace <id>        Scope commands to a specific workspace (overrides config)
+  --api-url <url>         Override the API origin (or set COHERENCE_API_URL env var)
+  --api-key <key>         Override the API key (or set COHERENCE_API_KEY env var)
+  --timeout <ms>          Override the request timeout (or set COHERENCE_TIMEOUT_MS)
+  --json                  Machine-readable JSON output (auto-enabled when piped)
+  --no-json               Force human-readable output even when piped
+
+\x1b[1mEnvironment variables:\x1b[0m
+  COHERENCE_API_URL       API origin (default: ${hubUrl})
+  COHERENCE_API_KEY       API key for write operations
+  COHERENCE_TIMEOUT_MS    Request timeout in milliseconds (default: 12000)
 
 \x1b[2mHub: ${hubUrl}\x1b[0m
 \x1b[2mDocs: https://coherencycoin.com\x1b[0m

--- a/cli/lib/commands/contributors.mjs
+++ b/cli/lib/commands/contributors.mjs
@@ -4,6 +4,7 @@
 
 import { get } from "../api.mjs";
 import { truncateWords as truncate } from "../ui/ansi.mjs";
+import { hasJsonFlag, printJson, printJsonError, stripJsonFlag } from "../ui/json.mjs";
 
 /** Truncate at word boundary, append "..." if needed */
 
@@ -17,11 +18,18 @@ function typeBadge(type) {
 }
 
 export async function listContributors(args) {
-  const limit = parseInt(args[0]) || 20;
+  const jsonMode = hasJsonFlag(args);
+  const clean = stripJsonFlag(args);
+  const limit = parseInt(clean[0]) || 20;
   const raw = await get("/api/contributors", { limit });
   const data = Array.isArray(raw) ? raw : (raw?.items || raw?.contributors);
   if (!data || !Array.isArray(data)) {
-    console.log("Could not fetch contributors.");
+    if (jsonMode) printJsonError("fetch_failed");
+    else console.log("Could not fetch contributors.");
+    return;
+  }
+  if (jsonMode) {
+    printJson(data);
     return;
   }
   if (data.length === 0) {
@@ -42,14 +50,22 @@ export async function listContributors(args) {
 }
 
 export async function showContributor(args) {
-  const id = args[0];
+  const jsonMode = hasJsonFlag(args);
+  const clean = stripJsonFlag(args);
+  const id = clean[0];
   if (!id) {
-    console.log("Usage: cc contributor <id>");
+    if (jsonMode) printJsonError("missing_contributor_id");
+    else console.log("Usage: cc contributor <id>");
     return;
   }
   const data = await get(`/api/contributors/${encodeURIComponent(id)}`);
   if (!data) {
-    console.log(`Contributor '${id}' not found.`);
+    if (jsonMode) printJsonError("contributor_not_found", { status: 404 });
+    else console.log(`Contributor '${id}' not found.`);
+    return;
+  }
+  if (jsonMode) {
+    printJson(data);
     return;
   }
   console.log();

--- a/cli/lib/commands/ideas.mjs
+++ b/cli/lib/commands/ideas.mjs
@@ -29,6 +29,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import ora from "ora";
 import { truncateWords as truncate } from "../ui/ansi.mjs";
+import { hasJsonFlag, printJson, printJsonError } from "../ui/json.mjs";
 
 /** Truncate at word boundary, append "..." if needed */
 
@@ -39,10 +40,13 @@ function miniBar(value, max, width = 5) {
 }
 
 export async function listIdeas(args) {
+  const jsonMode = hasJsonFlag(args);
   const isTTY = process.stdout.isTTY;
 
-  // Interactive picker if no args and TTY
-  if (isTTY && args.length === 0) {
+  // Interactive picker only when TTY AND not JSON mode AND no other args.
+  // When piping (`cc ideas | jq`) or passing `--json`, we always return
+  // structured data instead of opening a picker.
+  if (isTTY && !jsonMode && args.length === 0) {
     return runInteractivePicker();
   }
 
@@ -74,12 +78,25 @@ export async function listIdeas(args) {
 
   const raw = await get("/api/ideas", query);
   let data = Array.isArray(raw) ? raw : raw?.ideas;
-  if (!data || !Array.isArray(data)) { console.log("Could not fetch ideas."); return; }
+  if (!data || !Array.isArray(data)) {
+    if (jsonMode) {
+      printJsonError("fetch_failed");
+    } else {
+      console.log("Could not fetch ideas.");
+    }
+    return;
+  }
 
-  // Apply local filters
+  // Apply local filters (same in both modes)
   if (flags.type)   data = data.filter(i => i.work_type === flags.type);
   if (flags.status) data = data.filter(i => (i.manifestation_status || "none") === flags.status);
   if (flags.parent) data = data.filter(i => i.parent_idea_id === flags.parent);
+
+  // JSON mode: emit the (possibly empty) array and exit. Pipeline-friendly.
+  if (jsonMode) {
+    printJson(data);
+    return;
+  }
 
   if (data.length === 0) { console.log("No ideas match the filter."); return; }
 

--- a/cli/lib/commands/specs.mjs
+++ b/cli/lib/commands/specs.mjs
@@ -5,11 +5,16 @@
 import { get } from "../api.mjs";
 import { getActiveWorkspace, DEFAULT_WORKSPACE_ID } from "../config.mjs";
 import { truncateWords as truncate } from "../ui/ansi.mjs";
+import { hasJsonFlag, printJson, printJsonError, stripJsonFlag } from "../ui/json.mjs";
 
 /** Truncate at word boundary, append "..." if needed */
 
 export async function listSpecs(args) {
-  const limit = parseInt(args[0]) || 20;
+  const jsonMode = hasJsonFlag(args);
+  // Strip --json before parsing positional so `cc specs --json` still
+  // defaults to the right limit instead of trying to parseInt("--json").
+  const clean = stripJsonFlag(args);
+  const limit = parseInt(clean[0]) || 20;
   const query = { limit };
   const activeWorkspace = getActiveWorkspace();
   if (activeWorkspace && activeWorkspace !== DEFAULT_WORKSPACE_ID) {
@@ -17,9 +22,16 @@ export async function listSpecs(args) {
   }
   const data = await get("/api/spec-registry", query);
   if (!data || !Array.isArray(data)) {
-    console.log("Could not fetch specs.");
+    if (jsonMode) printJsonError("fetch_failed");
+    else console.log("Could not fetch specs.");
     return;
   }
+
+  if (jsonMode) {
+    printJson(data);
+    return;
+  }
+
   if (data.length === 0) {
     console.log("No specs registered.");
     return;
@@ -41,14 +53,22 @@ export async function listSpecs(args) {
 }
 
 export async function showSpec(args) {
-  const id = args[0];
+  const jsonMode = hasJsonFlag(args);
+  const clean = stripJsonFlag(args);
+  const id = clean[0];
   if (!id) {
-    console.log("Usage: cc spec <spec-id>");
+    if (jsonMode) printJsonError("missing_spec_id");
+    else console.log("Usage: cc spec <spec-id>");
     return;
   }
   const data = await get(`/api/spec-registry/${encodeURIComponent(id)}`);
   if (!data) {
-    console.log(`Spec '${id}' not found.`);
+    if (jsonMode) printJsonError("spec_not_found", { status: 404 });
+    else console.log(`Spec '${id}' not found.`);
+    return;
+  }
+  if (jsonMode) {
+    printJson(data);
     return;
   }
   console.log();

--- a/cli/lib/commands/status.mjs
+++ b/cli/lib/commands/status.mjs
@@ -4,6 +4,7 @@
 
 import { get } from "../api.mjs";
 import { getContributorId, getHubUrl, getFocus } from "../config.mjs";
+import { hasJsonFlag, printJson, printJsonError } from "../ui/json.mjs";
 import { hostname } from "node:os";
 import { execSync } from "node:child_process";
 import { stdin, stdout } from "node:process";
@@ -34,9 +35,10 @@ async function checkForUpdate(localVersion) {
   return null;
 }
 
-export async function showStatus() {
+export async function showStatus(args = []) {
   const isTTY = process.stdout.isTTY;
   const focus = getFocus();
+  const jsonMode = hasJsonFlag(args);
 
   // Fetch everything in parallel
   const [health, ideas, nodes, pendingData, runningData, completedData, coherence, ledger, messages] =
@@ -51,6 +53,36 @@ export async function showStatus() {
       getContributorId() ? get(`/api/contributions/ledger/${encodeURIComponent(getContributorId())}`) : null,
       getContributorId() ? get(`/api/federation/nodes/${encodeURIComponent(getContributorId())}/messages`, { unread_only: true, limit: 10 }) : null,
     ]);
+
+  // JSON mode — single structured payload covering every fetched source.
+  // The shape is intentionally flat so jq filters can pull any field
+  // without walking a deep tree.
+  if (jsonMode) {
+    const envelope = {
+      hub: getHubUrl(),
+      contributor_id: getContributorId(),
+      focus: { idea_id: focus.idea_id, task_id: focus.task_id },
+      health: health ?? null,
+      ideas_count: ideas ?? null,
+      nodes: Array.isArray(nodes) ? nodes : nodes?.items ?? null,
+      coherence: coherence ?? null,
+      tasks: {
+        pending: pendingData ?? null,
+        running: runningData ?? null,
+        completed: completedData ?? null,
+      },
+      ledger: ledger ?? null,
+      messages: messages ?? null,
+    };
+    // If every field is null, the API is likely unreachable.
+    const allNull = [health, ideas, nodes, pendingData, runningData, completedData, coherence].every((v) => v == null);
+    if (allNull) {
+      printJsonError("api_unreachable", { status: 0 });
+      return;
+    }
+    printJson(envelope);
+    return;
+  }
 
   const taskList = (d) => {
     if (!d) return [];

--- a/cli/lib/ui/json.mjs
+++ b/cli/lib/ui/json.mjs
@@ -1,0 +1,96 @@
+/**
+ * Shared --json output helpers for cc commands.
+ *
+ * Before this module, each command re-invented its own JSON handling:
+ *   - ops.mjs did `args.includes("--json")`
+ *   - rest.mjs  walked its parser looking for "--json"
+ *   - dif.mjs   had a parallel while-loop
+ *   - ontology.mjs had yet another parser
+ * Commands that never gained --json support (ideas, specs, contributors,
+ * tasks, governance, etc.) were invisible to jq pipelines and CI scripts.
+ *
+ * This module provides one place for:
+ *
+ *   - hasJsonFlag(args)         — boolean check, consumes the flag
+ *   - stripJsonFlag(args)       — returns `args` with `--json` removed
+ *   - printJson(data)           — pretty-prints JSON to stdout
+ *   - printJsonError(message)   — prints {error: message} and sets exit 1
+ *   - emit(data, {json, human}) — shared dispatch helper: in JSON mode
+ *                                  prints data; in human mode runs `human(data)`
+ *
+ * All functions honor the precedence:
+ *   explicit flag > stdout non-TTY (piped to jq/less) > default human mode
+ *
+ * Auto-detecting non-TTY means `cc ideas | jq '.[0]'` just works without
+ * the user having to remember `--json`.
+ */
+
+const JSON_FLAG = "--json";
+const NO_JSON_FLAG = "--no-json";
+
+/**
+ * Returns true if the user wants JSON output for this invocation.
+ * Precedence:
+ *   1. `--no-json`     → force human mode (even on a pipe)
+ *   2. `--json`        → force JSON mode
+ *   3. stdout is non-TTY → JSON mode (pipeable by default)
+ *   4. otherwise       → human mode
+ */
+export function hasJsonFlag(args) {
+  const list = Array.isArray(args) ? args : [];
+  if (list.includes(NO_JSON_FLAG)) return false;
+  if (list.includes(JSON_FLAG)) return true;
+  // Auto-detect: non-interactive stdout means the user is piping somewhere.
+  if (!process.stdout.isTTY) return true;
+  return false;
+}
+
+/**
+ * Returns a new array with `--json` and `--no-json` removed. Use this
+ * to pass a clean argv down to the existing positional-argument parsers
+ * without having to teach each one about the flag.
+ */
+export function stripJsonFlag(args) {
+  const list = Array.isArray(args) ? args : [];
+  return list.filter((a) => a !== JSON_FLAG && a !== NO_JSON_FLAG);
+}
+
+/** Pretty-print `data` to stdout. Called by commands in JSON mode. */
+export function printJson(data) {
+  // null/undefined → null (not an empty line) so `jq` can still parse.
+  process.stdout.write(JSON.stringify(data ?? null, null, 2) + "\n");
+}
+
+/**
+ * Emit a JSON error envelope and set process.exitCode = 1.
+ * Shape: { error: "..." [, code: "..."] [, status: 500] }
+ */
+export function printJsonError(message, { code, status } = {}) {
+  const envelope = { error: String(message || "unknown_error") };
+  if (code) envelope.code = String(code);
+  if (status != null) envelope.status = Number(status);
+  process.stdout.write(JSON.stringify(envelope, null, 2) + "\n");
+  process.exitCode = 1;
+}
+
+/**
+ * Shared dispatch helper. Commands call:
+ *
+ *   return emit(data, args, (d) => { ...existing table output... });
+ *
+ * and get --json / --no-json support for free. In JSON mode prints
+ * `data`; in human mode calls `human(data)`. If `data` is null/undefined,
+ * emits an error envelope or lets the human callback handle it (usually
+ * printing a "Could not fetch" message).
+ */
+export function emit(data, args, human) {
+  if (hasJsonFlag(args)) {
+    if (data == null) {
+      printJsonError("fetch_failed");
+      return;
+    }
+    printJson(data);
+    return;
+  }
+  if (typeof human === "function") human(data);
+}


### PR DESCRIPTION
Sixth PR in the review-and-improve series. Closes gaps in the **Alignment** and **Functionality** lenses on the CLI surface.

## Problem

The CLI had ad-hoc \`--json\` handling in 5 unrelated modules (config_editor, dif, ontology, ops, rest), each with its own parser. The most-used commands (ideas, specs, contributors, status, tasks, governance, etc.) had **no \`--json\` support at all**, so scripting with \`jq\` required parsing ANSI-colored table output by hand. Auto-TTY detection for \"piped somewhere, emit JSON\" didn't exist anywhere.

## Fix

New shared \`cli/lib/ui/json.mjs\` module:
- \`hasJsonFlag(args)\` — 4-tier precedence: \`--no-json\` > \`--json\` > stdout non-TTY > default human mode
- \`stripJsonFlag(args)\` — returns clean argv for positional parsers
- \`printJson(data)\` — jq-safe pretty-print
- \`printJsonError(msg, {code, status})\` — structured error envelope + \`process.exitCode = 1\`

Migrated commands: \`listIdeas\`, \`listSpecs\`, \`showSpec\`, \`listContributors\`, \`showContributor\`, \`showStatus\`.

All follow the same pattern:
\`\`\`js
const jsonMode = hasJsonFlag(args);
const clean = stripJsonFlag(args);
const data = await get(...);
if (!data) { jsonMode ? printJsonError(\"fetch_failed\") : console.log(\"Could not...\"); return; }
if (jsonMode) { printJson(data); return; }
// existing human output
\`\`\`

## Auto-detection

\`cc ideas | jq '.[0]'\` now Just Works — stdout is non-TTY so the CLI emits JSON. No flag needed. Interactive sessions still get the colored table.

## help text

\`cc help\` now documents the global flags and environment variables that have been undocumented:
- \`--workspace\`, \`--api-url\`, \`--api-key\`, \`--timeout\`, \`--json\`, \`--no-json\`
- \`COHERENCE_API_URL\`, \`COHERENCE_API_KEY\`, \`COHERENCE_TIMEOUT_MS\`

## Verification

\`\`\`
$ cc ideas 3 --json | jq '.[].id'
\"value-attribution\"
\"idea-realization-engine\"
\"portfolio-governance\"

$ cc status --json | jq 'keys'
[\"coherence\",\"contributor_id\",\"focus\",\"health\",\"hub\",\"ideas_count\",
 \"ledger\",\"messages\",\"nodes\",\"tasks\"]

$ cc ideas 2 | head -c 50  # piped — JSON auto-enabled
[
  {
    \"id\": \"value-attribution\",
\`\`\`

## Notes

- The 5 pre-existing ad-hoc \`--json\` implementations (ops, dif, rest, ontology, config_editor) are intentionally left untouched — they already work and have domain-specific logic.
- Follow-up PRs can migrate remaining list/show commands (tasks, governance, assets, lineage, news, treasury, etc.) with ~10-line diffs using the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)