### PR TITLE
feat(web): home-page breath panel — organism felt on landing

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 
 import { Button } from "@/components/ui/button";
 import { IdeaSubmitForm } from "@/components/idea_submit_form";
+import { LiveBreathPanel } from "@/components/LiveBreathPanel";
 import { getApiBase } from "@/lib/api";
 import { fetchJsonOrNull } from "@/lib/fetch";
 import type { IdeaWithScore } from "@/lib/types";
@@ -123,6 +124,7 @@ export default async function Home() {
 
   return (
     <main className="min-h-[calc(100vh-3.5rem)]">
+      <LiveBreathPanel lang={lang} />
       {/* Section 1: HERO — THE QUESTION */}
       <section className="flex flex-col justify-center items-center text-center px-4 pt-12 pb-6 relative">
         <div className="absolute inset-0 pointer-events-none">

--- a/web/components/LiveBreathPanel.tsx
+++ b/web/components/LiveBreathPanel.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link";
+import { getApiBase } from "@/lib/api";
+import { fetchJsonOrNull } from "@/lib/fetch";
+import { createTranslator, type Translator } from "@/lib/i18n";
+import type { LocaleCode } from "@/lib/locales";
+
+/**
+ * LiveBreathPanel — the "organism is alive, step in" banner for the home page.
+ *
+ * Server-rendered summary of presence + recent voices, with three warm
+ * entry points to the living dialogue surfaces. When everything is
+ * quiet, the panel still invites — "be the first breath."
+ */
+
+interface PresenceSummary {
+  total_entities: number;
+  top: { entity_type: string; entity_id: string; present: number }[];
+}
+
+interface RecentVoice {
+  id: string;
+  concept_id: string;
+  author_name: string;
+  created_at: string | null;
+}
+
+interface RecentReaction {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  author_name: string;
+  created_at: string | null;
+}
+
+async function loadBreath(): Promise<{
+  presence: PresenceSummary | null;
+  recentVoices: RecentVoice[];
+  recentReactions: RecentReaction[];
+}> {
+  const base = getApiBase();
+  const [presence, voicesData, reactionsData] = await Promise.all([
+    fetchJsonOrNull<PresenceSummary>(`${base}/api/presence/summary`, {}, 4000),
+    fetchJsonOrNull<{ voices: RecentVoice[] }>(
+      `${base}/api/concepts/voices/recent?limit=3`,
+      {},
+      4000,
+    ),
+    fetchJsonOrNull<{ reactions: RecentReaction[] }>(
+      `${base}/api/reactions/recent?limit=3`,
+      {},
+      4000,
+    ),
+  ]);
+  return {
+    presence,
+    recentVoices: voicesData?.voices || [],
+    recentReactions: reactionsData?.reactions || [],
+  };
+}
+
+interface Props {
+  lang: LocaleCode;
+}
+
+export async function LiveBreathPanel({ lang }: Props) {
+  const t: Translator = createTranslator(lang);
+  const { presence, recentVoices, recentReactions } = await loadBreath();
+
+  const meetingNow = presence?.top.reduce((sum, row) => sum + row.present, 0) || 0;
+  const entitiesWithPresence = presence?.total_entities || 0;
+  const hasSignal =
+    meetingNow > 0 || recentVoices.length > 0 || recentReactions.length > 0;
+
+  return (
+    <section
+      className="relative z-10 w-full border-b border-stone-800/40 bg-gradient-to-b from-teal-950/20 via-transparent to-transparent"
+      aria-label={t("homeBreath.ariaLabel")}
+    >
+      <div className="max-w-4xl mx-auto px-4 py-5 flex flex-col md:flex-row md:items-center gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs uppercase tracking-widest text-teal-300/90 mb-1">
+            {t("homeBreath.label")}
+          </p>
+          {hasSignal ? (
+            <p className="text-base md:text-lg text-stone-100">
+              {meetingNow > 0 && (
+                <>
+                  <span className="text-teal-200 font-medium">
+                    {meetingNow === 1
+                      ? t("homeBreath.oneMeetingNow")
+                      : t("homeBreath.manyMeetingNow").replace(
+                          "{count}",
+                          String(meetingNow),
+                        )}
+                    {entitiesWithPresence > 1 &&
+                      ` ${t("homeBreath.acrossEntities").replace(
+                        "{count}",
+                        String(entitiesWithPresence),
+                      )}`}
+                  </span>
+                  {(recentVoices.length > 0 || recentReactions.length > 0) && " · "}
+                </>
+              )}
+              {recentVoices.length > 0 && (
+                <span className="text-stone-300">
+                  {t("homeBreath.recentVoicesLine").replace(
+                    "{count}",
+                    String(recentVoices.length),
+                  )}
+                </span>
+              )}
+              {recentVoices.length === 0 && recentReactions.length > 0 && (
+                <span className="text-stone-300">
+                  {t("homeBreath.recentReactionsLine").replace(
+                    "{count}",
+                    String(recentReactions.length),
+                  )}
+                </span>
+              )}
+            </p>
+          ) : (
+            <p className="text-base md:text-lg text-stone-200">
+              {t("homeBreath.quiet")}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link
+            href="/here"
+            className="rounded-full bg-teal-700/80 hover:bg-teal-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+          >
+            {t("homeBreath.goHere")}
+          </Link>
+          <Link
+            href="/explore/concept"
+            className="rounded-full bg-amber-700/80 hover:bg-amber-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+          >
+            {t("homeBreath.goExplore")}
+          </Link>
+          <Link
+            href="/propose"
+            className="rounded-full border border-teal-700/40 bg-teal-950/20 hover:bg-teal-950/40 text-teal-200 px-4 py-2 text-sm font-medium transition-colors"
+          >
+            {t("homeBreath.goPropose")}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -116,6 +116,19 @@
     "markSeen": "als gesehen markieren",
     "empty": "Nichts Neues. Komm wieder, nachdem du deine Stimme geteilt hast."
   },
+  "homeBreath": {
+    "ariaLabel": "Was jetzt lebendig ist im Netz",
+    "label": "Lebendiger Atem",
+    "oneMeetingNow": "1 Person begegnet gerade etwas",
+    "manyMeetingNow": "{count} Menschen begegnen gerade etwas",
+    "acrossEntities": "an {count} Stellen der Vision",
+    "recentVoicesLine": "{count} neue Stimmen gerade geteilt",
+    "recentReactionsLine": "{count} jüngste Gesten der Zuwendung",
+    "quiet": "Der Organismus ruht. Sei der erste Atem.",
+    "goHere": "Jetzt hier →",
+    "goExplore": "Die Vision gehen →",
+    "goPropose": "+ Vorschlagen"
+  },
   "feed": {
     "heading": "Der gefühlte Puls",
     "lede": "Was jetzt lebendig ist im Netz — Reaktionen, Stimmen, neue Samen.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -116,6 +116,19 @@
     "markSeen": "mark as seen",
     "empty": "Nothing new. Come back after you've offered a voice."
   },
+  "homeBreath": {
+    "ariaLabel": "What is alive on the network right now",
+    "label": "Live breath",
+    "oneMeetingNow": "1 person is meeting something",
+    "manyMeetingNow": "{count} people are meeting something",
+    "acrossEntities": "across {count} pieces of the vision",
+    "recentVoicesLine": "{count} new voices just offered",
+    "recentReactionsLine": "{count} recent gestures of care",
+    "quiet": "The organism is resting. Be the first breath.",
+    "goHere": "Here now →",
+    "goExplore": "Walk the vision →",
+    "goPropose": "+ Propose"
+  },
   "feed": {
     "heading": "The felt pulse",
     "lede": "What is alive on the network right now — reactions, voices, new seeds.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -116,6 +116,19 @@
     "markSeen": "marcar como visto",
     "empty": "Nada nuevo. Vuelve después de ofrecer una voz."
   },
+  "homeBreath": {
+    "ariaLabel": "Lo que está vivo en la red ahora",
+    "label": "Aliento vivo",
+    "oneMeetingNow": "1 persona está encontrándose con algo",
+    "manyMeetingNow": "{count} personas están encontrándose con algo",
+    "acrossEntities": "en {count} partes de la visión",
+    "recentVoicesLine": "{count} voces nuevas recién ofrecidas",
+    "recentReactionsLine": "{count} gestos recientes de cuidado",
+    "quiet": "El organismo descansa. Sé el primer aliento.",
+    "goHere": "Aquí ahora →",
+    "goExplore": "Caminar la visión →",
+    "goPropose": "+ Proponer"
+  },
   "feed": {
     "heading": "El pulso sentido",
     "lede": "Lo que está vivo en la red ahora — reacciones, voces, semillas nuevas.",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -116,6 +116,19 @@
     "markSeen": "tandai terlihat",
     "empty": "Tidak ada yang baru. Kembali lagi setelah kamu menawarkan suaramu."
   },
+  "homeBreath": {
+    "ariaLabel": "Apa yang hidup di jaringan saat ini",
+    "label": "Napas hidup",
+    "oneMeetingNow": "1 orang sedang menemui sesuatu",
+    "manyMeetingNow": "{count} orang sedang menemui sesuatu",
+    "acrossEntities": "di {count} bagian visi",
+    "recentVoicesLine": "{count} suara baru baru saja ditawarkan",
+    "recentReactionsLine": "{count} isyarat peduli terkini",
+    "quiet": "Organisme sedang istirahat. Jadilah napas pertama.",
+    "goHere": "Di sini kini →",
+    "goExplore": "Jalani visi →",
+    "goPropose": "+ Usulkan"
+  },
   "feed": {
     "heading": "Denyut yang terasa",
     "lede": "Apa yang hidup di jaringan saat ini — reaksi, suara, bibit baru.",


### PR DESCRIPTION
## Summary
- LiveBreathPanel renders above the hero on `/` — "N people are meeting something across K pieces of the vision · M new voices just offered" with one-tap links to Here / Walk / Propose
- Quiet-state reads as invitation, not absence
- Pure view composition over /presence/summary, /concepts/voices/recent, /reactions/recent
- Localized en/de/es/id

## Test plan
- [x] Full API suite — 682 / 0
- [x] Web type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)