### PR TITLE
feat(web): inline 'say something' on the meeting surface

### DIFF
--- a/web/app/explore/[entityType]/page.tsx
+++ b/web/app/explore/[entityType]/page.tsx
@@ -101,6 +101,13 @@ export default async function ExplorePage({
         inviteHint: t("meeting.inviteHint"),
         othersHereOne: t("meeting.othersHereOne"),
         othersHereMany: t("meeting.othersHereMany"),
+        sayHeading: t("meeting.sayHeading"),
+        sayNamePlaceholder: t("meeting.sayNamePlaceholder"),
+        sayPlaceholder: t("meeting.sayPlaceholder"),
+        saySubmit: t("meeting.saySubmit"),
+        saySending: t("meeting.saySending"),
+        saySent: t("meeting.saySent"),
+        sayDismiss: t("meeting.sayDismiss"),
       }}
     />
   );

--- a/web/app/meet/[entityType]/[entityId]/page.tsx
+++ b/web/app/meet/[entityType]/[entityId]/page.tsx
@@ -289,6 +289,13 @@ export default async function MeetingPage({
           inviteHint: t("meeting.inviteHint"),
           othersHereOne: t("meeting.othersHereOne"),
           othersHereMany: t("meeting.othersHereMany"),
+          sayHeading: t("meeting.sayHeading"),
+          sayNamePlaceholder: t("meeting.sayNamePlaceholder"),
+          sayPlaceholder: t("meeting.sayPlaceholder"),
+          saySubmit: t("meeting.saySubmit"),
+          saySending: t("meeting.saySending"),
+          saySent: t("meeting.saySent"),
+          sayDismiss: t("meeting.sayDismiss"),
         }}
       />
       {entityType === "proposal" && (

--- a/web/components/ExplorePager.tsx
+++ b/web/components/ExplorePager.tsx
@@ -43,6 +43,13 @@ interface Props {
     inviteHint: string;
     othersHereOne?: string;
     othersHereMany?: string;
+    sayHeading?: string;
+    sayNamePlaceholder?: string;
+    sayPlaceholder?: string;
+    saySubmit?: string;
+    saySending?: string;
+    saySent?: string;
+    sayDismiss?: string;
   };
 }
 
@@ -186,6 +193,13 @@ export function ExplorePager({ entityType, strings }: Props) {
           inviteHint: strings.inviteHint,
           othersHereOne: strings.othersHereOne,
           othersHereMany: strings.othersHereMany,
+          sayHeading: strings.sayHeading,
+          sayNamePlaceholder: strings.sayNamePlaceholder,
+          sayPlaceholder: strings.sayPlaceholder,
+          saySubmit: strings.saySubmit,
+          saySending: strings.saySending,
+          saySent: strings.saySent,
+          sayDismiss: strings.sayDismiss,
         }}
       />
 

--- a/web/components/MeetingSurface.tsx
+++ b/web/components/MeetingSurface.tsx
@@ -59,6 +59,13 @@ interface Props {
     inviteHint: string;
     othersHereOne?: string;
     othersHereMany?: string;
+    sayHeading?: string;
+    sayNamePlaceholder?: string;
+    sayPlaceholder?: string;
+    saySubmit?: string;
+    saySending?: string;
+    saySent?: string;
+    sayDismiss?: string;
   };
 }
 
