### PR TITLE
feat: idea ← proposal back-link — honor the voices that birthed an idea

### DIFF
--- a/api/app/routers/proposals.py
+++ b/api/app/routers/proposals.py
@@ -86,6 +86,22 @@ async def tally(proposal_id: str) -> dict:
     return proposal_service.tally(proposal_id)
 
 
+@router.get(
+    "/proposals/by-idea/{idea_id}",
+    summary="Reverse lookup — the proposal (if any) that was lifted into this idea",
+    description=(
+        "Returns the proposal with its current tally so an idea page can "
+        "render its origin: the whispers that became it. Returns 404 when "
+        "the idea was not born from a proposal."
+    ),
+)
+async def proposal_by_idea(idea_id: str) -> dict:
+    p = proposal_service.get_proposal_by_idea(idea_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="no proposal lifted into this idea")
+    return p
+
+
 @router.post(
     "/proposals/{proposal_id}/resolve",
     summary="Lift a resonant proposal into a kinetic idea",

--- a/api/app/services/proposal_service.py
+++ b/api/app/services/proposal_service.py
@@ -149,6 +149,26 @@ def get_proposal(proposal_id: str) -> Optional[dict]:
     return _to_dict(rec) if rec else None
 
 
+def get_proposal_by_idea(idea_id: str) -> Optional[dict]:
+    """Reverse lookup: the proposal (if any) that was lifted into this idea.
+
+    Returns the proposal dict with an added ``tally`` summary so the
+    consumer can render the origin fully without a second fetch.
+    """
+    _ensure_schema()
+    with _session() as s:
+        rec = s.execute(
+            select(ProposalRecord).where(
+                ProposalRecord.resolved_as_idea_id == idea_id
+            )
+        ).scalar_one_or_none()
+    if not rec:
+        return None
+    payload = _to_dict(rec)
+    payload["tally"] = tally(rec.id)
+    return payload
+
+
 def list_proposals(
     *, limit: int = 50, only_open: bool = True
 ) -> list[dict]:

--- a/api/tests/test_flow_proposals.py
+++ b/api/tests/test_flow_proposals.py
@@ -127,6 +127,41 @@ async def test_resonant_proposal_lifts_into_idea():
 
 
 @pytest.mark.asyncio
+async def test_proposal_by_idea_returns_origin_with_tally():
+    """After a resonant proposal is lifted, /proposals/by-idea/{idea_id}
+    returns the origin proposal with its tally so the idea page can show
+    the voices that birthed it."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/proposals",
+            json={"title": "Origin test", "body": "trace", "author_name": "O"},
+        )
+        pid = r.json()["id"]
+        for emoji in ("💛", "💛", "💛", "🔥"):
+            await c.post(
+                f"/api/reactions/proposal/{pid}",
+                json={"author_name": "voter", "emoji": emoji},
+            )
+        r = await c.post(f"/api/proposals/{pid}/resolve")
+        idea_id = r.json()["idea_id"]
+
+        r = await c.get(f"/api/proposals/by-idea/{idea_id}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["id"] == pid
+        assert body["title"] == "Origin test"
+        assert body["tally"]["status"] == "resonant"
+        assert body["tally"]["counts"]["amplify"] == 1
+
+
+@pytest.mark.asyncio
+async def test_proposal_by_idea_404_when_idea_not_from_proposal():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/proposals/by-idea/not-a-lifted-idea")
+        assert r.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_non_resonant_proposal_refuses_to_lift():
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         r = await c.post(

--- a/web/app/ideas/[idea_id]/page.tsx
+++ b/web/app/ideas/[idea_id]/page.tsx
@@ -22,6 +22,7 @@ import { IdeaStakeForm } from "@/components/idea_stake_form";
 import IdeaLensPanel from "@/components/ideas/IdeaLensPanel";
 import IdeaDetailTabs from "@/components/ideas/IdeaDetailTabs";
 import { ReactionBar } from "@/components/ReactionBar";
+import { ProposalOrigin } from "@/components/ProposalOrigin";
 import { loadPublicWebConfig } from "@/lib/app-config";
 import type { IdeaQuestion, IdeaWithScore } from "@/lib/types";
 
@@ -420,6 +421,10 @@ export default async function IdeaDetailPage({ params }: { params: Promise<{ ide
           <Link href="/contribute" className="text-amber-600 dark:text-amber-400 hover:underline">Contribute</Link>
         </div>
       </nav>
+
+      <section className="max-w-3xl mx-auto px-4 pb-4">
+        <ProposalOrigin ideaId={idea.id} />
+      </section>
 
       <section className="max-w-3xl mx-auto px-4 pb-10">
         <ReactionBar entityType="idea" entityId={idea.id} />

--- a/web/app/meet/[entityType]/[entityId]/page.tsx
+++ b/web/app/meet/[entityType]/[entityId]/page.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locale
 import { createTranslator } from "@/lib/i18n";
 import { MeetingSurface } from "@/components/MeetingSurface";
 import { ProposalLift } from "@/components/ProposalLift";
+import { ProposalOrigin } from "@/components/ProposalOrigin";
 
 /**
  * /meet/[entityType]/[entityId] — full-screen meeting with a single entity.
@@ -226,6 +227,13 @@ export default async function MeetingPage({
         <div className="fixed bottom-28 left-0 right-0 px-4 z-20">
           <div className="max-w-md mx-auto">
             <ProposalLift proposalId={entityId} />
+          </div>
+        </div>
+      )}
+      {entityType === "idea" && (
+        <div className="fixed bottom-28 left-0 right-0 px-4 z-20">
+          <div className="max-w-md mx-auto">
+            <ProposalOrigin ideaId={entityId} />
           </div>
         </div>
       )}

--- a/web/components/ProposalOrigin.tsx
+++ b/web/components/ProposalOrigin.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * ProposalOrigin — the idea's birth certificate.
+ *
+ * When an idea was lifted from a resonant proposal, this component
+ * shows a small origin line on the idea's surface: the proposal title,
+ * its author, the tally that lifted it, and a link back to the
+ * proposal. Rendering nothing when the idea was authored directly —
+ * graceful absence.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import { useT, useLocale } from "@/components/MessagesProvider";
+
+interface Props {
+  ideaId: string;
+}
+
+interface Origin {
+  id: string;
+  title: string;
+  author_name: string;
+  resolved_at: string | null;
+  tally: {
+    counts: { support: number; amplify: number; decline: number };
+    weighted: { yes: number; no: number };
+    status: string;
+  };
+}
+
+export function ProposalOrigin({ ideaId }: Props) {
+  const t = useT();
+  const locale = useLocale();
+  const [origin, setOrigin] = useState<Origin | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(
+          `${getApiBase()}/api/proposals/by-idea/${encodeURIComponent(ideaId)}`,
+          { cache: "no-store" },
+        );
+        if (!cancelled) {
+          if (res.ok) {
+            setOrigin(await res.json());
+          } else {
+            setOrigin(null);
+          }
+        }
+      } catch {
+        if (!cancelled) setOrigin(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [ideaId]);
+
+  if (loading || !origin) return null;
+
+  const yes = origin.tally.counts.support + origin.tally.counts.amplify;
+  const no = origin.tally.counts.decline;
+  const resolvedLabel = origin.resolved_at
+    ? new Date(origin.resolved_at).toLocaleDateString(locale)
+    : "";
+
+  return (
+    <section className="rounded-md border border-emerald-700/30 bg-emerald-950/10 px-4 py-3 text-sm">
+      <div className="flex items-start gap-3">
+        <div className="text-xl leading-none shrink-0">🌱</div>
+        <div className="flex-1 min-w-0">
+          <p className="text-emerald-200/90 font-medium">
+            {t("proposalOrigin.lede")}
+          </p>
+          <p className="text-stone-300 mt-1">
+            <Link
+              href={`/meet/proposal/${encodeURIComponent(origin.id)}`}
+              className="text-amber-300 hover:text-amber-200 underline underline-offset-2"
+            >
+              “{origin.title}”
+            </Link>
+            {" — "}
+            <span className="text-stone-400">{origin.author_name}</span>
+          </p>
+          <p className="text-xs text-stone-500 mt-2">
+            {resolvedLabel && <span>{resolvedLabel} · </span>}
+            <span>
+              {yes} ↑ · {no} ↓
+            </span>
+            {origin.tally.counts.amplify > 0 && (
+              <span> · 🔥 {origin.tally.counts.amplify}</span>
+            )}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -164,6 +164,9 @@
     "thanks": "Dein Vorschlag ist im Weg.",
     "viewAll": "Alle Vorschläge sehen"
   },
+  "proposalOrigin": {
+    "lede": "Diese Idee wurde aus einem Vorschlag geboren, den das Kollektiv gehoben hat."
+  },
   "proposal": {
     "readyToLift": "Die Stimmen resonieren. Dieser Vorschlag kann zur Idee werden.",
     "lift": "In eine Idee heben",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -164,6 +164,9 @@
     "thanks": "Your proposal is in the walk.",
     "viewAll": "See all proposals"
   },
+  "proposalOrigin": {
+    "lede": "This idea was born from a proposal the collective lifted."
+  },
   "proposal": {
     "readyToLift": "The voices resonate. This proposal is ready to become an idea.",
     "lift": "Lift it into an idea",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -164,6 +164,9 @@
     "thanks": "Tu propuesta está en el camino.",
     "viewAll": "Ver todas las propuestas"
   },
+  "proposalOrigin": {
+    "lede": "Esta idea nació de una propuesta que el colectivo elevó."
+  },
   "proposal": {
     "readyToLift": "Las voces resuenan. Esta propuesta está lista para volverse una idea.",
     "lift": "Elevar a una idea",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -164,6 +164,9 @@
     "thanks": "Usulanmu ada di jalan.",
     "viewAll": "Lihat semua usulan"
   },
+  "proposalOrigin": {
+    "lede": "Ide ini lahir dari usulan yang diangkat oleh kolektif."
+  },
   "proposal": {
     "readyToLift": "Suara-suara beresonansi. Usulan ini siap menjadi ide.",
     "lift": "Angkat menjadi ide",


### PR DESCRIPTION
## Summary
- GET /api/proposals/by-idea/{idea_id} returns the origin proposal + tally
- ProposalOrigin component renders origin line on idea detail & meet pages
- Localized en/de/es/id; 404 when the idea has no proposal origin

## Test plan
- [x] pytest tests/test_flow_proposals.py → 10/10
- [x] Full API suite — 682
- [x] Web type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)