### PR TITLE
feat(web): /here — map of the organism's current attention

### DIFF
--- a/web/app/here/page.tsx
+++ b/web/app/here/page.tsx
@@ -1,0 +1,243 @@
+import Link from "next/link";
+import { cookies, headers } from "next/headers";
+
+import { getApiBase } from "@/lib/api";
+import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
+import { createTranslator } from "@/lib/i18n";
+import { FeedTabs } from "@/components/FeedTabs";
+import { NotificationBell } from "@/components/NotificationBell";
+
+/**
+ * /here — a map of the organism's current attention.
+ *
+ * Three signals rendered as one quiet page:
+ *   · presence — entities viewers are meeting in the last 90s
+ *   · recent voices — concepts where someone just offered lived testimony
+ *   · recent reactions — entities that just received a gesture of care
+ *
+ * Each item is a link to the meeting surface. The page answers "where
+ * is the organism's attention right now" for anyone who lands fresh.
+ */
+
+export const dynamic = "force-dynamic";
+
+interface PresenceRow {
+  entity_type: string;
+  entity_id: string;
+  present: number;
+}
+
+interface RecentReaction {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  author_name: string;
+  emoji: string | null;
+  comment: string | null;
+  locale: string;
+  created_at: string | null;
+}
+
+interface RecentVoice {
+  id: string;
+  concept_id: string;
+  author_name: string;
+  body: string;
+  locale: string;
+  location: string | null;
+  created_at: string | null;
+}
+
+function entityHref(entity_type: string, entity_id: string): string {
+  return `/meet/${entity_type}/${encodeURIComponent(entity_id)}`;
+}
+
+function relativeTime(iso: string | null, lang: LocaleCode): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const delta = Math.max(0, Date.now() - t);
+  const m = Math.round(delta / 60000);
+  if (m < 1) return "now";
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  if (d < 30) return `${d}d`;
+  return new Date(t).toLocaleDateString(lang);
+}
+
+async function fetchJson<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${getApiBase()}${path}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export default async function HerePage() {
+  const cookieLocale = (await cookies()).get("NEXT_LOCALE")?.value;
+  const headerLang = (await headers()).get("accept-language")?.split(",")[0]?.split("-")[0];
+  const candidate = cookieLocale || headerLang;
+  const lang: LocaleCode = isSupportedLocale(candidate) ? candidate : DEFAULT_LOCALE;
+  const t = createTranslator(lang);
+
+  const [presenceData, reactionsData, voicesData] = await Promise.all([
+    fetchJson<{ total_entities: number; top: PresenceRow[] }>("/api/presence/summary"),
+    fetchJson<{ reactions: RecentReaction[] }>("/api/reactions/recent?limit=10"),
+    fetchJson<{ voices: RecentVoice[] }>("/api/concepts/voices/recent?limit=10"),
+  ]);
+
+  const presenceRows = presenceData?.top || [];
+  const recentReactions = (reactionsData?.reactions || []).slice(0, 8);
+  const recentVoices = (voicesData?.voices || []).slice(0, 6);
+
+  const quiet =
+    presenceRows.length === 0 &&
+    recentReactions.length === 0 &&
+    recentVoices.length === 0;
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-6">
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl md:text-3xl font-light text-white mb-1">
+            {t("here.heading")}
+          </h1>
+          <p className="text-sm text-stone-400">{t("here.lede")}</p>
+        </div>
+        <NotificationBell />
+      </header>
+
+      <FeedTabs />
+
+      {quiet ? (
+        <section className="rounded-lg border border-stone-800/60 bg-stone-900/40 p-6 text-center">
+          <p className="text-stone-300 mb-3">{t("here.empty")}</p>
+          <Link
+            href="/vision"
+            className="inline-block rounded-md bg-amber-700/80 hover:bg-amber-600/90 text-stone-950 px-4 py-2 text-sm font-medium"
+          >
+            {t("here.emptyCta")}
+          </Link>
+        </section>
+      ) : (
+        <div className="space-y-6">
+          {presenceRows.length > 0 && (
+            <section>
+              <h2 className="text-xs uppercase tracking-widest text-teal-300/90 mb-2">
+                {t("here.meetingNow")}
+              </h2>
+              <ul className="space-y-2">
+                {presenceRows.map((row) => (
+                  <li
+                    key={`${row.entity_type}-${row.entity_id}`}
+                    className="rounded-lg border border-teal-800/40 bg-teal-950/10"
+                  >
+                    <Link
+                      href={entityHref(row.entity_type, row.entity_id)}
+                      className="flex items-center gap-3 p-3 hover:bg-teal-950/30 rounded-lg"
+                    >
+                      <div className="h-10 w-10 rounded-full bg-teal-500/10 ring-2 ring-teal-400/40 flex items-center justify-center text-sm font-light tabular-nums text-teal-200">
+                        {row.present}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-stone-200 truncate">{row.entity_id}</p>
+                        <p className="text-xs text-stone-500">
+                          {row.entity_type} · {row.present === 1 ? t("here.onePresent") : t("here.manyPresent").replace("{count}", String(row.present))}
+                        </p>
+                      </div>
+                      <span className="text-teal-300">→</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {recentVoices.length > 0 && (
+            <section>
+              <h2 className="text-xs uppercase tracking-widest text-amber-300/90 mb-2">
+                {t("here.recentVoices")}
+              </h2>
+              <ul className="space-y-2">
+                {recentVoices.map((v) => (
+                  <li
+                    key={v.id}
+                    className="rounded-lg border border-amber-800/30 bg-amber-950/10"
+                  >
+                    <Link
+                      href={`/vision/${encodeURIComponent(v.concept_id)}`}
+                      className="flex items-start gap-3 p-3 hover:bg-amber-950/30 rounded-lg"
+                    >
+                      <div className="text-2xl leading-none shrink-0 w-10 text-center">🌱</div>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm text-stone-200 line-clamp-2">{v.body}</p>
+                        <p className="text-xs text-stone-500 mt-1 flex flex-wrap gap-x-2">
+                          <span className="text-amber-300/90">{v.author_name}</span>
+                          {v.location && <span>· {v.location}</span>}
+                          <span>· {v.concept_id}</span>
+                          <span className="ml-auto">{relativeTime(v.created_at, lang)}</span>
+                        </p>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {recentReactions.length > 0 && (
+            <section>
+              <h2 className="text-xs uppercase tracking-widest text-stone-400 mb-2">
+                {t("here.recentReactions")}
+              </h2>
+              <ul className="space-y-2">
+                {recentReactions.map((r) => (
+                  <li
+                    key={r.id}
+                    className="rounded-lg border border-stone-800/50 bg-stone-900/40"
+                  >
+                    <Link
+                      href={entityHref(r.entity_type, r.entity_id)}
+                      className="flex items-start gap-3 p-3 hover:bg-stone-900 rounded-lg"
+                    >
+                      <div className="text-2xl leading-none shrink-0 w-10 text-center">
+                        {r.emoji || "💬"}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        {r.comment ? (
+                          <p className="text-sm text-stone-200 line-clamp-2">{r.comment}</p>
+                        ) : (
+                          <p className="text-sm text-stone-400">
+                            {r.entity_type}: {r.entity_id}
+                          </p>
+                        )}
+                        <p className="text-xs text-stone-500 mt-1 flex flex-wrap gap-x-2">
+                          <span className="text-amber-300/90">{r.author_name}</span>
+                          <span>· {r.entity_type}: {r.entity_id}</span>
+                          <span className="ml-auto">{relativeTime(r.created_at, lang)}</span>
+                        </p>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+
+      <footer className="mt-8 flex items-center justify-between gap-3 text-xs text-stone-500">
+        <Link href="/explore/concept" className="hover:text-amber-300/90">
+          {t("here.goExplore")}
+        </Link>
+        <Link href="/propose" className="hover:text-teal-300/90">
+          {t("here.goPropose")}
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/web/components/FeedTabs.tsx
+++ b/web/components/FeedTabs.tsx
@@ -14,13 +14,25 @@ export function FeedTabs() {
   const t = useT();
   const pathname = usePathname() || "";
   const isPersonal = pathname.startsWith("/feed/you");
+  const isHere = pathname.startsWith("/here");
+  const isCollective = !isPersonal && !isHere;
 
   return (
-    <nav className="flex items-center gap-1 mb-4 text-sm">
+    <nav className="flex items-center gap-1 mb-4 text-sm flex-wrap">
+      <Link
+        href="/here"
+        className={`px-3 py-1.5 rounded-full transition-colors ${
+          isHere
+            ? "bg-teal-700/70 text-stone-950 font-medium"
+            : "text-stone-400 hover:text-teal-300/90"
+        }`}
+      >
+        {t("feed.tabHere")}
+      </Link>
       <Link
         href="/feed"
         className={`px-3 py-1.5 rounded-full transition-colors ${
-          !isPersonal
+          isCollective
             ? "bg-amber-700/70 text-stone-950 font-medium"
             : "text-stone-400 hover:text-amber-300/90"
         }`}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -122,6 +122,7 @@
     "empty": "Der Strom ist still. Sei der erste Atem.",
     "exploreVision": "Die Vision erkunden",
     "stepIn": "Ins Netz eintreten",
+    "tabHere": "Jetzt hier",
     "tabCollective": "Alle",
     "tabPersonal": "Du",
     "personalHeading": "Deine Ecke",
@@ -131,6 +132,19 @@
     "personalNoIdentity": "Noch ist kein Name hier. Wähle einen, und deine Ecke beginnt.",
     "personalNoIdentityCta": "Ins Netz eintreten",
     "personalLoading": "Deine Ecke wird gesammelt …"
+  },
+  "here": {
+    "heading": "Wo gerade Aufmerksamkeit ist",
+    "lede": "Der Atem des Organismus jetzt — wer wem begegnet, was zuletzt gesagt und angerührt wurde.",
+    "empty": "Der Organismus ist gerade still. Begegne etwas, und du erweckst es.",
+    "emptyCta": "Einem Konzept begegnen",
+    "meetingNow": "Begegnen gerade",
+    "onePresent": "1 Person hier",
+    "manyPresent": "{count} Personen hier",
+    "recentVoices": "Jüngste Stimmen",
+    "recentReactions": "Jüngste Reaktionen",
+    "goExplore": "Einen Weg gehen →",
+    "goPropose": "+ Etwas vorschlagen"
   },
   "explore": {
     "empty": "Im Moment ist niemand Neues da. Versuche einen anderen Weg.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -122,6 +122,7 @@
     "empty": "The feed is quiet. Be the first breath.",
     "exploreVision": "Explore the vision",
     "stepIn": "Step into the network",
+    "tabHere": "Here now",
     "tabCollective": "Everyone",
     "tabPersonal": "You",
     "personalHeading": "Your corner",
@@ -131,6 +132,19 @@
     "personalNoIdentity": "No name is here yet. Choose one and your corner begins.",
     "personalNoIdentityCta": "Step into the network",
     "personalLoading": "Gathering your corner…"
+  },
+  "here": {
+    "heading": "Where attention is now",
+    "lede": "The organism's current breath — who is meeting what, and what was voiced and reacted to recently.",
+    "empty": "The organism is quiet right now. Meet something and you bring it to life.",
+    "emptyCta": "Meet a concept",
+    "meetingNow": "Meeting now",
+    "onePresent": "1 person here",
+    "manyPresent": "{count} people here",
+    "recentVoices": "Recent voices",
+    "recentReactions": "Recent reactions",
+    "goExplore": "Walk a serendipitous queue →",
+    "goPropose": "+ Propose something"
   },
   "explore": {
     "empty": "Nothing new to meet right now. Try a different walk.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -122,6 +122,7 @@
     "empty": "El flujo está en silencio. Sé el primer aliento.",
     "exploreVision": "Explora la visión",
     "stepIn": "Entra en la red",
+    "tabHere": "Aquí ahora",
     "tabCollective": "Todos",
     "tabPersonal": "Tú",
     "personalHeading": "Tu rincón",
@@ -131,6 +132,19 @@
     "personalNoIdentity": "Todavía no hay un nombre. Elige uno y tu rincón empieza.",
     "personalNoIdentityCta": "Entra en la red",
     "personalLoading": "Reuniendo tu rincón…"
+  },
+  "here": {
+    "heading": "Dónde está la atención ahora",
+    "lede": "El aliento del organismo ahora — quién se encuentra con qué, y qué se dijo y se tocó recientemente.",
+    "empty": "El organismo está en silencio ahora. Encuéntrate con algo y lo traes a la vida.",
+    "emptyCta": "Encuentra un concepto",
+    "meetingNow": "Se encuentran ahora",
+    "onePresent": "1 persona aquí",
+    "manyPresent": "{count} personas aquí",
+    "recentVoices": "Voces recientes",
+    "recentReactions": "Reacciones recientes",
+    "goExplore": "Caminar un camino →",
+    "goPropose": "+ Proponer algo"
   },
   "explore": {
     "empty": "Ahora no hay nadie nuevo por conocer. Prueba otro camino.",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -122,6 +122,7 @@
     "empty": "Arus sedang sunyi. Jadilah napas pertama.",
     "exploreVision": "Jelajahi visi",
     "stepIn": "Masuk ke jaringan",
+    "tabHere": "Di sini kini",
     "tabCollective": "Semua",
     "tabPersonal": "Kamu",
     "personalHeading": "Sudutmu",
@@ -131,6 +132,19 @@
     "personalNoIdentity": "Belum ada nama di sini. Pilih satu dan sudutmu dimulai.",
     "personalNoIdentityCta": "Masuk ke jaringan",
     "personalLoading": "Mengumpulkan sudutmu…"
+  },
+  "here": {
+    "heading": "Di mana perhatian sekarang",
+    "lede": "Napas organisme saat ini — siapa bertemu apa, dan apa yang disuarakan serta disentuh baru-baru ini.",
+    "empty": "Organisme sedang sunyi. Temui sesuatu dan kamu menghidupkannya.",
+    "emptyCta": "Temui sebuah konsep",
+    "meetingNow": "Bertemu sekarang",
+    "onePresent": "1 orang di sini",
+    "manyPresent": "{count} orang di sini",
+    "recentVoices": "Suara terkini",
+    "recentReactions": "Reaksi terkini",
+    "goExplore": "Jalani jalan →",
+    "goPropose": "+ Usulkan sesuatu"
   },
   "explore": {
     "empty": "Belum ada yang baru untuk ditemui. Coba jalan lain.",

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -20,6 +20,12 @@
   ],
   "shortcuts": [
     {
+      "name": "Here",
+      "short_name": "Here",
+      "url": "/here",
+      "description": "Where the organism's attention is right now"
+    },
+    {
       "name": "Feed",
       "short_name": "Feed",
       "url": "/feed",


### PR DESCRIPTION
## Summary
- New /here page renders presence + recent voices + recent reactions as one quiet scroll
- FeedTabs grows a "Here now" tab alongside Everyone and You
- PWA manifest gains a /here shortcut

## Test plan
- [x] Full API suite — 680 / 0 failed
- [x] Web type check clean
- [x] Manually verified the page renders with a mixed empty/populated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)