### PR TITLE
feat: voice → proposal ripening — complete the fractal

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -824,3 +824,41 @@ async def list_concept_voices(concept_id: str, limit: int = Query(50, ge=1, le=2
 async def recent_concept_voices(limit: int = Query(20, ge=1, le=100)) -> dict:
     voices = concept_voice_service.recent_voices(limit=limit)
     return {"voices": voices, "total": len(voices)}
+
+
+class VoiceRipenIn(BaseModel):
+    title: str | None = Field(
+        None,
+        description="Optional override — default derives from the voice's first sentence",
+    )
+    body: str | None = Field(
+        None,
+        description="Optional override — default uses the voice body verbatim",
+    )
+    author_id: str | None = None
+
+
+@router.post(
+    "/concepts/voices/{voice_id}/propose",
+    status_code=201,
+    summary="Ripen a voice into a proposal the collective can vote on",
+    description=(
+        "Any reader can lift a voice they find worth offering to the "
+        "collective. The proposal carries the voice's text forward and "
+        "links back to the concept where it was spoken. Idempotent."
+    ),
+)
+async def ripen_voice(voice_id: str, payload: VoiceRipenIn | None = None) -> dict:
+    payload = payload or VoiceRipenIn()
+    try:
+        return concept_voice_service.ripen_into_proposal(
+            voice_id,
+            title=payload.title,
+            body=payload.body,
+            author_id=payload.author_id,
+        )
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)

--- a/api/app/services/concept_voice_service.py
+++ b/api/app/services/concept_voice_service.py
@@ -23,7 +23,13 @@ from app.services.unified_db import Base
 
 
 class ConceptVoiceRecord(Base):
-    """One lived-experience testimony tied to a concept."""
+    """One lived-experience testimony tied to a concept.
+
+    A voice can ripen into a proposal when a reader finds it worth
+    offering to the collective for a vote. The ripening records a
+    one-way link ``proposed_as_proposal_id`` — the voice stays where
+    it was spoken; the proposal walks forward to meet the collective.
+    """
 
     __tablename__ = "concept_voices"
 
@@ -37,6 +43,9 @@ class ConceptVoiceRecord(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), index=True
     )
+    proposed_as_proposal_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
 
 
 def _session():
@@ -46,6 +55,44 @@ def _session():
 def _ensure_schema() -> None:
     # Engine creation auto-creates tables (checkfirst=True).
     _udb.engine()
+    _ensure_ripening_column()
+
+
+_RIPENING_COL_CHECKED = False
+
+
+def _ensure_ripening_column() -> None:
+    """Heal live SQLite DBs that predate the voice→proposal link."""
+    global _RIPENING_COL_CHECKED
+    if _RIPENING_COL_CHECKED:
+        return
+    try:
+        eng = _udb.engine()
+        with eng.connect() as conn:
+            if conn.dialect.name != "sqlite":
+                _RIPENING_COL_CHECKED = True
+                return
+            rows = conn.exec_driver_sql("PRAGMA table_info(concept_voices)").fetchall()
+            if not rows:
+                _RIPENING_COL_CHECKED = True
+                return
+            names = {r[1] for r in rows}
+            if "proposed_as_proposal_id" not in names:
+                conn.exec_driver_sql(
+                    "ALTER TABLE concept_voices ADD COLUMN proposed_as_proposal_id VARCHAR"
+                )
+                try:
+                    conn.exec_driver_sql(
+                        "CREATE INDEX IF NOT EXISTS ix_concept_voices_proposed_id "
+                        "ON concept_voices(proposed_as_proposal_id)"
+                    )
+                except Exception:
+                    pass
+                conn.commit()
+    except Exception:
+        pass
+    finally:
+        _RIPENING_COL_CHECKED = True
 
 
 def add_voice(
@@ -117,4 +164,106 @@ def _to_dict(rec: ConceptVoiceRecord) -> dict:
         "body": rec.body,
         "location": rec.location,
         "created_at": rec.created_at.isoformat() if rec.created_at else None,
+        "proposed_as_proposal_id": rec.proposed_as_proposal_id,
     }
