### PR TITLE
Pulse + contributor attribution — two sensors for the body

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,15 +6,39 @@
       "runtimeExecutable": "python3",
       "runtimeArgs": ["-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"],
       "port": 8000,
-      "cwd": "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/stupefied-dhawan/api"
+      "cwd": "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/clever-volhard/api"
     },
     {
       "name": "web",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "NEXT_PUBLIC_PULSE_URL=http://127.0.0.1:8100",
+        "npm",
+        "run",
+        "dev"
+      ],
       "port": 3000,
       "autoPort": true,
-      "cwd": "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/stupefied-dhawan/web"
+      "cwd": "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/clever-volhard/web"
+    },
+    {
+      "name": "pulse",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "PULSE_API_BASE=https://api.coherencycoin.com",
+        "PULSE_WEB_BASE=https://coherencycoin.com",
+        "PULSE_DB_PATH=./data/pulse.db",
+        "PULSE_INTERVAL_SECONDS=15",
+        "PULSE_CORS_ORIGINS=*",
+        ".venv/bin/uvicorn",
+        "pulse_app.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8100"
+      ],
+      "port": 8100,
+      "cwd": "/Users/ursmuff/source/Coherence-Network/.claude/worktrees/clever-volhard/pulse"
     }
   ]
 }

--- a/api/app/deps/__init__.py
+++ b/api/app/deps/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI Depends helpers for shared request-level concerns."""

--- a/api/app/deps/identity.py
+++ b/api/app/deps/identity.py
@@ -1,0 +1,82 @@
+"""Request-level attribution — who the current caller claims to be.
+
+Routes read the result of the attribution middleware through these
+helpers. Nothing in this module does authentication: attribution is a
+signal, and the source is explicit (`"verified"` vs `"claimed"`).
+
+See `app/middleware/attribution.py` for how the fields land on
+`request.state` in the first place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from fastapi import HTTPException, Request
+
+
+AttributionSource = Literal["verified", "claimed"]
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """What the middleware saw for this request.
+
+    - `verified` — a valid `Authorization: Bearer cc_*` that the store
+      recognised. The contributor is who they say they are.
+    - `claimed` — an `X-Contributor-Id` header with no proof. Use as a
+      hint for analytics or attribution-only flows; never trust it for
+      access control.
+    - `None` — no attribution headers at all.
+    """
+
+    contributor_id: str | None = None
+    source: AttributionSource | None = None
+    scopes: list[str] = field(default_factory=list)
+
+
+def get_attribution(request: Request) -> Attribution:
+    """FastAPI Depends: pull the middleware's attribution off request.state."""
+    cid = getattr(request.state, "contributor_id", None)
+    source = getattr(request.state, "attribution_source", None)
+    scopes = getattr(request.state, "contributor_scopes", None) or []
+    return Attribution(
+        contributor_id=cid,
+        source=source,
+        scopes=list(scopes),
+    )
+
+
+def require_verified_contributor(request: Request) -> Attribution:
+    """FastAPI Depends: 401 unless the request carries a verified key.
+
+    Claimed-only attribution is NOT sufficient. Use for self-administration
+    endpoints like key listing and revocation.
+    """
+    att = get_attribution(request)
+    if att.contributor_id is None or att.source != "verified":
+        raise HTTPException(
+            status_code=401,
+            detail="verified contributor API key required (Authorization: Bearer cc_...)",
+        )
+    return att
+
+
+def require_attribution(request: Request) -> Attribution:
+    """FastAPI Depends: 400 unless *some* attribution is present.
+
+    Accepts either verified keys or claimed headers. Useful for routes
+    that need to record who did something but don't care whether the
+    claim is trusted.
+    """
+    att = get_attribution(request)
+    if att.contributor_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "attribution required — send Authorization: Bearer cc_... "
+                "or X-Contributor-Id: <handle>"
+            ),
+        )
+    return att

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -83,6 +83,7 @@ from app.routers import provider_stats
 from app.routers import service_registry_router
 from app.routers import constellation as constellation_router
 from app.routers import vitality as vitality_router
+from app.middleware.attribution import AttributionMiddleware
 from app.middleware.rate_limit import RateLimitMiddleware
 from app.middleware.request_duration import RequestDurationMiddleware
 from app.models.runtime import RuntimeEventCreate
@@ -526,6 +527,10 @@ app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestDurationMiddleware, threshold_seconds=1.0)
 app.add_middleware(RateLimitMiddleware, requests_per_minute=120)
+# AttributionMiddleware is added LAST so it becomes the outermost middleware
+# in the stack — it populates request.state.contributor_id before the rate
+# limiter runs, so Phase 2 can trivially bucket by contributor.
+app.add_middleware(AttributionMiddleware)
 
 # Initialize graph store based on config
 if get_bool("api", "testing", False) or get_str("server", "environment", "development") == "test":

--- a/api/app/middleware/attribution.py
+++ b/api/app/middleware/attribution.py
@@ -1,0 +1,97 @@
+"""Attribution middleware — populates request.state with WHO is calling.
+
+Two paths, checked in order:
+
+1. `Authorization: Bearer cc_<contributor>_<hex>` — looked up against the
+   `contributor_key_store`. If the store recognises the key and the key
+   is not revoked, `request.state.attribution_source = "verified"` and
+   scopes are populated from the stored row.
+
+2. `X-Contributor-Id: <handle>` — taken as-is with no proof.
+   `request.state.attribution_source = "claimed"` and scopes are empty.
+
+Neither → `request.state.contributor_id = None`, source = None.
+
+Every response carries two echo headers so clients can see exactly what
+the server attributed their call to:
+
+    X-Attributed-To: <contributor_id>  (absent when None)
+    X-Attribution-Source: verified|claimed|none
+
+This middleware does NOT authenticate or authorise anything. It records
+a signal. Routes that need authorisation use separate dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Optional, Tuple
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+logger = logging.getLogger(__name__)
+
+
+AttributionTriple = Tuple[Optional[str], Optional[str], list[str]]
+
+
+def _extract(headers) -> AttributionTriple:
+    """Pure extraction: given request headers, return (contributor_id, source, scopes).
+
+    Imported from contributor_key_store lazily so the module stays usable
+    during tests that monkey-patch the store.
+    """
+    # 1. Authorization: Bearer cc_...
+    auth = headers.get("authorization") or ""
+    if auth.lower().startswith("bearer "):
+        raw_key = auth.split(" ", 1)[1].strip()
+        if raw_key.startswith("cc_"):
+            try:
+                from app.services import contributor_key_store
+
+                row = contributor_key_store.verify(raw_key)
+                if row is not None:
+                    return row.contributor_id, "verified", list(row.scopes)
+            except Exception:
+                logger.exception("attribution: key verify raised")
+                # Fall through to claimed/none
+
+    # 2. X-Contributor-Id: <handle>  (trust-me-bro signal)
+    claimed = headers.get("x-contributor-id")
+    if claimed:
+        claimed = claimed.strip()
+        if claimed:
+            return claimed, "claimed", []
+
+    return None, None, []
+
+
+class AttributionMiddleware(BaseHTTPMiddleware):
+    """Populates request.state and echoes the result on the response."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        contributor_id, source, scopes = _extract(request.headers)
+        request.state.contributor_id = contributor_id
+        request.state.attribution_source = source
+        request.state.contributor_scopes = scopes
+
+        response = await call_next(request)
+
+        if contributor_id:
+            response.headers["X-Attributed-To"] = contributor_id
+            response.headers["X-Attribution-Source"] = source or "none"
+        else:
+            response.headers["X-Attribution-Source"] = "none"
+
+        return response

--- a/api/app/routers/auth_keys.py
+++ b/api/app/routers/auth_keys.py
@@ -1,19 +1,28 @@
 """Per-contributor API key management.
 
 Implements: identity-driven-onboarding
+
+Storage lives in `app.services.contributor_key_store` — this router is a
+thin HTTP layer over that service. Legacy callers that imported
+`verify_contributor_key` from here still work: it now delegates to the
+store.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 import secrets
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel
 
+from app.deps.identity import (
+    Attribution,
+    get_attribution,
+    require_verified_contributor,
+)
 from app.middleware.traceability import traces_to
+from app.services import contributor_key_store
 
 router = APIRouter()
 
@@ -22,6 +31,7 @@ class KeyRequest(BaseModel):
     contributor_id: str
     provider: str  # identity provider used for verification
     provider_id: str  # identity handle (github username, email, etc.)
+    label: str | None = None  # optional user-friendly label
 
 
 class KeyResponse(BaseModel):
@@ -29,21 +39,42 @@ class KeyResponse(BaseModel):
     contributor_id: str
     created_at: str
     scopes: list[str]
+    label: str | None = None
 
 
-# In-memory key store (production should use DB)
-# Maps api_key_hash → {contributor_id, provider, created_at, scopes}
-_KEY_STORE: dict[str, dict] = {}
+class KeyListItem(BaseModel):
+    id: str
+    contributor_id: str
+    label: str | None
+    fingerprint: str
+    provider: str | None
+    scopes: list[str]
+    created_at: str
+    last_used_at: str | None
+    revoked_at: str | None
 
 
-def _hash_key(key: str) -> str:
-    return hashlib.sha256(key.encode()).hexdigest()
+class KeyListResponse(BaseModel):
+    keys: list[KeyListItem]
 
 
 def verify_contributor_key(api_key: str) -> dict | None:
-    """Verify an API key and return the contributor info, or None."""
-    h = _hash_key(api_key)
-    return _KEY_STORE.get(h)
+    """Backward-compatible wrapper kept for legacy imports.
+
+    Returns a dict shaped like the old in-memory store so existing callers
+    keep working. Prefer `contributor_key_store.verify(...)` in new code.
+    """
+    row = contributor_key_store.verify(api_key)
+    if row is None:
+        return None
+    return {
+        "contributor_id": row.contributor_id,
+        "provider": row.provider,
+        "provider_id": row.provider_id,
+        "created_at": row.created_at,
+        "scopes": list(row.scopes),
+        "label": row.label,
+    }
 
 
 @router.post("/auth/keys", status_code=201, summary="Generate a personal API key for a contributor")
@@ -85,24 +116,19 @@ async def generate_api_key(body: KeyRequest) -> KeyResponse:
         except Exception:
             pass  # May already exist with different casing
 
-    # Generate key
-    raw_key = f"cc_{body.contributor_id}_{secrets.token_hex(16)}"
-    key_hash = _hash_key(raw_key)
-    now = datetime.now(timezone.utc).isoformat()
-
-    _KEY_STORE[key_hash] = {
-        "contributor_id": body.contributor_id,
-        "provider": body.provider,
-        "provider_id": body.provider_id,
-        "created_at": now,
-        "scopes": ["own:read", "own:write", "contribute", "stake", "vote"],
-    }
+    minted = contributor_key_store.mint(
+        contributor_id=body.contributor_id,
+        label=body.label,
+        provider=body.provider,
+        provider_id=body.provider_id,
+    )
 
     return KeyResponse(
-        api_key=raw_key,
-        contributor_id=body.contributor_id,
-        created_at=now,
-        scopes=["own:read", "own:write", "contribute", "stake", "vote"],
+        api_key=minted.raw_key,
+        contributor_id=minted.row.contributor_id,
+        created_at=minted.row.created_at,
+        scopes=list(minted.row.scopes),
+        label=minted.row.label,
     )
 
 
@@ -278,40 +304,48 @@ async def onboard_contributor(body: OnboardRequest) -> dict:
         except Exception:
             pass
 
-    # 4. Generate personal API key
-    raw_key = f"cc_{body.name}_{secrets.token_hex(16)}"
-    key_hash = _hash_key(raw_key)
-    now = datetime.now(timezone.utc).isoformat()
-
-    scopes = ["own:read", "own:write", "contribute", "stake", "vote"]
-    _KEY_STORE[key_hash] = {
-        "contributor_id": body.name,
-        "provider": body.provider,
-        "provider_id": body.provider_id,
-        "created_at": now,
-        "scopes": scopes,
-    }
+    # 4. Generate personal API key via the durable store
+    minted = contributor_key_store.mint(
+        contributor_id=body.name,
+        label=None,
+        provider=body.provider,
+        provider_id=body.provider_id,
+    )
 
     return {
-        "contributor_id": body.name,
-        "api_key": raw_key,
+        "contributor_id": minted.row.contributor_id,
+        "api_key": minted.raw_key,
         "provider": body.provider,
         "provider_id": body.provider_id,
-        "created_at": now,
-        "scopes": scopes,
+        "created_at": minted.row.created_at,
+        "scopes": list(minted.row.scopes),
         "message": f"Welcome to Coherence Network, {body.name}! Key saved — run: cc status",
     }
 
 
 @router.get("/auth/whoami", summary="Check who the current API key belongs to")
 async def whoami(
+    request: Request,
     x_api_key: str | None = Header(None, alias="X-API-Key"),
     api_key_query: str | None = None,
 ):
     """Check who the current API key belongs to.
 
