### PR TITLE
feat(asset-renderer): render_events router closes the CC loop (R4)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -727,6 +727,8 @@ app.include_router(push_router.router, prefix="/api", tags=["push"])
 app.include_router(service_registry_router.router, prefix="/api", tags=["services"])
 app.include_router(cc_economics_router.router, prefix="/api", tags=["cc-economics"])
 app.include_router(cc_exchange_router.router, prefix="/api", tags=["cc-exchange"])
+from app.routers import renderers as renderers_router
+app.include_router(renderers_router.router, prefix="/api", tags=["renderers"])
 app.include_router(concepts.router, prefix="/api", tags=["concepts"])
 app.include_router(locales_router.router, prefix="/api", tags=["locales"])
 app.include_router(entity_views_router.router, prefix="/api", tags=["locales"])

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -729,6 +729,8 @@ app.include_router(cc_economics_router.router, prefix="/api", tags=["cc-economic
 app.include_router(cc_exchange_router.router, prefix="/api", tags=["cc-exchange"])
 from app.routers import renderers as renderers_router
 app.include_router(renderers_router.router, prefix="/api", tags=["renderers"])
+from app.routers import render_events as render_events_router
+app.include_router(render_events_router.router, prefix="/api", tags=["render-events"])
 app.include_router(concepts.router, prefix="/api", tags=["concepts"])
 app.include_router(locales_router.router, prefix="/api", tags=["locales"])
 app.include_router(entity_views_router.router, prefix="/api", tags=["locales"])

--- a/api/app/routers/render_events.py
+++ b/api/app/routers/render_events.py
@@ -1,0 +1,108 @@
+"""Render Events Router — log a render and attribute CC.
+
+Endpoints:
+  POST /api/render-events               - Log a render event, attribute CC
+  GET  /api/render-events/{event_id}    - Fetch a single event
+
+See specs/asset-renderer-plugin.md (R4). Closes the economic loop: a
+render event comes in with (asset_id, renderer_id, reader_id,
+duration_ms); the service computes the CC pool from engagement and
+splits it per the renderer's cc_split (or the platform default if
+none is registered).
+
+Storage is an in-process list for this first slice, matching the
+renderer registry. Graph-backed persistence is a follow-up.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.models.renderer import RenderCCSplit, RenderEvent
+from app.routers.renderers import _REGISTRY as _RENDERER_REGISTRY
+from app.services.render_attribution_service import attribute_render_cc
+
+router = APIRouter(prefix="/render-events", tags=["render-events"])
+
+
+# Base rate: 0.00001 CC per millisecond of engagement.
+# 15 seconds of engagement → 0.15 CC pool (example from spec).
+BASE_CC_RATE_PER_MS = Decimal("0.00001")
+
+
+# In-process event log. Single-process only for this slice.
+_EVENTS: Dict[UUID, RenderEvent] = {}
+
+
+class RenderEventCreate(BaseModel):
+    """Payload for POST /api/render-events."""
+
+    asset_id: str
+    renderer_id: str
+    reader_id: str
+    duration_ms: int = Field(ge=0)
+    asset_cc_split_override: RenderCCSplit | None = None
+
+
+@router.post(
+    "",
+    response_model=RenderEvent,
+    status_code=201,
+    summary="Log a render event and attribute CC",
+)
+async def log_render_event(body: RenderEventCreate) -> RenderEvent:
+    """Log a render, compute the CC pool, split it per override precedence.
+
+    - cc_pool = duration_ms * BASE_CC_RATE_PER_MS
+    - Override precedence: asset override > renderer default > platform 80/15/5
+    - Shares are validated to sum to 1.0 at the Pydantic layer.
+    """
+    renderer_default = None
+    renderer = _RENDERER_REGISTRY.get(body.renderer_id)
+    if renderer is not None:
+        renderer_default = renderer.cc_split
+
+    cc_pool = Decimal(body.duration_ms) * BASE_CC_RATE_PER_MS
+
+    attribution = attribute_render_cc(
+        cc_pool,
+        asset_override=body.asset_cc_split_override,
+        renderer_default=renderer_default,
+    )
+
+    event = RenderEvent(
+        asset_id=body.asset_id,
+        renderer_id=body.renderer_id,
+        reader_id=body.reader_id,
+        duration_ms=body.duration_ms,
+        cc_pool=cc_pool,
+        cc_asset_creator=attribution.cc_asset_creator,
+        cc_renderer_creator=attribution.cc_renderer_creator,
+        cc_host_node=attribution.cc_host_node,
+    )
+    _EVENTS[event.id] = event
+    return event
+
+
+@router.get(
+    "/{event_id}",
+    response_model=RenderEvent,
+    summary="Get a single render event by id",
+)
+async def get_render_event(event_id: UUID) -> RenderEvent:
+    if event_id not in _EVENTS:
+        raise HTTPException(
+            status_code=404,
+            detail=f"render event '{event_id}' not found",
+        )
+    return _EVENTS[event_id]
+
+
+def _reset_events_for_tests() -> None:
+    """Testing hook. Not part of the public API."""
+    _EVENTS.clear()

--- a/api/app/routers/renderers.py
+++ b/api/app/routers/renderers.py
@@ -1,0 +1,102 @@
+"""Renderer Router — pluggable asset renderer registry.
+
+Endpoints:
+  POST /api/renderers/register           - Register a renderer for MIME types
+  GET  /api/renderers                    - List registered renderers
+  GET  /api/renderers/for/{mime_type}    - Find best renderer for a MIME type
+  GET  /api/renderers/{renderer_id}      - Get one renderer
+
+See specs/asset-renderer-plugin.md (R2, R3, R7, R9).
+
+Storage is an in-process registry for this initial slice. Graph-backed
+storage is a follow-up once the router contract is exercised in tests
+and web clients; the spec's source map names graph storage as the
+target but doesn't require it to ship in the first PR.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.renderer import Renderer, RendererCreate
+
+router = APIRouter(prefix="/renderers", tags=["renderers"])
+
+
+# In-process registry. Thread-safe because FastAPI workers don't share memory
+# and this is the first slice before graph persistence.
+_REGISTRY: Dict[str, Renderer] = {}
+
+
+@router.post(
+    "/register",
+    response_model=Renderer,
+    status_code=201,
+    summary="Register a renderer for one or more MIME types",
+)
+async def register_renderer(body: RendererCreate) -> Renderer:
+    """Register a new renderer. Rejects duplicate IDs with 409.
+
+    cc_split validation (must sum to 1.0) and bundle-size validation
+    (≤ 500KB) are enforced by the Pydantic models at request parse time.
+    """
+    if body.id in _REGISTRY:
+        raise HTTPException(
+            status_code=409,
+            detail=f"renderer with id '{body.id}' already registered",
+        )
+    renderer = Renderer(**body.model_dump())
+    _REGISTRY[renderer.id] = renderer
+    return renderer
+
+
+@router.get("", response_model=List[Renderer], summary="List all registered renderers")
+async def list_renderers(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> List[Renderer]:
+    """List registered renderers, paginated by insertion order."""
+    items = list(_REGISTRY.values())
+    return items[offset : offset + limit]
+
+
+@router.get(
+    "/for/{mime_type:path}",
+    response_model=Renderer,
+    summary="Find the best renderer for a MIME type",
+)
+async def get_renderer_for_mime(mime_type: str) -> Renderer:
+    """Return the highest-version renderer that handles this MIME type.
+
+    Returns 404 if no renderer is registered for the type — the web client
+    should then fall back to a generic download surface per spec R3.
+    """
+    candidates = [r for r in _REGISTRY.values() if mime_type in r.mime_types]
+    if not candidates:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no renderer registered for mime type '{mime_type}'",
+        )
+    # Highest version wins (lexicographic; spec doesn't define strict semver yet).
+    return max(candidates, key=lambda r: r.version)
+
+
+@router.get(
+    "/{renderer_id}",
+    response_model=Renderer,
+    summary="Get a single renderer by id",
+)
+async def get_renderer(renderer_id: str) -> Renderer:
+    if renderer_id not in _REGISTRY:
+        raise HTTPException(
+            status_code=404,
+            detail=f"renderer '{renderer_id}' not found",
+        )
+    return _REGISTRY[renderer_id]
+
+
+def _reset_registry_for_tests() -> None:
+    """Testing hook. Not part of the public API."""
+    _REGISTRY.clear()

--- a/api/tests/test_render_events_router.py
+++ b/api/tests/test_render_events_router.py
@@ -1,0 +1,154 @@
+"""Tests for POST /api/render-events — the economic loop closure.
+
+Covers spec R4 (render event logs and attributes CC) end-to-end:
+- registering a renderer with a custom split means render events use it
+- no registered renderer falls back to platform default
+- asset override beats renderer default
+- cc_pool derives from duration_ms at the base rate
+- the three shares sum to cc_pool within rounding
+"""
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers.renderers import _reset_registry_for_tests
+from app.routers.render_events import _reset_events_for_tests
+
+
+@pytest.fixture
+def client():
+    _reset_registry_for_tests()
+    _reset_events_for_tests()
+    return TestClient(app)
+
+
+def _register_renderer(client, **overrides):
+    base = {
+        "id": "r1",
+        "name": "R1",
+        "mime_types": ["text/markdown"],
+        "creator_id": "contributor:bob",
+        "component_url": "https://cdn.example.com/r1.js",
+        "creation_cost_cc": "1.00",
+        "version": "1.0.0",
+    }
+    base.update(overrides)
+    return client.post("/api/renderers/register", json=base)
+
+
+def _render(client, **overrides):
+    base = {
+        "asset_id": "asset:a1",
+        "renderer_id": "r1",
+        "reader_id": "contributor:charlie",
+        "duration_ms": 15000,
+    }
+    base.update(overrides)
+    return client.post("/api/render-events", json=base)
+
+
+def test_render_event_with_default_split_and_pool(client):
+    _register_renderer(client)
+    response = _render(client, duration_ms=15000)
+    assert response.status_code == 201
+    body = response.json()
+    # cc_pool = 15000 * 0.00001 = 0.15
+    assert Decimal(body["cc_pool"]) == Decimal("0.15000")
+    # default 80/15/5 because renderer registered without cc_split
+    assert Decimal(body["cc_asset_creator"]) == Decimal("0.120000")
+    assert Decimal(body["cc_renderer_creator"]) == Decimal("0.022500")
+    assert Decimal(body["cc_host_node"]) == Decimal("0.007500")
+
+
+def test_render_event_uses_renderer_custom_split(client):
+    _register_renderer(
+        client,
+        cc_split={
+            "asset_creator": "0.70",
+            "renderer_creator": "0.25",
+            "host_node": "0.05",
+        },
+    )
+    response = _render(client, duration_ms=10000)
+    assert response.status_code == 201
+    body = response.json()
+    assert Decimal(body["cc_pool"]) == Decimal("0.10000")
+    assert Decimal(body["cc_asset_creator"]) == Decimal("0.070000")
+    assert Decimal(body["cc_renderer_creator"]) == Decimal("0.025000")
+    assert Decimal(body["cc_host_node"]) == Decimal("0.005000")
+
+
+def test_render_event_asset_override_beats_renderer_default(client):
+    _register_renderer(
+        client,
+        cc_split={
+            "asset_creator": "0.70",
+            "renderer_creator": "0.25",
+            "host_node": "0.05",
+        },
+    )
+    response = _render(
+        client,
+        duration_ms=10000,
+        asset_cc_split_override={
+            "asset_creator": "0.95",
+            "renderer_creator": "0.025",
+            "host_node": "0.025",
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert Decimal(body["cc_asset_creator"]) == Decimal("0.095000")
+
+
+def test_render_event_unknown_renderer_uses_platform_default(client):
+    # no renderer registered
+    response = _render(client, renderer_id="unknown-renderer", duration_ms=20000)
+    assert response.status_code == 201
+    body = response.json()
+    # platform default 80/15/5
+    assert Decimal(body["cc_pool"]) == Decimal("0.20000")
+    assert Decimal(body["cc_asset_creator"]) == Decimal("0.160000")
+
+
+def test_render_event_shares_sum_to_pool(client):
+    _register_renderer(client)
+    response = _render(client, duration_ms=7777)
+    body = response.json()
+    total = (
+        Decimal(body["cc_asset_creator"])
+        + Decimal(body["cc_renderer_creator"])
+        + Decimal(body["cc_host_node"])
+    )
+    assert total == Decimal(body["cc_pool"])
+
+
+def test_render_event_rejects_negative_duration(client):
+    _register_renderer(client)
+    response = _render(client, duration_ms=-1)
+    assert response.status_code == 422
+
+
+def test_render_event_zero_duration_yields_zero_pool(client):
+    _register_renderer(client)
+    response = _render(client, duration_ms=0)
+    assert response.status_code == 201
+    body = response.json()
+    assert Decimal(body["cc_pool"]) == Decimal("0")
+
+
+def test_get_render_event_by_id(client):
+    _register_renderer(client)
+    created = _render(client).json()
+    event_id = created["id"]
+    response = client.get(f"/api/render-events/{event_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == event_id
+
+
+def test_get_render_event_404(client):
+    response = client.get("/api/render-events/00000000-0000-0000-0000-000000000000")
+    assert response.status_code == 404

--- a/api/tests/test_renderers_router.py
+++ b/api/tests/test_renderers_router.py
@@ -1,0 +1,128 @@
+"""Route-level tests for /api/renderers/* endpoints.
+
+Covers spec R2 (renderer registration), R3 (lookup by MIME type),
+R5 (CC split validation at the HTTP boundary), R9 (bundle size cap).
+"""
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers.renderers import _reset_registry_for_tests
+
+
+@pytest.fixture
+def client():
+    _reset_registry_for_tests()
+    return TestClient(app)
+
+
+def _valid_payload(**overrides):
+    base = {
+        "id": "gltf-viewer-v1",
+        "name": "GLTF 3D Viewer",
+        "mime_types": ["model/gltf+json", "model/gltf-binary"],
+        "creator_id": "contributor:bob",
+        "component_url": "https://cdn.example.com/gltf-viewer-v1.js",
+        "creation_cost_cc": "12.00",
+        "version": "1.0.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_register_renderer_returns_201(client):
+    response = client.post("/api/renderers/register", json=_valid_payload())
+    assert response.status_code == 201
+    body = response.json()
+    assert body["id"] == "gltf-viewer-v1"
+    assert body["mime_types"] == ["model/gltf+json", "model/gltf-binary"]
+    assert "created_at" in body
+
+
+def test_register_duplicate_id_returns_409(client):
+    client.post("/api/renderers/register", json=_valid_payload())
+    second = client.post("/api/renderers/register", json=_valid_payload())
+    assert second.status_code == 409
+
+
+def test_register_rejects_split_that_does_not_sum_to_one(client):
+    payload = _valid_payload(
+        cc_split={
+            "asset_creator": "0.80",
+            "renderer_creator": "0.15",
+            "host_node": "0.10",  # total = 1.05
+        }
+    )
+    response = client.post("/api/renderers/register", json=payload)
+    assert response.status_code == 422
+
+
+def test_register_rejects_oversize_bundle(client):
+    payload = _valid_payload(max_bundle_bytes=512_001)
+    response = client.post("/api/renderers/register", json=payload)
+    assert response.status_code == 422
+
+
+def test_register_rejects_empty_mime_types(client):
+    payload = _valid_payload(mime_types=[])
+    response = client.post("/api/renderers/register", json=payload)
+    assert response.status_code == 422
+
+
+def test_list_renderers_empty(client):
+    response = client.get("/api/renderers")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_renderers_after_register(client):
+    client.post("/api/renderers/register", json=_valid_payload())
+    client.post(
+        "/api/renderers/register",
+        json=_valid_payload(id="md-v1", mime_types=["text/markdown"]),
+    )
+    response = client.get("/api/renderers")
+    assert response.status_code == 200
+    ids = [r["id"] for r in response.json()]
+    assert set(ids) == {"gltf-viewer-v1", "md-v1"}
+
+
+def test_get_renderer_by_id_200(client):
+    client.post("/api/renderers/register", json=_valid_payload())
+    response = client.get("/api/renderers/gltf-viewer-v1")
+    assert response.status_code == 200
+    assert response.json()["id"] == "gltf-viewer-v1"
+
+
+def test_get_renderer_by_id_404(client):
+    response = client.get("/api/renderers/nonexistent")
+    assert response.status_code == 404
+
+
+def test_get_renderer_for_mime_returns_match(client):
+    client.post("/api/renderers/register", json=_valid_payload())
+    response = client.get("/api/renderers/for/model/gltf+json")
+    assert response.status_code == 200
+    assert response.json()["id"] == "gltf-viewer-v1"
+
+
+def test_get_renderer_for_mime_404_when_no_match(client):
+    response = client.get("/api/renderers/for/audio/midi")
+    assert response.status_code == 404
+
+
+def test_get_renderer_for_mime_highest_version_wins(client):
+    client.post(
+        "/api/renderers/register",
+        json=_valid_payload(id="md-v1", mime_types=["text/markdown"], version="1.0.0"),
+    )
+    client.post(
+        "/api/renderers/register",
+        json=_valid_payload(id="md-v2", mime_types=["text/markdown"], version="2.0.0"),
+    )
+    response = client.get("/api/renderers/for/text/markdown")
+    assert response.status_code == 200
+    assert response.json()["id"] == "md-v2"


### PR DESCRIPTION
Closes the CC loop for asset-renderer-plugin spec R4.

`POST /api/render-events` accepts `(asset_id, renderer_id, reader_id, duration_ms, asset_cc_split_override?)`, computes `cc_pool = duration_ms × 0.00001 CC/ms` (15s → 0.15 CC, per spec example), resolves split per override precedence (asset > renderer-registered > platform 80/15/5), and returns the fully-attributed `RenderEvent`.

`GET /api/render-events/{event_id}` for retrieval.

**9 route tests** — default split, custom renderer split, asset override, unknown-renderer fallback, shares-sum-to-pool invariant, negative duration 422, zero duration, 404, round-trip fetch.

Router mounted in `app/main.py`. In-process storage for now; graph-backed persistence is a follow-up.

**Spec progress:** three PRs now on this previously-untouched-3-months draft.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_