### PR TITLE
Cycle Q: morning nudge shows warmth coming back

### DIFF
--- a/api/app/services/personal_feed_service.py
+++ b/api/app/services/personal_feed_service.py
@@ -263,17 +263,50 @@ def build_personal_feed(
 
             # 6. Reactions on concepts I voiced
             my_voices = s.execute(
-                select(ConceptVoiceRecord.concept_id).where(
+                select(ConceptVoiceRecord.concept_id, ConceptVoiceRecord.id).where(
                     ConceptVoiceRecord.author_id == contributor_id
                 )
             ).all()
             voiced_cids = {r[0] for r in my_voices}
+            my_voice_ids = {r[1] for r in my_voices}
             if voiced_cids:
                 rows = s.execute(
                     select(ReactionRecord)
                     .where(
                         ReactionRecord.entity_type == "concept",
                         ReactionRecord.entity_id.in_(voiced_cids),
+                        or_(
+                            ReactionRecord.author_id.is_(None),
+                            ReactionRecord.author_id != contributor_id,
+                        ),
+                    )
+                    .order_by(ReactionRecord.created_at.desc())
+                    .limit(limit)
+                ).scalars().all()
+                for r in rows:
+                    items.append(
+                        {
+                            "entity_type": r.entity_type,
+                            "entity_id": r.entity_id,
+                            "kind": "reaction_on_my_voice",
+                            "title": r.entity_id,
+                            "snippet": (r.comment or r.emoji or "")[:200],
+                            "actor_name": r.author_name,
+                            "reason": "reaction_on_my_voice",
+                            "reason_label": captions["reaction_on_my_voice"],
+                            "created_at": _iso(r.created_at),
+                        }
+                    )
+            # 6b. Reactions landed directly on my individual voices
+            # (entity_type="voice"). Cycle P made voices reactable at
+            # that entity_type, so the warmth someone offers to one of
+            # her specific sentences must surface here.
+            if my_voice_ids:
+                rows = s.execute(
+                    select(ReactionRecord)
+                    .where(
+                        ReactionRecord.entity_type == "voice",
+                        ReactionRecord.entity_id.in_(my_voice_ids),
                         or_(
                             ReactionRecord.author_id.is_(None),
                             ReactionRecord.author_id != contributor_id,
@@ -348,6 +381,36 @@ def build_personal_feed(
                             "created_at": _iso(r.created_at),
                         }
                     )
+                # Soft-identity warmth-back: reactions other readers
+                # laid on the voices she wrote under this name. This
+                # is how Mama's morning nudge learns that someone
+                # gave her a heart last night.
+                my_voice_ids = {v.id for v in v_rows}
+                if my_voice_ids:
+                    react_on_voice = s.execute(
+                        select(ReactionRecord)
+                        .where(
+                            ReactionRecord.entity_type == "voice",
+                            ReactionRecord.entity_id.in_(my_voice_ids),
+                            ReactionRecord.author_name != an,
+                        )
+                        .order_by(ReactionRecord.created_at.desc())
+                        .limit(limit)
+                    ).scalars().all()
+                    for r in react_on_voice:
+                        items.append(
+                            {
+                                "entity_type": r.entity_type,
+                                "entity_id": r.entity_id,
+                                "kind": "reaction_on_my_voice",
+                                "title": r.entity_id,
+                                "snippet": (r.comment or r.emoji or "")[:200],
+                                "actor_name": r.author_name,
+                                "reason": "reaction_on_my_voice",
+                                "reason_label": captions["reaction_on_my_voice"],
+                                "created_at": _iso(r.created_at),
+                            }
+                        )
 
     # Dedup by (entity_type, entity_id, reason, actor_name, created_at)
     seen = set()

--- a/web/components/MorningNudge.tsx
+++ b/web/components/MorningNudge.tsx
@@ -37,11 +37,22 @@ const MORNING_START_HOUR = 6;
 const MORNING_END_HOUR = 11;
 const MIN_HOURS_BETWEEN_VISITS = 8;
 
+interface WarmthEvent {
+  emoji: string | null;
+  actorName: string | null;
+  bodyPreview: string | null;
+}
+
 interface Digest {
   voices: number;
   newVoicesPreview: string | null;
   ideas: number;
   news: { title: string; url: string } | null;
+  // The warmth she received back on her own voice(s) since she last
+  // visited. Each event is one reaction another reader laid on
+  // something she said. Rendered before everything else because it
+  // is the closing of her contribution loop.
+  warmth: WarmthEvent[];
 }
 
 function localMorningWindow(): boolean {
@@ -103,7 +114,15 @@ export function MorningNudge() {
       // server-side (?lang=).
       const base = getApiBase();
       const lang = locale || "en";
-      const [voicesRes, ideasRes, newsRes] = await Promise.allSettled([
+      // Build the personal-feed URL from whichever identity she holds.
+      // Cycle O auto-graduates her to a contributor on first voice, so
+      // contributorId is the common case. We still pass author_name so
+      // voices recorded before she had a contributor_id still match.
+      const personalParams = new URLSearchParams({ limit: "20", lang });
+      if (contributorId) personalParams.set("contributor_id", contributorId);
+      if (storedName) personalParams.set("author_name", storedName);
+
+      const [voicesRes, ideasRes, newsRes, personalRes] = await Promise.allSettled([
         fetch(`${base}/api/concepts/voices/recent?limit=3`, { cache: "no-store" })
           .then((r) => (r.ok ? r.json() : null))
           .catch(() => null),
@@ -113,6 +132,13 @@ export function MorningNudge() {
         // Prefer living-collective-aligned sources. Resilience.org is
         // most likely to match nourishing/community/regeneration themes.
         fetch(`${base}/api/news/feed?source=resilience&limit=3&lang=${lang}`, { cache: "no-store" })
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null),
+        // The personal feed surfaces reactions on her voices, replies
+        // to her reactions, proposals she supported becoming ideas —
+        // the full shape of "the organism received you". We filter it
+        // down to what happened *since her last visit*.
+        fetch(`${base}/api/feed/personal?${personalParams}`, { cache: "no-store" })
           .then((r) => (r.ok ? r.json() : null))
           .catch(() => null),
       ]);
@@ -148,11 +174,45 @@ export function MorningNudge() {
         }
       }
 
-      const anythingWorthShowing = voices > 0 || ideas > 0 || !!news;
+      // Reactions/replies that landed on what she contributed — the
+      // shape that turns "you spoke" into "you were heard."
+      const warmth: WarmthEvent[] = [];
+      if (personalRes.status === "fulfilled" && personalRes.value) {
+        interface FeedItem {
+          reason?: string;
+          actor_name?: string | null;
+          snippet?: string | null;
+          created_at?: string | null;
+        }
+        const items = (personalRes.value.items || []) as FeedItem[];
+        const warmthReasons = new Set([
+          "reaction_on_my_voice",
+          "replied_to_me",
+          "lifted_from_my_proposal",
+          "lifted_from_proposal_i_supported",
+        ]);
+        for (const it of items) {
+          if (!it.reason || !warmthReasons.has(it.reason)) continue;
+          if (!it.created_at || Date.parse(it.created_at) <= lastVisitMs) continue;
+          // snippet shape depends on the reason — for reactions, the
+          // snippet is the emoji. For replies, it's the reply text.
+          const raw = (it.snippet || "").trim();
+          const emoji = raw.length > 0 && raw.length <= 6 ? raw : null;
+          warmth.push({
+            emoji,
+            actorName: it.actor_name || null,
+            bodyPreview: emoji ? null : raw.slice(0, 80),
+          });
+          if (warmth.length >= 3) break;
+        }
+      }
+
+      const anythingWorthShowing =
+        voices > 0 || ideas > 0 || !!news || warmth.length > 0;
       if (!anythingWorthShowing || cancelled) return;
 
       setName(storedName.trim());
-      setDigest({ voices, newVoicesPreview, ideas, news });
+      setDigest({ voices, newVoicesPreview, ideas, news, warmth });
       setVisible(true);
     })();
     return () => {
@@ -207,6 +267,32 @@ export function MorningNudge() {
       }
       className="mt-3"
     >
+      {/* Warmth-she-received comes first — the closing of her own
+          contribution loop takes precedence over network-wide updates. */}
+      {digest.warmth.length > 0 && (
+        <div className="space-y-1.5">
+          {digest.warmth.map((w, idx) => (
+            <p key={idx} className="text-foreground/90">
+              {w.emoji && (
+                <span className="text-lg mr-1.5" aria-hidden="true">{w.emoji}</span>
+              )}
+              <span>
+                {(w.actorName || t("morningNudge.someone"))}{" "}
+                <span className="text-muted-foreground">
+                  {w.emoji
+                    ? t("morningNudge.reactedToYourVoice")
+                    : t("morningNudge.repliedToYou")}
+                </span>
+              </span>
+              {w.bodyPreview && (
+                <span className="block text-sm italic text-muted-foreground mt-0.5 pl-6">
+                  {w.bodyPreview}
+                </span>
+              )}
+            </p>
+          ))}
+        </div>
+      )}
       {parts.length > 0 && <p>{parts.join(" · ")}</p>}
       {digest.newVoicesPreview && (
         <VoiceQuote>{digest.newVoicesPreview}</VoiceQuote>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -246,7 +246,10 @@
     "ideasOne": "1 neue Idee in deiner Nähe",
     "ideasMany": "{count} neue Ideen in deiner Nähe",
     "newsLead": "Aus der weiten Welt:",
-    "openCorner": "Deine Ecke öffnen"
+    "openCorner": "Deine Ecke öffnen",
+    "someone": "Jemand",
+    "reactedToYourVoice": "hat das auf deine Stimme gelegt.",
+    "repliedToYou": "hat dir geantwortet:"
   },
   "welcome": {
     "ariaLabel": "Willkommen — worum es hier geht",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -246,7 +246,10 @@
     "ideasOne": "1 new idea aligned with you",
     "ideasMany": "{count} new ideas aligned with you",
     "newsLead": "From the wider world:",
-    "openCorner": "Open your corner"
+    "openCorner": "Open your corner",
+    "someone": "Someone",
+    "reactedToYourVoice": "laid this on your voice.",
+    "repliedToYou": "replied to you:"
   },
   "welcome": {
     "ariaLabel": "Welcome — what this place is",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -246,7 +246,10 @@
     "ideasOne": "1 idea nueva alineada contigo",
     "ideasMany": "{count} ideas nuevas alineadas contigo",
     "newsLead": "Del mundo más amplio:",
-    "openCorner": "Abrir tu rincón"
+    "openCorner": "Abrir tu rincón",
+    "someone": "Alguien",
+    "reactedToYourVoice": "puso esto sobre tu voz.",
+    "repliedToYou": "te respondió:"
   },
   "welcome": {
     "ariaLabel": "Bienvenida — de qué se trata este lugar",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -246,7 +246,10 @@
     "ideasOne": "1 gagasan baru yang selaras denganmu",
     "ideasMany": "{count} gagasan baru yang selaras denganmu",
     "newsLead": "Dari dunia yang lebih luas:",
-    "openCorner": "Buka sudutmu"
+    "openCorner": "Buka sudutmu",
+    "someone": "Seseorang",
+    "reactedToYourVoice": "meletakkan ini pada suaramu.",
+    "repliedToYou": "membalasmu:"
   },
   "welcome": {
     "ariaLabel": "Selamat datang — tentang tempat ini",


### PR DESCRIPTION
## Summary
- MorningNudge now surfaces reactions-on-my-voice + replies-to-me at the top of the panel
- personal_feed_service reads entity_type='voice' reactions for both contributor_id and soft-identity (author_name) branches
- Four locales: 'someone', 'reactedToYourVoice', 'repliedToYou'

## Why
Cycle P made voices reactable. This makes that warmth visible to the person who spoke. Mama's contribution loop now closes: she speaks → is received → sees herself received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)