### PR TITLE
Cycle V: push notifications on by default, toggle off anytime

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -76,6 +76,7 @@ from app.routers import onboarding as onboarding_router
 from app.routers import openclaw_node_bridge
 from app.routers import pipeline
 from app.routers import pipeline_policies
+from app.routers import push as push_router
 from app.routers import ui_preferences as ui_preferences_router
 from app.routers import memberships as memberships_router
 from app.routers import activity as activity_router
@@ -716,6 +717,7 @@ app.include_router(treasury.router, prefix="/api", tags=["treasury"])
 app.include_router(provider_stats.router)
 app.include_router(pipeline.router, prefix="/api", tags=["pipeline"])
 app.include_router(pipeline_policies.router, prefix="/api", tags=["pipeline"])
+app.include_router(push_router.router, prefix="/api", tags=["push"])
 app.include_router(service_registry_router.router, prefix="/api", tags=["services"])
 app.include_router(cc_economics_router.router, prefix="/api", tags=["cc-economics"])
 app.include_router(cc_exchange_router.router, prefix="/api", tags=["cc-exchange"])

--- a/api/app/routers/push.py
+++ b/api/app/routers/push.py
@@ -72,6 +72,23 @@ async def subscribe(body: SubscriptionIn) -> dict:
     return {"ok": True, "subscription_id": rec["id"]}
 
 
