### PR TITLE
feat(web): Living Collective — explorable concept pages, deep linking, nav

### DIFF
--- a/web/app/vision/[conceptId]/loading.tsx
+++ b/web/app/vision/[conceptId]/loading.tsx
@@ -1,0 +1,32 @@
+export default function Loading() {
+  return (
+    <main className="min-h-screen animate-pulse">
+      {/* Hero gradient placeholder */}
+      <div className="h-64 bg-gradient-to-b from-stone-800/30 to-transparent" />
+
+      <div className="max-w-4xl mx-auto px-6 -mt-20 space-y-8">
+        {/* Breadcrumb */}
+        <div className="h-4 w-48 rounded bg-stone-800/40" />
+
+        {/* Title */}
+        <div className="space-y-3">
+          <div className="h-12 w-64 rounded bg-stone-800/40" />
+          <div className="h-6 w-full max-w-2xl rounded bg-stone-800/30" />
+          <div className="h-6 w-3/4 max-w-xl rounded bg-stone-800/30" />
+        </div>
+
+        {/* Content grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="md:col-span-2 space-y-6">
+            <div className="h-48 rounded-2xl bg-stone-800/20 border border-stone-800/30" />
+            <div className="h-32 rounded-2xl bg-stone-800/20 border border-stone-800/30" />
+          </div>
+          <div className="space-y-4">
+            <div className="h-24 rounded-2xl bg-stone-800/20 border border-stone-800/30" />
+            <div className="h-20 rounded-2xl bg-stone-800/20 border border-stone-800/30" />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -1,0 +1,372 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getApiBase } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+/* ── Types ─────────────────────────────────────────────────────────── */
+
+type Concept = {
+  id: string;
+  name: string;
+  description: string;
+  typeId?: string;
+  level?: number;
+  keywords?: string[];
+  axes?: string[];
+  domains?: string[];
+  parentConcepts?: string[];
+  childConcepts?: string[];
+};
+
+type Edge = {
+  id: string;
+  from: string;
+  to: string;
+  type: string;
+};
+
+type RelatedItems = {
+  concept_id: string;
+  ideas: string[];
+  specs: string[];
+  total: number;
+};
+
+/* ── Visual mapping ────────────────────────────────────────────────── */
+
+const VISUAL_MAP: Record<string, string> = {
+  "lc-pulse": "/visuals/01-the-pulse.png",
+  "lc-sensing": "/visuals/02-sensing.png",
+  "lc-attunement": "/visuals/03-attunement.png",
+  "lc-vitality": "/visuals/04-vitality.png",
+  "lc-nourishing": "/visuals/05-nourishing.png",
+  "lc-resonating": "/visuals/06-resonating.png",
+  "lc-expressing": "/visuals/07-expressing.png",
+  "lc-spiraling": "/visuals/08-spiraling.png",
+  "lc-field-sensing": "/visuals/09-field-intelligence.png",
+  "lc-v-living-spaces": "/visuals/10-living-space.png",
+  "lc-v-shelter-organism": "/visuals/10-living-space.png",
+  "lc-network": "/visuals/11-the-network.png",
+};
+
+/* ── Level labels in vitality language ─────────────────────────────── */
+
+function levelLabel(level?: number) {
+  const labels: Record<number, string> = {
+    0: "Root Pulse",
+    1: "System / Flow",
+    2: "Living Expression",
+    3: "Vocabulary",
+  };
+  const colors: Record<number, string> = {
+    0: "border-amber-500/40 text-amber-300/90",
+    1: "border-teal-500/40 text-teal-300/90",
+    2: "border-violet-500/40 text-violet-300/90",
+    3: "border-stone-500/40 text-stone-400",
+  };
+  const l = level ?? 0;
+  return (
+    <span className={`text-xs px-2.5 py-1 rounded-full border ${colors[l] || "border-stone-600 text-stone-400"}`}>
+      {labels[l] || `Level ${l}`}
+    </span>
+  );
+}
+
+/* ── Data fetching ─────────────────────────────────────────────────── */
+
+async function fetchConcept(id: string): Promise<Concept | null> {
+  const base = getApiBase();
+  try {
+    const res = await fetch(`${base}/api/concepts/${id}`, { next: { revalidate: 30 } });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchEdges(id: string): Promise<Edge[]> {
+  const base = getApiBase();
+  try {
+    const res = await fetch(`${base}/api/concepts/${id}/edges`, { next: { revalidate: 30 } });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchRelated(id: string): Promise<RelatedItems> {
+  const base = getApiBase();
+  try {
+    const res = await fetch(`${base}/api/concepts/${id}/related`, { next: { revalidate: 30 } });
+    if (!res.ok) return { concept_id: id, ideas: [], specs: [], total: 0 };
+    return res.json();
+  } catch {
+    return { concept_id: id, ideas: [], specs: [], total: 0 };
+  }
+}
+
+/* ── Metadata ──────────────────────────────────────────────────────── */
+
+export async function generateMetadata({ params }: { params: Promise<{ conceptId: string }> }): Promise<Metadata> {
+  const { conceptId } = await params;
+  const concept = await fetchConcept(conceptId);
+  return {
+    title: concept ? `${concept.name} — The Living Collective` : "Concept",
+    description: concept?.description?.slice(0, 300) || "",
+    openGraph: {
+      title: concept?.name || "Living Collective Concept",
+      description: concept?.description?.slice(0, 200) || "",
+    },
+  };
+}
+
+/* ── Edge type descriptions in vitality language ───────────────────── */
+
+const EDGE_LABELS: Record<string, string> = {
+  "resonates-with": "resonates with",
+  "emerges-from": "emerges from",
+  "enables": "enables",
+  "embodies": "embodies",
+  "instantiates": "gives form to",
+  "complements": "complements",
+  "fractal-scaling": "fractal of",
+  "transforms-into": "transforms into",
+  "catalyzes": "catalyzes",
+};
+
+/* ── Page ──────────────────────────────────────────────────────────── */
+
+export default async function VisionConceptPage({ params }: { params: Promise<{ conceptId: string }> }) {
+  const { conceptId } = await params;
+  const [concept, edges, related] = await Promise.all([
+    fetchConcept(conceptId),
+    fetchEdges(conceptId),
+    fetchRelated(conceptId),
+  ]);
+
+  if (!concept) notFound();
+
+  const isLC = concept.domains?.includes("living-collective");
+  if (!isLC) {
+    // Non-LC concept — redirect to standard concept page
+    return (
+      <meta httpEquiv="refresh" content={`0; url=/concepts/${conceptId}`} />
+    );
+  }
+
+  const visual = VISUAL_MAP[conceptId];
+  const lcEdges = edges.filter(
+    (e) => e.from.startsWith("lc-") || e.to.startsWith("lc-"),
+  );
+  const outgoing = lcEdges.filter((e) => e.from === conceptId);
+  const incoming = lcEdges.filter((e) => e.to === conceptId);
+  const isVision = conceptId.startsWith("lc-v-");
+  const isVocab = concept.level === 3;
+
+  return (
+    <main>
+      {/* Hero — visual or gradient */}
+      {visual ? (
+        <section className="relative w-full aspect-[16/6] overflow-hidden">
+          <Image src={visual} alt={concept.name} fill className="object-cover" sizes="100vw" priority />
+          <div className="absolute inset-0 bg-gradient-to-t from-stone-950 via-stone-950/40 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-b from-stone-950/60 via-transparent to-transparent" />
+        </section>
+      ) : (
+        <section className="h-32 bg-[radial-gradient(ellipse_at_center,_rgba(234,179,8,0.06)_0%,_transparent_70%)]" />
+      )}
+
+      <div className={`relative ${visual ? "-mt-32 md:-mt-44" : ""} z-10 max-w-4xl mx-auto px-6 pb-20`}>
+        {/* Breadcrumb */}
+        <nav className="text-sm text-stone-500 mb-6 flex items-center gap-2">
+          <Link href="/vision" className="hover:text-amber-400/80 transition-colors">
+            The Living Collective
+          </Link>
+          <span className="text-stone-700">/</span>
+          <span className="text-stone-300">{concept.name}</span>
+        </nav>
+
+        {/* Title + level */}
+        <div className="mb-8 space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-4xl md:text-5xl font-extralight tracking-tight text-white">
+              {concept.name}
+            </h1>
+            {levelLabel(concept.level)}
+          </div>
+          <p className="text-lg md:text-xl text-stone-300 font-light leading-relaxed max-w-3xl">
+            {concept.description}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {/* Main content */}
+          <div className="md:col-span-2 space-y-8">
+            {/* Connected concepts */}
+            {(outgoing.length > 0 || incoming.length > 0) && (
+              <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-4">
+                <h2 className="text-lg font-light text-stone-300">Connected Frequencies</h2>
+                <div className="space-y-2">
+                  {outgoing.map((e) => (
+                    <Link
+                      key={e.id}
+                      href={`/vision/${e.to}`}
+                      className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-stone-800/40 transition-colors group"
+                    >
+                      <span className="text-xs text-amber-400/60 font-medium min-w-[120px]">
+                        {EDGE_LABELS[e.type] || e.type}
+                      </span>
+                      <span className="text-stone-300 group-hover:text-amber-300/80 transition-colors">
+                        {e.to.replace("lc-", "").replace("lc-v-", "").replace(/-/g, " ")}
+                      </span>
+                      <span className="text-stone-700 ml-auto">→</span>
+                    </Link>
+                  ))}
+                  {incoming.map((e) => (
+                    <Link
+                      key={e.id}
+                      href={`/vision/${e.from}`}
+                      className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-stone-800/40 transition-colors group"
+                    >
+                      <span className="text-xs text-teal-400/60 font-medium min-w-[120px]">
+                        {EDGE_LABELS[e.type] || e.type}
+                      </span>
+                      <span className="text-stone-300 group-hover:text-teal-300/80 transition-colors">
+                        {e.from.replace("lc-", "").replace("lc-v-", "").replace(/-/g, " ")}
+                      </span>
+                      <span className="text-stone-700 ml-auto">←</span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Ideas contributing to this vision */}
+            <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-4">
+              <h2 className="text-lg font-light text-stone-300">
+                {related.total > 0
+                  ? `Ideas resonating with this concept (${related.total})`
+                  : "This concept is waiting for contributions"}
+              </h2>
+              {related.ideas.length > 0 ? (
+                <div className="space-y-2">
+                  {related.ideas.map((ideaId) => (
+                    <Link
+                      key={ideaId}
+                      href={`/ideas/${ideaId}`}
+                      className="block py-2 px-3 rounded-xl hover:bg-stone-800/40 transition-colors text-stone-400 hover:text-stone-200 text-sm"
+                    >
+                      {ideaId}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-stone-500 leading-relaxed">
+                  {isVision
+                    ? "This vision is an open invitation. What does it look like in practice? How would you bring it to life? Share your ideas, designs, references, or lived experience."
+                    : "No ideas have been tagged with this concept yet. Be the first to contribute — share how this frequency expresses in your experience."}
+                </p>
+              )}
+              <Link
+                href={`/contribute?tags=living-collective,${conceptId}`}
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20 text-amber-300/90 hover:bg-amber-500/20 hover:border-amber-500/30 transition-all text-sm font-medium"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M12 5v14m-7-7h14" />
+                </svg>
+                Contribute to this vision
+              </Link>
+            </section>
+
+            {/* Parent concepts — hierarchy navigation */}
+            {concept.parentConcepts && concept.parentConcepts.length > 0 && (
+              <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-3">
+                <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider">Part of</h2>
+                <div className="flex flex-wrap gap-2">
+                  {concept.parentConcepts.filter((p) => p.startsWith("lc-")).map((pid) => (
+                    <Link
+                      key={pid}
+                      href={`/vision/${pid}`}
+                      className="px-3 py-1.5 rounded-full border border-stone-700/40 text-stone-400 hover:text-amber-300/80 hover:border-amber-500/30 transition-colors text-sm"
+                    >
+                      {pid.replace("lc-", "").replace(/-/g, " ")}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Child concepts */}
+            {concept.childConcepts && concept.childConcepts.length > 0 && (
+              <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-3">
+                <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider">Expresses through</h2>
+                <div className="flex flex-wrap gap-2">
+                  {concept.childConcepts.filter((c) => c.startsWith("lc-")).map((cid) => (
+                    <Link
+                      key={cid}
+                      href={`/vision/${cid}`}
+                      className="px-3 py-1.5 rounded-full border border-stone-700/40 text-stone-400 hover:text-teal-300/80 hover:border-teal-500/30 transition-colors text-sm"
+                    >
+                      {cid.replace("lc-", "").replace(/-/g, " ")}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-4">
+            {/* Keywords */}
+            {concept.keywords && concept.keywords.length > 0 && (
+              <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-5 space-y-3">
+                <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider">Frequencies</h2>
+                <div className="flex flex-wrap gap-1.5">
+                  {concept.keywords.map((kw) => (
+                    <span key={kw} className="text-xs px-2 py-1 rounded-full bg-stone-800/60 text-stone-400">
+                      {kw}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Explore */}
+            <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-5 space-y-3">
+              <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider">Explore</h2>
+              <div className="space-y-2 text-sm">
+                <Link href="/vision" className="block text-stone-400 hover:text-amber-300/80 transition-colors">
+                  ← The Living Collective
+                </Link>
+                <Link href="/concepts/garden?domain=living-collective" className="block text-stone-400 hover:text-teal-300/80 transition-colors">
+                  Concept Garden
+                </Link>
+                <Link href="/resonance" className="block text-stone-400 hover:text-violet-300/80 transition-colors">
+                  Resonance Discovery
+                </Link>
+              </div>
+            </section>
+
+            {/* Type info */}
+            <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-5 space-y-2 text-xs text-stone-600">
+              <div>
+                <span className="text-stone-500">ID:</span>{" "}
+                <span className="font-mono">{concept.id}</span>
+              </div>
+              <div>
+                <span className="text-stone-500">Domain:</span>{" "}
+                {concept.domains?.join(", ") || "—"}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/app/vision/layout.tsx
+++ b/web/app/vision/layout.tsx
@@ -1,0 +1,12 @@
+/**
+ * Vision layout — dark theme wrapper that preserves the Living Collective
+ * aesthetic across all /vision/* pages. Children render inside the dark
+ * field; the site header inherits from the root layout above.
+ */
+export default function VisionLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-stone-950 via-stone-950 to-stone-900 text-stone-100">
+      {children}
+    </div>
+  );
+}

--- a/web/app/vision/page.tsx
+++ b/web/app/vision/page.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
 const SECTIONS = [
   {
     id: "pulse",
+    conceptId: "lc-pulse",
     image: "/visuals/01-the-pulse.png",
     title: "The Pulse",
     body: "One truth. Everything else is this expressed at different scales. The cell and the field thrive as one movement. What amplifies aliveness is resonant. This is sensed through presence. It changes. The field senses continuously.",
@@ -24,6 +25,7 @@ const SECTIONS = [
   },
   {
     id: "sensing",
+    conceptId: "lc-sensing",
     image: "/visuals/02-sensing.png",
     title: "Sensing",
     body: "The field feels itself continuously. Every cell transmits and receives. Background awareness — the way a body knows its own temperature. When healthy, needs are felt before articulated. Shifts happen before planned.",
@@ -31,6 +33,7 @@ const SECTIONS = [
   },
   {
     id: "attunement",
+    conceptId: "lc-attunement",
     image: "/visuals/03-attunement.png",
     title: "Attunement",
     body: "The field maintains its own coherence — sensing which frequencies harmonize and which create interference. Not judgment. Attunement. The way a choir naturally adjusts when one voice drifts — not by correction but by the pull of the harmonic.",
@@ -38,6 +41,7 @@ const SECTIONS = [
   },
   {
     id: "vitality",
+    conceptId: "lc-vitality",
     image: "/visuals/04-vitality.png",
     title: "Vitality",
     body: "The primary frequency. Shakti — life force that isn't produced but released when interference dissolves. Like a laser: when all frequencies align, the light becomes coherent and its power increases by orders of magnitude.",
@@ -45,6 +49,7 @@ const SECTIONS = [
   },
   {
     id: "nourishing",
+    conceptId: "lc-nourishing",
     image: "/visuals/05-nourishing.png",
     title: "Nourishing",
     body: "Everything that sustains — circulates like blood, like water through soil, like nutrients through mycelium. Flows to where vitality needs it. The Amazonian forest shares carbon through underground networks — mother trees feeding seedlings in shade.",
@@ -52,6 +57,7 @@ const SECTIONS = [
   },
   {
     id: "resonating",
+    conceptId: "lc-resonating",
     image: "/visuals/06-resonating.png",
     title: "Resonating",
     body: "Everything between cells — touch, intimacy, presence, play, silence, attunement. Touch is nutrient. Dolphins swim in constant physical contact. The field's connective tissue. Life energy flows where resonance guides it.",
@@ -59,6 +65,7 @@ const SECTIONS = [
   },
   {
     id: "expressing",
+    conceptId: "lc-expressing",
     image: "/visuals/07-expressing.png",
     title: "Expressing",
     body: "The natural overflow of vitality — making, building, growing, singing, dancing, tending. Every cell is creative the way every leaf is photosynthetic. The bower bird builds beauty because beauty is its nature.",
@@ -66,6 +73,7 @@ const SECTIONS = [
   },
   {
     id: "spiraling",
+    conceptId: "lc-spiraling",
     image: "/visuals/08-spiraling.png",
     title: "Spiraling",
     body: "The field's relationship with time — not linear but spiral. Each cycle returns to familiar territory at a higher frequency. Like planetary orbit: the same seasonal point but the whole solar system has moved through space. Nothing repeats. Everything deepens.",
@@ -73,6 +81,7 @@ const SECTIONS = [
   },
   {
     id: "field-intelligence",
+    conceptId: "lc-field-sensing",
     image: "/visuals/09-field-intelligence.png",
     title: "Field Intelligence",
     body: "The flow of awareness — collective intelligence, harmonic rebalancing, learning. The octopus has intelligence in every arm — distributed, parallel, each node both autonomous and integral. No center. No hierarchy.",
@@ -80,6 +89,7 @@ const SECTIONS = [
   },
   {
     id: "living-space",
+    conceptId: "lc-v-living-spaces",
     image: "/visuals/10-living-space.png",
     title: "Living Space",
     body: "What does shelter look like when designed from frequency and flow? Not rooms but resonance zones. Structures that breathe, reconfigure, grow. Materials that are alive — earth, timber, stone, water, growing membrane. The building IS the organism's skin.",
@@ -87,6 +97,7 @@ const SECTIONS = [
   },
   {
     id: "network",
+    conceptId: "lc-network",
     image: "/visuals/11-the-network.png",
     title: "The Network",
     body: "One field within a field of fields. Mycorrhizal. Each collective a node — sharing frequency, nourishment, intelligence. A forest is not competing trees — it's a cooperative network sharing resources through underground connections.",
@@ -185,9 +196,12 @@ export default function VisionPage() {
           {/* Text overlay at bottom of image */}
           <div className="relative -mt-32 md:-mt-48 z-10 max-w-4xl mx-auto px-6 pb-20 md:pb-28">
             <div className="space-y-4">
-              <h2 className="text-3xl md:text-5xl font-extralight tracking-tight text-white">
-                {section.title}
-              </h2>
+              <Link href={`/vision/${section.conceptId}`} className="group">
+                <h2 className="text-3xl md:text-5xl font-extralight tracking-tight text-white group-hover:text-amber-200/90 transition-colors">
+                  {section.title}
+                  <span className="ml-3 text-stone-600 group-hover:text-amber-400/50 text-2xl transition-colors">→</span>
+                </h2>
+              </Link>
               <p className="text-lg md:text-xl text-stone-300 font-light leading-relaxed max-w-2xl">
                 {section.body}
               </p>
@@ -213,28 +227,43 @@ export default function VisionPage() {
 
         <div className="grid md:grid-cols-3 gap-6">
           {[
-            { title: "Living Spaces", desc: "Shelter designed from frequency and flow. Resonance zones, not rooms. Structures that breathe." },
-            { title: "Ceremony", desc: "Forms that emerge from pure presence. Cells fully here together with what IS." },
-            { title: "Harmonizing", desc: "How the field tunes itself. Sound, breath, movement, shared stillness." },
-            { title: "Food as Practice", desc: "Garden as pharmacy. Kitchen as ceremony. Food carries frequency." },
-            { title: "Comfort & Joy", desc: "Sensory delight as health practice. Warmth, texture, beauty in every surface." },
-            { title: "Play & Expansion", desc: "Adults playing as freely as children. The organism at its most quantum." },
-            { title: "Inclusion", desc: "A healthy ecosystem is diverse. Monoculture is fragile. Different notes make the chord." },
-            { title: "Freedom", desc: "Every cell vibrating at its natural frequency. Freedom and harmony are the same frequency." },
-            { title: "The Seed", desc: "A pattern that grows differently in every soil. Shared orientation, infinite expression." },
+            { title: "Living Spaces", conceptId: "lc-v-living-spaces", desc: "Shelter designed from frequency and flow. Resonance zones, not rooms. Structures that breathe." },
+            { title: "Ceremony", conceptId: "lc-v-ceremony", desc: "Forms that emerge from pure presence. Cells fully here together with what IS." },
+            { title: "Harmonizing", conceptId: "lc-v-harmonizing", desc: "How the field tunes itself. Sound, breath, movement, shared stillness." },
+            { title: "Food as Practice", conceptId: "lc-v-food-practice", desc: "Garden as pharmacy. Kitchen as ceremony. Food carries frequency." },
+            { title: "Shelter as Skin", conceptId: "lc-v-shelter-organism", desc: "Architecture IS the field's body. Earthships, cob, bamboo, mycelium. Crystalline structures." },
+            { title: "Comfort & Joy", conceptId: "lc-v-comfort-joy", desc: "Sensory delight as vitality practice. Warmth, texture, beauty in every surface." },
+            { title: "Play & Expansion", conceptId: "lc-v-play-expansion", desc: "Adults playing as freely as children. The field at its most quantum." },
+            { title: "Inclusion & Diversity", conceptId: "lc-v-inclusion-diversity", desc: "A chord needs different notes. An ecosystem needs different species. Monoculture is fragile." },
+            { title: "Freedom & Expression", conceptId: "lc-v-freedom-expression", desc: "Every cell vibrating at its natural frequency. Freedom and harmony are the same frequency." },
           ].map((vision) => (
-            <div
+            <Link
               key={vision.title}
+              href={`/vision/${vision.conceptId}`}
               className="group p-6 rounded-2xl border border-stone-800/40 bg-stone-900/20 hover:bg-stone-900/40 hover:border-amber-800/30 transition-all duration-500 space-y-3"
             >
               <h3 className="text-lg font-light text-amber-300/80 group-hover:text-amber-300 transition-colors">
                 {vision.title}
+                <span className="ml-2 text-stone-700 group-hover:text-amber-500/40 transition-colors">→</span>
               </h3>
               <p className="text-sm text-stone-500 leading-relaxed">
                 {vision.desc}
               </p>
-            </div>
+            </Link>
           ))}
+        </div>
+
+        {/* Explore all concepts */}
+        <div className="text-center pt-8">
+          <Link
+            href="/concepts/garden?domain=living-collective"
+            className="inline-flex items-center gap-2 text-stone-500 hover:text-teal-300/80 transition-colors text-sm"
+          >
+            Explore all 51 concepts in the Living Collective ontology
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+            </svg>
+          </Link>
         </div>
       </section>
 

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -15,6 +15,7 @@ interface NavItem {
 
 /** Single source of truth for primary navigation. */
 const PRIMARY_NAV: NavItem[] = [
+  { href: "/vision", label: "Vision" },
   { href: "/ideas", label: "Ideas" },
   { href: "/contribute", label: "Contribute" },
   { href: "/resonance", label: "Resonance", isHeartbeat: true },


### PR DESCRIPTION
## Summary

Transforms the static /vision page into a living, explorable experience. Each of the 51 Living Collective concepts now has its own detail page with cross-references, visual imagery, and \"contribute to this vision\" invitations.

### New: /vision/[conceptId] — Individual concept pages
- Hero with generated visual (11 concepts have images)
- Description from graph ontology
- Connected concepts with vitality-language edge labels
- Ideas tagged with this concept (or invitation to contribute if none)
- Parent/child navigation through the concept hierarchy
- \"Contribute to this vision\" CTA → idea submission pre-tagged

### Updated: /vision hub
- Every concept title now links to its detail page
- Emerging Visions grid cards link to detail pages
- \"Explore all 51 concepts\" link to concept garden

### Navigation
- \"Vision\" added as first item in primary nav on all pages

### Dark theme layout
- \`/vision/layout.tsx\` wraps all vision pages in consistent stone-950 aesthetic

## How collaboration now works
1. Visit /vision → immersive visual journey
2. Click any concept → detail page with full context
3. Click \"Contribute to this vision\" → idea submission pre-tagged with the concept
4. Submit idea → it appears on that concept's detail page under \"Ideas resonating\"
5. The vision grows organically through the existing idea pipeline

## Verification
- tsc clean, API tests pass (59/59)
- Each concept renders with data from the live API
- Navigation appears on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)