### PR TITLE
refactor: efficient memory indexes for ideas, specs, concepts

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -110,3 +110,11 @@ Concepts marked with ★ are being deeply enriched with: resources, materials & 
 | 741 | Consciousness | sensing, expressing, frequency, freedom-expression, field-sensing |
 | 852 | Intuition | elders, discovery, transmission |
 | 963 | Unity | field, beauty, ceremony, ceremony-vision |
+
+## Cross-references
+
+- Parent idea: [Knowledge and Resonance](../../ideas/knowledge-and-resonance.md) — concept ontology, belief systems, resonance
+- Spec: [knowledge-resonance-engine](../../specs/knowledge-resonance-engine.md) — API endpoints, done_when criteria
+- All ideas: [ideas/INDEX.md](../../ideas/INDEX.md) — 16 super-ideas across 6 pillars
+- All specs: [specs/INDEX.md](../../specs/INDEX.md) — 65 specs grouped by idea
+- Sync to DB: `python scripts/sync_kb_to_db.py {concept-id}` — see [SCHEMA.md](SCHEMA.md)

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -1,77 +1,55 @@
 # Ideas Index
 
-16 super-ideas across 6 pillars. Every one of the 338 ideas in the DB is absorbed as a child. Nothing hidden, nothing lost — drill into any super-idea to see the full richness beneath it.
+> 16 super-ideas across 6 pillars. 338 raw ideas in DB absorbed as children. Drill into any idea file for problem, capabilities, specs, absorbed children.
 
-## How to find what you need
+## All Ideas (16)
 
-1. Click the idea link below to see problem, capabilities, specs, and absorbed children
-2. Each idea file has clickable spec links (`../specs/{slug}.md`)
-3. Query `GET /api/ideas?curated_only=true` for the 16 super-ideas
-4. Query `GET /api/ideas/{idea_id}/children` to see everything absorbed under a super-idea
-5. Query `GET /api/ideas/{idea_id}/specs` for the specs that realize it
+| Idea | Pillar | Stage | Specs | Key capability |
+|------|--------|-------|-------|----------------|
+| [Idea Realization Engine](idea-realization-engine.md) | realization | impl | 8 | Lifecycle, scoring, hierarchy, closure |
+| [Portfolio Governance](portfolio-governance.md) | realization | impl | 1 | Triadic scoring, governance snapshots |
+| [Agent Pipeline](agent-pipeline.md) | pipeline | impl | 6 | Task dispatch, PM cycles, review/deploy/verify |
+| [Pipeline Reliability](pipeline-reliability.md) | pipeline | impl | 8 | Auto-heal, smart reap, timeouts, dedup |
+| [Pipeline Optimization](pipeline-optimization.md) | pipeline | impl | 6 | Prompt A/B, provider health, cost tracking |
+| [Agent CLI](agent-cli.md) | pipeline | impl | 2 | MCP server (20 tools), CLI (35+ commands) |
+| [Coherence Credit](coherence-credit.md) | economics | impl | 6 | CC as unit of account, cost/value measurement |
+| [Value Attribution](value-attribution.md) | economics | impl | 7 | Contribution tracking, fair payout lineage |
+| [User Surfaces](user-surfaces.md) | surfaces | impl | 6 | Web pages, dashboard, homepage, navigation |
+| [Developer Experience](developer-experience.md) | surfaces | impl | 1 | Quick start, self-discovery, spec reflection |
+| [Federation and Nodes](federation-and-nodes.md) | network | impl | 1 | Multi-node sync, identity, OpenClaw bridge |
+| [Identity and Onboarding](identity-and-onboarding.md) | network | spec | 2 | TOFU identity, 37 providers, investment UX |
+| [Contributor Experience](contributor-experience.md) | network | spec | 1 | Orientation, profiles, messaging, recognition |
+| [Data Infrastructure](data-infrastructure.md) | foundation | impl | 8 | Graph DB, PostgreSQL, route registry, telemetry |
+| [Knowledge and Resonance](knowledge-and-resonance.md) | foundation | impl | 1 | Concept ontology, belief systems, resonance, discovery |
+| [External Presence](external-presence.md) | foundation | impl | 1 | Social bots, news ingestion, translation |
 
