### PR TITLE
Cycle O: auto-graduate soft identity to contributor on first voice

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -920,6 +920,9 @@ class ConceptVoiceIn(BaseModel):
     locale: str = "en"
     location: str | None = None
     author_id: str | None = None
+    # Short opaque client-supplied token so two visitors sharing a
+    # display name get distinct contributor_ids during auto-graduation.
+    device_fingerprint: str | None = None
 
 
 @router.post(
@@ -930,6 +933,12 @@ class ConceptVoiceIn(BaseModel):
 async def add_concept_voice(concept_id: str, body: ConceptVoiceIn, request: Request) -> dict:
     """Open write-back surface on any concept. Trust by default — no moderation
     queue. A voice is a short testimony: "this is how we live it here".
+
+    Soft-identity auto-graduation: if ``author_id`` is omitted, the service
+    creates a contributor node keyed by ``author_name`` + ``device_fingerprint``
+    and returns ``author_id`` in the response. The web client writes it back
+    to ``cc-contributor-id`` so the visitor is now a real contributor in
+    every subsequent surface — no signup screen involved.
     """
     if not concept_service.get_concept(concept_id):
         raise HTTPException(
@@ -944,6 +953,7 @@ async def add_concept_voice(concept_id: str, body: ConceptVoiceIn, request: Requ
             locale=body.locale,
             author_id=body.author_id,
             location=body.location,
+            device_fingerprint=body.device_fingerprint,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/api/app/services/concept_voice_service.py
+++ b/api/app/services/concept_voice_service.py
@@ -121,14 +121,59 @@ def add_voice(
     locale: str = "en",
     author_id: Optional[str] = None,
     location: Optional[str] = None,
+    device_fingerprint: Optional[str] = None,
 ) -> dict:
+    """Record a lived-experience voice on a concept.
+
+    Soft-identity auto-graduation: when the caller provides only
+    ``author_name`` (no ``author_id``), a contributor graph node is
+    quietly created for them — their voice becomes the registration
+    event. The returned dict includes ``author_id``; the web client
+    writes it back to localStorage so subsequent voices, reactions,
+    and proposals attribute correctly. No signup screen, no private
+    key, no gate — you become a contributor by caring enough to
+    speak.
+
+    ``device_fingerprint`` is an optional short opaque string from
+    the client that lets us disambiguate two contributors who share
+    a display name (e.g. two "Mama"s on different devices). When
+    absent we fall back to a random uuid suffix.
+    """
     _ensure_schema()
     if not concept_id or not body.strip() or not author_name.strip():
         raise ValueError("concept_id, author_name, and body are required")
+    trimmed_name = author_name.strip()
+
+    # Auto-graduate: if no author_id was supplied, try to find an
+    # existing contributor with the same display name + fingerprint;
+    # otherwise mint a fresh contributor node.
+    if not author_id:
+        try:
+            from app.services import contributor_service
+            from app.services import graph_service
+
+            suffix = (device_fingerprint or uuid4().hex[:8]).strip()[:24]
+            safe_name = "".join(c for c in trimmed_name.lower() if c.isalnum() or c in "-_") or "friend"
+            safe_suffix = "".join(c for c in suffix.lower() if c.isalnum() or c in "-_") or uuid4().hex[:8]
+            candidate_id = f"{safe_name}-{safe_suffix}"[:64]
+            existing = graph_service.get_node(f"contributor:{candidate_id}")
+            if existing:
+                author_id = existing.get("legacy_id") or candidate_id
+            else:
+                node = contributor_service.create_contributor(
+                    name=candidate_id,
+                    contributor_type="HUMAN",
+                )
+                author_id = node.get("legacy_id") or candidate_id
+        except Exception:
+            # If contributor creation fails for any reason, the voice
+            # still lands with just author_name — soft identity holds.
+            author_id = None
+
     rec = ConceptVoiceRecord(
         id=uuid4().hex,
         concept_id=concept_id,
-        author_name=author_name.strip(),
+        author_name=trimmed_name,
         author_id=author_id,
         locale=locale or "en",
         body=body.strip(),

--- a/web/components/MeetingSurface.tsx
+++ b/web/components/MeetingSurface.tsx
@@ -203,10 +203,18 @@ export function MeetingSurface({
       }
       setAuthorName(name);
       const base = getApiBase();
+      const fingerprint = ensureFingerprint();
       // For concepts, store as a voice (richer shape + ripens into proposals
       // later). For any other entity, store as a reaction with a comment.
+      //
+      // Auto-graduation: if the viewer doesn't have a contributor_id yet,
+      // the server mints one keyed by her name + device fingerprint and
+      // returns it in the voice payload. We persist it to localStorage so
+      // every subsequent surface (reactions, profile, feed) attributes
+      // her correctly. No signup screen, no private key — contribution
+      // IS the registration.
       if (entityType === "concept") {
-        await fetch(`${base}/api/concepts/${encodeURIComponent(entityId)}/voices`, {
+        const res = await fetch(`${base}/api/concepts/${encodeURIComponent(entityId)}/voices`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -214,8 +222,19 @@ export function MeetingSurface({
             body,
             locale,
             author_id: contributorId,
+            device_fingerprint: fingerprint,
           }),
         });
+        try {
+          if (res.ok) {
+            const voice = await res.json();
+            const newId = voice?.author_id;
+            if (newId && !contributorId) {
+              localStorage.setItem(CONTRIBUTOR_KEY, newId);
+              setContributorId(newId);
+            }
+          }
+        } catch { /* non-critical */ }
       } else {
         await fetch(`${base}/api/reactions/${entityType}/${entityId}`, {
           method: "POST",


### PR DESCRIPTION
## Summary
- Mama's voice becomes her registration. When she POSTs to /api/concepts/{id}/voices without an author_id, the server mints a contributor graph node keyed by her name + device fingerprint and returns author_id
- MeetingSurface sends the fingerprint, reads the response, writes author_id back to localStorage
- She never sees a signup screen

## Why
"A new contributor should receive an api-key automatically and they can see the usage and create and manage them if they choose to."

This is the prerequisite. You can't issue API keys to someone who isn't a contributor yet. Now the moment she voices, she is one — with a graph node, a queryable portfolio, an identity any future /api/keys/issue endpoint can attach capabilities to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)