### PR TITLE
fix: add cryptography + eth-account to pyproject.toml (real activation fix)

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "neo4j>=5.0.0",
     "PyNaCl>=1.5.0",
+    "cryptography>=41.0.0",
+    "eth-account>=0.13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

PR #999 added \`cryptography\` to \`requirements.txt\` but the prod Docker image builds from \`pyproject.toml\` (via \`pip install .\`). That's why verification public key was still empty after deploy — the image didn't actually install cryptography.

## Fix

Add both deps to \`pyproject.toml\` so the next rebuild installs them.

## Verification

After deploy completes, expect:
\`\`\`
$ curl https://api.coherencycoin.com/api/verification/public-key
{
  "algorithm": "Ed25519",
  "public_key_hex": "<real 64-char hex>",
  "usage": "..."
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)