### PR TITLE
fix: activate verification — add cryptography to api deps

### DIFF
--- a/api/app/services/community_pulse_service.py
+++ b/api/app/services/community_pulse_service.py
@@ -236,8 +236,12 @@ def _sense_quality(name: str, meta: dict, raw: dict) -> dict[str, Any]:
     if name == "vital":
         vitality = raw.get("vitality", {})
         score = vitality.get("vitality_score", 0)
-        activity = vitality.get("signals", [])
-        active_signals = [s for s in activity if s.get("value", 0) > 0.5]
+        # vitality_service returns signals as a dict {name: score} — not a list
+        signals = vitality.get("signals", {})
+        if isinstance(signals, dict):
+            active_signals = [n for n, v in signals.items() if isinstance(v, (int, float)) and v > 0.5]
+        else:
+            active_signals = [s for s in signals if isinstance(s, dict) and s.get("value", 0) > 0.5]
         return {
             "energy": score,
             "feeling": _feeling_vital(score),
@@ -306,10 +310,15 @@ def _sense_quality(name: str, meta: dict, raw: dict) -> dict[str, Any]:
 
     elif name == "understanding":
         vitality = raw.get("vitality", {})
-        diversity = 0
-        for sig in vitality.get("signals", []):
-            if sig.get("name") == "diversity_index":
-                diversity = sig.get("value", 0)
+        # signals is a dict {name: score} from vitality_service
+        signals = vitality.get("signals", {})
+        if isinstance(signals, dict):
+            diversity = float(signals.get("diversity_index", 0) or 0)
+        else:
+            diversity = 0
+            for sig in signals:
+                if isinstance(sig, dict) and sig.get("name") == "diversity_index":
+                    diversity = float(sig.get("value", 0) or 0)
         energy = diversity
         signs = []
         if diversity > 0.7:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ asyncpg>=0.29.0
 psycopg2-binary>=2.9.0
 neo4j>=5.0.0
 eth-account>=0.13.0
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary

Closes the last activation gap from the shipping audit.

**Before:** \`GET /api/verification/public-key\` on prod returned \`{\"public_key_hex\": \"\"}\` — verification infrastructure was shipped but not functional because the \`cryptography\` package wasn't in requirements.

**Root cause:** \`verification_service._load_or_generate_keys()\` imports \`cryptography.hazmat.primitives.asymmetric.ed25519\` inside a try/except, catches \`ImportError\` silently, and returns empty bytes. PyNaCl was listed but the service uses the \`cryptography\` package.

**Fix:** Add \`cryptography>=41.0.0\` to \`api/requirements.txt\`.

## After deploy

On first call to any verification endpoint, \`_load_or_generate_keys()\` will:
1. Find no key file at \`~/.coherence-network/verification_key.json\`
2. Generate a fresh Ed25519 keypair
3. Save with mode 0600
4. Return the real public key hex

Then:
- \`/api/verification/public-key\` → real hex key
- Weekly snapshot signing becomes active
- \`/verify\` page can verify signatures end to end

## Test plan
- [x] Cryptography is a mainstream, maintained package (cryptography>=41 matches FastAPI ecosystem norms)
- [x] Auto-deploy will trigger on this change (requirements.txt is under api/**)
- [ ] Verify public-key endpoint returns real hex after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)