### PR TITLE
feat: pulse — latency tempo, rich day tooltips, range toggle, overall %

### DIFF
--- a/pulse/pulse_app/analysis.py
+++ b/pulse/pulse_app/analysis.py
@@ -6,7 +6,7 @@ so it is trivially unit-testable with hand-crafted sample sequences.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Literal
 
@@ -88,6 +88,10 @@ class DayBucket:
     date: str            # YYYY-MM-DD
     samples: int
     failures: int
+    # Latency percentiles across successful samples for the day. None when
+    # there were no successful samples (so None and 0 stay visually distinct).
+    latency_p50_ms: int | None = None
+    latency_p95_ms: int | None = None
 
     @property
     def status(self) -> str:
@@ -101,36 +105,67 @@ class DayBucket:
         return "strained"
 
 
+def _percentile(sorted_values: list[int], pct: float) -> int | None:
+    """Nearest-rank percentile on an already-sorted list. None for empty input."""
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    # Nearest-rank: rank = ceil(pct/100 * N), 1-indexed
+    import math
+    rank = max(1, math.ceil((pct / 100.0) * len(sorted_values)))
+    return sorted_values[min(rank - 1, len(sorted_values) - 1)]
+
+
 def rollup_daily(samples: list[Sample], days: int, now: datetime | None = None) -> list[DayBucket]:
     """Group samples into the last `days` day-buckets ending today UTC.
 
     Days with no samples become DayBuckets with samples=0 and status=unknown.
+    Latency percentiles (p50/p95) are computed across the successful samples
+    of each day and return None for days with no successful samples.
     """
     if now is None:
         now = datetime.now(timezone.utc)
     today = now.astimezone(timezone.utc).date()
 
     # Pre-create every bucket so the output is always length `days`.
-    buckets: dict[date, list[int]] = {}
+    @dataclass
+    class _Accum:
+        samples: int = 0
+        failures: int = 0
+        ok_latencies: list[int] = field(default_factory=list)
+
+    buckets: dict[date, _Accum] = {}
     for i in range(days):
         d = today - timedelta(days=(days - 1 - i))
-        buckets[d] = [0, 0]  # [samples, failures]
+        buckets[d] = _Accum()
 
     for s in samples:
         d = _parse_iso(s.ts).date()
-        if d in buckets:
-            buckets[d][0] += 1
-            if not s.ok:
-                buckets[d][1] += 1
+        acc = buckets.get(d)
+        if acc is None:
+            continue
+        acc.samples += 1
+        if s.ok:
+            if s.latency_ms is not None:
+                acc.ok_latencies.append(int(s.latency_ms))
+        else:
+            acc.failures += 1
 
