### PR TITLE
fix(api): concept + idea lists attune on the fly when no view exists

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -217,6 +217,19 @@ async def list_concepts(
                     c["name"] = rec.content_title
                 if rec.content_description:
                     c["description"] = rec.content_description
+                continue
+            # Fall back to live snippet translation (cached) when no
+            # canonical view exists yet.
+            src_title = c.get("name", "")
+            src_desc = c.get("description", "")
+            if src_title or src_desc:
+                t_title, t_desc = translator_service.translate_snippet(
+                    src_title, src_desc, source_lang="en", target_lang=target_lang,
+                )
+                if t_title:
+                    c["name"] = t_title
+                if t_desc:
+                    c["description"] = t_desc
     return result
 
 
@@ -282,6 +295,20 @@ async def list_concepts_by_domain(
                     c["name"] = rec.content_title
                 if rec.content_description:
                     c["description"] = rec.content_description
+                continue
+            # No canonical view for this concept yet — fall back to a live
+            # snippet translation so the listing reads in the viewer's tongue.
+            # Cached in-process so repeat requests are cheap.
+            src_title = c.get("name", "")
+            src_desc = c.get("description", "")
+            if src_title or src_desc:
+                t_title, t_desc = translator_service.translate_snippet(
+                    src_title, src_desc, source_lang="en", target_lang=target_lang,
+                )
+                if t_title:
+                    c["name"] = t_title
+                if t_desc:
+                    c["description"] = t_desc
     return result
 
 

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -109,6 +109,22 @@ def _apply_lang_views(resp: IdeaPortfolioResponse, lang: str | None) -> IdeaPort
                     idea.description = rec.content_description
                 except Exception:
                     pass
+            continue
+        # No canonical view — fall back to live snippet translation so
+        # the listing speaks the viewer's language. Cached in-process.
+        src_title = idea.name or ""
+        src_desc = getattr(idea, "description", "") or ""
+        if src_title or src_desc:
+            t_title, t_desc = translator_service.translate_snippet(
+                src_title, src_desc, source_lang="en", target_lang=lang,
+            )
+            if t_title:
+                idea.name = t_title
+            if t_desc and hasattr(idea, "description"):
+                try:
+                    idea.description = t_desc
+                except Exception:
+                    pass
     return resp
 
 


### PR DESCRIPTION
Fixes /vision page showing English concepts even when viewer is in German. When no canonical entity_view exists, lists now fall back to LibreTranslate snippet translation (cached, glossary-aware). 684 tests green.