### PR TITLE
feat: pulse outcome organs — watch rendered pages, not just status codes

### DIFF
--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -3,82 +3,133 @@
 An "organ" is a single observable subsystem of the living network. Each organ
 declares which upstream endpoint it depends on and a small extractor function
 that decides, given a successful HTTP response, whether the organ is actually
-breathing or only pretending to breathe (e.g. /api/health can return 200 while
-reporting integrity_compromised=true internally).
+healthy. Extractors may check status, parsed JSON body shape, or rendered
+response text — whatever the organ needs.
 
-Organs are grouped by the upstream call they share, so a single round-trip to
-/api/health feeds several organ samples. This keeps the witness gentle on the
-network it watches.
+Two tiers:
+
+  - Infrastructure organs probe /api/health, /api/ready, and / for status
+    and structural health. They answer "is the plumbing up?".
+
+  - Outcome organs probe specific pages and API endpoints with assertions
+    on the rendered content or response shape. They answer "does this
+    surface actually give users what it's supposed to give?". An outcome
+    organ would have caught the /vitality shape-drift crash earlier in
+    this session, where the status was 200 but the page rendered
+    "Something went wrong".
+
+Organs are grouped by the upstream call they share, so a single round-trip
+to /api/health feeds several organ samples. The probe dispatcher issues
+exactly one GET per distinct upstream label per round.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from pulse_app.probe import UpstreamResult
 
 
-# Result of applying an extractor to a successful upstream response.
-# ok=False with a detail string means "the call succeeded but the organ is
-# not actually breathing" (e.g. integrity flag flipped).
+# Result of applying an extractor to an upstream response.
+# ok=False with a detail string means the organ is not healthy; the detail
+# is a short human explanation of what the witness saw.
 @dataclass(frozen=True)
 class OrganVerdict:
     ok: bool
     detail: str | None = None
 
 
-Extractor = Callable[[int, dict[str, Any] | None], OrganVerdict]
+Extractor = Callable[["UpstreamResult"], OrganVerdict]
 
 
 @dataclass(frozen=True)
 class Organ:
     """One observable subsystem."""
 
-    name: str                # stable id used in storage + API
-    label: str               # human-readable name for the UI
-    description: str         # one-line explanation
-    upstream: str            # one of UPSTREAM_* below
+    name: str               # stable id used in storage + API
+    label: str              # human-readable name for the UI
+    description: str        # one-line explanation
+    upstream: str           # one of UPSTREAM_* below
     extractor: Extractor
 
 
 # --- upstream labels ------------------------------------------------------
 
-UPSTREAM_API_HEALTH = "api_health"   # {API_BASE}/api/health
-UPSTREAM_API_READY = "api_ready"     # {API_BASE}/api/ready
-UPSTREAM_WEB_ROOT = "web_root"       # {WEB_BASE}/
+UPSTREAM_API_HEALTH = "api_health"     # {API_BASE}/api/health
+UPSTREAM_API_READY = "api_ready"       # {API_BASE}/api/ready
+UPSTREAM_API_IDEAS = "api_ideas"       # {API_BASE}/api/ideas
+UPSTREAM_API_VITALITY = "api_vitality"  # {API_BASE}/api/workspaces/coherence-network/vitality
+UPSTREAM_WEB_ROOT = "web_root"         # {WEB_BASE}/
+UPSTREAM_WEB_PULSE = "web_pulse"       # {WEB_BASE}/pulse
+UPSTREAM_WEB_VITALITY = "web_vitality"  # {WEB_BASE}/vitality
 
 
-# --- extractors -----------------------------------------------------------
+# Error boundary marker rendered by the Next.js root error.tsx. When this
+# string appears in an HTML response body we know the page crashed during
+# SSR or client hydration — regardless of the 200 status code.
+_NEXT_ERROR_MARKER = "Something went wrong"
+
+
+# --- helpers --------------------------------------------------------------
 
 def _is_ok(status: int) -> bool:
     return 200 <= status < 300
 
 
