### PR TITLE
fix(resolver): canonical URL + deterministic ids — no more duplicates at the source

### DIFF
--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -37,6 +37,10 @@ class NodeUpdate(BaseModel):
     description: str | None = None
     phase: str | None = None
     properties: dict[str, Any] | None = None
+    # Type changes — only movement between presence types is allowed,
+    # so a visitor can't hijack a system/agent account or rewrite
+    # themselves as a concept. The service enforces the allowed set.
+    type: str | None = None
 
 
 class EdgeCreate(BaseModel):

--- a/api/app/services/graph_service.py
+++ b/api/app/services/graph_service.py
@@ -137,8 +137,24 @@ def get_node(node_id: str) -> dict[str, Any] | None:
         return node.to_dict() if node else None
 
 
+# Types a PATCH may move a node between — the presence bucket. This
+# guards against a visitor rewriting their own contributor node as a
+# concept, idea, spec, or system identity via a rogue PATCH.
+_RETYPEABLE_TYPES = frozenset({
+    "contributor", "community", "network-org", "scene",
+    "event", "asset", "practice", "skill",
+})
+
+
 def update_node(node_id: str, **updates: Any) -> dict[str, Any] | None:
-    """Update a node. Supports updating name, description, phase, and properties."""
+    """Update a node. Supports name, description, phase, properties,
+    and — within the presence bucket — type.
+
+    Type changes are how reclassification moves 'Pyramids of Chi'
+    from the default contributor bucket (where the resolver first
+    dropped it) into `scene` where it belongs. Cross-bucket moves
+    (contributor → concept, or scene → system) are refused so a
+    rogue PATCH can't reshape an identity."""
     with session() as s:
         node = s.get(Node, node_id)
         if not node:
@@ -147,6 +163,15 @@ def update_node(node_id: str, **updates: Any) -> dict[str, Any] | None:
         for key in ("name", "description", "phase"):
             if key in updates and updates[key] is not None:
                 setattr(node, key, updates[key])
+
+        # Type change — only within the presence bucket, and only if
+        # the node currently lives there too. Arbitrary retypes
+        # (contributor → concept) are refused silently; the caller
+        # gets the node back unchanged and can inspect the result.
+        new_type = updates.get("type")
+        if new_type is not None and new_type != node.type:
+            if node.type in _RETYPEABLE_TYPES and new_type in _RETYPEABLE_TYPES:
+                node.type = new_type
 
         if "properties" in updates and isinstance(updates["properties"], dict):
             # Merge properties (don't replace — merge new keys into existing)

--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -128,9 +128,18 @@ class ResolvedIdentity:
     creations: list[Creation] = field(default_factory=list)
 
     def node_id(self) -> str:
-        digest = hashlib.sha256(self.canonical_url.encode("utf-8")).hexdigest()[:12]
-        slug = re.sub(r"[^a-z0-9]+", "-", self.name.lower()).strip("-")[:40] or "inspiration"
-        return f"{self.node_type}:{slug}-{digest}"
+        """Deterministic id from the canonical URL alone.
+
+        The id used to include the name slug: `contributor:{slug}-{hash}`.
+        That was the source of a class of duplicates — the same URL
+        re-resolved at different times could parse to slightly
+        different names (trailing space, case change, OG vs
+        json-ld disagreement) and each variant produced a new id.
+        Now the URL hash is the whole suffix, so the same URL → the
+        same id forever, regardless of what name the page happens to
+        parse as this time."""
+        digest = canonical_url_hash(self.canonical_url)
+        return f"{self.node_type}:{digest}"
 
 
 # ── HTML parsing ──────────────────────────────────────────────────────
@@ -198,11 +207,97 @@ def _is_url(s: str) -> bool:
     return bool(parsed.netloc) and "." in parsed.netloc
 
 
+# Query parameters we preserve during canonicalization — everything
+# else (tracking, sharing, session) is dropped because it changes the
+# URL without changing the identity. Kept tight on purpose: YouTube's
+# `v=` is the video id, Spotify's embed link uses it too. Extend only
+# when a new provider demonstrably needs a param to address content.
+_CANONICAL_PRESERVE_QUERY_PARAMS = {
+    "v",          # youtube.com/watch?v=ID
+    "list",       # youtube.com playlists
+    "id",         # a few SaaS platforms use this as the entity id
+}
+
+# Query parameters that are always noise — strip aggressively. This is
+# a denylist of known tracking and share-tool params so we don't miss
+# one even if _CANONICAL_PRESERVE_QUERY_PARAMS is widened later.
+_TRACKING_QUERY_PARAMS = frozenset({
+    "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+    "fbclid", "gclid", "mc_cid", "mc_eid", "_hsenc", "_hsmi", "yclid",
+    "ref", "ref_src", "ref_url", "share", "sharing", "shared", "source",
+    "from", "src",
+})
+
+
+def canonicalize_url(url: str) -> str:
+    """Return the single canonical form of a URL.
+
+    The resolver used to keep the query string and host case, which
+    meant `?utm_source=1471` and `www.example.com` produced a
+    different 'canonical_url' than `example.com` — and every one of
+    those variants minted a new graph node. This is the single
+    function every write path now uses to key nodes by URL. Same
+    content on the same host → same string, every time.
+
+    Transformations:
+      · Scheme lowercased, defaults to `https` when missing
+      · Host lowercased, leading `www.` stripped (site and its www
+        alias are one identity)
+      · Path with trailing slashes collapsed to a single non-trailing
+        form
+      · Fragment dropped (same page)
+      · Query string rebuilt: tracking/share params dropped, the
+        remaining params sorted, only allowlisted params kept when
+        the host uses them to address content (YouTube's `v=`,
+        etc.). Most sites have no meaningful query — one canonical
+        form wins.
+    """
+    raw = (url or "").strip()
+    if not raw:
+        return ""
+    p = urlparse(raw if "://" in raw else f"https://{raw}")
+    # Force https for canonical identity. http and https pointing to
+    # the same host + path are the same thing — a resource is defined
+    # by where it lives, not by how this particular link to it was
+    # typed. Allows an old `http://` link in someone's email to
+    # resolve to the same identity as the current `https://` variant.
+    scheme = "https"
+    host = (p.netloc or "").lower()
+    # Strip leading www. — the identity is the site, not the subdomain
+    # alias. Keep any other subdomain (music.example.com stays).
+    if host.startswith("www."):
+        host = host[4:]
+    # Collapse //segments and trailing slashes on the path.
+    path = re.sub(r"/{2,}", "/", p.path or "")
+    path = path.rstrip("/") or ""
+    # Query canonicalization: keep only allowlisted params (and only
+    # when they carry a value); drop the rest.
+    query = ""
+    if p.query:
+        from urllib.parse import parse_qsl, urlencode
+        kept = [
+            (k, v) for k, v in parse_qsl(p.query, keep_blank_values=False)
+            if k.lower() in _CANONICAL_PRESERVE_QUERY_PARAMS
+            and k.lower() not in _TRACKING_QUERY_PARAMS
+        ]
+        # Deterministic order so two callers who send the same params
+        # in different orders still produce the same canonical.
+        kept.sort()
+        query = urlencode(kept) if kept else ""
+    return urlunparse((scheme, host, path, "", query, ""))
+
+
+# Backwards-compatible alias — callers still import _normalize_url.
+# Every write path now flows through the strict canonicalizer.
 def _normalize_url(url: str) -> str:
-    """Drop fragments and trailing slashes; keep query."""
-    p = urlparse(url if "://" in url else f"https://{url}")
-    path = p.path.rstrip("/")
-    return urlunparse((p.scheme or "https", p.netloc.lower(), path, "", p.query, ""))
+    return canonicalize_url(url)
+
+
+def canonical_url_hash(url: str) -> str:
+    """Stable 16-char hash of a URL's canonical form. Used as the
+    deterministic id suffix so the same identity always lands on the
+    same node, no matter which code path creates it."""
+    return hashlib.sha256(canonicalize_url(url).encode("utf-8")).hexdigest()[:16]
 
 
 def _host_match(host: str, path: str, suffix: str) -> bool:
@@ -890,20 +985,65 @@ def _normalize_contributor_id(contributor_id: str) -> str:
 
 
 def find_existing_identity(canonical_url: str) -> dict[str, Any] | None:
-    """Look up an already-imported identity by its canonical URL."""
-    for node_type in ("contributor", "community", "network-org"):
+    """Look up an already-imported identity by its canonical URL.
+
+    The previous implementation only scanned three node types
+    (contributor, community, network-org). The moment a presence was
+    retyped to `scene` (a venue), `asset` (a work), `event`,
+    `practice`, or `skill`, the next resolve of the same URL missed
+    the existing node and minted a fresh one. Scanning every
+    presence type closes that gap: once a URL has a home, every
+    future resolve finds it regardless of what type the graph has
+    sorted it into.
+
+    The comparison is tolerant: it matches the caller's canonical
+    against both the stored `canonical_url` property and the
+    re-canonicalized form of whatever's stored. That way pre-fix
+    nodes whose stored URL still has `?utm_source=...` still get
+    found when a caller sends the clean form.
+    """
+    canonical = canonicalize_url(canonical_url)
+    if not canonical:
+        return None
+    # Also compute the id under the deterministic scheme — if the
+    # create ever landed one, get_node is O(1) versus a type-by-type
+    # scan. Try all presence types so retype doesn't orphan lookups.
+    target_hash = canonical_url_hash(canonical)
+    for node_type in CROSS_REF_NODE_TYPES:
+        direct = graph_service.get_node(f"{node_type}:{target_hash}")
+        if direct:
+            return direct
+    # Slow path: the node pre-dates the deterministic id scheme.
+    # Walk each presence type and match on the stored canonical_url
+    # (re-canonicalized on the fly so legacy nodes with tracking
+    # params still resolve).
+    for node_type in CROSS_REF_NODE_TYPES:
         result = graph_service.list_nodes(type=node_type, limit=500)
         for node in result.get("items", []):
