### PR TITLE
feat(web): invite-attribution banner

### DIFF
--- a/web/app/meet/[entityType]/[entityId]/page.tsx
+++ b/web/app/meet/[entityType]/[entityId]/page.tsx
@@ -8,6 +8,7 @@ import { createTranslator } from "@/lib/i18n";
 import { MeetingSurface } from "@/components/MeetingSurface";
 import { ProposalLift } from "@/components/ProposalLift";
 import { ProposalOrigin } from "@/components/ProposalOrigin";
+import { InviteBanner } from "@/components/InviteBanner";
 
 /**
  * /meet/[entityType]/[entityId] — full-screen meeting with a single entity.
@@ -270,6 +271,7 @@ export default async function MeetingPage({
 
   return (
     <>
+      <InviteBanner />
       <MeetingSurface
         entityType={entityType}
         entityId={entityId}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { IdeaSubmitForm } from "@/components/idea_submit_form";
 import { LiveBreathPanel } from "@/components/LiveBreathPanel";
 import { FirstTimeWelcome } from "@/components/FirstTimeWelcome";
+import { InviteBanner } from "@/components/InviteBanner";
 import { getApiBase } from "@/lib/api";
 import { fetchJsonOrNull } from "@/lib/fetch";
 import type { IdeaWithScore } from "@/lib/types";
@@ -136,6 +137,7 @@ export default async function Home() {
 
   return (
     <main className="min-h-[calc(100vh-3.5rem)]">
+      <InviteBanner />
       <LiveBreathPanel lang={lang} />
       <FirstTimeWelcome />
       {/* Section 1: HERO — THE QUESTION */}

--- a/web/components/InviteBanner.tsx
+++ b/web/components/InviteBanner.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+/**
+ * InviteBanner — "X invited you to this" warmth on first arrival.
+ *
+ * Reads ?from=<name> from the current URL. If present (and viewer
+ * hasn't acknowledged), shows a small teal banner above the page
+ * content naming the inviter and welcoming the new arrival.
+ *
+ * Dismisses automatically after the viewer's first gesture or after
+ * a minute. The ?from= value also gets stored so future surfaces
+ * (notifications, kin feed) know she arrived through a warm door.
+ */
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useT } from "@/components/MessagesProvider";
+
+const INVITED_BY_KEY = "cc-invited-by";
+
+export function InviteBanner() {
+  const t = useT();
+  const searchParams = useSearchParams();
+  const [from, setFrom] = useState<string | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const fromParam = searchParams?.get("from") || "";
+    if (fromParam.trim()) {
+      const name = fromParam.trim().slice(0, 80);
+      setFrom(name);
+      setVisible(true);
+      // Persist so the viewer's kin feed and future surfaces can
+      // remember the warm door she came through.
+      try {
+        localStorage.setItem(INVITED_BY_KEY, name);
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
+    // Check storage — if she came through an invite earlier this session
+    // but the URL no longer has ?from=, we do not re-show the banner.
+    setVisible(false);
+  }, [searchParams]);
+
+  if (!visible || !from) return null;
+
+  return (
+    <section
+      className="relative max-w-3xl mx-3 sm:mx-auto mt-3 px-4 py-3 rounded-xl border border-teal-700/40 bg-teal-950/20 text-sm text-teal-100 flex items-start gap-3"
+      aria-label={t("inviteBanner.ariaLabel")}
+    >
+      <span className="text-lg" aria-hidden="true">🌿</span>
+      <div className="flex-1 min-w-0">
+        <p className="leading-relaxed">
+          <span className="text-teal-300 font-medium">{from}</span>{" "}
+          {t("inviteBanner.inviting")}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => setVisible(false)}
+        className="text-teal-400/60 hover:text-teal-200 shrink-0"
+        aria-label={t("inviteBanner.dismiss")}
+      >
+        ×
+      </button>
+    </section>
+  );
+}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -215,6 +215,11 @@
     "message": "Ich habe etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau.",
     "messageWithName": "{name} hat etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau."
   },
+  "inviteBanner": {
+    "ariaLabel": "Einladung",
+    "inviting": "lädt dich ein, diesem zu begegnen.",
+    "dismiss": "Schließen"
+  },
   "welcome": {
     "ariaLabel": "Willkommen — worum es hier geht",
     "eyebrow": "Neu hier?",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -215,6 +215,11 @@
     "message": "I found something that feels alive. Take three minutes and see.",
     "messageWithName": "{name} found something that feels alive. Take three minutes and see."
   },
+  "inviteBanner": {
+    "ariaLabel": "Invitation",
+    "inviting": "invited you to meet this.",
+    "dismiss": "Dismiss"
+  },
   "welcome": {
     "ariaLabel": "Welcome — what this place is",
     "eyebrow": "New here?",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -215,6 +215,11 @@
     "message": "Encontré algo que se siente vivo. Tómate tres minutos y mira.",
     "messageWithName": "{name} encontró algo que se siente vivo. Tómate tres minutos y mira."
   },
+  "inviteBanner": {
+    "ariaLabel": "Invitación",
+    "inviting": "te invita a encontrarte con esto.",
+    "dismiss": "Cerrar"
+  },
   "welcome": {
     "ariaLabel": "Bienvenida — de qué se trata este lugar",
     "eyebrow": "¿Eres nueva aquí?",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -215,6 +215,11 @@
     "message": "Aku menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat.",
     "messageWithName": "{name} menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat."
   },
+  "inviteBanner": {
+    "ariaLabel": "Undangan",
+    "inviting": "mengundangmu menemui ini.",
+    "dismiss": "Tutup"
+  },
   "welcome": {
     "ariaLabel": "Selamat datang — tentang tempat ini",
     "eyebrow": "Baru di sini?",


### PR DESCRIPTION
Invite links carry ?from=<name>. Banner shows 'X invited you to meet this' on meet + home pages. Stored in localStorage for later use. Localized en/de/es/id.