### PR TITLE
fix: PrintButton client component for flyer SSR compat

### DIFF
--- a/web/app/vision/flyer/page.tsx
+++ b/web/app/vision/flyer/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import QRCode from "qrcode";
+import { PrintButton } from "@/components/vision/PrintButton";
 
 export const metadata: Metadata = {
   title: "Flyer — The Living Collective",
@@ -31,23 +33,16 @@ export default async function FlyerPage() {
         }
       `}</style>
 
-      {/* Screen: print button */}
+      {/* Screen: navigation + print */}
       <div className="no-print fixed top-4 right-4 z-50 flex gap-3">
-        <a
+        <Link
           href="/vision/flyer/posters"
           className="px-4 py-2 rounded-lg bg-stone-800 text-stone-300 hover:bg-stone-700 transition-colors text-sm"
         >
           View workspace posters
-        </a>
-        <button
-          onClick={() => {}}
-          className="px-4 py-2 rounded-lg bg-amber-600 text-white hover:bg-amber-500 transition-colors text-sm font-medium"
-          id="print-btn"
-        >
-          Print flyer
-        </button>
+        </Link>
+        <PrintButton label="Print flyer" />
       </div>
-      <script dangerouslySetInnerHTML={{ __html: `document.getElementById('print-btn')?.addEventListener('click', () => window.print())` }} />
 
       {/* ═══ FLYER 1: Main invitation flyer (letter/A4) ═══ */}
       <div className="print-page min-h-screen flex flex-col items-center justify-center p-8 bg-stone-50 text-stone-900 print:bg-white">

--- a/web/app/vision/flyer/posters/page.tsx
+++ b/web/app/vision/flyer/posters/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { PrintButton } from "@/components/vision/PrintButton";
 
 export const metadata: Metadata = {
   title: "Community Posters — The Living Collective",
@@ -186,13 +187,7 @@ export default function PostersPage() {
             across different landscapes, scales, and climates. Print these to surround
             your workspace with the vision.
           </p>
-          <button
-            id="print-posters-btn"
-            className="px-6 py-2 rounded-lg bg-amber-600 text-white hover:bg-amber-500 transition-colors text-sm font-medium"
-          >
-            Print all posters
-          </button>
-          <script dangerouslySetInnerHTML={{ __html: `document.getElementById('print-posters-btn')?.addEventListener('click', () => window.print())` }} />
+          <PrintButton label="Print all posters" />
         </div>
 
         {/* Colorado Section */}

--- a/web/components/vision/PrintButton.tsx
+++ b/web/components/vision/PrintButton.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export function PrintButton({ label = "Print" }: { label?: string }) {
+  return (
+    <button
+      onClick={() => window.print()}
+      className="px-4 py-2 rounded-lg bg-amber-600 text-white hover:bg-amber-500 transition-colors text-sm font-medium"
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `PrintButton` as a client component to fix Next.js SSR build error
- Server components cannot pass `onClick` handlers — the flyer and poster pages were failing to prerender
- Removes `dangerouslySetInnerHTML` script tags in favor of clean React component

## Test plan

- [x] `tsc --noEmit` clean
- [x] Fixes `Error: Event handlers cannot be passed to Client Component props` build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)