### PR TITLE
fix: /api/energy/pulse 500 — vitality signals shape mismatch

### DIFF
--- a/api/app/services/community_pulse_service.py
+++ b/api/app/services/community_pulse_service.py
@@ -236,8 +236,12 @@ def _sense_quality(name: str, meta: dict, raw: dict) -> dict[str, Any]:
     if name == "vital":
         vitality = raw.get("vitality", {})
         score = vitality.get("vitality_score", 0)
-        activity = vitality.get("signals", [])
-        active_signals = [s for s in activity if s.get("value", 0) > 0.5]
+        # vitality_service returns signals as a dict {name: score} — not a list
+        signals = vitality.get("signals", {})
+        if isinstance(signals, dict):
+            active_signals = [n for n, v in signals.items() if isinstance(v, (int, float)) and v > 0.5]
+        else:
+            active_signals = [s for s in signals if isinstance(s, dict) and s.get("value", 0) > 0.5]
         return {
             "energy": score,
             "feeling": _feeling_vital(score),
@@ -306,10 +310,15 @@ def _sense_quality(name: str, meta: dict, raw: dict) -> dict[str, Any]:
 
     elif name == "understanding":
         vitality = raw.get("vitality", {})
-        diversity = 0
-        for sig in vitality.get("signals", []):
-            if sig.get("name") == "diversity_index":
-                diversity = sig.get("value", 0)
+        # signals is a dict {name: score} from vitality_service
+        signals = vitality.get("signals", {})
+        if isinstance(signals, dict):
+            diversity = float(signals.get("diversity_index", 0) or 0)
+        else:
+            diversity = 0
+            for sig in signals:
+                if isinstance(sig, dict) and sig.get("name") == "diversity_index":
+                    diversity = float(sig.get("value", 0) or 0)
         energy = diversity
         signs = []
         if diversity > 0.7:


### PR DESCRIPTION
## Summary

Quick fix for a 500 error on \`/api/energy/pulse\` shipped in PR #992.

\`community_pulse_service\` expected \`vitality_service.compute_vitality()\` to return \`signals\` as a list-of-dicts. It actually returns a dict \`{signal_name: score}\`. Iterating over a dict yields string keys, so \`s.get(\"value\", 0)\` failed with \`AttributeError: 'str' object has no attribute 'get'\`.

## Fix

Two spots in \`_sense_quality\` now handle the dict shape correctly, with a fallback to list-of-dict for resilience.

## Verification

Before: \`GET /api/energy/pulse\` → 500
After: \`GET /api/energy/pulse\` → 200 with all 13 qualities returning felt descriptions.

Example live response:
\`\`\`
vital:     0.45 — Vital energy gathering, some centers pulsing
joyful:    0.49 — Sparks of joy in the work, more possible
abundant:  1.00 — Enough for everyone — the treasury honors every gift
curious:   0.21 — The familiar is comfortable — curiosity is an invitation
\`\`\`

## Test plan
- [x] 576 tests pass
- [x] /api/energy/pulse returns 200 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)