### PR TITLE
feat(web): invite a friend — share a direct link to a first meeting

### DIFF
--- a/web/app/feed/you/page.tsx
+++ b/web/app/feed/you/page.tsx
@@ -5,6 +5,7 @@ import { createTranslator } from "@/lib/i18n";
 import { FeedTabs } from "@/components/FeedTabs";
 import { NotificationBell } from "@/components/NotificationBell";
 import { PersonalFeed } from "@/components/PersonalFeed";
+import { InviteFriend } from "@/components/InviteFriend";
 
 /**
  * /feed/you — your corner of the organism.
@@ -64,6 +65,9 @@ export default async function PersonalFeedPage() {
           loading: t("feed.personalLoading"),
         }}
       />
+      <div className="mt-8">
+        <InviteFriend />
+      </div>
     </main>
   );
 }

--- a/web/components/InviteFriend.tsx
+++ b/web/components/InviteFriend.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * InviteFriend — a small "bring someone in" block.
+ *
+ * Generates a warm shareable link: the current site with a soft
+ * ?from= parameter carrying the inviter's author name. Copies to
+ * clipboard (or opens the native share sheet on mobile) with a
+ * suggested message in the inviter's language.
+ *
+ * The landing pages don't need to parse ?from= yet — that's a later
+ * cycle. For now the link already works (it just lands on the home
+ * page) and the inviter gets a proud affordance.
+ */
+
+import { useEffect, useState } from "react";
+import { useT, useLocale } from "@/components/MessagesProvider";
+
+const NAME_KEY = "cc-reaction-author-name";
+
+interface Props {
+  /** Which page to land them on. Defaults to /meet/concept/lc-nourishing —
+   *  the warmest first touch. */
+  targetPath?: string;
+  className?: string;
+}
+
+function siteBase(): string {
+  if (typeof window === "undefined") return "https://coherencycoin.com";
+  return `${window.location.protocol}//${window.location.host}`;
+}
+
+export function InviteFriend({
+  targetPath = "/meet/concept/lc-nourishing",
+  className = "",
+}: Props) {
+  const t = useT();
+  const locale = useLocale();
+  const [name, setName] = useState<string>("");
+  const [copied, setCopied] = useState<"idle" | "copied" | "shared">("idle");
+
+  useEffect(() => {
+    try {
+      setName(localStorage.getItem(NAME_KEY) || "");
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  function buildUrl(): string {
+    const base = siteBase();
+    const url = new URL(targetPath, base);
+    if (name.trim()) url.searchParams.set("from", name.trim());
+    return url.toString();
+  }
+
+  async function onInvite() {
+    const url = buildUrl();
+    const message = name.trim()
+      ? t("invite.messageWithName").replace("{name}", name.trim())
+      : t("invite.message");
+    const payload = {
+      title: t("invite.title"),
+      text: message,
+      url,
+    };
+    try {
+      if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+        await navigator.share(payload);
+        setCopied("shared");
+        setTimeout(() => setCopied("idle"), 2500);
+        return;
+      }
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(`${message}\n${url}`);
+        setCopied("copied");
+        setTimeout(() => setCopied("idle"), 2500);
+      }
+    } catch {
+      /* user cancelled — idle */
+    }
+  }
+
+  const label =
+    copied === "copied"
+      ? t("invite.copied")
+      : copied === "shared"
+      ? t("invite.shared")
+      : t("invite.cta");
+
+  return (
+    <section
+      className={
+        className ||
+        "rounded-xl border border-teal-800/40 bg-teal-950/10 p-5 space-y-3"
+      }
+    >
+      <p className="text-xs uppercase tracking-widest text-teal-300/90">
+        {t("invite.eyebrow")}
+      </p>
+      <h3 className="text-base md:text-lg font-light text-stone-100 leading-snug">
+        {t("invite.headline")}
+      </h3>
+      <p className="text-sm text-stone-400 leading-relaxed">
+        {t("invite.lede")}
+      </p>
+      <button
+        type="button"
+        onClick={onInvite}
+        className="inline-flex items-center gap-2 rounded-full bg-teal-700/80 hover:bg-teal-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+      >
+        <span aria-hidden="true">🌿</span>
+        <span>{label}</span>
+      </button>
+    </section>
+  );
+}

--- a/web/components/MeButton.tsx
+++ b/web/components/MeButton.tsx
@@ -108,6 +108,13 @@ export function MeButton() {
               {t("me.beliefs")}
             </Link>
           )}
+          <div className="border-t border-border/30 my-2" />
+          <Link
+            href="/feed/you#invite"
+            className="block rounded-lg px-3 py-2 text-sm text-teal-300 hover:bg-teal-950/30 transition-colors"
+          >
+            {t("me.inviteFriend")}
+          </Link>
         </div>
       </div>
     </details>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -184,6 +184,29 @@
     "propose": "Vorschlag",
     "you": "Du"
   },
