### PR TITLE
Polish: visual quality on morning-nudge + invite-banner + quick-phrase chips

### DIFF
--- a/web/app/meet/[entityType]/[entityId]/page.tsx
+++ b/web/app/meet/[entityType]/[entityId]/page.tsx
@@ -298,6 +298,9 @@ export default async function MeetingPage({
           saySending: t("meeting.saySending"),
           saySent: t("meeting.saySent"),
           sayDismiss: t("meeting.sayDismiss"),
+          quickPhrase1: t("meeting.quickPhrase1"),
+          quickPhrase2: t("meeting.quickPhrase2"),
+          quickPhrase3: t("meeting.quickPhrase3"),
         }}
       />
       {entityType === "proposal" && (

--- a/web/components/InviteBanner.tsx
+++ b/web/components/InviteBanner.tsx
@@ -153,42 +153,48 @@ export function InviteBanner() {
     return t("inviteBanner.inviting");
   })();
 
+  // Visual rules matching the morning-nudge frequency:
+  //   · deeper, calmer background so the warm names pop without clipping
+  //   · generous vertical rhythm — greeting on two lines when both names
+  //     are present, rather than a single clipped line
+  //   · higher-contrast prose (text-teal-50 vs the old text-teal-100)
+  //   · icon sized to the text, left-aligned with generous gap
   return (
     <section
-      className="relative max-w-3xl mx-3 sm:mx-auto mt-3 px-4 py-3 rounded-xl border border-teal-700/40 bg-teal-950/20 text-sm text-teal-100 flex items-start gap-3"
+      className="relative max-w-3xl mx-3 sm:mx-auto mt-3 px-4 py-3.5 rounded-xl border border-teal-600/25 bg-gradient-to-br from-stone-900/95 to-teal-950/30 text-sm text-teal-50 flex items-start gap-3 shadow-[0_1px_0_0_rgba(20,184,166,0.08)_inset]"
       aria-label={t("inviteBanner.ariaLabel")}
     >
-      <span className="text-lg" aria-hidden="true">🌿</span>
+      <span className="text-lg mt-0.5" aria-hidden="true">🌿</span>
       <div className="flex-1 min-w-0">
-        <p className="leading-relaxed">
-          {mode === "welcomeBack" && recipientName ? (
-            <>
-              <span className="text-teal-300 font-medium">{recipientName}</span>
-              {greeting.slice(recipientName.length)}
-            </>
-          ) : recipientName && from ? (
-            // Highlight both names
-            <>
+        {mode === "welcomeBack" && recipientName ? (
+          <p className="leading-relaxed">
+            <span className="text-teal-200 font-semibold">{recipientName}</span>
+            {greeting.slice(recipientName.length)}
+          </p>
+        ) : recipientName && from ? (
+          <>
+            <p className="text-teal-50 font-medium leading-snug">
               {t("inviteBanner.welcomeLead")}{" "}
-              <span className="text-teal-300 font-medium">{recipientName}</span>
-              {" — "}
-              <span className="text-teal-300 font-medium">{from}</span>{" "}
+              <span className="text-amber-200">{recipientName}</span>
+            </p>
+            <p className="text-teal-200/90 mt-0.5 leading-snug">
+              <span className="text-amber-200/90 font-medium">{from}</span>{" "}
               {t("inviteBanner.invitedYou")}
-            </>
-          ) : from ? (
-            <>
-              <span className="text-teal-300 font-medium">{from}</span>{" "}
-              {t("inviteBanner.inviting")}
-            </>
-          ) : (
-            greeting
-          )}
-        </p>
+            </p>
+          </>
+        ) : from ? (
+          <p className="leading-relaxed">
+            <span className="text-amber-200 font-medium">{from}</span>{" "}
+            {t("inviteBanner.inviting")}
+          </p>
+        ) : (
+          <p className="leading-relaxed">{greeting}</p>
+        )}
       </div>
       <button
         type="button"
         onClick={dismiss}
-        className="text-teal-400/60 hover:text-teal-200 shrink-0"
+        className="text-teal-400/70 hover:text-teal-100 shrink-0 -mr-1"
         aria-label={t("inviteBanner.dismiss")}
       >
         ×

--- a/web/components/MeetingSurface.tsx
+++ b/web/components/MeetingSurface.tsx
@@ -66,6 +66,12 @@ interface Props {
     saySending?: string;
     saySent?: string;
     sayDismiss?: string;
+    /** Three warm one-tap phrases a visitor can offer without typing.
+     *  Each phrase, when tapped, fills the voice body and enables the
+     *  submit button — so "offering" is as easy as tapping an emoji. */
+    quickPhrase1?: string;
+    quickPhrase2?: string;
+    quickPhrase3?: string;
   };
 }
 
@@ -328,6 +334,25 @@ export function MeetingSurface({
                   className="w-full rounded-md bg-stone-950/60 border border-stone-800 px-3 py-2 text-sm text-stone-200 placeholder-stone-600 focus:outline-none focus:border-amber-600/60 resize-y"
                   autoFocus
                 />
+                {/* One-tap phrases — for when words are hard or time is
+                    short. Tapping fills the textarea and the visitor can
+                    submit immediately, or keep typing to deepen it. */}
+                {(strings.quickPhrase1 || strings.quickPhrase2 || strings.quickPhrase3) && (
+                  <div className="flex flex-wrap gap-1.5 pt-1">
+                    {[strings.quickPhrase1, strings.quickPhrase2, strings.quickPhrase3]
+                      .filter((p): p is string => !!p && p.length > 0)
+                      .map((phrase) => (
+                        <button
+                          key={phrase}
+                          type="button"
+                          onClick={() => setSayText(phrase)}
+                          className="rounded-full border border-amber-700/40 bg-amber-950/20 hover:bg-amber-900/30 text-amber-100/90 text-xs px-3 py-1 transition-colors"
+                        >
+                          {phrase}
+                        </button>
+                      ))}
+                  </div>
+                )}
                 <div className="flex items-center gap-2">
                   <button
                     type="button"

--- a/web/components/MorningNudge.tsx
+++ b/web/components/MorningNudge.tsx
@@ -189,9 +189,17 @@ export function MorningNudge() {
     );
   }
 
+  // Visual rules for warmth + legibility:
+  //   · darker, calmer background (stone-900 with just a kiss of amber)
+  //     so warm accent color belongs to the content, not the frame
+  //   · eyebrow in high-contrast amber so the time-of-day lands
+  //   · heading in near-white for maximum reading calm
+  //   · the viewer's own quote (when present) becomes the hero — larger,
+  //     italic, warm cream rather than muted stone, with a generous
+  //     gold left-border that says "your voice is held here"
   return (
     <section
-      className="relative max-w-3xl mx-3 sm:mx-auto mt-3 px-4 py-4 rounded-2xl border border-amber-700/30 bg-gradient-to-br from-amber-950/20 via-stone-900/30 to-teal-950/20"
+      className="relative max-w-3xl mx-3 sm:mx-auto mt-3 px-4 py-5 rounded-2xl border border-amber-600/20 bg-gradient-to-br from-stone-900/95 via-stone-900/90 to-amber-950/25 shadow-[0_1px_0_0_rgba(217,119,6,0.08)_inset]"
       aria-label={t("morningNudge.ariaLabel")}
     >
       <button
@@ -202,10 +210,10 @@ export function MorningNudge() {
       >
         ×
       </button>
-      <p className="text-xs uppercase tracking-widest text-amber-300/90 mb-1">
+      <p className="text-[11px] uppercase tracking-[0.18em] text-amber-400 font-medium mb-1.5">
         {t("morningNudge.eyebrow")}
       </p>
-      <p className="text-base md:text-lg font-light text-stone-100 leading-snug mb-2">
+      <p className="text-base md:text-lg font-light text-stone-50 leading-snug mb-3">
         {t("morningNudge.heading").replace("{name}", name)}
       </p>
       {parts.length > 0 && (
@@ -214,12 +222,12 @@ export function MorningNudge() {
         </p>
       )}
       {digest.newVoicesPreview && (
-        <blockquote className="text-sm italic text-stone-400 border-l-2 border-teal-600/40 pl-3 mb-3 leading-relaxed">
+        <blockquote className="text-[15px] md:text-base italic text-amber-50/90 border-l-2 border-amber-500/60 pl-3.5 pr-1 mb-4 leading-relaxed">
           “{digest.newVoicesPreview}…”
         </blockquote>
       )}
       {digest.news && (
-        <div className="text-sm text-stone-300 mb-3">
+        <p className="text-sm text-stone-300 mb-3 leading-relaxed">
           <span className="text-stone-500 mr-1">{t("morningNudge.newsLead")}</span>
           <a
             href={digest.news.url}
@@ -229,11 +237,11 @@ export function MorningNudge() {
           >
             {digest.news.title}
           </a>
-        </div>
+        </p>
       )}
       <Link
         href="/feed/you"
-        className="inline-flex items-center gap-1 text-sm text-teal-300 hover:text-teal-200"
+        className="inline-flex items-center gap-1 text-sm font-medium text-amber-300 hover:text-amber-200"
       >
         {t("morningNudge.openCorner")} →
       </Link>

--- a/web/components/live_updates_controller.tsx
+++ b/web/components/live_updates_controller.tsx
@@ -156,7 +156,10 @@ export default function LiveUpdatesController() {
     : t("autoRefresh.statusOff");
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-4 z-40">
+    // Hidden on mobile — it's developer-facing chrome, not the warmest
+    // thing a first-time visitor from a phone should see. Desktop keeps
+    // the affordance for contributors who want to pause live refresh.
+    <div className="hidden md:block pointer-events-none fixed bottom-4 right-4 z-40">
       <details className="group pointer-events-auto">
         <summary className="list-none cursor-pointer rounded-full border border-border/70 bg-card/90 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur">
           {t("autoRefresh.label")} <span className="font-semibold text-foreground">{statusLabel}</span>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -355,7 +355,10 @@
     "saySubmit": "Anbieten",
     "saySending": "Wird gesendet …",
     "saySent": "Danke — deine Stimme ist hier.",
-    "sayDismiss": "nicht jetzt"
+    "sayDismiss": "nicht jetzt",
+    "quickPhrase1": "Das berührt mich",
+    "quickPhrase2": "Das fühlt sich lebendig an",
+    "quickPhrase3": "Ich möchte mehr davon"
   },
   "reactions": {
     "ariaLabel": "Reaktionen und Kommentare",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -355,7 +355,10 @@
     "saySubmit": "Offer this",
     "saySending": "Offering…",
     "saySent": "Thank you — your voice is here.",
-    "sayDismiss": "not now"
+    "sayDismiss": "not now",
+    "quickPhrase1": "This moves me",
+    "quickPhrase2": "This feels alive",
+    "quickPhrase3": "I want more of this"
   },
   "reactions": {
     "ariaLabel": "Reactions and comments",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -355,7 +355,10 @@
     "saySubmit": "Ofrecer",
     "saySending": "Enviando…",
     "saySent": "Gracias — tu voz está aquí.",
-    "sayDismiss": "ahora no"
+    "sayDismiss": "ahora no",
+    "quickPhrase1": "Esto me toca",
+    "quickPhrase2": "Esto se siente vivo",
+    "quickPhrase3": "Quiero más de esto"
   },
   "reactions": {
     "ariaLabel": "Reacciones y comentarios",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -355,7 +355,10 @@
     "saySubmit": "Tawarkan",
     "saySending": "Mengirim…",
     "saySent": "Terima kasih — suaramu ada di sini.",
-    "sayDismiss": "nanti saja"
+    "sayDismiss": "nanti saja",
+    "quickPhrase1": "Ini menggerakkanku",
+    "quickPhrase2": "Ini terasa hidup",
+    "quickPhrase3": "Aku ingin lebih"
   },
   "reactions": {
     "ariaLabel": "Reaksi dan komentar",


### PR DESCRIPTION
## Summary
- MorningNudge: calmer stone background, high-contrast eyebrow, her quote becomes the hero in warm amber italic
- InviteBanner: two-line layout when both names present — no more single clipped line
- MeetingSurface: three one-tap phrase chips so typing isn't the gate
- Live-update chip hidden on mobile

## Why
"Misalignment and visual artifacts are exit points we want to avoid." Also: "just look at each screen and feel into what is vibrant and alive."

🤖 Generated with [Claude Code](https://claude.com/claude-code)