### PR TITLE
feat(asset-renderer): POST /api/assets/register MIME-aware registration (R1)

### DIFF
--- a/api/app/models/asset.py
+++ b/api/app/models/asset.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
+from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AssetType(str, Enum):
@@ -44,3 +45,37 @@ class Asset(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ConceptTag(BaseModel):
+    """A weighted link from an asset to a Living Collective concept."""
+
+    concept_id: str
+    weight: float = Field(ge=0.0, le=1.0)
+
+
+class AssetRegistrationCreate(BaseModel):
+    """Payload for POST /api/assets/register — MIME-aware asset registration
+    that extends the legacy AssetCreate taxonomy (CODE/MODEL/CONTENT/DATA)
+    with free-form MIME types, content provenance, and concept tags.
+
+    See specs/asset-renderer-plugin.md (R1).
+    """
+
+    type: str = Field(description="MIME type or custom type identifier")
+    name: str
+    description: str
+    content_hash: str = Field(description="SHA-256 of raw content")
+    arweave_tx: Optional[str] = None
+    ipfs_cid: Optional[str] = None
+    concept_tags: List[ConceptTag] = Field(default_factory=list)
+    creator_id: str
+    creation_cost_cc: Decimal
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AssetRegistration(AssetRegistrationCreate):
+    """Registered asset with server-assigned id and timestamp."""
+
+    id: str = Field(description="asset:<uuid> identifier")
+    created_at: datetime

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -1,18 +1,62 @@
 """Assets router — backed by graph_nodes (type=asset)."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 from decimal import Decimal
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from app.models.asset import Asset, AssetCreate
+from app.models.asset import (
+    Asset,
+    AssetCreate,
+    AssetRegistration,
+    AssetRegistrationCreate,
+    ConceptTag,
+)
 from app.models.error import ErrorDetail
 from app.models.pagination import PaginatedResponse
 from app.services import graph_service
 from app.services.locale_projection import project, project_many, resolve_caller_lang
 
 router = APIRouter()
+
+
+def _node_to_registration(node: dict) -> AssetRegistration:
+    """Convert a graph node carrying MIME-aware asset properties to
+    an AssetRegistration model."""
+    props = node
+    concept_tags_raw = props.get("concept_tags", []) or []
+    concept_tags = [
+        ConceptTag(concept_id=t.get("concept_id"), weight=float(t.get("weight", 0)))
+        for t in concept_tags_raw
+    ]
+    creation_cost = Decimal(str(props.get("creation_cost_cc", "0")))
+    created_at_raw = props.get("created_at")
+    if isinstance(created_at_raw, str):
+        try:
+            created_at = datetime.fromisoformat(created_at_raw.replace("Z", "+00:00"))
+        except ValueError:
+            created_at = datetime.now(timezone.utc)
+    elif isinstance(created_at_raw, datetime):
+        created_at = created_at_raw
+    else:
+        created_at = datetime.now(timezone.utc)
+
+    return AssetRegistration(
+        id=node["id"],
+        type=props.get("mime_type") or props.get("asset_type", ""),
+        name=props.get("name", ""),
+        description=props.get("description", ""),
+        content_hash=props.get("content_hash", ""),
+        arweave_tx=props.get("arweave_tx"),
+        ipfs_cid=props.get("ipfs_cid"),
+        concept_tags=concept_tags,
+        creator_id=props.get("creator_id", ""),
+        creation_cost_cc=creation_cost,
+        metadata=props.get("metadata", {}) or {},
+        created_at=created_at,
+    )
 
 
 def _node_to_asset(node: dict) -> Asset:
@@ -52,6 +96,80 @@ async def create_asset(asset: AssetCreate) -> Asset:
         },
     )
     return asset_obj
+
+
+@router.post(
+    "/assets/register",
+    response_model=AssetRegistration,
+    status_code=201,
+    summary="Register a MIME-typed asset with content provenance",
+    responses={422: {"model": ErrorDetail, "description": "Validation error"}},
+)
+async def register_asset(body: AssetRegistrationCreate) -> AssetRegistration:
+    """Register an asset with full MIME type, content hash, storage
+    references, concept tags, and format-specific metadata.
+
+    Extends the legacy POST /api/assets — the legacy endpoint still
+    accepts CODE/MODEL/CONTENT/DATA taxonomy for pipeline contributions.
+    This endpoint supports arbitrary MIME types so a renderer can pair
+    with the asset by type. See specs/asset-renderer-plugin.md R1.
+    """
+    registration_id = f"asset:{uuid4()}"
+    now = datetime.now(timezone.utc)
+    concept_tags_serializable = [
+        {"concept_id": t.concept_id, "weight": t.weight}
+        for t in body.concept_tags
+    ]
+    graph_service.create_node(
+        id=registration_id,
+        type="asset",
+        name=body.name,
+        description=body.description,
+        phase="ice",
+        properties={
+            "mime_type": body.type,
+            "name": body.name,
+            "content_hash": body.content_hash,
+            "arweave_tx": body.arweave_tx,
+            "ipfs_cid": body.ipfs_cid,
+            "concept_tags": concept_tags_serializable,
+            "creator_id": body.creator_id,
+            "creation_cost_cc": str(body.creation_cost_cc),
+            "metadata": body.metadata,
+            "created_at": now.isoformat(),
+        },
+    )
+    return AssetRegistration(
+        id=registration_id,
+        type=body.type,
+        name=body.name,
+        description=body.description,
+        content_hash=body.content_hash,
+        arweave_tx=body.arweave_tx,
+        ipfs_cid=body.ipfs_cid,
+        concept_tags=body.concept_tags,
+        creator_id=body.creator_id,
+        creation_cost_cc=body.creation_cost_cc,
+        metadata=body.metadata,
+        created_at=now,
+    )
+
+
+@router.get(
+    "/assets/{asset_id}/registration",
+    response_model=AssetRegistration,
+    summary="Get MIME-aware asset registration",
+    responses={404: {"model": ErrorDetail, "description": "Asset registration not found"}},
+)
+async def get_asset_registration(asset_id: str) -> AssetRegistration:
+    """Retrieve full registration (MIME type, concept tags, provenance, metadata)
+    for an asset registered via POST /api/assets/register.
+    """
+    node_id = asset_id if asset_id.startswith("asset:") else f"asset:{asset_id}"
+    node = graph_service.get_node(node_id)
+    if not node or not node.get("mime_type"):
+        raise HTTPException(status_code=404, detail="Asset registration not found")
+    return _node_to_registration(node)
 
 
 @router.get(

--- a/api/tests/test_asset_registration.py
+++ b/api/tests/test_asset_registration.py
@@ -1,0 +1,124 @@
+"""Tests for POST /api/assets/register and GET /api/assets/{id}/registration.
+
+Covers spec R1 — MIME-aware asset registration with content provenance
+and concept tags.
+"""
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _valid_payload(**overrides):
+    base = {
+        "type": "model/gltf+json",
+        "name": "Forest Scene",
+        "description": "A detailed 3D forest environment",
+        "content_hash": "sha256:abc123",
+        "arweave_tx": "tx_abc123",
+        "ipfs_cid": "QmXyz",
+        "concept_tags": [
+            {"concept_id": "lc-land", "weight": 0.8},
+            {"concept_id": "lc-beauty", "weight": 0.4},
+        ],
+        "creator_id": "contributor:alice",
+        "creation_cost_cc": "5.00",
+        "metadata": {"vertices": 50000, "textures": 12},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_register_asset_returns_201_with_mime_type(client):
+    response = client.post("/api/assets/register", json=_valid_payload())
+    assert response.status_code == 201
+    body = response.json()
+    assert body["type"] == "model/gltf+json"
+    assert body["name"] == "Forest Scene"
+    assert body["content_hash"] == "sha256:abc123"
+    assert body["arweave_tx"] == "tx_abc123"
+    assert body["ipfs_cid"] == "QmXyz"
+    assert body["creator_id"] == "contributor:alice"
+    assert Decimal(body["creation_cost_cc"]) == Decimal("5.00")
+    assert body["metadata"]["vertices"] == 50000
+    assert body["id"].startswith("asset:")
+    assert "created_at" in body
+
+
+def test_register_asset_stores_concept_tags(client):
+    response = client.post("/api/assets/register", json=_valid_payload())
+    body = response.json()
+    assert len(body["concept_tags"]) == 2
+    tags = {t["concept_id"]: t["weight"] for t in body["concept_tags"]}
+    assert tags["lc-land"] == 0.8
+    assert tags["lc-beauty"] == 0.4
+
+
+def test_register_asset_accepts_empty_concept_tags(client):
+    response = client.post(
+        "/api/assets/register",
+        json=_valid_payload(concept_tags=[]),
+    )
+    assert response.status_code == 201
+    assert response.json()["concept_tags"] == []
+
+
+def test_register_asset_rejects_concept_tag_weight_above_one(client):
+    response = client.post(
+        "/api/assets/register",
+        json=_valid_payload(concept_tags=[{"concept_id": "lc-x", "weight": 1.5}]),
+    )
+    assert response.status_code == 422
+
+
+def test_register_asset_rejects_missing_required_fields(client):
+    payload = _valid_payload()
+    del payload["content_hash"]
+    response = client.post("/api/assets/register", json=payload)
+    assert response.status_code == 422
+
+
+def test_get_registration_roundtrip(client):
+    created = client.post("/api/assets/register", json=_valid_payload()).json()
+    asset_id = created["id"]
+    response = client.get(f"/api/assets/{asset_id}/registration")
+    assert response.status_code == 200
+    fetched = response.json()
+    assert fetched["id"] == asset_id
+    assert fetched["type"] == "model/gltf+json"
+    assert fetched["content_hash"] == "sha256:abc123"
+    assert len(fetched["concept_tags"]) == 2
+
+
+def test_get_registration_404_for_missing(client):
+    response = client.get("/api/assets/nonexistent/registration")
+    assert response.status_code == 404
+
+
+def test_register_accepts_mime_without_storage_refs(client):
+    payload = _valid_payload(arweave_tx=None, ipfs_cid=None)
+    response = client.post("/api/assets/register", json=payload)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["arweave_tx"] is None
+    assert body["ipfs_cid"] is None
+
+
+def test_legacy_create_asset_still_works(client):
+    """Spec constraint: existing POST /api/assets must not break."""
+    response = client.post(
+        "/api/assets",
+        json={"type": "CODE", "description": "legacy-asset via old endpoint"},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["type"] == "CODE"
+    assert body["description"] == "legacy-asset via old endpoint"


### PR DESCRIPTION
Closes the asset→renderer→event→attribution chain end-to-end. Before this, render events pointed at bare asset_ids; now an asset is registered with a MIME type that pairs with a renderer registered for that MIME type.

**New models** (`app/models/asset.py`):
- `ConceptTag` — weighted link to a Living Collective concept
- `AssetRegistrationCreate` — MIME + content_hash + arweave_tx + ipfs_cid + concept_tags + creator_id + creation_cost_cc + metadata
- `AssetRegistration` — adds server id + created_at

**New endpoints** (`app/routers/assets.py`):
- `POST /api/assets/register` — MIME-aware registration
- `GET /api/assets/{id}/registration` — retrieve full registration

Backed by existing `graph_service.create_node` / `get_node`. No new substrate.

**Existing endpoints unchanged** per spec constraint:
- `POST /api/assets` (legacy CODE/MODEL/CONTENT/DATA)
- `GET /api/assets/{id}`, `GET /api/assets`

**9 route tests**: roundtrip with metadata, concept tags, empty tags, weight>1 validation, missing-field 422, 404, optional storage refs, legacy endpoint unchanged.

Spec R1 now has an HTTP surface. The full chain — register asset with MIME, register renderer for MIME, render event computes CC pool and splits it — is end-to-end.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_