### PR TITLE
Cycle R: warm /people/[id] garden — names become doorways

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -1,0 +1,272 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cookies, headers } from "next/headers";
+import { getApiBase } from "@/lib/api";
+import { fetchJsonOrNull } from "@/lib/fetch";
+import { createTranslator } from "@/lib/i18n";
+import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
+import { Panel, VoiceQuote } from "@/components/Panel";
+
+/**
+ * /people/[id] — a warm public garden view of a contributor.
+ *
+ * When a reader encounters Mama's voice on a concept and wants to know
+ * "who is this", this is where they land. The page honors her:
+ *
+ *   · a generous greeting with her name
+ *   · the voices she has given, each quoted and attributed to the
+ *     concept where she offered it
+ *   · the warmth that has come back to her — reactions that others
+ *     laid on her voices, gathered here as a felt register
+ *   · a quiet doorway forward ("meet her here →")
+ *
+ * This is the companion to /profile/[contributorId], which stays the
+ * deeper technical view (public-key fingerprint, frequency profile,
+ * assets). /people speaks to the community; /profile speaks to
+ * contributors who want the data.
+ */
+
+export const dynamic = "force-dynamic";
+
+type ContributorNode = {
+  id?: string;
+  name?: string;
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+type FeedItem = {
+  entity_type: string;
+  entity_id: string;
+  kind: string;
+  title: string;
+  snippet: string;
+  actor_name: string | null;
+  reason: string;
+  reason_label: string;
+  created_at: string | null;
+};
+
+type FeedResponse = {
+  items: FeedItem[];
+  count: number;
+  locale: string;
+};
+
+async function fetchContributor(id: string): Promise<ContributorNode | null> {
+  const base = getApiBase();
+  return fetchJsonOrNull<ContributorNode>(
+    `${base}/api/contributors/${encodeURIComponent(id)}`,
+    {},
+    5000,
+  );
+}
+
+async function fetchFeed(id: string, lang: LocaleCode): Promise<FeedResponse | null> {
+  const base = getApiBase();
+  return fetchJsonOrNull<FeedResponse>(
+    `${base}/api/feed/personal?contributor_id=${encodeURIComponent(id)}&limit=40&lang=${lang}`,
+    {},
+    5000,
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  // Best-effort: show a human-ish title. We don't fetch here to keep
+  // the metadata path cheap.
+  const display = id.replace(/-[a-z0-9]{6,}$/, "").replace(/-/g, " ");
+  return {
+    title: `${display} — Coherence Network`,
+    description: `A corner of the organism held by ${display}.`,
+  };
+}
+
+function initialFromName(name: string): string {
+  const first = (name || "").trim().charAt(0);
+  return first ? first.toUpperCase() : "·";
+}
+
+function displayName(node: ContributorNode | null, fallback: string): string {
+  const raw = (node?.name as string) || fallback;
+  // contributor ids look like "mama-abc123"; trim the fingerprint suffix
+  // for display. The full id still appears in the URL.
+  return raw.replace(/-[a-z0-9]{6,}$/, "");
+}
+
+function groupByConcept(items: FeedItem[]): Map<string, FeedItem[]> {
+  const map = new Map<string, FeedItem[]>();
+  for (const it of items) {
+    const key = it.entity_id;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(it);
+  }
+  return map;
+}
+
+export default async function PersonPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const cookieLang = (await cookies()).get("NEXT_LOCALE")?.value;
+  const headerLang = (await headers())
+    .get("accept-language")
+    ?.split(",")[0]
+    ?.split("-")[0];
+  const lang: LocaleCode = isSupportedLocale(cookieLang)
+    ? cookieLang
+    : isSupportedLocale(headerLang)
+    ? headerLang
+    : DEFAULT_LOCALE;
+  const t = createTranslator(lang);
+
+  const [contributor, feed] = await Promise.all([
+    fetchContributor(id),
+    fetchFeed(id, lang),
+  ]);
+
+  const items = feed?.items || [];
+  const voices = items.filter((it) => it.reason === "i_voiced");
+  const warmth = items.filter(
+    (it) =>
+      it.reason === "reaction_on_my_voice" ||
+      it.reason === "replied_to_me",
+  );
+
+  // If we know nothing about this contributor — no node, no voices,
+  // no reactions — render a gentle not-found rather than a scary 404.
+  if (!contributor && items.length === 0) {
+    notFound();
+  }
+
+  const name = displayName(contributor, id);
+  const initial = initialFromName(name);
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 sm:px-6 py-10 space-y-6">
+      {/* Greeting */}
+      <Panel variant="warm" className="flex items-start gap-4">
+        <div
+          className="shrink-0 w-14 h-14 rounded-full flex items-center justify-center text-2xl font-light bg-[hsl(var(--primary)/0.2)] text-[hsl(var(--primary))] border border-[hsl(var(--primary)/0.3)]"
+          aria-hidden="true"
+        >
+          {initial}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
+            {t("people.eyebrow")}
+          </p>
+          <h1 className="text-2xl md:text-3xl font-light tracking-tight text-foreground">
+            {name}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1.5">
+            {t("people.tagline")
+              .replace("{voices}", String(voices.length))
+              .replace("{warmth}", String(warmth.length))}
+          </p>
+        </div>
+      </Panel>
+
+      {/* Voices she's given — her garden */}
+      {voices.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-sm uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] px-1">
+            {t("people.voicesHeading")}
+          </h2>
+          <ul className="space-y-3">
+            {voices.map((v, i) => (
+              <li key={`${v.entity_id}-${v.created_at}-${i}`}>
+                <Panel variant="neutral">
+                  <VoiceQuote
+                    attribution={
+                      <Link
+                        href={`/vision/${encodeURIComponent(v.entity_id)}`}
+                        className="text-[hsl(var(--chart-2))] hover:opacity-80 underline-offset-4 hover:underline"
+                      >
+                        {v.entity_id.replace(/^lc-/, "")} ·{" "}
+                        {v.created_at
+                          ? new Date(v.created_at).toLocaleDateString(lang)
+                          : ""}
+                      </Link>
+                    }
+                  >
+                    {v.snippet}
+                  </VoiceQuote>
+                </Panel>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Warmth received */}
+      {warmth.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-sm uppercase tracking-[0.18em] font-semibold text-[hsl(var(--chart-2))] px-1">
+            {t("people.warmthHeading")}
+          </h2>
+          <Panel variant="cool">
+            <ul className="space-y-2">
+              {warmth.map((w, i) => {
+                const emoji =
+                  w.snippet && w.snippet.length <= 6 ? w.snippet : null;
+                return (
+                  <li
+                    key={`${w.entity_id}-${w.created_at}-${i}`}
+                    className="flex items-start gap-2"
+                  >
+                    {emoji ? (
+                      <span className="text-lg leading-none mt-0.5" aria-hidden="true">
+                        {emoji}
+                      </span>
+                    ) : null}
+                    <span className="text-sm text-foreground/90">
+                      <span className="font-medium">
+                        {w.actor_name || t("people.someone")}
+                      </span>{" "}
+                      <span className="text-muted-foreground">
+                        {w.reason === "replied_to_me"
+                          ? t("people.replied")
+                          : t("people.reacted")}
+                      </span>
+                      {!emoji && w.snippet && (
+                        <span className="block italic text-muted-foreground mt-0.5">
+                          “{w.snippet}”
+                        </span>
+                      )}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </Panel>
+        </section>
+      )}
+
+      {/* Empty state when there's nothing yet */}
+      {voices.length === 0 && warmth.length === 0 && (
+        <Panel variant="empty" heading={t("people.emptyHeading")}>
+          <p>{t("people.emptyLede")}</p>
+        </Panel>
+      )}
+
+      {/* Quiet doorway */}
+      <div className="pt-2">
+        <Link
+          href="/vision"
+          className="inline-flex items-center gap-1 text-sm font-medium text-[hsl(var(--chart-2))] hover:opacity-80"
+        >
+          {t("people.backToVision")} →
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
+++ b/web/app/vision/[conceptId]/_components/ConceptVoices.tsx
@@ -20,6 +20,7 @@ interface Voice {
   id: string;
   concept_id: string;
   author_name: string;
+  author_id: string | null;
   locale: string;
   body: string;
   location: string | null;
@@ -159,7 +160,16 @@ export function ConceptVoices({ conceptId }: Props) {
             >
               <p className="text-stone-200 leading-relaxed whitespace-pre-wrap">{v.body}</p>
               <p className="text-xs text-stone-500 mt-3 flex flex-wrap gap-x-3 gap-y-1">
-                <span className="text-amber-300/80">{v.author_name}</span>
+                {v.author_id ? (
+                  <Link
+                    href={`/people/${encodeURIComponent(v.author_id)}`}
+                    className="text-amber-300/90 hover:text-amber-200 underline-offset-4 hover:underline transition-colors"
+                  >
+                    {v.author_name}
+                  </Link>
+                ) : (
+                  <span className="text-amber-300/80">{v.author_name}</span>
+                )}
                 {v.location && <span>· {v.location}</span>}
                 {v.created_at && (
                   <time dateTime={v.created_at}>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -236,6 +236,18 @@
     "welcomeBackNamed": "{name}, schön dass du wieder da bist. Hier ist, was für dich geschieht.",
     "dismiss": "Schließen"
   },
+  "people": {
+    "eyebrow": "Eine Ecke des Organismus",
+    "tagline": "{voices} Stimmen gegeben · {warmth} Herzen empfangen",
+    "voicesHeading": "Stimmen, die sie gegeben hat",
+    "warmthHeading": "Wärme, die zu ihr fand",
+    "someone": "Jemand",
+    "reacted": "hat das auf ihre Stimme gelegt.",
+    "replied": "hat geantwortet:",
+    "emptyHeading": "Ein Name, dessen Garten noch wartet.",
+    "emptyLede": "Sie hat eine Mitwirkenden-ID, aber noch nicht gesprochen oder Reaktionen empfangen. Ihre Ecke wartet.",
+    "backToVision": "Die Vision begehen"
+  },
   "morningNudge": {
     "ariaLabel": "Morgen-Rückblick",
     "eyebrow": "Guten Morgen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -236,6 +236,18 @@
     "welcomeBackNamed": "{name}, welcome back. Here's what's stirring for you.",
     "dismiss": "Dismiss"
   },
+  "people": {
+    "eyebrow": "A corner of the organism",
+    "tagline": "{voices} voices given · {warmth} hearts received",
+    "voicesHeading": "Voices she has given",
+    "warmthHeading": "Warmth that found her",
+    "someone": "Someone",
+    "reacted": "laid this on her voice.",
+    "replied": "replied:",
+    "emptyHeading": "A name without its garden yet.",
+    "emptyLede": "She has a contributor id but hasn't voiced or been reacted to yet. Her corner is waiting.",
+    "backToVision": "Walk the vision"
+  },
   "morningNudge": {
     "ariaLabel": "Morning catch-up",
     "eyebrow": "Good morning",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -236,6 +236,18 @@
     "welcomeBackNamed": "{name}, qué bueno volver a verte. Esto es lo que se mueve para ti.",
     "dismiss": "Cerrar"
   },
+  "people": {
+    "eyebrow": "Un rincón del organismo",
+    "tagline": "{voices} voces dadas · {warmth} corazones recibidos",
+    "voicesHeading": "Voces que ella ha dado",
+    "warmthHeading": "Calor que la encontró",
+    "someone": "Alguien",
+    "reacted": "puso esto sobre su voz.",
+    "replied": "respondió:",
+    "emptyHeading": "Un nombre cuyo jardín aún espera.",
+    "emptyLede": "Tiene un id de contribuyente pero aún no ha hablado ni ha recibido reacciones. Su rincón espera.",
+    "backToVision": "Caminar la visión"
+  },
   "morningNudge": {
     "ariaLabel": "Resumen de la mañana",
     "eyebrow": "Buenos días",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -236,6 +236,18 @@
     "welcomeBackNamed": "{name}, senang melihatmu kembali. Inilah yang hidup untukmu.",
     "dismiss": "Tutup"
   },
+  "people": {
+    "eyebrow": "Sudut dari organisme",
+    "tagline": "{voices} suara diberikan · {warmth} hati diterima",
+    "voicesHeading": "Suara yang ia berikan",
+    "warmthHeading": "Kehangatan yang menemukannya",
+    "someone": "Seseorang",
+    "reacted": "meletakkan ini pada suaranya.",
+    "replied": "membalas:",
+    "emptyHeading": "Nama yang tamannya masih menunggu.",
+    "emptyLede": "Ia memiliki id penyumbang tetapi belum bersuara atau menerima reaksi. Sudutnya menunggu.",
+    "backToVision": "Jelajahi visi"
+  },
   "morningNudge": {
     "ariaLabel": "Rangkuman pagi",
     "eyebrow": "Selamat pagi",


### PR DESCRIPTION
## Summary
- New /people/[id] route — a public garden view for every contributor: avatar initial, name, voices she's given, warmth that found her, quiet doorway back
- Voice attribution names on concept pages now link to /people/{author_id} when the voice has one (every post-Cycle-O voice does)
- Four locales for the new people section
- Uses Panel + VoiceQuote primitives so it shares the visual language of the rest of the arc

## Why
"When the community starts to form, people want to know who is this person who said such a beautiful thing." This turns every voice attribution into a doorway to the person — not a technical profile, a warm corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)