### PR TITLE
web: heal Next.js dynamic-slug conflict in /profile/[...]

### DIFF
--- a/web/app/profile/[contributorId]/beliefs/page.tsx
+++ b/web/app/profile/[contributorId]/beliefs/page.tsx
@@ -25,7 +25,8 @@ const API_BASE = getApiBase();
 
 export default function BeliefProfilePage() {
   const params = useParams();
-  const handle = typeof params?.handle === "string" ? params.handle : "";
+  const handle =
+    typeof params?.contributorId === "string" ? params.contributorId : "";
 
   const [profile, setProfile] = useState<BeliefProfile | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary

Prod web (`coherencycoin.com`) has been returning HTTP 500 on every SSR route since PR #975 merged. The API came up healthy at the target SHA; only the web side crashed per-request. Static chunks continued to serve, which meant the Node process was running but throwing on every request.

Running `next build && node .next/standalone/server.js` locally exposed the real error immediately:

```
Error: You cannot use different slug names for the same dynamic path
('handle' !== 'contributorId').
```

PR #975 added `/profile/[contributorId]/page.tsx` as the new contributor profile landing, while `/profile/[handle]/beliefs/page.tsx` was already in place from earlier work. Next.js rejects two different dynamic slug names at the same path level — the app was failing at its own routing table before any page component could render.

## Heal

Move the beliefs page under the same `[contributorId]` slug as the profile landing, and update the param read in the beliefs page from `params?.handle` to `params?.contributorId`. Both routes now live under `/profile/[contributorId]/{,beliefs}`, which is the form Next.js accepts. The public URL changes from `/profile/{handle}/beliefs` to `/profile/{contributorId}/beliefs`, which is consistent with how the rest of the contributor surface now identifies people.

This is a forward-fix replacing the revert in PR #989 (now closed). The user's three hundred files of contributor identity, frequency profiles, NFT tracking, bring-your-own-key, creator bridge, and concept story CRUD stay in place.

## Local verification

- `next build` — compiles cleanly, 68 static pages generated
- `node .next/standalone/server.js` on port 3737 — starts in 91ms, no unhandled rejections
- Routes hit locally with the same tool CI uses (`curl -sS -o /dev/null -w "%{http_code}"`):
  - `/` → 200
  - `/profile/test-id` → 200
  - `/profile/test-id/beliefs` → 200
  - `/vision/economy` → 200
  - `/flow` → 200
  - `/ideas` → 200

## The pattern worth naming

The original mistake in the PR #975 merge was merging without running `npm install && next build && next start` locally against the rebased branch. My local `node_modules` was stale from before the three.js packages landed, so my earlier local build failed on a missing-package error that I mis-read as "the container will fetch these on deploy, it's fine." The container did fetch them, and then the runtime crashed on a different issue entirely that my local setup would have caught if I had run a fresh install before merging.

The discipline this teaches, for every web-touching merge going forward: `npm install && npx next build && node .next/standalone/server.js` on a fresh port, then curl the top-level routes, before merging. The container is not special. The same code runs on the same Node version with the same package lock.

## Test plan

- [x] Local `next build` clean
- [x] Local server responds 200 on all tested routes
- [ ] Hostinger Auto Deploy runs on merge and Verify Public Deployment reports CLEAN across api and web
- [ ] `https://coherencycoin.com/` returns 200 on prod again

🤖 Generated with [Claude Code](https://claude.com/claude-code)