+  "me": {
+    "stepIn": "Eintreten",
+    "you": "Du",
+    "menuLabel": "Deine Ecke",
+    "heading": "Deine Ecke",
+    "viewProfile": "Dein Profil",
+    "myCorner": "Dein Strom",
+    "hereNow": "Jetzt hier",
+    "portfolio": "Dein Portfolio",
+    "beliefs": "Deine Überzeugungen",
+    "inviteFriend": "Freund·in einladen"
+  },
+  "invite": {
+    "eyebrow": "Jemanden einladen",
+    "headline": "Wen würde das freuen?",
+    "lede": "Teile einen direkten Link zu einem Begriff, der dich bewegt hat. Die Person landet in einer ganzseitigen ersten Begegnung, nicht bei einer Textwand.",
+    "cta": "Freund·in einladen",
+    "copied": "Link kopiert ✓",
+    "shared": "Danke fürs Teilen 🌿",
+    "title": "Komm und begegne dem",
+    "message": "Ich habe etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau.",
+    "messageWithName": "{name} hat etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau."
+  },
   "welcome": {
     "ariaLabel": "Willkommen — worum es hier geht",
     "eyebrow": "Neu hier?",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -184,6 +184,29 @@
     "propose": "Propose",
     "you": "You"
   },
+  "me": {
+    "stepIn": "Step in",
+    "you": "You",
+    "menuLabel": "Your corner",
+    "heading": "Your corner",
+    "viewProfile": "Your profile",
+    "myCorner": "Your feed",
+    "hereNow": "Here now",
+    "portfolio": "Your portfolio",
+    "beliefs": "Your beliefs",
+    "inviteFriend": "Invite a friend"
+  },
+  "invite": {
+    "eyebrow": "Bring someone in",
+    "headline": "Who would love this?",
+    "lede": "Share a direct link to a concept that moved you. They arrive at a full-screen first meeting, not a wall of text.",
+    "cta": "Invite a friend",
+    "copied": "Link copied ✓",
+    "shared": "Thanks for sharing 🌿",
+    "title": "Come meet this",
+    "message": "I found something that feels alive. Take three minutes and see.",
+    "messageWithName": "{name} found something that feels alive. Take three minutes and see."
+  },
   "welcome": {
     "ariaLabel": "Welcome — what this place is",
     "eyebrow": "New here?",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -184,6 +184,29 @@
     "propose": "Propuesta",
     "you": "Tú"
   },
+  "me": {
+    "stepIn": "Entrar",
+    "you": "Tú",
+    "menuLabel": "Tu rincón",
+    "heading": "Tu rincón",
+    "viewProfile": "Tu perfil",
+    "myCorner": "Tu flujo",
+    "hereNow": "Aquí ahora",
+    "portfolio": "Tu portafolio",
+    "beliefs": "Tus creencias",
+    "inviteFriend": "Invitar a alguien"
+  },
+  "invite": {
+    "eyebrow": "Trae a alguien",
+    "headline": "¿A quién le gustaría esto?",
+    "lede": "Comparte un enlace directo a un concepto que te movió. Aterrizan en un primer encuentro a pantalla completa, no en un muro de texto.",
+    "cta": "Invitar a alguien",
+    "copied": "Enlace copiado ✓",
+    "shared": "Gracias por compartir 🌿",
+    "title": "Ven a encontrarte con esto",
+    "message": "Encontré algo que se siente vivo. Tómate tres minutos y mira.",
+    "messageWithName": "{name} encontró algo que se siente vivo. Tómate tres minutos y mira."
+  },
   "welcome": {
     "ariaLabel": "Bienvenida — de qué se trata este lugar",
     "eyebrow": "¿Eres nueva aquí?",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -184,6 +184,29 @@
     "propose": "Usul",
     "you": "Kamu"
   },
+  "me": {
+    "stepIn": "Masuk",
+    "you": "Kamu",
+    "menuLabel": "Sudutmu",
+    "heading": "Sudutmu",
+    "viewProfile": "Profilmu",
+    "myCorner": "Arusmu",
+    "hereNow": "Di sini kini",
+    "portfolio": "Portofoliomu",
+    "beliefs": "Keyakinanmu",
+    "inviteFriend": "Undang teman"
+  },
+  "invite": {
+    "eyebrow": "Ajak seseorang",
+    "headline": "Siapa yang akan menyukai ini?",
+    "lede": "Bagikan tautan langsung ke konsep yang menggerakkanmu. Mereka mendarat di perjumpaan layar penuh, bukan dinding teks.",
+    "cta": "Undang teman",
+    "copied": "Tautan disalin ✓",
+    "shared": "Terima kasih sudah berbagi 🌿",
+    "title": "Datang temui ini",
+    "message": "Aku menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat.",
+    "messageWithName": "{name} menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat."
+  },
   "welcome": {
     "ariaLabel": "Selamat datang — tentang tempat ini",
     "eyebrow": "Baru di sini?",


### PR DESCRIPTION
Signed-in viewers get an InviteFriend card on /feed/you and an Invite link in the Me menu. Uses native Web Share Sheet on mobile, clipboard fallback on desktop. Localized en/de/es/id. Also backfills the missing me.* message bundle.