### PR TITLE
Tend: LANGUAGE_GUIDE relocated as language-guide.md — verbal counterpart

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -8,9 +8,10 @@
 1. Read THIS file to orient (~300 tokens)
 2. Read [BLUEPRINT.md](BLUEPRINT.md) when you want the whole fractal in one continuous narrative — the Pulse through the Seed, tied together with living analogies
 3. Read [visual-language.md](visual-language.md) when you want the aesthetic — the bioluminescent, organic, fractal palette the field renders through, and DALL-E prompts for core concepts
-4. Read the concept file you need (~500-1500 tokens each)
-5. After making changes to any concept, update the file AND this index
-6. Append changes to LOG.md
+4. Read [language-guide.md](language-guide.md) when you want the verbal vocabulary — word choices that carry vitality, skill descriptions, agent focus prompt patterns
+5. Read the concept file you need (~500-1500 tokens each)
+6. After making changes to any concept, update the file AND this index
+7. Append changes to LOG.md
 
 ## The Vision in One Paragraph
 

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,15 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-04-22] vision-kb | LANGUAGE_GUIDE relocated as language-guide.md — linguistic counterpart to visual-language
+
+- Tenth draft metabolism. LANGUAGE_GUIDE (203 lines) held the verbal grammar of the field: ~30 word-pair mappings (healer → vitality keeper, fix → harmonize, problem → signal, etc.), skill descriptions framed as vitality invitations, agent focus prompt patterns with two full examples (Living Structure agent, Nourishment agent), and a shorter version of the aligned-communities catalog.
+- Considered release (overlap with SCHEMA.md's Frequency Sensing section), but SCHEMA has only 8 word-pairs and no skill descriptions or agent-prompt patterns. LANGUAGE_GUIDE has substantial unique content. Relocated rather than released.
+- Relocated as `docs/vision-kb/language-guide.md` — root-level reference, linguistic counterpart to `visual-language.md`. git mv kept history. Title adjusted to "Language Guide — The Field's Vocabulary" with a bridging blockquote naming the relationship to both `visual-language.md` and `SCHEMA.md`'s Frequency Sensing section.
+- Added cross-ref from the "Real-World Aligned Examples" section to `resources/aligned-communities.md` for the fuller catalog, since that section overlaps what now lives in resources/.
+- INDEX.md "How to use this KB" now includes `language-guide.md` as step 4 (after INDEX, BLUEPRINT, visual-language). Four doors at root: map, narrative, aesthetic, verbal.
+- Three drafts remain: LIVED, REALIZATION, RESOURCES.
+
 ## [2026-04-22] vision-kb | VISUALS relocated as visual-language.md
 
 - Ninth draft metabolism. VISUALS (95 lines) held the aesthetic grammar of the Living Collective: unified visual language (warm gold + living teal + soft rose + deep violet + luminous white palette; organic fractal textures; no hard edges; bioluminescent self-illumination), plus eleven DALL-E prompts applying the palette to core concepts (the Pulse, Sensing, Attunement, Vitality, Nourishing, Resonating, Expressing, Spiraling, Field Sensing, Living Space, The Network).

--- a/docs/vision-kb/language-guide.md
+++ b/docs/vision-kb/language-guide.md
@@ -1,9 +1,11 @@
-# Living Collective — Language Guide
+# Language Guide — The Field's Vocabulary
 
 > Every word carries frequency. Words rooted in separation, brokenness, or lack
 > introduce that frequency into the field. This guide ensures all language in the
 > system — concept descriptions, UI labels, agent prompts, contributor invitations
 > — vibrates with vitality, wholeness, and joy.
+>
+> *Linguistic counterpart to [visual-language.md](visual-language.md). Where that one holds the aesthetic grammar, this one holds the verbal one. Together with [SCHEMA.md](SCHEMA.md)'s Frequency Sensing section (which has the short living-vs-institutional table and the "by the fire" test), they form the field's vocabulary discipline.*
 
 ## The Principle
 
@@ -155,6 +157,8 @@ YOUR FREQUENCY: How the field feeds itself
 ```
 
 ## Real-World Aligned Examples
+
+*Short illustrative catalog. For the fuller treatment — with what resonates, what we can learn, and how to connect — see [resources/aligned-communities.md](resources/aligned-communities.md).*
 
 Places and practices that already embody aspects of the vision:
 


### PR DESCRIPTION
## Summary

Tenth draft metabolized. **LANGUAGE_GUIDE** (203 lines) held the verbal grammar of the field — word choices that carry vitality rather than separation.

Relocated as `docs/vision-kb/language-guide.md` — root-level reference, linguistic counterpart to `visual-language.md`. Vision-kb root now has **four doors**: map (INDEX), narrative (BLUEPRINT), aesthetic (visual-language), verbal (language-guide).

## Considered release, chose relocate

SCHEMA.md's Frequency Sensing section overlaps — 8 word-pairs and the "by the fire" test. But LANGUAGE_GUIDE has substantial unique content beyond that:

- ~30 word-pair mappings (vs SCHEMA's 8): healer→vitality keeper, fix→harmonize, problem→signal, owner→steward, punishment→immune response, expert→deeply differentiated cell, etc.
- **Skill descriptions** framed as vitality invitations ("We need a healer" → "The field is ready for a vitality keeper — someone whose presence amplifies the glow")
- **Agent focus prompt patterns** with two complete examples (Living Structure agent, Nourishment agent) — ready-to-use system-prompt templates for domain-specific sub-agents

Not a release.

## Cross-reference added

LANGUAGE_GUIDE's "Real-World Aligned Examples" section now cross-references `resources/aligned-communities.md` for the fuller catalog — since that ripened form already exists. Keeping the short illustrative version in place as it serves the language-discipline context.

## Test plan

- [x] `git mv` preserved history (95% similarity)
- [x] INDEX.md "How to use" now lists language-guide as step 4
- [x] Bridging blockquote names relationship to visual-language and SCHEMA

## Remaining

Three drafts: LIVED, REALIZATION, RESOURCES.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_