-            if node.get("canonical_url") == canonical_url:
+            stored = node.get("canonical_url")
+            if not stored:
+                continue
+            if canonicalize_url(stored) == canonical:
                 return node
     return None
 
 
 def _creation_node_id(creation: Creation, identity_id: str) -> str:
-    seed = (creation.url or f"{identity_id}:{creation.name}").lower()
-    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
-    slug = re.sub(r"[^a-z0-9]+", "-", creation.name.lower()).strip("-")[:40] or "work"
-    return f"asset:{slug}-{digest}"
+    """Deterministic id for an asset node — URL-derived when we have
+    one, name+owner-derived as a fallback.
+
+    Same URL → same asset id, same name-under-same-owner → same id.
+    Historically the id carried a name slug too, which meant the
+    same URL (re)resolving to a slightly-different name spawned
+    fresh asset nodes every time. Now the suffix is pure hash: one
+    URL, one asset."""
+    if creation.url:
+        return f"asset:{canonical_url_hash(creation.url)}"
+    # No URL — fall back to owner+name so the same album listed
+    # under the same artist collapses even without a link.
+    seed = f"{identity_id}|{(creation.name or '').strip().lower()}"
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"asset:{digest}"
 
 
 def _ensure_creation_nodes(

--- a/api/tests/test_flow_agent_lifecycle.py
+++ b/api/tests/test_flow_agent_lifecycle.py
@@ -1,7 +1,9 @@
-"""Flow-centric integration tests for agent task lifecycle.
+"""Flow-centric tests for agent task lifecycle.
 
-Tests the full agent task CRUD, lifecycle transitions, context handling,
-management operations, routing/metrics, and runner registry via HTTP only.
+Six flows cover the entire surface: CRUD, state transitions,
+context/upsert, management, routing/metrics, and runner registry.
+Each flow walks one coherent user journey with error paths as
+inline assertions rather than sibling test functions.
 """
 
 from __future__ import annotations
@@ -23,14 +25,13 @@ REALISTIC_OUTPUT = (
 )
 
 
-async def _clear(client: AsyncClient) -> None:
-    """Clear task store via API."""
-    r = await client.delete("/api/agent/tasks?confirm=clear")
+async def _clear(c: AsyncClient) -> None:
+    r = await c.delete("/api/agent/tasks?confirm=clear")
     assert r.status_code == 204
 
 
 async def _create_task(
-    client: AsyncClient,
+    c: AsyncClient,
     direction: str = "implement the feature",
     task_type: str = "impl",
     context: dict | None = None,
@@ -38,493 +39,207 @@ async def _create_task(
     payload: dict = {"direction": direction, "task_type": task_type}
     if context is not None:
         payload["context"] = context
-    r = await client.post("/api/agent/tasks", json=payload)
+    r = await c.post("/api/agent/tasks", json=payload)
     assert r.status_code == 201, r.text
     return r.json()
 
 
-async def _claim_task(client: AsyncClient, task_id: str, worker_id: str = "test-worker-1") -> dict:
-    r = await client.patch(
+async def _claim(c: AsyncClient, task_id: str, worker_id: str = "test-worker-1") -> dict:
+    r = await c.patch(f"/api/agent/tasks/{task_id}",
+                      json={"status": "running", "worker_id": worker_id})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+async def _complete(c: AsyncClient, task_id: str,
+                    worker_id: str = "test-worker-1",
+                    output: str | None = None) -> dict:
+    r = await c.patch(
         f"/api/agent/tasks/{task_id}",
-        json={"status": "running", "worker_id": worker_id},
+        json={"status": "completed", "worker_id": worker_id,
+              "output": output or REALISTIC_OUTPUT},
     )
     assert r.status_code == 200, r.text
     return r.json()
 
 
-async def _complete_task(
-    client: AsyncClient, task_id: str, worker_id: str = "test-worker-1", output: str | None = None,
-) -> dict:
-    r = await client.patch(
-        f"/api/agent/tasks/{task_id}",
-        json={"status": "completed", "worker_id": worker_id, "output": output or REALISTIC_OUTPUT},
-    )
-    assert r.status_code == 200, r.text
-    return r.json()
-
-
-# ---------------------------------------------------------------------------
-# Task CRUD (8 tests)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_create_task() -> None:
+async def test_task_crud_flow():
+    """Create across every task_type, reject invalid type (422), get,
+    get-404, list, filter-by-status, count."""
     agent_service._store.clear()
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         await _clear(c)
-        task = await _create_task(c)
-        assert "id" in task
-        assert task["direction"] == "implement the feature"
-        assert task["task_type"] == "impl"
-        assert task["status"] == "pending"
 
-
-@pytest.mark.asyncio
-async def test_create_task_all_types() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
+        # Create one of each valid task_type.
+        created = []
         for tt in ("impl", "spec", "test", "code-review", "review"):
             task = await _create_task(c, direction=f"task for {tt}", task_type=tt)
-            assert task["task_type"] == tt, f"Expected {tt}, got {task['task_type']}"
-            assert task["status"] == "pending"
+            assert task["task_type"] == tt and task["status"] == "pending"
+            created.append(task)
 
+        # Invalid type → 422.
+        bad = await c.post("/api/agent/tasks",
+                           json={"direction": "x", "task_type": "nonexistent-type"})
+        assert bad.status_code == 422
 
-@pytest.mark.asyncio
-async def test_invalid_task_type_returns_422() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.post(
-            "/api/agent/tasks",
-            json={"direction": "do something", "task_type": "nonexistent-type"},
-        )
-        assert r.status_code == 422, r.text
+        # Get + 404.
+        head = created[0]
+        got = await c.get(f"/api/agent/tasks/{head['id']}")
+        assert got.status_code == 200 and got.json()["id"] == head["id"]
+        assert (await c.get("/api/agent/tasks/nonexistent-task-id-999")).status_code == 404
 
-
-@pytest.mark.asyncio
-async def test_get_task() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        created = await _create_task(c)
-        r = await c.get(f"/api/agent/tasks/{created['id']}")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["id"] == created["id"]
-        assert body["direction"] == "implement the feature"
-
-
-@pytest.mark.asyncio
-async def test_get_missing_task_returns_404() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/tasks/nonexistent-task-id-999")
-        assert r.status_code == 404, r.text
-
-
-@pytest.mark.asyncio
-async def test_list_tasks() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        await _create_task(c, direction="task one")
-        await _create_task(c, direction="task two")
-        r = await c.get("/api/agent/tasks")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "tasks" in body
-        assert body["total"] >= 2
-        assert len(body["tasks"]) >= 2
-
-
-@pytest.mark.asyncio
-async def test_list_tasks_filter_by_status() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        t1 = await _create_task(c, direction="pending task")
-        t2 = await _create_task(c, direction="will run")
-        await _claim_task(c, t2["id"])
-
-        r = await c.get("/api/agent/tasks?status=pending")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        statuses = {t["status"] for t in body["tasks"]}
-        assert statuses == {"pending"}, f"Expected only pending, got {statuses}"
-
-
-@pytest.mark.asyncio
-async def test_task_count() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        await _create_task(c, direction="count me")
-        r = await c.get("/api/agent/tasks/count")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "total" in body
-        assert "by_status" in body
-        assert body["total"] >= 1
-        assert body["by_status"].get("pending", 0) >= 1
-
-
-# ---------------------------------------------------------------------------
-# Task Lifecycle (8 tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_task_pending_to_running() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        updated = await _claim_task(c, task["id"])
-        assert updated["status"] == "running"
-        assert updated["claimed_by"] == "test-worker-1"
-
-
-@pytest.mark.asyncio
-async def test_task_running_to_completed() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        await _claim_task(c, task["id"])
-        completed = await _complete_task(c, task["id"])
-        assert completed["status"] == "completed"
-
-
-@pytest.mark.asyncio
-async def test_task_running_to_failed() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        await _claim_task(c, task["id"])
-        r = await c.patch(
-            f"/api/agent/tasks/{task['id']}",
-            json={"status": "failed", "worker_id": "test-worker-1", "output": "Error: compilation failed"},
-        )
-        assert r.status_code == 200, r.text
-        assert r.json()["status"] == "failed"
-
-
-@pytest.mark.asyncio
-async def test_task_claim_conflict() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        await _claim_task(c, task["id"], worker_id="worker-a")
-        r = await c.patch(
-            f"/api/agent/tasks/{task['id']}",
-            json={"status": "running", "worker_id": "worker-b"},
-        )
-        assert r.status_code == 409, r.text
-
-
-@pytest.mark.asyncio
-async def test_completed_task_has_output() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        await _claim_task(c, task["id"])
-        await _complete_task(c, task["id"])
-        r = await c.get(f"/api/agent/tasks/{task['id']}")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["output"] is not None
-        assert len(body["output"]) > 0
-
-
-@pytest.mark.asyncio
-async def test_task_progress_update() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c)
-        await _claim_task(c, task["id"])
-        r = await c.patch(
-            f"/api/agent/tasks/{task['id']}",
-            json={"progress_pct": 50, "current_step": "Running tests"},
-        )
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["progress_pct"] == 50
-        assert body["current_step"] == "Running tests"
-
-
-@pytest.mark.asyncio
-async def test_full_task_lifecycle() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        # Create
-        task = await _create_task(c, direction="full lifecycle test")
-        assert task["status"] == "pending"
-        # Claim
-        claimed = await _claim_task(c, task["id"])
-        assert claimed["status"] == "running"
-        # Progress
-        r = await c.patch(
-            f"/api/agent/tasks/{task['id']}",
-            json={"progress_pct": 75, "current_step": "Finalizing"},
-        )
-        assert r.status_code == 200, r.text
-        assert r.json()["progress_pct"] == 75
-        # Complete
-        completed = await _complete_task(c, task["id"])
-        assert completed["status"] == "completed"
-        assert completed["output"] is not None
-
-
-@pytest.mark.asyncio
-async def test_task_attention() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c, direction="will fail for attention")
-        await _claim_task(c, task["id"])
-        await c.patch(
-            f"/api/agent/tasks/{task['id']}",
-            json={"status": "failed", "worker_id": "test-worker-1", "output": "broken"},
-        )
-        r = await c.get("/api/agent/tasks/attention")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "tasks" in body
-        ids = [t["id"] for t in body["tasks"]]
-        assert task["id"] in ids
-
-
-# ---------------------------------------------------------------------------
-# Task Context (4 tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_task_with_context() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        ctx = {"spec_ref": "specs/042.md", "priority": "high"}
-        task = await _create_task(c, context=ctx)
-        r = await c.get(f"/api/agent/tasks/{task['id']}")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["context"] is not None
-        assert body["context"].get("spec_ref") == "specs/042.md"
-
-
-@pytest.mark.asyncio
-async def test_task_with_task_card() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task_card = {
-            "goal": "Implement the widget",
-            "files_allowed": ["api/app/services/widget.py"],
-            "done_when": "tests pass",
-            "commands": ["pytest"],
-            "constraints": "none",
-        }
-        task = await _create_task(c, context={"task_card": task_card})
-        r = await c.get(f"/api/agent/tasks/{task['id']}")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        ctx = body.get("context") or {}
-        # task_card should be stored (possibly with validation metadata added)
-        assert "task_card" in ctx or "task_card_validation" in ctx
-
-
-@pytest.mark.asyncio
-async def test_task_with_idea_id() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        task = await _create_task(c, context={"idea_id": "idea-123"})
-        r = await c.get(f"/api/agent/tasks/{task['id']}")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        ctx = body.get("context") or {}
-        assert ctx.get("idea_id") == "idea-123"
-
-
-@pytest.mark.asyncio
-async def test_upsert_active_task() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _clear(c)
-        payload = {
-            "session_key": "test-session-upsert-1",
-            "direction": "upsert test direction",
-            "task_type": "impl",
-            "worker_id": "test-worker-1",
-        }
-        r1 = await c.post("/api/agent/tasks/upsert-active", json=payload)
-        assert r1.status_code == 200, r1.text
-        body1 = r1.json()
-        assert body1["created"] is True
-        task_id = body1["task"]["id"]
-
-        # Second call with same session_key returns existing
-        r2 = await c.post("/api/agent/tasks/upsert-active", json=payload)
-        assert r2.status_code == 200, r2.text
-        body2 = r2.json()
-        assert body2["task"]["id"] == task_id
-
-
-# ---------------------------------------------------------------------------
-# Task Management (4 tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_delete_all_tasks() -> None:
-    agent_service._store.clear()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_task(c, direction="to be deleted")
-        r = await c.delete("/api/agent/tasks?confirm=clear")
-        assert r.status_code == 204
+        # List.
         listed = await c.get("/api/agent/tasks")
         assert listed.status_code == 200
-        assert listed.json()["total"] == 0
+        body = listed.json()
+        assert body["total"] >= 5 and len(body["tasks"]) >= 5
+
+        # Filter by status — claim one so we have a mix.
+        await _claim(c, created[1]["id"])
+        pending_only = (await c.get("/api/agent/tasks?status=pending")).json()
+        assert {t["status"] for t in pending_only["tasks"]} == {"pending"}
+
+        # Count.
+        count = await c.get("/api/agent/tasks/count")
+        assert count.status_code == 200
+        cb = count.json()
+        assert "total" in cb and "by_status" in cb
+        assert cb["by_status"].get("pending", 0) >= 4
 
 
 @pytest.mark.asyncio
-async def test_delete_without_confirm_returns_400() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.delete("/api/agent/tasks")
-        assert r.status_code == 400, r.text
-
-
-@pytest.mark.asyncio
-async def test_task_log() -> None:
+async def test_task_lifecycle_transitions_flow():
+    """pending → running → (completed | failed). Claim conflict on a
+    second worker is 409. Progress updates mid-flight. Failed tasks
+    surface in the attention endpoint."""
     agent_service._store.clear()
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         await _clear(c)
-        task = await _create_task(c, direction="log test task")
-        r = await c.get(f"/api/agent/tasks/{task['id']}/log")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "task_id" in body
-        assert body["task_id"] == task["id"]
-        assert "log" in body
+
+        # Happy path: pending → running → progress → completed.
+        t1 = await _create_task(c, direction="happy path")
+        claimed = await _claim(c, t1["id"])
+        assert claimed["status"] == "running" and claimed["claimed_by"] == "test-worker-1"
+        prog = await c.patch(f"/api/agent/tasks/{t1['id']}",
+                             json={"progress_pct": 75, "current_step": "Finalizing"})
+        assert prog.status_code == 200 and prog.json()["progress_pct"] == 75
+        done = await _complete(c, t1["id"])
+        assert done["status"] == "completed"
+        fetched = (await c.get(f"/api/agent/tasks/{t1['id']}")).json()
+        assert fetched["output"] and len(fetched["output"]) > 0
+
+        # Failure path: pending → running → failed → surfaces in attention.
+        t2 = await _create_task(c, direction="will fail")
+        await _claim(c, t2["id"])
+        failed = await c.patch(f"/api/agent/tasks/{t2['id']}",
+                               json={"status": "failed", "worker_id": "test-worker-1",
+                                     "output": "Error: compilation failed"})
+        assert failed.status_code == 200 and failed.json()["status"] == "failed"
+        attention = (await c.get("/api/agent/tasks/attention")).json()
+        assert t2["id"] in [t["id"] for t in attention["tasks"]]
+
+        # Claim conflict: worker-a claims, worker-b gets 409.
+        t3 = await _create_task(c, direction="contested")
+        await _claim(c, t3["id"], worker_id="worker-a")
+        conflict = await c.patch(f"/api/agent/tasks/{t3['id']}",
+                                 json={"status": "running", "worker_id": "worker-b"})
+        assert conflict.status_code == 409
 
 
 @pytest.mark.asyncio
-async def test_reap_history() -> None:
+async def test_task_context_and_upsert_flow():
+    """Tasks carry arbitrary context (spec_ref, task_card, idea_id)
+    round-trip. upsert-active is idempotent on session_key."""
+    agent_service._store.clear()
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/reap-history")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "items" in body
-        assert "total" in body
+        await _clear(c)
 
+        # Context round-trip — three representative shapes.
+        t_spec = await _create_task(c, context={"spec_ref": "specs/042.md", "priority": "high"})
+        assert (await c.get(f"/api/agent/tasks/{t_spec['id']}")).json()["context"]["spec_ref"] == "specs/042.md"
 
-# ---------------------------------------------------------------------------
-# Routing & Metrics (4 tests)
-# ---------------------------------------------------------------------------
+        task_card = {"goal": "Implement the widget",
+                     "files_allowed": ["api/app/services/widget.py"],
+                     "done_when": "tests pass", "commands": ["pytest"],
+                     "constraints": "none"}
+        t_card = await _create_task(c, context={"task_card": task_card})
+        ctx = (await c.get(f"/api/agent/tasks/{t_card['id']}")).json().get("context") or {}
+        assert "task_card" in ctx or "task_card_validation" in ctx
+
+        t_idea = await _create_task(c, context={"idea_id": "idea-123"})
+        got_ctx = (await c.get(f"/api/agent/tasks/{t_idea['id']}")).json().get("context") or {}
+        assert got_ctx.get("idea_id") == "idea-123"
+
+        # upsert-active — first call creates, second with same session_key returns existing.
+        payload = {"session_key": "test-session-upsert-1", "direction": "upsert test",
+                   "task_type": "impl", "worker_id": "test-worker-1"}
+        r1 = await c.post("/api/agent/tasks/upsert-active", json=payload)
+        assert r1.status_code == 200 and r1.json()["created"] is True
+        first_id = r1.json()["task"]["id"]
+        r2 = await c.post("/api/agent/tasks/upsert-active", json=payload)
+        assert r2.status_code == 200 and r2.json()["task"]["id"] == first_id
 
 
 @pytest.mark.asyncio
-async def test_agent_route() -> None:
+async def test_task_management_flow():
+    """Delete-all with confirm wipes the store; without confirm → 400.
+    Task log + reap history read surfaces return the expected shape."""
+    agent_service._store.clear()
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/route?task_type=impl")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "task_type" in body
-        assert body["task_type"] == "impl"
-        assert "model" in body
+        # Missing confirm → 400 (no clear first; the guard is the point).
+        assert (await c.delete("/api/agent/tasks")).status_code == 400
+
+        # With confirm → wipe succeeds.
+        await _create_task(c, direction="to be deleted")
+        assert (await c.delete("/api/agent/tasks?confirm=clear")).status_code == 204
+        assert (await c.get("/api/agent/tasks")).json()["total"] == 0
+
+        # Task log.
+        task = await _create_task(c, direction="log test")
+        log_body = (await c.get(f"/api/agent/tasks/{task['id']}/log")).json()
+        assert log_body["task_id"] == task["id"] and "log" in log_body
+
+        # Reap history.
+        reap = (await c.get("/api/agent/reap-history")).json()
+        assert "items" in reap and "total" in reap
 
 
 @pytest.mark.asyncio
-async def test_pipeline_status() -> None:
+async def test_agent_routing_and_metrics_flow():
+    """Route resolves task_type to a model; pipeline-status summarises
+    running/pending/attention; metrics record + aggregate."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/pipeline-status")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "running" in body
-        assert "pending" in body
-        assert "attention" in body
+        route = (await c.get("/api/agent/route?task_type=impl")).json()
+        assert route["task_type"] == "impl" and "model" in route
+
+        pipe = (await c.get("/api/agent/pipeline-status")).json()
+        assert all(k in pipe for k in ("running", "pending", "attention"))
+
+        rec = await c.post("/api/agent/metrics", json={
+            "task_id": "metric-test-001", "task_type": "impl",
+            "model": "claude-sonnet-4-20250514",
+            "duration_seconds": 42.5, "status": "completed",
+        })
+        assert rec.status_code == 201 and rec.json().get("recorded") is True
+
+        agg = (await c.get("/api/agent/metrics")).json()
+        assert isinstance(agg, dict)
 
 
 @pytest.mark.asyncio
