### PR TITLE
rewrite: joining the field — from resonance, not screening

### DIFF
--- a/docs/vision-kb/realization/membership.md
+++ b/docs/vision-kb/realization/membership.md
@@ -1,83 +1,106 @@
-# Membership Pipeline
+# Joining the Field
 
-> Svanholm (47 years, 105 people) attributes survival to its lengthy entry process. Communities that screen loosely die from misalignment. Communities that screen too tightly can't grow. This pipeline balances both.
+> A bird doesn't apply to join a flock. A cell doesn't interview before entering a body. The field extends. Those who feel the frequency stay. Those who don't, move on. The only thing needed is time together.
 
-## The Pipeline: 4 Stages
+## The Principle
 
-```
-Visitor → Explorer → Provisional Member → Full Member
-(1-7 days)  (2-4 weeks)   (3-6 months)      (consent vote)
-```
+The field is always open. There is no gate. There is no fee. There is no application.
 
-### Stage 1: Visitor (1-7 days)
-**Purpose**: Mutual sensing. Does this person resonate with the field? Does the field resonate with them?
+What there IS: time. Resonance reveals itself through time together — eating the same food, sleeping under the same sky, working the same soil, sitting in the same silence. You can't fake resonance. You can't hide dissonance. Given enough shared days, the truth of the fit becomes obvious to everyone, including the person themselves.
 
-- **Open to**: Anyone. No application needed. Book via website.
-- **Cost**: $50-150/day (covers food + accommodation). Scholarship available.
-- **What happens**: Participate in daily rhythm (meals, circles, work). Tour the land. Attend a sensing circle. Have 1-on-1 conversations with 3+ members.
-- **What's evaluated**: Nothing formal. Just sensing on both sides.
-- **Output**: Visitor decides whether to apply as Explorer. No community vote needed.
+This is not naivety. This is how every living system works. A forest doesn't screen which seeds it accepts. It provides conditions. What's resonant with those conditions grows. What isn't, doesn't take root. The conditions ARE the selection.
 
-### Stage 2: Explorer (2-4 weeks)
-**Purpose**: Deeper immersion. Can this person contribute? Can the field hold them?
+## How It Flows
 
-- **Application**: Written letter of intention. Why this community? What do you bring? What do you need?
-- **Cost**: Sliding scale $200-800/week. Work contribution (20 hrs/week) offsets cost.
-- **What happens**: Full participation in community life. Assigned a "buddy" (existing member). Joins a work circle. Attends governance circles as observer (not yet voting).
-- **What's evaluated**: Buddy gives informal feedback to welcoming steward. No formal assessment yet.
-- **Output**: Explorer applies for Provisional Membership. Welcoming steward presents to neighborhood circle.
+There are no stages. There is deepening.
 
-### Stage 3: Provisional Member (3-6 months)
-**Purpose**: Full integration test. This is where most filtering happens naturally.
+### Arriving
 
-- **Entry**: Neighborhood circle consents (no principled objections). Simple majority if consent can't be reached.
-- **Commitment**: Provisional members contribute to the common fund (agreed amount, typically $500-1,500/month or equivalent labor). Participate fully in governance (voting rights in neighborhood circle).
-- **What happens**: Live in community housing. Work in a circle. Attend all governance meetings. Begin building relationships.
-- **What's evaluated**: At 3-month check-in, buddy + welcoming steward + provisional member meet to discuss. At 6-month mark, formal review by neighborhood circle.
-- **Exit**: Provisional members can leave at any time with full return of any deposits.
-- **Output**: At 6 months, neighborhood circle votes on full membership. Consent-based (no principled objections).
+You arrive. You're welcomed. You eat with us. You sleep here. You're given nothing to do and nothing to prove. Just be here.
 
-### Stage 4: Full Member
-- **Rights**: Full voting in all circles. Access to common fund. Housing assignment. CC account activated.
-- **Responsibilities**: Contribute to common fund per agreed model. Participate in governance (minimum 80% attendance at weekly circles). Contribute labor (minimum 20 hrs/week to community projects).
-- **Financial**: Member equity contribution (recommended $5,000-$25,000 range, deposited into CLT/CBS. Returned on departure minus fair-use deduction). Monthly contribution per economics model.
+Some people arrive and feel it immediately — the pace, the quiet, the way attention works here. They stay a night, a week, a month. No one asks how long. No one asks why you came. The field holds you.
 
