### PR TITLE
feat(asset-renderer): per-asset analytics endpoint (R11)

### DIFF
--- a/api/app/routers/render_events.py
+++ b/api/app/routers/render_events.py
@@ -1,23 +1,24 @@
-"""Render Events Router — log a render and attribute CC.
+"""Render Events Router — log a render, attribute CC, aggregate analytics.
 
 Endpoints:
-  POST /api/render-events               - Log a render event, attribute CC
-  GET  /api/render-events/{event_id}    - Fetch a single event
+  POST /api/render-events                         - Log a render event, attribute CC
+  GET  /api/render-events/{event_id}              - Fetch a single event
+  GET  /api/render-events/analytics/{asset_id}    - Aggregate per-asset analytics
 
-See specs/asset-renderer-plugin.md (R4). Closes the economic loop: a
-render event comes in with (asset_id, renderer_id, reader_id,
+See specs/asset-renderer-plugin.md (R4, R11). Closes the economic loop:
+a render event comes in with (asset_id, renderer_id, reader_id,
 duration_ms); the service computes the CC pool from engagement and
 splits it per the renderer's cc_split (or the platform default if
-none is registered).
+none is registered). Analytics aggregates events per asset.
 
-Storage is an in-process list for this first slice, matching the
+Storage is an in-process dict for this first slice, matching the
 renderer registry. Graph-backed persistence is a follow-up.
 """
 
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Dict
+from typing import Dict, List
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
@@ -87,6 +88,72 @@ async def log_render_event(body: RenderEventCreate) -> RenderEvent:
     )
     _EVENTS[event.id] = event
     return event
+
+
+class AssetAnalytics(BaseModel):
+    """Aggregated analytics for a single asset across all render events."""
+
+    asset_id: str
+    total_renders: int
+    unique_readers: int
+    avg_duration_ms: int
+    total_cc_earned: Decimal
+    cc_to_asset_creator: Decimal
+    cc_to_renderer_creators: Decimal
+    cc_to_host_nodes: Decimal
+
+
+@router.get(
+    "/analytics/{asset_id:path}",
+    response_model=AssetAnalytics,
+    summary="Aggregate analytics for a single asset",
+)
+async def get_asset_analytics(asset_id: str) -> AssetAnalytics:
+    """Return aggregated render count, CC earned per role, unique readers,
+    and average engagement duration for a single asset.
+
+    Returns zero-valued analytics (not 404) for an asset with no events —
+    every asset has an analytics surface; the answer is just "nothing yet"
+    until a render happens.
+
+    Note on scope: the spec's `top_concepts` field (concept tags weighted
+    by render count) requires concept-tag integration at the asset
+    registration layer. Not yet wired here — belongs in a follow-up once
+    POST /api/assets/register is implemented.
+    """
+    events: List[RenderEvent] = [e for e in _EVENTS.values() if e.asset_id == asset_id]
+
+    if not events:
+        zero = Decimal("0")
+        return AssetAnalytics(
+            asset_id=asset_id,
+            total_renders=0,
+            unique_readers=0,
+            avg_duration_ms=0,
+            total_cc_earned=zero,
+            cc_to_asset_creator=zero,
+            cc_to_renderer_creators=zero,
+            cc_to_host_nodes=zero,
+        )
+
+    unique_readers = len({e.reader_id for e in events})
+    avg_duration = sum(e.duration_ms for e in events) // len(events)
+
+    total_pool = sum((e.cc_pool for e in events), Decimal("0"))
+    total_asset = sum((e.cc_asset_creator for e in events), Decimal("0"))
+    total_renderer = sum((e.cc_renderer_creator for e in events), Decimal("0"))
+    total_host = sum((e.cc_host_node for e in events), Decimal("0"))
+
+    return AssetAnalytics(
+        asset_id=asset_id,
+        total_renders=len(events),
+        unique_readers=unique_readers,
+        avg_duration_ms=avg_duration,
+        total_cc_earned=total_pool,
+        cc_to_asset_creator=total_asset,
+        cc_to_renderer_creators=total_renderer,
+        cc_to_host_nodes=total_host,
+    )
 
 
 @router.get(

--- a/api/tests/test_render_events_router.py
+++ b/api/tests/test_render_events_router.py
@@ -152,3 +152,72 @@ def test_get_render_event_by_id(client):
 def test_get_render_event_404(client):
     response = client.get("/api/render-events/00000000-0000-0000-0000-000000000000")
     assert response.status_code == 404
+
+
+# ---------- GET /api/render-events/analytics/{asset_id} (R11) ----------
+
+
+def test_analytics_empty_asset_returns_zeros(client):
+    response = client.get("/api/render-events/analytics/asset:never-rendered")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["asset_id"] == "asset:never-rendered"
+    assert body["total_renders"] == 0
+    assert body["unique_readers"] == 0
+    assert body["avg_duration_ms"] == 0
+    assert Decimal(body["total_cc_earned"]) == Decimal("0")
+
+
+def test_analytics_aggregates_single_asset(client):
+    _register_renderer(client)
+    # Three renders, same asset, two unique readers
+    _render(client, asset_id="asset:a1", reader_id="u1", duration_ms=10000)
+    _render(client, asset_id="asset:a1", reader_id="u2", duration_ms=20000)
+    _render(client, asset_id="asset:a1", reader_id="u1", duration_ms=30000)
+
+    response = client.get("/api/render-events/analytics/asset:a1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_renders"] == 3
+    assert body["unique_readers"] == 2
+    assert body["avg_duration_ms"] == 20000  # (10k+20k+30k)/3
+    # cc_pool = (10000+20000+30000) * 0.00001 = 0.60
+    assert Decimal(body["total_cc_earned"]) == Decimal("0.60000")
+    # default 80/15/5 → asset creator = 0.60 * 0.80 = 0.48
+    assert Decimal(body["cc_to_asset_creator"]) == Decimal("0.480000")
+    assert Decimal(body["cc_to_renderer_creators"]) == Decimal("0.090000")
+    assert Decimal(body["cc_to_host_nodes"]) == Decimal("0.030000")
+
+
+def test_analytics_does_not_cross_assets(client):
+    _register_renderer(client)
+    _render(client, asset_id="asset:a1", reader_id="u1", duration_ms=10000)
+    _render(client, asset_id="asset:a2", reader_id="u1", duration_ms=50000)
+
+    a1 = client.get("/api/render-events/analytics/asset:a1").json()
+    a2 = client.get("/api/render-events/analytics/asset:a2").json()
+    assert a1["total_renders"] == 1
+    assert a2["total_renders"] == 1
+    assert Decimal(a1["total_cc_earned"]) == Decimal("0.10000")
+    assert Decimal(a2["total_cc_earned"]) == Decimal("0.50000")
+
+
+def test_analytics_sums_reconcile_to_total(client):
+    _register_renderer(
+        client,
+        cc_split={
+            "asset_creator": "0.70",
+            "renderer_creator": "0.25",
+            "host_node": "0.05",
+        },
+    )
+    _render(client, asset_id="asset:a1", reader_id="u1", duration_ms=13579)
+    _render(client, asset_id="asset:a1", reader_id="u2", duration_ms=24680)
+
+    body = client.get("/api/render-events/analytics/asset:a1").json()
+    total_shares = (
+        Decimal(body["cc_to_asset_creator"])
+        + Decimal(body["cc_to_renderer_creators"])
+        + Decimal(body["cc_to_host_nodes"])
+    )
+    assert total_shares == Decimal(body["total_cc_earned"])


### PR DESCRIPTION
`GET /api/render-events/analytics/{asset_id}` aggregates render events per asset:

- `total_renders`, `unique_readers`, `avg_duration_ms`
- `total_cc_earned`
- `cc_to_asset_creator`, `cc_to_renderer_creators`, `cc_to_host_nodes`

Zero-asset returns zero-valued analytics (not 404) — every asset has an analytics surface from the moment it's addressable.

**Not yet:** `top_concepts` — needs concept-tag integration at the asset-registration layer; belongs with `POST /api/assets/register`.

**4 new tests:** empty-asset zeros, multi-render aggregation, cross-asset isolation, sums-reconcile-to-total invariant.

Spec R11 now has an HTTP surface. The economic sensing the concept layer promised has a first queryable face.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_