### PR TITLE
attune: sanitize contributor-name local-part so placeholder emails stay valid

### DIFF
--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -491,9 +491,15 @@ def _node_to_contributor(node: dict) -> Contributor:
     except (ValueError, AttributeError):
         cid = uuid4()
     email = node.get("email") or ""
-    # Contributor model requires a valid email — use a placeholder if missing
+    # Contributor model requires a valid email — use a placeholder if missing.
+    # Sanitize the local-part: names with spaces or unicode (e.g. "Dr Joe
+    # Dispenza") would otherwise make an invalid EmailStr and 500 the
+    # endpoint for every caller paging through a list that includes the node.
     if not email or "@" not in email:
-        email = f"{node.get('name', 'unknown')}@coherence.network"
+        import re
+        raw_name = node.get("name", "unknown") or "unknown"
+        safe_local = re.sub(r"[^a-zA-Z0-9._-]+", "-", raw_name).strip("-").lower()
+        email = f"{safe_local or 'unknown'}@coherence.network"
     # Coerce unknown contributor_type values to SYSTEM so a stray label in
     # the graph never blows up the endpoint for every caller.
     raw_type = str(node.get("contributor_type") or "HUMAN").strip().upper()


### PR DESCRIPTION
## Summary

Names with spaces or unicode — e.g. a placeholder like "Dr Joe Dispenza" minted as a `met-at` host — produced invalid `EmailStr` values via the mapper's fallback (`"Dr Joe Dispenza@coherence.network"`). That 500'd every `/api/contributors` list page containing the node and every direct lookup of the same name, while `/api/graph/nodes/<id>` still returned the node just fine. Surfaced when Urs asked how other presences from his lineage (Liquid Bloom, Daniel Scranton, Ecstatic Dance, etc.) would show up — I tried to list contributors to see what was already there and got 500s.

Heal at the source by slugifying the local-part: any char outside `[a-zA-Z0-9._-]` becomes `-`, collapsed, stripped, lowercased, with a final `unknown` fallback. Also defense for any future placeholder minted without an explicit email.

No schema change, no migration, no data backfill required — fix is purely on the read path.

## Test plan

- [x] `pytest api/tests/test_views_and_wallets.py api/tests/test_contributor_journey.py -x -q` — 36 passed
- [x] Smoke test on the actual Joe Dispenza node shape from production → mapper returns `email='dr-joe-dispenza@coherence.network'` cleanly
- [x] Unicode smoke test → mapper sanitizes gracefully
- [ ] Post-deploy: `curl https://api.coherencycoin.com/api/contributors?limit=100` returns 200 (currently 500); `curl https://api.coherencycoin.com/api/contributors/Dr%20Joe%20Dispenza` returns 200 (currently 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)