+class UnsubscribeIn(BaseModel):
+    endpoint: str = Field(..., description="The browser's PushSubscription.endpoint URL")
+
+
+@router.post(
+    "/push/unsubscribe",
+    summary="Forget a browser's push subscription (called when the user toggles off)",
+)
+async def unsubscribe(body: UnsubscribeIn) -> dict:
+    """Remove the subscription for the given endpoint. Idempotent —
+    returns ok even if the row was already gone, since the user's
+    intent ("don't push me") doesn't depend on the row's current state.
+    """
+    removed = push_svc.remove_subscription(endpoint=body.endpoint)
+    return {"ok": True, "removed": removed}
+
+
 @router.post(
     "/push/send",
     summary="Trigger a push to a contributor or device (admin-only)",

--- a/api/app/routers/push.py
+++ b/api/app/routers/push.py
@@ -1,0 +1,100 @@
+"""Web Push router — subscribe, unsubscribe, send.
+
+Three endpoints:
+  · GET  /api/push/vapid-public-key  — the browser needs this to subscribe
+  · POST /api/push/subscribe         — browser registers after subscribe()
+  · POST /api/push/send              — admin-only, triggers a push
+
+The send endpoint uses the existing API-key auth so only authorized
+callers can fire pushes to a specific contributor.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.middleware.auth import require_api_key
+from app.services import push_subscription_service as push_svc
+
+router = APIRouter()
+
+
+class SubscriptionIn(BaseModel):
+    """Matches the shape the browser's PushManager returns, plus
+    optional identity hooks so the server can route pushes to a
+    specific contributor or device."""
+    subscription: dict = Field(..., description="The browser PushSubscription.toJSON() payload")
+    contributor_id: str | None = None
+    fingerprint: str | None = None
+    user_agent: str | None = None
+    locale: str | None = None
+
+
+class SendIn(BaseModel):
+    contributor_id: str | None = None
+    fingerprint: str | None = None
+    title: str
+    body: str
+    url: str = "/feed/you"
+    icon: str = "/icon.svg"
+
+
+@router.get(
+    "/push/vapid-public-key",
+    summary="Return the VAPID public key the browser needs to subscribe",
+)
+async def get_vapid_public_key() -> dict:
+    key = push_svc.vapid_public_key()
+    if not key:
+        raise HTTPException(
+            status_code=503,
+            detail="Push notifications are not configured on this server",
+        )
+    return {"public_key": key, "configured": True}
+
+
+@router.post(
+    "/push/subscribe",
+    status_code=201,
+    summary="Register a browser's push subscription",
+)
+async def subscribe(body: SubscriptionIn) -> dict:
+    try:
+        rec = push_svc.upsert_subscription(
+            subscription=body.subscription,
+            contributor_id=body.contributor_id,
+            fingerprint=body.fingerprint,
+            user_agent=body.user_agent,
+            locale=body.locale,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"ok": True, "subscription_id": rec["id"]}
+
+
+@router.post(
+    "/push/send",
+    summary="Trigger a push to a contributor or device (admin-only)",
+)
+async def send(body: SendIn, _key: str = Depends(require_api_key)) -> dict:
+    if not body.contributor_id and not body.fingerprint:
+        raise HTTPException(
+            status_code=400,
+            detail="Must specify contributor_id or fingerprint",
+        )
+    if not push_svc.is_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Push notifications are not configured on this server",
+        )
+    try:
+        return push_svc.send_push(
+            contributor_id=body.contributor_id,
+            fingerprint=body.fingerprint,
+            title=body.title,
+            body=body.body,
+            url=body.url,
+            icon=body.icon,
+        )
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))

--- a/api/app/services/push_subscription_service.py
+++ b/api/app/services/push_subscription_service.py
@@ -1,0 +1,279 @@
+"""Web Push subscription storage + send.
+
+Flow:
+  1. Client calls /api/push/vapid-public-key → gets the public key
+  2. Client registers a service worker, calls pushManager.subscribe() with
+     the VAPID public key, sends the resulting PushSubscription JSON +
+     its contributor_id (or fingerprint) to /api/push/subscribe
+  3. Server stores the subscription in push_subscriptions table
+  4. Server can send a push via send_push(contributor_id, body)
+
+VAPID keys live in ~/.coherence-network/keys.json or env vars so the
+private key is never in git.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from pywebpush import WebPushException, webpush
+from sqlalchemy import DateTime, String, Text, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.services import unified_db as _udb
+from app.services.unified_db import Base
+
+log = logging.getLogger("coherence.push")
+
+
+class PushSubscriptionRecord(Base):
+    """One browser's push subscription, tied loosely to a contributor.
+
+    The subscription JSON contains endpoint + keys (p256dh, auth) that
+    the browser generates; we store it verbatim and replay it when we
+    want to send a push.
+    """
+
+    __tablename__ = "push_subscriptions"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    contributor_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    fingerprint: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    # The endpoint URL doubles as a natural uniqueness key — the browser
+    # returns the same endpoint for a given subscription until it is
+    # rotated or revoked.
+    endpoint: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    subscription_json: Mapped[str] = mapped_column(Text, nullable=False)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
+    locale: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+
+
+def _session():
+    return _udb.session()
+
+
+def _ensure_schema() -> None:
+    _udb.engine()
+
+
+# ---------------------------------------------------------------------------
+# VAPID key loading
+# ---------------------------------------------------------------------------
+
+_VAPID_CACHE: dict[str, str] | None = None
+
+
+def _load_vapid() -> dict[str, str]:
+    """Load VAPID keys from config. Prefer mounted keystore, fall back to
+    env vars. Returns {'public': <base64url>, 'private': <PEM>, 'subject': <mailto>}.
+
+    Never logs the private key. Returns an empty dict if keys aren't set
+    so push endpoints can respond with a clear "not configured" error
+    rather than a traceback.
+    """
+    global _VAPID_CACHE
+    if _VAPID_CACHE is not None:
+        return _VAPID_CACHE
+
+    keys: dict[str, str] = {}
+    keystore_path = Path.home() / ".coherence-network" / "keys.json"
+    if keystore_path.exists():
+        try:
+            data = json.loads(keystore_path.read_text())
+            vp = data.get("vapid") or {}
+            if isinstance(vp, dict):
+                if vp.get("public"):
+                    keys["public"] = vp["public"]
+                if vp.get("private"):
+                    keys["private"] = vp["private"]
+                if vp.get("subject"):
+                    keys["subject"] = vp["subject"]
+        except Exception as e:
+            log.warning("vapid: keystore read failed: %s", type(e).__name__)
+
+    # Env-var overrides (allow the VPS to inject via docker compose)
+    if os.environ.get("VAPID_PUBLIC_KEY"):
+        keys["public"] = os.environ["VAPID_PUBLIC_KEY"]
+    if os.environ.get("VAPID_PRIVATE_KEY"):
+        # Accept either a PEM (with \n literals) or a path to a PEM file
+        val = os.environ["VAPID_PRIVATE_KEY"]
+        if val.strip().startswith("-----BEGIN"):
+            keys["private"] = val.replace("\\n", "\n")
+        elif Path(val).exists():
+            try:
+                keys["private"] = Path(val).read_text()
+            except Exception:
+                pass
+    if os.environ.get("VAPID_SUBJECT"):
+        keys["subject"] = os.environ["VAPID_SUBJECT"]
+
+    if "subject" not in keys:
+        keys["subject"] = "mailto:push@coherencycoin.com"
+
+    _VAPID_CACHE = keys
+    return keys
+
+
+def vapid_public_key() -> str | None:
+    """Safe to expose to clients — the browser needs this to subscribe."""
+    return _load_vapid().get("public")
+
+
+def is_configured() -> bool:
+    keys = _load_vapid()
+    return bool(keys.get("public") and keys.get("private"))
+
+
+# ---------------------------------------------------------------------------
+# Subscription storage
+# ---------------------------------------------------------------------------
+
+
+def upsert_subscription(
+    *,
+    subscription: dict,
+    contributor_id: Optional[str] = None,
+    fingerprint: Optional[str] = None,
+    user_agent: Optional[str] = None,
+    locale: Optional[str] = None,
+) -> dict:
+    """Store (or refresh) a browser's push subscription."""
+    _ensure_schema()
+    endpoint = (subscription or {}).get("endpoint")
+    if not endpoint:
+        raise ValueError("subscription.endpoint is required")
+    payload = json.dumps(subscription)
+    with _session() as s:
+        existing = s.execute(
+            select(PushSubscriptionRecord).where(PushSubscriptionRecord.endpoint == endpoint)
+        ).scalar_one_or_none()
+        if existing:
+            existing.subscription_json = payload
+            existing.contributor_id = contributor_id or existing.contributor_id
+            existing.fingerprint = fingerprint or existing.fingerprint
+            existing.user_agent = user_agent or existing.user_agent
+            existing.locale = locale or existing.locale
+            s.commit()
+            s.refresh(existing)
+            return _to_dict(existing)
+        rec = PushSubscriptionRecord(
+            id=uuid4().hex,
+            contributor_id=contributor_id,
+            fingerprint=fingerprint,
+            endpoint=endpoint,
+            subscription_json=payload,
+            user_agent=user_agent,
+            locale=locale,
+        )
+        s.add(rec)
+        s.commit()
+        s.refresh(rec)
+        return _to_dict(rec)
+
+
+def _to_dict(rec: PushSubscriptionRecord) -> dict:
+    return {
+        "id": rec.id,
+        "contributor_id": rec.contributor_id,
+        "fingerprint": rec.fingerprint,
+        "endpoint": rec.endpoint,
+        "created_at": rec.created_at.isoformat() if rec.created_at else None,
+        "locale": rec.locale,
+    }
+
+
+def subscriptions_for(
+    contributor_id: Optional[str] = None,
+    fingerprint: Optional[str] = None,
+) -> list[dict]:
+    _ensure_schema()
+    with _session() as s:
+        q = select(PushSubscriptionRecord)
+        if contributor_id:
+            q = q.where(PushSubscriptionRecord.contributor_id == contributor_id)
+        elif fingerprint:
+            q = q.where(PushSubscriptionRecord.fingerprint == fingerprint)
+        else:
+            return []
+        rows = s.execute(q).scalars().all()
+    return [
+        {**_to_dict(r), "subscription_json": r.subscription_json} for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Send a push
+# ---------------------------------------------------------------------------
+
+
+def send_push(
+    *,
+    contributor_id: Optional[str] = None,
+    fingerprint: Optional[str] = None,
+    title: str,
+    body: str,
+    url: str = "/feed/you",
+    icon: str = "/icon.svg",
+) -> dict:
+    """Send a push to every subscription matching the selector.
+
+    Returns {sent, failed, endpoints_removed} — any 404/410 endpoint is
+    treated as a rotated subscription and pruned.
+    """
+    keys = _load_vapid()
+    if not (keys.get("public") and keys.get("private")):
+        raise RuntimeError("VAPID keys not configured")
+
+    subs = subscriptions_for(contributor_id=contributor_id, fingerprint=fingerprint)
+    if not subs:
+        return {"sent": 0, "failed": 0, "endpoints_removed": 0, "note": "no subscriptions"}
+
+    sent = 0
+    failed = 0
+    removed = 0
+    payload = json.dumps({"title": title, "body": body, "url": url, "icon": icon})
+
+    for s in subs:
+        try:
+            webpush(
+                subscription_info=json.loads(s["subscription_json"]),
+                data=payload,
+                vapid_private_key=keys["private"],
+                vapid_claims={"sub": keys["subject"]},
+            )
+            sent += 1
+        except WebPushException as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status in (404, 410):
+                # Subscription is gone — drop it
+                _ensure_schema()
+                with _session() as db:
+                    rec = db.execute(
+                        select(PushSubscriptionRecord).where(
+                            PushSubscriptionRecord.endpoint == s["endpoint"]
+                        )
+                    ).scalar_one_or_none()
+                    if rec:
+                        db.delete(rec)
+                        db.commit()
+                        removed += 1
+            else:
+                log.warning("push send failed: status=%s type=%s", status, type(e).__name__)
+                failed += 1
+        except Exception as e:
+            log.warning("push send failed: %s", type(e).__name__)
+            failed += 1
+
+    return {"sent": sent, "failed": failed, "endpoints_removed": removed}

--- a/api/app/services/push_subscription_service.py
+++ b/api/app/services/push_subscription_service.py
@@ -8,8 +8,11 @@ Flow:
   3. Server stores the subscription in push_subscriptions table
   4. Server can send a push via send_push(contributor_id, body)
 
-VAPID keys live in ~/.coherence-network/keys.json or env vars so the
-private key is never in git.
+VAPID keys live in the mounted deployment config at
+`~/.coherence-network/config.json` under the `vapid` section — so the
+private key is never in git. Env vars (VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY
+/ VAPID_SUBJECT) are accepted as a fallback for local dev, but production
+reads the mounted config file (same place auth keys + DB URL live).
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ from pywebpush import WebPushException, webpush
 from sqlalchemy import DateTime, String, Text, select
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.config_loader import api_config
 from app.services import unified_db as _udb
 from app.services.unified_db import Base
 
@@ -76,38 +80,43 @@ _VAPID_CACHE: dict[str, str] | None = None
 
 
 def _load_vapid() -> dict[str, str]:
-    """Load VAPID keys from config. Prefer mounted keystore, fall back to
-    env vars. Returns {'public': <base64url>, 'private': <PEM>, 'subject': <mailto>}.
+    """Load VAPID keys from the mounted deployment config, with env-var
+    fallback for local dev.
 
-    Never logs the private key. Returns an empty dict if keys aren't set
-    so push endpoints can respond with a clear "not configured" error
-    rather than a traceback.
+    Returns {'public': <base64url>, 'private': <PEM>, 'subject': <mailto>}.
+
+    Never logs the private key. Returns a keys dict without public/private
+    when the server isn't configured, so push endpoints can respond with a
+    clear "not configured" error instead of a traceback.
     """
     global _VAPID_CACHE
     if _VAPID_CACHE is not None:
         return _VAPID_CACHE
 
     keys: dict[str, str] = {}
-    keystore_path = Path.home() / ".coherence-network" / "keys.json"
-    if keystore_path.exists():
-        try:
-            data = json.loads(keystore_path.read_text())
-            vp = data.get("vapid") or {}
-            if isinstance(vp, dict):
-                if vp.get("public"):
-                    keys["public"] = vp["public"]
-                if vp.get("private"):
-                    keys["private"] = vp["private"]
-                if vp.get("subject"):
-                    keys["subject"] = vp["subject"]
-        except Exception as e:
-            log.warning("vapid: keystore read failed: %s", type(e).__name__)
 
-    # Env-var overrides (allow the VPS to inject via docker compose)
-    if os.environ.get("VAPID_PUBLIC_KEY"):
+    # Preferred: mounted config overlay (same place auth + DB live).
+    # config.json shape:
+    #   "vapid": { "public": "...", "private": "-----BEGIN ...", "subject": "mailto:..." }
+    try:
+        cfg_public = api_config("vapid", "public")
+        cfg_private = api_config("vapid", "private")
+        cfg_subject = api_config("vapid", "subject")
+        if cfg_public:
+            keys["public"] = str(cfg_public)
+        if cfg_private:
+            # Tolerate escaped newlines if someone edited the JSON by hand
+            pem = str(cfg_private)
+            keys["private"] = pem.replace("\\n", "\n") if "\\n" in pem else pem
+        if cfg_subject:
+            keys["subject"] = str(cfg_subject)
+    except Exception as e:
+        log.warning("vapid: config read failed: %s", type(e).__name__)
+
+    # Env-var fallback (useful for local dev / test overrides only)
+    if not keys.get("public") and os.environ.get("VAPID_PUBLIC_KEY"):
         keys["public"] = os.environ["VAPID_PUBLIC_KEY"]
-    if os.environ.get("VAPID_PRIVATE_KEY"):
-        # Accept either a PEM (with \n literals) or a path to a PEM file
+    if not keys.get("private") and os.environ.get("VAPID_PRIVATE_KEY"):
         val = os.environ["VAPID_PRIVATE_KEY"]
         if val.strip().startswith("-----BEGIN"):
             keys["private"] = val.replace("\\n", "\n")
@@ -116,7 +125,7 @@ def _load_vapid() -> dict[str, str]:
                 keys["private"] = Path(val).read_text()
             except Exception:
                 pass
-    if os.environ.get("VAPID_SUBJECT"):
+    if not keys.get("subject") and os.environ.get("VAPID_SUBJECT"):
         keys["subject"] = os.environ["VAPID_SUBJECT"]
 
     if "subject" not in keys:

--- a/api/app/services/push_subscription_service.py
+++ b/api/app/services/push_subscription_service.py
@@ -203,6 +203,27 @@ def _to_dict(rec: PushSubscriptionRecord) -> dict:
     }
 
 
+def remove_subscription(*, endpoint: str) -> bool:
+    """Drop a single browser's push subscription by its endpoint.
+
+    Returns True if a row was deleted, False if no match. The endpoint
+    is the natural key the browser also sends to /api/push/subscribe,
+    so the client always knows what to ask the server to forget.
+    """
+    if not endpoint:
+        return False
+    _ensure_schema()
+    with _session() as s:
+        rec = s.execute(
+            select(PushSubscriptionRecord).where(PushSubscriptionRecord.endpoint == endpoint)
+        ).scalar_one_or_none()
+        if not rec:
+            return False
+        s.delete(rec)
+        s.commit()
+        return True
+
+
 def subscriptions_for(
     contributor_id: Optional[str] = None,
     fingerprint: Optional[str] = None,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "PyNaCl>=1.5.0",
     "cryptography>=41.0.0",
     "eth-account>=0.13.0",
+    "pywebpush>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/web/app/feed/you/page.tsx
+++ b/web/app/feed/you/page.tsx
@@ -9,6 +9,7 @@ import { InviteFriend } from "@/components/InviteFriend";
 import { SinceLastVisit } from "@/components/SinceLastVisit";
 import { KinActivity } from "@/components/KinActivity";
 import { MorningNudge } from "@/components/MorningNudge";
+import { EnablePush } from "@/components/EnablePush";
 
 /**
  * /feed/you — your corner of the organism.
@@ -61,6 +62,7 @@ export default async function PersonalFeedPage() {
       <FeedTabs />
       <div className="mb-4 space-y-4">
         <MorningNudge />
+        <EnablePush />
         <SinceLastVisit />
         <KinActivity />
       </div>

--- a/web/components/EnablePush.tsx
+++ b/web/components/EnablePush.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+/**
+ * EnablePush — the small warm affordance that invites a visitor to let
+ * the organism speak back when the app is closed.
+ *
+ * Flow on tap:
+ *   1. Register /sw.js as a service worker
+ *   2. Fetch the VAPID public key from the API
+ *   3. Call pushManager.subscribe() with that key
+ *   4. POST the resulting PushSubscription to /api/push/subscribe
+ *      along with the viewer's contributor_id and fingerprint
+ *   5. Flip to "subscribed" state — future pushes land on her device
+ *
+ * Iron-cast gating: only renders when the browser actually supports
+ * service workers + push. iOS requires the site be added to the home
+ * screen first (PWA install), so on iOS we show a short instruction
+ * instead of a broken button.
+ */
+
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import { useT, useLocale } from "@/components/MessagesProvider";
+import { ensureFingerprint, readIdentity } from "@/lib/identity";
+
+type State =
+  | "loading"        // determining browser support + current state
+  | "unsupported"    // this browser can't do web push
+  | "ios-install"    // iOS Safari: must install PWA first
+  | "ready"          // supported, not yet subscribed
+  | "subscribing"    // in-flight
+  | "subscribed"     // done
+  | "denied"         // user said no to notification permission
+  | "error";
+
+function urlB64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const b64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(b64);
+  const buffer = new ArrayBuffer(raw.length);
+  const out = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+function isIosSafari(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent || "";
+  const iOS = /iPad|iPhone|iPod/.test(ua);
+  const webkit = /WebKit/.test(ua);
+  const notChrome = !/CriOS|FxiOS/.test(ua);
+  return iOS && webkit && notChrome;
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.matchMedia?.("(display-mode: standalone)").matches ||
+    (navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
+export function EnablePush() {
+  const t = useT();
+  const locale = useLocale();
+  const [state, setState] = useState<State>("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (typeof window === "undefined") return;
+        if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+          if (isIosSafari() && !isStandalone()) {
+            setState("ios-install");
+          } else {
+            setState("unsupported");
+          }
+          return;
+        }
+        // On iOS, push only works if the site is installed to home screen
+        if (isIosSafari() && !isStandalone()) {
+          setState("ios-install");
+          return;
+        }
+        const reg = await navigator.serviceWorker.register("/sw.js");
+        const existing = await reg.pushManager.getSubscription();
+        if (existing) {
+          setState("subscribed");
+          return;
+        }
+        if (Notification.permission === "denied") {
+          setState("denied");
+          return;
+        }
+        setState("ready");
+      } catch (e) {
+        setError(String(e));
+        setState("error");
+      }
+    })();
+  }, []);
+
+  async function subscribe() {
+    setState("subscribing");
+    setError(null);
+    try {
+      const base = getApiBase();
+      const keyRes = await fetch(`${base}/api/push/vapid-public-key`);
+      if (!keyRes.ok) {
+        throw new Error(`vapid key endpoint: ${keyRes.status}`);
+      }
+      const { public_key } = await keyRes.json();
+      if (!public_key) throw new Error("no public key");
+
+      const reg = await navigator.serviceWorker.register("/sw.js");
+      await navigator.serviceWorker.ready;
+
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        setState(permission === "denied" ? "denied" : "ready");
+        return;
+      }
+
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlB64ToUint8Array(public_key),
+      });
+
+      const { contributorId, fingerprint } = readIdentity();
+      const fp = fingerprint || ensureFingerprint();
+
+      const subRes = await fetch(`${base}/api/push/subscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subscription: sub.toJSON(),
+          contributor_id: contributorId || undefined,
+          fingerprint: fp,
+          user_agent: navigator.userAgent,
+          locale,
+        }),
+      });
+      if (!subRes.ok) {
+        throw new Error(`subscribe endpoint: ${subRes.status}`);
+      }
+      setState("subscribed");
+    } catch (e) {
+      setError(String(e));
+      setState("error");
+    }
+  }
+
+  if (state === "loading" || state === "unsupported") return null;
+
+  // One small container — warm, present, not insistent.
+  return (
+    <section
+      className="max-w-3xl mx-3 sm:mx-auto mt-3 px-5 py-4 rounded-2xl border border-[hsl(var(--primary)/0.25)] bg-card"
+      aria-label={t("enablePush.ariaLabel")}
+    >
+      <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
+        {t("enablePush.eyebrow")}
+      </p>
+      {state === "ready" && (
+        <>
+          <p className="text-base font-light text-foreground leading-snug mb-3">
+            {t("enablePush.heading")}
+          </p>
+          <p className="text-sm text-muted-foreground leading-relaxed mb-3">
+            {t("enablePush.lede")}
+          </p>
+          <button
+            type="button"
+            onClick={subscribe}
+            className="inline-flex items-center gap-2 rounded-full bg-[hsl(var(--primary))] hover:opacity-90 text-[hsl(var(--primary-foreground))] px-4 py-2 text-sm font-medium transition-opacity"
+          >
+            {t("enablePush.cta")}
+          </button>
+        </>
+      )}
+      {state === "subscribing" && (
+        <p className="text-sm text-muted-foreground">{t("enablePush.subscribing")}</p>
+      )}
+      {state === "subscribed" && (
+        <p className="text-sm text-foreground">
+          <span className="text-lg mr-1.5" aria-hidden="true">✓</span>
+          {t("enablePush.subscribed")}
+        </p>
+      )}
+      {state === "ios-install" && (
+        <>
+          <p className="text-base font-light text-foreground leading-snug mb-2">
+            {t("enablePush.iosHeading")}
+          </p>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {t("enablePush.iosLede")}
+          </p>
+        </>
+      )}
+      {state === "denied" && (
+        <p className="text-sm text-muted-foreground">{t("enablePush.denied")}</p>
+      )}
+      {state === "error" && (
+        <p className="text-sm text-muted-foreground">
+          {t("enablePush.error")}
+          {error && <span className="block mt-1 text-xs opacity-60">{error}</span>}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/web/components/EnablePush.tsx
+++ b/web/components/EnablePush.tsx
@@ -1,36 +1,46 @@
 "use client";
 
 /**
- * EnablePush — the small warm affordance that invites a visitor to let
- * the organism speak back when the app is closed.
+ * EnablePush — a small affordance that frames push notifications as
+ * "on by default, turn them off anytime."
  *
- * Flow on tap:
- *   1. Register /sw.js as a service worker
- *   2. Fetch the VAPID public key from the API
- *   3. Call pushManager.subscribe() with that key
- *   4. POST the resulting PushSubscription to /api/push/subscribe
- *      along with the viewer's contributor_id and fingerprint
- *   5. Flip to "subscribed" state — future pushes land on her device
+ * Default posture is ON, not opt-in. The reasoning:
+ *   · A visitor who reaches /feed/you has already chosen their corner.
+ *     The organism speaking back is part of that corner, not a separate
+ *     consent mechanism.
+ *   · Browsers won't let us auto-prompt for permission (anti-abuse), so
+ *     the first tap still has to confirm. But everything *after* that
+ *     first confirmation stays on without a single follow-up tap, until
+ *     the visitor turns it off.
  *
- * Iron-cast gating: only renders when the browser actually supports
- * service workers + push. iOS requires the site be added to the home
- * screen first (PWA install), so on iOS we show a short instruction
- * instead of a broken button.
+ * State machine:
+ *   loading      — determining browser support + current state
+ *   unsupported  — this browser can't do web push (rendered as null)
+ *   ios-install  — iOS Safari: must add to home screen first
+ *   on           — permission granted + subscription on file
+ *   off          — no subscription (default-deny, or toggled off)
+ *   working      — in-flight transition (subscribing or unsubscribing)
+ *   error        — show the error so we can debug
+ *
+ * Auto-on optimization: on mount, if Notification.permission is already
+ * "granted" but no subscription exists locally, silently subscribe. This
+ * is true "on by default" for visitors who've granted permission before
+ * (even from a different page/visit) — they get a working subscription
+ * with zero taps.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getApiBase } from "@/lib/api";
 import { useT, useLocale } from "@/components/MessagesProvider";
 import { ensureFingerprint, readIdentity } from "@/lib/identity";
 
 type State =
-  | "loading"        // determining browser support + current state
-  | "unsupported"    // this browser can't do web push
-  | "ios-install"    // iOS Safari: must install PWA first
-  | "ready"          // supported, not yet subscribed
-  | "subscribing"    // in-flight
-  | "subscribed"     // done
-  | "denied"         // user said no to notification permission
+  | "loading"
+  | "unsupported"
+  | "ios-install"
+  | "on"
+  | "off"
+  | "working"
   | "error";
 
 function urlB64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
@@ -65,6 +75,80 @@ export function EnablePush() {
   const locale = useLocale();
   const [state, setState] = useState<State>("loading");
   const [error, setError] = useState<string | null>(null);
+  // Prevent the auto-subscribe pass from racing a manual click
+  const autoSubAttempted = useRef(false);
+
+  /**
+   * Subscribe flow. Returns true when a subscription is on file at the
+   * end (either freshly created or already there).
+   *
+   * If `silent`, we won't call requestPermission() — only proceed when
+   * permission is already granted. This is what the auto-on path uses
+   * to avoid surprising the visitor with a prompt at page load.
+   */
+  async function doSubscribe(opts: { silent: boolean }): Promise<boolean> {
+    const base = getApiBase();
+    const keyRes = await fetch(`${base}/api/push/vapid-public-key`);
+    if (!keyRes.ok) throw new Error(`vapid key endpoint: ${keyRes.status}`);
+    const { public_key } = await keyRes.json();
+    if (!public_key) throw new Error("no public key");
+
+    const reg = await navigator.serviceWorker.register("/sw.js");
+    await navigator.serviceWorker.ready;
+
+    if (Notification.permission !== "granted") {
+      if (opts.silent) return false;
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") return false;
+    }
+
+    const sub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlB64ToUint8Array(public_key),
+    });
+
+    const { contributorId, fingerprint } = readIdentity();
+    const fp = fingerprint || ensureFingerprint();
+
+    const subRes = await fetch(`${base}/api/push/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        subscription: sub.toJSON(),
+        contributor_id: contributorId || undefined,
+        fingerprint: fp,
+        user_agent: navigator.userAgent,
+        locale,
+      }),
+    });
+    if (!subRes.ok) throw new Error(`subscribe endpoint: ${subRes.status}`);
+    return true;
+  }
+
+  /**
+   * Unsubscribe flow. Removes the local PushSubscription and tells the
+   * server to drop the row. Idempotent — safe even if either side is
+   * already cleared.
+   */
+  async function doUnsubscribe(): Promise<void> {
+    const base = getApiBase();
+    const reg = await navigator.serviceWorker.getRegistration("/sw.js");
+    if (!reg) return;
+    const existing = await reg.pushManager.getSubscription();
+    if (existing) {
+      const endpoint = existing.endpoint;
+      try {
+        await existing.unsubscribe();
+      } catch {
+        // browser-side failure shouldn't block server-side cleanup
+      }
+      await fetch(`${base}/api/push/unsubscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ endpoint }),
+      }).catch(() => undefined);
+    }
+  }
 
   useEffect(() => {
     (async () => {
@@ -78,135 +162,149 @@ export function EnablePush() {
           }
           return;
         }
-        // On iOS, push only works if the site is installed to home screen
         if (isIosSafari() && !isStandalone()) {
           setState("ios-install");
           return;
         }
+
         const reg = await navigator.serviceWorker.register("/sw.js");
         const existing = await reg.pushManager.getSubscription();
         if (existing) {
-          setState("subscribed");
+          setState("on");
           return;
         }
-        if (Notification.permission === "denied") {
-          setState("denied");
-          return;
+
+        // Auto-on path: if permission is already granted, subscribe
+        // silently — the visitor never has to tap.
+        if (Notification.permission === "granted" && !autoSubAttempted.current) {
+          autoSubAttempted.current = true;
+          try {
+            const ok = await doSubscribe({ silent: true });
+            setState(ok ? "on" : "off");
+            return;
+          } catch (e) {
+            // Non-fatal; fall through to render the manual toggle
+            console.warn("auto-subscribe failed:", e);
+          }
         }
-        setState("ready");
+        setState("off");
       } catch (e) {
         setError(String(e));
         setState("error");
       }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function subscribe() {
-    setState("subscribing");
-    setError(null);
-    try {
-      const base = getApiBase();
-      const keyRes = await fetch(`${base}/api/push/vapid-public-key`);
-      if (!keyRes.ok) {
-        throw new Error(`vapid key endpoint: ${keyRes.status}`);
+  async function handleToggle() {
+    if (state === "working") return;
+    if (state === "on") {
+      setState("working");
+      setError(null);
+      try {
+        await doUnsubscribe();
+        setState("off");
+      } catch (e) {
+        setError(String(e));
+        setState("error");
       }
-      const { public_key } = await keyRes.json();
-      if (!public_key) throw new Error("no public key");
-
-      const reg = await navigator.serviceWorker.register("/sw.js");
-      await navigator.serviceWorker.ready;
-
-      const permission = await Notification.requestPermission();
-      if (permission !== "granted") {
-        setState(permission === "denied" ? "denied" : "ready");
-        return;
+      return;
+    }
+    if (state === "off") {
+      setState("working");
+      setError(null);
+      try {
+        const ok = await doSubscribe({ silent: false });
+        setState(ok ? "on" : "off");
+      } catch (e) {
+        setError(String(e));
+        setState("error");
       }
-
-      const sub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: urlB64ToUint8Array(public_key),
-      });
-
-      const { contributorId, fingerprint } = readIdentity();
-      const fp = fingerprint || ensureFingerprint();
-
-      const subRes = await fetch(`${base}/api/push/subscribe`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          subscription: sub.toJSON(),
-          contributor_id: contributorId || undefined,
-          fingerprint: fp,
-          user_agent: navigator.userAgent,
-          locale,
-        }),
-      });
-      if (!subRes.ok) {
-        throw new Error(`subscribe endpoint: ${subRes.status}`);
-      }
-      setState("subscribed");
-    } catch (e) {
-      setError(String(e));
-      setState("error");
+      return;
     }
   }
 
   if (state === "loading" || state === "unsupported") return null;
 
-  // One small container — warm, present, not insistent.
+  // The iOS install nudge stays a card — there's nothing to toggle yet.
+  if (state === "ios-install") {
+    return (
+      <section
+        className="max-w-3xl mx-3 sm:mx-auto mt-3 px-5 py-4 rounded-2xl border border-[hsl(var(--primary)/0.25)] bg-card"
+        aria-label={t("enablePush.ariaLabel")}
+      >
+        <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
+          {t("enablePush.eyebrow")}
+        </p>
+        <p className="text-base font-light text-foreground leading-snug mb-2">
+          {t("enablePush.iosHeading")}
+        </p>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {t("enablePush.iosLede")}
+        </p>
+      </section>
+    );
+  }
+
+  const isOn = state === "on";
+  const isWorking = state === "working";
+  // Toggle defaults to ON visually unless we know we're off or errored.
+  // (loading already returned null above.)
+  const visuallyOn = isOn || isWorking;
+
   return (
     <section
       className="max-w-3xl mx-3 sm:mx-auto mt-3 px-5 py-4 rounded-2xl border border-[hsl(var(--primary)/0.25)] bg-card"
       aria-label={t("enablePush.ariaLabel")}
     >
-      <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
-        {t("enablePush.eyebrow")}
-      </p>
-      {state === "ready" && (
-        <>
-          <p className="text-base font-light text-foreground leading-snug mb-3">
-            {t("enablePush.heading")}
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="text-[11px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
+            {t("enablePush.eyebrow")}
           </p>
-          <p className="text-sm text-muted-foreground leading-relaxed mb-3">
-            {t("enablePush.lede")}
-          </p>
-          <button
-            type="button"
-            onClick={subscribe}
-            className="inline-flex items-center gap-2 rounded-full bg-[hsl(var(--primary))] hover:opacity-90 text-[hsl(var(--primary-foreground))] px-4 py-2 text-sm font-medium transition-opacity"
-          >
-            {t("enablePush.cta")}
-          </button>
-        </>
-      )}
-      {state === "subscribing" && (
-        <p className="text-sm text-muted-foreground">{t("enablePush.subscribing")}</p>
-      )}
-      {state === "subscribed" && (
-        <p className="text-sm text-foreground">
-          <span className="text-lg mr-1.5" aria-hidden="true">✓</span>
-          {t("enablePush.subscribed")}
-        </p>
-      )}
-      {state === "ios-install" && (
-        <>
-          <p className="text-base font-light text-foreground leading-snug mb-2">
-            {t("enablePush.iosHeading")}
+          <p className="text-base font-light text-foreground leading-snug mb-1">
+            {isOn
+              ? t("enablePush.onHeading")
+              : t("enablePush.offHeading")}
           </p>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            {t("enablePush.iosLede")}
+            {isOn
+              ? t("enablePush.onLede")
+              : t("enablePush.offLede")}
           </p>
-        </>
-      )}
-      {state === "denied" && (
-        <p className="text-sm text-muted-foreground">{t("enablePush.denied")}</p>
-      )}
-      {state === "error" && (
-        <p className="text-sm text-muted-foreground">
-          {t("enablePush.error")}
-          {error && <span className="block mt-1 text-xs opacity-60">{error}</span>}
-        </p>
-      )}
+          {state === "error" && error && (
+            <p className="mt-2 text-xs text-muted-foreground opacity-70">
+              {t("enablePush.error")}
+              <span className="block mt-1 opacity-60">{error}</span>
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={visuallyOn}
+          aria-label={
+            isOn ? t("enablePush.toggleOffAria") : t("enablePush.toggleOnAria")
+          }
+          onClick={handleToggle}
+          disabled={isWorking}
+          className={[
+            "relative inline-flex shrink-0 items-center h-7 w-12 rounded-full transition-colors",
+            visuallyOn
+              ? "bg-[hsl(var(--primary))]"
+              : "bg-muted border border-border",
+            isWorking ? "opacity-60" : "",
+          ].join(" ")}
+        >
+          <span
+            className={[
+              "inline-block h-5 w-5 rounded-full bg-white shadow transition-transform",
+              visuallyOn ? "translate-x-6" : "translate-x-1",
+            ].join(" ")}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
     </section>
   );
 }

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -236,6 +236,19 @@
     "welcomeBackNamed": "{name}, schön dass du wieder da bist. Hier ist, was für dich geschieht.",
     "dismiss": "Schließen"
   },
+  "enablePush": {
+    "ariaLabel": "Morgen-Benachrichtigungen",
+    "eyebrow": "Eine sanfte Tür",
+    "heading": "Lass den Organismus zurücksprechen.",
+    "lede": "Eine stille Nachricht am Morgen, wenn eine Stimme zu etwas kommt, das du berührt hast, oder ein Herz auf dem landet, was du gesagt hast. Du kannst es jederzeit ausschalten.",
+    "cta": "Morgennachrichten empfangen",
+    "subscribing": "Frage dein Gerät …",
+    "subscribed": "Dein Gerät ist bereit. Eine Nachricht findet dich, wenn etwas Lebendiges auf dich wartet.",
+    "iosHeading": "Füge das erst zum Startbildschirm hinzu",
+    "iosLede": "Auf dem iPhone brauchen Morgennachrichten eine installierte App. Tippe auf das Teilen-Symbol unten, dann „Zum Home-Bildschirm hinzufügen“, und öffne sie von dort.",
+    "denied": "Dein Gerät lehnt Benachrichtigungen ab. Aktiviere sie in Einstellungen → Mitteilungen → Safari, um Morgennachrichten zu empfangen.",
+    "error": "Etwas hat das Abonnement aufgehalten. Versuch es gleich noch einmal."
+  },
   "people": {
     "eyebrow": "Eine Ecke des Organismus",
     "voicesHeading": "Stimmen, die sie gegeben hat",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -239,15 +239,15 @@
   "enablePush": {
     "ariaLabel": "Morgen-Benachrichtigungen",
     "eyebrow": "Eine sanfte Tür",
-    "heading": "Lass den Organismus zurücksprechen.",
-    "lede": "Eine stille Nachricht am Morgen, wenn eine Stimme zu etwas kommt, das du berührt hast, oder ein Herz auf dem landet, was du gesagt hast. Du kannst es jederzeit ausschalten.",
-    "cta": "Morgennachrichten empfangen",
-    "subscribing": "Frage dein Gerät …",
-    "subscribed": "Dein Gerät ist bereit. Eine Nachricht findet dich, wenn etwas Lebendiges auf dich wartet.",
+    "onHeading": "Morgennachrichten sind an.",
+    "onLede": "Eine stille Nachricht findet dich, wenn eine Stimme zu etwas kommt, das du berührt hast, oder ein Herz auf dem landet, was du gesagt hast. Jederzeit ausschalten.",
+    "offHeading": "Morgennachrichten sind aus.",
+    "offLede": "Schalte ein, um eine stille Nachricht zu erhalten, wenn eine Stimme zu etwas kommt, das du berührt hast, oder ein Herz auf dem landet, was du gesagt hast.",
+    "toggleOnAria": "Morgennachrichten einschalten",
+    "toggleOffAria": "Morgennachrichten ausschalten",
     "iosHeading": "Füge das erst zum Startbildschirm hinzu",
     "iosLede": "Auf dem iPhone brauchen Morgennachrichten eine installierte App. Tippe auf das Teilen-Symbol unten, dann „Zum Home-Bildschirm hinzufügen“, und öffne sie von dort.",
-    "denied": "Dein Gerät lehnt Benachrichtigungen ab. Aktiviere sie in Einstellungen → Mitteilungen → Safari, um Morgennachrichten zu empfangen.",
-    "error": "Etwas hat das Abonnement aufgehalten. Versuch es gleich noch einmal."
+    "error": "Etwas hat die Änderung aufgehalten. Versuch es gleich noch einmal."
   },
   "people": {
     "eyebrow": "Eine Ecke des Organismus",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -236,6 +236,19 @@
     "welcomeBackNamed": "{name}, welcome back. Here's what's stirring for you.",
     "dismiss": "Dismiss"
   },
+  "enablePush": {
+    "ariaLabel": "Morning notifications",
+    "eyebrow": "A gentle door",
+    "heading": "Let the organism speak back.",
+    "lede": "One quiet note in the morning when a voice arrives on something you touched, or a heart lands on what you said. You can turn it off any time.",
+    "cta": "Receive morning notes",
+    "subscribing": "Asking your device…",
+    "subscribed": "Your device is ready. A note will find you when something alive is waiting.",
+    "iosHeading": "Add this to your home screen first",
+    "iosLede": "On iPhone, morning notifications need the app installed. Tap the share icon below, then 'Add to Home Screen', then open it from there.",
+    "denied": "Your device is declining notifications. Enable them in Settings → Notifications → Safari to receive morning notes.",
+    "error": "Something prevented the subscription from landing. Try again in a moment."
+  },
   "people": {
     "eyebrow": "A corner of the organism",
     "voicesHeading": "Voices she has given",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -239,15 +239,15 @@
   "enablePush": {
     "ariaLabel": "Morning notifications",
     "eyebrow": "A gentle door",
-    "heading": "Let the organism speak back.",
-    "lede": "One quiet note in the morning when a voice arrives on something you touched, or a heart lands on what you said. You can turn it off any time.",
-    "cta": "Receive morning notes",
-    "subscribing": "Asking your device…",
-    "subscribed": "Your device is ready. A note will find you when something alive is waiting.",
+    "onHeading": "Morning notes are on.",
+    "onLede": "A quiet note will find you when a voice arrives on something you touched, or a heart lands on what you said. Turn off any time.",
+    "offHeading": "Morning notes are off.",
+    "offLede": "Turn on to receive a quiet note when a voice arrives on something you touched, or a heart lands on what you said.",
+    "toggleOnAria": "Turn morning notes on",
+    "toggleOffAria": "Turn morning notes off",
     "iosHeading": "Add this to your home screen first",
     "iosLede": "On iPhone, morning notifications need the app installed. Tap the share icon below, then 'Add to Home Screen', then open it from there.",
-    "denied": "Your device is declining notifications. Enable them in Settings → Notifications → Safari to receive morning notes.",
-    "error": "Something prevented the subscription from landing. Try again in a moment."
+    "error": "Something prevented the change from landing. Try again in a moment."
   },
   "people": {
     "eyebrow": "A corner of the organism",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -236,6 +236,19 @@
     "welcomeBackNamed": "{name}, qué bueno volver a verte. Esto es lo que se mueve para ti.",
     "dismiss": "Cerrar"
   },
+  "enablePush": {
+    "ariaLabel": "Notificaciones de la mañana",
+    "eyebrow": "Una puerta suave",
+    "heading": "Deja que el organismo te responda.",
+    "lede": "Una nota tranquila por la mañana cuando una voz llega a algo que tocaste, o un corazón se posa en lo que dijiste. Puedes apagarlo cuando quieras.",
+    "cta": "Recibir notas de la mañana",
+    "subscribing": "Preguntando a tu dispositivo…",
+    "subscribed": "Tu dispositivo está listo. Una nota te encontrará cuando algo vivo te espere.",
+    "iosHeading": "Primero añade esto a tu pantalla de inicio",
+    "iosLede": "En iPhone, las notificaciones de la mañana necesitan que la app esté instalada. Toca el ícono de compartir abajo, luego «Añadir a pantalla de inicio», y ábrelo desde ahí.",
+    "denied": "Tu dispositivo rechaza las notificaciones. Actívalas en Ajustes → Notificaciones → Safari para recibir notas de la mañana.",
+    "error": "Algo impidió que la suscripción llegara. Intenta de nuevo en un momento."
+  },
   "people": {
     "eyebrow": "Un rincón del organismo",
     "voicesHeading": "Voces que ella ha dado",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -239,15 +239,15 @@
   "enablePush": {
     "ariaLabel": "Notificaciones de la mañana",
     "eyebrow": "Una puerta suave",
-    "heading": "Deja que el organismo te responda.",
-    "lede": "Una nota tranquila por la mañana cuando una voz llega a algo que tocaste, o un corazón se posa en lo que dijiste. Puedes apagarlo cuando quieras.",
-    "cta": "Recibir notas de la mañana",
-    "subscribing": "Preguntando a tu dispositivo…",
-    "subscribed": "Tu dispositivo está listo. Una nota te encontrará cuando algo vivo te espere.",
+    "onHeading": "Las notas de la mañana están encendidas.",
+    "onLede": "Una nota tranquila te encontrará cuando una voz llegue a algo que tocaste, o un corazón se pose en lo que dijiste. Apaga cuando quieras.",
+    "offHeading": "Las notas de la mañana están apagadas.",
+    "offLede": "Enciende para recibir una nota tranquila cuando una voz llegue a algo que tocaste, o un corazón se pose en lo que dijiste.",
+    "toggleOnAria": "Encender las notas de la mañana",
+    "toggleOffAria": "Apagar las notas de la mañana",
     "iosHeading": "Primero añade esto a tu pantalla de inicio",
     "iosLede": "En iPhone, las notificaciones de la mañana necesitan que la app esté instalada. Toca el ícono de compartir abajo, luego «Añadir a pantalla de inicio», y ábrelo desde ahí.",
-    "denied": "Tu dispositivo rechaza las notificaciones. Actívalas en Ajustes → Notificaciones → Safari para recibir notas de la mañana.",
-    "error": "Algo impidió que la suscripción llegara. Intenta de nuevo en un momento."
+    "error": "Algo impidió que el cambio llegara. Intenta de nuevo en un momento."
   },
   "people": {
     "eyebrow": "Un rincón del organismo",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -236,6 +236,19 @@
     "welcomeBackNamed": "{name}, senang melihatmu kembali. Inilah yang hidup untukmu.",
     "dismiss": "Tutup"
   },
+  "enablePush": {
+    "ariaLabel": "Pemberitahuan pagi",
+    "eyebrow": "Pintu yang lembut",
+    "heading": "Biarkan organisme berbicara kembali.",
+    "lede": "Satu pesan tenang di pagi hari ketika suara datang ke sesuatu yang kamu sentuh, atau hati hinggap pada yang kamu katakan. Bisa dimatikan kapan saja.",
+    "cta": "Terima pesan pagi",
+    "subscribing": "Bertanya pada perangkatmu…",
+    "subscribed": "Perangkatmu siap. Sebuah pesan akan menemukanmu ketika sesuatu yang hidup menantimu.",
+    "iosHeading": "Tambahkan ini ke layar utama dulu",
+    "iosLede": "Di iPhone, pemberitahuan pagi memerlukan aplikasi yang terpasang. Tekan ikon bagikan di bawah, lalu 'Tambah ke Layar Utama', lalu buka dari sana.",
+    "denied": "Perangkatmu menolak pemberitahuan. Aktifkan di Pengaturan → Notifikasi → Safari untuk menerima pesan pagi.",
+    "error": "Sesuatu menghalangi langganan. Coba lagi sebentar lagi."
+  },
   "people": {
     "eyebrow": "Sudut dari organisme",
     "voicesHeading": "Suara yang ia berikan",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -239,15 +239,15 @@
   "enablePush": {
     "ariaLabel": "Pemberitahuan pagi",
     "eyebrow": "Pintu yang lembut",
-    "heading": "Biarkan organisme berbicara kembali.",
-    "lede": "Satu pesan tenang di pagi hari ketika suara datang ke sesuatu yang kamu sentuh, atau hati hinggap pada yang kamu katakan. Bisa dimatikan kapan saja.",
-    "cta": "Terima pesan pagi",
-    "subscribing": "Bertanya pada perangkatmu…",
-    "subscribed": "Perangkatmu siap. Sebuah pesan akan menemukanmu ketika sesuatu yang hidup menantimu.",
+    "onHeading": "Pesan pagi menyala.",
+    "onLede": "Sebuah pesan tenang akan menemukanmu ketika suara datang ke sesuatu yang kamu sentuh, atau hati hinggap pada yang kamu katakan. Matikan kapan saja.",
+    "offHeading": "Pesan pagi mati.",
+    "offLede": "Nyalakan untuk menerima pesan tenang ketika suara datang ke sesuatu yang kamu sentuh, atau hati hinggap pada yang kamu katakan.",
+    "toggleOnAria": "Nyalakan pesan pagi",
+    "toggleOffAria": "Matikan pesan pagi",
     "iosHeading": "Tambahkan ini ke layar utama dulu",
     "iosLede": "Di iPhone, pemberitahuan pagi memerlukan aplikasi yang terpasang. Tekan ikon bagikan di bawah, lalu 'Tambah ke Layar Utama', lalu buka dari sana.",
-    "denied": "Perangkatmu menolak pemberitahuan. Aktifkan di Pengaturan → Notifikasi → Safari untuk menerima pesan pagi.",
-    "error": "Sesuatu menghalangi langganan. Coba lagi sebentar lagi."
+    "error": "Sesuatu menghalangi perubahan. Coba lagi sebentar lagi."
   },
   "people": {
     "eyebrow": "Sudut dari organisme",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,61 @@
+/* Coherence Network service worker.
+ *
+ * Minimal: registers push event + notification click handlers so real
+ * browser pushes can land on the device lock screen even when the app
+ * tab is closed.
+ *
+ * Payload shape (JSON):
+ *   { "title": "...", "body": "...", "url": "/feed/you", "icon": "/icon.svg" }
+ */
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  if (event.data) {
+    try {
+      payload = event.data.json();
+    } catch {
+      payload = { title: "Coherence Network", body: event.data.text() };
+    }
+  }
+  const title = payload.title || "Coherence Network";
+  const body = payload.body || "";
+  const url = payload.url || "/feed/you";
+  const icon = payload.icon || "/icon.svg";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon,
+      badge: icon,
+      data: { url },
+      // Keep the notification quiet — no vibration, no sound override.
+      // The OS ringer profile wins.
+      silent: false,
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const target = (event.notification.data && event.notification.data.url) || "/feed/you";
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((list) => {
+      // If a Coherence tab is already open, focus it and navigate.
+      for (const client of list) {
+        if ("focus" in client) {
+          client.focus();
+          if ("navigate" in client) client.navigate(target);
+          return;
+        }
+      }
+      return self.clients.openWindow(target);
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- Reframe the push affordance from "tap to subscribe" to "morning notes are on, turn off any time"
- New `POST /api/push/unsubscribe` endpoint backs the off switch
- Auto-on on mount: if `Notification.permission === "granted"` and no subscription exists locally, subscribe silently — visitors who granted permission previously get a working subscription with zero taps
- Toggle is always visible, both on and off, so the visitor can change their mind any time
- en/de/es/id copy updated

## Why
"On by default" is a warmer posture than "click to enable." A visitor who reaches `/feed/you` already chose their corner; the organism speaking back is part of that corner, not a separate consent flow. Browsers still require a user gesture for the very first permission prompt — that's anti-abuse policy and we can't override it — but the framing makes the default intent clear and the off switch is right there.

## Test plan
- [ ] Open `/feed/you`, see the toggle visually ON (or OFF if not yet subscribed)
- [ ] Tap OFF → toggle slides off, server gets `/api/push/unsubscribe`
- [ ] Tap ON → permission prompt fires, subscription registers
- [ ] Reload page after subscribing — toggle stays ON, no permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)