### PR TITLE
feat: Tier 2 enrichment + Blueprints section on vision page

### DIFF
--- a/docs/vision-kb/concepts/lc-ceremony.md
+++ b/docs/vision-kb/concepts/lc-ceremony.md
@@ -1,8 +1,8 @@
 ---
 id: lc-ceremony
 hz: 963
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Ceremony
@@ -26,6 +26,17 @@ Our ceremonies emerge from presence, not prescription. But they carry echoes of 
 ## Blueprint
 Fire circle every new moon. Seasonal ceremonies at solstice and equinox. Arrival ceremony for new members (simple: the community sings them in). Departure ceremony (the community sings them out). No prescribed forms — let the moment teach the ceremony.
 
+## Resources
+- [The Work That Reconnects by Joanna Macy](https://workthatreconnects.org/) — free facilitation guides for group ceremonies of gratitude and grief (type: guide)
+- [Damanhur](https://www.damanhur.org/) — Italian ecovillage with underground Temples of Humankind, ceremony-centered community (type: community)
+- [Sociocracy For All](https://www.sociocracyforall.org/) — meeting-as-ceremony, consent rounds as ritual (type: guide)
+- [Rainbow Gatherings](https://www.welcomehome.org/) — temporary communities built around ceremony and sharing (type: community)
+
+## Visuals
+1. **Fire circle at new moon** — `photorealistic group of people gathered around fire pit at night under stars, faces lit by firelight, drums nearby, singing, wilderness setting, new moon sky full of stars`
+2. **Solstice ceremony at dawn** — `photorealistic community gathered on hilltop at winter solstice dawn, facing east, hands joined, first light breaking over mountains, breath visible in cold air, candles`
+3. **Arrival ceremony** — `photorealistic community welcoming a new member at entrance gate, flowers, singing, hands reaching out, joyful faces, earthen buildings behind, warm golden light`
+
 ## Living Examples
 - **Elephants mourning** — the herd circles, touches, stands in silence. Returns to bones years later.
 - **Japanese tea ceremony** — every movement intentional, beauty in simplicity, presence distilled
@@ -46,8 +57,9 @@ Fire circle every new moon. Seasonal ceremonies at solstice and equinox. Arrival
 Ceremony (already enriched — this adds to the existing content if not present)
 
 ## Open Questions
-- What aspects of Ceremony need deeper research?
-- What real-world examples are we missing?
+- How to create ceremonies that resonate across diverse spiritual backgrounds?
+- What ceremonies does a community need at minimum? (Arrival, departure, solstice, new moon?)
+- How to allow ceremony to emerge spontaneously vs planning it?
 
 ## Cross-References
-→ lc-resonating
+→ lc-v-ceremony-vision, lc-stillness, lc-elders, lc-offering

--- a/docs/vision-kb/concepts/lc-circulation.md
+++ b/docs/vision-kb/concepts/lc-circulation.md
@@ -1,8 +1,8 @@
 ---
 id: lc-circulation
 hz: 528
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Circulation
@@ -18,6 +18,16 @@ Resources flow like the mycorrhizal network beneath a forest: nutrients from whe
 ## Blueprint
 Common fund covers all basic needs: food, shelter, energy, health, education. Individual cells don't handle money for daily life. External income from community enterprises flows into the common fund. Surplus circulates to the network — other communities, land regeneration, seeding new fields.
 
+## Resources
+- 📖 [Sacred Economics](https://sacred-economics.com/) — Charles Eisenstein, free online book on gift economy and resource circulation (type: book)
+- 📖 [Sociocracy For All](https://www.sociocracyforall.org/) — consent-based resource allocation and governance (type: guide)
+- 🌐 [Foundation for Intentional Community](https://www.ic.org/) — community economics models from 1000+ communities (type: community)
+- 📖 [Grounded Solutions - CLT Resources](https://groundedsolutions.org/) — community land trust models for shared economics (type: guide)
+
+## Visuals
+1. **Common fund visualization** — `photorealistic community meeting room with transparent glass jar of coins and bills on table, people discussing around circular table, whiteboard showing flow diagram of resources, warm light`
+2. **Mycorrhizal network diagram** — `photorealistic illustration of underground fungal network connecting tree roots, nutrients flowing as glowing particles between trees, forest floor with mushrooms, cross-section view`
+
 ## Living Examples
 - **Mycorrhizal network** — mother trees feed seedlings through underground fungal highways
 - **Blood circulation** — oxygen to every cell, waste removed, no cell pays
@@ -31,8 +41,9 @@ Common fund covers all basic needs: food, shelter, energy, health, education. In
 Circulation is where Nourishing meets Field Intelligence — resources flow because the field senses where they're needed. It replaces economics with biology.
 
 ## Open Questions
-- What aspects of Circulation need deeper research?
-- What real-world examples are we missing?
+- How to handle the transition from individual income to common fund?
+- What's the right balance between shared resources and personal autonomy?
+- How to interface with external economy (taxes, health insurance, pensions)?
 
 ## Cross-References
-→ lc-nourishing, lc-field-sensing
+→ lc-offering, lc-v-mycorrhizal, lc-nourishment

--- a/docs/vision-kb/concepts/lc-composting.md
+++ b/docs/vision-kb/concepts/lc-composting.md
@@ -1,8 +1,8 @@
 ---
 id: lc-composting
 hz: 285
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Composting
@@ -18,6 +18,15 @@ How the field transforms what has completed into nourishment for what's emerging
 ## Blueprint
 Physical composting stations visible throughout the community — food scraps, humanure, garden waste. When a project, practice, or relationship completes, hold a 'composting ceremony': acknowledge what was, harvest the learnings, release the form. Annual review: what structures have completed their lifecycle?
 
+## Resources
+- 📖 [Humanure Handbook](https://humanurehandbook.com/) — Joseph Jenkins' free guide to composting human waste safely (type: book)
+- 📖 [ATTRA Composting Guide](https://attra.ncat.org/) — free publications on farm-scale composting systems (type: guide)
+- 🌐 [Appropedia Composting](https://www.appropedia.org/) — open wiki articles on composting toilets, vermicomposting, and more (type: community)
+
+## Visuals
+1. **Community compost station** — `photorealistic three-bin composting system in community garden, person turning compost with pitchfork, steam rising from hot pile, vegetable scraps, earthworms visible, fruit trees nearby`
+2. **Composting ceremony** — `photorealistic group of people in circle outdoors at sunset, placing objects into a fire, releasing and letting go, expressions of peace, autumn leaves, golden light`
+
 ## Living Examples
 - **Forest floor** — fallen leaves become soil become new trees in continuous cycle
 - **Fermentation** — 'spoiled' food becomes kimchi, wine, cheese, miso — more complex, more nourishing
@@ -31,8 +40,9 @@ Physical composting stations visible throughout the community — food scraps, h
 Composting replaces the concept of grief, loss, death. Nothing ends — everything transforms. It connects to Phase Transitions (the larger lifecycle) and Rest (composting IS integration).
 
 ## Open Questions
-- What aspects of Composting need deeper research?
-- What real-world examples are we missing?
+- How to make composting toilets acceptable to newcomers?
+- What's the right metaphor for "composting" relationships or projects that have ended?
+- How to build a composting system that handles waste for 200 people?
 
 ## Cross-References
-→ lc-spiraling
+→ lc-v-phase-transition, lc-rest, lc-nourishment, lc-land

--- a/docs/vision-kb/concepts/lc-elders.md
+++ b/docs/vision-kb/concepts/lc-elders.md
@@ -1,8 +1,8 @@
 ---
 id: lc-elders
 hz: 852
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Elders
@@ -17,6 +17,15 @@ The field's root system. Depth, pattern recognition, grounding. The elephant mat
 
 ## Blueprint
 Elders sit at the center of decision-making, not the periphery. 'Elder walks' weekly — an elder walks with anyone who wants to talk, no agenda. Elder housing is in the heart of the community, not separate. Skills and stories are transmitted through daily proximity, not scheduled workshops.
+
+## Resources
+- [Hesperian Health Guides](https://hesperian.org/books-and-resources/) — community health including elder care in resource-limited settings (type: book)
+- [Foundation for Intentional Community](https://www.ic.org/) — aging-in-community models and elder housing designs (type: community)
+- [Cohousing - Senior Cohousing](https://www.cohousing.org/) — elder-centered cohousing design patterns (type: guide)
+
+## Visuals
+1. **Elder walk** — `photorealistic elderly person walking with young adult along garden path in community, deep conversation, autumn trees, dappled light, herbs along path, peaceful`
+2. **Story circle** — `photorealistic elder telling story to group of children and adults around fire in earthen common room, animated gestures, children wide-eyed, warm light, cushions`
 
 ## Living Examples
 - **Elephant matriarch** — the oldest female leads because she remembers where water was in the last drought
@@ -33,8 +42,9 @@ Elders sit at the center of decision-making, not the periphery. 'Elder walks' we
 Elders are the Spiraling flow as accumulated wisdom. They ground the field when it's turbulent and remind it of what it's been through. They connect to Discovery (transmission of knowing) and Ceremony (holding the deepest rituals).
 
 ## Open Questions
-- What aspects of Elders need deeper research?
-- What real-world examples are we missing?
+- How to design elder housing that's central (not peripheral) to community life?
+- What decision-making power should elders have vs younger members?
+- How to attract elders to a new community that has no track record?
 
 ## Cross-References
-→ lc-spiraling
+→ lc-ceremony, lc-v-discovery, lc-health, lc-stillness

--- a/docs/vision-kb/concepts/lc-offering.md
+++ b/docs/vision-kb/concepts/lc-offering.md
@@ -1,8 +1,8 @@
 ---
 id: lc-offering
 hz: 528
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Offering
@@ -18,6 +18,16 @@ What flows from a cell's natural frequency. Heart beats because that's its natur
 ## Blueprint
 No assigned roles. A 'resonance board' where the community posts what it needs; people step forward from resonance, not obligation. Weekly 'offering circle' where anyone can share what they want to contribute. Track offerings, not hours — what did you give that was alive?
 
+## Resources
+- 📖 [Sacred Economics by Charles Eisenstein](https://sacred-economics.com/) — free online book on gift economy and offering-based economics (type: book)
+- 📖 [Sociocracy For All](https://www.sociocracyforall.org/) — consent-based governance where contribution flows from resonance (type: guide)
+- 🌐 [Foundation for Intentional Community](https://www.ic.org/) — 1000+ communities modeling offering-based economies (type: community)
+- 📖 [Gift Economy resources](https://www.gifteconomy.org.au/) — guides on building gift economy practices (type: guide)
+
+## Visuals
+1. **Resonance board** — `photorealistic community bulletin board on wooden wall showing needs and offerings pinned with colorful cards, people reading and adding cards, earthen wall, warm light, plants nearby`
+2. **Offering circle** — `photorealistic group of people sitting in circle outdoors on cushions, sharing skills and gifts, someone demonstrating woodworking, another playing music, warm afternoon light, garden setting`
+
 ## Living Examples
 - **Dawn bird chorus** — each species singing its frequency, the forest symphony emerges
 - **A master carpenter finishing a joint** — the precision IS the offering, the beauty IS the function
@@ -31,8 +41,9 @@ No assigned roles. A 'resonance board' where the community posts what it needs; 
 Offering is the Expressing flow as service. It replaces the concept of 'work' — there is no work, only expression that happens to nourish the field.
 
 ## Open Questions
-- What aspects of Offering need deeper research?
-- What real-world examples are we missing?
+- How to handle free-riding without creating surveillance?
+- When does offering-based economics need to interface with money (medical, legal, taxes)?
+- How to support members whose natural offering isn't yet visible to them?
 
 ## Cross-References
-→ lc-expressing
+→ lc-circulation, lc-ceremony, lc-stillness

--- a/docs/vision-kb/concepts/lc-play.md
+++ b/docs/vision-kb/concepts/lc-play.md
@@ -1,8 +1,8 @@
 ---
 id: lc-play
 hz: 396
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Play
@@ -24,6 +24,17 @@ In the field, adults play as freely as children. Improv theater principles (yes-
 ## Blueprint
 Designate an adventure playground with loose materials (wood, rope, tires, fabric, water). Weekly improv night. Monthly 'ridiculous games' tournament. No productive purpose required. Adults play alongside children. Budget for play equipment as essential infrastructure, not luxury.
 
+## Resources
+- 📖 [The Art of Play](https://www.playgroundideas.org/) — Playground Ideas, open-source playground designs for communities worldwide (type: guide)
+- 📖 [Adventure Playground Guide](https://www.popupadventureplay.org/) — Pop-Up Adventure Play, free resources for adventure play (type: guide)
+- 📖 [Sociocracy For All](https://www.sociocracyforall.org/) — governance through play and consent (type: guide)
+- 🌐 [Permies.com](https://permies.com/) — homesteading community with natural play and outdoor education forums (type: community)
+
+## Visuals
+1. **Adventure playground** — `photorealistic adventure playground in intentional community, children and adults climbing wooden structures, loose materials, mud kitchen, tire swings, trees, laughter, afternoon light`
+2. **Improv night in common house** — `photorealistic group of adults doing improv theater in round earthen common room, expressive gestures, audience laughing, warm firelight, cushions on floor`
+3. **Water play in summer** — `photorealistic natural swimming pond with people splashing, rope swing, wooden dock, wildflowers, children and adults playing together, mountains in background`
+
 ## Living Examples
 - **Dolphins** — up to 80% of waking time in play. The most intelligent, socially complex marine mammals.
 - **Rough-and-tumble play in mammals** — develops body awareness, emotional regulation, social skills
@@ -43,8 +54,9 @@ Designate an adventure playground with loose materials (wood, rope, tires, fabri
 Play is the Resonating flow at its most creative. It connects to Discovery (learning through play), Expressing (creation through play), and Comfort/Joy (pleasure as practice).
 
 ## Open Questions
-- What aspects of Play need deeper research?
-- What real-world examples are we missing?
+- How to keep adult play alive when work pressure builds?
+- What play structures serve both children and adults?
+- How to integrate play into decision-making (sociocratic games)?
 
 ## Cross-References
-→ lc-resonating
+→ lc-v-play-expansion, lc-space, lc-ceremony

--- a/docs/vision-kb/concepts/lc-rest.md
+++ b/docs/vision-kb/concepts/lc-rest.md
@@ -1,8 +1,8 @@
 ---
 id: lc-rest
 hz: 174
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Integration
@@ -17,6 +17,15 @@ How the field repairs, weaves new connections, dreams. Not the absence of activi
 
 ## Blueprint
 Designate a 'sanctuary' space that is always silent, always available. Enforce a collective rest period (2-4pm) where no loud activity happens. Honor seasonal rest: winter has fewer projects, longer evenings, more fire circles. When someone needs deep rest, the community reorganizes around them without discussion.
+
+## Resources
+- [Plum Village](https://plumvillage.org/) — Thich Nhat Hanh's community rest and mindfulness practices (type: guide)
+- [Sabbath/Sabbatical traditions](https://www.ic.org/) — intentional community approaches to cyclical rest (type: community)
+- [Taize Community](https://www.taize.fr/) — ecumenical community modeling rhythms of activity and rest (type: community)
+
+## Visuals
+1. **Sanctuary space** — `photorealistic quiet sanctuary room with soft natural light, cushions and blankets, plants, curved earthen walls, person sleeping peacefully, candle, warm afternoon light filtering through curtain`
+2. **Winter evening fire circle** — `photorealistic small group around indoor fireplace in earthen common room during winter evening, blankets, tea, storytelling, snow visible through window, warm flickering light`
 
 ## Living Examples
 - **Forest in winter** — still above, composting below, preparing the next explosion of growth
@@ -33,8 +42,9 @@ Designate a 'sanctuary' space that is always silent, always available. Enforce a
 Rest/Integration is the Nourishing flow in its receptive phase. Without it, the field burns out. It connects to Rhythm (daily and seasonal cycles) and Stillness (the conscious practice of pause).
 
 ## Open Questions
-- What aspects of Integration need deeper research?
-- What real-world examples are we missing?
+- How to honor individual rest needs without disrupting community rhythm?
+- What's the right seasonal work/rest ratio? (Winter: 60% rest / Summer: 30% rest?)
+- How to create a culture where rest is valued as much as productivity?
 
 ## Cross-References
-→ lc-nourishing
+→ lc-stillness, lc-composting, lc-health, lc-space

--- a/docs/vision-kb/concepts/lc-stillness.md
+++ b/docs/vision-kb/concepts/lc-stillness.md
@@ -1,8 +1,8 @@
 ---
 id: lc-stillness
 hz: 174
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Stillness
@@ -18,6 +18,15 @@ The deepest sensing. Shared silence has a density that individual silence doesn'
 ## Blueprint
 Morning silence (6-7am): the whole community holds quiet. A dedicated stillness sanctuary with cushions, blankets, dim light — always available. Weekly group sit (30-60 min). The community learns to let silence hold conversations — pauses are not awkward, they're deep.
 
+## Resources
+- 📖 [Plum Village Practice Resources](https://plumvillage.org/) — Thich Nhat Hanh's community practice guides, free online (type: guide)
+- 📖 [Insight Timer](https://insighttimer.com/) — free meditation app with 150,000+ guided practices (type: guide)
+- 🌐 [Taize Community](https://www.taize.fr/) — ecumenical community known for shared contemplative silence (type: community)
+
+## Visuals
+1. **Morning silence sanctuary** — `photorealistic small round meditation room with cushions on earthen floor, single candle, dawn light through round window, plants, person sitting in stillness, peaceful`
+2. **Group sit at dawn** — `photorealistic group of people sitting in silent meditation outdoors at dawn, mist rising from grass, trees silhouetted, sky turning pink, bare feet on earth, absolute stillness`
+
 ## Living Examples
 - **Dawn in a forest** — the moment before birdsong begins, everything listening together
 - **Quaker meeting** — sitting in silence until someone is moved to speak by genuine inner knowing
@@ -31,8 +40,9 @@ Morning silence (6-7am): the whole community holds quiet. A dedicated stillness 
 Stillness is the Resonating flow in its receptive mode — the complement to Play's active mode. It connects to Sensing (silence sharpens awareness), Ceremony (presence is the heart of honoring), and Rest (deep stillness regenerates).
 
 ## Open Questions
-- What aspects of Stillness need deeper research?
-- What real-world examples are we missing?
+- How to maintain group silence when some members are uncomfortable with it?
+- What's the minimum daily stillness practice for community coherence?
+- How to design acoustic spaces that truly hold silence?
 
 ## Cross-References
-→ lc-resonating
+→ lc-rest, lc-ceremony, lc-space, lc-health

--- a/docs/vision-kb/concepts/lc-v-food-practice.md
+++ b/docs/vision-kb/concepts/lc-v-food-practice.md
@@ -1,8 +1,8 @@
 ---
 id: lc-v-food-practice
 hz: 174
-status: seed
-updated: 2026-04-13
+status: expanding
+updated: 2026-04-14
 ---
 
 # Food as Living Practice
@@ -17,6 +17,18 @@ Garden as pharmacy. Kitchen as laboratory. Meal as ceremony. What happens when g
 
 ## Blueprint
 Key elements: 7-layer food forest (permaculture), fermentation station, communal cooking (minimum 2 people, ideally 4+), seasonal menu that follows the land, foraging integration, compost cycle visible, herb spiral near kitchen, no processed foods, children involved in all stages.
+
+## Resources
+- 📐 [One Community - Transition Kitchen](https://onecommunityglobal.org/transition-kitchen/) — open-source community kitchen design (type: blueprint)
+- 📖 [Wild Fermentation by Sandor Katz](https://www.wildfermentation.com/) — comprehensive fermentation guide and community (type: book)
+- 📖 [Andrew Millison - Permaculture](https://open.oregonstate.education/permaculture/) — free open textbook on food forest design (type: book)
+- 🌐 [Permaculture Research Institute](https://permaculturenews.org/) — food forest case studies and guides (type: community)
+- 📖 [ATTRA Sustainable Agriculture](https://attra.ncat.org/) — 300+ free publications on organic food production (type: guide)
+
+## Visuals
+1. **Harvest morning** — `photorealistic group of people harvesting vegetables in community garden at morning, baskets full of tomatoes peppers greens, food forest in background, dappled light, bare feet in soil`
+2. **Communal cooking** — `photorealistic four people cooking together in large community kitchen, chopping vegetables, stirring large pot, herbs hanging, laughter, steam, wooden counters, earthen walls`
+3. **Herb spiral** — `photorealistic stone herb spiral garden with diverse medicinal and culinary herbs, labels, person picking herbs, morning dew, community buildings in background`
 
 ## Living Examples
 - **Zaytuna Farm (Geoff Lawton, Australia)** — 66-acre permaculture demonstration, food forest, regenerative water
@@ -33,8 +45,9 @@ Key elements: 7-layer food forest (permaculture), fermentation station, communal
 Food as Practice is where Nourishing meets Ceremony. The kitchen-hearth is the field's literal heart. Meals are the most natural resonance practice — cells aligning through shared substance. The garden is where the field meets the land.
 
 ## Open Questions
-- What aspects of Food as Living Practice need deeper research?
-- What real-world examples are we missing?
+- How to maintain food practice when community members have different dietary needs?
+- What's the minimum garden size to meaningfully supplement a community's food?
+- How to make food preservation (fermentation, drying, canning) a joyful communal activity?
 
 ## Cross-References
-→ lc-nourishment
+→ lc-nourishment, lc-land, lc-health, lc-ceremony

--- a/web/app/vision/page.tsx
+++ b/web/app/vision/page.tsx
@@ -328,6 +328,64 @@ export default function VisionPage() {
         </div>
       </section>
 
+      {/* Blueprints & Resources — enriched concepts with real building data */}
+      <section className="border-t border-stone-800/30">
+        <div className="max-w-5xl mx-auto px-6 py-24 space-y-10">
+          <div className="text-center space-y-4">
+            <h2 className="text-3xl md:text-4xl font-extralight text-stone-300">
+              Blueprints & Resources
+            </h2>
+            <p className="text-stone-500 text-lg max-w-2xl mx-auto">
+              Real open-source plans, materials, costs, and methods for each aspect of the community.
+              Each concept page has resources you can use today.
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              { title: "Space", id: "lc-space", desc: "Common houses, private nests, workshops. Cob, timber, rammed earth.", tag: "7 resources" },
+              { title: "Nourishment", id: "lc-nourishment", desc: "Food forests, community kitchens, fermentation. Permaculture plans.", tag: "8 resources" },
+              { title: "Land", id: "lc-land", desc: "Keyline design, CLT setup, regeneration. Water harvesting systems.", tag: "8 resources" },
+              { title: "Energy", id: "lc-energy", desc: "Solar arrays, biogas, micro-hydro. Open-source charge controllers.", tag: "8 resources" },
+              { title: "Health", id: "lc-health", desc: "Herb gardens, apothecary, sauna. Community health worker training.", tag: "6 resources" },
+              { title: "Instruments", id: "lc-instruments", desc: "Sensor networks, maker spaces, fab labs. IoT for gardens & energy.", tag: "7 resources" },
+              { title: "Shelter", id: "lc-v-shelter-organism", desc: "Cob, CEB, SuperAdobe, bamboo, mycelium. Open-source building plans.", tag: "11 resources" },
+              { title: "Living Spaces", id: "lc-v-living-spaces", desc: "Pattern language, cohousing design. Inside-outside gradients.", tag: "8 resources" },
+            ].map((bp) => (
+              <Link
+                key={bp.id}
+                href={`/vision/${bp.id}`}
+                className="group p-5 rounded-2xl border border-teal-800/30 bg-teal-900/10 hover:bg-teal-900/20 hover:border-teal-700/40 transition-all duration-300 space-y-2"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="text-base font-medium text-teal-300/90 group-hover:text-teal-200 transition-colors">
+                    {bp.title}
+                  </h3>
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-teal-500/10 text-teal-400/70 border border-teal-500/20">
+                    {bp.tag}
+                  </span>
+                </div>
+                <p className="text-xs text-stone-500 leading-relaxed">
+                  {bp.desc}
+                </p>
+              </Link>
+            ))}
+          </div>
+
+          <div className="text-center pt-4">
+            <Link
+              href="/concepts/garden?domain=living-collective"
+              className="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl bg-teal-500/10 border border-teal-500/20 text-teal-300/80 hover:bg-teal-500/20 transition-all text-sm font-medium"
+            >
+              Browse all 51 concepts
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M5 12h14m0 0l-6-6m6 6l-6 6" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Emerging visions */}
       <section className="max-w-4xl mx-auto px-6 py-32 space-y-16">
         <div className="text-center space-y-4">
@@ -369,17 +427,6 @@ export default function VisionPage() {
         </div>
 
         {/* Explore all concepts */}
-        <div className="text-center pt-8">
-          <Link
-            href="/concepts/garden?domain=living-collective"
-            className="inline-flex items-center gap-2 text-stone-500 hover:text-teal-300/80 transition-colors text-sm"
-          >
-            Explore all 51 concepts in the Living Collective ontology
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path d="M5 12h14m0 0l-6-6m6 6l-6 6" />
-            </svg>
-          </Link>
-        </div>
       </section>
 
       {/* Orientation */}


### PR DESCRIPTION
## Summary
- 9 Tier 2 activity concepts enriched with Resources + Visuals (play, composting, offering, circulation, stillness, food-practice, rest, ceremony, elders)
- **New "Blueprints & Resources" section** on vision page highlighting 8 enriched concepts with resource counts
- "Browse all 51 concepts" button moved to prominent position

## Test plan
- [x] 483 tests pass
- [ ] Deploy and verify vision page shows Blueprints section
- [ ] Sync Tier 2 concepts to DB
- [ ] Verify concept detail pages render enriched content

🤖 Generated with [Claude Code](https://claude.com/claude-code)