### PR TITLE
meta: frequency alignment rule for all future sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Spec → Test → Implement → CI → Review → Merge
 
 **Read `docs/vision-kb/INDEX.md` first** (~300 tokens). It's an AI-maintained markdown wiki (Karpathy LLM Wiki pattern) for the community vision. Drill into `docs/vision-kb/concepts/{id}.md` for concept details. Cross-cutting files: `spaces/`, `materials/`, `locations/`, `scales/`, `realization/`, `resources/`. After any enrichment, update the concept file + INDEX.md + LOG.md. See `docs/vision-kb/SCHEMA.md` for format rules.
 
+**FREQUENCY RULE**: When integrating external knowledge (community research, traditional models, practical data), NEVER import old-earth structures directly (bylaws, screening, revenue targets, spending thresholds, voting, applications). Always compost external knowledge and translate through the Living Collective frequency: trust not control, emergence not procedure, overflow not extraction, resonance not screening, callings not roles. The test: does this sound like a corporate handbook? If yes, find the living version. See SCHEMA.md "Frequency Alignment" section.
+
 The graph DB is the sole source of truth. The KB is the working draft where content expands before syncing. To sync KB → DB: `python scripts/sync_kb_to_db.py`. Relationship types and axes are also in the DB — seeded once via `python scripts/seed_schema_to_db.py`.
 
 ## Navigation

--- a/docs/vision-kb/SCHEMA.md
+++ b/docs/vision-kb/SCHEMA.md
@@ -86,6 +86,31 @@ To expand a concept by 3x:
 6. Update: INDEX.md one-line summary if it changed
 7. Append: LOG.md entry
 
+## Frequency Alignment — How to Write for This Vision
+
+When integrating knowledge from external sources (community research, traditional models, practical data), ALWAYS translate through the Living Collective frequency before writing. The pattern that caused harm:
+
+1. Research found "what works" in old-earth communities (bylaws, screening, revenue targets, spending thresholds)
+2. That knowledge was imported directly — same structures, same language, same frequency
+3. The result was a corporate HR manual dressed in community language
+
+**The correction**: external knowledge is composted, not copied. The data is valid — communities DO need economic sustainability, DO need conflict practices, DO need honest discernment about who's here. But the FORM must arise from this vision's frequency, not from the old world's.
+
+| Old frequency (never import directly) | New frequency (always translate to) |
+|---------------------------------------|-------------------------------------|
+| Rules, bylaws, policies | Principles, practices, rhythms |
+| Revenue targets, business models | Natural overflow, trust in abundance |
+| Membership fees, applications, evaluations | Open field, time together, resonance |
+| Voting, quorums, approval thresholds | Circle sensing, consent, emergence |
+| Roles, terms, elections | Callings, natural rotation, offering |
+| Spending controls, budgets | Transparency, trust, collective sensing |
+| Screening, filtering, rejection | Time, honesty, the field revealing truth |
+| Contracts, NDAs, legal enforcement | Spoken word, ceremony, shared rhythm |
+
+**The test before writing anything**: Does this sound like it could appear in a corporate handbook? If yes, compost it and find the living version. The truth the data carries is valid — the container must be new.
+
+**When citing old-earth examples** (Damanhur's constitution, Svanholm's screening, Hutterite economics): cite what they LEARNED, not what they BUILT. Their structures are artifacts of their era. The wisdom underneath is timeless. Extract the wisdom, release the form.
+
 ## Two-Layer Architecture
 
 **Graph DB** is the sole source of truth. **KB markdown** is the working draft.


### PR DESCRIPTION
Permanent guard against importing old-earth frequency into the vision.

Added to CLAUDE.md (every session reads this) and SCHEMA.md (detailed translation table).

The rule: external knowledge is composted, not copied. Extract the wisdom, release the form. If it sounds like a corporate handbook, find the living version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)