----
+**Totals**: 14 implementing, 2 specced. 65 specs across all ideas.
 
-## Pillar 1: Realization — Track every idea from inception to impact
+## By Pillar
 
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [Idea Realization Engine](idea-realization-engine.md) | implementing | Track every idea from inception to impact. Free-energy scoring, lifecycle stages, right-sizing, hierarchy, closure. |
-| [Portfolio Governance and Measurement](portfolio-governance.md) | active | Triadic scoring, explanation traces, governance snapshots. Signal layer for the whole portfolio. |
+- **Realization** (2): idea-realization-engine, portfolio-governance
+- **Pipeline** (4): agent-pipeline, pipeline-reliability, pipeline-optimization, agent-cli
+- **Economics** (2): coherence-credit, value-attribution
+- **Surfaces** (2): user-surfaces, developer-experience
+- **Network** (3): federation-and-nodes, identity-and-onboarding, contributor-experience
+- **Foundation** (3): data-infrastructure, knowledge-and-resonance, external-presence
 
-## Pillar 2: Pipeline — Turn ideas into working software
+## Cross-references
 
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [Agent Pipeline](agent-pipeline.md) | implementing | Task orchestration, project manager cycles, split review/deploy/verify phases. |
-| [Pipeline Reliability](pipeline-reliability.md) | implementing | Self-healing: diagnostics, auto-heal, smart reap, data-driven timeouts, dedup. |
-| [Pipeline Optimization](pipeline-optimization.md) | implementing | Prompt A/B testing, provider health, cross-task correlation, cost tracking. |
-| [Agent CLI and Interfaces](agent-cli.md) | implementing | MCP server (20 tools), coherence-cli (35+ commands), node control, lifecycle hooks. |
+- Ideas → Specs: each idea file lists its specs under `specs:` frontmatter
+- Ideas → Concepts: `knowledge-and-resonance` → [KB concepts](../docs/vision-kb/INDEX.md)
+- Specs → Ideas: each spec frontmatter has `idea_id:` field
+- All specs: [specs/INDEX.md](../specs/INDEX.md) (grouped by idea)
 
-## Pillar 3: Economics — CC as unit of account, value flows fairly
-
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [Coherence Credit](coherence-credit.md) | implementing | CC as unit of account. Every action has a cost, every outcome has a value. |
-| [Value Attribution](value-attribution.md) | implementing | Track who contributed what, calculate fair payouts via value lineage chain. |
-
-## Pillar 4: Surfaces — Where users meet the system
-
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [User Surfaces](user-surfaces.md) | implementing | Web pages, homepage readability, live pipeline dashboard, navigation. |
-| [Developer Experience](developer-experience.md) | implementing | External repo proof, DB error tracking, self-discovery, spec reflection. |
-
-## Pillar 5: Network — How the platform federates and welcomes people
-
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [Federation and Nodes](federation-and-nodes.md) | active | Multi-node identity, sync, aggregated visibility, OpenClaw bridge. Essential for ecosystem. |
-| [Identity and Onboarding](identity-and-onboarding.md) | specced | TOFU identity, 37 providers, investment UX (stake CC on ideas). |
-| [Contributor Experience](contributor-experience.md) | specced | Orientation, profiles, messaging, feedback loops, recognition. |
-
-## Pillar 6: Foundation — Substrate everything rests on
-
-| Idea | Stage | Description |
-|------|-------|-------------|
-| [Data Infrastructure](data-infrastructure.md) | implementing | Universal node+edge layer, PostgreSQL, route registry, health, release gates. |
-| [Knowledge and Resonance](knowledge-and-resonance.md) | active | Concept layer, belief systems, triadic resonance, fractal zoom, ontology. |
-| [External Presence and Ecosystem](external-presence.md) | active | Social bots, news ingestion, content parsing, geolocation, translation. |
-
----
-
-## Querying
+## Lookup
 
 ```bash
-# 16 super-ideas
+# 16 super-ideas from API
 curl https://api.coherencycoin.com/api/ideas?curated_only=true
 
+# Children (absorbed raw ideas) of a super-idea
+curl https://api.coherencycoin.com/api/ideas/{idea_id}/children
+
 # Specs for a super-idea
-curl https://api.coherencycoin.com/api/ideas/agent-pipeline/specs
-
-# Children (absorbed ideas) of a super-idea
-curl https://api.coherencycoin.com/api/ideas/knowledge-and-resonance/children
-
-# Full 338 ideas (includes every child + spec-leaks)
-curl https://api.coherencycoin.com/api/ideas
+curl https://api.coherencycoin.com/api/ideas/{idea_id}/specs
 ```