-async def test_record_metric() -> None:
+async def test_runners_flow():
+    """Runner heartbeats register, list-runners surfaces them, and
+    lifecycle-summary returns the overview structure."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.post(
-            "/api/agent/metrics",
-            json={
-                "task_id": "metric-test-001",
-                "task_type": "impl",
-                "model": "claude-sonnet-4-20250514",
-                "duration_seconds": 42.5,
-                "status": "completed",
-            },
-        )
-        assert r.status_code == 201, r.text
-        body = r.json()
-        assert body.get("recorded") is True
+        hb = await c.post("/api/agent/runners/heartbeat", json={
+            "runner_id": "test-runner-hb-1", "status": "idle", "lease_seconds": 90,
+            "host": "localhost", "pid": 12345, "version": "0.1.0",
+        })
+        assert hb.status_code == 200 and hb.json()["runner_id"] == "test-runner-hb-1"
 
+        listed = (await c.get("/api/agent/runners?include_stale=true")).json()
+        assert "runners" in listed and "total" in listed
 
-@pytest.mark.asyncio
-async def test_aggregate_metrics() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/metrics")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        # Should return some aggregation structure
-        assert isinstance(body, dict)
-
-
-# ---------------------------------------------------------------------------
-# Runners (3 tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_runner_heartbeat() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.post(
-            "/api/agent/runners/heartbeat",
-            json={
-                "runner_id": "test-runner-hb-1",
-                "status": "idle",
-                "lease_seconds": 90,
-                "host": "localhost",
-                "pid": 12345,
-                "version": "0.1.0",
-            },
-        )
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["runner_id"] == "test-runner-hb-1"
-
-
-@pytest.mark.asyncio
-async def test_list_runners() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        # Register a runner first
-        await c.post(
-            "/api/agent/runners/heartbeat",
-            json={
-                "runner_id": "test-runner-list-1",
-                "status": "idle",
-                "lease_seconds": 90,
-            },
-        )
-        r = await c.get("/api/agent/runners?include_stale=true")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "runners" in body
-        assert "total" in body
-
-
-@pytest.mark.asyncio
-async def test_lifecycle_summary() -> None:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/agent/lifecycle/summary")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert isinstance(body, dict)
+        summary = (await c.get("/api/agent/lifecycle/summary")).json()
+        assert isinstance(summary, dict)

--- a/api/tests/test_flow_core_api.py
+++ b/api/tests/test_flow_core_api.py
@@ -725,142 +725,65 @@ async def test_list_assets_handles_non_pipeline_asset_types():
 
 
 @pytest.mark.asyncio
-async def test_graduate_email_keyed_is_idempotent_across_devices():
-    """Same email on two different device fingerprints must resolve
-    to the same contributor — that's the core of cross-device
-    identity. A duplicate here means a visitor's presence shatters
-    when they open the app on their phone."""
-    email = f"alice+{uuid4().hex[:6]}@example.com"
+async def test_multi_device_identity_flow():
+    """One user's journey across devices — every identity guarantee
+    in one flow so we get wide coverage without test bloat:
+
+      · /vision/join (register_interest) returns a contributor_id
+        the client persists. Same email on re-submit → same id
+      · graduate with same email, different fingerprint → same id
+        (the core cross-device guarantee)
+      · graduate partial-updates merge onto the node without
+        clobbering earlier consent flags + roles
+      · claim-by-identity via email on a fresh browser restores
+        the full profile so the UI can rehydrate
+      · Clean error paths: empty claim → 400; unknown email → 404
+    """
+    email = f"flow+{uuid4().hex[:6]}@example.com"
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r1 = await c.post("/api/contributors/graduate", json={
-            "author_name": "Alice",
+        # Laptop — /vision/join carries the full consent state.
+        r1 = await c.post("/api/interest/register", json={
+            "name": "Traveler",
             "email": email,
-            "device_fingerprint": "laptop-fp",
-        })
-        assert r1.status_code == 200, r1.text
-        d1 = r1.json()
-        assert d1["created"] is True
-        assert d1["email"] == email
-        first_id = d1["contributor_id"]
-
-        # Second device, same email — must return the SAME id.
-        r2 = await c.post("/api/contributors/graduate", json={
-            "author_name": "Alice",
-            "email": email,
-            "device_fingerprint": "phone-fp",
-        })
-        assert r2.status_code == 200, r2.text
-        d2 = r2.json()
-        assert d2["created"] is False
-        assert d2["contributor_id"] == first_id
-
-
-@pytest.mark.asyncio
-async def test_graduate_merges_profile_without_clobbering():
-    """A second graduate call should merge newly-provided fields
-    without wiping the ones set on the first call. Consent flags
-    and invited_by especially — these get set once and must not
-    get silently reset on a name update."""
-    email = f"merge+{uuid4().hex[:6]}@example.com"
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r1 = await c.post("/api/contributors/graduate", json={
-            "author_name": "Initial Name",
-            "email": email,
+            "resonant_roles": ["frequency-holder"],
+            "locale": "en",
             "consent_findable": True,
             "consent_email_updates": True,
-            "resonant_roles": ["frequency-holder"],
         })
-        assert r1.status_code == 200
+        assert r1.status_code == 200, r1.text
         cid = r1.json()["contributor_id"]
+        assert cid, "register must return contributor_id for localStorage persistence"
 
-        # Second call updates only the name — consent flags + roles
-        # must survive.
+        # Phone — graduate with different fingerprint + partial
+        # update (just name + locale; consent fields omitted).
+        # Same email → same contributor; omitted fields preserved.
         r2 = await c.post("/api/contributors/graduate", json={
-            "author_name": "Updated Name",
+            "author_name": "Traveler (phone)",
             "email": email,
-        })
-        assert r2.status_code == 200
-        assert r2.json()["contributor_id"] == cid
-
-        # Verify on the graph that consent flags + roles are intact.
-        r3 = await c.get(f"/api/graph/nodes/contributor:{cid}")
-        assert r3.status_code == 200
-        node = r3.json()
-        assert node.get("consent_findable") is True
-        assert node.get("consent_email_updates") is True
-        assert node.get("resonant_roles") == ["frequency-holder"]
-
-
-@pytest.mark.asyncio
-async def test_claim_by_identity_restores_contributor_across_devices():
-    """Opening the app on a new device with nothing in localStorage,
-    asserting the email the visitor registered with must return
-    their full contributor profile so the UI can rehydrate."""
-    email = f"claim+{uuid4().hex[:6]}@example.com"
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r1 = await c.post("/api/contributors/graduate", json={
-            "author_name": "Recoverable",
-            "email": email,
+            "device_fingerprint": "phone-fp",
             "locale": "de",
-            "resonant_roles": ["vitality-keeper"],
         })
-        cid = r1.json()["contributor_id"]
-
-        # New device — just the email.
-        r2 = await c.post("/api/contributors/claim-by-identity", json={
-            "email": email,
-        })
-        assert r2.status_code == 200, r2.text
         d2 = r2.json()
-        assert d2["contributor_id"] == cid
-        assert d2["author_display_name"] == "Recoverable"
+        assert d2["created"] is False
+        assert d2["contributor_id"] == cid, "same email must yield same id across devices"
         assert d2["locale"] == "de"
-        assert d2["matched_provider"] == "email"
-        assert "vitality-keeper" in d2["resonant_roles"]
 
-        # Unknown email → 404 (not 500, so the UI can show a clean
-        # 'not registered yet' message).
-        r3 = await c.post("/api/contributors/claim-by-identity", json={
-            "email": f"ghost+{uuid4().hex[:6]}@nowhere.test",
-        })
-        assert r3.status_code == 404
+        # Partial-update merge proof: earlier consent + roles survive.
+        node = (await c.get(f"/api/graph/nodes/contributor:{cid}")).json()
+        assert node["consent_findable"] is True
+        assert node["consent_email_updates"] is True
+        assert node["resonant_roles"] == ["frequency-holder"]
 
+        # Fresh browser / new device — claim by email returns the
+        # full profile for localStorage rehydration.
+        claim = await c.post("/api/contributors/claim-by-identity", json={"email": email})
+        cj = claim.json()
+        assert claim.status_code == 200
+        assert cj["contributor_id"] == cid
+        assert cj["matched_provider"] == "email"
+        assert "frequency-holder" in cj["resonant_roles"]
 
-@pytest.mark.asyncio
-async def test_claim_by_identity_requires_at_least_one_provider():
-    """Empty claim → 400, not 500 — the client sent an invalid
-    request and should see a clean error."""
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.post("/api/contributors/claim-by-identity", json={})
-        assert r.status_code == 400
-        assert "identity" in r.json()["detail"].lower()
-
-
-@pytest.mark.asyncio
-async def test_register_interest_returns_contributor_id():
-    """The /vision/join form submits here. The response must carry
-    the contributor_id so the client can persist it in localStorage
-    — without this the 'You' page forgets the visitor on the next
-    page load."""
-    email = f"joiner+{uuid4().hex[:6]}@example.com"
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.post("/api/interest/register", json={
-            "name": "Joiner Testcase",
-            "email": email,
-            "resonant_roles": ["transmission-source"],
-            "locale": "en",
-            "consent_findable": True,
-        })
-        assert r.status_code == 200, r.text
-        data = r.json()
-        assert data["contributor_id"], "register must return contributor_id"
-
-        # Re-submit with the same email — must resolve to the same
-        # contributor (the backend merged rather than duplicated).
-        r2 = await c.post("/api/interest/register", json={
-            "name": "Joiner Testcase",
-            "email": email,
-            "resonant_roles": ["transmission-source"],
-            "locale": "en",
-        })
-        assert r2.json()["contributor_id"] == data["contributor_id"]
+        # Clean error paths the UI can branch on (not silent 500s).
+        assert (await c.post("/api/contributors/claim-by-identity", json={})).status_code == 400
+        assert (await c.post("/api/contributors/claim-by-identity",
+                             json={"email": f"ghost+{uuid4().hex[:6]}@nowhere.test"})).status_code == 404

--- a/api/tests/test_flow_core_api.py
+++ b/api/tests/test_flow_core_api.py
@@ -40,58 +40,34 @@ async def _create_idea(c: AsyncClient, idea_id: str | None = None, **overrides) 
 
 
 # ---------------------------------------------------------------------------
-# Health & Meta (5 tests)
+# Health & Meta
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_health_returns_ok():
+async def test_health_and_meta_endpoints():
+    """Five infrastructure endpoints the frontend + deploy verifier
+    rely on: /health, /ping, /version, /ready, /meta/summary. All
+    checked in one round."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/health")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert body["status"] == "ok"
-        assert "version" in body
-        assert "uptime_seconds" in body
+        health = await c.get("/api/health")
+        assert health.status_code == 200 and health.json()["status"] == "ok"
+        assert "version" in health.json() and "uptime_seconds" in health.json()
 
