### PR TITLE
feat: real-user traffic + slow-but-up sensing

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -86,6 +86,7 @@ from app.routers import vitality as vitality_router
 from app.middleware.attribution import AttributionMiddleware
 from app.middleware.rate_limit import RateLimitMiddleware
 from app.middleware.request_duration import RequestDurationMiddleware
+from app.middleware.request_outcomes import RequestOutcomesMiddleware
 from app.models.runtime import RuntimeEventCreate
 from app.services import runtime_service
 
@@ -526,6 +527,11 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestDurationMiddleware, threshold_seconds=1.0)
+# RequestOutcomesMiddleware sits inside RateLimitMiddleware (added later
+# = outer) so it counts requests that actually reached the route, not
+# ones rejected at the rate-limit layer. Its snapshot is exposed via
+# /api/health for the pulse witness to read.
+app.add_middleware(RequestOutcomesMiddleware)
 app.add_middleware(RateLimitMiddleware)
 # AttributionMiddleware is added LAST so it becomes the outermost middleware
 # in the stack — it populates request.state.contributor_id before the rate

--- a/api/app/middleware/request_outcomes.py
+++ b/api/app/middleware/request_outcomes.py
@@ -1,0 +1,144 @@
+"""Rolling request-outcome counters for the pulse witness to read.
+
+The witness probes `/api/health` every 30 seconds. That tells it whether
+the synthetic call succeeded, but it says nothing about the hundreds of
+other requests that might be failing for real users between probe rounds.
+
+This middleware keeps a tiny in-memory bucket of per-minute outcomes,
+grouped by status-code class (2xx / 3xx / 4xx / 5xx), and exposes them
+via `recent_outcomes_snapshot()`. The health endpoint includes the
+snapshot in its response body, so pulse's api organ sees real traffic
+shape without needing any new probe targets.
+
+Design notes:
+- Tumbling one-minute buckets keyed by epoch minute. When the window
+  rolls, old buckets are dropped from the left. Lock-free: one dict
+  append per request plus an occasional prune, no shared-state
+  contention worth worrying about.
+- Buckets drop paths entirely — we only record status class and count.
+  Path-level slicing would be valuable but also noisy and private; if a
+  specific path needs monitoring, add a synthetic outcome organ for it
+  (see pulse_app/organs.py).
+- Health endpoint probes are excluded from the counter. Pulse itself
+  hits /api/health every 30s, and we don't want the witness to be its
+  own biggest caller in the counter.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from threading import Lock
+from typing import Any
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+# Paths we don't count — they're noise from the monitor itself or from
+# readiness/liveness probes that aren't real user traffic.
+_EXCLUDED_PATHS = frozenset(
+    [
+        "/api/health",
+        "/api/ready",
+        "/api/ping",
+        "/api/version",
+        "/health",
+        "/",
+    ]
+)
+
+# How many minutes of history to keep. The counter exposes "last 1 min"
+# and "last 5 min" by summing the rightmost buckets.
+_RETENTION_MINUTES = 5
+
+
+# Shared state: { epoch_minute: { "2xx": int, "3xx": int, "4xx": int, "5xx": int } }
+_buckets: dict[int, dict[str, int]] = {}
+_lock = Lock()
+
+
+def _class_for(status: int) -> str:
+    if 200 <= status < 300:
+        return "2xx"
+    if 300 <= status < 400:
+        return "3xx"
+    if 400 <= status < 500:
+        return "4xx"
+    return "5xx"
+
+
+def _now_minute() -> int:
+    return int(time.time() // 60)
+
+
+def _prune_locked(now_min: int) -> None:
+    """Drop buckets older than the retention window. Caller holds _lock."""
+    cutoff = now_min - _RETENTION_MINUTES
+    for key in [k for k in _buckets if k <= cutoff]:
+        del _buckets[key]
+
+
+def record_outcome(status: int) -> None:
+    """Increment the bucket for the current minute + status class."""
+    now_min = _now_minute()
+    cls = _class_for(status)
+    with _lock:
+        _prune_locked(now_min)
+        bucket = _buckets.setdefault(now_min, {"2xx": 0, "3xx": 0, "4xx": 0, "5xx": 0})
+        bucket[cls] += 1
+
+
+def recent_outcomes_snapshot() -> dict[str, Any]:
+    """Return an aggregate over the last-1-minute and last-5-minute windows.
+
+    Shape (designed to be stable enough for pulse extractors to read):
+
+        {
+          "last_1m":  {"2xx": int, "3xx": int, "4xx": int, "5xx": int, "total": int},
+          "last_5m":  {"2xx": int, "3xx": int, "4xx": int, "5xx": int, "total": int},
+          "as_of_minute": int,   # epoch minute of the snapshot
+        }
+    """
+    now_min = _now_minute()
+    with _lock:
+        _prune_locked(now_min)
+        one_min_keys = [now_min]
+        five_min_keys = [now_min - i for i in range(_RETENTION_MINUTES)]
+
+        def _sum(keys: list[int]) -> dict[str, int]:
+            out = {"2xx": 0, "3xx": 0, "4xx": 0, "5xx": 0}
+            for k in keys:
+                b = _buckets.get(k)
+                if not b:
+                    continue
+                for cls in out:
+                    out[cls] += b.get(cls, 0)
+            out["total"] = sum(out.values())
+            return out
+
+        return {
+            "last_1m": _sum(one_min_keys),
+            "last_5m": _sum(five_min_keys),
+            "as_of_minute": now_min,
+        }
+
+
+def _reset_for_tests() -> None:  # pragma: no cover — test helper
+    with _lock:
+        _buckets.clear()
+
+
+class RequestOutcomesMiddleware(BaseHTTPMiddleware):
+    """Record the outcome of every non-excluded request."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        path = request.url.path
+        if path not in _EXCLUDED_PATHS:
+            try:
+                record_outcome(response.status_code)
+            except Exception:
+                # Never let the counter break a request.
+                pass
+        return response

