### PR TITLE
feat(home): lead with one real concept, not the SaaS question

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import { cookies, headers } from "next/headers";
 
@@ -10,6 +11,7 @@ import { MorningNudge } from "@/components/MorningNudge";
 import { getApiBase } from "@/lib/api";
 import { fetchJsonOrNull } from "@/lib/fetch";
 import type { IdeaWithScore } from "@/lib/types";
+import type { Concept } from "@/lib/types/vision";
 import { createTranslator, type Translator } from "@/lib/i18n";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
 
@@ -85,6 +87,23 @@ async function loadNodeCount(): Promise<number> {
   }
 }
 
+/**
+ * Load the concept that greets every first-time visitor on the home
+ * page. lc-pulse is the root of the Living Collective ontology — the
+ * warmest and most universally felt note to walk in on.
+ *
+ * If the fetch fails, we simply skip the featured card — the rest of
+ * the page still works.
+ */
+async function loadFeaturedConcept(lang: LocaleCode): Promise<Concept | null> {
+  const qs = lang === DEFAULT_LOCALE ? "" : `?lang=${lang}`;
+  return fetchJsonOrNull<Concept>(
+    `${getApiBase()}/api/concepts/lc-pulse${qs}`,
+    {},
+    5000,
+  );
+}
+
 function formatNumber(value: number | undefined, locale: string): string {
   if (typeof value !== "number" || Number.isNaN(value)) return "0";
   return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(value);
@@ -123,11 +142,12 @@ export default async function Home() {
     : DEFAULT_LOCALE;
   const t = createTranslator(lang);
 
-  const [ideasData, resonanceItems, coherenceScore, nodeCount] = await Promise.all([
+  const [ideasData, resonanceItems, coherenceScore, nodeCount, featuredConcept] = await Promise.all([
     loadIdeas(lang),
     loadResonance(lang),
     loadCoherenceScore(),
     loadNodeCount(),
+    loadFeaturedConcept(lang),
   ]);
 
   const summary = ideasData?.summary;
@@ -142,6 +162,80 @@ export default async function Home() {
       <MorningNudge />
       <LiveBreathPanel lang={lang} />
       <FirstTimeWelcome />
+
+      {/*
+       * Section 0: MEET ONE CONCEPT.
+       *
+       * A cold visitor arrives and needs to see — not be told — what
+       * this place is. The first felt content on the home page is one
+       * real concept from the Living Collective, rendered as a warm
+       * card: its visual, its name, its description, and a "walk in"
+       * doorway to the full concept page. lc-pulse (the root) is the
+       * default; a future cycle can rotate to a concept that's
+       * currently being met by other visitors, or to one the viewer
+       * hasn't seen yet.
+       *
+       * This is the strongest send-to-friend surface on the page. A
+       * friend who lands here sees the beauty first, the form later.
+       */}
+      {featuredConcept && (
+        <section className="px-4 sm:px-6 pt-6 pb-4 max-w-3xl mx-auto animate-fade-in-up">
+          <p className="text-[11px] uppercase tracking-[0.22em] font-semibold text-[hsl(var(--chart-2))] mb-3 text-center">
+            {t("home.meetOneConceptEyebrow")}
+          </p>
+          <Link
+            href={`/vision/${featuredConcept.id}`}
+            className="block group rounded-2xl overflow-hidden border border-border hover:border-[hsl(var(--primary)/0.6)] transition-colors bg-card shadow-sm hover:shadow-md"
+          >
+            {featuredConcept.visual_path && (
+              <div className="relative aspect-[16/9] overflow-hidden">
+                <Image
+                  src={featuredConcept.visual_path}
+                  alt={featuredConcept.name}
+                  fill
+                  className="object-cover group-hover:scale-[1.03] transition-transform duration-700"
+                  sizes="(max-width: 768px) 100vw, 768px"
+                  priority
+                  unoptimized={featuredConcept.visual_path.startsWith("http")}
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-stone-950/60 via-transparent to-transparent" />
+                <div className="absolute bottom-4 left-5 right-5">
+                  <h2 className="text-2xl md:text-3xl font-light tracking-tight text-white drop-shadow-md">
+                    {featuredConcept.name}
+                  </h2>
+                </div>
+              </div>
+            )}
+            <div className="p-5 space-y-3">
+              {!featuredConcept.visual_path && (
+                <h2 className="text-2xl md:text-3xl font-light tracking-tight text-foreground">
+                  {featuredConcept.name}
+                </h2>
+              )}
+              <p className="text-sm md:text-base text-foreground/85 leading-relaxed line-clamp-3">
+                {featuredConcept.description}
+              </p>
+              <div className="flex items-center justify-between pt-1">
+                <span className="text-sm text-muted-foreground">
+                  {t("home.walkInHint")}
+                </span>
+                <span className="text-[hsl(var(--primary))] font-medium group-hover:translate-x-1 transition-transform">
+                  {t("home.walkInCta")} →
+                </span>
+              </div>
+            </div>
+          </Link>
+          <p className="mt-3 text-center">
+            <Link
+              href="/vision"
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 decoration-dotted"
+            >
+              {t("home.orSeeAllConcepts")}
+            </Link>
+          </p>
+        </section>
+      )}
+
       {/* Section 1: HERO — THE QUESTION */}
       <section className="flex flex-col justify-center items-center text-center px-4 pt-12 pb-6 relative">
         <div className="absolute inset-0 pointer-events-none">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -895,6 +895,10 @@
     "orientationReturn": "← Zurück zum Netz"
   },
   "home": {
+    "meetOneConceptEyebrow": "Begegne einem Begriff",
+    "walkInHint": "Geh die Geschichte. Reagieren willkommen.",
+    "walkInCta": "Eintreten",
+    "orSeeAllConcepts": "oder sieh alle 51 Begriffe der Lebendigen Gemeinschaft",
     "heroHeadline": "Welche Idee trägst du?",
     "heroLede": "Ein Muster, das du bemerkt hast. Eine Lücke, die geschlossen werden will. Ein besserer Weg. Teile sie – irgendwo wartet jemand genau darauf.",
     "statIdeasAlive": "lebendige Ideen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -895,6 +895,10 @@
     "orientationReturn": "← Return to the network"
   },
   "home": {
+    "meetOneConceptEyebrow": "Meet one concept",
+    "walkInHint": "Walk the story. Reacting invited.",
+    "walkInCta": "Walk in",
+    "orSeeAllConcepts": "or see all 51 concepts in the Living Collective",
     "heroHeadline": "What idea are you holding?",
     "heroLede": "A pattern you noticed. A gap that needs filling. A better way. Share it — someone out there is looking for exactly this.",
     "statIdeasAlive": "ideas alive",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -895,6 +895,10 @@
     "orientationReturn": "← Volver a la red"
   },
   "home": {
+    "meetOneConceptEyebrow": "Encuentra un concepto",
+    "walkInHint": "Camina la historia. Reaccionar invitado.",
+    "walkInCta": "Entrar",
+    "orSeeAllConcepts": "o ve los 51 conceptos de la Comunidad Viva",
     "heroHeadline": "¿Qué idea llevas dentro?",
     "heroLede": "Un patrón que notaste. Un vacío que quiere llenarse. Un camino mejor. Compártela — alguien en algún lugar busca exactamente esto.",
     "statIdeasAlive": "ideas vivas",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -895,6 +895,10 @@
     "orientationReturn": "← Kembali ke jejaring"
   },
   "home": {
+    "meetOneConceptEyebrow": "Temui satu konsep",
+    "walkInHint": "Susuri kisahnya. Reaksi dipersilakan.",
+    "walkInCta": "Masuk",
+    "orSeeAllConcepts": "atau lihat seluruh 51 konsep Komunitas yang Hidup",
     "heroHeadline": "Gagasan apa yang kamu bawa?",
     "heroLede": "Pola yang kamu lihat. Celah yang ingin diisi. Jalan yang lebih baik. Bagikan — seseorang di luar sana sedang mencari hal ini.",
     "statIdeasAlive": "gagasan hidup",


### PR DESCRIPTION
## Summary
- Home page now opens with a Featured Concept card immediately after the FirstTimeWelcome panel
- The card renders lc-pulse with its real visual + title overlaid on the image + description + "Walk in →" doorway
- A small "or see all 51 concepts in the Living Collective" link below for visitors who want the catalog
- Existing "What idea are you holding?" hero + IdeaSubmitForm stays below — demoted, not removed
- Four locales: en / de / es / id

## Why
The wow lives on concept pages (real image + meeting frame + voice doorway). The home page was hiding it behind a SaaS-style "share an idea" form. A friend opening the link should see the beauty first, not the form. This is unlock #4 of 5 in the send-to-friend first-impression sequence.

## Test plan
- [ ] Home page on mobile shows the Featured Concept card before the hero question
- [ ] Tapping the card or "Walk in →" navigates to /vision/lc-pulse
- [ ] "or see all 51 concepts" link goes to /vision
- [ ] Existing IdeaSubmitForm still functional below the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)