### PR TITLE
Cycle J: invite-with-name (pre-named arrival, returning-visitor recognition)

### DIFF
--- a/web/components/InviteBanner.tsx
+++ b/web/components/InviteBanner.tsx
@@ -1,50 +1,157 @@
 "use client";
 
 /**
- * InviteBanner — "X invited you to this" warmth on first arrival.
+ * InviteBanner — "X invited you" warmth on first arrival.
  *
- * Reads ?from=<name> from the current URL. If present (and viewer
- * hasn't acknowledged), shows a small teal banner above the page
- * content naming the inviter and welcoming the new arrival.
+ * Reads ?from=<inviter>&name=<recipient>&invited_by=<id> from the URL.
  *
- * Dismisses automatically after the viewer's first gesture or after
- * a minute. The ?from= value also gets stored so future surfaces
- * (notifications, kin feed) know she arrived through a warm door.
+ * First-time arrival (no identity stored yet):
+ *   • Writes `name` into `cc-reaction-author-name` so she is now
+ *     "pre-registered" — able to react, voice, comment without
+ *     seeing a registration screen.
+ *   • Writes `invited_by` into `cc-invited-by` for the kin graph.
+ *   • Records first-seen timestamp in `cc-last-visit-at` so the
+ *     next visit's SinceLastVisit counts from now.
+ *   • Shows a personalized banner: "Welcome, <name> — <inviter>
+ *     invited you to meet this."
+ *
+ * Returning arrival (identity already stored):
+ *   • Does not overwrite stored name — the device's identity wins.
+ *   • Shows a "Welcome back" variant if the URL still carries the
+ *     invite params (she followed the original link again).
+ *   • Still records the invite-by attribution if not yet set.
+ *
+ * Dismiss: a small × hides for this session. Auto-hides when the
+ * search params are cleared (e.g. after navigation without ?from).
  */
 
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useT } from "@/components/MessagesProvider";
 
+const NAME_KEY = "cc-reaction-author-name";
+const CONTRIBUTOR_KEY = "cc-contributor-id";
 const INVITED_BY_KEY = "cc-invited-by";