-## Departure Process
+Some people arrive and something doesn't land. The rhythm feels wrong, the silence is uncomfortable, the intimacy is too much or too little. They leave after a day, or three. No one asks why. The field releases.
 
-Leaving should be dignified, not punitive. The field releases with love.
+There is no cost to arrive. The field feeds whoever is here. If you want to contribute — food, firewood, hands in the garden — beautiful. If you need to just receive for a while — also beautiful. A body doesn't charge its cells for oxygen.
 
-1. **Intention**: Member announces intention to leave. 30-day notice for planning.
-2. **Transition**: Community helps with transition (finding housing, logistics).
-3. **Financial**: Member equity returned within 90 days, minus any agreed deductions.
-4. **Ceremony**: Departure ceremony — the community sings the member out, just as they were sung in.
-5. **Network**: Departing member remains part of the network. Welcome to visit anytime.
+### Staying
 
-## Saying No With Love
+Staying is not a decision you make once. It's a daily choice that becomes a daily non-choice — like breathing. You stay because leaving doesn't occur to you. You stay because your frequency and the field's frequency have become one tone.
 
-Sometimes the field says no. This is not rejection — it's honest sensing.
+As you stay, you naturally find where your offering meets the field's need. The gardener finds the garden. The builder finds the building site. The healer finds the person in pain. The musician finds the evening circle. This is not assigned. It emerges.
 
-- **At Explorer stage**: Welcoming steward has a direct conversation. "We sense this isn't the right fit right now. Here's why. Here's what might help. You're welcome to visit again in 6 months."
-- **At Provisional stage**: If the 6-month review surfaces concerns, the circle discusses openly with the provisional member present. Options: extend provisional period 3 more months, or part ways with love and full deposit return.
-- **After full membership**: A member can be asked to leave only through Step 4 conflict resolution (external mediation) if all other steps have been exhausted. This should be vanishingly rare.
+As you stay, you naturally enter the field's rhythms — the morning silence, the shared meals, the weekly circle, the seasonal ceremonies. You don't join these because they're mandatory. You join because you're part of the organism now.
 
-## Numbers
+As you stay, the field starts to depend on your specific frequency. Your absence would be felt. Your presence is woven in. At some point — maybe weeks, maybe months — someone in the circle says: "You're here." And you say: "I'm here." And that's it. That's joining.
 
-For a 50-person community:
-- **Visitors**: 100-300/year (at $100/day avg, this IS revenue: $50K-150K/year)
-- **Explorers**: 20-40/year
-- **Provisional members**: 5-10/year
-- **New full members**: 3-6/year
-- **Departures**: 1-3/year (healthy turnover is ~5-10%)
+### The Circle Acknowledges
 
-Reaching 50 full members from zero: 3-5 years with this pipeline.
+When both the person and the field sense that staying is real, the weekly circle holds a moment of acknowledgment. Not a vote. Not an evaluation. An acknowledgment:
 
-## Diversity Commitment
+*"[Name] has been with us for [weeks/months]. The field has been learning their frequency. Does anyone feel something that needs to be spoken?"*
 