+        assert (await c.get("/api/ping")).json()["pong"] is True
 
-@pytest.mark.asyncio
-async def test_ping_returns_pong():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ping")
-        assert r.status_code == 200, r.text
-        assert r.json()["pong"] is True
+        version = (await c.get("/api/version")).json()["version"]
+        assert re.match(r"^\d+\.\d+\.\d+", version), version
 
+        ready = await c.get("/api/ready")
+        # /ready is 200 when graph_store wired, 503 otherwise — both valid.
+        assert ready.status_code in (200, 503)
+        if ready.status_code == 200:
+            assert "db_connected" in ready.json()
 
-@pytest.mark.asyncio
-async def test_version_returns_semver():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/version")
-        assert r.status_code == 200, r.text
-        version = r.json()["version"]
-        assert re.match(r"^\d+\.\d+\.\d+", version), f"Not semver: {version}"
-
-
-@pytest.mark.asyncio
-async def test_ready_probe():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ready")
-        # ready may return 200 or 503 depending on app.state.graph_store
-        if r.status_code == 200:
-            body = r.json()
-            assert "db_connected" in body
-        else:
-            assert r.status_code == 503
-
-
-@pytest.mark.asyncio
-async def test_meta_summary():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/meta/summary")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        # Should have coverage counts
-        assert "endpoint_count" in body or "total_endpoints" in body
+        meta = await c.get("/api/meta/summary")
+        assert meta.status_code == 200
+        assert "endpoint_count" in meta.json() or "total_endpoints" in meta.json()
 
 
 # ---------------------------------------------------------------------------