+
+
+def get_voice(voice_id: str) -> Optional[dict]:
+    _ensure_schema()
+    with _session() as s:
+        rec = s.get(ConceptVoiceRecord, voice_id)
+    return _to_dict(rec) if rec else None
+
+
+def ripen_into_proposal(
+    voice_id: str,
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+    author_id: Optional[str] = None,
+) -> dict:
+    """Lift a voice into a proposal the collective can vote on.
+
+    Idempotent: if already ripened, returns the existing proposal id.
+    The proposal's title defaults to the voice's first sentence (or its
+    body truncated); body defaults to the full voice text. The
+    proposal is linked back to the concept where the voice was spoken.
+    """
+    from app.services import proposal_service
+    _ensure_schema()
+    with _session() as s:
+        rec = s.get(ConceptVoiceRecord, voice_id)
+        if rec is None:
+            raise ValueError("voice not found")
+        if rec.proposed_as_proposal_id:
+            existing = proposal_service.get_proposal(rec.proposed_as_proposal_id)
+            return {
+                "voice": _to_dict(rec),
+                "proposal_id": rec.proposed_as_proposal_id,
+                "proposal": existing,
+                "already_ripened": True,
+            }
+        voice_dict = _to_dict(rec)
+        author_name = rec.author_name
+        voice_body = rec.body or ""
+        concept_id = rec.concept_id
+        locale = rec.locale
+    derived_title = (title or _derive_title(voice_body))[:200]
+    derived_body = (body or voice_body).strip()
+    if not derived_title:
+        raise ValueError("could not derive proposal title from voice")
+
+    created = proposal_service.create_proposal(
+        title=derived_title,
+        body=derived_body,
+        author_name=author_name,
+        author_id=author_id,
+        linked_entity_type="concept",
+        linked_entity_id=concept_id,
+        locale=locale,
+    )
+    proposal_id = created.get("id")
+    if not proposal_id:
+        raise RuntimeError("proposal creation did not return an id")
+
+    with _session() as s:
+        rec = s.get(ConceptVoiceRecord, voice_id)
+        if rec is None:
+            raise ValueError("voice vanished mid-ripening")
+        if rec.proposed_as_proposal_id:
+            # Second-writer loses the race gracefully.
+            return {
+                "voice": _to_dict(rec),
+                "proposal_id": rec.proposed_as_proposal_id,
+                "proposal": proposal_service.get_proposal(rec.proposed_as_proposal_id),
+                "already_ripened": True,
+            }
+        rec.proposed_as_proposal_id = proposal_id
+        s.add(rec)
+        s.commit()
+        s.refresh(rec)
+        voice_dict = _to_dict(rec)
+    return {
+        "voice": voice_dict,
+        "proposal_id": proposal_id,
+        "proposal": created,
+        "already_ripened": False,
+    }
+
+
+def _derive_title(body: str) -> str:
+    """Pick a warm one-line title from a voice. First sentence or ~80 chars."""
+    s = (body or "").strip()
+    if not s:
+        return ""
+    # First sentence up to a terminator
+    for terminator in (". ", "! ", "? ", "\n"):
+        idx = s.find(terminator)
+        if 0 < idx < 200:
+            return s[: idx + 1].strip(".!? ").strip()
+    if len(s) <= 120:
+        return s
+    # Fall back to a gentle truncation at the last word boundary under 120 chars
+    truncated = s[:120]
+    space = truncated.rfind(" ")
+    return (truncated[:space] if space > 40 else truncated).rstrip(".!? ").strip() + "…"

--- a/api/tests/test_flow_vitality.py
+++ b/api/tests/test_flow_vitality.py
@@ -190,6 +190,58 @@ async def test_voice_rejects_empty_body():
 
 
 @pytest.mark.asyncio