--- a/api/app/routers/health.py
+++ b/api/app/routers/health.py
@@ -4,11 +4,12 @@ from datetime import datetime, timezone
 import logging
 import os
 import ast
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.middleware.request_outcomes import recent_outcomes_snapshot
 from app.services import persistence_contract_service
 from app.services import unified_db
 from app.services import audit_ledger_service
@@ -123,6 +124,17 @@ class HealthResponse(_BaseHealthResponse):
     smart_reap_import_error: Annotated[
         str | None,
         Field(description="Import error message if smart_reap_service failed to load"),
+    ] = None
+    recent_outcomes: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description=(
+                "Real-user traffic outcome snapshot from "
+                "RequestOutcomesMiddleware: rolling per-status-class counts "
+                "over the last 1 and 5 minutes. Read by pulse to flag the "
+                "api organ as strained when recent_outcomes.last_1m.5xx > 0."
+            )
+        ),
     ] = None
 
 
@@ -250,6 +262,14 @@ async def health():
         smart_reap_available = False
         smart_reap_import_error = str(_e)
 
+    # Real-user traffic outcome snapshot. If the middleware isn't wired
+    # (e.g. during a test client run without the full stack), this fails
+    # softly and the field is None.
+    try:
+        recent_outcomes = recent_outcomes_snapshot()
+    except Exception:
+        recent_outcomes = None
+
     return HealthResponse(
         status="ok",
         version=HEALTH_VERSION,
@@ -263,4 +283,5 @@ async def health():
         schema_ok=schema_ok,
         smart_reap_available=smart_reap_available,
         smart_reap_import_error=smart_reap_import_error,
+        recent_outcomes=recent_outcomes,
     )