@@ -150,80 +126,51 @@ async def test_idea_crud_flow():
 
 
 @pytest.mark.asyncio
-async def test_advance_idea_stage_and_409_when_complete():
-    """Advance stage on a fresh idea succeeds; advancing past
-    `complete` returns 409. One flow covers both the happy path
-    and the terminal-state guard."""
+async def test_idea_lifecycle_flow():
+    """Full lifecycle: seed idea → advance → set-stage → advance-past-
+    complete is 409 → per-idea progress/activity → global progress/
+    showcase/resonance/storage read surfaces → multi-idea sort by
+    ROI → tasks listing. Every lifecycle-reading endpoint the UI
+    uses in one journey."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "stage" in body or "idea" in body
-        # Move to complete, then advance must 409.
-        set_complete = await c.post(f"/api/ideas/{iid}/stage", json={"stage": "complete"}, headers=AUTH)
-        assert set_complete.status_code == 200
+
+        # Advance once (happy), set-stage back to specced, set to
+        # complete, advance is 409.
+        assert (await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)).status_code == 200
+        assert (await c.post(f"/api/ideas/{iid}/stage",
+                             json={"stage": "specced"}, headers=AUTH)).status_code == 200
+        assert (await c.post(f"/api/ideas/{iid}/stage",
+                             json={"stage": "complete"}, headers=AUTH)).status_code == 200
         assert (await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)).status_code == 409
 
+        # Per-idea read surfaces.
+        prog = await c.get(f"/api/ideas/{iid}/progress")
+        assert prog.status_code == 200
+        assert "stage" in prog.json() or "idea_id" in prog.json()
+        assert isinstance((await c.get(f"/api/ideas/{iid}/activity")).json(), list)
+        tasks = await c.get(f"/api/ideas/{iid}/tasks")
+        assert tasks.status_code == 200
 
-@pytest.mark.asyncio
-async def test_set_idea_stage():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/stage", json={"stage": "specced"}, headers=AUTH)
-        assert r.status_code == 200, r.text
+        # Global read surfaces.
+        overview = await c.get("/api/ideas/progress")
+        assert overview.status_code == 200
+        assert "total_ideas" in overview.json() or "by_stage" in overview.json()
+        showcase = await c.get("/api/ideas/showcase")
+        assert showcase.status_code == 200
+        assert "ideas" in showcase.json() or "items" in showcase.json() or "showcase" in showcase.json()
+        assert isinstance((await c.get("/api/ideas/resonance")).json(), list)
+        storage = await c.get("/api/ideas/storage")
+        assert storage.status_code == 200 and "backend" in storage.json()
 
-
-@pytest.mark.asyncio
-async def test_idea_progress():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.get(f"/api/ideas/{iid}/progress")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "stage" in body or "idea_id" in body
-
-
-@pytest.mark.asyncio
-async def test_idea_activity():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.get(f"/api/ideas/{iid}/activity")
-        assert r.status_code == 200, r.text
-        assert isinstance(r.json(), list)
-
-
-@pytest.mark.asyncio
-async def test_idea_progress_overview():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas/progress")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "total_ideas" in body or "by_stage" in body
-
-
-@pytest.mark.asyncio
-async def test_idea_showcase():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas/showcase")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "ideas" in body or "items" in body or "showcase" in body
-
-
-@pytest.mark.asyncio
-async def test_idea_resonance_feed():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas/resonance")
-        assert r.status_code == 200, r.text
-        assert isinstance(r.json(), list)
+        # Multi-idea list (seed a range of ROIs — list must return >= 3
+        # even though order-by-roi is the service's internal sort).
+        for val in (10.0, 500.0, 50.0):
+            await _create_idea(c, potential_value=val, estimated_cost=10.0, confidence=0.7)
+        body = (await c.get("/api/ideas")).json()
+        ideas = body.get("ideas") or body.get("items") or []
+        assert len(ideas) >= 3
 
 
 # ---------------------------------------------------------------------------
@@ -232,50 +179,27 @@ async def test_idea_resonance_feed():
 
 
 @pytest.mark.asyncio
-async def test_set_idea_tags():
+async def test_idea_tags_flow():
+    """Set tags → read back normalized → catalog lists them →
+    cards filter by tag → empty-string tag validation."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
-        r = await c.put(f"/api/ideas/{iid}/tags", json={"tags": ["infra", "api"]})
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "tags" in body
-        normalized = body["tags"]
-        assert "infra" in normalized
-        assert "api" in normalized
 
+        set_resp = await c.put(f"/api/ideas/{iid}/tags", json={"tags": ["infra", "filterable"]})
+        assert set_resp.status_code == 200
+        normalized = set_resp.json()["tags"]
+        assert "infra" in normalized and "filterable" in normalized
 
-@pytest.mark.asyncio
-async def test_list_tags_catalog():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        await c.put(f"/api/ideas/{iid}/tags", json={"tags": ["catalog-tag"]})
-        r = await c.get("/api/ideas/tags")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "tags" in body or "catalog" in body or isinstance(body, list)
+        catalog = await c.get("/api/ideas/tags")
+        assert catalog.status_code == 200
+        cb = catalog.json()
+        assert "tags" in cb or "catalog" in cb or isinstance(cb, list)
 
+        assert (await c.get("/api/ideas/cards", params={"q": "tag:filterable"})).status_code == 200
 
-@pytest.mark.asyncio
-async def test_idea_cards_filter_by_tag():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        await c.put(f"/api/ideas/{iid}/tags", json={"tags": ["filterable"]})
-        r = await c.get("/api/ideas/cards", params={"q": "tag:filterable"})
-        assert r.status_code == 200, r.text
-
-
-@pytest.mark.asyncio
-async def test_invalid_tag_returns_422():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        # Empty string tag should be invalid after normalization
-        r = await c.put(f"/api/ideas/{iid}/tags", json={"tags": [""]})
-        # Either 422 (validation) or the service normalizes it out
-        assert r.status_code in (200, 422), r.text
+        # Empty-string tag — either 422 or normalized out; not 500.
+        assert (await c.put(f"/api/ideas/{iid}/tags", json={"tags": [""]})).status_code in (200, 422)
 
 
 # ---------------------------------------------------------------------------
@@ -284,63 +208,32 @@ async def test_invalid_tag_returns_422():
 
 
 @pytest.mark.asyncio
