### PR TITLE
feat(web): locale switcher in site header — reachable from every page

### DIFF
--- a/web/components/LocaleSwitcherCompact.tsx
+++ b/web/components/LocaleSwitcherCompact.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+/**
+ * LocaleSwitcherCompact — the smallest possible language toggle for the
+ * site header (desktop + mobile menu). Four letters, no caption, no
+ * pending/stale chrome. Clicking sets the NEXT_LOCALE cookie and pushes
+ * a route with ?lang=<code> so server components re-render in the new
+ * language on the very next navigation.
+ */
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import { LOCALES, DEFAULT_LOCALE, type LocaleCode } from "@/lib/locales";
+import { useLocale } from "@/components/MessagesProvider";
+
+interface Props {
+  ariaLabel?: string;
+  className?: string;
+  size?: "sm" | "xs";
+}
+
+export function LocaleSwitcherCompact({
+  ariaLabel,
+  className = "",
+  size = "sm",
+}: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentLang = useLocale();
+
+  const setLang = useCallback(
+    (code: LocaleCode) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      if (code === DEFAULT_LOCALE) {
+        params.delete("lang");
+      } else {
+        params.set("lang", code);
+      }
+      const qs = params.toString();
+      const next = qs ? `${pathname}?${qs}` : pathname || "/";
+      document.cookie = `NEXT_LOCALE=${code}; path=/; max-age=${60 * 60 * 24 * 365}`;
+      router.push(next);
+      router.refresh();
+    },
+    [router, pathname, searchParams],
+  );
+
+  const padding = size === "xs" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-1 text-xs";
+
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={`inline-flex items-center gap-0.5 rounded-lg border border-border/40 bg-background/60 p-0.5 ${className}`}
+    >
+      {LOCALES.map((loc) => {
+        const isCurrent = loc.code === currentLang;
+        return (
+          <button
+            key={loc.code}
+            type="button"
+            onClick={() => setLang(loc.code)}
+            className={`${padding} rounded font-medium uppercase tracking-wider transition-colors ${
+              isCurrent
+                ? "bg-amber-500/20 text-amber-200"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent/40"
+            }`}
+            title={loc.nativeName}
+            aria-pressed={isCurrent}
+            aria-label={loc.nativeName}
+          >
+            {loc.code}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -6,6 +6,7 @@ import { ActiveNavLink } from "./active_nav_link";
 import { ThemeToggle } from "./theme-toggle";
 import { ModeSwitcher } from "./mode-switcher";
 import { WorkspacePicker } from "./workspace-picker";
+import { LocaleSwitcherCompact } from "./LocaleSwitcherCompact";
 import { createTranslator } from "@/lib/i18n";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
 
@@ -88,6 +89,11 @@ export default async function SiteHeader() {
           {/* Workspace picker — Wave 2 multi-tenancy */}
           <WorkspacePicker />
 
+          {/* Locale switcher — visible on desktop, always reachable */}
+          <div className="hidden md:block">
+            <LocaleSwitcherCompact ariaLabel={t("locale.switcherLabel")} />
+          </div>
+
           {/* Mode switcher — expert / simple */}
           <ModeSwitcher />
 
@@ -143,6 +149,16 @@ export default async function SiteHeader() {
               aria-label={t("nav.mobile")}
             >
               <div className="p-3 space-y-1">
+                <div className="flex items-center justify-between px-2 py-1.5">
+                  <span className="text-[11px] uppercase tracking-wider text-muted-foreground/80">
+                    {t("locale.switcherLabel")}
+                  </span>
+                  <LocaleSwitcherCompact
+                    ariaLabel={t("locale.switcherLabel")}
+                    size="xs"
+                  />
+                </div>
+                <div className="border-t border-border/30 my-2" />
                 {PRIMARY_NAV.map((n) => (
                   <Link
                     key={n.href}


### PR DESCRIPTION
Compact 4-letter switcher in desktop header + top of mobile hamburger. Unblocks language change from anywhere. Type check clean.