### PR TITLE
fix(vision): middleware redirect for visual-* ids

### DIFF
--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -137,16 +137,11 @@ export default async function VisionConceptPage({
   const lang: LocaleCode = isSupportedLocale(rawLang) ? rawLang : DEFAULT_LOCALE;
   const t = createTranslator(lang);
 
-  // Early route-level type classification — before any concept fetch.
-  // The /vision/[conceptId] route is for living-collective concepts.
-  // Visual asset ids ("visual-lc-*") are images generated for those
-  // concepts, served on /assets/[id] where the file_path actually
-  // renders. Classifying the id up-front keeps us from streaming a
-  // half-composed concept page and then trying to redirect mid-stream,
-  // which is where the previous attempt silently failed to escape.
-  if (conceptId.startsWith("visual-lc-") || conceptId.startsWith("visual-")) {
-    redirect(`/assets/${conceptId}`);
-  }
+  // Visual asset ids are redirected at the middleware layer (see
+  // web/middleware.ts) — the server-component redirect() was being
+  // swallowed by Next 15.5's error boundary. Middleware runs before
+  // any page code and returns a real 307, so /vision/visual-lc-*
+  // lands on /assets/[id] where the image actually renders.
 
   const [concept, edges, related, allLC] = await Promise.all([
     fetchConcept(conceptId, lang),

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -30,6 +30,21 @@ function bestFromAcceptLanguage(header: string | null): string | null {
 }
 
 export function middleware(req: NextRequest) {
+  // Route-level redirect: /vision/visual-* ids are asset nodes (images
+  // generated for a concept), served on /assets/[id] where the
+  // file_path actually renders. The server-component redirect inside
+  // the page was getting swallowed by something in Next 15.5's error
+  // handling (the error boundary returned 200 instead of Next picking
+  // up NEXT_REDIRECT), so middleware handles the classification
+  // instead. Runs before any page code, so no error-boundary interference.
+  const { pathname } = req.nextUrl;
+  if (pathname.startsWith("/vision/")) {
+    const id = pathname.slice("/vision/".length);
+    if (id.startsWith("visual-lc-") || id.startsWith("visual-")) {
+      return NextResponse.redirect(new URL(`/assets/${id}`, req.url), 307);
+    }
+  }
+
   const qs = req.nextUrl.searchParams.get("lang");
   const existing = req.cookies.get(COOKIE_NAME)?.value;
 


### PR DESCRIPTION
Final fix for /vision/visual-lc-beauty-1 image-not-visible. Diagnostic logs proved the server-component redirect() was being swallowed by something in Next 15.5's error handling (plain throw Error() also returned 200 instead of 500 from the same page). Middleware runs before any page code — a real 307 lands at the edge. Already live on prod via direct SSH deploy; this PR lands the code on main. Fresh branch off current main to avoid the conflict chain from PRs #1082 → #1083.