### PR TITLE
Cycle S: invite-chain lineage persisted server-side

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -923,6 +923,10 @@ class ConceptVoiceIn(BaseModel):
     # Short opaque client-supplied token so two visitors sharing a
     # display name get distinct contributor_ids during auto-graduation.
     device_fingerprint: str | None = None
+    # Chain lineage: the contributor_id of whoever invited this
+    # person here. Recorded on the new contributor node at
+    # auto-graduation so the invite chain is queryable in the graph.
+    invited_by: str | None = None
 
 
 @router.post(
@@ -939,6 +943,9 @@ async def add_concept_voice(concept_id: str, body: ConceptVoiceIn, request: Requ
     and returns ``author_id`` in the response. The web client writes it back
     to ``cc-contributor-id`` so the visitor is now a real contributor in
     every subsequent surface — no signup screen involved.
+
+    When ``invited_by`` is present, the chain lineage is recorded on the
+    new contributor node so the invite graph is preserved server-side.
     """
     if not concept_service.get_concept(concept_id):
         raise HTTPException(
@@ -954,6 +961,7 @@ async def add_concept_voice(concept_id: str, body: ConceptVoiceIn, request: Requ
             author_id=body.author_id,
             location=body.location,
             device_fingerprint=body.device_fingerprint,
+            invited_by=body.invited_by,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -4,13 +4,88 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
 
 from app.models.contributor import Contributor, ContributorCreate
 from app.models.error import ErrorDetail
 from app.models.pagination import PaginatedResponse
-from app.services import graph_service
+from app.services import graph_service, contributor_service
 
 router = APIRouter()
+
+
+class GraduateIn(BaseModel):
+    """Soft-identity graduation request.
+
+    A visitor who wants to invite/react/voice can graduate to a real
+    contributor node without a signup form — just a display name + a
+    per-device fingerprint. No email, no password, no public key. The
+    same frequency as the voice-posting auto-graduation in
+    concept_voice_service.
+    """
+    author_name: str
+    device_fingerprint: str | None = None
+    invited_by: str | None = None
+
+
+class GraduateOut(BaseModel):
+    contributor_id: str
+    created: bool
+    invited_by: str | None = None
+
+
+@router.post(
+    "/contributors/graduate",
+    response_model=GraduateOut,
+    summary="Soft-identity graduation — mint a contributor node from name + fingerprint",
+)
+def graduate_contributor(body: GraduateIn) -> GraduateOut:
+    """Create (or return) a contributor node keyed by name + fingerprint.
+
+    Idempotent: calling twice with the same name+fingerprint returns
+    the existing node. When ``invited_by`` is supplied and the
+    contributor is new, we record the invite-chain link on the
+    contributor's graph properties so the lineage is preserved in the
+    database, not just the inviter's localStorage.
+    """
+    name = (body.author_name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="author_name is required")
+    fp = (body.device_fingerprint or uuid4().hex[:8]).strip()[:24]
+    safe_name = "".join(c for c in name.lower() if c.isalnum() or c in "-_") or "friend"
+    safe_fp = "".join(c for c in fp.lower() if c.isalnum() or c in "-_") or uuid4().hex[:8]
+    candidate_id = f"{safe_name}-{safe_fp}"[:64]
+
+    existing = graph_service.get_node(f"contributor:{candidate_id}")
+    if existing:
+        return GraduateOut(
+            contributor_id=candidate_id,
+            created=False,
+            invited_by=(existing.get("invited_by") if isinstance(existing, dict) else None) or None,
+        )
+
+    # Create, and record invited_by attribution on the properties so the
+    # chain is queryable server-side.
+    invited_by = (body.invited_by or "").strip() or None
+    node_id = f"contributor:{candidate_id}"
+    graph_service.create_node(
+        id=node_id,
+        type="contributor",
+        name=candidate_id,
+        description="HUMAN contributor",
+        phase="water",
+        properties={
+            "contributor_type": "HUMAN",
+            "email": f"{candidate_id}@coherence.network",
+            "author_display_name": name,
+            "invited_by": invited_by,
+        },
+    )
+    return GraduateOut(
+        contributor_id=candidate_id,
+        created=True,
+        invited_by=invited_by,
+    )
 
 
 def _node_to_contributor(node: dict) -> Contributor:

--- a/api/app/services/concept_voice_service.py
+++ b/api/app/services/concept_voice_service.py
@@ -122,6 +122,7 @@ def add_voice(
     author_id: Optional[str] = None,
     location: Optional[str] = None,
     device_fingerprint: Optional[str] = None,
+    invited_by: Optional[str] = None,
 ) -> dict:
     """Record a lived-experience voice on a concept.
 
@@ -138,6 +139,11 @@ def add_voice(
     the client that lets us disambiguate two contributors who share
     a display name (e.g. two "Mama"s on different devices). When
     absent we fall back to a random uuid suffix.
+
+    ``invited_by`` records the chain of who brought this person in.
+    When a new contributor node is minted during auto-graduation,
+    the inviter's contributor_id is attached as a graph property so
+    the lineage is queryable server-side, not only in localStorage.
     """
     _ensure_schema()
     if not concept_id or not body.strip() or not author_name.strip():
@@ -149,22 +155,35 @@ def add_voice(
     # otherwise mint a fresh contributor node.
     if not author_id:
         try:
-            from app.services import contributor_service
             from app.services import graph_service
 
             suffix = (device_fingerprint or uuid4().hex[:8]).strip()[:24]
             safe_name = "".join(c for c in trimmed_name.lower() if c.isalnum() or c in "-_") or "friend"
             safe_suffix = "".join(c for c in suffix.lower() if c.isalnum() or c in "-_") or uuid4().hex[:8]
             candidate_id = f"{safe_name}-{safe_suffix}"[:64]
-            existing = graph_service.get_node(f"contributor:{candidate_id}")
+            node_id = f"contributor:{candidate_id}"
+            existing = graph_service.get_node(node_id)
             if existing:
                 author_id = existing.get("legacy_id") or candidate_id
             else:
-                node = contributor_service.create_contributor(
+                # Create the node directly so we can attach the
+                # author_display_name + invited_by properties at
+                # birth — those matter for the community-facing
+                # /people page and for chain lineage.
+                graph_service.create_node(
+                    id=node_id,
+                    type="contributor",
                     name=candidate_id,
-                    contributor_type="HUMAN",
+                    description="HUMAN contributor",
+                    phase="water",
+                    properties={
+                        "contributor_type": "HUMAN",
+                        "email": f"{candidate_id}@coherence.network",
+                        "author_display_name": trimmed_name,
+                        "invited_by": (invited_by or "").strip() or None,
+                    },
                 )
-                author_id = node.get("legacy_id") or candidate_id
+                author_id = candidate_id
         except Exception:
             # If contributor creation fails for any reason, the voice
             # still lands with just author_name — soft identity holds.

--- a/web/components/InviteFriend.tsx
+++ b/web/components/InviteFriend.tsx
@@ -28,9 +28,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useT, useLocale } from "@/components/MessagesProvider";
 import { createTranslator } from "@/lib/i18n";
 import { LOCALES, type LocaleCode } from "@/lib/locales";
-
-const NAME_KEY = "cc-reaction-author-name";
-const CONTRIBUTOR_KEY = "cc-contributor-id";
+import { ensureContributorId, NAME_KEY, CONTRIBUTOR_KEY } from "@/lib/identity";
+import { getApiBase } from "@/lib/api";
 
 // Language selection for the invite link.
 // "auto" means "no ?lang= in URL" — let middleware pick from the
@@ -74,12 +73,12 @@ export function InviteFriend({
     }
   }, []);
 
-  function buildUrl(): string {
+  function buildUrlWithId(resolvedInviterId: string): string {
     const base = siteBase();
     const url = new URL(targetPath, base);
     if (inviterName.trim()) url.searchParams.set("from", inviterName.trim());
     if (recipientName.trim()) url.searchParams.set("name", recipientName.trim().slice(0, 80));
-    if (inviterId.trim()) url.searchParams.set("invited_by", inviterId.trim());
+    if (resolvedInviterId.trim()) url.searchParams.set("invited_by", resolvedInviterId.trim());
     // Language policy:
     //   "auto" (default) — no ?lang= in URL. The middleware honors
     //     the recipient's browser Accept-Language on first paint.
@@ -102,7 +101,23 @@ export function InviteFriend({
   const tShare = useMemo(() => createTranslator(shareLang), [shareLang]);
 
   async function onInvite() {
-    const url = buildUrl();
+    // Before building the URL: if the inviter doesn't have a
+    // contributor_id yet, graduate them. An invitation IS an active
+    // gesture — "I'm sending someone here" is reason enough to mint
+    // a node. Without this step, the invite chain would degrade to
+    // display-name matching (not unique) and the lineage would be
+    // lost in the graph.
+    let activeInviterId = inviterId;
+    if (!activeInviterId && inviterName.trim()) {
+      try {
+        const minted = await ensureContributorId(getApiBase());
+        if (minted) {
+          activeInviterId = minted;
+          setInviterId(minted);
+        }
+      } catch { /* best-effort */ }
+    }
+    const url = buildUrlWithId(activeInviterId);
     const rName = recipientName.trim();
     const iName = inviterName.trim();
     // Pick the warmest localized line we have — in the recipient's language

--- a/web/components/MeetingSurface.tsx
+++ b/web/components/MeetingSurface.tsx
@@ -204,6 +204,14 @@ export function MeetingSurface({
       setAuthorName(name);
       const base = getApiBase();
       const fingerprint = ensureFingerprint();
+      // Chain lineage: if this viewer came through an invite link,
+      // ``cc-invited-by`` holds the inviter's contributor_id. Forward
+      // it so the server records the invite chain on the new
+      // contributor node at auto-graduation time.
+      let invitedBy = "";
+      try {
+        invitedBy = localStorage.getItem("cc-invited-by") || "";
+      } catch { /* ignore */ }
       // For concepts, store as a voice (richer shape + ripens into proposals
       // later). For any other entity, store as a reaction with a comment.
       //
@@ -223,6 +231,7 @@ export function MeetingSurface({
             locale,
             author_id: contributorId,
             device_fingerprint: fingerprint,
+            invited_by: invitedBy || undefined,
           }),
         });
         try {

--- a/web/lib/identity.ts
+++ b/web/lib/identity.ts
@@ -1,0 +1,102 @@
+/**
+ * Soft-identity helpers shared across client surfaces.
+ *
+ * The Coherence Network uses three localStorage keys to hold a
+ * visitor's presence:
+ *
+ *   · cc-reaction-author-name   — her human display name
+ *   · cc-contributor-id         — the slug-id of her contributor
+ *                                 graph node (once graduated)
+ *   · cc-presence-fingerprint   — a short opaque per-device
+ *                                 token so two visitors sharing a
+ *                                 display name land on distinct
+ *                                 contributor nodes
+ *   · cc-invited-by             — the contributor_id of whoever
+ *                                 invited her, if any — the root
+ *                                 of her invite chain
+ *
+ * Every write into these keys runs through this module so the
+ * surfaces stay consistent.
+ */
+
+export const NAME_KEY = "cc-reaction-author-name";
+export const CONTRIBUTOR_KEY = "cc-contributor-id";
+export const FINGERPRINT_KEY = "cc-presence-fingerprint";
+export const INVITED_BY_KEY = "cc-invited-by";
+
+export function ensureFingerprint(): string {
+  try {
+    const existing = localStorage.getItem(FINGERPRINT_KEY);
+    if (existing) return existing;
+    const fresh = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    localStorage.setItem(FINGERPRINT_KEY, fresh);
+    return fresh;
+  } catch {
+    return `anon-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
+
+export function readIdentity(): {
+  name: string;
+  contributorId: string;
+  fingerprint: string;
+  invitedBy: string;
+} {
+  let name = "";
+  let contributorId = "";
+  let invitedBy = "";
+  try {
+    name = localStorage.getItem(NAME_KEY) || "";
+    contributorId = localStorage.getItem(CONTRIBUTOR_KEY) || "";
+    invitedBy = localStorage.getItem(INVITED_BY_KEY) || "";
+  } catch {
+    /* ignore */
+  }
+  const fingerprint = ensureFingerprint();
+  return { name, contributorId, fingerprint, invitedBy };
+}
+
+/**
+ * Ensure the caller has a real contributor_id. When they already
+ * have one, returns it unchanged. When they don't, calls the
+ * graduate endpoint with their name + device fingerprint and
+ * persists the returned id. Idempotent — safe to call repeatedly.
+ *
+ * The graduate endpoint is intentionally lightweight: no email,
+ * no password, no public key. A contributor by caring enough to
+ * share something — the same frequency as the voice-posting
+ * auto-graduation.
+ */
+export async function ensureContributorId(
+  apiBase: string,
+): Promise<string | null> {
+  const { name, contributorId, fingerprint, invitedBy } = readIdentity();
+  if (contributorId) return contributorId;
+  if (!name.trim()) return null;
+  try {
+    const body: Record<string, string> = {
+      author_name: name.trim(),
+      device_fingerprint: fingerprint,
+    };
+    if (invitedBy.trim()) body.invited_by = invitedBy.trim();
+    const res = await fetch(`${apiBase}/api/contributors/graduate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const id: string = data.contributor_id;
+    if (id) {
+      try {
+        localStorage.setItem(CONTRIBUTOR_KEY, id);
+      } catch {
+        /* ignore */
+      }
+      return id;
+    }
+  } catch {
+    /* transient */
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- New POST /api/contributors/graduate — lightweight soft-identity graduation (name + fingerprint + optional invited_by). Idempotent.
- New web/lib/identity.ts — shared localStorage helpers incl. ensureContributorId that calls graduate when needed
- InviteFriend calls ensureContributorId before building the URL, so the inviter is a real contributor by the time they share
- MeetingSurface voice POST forwards invited_by from cc-invited-by; server records it on the new contributor node's graph properties
- concept_voice_service.add_voice accepts invited_by and attaches it at node creation

## Why
"I will meet a friend soon — can you make sure the invite and share functionality works with tracking and registration so that when he invites new friends or comments it will be tracked already and we are not losing any information?"

Before this change: if the inviter had no contributor_id yet, invite URLs were missing ?invited_by=<id> and the lineage degraded to non-unique display-name matching. Also: invited_by was only kept in the invitee's localStorage — a cleared browser wiped it.

After: every invite URL carries a real contributor id, every first-voice mints a contributor with the chain lineage baked into the graph node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)