+async def test_voice_ripens_into_proposal_linked_back_to_concept():
+    """A voice on a concept can be lifted into a proposal. The proposal
+    carries the voice's text, a derived title, and links back to the
+    source concept. Idempotent."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        cid = "lc-voice-ripen"
+        await c.post(
+            "/api/graph/nodes",
+            json={
+                "id": cid, "type": "concept", "name": "Voice ripen",
+                "description": "T", "properties": {"domains": ["living-collective"]},
+            },
+        )
+        r = await c.post(
+            f"/api/concepts/{cid}/voices",
+            json={
+                "author_name": "Ana",
+                "body": "We should share the rice harvest on Sundays. This weaves us tighter.",
+                "locale": "en",
+            },
+        )
+        vid = r.json()["id"]
+        r = await c.post(f"/api/concepts/voices/{vid}/propose")
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["already_ripened"] is False
+        prop = body["proposal"]
+        assert prop["title"].startswith("We should share")
+        assert prop["linked_entity_type"] == "concept"
+        assert prop["linked_entity_id"] == cid
+        # Idempotent
+        r2 = await c.post(f"/api/concepts/voices/{vid}/propose")
+        assert r2.status_code == 201
+        assert r2.json()["already_ripened"] is True
+        assert r2.json()["proposal_id"] == body["proposal_id"]
+
+        # Voice list now carries the back-pointer
+        r = await c.get(f"/api/concepts/{cid}/voices")
+        voices = r.json()["voices"]
+        matching = [v for v in voices if v["id"] == vid]
+        assert matching
+        assert matching[0]["proposed_as_proposal_id"] == body["proposal_id"]
+
+
+@pytest.mark.asyncio
+async def test_ripen_unknown_voice_returns_404():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/concepts/voices/no-such-voice/propose")
+        assert r.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_recent_voices_surface_across_concepts():
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         for cid in ("lc-voice-recent-a", "lc-voice-recent-b"):

--- a/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
+++ b/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
@@ -8,9 +8,12 @@
  * existing voices as a warm invitation.
  */
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getApiBase } from "@/lib/api";
 import { useT, useLocale } from "@/components/MessagesProvider";
+
+const CONTRIBUTOR_KEY = "cc-contributor-id";
 
 interface Voice {
   id: string;
@@ -20,6 +23,7 @@ interface Voice {
   body: string;
   location: string | null;
   created_at: string | null;
+  proposed_as_proposal_id: string | null;
 }
 
 interface Props {
@@ -32,6 +36,7 @@ export function ConceptVoices({ conceptId }: Props) {
 
   const [voices, setVoices] = useState<Voice[] | null>(null);
   const [loading, setLoading] = useState(true);
+  const [ripening, setRipening] = useState<string | null>(null);
 
   // Form state
   const [authorName, setAuthorName] = useState("");
@@ -64,6 +69,34 @@ export function ConceptVoices({ conceptId }: Props) {
       cancelled = true;
     };
   }, [conceptId]);
+
+  async function ripenVoice(voiceId: string) {
+    setRipening(voiceId);
+    try {
+      let authorId: string | null = null;
+      try {
+        authorId = localStorage.getItem(CONTRIBUTOR_KEY);
+      } catch {
+        /* ignore */
+      }
+      const base = getApiBase();
+      const res = await fetch(`${base}/api/concepts/voices/${voiceId}/propose`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ author_id: authorId }),
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      const pid: string = data.proposal_id;
+      setVoices((prev) =>
+        (prev || []).map((v) =>
+          v.id === voiceId ? { ...v, proposed_as_proposal_id: pid } : v,
+        ),
+      );
+    } finally {
+      setRipening(null);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -134,6 +167,25 @@ export function ConceptVoices({ conceptId }: Props) {
                 )}
                 <span className="uppercase tracking-wide">· {v.locale}</span>
               </p>
+              <div className="mt-3 flex items-center gap-3 text-xs">
+                {v.proposed_as_proposal_id ? (
+                  <Link
+                    href={`/meet/proposal/${encodeURIComponent(v.proposed_as_proposal_id)}`}
+                    className="text-emerald-300 hover:text-emerald-200"
+                  >
+                    {t("vision.voiceBecameProposal")} →
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => ripenVoice(v.id)}
+                    disabled={ripening === v.id}
+                    className="rounded-full border border-teal-700/40 bg-teal-950/20 hover:bg-teal-950/40 text-teal-200 px-3 py-1 transition-colors disabled:opacity-50"
+                  >
+                    {ripening === v.id ? t("vision.voiceRipening") : t("vision.voiceRipen")}
+                  </button>
+                )}
+              </div>
             </li>
           ))}
         </ul>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -108,7 +108,10 @@
     "voicesSubmit": "Diese Stimme teilen",
     "voicesSubmitting": "Wird geteilt …",
     "voicesThankYou": "Danke — deine Stimme ist hier.",
-    "voicesLoading": "Lausche auf Stimmen …"
+    "voicesLoading": "Lausche auf Stimmen …",
+    "voiceRipen": "Diese Stimme zu einem Vorschlag heben",
+    "voiceRipening": "Wird gehoben …",
+    "voiceBecameProposal": "Diese Stimme wurde zu einem Vorschlag"
   },
   "notifications": {
     "bellLabel": "Neue Antworten und Erwähnungen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -108,7 +108,10 @@
     "voicesSubmit": "Offer this voice",
     "voicesSubmitting": "Offering…",
     "voicesThankYou": "Thank you — your voice is here.",
-    "voicesLoading": "Listening for voices…"
+    "voicesLoading": "Listening for voices…",
+    "voiceRipen": "Lift this voice into a proposal",
+    "voiceRipening": "Lifting…",
+    "voiceBecameProposal": "This voice became a proposal"
   },
   "notifications": {
     "bellLabel": "Recent replies and mentions",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -108,7 +108,10 @@
     "voicesSubmit": "Ofrecer esta voz",
     "voicesSubmitting": "Ofreciendo…",
     "voicesThankYou": "Gracias — tu voz está aquí.",
-    "voicesLoading": "Escuchando voces…"
+    "voicesLoading": "Escuchando voces…",
+    "voiceRipen": "Elevar esta voz a una propuesta",
+    "voiceRipening": "Elevando…",
+    "voiceBecameProposal": "Esta voz se volvió una propuesta"
   },
   "notifications": {
     "bellLabel": "Respuestas y menciones recientes",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -108,7 +108,10 @@
     "voicesSubmit": "Tawarkan suara ini",
     "voicesSubmitting": "Menawarkan…",
     "voicesThankYou": "Terima kasih — suaramu ada di sini.",
-    "voicesLoading": "Mendengarkan suara…"
+    "voicesLoading": "Mendengarkan suara…",
+    "voiceRipen": "Angkat suara ini menjadi usulan",
+    "voiceRipening": "Mengangkat…",
+    "voiceBecameProposal": "Suara ini menjadi usulan"
   },
   "notifications": {
     "bellLabel": "Balasan dan sebutan terbaru",


### PR DESCRIPTION
## Summary
- Voices gain `proposed_as_proposal_id` + idempotent schema-evolve
- `POST /api/concepts/voices/{voice_id}/propose` lifts a voice into a proposal with link-back
- ConceptVoices shows a "Lift this voice" button per voice, swaps to a "became a proposal" link after ripening
- Completes the ladder: voice → proposal → idea

## Test plan
- [x] pytest tests/test_flow_vitality.py → 16/16
- [x] Full suite → 684 / 0
- [x] Web type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)