### PR TITLE
deploy: extend verify patience to 404 during rollout window

### DIFF
--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -113,11 +113,22 @@ check_url() {
       return 1
     fi
 
-    if [[ "$status" == "502" || "$status" == "503" || "$status" == "504" ]] && (( $(date +%s) < deadline )); then
-      echo "WARN: gateway status ${status}; waiting ${GATEWAY_PATIENCE_INTERVAL}s for upstream to reconnect..."
-      sleep "$GATEWAY_PATIENCE_INTERVAL"
-      continue
-    fi
+    # Patient retry covers the brief window right after a rollout where the
+    # gateway is reconnecting to a fresh upstream. 502/503/504 are the
+    # expected "backend unreachable" signals, but 404 also appears briefly
+    # when Traefik has torn down the old route and not yet registered the
+    # new one — the catch-all handler returns 404 while the routing table
+    # is mid-update. Treating 404 as a transient during the rollout window
+    # lets the body finish its own breath before the verify script reports.
+    case "$status" in
+      502|503|504|404)
+        if (( $(date +%s) < deadline )); then
+          echo "WARN: rollout status ${status}; waiting ${GATEWAY_PATIENCE_INTERVAL}s for the gateway to settle..."
+          sleep "$GATEWAY_PATIENCE_INTERVAL"
+          continue
+        fi
+        ;;
+    esac
     break
   done
 


### PR DESCRIPTION
## Summary

The verify script's earlier patience heal covered 502/503/504 gateway errors during the brief window after a fresh rollout when Traefik is reconnecting to a new upstream. PR #990's Hostinger Auto Deploy run showed the next layer of the same pattern: the first `/api/health` check got an HTTP 404, the script immediately bailed, and every check that happened a few seconds later got clean 200s. The field was fine. The verify was impatient by one status code.

The 404 in this window is not a missing route — it is Traefik serving a catch-all while the routing table is mid-update, after the old upstream has been torn down but before the new one has registered. Widening the transient-status case to include 404 alongside 502/503/504 absorbs this brief transition into the same 90-second patience window the earlier heal established. Permanent 404s still fail after the window closes, so a truly broken route cannot hide behind this.

Also renames the log line from `gateway status` to `rollout status` — 404 is a routing-table signal rather than a backend-reachability one, and the phrase names what the pause is actually waiting for.

## Evidence from the previous run (PR #990)

```
23:46:13  HTTP status: 404  ← first check, bailed immediately
23:46:26  HTTP status: 200
23:46:28  HTTP status: 200
23:46:38  HTTP status: 200
(all subsequent checks: 200)
```

The deploy workflow reported failure even though prod was healthy; the false alarm landed in the skin sensing as urgent attention that the organism did not actually need.

## Test plan

- [x] `bash -n scripts/verify_web_api_deploy.sh` — syntax clean
- [ ] Next deploy after merge — the workflow reports CLEAN because the first check either gets 200 immediately or waits through the brief rollout window

🤖 Generated with [Claude Code](https://claude.com/claude-code)