+const LAST_VISIT_KEY = "cc-last-visit-at";
+const DISMISS_KEY = "cc-invite-banner-dismissed";
+
+type Mode = "welcome" | "welcomeBack" | null;
 
 export function InviteBanner() {
   const t = useT();
   const searchParams = useSearchParams();
   const [from, setFrom] = useState<string | null>(null);
+  const [recipientName, setRecipientName] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>(null);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const fromParam = searchParams?.get("from") || "";
-    if (fromParam.trim()) {
-      const name = fromParam.trim().slice(0, 80);
-      setFrom(name);
-      setVisible(true);
-      // Persist so the viewer's kin feed and future surfaces can
-      // remember the warm door she came through.
+    const fromParam = (searchParams?.get("from") || "").trim().slice(0, 80);
+    const nameParam = (searchParams?.get("name") || "").trim().slice(0, 80);
+    const invitedByParam = (searchParams?.get("invited_by") || "").trim().slice(0, 200);
+
+    // No invite params — nothing to do.
+    if (!fromParam && !nameParam) {
+      setVisible(false);
+      return;
+    }
+
+    let storedName = "";
+    let storedContributorId = "";
+    let dismissed = "";
+    try {
+      storedName = localStorage.getItem(NAME_KEY) || "";
+      storedContributorId = localStorage.getItem(CONTRIBUTOR_KEY) || "";
+      dismissed = sessionStorage.getItem(DISMISS_KEY) || "";
+    } catch {
+      /* ignore */
+    }
+
+    const hasIdentity = Boolean(storedName.trim() || storedContributorId.trim());
+
+    // First-time arrival: pre-register with the name the inviter chose.
+    if (!hasIdentity && nameParam) {
       try {
-        localStorage.setItem(INVITED_BY_KEY, name);
+        localStorage.setItem(NAME_KEY, nameParam);
+        // Seed the return-visit memory so "since last visit" counts
+        // forward from this first touch.
+        if (!localStorage.getItem(LAST_VISIT_KEY)) {
+          localStorage.setItem(LAST_VISIT_KEY, new Date().toISOString());
+        }
       } catch {
         /* ignore */
       }
-      return;
+      setRecipientName(nameParam);
+      setMode("welcome");
+    } else if (hasIdentity) {
+      // Returning — honor the stored name. If URL also carries a
+      // name, prefer the stored one for the greeting (device wins).
+      const display = storedName.trim() || nameParam;
+      setRecipientName(display || null);
+      setMode("welcomeBack");
+    } else {
+      // No stored identity and no recipient name — just the generic
+      // "X invited you" banner (backwards-compatible with Cycle H).
+      setMode("welcome");
     }
-    // Check storage — if she came through an invite earlier this session
-    // but the URL no longer has ?from=, we do not re-show the banner.
-    setVisible(false);
+
+    if (invitedByParam) {
+      try {
+        // Always record who sent the door — even for returning
+        // visitors — if not yet set.
+        if (!localStorage.getItem(INVITED_BY_KEY)) {
+          localStorage.setItem(INVITED_BY_KEY, invitedByParam);
+        }
+      } catch {
+        /* ignore */
+      }
+    } else if (fromParam) {
+      // Fallback attribution by inviter display name.
+      try {
+        if (!localStorage.getItem(INVITED_BY_KEY)) {
+          localStorage.setItem(INVITED_BY_KEY, fromParam);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
+    setFrom(fromParam || null);
+    setVisible(!dismissed);
   }, [searchParams]);
 
-  if (!visible || !from) return null;
+  function dismiss() {
+    try {
+      sessionStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setVisible(false);
+  }
+
+  if (!visible || !mode) return null;
+  if (!from && !recipientName) return null;
+
+  // Compose the greeting from whatever pieces we have.
+  const greeting = (() => {
+    if (mode === "welcomeBack" && recipientName) {
+      // "Welcome back, <name>."
+      return t("inviteBanner.welcomeBackNamed").replace("{name}", recipientName);
+    }
+    if (recipientName && from) {
+      // "Welcome, <name> — <inviter> invited you."
+      return t("inviteBanner.welcomeNamedFrom")
+        .replace("{name}", recipientName)
+        .replace("{from}", from);
+    }
+    if (recipientName) {
+      return t("inviteBanner.welcomeNamed").replace("{name}", recipientName);
+    }
+    if (from) {
+      return `${from} ${t("inviteBanner.inviting")}`;
+    }
+    return t("inviteBanner.inviting");
+  })();
 
   return (
     <section
@@ -54,13 +161,33 @@ export function InviteBanner() {
       <span className="text-lg" aria-hidden="true">🌿</span>
       <div className="flex-1 min-w-0">
         <p className="leading-relaxed">
-          <span className="text-teal-300 font-medium">{from}</span>{" "}
-          {t("inviteBanner.inviting")}
+          {mode === "welcomeBack" && recipientName ? (
+            <>
+              <span className="text-teal-300 font-medium">{recipientName}</span>
+              {greeting.slice(recipientName.length)}
+            </>
+          ) : recipientName && from ? (
+            // Highlight both names
+            <>
+              {t("inviteBanner.welcomeLead")}{" "}
+              <span className="text-teal-300 font-medium">{recipientName}</span>
+              {" — "}
+              <span className="text-teal-300 font-medium">{from}</span>{" "}
+              {t("inviteBanner.invitedYou")}
+            </>
+          ) : from ? (
+            <>
+              <span className="text-teal-300 font-medium">{from}</span>{" "}
+              {t("inviteBanner.inviting")}
+            </>
+          ) : (
+            greeting
+          )}
         </p>
       </div>
       <button
         type="button"
-        onClick={() => setVisible(false)}
+        onClick={dismiss}
         className="text-teal-400/60 hover:text-teal-200 shrink-0"
         aria-label={t("inviteBanner.dismiss")}
       >

--- a/web/components/InviteFriend.tsx
+++ b/web/components/InviteFriend.tsx
@@ -3,20 +3,28 @@
 /**
  * InviteFriend — a small "bring someone in" block.
  *
- * Generates a warm shareable link: the current site with a soft
- * ?from= parameter carrying the inviter's author name. Copies to
- * clipboard (or opens the native share sheet on mobile) with a
- * suggested message in the inviter's language.
+ * The inviter types the recipient's name (first name is enough), and
+ * optionally the concept / idea they want to share. The generated link
+ * carries both the inviter's name and the recipient's name:
  *
- * The landing pages don't need to parse ?from= yet — that's a later
- * cycle. For now the link already works (it just lands on the home
- * page) and the inviter gets a proud affordance.
+ *   /meet/.../?from=<inviter>&name=<recipient>&invited_by=<contributor-id>
+ *
+ * When the recipient taps the link, InviteBanner writes `name` into
+ * `cc-reaction-author-name` so she arrives already carrying a soft
+ * identity — no registration screen, no private key, no friction.
+ * She can react, voice, comment immediately. Phone/email/wallet can
+ * follow at her pace via the incremental profile card.
+ *
+ * If the recipient has been here before (any identity already stored),
+ * we do not overwrite — her device's identity wins over URL claims.
+ * Uses Web Share API when available, clipboard as fallback.
  */
 
 import { useEffect, useState } from "react";
 import { useT, useLocale } from "@/components/MessagesProvider";
 
 const NAME_KEY = "cc-reaction-author-name";
+const CONTRIBUTOR_KEY = "cc-contributor-id";
 
 interface Props {
   /** Which page to land them on. Defaults to /meet/concept/lc-nourishing —
@@ -36,12 +44,15 @@ export function InviteFriend({
 }: Props) {
   const t = useT();
   const locale = useLocale();
-  const [name, setName] = useState<string>("");
+  const [inviterName, setInviterName] = useState<string>("");
+  const [inviterId, setInviterId] = useState<string>("");
+  const [recipientName, setRecipientName] = useState<string>("");
   const [copied, setCopied] = useState<"idle" | "copied" | "shared">("idle");
 
   useEffect(() => {
     try {
-      setName(localStorage.getItem(NAME_KEY) || "");
+      setInviterName(localStorage.getItem(NAME_KEY) || "");
+      setInviterId(localStorage.getItem(CONTRIBUTOR_KEY) || "");
     } catch {
       /* ignore */
     }
@@ -50,15 +61,31 @@ export function InviteFriend({
   function buildUrl(): string {
     const base = siteBase();
     const url = new URL(targetPath, base);
-    if (name.trim()) url.searchParams.set("from", name.trim());
+    if (inviterName.trim()) url.searchParams.set("from", inviterName.trim());
+    if (recipientName.trim()) url.searchParams.set("name", recipientName.trim().slice(0, 80));
+    if (inviterId.trim()) url.searchParams.set("invited_by", inviterId.trim());
+    // Hint the UI to the inviter's language so the banner greets in
+    // a tongue the sender chose. The receiver's browser detection
+    // still wins if different and supported.
+    if (locale) url.searchParams.set("lang", locale);
     return url.toString();
   }
 
   async function onInvite() {
     const url = buildUrl();
-    const message = name.trim()
-      ? t("invite.messageWithName").replace("{name}", name.trim())
-      : t("invite.message");
+    const rName = recipientName.trim();
+    const iName = inviterName.trim();
+    // Pick the warmest localized line we have
+    let message: string;
+    if (rName && iName) {
+      message = t("invite.messageWithBoth")
+        .replace("{recipient}", rName)
+        .replace("{name}", iName);
+    } else if (iName) {
+      message = t("invite.messageWithName").replace("{name}", iName);
+    } else {
+      message = t("invite.message");
+    }
     const payload = {
       title: t("invite.title"),
       text: message,
@@ -88,8 +115,11 @@ export function InviteFriend({
       ? t("invite.shared")
       : t("invite.cta");
 
+  const ready = recipientName.trim().length > 0;
+
   return (
     <section
+      id="invite"
       className={
         className ||
         "rounded-xl border border-teal-800/40 bg-teal-950/10 p-5 space-y-3"
@@ -104,10 +134,28 @@ export function InviteFriend({
       <p className="text-sm text-stone-400 leading-relaxed">
         {t("invite.lede")}
       </p>
+      <div className="space-y-2">
+        <label className="block text-xs text-stone-400" htmlFor="invite-recipient">
+          {t("invite.recipientLabel")}
+        </label>
+        <input
+          id="invite-recipient"
+          type="text"
+          value={recipientName}
+          onChange={(e) => setRecipientName(e.target.value)}
+          placeholder={t("invite.recipientPlaceholder")}
+          maxLength={80}
+          className="w-full rounded-lg border border-teal-900/50 bg-stone-950/60 px-3 py-2 text-sm text-stone-100 placeholder:text-stone-600 focus:border-teal-600 focus:outline-none"
+        />
+        <p className="text-[11px] text-stone-500 leading-snug">
+          {t("invite.recipientHint")}
+        </p>
+      </div>
       <button
         type="button"
         onClick={onInvite}
-        className="inline-flex items-center gap-2 rounded-full bg-teal-700/80 hover:bg-teal-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+        disabled={!ready}
+        className="inline-flex items-center gap-2 rounded-full bg-teal-700/80 hover:bg-teal-600/90 disabled:bg-stone-800/40 disabled:text-stone-500 disabled:cursor-not-allowed text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
       >
         <span aria-hidden="true">🌿</span>
         <span>{label}</span>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -217,11 +217,20 @@
     "shared": "Danke fürs Teilen 🌿",
     "title": "Komm und begegne dem",
     "message": "Ich habe etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau.",
-    "messageWithName": "{name} hat etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau."
+    "messageWithName": "{name} hat etwas gefunden, das sich lebendig anfühlt. Nimm dir drei Minuten und schau.",
+    "messageWithBoth": "{name} hat an dich gedacht, {recipient}. Etwas Lebendiges wartet — nimm dir drei Minuten und schau.",
+    "recipientLabel": "Ihr Name",
+    "recipientPlaceholder": "z. B. Mama, Sam, Aisha",
+    "recipientHint": "Sie kommt schon mit Namen begrüßt an — nichts zu registrieren, nichts zu merken."
   },
   "inviteBanner": {
     "ariaLabel": "Einladung",
     "inviting": "lädt dich ein, diesem zu begegnen.",
+    "welcomeLead": "Willkommen,",
+    "invitedYou": "lädt dich ein, diesem zu begegnen.",
+    "welcomeNamed": "Willkommen, {name}.",
+    "welcomeNamedFrom": "Willkommen, {name} — {from} lädt dich ein, diesem zu begegnen.",
+    "welcomeBackNamed": "{name}, schön dass du wieder da bist. Hier ist, was für dich geschieht.",
     "dismiss": "Schließen"
   },
   "welcome": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -217,11 +217,20 @@
     "shared": "Thanks for sharing 🌿",
     "title": "Come meet this",
     "message": "I found something that feels alive. Take three minutes and see.",
-    "messageWithName": "{name} found something that feels alive. Take three minutes and see."
+    "messageWithName": "{name} found something that feels alive. Take three minutes and see.",
+    "messageWithBoth": "{name} thought of you, {recipient}. Something alive is waiting — take three minutes and see.",
+    "recipientLabel": "Their name",
+    "recipientPlaceholder": "e.g. Mama, Sam, Aisha",
+    "recipientHint": "They arrive already greeted by name — nothing to register, nothing to remember."
   },
   "inviteBanner": {
     "ariaLabel": "Invitation",
     "inviting": "invited you to meet this.",
+    "welcomeLead": "Welcome,",
+    "invitedYou": "invited you to meet this.",
+    "welcomeNamed": "Welcome, {name}.",
+    "welcomeNamedFrom": "Welcome, {name} — {from} invited you to meet this.",
+    "welcomeBackNamed": "{name}, welcome back. Here's what's stirring for you.",
     "dismiss": "Dismiss"
   },
   "welcome": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -217,11 +217,20 @@
     "shared": "Gracias por compartir 🌿",
     "title": "Ven a encontrarte con esto",
     "message": "Encontré algo que se siente vivo. Tómate tres minutos y mira.",
-    "messageWithName": "{name} encontró algo que se siente vivo. Tómate tres minutos y mira."
+    "messageWithName": "{name} encontró algo que se siente vivo. Tómate tres minutos y mira.",
+    "messageWithBoth": "{name} pensó en ti, {recipient}. Algo vivo te espera — tómate tres minutos y mira.",
+    "recipientLabel": "Su nombre",
+    "recipientPlaceholder": "p. ej. Mamá, Sam, Aisha",
+    "recipientHint": "Llega saludada por su nombre — nada que registrar, nada que recordar."
   },
   "inviteBanner": {
     "ariaLabel": "Invitación",
     "inviting": "te invita a encontrarte con esto.",
+    "welcomeLead": "Bienvenida,",
+    "invitedYou": "te invita a encontrarte con esto.",
+    "welcomeNamed": "Bienvenida, {name}.",
+    "welcomeNamedFrom": "Bienvenida, {name} — {from} te invita a encontrarte con esto.",
+    "welcomeBackNamed": "{name}, qué bueno volver a verte. Esto es lo que se mueve para ti.",
     "dismiss": "Cerrar"
   },
   "welcome": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -217,11 +217,20 @@
     "shared": "Terima kasih sudah berbagi 🌿",
     "title": "Datang temui ini",
     "message": "Aku menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat.",
-    "messageWithName": "{name} menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat."
+    "messageWithName": "{name} menemukan sesuatu yang terasa hidup. Ambil tiga menit dan lihat.",
+    "messageWithBoth": "{name} memikirkanmu, {recipient}. Sesuatu yang hidup menantimu — ambil tiga menit dan lihat.",
+    "recipientLabel": "Nama mereka",
+    "recipientPlaceholder": "mis. Mama, Sam, Aisha",
+    "recipientHint": "Mereka tiba sudah disapa dengan nama — tidak ada yang perlu didaftar, tidak ada yang perlu diingat."
   },
   "inviteBanner": {
     "ariaLabel": "Undangan",
     "inviting": "mengundangmu menemui ini.",
+    "welcomeLead": "Selamat datang,",
+    "invitedYou": "mengundangmu menemui ini.",
+    "welcomeNamed": "Selamat datang, {name}.",
+    "welcomeNamedFrom": "Selamat datang, {name} — {from} mengundangmu menemui ini.",
+    "welcomeBackNamed": "{name}, senang melihatmu kembali. Inilah yang hidup untukmu.",
     "dismiss": "Tutup"
   },
   "welcome": {


### PR DESCRIPTION
## Summary
- Inviter adds the recipient's first name to the invitation. Link becomes `?from=<inviter>&name=<recipient>&invited_by=<id>&lang=<locale>`
- On first arrival: pre-register by writing `name` to `cc-reaction-author-name` — she can react, voice, comment without any registration screen
- On return visits: honor the device's stored identity (no overwrite, no duplicate), banner greets back by name

## Why
"How is she adding her name, phone, email, wallet? The invitation should already contain her name so she is automatically registered, and she can add phone/email/wallet at her pace."

"When she clicks the link again, find her prior registration — no duplicate — and welcome her back with updates for her interests."

## Test plan
- [ ] Inviter on /feed/you#invite types "Mama", shares, URL contains `name=Mama`
- [ ] New device lands on `?from=Patrick&name=Mama` → banner reads "Welcome, Mama — Patrick invited you…", `cc-reaction-author-name=Mama` persists
- [ ] Same device clicks the same link next day → banner reads "Mama, welcome back." — no overwrite, no duplicate identity
- [ ] `?lang=de` honored by middleware so banner renders in German from first paint
- [ ] Four-locale build clean, no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)