-    return [
-        DayBucket(
-            date=d.isoformat(),
-            samples=buckets[d][0],
-            failures=buckets[d][1],
+    out: list[DayBucket] = []
+    for d in sorted(buckets.keys()):
+        acc = buckets[d]
+        acc.ok_latencies.sort()
+        out.append(
+            DayBucket(
+                date=d.isoformat(),
+                samples=acc.samples,
+                failures=acc.failures,
+                latency_p50_ms=_percentile(acc.ok_latencies, 50),
+                latency_p95_ms=_percentile(acc.ok_latencies, 95),
+            )
         )
-        for d in sorted(buckets.keys())
-    ]
+    return out
 
 
 def uptime_percent(samples: list[Sample]) -> float:
@@ -139,6 +174,14 @@ def uptime_percent(samples: list[Sample]) -> float:
         return 0.0
     ok = sum(1 for s in samples if s.ok)
     return round(100.0 * ok / len(samples), 2)
+
+
+def latency_percentiles(samples: list[Sample]) -> tuple[int | None, int | None]:
+    """Return (p50_ms, p95_ms) across the successful samples, or (None, None)."""
+    ok_latencies = sorted(
+        int(s.latency_ms) for s in samples if s.ok and s.latency_ms is not None
+    )
+    return _percentile(ok_latencies, 50), _percentile(ok_latencies, 95)
 
 
 # --- current status -------------------------------------------------------

--- a/pulse/pulse_app/main.py
+++ b/pulse/pulse_app/main.py
@@ -23,6 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pulse_app import __version__
 from pulse_app.analysis import (
     duration_seconds_until_now,
+    latency_percentiles,
     overall_status,
     rollup_daily,
     silence_duration,
@@ -36,6 +37,7 @@ from pulse_app.models import (
     OrganHistory,
     OrganNow,
     PulseHistory,
+    PulseHistoryOverall,
     PulseNow,
     PulseSilences,
     Silence,
@@ -204,27 +206,47 @@ async def pulse_history(days: int = Query(90, ge=1, le=180)) -> PulseHistory:
     for organ in ORGANS:
         samples = store.samples_for_organ_since(organ.name, since)
         buckets = rollup_daily(samples, days=days, now=now)
+        p50, p95 = latency_percentiles(samples)
         organ_histories.append(
             OrganHistory(
                 name=organ.name,
                 label=organ.label,
                 description=organ.description,
                 uptime_pct=uptime_percent(samples),
+                latency_p50_ms=p50,
+                latency_p95_ms=p95,
                 daily=[
                     DailyBar(
                         date=b.date,
                         status=b.status,  # type: ignore[arg-type]
                         samples=b.samples,
                         failures=b.failures,
+                        latency_p50_ms=b.latency_p50_ms,
+                        latency_p95_ms=b.latency_p95_ms,
                     )
                     for b in buckets
                 ],
             )
         )
 
+    # Cross-organ rollup for the banner.
+    if organ_histories:
+        avg_uptime = round(
+            sum(o.uptime_pct for o in organ_histories) / len(organ_histories), 2
+        )
+        worst = min(organ_histories, key=lambda o: o.uptime_pct)
+        overall = PulseHistoryOverall(
+            uptime_pct=avg_uptime,
+            worst_uptime_pct=worst.uptime_pct,
+            worst_organ=worst.name if worst.uptime_pct < 100 else None,
+        )
+    else:
+        overall = PulseHistoryOverall(uptime_pct=0.0, worst_uptime_pct=0.0, worst_organ=None)
+
     return PulseHistory(
         days=days,
         generated_at=iso_utc(now),
+        overall=overall,
         organs=organ_histories,
     )
 

--- a/pulse/pulse_app/models.py
+++ b/pulse/pulse_app/models.py
@@ -69,6 +69,14 @@ class DailyBar(BaseModel):
     status: BreathStatus
     samples: int
     failures: int
+    latency_p50_ms: int | None = Field(
+        default=None,
+        description="p50 latency across successful samples for the day (ms); None when no successes",
+    )
+    latency_p95_ms: int | None = Field(
+        default=None,
+        description="p95 latency across successful samples for the day (ms); None when no successes",
+    )
 
 
 class OrganHistory(BaseModel):
@@ -80,7 +88,31 @@ class OrganHistory(BaseModel):
     uptime_pct: float = Field(
         description="Steady-breath percentage across the requested window"
     )
+    latency_p50_ms: int | None = Field(
+        default=None,
+        description="p50 latency across all successful samples in the window (ms)",
+    )
+    latency_p95_ms: int | None = Field(
+        default=None,
+        description="p95 latency across all successful samples in the window (ms)",
+    )
     daily: list[DailyBar]
+
+
+class PulseHistoryOverall(BaseModel):
+    """Rollup across all organs for the requested window."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uptime_pct: float = Field(
+        description="Average steady-breath percentage across all organs in the window"
+    )
+    worst_uptime_pct: float = Field(
+        description="The lowest per-organ uptime in the window (which organ is struggling most)"
+    )
+    worst_organ: str | None = Field(
+        default=None, description="Name of the organ with the lowest uptime, if any"
+    )
 
 
 class PulseHistory(BaseModel):
@@ -90,6 +122,7 @@ class PulseHistory(BaseModel):
 
     days: int
     generated_at: str
+    overall: PulseHistoryOverall
     organs: list[OrganHistory]
 
 

--- a/pulse/tests/test_analysis.py
+++ b/pulse/tests/test_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from pulse_app.analysis import (
+    latency_percentiles,
     overall_status,
     reconcile_silences,
     rollup_daily,
@@ -132,6 +133,77 @@ def test_rollup_half_or_more_failures_is_silent():
     ]
     buckets = rollup_daily(samples, days=1, now=now)
     assert buckets[0].status == "silent"
+
+
+# --- latency aggregation -------------------------------------------------
+
+def test_rollup_computes_latency_percentiles_on_successful_samples():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    # 10 successful samples today with latencies 10..100 (step 10)
+    samples = [
+        Sample(ts=f"2026-04-15T{hour:02d}:00:00Z", organ="api", ok=True,
+               latency_ms=(hour + 1) * 10, detail=None)
+        for hour in range(10)
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    b = buckets[0]
+    assert b.samples == 10
+    assert b.failures == 0
+    # Nearest-rank p50 on a sorted 10-element list = 5th element (10, 20, 30, 40, 50)
+    assert b.latency_p50_ms == 50
+    # p95 on a 10-element list = ceil(.95*10)=10th element = 100
+    assert b.latency_p95_ms == 100
+
+
+def test_rollup_latency_ignores_failed_samples():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    # 3 ok latencies (100, 200, 300), 2 failed with very high latencies
+    samples = [
+        Sample(ts="2026-04-15T09:00:00Z", organ="api", ok=True, latency_ms=100, detail=None),
+        Sample(ts="2026-04-15T10:00:00Z", organ="api", ok=True, latency_ms=200, detail=None),
+        Sample(ts="2026-04-15T11:00:00Z", organ="api", ok=True, latency_ms=300, detail=None),
+        Sample(ts="2026-04-15T12:00:00Z", organ="api", ok=False, latency_ms=9999, detail="timeout"),
+        Sample(ts="2026-04-15T13:00:00Z", organ="api", ok=False, latency_ms=9999, detail="timeout"),
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    b = buckets[0]
+    # Percentiles come from the ok samples only, not the failures
+    assert b.latency_p50_ms == 200
+    assert b.latency_p95_ms == 300
+
+
+def test_rollup_latency_none_when_no_successes():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    samples = [
+        Sample(ts="2026-04-15T09:00:00Z", organ="api", ok=False, latency_ms=10, detail="x"),
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    assert buckets[0].latency_p50_ms is None
+    assert buckets[0].latency_p95_ms is None
+
+
+def test_rollup_latency_none_for_empty_day():
+    now = datetime(2026, 4, 15, 12, 0, tzinfo=timezone.utc)
+    buckets = rollup_daily([], days=3, now=now)
+    for b in buckets:
+        assert b.latency_p50_ms is None
+        assert b.latency_p95_ms is None
+
+
+def test_latency_percentiles_window():
+    samples = [
+        Sample(ts="2026-04-15T09:00:00Z", organ="api", ok=True, latency_ms=100, detail=None),
+        Sample(ts="2026-04-15T10:00:00Z", organ="api", ok=True, latency_ms=200, detail=None),
+        Sample(ts="2026-04-15T11:00:00Z", organ="api", ok=True, latency_ms=300, detail=None),
+        Sample(ts="2026-04-15T12:00:00Z", organ="api", ok=True, latency_ms=400, detail=None),
+    ]
+    p50, p95 = latency_percentiles(samples)
+    assert p50 == 200  # ceil(.5*4)=2nd element = 200
+    assert p95 == 400  # ceil(.95*4)=4th element = 400
+
+
+def test_latency_percentiles_empty():
+    assert latency_percentiles([]) == (None, None)
 
 
 # --- reconcile_silences ---------------------------------------------------

--- a/web/app/pulse/day-tooltip.tsx
+++ b/web/app/pulse/day-tooltip.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useId, useState } from "react";
+import type { DailyBar, Silence } from "./types";
+import { STATUS_LABEL, formatDuration } from "./status-tokens";
+
+/**
+ * Rich hover/focus tooltip anchored to a single day bar.
+ *
+ * The bar is a real interactive element (button), so tooltips work on
+ * mouse, touch (tap to toggle), and keyboard (focus to show, Escape to
+ * hide). The tooltip content is composed from the day's bucket data plus
+ * any silences whose window overlaps that day, so hovering a red bar
+ * tells you exactly what the witness recorded.
+ */
+export function DayBar({
+  day,
+  silencesForDay,
+  organLabel,
+  barClass,
+}: {
+  day: DailyBar;
+  silencesForDay: Silence[];
+  organLabel: string;
+  barClass: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  const tooltipId = useId();
+
+  const title = `${organLabel} · ${day.date}`;
+  const statusLabel = STATUS_LABEL[day.status];
+  const noData = day.samples === 0;
+
+  return (
+    <div className="relative flex-1 min-w-[3px]">
+      <button
+        type="button"
+        aria-describedby={visible ? tooltipId : undefined}
+        aria-label={`${title} · ${statusLabel}${
+          noData ? " · no samples" : ` · ${day.samples} samples, ${day.failures} failures`
+        }`}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+        onClick={() => setVisible((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") setVisible(false);
+        }}
+        className={`block w-full rounded-sm ${barClass} hover:opacity-100 opacity-90 focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-emerald-400/60 transition-opacity`}
+        style={{ height: noData ? "35%" : "100%", minHeight: "4px" }}
+      />
+      {visible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20 w-64 rounded-xl border border-border/40 bg-popover/95 backdrop-blur-md shadow-xl p-3 text-left pointer-events-none"
+        >
+          <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            {organLabel}
+          </p>
+          <p className="text-sm font-medium">{day.date}</p>
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">state</span>
+            <span className="text-xs font-medium">{statusLabel}</span>
+          </div>
+          {noData ? (
+            <p className="mt-2 text-xs text-muted-foreground italic">
+              no samples recorded — witness was quiet this day
+            </p>
+          ) : (
+            <>
+              <div className="mt-2 flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">samples</span>
+                <span className="text-xs font-mono">{day.samples}</span>
+              </div>
+              {day.failures > 0 && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">failures</span>
+                  <span className="text-xs font-mono text-rose-400">
+                    {day.failures}
+                  </span>
+                </div>
+              )}
+              {day.latency_p50_ms !== null && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">p50</span>
+                  <span className="text-xs font-mono">{day.latency_p50_ms} ms</span>
+                </div>
+              )}
+              {day.latency_p95_ms !== null && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">p95</span>
+                  <span className="text-xs font-mono">{day.latency_p95_ms} ms</span>
+                </div>
+              )}
+            </>
+          )}
+          {silencesForDay.length > 0 && (
+            <div className="mt-3 border-t border-border/30 pt-2 space-y-1">
+              <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                silences on this day
+              </p>
+              {silencesForDay.map((s) => (
+                <div key={s.id} className="text-xs">
+                  <span
+                    className={
+                      s.severity === "silent" ? "text-rose-400" : "text-amber-400"
+                    }
+                  >
+                    {s.severity}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {" · "}
+                    {formatDuration(s.duration_seconds)}
+                  </span>
+                  {s.note && (
+                    <p className="text-muted-foreground italic truncate">{s.note}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/app/pulse/latency-sparkline.tsx
+++ b/web/app/pulse/latency-sparkline.tsx
@@ -1,0 +1,92 @@
+import type { DailyBar } from "./types";
+
+/**
+ * Small inline SVG sparkline of daily p50 latency across the window.
+ *
+ * Days with no successful samples are skipped (no point plotted there) so
+ * gaps appear as breaks in the line rather than phantom zeros. A faint
+ * reference band shows p50..p95 where both exist.
+ */
+export function LatencySparkline({
+  daily,
+  width = 240,
+  height = 24,
+}: {
+  daily: DailyBar[];
+  width?: number;
+  height?: number;
+}) {
+  const points = daily
+    .map((d, i) => ({
+      i,
+      p50: d.latency_p50_ms,
+      p95: d.latency_p95_ms,
+    }))
+    .filter((p) => p.p50 !== null);
+
+  if (points.length === 0) {
+    return (
+      <div
+        className="text-[10px] text-muted-foreground/60 italic"
+        style={{ width, height }}
+      >
+        no latency data yet
+      </div>
+    );
+  }
+
+  const xs = points.map((p) => p.i);
+  const values = points.flatMap((p) => [p.p50 as number, p.p95 ?? (p.p50 as number)]);
+  const minY = Math.min(...values);
+  const maxY = Math.max(...values);
+  const yRange = Math.max(1, maxY - minY);
+  const xRange = Math.max(1, daily.length - 1);
+
+  const toX = (i: number) => (i / xRange) * (width - 4) + 2;
+  const toY = (v: number) =>
+    height - 2 - ((v - minY) / yRange) * (height - 4);
+
+  // Band polygon: p95 top to p50 bottom (reversed) — creates a filled area.
+  const bandTop = points.map((p) => `${toX(p.i)},${toY(p.p95 ?? (p.p50 as number))}`);
+  const bandBottom = [...points]
+    .reverse()
+    .map((p) => `${toX(p.i)},${toY(p.p50 as number)}`);
+  const bandPoly = [...bandTop, ...bandBottom].join(" ");
+
+  const p50Path = points
+    .map((p, idx) => {
+      const cmd = idx === 0 ? "M" : "L";
+      return `${cmd}${toX(p.i).toFixed(1)},${toY(p.p50 as number).toFixed(1)}`;
+    })
+    .join(" ");
+
+  const latest = points[points.length - 1];
+  const latestLabel =
+    latest.p50 !== null ? `${latest.p50} ms` : "—";
+
+  return (
+    <div className="flex items-center gap-2">
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        className="flex-shrink-0"
+        aria-label={`latency p50 sparkline, latest ${latestLabel}`}
+      >
+        <polygon points={bandPoly} fill="currentColor" opacity={0.15} />
+        <path
+          d={p50Path}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity={0.9}
+        />
+      </svg>
+      <span className="text-[10px] font-mono text-muted-foreground whitespace-nowrap">
+        {latestLabel}
+      </span>
+    </div>
+  );
+}

--- a/web/app/pulse/organ-row.tsx
+++ b/web/app/pulse/organ-row.tsx
@@ -1,17 +1,24 @@
-import type { OrganHistory, OrganNow } from "./types";
-import { STATUS_BAR, STATUS_DOT, STATUS_LABEL, STATUS_TEXT } from "./status-tokens";
+import type { OrganHistory, OrganNow, Silence } from "./types";
+import { STATUS_BAR, STATUS_DOT, STATUS_TEXT } from "./status-tokens";
+import { DayBar } from "./day-tooltip";
+import { LatencySparkline } from "./latency-sparkline";
+import { silencesOnDay } from "./silences-on-day";
 
 /**
- * One organ, one row. Current status dot on the left, label and uptime %
- * in the middle, a 90-day bar chart on the right. The bars are plain
- * CSS grid divs — no charting library — so this component has zero JS cost.
+ * One organ, one row. Current status dot on the left, label, uptime %, and
+ * a N-day daily bar chart on the right. Each bar is a rich-tooltip DayBar
+ * that shows the samples/failures/latency of that day plus any silences
+ * that overlapped it. A small latency sparkline sits under the bar chart
+ * so you can see the body's tempo, not just its aliveness.
  */
 export function OrganRow({
   now,
   history,
+  silences,
 }: {
   now: OrganNow | undefined;
   history: OrganHistory;
+  silences: Silence[];
 }) {
   const currentStatus = now?.status ?? "unknown";
   const uptime = history.uptime_pct;
@@ -19,6 +26,12 @@ export function OrganRow({
     history.daily.every((d) => d.samples === 0)
       ? "—"
       : `${uptime.toFixed(uptime === 100 ? 0 : 2)}%`;
+
+  // Pre-compute silences per day once rather than per-bar.
+  const byDate: Record<string, Silence[]> = {};
+  for (const d of history.daily) {
+    byDate[d.date] = silencesOnDay(silences, d.date);
+  }
 
   return (
     <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 space-y-4">
@@ -56,15 +69,12 @@ export function OrganRow({
           aria-label={`${history.label} daily breath over ${history.daily.length} days`}
         >
           {history.daily.map((d) => (
-            <div
+            <DayBar
               key={d.date}
-              className={`flex-1 min-w-[3px] rounded-sm ${STATUS_BAR[d.status]} hover:opacity-100 opacity-90 transition-opacity`}
-              style={{ height: d.samples === 0 ? "35%" : "100%" }}
-              title={`${d.date} · ${STATUS_LABEL[d.status]}${
-                d.samples > 0
-                  ? ` · ${d.samples} sample${d.samples > 1 ? "s" : ""}, ${d.failures} failure${d.failures === 1 ? "" : "s"}`
-                  : " · no samples"
-              }`}
+              day={d}
+              silencesForDay={byDate[d.date] ?? []}
+              organLabel={history.label}
+              barClass={STATUS_BAR[d.status]}
             />
           ))}
         </div>
@@ -73,6 +83,18 @@ export function OrganRow({
           <span>today</span>
         </div>
       </div>
+
+      {/* Latency sparkline — collected all along, finally visible */}
+      {history.latency_p50_ms !== null && (
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            tempo
+          </p>
+          <div className={STATUS_TEXT[currentStatus]}>
+            <LatencySparkline daily={history.daily} />
+          </div>
+        </div>
+      )}
 
       {/* Detail line when not breathing */}
       {now && now.detail && currentStatus !== "breathing" && (

--- a/web/app/pulse/overall-banner.tsx
+++ b/web/app/pulse/overall-banner.tsx
@@ -1,4 +1,4 @@
-import type { BreathStatus, OngoingSilence } from "./types";
+import type { BreathStatus, OngoingSilence, PulseHistoryOverall } from "./types";
 import { STATUS_BANNER, STATUS_DOT, STATUS_LABEL, formatDuration } from "./status-tokens";
 
 const HEADLINE: Record<BreathStatus, string> = {
@@ -23,41 +23,71 @@ export function OverallBanner({
   overall,
   checkedAt,
   ongoing,
+  historyOverall,
+  windowDays,
 }: {
   overall: BreathStatus;
   checkedAt: string;
   ongoing: OngoingSilence[];
+  historyOverall: PulseHistoryOverall | null;
+  windowDays: number;
 }) {
   const tokens = STATUS_BANNER[overall];
   const checked = new Date(checkedAt);
+  const uptimeAvailable =
+    historyOverall !== null && historyOverall.uptime_pct > 0;
 
   return (
     <section
       className={`rounded-3xl border ${tokens.border} bg-gradient-to-b ${tokens.bg} p-8 shadow-lg ${tokens.glow}`}
       aria-label="Overall pulse"
     >
-      <div className="flex items-center gap-3">
-        <span
-          className={`relative inline-flex h-3 w-3 rounded-full ${STATUS_DOT[overall]}`}
-          aria-hidden="true"
-        >
-          {overall === "breathing" && (
-            <span className="absolute inset-0 animate-ping rounded-full bg-emerald-400/40" />
-          )}
-        </span>
-        <p className="text-xs uppercase tracking-widest text-muted-foreground">
-          {STATUS_LABEL[overall]}
-        </p>
+      <div className="flex items-start justify-between gap-6 flex-wrap">
+        <div className="min-w-0">
+          <div className="flex items-center gap-3">
+            <span
+              className={`relative inline-flex h-3 w-3 rounded-full ${STATUS_DOT[overall]}`}
+              aria-hidden="true"
+            >
+              {overall === "breathing" && (
+                <span className="absolute inset-0 animate-ping rounded-full bg-emerald-400/40" />
+              )}
+            </span>
+            <p className="text-xs uppercase tracking-widest text-muted-foreground">
+              {STATUS_LABEL[overall]}
+            </p>
+          </div>
+          <h2 className={`mt-3 text-3xl font-light tracking-tight ${tokens.text}`}>
+            {HEADLINE[overall]}
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground leading-relaxed">
+            {SUBTITLE[overall]}
+          </p>
+          <p className="mt-4 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+            Listened at {checked.toLocaleString()}
+          </p>
+        </div>
+        {uptimeAvailable && historyOverall && (
+          <div className="text-right flex-shrink-0">
+            <p className={`text-5xl font-extralight ${tokens.text}`}>
+              {historyOverall.uptime_pct.toFixed(
+                historyOverall.uptime_pct === 100 ? 0 : 2,
+              )}
+              <span className="text-2xl">%</span>
+            </p>
+            <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 mt-1">
+              steady breath · {windowDays}d
+            </p>
+            {historyOverall.worst_organ && (
+              <p className="text-[11px] text-muted-foreground mt-1">
+                weakest organ:{" "}
+                <span className="font-mono">{historyOverall.worst_organ}</span>{" "}
+                ({historyOverall.worst_uptime_pct.toFixed(2)}%)
+              </p>
+            )}
+          </div>
+        )}
       </div>
-      <h2 className={`mt-3 text-3xl font-light tracking-tight ${tokens.text}`}>
-        {HEADLINE[overall]}
-      </h2>
-      <p className="mt-2 max-w-2xl text-sm text-muted-foreground leading-relaxed">
-        {SUBTITLE[overall]}
-      </p>
-      <p className="mt-4 text-[11px] uppercase tracking-wider text-muted-foreground/70">
-        Listened at {checked.toLocaleString()}
-      </p>
 
       {ongoing.length > 0 && (
         <div className="mt-6 rounded-xl border border-border/40 bg-background/40 p-4 space-y-2">

--- a/web/app/pulse/page.tsx
+++ b/web/app/pulse/page.tsx
@@ -5,6 +5,7 @@ import { getPulseBaseServer } from "@/lib/pulse-server";
 
 import { OrganRow } from "./organ-row";
 import { OverallBanner } from "./overall-banner";
+import { RangeToggle } from "./range-toggle";
 import { SilenceList } from "./silence-list";
 import { WitnessQuiet } from "./witness-quiet";
 import type { PulseHistory, PulseNow, PulseSilences } from "./types";
@@ -19,7 +20,8 @@ export const metadata: Metadata = {
 // anything finer is wasted work.
 export const revalidate = 60;
 
-const DAYS = 90;
+const ALLOWED_DAYS = [7, 30, 90] as const;
+const DEFAULT_DAYS = 90;
 
 type PulseSnapshot = {
   now: PulseNow | null;
@@ -27,14 +29,14 @@ type PulseSnapshot = {
   silences: PulseSilences | null;
 };
 
-async function loadPulse(base: string): Promise<PulseSnapshot> {
+async function loadPulse(base: string, days: number): Promise<PulseSnapshot> {
   if (!base) return { now: null, history: null, silences: null };
 
   const opts: RequestInit = { cache: "no-store" };
   const urls = [
     `${base}/pulse/now`,
-    `${base}/pulse/history?days=${DAYS}`,
-    `${base}/pulse/silences?days=${DAYS}`,
+    `${base}/pulse/history?days=${days}`,
+    `${base}/pulse/silences?days=${days}`,
   ];
 
   try {
@@ -65,25 +67,42 @@ async function loadPulse(base: string): Promise<PulseSnapshot> {
   }
 }
 
-export default async function PulsePage() {
+function resolveDays(raw: string | string[] | undefined): number {
+  const s = Array.isArray(raw) ? raw[0] : raw;
+  const n = Number(s);
+  if (ALLOWED_DAYS.includes(n as (typeof ALLOWED_DAYS)[number])) return n;
+  return DEFAULT_DAYS;
+}
+
+export default async function PulsePage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ days?: string | string[] }>;
+}) {
+  const params = (await searchParams) ?? {};
+  const days = resolveDays(params.days);
   const pulseBase = getPulseBaseServer();
-  const { now, history, silences } = await loadPulse(pulseBase);
+  const { now, history, silences } = await loadPulse(pulseBase, days);
   const witnessAlive = now !== null && history !== null;
 
   const organsNowByName = new Map(
     (now?.organs ?? []).map((o) => [o.name, o]),
   );
+  const silenceList = silences?.silences ?? [];
 
   return (
     <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-8 max-w-5xl mx-auto space-y-8">
       {/* Header */}
-      <header className="space-y-2">
-        <div className="flex items-center gap-3">
-          <span className="relative inline-flex h-3 w-3" aria-hidden="true">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400/40" />
-            <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500/80" />
-          </span>
-          <h1 className="text-3xl font-bold tracking-tight">Pulse</h1>
+      <header className="space-y-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <span className="relative inline-flex h-3 w-3" aria-hidden="true">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400/40" />
+              <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500/80" />
+            </span>
+            <h1 className="text-3xl font-bold tracking-tight">Pulse</h1>
+          </div>
+          {witnessAlive && <RangeToggle active={days} />}
         </div>
         <p className="max-w-3xl text-muted-foreground leading-relaxed">
           The breath of our living body, remembered. An external witness
@@ -98,6 +117,8 @@ export default async function PulsePage() {
             overall={now.overall}
             checkedAt={now.checked_at}
             ongoing={now.ongoing_silences}
+            historyOverall={history.overall ?? null}
+            windowDays={days}
           />
 
           <section className="space-y-3">
@@ -108,12 +129,13 @@ export default async function PulsePage() {
                   key={organ.name}
                   history={organ}
                   now={organsNowByName.get(organ.name)}
+                  silences={silenceList.filter((s) => s.organ === organ.name)}
                 />
               ))}
             </div>
           </section>
 
-          <SilenceList silences={silences?.silences ?? []} />
+          <SilenceList silences={silenceList} />
 
           <p className="text-[11px] text-muted-foreground/60 text-center">
             Witness started {new Date(now.witness_started_at).toLocaleString()}

--- a/web/app/pulse/range-toggle.tsx
+++ b/web/app/pulse/range-toggle.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+/**
+ * Three-button time-range selector. Pure server component — clicking any
+ * option updates the URL (?days=N) and the async page re-renders against
+ * that window. No client state, no re-fetch logic.
+ */
+export function RangeToggle({ active }: { active: number }) {
+  const options = [7, 30, 90];
+  return (
+    <div
+      className="inline-flex items-center rounded-full border border-border/40 bg-background/40 p-0.5 text-xs"
+      role="group"
+      aria-label="Time range"
+    >
+      {options.map((n) => {
+        const isActive = n === active;
+        return (
+          <Link
+            key={n}
+            href={`/pulse?days=${n}`}
+            scroll={false}
+            className={`px-3 py-1 rounded-full transition-colors ${
+              isActive
+                ? "bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent/30"
+            }`}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {n}d
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/app/pulse/silence-list.tsx
+++ b/web/app/pulse/silence-list.tsx
@@ -55,6 +55,11 @@ export function SilenceList({ silences }: { silences: Silence[] }) {
                   {start.toLocaleString()}
                   {end && ` → ${end.toLocaleString()}`}
                 </p>
+                {s.note && (
+                  <p className="text-xs italic text-muted-foreground/80 mt-1 line-clamp-2">
+                    {s.note}
+                  </p>
+                )}
               </div>
               <p className="text-xs text-muted-foreground font-mono text-right">
                 {formatDuration(s.duration_seconds)}

--- a/web/app/pulse/silences-on-day.ts
+++ b/web/app/pulse/silences-on-day.ts
@@ -1,0 +1,18 @@
+import type { Silence } from "./types";
+
+/**
+ * Pick the silences that overlap a given YYYY-MM-DD (UTC) window.
+ *
+ * Kept in its own plain-TS module (no "use client" directive) so it can
+ * be called from both server components and client components without
+ * tripping Next's client/server boundary.
+ */
+export function silencesOnDay(silences: Silence[], dateIso: string): Silence[] {
+  const dayStart = new Date(`${dateIso}T00:00:00Z`).getTime();
+  const dayEnd = dayStart + 24 * 60 * 60 * 1000;
+  return silences.filter((s) => {
+    const start = new Date(s.started_at).getTime();
+    const end = s.ended_at ? new Date(s.ended_at).getTime() : Date.now();
+    return start < dayEnd && end >= dayStart;
+  });
+}

--- a/web/app/pulse/types.ts
+++ b/web/app/pulse/types.ts
@@ -36,6 +36,8 @@ export type DailyBar = {
   status: BreathStatus;
   samples: number;
   failures: number;
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
 };
 
 export type OrganHistory = {
@@ -43,12 +45,21 @@ export type OrganHistory = {
   label: string;
   description: string;
   uptime_pct: number;
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
   daily: DailyBar[];
+};
+
+export type PulseHistoryOverall = {
+  uptime_pct: number;
+  worst_uptime_pct: number;
+  worst_organ: string | null;
 };
 
 export type PulseHistory = {
   days: number;
   generated_at: string;
+  overall: PulseHistoryOverall;
   organs: OrganHistory[];
 };
 


### PR DESCRIPTION
Five visible upgrades + one sensing upgrade, motivated by the parity walk against status.claude.com.

## Sensing
- `rollup_daily` computes p50/p95 latency per day across successful samples (nearest-rank)
- New `latency_percentiles()` helper for window-level rollup
- `DailyBar`, `OrganHistory`, and new `PulseHistoryOverall` models carry the new fields
- `/pulse/history` returns `overall: {uptime_pct, worst_uptime_pct, worst_organ}` + daily/organ p50/p95

## Visualization
- `DayBar` — real interactive button with rich hover/focus/tap tooltip showing date, state, samples, failures, p50, p95, and any silences overlapping the day. Biggest Claude-parity gain.
- `LatencySparkline` — inline SVG under each organ row, p50 line + p50..p95 band
- `RangeToggle` — 7/30/90 server-component switch via searchParams (no client state)
- `OverallBanner` — big uptime % + weakest-organ hint
- `SilenceList` renders `silence.note` (data model always had it, UI was swallowing)

## Verified in preview
- 7d: 42 bars × 6 organs
- 30d: 180 bars
- 90d: 540 bars
- Tooltip: click shows samples=801, failures=13, p50=476ms, p95=1180ms, "silences on this day"

44 pulse tests passing. Web typecheck clean.

## Deliberately not in this pass
- Maintenance state, finer severity, operator-posted incident updates — each needs auth + new table + operator UI; shipping half-done is lying tissue
- Subscriptions (email/SMS/Slack/webhook/Atom) — Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)