### PR TITLE
fix(vision): title contrast over the hero image

### DIFF
--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -194,13 +194,30 @@ export default async function VisionConceptPage({
           <span className="text-stone-300">{concept.name}</span>
         </nav>
 
-        {/* Title + level */}
+        {/* Title + level.
+            When a concept has a visual, the title sits on top of the
+            hero image (with a dark gradient overlay), so it needs
+            light text regardless of the visitor's theme preference.
+            When there is no visual, the title sits on the page
+            background, so it uses theme-aware foreground. */}
         <div className="mb-6 space-y-3">
           <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-4xl md:text-5xl font-extralight tracking-tight text-foreground">{concept.name}</h1>
+            <h1
+              className={`text-4xl md:text-5xl font-extralight tracking-tight ${
+                visual ? "text-white" : "text-foreground"
+              }`}
+            >
+              {concept.name}
+            </h1>
             <LevelBadge level={concept.level} />
           </div>
-          <p className="text-lg md:text-xl text-foreground/85 font-light leading-relaxed max-w-3xl">{concept.description}</p>
+          <p
+            className={`text-lg md:text-xl font-light leading-relaxed max-w-3xl ${
+              visual ? "text-stone-200" : "text-foreground/85"
+            }`}
+          >
+            {concept.description}
+          </p>
           <ReaderPresence conceptId={conceptId} />
         </div>
 


### PR DESCRIPTION
## Summary
- Conditionalize the concept-page title + lede colors: `text-white` when a visual is present (hero image with dark gradient overlay), `text-foreground` otherwise
- Fixes the regression from #1067 where the title disappeared into the warm hero photo in light mode

## Test plan
- [ ] `/vision/lc-pulse` (has visual) in light mode: "The Pulse" renders white + readable over the fire-circle image
- [ ] `/vision/lc-pulse` in dark mode: no change (still white)
- [ ] A concept with no visual: title readable in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)