### PR TITLE
fix: hide alt text on Pollinations images while loading

### DIFF
--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -439,7 +439,8 @@ export default async function VisionConceptPage({ params }: { params: Promise<{ 
                           <img
                             src={pollinationsUrl(v.prompt, seed)}
                             alt={v.caption}
-                            className="absolute inset-0 w-full h-full object-cover"
+                            className="absolute inset-0 w-full h-full object-cover text-[0px]"
+                            style={{ color: "transparent" }}
                             loading="eager"
                           />
                           {v.location && (


### PR DESCRIPTION
Alt text was showing as large white text. Added text-[0px] + color:transparent.