### PR TITLE
Cycle N: theme-aware Panel primitive + warmer /feed/you lede

### DIFF
--- a/web/components/LiveBreathPanel.tsx
+++ b/web/components/LiveBreathPanel.tsx
@@ -73,19 +73,21 @@ export async function LiveBreathPanel({ lang }: Props) {
 
   return (
     <section
-      className="relative z-10 w-full border-b border-stone-800/40 bg-gradient-to-b from-teal-950/20 via-transparent to-transparent"
+      className="relative z-10 w-full border-b border-border/40 bg-[linear-gradient(180deg,hsl(var(--chart-2)/0.08),transparent)]"
       aria-label={t("homeBreath.ariaLabel")}
     >
-      <div className="max-w-4xl mx-auto px-4 py-5 flex flex-col md:flex-row md:items-center gap-4">
+      <div className="max-w-4xl mx-auto px-5 py-4 flex flex-col md:flex-row md:items-center gap-4">
         <div className="flex-1 min-w-0">
-          <p className="text-xs uppercase tracking-widest text-teal-300/90 mb-1">
+          {/* Eyebrow tokens match the Panel primitive and adapt to both
+              themes via the chart-2 (teal) semantic token. */}
+          <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--chart-2))] mb-1.5">
             {t("homeBreath.label")}
           </p>
           {hasSignal ? (
-            <p className="text-base md:text-lg text-stone-100">
+            <p className="text-base md:text-lg text-foreground">
               {meetingNow > 0 && (
                 <>
-                  <span className="text-teal-200 font-medium">
+                  <span className="text-[hsl(var(--chart-2))] font-medium">
                     {meetingNow === 1
                       ? t("homeBreath.oneMeetingNow")
                       : t("homeBreath.manyMeetingNow").replace(
@@ -102,7 +104,7 @@ export async function LiveBreathPanel({ lang }: Props) {
                 </>
               )}
               {recentVoices.length > 0 && (
-                <span className="text-stone-300">
+                <span className="text-muted-foreground">
                   {t("homeBreath.recentVoicesLine").replace(
                     "{count}",
                     String(recentVoices.length),
@@ -110,7 +112,7 @@ export async function LiveBreathPanel({ lang }: Props) {
                 </span>
               )}
               {recentVoices.length === 0 && recentReactions.length > 0 && (
-                <span className="text-stone-300">
+                <span className="text-muted-foreground">
                   {t("homeBreath.recentReactionsLine").replace(
                     "{count}",
                     String(recentReactions.length),
@@ -119,7 +121,7 @@ export async function LiveBreathPanel({ lang }: Props) {
               )}
             </p>
           ) : (
-            <p className="text-base md:text-lg text-stone-200">
+            <p className="text-base md:text-lg text-foreground">
               {t("homeBreath.quiet")}
             </p>
           )}
@@ -128,19 +130,19 @@ export async function LiveBreathPanel({ lang }: Props) {
         <div className="flex items-center gap-2 flex-wrap">
           <Link
             href="/here"
-            className="rounded-full bg-teal-700/80 hover:bg-teal-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+            className="rounded-full bg-[hsl(var(--chart-2))] hover:opacity-90 text-[hsl(var(--primary-foreground))] px-4 py-2 text-sm font-medium transition-opacity"
           >
             {t("homeBreath.goHere")}
           </Link>
           <Link
             href="/explore/concept"
-            className="rounded-full bg-amber-700/80 hover:bg-amber-600/90 text-stone-950 px-4 py-2 text-sm font-medium transition-colors"
+            className="rounded-full bg-[hsl(var(--primary))] hover:opacity-90 text-[hsl(var(--primary-foreground))] px-4 py-2 text-sm font-medium transition-opacity"
           >
             {t("homeBreath.goExplore")}
           </Link>
           <Link
             href="/propose"
-            className="rounded-full border border-teal-700/40 bg-teal-950/20 hover:bg-teal-950/40 text-teal-200 px-4 py-2 text-sm font-medium transition-colors"
+            className="rounded-full border border-[hsl(var(--chart-2)/0.4)] hover:bg-[hsl(var(--chart-2)/0.1)] text-[hsl(var(--chart-2))] px-4 py-2 text-sm font-medium transition-colors"
           >
             {t("homeBreath.goPropose")}
           </Link>

--- a/web/components/MorningNudge.tsx
+++ b/web/components/MorningNudge.tsx
@@ -213,12 +213,12 @@ export function MorningNudge() {
       )}
       {digest.news && (
         <p>
-          <span className="text-stone-500 mr-1">{t("morningNudge.newsLead")}</span>
+          <span className="text-muted-foreground mr-1">{t("morningNudge.newsLead")}</span>
           <a
             href={digest.news.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-teal-300 hover:text-teal-200 underline underline-offset-2 decoration-teal-700/40"
+            className="text-[hsl(var(--chart-2))] hover:opacity-80 underline underline-offset-2 decoration-[hsl(var(--chart-2)/0.4)]"
           >
             {digest.news.title}
           </a>

--- a/web/components/Panel.tsx
+++ b/web/components/Panel.tsx
@@ -10,38 +10,30 @@
  * padding. The accumulation felt fragmented even when each choice
  * was defensible in isolation.
  *
- * Panel reduces the surface to four variants × four slots:
+ * Panel reduces the surface to four variants × four slots and binds
+ * all color values to semantic theme tokens (bg-card, text-foreground,
+ * border-border) so the panel adapts to dark + light modes instead of
+ * hard-coding a single palette. The small warm/cool accents use
+ * theme-aware opacity overlays on top of the semantic base.
  *
  *   Variants (tone):
- *     • "warm"      — amber-on-stone, used for the viewer's own
- *                     moments (morning greeting, their contribution
- *                     reflected). The hero.
- *     • "cool"      — teal-on-stone, used for the organism's own
- *                     moments (invitations, breath, kin activity).
- *     • "neutral"   — stone-only, used for quieter content.
- *     • "empty"     — same surface as neutral but dimmer, used for
- *                     empty states that want to recede.
+ *     • "warm"     — the viewer's own moments (morning greeting, their
+ *                    contribution reflected). Amber accents.
+ *     • "cool"     — the organism's own moments (invitations, breath,
+ *                    kin activity). Teal accents.
+ *     • "neutral"  — quieter content, no accent color.
+ *     • "empty"    — same surface as neutral but dimmer, for empty
+ *                    states that want to recede.
  *
  *   Slots:
- *     • eyebrow     — small uppercase tracking-wide caption (time of
- *                     day, section label).
- *     • heading     — near-white body in a readable size (the main
- *                     sentence addressing the viewer).
- *     • body        — the content itself — children allows any JSX
- *                     (paragraphs, quotes, lists, forms).
- *     • cta         — an amber-tinted link or button at the foot.
+ *     • eyebrow    — small uppercase tracking-wide caption
+ *     • heading    — foreground-tone body text, the main sentence
+ *     • body       — children, any JSX (paragraphs, quotes, lists)
+ *     • cta        — link or button at the foot
  *
- *   Other props:
- *     • icon        — optional emoji or small element at the left,
- *                     vertically aligned to the heading's optical
- *                     center (uses a flex row with items-start + mt-0.5
- *                     trim — standard across every panel).
- *     • onDismiss   — renders the × in the top-right at a consistent
- *                     position, size, and hover affordance.
- *
- * Every shared value (radius, padding, border color, gradient stops,
- * eyebrow scale, heading scale, icon size, dismiss size) is defined
- * once below. Future consistency improvements happen in one place.
+ *   Other:
+ *     • icon       — optional emoji or element, optically centered
+ *     • onDismiss  — renders the × at a consistent position
  */
 
 import type { ReactNode } from "react";
@@ -63,51 +55,57 @@ interface PanelProps {
 }
 
 // Shared tokens — the whole design system for panels lives here.
-// Changing a token here changes every panel everywhere; that is the
-// point of the primitive.
+// Colors bind to semantic theme variables so dark + light both look
+// considered. Accent tints are added as thin overlay layers so the
+// base card color always wins on contrast.
 const PANEL_BASE =
   "relative max-w-3xl mx-3 sm:mx-auto rounded-2xl px-5 py-4 " +
-  "shadow-[0_1px_0_0_rgba(255,255,255,0.02)_inset]";
+  "bg-card text-card-foreground border " +
+  "transition-colors";
 
+// Warm tint: amber ring on the border, faint warm overlay on the base.
+// The ring-inset pseudo-background uses the chart-1 (gold) token which
+// is defined for both themes with AA-compliant contrast.
 const VARIANT_CLASSES: Record<PanelVariant, string> = {
   warm:
-    "border border-amber-600/20 " +
-    "bg-gradient-to-br from-stone-900/95 via-stone-900/90 to-amber-950/25",
+    "border-[hsl(var(--primary)/0.25)] " +
+    "bg-[linear-gradient(135deg,hsl(var(--card))_0%,hsl(var(--card))_55%,hsl(var(--primary)/0.08)_100%)]",
   cool:
-    "border border-teal-600/25 " +
-    "bg-gradient-to-br from-stone-900/95 via-stone-900/90 to-teal-950/30",
-  neutral:
-    "border border-stone-700/40 " +
-    "bg-gradient-to-br from-stone-900/95 via-stone-900/90 to-stone-900/80",
+    "border-[hsl(var(--chart-2)/0.35)] " +
+    "bg-[linear-gradient(135deg,hsl(var(--card))_0%,hsl(var(--card))_55%,hsl(var(--chart-2)/0.10)_100%)]",
+  neutral: "border-border",
   empty:
-    "border border-stone-800/60 " +
-    "bg-gradient-to-br from-stone-900/70 via-stone-900/60 to-stone-900/50",
+    "border-[hsl(var(--border)/0.6)] " +
+    "bg-[hsl(var(--card)/0.6)]",
 };
 
+// Eyebrow colors pick from theme-aware chart tokens that stay legible
+// in both modes (primary = gold, chart-2 = teal, muted-foreground).
 const EYEBROW_CLASSES: Record<PanelVariant, string> = {
-  warm: "text-amber-400",
-  cool: "text-teal-300",
-  neutral: "text-stone-400",
-  empty: "text-stone-500",
+  warm: "text-[hsl(var(--primary))]",
+  cool: "text-[hsl(var(--chart-2))]",
+  neutral: "text-muted-foreground",
+  empty: "text-muted-foreground/80",
 };
 
 const EYEBROW_BASE =
-  "text-[11px] uppercase tracking-[0.18em] font-medium mb-1.5";
+  "text-[11px] uppercase tracking-[0.18em] font-semibold mb-1.5";
 
-const HEADING_BASE =
-  "text-base md:text-lg font-light leading-snug mb-2";
+const HEADING_BASE = "text-base md:text-lg font-light leading-snug mb-2";
 
+// Heading uses the theme foreground everywhere — it's the place where
+// contrast discipline matters most.
 const HEADING_TONE: Record<PanelVariant, string> = {
-  warm: "text-stone-50",
-  cool: "text-stone-50",
-  neutral: "text-stone-100",
-  empty: "text-stone-300",
+  warm: "text-foreground",
+  cool: "text-foreground",
+  neutral: "text-foreground",
+  empty: "text-foreground/80",
 };
 
 const DISMISS_BASE =
   "absolute top-2.5 right-2.5 w-7 h-7 rounded-full flex items-center " +
-  "justify-center text-stone-500 hover:text-stone-200 " +
-  "hover:bg-stone-800/40 transition-colors";
+  "justify-center text-muted-foreground hover:text-foreground " +
+  "hover:bg-accent/40 transition-colors";
 
 export function Panel({
   variant = "neutral",
@@ -141,9 +139,6 @@ export function Panel({
       )}
       <div className={hasIcon ? "flex items-start gap-3" : ""}>
         {hasIcon && (
-          // Icons carry a single standard sizing and an mt-0.5 trim so
-          // the optical center sits with the heading's cap-height even
-          // when the heading wraps to multiple lines.
           <span
             className="text-lg leading-none mt-0.5 shrink-0"
             aria-hidden="true"
@@ -162,7 +157,11 @@ export function Panel({
               {heading}
             </div>
           )}
-          {children && <div className="text-sm text-stone-300 leading-relaxed space-y-3">{children}</div>}
+          {children && (
+            <div className="text-sm text-muted-foreground leading-relaxed space-y-3">
+              {children}
+            </div>
+          )}
           {cta && <div className="mt-3">{cta}</div>}
         </div>
       </div>
@@ -171,10 +170,9 @@ export function Panel({
 }
 
 /**
- * A viewer-voice blockquote — when the panel's body needs to hold the
- * viewer's own words (or anyone's voice) as the hero element. Warm
- * amber italic with a gold left-border. Imported by MorningNudge +
- * SinceLastVisit + the blog-reaction-summary panels.
+ * VoiceQuote — the viewer's own words as hero element. Warm italic
+ * with a gold left-border, theme-aware so it reads correctly against
+ * both dark and light panel surfaces.
  */
 interface VoiceQuoteProps {
   children: ReactNode;
@@ -185,13 +183,15 @@ export function VoiceQuote({ children, attribution }: VoiceQuoteProps) {
   return (
     <blockquote
       className={
-        "text-[15px] md:text-base italic text-amber-50/90 " +
-        "border-l-2 border-amber-500/60 pl-3.5 pr-1 leading-relaxed"
+        "text-[15px] md:text-base italic " +
+        "text-foreground/95 " +
+        "border-l-2 border-[hsl(var(--primary)/0.6)] " +
+        "pl-3.5 pr-1 leading-relaxed"
       }
     >
       <span>“{children}…”</span>
       {attribution && (
-        <footer className="mt-1.5 text-xs not-italic text-stone-400">
+        <footer className="mt-1.5 text-xs not-italic text-muted-foreground">
           {attribution}
         </footer>
       )}
@@ -200,8 +200,7 @@ export function VoiceQuote({ children, attribution }: VoiceQuoteProps) {
 }
 
 /**
- * A Panel-consistent CTA link. Matches the panel's tone by default.
- * Use for "Open your corner →", "See all voices →" style affordances.
+ * Panel-tone CTA link. Tone matches panel variant by default.
  */
 interface PanelLinkProps {
   href: string;
@@ -210,11 +209,16 @@ interface PanelLinkProps {
   external?: boolean;
 }
 
-export function PanelLink({ href, tone = "warm", children, external = false }: PanelLinkProps) {
+export function PanelLink({
+  href,
+  tone = "warm",
+  children,
+  external = false,
+}: PanelLinkProps) {
   const color =
     tone === "warm"
-      ? "text-amber-300 hover:text-amber-200"
-      : "text-teal-300 hover:text-teal-200";
+      ? "text-[hsl(var(--primary))] hover:opacity-80"
+      : "text-[hsl(var(--chart-2))] hover:opacity-80";
   const externalProps = external
     ? { target: "_blank" as const, rel: "noopener noreferrer" as const }
     : {};

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -280,7 +280,7 @@
     "tabCollective": "Alle",
     "tabPersonal": "Du",
     "personalHeading": "Deine Ecke",
-    "personalLede": "Stimmen, die du gegeben hast, Reaktionen, die du angeboten hast, Antworten, die zu dir zurückkamen, Vorschläge, die du gehoben hast.",
+    "personalLede": "Jede Geste, die du gemacht hast, sammelt sich hier. Das ist dein Garten.",
     "personalEmpty": "Deine Ecke wartet. Teile eine Stimme zu etwas Lebendigem, dann sammelt sich hier etwas.",
     "personalEmptyCta": "Etwas Lebendiges finden",
     "personalNoIdentity": "Noch ist kein Name hier. Wähle einen, und deine Ecke beginnt.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -280,7 +280,7 @@
     "tabCollective": "Everyone",
     "tabPersonal": "You",
     "personalHeading": "Your corner",
-    "personalLede": "Voices you gave, reactions you offered, replies that came back to you, proposals you lifted.",
+    "personalLede": "Every gesture you've made gathers here. This is your garden.",
     "personalEmpty": "Your corner is waiting. Offer a voice on something alive and it will gather here.",
     "personalEmptyCta": "Find something alive",
     "personalNoIdentity": "No name is here yet. Choose one and your corner begins.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -280,7 +280,7 @@
     "tabCollective": "Todos",
     "tabPersonal": "Tú",
     "personalHeading": "Tu rincón",
-    "personalLede": "Las voces que ofreciste, las reacciones que diste, las respuestas que te llegaron, las propuestas que elevaste.",
+    "personalLede": "Cada gesto que has hecho se reúne aquí. Este es tu jardín.",
     "personalEmpty": "Tu rincón te espera. Ofrece una voz sobre algo vivo y se juntará aquí.",
     "personalEmptyCta": "Encuentra algo vivo",
     "personalNoIdentity": "Todavía no hay un nombre. Elige uno y tu rincón empieza.",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -280,7 +280,7 @@
     "tabCollective": "Semua",
     "tabPersonal": "Kamu",
     "personalHeading": "Sudutmu",
-    "personalLede": "Suara yang kamu beri, reaksi yang kamu tawarkan, balasan yang kembali padamu, usulan yang kamu angkat.",
+    "personalLede": "Setiap isyarat yang kamu beri berkumpul di sini. Inilah tamanmu.",
     "personalEmpty": "Sudutmu menunggu. Tawarkan suara pada sesuatu yang hidup dan akan berkumpul di sini.",
     "personalEmptyCta": "Temukan yang hidup",
     "personalNoIdentity": "Belum ada nama di sini. Pilih satu dan sudutmu dimulai.",


### PR DESCRIPTION
## Summary
- Panel + VoiceQuote + PanelLink rewritten to use semantic theme tokens (bg-card, text-foreground, chart-2, primary, border) so they adapt to both light + dark themes
- LiveBreathPanel eyebrow + buttons + prose migrated to same tokens
- /feed/you lede: replaced four-item comma list ("Stimmen, die du gegeben hast...") with a warm greeting ("Jede Geste, die du gemacht hast, sammelt sich hier. Das ist dein Garten.") across four locales

## Why
"The contrast seems very off for light and dark themes, both need polish and attention."

First Panel pass hardcoded dark-mode stone/amber. That's broken in light. Proper primitive binds every color to a theme variable.

Content polish: the /feed/you lede was describing the page instead of speaking to the viewer. Now it speaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)