### PR TITLE
Cycle P: voices become a choir (reactable voice cards)

### DIFF
--- a/api/app/services/reaction_service.py
+++ b/api/app/services/reaction_service.py
@@ -47,6 +47,13 @@ SUPPORTED_ENTITY_TYPES = {
     "agent_run",
     # Proposals — the collective votes on them through the same meeting gesture
     "proposal",
+    # Voices — a reader can react directly to a concept voice, turning a
+    # list of voices into a choir where each testimony is itself a surface
+    # for care. The entity_id is the voice's uuid.
+    "voice",
+    # Blog-post chapter — per-section reactions on /blog/ana-walks etc.
+    # (already used informally by the ana-walks ReactionBar drops)
+    "blog",
 }
 
 

--- a/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
+++ b/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getApiBase } from "@/lib/api";
 import { useT, useLocale } from "@/components/MessagesProvider";
+import { ReactionBar } from "@/components/ReactionBar";
 
 const CONTRIBUTOR_KEY = "cc-contributor-id";
 
@@ -167,6 +168,21 @@ export function ConceptVoices({ conceptId }: Props) {
                 )}
                 <span className="uppercase tracking-wide">· {v.locale}</span>
               </p>
+              {/* Each voice is itself a surface for care — a reader can
+                  react with a warm emoji or add a short reply. This turns
+                  the voice list into a choir: her sentence, others' hearts
+                  arriving under it, a felt sense of being received. The
+                  emoji palette here is intentionally smaller than the
+                  concept-level bar so voice-reactions read as light,
+                  intimate gestures rather than a full decision surface. */}
+              <div className="mt-3 border-t border-stone-800/40 pt-3">
+                <ReactionBar
+                  entityType="voice"
+                  entityId={v.id}
+                  palette={["💛", "🙏", "🌱", "🫶"]}
+                  compact
+                />
+              </div>
               <div className="mt-3 flex items-center gap-3 text-xs">
                 {v.proposed_as_proposal_id ? (
                   <Link

--- a/web/components/ReactionBar.tsx
+++ b/web/components/ReactionBar.tsx
@@ -27,7 +27,9 @@ type EntityType =
   | "workspace"
   | "asset"
   | "contribution"
-  | "story";
+  | "story"
+  | "voice"
+  | "blog";
 
 interface Reaction {
   id: string;


### PR DESCRIPTION
Each voice on /vision/{conceptId} now carries its own compact ReactionBar. Readers can tap 💛🙏🌱🫶 on a testimony and the warmth lands directly on that voice. The list becomes a choir.