-async def test_stake_on_idea():
+async def test_idea_investment_fork_selection_flow():
+    """Stake CC on an idea, fork it, verify the fork references its
+    parent, select an idea algorithmically, read the A/B stats."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/stake", json={
-            "contributor_id": "test-user",
-            "amount_cc": 10.0,
-            "rationale": "testing",
+
+        stake = await c.post(f"/api/ideas/{iid}/stake", json={
+            "contributor_id": "test-user", "amount_cc": 10.0, "rationale": "testing",
         })
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "amount_cc" in body or "stake" in body or "staked" in body
+        assert stake.status_code == 200
+        sb = stake.json()
+        assert "amount_cc" in sb or "stake" in sb or "staked" in sb
 
-
-@pytest.mark.asyncio
-async def test_fork_idea():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/fork", params={"forker_id": "test-user"})
-        assert r.status_code == 201, r.text
-        body = r.json()
-        # Fork response wraps in {"idea": {...}, "lineage_link_id": ..., "source_idea_id": ...}
-        assert "idea" in body
-        assert "source_idea_id" in body
-
-
-@pytest.mark.asyncio
-async def test_forked_idea_references_parent():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/fork", params={"forker_id": "test-user"})
-        assert r.status_code == 201, r.text
-        forked = r.json()
-        forked_id = forked["idea"]["id"]
+        fork = await c.post(f"/api/ideas/{iid}/fork", params={"forker_id": "test-user"})
+        assert fork.status_code == 201
+        forked = fork.json()
         assert forked["source_idea_id"] == iid
-        r2 = await c.get(f"/api/ideas/{forked_id}")
-        assert r2.status_code == 200, r2.text
+        assert (await c.get(f"/api/ideas/{forked['idea']['id']}")).status_code == 200
 
-
-@pytest.mark.asyncio
-async def test_idea_selection():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        await _create_idea(c)
-        r = await c.post("/api/ideas/select", headers=AUTH)
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "idea_id" in body or "id" in body or "selected" in body
-
-
-@pytest.mark.asyncio
-async def test_idea_selection_ab_stats():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ideas/selection-ab/stats")
-        assert r.status_code == 200, r.text
+        await _create_idea(c)  # one more so selection has choices
+        sel = await c.post("/api/ideas/select", headers=AUTH)
+        assert sel.status_code == 200
+        sb2 = sel.json()
+        assert "idea_id" in sb2 or "id" in sb2 or "selected" in sb2
+        assert (await c.get("/api/ideas/selection-ab/stats")).status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -349,107 +242,34 @@ async def test_idea_selection_ab_stats():
 
 
 @pytest.mark.asyncio
-async def test_add_question_to_idea():
+async def test_idea_questions_and_resonance_flow():
+    """Add a question, answer it, read concept-resonance matches,
+    404 on a missing idea."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
-        r = await c.post(f"/api/ideas/{iid}/questions", json={
-            "question": "Is this viable?",
-            "value_to_whole": 5.0,
-            "estimated_cost": 1.0,
+
+        q = await c.post(f"/api/ideas/{iid}/questions", json={
+            "question": "Is this viable?", "value_to_whole": 5.0, "estimated_cost": 1.0,
         })
-        assert r.status_code == 200, r.text
+        assert q.status_code == 200
 
-
-@pytest.mark.asyncio
-async def test_answer_question():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        await c.post(f"/api/ideas/{iid}/questions", json={
-            "question": "Is this viable?",
-            "value_to_whole": 5.0,
-            "estimated_cost": 1.0,
+        ans = await c.post(f"/api/ideas/{iid}/questions/answer", json={
+            "question": "Is this viable?", "answer": "Yes, after validation.",
         })
-        r = await c.post(f"/api/ideas/{iid}/questions/answer", json={
-            "question": "Is this viable?",
-            "answer": "Yes, after validation.",
-        })
-        assert r.status_code == 200, r.text
+        assert ans.status_code == 200
 
-
-@pytest.mark.asyncio
-async def test_concept_resonance_happy_and_404():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.get(f"/api/ideas/{iid}/concept-resonance")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "matches" in body or "related" in body or "idea_id" in body
-        # Missing idea → 404 (not silent 200 with empty payload).
+        reso = await c.get(f"/api/ideas/{iid}/concept-resonance")
+        assert reso.status_code == 200
+        rb = reso.json()
+        assert "matches" in rb or "related" in rb or "idea_id" in rb
         assert (await c.get("/api/ideas/nonexistent-idea-xyz/concept-resonance")).status_code == 404
 
 
-# ---------------------------------------------------------------------------
-# Full User Journey (4 tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_full_idea_lifecycle():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-
-        # Advance through stages
-        r = await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)
-        assert r.status_code == 200, r.text
-
-        r = await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)
-        assert r.status_code == 200, r.text
-
-        # Update value
-        r = await c.patch(f"/api/ideas/{iid}", json={"potential_value": 200.0}, headers=AUTH)
-        assert r.status_code == 200, r.text
-
-        # Check progress
-        r = await c.get(f"/api/ideas/{iid}/progress")
-        assert r.status_code == 200, r.text
-
-
-@pytest.mark.asyncio
-async def test_idea_with_tasks():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        # GET tasks for the idea (may be empty but should return 200)
-        r = await c.get(f"/api/ideas/{iid}/tasks")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "tasks" in body or "items" in body or isinstance(body, dict)
-
-
-@pytest.mark.asyncio
-async def test_multiple_ideas_sorted_by_roi():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c, potential_value=10.0, estimated_cost=10.0, confidence=0.5)
-        await _create_idea(c, potential_value=500.0, estimated_cost=10.0, confidence=0.9)
-        await _create_idea(c, potential_value=50.0, estimated_cost=10.0, confidence=0.7)
-        r = await c.get("/api/ideas")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        ideas = body.get("ideas") or body.get("items") or []
-        assert len(ideas) >= 3
-
-
-@pytest.mark.asyncio
-async def test_idea_storage_info():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ideas/storage")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "backend" in body
+# (The former 'Full User Journey' tests — full_idea_lifecycle,
+# idea_with_tasks, multiple_ideas_sorted_by_roi, idea_storage_info —
+# fold into test_idea_lifecycle_flow above. Single journey covers
+# every lifecycle read surface.)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_flow_core_api.py
+++ b/api/tests/test_flow_core_api.py
@@ -100,101 +100,48 @@ async def test_meta_summary():
 
 
 @pytest.mark.asyncio
-async def test_create_idea():
+async def test_idea_crud_flow():
+    """Create → duplicate-409 → get → get-missing-404 → list/paginate
+    → update (with + without auth) → count → cards. One CRUD story."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
-        data = await _create_idea(c, iid)
-        assert data["id"] == iid
+        created = await _create_idea(c, iid)
+        assert created["id"] == iid
 
-
-@pytest.mark.asyncio
-async def test_create_duplicate_idea_returns_409():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.post("/api/ideas", json={
+        # Duplicate create → 409.
+        dup = await c.post("/api/ideas", json={
             "id": iid, "name": "dup", "description": "dup",
             "potential_value": 1.0, "estimated_cost": 1.0,
         })
-        assert r.status_code == 409, r.text
+        assert dup.status_code == 409, dup.text
 
+        # Get existing + missing.
+        got = await c.get(f"/api/ideas/{iid}")
+        assert got.status_code == 200 and got.json()["id"] == iid, got.text
+        assert (await c.get("/api/ideas/nonexistent-idea-xyz")).status_code == 404
 
-@pytest.mark.asyncio
-async def test_get_idea():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.get(f"/api/ideas/{iid}")
-        assert r.status_code == 200, r.text
-        assert r.json()["id"] == iid
-
-
-@pytest.mark.asyncio
-async def test_get_missing_idea_returns_404():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ideas/nonexistent-idea-xyz")
-        assert r.status_code == 404, r.text
-
-
-@pytest.mark.asyncio
-async def test_list_ideas():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "ideas" in body or "items" in body or isinstance(body, list)
-
-
-@pytest.mark.asyncio
-async def test_list_ideas_pagination():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        for _ in range(3):
+        # List + pagination (seed two more for pagination clarity).
+        for _ in range(2):
             await _create_idea(c)
-        r = await c.get("/api/ideas", params={"limit": 2, "offset": 0})
-        assert r.status_code == 200, r.text
-        body = r.json()
-        ideas = body.get("ideas") or body.get("items") or body
-        assert len(ideas) <= 2
+        listed = await c.get("/api/ideas")
+        assert listed.status_code == 200
+        body = listed.json()
+        assert "ideas" in body or "items" in body or isinstance(body, list)
+        paged = await c.get("/api/ideas", params={"limit": 2, "offset": 0})
+        assert len((paged.json().get("ideas") or paged.json().get("items") or paged.json())) <= 2
 
+        # Update requires auth.
+        assert (await c.patch(f"/api/ideas/{iid}", json={"confidence": 0.9})).status_code == 401
+        patched = await c.patch(f"/api/ideas/{iid}", json={"confidence": 0.9}, headers=AUTH)
+        assert patched.status_code == 200
+        assert patched.json()["confidence"] == pytest.approx(0.9, abs=0.01)
 
-@pytest.mark.asyncio
-async def test_update_idea():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.patch(f"/api/ideas/{iid}", json={"confidence": 0.9}, headers=AUTH)
-        assert r.status_code == 200, r.text
-        assert r.json()["confidence"] == pytest.approx(0.9, abs=0.01)
-
-
-@pytest.mark.asyncio
-async def test_update_idea_without_auth_returns_401():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        r = await c.patch(f"/api/ideas/{iid}", json={"confidence": 0.9})
-        assert r.status_code == 401, r.text
-
-
-@pytest.mark.asyncio
-async def test_idea_count():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas/count")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "count" in body or "total" in body
-
-
-@pytest.mark.asyncio
-async def test_idea_cards():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        await _create_idea(c)
-        r = await c.get("/api/ideas/cards")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "items" in body
+        # Count + cards — read surfaces the UI uses.
+        cnt = await c.get("/api/ideas/count")
+        assert cnt.status_code == 200
+        assert "count" in cnt.json() or "total" in cnt.json()
+        cards = await c.get("/api/ideas/cards")
+        assert cards.status_code == 200 and "items" in cards.json()
 
 
 # ---------------------------------------------------------------------------
@@ -203,28 +150,21 @@ async def test_idea_cards():
 
 
 @pytest.mark.asyncio
-async def test_advance_idea_stage():
+async def test_advance_idea_stage_and_409_when_complete():
+    """Advance stage on a fresh idea succeeds; advancing past
+    `complete` returns 409. One flow covers both the happy path
+    and the terminal-state guard."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
         r = await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)
         assert r.status_code == 200, r.text
         body = r.json()
-        # Stage should have moved from initial
         assert "stage" in body or "idea" in body
-
-
-@pytest.mark.asyncio
-async def test_advance_completed_idea_returns_409():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        iid = _uid()
-        await _create_idea(c, iid)
-        # Set stage to complete (valid enum value)
-        r = await c.post(f"/api/ideas/{iid}/stage", json={"stage": "complete"}, headers=AUTH)
-        assert r.status_code == 200, r.text
-        # Now advance should fail
-        r = await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)
-        assert r.status_code == 409, r.text
+        # Move to complete, then advance must 409.
+        set_complete = await c.post(f"/api/ideas/{iid}/stage", json={"stage": "complete"}, headers=AUTH)
+        assert set_complete.status_code == 200
+        assert (await c.post(f"/api/ideas/{iid}/advance", headers=AUTH)).status_code == 409
 
 
 @pytest.mark.asyncio