@@ -77,6 +84,10 @@ export function MeetingSurface({
   const [contributorId, setContributorId] = useState<string | null>(null);
   const [pulse, setPulse] = useState(false);
   const [othersHere, setOthersHere] = useState(0);
+  const [sayOpen, setSayOpen] = useState(false);
+  const [sayText, setSayText] = useState("");
+  const [sayingName, setSayingName] = useState("");
+  const [sayState, setSayState] = useState<"idle" | "sending" | "sent">("idle");
   const fingerprintRef = useRef<string>("");
   const heartbeat = useRef<ReturnType<typeof setInterval> | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -163,7 +174,65 @@ export function MeetingSurface({
       });
       triggerPulse();
       loadMeeting();
+      // After the first warm gesture, invite a sentence. The panel opens
+      // only if the viewer hasn't already sent a voice this session.
+      if (emoji !== "➡️" && sayState !== "sent") {
+        setSayOpen(true);
+        setSayingName(authorName);
+      }
     } catch { /* transient */ }
+  }
+
+  async function saySomething() {
+    const name = sayingName.trim();
+    const body = sayText.trim();
+    if (!name || !body) return;
+    setSayState("sending");
+    try {
+      // Store the name in localStorage for future visits
+      try {
+        localStorage.setItem(NAME_KEY, name);
+      } catch {
+        /* ignore */
+      }
+      setAuthorName(name);
+      const base = getApiBase();
+      // For concepts, store as a voice (richer shape + ripens into proposals
+      // later). For any other entity, store as a reaction with a comment.
+      if (entityType === "concept") {
+        await fetch(`${base}/api/concepts/${encodeURIComponent(entityId)}/voices`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            author_name: name,
+            body,
+            locale,
+            author_id: contributorId,
+          }),
+        });
+      } else {
+        await fetch(`${base}/api/reactions/${entityType}/${entityId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            author_name: name,
+            comment: body,
+            locale,
+            author_id: contributorId,
+          }),
+        });
+      }
+      setSayState("sent");
+      setSayText("");
+      triggerPulse();
+      loadMeeting();
+      setTimeout(() => {
+        setSayOpen(false);
+        setSayState("idle");
+      }, 2400);
+    } catch {
+      setSayState("idle");
+    }
   }
 
   const pulseLabel =
@@ -226,6 +295,70 @@ export function MeetingSurface({
           <p className="text-base md:text-lg text-stone-300 max-w-xl w-full leading-relaxed break-words whitespace-normal px-1">{description}</p>
         )}
       </section>
+
+      {/* Inline voice/comment — opens after a warm reaction.
+          For concepts, stores as a voice; elsewhere as a commented
+          reaction. Same gesture surface, different shape underneath. */}
+      {sayOpen && (
+        <section className="px-5 pb-4 border-t border-stone-800/60 bg-stone-900/40">
+          <div className="max-w-md mx-auto pt-4 space-y-2">
+            {sayState === "sent" ? (
+              <p className="text-sm text-emerald-300 text-center py-3">
+                {strings.saySent || "Thank you — your voice is here."}
+              </p>
+            ) : (
+              <>
+                <label className="text-xs uppercase tracking-widest text-amber-300/90">
+                  {strings.sayHeading || "Say something?"}
+                </label>
+                <input
+                  type="text"
+                  value={sayingName}
+                  onChange={(e) => setSayingName(e.target.value)}
+                  placeholder={strings.sayNamePlaceholder || "Your name"}
+                  className="w-full rounded-md bg-stone-950/60 border border-stone-800 px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-600/60"
+                  maxLength={80}
+                />
+                <textarea
+                  value={sayText}
+                  onChange={(e) => setSayText(e.target.value)}
+                  placeholder={strings.sayPlaceholder || "Two sentences is enough."}
+                  rows={2}
+                  maxLength={1000}
+                  className="w-full rounded-md bg-stone-950/60 border border-stone-800 px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-600/60 resize-y"
+                  autoFocus
+                />
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={saySomething}
+                    disabled={
+                      sayState === "sending" ||
+                      !sayingName.trim() ||
+                      !sayText.trim()
+                    }
+                    className="rounded-full bg-amber-700/80 hover:bg-amber-600/90 disabled:bg-stone-800 disabled:text-stone-600 text-stone-950 px-4 py-1.5 text-sm font-medium transition-colors"
+                  >
+                    {sayState === "sending"
+                      ? strings.saySending || "Sending…"
+                      : strings.saySubmit || "Offer this"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSayOpen(false);
+                      setSayText("");
+                    }}
+                    className="text-xs text-stone-500 hover:text-stone-300"
+                  >
+                    {strings.sayDismiss || "later"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+      )}
 
       {/* Bottom gesture row */}
       <footer className="px-5 pb-6 pt-4 border-t border-stone-800/60">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -315,7 +315,14 @@
     "amplify": "verstärken",
     "inviteHint": "Deine Geste hat beide Pulse gehoben. Tritt bei, damit dein Name mitgeht",
     "othersHereOne": "Eine weitere Person ist hier",
-    "othersHereMany": "{count} weitere sind hier"
+    "othersHereMany": "{count} weitere sind hier",
+    "sayHeading": "Möchtest du etwas sagen?",
+    "sayNamePlaceholder": "Dein Name",
+    "sayPlaceholder": "Zwei Sätze reichen. Was hast du gespürt?",
+    "saySubmit": "Anbieten",
+    "saySending": "Wird gesendet …",
+    "saySent": "Danke — deine Stimme ist hier.",
+    "sayDismiss": "nicht jetzt"
   },
   "reactions": {
     "ariaLabel": "Reaktionen und Kommentare",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -315,7 +315,14 @@
     "amplify": "amplify",
     "inviteHint": "Your gesture raised both pulses. Join so your name walks with it",
     "othersHereOne": "1 other here now",
-    "othersHereMany": "{count} others here now"
+    "othersHereMany": "{count} others here now",
+    "sayHeading": "Want to say something?",
+    "sayNamePlaceholder": "Your name",
+    "sayPlaceholder": "Two sentences is enough. What did you feel?",
+    "saySubmit": "Offer this",
+    "saySending": "Offering…",
+    "saySent": "Thank you — your voice is here.",
+    "sayDismiss": "not now"
   },
   "reactions": {
     "ariaLabel": "Reactions and comments",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -315,7 +315,14 @@
     "amplify": "amplificar",
     "inviteHint": "Tu gesto elevó ambos pulsos. Únete para que tu nombre lo acompañe",
     "othersHereOne": "Una persona más está aquí",
-    "othersHereMany": "{count} personas más están aquí"
+    "othersHereMany": "{count} personas más están aquí",
+    "sayHeading": "¿Quieres decir algo?",
+    "sayNamePlaceholder": "Tu nombre",
+    "sayPlaceholder": "Dos frases son suficientes. ¿Qué sentiste?",
+    "saySubmit": "Ofrecer",
+    "saySending": "Enviando…",
+    "saySent": "Gracias — tu voz está aquí.",
+    "sayDismiss": "ahora no"
   },
   "reactions": {
     "ariaLabel": "Reacciones y comentarios",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -315,7 +315,14 @@
     "amplify": "perkuat",
     "inviteHint": "Isyaratmu menaikkan dua denyut. Bergabunglah agar namamu menyertai",
     "othersHereOne": "1 orang lain di sini",
-    "othersHereMany": "{count} orang lain di sini"
+    "othersHereMany": "{count} orang lain di sini",
+    "sayHeading": "Ingin mengatakan sesuatu?",
+    "sayNamePlaceholder": "Namamu",
+    "sayPlaceholder": "Dua kalimat sudah cukup. Apa yang kamu rasakan?",
+    "saySubmit": "Tawarkan",
+    "saySending": "Mengirim…",
+    "saySent": "Terima kasih — suaramu ada di sini.",
+    "sayDismiss": "nanti saja"
   },
   "reactions": {
     "ariaLabel": "Reaksi dan komentar",


### PR DESCRIPTION
After the first warm gesture (💛/🔥), a small inline panel opens on the meeting page with name + textarea + submit. For concepts it stores as a voice; elsewhere as a commented reaction. No navigation needed for her mother to leave 2 sentences in German. Localized. Type check clean.