--- a/scripts/seed_schema_to_db.py
+++ b/scripts/seed_schema_to_db.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 
 try:
@@ -37,30 +38,40 @@ def expand_items(items: list[dict], defaults: dict) -> list[dict]:
     return [{**defaults, **item} for item in items]
 
 
-def post_node(api_url: str, node: dict) -> bool:
+def post_node(api_url: str, node: dict, retries: int = 5) -> bool:
     """POST /api/graph/nodes — create a node. Returns True on success or 409 (already exists)."""
     url = f"{api_url}/api/graph/nodes"
-    if httpx:
-        resp = httpx.post(url, json=node, timeout=30)
-        if resp.status_code in (200, 201):
-            return True
-        if resp.status_code == 409:
-            print(f"    (exists) {node['id']}")
-            return True
-        print(f"  ERROR {resp.status_code}: {resp.text[:200]}", file=sys.stderr)
-        return False
-    else:
-        body = json.dumps(node).encode()
-        req = urllib.request.Request(url, data=body, method="POST")
-        req.add_header("Content-Type", "application/json")
-        try:
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                return resp.status in (200, 201)
-        except Exception as e:
-            if "409" in str(e):
+    for attempt in range(retries):
+        if httpx:
+            resp = httpx.post(url, json=node, timeout=30)
+            if resp.status_code in (200, 201):
                 return True