--- a/api/tests/test_request_outcomes_middleware.py
+++ b/api/tests/test_request_outcomes_middleware.py
@@ -1,0 +1,124 @@
+"""Tests for the per-minute request outcomes counter."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from app.middleware.request_outcomes import (
+    RequestOutcomesMiddleware,
+    _reset_for_tests,
+    recent_outcomes_snapshot,
+)
+
+
+def _build_probe_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestOutcomesMiddleware)
+
+    @app.get("/api/ideas")
+    async def ideas():
+        return {"ideas": []}
+
+    @app.get("/api/ideas/boom")
+    async def ideas_boom():
+        raise HTTPException(status_code=500, detail="synthetic")
+
+    @app.get("/api/ideas/notfound")
+    async def ideas_notfound():
+        raise HTTPException(status_code=404, detail="nope")
+
+    @app.get("/api/health")
+    async def health():
+        # Health is excluded from the counter — this is the synthetic
+        # probe path. If it weren't excluded, the witness's own probes
+        # would be the biggest caller.
+        return {"status": "ok"}
+
+    return app
+
+
+async def _client():
+    app = _build_probe_app()
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_empty_snapshot_has_zero_counts():
+    _reset_for_tests()
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["total"] == 0
+    assert snap["last_1m"]["5xx"] == 0
+    assert snap["last_5m"]["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_2xx_counted():
+    _reset_for_tests()
+    async with await _client() as c:
+        r = await c.get("/api/ideas")
+    assert r.status_code == 200
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["2xx"] == 1
+    assert snap["last_1m"]["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_5xx_counted():
+    _reset_for_tests()
+    async with await _client() as c:
+        r = await c.get("/api/ideas/boom")
+    assert r.status_code == 500
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["5xx"] == 1
+    assert snap["last_1m"]["2xx"] == 0
+
+
+@pytest.mark.asyncio
+async def test_4xx_counted():
+    _reset_for_tests()
+    async with await _client() as c:
+        r = await c.get("/api/ideas/notfound")
+    assert r.status_code == 404
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["4xx"] == 1
+    assert snap["last_1m"]["5xx"] == 0
+
+
+@pytest.mark.asyncio
+async def test_health_excluded_from_counter():
+    """The witness's own probe path must not pollute the real-user traffic counter."""
+    _reset_for_tests()
+    async with await _client() as c:
+        for _ in range(10):
+            await c.get("/api/health")
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["total"] == 0
+    assert snap["last_1m"]["2xx"] == 0
+
+
+@pytest.mark.asyncio
+async def test_mixed_traffic():
+    _reset_for_tests()
+    async with await _client() as c:
+        for _ in range(3):
+            await c.get("/api/ideas")
+        await c.get("/api/ideas/boom")
+        await c.get("/api/ideas/notfound")
+        await c.get("/api/health")  # excluded
+    snap = recent_outcomes_snapshot()
+    assert snap["last_1m"]["2xx"] == 3
+    assert snap["last_1m"]["4xx"] == 1
+    assert snap["last_1m"]["5xx"] == 1
+    assert snap["last_1m"]["total"] == 5  # health excluded
+
+
+@pytest.mark.asyncio
+async def test_snapshot_shape_stable():
+    """The snapshot shape is the contract pulse's extract_api reads against."""
+    _reset_for_tests()
+    snap = recent_outcomes_snapshot()
+    assert set(snap.keys()) == {"last_1m", "last_5m", "as_of_minute"}
+    for window in ("last_1m", "last_5m"):
+        assert set(snap[window].keys()) == {"2xx", "3xx", "4xx", "5xx", "total"}

--- a/pulse/pulse_app/analysis.py
+++ b/pulse/pulse_app/analysis.py
@@ -189,7 +189,14 @@ def latency_percentiles(samples: list[Sample]) -> tuple[int | None, int | None]:
 def status_from_last_sample(sample: Sample | None) -> str:
     if sample is None:
         return "unknown"
-    return "breathing" if sample.ok else "silent"
+    if not sample.ok:
+        return "silent"
+    # A successful probe with a "slow:" detail was flagged by probe._apply
+    # because its latency crossed the organ's threshold. It breathes, but
+    # it's straining.
+    if sample.detail and sample.detail.startswith("slow: "):
+        return "strained"
+    return "breathing"
 
 
 def overall_status(organ_statuses: list[str]) -> str:

--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -48,11 +48,17 @@ Extractor = Callable[["UpstreamResult"], OrganVerdict]
 class Organ:
     """One observable subsystem."""
 
