### PR TITLE
Tend: STORIES relocated — new stories/ room seeded in vision-kb

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -105,6 +105,7 @@ Teachings that sit alongside the fractal rather than inside it — the physics, 
 - **[scales/INDEX.md](scales/INDEX.md)** — 50 / 100 / 200 people configurations
 - **[realization/INDEX.md](realization/INDEX.md)** — governance as attention, economics as overflow, membership as time together, emergent phases from gathering to fruiting
 - **[resources/INDEX.md](resources/INDEX.md)** — open-source plans, reference communities, books
+- **[stories/INDEX.md](stories/INDEX.md)** — scenes from the field: seven vignettes (Water Temple, Textile Keeper, Elders, Market Day, Sound Journey, Fern's arrival, the Skeptic) where the vision is lived rather than described
 
 ## ★ Priority Concepts (Tier 1)
 

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,15 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-04-22] stories | STORIES relocated — new stories/ room in vision-kb
+
+- Seventh draft metabolism. STORIES (148 lines) held seven vignettes from the field: The Morning of the Water Temple, The Textile Keeper's Offering, The Elder Council (That Isn't a Council), Market Day / The Offering Circle, The Thursday Sound Journey, Fern's Ninety-Day Arrival, What the Skeptic Sees. Each scene seeds a felt sense that abstract teaching cannot reach.
+- Seeded a new `stories/` subdirectory in vision-kb and placed the full draft as `stories/INDEX.md`. git mv preserved history. Title adjusted to "Stories — Scenes from the Field" with a bridging blockquote naming the seven scenes and what stories do differently from concepts and guides.
+- Added pointer to `stories/` in vision-kb INDEX under Cross-cutting Reference Files.
+- Future stories can become individual files in `stories/` (e.g., `water-temple.md`, `sound-journey.md`) if the directory grows. For now the INDEX holds the whole collection as one reading.
+- **Why a new room**: stories are a different organ than concepts (teaching) or guides (instructing). They show the field being lived. Having their own room acknowledges that difference in kind. The vision-kb is now richer for having a place where narrative lives.
+- Six drafts remain: ALIGNED, LANGUAGE_GUIDE, LIVED, REALIZATION, RESOURCES, VISUALS.
+
 ## [2026-04-22] vision-kb | BLUEPRINT relocated as narrative companion to INDEX
 
 - Sixth draft metabolism. BLUEPRINT (231 lines) wasn't ripened into INDEX.md and wasn't a concept. It is the **synoptic narrative** of the whole fractal — the Pulse, the three Living Systems, the five Flows, the twenty-one Living Expressions, the nine Emerging Visions, the Seed — tied together with living analogies (mycelial networks, dolphin pods, elephant matriarchs, coral reefs, redwood groves) and the Pleiadian/Lemurian/Arcturian framings that live beneath the concept layer.

--- a/docs/vision-kb/stories/INDEX.md
+++ b/docs/vision-kb/stories/INDEX.md
@@ -1,7 +1,9 @@
-# The Living Collective — Stories
+# Stories — Scenes from the Field
 
 > These are not hypothetical. They are memories from a future that is forming.
 > Read them slowly. Feel where you fit. You do fit. Everyone does.
+>
+> *Where concepts teach and guides instruct, stories show. Seven scenes where characters live the field: the Water Temple at dawn, the Textile Keeper's collection, the Elder Council That Isn't a Council, Market Day as Offering Circle, the Thursday Sound Journey, Fern's ninety-day arrival, and the Skeptical Journalist who stayed. Each scene seeds a felt sense that abstract teaching cannot reach.*
 
 ---
 


### PR DESCRIPTION
## Summary

Seventh draft metabolized, and the first to **seed a new subdirectory**.

**STORIES** (148 lines) held seven vignettes from the field:

- The Morning of the Water Temple
- The Textile Keeper's Offering
- The Elder Council (That Isn't a Council)
- Market Day / The Offering Circle
- The Thursday Sound Journey
- When Someone New Arrives (Fern's 90-day arrival)
- What the Skeptic Sees

Each scene seeds a felt sense that abstract teaching cannot reach. The draft belongs in a room the KB didn't have yet.

Created `docs/vision-kb/stories/` and relocated the draft as `stories/INDEX.md`. Future stories can become individual files (`stories/water-temple.md`, `stories/sound-journey.md`) if the room grows; for now the INDEX holds the whole collection as one reading.

## Why a new room

Stories are a different organ than concepts (which teach) or guides (which instruct). They **show** the field being lived — characters, specific moments, sensory detail, the felt quality of an ordinary morning. Having their own room acknowledges the difference in kind. The vision-kb is now richer for having a place where narrative lives.

## Test plan

- [x] `git mv` preserved history (97% similarity)
- [x] `stories/` subdirectory created
- [x] Vision-kb INDEX.md references stories/ under Cross-cutting Reference Files
- [x] No concept count change (stories are not concepts)

## Remaining

Six drafts: ALIGNED, LANGUAGE_GUIDE, LIVED, REALIZATION, RESOURCES, VISUALS.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_