### PR TITLE
Cycle K: invite language selector (auto-detect default, inviter override)

### DIFF
--- a/web/components/InviteFriend.tsx
+++ b/web/components/InviteFriend.tsx
@@ -3,28 +3,40 @@
 /**
  * InviteFriend — a small "bring someone in" block.
  *
- * The inviter types the recipient's name (first name is enough), and
- * optionally the concept / idea they want to share. The generated link
- * carries both the inviter's name and the recipient's name:
+ * The inviter types the recipient's name (first name is enough) and
+ * picks the language the recipient should arrive in. The generated
+ * link:
  *
- *   /meet/.../?from=<inviter>&name=<recipient>&invited_by=<contributor-id>
+ *   /meet/.../?from=<inviter>&name=<recipient>&invited_by=<contributor-id>[&lang=<locale>]
+ *
+ * Language selector defaults to "auto-detect from her browser" (no
+ * ?lang= in the URL, middleware picks from Accept-Language). The
+ * inviter can override per-invite — e.g. Patrick (browsing in English)
+ * wants his German mother to arrive in German without setting his own
+ * site to German first.
  *
  * When the recipient taps the link, InviteBanner writes `name` into
  * `cc-reaction-author-name` so she arrives already carrying a soft
  * identity — no registration screen, no private key, no friction.
- * She can react, voice, comment immediately. Phone/email/wallet can
- * follow at her pace via the incremental profile card.
  *
- * If the recipient has been here before (any identity already stored),
- * we do not overwrite — her device's identity wins over URL claims.
+ * On return visits, InviteBanner honors her device's identity; no
+ * duplicates. See InviteBanner for that half of the contract.
  * Uses Web Share API when available, clipboard as fallback.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useT, useLocale } from "@/components/MessagesProvider";
+import { createTranslator } from "@/lib/i18n";
+import { LOCALES, type LocaleCode } from "@/lib/locales";
 
 const NAME_KEY = "cc-reaction-author-name";
 const CONTRIBUTOR_KEY = "cc-contributor-id";
+
+// Language selection for the invite link.
+// "auto" means "no ?lang= in URL" — let middleware pick from the
+// recipient's Accept-Language header. This is the safest default
+// because it honors her device, not the inviter's.
+type InviteLang = "auto" | LocaleCode;
 
 interface Props {
   /** Which page to land them on. Defaults to /meet/concept/lc-nourishing —
@@ -47,6 +59,10 @@ export function InviteFriend({
   const [inviterName, setInviterName] = useState<string>("");
   const [inviterId, setInviterId] = useState<string>("");
   const [recipientName, setRecipientName] = useState<string>("");
+  // Default to "auto" — let the recipient's own browser decide.
+  // The inviter's own locale is just a UI language for this form,
+  // not a claim about what the recipient speaks.
+  const [inviteLang, setInviteLang] = useState<InviteLang>("auto");
   const [copied, setCopied] = useState<"idle" | "copied" | "shared">("idle");
 
   useEffect(() => {
@@ -64,30 +80,44 @@ export function InviteFriend({
     if (inviterName.trim()) url.searchParams.set("from", inviterName.trim());
     if (recipientName.trim()) url.searchParams.set("name", recipientName.trim().slice(0, 80));
     if (inviterId.trim()) url.searchParams.set("invited_by", inviterId.trim());
-    // Hint the UI to the inviter's language so the banner greets in
-    // a tongue the sender chose. The receiver's browser detection
-    // still wins if different and supported.
-    if (locale) url.searchParams.set("lang", locale);
+    // Language policy:
+    //   "auto" (default) — no ?lang= in URL. The middleware honors
+    //     the recipient's browser Accept-Language on first paint.
+    //     This is the warmest default: the recipient's own device
+    //     decides, not the inviter.
+    //   explicit locale — inviter overrides for this recipient,
+    //     e.g. Patrick (English UI) inviting his German mother.
+    if (inviteLang !== "auto") {
+      url.searchParams.set("lang", inviteLang);
+    }
     return url.toString();
   }
+
+  // Compose the share message in the recipient's language when the
+  // inviter picked one explicitly. For "auto" we fall back to the
+  // inviter's UI locale — that's what they'll be reading anyway in
+  // the share sheet, and the recipient's device will retranslate
+  // the site once she taps through.
+  const shareLang: LocaleCode = inviteLang === "auto" ? (locale as LocaleCode) : inviteLang;
+  const tShare = useMemo(() => createTranslator(shareLang), [shareLang]);
 
   async function onInvite() {
     const url = buildUrl();
     const rName = recipientName.trim();
     const iName = inviterName.trim();
-    // Pick the warmest localized line we have
+    // Pick the warmest localized line we have — in the recipient's language
     let message: string;
     if (rName && iName) {
-      message = t("invite.messageWithBoth")
+      message = tShare("invite.messageWithBoth")
         .replace("{recipient}", rName)
         .replace("{name}", iName);
     } else if (iName) {
-      message = t("invite.messageWithName").replace("{name}", iName);
+      message = tShare("invite.messageWithName").replace("{name}", iName);
     } else {
-      message = t("invite.message");
+      message = tShare("invite.message");
     }
     const payload = {
-      title: t("invite.title"),
+      title: tShare("invite.title"),
       text: message,
       url,
     };
@@ -149,6 +179,27 @@ export function InviteFriend({
         />
         <p className="text-[11px] text-stone-500 leading-snug">
           {t("invite.recipientHint")}
+        </p>
+      </div>
+      <div className="space-y-2">
+        <label className="block text-xs text-stone-400" htmlFor="invite-lang">
+          {t("invite.langLabel")}
+        </label>
+        <select
+          id="invite-lang"
+          value={inviteLang}
+          onChange={(e) => setInviteLang(e.target.value as InviteLang)}
+          className="w-full rounded-lg border border-teal-900/50 bg-stone-950/60 px-3 py-2 text-sm text-stone-100 focus:border-teal-600 focus:outline-none"
+        >
+          <option value="auto">{t("invite.langAuto")}</option>
+          {LOCALES.map((l) => (
+            <option key={l.code} value={l.code}>
+              {l.nativeName}
+            </option>
+          ))}
+        </select>
+        <p className="text-[11px] text-stone-500 leading-snug">
+          {t("invite.langHint")}
         </p>
       </div>
       <button

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -221,7 +221,10 @@
     "messageWithBoth": "{name} hat an dich gedacht, {recipient}. Etwas Lebendiges wartet — nimm dir drei Minuten und schau.",
     "recipientLabel": "Ihr Name",
     "recipientPlaceholder": "z. B. Mama, Sam, Aisha",
-    "recipientHint": "Sie kommt schon mit Namen begrüßt an — nichts zu registrieren, nichts zu merken."
+    "recipientHint": "Sie kommt schon mit Namen begrüßt an — nichts zu registrieren, nichts zu merken.",
+    "langLabel": "Ihre Sprache",
+    "langAuto": "Ihr Gerät soll entscheiden",
+    "langHint": "Standardmäßig wählt ihr Handy die Sprache. Überschreib das hier, wenn du sie besser kennst als ihre Browser-Einstellungen."
   },
   "inviteBanner": {
     "ariaLabel": "Einladung",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -221,7 +221,10 @@
     "messageWithBoth": "{name} thought of you, {recipient}. Something alive is waiting — take three minutes and see.",
     "recipientLabel": "Their name",
     "recipientPlaceholder": "e.g. Mama, Sam, Aisha",
-    "recipientHint": "They arrive already greeted by name — nothing to register, nothing to remember."
+    "recipientHint": "They arrive already greeted by name — nothing to register, nothing to remember.",
+    "langLabel": "Their language",
+    "langAuto": "Let her device decide",
+    "langHint": "By default, her phone picks the language. Override here if you know her better than her browser settings do."
   },
   "inviteBanner": {
     "ariaLabel": "Invitation",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -221,7 +221,10 @@
     "messageWithBoth": "{name} pensó en ti, {recipient}. Algo vivo te espera — tómate tres minutos y mira.",
     "recipientLabel": "Su nombre",
     "recipientPlaceholder": "p. ej. Mamá, Sam, Aisha",
-    "recipientHint": "Llega saludada por su nombre — nada que registrar, nada que recordar."
+    "recipientHint": "Llega saludada por su nombre — nada que registrar, nada que recordar.",
+    "langLabel": "Su idioma",
+    "langAuto": "Deja que su dispositivo decida",
+    "langHint": "Por defecto, su teléfono elige el idioma. Cámbialo aquí si la conoces mejor que sus ajustes del navegador."
   },
   "inviteBanner": {
     "ariaLabel": "Invitación",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -221,7 +221,10 @@
     "messageWithBoth": "{name} memikirkanmu, {recipient}. Sesuatu yang hidup menantimu — ambil tiga menit dan lihat.",
     "recipientLabel": "Nama mereka",
     "recipientPlaceholder": "mis. Mama, Sam, Aisha",
-    "recipientHint": "Mereka tiba sudah disapa dengan nama — tidak ada yang perlu didaftar, tidak ada yang perlu diingat."
+    "recipientHint": "Mereka tiba sudah disapa dengan nama — tidak ada yang perlu didaftar, tidak ada yang perlu diingat.",
+    "langLabel": "Bahasa mereka",
+    "langAuto": "Biarkan perangkatnya memilih",
+    "langHint": "Secara default, ponselnya memilih bahasa. Ganti di sini jika kamu mengenalnya lebih baik dari pengaturan peramban-nya."
   },
   "inviteBanner": {
     "ariaLabel": "Undangan",


### PR DESCRIPTION
## Summary
- Inviter picks the language for this specific invite, defaulting to "Let her device decide" (no \`?lang=\` — middleware honors Accept-Language)
- Inviter can override per-invite (e.g. English-browsing Patrick sends his German mother an invite in German without switching his own UI)
- Share message in WhatsApp/SMS preview now renders in the recipient's language when chosen

## Why
"Language carrying over is good and in my case is not what I need — I'm speaking English and she is speaking German."

## Test plan
- [ ] /feed/you#invite has a language dropdown defaulting to "Let her device decide"
- [ ] With default, shared URL has no \`?lang=\` param
- [ ] Picking German → URL gets \`?lang=de\` + WhatsApp preview text is in German
- [ ] TS + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)