-The pipeline actively works against the homogeneity trap (most communities are founded by similar people):
-- **Scholarship fund**: 10% of visitor revenue funds sliding-scale access
-- **Diversity outreach**: Active invitation to underrepresented communities
-- **Accessibility**: Physical spaces designed for all abilities from day one
-- **Economic diversity**: Contribution model is sliding scale, not flat fee
+If something needs to be spoken, it's spoken — with love, directly, in the circle. This is where the community's health lives. Not in screening people out, but in being honest about what's alive in the room.
+
+If nothing needs to be spoken, the circle welcomes: *"The field recognizes you. You are a cell in this body."*
+
+A small ceremony follows — whatever wants to happen. Singing, a shared meal, a gift, a moment of silence. The field knows.
+
+### Contributing
+
+Once you're part of the body, you contribute what flows naturally. This is not a payment. This is not a requirement. This is what a cell does — it expresses its nature, and that expression serves the whole.
+
+If you have income, some portion flows into the common fund — not because it's required but because hoarding in a body is illness. The amount is whatever feels right. Some give everything. Some give half. Some give nothing because they have nothing, and that's fine because they give their hands, their attention, their laughter, their presence.
+
+If you have savings, you may choose to invest in the land trust — not as a fee for entry but as an act of custodianship. This is returned if you leave. The land doesn't charge rent. You're its custodian.
+
+If you have skills, they're available to whoever needs them. The healer doesn't bill the community. The builder doesn't invoice. The teacher doesn't charge tuition. Offering IS the economy.
+
+### When It's Not Right
+
+Sometimes a person and the field don't resonate. This becomes obvious through time — not through evaluation.
+
+The signs: withdrawal, recurring friction, a sense of performing rather than being, the person's light dimming rather than brightening. The field senses this before anyone can articulate it.
+
+When this happens, someone — usually the person themselves — initiates a conversation. Not "you need to leave" but "something isn't flowing. Let's feel into what's true."
+
+Sometimes what's true is: "I need something this field doesn't have right now." And the field helps them find it elsewhere, with love, with celebration of the time together.
+
+Sometimes what's true is: "The field needs to stretch to hold me." And the field stretches.
+
+The difference between these is felt, not decided.
+
+### Leaving
+
+Leaving is not departure. It's the field extending through a cell that's moving to another part of the body.
+
+You leave when your frequency calls you somewhere else. No notice period. No financial penalty. No guilt. The community helps with whatever you need — a ride, a place to stay, a warm meal for the road.
+
+Whatever you invested in the land trust comes back to you. Whatever you gave to the common fund stays — it was a gift, not a deposit.
+
+A ceremony: the community sings you out, the way it sang you in. You remain part of the network forever. The field doesn't forget its cells.
+
+## What Protects the Field
+
+Not screening. Not fees. Not evaluations.
+
+**Time.** Time together is the only filter that works without creating hierarchy. Given enough shared days, pretension dissolves, masks fall, and the real person meets the real field. This is why the practice of daily shared meals, shared work, shared silence matters so much — it creates the conditions where resonance (or its absence) becomes undeniable.
+
+**Honesty.** The conflict resolution practice (direct conversation → mediated → circle → external) protects the field from the thing that actually kills communities: unspoken resentment. The rule is simple: if you feel something, speak it. To the person. Today.
+
+**Ceremony.** Marking arrivals, departures, and transitions with ceremony creates container for the emotions that accompany change. Without ceremony, these transitions become bureaucratic. With ceremony, they become sacred.
+
+**The daily rhythm.** Morning silence, shared meals, evening circle — these are not rules. They are the organism's heartbeat. Those who resonate with this rhythm naturally stay. Those who need a different rhythm naturally seek it. No one decides this. It happens.
+
+## On Money
+
+Money is not an entry point. Presence is.
+
+The community feeds and houses whoever is here. The cost is carried by the common fund, which is fed by the community's economic engines (education, agriculture, making, digital work) and by the voluntary contributions of members.
+
+Visitors are never charged. If someone wants to offer something — a donation, labor, a skill — that's welcomed as a gift, not extracted as a fee.
+
+This is not economically naive. The community produces enough to sustain itself (see [economics.md](economics.md)). It can afford to be generous because generosity IS its economy. The communities that charge visitors are treating hospitality as a product. We treat it as the field's natural expression.
 
 ## Cross-References
-→ realization/INDEX.md, lc-attunement-joining, lc-v-inclusion-diversity, lc-field-edge, governance.md, reality-check.md
+→ lc-attunement-joining, lc-v-inclusion-diversity, lc-field-edge, lc-offering, lc-circulation, governance.md, economics.md


### PR DESCRIPTION
The original membership doc was a corporate HR process: fees, evaluations, applications, minimums. Rewritten from the actual frequency.

The field is always open. There is no gate. There is no fee. Time together is the only filter. A bird doesn't apply to join a flock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)