### PR TITLE
fix(vision): early redirect for visual-* ids

### DIFF
--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -143,10 +143,19 @@ export default async function VisionConceptPage({
 
   // When /api/concepts/{id} returns null, the id might still exist as
   // a different node type (asset, contributor, etc.). Check the graph
-  // node directly and redirect to the right surface rather than
-  // 404ing a valid id — /vision/visual-lc-beauty-1 is an asset, and
-  // the visitor expects to see the image, not a 'not found' page.
+  // node and redirect to the right surface rather than 404ing a valid
+  // id — /vision/visual-lc-beauty-1 is an asset, and the visitor
+  // expects to see the image, not a "not found" page.
+  //
+  // Critical: redirect() throws NEXT_REDIRECT as the mechanism Next
+  // uses to turn a server-component redirect into a 307. If redirect()
+  // ran inside a try/catch, the catch would swallow that marker and
+  // the browser would never see the redirect. So the fetch lives in
+  // its own try (to tolerate a transient api failure), and redirect()
+  // is invoked *outside* the try on the resolved type — any
+  // NEXT_REDIRECT propagates freely.
   if (!concept) {
+    let fallbackType: string | null = null;
     try {
       const base = getApiBase();
       const nodeRes = await fetch(
@@ -154,13 +163,14 @@ export default async function VisionConceptPage({
         { next: { revalidate: 30 } },
       );
       if (nodeRes.ok) {
-        const node = await nodeRes.json() as { type?: string };
-        if (node.type === "asset") redirect(`/assets/${conceptId}`);
-        if (node.type) redirect(`/nodes/${conceptId}`);
+        const node = (await nodeRes.json()) as { type?: string };
+        fallbackType = node.type ?? null;
       }
     } catch {
-      /* fall through to notFound below */
+      /* no fallback type — fall through to notFound below */
     }
+    if (fallbackType === "asset") redirect(`/assets/${conceptId}`);
+    if (fallbackType) redirect(`/nodes/${conceptId}`);
     notFound();
   }
 

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -37,9 +37,12 @@ async function fetchConcept(id: string, lang?: LocaleCode): Promise<Concept | nu
   // Always forward the lang — the API decides whether a view exists and what
   // to return. Omitting lang would surface the anchor (freshest) view, which
   // is correct for "no preference" but wrong for "explicitly chose English".
+  // No cache: the 404 path feeds a redirect decision downstream, and a
+  // stale cached response for a mis-classified id (e.g. asset with
+  // concept shape) would bypass the redirect and render an empty page.
   const qs = lang ? `?lang=${lang}` : "";
   try {
-    const res = await fetch(`${base}/api/concepts/${id}${qs}`, { next: { revalidate: 30 } });
+    const res = await fetch(`${base}/api/concepts/${id}${qs}`, { cache: "no-store" });
     if (!res.ok) return null;
     return res.json();
   } catch { return null; }
@@ -134,6 +137,17 @@ export default async function VisionConceptPage({
   const lang: LocaleCode = isSupportedLocale(rawLang) ? rawLang : DEFAULT_LOCALE;
   const t = createTranslator(lang);
 
+  // Early route-level type classification — before any concept fetch.
+  // The /vision/[conceptId] route is for living-collective concepts.
+  // Visual asset ids ("visual-lc-*") are images generated for those
+  // concepts, served on /assets/[id] where the file_path actually
+  // renders. Classifying the id up-front keeps us from streaming a
+  // half-composed concept page and then trying to redirect mid-stream,
+  // which is where the previous attempt silently failed to escape.
+  if (conceptId.startsWith("visual-lc-") || conceptId.startsWith("visual-")) {
+    redirect(`/assets/${conceptId}`);
+  }
+
   const [concept, edges, related, allLC] = await Promise.all([
     fetchConcept(conceptId, lang),
     fetchEdges(conceptId),
@@ -160,7 +174,7 @@ export default async function VisionConceptPage({
       const base = getApiBase();
       const nodeRes = await fetch(
         `${base}/api/graph/nodes/${encodeURIComponent(conceptId)}`,
-        { next: { revalidate: 30 } },
+        { cache: "no-store" },
       );
       if (nodeRes.ok) {
         const node = (await nodeRes.json()) as { type?: string };


### PR DESCRIPTION
Pulling the classification up to the top of the page component, before any fetches begin, so redirect() fires before streaming starts. Previous attempt in PR #1081 had the right plumbing but the redirect was being lost somewhere in Next 15's streaming machinery. Early exit avoids the race entirely. Also switches fetchConcept to no-store so stale 200 responses from before the concept_service guard can't mask the 404.