### PR TITLE
feat: locale auto-detect on first visit + locale row in registration + header fixes

### DIFF
--- a/api/app/routers/interest.py
+++ b/api/app/routers/interest.py
@@ -30,11 +30,18 @@ class RegisterInterestRequest(BaseModel):
     offering: str = ""
     resonant_roles: list[str] = []
     message: str = ""
+    locale: str = "en"
     consent_share_name: bool = False
     consent_share_location: bool = False
     consent_share_skills: bool = False
     consent_findable: bool = False
     consent_email_updates: bool = False
+
+    @field_validator("locale")
+    @classmethod
+    def validate_locale(cls, v: str) -> str:
+        v = (v or "").strip().lower()
+        return v if v in {"en", "de", "es", "id"} else "en"
 
     @field_validator("name")
     @classmethod
@@ -110,6 +117,7 @@ async def register_interest(body: RegisterInterestRequest) -> RegisterInterestRe
             offering=body.offering,
             resonant_roles=body.resonant_roles,
             message=body.message,
+            locale=body.locale,
             consent_share_name=body.consent_share_name,
             consent_share_location=body.consent_share_location,
             consent_share_skills=body.consent_share_skills,

--- a/api/app/services/interest_service.py
+++ b/api/app/services/interest_service.py
@@ -64,6 +64,7 @@ def register_interest(
     offering: str = "",
     resonant_roles: list[str] | None = None,
     message: str = "",
+    locale: str = "en",
     consent_share_name: bool = False,
     consent_share_location: bool = False,
     consent_share_skills: bool = False,
@@ -76,6 +77,11 @@ def register_interest(
     # Validate roles
     roles = [r for r in (resonant_roles or []) if r in VALID_ROLES]
 
+    # Normalize locale to one of the supported codes; fall back to en.
+    locale_code = (locale or "en").strip().lower()
+    if locale_code not in {"en", "de", "es", "id"}:
+        locale_code = "en"
+
     properties: dict[str, Any] = {
         "email": email,
         "location": location,
@@ -83,6 +89,7 @@ def register_interest(
         "offering": offering,
         "resonant_roles": roles,
         "message": message,
+        "locale": locale_code,
         "consent_share_name": consent_share_name,
         "consent_share_location": consent_share_location,
         "consent_share_skills": consent_share_skills,

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import "./globals.css";
 import RuntimeBeacon from "@/components/runtime-beacon";
 
@@ -72,7 +72,19 @@ export default async function RootLayout({
   const publicConfig = loadPublicWebConfig();
   const cookieStore = await cookies();
   const cookieLang = cookieStore.get("NEXT_LOCALE")?.value;
-  const lang: LocaleCode = isSupportedLocale(cookieLang) ? cookieLang : DEFAULT_LOCALE;
+  // Cookie takes precedence (set by middleware or by an explicit switcher
+  // click). On first visit before the middleware response is honored,
+  // fall back to Accept-Language so the *very first render* already meets
+  // the viewer in their language.
+  const headerLang = (await headers())
+    .get("accept-language")
+    ?.split(",")[0]
+    ?.split("-")[0];
+  const lang: LocaleCode = isSupportedLocale(cookieLang)
+    ? cookieLang
+    : isSupportedLocale(headerLang)
+    ? headerLang
+    : DEFAULT_LOCALE;
   const messages = getMessages(lang);
   const fallback = getMessages(DEFAULT_LOCALE);
   const t = createTranslator(lang);

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import { Button } from "@/components/ui/button";
 import { IdeaSubmitForm } from "@/components/idea_submit_form";
@@ -106,7 +106,18 @@ function timeAgo(iso: string, t: Translator): string {
 export default async function Home() {
   const cookieStore = await cookies();
   const cookieLang = cookieStore.get("NEXT_LOCALE")?.value;
-  const lang: LocaleCode = isSupportedLocale(cookieLang) ? cookieLang : DEFAULT_LOCALE;
+  // First-visit auto-detect — fall back to Accept-Language so the home
+  // page meets the viewer in their language on the very first render,
+  // before the middleware-set cookie is visible on subsequent requests.
+  const headerLang = (await headers())
+    .get("accept-language")
+    ?.split(",")[0]
+    ?.split("-")[0];
+  const lang: LocaleCode = isSupportedLocale(cookieLang)
+    ? cookieLang
+    : isSupportedLocale(headerLang)
+    ? headerLang
+    : DEFAULT_LOCALE;
   const t = createTranslator(lang);
 
   const [ideasData, resonanceItems, coherenceScore, nodeCount] = await Promise.all([

--- a/web/components/MeButton.tsx
+++ b/web/components/MeButton.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * MeButton — visible only to viewers with a stored identity.
+ *
+ * Reads `cc-contributor-id` / `cc-reaction-author-name` from localStorage
+ * and renders a small avatar-ish affordance that opens a pop-up with
+ * links to the viewer's personal surfaces: profile, corner feed,
+ * notifications, contributions.
+ *
+ * When there is no identity, the component renders a "Sign in" pill
+ * linking to /vision/join instead — so the header always carries the
+ * right invitation.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useT } from "@/components/MessagesProvider";
+
+const CONTRIBUTOR_KEY = "cc-contributor-id";
+const NAME_KEY = "cc-reaction-author-name";
+
+export function MeButton() {
+  const t = useT();
+  const [contributorId, setContributorId] = useState<string | null>(null);
+  const [authorName, setAuthorName] = useState<string>("");
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    try {
+      setContributorId(localStorage.getItem(CONTRIBUTOR_KEY));
+      setAuthorName(localStorage.getItem(NAME_KEY) || "");
+    } catch {
+      /* ignore */
+    }
+    setReady(true);
+  }, []);
+
+  if (!ready) return null;
+
+  // No identity yet — offer the gentle door
+  if (!contributorId && !authorName.trim()) {
+    return (
+      <Link
+        href="/vision/join"
+        className="rounded-full border border-teal-700/40 bg-teal-950/20 hover:bg-teal-950/40 text-teal-200 px-3 py-1 text-xs font-medium transition-colors"
+      >
+        {t("me.stepIn")}
+      </Link>
+    );
+  }
+
+  const display = authorName.trim() || t("me.you");
+  const initial = (display[0] || "·").toUpperCase();
+  const profileHref = contributorId
+    ? `/profile/${encodeURIComponent(contributorId)}`
+    : "/feed/you";
+
+  return (
+    <details className="relative">
+      <summary
+        className="list-none cursor-pointer flex items-center gap-2 rounded-full border border-border/40 bg-background/60 px-2 py-1 text-sm hover:border-border hover:bg-accent/40 transition-colors"
+        aria-label={t("me.menuLabel")}
+      >
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-amber-500/30 to-teal-500/30 text-xs font-medium text-amber-200">
+          {initial}
+        </span>
+        <span className="hidden md:inline max-w-[6rem] truncate text-foreground/90">
+          {display}
+        </span>
+      </summary>
+      <div className="absolute right-0 mt-2 w-56 rounded-xl border border-border/50 bg-popover/95 backdrop-blur-md shadow-xl z-50">
+        <div className="p-3 space-y-0.5">
+          <div className="px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground/80">
+            {t("me.heading")}
+          </div>
+          <Link
+            href={profileHref}
+            className="block rounded-lg px-3 py-2 text-sm hover:bg-accent/60 transition-colors"
+          >
+            {t("me.viewProfile")}
+          </Link>
+          <Link
+            href="/feed/you"
+            className="block rounded-lg px-3 py-2 text-sm hover:bg-accent/60 transition-colors"
+          >
+            {t("me.myCorner")}
+          </Link>
+          <Link
+            href="/here"
+            className="block rounded-lg px-3 py-2 text-sm hover:bg-accent/60 transition-colors"
+          >
+            {t("me.hereNow")}
+          </Link>
+          {contributorId && (
+            <Link
+              href={`/contributors/${encodeURIComponent(contributorId)}/portfolio`}
+              className="block rounded-lg px-3 py-2 text-sm hover:bg-accent/60 transition-colors"
+            >
+              {t("me.portfolio")}
+            </Link>
+          )}
+          {contributorId && (
+            <Link
+              href={`/profile/${encodeURIComponent(contributorId)}/beliefs`}
+              className="block rounded-lg px-3 py-2 text-sm hover:bg-accent/60 transition-colors"
+            >
+              {t("me.beliefs")}
+            </Link>
+          )}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * ShareButton — tiny share affordance that uses the native sheet
+ * (navigator.share) when available, otherwise copies the URL to the
+ * clipboard and acknowledges.
+ */
+
+import { useState } from "react";
+import { useT } from "@/components/MessagesProvider";
+
+interface Props {
+  /** Absolute URL to share. Falls back to current window.location.href. */
+  url?: string;
+  /** Title to accompany the share payload. */
+  title?: string;
+  /** Short description accompanying the share payload. */
+  text?: string;
+  /** Optional className overriding the default pill styling. */
+  className?: string;
+}
+
+export function ShareButton({ url, title, text, className = "" }: Props) {
+  const t = useT();
+  const [status, setStatus] = useState<"idle" | "copied" | "shared" | "error">("idle");
+
+  async function onShare() {
+    const shareUrl = url || (typeof window !== "undefined" ? window.location.href : "");
+    const payload = {
+      url: shareUrl,
+      title: title || (typeof document !== "undefined" ? document.title : ""),
+      text: text || "",
+    };
+    try {
+      if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+        await navigator.share(payload);
+        setStatus("shared");
+        setTimeout(() => setStatus("idle"), 2000);
+        return;
+      }
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(shareUrl);
+        setStatus("copied");
+        setTimeout(() => setStatus("idle"), 2000);
+        return;
+      }
+      setStatus("error");
+      setTimeout(() => setStatus("idle"), 2000);
+    } catch {
+      // User cancelled the native sheet — treat as idle.
+      setStatus("idle");
+    }
+  }
+
+  const label =
+    status === "copied"
+      ? t("share.copied")
+      : status === "shared"
+      ? t("share.shared")
+      : status === "error"
+      ? t("share.error")
+      : t("share.action");
+
+  return (
+    <button
+      type="button"
+      onClick={onShare}
+      className={
+        className ||
+        "inline-flex items-center gap-1.5 rounded-full border border-border/40 bg-background/60 hover:bg-accent/40 text-sm px-3 py-1 transition-colors"
+      }
+      aria-label={t("share.action")}
+    >
+      <span aria-hidden="true">↗</span>
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from "./theme-toggle";
 import { ModeSwitcher } from "./mode-switcher";
 import { WorkspacePicker } from "./workspace-picker";
 import { LocaleSwitcherCompact } from "./LocaleSwitcherCompact";
+import { MeButton } from "./MeButton";
 import { createTranslator } from "@/lib/i18n";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
 
@@ -100,6 +101,9 @@ export default async function SiteHeader() {
           {/* Theme toggle — Spec 165 */}
           <ThemeToggle />
 
+          {/* Me — the signed-in contributor's doorway to their own surfaces */}
+          <MeButton />
+
           {/* Desktop "More" dropdown — secondary pages */}
           <details className="relative hidden md:block group">
             <summary
@@ -145,7 +149,7 @@ export default async function SiteHeader() {
               {t("header.menu")}
             </summary>
             <nav
-              className="absolute right-0 mt-2 w-56 rounded-xl border border-border/50 bg-popover/95 backdrop-blur-md shadow-xl"
+              className="absolute right-0 mt-2 w-56 max-h-[calc(100vh-6rem)] overflow-y-auto rounded-xl border border-border/50 bg-popover/95 backdrop-blur-md shadow-xl overscroll-contain"
               aria-label={t("nav.mobile")}
             >
               <div className="p-3 space-y-1">

--- a/web/components/vision/InterestForm.tsx
+++ b/web/components/vision/InterestForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { useT } from "@/components/MessagesProvider";
+import { useT, useLocale } from "@/components/MessagesProvider";
+import { LOCALES, type LocaleCode } from "@/lib/locales";
 
 type RoleKey =
   | "livingStructureWeaver"
@@ -29,6 +30,7 @@ type FormState = {
   offering: string;
   resonant_roles: string[];
   message: string;
+  locale: LocaleCode;
   consent_share_name: boolean;
   consent_share_location: boolean;
   consent_share_skills: boolean;
@@ -36,24 +38,28 @@ type FormState = {
   consent_email_updates: boolean;
 };
 
-const INITIAL: FormState = {
-  name: "",
-  email: "",
-  location: "",
-  skills: "",
-  offering: "",
-  resonant_roles: [],
-  message: "",
-  consent_share_name: false,
-  consent_share_location: false,
-  consent_share_skills: false,
-  consent_findable: false,
-  consent_email_updates: false,
-};
+function initialState(detected: LocaleCode): FormState {
+  return {
+    name: "",
+    email: "",
+    location: "",
+    skills: "",
+    offering: "",
+    resonant_roles: [],
+    message: "",
+    locale: detected,
+    consent_share_name: false,
+    consent_share_location: false,
+    consent_share_skills: false,
+    consent_findable: false,
+    consent_email_updates: false,
+  };
+}
 
 export function InterestForm() {
   const t = useT();
-  const [form, setForm] = useState<FormState>(INITIAL);
+  const detectedLocale = useLocale() as LocaleCode;
+  const [form, setForm] = useState<FormState>(() => initialState(detectedLocale));
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState("");
@@ -105,7 +111,7 @@ export function InterestForm() {
           {form.consent_email_updates && t("interestForm.thanksUpdates")}
         </p>
         <button
-          onClick={() => { setSubmitted(false); setForm(INITIAL); }}
+          onClick={() => { setSubmitted(false); setForm(initialState(detectedLocale)); }}
           className="text-sm text-stone-600 hover:text-stone-400 transition-colors"
         >
           {t("interestForm.registerAgain")}
@@ -116,6 +122,40 @@ export function InterestForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
+      {/* Your language — pre-filled from the viewer's current locale.
+          Always visible so the contributor can correct the guess. */}
+      <div className="space-y-2">
+        <label className="text-sm text-stone-400">
+          {t("interestForm.labelLocale")}
+        </label>
+        <div className="flex flex-wrap items-center gap-2">
+          {LOCALES.map((loc) => {
+            const selected = form.locale === loc.code;
+            return (
+              <button
+                key={loc.code}
+                type="button"
+                onClick={() => setForm({ ...form, locale: loc.code })}
+                aria-pressed={selected}
+                className={`rounded-full px-3 py-1.5 text-sm border transition-colors ${
+                  selected
+                    ? "border-amber-500/60 bg-amber-500/10 text-amber-200"
+                    : "border-stone-800/60 bg-stone-900/40 text-stone-400 hover:border-stone-700 hover:text-stone-300"
+                }`}
+              >
+                <span className="font-medium uppercase tracking-wider mr-2 text-xs">
+                  {loc.code}
+                </span>
+                {loc.nativeName}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-stone-600 leading-relaxed">
+          {t("interestForm.localeHint")}
+        </p>
+      </div>
+
       {/* Name + Email */}
       <div className="grid md:grid-cols-2 gap-6">
         <div className="space-y-2">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -142,6 +142,8 @@
     "thanksBody": "Deine Resonanz ist registriert. Du bist jetzt Teil des sich formenden Feldes.",
     "thanksUpdates": "Wir halten dich im Fluss, während die Dinge entstehen.",
     "registerAgain": "Eine weitere Seele eintragen",
+    "labelLocale": "Deine Sprache",
+    "localeHint": "Wir wenden uns in dieser Sprache an dich. Oben auf der Seite kannst du sie jederzeit ändern.",
     "labelName": "Dein Name *",
     "placeholderName": "Wie das Feld dich kennt",
     "labelEmail": "E-Mail *",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -142,6 +142,8 @@
     "thanksBody": "Your resonance has been registered. You are now part of the forming field.",
     "thanksUpdates": "We'll keep you in the flow as things emerge.",
     "registerAgain": "Register another soul",
+    "labelLocale": "Your language",
+    "localeHint": "We'll reach you in this language. You can change it any time from the top of the page.",
     "labelName": "Your name *",
     "placeholderName": "How the field knows you",
     "labelEmail": "Email *",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -142,6 +142,8 @@
     "thanksBody": "Tu resonancia se ha registrado. Ahora eres parte del campo que se forma.",
     "thanksUpdates": "Te mantendremos en el flujo a medida que surjan cosas.",
     "registerAgain": "Registrar otra alma",
+    "labelLocale": "Tu idioma",
+    "localeHint": "Te contactaremos en este idioma. Puedes cambiarlo en cualquier momento desde la parte superior.",
     "labelName": "Tu nombre *",
     "placeholderName": "Cómo te conoce el campo",
     "labelEmail": "Correo *",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -142,6 +142,8 @@
     "thanksBody": "Resonansimu sudah tercatat. Kamu sekarang bagian dari medan yang sedang terbentuk.",
     "thanksUpdates": "Kami akan menjagamu tetap dalam alir seiring hal-hal muncul.",
     "registerAgain": "Daftarkan jiwa lain",
+    "labelLocale": "Bahasamu",
+    "localeHint": "Kami akan menghubungimu dalam bahasa ini. Kamu bisa mengubahnya kapan saja dari bagian atas halaman.",
     "labelName": "Namamu *",
     "placeholderName": "Bagaimana medan mengenalmu",
     "labelEmail": "Surel *",

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -4,22 +4,70 @@ const SUPPORTED = new Set(["en", "de", "es", "id"]);
 const COOKIE_NAME = "NEXT_LOCALE";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 
+/**
+ * Resolve the best-guess locale from the Accept-Language header.
+ *
+ * Honors quality weights (q=0.8 etc), picks the highest-q supported
+ * language prefix. Returns null when nothing matches.
+ */
+function bestFromAcceptLanguage(header: string | null): string | null {
+  if (!header) return null;
+  const candidates = header
+    .split(",")
+    .map((raw) => {
+      const [tag, ...params] = raw.trim().split(";");
+      const qParam = params.find((p) => p.trim().startsWith("q="));
+      const q = qParam ? parseFloat(qParam.split("=")[1]) || 0 : 1;
+      const prefix = (tag || "").split("-")[0].toLowerCase();
+      return { prefix, q };
+    })
+    .filter((c) => c.prefix && !Number.isNaN(c.q))
+    .sort((a, b) => b.q - a.q);
+  for (const c of candidates) {
+    if (SUPPORTED.has(c.prefix)) return c.prefix;
+  }
+  return null;
+}
+
 export function middleware(req: NextRequest) {
   const qs = req.nextUrl.searchParams.get("lang");
-  if (!qs || !SUPPORTED.has(qs)) return NextResponse.next();
-
   const existing = req.cookies.get(COOKIE_NAME)?.value;
-  if (existing === qs) return NextResponse.next();
 
-  const res = NextResponse.next();
-  res.cookies.set({
-    name: COOKIE_NAME,
-    value: qs,
-    path: "/",
-    maxAge: COOKIE_MAX_AGE,
-    sameSite: "lax",
-  });
-  return res;
+  // Explicit ?lang= overrides everything and gets persisted on the cookie.
+  if (qs && SUPPORTED.has(qs)) {
+    if (existing === qs) return NextResponse.next();
+    const res = NextResponse.next();
+    res.cookies.set({
+      name: COOKIE_NAME,
+      value: qs,
+      path: "/",
+      maxAge: COOKIE_MAX_AGE,
+      sameSite: "lax",
+    });
+    return res;
+  }
+
+  // First-visit auto-detection: no ?lang=, no existing cookie. Read the
+  // browser's Accept-Language and persist the best-guess locale so the
+  // rest of the session honors it. Writes the cookie even on the very
+  // first request so server components rendering after the middleware
+  // see the detected locale via cookies().
+  if (!existing) {
+    const detected = bestFromAcceptLanguage(req.headers.get("accept-language"));
+    if (detected) {
+      const res = NextResponse.next();
+      res.cookies.set({
+        name: COOKIE_NAME,
+        value: detected,
+        path: "/",
+        maxAge: COOKIE_MAX_AGE,
+        sameSite: "lax",
+      });
+      return res;
+    }
+  }
+
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
- Middleware: first-visit Accept-Language detection, writes NEXT_LOCALE cookie for persistence
- layout + home: fall back to Accept-Language so the very first render is already localized
- InterestForm: visible locale row pre-filled from detected locale; stored on contributor graph node
- Plus in-flight cycle-23 work that was sitting uncommitted: Me button in header, Share button component, mobile menu max-height fix

684 tests green, type check clean.