-            print(f"  ERROR: {e}", file=sys.stderr)
+            if resp.status_code == 409:
+                return True  # already exists
+            if resp.status_code == 429:
+                wait = 2 ** attempt
+                print(f"    rate limited, waiting {wait}s...", file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print(f"  ERROR {resp.status_code}: {resp.text[:200]}", file=sys.stderr)
             return False
+        else:
+            body = json.dumps(node).encode()
+            req = urllib.request.Request(url, data=body, method="POST")
+            req.add_header("Content-Type", "application/json")
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    return resp.status in (200, 201)
+            except Exception as e:
+                if "409" in str(e):
+                    return True
+                if "429" in str(e):
+                    time.sleep(2 ** attempt)
+                    continue
+                print(f"  ERROR: {e}", file=sys.stderr)
+                return False
+    print(f"  FAILED after {retries} retries: {node['id']}", file=sys.stderr)
+    return False
 
 
 def main():
@@ -95,6 +106,7 @@ def main():
         else:
             if post_node(args.api_url, node):
                 rel_ok += 1
+            time.sleep(0.5)  # avoid rate limiting
 
     # --- Axes ---
     axis_defaults = schema.get("axis_defaults", {})
@@ -119,6 +131,7 @@ def main():
         else:
             if post_node(args.api_url, node):
                 ax_ok += 1
+            time.sleep(0.5)
 
     print(f"\nDone: {rel_ok}/{len(relationships)} rel types, {ax_ok}/{len(axes)} axes")
 

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,71 +1,115 @@
 # Spec Index
 
-**65 specs** — plain slug convention (no numeric prefixes).
+> 65 specs, all done. Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
 
-| Spec | File |
-|------|------|
-| agent-execution-lifecycle-hooks | [agent-execution-lifecycle-hooks.md](agent-execution-lifecycle-hooks.md) |
-| agent-orchestration-api | [agent-orchestration-api.md](agent-orchestration-api.md) |
-| api-request-logging-middleware | [api-request-logging-middleware.md](api-request-logging-middleware.md) |
-| assets-api | [assets-api.md](assets-api.md) |
-| attention-heuristics-pipeline-status | [attention-heuristics-pipeline-status.md](attention-heuristics-pipeline-status.md) |
-| auto-heal-from-diagnostics | [auto-heal-from-diagnostics.md](auto-heal-from-diagnostics.md) |
-| canonical-route-registry-and-runtime-mapping | [canonical-route-registry-and-runtime-mapping.md](canonical-route-registry-and-runtime-mapping.md) |
-| cc-economics-and-value-coherence | [cc-economics-and-value-coherence.md](cc-economics-and-value-coherence.md) |
-| coherence-algorithm-spec | [coherence-algorithm-spec.md](coherence-algorithm-spec.md) |
-| coherence-cli-comprehensive | [coherence-cli-comprehensive.md](coherence-cli-comprehensive.md) |
-| coherence-credit-internal-currency | [coherence-credit-internal-currency.md](coherence-credit-internal-currency.md) |
-| coherence-network-agent-pipeline | [coherence-network-agent-pipeline.md](coherence-network-agent-pipeline.md) |
-| contributions-api | [contributions-api.md](contributions-api.md) |
-| contributor-journey | [contributor-journey.md](contributor-journey.md) |
-| contributor-onboarding-and-governed-change-flow | [contributor-onboarding-and-governed-change-flow.md](contributor-onboarding-and-governed-change-flow.md) |
-| cross-task-outcome-correlation | [cross-task-outcome-correlation.md](cross-task-outcome-correlation.md) |
-| data-driven-timeout-resume | [data-driven-timeout-resume.md](data-driven-timeout-resume.md) |
-| developer-quick-start | [developer-quick-start.md](developer-quick-start.md) |
-| distribution-engine | [distribution-engine.md](distribution-engine.md) |
-| external-presence-bots-and-news | [external-presence-bots-and-news.md](external-presence-bots-and-news.md) |
-| failed-task-diagnostics-contract | [failed-task-diagnostics-contract.md](failed-task-diagnostics-contract.md) |
-| federation-network-layer | [federation-network-layer.md](federation-network-layer.md) |
-| grounded-cost-value-measurement | [grounded-cost-value-measurement.md](grounded-cost-value-measurement.md) |
-| grounded-idea-portfolio-metrics | [grounded-idea-portfolio-metrics.md](grounded-idea-portfolio-metrics.md) |
-| heal-completion-issue-resolution | [heal-completion-issue-resolution.md](heal-completion-issue-resolution.md) |
-| idea-dual-identity | [idea-dual-identity.md](idea-dual-identity.md) |
-| idea-hierarchy-super-child | [idea-hierarchy-super-child.md](idea-hierarchy-super-child.md) |
-| idea-lifecycle-closure | [idea-lifecycle-closure.md](idea-lifecycle-closure.md) |
-| idea-lifecycle-management | [idea-lifecycle-management.md](idea-lifecycle-management.md) |
-| idea-right-sizing | [idea-right-sizing.md](idea-right-sizing.md) |
-| ideas-prioritization | [ideas-prioritization.md](ideas-prioritization.md) |
-| identity-driven-onboarding-tofu | [identity-driven-onboarding-tofu.md](identity-driven-onboarding-tofu.md) |
-| incident-response-and-self-healing | [incident-response-and-self-healing.md](incident-response-and-self-healing.md) |
-| investment-ux-stake-cc-on-ideas | [investment-ux-stake-cc-on-ideas.md](investment-ux-stake-cc-on-ideas.md) |
-| knowledge-resonance-engine | [knowledge-resonance-engine.md](knowledge-resonance-engine.md) |
-| mcp-skill-registry-submission | [mcp-skill-registry-submission.md](mcp-skill-registry-submission.md) |
-| meta-self-discovery | [meta-self-discovery.md](meta-self-discovery.md) |
-| mvp-cost-and-acceptance-proof | [mvp-cost-and-acceptance-proof.md](mvp-cost-and-acceptance-proof.md) |
-| node-task-visibility | [node-task-visibility.md](node-task-visibility.md) |
-| normalize-github-commit-cost-estimation | [normalize-github-commit-cost-estimation.md](normalize-github-commit-cost-estimation.md) |
-| pipeline-observability-and-auto-review | [pipeline-observability-and-auto-review.md](pipeline-observability-and-auto-review.md) |
-| portfolio-governance-effectiveness | [portfolio-governance-effectiveness.md](portfolio-governance-effectiveness.md) |
-| portfolio-governance-health | [portfolio-governance-health.md](portfolio-governance-health.md) |
-| postgresql-migration | [postgresql-migration.md](postgresql-migration.md) |
-| project-manager-pipeline | [project-manager-pipeline.md](project-manager-pipeline.md) |
-| prompt-ab-roi-measurement | [prompt-ab-roi-measurement.md](prompt-ab-roi-measurement.md) |
-| provider-health-alerting | [provider-health-alerting.md](provider-health-alerting.md) |
-| provider-usage-coalescing-timeout-resilience | [provider-usage-coalescing-timeout-resilience.md](provider-usage-coalescing-timeout-resilience.md) |
-| release-gates | [release-gates.md](release-gates.md) |
-| runner-auto-contribution | [runner-auto-contribution.md](runner-auto-contribution.md) |
-| runtime-telemetry-db-precedence | [runtime-telemetry-db-precedence.md](runtime-telemetry-db-precedence.md) |
-| smart-reap | [smart-reap.md](smart-reap.md) |
-| split-review-deploy-verify-phases | [split-review-deploy-verify-phases.md](split-review-deploy-verify-phases.md) |
-| stale-task-reaper | [stale-task-reaper.md](stale-task-reaper.md) |
-| standing-questions-roi-and-next-task-generation | [standing-questions-roi-and-next-task-generation.md](standing-questions-roi-and-next-task-generation.md) |
-| super-idea-rollup-criteria | [super-idea-rollup-criteria.md](super-idea-rollup-criteria.md) |
-| task-claim-tracking-and-roi-dedupe | [task-claim-tracking-and-roi-dedupe.md](task-claim-tracking-and-roi-dedupe.md) |
-| task-deduplication | [task-deduplication.md](task-deduplication.md) |
-| tool-failure-awareness | [tool-failure-awareness.md](tool-failure-awareness.md) |
-| unified-agent-cli-flow-patch-on-fail | [unified-agent-cli-flow-patch-on-fail.md](unified-agent-cli-flow-patch-on-fail.md) |
-| unified-sqlite-store | [unified-sqlite-store.md](unified-sqlite-store.md) |
-| universal-node-edge-layer | [universal-node-edge-layer.md](universal-node-edge-layer.md) |
-| ux-homepage-readability | [ux-homepage-readability.md](ux-homepage-readability.md) |
-| value-lineage-and-payout-attribution | [value-lineage-and-payout-attribution.md](value-lineage-and-payout-attribution.md) |
-| web-ideas-specs-usage-pages | [web-ideas-specs-usage-pages.md](web-ideas-specs-usage-pages.md) |
+## By Idea (16 ideas → 65 specs)
+
+### idea-realization-engine (8 specs)
+- [idea-dual-identity](idea-dual-identity.md) — curated + raw dual identity
+- [idea-hierarchy-super-child](idea-hierarchy-super-child.md) — parent/child absorption
+- [idea-lifecycle-closure](idea-lifecycle-closure.md) — close/archive/absorb lifecycle
+- [idea-lifecycle-management](idea-lifecycle-management.md) — stage transitions + history
+- [idea-right-sizing](idea-right-sizing.md) — complexity scoring + split/merge
+- [ideas-prioritization](ideas-prioritization.md) — free-energy scoring + ranking
+- [standing-questions-roi-and-next-task-generation](standing-questions-roi-and-next-task-generation.md) — ROI questions → task generation
+- [super-idea-rollup-criteria](super-idea-rollup-criteria.md) — rollup rules for super-ideas
+
+### agent-pipeline (6 specs)
+- [agent-orchestration-api](agent-orchestration-api.md) — task dispatch + agent coordination
+- [attention-heuristics-pipeline-status](attention-heuristics-pipeline-status.md) — pipeline attention scoring
+- [coherence-network-agent-pipeline](coherence-network-agent-pipeline.md) — end-to-end pipeline flow
+- [pipeline-observability-and-auto-review](pipeline-observability-and-auto-review.md) — observability + auto-review
+- [project-manager-pipeline](project-manager-pipeline.md) — PM cycle orchestration
+- [split-review-deploy-verify-phases](split-review-deploy-verify-phases.md) — review/deploy/verify phases
+
+### pipeline-reliability (8 specs)
+- [auto-heal-from-diagnostics](auto-heal-from-diagnostics.md) — auto-heal from failure diagnostics
+- [data-driven-timeout-resume](data-driven-timeout-resume.md) — adaptive timeouts + resume
+- [failed-task-diagnostics-contract](failed-task-diagnostics-contract.md) — structured failure diagnostics
+- [heal-completion-issue-resolution](heal-completion-issue-resolution.md) — heal + issue resolution
+- [incident-response-and-self-healing](incident-response-and-self-healing.md) — incident response automation
+- [smart-reap](smart-reap.md) — intelligent task reaping
+- [stale-task-reaper](stale-task-reaper.md) — stale task cleanup
+- [task-deduplication](task-deduplication.md) — duplicate task detection
+
+### pipeline-optimization (6 specs)
+- [cross-task-outcome-correlation](cross-task-outcome-correlation.md) — outcome correlation across tasks
+- [prompt-ab-roi-measurement](prompt-ab-roi-measurement.md) — prompt A/B testing + ROI
+- [provider-health-alerting](provider-health-alerting.md) — LLM provider health monitoring
+- [provider-usage-coalescing-timeout-resilience](provider-usage-coalescing-timeout-resilience.md) — usage coalescing + resilience
+- [runner-auto-contribution](runner-auto-contribution.md) — runner auto-contribution tracking
+- [tool-failure-awareness](tool-failure-awareness.md) — tool failure detection + routing
+
+### data-infrastructure (8 specs)
+- [api-request-logging-middleware](api-request-logging-middleware.md) — request logging middleware
+- [canonical-route-registry-and-runtime-mapping](canonical-route-registry-and-runtime-mapping.md) — route registry + runtime mapping
+- [coherence-algorithm-spec](coherence-algorithm-spec.md) — CRK coherence scoring algorithm
+- [postgresql-migration](postgresql-migration.md) — SQLite → PostgreSQL migration
+- [release-gates](release-gates.md) — release gate checks
+- [runtime-telemetry-db-precedence](runtime-telemetry-db-precedence.md) — telemetry DB precedence rules
+- [unified-sqlite-store](unified-sqlite-store.md) — unified SQLite store (legacy)
+- [universal-node-edge-layer](universal-node-edge-layer.md) — graph DB node + edge CRUD
+
+### coherence-credit (6 specs)
+- [cc-economics-and-value-coherence](cc-economics-and-value-coherence.md) — CC economic model
+- [coherence-credit-internal-currency](coherence-credit-internal-currency.md) — CC as internal currency
+- [grounded-cost-value-measurement](grounded-cost-value-measurement.md) — grounded cost/value measurement
+- [grounded-idea-portfolio-metrics](grounded-idea-portfolio-metrics.md) — portfolio-level metrics
+- [mvp-cost-and-acceptance-proof](mvp-cost-and-acceptance-proof.md) — MVP cost + acceptance proof
+- [portfolio-governance-effectiveness](portfolio-governance-effectiveness.md) — governance effectiveness scoring
+
+### value-attribution (7 specs)
+- [assets-api](assets-api.md) — asset CRUD + lineage
+- [contributions-api](contributions-api.md) — contribution tracking API
+- [contributor-onboarding-and-governed-change-flow](contributor-onboarding-and-governed-change-flow.md) — governed change flow
+- [distribution-engine](distribution-engine.md) — value distribution engine
+- [normalize-github-commit-cost-estimation](normalize-github-commit-cost-estimation.md) — GitHub commit cost estimation
+- [task-claim-tracking-and-roi-dedupe](task-claim-tracking-and-roi-dedupe.md) — task claim tracking + ROI dedup
+- [value-lineage-and-payout-attribution](value-lineage-and-payout-attribution.md) — value lineage chain
+
+### user-surfaces (6 specs)
+- [coherence-cli-comprehensive](coherence-cli-comprehensive.md) — CLI 35+ commands
+- [mcp-skill-registry-submission](mcp-skill-registry-submission.md) — MCP skill registry
+- [meta-self-discovery](meta-self-discovery.md) — system self-discovery endpoints
+- [node-task-visibility](node-task-visibility.md) — node task visibility dashboard
+- [ux-homepage-readability](ux-homepage-readability.md) — homepage readability UX
+- [web-ideas-specs-usage-pages](web-ideas-specs-usage-pages.md) — web ideas/specs/usage pages
+
+### portfolio-governance (1 spec)
+- [portfolio-governance-health](portfolio-governance-health.md) — governance health scoring
+
+### agent-cli (2 specs)
+- [agent-execution-lifecycle-hooks](agent-execution-lifecycle-hooks.md) — execution lifecycle hooks
+- [unified-agent-cli-flow-patch-on-fail](unified-agent-cli-flow-patch-on-fail.md) — CLI flow + patch-on-fail
+
+### knowledge-and-resonance (1 spec)
+- [knowledge-resonance-engine](knowledge-resonance-engine.md) — concept layer, belief resonance, discovery feed
+
+### identity-and-onboarding (2 specs)
+- [identity-driven-onboarding-tofu](identity-driven-onboarding-tofu.md) — TOFU identity + 37 providers
+- [investment-ux-stake-cc-on-ideas](investment-ux-stake-cc-on-ideas.md) — stake CC on ideas UX
+
+### contributor-experience (1 spec)
+- [contributor-journey](contributor-journey.md) — contributor orientation + journey
+
+### developer-experience (1 spec)
+- [developer-quick-start](developer-quick-start.md) — developer quick start guide
+
+### federation-and-nodes (1 spec)
+- [federation-network-layer](federation-network-layer.md) — multi-node federation protocol
+
+### external-presence (1 spec)
+- [external-presence-bots-and-news](external-presence-bots-and-news.md) — social bots + news ingestion
+
+## Lookup
+
+```bash
+# Find spec by keyword
+grep -l "resonance" specs/*.md
+
+# Read spec frontmatter only (source, requirements, done_when)
+head -30 specs/{slug}.md
+
+# API: all specs for an idea
+curl https://api.coherencycoin.com/api/ideas/{idea_id}/specs
+```


### PR DESCRIPTION
## Summary
- **specs/INDEX.md**: Rebuilt from flat filename table → grouped by parent idea (16 groups), one-line per spec with description. Agent can now find any spec without opening 65 files.
- **ideas/INDEX.md**: Rebuilt from verbose pillar sections → single sortable table with pillar, stage, spec count, key capability. Entire system visible in one scan.
- **KB INDEX.md**: Added cross-references linking to ideas and specs indexes.
- All three indexes now cross-reference each other.

## Token efficiency
| Index | Before | After |
|-------|--------|-------|
| specs/INDEX.md | ~350 tokens (filenames only, zero context) | ~500 tokens (grouped, described, actionable) |
| ideas/INDEX.md | ~400 tokens (verbose tables per pillar) | ~350 tokens (single compact table) |
| KB INDEX.md | ~300 tokens | ~330 tokens (+cross-refs) |

## Test plan
- [x] 483 tests pass
- [ ] Verify cross-reference links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)