### PR TITLE
feat(asset-renderer): models + attribution service + tests (R4, R5, R9)

### DIFF
--- a/api/app/models/renderer.py
+++ b/api/app/models/renderer.py
@@ -1,0 +1,91 @@
+"""Renderer and render-event models for the asset-renderer-plugin spec.
+
+Part of the pluggable-renderer system where contributors can register
+any MIME type as an asset and any renderer that displays those types
+earns a share of the CC attributed on every render.
+
+See specs/asset-renderer-plugin.md for the full contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+DEFAULT_ASSET_CREATOR_SHARE = Decimal("0.80")
+DEFAULT_RENDERER_CREATOR_SHARE = Decimal("0.15")
+DEFAULT_HOST_NODE_SHARE = Decimal("0.05")
+
+# Sum-of-shares tolerance for decimal rounding.
+_SHARE_TOLERANCE = Decimal("0.001")
+
+MAX_RENDERER_BUNDLE_BYTES = 512_000  # 500KB hard cap per spec R9
+
+
+class RenderCCSplit(BaseModel):
+    """CC split for a render event.
+
+    Three shares that must sum to 1.0 (100%) within rounding tolerance.
+    Default is 80/15/5: the creator who made the content, the creator
+    who made it viewable, the node that served it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_creator: Decimal = Field(default=DEFAULT_ASSET_CREATOR_SHARE, ge=0, le=1)
+    renderer_creator: Decimal = Field(default=DEFAULT_RENDERER_CREATOR_SHARE, ge=0, le=1)
+    host_node: Decimal = Field(default=DEFAULT_HOST_NODE_SHARE, ge=0, le=1)
+
+    @model_validator(mode="after")
+    def shares_sum_to_one(self) -> "RenderCCSplit":
+        total = self.asset_creator + self.renderer_creator + self.host_node
+        if abs(total - Decimal("1")) > _SHARE_TOLERANCE:
+            raise ValueError(
+                f"CC split shares must sum to 1.0, got {total} "
+                f"(asset_creator={self.asset_creator}, "
+                f"renderer_creator={self.renderer_creator}, "
+                f"host_node={self.host_node})"
+            )
+        return self
+
+
+class RendererCreate(BaseModel):
+    """Payload for POST /api/renderers/register."""
+
+    id: str
+    name: str
+    mime_types: List[str] = Field(min_length=1)
+    creator_id: str
+    component_url: str
+    creation_cost_cc: Decimal
+    version: str
+    cc_split: Optional[RenderCCSplit] = None
+    max_bundle_bytes: int = Field(default=MAX_RENDERER_BUNDLE_BYTES, le=MAX_RENDERER_BUNDLE_BYTES)
+
+
+class Renderer(RendererCreate):
+    """A registered renderer stored as a graph node."""
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class RenderEvent(BaseModel):
+    """Outcome of a single render: which asset, which renderer, which reader,
+    how long, and how the CC pool was split across the three parties.
+    """
+
+    id: UUID = Field(default_factory=uuid4)
+    asset_id: str
+    renderer_id: str
+    reader_id: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    duration_ms: int = Field(ge=0)
+    cc_pool: Decimal
+    cc_asset_creator: Decimal
+    cc_renderer_creator: Decimal
+    cc_host_node: Decimal

