### PR TITLE
feat(web): OG previews on /meet, /feed, /here, /propose, /explore

### DIFF
--- a/web/app/explore/[entityType]/page.tsx
+++ b/web/app/explore/[entityType]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 import { notFound } from "next/navigation";
 
@@ -19,6 +20,51 @@ const SUPPORTED_TYPES = new Set([
   "contributor",
   "proposal",
 ]);
+
+const TYPE_LABEL: Record<string, { title: string; description: string }> = {
+  concept: {
+    title: "Walk the concepts — Coherence Network",
+    description: "Meet one Living Collective concept at a time. Every gesture lifts both pulses.",
+  },
+  idea: {
+    title: "Walk the ideas — Coherence Network",
+    description: "Meet ideas being realized, one at a time.",
+  },
+  contributor: {
+    title: "Walk with contributors — Coherence Network",
+    description: "Meet the people weaving this network.",
+  },
+  proposal: {
+    title: "Walk the proposals — Coherence Network",
+    description: "Meet proposals the collective is considering. Vote with your reactions.",
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ entityType: string }>;
+}): Promise<Metadata> {
+  const { entityType } = await params;
+  const meta = TYPE_LABEL[entityType];
+  if (!meta) return { title: "Explore — Coherence Network" };
+  return {
+    title: meta.title,
+    description: meta.description,
+    openGraph: {
+      type: "website",
+      siteName: "Coherence Network",
+      title: meta.title,
+      description: meta.description,
+      images: [{ url: "/assets/logo.svg" }],
+    },
+    twitter: {
+      card: "summary",
+      title: meta.title,
+      description: meta.description,
+    },
+  };
+}
 
 export default async function ExplorePage({
   params,

--- a/web/app/feed/page.tsx
+++ b/web/app/feed/page.tsx
@@ -17,7 +17,26 @@ import { FeedTabs } from "@/components/FeedTabs";
  * reader deeper, not toward outrage or comparison.
  */
 
+import type { Metadata } from "next";
+
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "The felt pulse — Coherence Network",
+  description: "What is alive on the network right now — reactions, voices, new seeds.",
+  openGraph: {
+    type: "website",
+    siteName: "Coherence Network",
+    title: "The felt pulse",
+    description: "What is alive on the network right now — reactions, voices, new seeds.",
+    images: [{ url: "/assets/logo.svg" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "The felt pulse — Coherence Network",
+    description: "What is alive on the network right now — reactions, voices, new seeds.",
+  },
+};
 
 interface Reaction {
   id: string;

--- a/web/app/feed/you/page.tsx
+++ b/web/app/feed/you/page.tsx
@@ -15,7 +15,26 @@ import { PersonalFeed } from "@/components/PersonalFeed";
  * identity lives in localStorage; the server doesn't know who you are.
  */
 
+import type { Metadata } from "next";
+
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Your corner — Coherence Network",
+  description: "Voices you gave, reactions you offered, replies that came back to you, proposals you lifted.",
+  openGraph: {
+    type: "website",
+    siteName: "Coherence Network",
+    title: "Your corner of the organism",
+    description: "Voices you gave, reactions you offered, replies that came back to you.",
+    images: [{ url: "/assets/logo.svg" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "Your corner — Coherence Network",
+    description: "Your corner of the organism.",
+  },
+};
 
 export default async function PersonalFeedPage() {
   const cookieLocale = (await cookies()).get("NEXT_LOCALE")?.value;

--- a/web/app/here/page.tsx
+++ b/web/app/here/page.tsx
@@ -19,7 +19,26 @@ import { NotificationBell } from "@/components/NotificationBell";
  * is the organism's attention right now" for anyone who lands fresh.
  */
 
+import type { Metadata } from "next";
+
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Here now — Coherence Network",
+  description: "Where the organism's attention is right now — who is meeting what, and what was just voiced.",
+  openGraph: {
+    type: "website",
+    siteName: "Coherence Network",
+    title: "Here now",
+    description: "Where the organism's attention is right now.",
+    images: [{ url: "/assets/logo.svg" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "Here now — Coherence Network",
+    description: "Where the organism's attention is right now.",
+  },
+};
 
 interface PresenceRow {
   entity_type: string;

--- a/web/app/meet/[entityType]/[entityId]/page.tsx
+++ b/web/app/meet/[entityType]/[entityId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cookies, headers } from "next/headers";
 
@@ -182,6 +183,73 @@ async function fetchEntityFacet(
     return null;
   }
 }
+
+
+// Human-readable label per entity type for page titles + OG previews.
+const TYPE_LABEL: Record<string, string> = {
+  concept: "Concept",
+  idea: "Idea",
+  spec: "Spec",
+  contributor: "Contributor",
+  community: "Community",
+  workspace: "Workspace",
+  asset: "Asset",
+  contribution: "Contribution",
+  story: "Story",
+  config: "Config",
+  insight: "Insight",
+  agent_task: "Agent task",
+  agent_run: "Agent run",
+  proposal: "Proposal",
+};
+
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ entityType: string; entityId: string }>;
+}): Promise<Metadata> {
+  const { entityType, entityId } = await params;
+  if (!SUPPORTED_TYPES.has(entityType)) {
+    return { title: "Meeting | Coherence Network" };
+  }
+  const cookieLocale = (await cookies()).get("NEXT_LOCALE")?.value;
+  const headerLang = (await headers())
+    .get("accept-language")
+    ?.split(",")[0]
+    ?.split("-")[0];
+  const candidate = cookieLocale || headerLang;
+  const lang: LocaleCode = isSupportedLocale(candidate) ? candidate : DEFAULT_LOCALE;
+
+  const facet = await fetchEntityFacet(entityType, entityId, lang);
+  if (!facet) {
+    return { title: `${TYPE_LABEL[entityType] || entityType} | Coherence Network` };
+  }
+
+  const typeLabel = TYPE_LABEL[entityType] || entityType;
+  const title = `${facet.title} — ${typeLabel}`;
+  const description = (facet.description || "").slice(0, 280);
+  const image = facet.imageUrl || undefined;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      type: "website",
+      siteName: "Coherence Network",
+      title,
+      description,
+      ...(image ? { images: [{ url: image, width: 1200, height: 630 }] } : {}),
+    },
+    twitter: {
+      card: image ? "summary_large_image" : "summary",
+      title,
+      description,
+      ...(image ? { images: [image] } : {}),
+    },
+  };
+}
+
 
 export default async function MeetingPage({
   params,

--- a/web/app/propose/page.tsx
+++ b/web/app/propose/page.tsx
@@ -13,7 +13,26 @@ import { ProposeForm } from "@/components/ProposeForm";
  * tally after the window closes.
  */
 
+import type { Metadata } from "next";
+
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Propose — Coherence Network",
+  description: "Offer something for the collective to meet. Reactions become the vote.",
+  openGraph: {
+    type: "website",
+    siteName: "Coherence Network",
+    title: "Propose to the collective",
+    description: "Offer something for the collective to meet. Reactions become the vote.",
+    images: [{ url: "/assets/logo.svg" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "Propose — Coherence Network",
+    description: "Offer something for the collective to meet.",
+  },
+};
 
 export default async function ProposePage() {
   const cookieLocale = (await cookies()).get("NEXT_LOCALE")?.value;


### PR DESCRIPTION
Shared URLs now render rich previews in Twitter/Slack/WhatsApp/Discord. 684 tests green, type check clean. Pure view composition; no API additions.