### PR TITLE
fix(web): MeetingSurface description takes full width on mobile

### DIFF
--- a/web/components/MeetingSurface.tsx
+++ b/web/components/MeetingSurface.tsx
@@ -223,7 +223,7 @@ export function MeetingSurface({
         )}
         <h1 className="text-3xl md:text-4xl font-light tracking-tight mb-3">{title}</h1>
         {description && (
-          <p className="text-base md:text-lg text-stone-300 max-w-xl leading-relaxed">{description}</p>
+          <p className="text-base md:text-lg text-stone-300 max-w-xl w-full leading-relaxed break-words whitespace-normal px-1">{description}</p>
         )}
       </section>
 


### PR DESCRIPTION
Follow-up to PR 1027 — the description p element needed w-full and break-words so it fills its parent on mobile rather than sizing to content.