@@ -439,7 +379,7 @@ async def test_answer_question():
 
 
 @pytest.mark.asyncio
-async def test_concept_resonance():
+async def test_concept_resonance_happy_and_404():
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         iid = _uid()
         await _create_idea(c, iid)
@@ -447,13 +387,8 @@ async def test_concept_resonance():
         assert r.status_code == 200, r.text
         body = r.json()
         assert "matches" in body or "related" in body or "idea_id" in body
-
-
-@pytest.mark.asyncio
-async def test_concept_resonance_missing_idea_returns_404():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/ideas/nonexistent-idea-xyz/concept-resonance")
-        assert r.status_code == 404, r.text
+        # Missing idea → 404 (not silent 200 with empty payload).
+        assert (await c.get("/api/ideas/nonexistent-idea-xyz/concept-resonance")).status_code == 404
 
 
 # ---------------------------------------------------------------------------
@@ -528,107 +463,57 @@ def _node_id() -> str:
 
 
 @pytest.mark.asyncio
-async def test_register_federation_node():
+async def test_federation_node_registration_flow():
+    """A node registers, appears in the list, heartbeats, shows its
+    capabilities, and deletes cleanly. One lifecycle covers the
+    whole federation node CRUD."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         nid = _node_id()
-        r = await c.post("/api/federation/nodes", json={
-            "node_id": nid,
-            "hostname": "test-host",
-            "os_type": "linux",
-            "providers": ["claude"],
-            "capabilities": {},
-        })
-        assert r.status_code == 201, r.text
-        assert r.json()["node_id"] == nid
-
-
-@pytest.mark.asyncio
-async def test_list_federation_nodes():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        nid = _node_id()
-        await c.post("/api/federation/nodes", json={
-            "node_id": nid,
-            "hostname": "test-host",
-            "os_type": "linux",
-        })
-        r = await c.get("/api/federation/nodes")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        nodes = body if isinstance(body, list) else body.get("nodes", [])
-        node_ids = [n.get("node_id") for n in nodes]
-        assert nid in node_ids
-
-
-@pytest.mark.asyncio
-async def test_node_heartbeat():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        nid = _node_id()
-        await c.post("/api/federation/nodes", json={
-            "node_id": nid,
-            "hostname": "test-host",
-            "os_type": "linux",
-        })
-        r = await c.post(f"/api/federation/nodes/{nid}/heartbeat", json={
-            "status": "idle",
-        })
-        assert r.status_code == 200, r.text
-
-
-@pytest.mark.asyncio
-async def test_fleet_capabilities():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        nid = _node_id()
-        await c.post("/api/federation/nodes", json={
+        reg = await c.post("/api/federation/nodes", json={
             "node_id": nid,
             "hostname": "test-host",
             "os_type": "linux",
             "providers": ["claude"],
             "capabilities": {"task_execution": True},
         })
-        r = await c.get("/api/federation/nodes/capabilities")
-        assert r.status_code == 200, r.text
+        assert reg.status_code == 201 and reg.json()["node_id"] == nid, reg.text
+
+        listed = await c.get("/api/federation/nodes")
+        assert listed.status_code == 200
+        nodes = listed.json() if isinstance(listed.json(), list) else listed.json().get("nodes", [])
+        assert nid in [n.get("node_id") for n in nodes]
+
+        beat = await c.post(f"/api/federation/nodes/{nid}/heartbeat", json={"status": "idle"})
+        assert beat.status_code == 200, beat.text
+
+        caps = await c.get("/api/federation/nodes/capabilities")
+        assert caps.status_code == 200, caps.text
+
+        assert (await c.delete(f"/api/federation/nodes/{nid}")).status_code == 204
 
 
 @pytest.mark.asyncio
-async def test_node_messaging():
+async def test_federation_node_messaging_flow():
+    """Two nodes register, one sends the other a message, the
+    receiver retrieves it. Kept separate from the registration flow
+    because messaging has its own semantics (not just CRUD)."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        sender = _node_id()
-        receiver = _node_id()
-        # Register both
-        await c.post("/api/federation/nodes", json={
-            "node_id": sender, "hostname": "sender-host", "os_type": "linux",
+        sender, receiver = _node_id(), _node_id()
+        for nid, host in [(sender, "sender-host"), (receiver, "receiver-host")]:
+            await c.post("/api/federation/nodes", json={
+                "node_id": nid, "hostname": host, "os_type": "linux",
+            })
+        sent = await c.post(f"/api/federation/nodes/{sender}/messages", json={
+            "from_node": sender, "to_node": receiver,
+            "type": "text", "text": "hello from test",
         })
-        await c.post("/api/federation/nodes", json={
-            "node_id": receiver, "hostname": "receiver-host", "os_type": "linux",
-        })
-        # Send message
-        r = await c.post(f"/api/federation/nodes/{sender}/messages", json={
-            "from_node": sender,
-            "to_node": receiver,
-            "type": "text",
-            "text": "hello from test",
-        })
-        assert r.status_code == 201, r.text
+        assert sent.status_code == 201, sent.text
 
-        # Retrieve messages
-        r2 = await c.get(f"/api/federation/nodes/{receiver}/messages", params={"unread_only": "false"})
-        assert r2.status_code == 200, r2.text
-        body = r2.json()
-        msgs = body.get("messages", [])
-        assert any(m.get("text") == "hello from test" for m in msgs), f"Message not found in {msgs}"
-
-
-@pytest.mark.asyncio
-async def test_delete_node():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        nid = _node_id()
-        await c.post("/api/federation/nodes", json={
-            "node_id": nid,
-            "hostname": "test-host",
-            "os_type": "linux",
-        })
-        r = await c.delete(f"/api/federation/nodes/{nid}")
-        assert r.status_code == 204, r.text
+        got = await c.get(f"/api/federation/nodes/{receiver}/messages",
+                          params={"unread_only": "false"})
+        assert got.status_code == 200, got.text
+        msgs = got.json().get("messages", [])
+        assert any(m.get("text") == "hello from test" for m in msgs), msgs
 
 
 # ---------------------------------------------------------------------------
@@ -637,23 +522,12 @@ async def test_delete_node():
 
 
 @pytest.mark.asyncio
-async def test_list_providers():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.get("/api/providers")
-        assert r.status_code == 200, r.text
-        body = r.json()
-        assert "providers" in body
-        assert isinstance(body["providers"], list)
-
-
-@pytest.mark.asyncio
-async def test_providers_includes_expected():
+async def test_list_providers_returns_at_least_one():
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         r = await c.get("/api/providers")
         assert r.status_code == 200, r.text
         providers = r.json()["providers"]
-        provider_ids = [p.get("id") or p for p in providers]
-        assert len(provider_ids) >= 1, "Expected at least one provider"
+        assert isinstance(providers, list) and len(providers) >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -662,29 +536,20 @@ async def test_providers_includes_expected():
 
 
 @pytest.mark.asyncio
-async def test_spec_delete_and_verify_gone():
+async def test_spec_delete_flow():
+    """Create spec → delete → gone (404 on re-get). Deleting an
+    already-missing spec is also 404 so the UI can treat 'not
+    found' as idempotent."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
         sid = _uid("spec")
         r = await c.post("/api/spec-registry", json={
             "spec_id": sid, "title": "Deletable", "summary": "Will be deleted.",
         }, headers=AUTH)
         assert r.status_code == 201, r.text
-
-        r2 = await c.get(f"/api/spec-registry/{sid}")
-        assert r2.status_code == 200, r2.text
-
-        r3 = await c.delete(f"/api/spec-registry/{sid}", headers=AUTH)
-        assert r3.status_code == 204, r3.text
-
-        r4 = await c.get(f"/api/spec-registry/{sid}")
-        assert r4.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_spec_delete_not_found_returns_404():
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        r = await c.delete("/api/spec-registry/nonexistent-spec", headers=AUTH)
-        assert r.status_code == 404
+        assert (await c.get(f"/api/spec-registry/{sid}")).status_code == 200
+        assert (await c.delete(f"/api/spec-registry/{sid}", headers=AUTH)).status_code == 204
+        assert (await c.get(f"/api/spec-registry/{sid}")).status_code == 404
+        assert (await c.delete("/api/spec-registry/nonexistent-spec", headers=AUTH)).status_code == 404
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_inspired_by.py
+++ b/api/tests/test_inspired_by.py
@@ -253,6 +253,88 @@ async def test_idempotent_on_canonical_url():
         assert first.json()["identity"]["id"] == second.json()["identity"]["id"]
 
 
+@pytest.mark.asyncio
+async def test_resolver_prevents_duplicates_across_variants_and_retype():
+    """The resolver's duplicate-prevention contract, exercised as one
+    flow. Every duplicate pattern we've watched appear in prod is
+    captured in the assertions below:
+
+      · URL variants (utm / www / http / trailing slash / fragment)
+        must collapse to one canonical form → one id
+      · Same canonical URL with wildly different parsed names must
+        produce the SAME node id (name is out of the slug)
+      · Retyping a resolved node (contributor → scene via the
+        reclassification pass) must not orphan it — a later resolve
+        of the same URL must find the retyped node, not mint a new
+        contributor
+
+    One test, one story, no subtests — matching the test-weight
+    discipline: each flow covers the whole contract."""
+    # 1. Canonicalization collapses every noisy variant we've seen.
+    variants = [
+        "https://liquidbloom.bandcamp.com/",
+        "https://www.liquidbloom.bandcamp.com",
+        "http://Liquidbloom.bandcamp.com/?utm_source=1471&fbclid=abc",
+        "https://liquidbloom.bandcamp.com/#fragment",
+        "https://www.liquidbloom.bandcamp.com//",
+        "Liquidbloom.bandcamp.com",
+    ]
+    canonicals = {service.canonicalize_url(v) for v in variants}
+    assert len(canonicals) == 1, f"variants must collapse: {canonicals}"
+    # YouTube `v=` survives (content-addressing); utm dropped.
+    assert (
+        service.canonicalize_url("https://youtube.com/watch?v=abc&utm_source=share")
+        == service.canonicalize_url("https://www.youtube.com/watch?v=abc")
+    )
+
+    # 2. node_id is pure canonical-URL hash — name parse variance
+    #    doesn't change the id.
+    r_variants = [
+        service.ResolvedIdentity(
+            input="x", name=nm, description="", canonical_url=u,
+            provider="bandcamp", provider_id="liquidbloom", node_type="contributor",
+        )
+        for nm, u in [
+            ("Liquid Bloom", "https://liquidbloom.bandcamp.com"),
+            ("liquidbloom", "https://www.liquidbloom.bandcamp.com/?utm_source=x"),
+            ("Liquid  Bloom  ", "http://liquidbloom.bandcamp.com#frag"),
+        ]
+    ]
+    ids = {r.node_id() for r in r_variants}
+    assert len(ids) == 1, f"same canonical URL must yield one id, got {ids}"
+    only_id = ids.pop()
+    assert only_id.startswith("contributor:")
+    suffix = only_id.split(":", 1)[1]
+    assert len(suffix) == 16 and all(c in "0123456789abcdef" for c in suffix), suffix
+
+    # 3. Full resolve → retype → resolve-again flow. The bug this
+    #    replaces had `find_existing_identity` only scanning three
+    #    types; retyping the node to `scene` left it orphaned, and
+    #    the next resolve minted a duplicate contributor.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        source = await _create_source(c)
+        with patch.object(service, "_fetch", _fake_fetch(ARTIST_HTML, "https://liquidbloom.bandcamp.com/")):
+            first = await c.post("/api/inspired-by", json={
+                "name": "https://liquidbloom.bandcamp.com",
+                "source_contributor_id": source,
+            })
+        identity_id = first.json()["identity"]["id"]
+
+        rt = await c.patch(f"/api/graph/nodes/{identity_id}", json={"type": "scene"})
+        assert rt.status_code == 200 and rt.json()["type"] == "scene", rt.text
+
+        # Same URL, wildly different cosmetic (utm, www, case).
+        with patch.object(service, "_fetch", _fake_fetch(ARTIST_HTML, "https://liquidbloom.bandcamp.com/")):
+            second = await c.post("/api/inspired-by", json={
+                "name": "http://www.Liquidbloom.bandcamp.com/?utm_source=x",
+                "source_contributor_id": source,
+            })
+        body = second.json()
+        assert body["identity_created"] is False, "retyped node must be found, not re-created"
+        assert body["identity"]["id"] == identity_id
+        assert body["identity"]["type"] == "scene"
+
+
 def test_fetch_refuses_internal_addresses():
     """SSRF guard: the resolver must not reach loopback, private, or
     link-local addresses even if a user posts one directly. This is

--- a/api/tests/test_inspired_by.py
+++ b/api/tests/test_inspired_by.py
@@ -234,25 +234,6 @@ async def test_event_resolves_to_community_identity():
 
 
 @pytest.mark.asyncio
-async def test_idempotent_on_canonical_url():
-    """Re-adding the same identity reuses the node and reports edge_existed."""
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
-        source = await _create_source(c)
-        with patch.object(service, "_fetch", _fake_fetch(ARTIST_HTML, "https://liquidbloom.bandcamp.com/")):
-            first = await c.post("/api/inspired-by", json={
-                "name": "https://liquidbloom.bandcamp.com",
-                "source_contributor_id": source,
-            })
-            second = await c.post("/api/inspired-by", json={
-                "name": "https://liquidbloom.bandcamp.com",
-                "source_contributor_id": source,
-            })
-        assert first.json()["identity_created"] is True
-        assert second.json()["identity_created"] is False
-        assert second.json()["edge_existed"] is True
-        assert first.json()["identity"]["id"] == second.json()["identity"]["id"]
-
-
 @pytest.mark.asyncio
 async def test_resolver_prevents_duplicates_across_variants_and_retype():
     """The resolver's duplicate-prevention contract, exercised as one

--- a/web/app/profile/[contributorId]/page.tsx
+++ b/web/app/profile/[contributorId]/page.tsx
@@ -44,7 +44,43 @@ type AssetListResponse = {
   total: number;
 };
 
+type ContributorNode = {
+  id: string;
+  name?: string;
+  description?: string;
+  author_display_name?: string;
+  email?: string;
+  location?: string;
+  skills?: string;
+  offering?: string;
+  resonant_roles?: string[];
+  locale?: string;
+  [key: string]: unknown;
+};
+
 /* ── Data fetching ────────────────────────────────────────────────── */
+
+async function fetchContributorNode(contributorId: string): Promise<ContributorNode | null> {
+  // Check the graph node itself — this is the source of truth for
+  // "does this contributor exist". The public-key and frequency-
+  // profile endpoints 404 for any contributor who registered
+  // without a keypair (most humans) or hasn't built up enough graph
+  // activity to derive a frequency fingerprint yet. The profile page
+  // should still render for them — that's most visitors on day one.
+  const base = getApiBase();
+  const nodeId = contributorId.startsWith("contributor:")
+    ? contributorId
+    : `contributor:${contributorId}`;
+  try {
+    const res = await fetch(`${base}/api/graph/nodes/${encodeURIComponent(nodeId)}`, {
+      next: { revalidate: 30 },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
 
 async function fetchPublicKey(contributorId: string): Promise<PublicKeyResponse | null> {
   const base = getApiBase();
@@ -123,9 +159,13 @@ export async function generateMetadata({
   params: Promise<{ contributorId: string }>;
 }): Promise<Metadata> {
   const { contributorId } = await params;
+  const contributor = await fetchContributorNode(contributorId);
+  const name = contributor?.author_display_name || contributor?.name || contributorId;
+  const lede = contributor?.offering || contributor?.skills
+    || `Public profile and frequency fingerprint for contributor ${name} on the Coherence Network.`;
   return {
-    title: `${contributorId} — Contributor Profile`,
-    description: `Public profile and frequency fingerprint for contributor ${contributorId} on the Coherence Network.`,
+    title: `${name} — Contributor Profile`,
+    description: lede.slice(0, 200),
   };
 }
 
@@ -138,19 +178,24 @@ export default async function ContributorProfilePage({
 }) {
   const { contributorId } = await params;
 
-  const [publicKeyData, profile, assets] = await Promise.all([
+  const [contributor, publicKeyData, profile, assets] = await Promise.all([
+    fetchContributorNode(contributorId),
     fetchPublicKey(contributorId),
     fetchFrequencyProfile(contributorId),
     fetchAssets(contributorId),
   ]);
 
-  // If there is no profile AND no public key, this contributor does not exist
-  if (!profile && !publicKeyData) {
+  // A contributor exists when any of three signals land: the graph
+  // node (source of truth), a registered public key, or a built-up
+  // frequency profile. 404 only when ALL three are missing — a real
+  // 'nobody's here' case, not just 'hasn't generated keys yet'.
+  if (!contributor && !profile && !publicKeyData) {
     notFound();
   }
 
   const pubKeyHex = publicKeyData?.public_key_hex;
   const fp = pubKeyHex ? fingerprint(pubKeyHex) : null;
+  const displayName = contributor?.author_display_name || contributor?.name || contributorId;
 
   return (
     <main className="min-h-screen px-4 sm:px-6 lg:px-8 py-8 max-w-4xl mx-auto space-y-8">
@@ -160,8 +205,33 @@ export default async function ContributorProfilePage({
           Contributor Profile
         </p>
         <h1 className="text-3xl md:text-4xl font-light tracking-tight">
-          {contributorId}
+          {displayName}
         </h1>
+        {contributor?.location && (
+          <p className="text-sm text-muted-foreground">{contributor.location}</p>
+        )}
+        {contributor?.skills && (
+          <p className="text-sm text-foreground/85 leading-relaxed max-w-2xl">
+            {contributor.skills}
+          </p>
+        )}
+        {contributor?.offering && (
+          <p className="text-sm text-foreground/85 leading-relaxed max-w-2xl italic">
+            {contributor.offering}
+          </p>
+        )}
+        {contributor?.resonant_roles && contributor.resonant_roles.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {contributor.resonant_roles.map((role) => (
+              <span
+                key={role}
+                className="inline-flex items-center rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-400 border border-amber-500/20"
+              >
+                {role.replace(/-/g, " ")}
+              </span>
+            ))}
+          </div>
+        )}
 
         {pubKeyHex ? (
           <div className="space-y-2">


### PR DESCRIPTION
## Summary

- URL canonicalization now strict: same URL in any form (utm, www, http, case, trailing slash) → one canonical string
- `node_id()` is pure URL hash — name is out of the slug so a re-parse with a slightly different name can't mint a duplicate
- `find_existing_identity` scans all eight presence types, with O(1) fast-path via deterministic id
- Discovered + fixed silent bug: `PATCH /api/graph/nodes/{id}` ignored type changes — that's why `heal_presences` on prod reported "Retyped: 24" but Pyramids of Chi / Boulder Theater / Unison Festival are still showing under contributors. Now `NodeUpdate` accepts `type`, and the service enforces moves stay within the presence bucket

## Test plan

- [x] 13 resolver flow tests pass (one new consolidated flow test covers canonicalization + deterministic id + retype + re-resolve in one story — per test-weight discipline)
- [x] 294 flow tests in 19s (no regression)
- [ ] Deploy to prod and re-run `heal_presences.py` — this time retype PATCHes will land, moving the 24 mis-bucketed nodes into their honest types

Follow-ups staged (separate PRs when wanted):
- DB-level unique index on canonical_url_hash (catches race conditions)
- Event deterministic id from (title+when+primary), gathering POST becomes upsert
- Placeholder-to-resolved bridge (resolve for a name that matches a placeholder merges rather than creates parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)