--- a/api/app/services/render_attribution_service.py
+++ b/api/app/services/render_attribution_service.py
@@ -1,0 +1,72 @@
+"""Render attribution service.
+
+Pure-logic piece of the asset-renderer-plugin spec (R4, R5). Given a
+render event, split the CC pool across asset creator, renderer creator,
+and host node according to a configurable split.
+
+Override precedence per spec:
+  1. Asset creator override (set per-asset by the content creator)
+  2. Renderer default split (set at renderer registration)
+  3. Platform default (80/15/5)
+
+Pydantic validation on RenderCCSplit ensures the three shares sum to
+1.0 before any attribution is computed, so cc_pool always reconciles
+to the three returned amounts within decimal tolerance.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import NamedTuple, Optional
+
+from app.models.renderer import (
+    DEFAULT_ASSET_CREATOR_SHARE,
+    DEFAULT_HOST_NODE_SHARE,
+    DEFAULT_RENDERER_CREATOR_SHARE,
+    RenderCCSplit,
+)
+
+
+class RenderAttribution(NamedTuple):
+    """The three per-party amounts a render pool is split into."""
+
+    cc_asset_creator: Decimal
+    cc_renderer_creator: Decimal
+    cc_host_node: Decimal
+
+
+_PLATFORM_DEFAULT = RenderCCSplit(
+    asset_creator=DEFAULT_ASSET_CREATOR_SHARE,
+    renderer_creator=DEFAULT_RENDERER_CREATOR_SHARE,
+    host_node=DEFAULT_HOST_NODE_SHARE,
+)
+
+
+def resolve_split(
+    asset_override: Optional[RenderCCSplit] = None,
+    renderer_default: Optional[RenderCCSplit] = None,
+) -> RenderCCSplit:
+    """Resolve which split applies per the override precedence.
+
+    Asset override beats renderer default beats platform default.
+    """
+    if asset_override is not None:
+        return asset_override
+    if renderer_default is not None:
+        return renderer_default
+    return _PLATFORM_DEFAULT
+
+
+def attribute_render_cc(
+    cc_pool: Decimal,
+    *,
+    asset_override: Optional[RenderCCSplit] = None,
+    renderer_default: Optional[RenderCCSplit] = None,
+) -> RenderAttribution:
+    """Split a render's CC pool into per-party attributions."""
+    split = resolve_split(asset_override, renderer_default)
+    return RenderAttribution(
+        cc_asset_creator=cc_pool * split.asset_creator,
+        cc_renderer_creator=cc_pool * split.renderer_creator,
+        cc_host_node=cc_pool * split.host_node,
+    )