-    name: str               # stable id used in storage + API
-    label: str              # human-readable name for the UI
-    description: str        # one-line explanation
-    upstream: str           # one of UPSTREAM_* below
+    name: str                          # stable id used in storage + API
+    label: str                         # human-readable name for the UI
+    description: str                   # one-line explanation
+    upstream: str                      # one of UPSTREAM_* below
     extractor: Extractor
+    latency_threshold_ms: int = 2000   # above this, a successful probe is
+                                       # still flagged "slow: Xms > Yms" —
+                                       # the sample is ok=True but its
+                                       # detail is set, so the current
+                                       # status reads as "strained" while
+                                       # the historical uptime stays at 100%
 
 
 # --- upstream labels ------------------------------------------------------
@@ -93,7 +99,18 @@ def _require_text(result: "UpstreamResult") -> str | None:
 # ==========================================================================
 
 def extract_api(r: "UpstreamResult") -> OrganVerdict:
-    """API organ: /api/health returns 200 with status == "ok"."""
+    """API organ: /api/health status ok + no 5xx in real user traffic.
+
+    The api container exposes `recent_outcomes` in the health response via
+    RequestOutcomesMiddleware. It's a rolling 1-and-5 minute snapshot of
+    per-status-class counts across all non-health routes. When the last
+    minute has any 5xx responses, the organ is flagged "slow: N× 5xx in
+    last 1m" — the probe itself still succeeded, so the sample is ok=True
+    with a slow-style detail, and `status_from_last_sample` maps that to
+    'strained' instead of 'silent'. This means real-user 5xx counts show
+    up as strain on the pulse page within 30 seconds of occurring, even
+    on routes the synthetic probes don't touch.
+    """
     if not _is_ok(r.status):
         return OrganVerdict(False, f"HTTP {r.status}")
     body = _require_body(r)
@@ -101,6 +118,29 @@ def extract_api(r: "UpstreamResult") -> OrganVerdict:
         return OrganVerdict(False, "empty response body")
     if body.get("status") != "ok":
         return OrganVerdict(False, f"status={body.get('status')!r}")
+
+    # Real user traffic check — never gates ok=True; surfaces as a
+    # "slow:" detail so status_from_last_sample reads strained.
+    outcomes = body.get("recent_outcomes")
+    if isinstance(outcomes, dict):
+        last_1m = outcomes.get("last_1m") or {}
+        recent_5xx = int(last_1m.get("5xx") or 0)
+        recent_4xx = int(last_1m.get("4xx") or 0)
+        recent_total = int(last_1m.get("total") or 0)
+        if recent_5xx > 0:
+            return OrganVerdict(
+                True,
+                f"slow: {recent_5xx}× 5xx in last 1m (of {recent_total} requests)",
+            )
+        # A very high 4xx rate usually means broken clients, not broken
+        # api — but if nearly everything is 4xx, something upstream is
+        # feeding the api bad requests en masse. Flag only at high ratio.
+        if recent_total >= 20 and recent_4xx * 2 > recent_total:
+            return OrganVerdict(
+                True,
+                f"slow: {recent_4xx}× 4xx in last 1m (of {recent_total} requests)",
+            )
+
     return OrganVerdict(True)
 
 
@@ -313,13 +353,14 @@ ORGANS: list[Organ] = [
         upstream=UPSTREAM_API_HEALTH,
         extractor=extract_audit,
     ),