-def extract_api(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+def _require_body(result: "UpstreamResult") -> dict | None:
+    """Return the parsed JSON body or None. Used by JSON-shaped extractors."""
+    return result.body if isinstance(result.body, dict) else None
+
+
+def _require_text(result: "UpstreamResult") -> str | None:
+    """Return the raw text body or None. Used by text/HTML-shaped extractors."""
+    return result.text if isinstance(result.text, str) and result.text else None
+
+
+# ==========================================================================
+# Infrastructure extractors — status + JSON shape
+# ==========================================================================
+
+def extract_api(r: "UpstreamResult") -> OrganVerdict:
     """API organ: /api/health returns 200 with status == "ok"."""
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
-    if not body:
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
         return OrganVerdict(False, "empty response body")
     if body.get("status") != "ok":
         return OrganVerdict(False, f"status={body.get('status')!r}")
     return OrganVerdict(True)
 
 
-def extract_web(status: int, _body: dict[str, Any] | None) -> OrganVerdict:
-    """Web organ: root returns 2xx (body is HTML, we don't parse it)."""
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
+def extract_schema(r: "UpstreamResult") -> OrganVerdict:
+    """Schema organ: /api/health body.schema_ok == true."""
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    if not body.get("schema_ok", True):
+        return OrganVerdict(False, "schema_ok=false")
     return OrganVerdict(True)
 
 
-def _ready_503_reason(body: dict[str, Any] | None) -> str:
-    """The 503 detail on /api/ready has two distinct causes.
+def extract_audit(r: "UpstreamResult") -> OrganVerdict:
+    """Audit-integrity organ: /api/health body.integrity_compromised == false."""
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    if body.get("integrity_compromised"):
+        return OrganVerdict(False, "integrity_compromised=true")
+    return OrganVerdict(True)
 
-    When graph_store is None the detail is the plain string 'not ready'.
-    When the persistence contract fails the detail is a dict with
-    error == 'persistence_contract_failed'. We use this to distinguish
-    postgres-side failures from neo4j-side failures below.
-    """
+
+def _ready_503_reason(body: dict | None) -> str:
+    """/api/ready returns 503 for two distinct causes — distinguish them."""
     if not body:
         return "unknown"
     detail = body.get("detail")
@@ -89,67 +140,137 @@ def _ready_503_reason(body: dict[str, Any] | None) -> str:
     return "unknown"
 
 
-def extract_postgres(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+def extract_postgres(r: "UpstreamResult") -> OrganVerdict:
     """Postgres organ: db_connected true, or persistence contract failing."""
-    if status == 503:
-        reason = _ready_503_reason(body)
+    if r.status == 503:
+        reason = _ready_503_reason(r.body)
         if reason == "persistence_contract_failed":
             return OrganVerdict(False, "persistence contract failed")
-        # graph_store_missing is a neo4j signal, not a postgres signal —
-        # we can't tell postgres state from this response, so call it unknown
-        # by returning ok=False with a neutral note.
         return OrganVerdict(False, "unknown (ready=503)")
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
-    if not body:
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
         return OrganVerdict(False, "empty response body")
     if not body.get("db_connected"):
         return OrganVerdict(False, "db_connected=false")
     return OrganVerdict(True)
 
 
-def extract_neo4j(status: int, body: dict[str, Any] | None) -> OrganVerdict:
+def extract_neo4j(r: "UpstreamResult") -> OrganVerdict:
     """Neo4j organ: 503 only counts when graph_store is specifically missing."""
-    if status == 503:
-        reason = _ready_503_reason(body)
+    if r.status == 503:
+        reason = _ready_503_reason(r.body)
         if reason == "graph_store_missing":
             return OrganVerdict(False, "graph_store unavailable")
-        # 503 for some other reason is not a neo4j signal — neo4j may be fine.
         return OrganVerdict(True)
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
-    if not body:
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
         return OrganVerdict(False, "empty response body")
     if body.get("status") != "ready":
         return OrganVerdict(False, f"ready status={body.get('status')!r}")
     return OrganVerdict(True)
 
 
-def extract_schema(status: int, body: dict[str, Any] | None) -> OrganVerdict:
-    """Schema organ: /api/health body.schema_ok==true."""
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
-    if not body:
+# ==========================================================================
+# Outcome extractors — status + rendered content / full response shape
+# ==========================================================================
+
+def extract_web(r: "UpstreamResult") -> OrganVerdict:
+    """Web root organ: homepage serves HTML with Coherence Network branding."""
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    text = _require_text(r)
+    if text is None:
         return OrganVerdict(False, "empty response body")
-    if not body.get("schema_ok", True):
-        return OrganVerdict(False, "schema_ok=false")
+    if _NEXT_ERROR_MARKER in text:
+        return OrganVerdict(False, "error boundary rendered")
+    if "Coherence Network" not in text:
+        return OrganVerdict(False, "missing Coherence Network branding")
     return OrganVerdict(True)
 
 
-def extract_audit(status: int, body: dict[str, Any] | None) -> OrganVerdict:
-    """Audit-integrity organ: /api/health body.integrity_compromised==false."""
-    if not _is_ok(status):
-        return OrganVerdict(False, f"HTTP {status}")
-    if not body:
+def extract_web_pulse(r: "UpstreamResult") -> OrganVerdict:
+    """/pulse page renders the Pulse header and doesn't trip the error boundary."""
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    text = _require_text(r)
+    if text is None:
         return OrganVerdict(False, "empty response body")
-    if body.get("integrity_compromised"):
-        return OrganVerdict(False, "integrity_compromised=true")
+    if _NEXT_ERROR_MARKER in text:
+        return OrganVerdict(False, "error boundary rendered")
+    if ">Pulse<" not in text:
+        return OrganVerdict(False, "missing Pulse h1")
     return OrganVerdict(True)
 
 
-# --- the canonical organ list ---------------------------------------------
+def extract_web_vitality(r: "UpstreamResult") -> OrganVerdict:
+    """/vitality page renders the Vitality header and Diversity Index signal.
+
+    This is the outcome organ that would have caught the signals.map crash
+    earlier in the session, where /vitality returned HTTP 200 with an
+    error boundary HTML body because the api response shape had drifted
+    and the frontend was calling .map on a dict.
+    """
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    text = _require_text(r)
+    if text is None:
+        return OrganVerdict(False, "empty response body")
+    if _NEXT_ERROR_MARKER in text:
+        return OrganVerdict(False, "error boundary rendered")
+    if "Vitality" not in text:
+        return OrganVerdict(False, "missing Vitality header")
+    if "Diversity Index" not in text:
+        return OrganVerdict(False, "missing Diversity Index signal")
+    return OrganVerdict(True)
+
+
+def extract_api_ideas(r: "UpstreamResult") -> OrganVerdict:
+    """/api/ideas returns a dict with an 'ideas' list (the prod shape)."""
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    ideas = body.get("ideas")
+    if ideas is None:
+        return OrganVerdict(False, "missing 'ideas' key")
+    if not isinstance(ideas, list):
+        return OrganVerdict(False, f"ideas is {type(ideas).__name__}, expected list")
+    return OrganVerdict(True)
+
+
+def extract_api_vitality(r: "UpstreamResult") -> OrganVerdict:
+    """/api/workspaces/coherence-network/vitality returns the expected signals shape.
+
+    This is the companion to extract_web_vitality — if the api shape
+    drifts, this organ flags it directly, before the frontend has a
+    chance to render an error boundary.
+    """
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    signals = body.get("signals")
+    if signals is None:
+        return OrganVerdict(False, "missing 'signals' key")
+    if not isinstance(signals, dict):
+        return OrganVerdict(False, f"signals is {type(signals).__name__}, expected dict")
+    if "diversity_index" not in signals:
+        return OrganVerdict(False, "missing signals.diversity_index")
+    return OrganVerdict(True)
+
+
+# ==========================================================================
+# The canonical organ list
+# ==========================================================================
 
 ORGANS: list[Organ] = [
+    # --- infrastructure ---
     Organ(
         name="api",
         label="API",
@@ -192,6 +313,36 @@ ORGANS: list[Organ] = [
         upstream=UPSTREAM_API_HEALTH,
         extractor=extract_audit,
     ),
+    # --- outcome organs: rendered pages ---
+    Organ(
+        name="page_pulse",
+        label="Pulse page",
+        description="The /pulse surface — the organ that shows the other organs to the world.",
+        upstream=UPSTREAM_WEB_PULSE,
+        extractor=extract_web_pulse,
+    ),
+    Organ(
+        name="page_vitality",
+        label="Vitality page",
+        description="The /vitality surface — the deeper signal of life, rendered for humans.",
+        upstream=UPSTREAM_WEB_VITALITY,
+        extractor=extract_web_vitality,
+    ),
+    # --- outcome organs: api surface shape ---
+    Organ(
+        name="endpoint_ideas",
+        label="Ideas endpoint",
+        description="GET /api/ideas — the primary data surface for the idea pipeline.",
+        upstream=UPSTREAM_API_IDEAS,
+        extractor=extract_api_ideas,
+    ),
+    Organ(
+        name="endpoint_vitality",
+        label="Vitality endpoint",
+        description="GET /api/workspaces/coherence-network/vitality — the living signals shape.",
+        upstream=UPSTREAM_API_VITALITY,
+        extractor=extract_api_vitality,
+    ),
 ]
 
 
@@ -201,3 +352,16 @@ def organs_by_name() -> dict[str, Organ]:
 
 def organs_for_upstream(upstream: str) -> list[Organ]:
     return [o for o in ORGANS if o.upstream == upstream]
+
+
+def upstreams_in_use() -> list[str]:
+    """Return the distinct upstream labels any organ is currently using.
+
+    Order is stable (first-seen-in-ORGANS), so the probe dispatcher
+    issues requests in a predictable, debuggable order.
+    """
+    seen: list[str] = []
+    for organ in ORGANS:
+        if organ.upstream not in seen:
+            seen.append(organ.upstream)
+    return seen

--- a/pulse/pulse_app/probe.py
+++ b/pulse/pulse_app/probe.py
@@ -1,25 +1,31 @@
 """HTTP probes — one shared round-trip per upstream, fanned out to organs.
 
 We are gentle on the network we watch. Rather than hitting six endpoints to
-get six organ samples, we hit three upstreams (/api/health, /api/ready, /)
-and apply each organ's extractor to the shared response.
+get six organ samples, we hit a small set of upstreams and apply each
+organ's extractor to the shared response. Each organ declares its own
+upstream; the probe dispatcher groups organs by upstream and issues one
+GET per group, so duplicate organs cost nothing.
+
+Each upstream result carries the response status, the parsed JSON body
+(when the upstream is JSON-shaped), the raw response text (when the
+upstream is HTML-shaped), and the latency. Extractors receive the full
+UpstreamResult so they can check whatever they need — status, body
+shape, or rendered text markers.
 """
 
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterable
 
 import httpx
 
 from pulse_app.organs import (
     ORGANS,
-    UPSTREAM_API_HEALTH,
-    UPSTREAM_API_READY,
-    UPSTREAM_WEB_ROOT,
     Organ,
     organs_for_upstream,
+    upstreams_in_use,
 )
 from pulse_app.storage import Sample, iso_utc
 
@@ -27,16 +33,21 @@ from pulse_app.storage import Sample, iso_utc
 # Per-upstream result of one probe attempt, shared across organs.
 @dataclass(frozen=True)
 class UpstreamResult:
-    status: int              # HTTP status, or 0 on network error
-    body: dict[str, Any] | None
+    status: int                   # HTTP status, or 0 on network error
+    body: dict[str, Any] | None   # Parsed JSON when kind=json, else None
+    text: str | None              # Raw response text when kind=text, else None
     latency_ms: int
-    error: str | None        # transport error text, or None
+    error: str | None             # Transport error text, or None
 
 
 async def _probe_upstream(
-    client: httpx.AsyncClient, url: str, parse_json: bool
+    client: httpx.AsyncClient, url: str, kind: str
 ) -> UpstreamResult:
     """Fetch one upstream once, return a shared UpstreamResult.
+
+    `kind` is one of "json" (parse body into dict) or "text" (keep raw
+    response text for content-marker checks). JSON responses for
+    "text" upstreams still parse successfully; that's fine.
 
     We swallow all exceptions deliberately: a probe failure is a signal,
     not an error in the monitor.
@@ -46,25 +57,35 @@ async def _probe_upstream(
         resp = await client.get(url)
         elapsed = int((time.perf_counter() - start) * 1000)
         body: dict[str, Any] | None = None
-        if parse_json:
+        text: str | None = None
+        if kind == "json":
             try:
                 raw = resp.json()
                 if isinstance(raw, dict):
                     body = raw
             except Exception:
                 body = None
+        else:  # "text"
+            try:
+                text = resp.text
+            except Exception:
+                text = None
         return UpstreamResult(
-            status=resp.status_code, body=body, latency_ms=elapsed, error=None
+            status=resp.status_code,
+            body=body,
+            text=text,
+            latency_ms=elapsed,
+            error=None,
         )
     except httpx.HTTPError as exc:
         elapsed = int((time.perf_counter() - start) * 1000)
         return UpstreamResult(
-            status=0, body=None, latency_ms=elapsed, error=_short_error(exc)
+            status=0, body=None, text=None, latency_ms=elapsed, error=_short_error(exc)
         )
     except Exception as exc:  # pragma: no cover — defensive
         elapsed = int((time.perf_counter() - start) * 1000)
         return UpstreamResult(
-            status=0, body=None, latency_ms=elapsed, error=_short_error(exc)
+            status=0, body=None, text=None, latency_ms=elapsed, error=_short_error(exc)
         )
 
 
@@ -82,7 +103,7 @@ def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
             latency_ms=result.latency_ms,
             detail=result.error,
         )
-    verdict = organ.extractor(result.status, result.body)
+    verdict = organ.extractor(result)
     return Sample(
         ts=ts,
         organ=organ.name,
@@ -92,12 +113,31 @@ def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
     )
 
 
+def _build_url(upstream: str, api_base: str, web_base: str) -> tuple[str, str]:
+    """Map an upstream label to (url, kind). See organs.py for the labels."""
+    api = api_base.rstrip("/")
+    web = web_base.rstrip("/")
+    mapping: dict[str, tuple[str, str]] = {
+        "api_health": (f"{api}/api/health", "json"),
+        "api_ready": (f"{api}/api/ready", "json"),
+        "api_ideas": (f"{api}/api/ideas", "json"),
+        "api_vitality": (f"{api}/api/workspaces/coherence-network/vitality", "json"),
+        "web_root": (f"{web}/", "text"),
+        "web_pulse": (f"{web}/pulse", "text"),
+        "web_vitality": (f"{web}/vitality", "text"),
+    }
+    if upstream not in mapping:
+        raise ValueError(f"unknown upstream label: {upstream}")
+    return mapping[upstream]
+
+
 async def probe_all(
     api_base: str, web_base: str, client: httpx.AsyncClient | None = None
 ) -> list[Sample]:
     """Run one round of probes for every organ.
 
     Returns a list of samples in ORGANS order, all tagged with the same ts.
+    Each upstream is fetched exactly once even if multiple organs share it.
     """
     ts = iso_utc()
     owns_client = client is None
@@ -105,27 +145,13 @@ async def probe_all(
         client = httpx.AsyncClient(
             timeout=httpx.Timeout(10.0, connect=5.0),
             follow_redirects=True,
-            headers={"User-Agent": "pulse-monitor/0.1 (+https://coherencycoin.com)"},
+            headers={"User-Agent": "pulse-monitor/0.2 (+https://coherencycoin.com)"},
         )
     try:
-        api_health_url = f"{api_base.rstrip('/')}/api/health"
-        api_ready_url = f"{api_base.rstrip('/')}/api/ready"
-        web_root_url = f"{web_base.rstrip('/')}/"
-
-        # Only call upstreams that actually have organs pointing at them.
         results: dict[str, UpstreamResult] = {}
-        if organs_for_upstream(UPSTREAM_API_HEALTH):
-            results[UPSTREAM_API_HEALTH] = await _probe_upstream(
-                client, api_health_url, parse_json=True
-            )
-        if organs_for_upstream(UPSTREAM_API_READY):
-            results[UPSTREAM_API_READY] = await _probe_upstream(
-                client, api_ready_url, parse_json=True
-            )
-        if organs_for_upstream(UPSTREAM_WEB_ROOT):
-            results[UPSTREAM_WEB_ROOT] = await _probe_upstream(
-                client, web_root_url, parse_json=False
-            )
+        for upstream in upstreams_in_use():
+            url, kind = _build_url(upstream, api_base, web_base)
+            results[upstream] = await _probe_upstream(client, url, kind)
 
         return [_apply(o, results[o.upstream], ts) for o in ORGANS]
     finally:

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -39,8 +39,68 @@ HEALTHY_READY = {
     "integrity_compromised": False,
 }
 
+HEALTHY_IDEAS = {
+    "ideas": [
+        {"id": "idea-1", "name": "First idea", "description": "..."},
+        {"id": "idea-2", "name": "Second idea", "description": "..."},
+    ],
+    "pagination": {"total": 2, "page": 1, "page_size": 50},
+    "summary": {"count": 2},
+}
 
-def _handler(api_health_body=None, ready_body=None, ready_status=200, web_status=200):
+HEALTHY_VITALITY = {
+    "workspace_id": "coherence-network",
+    "vitality_score": 0.69,
+    "health_description": "Growing",
+    "signals": {
+        "diversity_index": 0.5,
+        "resonance_density": 0.8,
+        "flow_rate": 0.7,
+        "breath_rhythm": {"gas": 0.3, "water": 0.4, "ice": 0.3},
+        "connection_strength": 0.6,
+        "activity_pulse": 0.55,
+    },
+    "generated_at": "2026-04-15T12:00:00Z",
+}
+
+HEALTHY_HOME_HTML = """<!DOCTYPE html><html><body>
+<a href="/">Coherence Network</a>
+<main>welcome to the living network</main>
+</body></html>"""
+
+HEALTHY_PULSE_HTML = """<!DOCTYPE html><html><body>
+<h1>Pulse</h1>
+<p>The breath of our living body, remembered.</p>
+<section>All organs breathing</section>
+</body></html>"""
+
+HEALTHY_VITALITY_HTML = """<!DOCTYPE html><html><body>
+<h1>Vitality</h1>
+<p>Network Vitality 69%</p>
+<h3>Diversity Index</h3><h3>Resonance Density</h3>
+</body></html>"""
+
+# Marker Next.js emits when an error boundary catches a render failure.
+ERROR_BOUNDARY_HTML = """<!DOCTYPE html><html><body>
+<h2>Something went wrong</h2>
+</body></html>"""
+
+
+def _handler(
+    api_health_body=None,
+    ready_body=None,
+    ready_status=200,
+    ideas_body=None,
+    ideas_status=200,
+    vitality_api_body=None,
+    vitality_api_status=200,
+    web_status=200,
+    web_body=HEALTHY_HOME_HTML,
+    web_pulse_status=200,
+    web_pulse_body=HEALTHY_PULSE_HTML,
+    web_vitality_status=200,
+    web_vitality_body=HEALTHY_VITALITY_HTML,
+):
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path == "/api/health":
@@ -55,8 +115,24 @@ def _handler(api_health_body=None, ready_body=None, ready_status=200, web_status
                 content=json.dumps(ready_body or HEALTHY_READY),
                 headers={"content-type": "application/json"},
             )
+        if path == "/api/ideas":
+            return httpx.Response(
+                ideas_status,
+                content=json.dumps(ideas_body if ideas_body is not None else HEALTHY_IDEAS),
+                headers={"content-type": "application/json"},
+            )
+        if path == "/api/workspaces/coherence-network/vitality":
+            return httpx.Response(
+                vitality_api_status,
+                content=json.dumps(vitality_api_body if vitality_api_body is not None else HEALTHY_VITALITY),
+                headers={"content-type": "application/json"},
+            )
         if path == "/":
-            return httpx.Response(web_status, content="<html></html>")
+            return httpx.Response(web_status, content=web_body, headers={"content-type": "text/html"})
+        if path == "/pulse":
+            return httpx.Response(web_pulse_status, content=web_pulse_body, headers={"content-type": "text/html"})
+        if path == "/vitality":
+            return httpx.Response(web_vitality_status, content=web_vitality_body, headers={"content-type": "text/html"})
         return httpx.Response(404, content="not found")
 
     return handler
@@ -69,12 +145,18 @@ async def _run(handler) -> dict[str, object]:
     return {s.organ: s for s in samples}
 
 
+# ----- infrastructure organs ------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_all_healthy():
     by = await _run(_handler())
-    assert set(by.keys()) == {"api", "web", "postgres", "neo4j", "schema", "audit_integrity"}
-    for s in by.values():
-        assert s.ok is True, f"{s.organ} not ok: {s.detail}"
+    expected = {
+        "api", "web", "postgres", "neo4j", "schema", "audit_integrity",
+        "page_pulse", "page_vitality", "endpoint_ideas", "endpoint_vitality",
+    }
+    assert set(by.keys()) == expected
+    for name, sample in by.items():
+        assert sample.ok is True, f"{name} not ok: {sample.detail}"
 
 
 @pytest.mark.asyncio
@@ -82,7 +164,6 @@ async def test_api_status_not_ok():
     bad = {**HEALTHY_HEALTH, "status": "degraded"}
     by = await _run(_handler(api_health_body=bad))
     assert by["api"].ok is False
-    # Schema and audit still read from same body — they should still be OK.
     assert by["schema"].ok is True
     assert by["audit_integrity"].ok is True
 
@@ -91,7 +172,7 @@ async def test_api_status_not_ok():
 async def test_integrity_compromised_flags_audit_only():
     bad = {**HEALTHY_HEALTH, "integrity_compromised": True}
     by = await _run(_handler(api_health_body=bad))
-    assert by["api"].ok is True         # status=="ok" still
+    assert by["api"].ok is True
     assert by["audit_integrity"].ok is False
     assert "integrity" in (by["audit_integrity"].detail or "")
 
@@ -106,18 +187,15 @@ async def test_schema_not_ok():
 
 @pytest.mark.asyncio
 async def test_ready_503_graph_store_missing_flags_neo4j():
-    # FastAPI HTTPException with plain detail='not ready' when graph_store is None.
     body = {"detail": "not ready"}
     by = await _run(_handler(ready_status=503, ready_body=body))
     assert by["neo4j"].ok is False
     assert "graph_store" in (by["neo4j"].detail or "")
-    # API organ reads a different upstream, so it's unaffected.
     assert by["api"].ok is True
 
 
 @pytest.mark.asyncio
 async def test_ready_503_persistence_contract_flags_postgres_not_neo4j():
-    # The real shape seen in prod: detail is a dict with persistence_contract_failed.
     body = {
         "detail": {
             "error": "persistence_contract_failed",
@@ -128,7 +206,6 @@ async def test_ready_503_persistence_contract_flags_postgres_not_neo4j():
     by = await _run(_handler(ready_status=503, ready_body=body))
     assert by["postgres"].ok is False
     assert "persistence" in (by["postgres"].detail or "")
-    # neo4j is not implicated by this 503 cause.
     assert by["neo4j"].ok is True
 
 
@@ -140,12 +217,110 @@ async def test_db_disconnected_flags_postgres_only():
     assert by["neo4j"].ok is True
 
 
+# ----- web root organ ------------------------------------------------------
+
 @pytest.mark.asyncio
 async def test_web_down():
     by = await _run(_handler(web_status=503))
     assert by["web"].ok is False
     assert by["api"].ok is True
 
+
+@pytest.mark.asyncio
+async def test_web_missing_branding():
+    by = await _run(_handler(web_body="<html><body>different site</body></html>"))
+    assert by["web"].ok is False
+    assert "Coherence Network" in (by["web"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_web_error_boundary_flags_silent():
+    by = await _run(_handler(web_body=ERROR_BOUNDARY_HTML))
+    assert by["web"].ok is False
+    assert "error boundary" in (by["web"].detail or "")
+
+
+# ----- outcome organs: pages ------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_page_pulse_error_boundary():
+    """This is the class of bug the outcome organs were built to catch."""
+    by = await _run(_handler(web_pulse_body=ERROR_BOUNDARY_HTML))
+    assert by["page_pulse"].ok is False
+    assert "error boundary" in (by["page_pulse"].detail or "")
+    # Infrastructure organs are unaffected — this is a page-level sensing win.
+    assert by["api"].ok is True
+    assert by["web"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_page_pulse_missing_h1():
+    body = "<html><body>Pulse is broken — no h1 here</body></html>"
+    by = await _run(_handler(web_pulse_body=body))
+    assert by["page_pulse"].ok is False
+    assert "Pulse h1" in (by["page_pulse"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_page_vitality_error_boundary_catches_signals_map_crash():
+    """The exact class of bug this session hit: /vitality renders an error boundary."""
+    by = await _run(_handler(web_vitality_body=ERROR_BOUNDARY_HTML))
+    assert by["page_vitality"].ok is False
+    assert "error boundary" in (by["page_vitality"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_page_vitality_missing_diversity_signal():
+    body = "<html><body><h1>Vitality</h1><p>but no signals</p></body></html>"
+    by = await _run(_handler(web_vitality_body=body))
+    assert by["page_vitality"].ok is False
+    assert "Diversity" in (by["page_vitality"].detail or "")
+
+
+# ----- outcome organs: api shape -------------------------------------------
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_missing_ideas_key():
+    body = {"pagination": {}, "summary": {}}  # no ideas key at all
+    by = await _run(_handler(ideas_body=body))
+    assert by["endpoint_ideas"].ok is False
+    assert "ideas" in (by["endpoint_ideas"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_wrong_type():
+    body = {"ideas": {"not": "a list"}}
+    by = await _run(_handler(ideas_body=body))
+    assert by["endpoint_ideas"].ok is False
+    assert "list" in (by["endpoint_ideas"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_http_error():
+    by = await _run(_handler(ideas_status=500))
+    assert by["endpoint_ideas"].ok is False
+    assert "500" in (by["endpoint_ideas"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_vitality_shape_drift():
+    """Signals is an array, not a dict — the historical drift this session hit."""
+    body = {**HEALTHY_VITALITY, "signals": ["array", "instead", "of", "dict"]}
+    by = await _run(_handler(vitality_api_body=body))
+    assert by["endpoint_vitality"].ok is False
+    assert "signals" in (by["endpoint_vitality"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_vitality_missing_diversity_index():
+    partial_signals = {k: v for k, v in HEALTHY_VITALITY["signals"].items() if k != "diversity_index"}
+    body = {**HEALTHY_VITALITY, "signals": partial_signals}
+    by = await _run(_handler(vitality_api_body=body))
+    assert by["endpoint_vitality"].ok is False
+    assert "diversity_index" in (by["endpoint_vitality"].detail or "")
+
+
+# ----- network errors ------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_network_error_marks_everything_down():


### PR DESCRIPTION
Closes the sensing gap the /vitality crash surfaced earlier in this session. The api was returning 200, /api/ready was returning 200, all six infrastructure organs said "breathing" — while the actual page rendered "Something went wrong" because the api response shape had drifted and the frontend was calling .map() on a dict.

## Four new outcome organs

| name | upstream | assertion |
|---|---|---|
| page_pulse | GET /pulse | contains "Pulse" h1, no error boundary |
| page_vitality | GET /vitality | contains "Vitality" + "Diversity Index", no error boundary |
| endpoint_ideas | GET /api/ideas | body.ideas is a list |
| endpoint_vitality | GET /api/w../vitality | body.signals.diversity_index present |

The strengthened web organ also now asserts "Coherence Network" branding on /, not just a 2xx.

## Infrastructure

- `UpstreamResult` carries `text: str | None` for HTML-shaped upstreams alongside the existing `body` for JSON-shaped ones
- Extractors take the full `UpstreamResult` — all 6 existing ones refactored, all new ones follow the same shape
- `probe.py` dispatches via `upstreams_in_use()` which walks the ORGANS list and returns distinct upstream labels. New organs sharing an existing upstream cost zero extra HTTP requests; new upstreams cost one.
- `_NEXT_ERROR_MARKER = "Something went wrong"` is a single constant any text extractor can borrow to detect rendered error boundaries.

## Tests

55 pulse (was 44). The test that matters most is `test_page_vitality_error_boundary_catches_signals_map_crash` — a regression guard for the exact class of bug this session hit.

## What this doesn't do

- Real-user traffic counters (500s on /api/ideas/<id> that synthetic probes don't hit)
- Slow-but-up state (latency data exists, thresholds don't)
- Docker log scraping for web SSR errors

Each deserves its own attention; flagged in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)