--- a/api/tests/test_asset_renderer.py
+++ b/api/tests/test_asset_renderer.py
@@ -1,0 +1,183 @@
+"""Tests for the asset-renderer-plugin spec pure-logic pieces.
+
+Covers CC split validation and attribution (spec R4, R5, R9). Integration
+tests — registering assets, registering renderers, rendering events
+through the graph — remain TODO and belong in a subsequent PR that wires
+up the router and graph storage.
+"""
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.renderer import (
+    MAX_RENDERER_BUNDLE_BYTES,
+    RenderCCSplit,
+    RendererCreate,
+)
+from app.services.render_attribution_service import (
+    attribute_render_cc,
+    resolve_split,
+)
+
+
+# ---------- RenderCCSplit validation (spec R5) ----------
+
+
+def test_cc_split_default_is_80_15_5():
+    split = RenderCCSplit()
+    assert split.asset_creator == Decimal("0.80")
+    assert split.renderer_creator == Decimal("0.15")
+    assert split.host_node == Decimal("0.05")
+    total = split.asset_creator + split.renderer_creator + split.host_node
+    assert total == Decimal("1.00")
+
+
+def test_cc_split_custom_sums_to_one():
+    split = RenderCCSplit(
+        asset_creator=Decimal("0.75"),
+        renderer_creator=Decimal("0.20"),
+        host_node=Decimal("0.05"),
+    )
+    total = split.asset_creator + split.renderer_creator + split.host_node
+    assert total == Decimal("1.00")
+
+
+def test_cc_split_validation_rejects_oversum():
+    with pytest.raises(ValidationError):
+        RenderCCSplit(
+            asset_creator=Decimal("0.80"),
+            renderer_creator=Decimal("0.15"),
+            host_node=Decimal("0.10"),  # total = 1.05
+        )
+
+
+def test_cc_split_validation_rejects_undersum():
+    with pytest.raises(ValidationError):
+        RenderCCSplit(
+            asset_creator=Decimal("0.50"),
+            renderer_creator=Decimal("0.15"),
+            host_node=Decimal("0.05"),  # total = 0.70
+        )
+
+
+def test_cc_split_rejects_negative_share():
+    with pytest.raises(ValidationError):
+        RenderCCSplit(
+            asset_creator=Decimal("1.10"),
+            renderer_creator=Decimal("-0.05"),
+            host_node=Decimal("-0.05"),
+        )
+
+
+# ---------- attribute_render_cc (spec R4) ----------
+
+
+def test_attribute_uses_platform_default_when_no_overrides():
+    attribution = attribute_render_cc(Decimal("1.00"))
+    assert attribution.cc_asset_creator == Decimal("0.8000")
+    assert attribution.cc_renderer_creator == Decimal("0.1500")
+    assert attribution.cc_host_node == Decimal("0.0500")
+
+
+def test_attribute_uses_renderer_default_when_no_asset_override():
+    renderer_split = RenderCCSplit(
+        asset_creator=Decimal("0.70"),
+        renderer_creator=Decimal("0.25"),
+        host_node=Decimal("0.05"),
+    )
+    attribution = attribute_render_cc(
+        Decimal("1.00"),
+        renderer_default=renderer_split,
+    )
+    assert attribution.cc_asset_creator == Decimal("0.7000")
+    assert attribution.cc_renderer_creator == Decimal("0.2500")
+    assert attribution.cc_host_node == Decimal("0.0500")
+
+
+def test_attribute_asset_override_beats_renderer_default():
+    renderer_split = RenderCCSplit(
+        asset_creator=Decimal("0.70"),
+        renderer_creator=Decimal("0.25"),
+        host_node=Decimal("0.05"),
+    )
+    asset_split = RenderCCSplit(
+        asset_creator=Decimal("0.90"),
+        renderer_creator=Decimal("0.05"),
+        host_node=Decimal("0.05"),
+    )
+    attribution = attribute_render_cc(
+        Decimal("1.00"),
+        asset_override=asset_split,
+        renderer_default=renderer_split,
+    )
+    assert attribution.cc_asset_creator == Decimal("0.9000")
+    assert attribution.cc_renderer_creator == Decimal("0.0500")
+    assert attribution.cc_host_node == Decimal("0.0500")
+
+
+def test_attribute_preserves_pool_total():
+    attribution = attribute_render_cc(Decimal("10.00"))
+    total = (
+        attribution.cc_asset_creator
+        + attribution.cc_renderer_creator
+        + attribution.cc_host_node
+    )
+    assert total == Decimal("10.0000")
+
+
+def test_attribute_zero_pool_returns_zero_shares():
+    attribution = attribute_render_cc(Decimal("0"))
+    assert attribution.cc_asset_creator == Decimal("0")
+    assert attribution.cc_renderer_creator == Decimal("0")
+    assert attribution.cc_host_node == Decimal("0")
+
+
+def test_resolve_split_returns_platform_default_when_both_none():
+    split = resolve_split(None, None)
+    assert split.asset_creator == Decimal("0.80")
+
+
+# ---------- RendererCreate bundle-size constraint (spec R9) ----------
+
+
+def test_renderer_create_rejects_oversize_bundle():
+    with pytest.raises(ValidationError):
+        RendererCreate(
+            id="oversize-v1",
+            name="Oversize Renderer",
+            mime_types=["text/plain"],
+            creator_id="contributor:alice",
+            component_url="https://example.com/r.js",
+            creation_cost_cc=Decimal("1.00"),
+            version="1.0.0",
+            max_bundle_bytes=MAX_RENDERER_BUNDLE_BYTES + 1,
+        )
+
+
+def test_renderer_create_accepts_bundle_at_max():
+    renderer = RendererCreate(
+        id="max-v1",
+        name="Max-size Renderer",
+        mime_types=["text/plain"],
+        creator_id="contributor:alice",
+        component_url="https://example.com/r.js",
+        creation_cost_cc=Decimal("1.00"),
+        version="1.0.0",
+        max_bundle_bytes=MAX_RENDERER_BUNDLE_BYTES,
+    )
+    assert renderer.max_bundle_bytes == MAX_RENDERER_BUNDLE_BYTES
+
+
+def test_renderer_create_requires_at_least_one_mime_type():
+    with pytest.raises(ValidationError):
+        RendererCreate(
+            id="empty-mimes",
+            name="Empty MIMEs",
+            mime_types=[],  # min_length=1
+            creator_id="contributor:alice",
+            component_url="https://example.com/r.js",
+            creation_cost_cc=Decimal("1.00"),
+            version="1.0.0",
+        )


### PR DESCRIPTION
First implementation piece of `specs/asset-renderer-plugin.md`. Pure-logic pieces that don't require graph storage.

**Files**
- `api/app/models/renderer.py` — `RenderCCSplit` (validates sum=1.0), `RendererCreate`, `Renderer`, `RenderEvent`; 500KB bundle cap
- `api/app/services/render_attribution_service.py` — `attribute_render_cc()`, `resolve_split()` with override precedence
- `api/tests/test_asset_renderer.py` — 14 tests

**Covers** R4 (render event attribution), R5 (configurable split with override precedence), R9 (500KB bundle cap), and the related validation of R7/R2 basics.

**Does not cover yet** — router endpoints, graph storage, web SDK, dynamic component loading. Those belong in subsequent PRs against the same spec.

Moves this spec from zero-code (untouched 3 months) to tested-foundation.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_