### PR TITLE
fix: auth + environment honor env vars (decompose dev-key-in-prod)

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -5,15 +5,24 @@ Configuration precedence:
   2. ~/.coherence-network/config.json
   3. hard-coded defaults
 
-No environment variables are read for application config — with ONE
-infrastructure-shaped exception: `database_url()` honors the standard
-`DATABASE_URL` environment variable with higher precedence than the
-config file's default, and per-service overrides honor
-`<SERVICE>_DATABASE_URL` (uppercased) when set. Rationale: the database
-URL is the canonical 12-factor override. Dev environments keep the
-config-file sqlite default; production compose files set
-`DATABASE_URL=postgresql://...` and have it flow through without
-needing to edit the checked-in config file.
+No environment variables are read for application config — with a
+deliberately small set of infrastructure-shaped exceptions. Each helper
+below has its own precedence docstring; the common shape is
+
+    env var (if set) → config file → hard-coded default
+
+Exceptions:
+  - `database_url()`        honors DATABASE_URL (and <SERVICE>_DATABASE_URL)
+  - `server_environment()`  honors ENVIRONMENT (dev/staging/production/test)
+  - `auth_api_key()`        honors AUTH_API_KEY
+  - `auth_admin_key()`      honors AUTH_ADMIN_KEY
+
+Rationale: these are 12-factor infrastructure values that routinely
+differ between dev (sqlite, dev-key, development) and production (real
+postgres, strong random keys, production environment). Letting the env
+var override the config file's default keeps the config file honest as
+a dev-friendly starting point while still honoring production intent
+without needing to edit the checked-in config.
 
 Usage:
     from app.config_loader import api_config, database_url
@@ -524,13 +533,6 @@ def database_url(service: str | None = None) -> str:
       3. Global DATABASE_URL env var  (standard 12-factor override)
       4. Global config default        (config.database.url)
       5. Fallback                     (sqlite:///data/coherence.db)
-
-    The rest of this module refuses to read env vars for application
-    config, but the database URL is an infrastructure-shaped value that
-    routinely differs between dev (sqlite), staging, and production
-    (postgres). Letting the env var override the config file's default
-    keeps the config file honest as a dev-friendly starting point while
-    still honoring production's explicit intent.
     """
     config = _load()
     if service:
@@ -544,6 +546,51 @@ def database_url(service: str | None = None) -> str:
     if env_global:
         return env_global
     return str(config.get("database", {}).get("url", "sqlite:///data/coherence.db"))
+
+
+def server_environment() -> str:
+    """Resolve the server environment name.
+
+    Precedence: ENVIRONMENT env var → config.server.environment → "development".
+
+    Valid values conventionally: "development", "test", "testing",
+    "staging", "production". Callers that need a boolean use
+    `app.services.config_service.is_production()` which delegates here.
+    """
+    env = os.environ.get("ENVIRONMENT", "").strip().lower()
+    if env:
+        return env
+    config = _load()
+    return str(config.get("server", {}).get("environment", "development"))
+
+
+def auth_api_key() -> str:
+    """Resolve the shared API key used by `require_api_key`.
+
+    Precedence: AUTH_API_KEY env var → config.auth.api_key → "dev-key".
+
+    The keystore (`~/.coherence-network/keys.json`) is read by
+    `config_service.get_config()` which takes precedence over this
+    helper for CLI/user contexts. This helper is for server-side
+    middleware that must enforce a single canonical key.
+    """
+    env_key = os.environ.get("AUTH_API_KEY", "").strip()
+    if env_key:
+        return env_key
+    config = _load()
+    return str(config.get("auth", {}).get("api_key", "dev-key"))
+
+
+def auth_admin_key() -> str:
+    """Resolve the admin key used for destructive operations.
+
+    Precedence: AUTH_ADMIN_KEY env var → config.auth.admin_key → "dev-admin".
+    """
+    env_key = os.environ.get("AUTH_ADMIN_KEY", "").strip()
+    if env_key:
+        return env_key
+    config = _load()
+    return str(config.get("auth", {}).get("admin_key", "dev-admin"))
 
 
 def get_float(section: str, key: str, default: float = 0.0) -> float:

--- a/api/app/middleware/auth.py
+++ b/api/app/middleware/auth.py
@@ -5,24 +5,27 @@ Three auth levels:
 - API_KEY: requires X-API-Key header (mutating endpoints)
 - ADMIN: requires X-Admin-Key header (destructive operations)
 
-Keys configured in api/config/api.json under auth.api_key and auth.admin_key.
+Keys resolve via `config_loader.auth_api_key()` /
+`config_loader.auth_admin_key()`, which honor `AUTH_API_KEY` /
+`AUTH_ADMIN_KEY` env vars (12-factor) before falling back to
+api/config/api.json.
 """
 
 from fastapi import Header, HTTPException
 
-from app.config_loader import get_str
-from app.services.config_service import get_api_key, is_production
+from app.config_loader import auth_admin_key, auth_api_key
+from app.services.config_service import is_production
 
 def _current_api_key() -> str:
     if _API_KEY is not None:
         return _API_KEY
-    return get_str("auth", "api_key", default="dev-key") or get_api_key()
+    return auth_api_key()
 
 
 def _current_admin_key() -> str:
     if _ADMIN_KEY is not None:
         return _ADMIN_KEY
-    return get_str("auth", "admin_key", default="dev-admin") or "dev-admin"
+    return auth_admin_key()
 
 
 def _in_production() -> bool:

--- a/api/app/services/config_service.py
+++ b/api/app/services/config_service.py
@@ -191,7 +191,10 @@ def get_node_id() -> str:
 
 
 def is_production() -> bool:
-    return get_config().get("environment") == "production"
+    # Honour the ENVIRONMENT env var (via config_loader.server_environment)
+    # before the cached config, so a production container can declare
+    # itself production without editing the checked-in config file.
+    return config_loader.server_environment() == "production"
 
 
 def get_providers() -> list[str]:
@@ -204,7 +207,7 @@ def get_api_base() -> str:
 
 
 def get_environment() -> str:
-    return str(get_config().get("environment") or "development")
+    return config_loader.server_environment()
 
 
 def get_contributor_id() -> str | None:


### PR DESCRIPTION
Narrow fix. Production was running on auth.api_key="dev-key" and server.environment="development" because config_loader refused env vars. is_production() was False so the fail-fast guard was bypassed.

Three new helpers in config_loader: server_environment(), auth_api_key(), auth_admin_key() — each checks env var before config. is_production() and middleware/auth.py route through them. No changes to existing API contract.

Next step after merge: set ENVIRONMENT, AUTH_API_KEY, AUTH_ADMIN_KEY in the VPS compose .env and in the api service's environment block.

123 regression tests passing in 4.42s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)