### PR TITLE
fix: database_url honors DATABASE_URL env var

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -5,7 +5,15 @@ Configuration precedence:
   2. ~/.coherence-network/config.json
   3. hard-coded defaults
 
-No environment variables are read for application config.
+No environment variables are read for application config — with ONE
+infrastructure-shaped exception: `database_url()` honors the standard
+`DATABASE_URL` environment variable with higher precedence than the
+config file's default, and per-service overrides honor
+`<SERVICE>_DATABASE_URL` (uppercased) when set. Rationale: the database
+URL is the canonical 12-factor override. Dev environments keep the
+config-file sqlite default; production compose files set
+`DATABASE_URL=postgresql://...` and have it flow through without
+needing to edit the checked-in config file.
 
 Usage:
     from app.config_loader import api_config, database_url
@@ -18,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -507,11 +516,33 @@ def full_config() -> dict[str, Any]:
 
 
 def database_url(service: str | None = None) -> str:
+    """Resolve the database URL for a domain, or the global default.
+
+    Precedence (highest wins):
+      1. Per-service config override  (config.database_overrides.<service>)
+      2. Per-service env var          (<SERVICE>_DATABASE_URL, uppercased)
+      3. Global DATABASE_URL env var  (standard 12-factor override)
+      4. Global config default        (config.database.url)
+      5. Fallback                     (sqlite:///data/coherence.db)
+
+    The rest of this module refuses to read env vars for application
+    config, but the database URL is an infrastructure-shaped value that
+    routinely differs between dev (sqlite), staging, and production
+    (postgres). Letting the env var override the config file's default
+    keeps the config file honest as a dev-friendly starting point while
+    still honoring production's explicit intent.
+    """
     config = _load()
     if service:
         override = config.get("database_overrides", {}).get(service)
         if override:
             return str(override)
+        env_service = os.environ.get(f"{service.upper()}_DATABASE_URL", "").strip()
+        if env_service:
+            return env_service
+    env_global = os.environ.get("DATABASE_URL", "").strip()
+    if env_global:
+        return env_global
     return str(config.get("database", {}).get("url", "sqlite:///data/coherence.db"))
 
 


### PR DESCRIPTION
## Summary

Fixes the `persistence_contract_failed` condition that the newly-shipped Pulse monitor surfaced the moment it started probing production. Root cause: `config_loader.database_url()` refused to read environment variables, so despite the production compose file setting `DATABASE_URL=postgresql://...`, the api was silently running on the checked-in dev default of `sqlite:///data/coherence.db` — which meant `app.state.graph_store` was `InMemoryGraphStore` and `runtime_event_store` was sqlite, and two domains failed the persistence contract.

Narrow fix: `database_url()` (and only that function) now honors:
1. Per-service config override (`database_overrides.<service>`)
2. Per-service env var (`<SERVICE>_DATABASE_URL`)
3. Global `DATABASE_URL` env var ← new
4. Global config default (`database.url`)
5. Fallback (`sqlite:///data/coherence.db`)

The rest of `config_loader` continues to refuse env vars for application config (auth keys, agent settings, etc.). The module docstring is updated to declare this single infrastructure-shaped exception explicitly rather than pretending none exist.

## Why narrow

Dev environments keep their sqlite-by-default behavior (no env var set → config default wins). Production compose files that already set `DATABASE_URL` get it honored. No API changes, no test changes, no migrations — a single function's precedence order.

## Test plan

- [x] `python3 -m pytest api/tests/test_flow_core_api.py api/tests/test_cc_economics.py api/tests/test_contributor_journey.py api/tests/test_flow_pipeline.py api/tests/test_attribution_middleware.py api/tests/test_contributor_key_store.py api/tests/test_auth_keys_api.py api/tests/test_developer_quick_start.py -q` — **131 passed in 8.52s**
- [ ] After deploy, `curl https://pulse.coherencycoin.com/pulse/now` should show `postgres: breathing` instead of `postgres: silent — persistence contract failed`
- [ ] After deploy, `curl https://api.coherencycoin.com/api/ready` should return 200 instead of 503

## What this fixes in the field

- Contributors, assets, contributions were persisting to an in-memory graph store that evaporated on every container restart. They now persist to the shared postgres instance.
- Runtime usage metrics were persisting to a sqlite file inside the container, unreadable from any other service. They now persist to postgres alongside everything else.
- The pulse monitor's postgres organ will flip from "silent" to "breathing" within one probe round of the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)