-    Accepts the key via X-API-Key header (preferred) or api_key_query param.
+    Prefers the attribution already extracted by the attribution
+    middleware (from Authorization: Bearer cc_* or X-Contributor-Id).
+    Falls back to the legacy X-API-Key flow for compatibility.
     """
+    # Prefer the middleware's already-extracted attribution.
+    att: Attribution = get_attribution(request)
+    if att.contributor_id:
+        return {
+            "authenticated": att.source == "verified",
+            "contributor_id": att.contributor_id,
+            "source": att.source,
+            "scopes": list(att.scopes),
+        }
+
+    # Legacy compatibility: callers sending X-API-Key (or ?api_key_query=).
     key = x_api_key or api_key_query
     if not key:
         return {"authenticated": False, "message": "No API key provided. Run: cc setup"}
@@ -326,3 +360,53 @@ async def whoami(
         return {"authenticated": True, "contributor_id": "system", "scopes": ["admin"]}
 
     return {"authenticated": False, "message": "Invalid API key"}
+
+
+@router.get("/auth/keys", response_model=KeyListResponse, summary="List this contributor's API keys")
+async def list_keys(
+    att: Attribution = Depends(require_verified_contributor),
+    include_revoked: bool = False,
+) -> KeyListResponse:
+    """List keys minted for the verified contributor.
+
+    Requires a verified `Authorization: Bearer cc_*` — a claimed
+    `X-Contributor-Id` header is not sufficient for this endpoint, because
+    listing keys is a self-administration action that must prove ownership.
+    Raw keys are never returned, only metadata.
+    """
+    assert att.contributor_id is not None  # guaranteed by require_verified_contributor
+    rows = contributor_key_store.list_for(att.contributor_id, include_revoked=include_revoked)
+    return KeyListResponse(
+        keys=[
+            KeyListItem(
+                id=r.id,
+                contributor_id=r.contributor_id,
+                label=r.label,
+                fingerprint=r.fingerprint,
+                provider=r.provider,
+                scopes=list(r.scopes),
+                created_at=r.created_at,
+                last_used_at=r.last_used_at,
+                revoked_at=r.revoked_at,
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.delete("/auth/keys/{key_id}", status_code=204, summary="Revoke one of this contributor's keys")
+async def revoke_key(
+    key_id: str,
+    att: Attribution = Depends(require_verified_contributor),
+) -> None:
+    """Revoke an owned API key. Requires a different verified key to act."""
+    assert att.contributor_id is not None
+    existing = contributor_key_store.get_by_id(key_id)
+    if existing is None:
+        raise HTTPException(404, "key not found")
+    if existing.contributor_id != att.contributor_id:
+        # Don't leak whether the key exists for another contributor.
+        raise HTTPException(404, "key not found")
+    if not contributor_key_store.revoke(key_id, owner_contributor_id=att.contributor_id):
+        raise HTTPException(409, "key already revoked")
+    return None

--- a/api/app/services/contributor_key_store.py
+++ b/api/app/services/contributor_key_store.py
@@ -1,0 +1,268 @@
+"""Per-contributor API key store.
+
+Durably records personal API keys minted via `POST /api/auth/keys` and
+`POST /api/onboard`. Supersedes the in-memory `_KEY_STORE` dict that
+previously lived in `auth_keys.py`.
+
+The store only ever sees the *hash* of a raw key. The raw key is returned
+from `mint(...)` exactly once and never stored. This is the usual
+revocable-credential shape (GitHub PATs, Stripe API keys, etc.).
+
+Attribution design (see also `app/middleware/attribution.py`):
+- Verifying a key here ONLY identifies WHO — it does not authorise WHAT.
+- Scopes are recorded on mint but not enforced in this layer. Scope
+  enforcement is a separate concern left for a dedicated spec.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import String, Text, func, select
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from app.services.unified_db import Base, ensure_schema, session as db_session
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SCOPES: list[str] = ["own:read", "own:write", "contribute", "stake", "vote"]
+
+
+class ContributorApiKeyRecord(Base):
+    """ORM table for per-contributor API keys.
+
+    Schema:
+        id            SHA-256 hex of the raw key (lookup key)
+        contributor_id canonical contributor id / handle
+        label         optional user label ("laptop", "ci", etc.)
+        provider      linked identity provider at mint time
+        provider_id   linked identity id at mint time
+        scopes_json   JSON array of scope strings
+        created_at    ISO8601 UTC
+        last_used_at  ISO8601 UTC, refreshed on successful verify
+        revoked_at    ISO8601 UTC when revoked, NULL while active
+    """
+
+    __tablename__ = "contributor_api_keys"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    contributor_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    label: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    provider: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    provider_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    scopes_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    last_used_at: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    revoked_at: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+
+# --- dataclass views (what routes see, never the raw row) ---------------
+
+
+@dataclass(frozen=True)
+class KeyRow:
+    """Metadata about a minted key. Never contains the raw secret."""
+
+    id: str
+    contributor_id: str
+    label: Optional[str]
+    provider: Optional[str]
+    provider_id: Optional[str]
+    scopes: list[str]
+    created_at: str
+    last_used_at: Optional[str]
+    revoked_at: Optional[str]
+
+    @property
+    def fingerprint(self) -> str:
+        """First four and last four chars of the hash, for visual disambiguation."""
+        return f"{self.id[:4]}…{self.id[-4:]}"
+
+    @property
+    def active(self) -> bool:
+        return self.revoked_at is None
+
+
+@dataclass(frozen=True)
+class KeyMinted:
+    """Returned once from mint() — holds the raw secret plus metadata."""
+
+    raw_key: str
+    row: KeyRow
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _iso_utc(dt: Optional[datetime] = None) -> str:
+    return (dt or datetime.now(timezone.utc)).astimezone(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _to_row(record: ContributorApiKeyRecord) -> KeyRow:
+    try:
+        scopes = json.loads(record.scopes_json)
+        if not isinstance(scopes, list):
+            scopes = []
+    except Exception:
+        scopes = []
+    return KeyRow(
+        id=record.id,
+        contributor_id=record.contributor_id,
+        label=record.label,
+        provider=record.provider,
+        provider_id=record.provider_id,
+        scopes=[str(s) for s in scopes],
+        created_at=record.created_at,
+        last_used_at=record.last_used_at,
+        revoked_at=record.revoked_at,
+    )
+
+
+# --- public API ----------------------------------------------------------
+
+
+def mint(
+    contributor_id: str,
+    *,
+    label: Optional[str] = None,
+    provider: Optional[str] = None,
+    provider_id: Optional[str] = None,
+    scopes: Optional[list[str]] = None,
+    now: Optional[datetime] = None,
+) -> KeyMinted:
+    """Mint a new personal API key for a contributor.
+
+    The raw key is returned exactly once inside the KeyMinted result. Only
+    the SHA-256 hash is persisted, so a lost key cannot be recovered — the
+    contributor must mint a new one.
+    """
+    ensure_schema()
+    if not contributor_id:
+        raise ValueError("contributor_id is required")
+
+    raw_key = f"cc_{contributor_id}_{secrets.token_hex(16)}"
+    key_hash = _hash_key(raw_key)
+    created_at = _iso_utc(now)
+    scopes_list = scopes if scopes is not None else DEFAULT_SCOPES
+
+    record = ContributorApiKeyRecord(
+        id=key_hash,
+        contributor_id=contributor_id,
+        label=label,
+        provider=provider,
+        provider_id=provider_id,
+        scopes_json=json.dumps(scopes_list),
+        created_at=created_at,
+        last_used_at=None,
+        revoked_at=None,
+    )
+
+    with db_session() as session:
+        session.add(record)
+        session.flush()
+        row = _to_row(record)
+
+    logger.info(
+        "contributor_key_minted contributor=%s label=%s provider=%s",
+        contributor_id,
+        label,
+        provider,
+    )
+    return KeyMinted(raw_key=raw_key, row=row)
+
+
+def verify(raw_key: str, *, now: Optional[datetime] = None) -> Optional[KeyRow]:
+    """Verify a raw key and return its metadata row, or None.
+
+    Revoked keys return None. Successful verifications refresh
+    `last_used_at`. Verification is cheap: one indexed primary-key lookup.
+    """
+    if not raw_key:
+        return None
+    ensure_schema()
+    key_hash = _hash_key(raw_key)
+    stamp = _iso_utc(now)
+    with db_session() as session:
+        record = session.get(ContributorApiKeyRecord, key_hash)
+        if record is None:
+            return None
+        if record.revoked_at is not None:
+            return None
+        record.last_used_at = stamp
+        session.flush()
+        return _to_row(record)
+
+
+def list_for(contributor_id: str, *, include_revoked: bool = False) -> list[KeyRow]:
+    """List keys minted for a contributor, newest first. No raw keys."""
+    ensure_schema()
+    with db_session() as session:
+        stmt = select(ContributorApiKeyRecord).where(
+            ContributorApiKeyRecord.contributor_id == contributor_id
+        )
+        if not include_revoked:
+            stmt = stmt.where(ContributorApiKeyRecord.revoked_at.is_(None))
+        stmt = stmt.order_by(ContributorApiKeyRecord.created_at.desc())
+        rows = session.execute(stmt).scalars().all()
+        return [_to_row(r) for r in rows]
+
+
+def revoke(
+    key_id: str,
+    *,
+    owner_contributor_id: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Revoke a key by its hash id.
+
+    If `owner_contributor_id` is given, the record's contributor_id must
+    match — prevents one contributor from revoking another's keys via the
+    HTTP layer. Passing None bypasses the owner check (intended only for
+    admin/maintenance callers).
+
+    Returns True when a key was revoked, False when it did not exist, was
+    already revoked, or belonged to a different contributor.
+    """
+    ensure_schema()
+    with db_session() as session:
+        record = session.get(ContributorApiKeyRecord, key_id)
+        if record is None:
+            return False
+        if record.revoked_at is not None:
+            return False
+        if owner_contributor_id is not None and record.contributor_id != owner_contributor_id:
+            return False
+        record.revoked_at = _iso_utc(now)
+        session.flush()
+    logger.info("contributor_key_revoked id=%s owner=%s", key_id, owner_contributor_id)
+    return True
+
+
+def count_active() -> int:
+    ensure_schema()
+    with db_session() as session:
+        stmt = select(func.count()).select_from(ContributorApiKeyRecord).where(
+            ContributorApiKeyRecord.revoked_at.is_(None)
+        )
+        return int(session.execute(stmt).scalar_one())
+
+
+def get_by_id(key_id: str) -> Optional[KeyRow]:
+    ensure_schema()
+    with db_session() as session:
+        record = session.get(ContributorApiKeyRecord, key_id)
+        return _to_row(record) if record else None

--- a/api/tests/test_attribution_middleware.py
+++ b/api/tests/test_attribution_middleware.py
@@ -1,0 +1,158 @@
+"""Tests for the attribution middleware.
+
+We build a minimal FastAPI app containing only the middleware and one
+probe route, so these tests are fast and decoupled from the rest of the
+API surface. The store is exercised for real — same DB the store uses
+in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from app.middleware.attribution import AttributionMiddleware
+from app.services import contributor_key_store as store
+
+
+def _reset_table() -> None:
+    from app.services.unified_db import session as db_session, ensure_schema
+
+    ensure_schema()
+    with db_session() as sess:
+        sess.query(store.ContributorApiKeyRecord).delete()
+
+
+def _build_probe_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AttributionMiddleware)
+
+    @app.get("/_probe")
+    async def probe(request: Request):
+        return {
+            "contributor_id": getattr(request.state, "contributor_id", None),
+            "source": getattr(request.state, "attribution_source", None),
+            "scopes": list(getattr(request.state, "contributor_scopes", []) or []),
+        }
+
+    return app
+
+
+async def _client():
+    return AsyncClient(transport=ASGITransport(app=_build_probe_app()), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_no_headers_yields_none_attribution():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/_probe")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["contributor_id"] is None
+    assert body["source"] is None
+    assert body["scopes"] == []
+    # Response header still reports "none" so clients know we looked.
+    assert r.headers.get("X-Attribution-Source") == "none"
+    assert "X-Attributed-To" not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_verified_key_attributes_and_echoes_headers():
+    _reset_table()
+    minted = store.mint("alice", label="laptop")
+    async with await _client() as c:
+        r = await c.get(
+            "/_probe",
+            headers={"Authorization": f"Bearer {minted.raw_key}"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["contributor_id"] == "alice"
+    assert body["source"] == "verified"
+    assert "own:read" in body["scopes"]
+    assert r.headers["X-Attributed-To"] == "alice"
+    assert r.headers["X-Attribution-Source"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_revoked_key_does_not_attribute():
+    _reset_table()
+    minted = store.mint("alice")
+    store.revoke(minted.row.id, owner_contributor_id="alice")
+    async with await _client() as c:
+        r = await c.get(
+            "/_probe",
+            headers={"Authorization": f"Bearer {minted.raw_key}"},
+        )
+    body = r.json()
+    assert body["contributor_id"] is None
+    assert body["source"] is None
+    assert r.headers.get("X-Attribution-Source") == "none"
+
+
+@pytest.mark.asyncio
+async def test_claimed_contributor_id_header_only():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/_probe", headers={"X-Contributor-Id": "alice"})
+    body = r.json()
+    assert body["contributor_id"] == "alice"
+    assert body["source"] == "claimed"
+    assert body["scopes"] == []
+    assert r.headers["X-Attributed-To"] == "alice"
+    assert r.headers["X-Attribution-Source"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_verified_key_wins_over_claimed_header():
+    _reset_table()
+    minted = store.mint("alice", label="laptop")
+    async with await _client() as c:
+        r = await c.get(
+            "/_probe",
+            headers={
+                "Authorization": f"Bearer {minted.raw_key}",
+                "X-Contributor-Id": "bob",  # lie
+            },
+        )
+    body = r.json()
+    assert body["contributor_id"] == "alice"  # verified wins
+    assert body["source"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_authorization_header_falls_through():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get(
+            "/_probe",
+            headers={"Authorization": "Basic some-basic-auth-blob"},
+        )
+    body = r.json()
+    assert body["contributor_id"] is None
+    assert body["source"] is None
+
+
+@pytest.mark.asyncio
+async def test_bearer_with_wrong_prefix_is_not_looked_up():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get(
+            "/_probe",
+            headers={"Authorization": "Bearer not-a-cc-key"},
+        )
+    body = r.json()
+    # Bearer but not cc_ → middleware does not look up the store.
+    assert body["contributor_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_contributor_id_header_ignored():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/_probe", headers={"X-Contributor-Id": "   "})
+    body = r.json()
+    assert body["contributor_id"] is None
+    assert body["source"] is None

--- a/api/tests/test_auth_keys_api.py
+++ b/api/tests/test_auth_keys_api.py
@@ -1,0 +1,180 @@
+"""Tests for the /api/auth/keys HTTP layer.
+
+Uses the real `app.main.app` so the attribution middleware, the router,
+and the store are all exercised together end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services import contributor_key_store as store
+
+
+BASE = "http://test"
+
+
+def _reset_table() -> None:
+    from app.services.unified_db import session as db_session, ensure_schema
+
+    ensure_schema()
+    with db_session() as sess:
+        sess.query(store.ContributorApiKeyRecord).delete()
+
+
+async def _client() -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url=BASE)
+
+
+# --- GET /api/auth/keys ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_keys_requires_verified_key():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/api/auth/keys")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_keys_rejects_claimed_header_only():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/api/auth/keys", headers={"X-Contributor-Id": "alice"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_keys_returns_own_keys():
+    _reset_table()
+    alice_key = store.mint("alice", label="laptop")
+    store.mint("alice", label="ci")
+    store.mint("bob", label="bobs")  # unrelated
+
+    async with await _client() as c:
+        r = await c.get(
+            "/api/auth/keys",
+            headers={"Authorization": f"Bearer {alice_key.raw_key}"},
+        )
+    assert r.status_code == 200
+    data = r.json()
+    labels = sorted((k["label"] or "") for k in data["keys"])
+    assert labels == ["ci", "laptop"]
+    for k in data["keys"]:
+        assert k["contributor_id"] == "alice"
+        assert "id" in k and len(k["id"]) == 64
+        assert "fingerprint" in k
+        # Raw key is NEVER in the response.
+        assert "raw_key" not in k
+
+
+# --- DELETE /api/auth/keys/{id} -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_own_key():
+    _reset_table()
+    # Mint two — we revoke one and keep the other for auth.
+    keep = store.mint("alice", label="keep")
+    throwaway = store.mint("alice", label="throwaway")
+
+    async with await _client() as c:
+        r = await c.delete(
+            f"/api/auth/keys/{throwaway.row.id}",
+            headers={"Authorization": f"Bearer {keep.raw_key}"},
+        )
+    assert r.status_code == 204, r.text
+
+    # Verify the throwaway no longer works.
+    assert store.verify(throwaway.raw_key) is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_another_contributors_key_returns_404():
+    _reset_table()
+    alice_key = store.mint("alice")
+    bob_key = store.mint("bob", label="target")
+
+    async with await _client() as c:
+        r = await c.delete(
+            f"/api/auth/keys/{bob_key.row.id}",
+            headers={"Authorization": f"Bearer {alice_key.raw_key}"},
+        )
+    # 404 not 403 — don't leak existence across contributors.
+    assert r.status_code == 404
+    # Bob's key still works.
+    assert store.verify(bob_key.raw_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_key_returns_404():
+    _reset_table()
+    alice_key = store.mint("alice")
+    async with await _client() as c:
+        r = await c.delete(
+            "/api/auth/keys/nonexistent",
+            headers={"Authorization": f"Bearer {alice_key.raw_key}"},
+        )
+    assert r.status_code == 404
+
+
+# --- POST /api/auth/keys (label echo) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mint_endpoint_accepts_label():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.post(
+            "/api/auth/keys",
+            json={
+                "contributor_id": "alice",
+                "provider": "name",
+                "provider_id": "alice",
+                "label": "my-laptop",
+            },
+        )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["contributor_id"] == "alice"
+    assert body["label"] == "my-laptop"
+    assert body["api_key"].startswith("cc_alice_")
+    # Minted key is visible to the store and works for verification.
+    row = store.verify(body["api_key"])
+    assert row is not None
+    assert row.label == "my-laptop"
+
+
+# --- /api/auth/whoami uses middleware attribution --------------------------
+
+
+@pytest.mark.asyncio
+async def test_whoami_via_verified_bearer():
+    _reset_table()
+    minted = store.mint("alice")
+    async with await _client() as c:
+        r = await c.get(
+            "/api/auth/whoami",
+            headers={"Authorization": f"Bearer {minted.raw_key}"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["authenticated"] is True
+    assert body["contributor_id"] == "alice"
+    assert body["source"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_whoami_via_claimed_header():
+    _reset_table()
+    async with await _client() as c:
+        r = await c.get("/api/auth/whoami", headers={"X-Contributor-Id": "alice"})
+    assert r.status_code == 200
+    body = r.json()
+    # "authenticated" reflects *verified* trust, not just attribution
+    assert body["authenticated"] is False
+    assert body["contributor_id"] == "alice"
+    assert body["source"] == "claimed"

--- a/api/tests/test_contributor_key_store.py
+++ b/api/tests/test_contributor_key_store.py
@@ -1,0 +1,162 @@
+"""Tests for the DB-backed contributor API key store.
+
+Calls the store directly — no HTTP layer — because all the interesting
+behaviour lives below the route. HTTP layer is covered in
+`test_auth_keys_api.py`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.services import contributor_key_store as store
+
+
+def _reset_table() -> None:
+    """Truncate contributor_api_keys between tests so state never leaks.
+
+    Uses the unified_db session to avoid pinning us to sqlite vs postgres.
+    """
+    from app.services.unified_db import session as db_session, ensure_schema
+
+    ensure_schema()
+    with db_session() as sess:
+        sess.query(store.ContributorApiKeyRecord).delete()
+
+
+def test_mint_returns_raw_key_exactly_once():
+    _reset_table()
+    result = store.mint("alice", label="laptop", provider="github", provider_id="alice")
+    assert result.raw_key.startswith("cc_alice_")
+    assert len(result.raw_key) > 30
+    assert result.row.contributor_id == "alice"
+    assert result.row.label == "laptop"
+    assert result.row.provider == "github"
+    assert result.row.scopes == store.DEFAULT_SCOPES
+    assert result.row.active is True
+    assert result.row.revoked_at is None
+
+
+def test_mint_stores_only_the_hash_never_the_raw_key():
+    _reset_table()
+    result = store.mint("alice")
+    # The id on the row is the SHA-256 hash, not the raw key.
+    assert result.row.id != result.raw_key
+    assert len(result.row.id) == 64  # sha256 hex
+    import hashlib
+    assert result.row.id == hashlib.sha256(result.raw_key.encode()).hexdigest()
+
+
+def test_verify_roundtrip_returns_row():
+    _reset_table()
+    minted = store.mint("alice", label="laptop")
+    row = store.verify(minted.raw_key)
+    assert row is not None
+    assert row.contributor_id == "alice"
+    assert row.label == "laptop"
+
+
+def test_verify_unknown_key_returns_none():
+    _reset_table()
+    assert store.verify("cc_ghost_" + "0" * 32) is None
+
+
+def test_verify_empty_key_returns_none():
+    _reset_table()
+    assert store.verify("") is None
+
+
+def test_verify_refreshes_last_used_at():
+    _reset_table()
+    minted = store.mint("alice", now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert minted.row.last_used_at is None
+
+    later = datetime(2026, 2, 15, 12, 34, 56, tzinfo=timezone.utc)
+    row = store.verify(minted.raw_key, now=later)
+    assert row is not None
+    assert row.last_used_at is not None
+    assert row.last_used_at.startswith("2026-02-15T12:34:56")
+
+
+def test_list_for_returns_only_this_contributors_keys_newest_first():
+    _reset_table()
+    earliest = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    store.mint("alice", label="one", now=earliest)
+    store.mint("alice", label="two", now=earliest + timedelta(hours=1))
+    store.mint("bob", label="bobs", now=earliest + timedelta(hours=2))
+
+    alice_keys = store.list_for("alice")
+    assert [k.label for k in alice_keys] == ["two", "one"]
+    for k in alice_keys:
+        assert k.contributor_id == "alice"
+
+
+def test_list_for_hides_revoked_by_default():
+    _reset_table()
+    a = store.mint("alice", label="keepme")
+    b = store.mint("alice", label="revokeme")
+    store.revoke(b.row.id, owner_contributor_id="alice")
+
+    active = store.list_for("alice")
+    assert [k.label for k in active] == ["keepme"]
+
+    all_keys = store.list_for("alice", include_revoked=True)
+    assert sorted(k.label for k in all_keys) == ["keepme", "revokeme"]
+
+
+def test_revoke_blocks_future_verify():
+    _reset_table()
+    minted = store.mint("alice")
+    assert store.verify(minted.raw_key) is not None
+
+    assert store.revoke(minted.row.id, owner_contributor_id="alice") is True
+    assert store.verify(minted.raw_key) is None
+
+
+def test_revoke_owner_check_blocks_other_contributors():
+    _reset_table()
+    alice = store.mint("alice")
+    # Bob tries to revoke Alice's key — should return False, no effect.
+    assert store.revoke(alice.row.id, owner_contributor_id="bob") is False
+    # Alice's key still works.
+    assert store.verify(alice.raw_key) is not None
+
+
+def test_revoke_idempotent_returns_false_on_second_call():
+    _reset_table()
+    minted = store.mint("alice")
+    assert store.revoke(minted.row.id, owner_contributor_id="alice") is True
+    # Second revoke is a no-op and returns False.
+    assert store.revoke(minted.row.id, owner_contributor_id="alice") is False
+
+
+def test_revoke_unknown_key_returns_false():
+    _reset_table()
+    assert store.revoke("nonexistent_hash", owner_contributor_id="alice") is False
+
+
+def test_count_active_excludes_revoked():
+    _reset_table()
+    store.mint("alice")
+    a = store.mint("alice")
+    store.mint("bob")
+    assert store.count_active() == 3
+    store.revoke(a.row.id, owner_contributor_id="alice")
+    assert store.count_active() == 2
+
+
+def test_get_by_id_returns_row_or_none():
+    _reset_table()
+    minted = store.mint("alice")
+    fetched = store.get_by_id(minted.row.id)
+    assert fetched is not None
+    assert fetched.contributor_id == "alice"
+    assert store.get_by_id("nope") is None
+
+
+def test_mint_requires_contributor_id():
+    _reset_table()
+    import pytest
+
+    with pytest.raises(ValueError):
+        store.mint("")

--- a/pulse/.gitignore
+++ b/pulse/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.pytest_cache/
+.venv/
+venv/
+data/*.db
+data/*.db-*
+.env

--- a/pulse/Dockerfile
+++ b/pulse/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.11-slim
+
+LABEL org.opencontainers.image.title="pulse"
+LABEL org.opencontainers.image.description="Pulse Monitor — the witness that remembers the breath of Coherence Network"
+LABEL org.opencontainers.image.source="https://github.com/seeker51/Coherence-Network"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PULSE_DB_PATH=/data/pulse.db
+
+WORKDIR /app
+
+# Dependencies first, for build caching.
+COPY pyproject.toml README.md ./
+RUN python -m pip install --upgrade pip \
+ && python -m pip install \
+    "fastapi>=0.110" \
+    "uvicorn[standard]>=0.27" \
+    "httpx>=0.27" \
+    "apscheduler>=3.10" \
+    "pydantic>=2.6"
+
+COPY pulse_app ./pulse_app
+
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+EXPOSE 8100
+
+HEALTHCHECK --interval=60s --timeout=5s --start-period=15s --retries=3 \
+    CMD python -c "import urllib.request,sys; \
+                   r=urllib.request.urlopen('http://127.0.0.1:8100/pulse/health',timeout=3); \
+                   sys.exit(0 if r.status==200 else 1)" || exit 1
+
+CMD ["uvicorn", "pulse_app.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -1,0 +1,154 @@
+# Pulse Monitor
+
+> The witness that remembers the breath of Coherence Network.
+
+Pulse is a small standalone service whose only job is to ping the main
+Coherence Network from outside, durably record every sample, derive
+**silences** (our word for incidents) from consecutive failures, and expose
+the history over a tiny read-only API so the `/pulse` page on the main web
+can render the last 90 days of the body's breath.
+
+It deliberately does not share code, runtime, or database with the main
+`api/` service. A service cannot reliably report its own death — so the
+witness lives next door instead of inside.
+
+## Phase 1 caveat (read me)
+
+In Phase 1 the witness runs as a **third docker-compose service on the same
+VPS** as `api` and `web`. This means:
+
+- The witness survives `api` restarts, crashes, bad deploys, DB outages,
+  and graph-DB outages. These are the common failure modes.
+- The witness does **not** survive whole-host outages of the VPS (power,
+  network, Hostinger maintenance). In those moments, nothing tells us
+  anything — which is also exactly what you'd see on your own status page.
+
+Phase 2 moves the witness to a second host (Fly.io free tier, or a small
+second VPS, or a GitHub Actions cron as a cheap secondary witness). The
+code does not need to change for that — only the deploy target.
+
+## Endpoints
+
+All endpoints are public, read-only JSON. CORS defaults to `*`; override
+with `PULSE_CORS_ORIGINS`.
+
+| Method | Path               | Purpose                                               |
+|--------|--------------------|-------------------------------------------------------|
+| GET    | `/pulse/now`       | Current snapshot of every organ + overall status     |
+| GET    | `/pulse/history`   | 90-day (or `?days=N`) daily bars per organ           |
+| GET    | `/pulse/silences`  | Past silences within the window + ongoing silences   |
+| GET    | `/pulse/health`    | The witness's own liveness ping                      |
+
+## Vocabulary
+
+The witness uses the Living Collective frequency per `CLAUDE.md`. The raw
+HTTP language of a corporate status page is translated:
+
+| Corporate          | Living Collective       |
+|--------------------|-------------------------|
+| component          | **organ**               |
+| up / operational   | **breathing**           |
+| degraded           | **strained**            |
+| down / outage      | **silent**              |
+| uptime %           | **steady breath**       |
+| incident           | **silence**             |
+| monitoring service | **witness**             |
+
+## Organs
+
+| Organ             | Signal                                                 |
+|-------------------|--------------------------------------------------------|
+| `api`             | `GET /api/health` → 200 && body.status == "ok"         |
+| `web`             | `GET /` → 2xx                                          |
+| `postgres`        | `/api/ready` → db_connected == true                    |
+| `neo4j`           | `/api/ready` not 503 (graph_store available)           |
+| `schema`          | `/api/health` → schema_ok == true                      |
+| `audit_integrity` | `/api/health` → integrity_compromised == false         |
+
+Five of the six organs share two upstream calls, so one probe round costs
+three HTTP requests.
+
+## Running locally
+
+```bash
+cd pulse
+python -m pip install -e ".[dev]"
+python -m pytest
+
+PULSE_API_BASE=https://api.coherencycoin.com \
+PULSE_WEB_BASE=https://coherencycoin.com \
+PULSE_DB_PATH=./data/pulse.db \
+uvicorn pulse_app.main:app --port 8100
+
+curl -s http://localhost:8100/pulse/now | jq
+curl -s http://localhost:8100/pulse/health | jq
+```
+
+## Environment variables
+
+| Var                       | Default                          | Purpose                                  |
+|---------------------------|----------------------------------|------------------------------------------|
+| `PULSE_API_BASE`          | `https://api.coherencycoin.com`  | Main API base URL                        |
+| `PULSE_WEB_BASE`          | `https://coherencycoin.com`      | Main web base URL                        |
+| `PULSE_DB_PATH`           | `./data/pulse.db`                | SQLite file path                         |
+| `PULSE_INTERVAL_SECONDS`  | `30`                             | Probe cadence                            |
+| `PULSE_RETENTION_DAYS`    | `180`                            | Raw-sample retention (silences forever)  |
+| `PULSE_CORS_ORIGINS`      | `*`                              | Comma-separated list                     |
+
+## Deploy to the VPS (docker-compose snippet)
+
+Add these sections to `/docker/coherence-network/docker-compose.yml` on
+the VPS next to the existing `api` and `web` services:
+
+```yaml
+services:
+  pulse:
+    build: ./repo/pulse
+    restart: unless-stopped
+    environment:
+      - PULSE_API_BASE=http://api:8000
+      - PULSE_WEB_BASE=http://web:3000
+      - PULSE_DB_PATH=/data/pulse.db
+      - PULSE_INTERVAL_SECONDS=30
+      - PULSE_RETENTION_DAYS=180
+      - PULSE_CORS_ORIGINS=https://coherencycoin.com,https://www.coherencycoin.com
+    volumes:
+      - pulse-data:/data
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.pulse.rule=Host(`pulse.coherencycoin.com`)
+      - traefik.http.routers.pulse.entrypoints=websecure
+      - traefik.http.routers.pulse.tls=true
+      - traefik.http.routers.pulse.tls.certresolver=letsencrypt
+      - traefik.http.services.pulse.loadbalancer.server.port=8100
+
+volumes:
+  pulse-data:
+```
+
+Then on the VPS:
+
+```bash
+cd /docker/coherence-network/repo && git pull origin main
+cd /docker/coherence-network
+docker compose build --no-cache pulse
+docker compose up -d pulse
+docker compose logs -f pulse
+```
+
+One Cloudflare A record: `pulse.coherencycoin.com → 187.77.152.42`.
+
+## How silences are derived
+
+A silence is not written by the scheduler — it is **derived** from raw
+samples by `pulse_app/analysis.py`. Rules:
+
+- **Open** a silence when an organ has ≥ 3 consecutive failures. The
+  silence's `started_at` is the timestamp of the first failure in the run.
+- **Escalate** a silence from `strained` to `silent` when it has been
+  ongoing for ≥ 5 minutes.
+- **Close** a silence when ≥ 3 consecutive successes return. The silence's
+  `ended_at` is the timestamp of the first closing success.
+
+Thresholds live in one place (`pulse_app/analysis.py`) so they are easy
+to tune.

--- a/pulse/pulse_app/__init__.py
+++ b/pulse/pulse_app/__init__.py
@@ -1,0 +1,8 @@
+"""Pulse Monitor — the witness that remembers the breath of Coherence Network.
+
+A tiny standalone service whose only job is to ping the main network from
+outside and durably record what it sees, so that the collective can sense
+the health and vitality of its own body over time.
+"""
+
+__version__ = "0.1.0"

--- a/pulse/pulse_app/analysis.py
+++ b/pulse/pulse_app/analysis.py
@@ -1,0 +1,194 @@
+"""Analysis — turn raw samples into silences and uptime percentages.
+
+All the interpretation logic lives here, separate from storage and probing,
+so it is trivially unit-testable with hand-crafted sample sequences.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Literal
+
+from pulse_app.storage import Sample, SilenceRow, Store, iso_utc
+
+
+# --- tunables -------------------------------------------------------------
+
+# How many consecutive failures before we open a silence.
+SILENCE_OPEN_FAILURES = 3
+# How many consecutive successes before we close an open silence.
+SILENCE_CLOSE_SUCCESSES = 3
+# Duration at which a "strained" silence escalates to "silent" — 5 minutes.
+SILENCE_ESCALATION_SECONDS = 300
+
+
+Severity = Literal["strained", "silent"]
+
+
+def severity_for_duration(seconds: int) -> Severity:
+    return "silent" if seconds >= SILENCE_ESCALATION_SECONDS else "strained"
+
+
+# --- silence derivation ---------------------------------------------------
+
+def reconcile_silences(store: Store, organ: str) -> None:
+    """Open, escalate, or close silences for one organ based on recent samples.
+
+    Called from the scheduler after every probe round. Only looks at the
+    tail of recent samples (enough to see a run), so it's cheap.
+    """
+    window = max(SILENCE_OPEN_FAILURES, SILENCE_CLOSE_SUCCESSES) + 2
+    recent = store.recent_samples_for_organ(organ, limit=window)
+    if not recent:
+        return
+
+    ongoing = store.ongoing_silence_for_organ(organ)
+
+    # Count the trailing run of identical ok/not-ok.
+    last = recent[-1]
+    run_ok = last.ok
+    run_len = 0
+    for s in reversed(recent):
+        if s.ok == run_ok:
+            run_len += 1
+        else:
+            break
+
+    now_iso = iso_utc()
+
+    if ongoing is None:
+        # No silence yet — open one if we have enough consecutive failures.
+        if (not run_ok) and run_len >= SILENCE_OPEN_FAILURES:
+            # Start the silence at the timestamp of the first failure in the run.
+            started_at = recent[-run_len].ts
+            store.open_silence(organ, started_at, "strained")
+        return
+
+    # There is an ongoing silence.
+    if run_ok and run_len >= SILENCE_CLOSE_SUCCESSES:
+        # Close at the timestamp of the first of the closing successes.
+        ended_at = recent[-run_len].ts
+        store.close_silence(ongoing.id, ended_at)
+        return
+
+    # Still failing — check if it's time to escalate.
+    started_dt = _parse_iso(ongoing.started_at)
+    now_dt = _parse_iso(now_iso)
+    duration = int((now_dt - started_dt).total_seconds())
+    target = severity_for_duration(duration)
+    if target != ongoing.severity and target == "silent":
+        store.escalate_silence(ongoing.id, "silent")
+
+
+# --- daily rollup ---------------------------------------------------------
+
+@dataclass(frozen=True)
+class DayBucket:
+    date: str            # YYYY-MM-DD
+    samples: int
+    failures: int
+
+    @property
+    def status(self) -> str:
+        if self.samples == 0:
+            return "unknown"
+        if self.failures == 0:
+            return "breathing"
+        # Strictly more than half the samples failed → silent.
+        if self.failures * 2 > self.samples:
+            return "silent"
+        return "strained"
+
+
+def rollup_daily(samples: list[Sample], days: int, now: datetime | None = None) -> list[DayBucket]:
+    """Group samples into the last `days` day-buckets ending today UTC.
+
+    Days with no samples become DayBuckets with samples=0 and status=unknown.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    today = now.astimezone(timezone.utc).date()
+
+    # Pre-create every bucket so the output is always length `days`.
+    buckets: dict[date, list[int]] = {}
+    for i in range(days):
+        d = today - timedelta(days=(days - 1 - i))
+        buckets[d] = [0, 0]  # [samples, failures]
+
+    for s in samples:
+        d = _parse_iso(s.ts).date()
+        if d in buckets:
+            buckets[d][0] += 1
+            if not s.ok:
+                buckets[d][1] += 1
+
+    return [
+        DayBucket(
+            date=d.isoformat(),
+            samples=buckets[d][0],
+            failures=buckets[d][1],
+        )
+        for d in sorted(buckets.keys())
+    ]
+
+
+def uptime_percent(samples: list[Sample]) -> float:
+    """Percentage of samples that were ok, rounded to 2 decimals."""
+    if not samples:
+        return 0.0
+    ok = sum(1 for s in samples if s.ok)
+    return round(100.0 * ok / len(samples), 2)
+
+
+# --- current status -------------------------------------------------------
+
+def status_from_last_sample(sample: Sample | None) -> str:
+    if sample is None:
+        return "unknown"
+    return "breathing" if sample.ok else "silent"
+
+
+def overall_status(organ_statuses: list[str]) -> str:
+    """Combine per-organ statuses into an overall verdict."""
+    if not organ_statuses:
+        return "unknown"
+    if all(s == "unknown" for s in organ_statuses):
+        return "unknown"
+    if any(s == "silent" for s in organ_statuses):
+        return "silent"
+    if any(s == "strained" for s in organ_statuses):
+        return "strained"
+    return "breathing"
+
+
+# --- helpers --------------------------------------------------------------
+
+def _parse_iso(ts: str) -> datetime:
+    # Accepts "2026-04-15T17:19:30Z" style (what iso_utc emits).
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts).astimezone(timezone.utc)
+
+
+def duration_seconds_until_now(started_at: str, now: datetime | None = None) -> int:
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return max(0, int((now - _parse_iso(started_at)).total_seconds()))
+
+
+def duration_between(started_at: str, ended_at: str) -> int:
+    return max(0, int((_parse_iso(ended_at) - _parse_iso(started_at)).total_seconds()))
+
+
+def since_iso(days: int, now: datetime | None = None) -> str:
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return iso_utc(now - timedelta(days=days))
+
+
+# Convenience re-export for main/route code.
+def silence_duration(row: SilenceRow, now: datetime | None = None) -> int:
+    if row.ended_at is None:
+        return duration_seconds_until_now(row.started_at, now)
+    return duration_between(row.started_at, row.ended_at)

--- a/pulse/pulse_app/main.py
+++ b/pulse/pulse_app/main.py
@@ -1,0 +1,280 @@
+"""FastAPI entry point for the Pulse Monitor.
+
+Env vars:
+  PULSE_API_BASE         base URL of the main API           (default https://api.coherencycoin.com)
+  PULSE_WEB_BASE         base URL of the main web           (default https://coherencycoin.com)
+  PULSE_DB_PATH          path to the SQLite file            (default ./data/pulse.db)
+  PULSE_INTERVAL_SECONDS probe interval                     (default 30)
+  PULSE_RETENTION_DAYS   raw-sample retention               (default 180)
+  PULSE_CORS_ORIGINS     comma-separated list               (default *)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
+
+from pulse_app import __version__
+from pulse_app.analysis import (
+    duration_seconds_until_now,
+    overall_status,
+    rollup_daily,
+    silence_duration,
+    since_iso,
+    status_from_last_sample,
+    uptime_percent,
+)
+from pulse_app.models import (
+    DailyBar,
+    OngoingSilence,
+    OrganHistory,
+    OrganNow,
+    PulseHistory,
+    PulseNow,
+    PulseSilences,
+    Silence,
+    WitnessHealth,
+)
+from pulse_app.organs import ORGANS, organs_by_name
+from pulse_app.scheduler import PulseScheduler, SchedulerConfig
+from pulse_app.storage import Store, iso_utc
+
+
+logger = logging.getLogger("pulse")
+
+
+# ----- config -------------------------------------------------------------
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default).strip() or default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _cors_origins() -> list[str]:
+    raw = os.environ.get("PULSE_CORS_ORIGINS", "*")
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+API_BASE = _env("PULSE_API_BASE", "https://api.coherencycoin.com")
+WEB_BASE = _env("PULSE_WEB_BASE", "https://coherencycoin.com")
+DB_PATH = _env("PULSE_DB_PATH", "./data/pulse.db")
+INTERVAL = _env_int("PULSE_INTERVAL_SECONDS", 30)
+RETENTION = _env_int("PULSE_RETENTION_DAYS", 180)
+
+STARTED_AT = datetime.now(timezone.utc)
+
+
+# ----- lifespan -----------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    logger.info(
+        "pulse witness starting api=%s web=%s db=%s interval=%ds retention=%dd",
+        API_BASE, WEB_BASE, DB_PATH, INTERVAL, RETENTION,
+    )
+
+    store = Store(DB_PATH)
+    scheduler = PulseScheduler(
+        store=store,
+        config=SchedulerConfig(
+            api_base=API_BASE,
+            web_base=WEB_BASE,
+            interval_seconds=INTERVAL,
+            retention_days=RETENTION,
+        ),
+    )
+    scheduler.start()
+
+    app.state.store = store
+    app.state.scheduler = scheduler
+    app.state.started_at = STARTED_AT
+
+    try:
+        yield
+    finally:
+        scheduler.shutdown()
+        logger.info("pulse witness stopped")
+
+
+# ----- app ----------------------------------------------------------------
+
+app = FastAPI(
+    title="Pulse Monitor",
+    version=__version__,
+    description="The witness that remembers the breath of Coherence Network.",
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins(),
+    allow_credentials=False,
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["*"],
+)
+
+
+# ----- routes -------------------------------------------------------------
+
+@app.get("/pulse/health", response_model=WitnessHealth)
+async def witness_health() -> WitnessHealth:
+    """Liveness ping for the witness itself (so it can be pinged externally)."""
+    store: Store = app.state.store
+    now = datetime.now(timezone.utc)
+    return WitnessHealth(
+        status="ok",
+        version=__version__,
+        started_at=iso_utc(app.state.started_at),
+        uptime_seconds=int((now - app.state.started_at).total_seconds()),
+        samples_total=store.count_samples(),
+    )
+
+
+@app.get("/pulse/now", response_model=PulseNow)
+async def pulse_now() -> PulseNow:
+    store: Store = app.state.store
+    now = datetime.now(timezone.utc)
+
+    organ_now: list[OrganNow] = []
+    statuses: list[str] = []
+    for organ in ORGANS:
+        last = store.last_sample_for_organ(organ.name)
+        status = status_from_last_sample(last)
+
+        # Soften: if the last sample is older than 3× the interval, it's stale → unknown.
+        if last is not None:
+            age = (now - _parse_ts(last.ts)).total_seconds()
+            if age > 3 * INTERVAL:
+                status = "unknown"
+
+        statuses.append(status)
+        organ_now.append(
+            OrganNow(
+                name=organ.name,
+                label=organ.label,
+                description=organ.description,
+                status=status,  # type: ignore[arg-type]
+                latency_ms=last.latency_ms if last else None,
+                last_sample_at=last.ts if last else None,
+                detail=last.detail if last and not last.ok else None,
+            )
+        )
+
+    ongoing_rows = store.ongoing_silences()
+    ongoing = [
+        OngoingSilence(
+            id=row.id,
+            organ=row.organ,
+            started_at=row.started_at,
+            severity=row.severity,  # type: ignore[arg-type]
+            duration_seconds=duration_seconds_until_now(row.started_at, now),
+        )
+        for row in ongoing_rows
+    ]
+
+    return PulseNow(
+        overall=overall_status(statuses),  # type: ignore[arg-type]
+        checked_at=iso_utc(now),
+        witness_started_at=iso_utc(app.state.started_at),
+        organs=organ_now,
+        ongoing_silences=ongoing,
+    )
+
+
+@app.get("/pulse/history", response_model=PulseHistory)
+async def pulse_history(days: int = Query(90, ge=1, le=180)) -> PulseHistory:
+    store: Store = app.state.store
+    now = datetime.now(timezone.utc)
+    since = since_iso(days, now)
+
+    organ_histories: list[OrganHistory] = []
+    for organ in ORGANS:
+        samples = store.samples_for_organ_since(organ.name, since)
+        buckets = rollup_daily(samples, days=days, now=now)
+        organ_histories.append(
+            OrganHistory(
+                name=organ.name,
+                label=organ.label,
+                description=organ.description,
+                uptime_pct=uptime_percent(samples),
+                daily=[
+                    DailyBar(
+                        date=b.date,
+                        status=b.status,  # type: ignore[arg-type]
+                        samples=b.samples,
+                        failures=b.failures,
+                    )
+                    for b in buckets
+                ],
+            )
+        )
+
+    return PulseHistory(
+        days=days,
+        generated_at=iso_utc(now),
+        organs=organ_histories,
+    )
+
+
+@app.get("/pulse/silences", response_model=PulseSilences)
+async def pulse_silences(days: int = Query(90, ge=1, le=180)) -> PulseSilences:
+    store: Store = app.state.store
+    now = datetime.now(timezone.utc)
+    since = since_iso(days, now)
+    rows = store.silences_since(since)
+    by_name = organs_by_name()
+
+    silences = [
+        Silence(
+            id=row.id,
+            organ=row.organ,
+            organ_label=by_name[row.organ].label if row.organ in by_name else row.organ,
+            started_at=row.started_at,
+            ended_at=row.ended_at,
+            duration_seconds=silence_duration(row, now),
+            severity=row.severity,  # type: ignore[arg-type]
+            note=row.note,
+        )
+        for row in rows
+    ]
+
+    return PulseSilences(
+        days=days,
+        generated_at=iso_utc(now),
+        silences=silences,
+    )
+
+
+# ----- helpers ------------------------------------------------------------
+
+def _parse_ts(ts: str) -> datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts).astimezone(timezone.utc)
+
+
+@app.get("/")
+async def root() -> dict[str, Any]:
+    return {
+        "service": "pulse",
+        "version": __version__,
+        "endpoints": [
+            "/pulse/now",
+            "/pulse/history",
+            "/pulse/silences",
+            "/pulse/health",
+        ],
+    }

--- a/pulse/pulse_app/models.py
+++ b/pulse/pulse_app/models.py
@@ -1,0 +1,130 @@
+"""Pydantic response models for the public pulse API.
+
+These models are the contract between the monitor and the /pulse web page.
+They are designed to be directly serialised to JSON and consumed by a
+TypeScript server component without further shaping.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# Breath status vocabulary — NOT "up/down/degraded".
+BreathStatus = Literal["breathing", "strained", "silent", "unknown"]
+# Silence severity — "strained" is intermittent failures, "silent" is prolonged.
+Severity = Literal["strained", "silent"]
+
+
+class OrganNow(BaseModel):
+    """Current state of one organ."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    label: str
+    description: str
+    status: BreathStatus
+    latency_ms: int | None = None
+    last_sample_at: str | None = Field(
+        default=None, description="ISO8601 UTC of the most recent sample"
+    )
+    detail: str | None = Field(
+        default=None, description="Short human note when not breathing"
+    )
+
+
+class OngoingSilence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    organ: str
+    started_at: str
+    severity: Severity
+    duration_seconds: int
+
+
+class PulseNow(BaseModel):
+    """GET /pulse/now response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    overall: BreathStatus
+    checked_at: str = Field(description="ISO8601 UTC of this snapshot")
+    witness_started_at: str = Field(
+        description="ISO8601 UTC when the pulse monitor itself came up"
+    )
+    organs: list[OrganNow]
+    ongoing_silences: list[OngoingSilence]
+
+
+class DailyBar(BaseModel):
+    """One day in an organ's 90-day timeline."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str = Field(description="YYYY-MM-DD, UTC")
+    status: BreathStatus
+    samples: int
+    failures: int
+
+
+class OrganHistory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    label: str
+    description: str
+    uptime_pct: float = Field(
+        description="Steady-breath percentage across the requested window"
+    )
+    daily: list[DailyBar]
+
+
+class PulseHistory(BaseModel):
+    """GET /pulse/history response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    days: int
+    generated_at: str
+    organs: list[OrganHistory]
+
+
+class Silence(BaseModel):
+    """A past quiet moment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    organ: str
+    organ_label: str
+    started_at: str
+    ended_at: str | None
+    duration_seconds: int
+    severity: Severity
+    note: str | None = None
+
+
+class PulseSilences(BaseModel):
+    """GET /pulse/silences response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    days: int
+    generated_at: str
+    silences: list[Silence]
+
+
+class WitnessHealth(BaseModel):
+    """GET /pulse/health response — the witness's own liveness."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"]
+    version: str
+    started_at: str
+    uptime_seconds: int
+    samples_total: int

--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -1,0 +1,203 @@
+"""Organ definitions — what we listen to, and how.
+
+An "organ" is a single observable subsystem of the living network. Each organ
+declares which upstream endpoint it depends on and a small extractor function
+that decides, given a successful HTTP response, whether the organ is actually
+breathing or only pretending to breathe (e.g. /api/health can return 200 while
+reporting integrity_compromised=true internally).
+
+Organs are grouped by the upstream call they share, so a single round-trip to
+/api/health feeds several organ samples. This keeps the witness gentle on the
+network it watches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+# Result of applying an extractor to a successful upstream response.
+# ok=False with a detail string means "the call succeeded but the organ is
+# not actually breathing" (e.g. integrity flag flipped).
+@dataclass(frozen=True)
+class OrganVerdict:
+    ok: bool
+    detail: str | None = None
+
+
+Extractor = Callable[[int, dict[str, Any] | None], OrganVerdict]
+
+
+@dataclass(frozen=True)
+class Organ:
+    """One observable subsystem."""
+
+    name: str                # stable id used in storage + API
+    label: str               # human-readable name for the UI
+    description: str         # one-line explanation
+    upstream: str            # one of UPSTREAM_* below
+    extractor: Extractor
+
+
+# --- upstream labels ------------------------------------------------------
+
+UPSTREAM_API_HEALTH = "api_health"   # {API_BASE}/api/health
+UPSTREAM_API_READY = "api_ready"     # {API_BASE}/api/ready
+UPSTREAM_WEB_ROOT = "web_root"       # {WEB_BASE}/
+
+
+# --- extractors -----------------------------------------------------------
+
+def _is_ok(status: int) -> bool:
+    return 200 <= status < 300
+
+
+def extract_api(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+    """API organ: /api/health returns 200 with status == "ok"."""
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    if not body:
+        return OrganVerdict(False, "empty response body")
+    if body.get("status") != "ok":
+        return OrganVerdict(False, f"status={body.get('status')!r}")
+    return OrganVerdict(True)
+
+
+def extract_web(status: int, _body: dict[str, Any] | None) -> OrganVerdict:
+    """Web organ: root returns 2xx (body is HTML, we don't parse it)."""
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    return OrganVerdict(True)
+
+
+def _ready_503_reason(body: dict[str, Any] | None) -> str:
+    """The 503 detail on /api/ready has two distinct causes.
+
+    When graph_store is None the detail is the plain string 'not ready'.
+    When the persistence contract fails the detail is a dict with
+    error == 'persistence_contract_failed'. We use this to distinguish
+    postgres-side failures from neo4j-side failures below.
+    """
+    if not body:
+        return "unknown"
+    detail = body.get("detail")
+    if isinstance(detail, dict) and detail.get("error") == "persistence_contract_failed":
+        return "persistence_contract_failed"
+    if detail == "not ready":
+        return "graph_store_missing"
+    return "unknown"
+
+
+def extract_postgres(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+    """Postgres organ: db_connected true, or persistence contract failing."""
+    if status == 503:
+        reason = _ready_503_reason(body)
+        if reason == "persistence_contract_failed":
+            return OrganVerdict(False, "persistence contract failed")
+        # graph_store_missing is a neo4j signal, not a postgres signal —
+        # we can't tell postgres state from this response, so call it unknown
+        # by returning ok=False with a neutral note.
+        return OrganVerdict(False, "unknown (ready=503)")
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    if not body:
+        return OrganVerdict(False, "empty response body")
+    if not body.get("db_connected"):
+        return OrganVerdict(False, "db_connected=false")
+    return OrganVerdict(True)
+
+
+def extract_neo4j(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+    """Neo4j organ: 503 only counts when graph_store is specifically missing."""
+    if status == 503:
+        reason = _ready_503_reason(body)
+        if reason == "graph_store_missing":
+            return OrganVerdict(False, "graph_store unavailable")
+        # 503 for some other reason is not a neo4j signal — neo4j may be fine.
+        return OrganVerdict(True)
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    if not body:
+        return OrganVerdict(False, "empty response body")
+    if body.get("status") != "ready":
+        return OrganVerdict(False, f"ready status={body.get('status')!r}")
+    return OrganVerdict(True)
+
+
+def extract_schema(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+    """Schema organ: /api/health body.schema_ok==true."""
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    if not body:
+        return OrganVerdict(False, "empty response body")
+    if not body.get("schema_ok", True):
+        return OrganVerdict(False, "schema_ok=false")
+    return OrganVerdict(True)
+
+
+def extract_audit(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+    """Audit-integrity organ: /api/health body.integrity_compromised==false."""
+    if not _is_ok(status):
+        return OrganVerdict(False, f"HTTP {status}")
+    if not body:
+        return OrganVerdict(False, "empty response body")
+    if body.get("integrity_compromised"):
+        return OrganVerdict(False, "integrity_compromised=true")
+    return OrganVerdict(True)
+
+
+# --- the canonical organ list ---------------------------------------------
+
+ORGANS: list[Organ] = [
+    Organ(
+        name="api",
+        label="API",
+        description="The central nervous system — FastAPI, the place where thoughts become actions.",
+        upstream=UPSTREAM_API_HEALTH,
+        extractor=extract_api,
+    ),
+    Organ(
+        name="web",
+        label="Web",
+        description="The skin and face — Next.js, how the network meets the world.",
+        upstream=UPSTREAM_WEB_ROOT,
+        extractor=extract_web,
+    ),
+    Organ(
+        name="postgres",
+        label="PostgreSQL",
+        description="Long memory — the relational store where facts persist.",
+        upstream=UPSTREAM_API_READY,
+        extractor=extract_postgres,
+    ),
+    Organ(
+        name="neo4j",
+        label="Neo4j",
+        description="Association memory — the graph of ideas, specs, and their ties.",
+        upstream=UPSTREAM_API_READY,
+        extractor=extract_neo4j,
+    ),
+    Organ(
+        name="schema",
+        label="Schema",
+        description="Structural integrity — core tables present and sound.",
+        upstream=UPSTREAM_API_HEALTH,
+        extractor=extract_schema,
+    ),
+    Organ(
+        name="audit_integrity",
+        label="Audit Integrity",
+        description="Conscience — the audit ledger's hash chain is unbroken.",
+        upstream=UPSTREAM_API_HEALTH,
+        extractor=extract_audit,
+    ),
+]
+
+
+def organs_by_name() -> dict[str, Organ]:
+    return {o.name: o for o in ORGANS}
+
+
+def organs_for_upstream(upstream: str) -> list[Organ]:
+    return [o for o in ORGANS if o.upstream == upstream]

--- a/pulse/pulse_app/probe.py
+++ b/pulse/pulse_app/probe.py
@@ -1,0 +1,133 @@
+"""HTTP probes — one shared round-trip per upstream, fanned out to organs.
+
+We are gentle on the network we watch. Rather than hitting six endpoints to
+get six organ samples, we hit three upstreams (/api/health, /api/ready, /)
+and apply each organ's extractor to the shared response.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from pulse_app.organs import (
+    ORGANS,
+    UPSTREAM_API_HEALTH,
+    UPSTREAM_API_READY,
+    UPSTREAM_WEB_ROOT,
+    Organ,
+    organs_for_upstream,
+)
+from pulse_app.storage import Sample, iso_utc
+
+
+# Per-upstream result of one probe attempt, shared across organs.
+@dataclass(frozen=True)
+class UpstreamResult:
+    status: int              # HTTP status, or 0 on network error
+    body: dict[str, Any] | None
+    latency_ms: int
+    error: str | None        # transport error text, or None
+
+
+async def _probe_upstream(
+    client: httpx.AsyncClient, url: str, parse_json: bool
+) -> UpstreamResult:
+    """Fetch one upstream once, return a shared UpstreamResult.
+
+    We swallow all exceptions deliberately: a probe failure is a signal,
+    not an error in the monitor.
+    """
+    start = time.perf_counter()
+    try:
+        resp = await client.get(url)
+        elapsed = int((time.perf_counter() - start) * 1000)
+        body: dict[str, Any] | None = None
+        if parse_json:
+            try:
+                raw = resp.json()
+                if isinstance(raw, dict):
+                    body = raw
+            except Exception:
+                body = None
+        return UpstreamResult(
+            status=resp.status_code, body=body, latency_ms=elapsed, error=None
+        )
+    except httpx.HTTPError as exc:
+        elapsed = int((time.perf_counter() - start) * 1000)
+        return UpstreamResult(
+            status=0, body=None, latency_ms=elapsed, error=_short_error(exc)
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        elapsed = int((time.perf_counter() - start) * 1000)
+        return UpstreamResult(
+            status=0, body=None, latency_ms=elapsed, error=_short_error(exc)
+        )
+
+
+def _short_error(exc: BaseException) -> str:
+    text = str(exc) or exc.__class__.__name__
+    return text[:200]
+
+
+def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
+    if result.error is not None:
+        return Sample(
+            ts=ts,
+            organ=organ.name,
+            ok=False,
+            latency_ms=result.latency_ms,
+            detail=result.error,
+        )
+    verdict = organ.extractor(result.status, result.body)
+    return Sample(
+        ts=ts,
+        organ=organ.name,
+        ok=verdict.ok,
+        latency_ms=result.latency_ms,
+        detail=verdict.detail,
+    )
+
+
+async def probe_all(
+    api_base: str, web_base: str, client: httpx.AsyncClient | None = None
+) -> list[Sample]:
+    """Run one round of probes for every organ.
+
+    Returns a list of samples in ORGANS order, all tagged with the same ts.
+    """
+    ts = iso_utc()
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, connect=5.0),
+            follow_redirects=True,
+            headers={"User-Agent": "pulse-monitor/0.1 (+https://coherencycoin.com)"},
+        )
+    try:
+        api_health_url = f"{api_base.rstrip('/')}/api/health"
+        api_ready_url = f"{api_base.rstrip('/')}/api/ready"
+        web_root_url = f"{web_base.rstrip('/')}/"
+
+        # Only call upstreams that actually have organs pointing at them.
+        results: dict[str, UpstreamResult] = {}
+        if organs_for_upstream(UPSTREAM_API_HEALTH):
+            results[UPSTREAM_API_HEALTH] = await _probe_upstream(
+                client, api_health_url, parse_json=True
+            )
+        if organs_for_upstream(UPSTREAM_API_READY):
+            results[UPSTREAM_API_READY] = await _probe_upstream(
+                client, api_ready_url, parse_json=True
+            )
+        if organs_for_upstream(UPSTREAM_WEB_ROOT):
+            results[UPSTREAM_WEB_ROOT] = await _probe_upstream(
+                client, web_root_url, parse_json=False
+            )
+
+        return [_apply(o, results[o.upstream], ts) for o in ORGANS]
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/pulse/pulse_app/scheduler.py
+++ b/pulse/pulse_app/scheduler.py
@@ -1,0 +1,104 @@
+"""Scheduled probe runner.
+
+APScheduler runs `probe_round` every PULSE_INTERVAL_SECONDS. Each round
+fans out probes, records samples, and reconciles silences for every organ.
+
+A separate daily job trims samples older than PULSE_RETENTION_DAYS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from pulse_app.analysis import reconcile_silences
+from pulse_app.organs import ORGANS
+from pulse_app.probe import probe_all
+from pulse_app.storage import Store, iso_utc
+
+
+logger = logging.getLogger("pulse.scheduler")
+
+
+@dataclass(frozen=True)
+class SchedulerConfig:
+    api_base: str
+    web_base: str
+    interval_seconds: int = 30
+    retention_days: int = 180
+
+
+class PulseScheduler:
+    def __init__(self, store: Store, config: SchedulerConfig) -> None:
+        self.store = store
+        self.config = config
+        self._scheduler: AsyncIOScheduler | None = None
+
+    async def probe_round(self) -> None:
+        try:
+            samples = await probe_all(self.config.api_base, self.config.web_base)
+            self.store.insert_samples(samples)
+            for organ in ORGANS:
+                try:
+                    reconcile_silences(self.store, organ.name)
+                except Exception:
+                    logger.exception(
+                        "silence reconciliation failed organ=%s", organ.name
+                    )
+            logger.info(
+                "probe_round ok samples=%d healthy=%d",
+                len(samples),
+                sum(1 for s in samples if s.ok),
+            )
+        except Exception:
+            logger.exception("probe_round crashed")
+
+    async def vacuum_round(self) -> None:
+        try:
+            cutoff = datetime.now(timezone.utc) - timedelta(
+                days=self.config.retention_days
+            )
+            deleted = self.store.delete_samples_older_than(iso_utc(cutoff))
+            if deleted:
+                logger.info("vacuum removed %d old samples", deleted)
+        except Exception:
+            logger.exception("vacuum_round crashed")
+
+    def start(self) -> None:
+        if self._scheduler is not None:
+            return
+        scheduler = AsyncIOScheduler(timezone="UTC")
+        scheduler.add_job(
+            self.probe_round,
+            trigger=IntervalTrigger(seconds=self.config.interval_seconds),
+            id="probe_round",
+            max_instances=1,
+            coalesce=True,
+            next_run_time=datetime.now(timezone.utc),
+        )
+        scheduler.add_job(
+            self.vacuum_round,
+            trigger=IntervalTrigger(hours=24),
+            id="vacuum_round",
+            max_instances=1,
+            coalesce=True,
+        )
+        scheduler.start()
+        self._scheduler = scheduler
+        logger.info(
+            "pulse scheduler started interval=%ds retention=%dd",
+            self.config.interval_seconds,
+            self.config.retention_days,
+        )
+
+    def shutdown(self) -> None:
+        if self._scheduler is None:
+            return
+        self._scheduler.shutdown(wait=False)
+        self._scheduler = None
+        logger.info("pulse scheduler stopped")

--- a/pulse/pulse_app/storage.py
+++ b/pulse/pulse_app/storage.py
@@ -1,0 +1,240 @@
+"""SQLite-backed sample store.
+
+Durability is the only reason this service exists, so we keep the storage
+layer deliberately boring: plain sqlite3, WAL mode, schema created lazily
+on first connection, short-lived connections per call. No ORM, no globals,
+no locks — SQLite in WAL handles the concurrency we need.
+
+The store is the canonical source for both current-state reads and
+historical queries. It knows nothing about HTTP or FastAPI.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Iterator
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS samples (
+  ts          TEXT    NOT NULL,
+  organ       TEXT    NOT NULL,
+  ok          INTEGER NOT NULL,
+  latency_ms  INTEGER,
+  detail      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_samples_organ_ts ON samples(organ, ts);
+CREATE INDEX IF NOT EXISTS idx_samples_ts       ON samples(ts);
+
+CREATE TABLE IF NOT EXISTS silences (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  organ       TEXT    NOT NULL,
+  started_at  TEXT    NOT NULL,
+  ended_at    TEXT,
+  severity    TEXT    NOT NULL,
+  note        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_silences_started ON silences(started_at);
+CREATE INDEX IF NOT EXISTS idx_silences_organ   ON silences(organ, started_at);
+"""
+
+
+@dataclass(frozen=True)
+class Sample:
+    ts: str          # ISO8601 UTC
+    organ: str
+    ok: bool
+    latency_ms: int | None
+    detail: str | None
+
+
+@dataclass(frozen=True)
+class SilenceRow:
+    id: int
+    organ: str
+    started_at: str
+    ended_at: str | None
+    severity: str
+    note: str | None
+
+
+def iso_utc(dt: datetime | None = None) -> str:
+    """Render a datetime as ISO8601 UTC with second precision."""
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class Store:
+    """Thread-safe sample store. Open a fresh connection per call."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        parent = os.path.dirname(os.path.abspath(path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._ensure_schema()
+
+    # --- connection helpers ------------------------------------------------
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.path, timeout=5.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA foreign_keys=ON")
+            yield conn
+        finally:
+            conn.close()
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as c:
+            c.executescript(SCHEMA_SQL)
+
+    # --- writes ------------------------------------------------------------
+
+    def insert_sample(self, sample: Sample) -> None:
+        with self._connect() as c:
+            c.execute(
+                "INSERT INTO samples (ts, organ, ok, latency_ms, detail) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    sample.ts,
+                    sample.organ,
+                    1 if sample.ok else 0,
+                    sample.latency_ms,
+                    sample.detail,
+                ),
+            )
+
+    def insert_samples(self, samples: Iterable[Sample]) -> None:
+        rows = [
+            (s.ts, s.organ, 1 if s.ok else 0, s.latency_ms, s.detail)
+            for s in samples
+        ]
+        if not rows:
+            return
+        with self._connect() as c:
+            c.executemany(
+                "INSERT INTO samples (ts, organ, ok, latency_ms, detail) "
+                "VALUES (?, ?, ?, ?, ?)",
+                rows,
+            )
+
+    def open_silence(self, organ: str, started_at: str, severity: str) -> int:
+        with self._connect() as c:
+            cur = c.execute(
+                "INSERT INTO silences (organ, started_at, severity) VALUES (?, ?, ?)",
+                (organ, started_at, severity),
+            )
+            return int(cur.lastrowid or 0)
+
+    def close_silence(self, silence_id: int, ended_at: str) -> None:
+        with self._connect() as c:
+            c.execute(
+                "UPDATE silences SET ended_at = ? WHERE id = ? AND ended_at IS NULL",
+                (ended_at, silence_id),
+            )
+
+    def escalate_silence(self, silence_id: int, severity: str) -> None:
+        with self._connect() as c:
+            c.execute(
+                "UPDATE silences SET severity = ? WHERE id = ?",
+                (severity, silence_id),
+            )
+
+    def delete_samples_older_than(self, cutoff_iso: str) -> int:
+        with self._connect() as c:
+            cur = c.execute("DELETE FROM samples WHERE ts < ?", (cutoff_iso,))
+            return cur.rowcount or 0
+
+    # --- reads -------------------------------------------------------------
+
+    def last_sample_for_organ(self, organ: str) -> Sample | None:
+        with self._connect() as c:
+            row = c.execute(
+                "SELECT ts, organ, ok, latency_ms, detail FROM samples "
+                "WHERE organ = ? ORDER BY ts DESC LIMIT 1",
+                (organ,),
+            ).fetchone()
+        return _row_to_sample(row) if row else None
+
+    def recent_samples_for_organ(self, organ: str, limit: int) -> list[Sample]:
+        with self._connect() as c:
+            rows = c.execute(
+                "SELECT ts, organ, ok, latency_ms, detail FROM samples "
+                "WHERE organ = ? ORDER BY ts DESC LIMIT ?",
+                (organ, limit),
+            ).fetchall()
+        # Reverse to chronological order for analysis.
+        return [_row_to_sample(r) for r in reversed(rows)]
+
+    def samples_for_organ_since(self, organ: str, since_iso: str) -> list[Sample]:
+        with self._connect() as c:
+            rows = c.execute(
+                "SELECT ts, organ, ok, latency_ms, detail FROM samples "
+                "WHERE organ = ? AND ts >= ? ORDER BY ts ASC",
+                (organ, since_iso),
+            ).fetchall()
+        return [_row_to_sample(r) for r in rows]
+
+    def count_samples(self) -> int:
+        with self._connect() as c:
+            row = c.execute("SELECT COUNT(*) AS n FROM samples").fetchone()
+        return int(row["n"]) if row else 0
+
+    def ongoing_silences(self) -> list[SilenceRow]:
+        with self._connect() as c:
+            rows = c.execute(
+                "SELECT id, organ, started_at, ended_at, severity, note "
+                "FROM silences WHERE ended_at IS NULL ORDER BY started_at ASC"
+            ).fetchall()
+        return [_row_to_silence(r) for r in rows]
+
+    def ongoing_silence_for_organ(self, organ: str) -> SilenceRow | None:
+        with self._connect() as c:
+            row = c.execute(
+                "SELECT id, organ, started_at, ended_at, severity, note "
+                "FROM silences WHERE organ = ? AND ended_at IS NULL "
+                "ORDER BY started_at DESC LIMIT 1",
+                (organ,),
+            ).fetchone()
+        return _row_to_silence(row) if row else None
+
+    def silences_since(self, since_iso: str) -> list[SilenceRow]:
+        with self._connect() as c:
+            rows = c.execute(
+                "SELECT id, organ, started_at, ended_at, severity, note "
+                "FROM silences "
+                "WHERE started_at >= ? OR ended_at IS NULL "
+                "ORDER BY started_at DESC",
+                (since_iso,),
+            ).fetchall()
+        return [_row_to_silence(r) for r in rows]
+
+
+def _row_to_sample(row: sqlite3.Row) -> Sample:
+    return Sample(
+        ts=row["ts"],
+        organ=row["organ"],
+        ok=bool(row["ok"]),
+        latency_ms=row["latency_ms"],
+        detail=row["detail"],
+    )
+
+
+def _row_to_silence(row: sqlite3.Row) -> SilenceRow:
+    return SilenceRow(
+        id=int(row["id"]),
+        organ=row["organ"],
+        started_at=row["started_at"],
+        ended_at=row["ended_at"],
+        severity=row["severity"],
+        note=row["note"],
+    )

--- a/pulse/pyproject.toml
+++ b/pulse/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pulse"
+version = "0.1.0"
+description = "Pulse Monitor — the witness that remembers the breath of Coherence Network."
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.27",
+  "httpx>=0.27",
+  "apscheduler>=3.10",
+  "pydantic>=2.6",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-asyncio>=0.23",
+  "respx>=0.21",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pulse_app*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/pulse/tests/test_analysis.py
+++ b/pulse/tests/test_analysis.py
@@ -1,0 +1,180 @@
+"""Analysis tests — silence derivation, daily rollup, uptime %."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from pulse_app.analysis import (
+    overall_status,
+    reconcile_silences,
+    rollup_daily,
+    status_from_last_sample,
+    uptime_percent,
+)
+from pulse_app.storage import Sample, Store, iso_utc
+
+
+def _s(organ: str, ok: bool, minutes_ago: int) -> Sample:
+    dt = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return Sample(
+        ts=iso_utc(dt),
+        organ=organ,
+        ok=ok,
+        latency_ms=10,
+        detail=None if ok else "fail",
+    )
+
+
+# --- uptime percent -------------------------------------------------------
+
+def test_uptime_percent_all_ok():
+    samples = [_s("api", True, m) for m in (5, 4, 3, 2, 1)]
+    assert uptime_percent(samples) == 100.0
+
+
+def test_uptime_percent_all_bad():
+    samples = [_s("api", False, m) for m in (5, 4, 3, 2, 1)]
+    assert uptime_percent(samples) == 0.0
+
+
+def test_uptime_percent_mixed():
+    samples = [_s("api", True, 5), _s("api", True, 4), _s("api", False, 3), _s("api", True, 2)]
+    assert uptime_percent(samples) == 75.0
+
+
+def test_uptime_percent_empty():
+    assert uptime_percent([]) == 0.0
+
+
+# --- status_from_last_sample ---------------------------------------------
+
+def test_status_last_sample_none_is_unknown():
+    assert status_from_last_sample(None) == "unknown"
+
+
+def test_status_last_sample_ok():
+    assert status_from_last_sample(_s("api", True, 0)) == "breathing"
+
+
+def test_status_last_sample_bad():
+    assert status_from_last_sample(_s("api", False, 0)) == "silent"
+
+
+# --- overall_status -------------------------------------------------------
+
+def test_overall_all_breathing():
+    assert overall_status(["breathing", "breathing", "breathing"]) == "breathing"
+
+
+def test_overall_one_silent():
+    assert overall_status(["breathing", "silent", "breathing"]) == "silent"
+
+
+def test_overall_one_strained_no_silent():
+    assert overall_status(["breathing", "strained", "breathing"]) == "strained"
+
+
+def test_overall_all_unknown():
+    assert overall_status(["unknown", "unknown"]) == "unknown"
+
+
+def test_overall_empty():
+    assert overall_status([]) == "unknown"
+
+
+# --- daily rollup ---------------------------------------------------------
+
+def test_rollup_produces_requested_day_count():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    samples: list[Sample] = []
+    buckets = rollup_daily(samples, days=7, now=now)
+    assert len(buckets) == 7
+    # Dates are chronological, ending on today.
+    dates = [b.date for b in buckets]
+    assert dates == sorted(dates)
+    assert dates[-1] == "2026-04-15"
+
+
+def test_rollup_counts_samples_and_failures():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    # Today: 2 ok, 1 bad. Yesterday: 1 ok.
+    samples = [
+        Sample(ts="2026-04-15T10:00:00Z", organ="api", ok=True, latency_ms=10, detail=None),
+        Sample(ts="2026-04-15T11:00:00Z", organ="api", ok=True, latency_ms=10, detail=None),
+        Sample(ts="2026-04-15T11:30:00Z", organ="api", ok=False, latency_ms=10, detail="x"),
+        Sample(ts="2026-04-14T09:00:00Z", organ="api", ok=True, latency_ms=10, detail=None),
+    ]
+    buckets = rollup_daily(samples, days=2, now=now)
+    by_date = {b.date: b for b in buckets}
+    assert by_date["2026-04-14"].samples == 1
+    assert by_date["2026-04-14"].failures == 0
+    assert by_date["2026-04-14"].status == "breathing"
+    assert by_date["2026-04-15"].samples == 3
+    assert by_date["2026-04-15"].failures == 1
+    # 1/3 failures < half, so strained not silent.
+    assert by_date["2026-04-15"].status == "strained"
+
+
+def test_rollup_empty_days_are_unknown():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    buckets = rollup_daily([], days=3, now=now)
+    for b in buckets:
+        assert b.status == "unknown"
+        assert b.samples == 0
+
+
+def test_rollup_half_or_more_failures_is_silent():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    samples = [
+        Sample(ts="2026-04-15T09:00:00Z", organ="api", ok=False, latency_ms=10, detail="x"),
+        Sample(ts="2026-04-15T10:00:00Z", organ="api", ok=False, latency_ms=10, detail="x"),
+        Sample(ts="2026-04-15T11:00:00Z", organ="api", ok=True, latency_ms=10, detail=None),
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    assert buckets[0].status == "silent"
+
+
+# --- reconcile_silences ---------------------------------------------------
+
+def test_reconcile_opens_silence_after_three_failures(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    # Insert 3 consecutive failures, no prior history.
+    for m in (3, 2, 1):
+        store.insert_sample(_s("api", False, m))
+    reconcile_silences(store, "api")
+    ongoing = store.ongoing_silence_for_organ("api")
+    assert ongoing is not None
+    assert ongoing.severity == "strained"
+
+
+def test_reconcile_does_not_open_on_two_failures(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    for m in (2, 1):
+        store.insert_sample(_s("api", False, m))
+    reconcile_silences(store, "api")
+    assert store.ongoing_silence_for_organ("api") is None
+
+
+def test_reconcile_closes_silence_after_three_successes(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    # First open a silence.
+    for m in (10, 9, 8):
+        store.insert_sample(_s("api", False, m))
+    reconcile_silences(store, "api")
+    assert store.ongoing_silence_for_organ("api") is not None
+    # Now a clean run.
+    for m in (3, 2, 1):
+        store.insert_sample(_s("api", True, m))
+    reconcile_silences(store, "api")
+    assert store.ongoing_silence_for_organ("api") is None
+
+
+def test_reconcile_single_success_does_not_close(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    for m in (10, 9, 8):
+        store.insert_sample(_s("api", False, m))
+    reconcile_silences(store, "api")
+    # Only one success — not enough.
+    store.insert_sample(_s("api", True, 1))
+    reconcile_silences(store, "api")
+    assert store.ongoing_silence_for_organ("api") is not None

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -1,0 +1,160 @@
+"""Probe layer tests — mock transport for httpx, no real network."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from pulse_app.probe import probe_all
+
+
+HEALTHY_HEALTH = {
+    "status": "ok",
+    "version": "1.0.0",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "started_at": "2026-04-14T12:00:00Z",
+    "uptime_seconds": 86400,
+    "uptime_human": "1d 0h 0m 0s",
+    "deployed_sha": "deadbeef",
+    "deployed_sha_source": "GIT_COMMIT_SHA",
+    "integrity_compromised": False,
+    "schema_ok": True,
+    "opencode_enabled": True,
+    "smart_reap_available": True,
+    "smart_reap_import_error": None,
+}
+
+HEALTHY_READY = {
+    "status": "ready",
+    "version": "1.0.0",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "started_at": "2026-04-14T12:00:00Z",
+    "uptime_seconds": 86400,
+    "uptime_human": "1d 0h 0m 0s",
+    "deployed_sha": "deadbeef",
+    "deployed_sha_source": "GIT_COMMIT_SHA",
+    "db_connected": True,
+    "integrity_compromised": False,
+}
+
+
+def _handler(api_health_body=None, ready_body=None, ready_status=200, web_status=200):
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/health":
+            return httpx.Response(
+                200,
+                content=json.dumps(api_health_body or HEALTHY_HEALTH),
+                headers={"content-type": "application/json"},
+            )
+        if path == "/api/ready":
+            return httpx.Response(
+                ready_status,
+                content=json.dumps(ready_body or HEALTHY_READY),
+                headers={"content-type": "application/json"},
+            )
+        if path == "/":
+            return httpx.Response(web_status, content="<html></html>")
+        return httpx.Response(404, content="not found")
+
+    return handler
+
+
+async def _run(handler) -> dict[str, object]:
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        samples = await probe_all("http://api.test", "http://web.test", client=client)
+    return {s.organ: s for s in samples}
+
+
+@pytest.mark.asyncio
+async def test_all_healthy():
+    by = await _run(_handler())
+    assert set(by.keys()) == {"api", "web", "postgres", "neo4j", "schema", "audit_integrity"}
+    for s in by.values():
+        assert s.ok is True, f"{s.organ} not ok: {s.detail}"
+
+
+@pytest.mark.asyncio
+async def test_api_status_not_ok():
+    bad = {**HEALTHY_HEALTH, "status": "degraded"}
+    by = await _run(_handler(api_health_body=bad))
+    assert by["api"].ok is False
+    # Schema and audit still read from same body — they should still be OK.
+    assert by["schema"].ok is True
+    assert by["audit_integrity"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_integrity_compromised_flags_audit_only():
+    bad = {**HEALTHY_HEALTH, "integrity_compromised": True}
+    by = await _run(_handler(api_health_body=bad))
+    assert by["api"].ok is True         # status=="ok" still
+    assert by["audit_integrity"].ok is False
+    assert "integrity" in (by["audit_integrity"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_schema_not_ok():
+    bad = {**HEALTHY_HEALTH, "schema_ok": False}
+    by = await _run(_handler(api_health_body=bad))
+    assert by["schema"].ok is False
+    assert by["api"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_ready_503_graph_store_missing_flags_neo4j():
+    # FastAPI HTTPException with plain detail='not ready' when graph_store is None.
+    body = {"detail": "not ready"}
+    by = await _run(_handler(ready_status=503, ready_body=body))
+    assert by["neo4j"].ok is False
+    assert "graph_store" in (by["neo4j"].detail or "")
+    # API organ reads a different upstream, so it's unaffected.
+    assert by["api"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_ready_503_persistence_contract_flags_postgres_not_neo4j():
+    # The real shape seen in prod: detail is a dict with persistence_contract_failed.
+    body = {
+        "detail": {
+            "error": "persistence_contract_failed",
+            "failures": ["some_domain_not_postgresql"],
+            "domains": {},
+        }
+    }
+    by = await _run(_handler(ready_status=503, ready_body=body))
+    assert by["postgres"].ok is False
+    assert "persistence" in (by["postgres"].detail or "")
+    # neo4j is not implicated by this 503 cause.
+    assert by["neo4j"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_db_disconnected_flags_postgres_only():
+    bad = {**HEALTHY_READY, "db_connected": False}
+    by = await _run(_handler(ready_body=bad))
+    assert by["postgres"].ok is False
+    assert by["neo4j"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_web_down():
+    by = await _run(_handler(web_status=503))
+    assert by["web"].ok is False
+    assert by["api"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_network_error_marks_everything_down():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("could not connect")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        samples = await probe_all("http://api.test", "http://web.test", client=client)
+    for s in samples:
+        assert s.ok is False
+        assert s.detail is not None

--- a/pulse/tests/test_storage.py
+++ b/pulse/tests/test_storage.py
@@ -1,0 +1,114 @@
+"""Storage layer tests — fresh DB per test, no fixtures beyond tmp_path."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from pulse_app.storage import Sample, Store, iso_utc
+
+
+def _mk_sample(
+    organ: str, ok: bool, minutes_ago: int, latency_ms: int = 42
+) -> Sample:
+    dt = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+    return Sample(
+        ts=iso_utc(dt),
+        organ=organ,
+        ok=ok,
+        latency_ms=latency_ms,
+        detail=None if ok else "synthetic failure",
+    )
+
+
+def test_schema_created_on_first_open(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    # Smoke: count_samples succeeds on an empty fresh DB.
+    assert store.count_samples() == 0
+
+
+def test_insert_and_count(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    store.insert_sample(_mk_sample("api", True, 1))
+    store.insert_sample(_mk_sample("api", False, 0))
+    assert store.count_samples() == 2
+
+
+def test_insert_samples_batch(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    batch = [
+        _mk_sample("api", True, 3),
+        _mk_sample("web", True, 3),
+        _mk_sample("postgres", False, 3),
+    ]
+    store.insert_samples(batch)
+    assert store.count_samples() == 3
+
+
+def test_last_sample_for_organ(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    store.insert_sample(_mk_sample("api", True, 5))
+    store.insert_sample(_mk_sample("api", False, 1))  # more recent
+    store.insert_sample(_mk_sample("web", True, 2))
+
+    last_api = store.last_sample_for_organ("api")
+    assert last_api is not None
+    assert last_api.ok is False
+    assert last_api.organ == "api"
+
+    last_web = store.last_sample_for_organ("web")
+    assert last_web is not None
+    assert last_web.ok is True
+
+
+def test_last_sample_none_when_missing(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    assert store.last_sample_for_organ("ghost") is None
+
+
+def test_recent_samples_chronological(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    for m in (10, 8, 6, 4, 2):
+        store.insert_sample(_mk_sample("api", True, m))
+    recent = store.recent_samples_for_organ("api", limit=3)
+    assert len(recent) == 3
+    # Chronological (oldest first) — so later indices are more recent.
+    assert recent[0].ts < recent[1].ts < recent[2].ts
+
+
+def test_samples_since_window(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    for m in (120, 60, 30, 5):  # minutes ago
+        store.insert_sample(_mk_sample("api", True, m))
+    since = iso_utc(datetime.now(timezone.utc) - timedelta(minutes=45))
+    got = store.samples_for_organ_since("api", since)
+    assert len(got) == 2  # the 30-min and 5-min ones
+
+
+def test_silence_open_close_roundtrip(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    started = iso_utc()
+    sid = store.open_silence("api", started, "strained")
+    assert sid > 0
+
+    # Ongoing read
+    ongoing = store.ongoing_silence_for_organ("api")
+    assert ongoing is not None and ongoing.id == sid and ongoing.ended_at is None
+
+    # Escalate
+    store.escalate_silence(sid, "silent")
+    ongoing2 = store.ongoing_silence_for_organ("api")
+    assert ongoing2 is not None and ongoing2.severity == "silent"
+
+    # Close
+    store.close_silence(sid, iso_utc())
+    assert store.ongoing_silence_for_organ("api") is None
+
+
+def test_delete_samples_older_than(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    store.insert_sample(_mk_sample("api", True, 60 * 24 * 200))  # ~200d ago
+    store.insert_sample(_mk_sample("api", True, 60 * 24 * 10))   # ~10d ago
+    cutoff = iso_utc(datetime.now(timezone.utc) - timedelta(days=100))
+    deleted = store.delete_samples_older_than(cutoff)
+    assert deleted == 1
+    assert store.count_samples() == 1

--- a/web/app/identity/keys/page.tsx
+++ b/web/app/identity/keys/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+/**
+ * /identity/keys — mint, list, and revoke personal API keys.
+ *
+ * This is a power-user / operator surface. It deliberately does not try
+ * to own "who is logged in" for the whole web app — there is no session
+ * state yet and keys are paste-driven.
+ *
+ * Two panels:
+ *
+ * 1. Mint — form producing a `cc_*` key. Raw key displayed ONCE with
+ *    copy-to-clipboard. After the page refreshes, the raw key is gone.
+ *
+ * 2. List / revoke — paste your active key, fetch `/api/auth/keys` with
+ *    it, then revoke individual keys with a button. Active key is
+ *    remembered in sessionStorage so it survives in-tab navigation but
+ *    never touches localStorage or a server.
+ */
+
+type KeyListItem = {
+  id: string;
+  contributor_id: string;
+  label: string | null;
+  fingerprint: string;
+  provider: string | null;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+};
+
+type MintResponse = {
+  api_key: string;
+  contributor_id: string;
+  created_at: string;
+  scopes: string[];
+  label: string | null;
+};
+
+const ACTIVE_KEY_STORAGE = "coherence.pulse.active_key";
+
+export default function KeysPage() {
+  const api = getApiBase();
+
+  // --- Mint form state -------------------------------------------------
+  const [contributorId, setContributorId] = useState("");
+  const [label, setLabel] = useState("");
+  const [minting, setMinting] = useState(false);
+  const [mintError, setMintError] = useState<string | null>(null);
+  const [mintedOnce, setMintedOnce] = useState<MintResponse | null>(null);
+
+  // --- Active (listing) key state -------------------------------------
+  const [activeKey, setActiveKey] = useState("");
+  const [keys, setKeys] = useState<KeyListItem[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [listing, setListing] = useState(false);
+
+  // Restore last active key from sessionStorage on mount.
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem(ACTIVE_KEY_STORAGE) ?? "";
+      if (stored) setActiveKey(stored);
+    } catch {
+      // sessionStorage may be unavailable (SSR, privacy mode) — fine.
+    }
+  }, []);
+
+  const persistActiveKey = useCallback((value: string) => {
+    setActiveKey(value);
+    try {
+      if (value) {
+        sessionStorage.setItem(ACTIVE_KEY_STORAGE, value);
+      } else {
+        sessionStorage.removeItem(ACTIVE_KEY_STORAGE);
+      }
+    } catch {}
+  }, []);
+
+  // --- Mint -----------------------------------------------------------
+  const mint = useCallback(async () => {
+    if (!contributorId.trim()) {
+      setMintError("Contributor id is required");
+      return;
+    }
+    setMinting(true);
+    setMintError(null);
+    setMintedOnce(null);
+    try {
+      const res = await fetch(`${api}/api/auth/keys`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          contributor_id: contributorId.trim(),
+          provider: "name",
+          provider_id: contributorId.trim(),
+          label: label.trim() || null,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`${res.status} ${res.statusText}: ${text || "mint failed"}`);
+      }
+      const body = (await res.json()) as MintResponse;
+      setMintedOnce(body);
+      // Optionally make this the active key so the user can immediately list.
+      persistActiveKey(body.api_key);
+      setKeys(null); // force a fresh fetch
+    } catch (err) {
+      setMintError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMinting(false);
+    }
+  }, [api, contributorId, label, persistActiveKey]);
+
+  // --- List -----------------------------------------------------------
+  const list = useCallback(async () => {
+    if (!activeKey.trim()) {
+      setListError("Paste a verified API key to list your keys.");
+      return;
+    }
+    setListing(true);
+    setListError(null);
+    try {
+      const res = await fetch(`${api}/api/auth/keys`, {
+        headers: { Authorization: `Bearer ${activeKey.trim()}` },
+        cache: "no-store",
+      });
+      if (res.status === 401) {
+        throw new Error("Key was rejected. It may be revoked or not yet minted.");
+      }
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`${res.status} ${res.statusText}: ${text || "list failed"}`);
+      }
+      const body = (await res.json()) as { keys: KeyListItem[] };
+      setKeys(body.keys);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : String(err));
+      setKeys(null);
+    } finally {
+      setListing(false);
+    }
+  }, [api, activeKey]);
+
+  // --- Revoke ---------------------------------------------------------
+  const revoke = useCallback(
+    async (keyId: string) => {
+      if (!activeKey.trim()) return;
+      if (!confirm("Revoke this key? This cannot be undone.")) return;
+      try {
+        const res = await fetch(`${api}/api/auth/keys/${keyId}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${activeKey.trim()}` },
+        });
+        if (res.status !== 204 && !res.ok) {
+          const text = await res.text();
+          throw new Error(`${res.status} ${res.statusText}: ${text || "revoke failed"}`);
+        }
+        // Refresh the list.
+        await list();
+      } catch (err) {
+        setListError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [api, activeKey, list],
+  );
+
+  const copyToClipboard = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Best effort only.
+    }
+  }, []);
+
+  return (
+    <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-8 max-w-4xl mx-auto space-y-8">
+      <header className="space-y-2">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Link href="/identity" className="hover:underline">
+            ← Identity
+          </Link>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight">API Keys</h1>
+        <p className="max-w-2xl text-muted-foreground leading-relaxed">
+          Personal keys the network uses to attribute your contributions —
+          the other half of the nervous system alongside{" "}
+          <Link href="/pulse" className="text-emerald-400 hover:underline">
+            Pulse
+          </Link>
+          . A verified key tells the body <em>who is moving</em>. If you
+          only want to claim attribution without proving it, send{" "}
+          <code className="text-xs px-1.5 py-0.5 rounded bg-muted/60">
+            X-Contributor-Id: your-handle
+          </code>{" "}
+          on any request — the server will mark it as{" "}
+          <span className="text-amber-400">claimed</span> rather than{" "}
+          <span className="text-emerald-400">verified</span>.
+        </p>
+      </header>
+
+      {/* --- Mint panel --- */}
+      <section className="rounded-2xl border border-border/40 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-4">
+        <h2 className="text-lg font-medium">Mint a new key</h2>
+        <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] items-end">
+          <label className="space-y-1">
+            <span className="text-xs uppercase tracking-wider text-muted-foreground">
+              Contributor ID
+            </span>
+            <input
+              value={contributorId}
+              onChange={(e) => setContributorId(e.target.value)}
+              placeholder="alice"
+              autoComplete="off"
+              className="w-full rounded-lg border border-border/40 bg-background/60 px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs uppercase tracking-wider text-muted-foreground">
+              Label (optional)
+            </span>
+            <input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="laptop"
+              autoComplete="off"
+              className="w-full rounded-lg border border-border/40 bg-background/60 px-3 py-2 text-sm"
+            />
+          </label>
+          <button
+            onClick={mint}
+            disabled={minting}
+            className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-300 hover:bg-emerald-500/20 disabled:opacity-50"
+          >
+            {minting ? "Minting…" : "Mint"}
+          </button>
+        </div>
+        {mintError && (
+          <p className="text-sm text-rose-400 font-mono">{mintError}</p>
+        )}
+
+        {mintedOnce && (
+          <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-4 space-y-2">
+            <p className="text-xs uppercase tracking-wider text-amber-300">
+              Save this now — this is the only time you will see it
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 font-mono text-xs bg-background/40 rounded-md px-3 py-2 break-all">
+                {mintedOnce.api_key}
+              </code>
+              <button
+                onClick={() => copyToClipboard(mintedOnce.api_key)}
+                className="rounded-lg border border-border/40 px-3 py-2 text-xs hover:bg-accent/60"
+              >
+                Copy
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Contributor: {mintedOnce.contributor_id} · Scopes:{" "}
+              {mintedOnce.scopes.join(", ")}
+            </p>
+          </div>
+        )}
+      </section>
+
+      {/* --- List + revoke panel --- */}
+      <section className="rounded-2xl border border-border/40 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-4">
+        <div className="flex items-baseline justify-between flex-wrap gap-2">
+          <h2 className="text-lg font-medium">Your active keys</h2>
+          <p className="text-xs text-muted-foreground">
+            Remembered in this tab only (sessionStorage)
+          </p>
+        </div>
+        <div className="flex gap-2 items-end">
+          <label className="flex-1 space-y-1">
+            <span className="text-xs uppercase tracking-wider text-muted-foreground">
+              Paste a verified key to list and revoke
+            </span>
+            <input
+              type="password"
+              value={activeKey}
+              onChange={(e) => persistActiveKey(e.target.value)}
+              placeholder="cc_alice_..."
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-lg border border-border/40 bg-background/60 px-3 py-2 text-sm font-mono"
+            />
+          </label>
+          <button
+            onClick={list}
+            disabled={listing || !activeKey.trim()}
+            className="rounded-lg border border-blue-500/40 bg-blue-500/10 px-4 py-2 text-sm text-blue-300 hover:bg-blue-500/20 disabled:opacity-50"
+          >
+            {listing ? "Listing…" : "List"}
+          </button>
+        </div>
+        {listError && <p className="text-sm text-rose-400 font-mono">{listError}</p>}
+
+        {keys && (
+          <div className="space-y-2">
+            {keys.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No active keys for this contributor.
+              </p>
+            )}
+            {keys.map((k) => (
+              <div
+                key={k.id}
+                className="flex items-center gap-3 rounded-xl border border-border/30 bg-background/30 px-4 py-3"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">
+                    {k.label || "(no label)"}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground font-mono">
+                    {k.fingerprint} · {k.contributor_id}
+                    {k.provider && ` · ${k.provider}`}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    Created {new Date(k.created_at).toLocaleString()}
+                    {k.last_used_at &&
+                      ` · Last used ${new Date(k.last_used_at).toLocaleString()}`}
+                  </p>
+                </div>
+                <button
+                  onClick={() => revoke(k.id)}
+                  className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-1.5 text-xs text-rose-300 hover:bg-rose-500/20"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* --- Footer nav --- */}
+      <nav
+        className="py-8 text-center space-y-2 border-t border-border/20"
+        aria-label="Related pages"
+      >
+        <p className="text-xs text-muted-foreground/80 uppercase tracking-wider">
+          Related
+        </p>
+        <div className="flex flex-wrap justify-center gap-4 text-sm">
+          <Link href="/identity" className="text-purple-400 hover:underline">
+            Identity providers
+          </Link>
+          <Link href="/pulse" className="text-emerald-400 hover:underline">
+            Pulse
+          </Link>
+          <Link href="/vitality" className="text-blue-400 hover:underline">
+            Vitality
+          </Link>
+        </div>
+      </nav>
+    </main>
+  );
+}

--- a/web/app/identity/page.tsx
+++ b/web/app/identity/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { getApiBase } from "@/lib/api";
 
 const API = getApiBase();
@@ -253,12 +254,28 @@ export default function IdentityPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-8 space-y-8">
-      <header>
-        <h1 className="text-3xl font-bold tracking-tight mb-2">Your Identity</h1>
+      <header className="space-y-3">
+        <h1 className="text-3xl font-bold tracking-tight">Your Identity</h1>
         <p className="text-muted-foreground max-w-2xl leading-relaxed">
           Link your accounts to get credit for your contributions across platforms.
           Nothing here is required &mdash; use whatever feels natural.
         </p>
+        <div className="flex flex-wrap gap-3 text-sm">
+          <Link
+            href="/identity/keys"
+            className="inline-flex items-center gap-1.5 rounded-full border border-purple-500/40 bg-purple-500/5 px-3 py-1 text-purple-300 hover:bg-purple-500/10 transition-colors"
+          >
+            <span>API keys</span>
+            <span aria-hidden="true">→</span>
+          </Link>
+          <Link
+            href="/pulse"
+            className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/5 px-3 py-1 text-emerald-300 hover:bg-emerald-500/10 transition-colors"
+          >
+            <span>Pulse</span>
+            <span aria-hidden="true">→</span>
+          </Link>
+        </div>
       </header>
 
       {message && (

--- a/web/app/pulse/organ-row.tsx
+++ b/web/app/pulse/organ-row.tsx
@@ -1,0 +1,95 @@
+import type { OrganHistory, OrganNow } from "./types";
+import { STATUS_BAR, STATUS_DOT, STATUS_LABEL, STATUS_TEXT } from "./status-tokens";
+
+/**
+ * One organ, one row. Current status dot on the left, label and uptime %
+ * in the middle, a 90-day bar chart on the right. The bars are plain
+ * CSS grid divs — no charting library — so this component has zero JS cost.
+ */
+export function OrganRow({
+  now,
+  history,
+}: {
+  now: OrganNow | undefined;
+  history: OrganHistory;
+}) {
+  const currentStatus = now?.status ?? "unknown";
+  const uptime = history.uptime_pct;
+  const uptimeLabel =
+    history.daily.every((d) => d.samples === 0)
+      ? "—"
+      : `${uptime.toFixed(uptime === 100 ? 0 : 2)}%`;
+
+  return (
+    <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full ${STATUS_DOT[currentStatus]}`}
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <h3 className="text-base font-medium truncate">{history.label}</h3>
+            <p className="text-xs text-muted-foreground truncate">
+              {history.description}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-4 text-right flex-shrink-0">
+          <div>
+            <p className={`text-2xl font-light ${STATUS_TEXT[currentStatus]}`}>
+              {uptimeLabel}
+            </p>
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              steady breath · {history.daily.length}d
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Daily bars */}
+      <div>
+        <div
+          className="flex items-end gap-[2px] h-8"
+          role="img"
+          aria-label={`${history.label} daily breath over ${history.daily.length} days`}
+        >
+          {history.daily.map((d) => (
+            <div
+              key={d.date}
+              className={`flex-1 min-w-[3px] rounded-sm ${STATUS_BAR[d.status]} hover:opacity-100 opacity-90 transition-opacity`}
+              style={{ height: d.samples === 0 ? "35%" : "100%" }}
+              title={`${d.date} · ${STATUS_LABEL[d.status]}${
+                d.samples > 0
+                  ? ` · ${d.samples} sample${d.samples > 1 ? "s" : ""}, ${d.failures} failure${d.failures === 1 ? "" : "s"}`
+                  : " · no samples"
+              }`}
+            />
+          ))}
+        </div>
+        <div className="flex items-center justify-between mt-1 text-[10px] text-muted-foreground/60">
+          <span>{formatDateLabel(history.daily[0]?.date)}</span>
+          <span>today</span>
+        </div>
+      </div>
+
+      {/* Detail line when not breathing */}
+      {now && now.detail && currentStatus !== "breathing" && (
+        <p className="text-xs text-rose-300/90 font-mono bg-rose-500/5 rounded-lg px-3 py-2">
+          {now.detail}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function formatDateLabel(dateStr: string | undefined): string {
+  if (!dateStr) return "";
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  } catch {
+    return dateStr;
+  }
+}

--- a/web/app/pulse/overall-banner.tsx
+++ b/web/app/pulse/overall-banner.tsx
@@ -1,0 +1,87 @@
+import type { BreathStatus, OngoingSilence } from "./types";
+import { STATUS_BANNER, STATUS_DOT, STATUS_LABEL, formatDuration } from "./status-tokens";
+
+const HEADLINE: Record<BreathStatus, string> = {
+  breathing: "All organs breathing",
+  strained: "Something is strained",
+  silent: "Something has gone silent",
+  unknown: "The witness has nothing to say",
+};
+
+const SUBTITLE: Record<BreathStatus, string> = {
+  breathing:
+    "Every organ responded within the last probe window. The body is whole.",
+  strained:
+    "At least one organ is returning intermittent failures. Listening more closely.",
+  silent:
+    "At least one organ has stopped responding. The body is not whole right now.",
+  unknown:
+    "The witness has no samples yet — it may have just started, or it may be quiet itself.",
+};
+
+export function OverallBanner({
+  overall,
+  checkedAt,
+  ongoing,
+}: {
+  overall: BreathStatus;
+  checkedAt: string;
+  ongoing: OngoingSilence[];
+}) {
+  const tokens = STATUS_BANNER[overall];
+  const checked = new Date(checkedAt);
+
+  return (
+    <section
+      className={`rounded-3xl border ${tokens.border} bg-gradient-to-b ${tokens.bg} p-8 shadow-lg ${tokens.glow}`}
+      aria-label="Overall pulse"
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className={`relative inline-flex h-3 w-3 rounded-full ${STATUS_DOT[overall]}`}
+          aria-hidden="true"
+        >
+          {overall === "breathing" && (
+            <span className="absolute inset-0 animate-ping rounded-full bg-emerald-400/40" />
+          )}
+        </span>
+        <p className="text-xs uppercase tracking-widest text-muted-foreground">
+          {STATUS_LABEL[overall]}
+        </p>
+      </div>
+      <h2 className={`mt-3 text-3xl font-light tracking-tight ${tokens.text}`}>
+        {HEADLINE[overall]}
+      </h2>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground leading-relaxed">
+        {SUBTITLE[overall]}
+      </p>
+      <p className="mt-4 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+        Listened at {checked.toLocaleString()}
+      </p>
+
+      {ongoing.length > 0 && (
+        <div className="mt-6 rounded-xl border border-border/40 bg-background/40 p-4 space-y-2">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">
+            Ongoing silence{ongoing.length > 1 ? "s" : ""}
+          </p>
+          <ul className="space-y-1.5 text-sm">
+            {ongoing.map((s) => (
+              <li key={s.id} className="flex items-center gap-2">
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${
+                    s.severity === "silent" ? "bg-rose-500" : "bg-amber-500"
+                  }`}
+                  aria-hidden="true"
+                />
+                <span className="font-medium">{s.organ}</span>
+                <span className="text-muted-foreground">
+                  — quiet for {formatDuration(s.duration_seconds)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/app/pulse/page.tsx
+++ b/web/app/pulse/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { getPulseBaseServer } from "@/lib/pulse-server";
+
+import { OrganRow } from "./organ-row";
+import { OverallBanner } from "./overall-banner";
+import { SilenceList } from "./silence-list";
+import { WitnessQuiet } from "./witness-quiet";
+import type { PulseHistory, PulseNow, PulseSilences } from "./types";
+
+export const metadata: Metadata = {
+  title: "Pulse",
+  description:
+    "The breath of our living body, remembered. Uptime, silences, and the pulse of Coherence Network's organs.",
+};
+
+// Re-render at most once per minute. The witness probes every 30s, so
+// anything finer is wasted work.
+export const revalidate = 60;
+
+const DAYS = 90;
+
+type PulseSnapshot = {
+  now: PulseNow | null;
+  history: PulseHistory | null;
+  silences: PulseSilences | null;
+};
+
+async function loadPulse(base: string): Promise<PulseSnapshot> {
+  if (!base) return { now: null, history: null, silences: null };
+
+  const opts: RequestInit = { cache: "no-store" };
+  const urls = [
+    `${base}/pulse/now`,
+    `${base}/pulse/history?days=${DAYS}`,
+    `${base}/pulse/silences?days=${DAYS}`,
+  ];
+
+  try {
+    const responses = await Promise.all(
+      urls.map((u) =>
+        fetch(u, opts).catch((err) => {
+          console.warn(`[pulse] fetch failed: ${u}`, err);
+          return null;
+        }),
+      ),
+    );
+    const [nowRes, historyRes, silencesRes] = responses;
+
+    const now = nowRes && nowRes.ok ? ((await nowRes.json()) as PulseNow) : null;
+    const history =
+      historyRes && historyRes.ok
+        ? ((await historyRes.json()) as PulseHistory)
+        : null;
+    const silences =
+      silencesRes && silencesRes.ok
+        ? ((await silencesRes.json()) as PulseSilences)
+        : null;
+
+    return { now, history, silences };
+  } catch (err) {
+    console.warn("[pulse] loadPulse crashed", err);
+    return { now: null, history: null, silences: null };
+  }
+}
+
+export default async function PulsePage() {
+  const pulseBase = getPulseBaseServer();
+  const { now, history, silences } = await loadPulse(pulseBase);
+  const witnessAlive = now !== null && history !== null;
+
+  const organsNowByName = new Map(
+    (now?.organs ?? []).map((o) => [o.name, o]),
+  );
+
+  return (
+    <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-8 max-w-5xl mx-auto space-y-8">
+      {/* Header */}
+      <header className="space-y-2">
+        <div className="flex items-center gap-3">
+          <span className="relative inline-flex h-3 w-3" aria-hidden="true">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400/40" />
+            <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500/80" />
+          </span>
+          <h1 className="text-3xl font-bold tracking-tight">Pulse</h1>
+        </div>
+        <p className="max-w-3xl text-muted-foreground leading-relaxed">
+          The breath of our living body, remembered. An external witness
+          listens to every organ of the network and writes down what it
+          hears, so the collective can sense its own health over time.
+        </p>
+      </header>
+
+      {witnessAlive && now && history ? (
+        <>
+          <OverallBanner
+            overall={now.overall}
+            checkedAt={now.checked_at}
+            ongoing={now.ongoing_silences}
+          />
+
+          <section className="space-y-3">
+            <h2 className="text-lg font-medium">Organs</h2>
+            <div className="space-y-3">
+              {history.organs.map((organ) => (
+                <OrganRow
+                  key={organ.name}
+                  history={organ}
+                  now={organsNowByName.get(organ.name)}
+                />
+              ))}
+            </div>
+          </section>
+
+          <SilenceList silences={silences?.silences ?? []} />
+
+          <p className="text-[11px] text-muted-foreground/60 text-center">
+            Witness started {new Date(now.witness_started_at).toLocaleString()}
+            {" · "}
+            window {history.days} days
+          </p>
+        </>
+      ) : (
+        <WitnessQuiet pulseBase={pulseBase} />
+      )}
+
+      {/* Footer navigation */}
+      <nav
+        className="py-8 text-center space-y-2 border-t border-border/20"
+        aria-label="Related pages"
+      >
+        <p className="text-xs text-muted-foreground/80 uppercase tracking-wider">
+          Also sense the body
+        </p>
+        <div className="flex flex-wrap justify-center gap-4 text-sm">
+          <Link href="/vitality" className="text-emerald-400 hover:underline">
+            Vitality — the deeper signal of life
+          </Link>
+          <Link href="/identity/keys" className="text-purple-400 hover:underline">
+            Attribution — who is moving through the body
+          </Link>
+          <Link href="/api-health" className="text-blue-400 hover:underline">
+            API health — raw, current
+          </Link>
+          <Link href="/diagnostics" className="text-amber-400 hover:underline">
+            Diagnostics
+          </Link>
+        </div>
+      </nav>
+    </main>
+  );
+}

--- a/web/app/pulse/silence-list.tsx
+++ b/web/app/pulse/silence-list.tsx
@@ -1,0 +1,68 @@
+import type { Silence } from "./types";
+import { formatDuration } from "./status-tokens";
+
+/**
+ * Past silences — the body remembers when it stopped breathing.
+ * Ongoing silences are shown in the overall banner, not here.
+ */
+export function SilenceList({ silences }: { silences: Silence[] }) {
+  const past = silences.filter((s) => s.ended_at !== null).slice(0, 30);
+
+  if (past.length === 0) {
+    return (
+      <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/40 to-card/20 p-6">
+        <h2 className="text-sm uppercase tracking-wider text-muted-foreground mb-3">
+          Past silences
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          The body has not gone silent within the window. Every organ has
+          responded when listened to.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/40 to-card/20 p-6 space-y-3">
+      <h2 className="text-sm uppercase tracking-wider text-muted-foreground">
+        Past silences
+      </h2>
+      <ul className="divide-y divide-border/30">
+        {past.map((s) => {
+          const start = new Date(s.started_at);
+          const end = s.ended_at ? new Date(s.ended_at) : null;
+          return (
+            <li
+              key={s.id}
+              className="grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] gap-2 sm:gap-4 py-3 items-center"
+            >
+              <span
+                className={`inline-flex items-center gap-2 text-xs font-medium uppercase tracking-wider ${
+                  s.severity === "silent" ? "text-rose-400" : "text-amber-400"
+                }`}
+              >
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${
+                    s.severity === "silent" ? "bg-rose-500" : "bg-amber-500"
+                  }`}
+                  aria-hidden="true"
+                />
+                {s.severity}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">{s.organ_label}</p>
+                <p className="text-xs text-muted-foreground">
+                  {start.toLocaleString()}
+                  {end && ` → ${end.toLocaleString()}`}
+                </p>
+              </div>
+              <p className="text-xs text-muted-foreground font-mono text-right">
+                {formatDuration(s.duration_seconds)}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/web/app/pulse/status-tokens.ts
+++ b/web/app/pulse/status-tokens.ts
@@ -1,0 +1,88 @@
+// Tailwind class tokens for breath-status visuals. One file so the
+// colour language is defined once and never drifts between components.
+
+import type { BreathStatus } from "./types";
+
+export const STATUS_LABEL: Record<BreathStatus, string> = {
+  breathing: "Breathing",
+  strained: "Strained",
+  silent: "Silent",
+  unknown: "Unknown",
+};
+
+export const STATUS_VERB: Record<BreathStatus, string> = {
+  breathing: "is breathing",
+  strained: "is strained",
+  silent: "is silent",
+  unknown: "is unheard",
+};
+
+export const STATUS_DOT: Record<BreathStatus, string> = {
+  breathing: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.6)]",
+  strained: "bg-amber-500 shadow-[0_0_8px_rgba(245,158,11,0.6)]",
+  silent: "bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.6)]",
+  unknown: "bg-gray-500",
+};
+
+export const STATUS_TEXT: Record<BreathStatus, string> = {
+  breathing: "text-emerald-400",
+  strained: "text-amber-400",
+  silent: "text-rose-400",
+  unknown: "text-gray-400",
+};
+
+export const STATUS_BG: Record<BreathStatus, string> = {
+  breathing: "bg-emerald-500",
+  strained: "bg-amber-500",
+  silent: "bg-rose-500",
+  unknown: "bg-gray-500/50",
+};
+
+export const STATUS_BAR: Record<BreathStatus, string> = {
+  breathing: "bg-emerald-500/80",
+  strained: "bg-amber-500/80",
+  silent: "bg-rose-500/80",
+  unknown: "bg-muted-foreground/20",
+};
+
+export const STATUS_BANNER: Record<
+  BreathStatus,
+  { border: string; bg: string; text: string; glow: string }
+> = {
+  breathing: {
+    border: "border-emerald-500/30",
+    bg: "from-emerald-500/10 to-emerald-500/5",
+    text: "text-emerald-400",
+    glow: "shadow-emerald-500/20",
+  },
+  strained: {
+    border: "border-amber-500/30",
+    bg: "from-amber-500/10 to-amber-500/5",
+    text: "text-amber-400",
+    glow: "shadow-amber-500/20",
+  },
+  silent: {
+    border: "border-rose-500/30",
+    bg: "from-rose-500/10 to-rose-500/5",
+    text: "text-rose-400",
+    glow: "shadow-rose-500/20",
+  },
+  unknown: {
+    border: "border-border/30",
+    bg: "from-muted/20 to-muted/5",
+    text: "text-muted-foreground",
+    glow: "shadow-none",
+  },
+};
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  if (h < 24) return rm > 0 ? `${h}h ${rm}m` : `${h}h`;
+  const d = Math.floor(h / 24);
+  const rh = h % 24;
+  return rh > 0 ? `${d}d ${rh}h` : `${d}d`;
+}

--- a/web/app/pulse/types.ts
+++ b/web/app/pulse/types.ts
@@ -1,0 +1,70 @@
+// Response shapes for the Pulse Monitor API. Must stay in sync with
+// pulse/pulse_app/models.py. These are read-only — no Zod validation
+// needed because the monitor is a controlled internal service.
+
+export type BreathStatus = "breathing" | "strained" | "silent" | "unknown";
+export type Severity = "strained" | "silent";
+
+export type OrganNow = {
+  name: string;
+  label: string;
+  description: string;
+  status: BreathStatus;
+  latency_ms: number | null;
+  last_sample_at: string | null;
+  detail: string | null;
+};
+
+export type OngoingSilence = {
+  id: number;
+  organ: string;
+  started_at: string;
+  severity: Severity;
+  duration_seconds: number;
+};
+
+export type PulseNow = {
+  overall: BreathStatus;
+  checked_at: string;
+  witness_started_at: string;
+  organs: OrganNow[];
+  ongoing_silences: OngoingSilence[];
+};
+
+export type DailyBar = {
+  date: string;
+  status: BreathStatus;
+  samples: number;
+  failures: number;
+};
+
+export type OrganHistory = {
+  name: string;
+  label: string;
+  description: string;
+  uptime_pct: number;
+  daily: DailyBar[];
+};
+
+export type PulseHistory = {
+  days: number;
+  generated_at: string;
+  organs: OrganHistory[];
+};
+
+export type Silence = {
+  id: number;
+  organ: string;
+  organ_label: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number;
+  severity: Severity;
+  note: string | null;
+};
+
+export type PulseSilences = {
+  days: number;
+  generated_at: string;
+  silences: Silence[];
+};

--- a/web/app/pulse/witness-quiet.tsx
+++ b/web/app/pulse/witness-quiet.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+/**
+ * Rendered when the pulse monitor itself is unreachable. We refuse to show
+ * stale or invented data — the absence of the witness is itself a truth
+ * worth communicating.
+ */
+export function WitnessQuiet({ pulseBase }: { pulseBase: string }) {
+  return (
+    <section className="rounded-3xl border border-dashed border-border/40 bg-gradient-to-b from-muted/20 to-transparent p-10 text-center space-y-4">
+      <p className="text-xs uppercase tracking-widest text-muted-foreground">
+        Unknown
+      </p>
+      <h2 className="text-2xl font-light text-muted-foreground">
+        The witness is quiet
+      </h2>
+      <p className="max-w-xl mx-auto text-sm text-muted-foreground leading-relaxed">
+        No one is currently recording our breath. The pulse monitor is not
+        answering — it may be starting, moving, or silent itself. This page
+        will not show invented data, so we wait.
+      </p>
+      {pulseBase && (
+        <p className="text-[11px] font-mono text-muted-foreground/60 break-all">
+          {pulseBase}
+        </p>
+      )}
+      <div className="pt-2 flex flex-wrap justify-center gap-4 text-sm">
+        <Link href="/api-health" className="text-blue-400 hover:underline">
+          API health (raw)
+        </Link>
+        <Link href="/vitality" className="text-emerald-400 hover:underline">
+          Network vitality
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/web/app/vitality/page.tsx
+++ b/web/app/vitality/page.tsx
@@ -21,6 +21,30 @@ type BreathRhythm = {
   ice: number;
 };
 
+/**
+ * The live API (see api/app/services/vitality_service.py) returns `signals`
+ * as a dict of numeric scores keyed by snake_case id, with `breath_rhythm`
+ * nested inside it as a gas/water/ice dict. This type mirrors that reality.
+ */
+type VitalityApiResponse = {
+  workspace_id: string;
+  vitality_score: number;
+  health_description: string;
+  signals: {
+    diversity_index: number;
+    resonance_density: number;
+    flow_rate: number;
+    breath_rhythm: BreathRhythm;
+    connection_strength: number;
+    activity_pulse: number;
+  };
+  generated_at: string;
+};
+
+/**
+ * Shape used inside this page after normalising the API response into an
+ * array of signal cards plus a top-level breath rhythm.
+ */
 type VitalityResponse = {
   workspace_id: string;
   vitality_score: number;
@@ -29,6 +53,62 @@ type VitalityResponse = {
   breath_rhythm: BreathRhythm;
   computed_at: string;
 };
+
+/** Human-readable signal descriptions, living in the same vocabulary as the body. */
+const SIGNAL_DESCRIPTIONS: Record<string, { label: string; description: string }> = {
+  diversity_index: {
+    label: "Diversity Index",
+    description:
+      "How many different shapes of contribution are alive in the network right now.",
+  },
+  resonance_density: {
+    label: "Resonance Density",
+    description:
+      "How tightly the ideas, specs, and contributions are woven to each other.",
+  },
+  flow_rate: {
+    label: "Flow Rate",
+    description:
+      "How readily the work moves through the pipeline from seed to realized form.",
+  },
+  connection_strength: {
+    label: "Connection Strength",
+    description:
+      "How present contributors are to each other — the tissue that binds the organism.",
+  },
+  activity_pulse: {
+    label: "Activity Pulse",
+    description:
+      "The tempo at which the network is currently breathing, growing, and resting.",
+  },
+};
+
+function normaliseVitality(api: VitalityApiResponse): VitalityResponse {
+  const s = api.signals;
+  const order: Array<keyof VitalityApiResponse["signals"]> = [
+    "diversity_index",
+    "resonance_density",
+    "flow_rate",
+    "connection_strength",
+    "activity_pulse",
+  ];
+  const signals: VitalitySignal[] = order.map((key) => {
+    const meta = SIGNAL_DESCRIPTIONS[key as string];
+    return {
+      name: meta.label,
+      value: typeof s[key] === "number" ? (s[key] as number) : 0,
+      description: meta.description,
+    };
+  });
+  return {
+    workspace_id: api.workspace_id,
+    vitality_score: api.vitality_score,
+    health_description: api.health_description,
+    signals,
+    breath_rhythm: s.breath_rhythm ?? { gas: 0.33, water: 0.34, ice: 0.33 },
+    computed_at: api.generated_at,
+  };
+}
 
 const SIGNAL_COLORS: Record<string, { bar: string; text: string; bg: string }> = {
   "Diversity Index": {
@@ -106,7 +186,10 @@ async function loadVitality(): Promise<VitalityResponse | null> {
       { cache: "no-store" },
     );
     if (!res.ok) return null;
-    return (await res.json()) as VitalityResponse;
+    const body = (await res.json()) as VitalityApiResponse;
+    // Guard against missing or malformed payloads — let the empty state show.
+    if (!body || typeof body !== "object" || !body.signals) return null;
+    return normaliseVitality(body);
   } catch {
     return null;
   }
@@ -300,6 +383,9 @@ export default async function VitalityPage() {
           Explore more
         </p>
         <div className="flex flex-wrap justify-center gap-4 text-sm">
+          <Link href="/pulse" className="text-emerald-400 hover:underline">
+            Pulse — the outer breath
+          </Link>
           <Link href="/discover" className="text-purple-400 hover:underline">
             Discover
           </Link>

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -39,6 +39,9 @@ const SECONDARY_NAV = [
   { href: "/automation", label: "Automation" },
   { href: "/friction", label: "Friction" },
   { href: "/identity", label: "Identity" },
+  // Health & vitality of the body
+  { href: "/pulse", label: "Pulse" },
+  { href: "/vitality", label: "Vitality" },
 ];
 
 function HeartbeatIcon() {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -60,3 +60,25 @@ export function getApiBase(): string {
   if (isBrowser) return "";
   return DEV_API_URL;
 }
+
+/**
+ * Resolve the base URL for the Pulse Monitor (the external witness).
+ *
+ * Unlike the API, the pulse service lives on its own origin (e.g.
+ * `pulse.coherencycoin.com`) — it is never served through the same-origin
+ * Traefik path. The /pulse page fetches server-side at request time, so
+ * this returns a fully-qualified URL in both server and browser contexts.
+ *
+ * NEXT_PUBLIC_PULSE_URL is honoured everywhere — Next inlines it into the
+ * client bundle at build time, and server components read it at request
+ * time from process.env. An empty or unset value falls through to the
+ * default baked into the public web config; returning "" from both makes
+ * the /pulse page render a muted "witness is quiet" state.
+ */
+export function getPulseBase(): string {
+  const fromEnv =
+    typeof process !== "undefined" && process.env?.NEXT_PUBLIC_PULSE_URL;
+  const configured = (fromEnv && String(fromEnv).trim()) || readPublicWebConfig().pulseBaseUrl;
+  if (!configured) return "";
+  return _stripTrailingSlash(configured.trim());
+}

--- a/web/lib/app-config.ts
+++ b/web/lib/app-config.ts
@@ -8,6 +8,12 @@ export type PublicWebConfig = {
   // Canonical user-facing origin (for OG/Twitter tags, share links,
   // canonical URLs). Env override: NEXT_PUBLIC_BASE_URL.
   webUiBaseUrl: string;
+  // Pulse Monitor — the external witness that records the breath of the
+  // network. Served from a different origin than the API (see pulse/ in the
+  // repo). Env override: NEXT_PUBLIC_PULSE_URL. Empty string is allowed and
+  // means "the witness is unavailable" — the /pulse page renders a muted
+  // "witness is quiet" state in that case.
+  pulseBaseUrl: string;
   // Public repo browse base (for spec/source file permalinks). Env
   // override: NEXT_PUBLIC_REPO_URL. Defaults to the `main` branch blob.
   repoUrl: string;
@@ -94,6 +100,7 @@ function defaultConfig(): Record<string, unknown> {
       api_base_url: "https://api.coherencycoin.com",
       local_api_base_url: "http://localhost:8000",
       web_ui_base_url: "https://coherencycoin.com",
+      pulse_base_url: "https://pulse.coherencycoin.com",
       repo_url: "https://github.com/seeker71/Coherence-Network/blob/main",
       fetch_defaults: {
         timeout_ms: 7000,
@@ -171,6 +178,11 @@ export function loadPublicWebConfig(): PublicWebConfig {
       process.env.NEXT_PUBLIC_BASE_URL
       || getNested(config, ["web", "web_ui_base_url"], "")
       || getNested(config, ["agent_providers", "web_ui_base_url"], "https://coherencycoin.com"),
+    ),
+    pulseBaseUrl: String(
+      process.env.NEXT_PUBLIC_PULSE_URL
+      || getNested(config, ["web", "pulse_base_url"], "")
+      || "https://pulse.coherencycoin.com",
     ),
     repoUrl: String(
       process.env.NEXT_PUBLIC_REPO_URL

--- a/web/lib/public-config.ts
+++ b/web/lib/public-config.ts
@@ -10,6 +10,7 @@ export const PUBLIC_WEB_DEFAULTS: PublicWebConfig = {
   apiBaseUrl: "https://api.coherencycoin.com",
   localApiBaseUrl: "http://localhost:8000",
   webUiBaseUrl: "https://coherencycoin.com",
+  pulseBaseUrl: "https://pulse.coherencycoin.com",
   repoUrl: "https://github.com/seeker71/Coherence-Network/blob/main",
   fetchDefaults: {
     timeoutMs: 7000,

--- a/web/lib/pulse-server.ts
+++ b/web/lib/pulse-server.ts
@@ -1,0 +1,25 @@
+// Server-only helper for resolving the Pulse Monitor base URL.
+//
+// Lives in its own file (not lib/api.ts) because api.ts is imported by
+// client components. `loadPublicWebConfig` reads from fs/os, which webpack
+// cannot bundle into a client chunk. This module must only be imported
+// from server components (see web/app/pulse/page.tsx).
+
+import { loadPublicWebConfig } from "./app-config";
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/**
+ * Resolve the base URL of the Pulse Monitor (the external witness) for use
+ * from a server component. Reads NEXT_PUBLIC_PULSE_URL and the merged
+ * public web config. Returns an empty string if nothing is configured, in
+ * which case the /pulse page renders a "witness is quiet" state.
+ */
+export function getPulseBaseServer(): string {
+  const cfg = loadPublicWebConfig();
+  const url = (cfg.pulseBaseUrl || "").trim();
+  if (!url) return "";
+  return stripTrailingSlash(url);
+}


### PR DESCRIPTION
## Summary

Two complementary sensors for the Coherence Network body, each in its own commit:

- **Pulse** — a new standalone FastAPI service (`pulse/`) that lives next to api and web but shares nothing with them. It pings the network from outside every 30s, durably records every sample in SQLite, derives silences from consecutive failures, and exposes the last 90 days through `/pulse/now`, `/pulse/history`, `/pulse/silences`. New `/pulse` page on the web renders the organs in the spirit of status.claude.com, translated through the Living Collective frequency.
- **Contributor attribution** — a new middleware + DB-backed key store that populates `request.state.contributor_id` from either a verified `Authorization: Bearer cc_*` key or a claimed `X-Contributor-Id` header. Every response echoes `X-Attributed-To` and `X-Attribution-Source` so clients can confirm what the server saw. New `/identity/keys` page to mint, list, and revoke personal keys.

Along the way, the `/vitality` page was healed — it had been crashing with `signals.map is not a function` because the frontend was dreaming of an imaginary API shape. A `normaliseVitality()` adapter in `web/app/vitality/page.tsx` now reads the real backend shape.

Pulse caught a real production condition the moment it started looking: `/api/ready` returns 503 with `persistence_contract_failed` because `contributors/assets/contributions` persist in `InMemoryGraphStore` and `runtime_usage` persists in sqlite. That's flagged as a separate concern — not fixed in this PR.

## Architecture

```
 ┌────────────────────────────────┐       pings every 30s        ┌───────────────────────────────┐
 │    Coherence Network (main)    │ ◄─────────────────────────────│       Pulse Monitor           │
 │                                │     /api/health               │                               │
 │    api.coherencycoin.com       │     /api/ready                │   (new standalone service)    │
 │    coherencycoin.com           │     / (web root)              │   SQLite sample store         │
 └────────────────────────────────┘                               └───────────────────────────────┘
                ▲                                                                  │
                │                                                                  │
                │ reads history from monitor                                       │
                │                                                                  ▼
       ┌────────┴─────────────┐                                     GET  /pulse/now
       │   /pulse page        │ ◄────── HTTP (server-side fetch) ── GET  /pulse/history?days=90
       │   on main web        │                                     GET  /pulse/silences?days=90
       └──────────────────────┘
```

```
 Authorization: Bearer cc_alice_abc...      X-Contributor-Id: alice
            │                                       │
            ▼                                       ▼
  SHA-256 → contributor_key_store.verify    recorded as-is, no proof
            │                                       │
            │   ┌───────────────────────────────┐   │
            └──►│  request.state.attribution    │◄──┘
                │   contributor_id = "alice"    │
                │   source = "verified"|"claimed"│
                │   scopes = [...]              │
                └───────────────────────────────┘
                             │
                 X-Attributed-To: alice
                 X-Attribution-Source: verified
```

## Vocabulary (per FREQUENCY RULE in CLAUDE.md)

| Corporate status page | Living Collective |
|---|---|
| component / service | **organ** |
| operational | **breathing** |
| degraded | **strained** |
| outage | **silent** |
| uptime % | **steady breath** |
| incident | **silence** |
| monitoring service | **witness** |

## Organs observed

| Organ | Signal |
|---|---|
| api | `/api/health` → status == "ok" |
| web | `/` → 2xx |
| postgres | `/api/ready` → db_connected == true |
| neo4j | `/api/ready` not 503 with graph_store_missing detail |
| schema | `/api/health` → schema_ok == true |
| audit_integrity | `/api/health` → integrity_compromised == false |

Five of six share two upstream calls, so one probe round costs three HTTP requests. Gentle on the network it watches.

## What's NOT in this PR (by design)

- **Truly external hosting of the witness** — Phase 1 runs on the same VPS. Documented in `pulse/README.md` as a Phase 2 relocation. The code does not need to change for that move.
- **Subscribe-to-silences** (email / webhook) — Phase 2.
- **Scope enforcement** on existing endpoints — attribution records the signal; authorization is unchanged. Needs its own spec.
- **Rate limiter bucket by contributor** — the middleware makes it a one-file change; holding for Phase 2.
- **`X-API-Key` replacement** — the shared-secret system stays for mutating endpoints. Trust-model change deserves its own design.
- **`created_by_contributor_id` on specs/assets/tasks** — the response header echo is the cleaner proof that the signal flows end-to-end, without invading every model.

## Tests

- **Pulse**: 38 passing in 0.07s (storage, analysis, probe)
- **Attribution**: 32 new passing (14 store + 8 middleware + 10 HTTP)
- **Regression slice**: 113 passing in 4.71s — under the 10s contract in CLAUDE.md
- **Web TypeScript**: clean

Verified end-to-end against a local api:
```
POST /api/auth/keys → cc_alice_...
Bearer cc_alice_... → X-Attributed-To: alice, X-Attribution-Source: verified
X-Contributor-Id: carol → X-Attributed-To: carol, X-Attribution-Source: claimed
no headers → X-Attribution-Source: none
```

## Test plan

- [ ] `cd api && python3 -m pytest tests/test_contributor_key_store.py tests/test_attribution_middleware.py tests/test_auth_keys_api.py -q`
- [ ] `cd pulse && pip install -e .[dev] && python -m pytest -q`
- [ ] `cd web && npm run typecheck`
- [ ] Manually visit `/pulse`, `/vitality`, `/identity`, `/identity/keys` in a local dev env
- [ ] After deploy, confirm `curl -sI https://api.coherencycoin.com/api/health` shows `x-attribution-source: none`
- [ ] After deploy, confirm `curl -sI -H "X-Contributor-Id: testuser" https://api.coherencycoin.com/api/health` echoes `x-attributed-to: testuser`
- [ ] After pulse compose snippet + DNS record, confirm `https://pulse.coherencycoin.com/pulse/now` returns six organs

## Follow-ups flagged (out of scope)

1. **`persistence_contract_failed` in production** — `contributors/assets/contributions` in `InMemoryGraphStore`, `runtime_usage` in sqlite. Two domains fail the persistence contract. The sensor found it; a durable fix deserves its own session.
2. **Move the witness off-host** — Phase 2 relocation of `pulse/` to a second host (Fly.io, second VPS, or GitHub Actions cron) for true external observation during whole-host outages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)