### PR TITLE
Cycle U: remove /people count tagline — specifics below are the real reflection

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -182,11 +182,11 @@ export default async function PersonPage({
           <h1 className="text-2xl md:text-3xl font-light tracking-tight text-foreground">
             {name}
           </h1>
-          <p className="text-sm text-muted-foreground mt-1.5">
-            {t("people.tagline")
-              .replace("{voices}", String(voices.length))
-              .replace("{warmth}", String(warmth.length))}
-          </p>
+          {/* No tagline. The sections below carry the substance —
+              her actual voices, the actual warmth she has received.
+              A one-line summary at the top would be scorekeeping
+              translated into template sentences; the specifics below
+              are the only honest reflection of who she is. */}
         </div>
       </Panel>
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -238,7 +238,6 @@
   },
   "people": {
     "eyebrow": "Eine Ecke des Organismus",
-    "tagline": "{voices} Stimmen gegeben · {warmth} Herzen empfangen",
     "voicesHeading": "Stimmen, die sie gegeben hat",
     "warmthHeading": "Wärme, die zu ihr fand",
     "someone": "Jemand",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -238,7 +238,6 @@
   },
   "people": {
     "eyebrow": "A corner of the organism",
-    "tagline": "{voices} voices given · {warmth} hearts received",
     "voicesHeading": "Voices she has given",
     "warmthHeading": "Warmth that found her",
     "someone": "Someone",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -238,7 +238,6 @@
   },
   "people": {
     "eyebrow": "Un rincón del organismo",
-    "tagline": "{voices} voces dadas · {warmth} corazones recibidos",
     "voicesHeading": "Voces que ella ha dado",
     "warmthHeading": "Calor que la encontró",
     "someone": "Alguien",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -238,7 +238,6 @@
   },
   "people": {
     "eyebrow": "Sudut dari organisme",
-    "tagline": "{voices} suara diberikan · {warmth} hati diterima",
     "voicesHeading": "Suara yang ia berikan",
     "warmthHeading": "Kehangatan yang menemukannya",
     "someone": "Seseorang",


### PR DESCRIPTION
## Summary
- Removed the count-based "{voices} voices · {warmth} hearts" tagline on /people
- No phrase-bucket replacement: the sections below (her voices, warmth she received) already ARE the reflection; summarizing them on one line was scorekeeping dressed up

## Why
A tally translated into a lookup of hand-written phrases is still the system tracking thresholds. The organism speaks through the lived specifics — her actual sentences, the actual hearts laid on them — not through a cardinality summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)