-    # --- outcome organs: rendered pages ---
+    # --- outcome organs: rendered pages (SSR is slower than a JSON response) ---
     Organ(
         name="page_pulse",
         label="Pulse page",
         description="The /pulse surface — the organ that shows the other organs to the world.",
         upstream=UPSTREAM_WEB_PULSE,
         extractor=extract_web_pulse,
+        latency_threshold_ms=3000,
     ),
     Organ(
         name="page_vitality",
@@ -327,6 +368,7 @@ ORGANS: list[Organ] = [
         description="The /vitality surface — the deeper signal of life, rendered for humans.",
         upstream=UPSTREAM_WEB_VITALITY,
         extractor=extract_web_vitality,
+        latency_threshold_ms=3000,
     ),
     # --- outcome organs: api surface shape ---
     Organ(
@@ -335,6 +377,7 @@ ORGANS: list[Organ] = [
         description="GET /api/ideas — the primary data surface for the idea pipeline.",
         upstream=UPSTREAM_API_IDEAS,
         extractor=extract_api_ideas,
+        latency_threshold_ms=1500,
     ),
     Organ(
         name="endpoint_vitality",
@@ -342,6 +385,7 @@ ORGANS: list[Organ] = [
         description="GET /api/workspaces/coherence-network/vitality — the living signals shape.",
         upstream=UPSTREAM_API_VITALITY,
         extractor=extract_api_vitality,
+        latency_threshold_ms=1500,
     ),
 ]
 

--- a/pulse/pulse_app/probe.py
+++ b/pulse/pulse_app/probe.py
@@ -94,6 +94,9 @@ def _short_error(exc: BaseException) -> str:
     return text[:200]
 
 
+_SLOW_PREFIX = "slow: "
+
+
 def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
     if result.error is not None:
         return Sample(
@@ -104,12 +107,25 @@ def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
             detail=result.error,
         )
     verdict = organ.extractor(result)
+    detail = verdict.detail
+    # Post-verdict threshold check: a probe that passed content assertions
+    # can still be "slow" — detail is set but ok stays True. The current
+    # status then reads as "strained" via status_from_last_sample while
+    # the historical uptime stays at 100% (nothing was wrong, just slow).
+    if (
+        verdict.ok
+        and organ.latency_threshold_ms
+        and result.latency_ms > organ.latency_threshold_ms
+    ):
+        detail = (
+            f"{_SLOW_PREFIX}{result.latency_ms}ms > {organ.latency_threshold_ms}ms threshold"
+        )
     return Sample(
         ts=ts,
         organ=organ.name,
         ok=verdict.ok,
         latency_ms=result.latency_ms,
-        detail=verdict.detail,
+        detail=detail,
     )
 
 

--- a/pulse/tests/test_analysis.py
+++ b/pulse/tests/test_analysis.py
@@ -61,6 +61,28 @@ def test_status_last_sample_bad():
     assert status_from_last_sample(_s("api", False, 0)) == "silent"
 
 
+def test_status_last_sample_slow_is_strained():
+    slow_sample = Sample(
+        ts=iso_utc(),
+        organ="api",
+        ok=True,
+        latency_ms=3500,
+        detail="slow: 3500ms > 2000ms threshold",
+    )
+    assert status_from_last_sample(slow_sample) == "strained"
+
+
+def test_status_last_sample_detail_other_than_slow_is_still_breathing():
+    weird_sample = Sample(
+        ts=iso_utc(),
+        organ="api",
+        ok=True,
+        latency_ms=100,
+        detail="some other detail",
+    )
+    assert status_from_last_sample(weird_sample) == "breathing"
+
+
 # --- overall_status -------------------------------------------------------
 
 def test_overall_all_breathing():

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -160,6 +160,51 @@ async def test_all_healthy():
 
 
 @pytest.mark.asyncio
+async def test_api_flags_strained_on_recent_5xx():
+    """Real-user 5xx count surfaces as strain on the api organ."""
+    body = {**HEALTHY_HEALTH, "recent_outcomes": {
+        "last_1m": {"2xx": 100, "3xx": 0, "4xx": 2, "5xx": 3, "total": 105},
+        "last_5m": {"2xx": 500, "3xx": 0, "4xx": 5, "5xx": 3, "total": 508},
+        "as_of_minute": 29000000,
+    }}
+    by = await _run(_handler(api_health_body=body))
+    api_sample = by["api"]
+    assert api_sample.ok is True  # the probe itself succeeded
+    assert api_sample.detail is not None
+    assert api_sample.detail.startswith("slow: ")
+    assert "5xx" in api_sample.detail
+    assert "last 1m" in api_sample.detail
+
+
+@pytest.mark.asyncio
+async def test_api_flags_strained_on_heavy_4xx_rate():
+    """When most recent traffic is 4xx, flag the api as straining."""
+    body = {**HEALTHY_HEALTH, "recent_outcomes": {
+        "last_1m": {"2xx": 5, "3xx": 0, "4xx": 25, "5xx": 0, "total": 30},
+        "last_5m": {"2xx": 20, "3xx": 0, "4xx": 80, "5xx": 0, "total": 100},
+        "as_of_minute": 29000000,
+    }}
+    by = await _run(_handler(api_health_body=body))
+    api_sample = by["api"]
+    assert api_sample.ok is True
+    assert api_sample.detail is not None
+    assert "4xx" in api_sample.detail
+
+
+@pytest.mark.asyncio
+async def test_api_does_not_strain_on_small_4xx_count():
+    """A handful of 4xx is normal user error — don't flag."""
+    body = {**HEALTHY_HEALTH, "recent_outcomes": {
+        "last_1m": {"2xx": 100, "3xx": 0, "4xx": 3, "5xx": 0, "total": 103},
+        "last_5m": {"2xx": 500, "3xx": 0, "4xx": 10, "5xx": 0, "total": 510},
+        "as_of_minute": 29000000,
+    }}
+    by = await _run(_handler(api_health_body=body))
+    assert by["api"].ok is True
+    assert by["api"].detail is None
+
+
+@pytest.mark.asyncio
 async def test_api_status_not_ok():
     bad = {**HEALTHY_HEALTH, "status": "degraded"}
     by = await _run(_handler(api_health_body=bad))
@@ -321,6 +366,36 @@ async def test_endpoint_vitality_missing_diversity_index():
 
 
 # ----- network errors ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_slow_probe_flags_strained_not_silent(monkeypatch):
+    """A successful probe that crossed the threshold is ok=True with a slow detail."""
+    from pulse_app import organs, probe
+
+    # Rewrite the test to inject a slow latency by monkey-patching the probe helper.
+    original = probe._probe_upstream
+
+    async def slow_probe(client, url, kind):
+        r = await original(client, url, kind)
+        # Replace with a 3-second latency on the api_health upstream
+        if url.endswith("/api/health"):
+            return probe.UpstreamResult(
+                status=r.status, body=r.body, text=r.text,
+                latency_ms=3500, error=None,
+            )
+        return r
+
+    monkeypatch.setattr(probe, "_probe_upstream", slow_probe)
+
+    by = await _run(_handler())
+    # api organ's default threshold is 2000ms, so 3500ms is flagged
+    api_sample = by["api"]
+    assert api_sample.ok is True  # the body was fine
+    assert api_sample.detail is not None
+    assert api_sample.detail.startswith("slow: ")
+    assert "3500ms" in api_sample.detail
+    assert "2000ms" in api_sample.detail
+
 
 @pytest.mark.asyncio
 async def test_network_error_marks_everything_down():


### PR DESCRIPTION
Two sensing gaps closed in one motion, tightening the pulse<->api loop.

**1. Slow-but-up.** Per-organ `latency_threshold_ms` (default 2000, SSR 3000, data 1500). After the extractor says ok, probe._apply checks latency vs threshold; slow probes become `ok=True` with detail `slow: Xms > Yms threshold`. `status_from_last_sample` reads that as 'strained', so the organ goes amber in the banner within 30s. History stays green (nothing was wrong, just sluggish) — the tempo sparkline reveals the drift.

**2. Real-user traffic counter.** New `RequestOutcomesMiddleware` keeps a tumbling per-minute bucket of 2xx/3xx/4xx/5xx across every non-probe route. Snapshot exposed on `/api/health.recent_outcomes` as `{last_1m, last_5m, as_of_minute}`. Pulse's `extract_api` reads it: 5xx in last minute → strained with `slow: N× 5xx in last 1m`, majority-4xx on ≥20 requests → strained, handful of 4xx stays green. Health/ready/ping/version/root are excluded so the witness doesn't pollute its own counter.

Closes the blindness-to-real-traffic gap: when a route we don't synthetically probe starts returning 500s, the api organ flags strained within 30 seconds without any new probe target.

Tests: 61 pulse (+3), 7 new api middleware, 95 regression slice green in 4.05s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)