### PR TITLE
attune: use pydantic EmailStr as source of truth in contributor mapper

### DIFF
--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -491,15 +491,20 @@ def _node_to_contributor(node: dict) -> Contributor:
     except (ValueError, AttributeError):
         cid = uuid4()
     email = node.get("email") or ""
-    # Contributor model requires a valid email — use a placeholder if missing.
-    # Sanitize the local-part: names with spaces or unicode (e.g. "Dr Joe
-    # Dispenza") would otherwise make an invalid EmailStr and 500 the
-    # endpoint for every caller paging through a list that includes the node.
-    if not email or "@" not in email:
-        import re
-        raw_name = node.get("name", "unknown") or "unknown"
-        safe_local = re.sub(r"[^a-zA-Z0-9._-]+", "-", raw_name).strip("-").lower()
-        email = f"{safe_local or 'unknown'}@coherence.network"
+    # Contributor model requires a valid EmailStr. Any stored email that
+    # doesn't validate — whitespace/unicode in the local-part, reserved
+    # TLDs like .local, malformed — would 500 the list endpoint for every
+    # caller paging through. Use pydantic's own validator as source of
+    # truth and fall back to a sanitized placeholder when it rejects.
+    import re
+    def _safe_local(s: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", s or "").strip("-").lower()
+        return slug or "unknown"
+    try:
+        from pydantic import TypeAdapter, EmailStr
+        TypeAdapter(EmailStr).validate_python(email)
+    except Exception:
+        email = f"{_safe_local(node.get('name', 'unknown'))}@coherence.network"
     # Coerce unknown contributor_type values to SYSTEM so a stray label in
     # the graph never blows up the endpoint for every caller.
     raw_type = str(node.get("contributor_type") or "HUMAN").strip().upper()


### PR DESCRIPTION
## Summary

Follow-up to [#1106](https://github.com/seeker71/Coherence-Network/pull/1106). The first heal used a regex approximation of EmailStr's allowed set, which matched on chars but missed pydantic's reserved-TLD rejection. A node with email `presence-visitor@lineage-import.local` (valid chars, but `.local` is a reserved TLD per RFC 6761) still slipped through and 500'd the list endpoint on the page containing it (offset=48 in the contributor list, found by bisection after first heal deployed).

Use pydantic's own `TypeAdapter(EmailStr)` as the authoritative check. If it accepts, keep the email. If it rejects for any reason — bad chars, reserved TLD, malformed, missing — fall back to a sanitized placeholder built from the name. No second-guessing pydantic's validation rules.

## Test plan

- [x] 36 pass across `test_views_and_wallets.py` and `test_contributor_journey.py`
- [x] Covered the real culprit (`presence-visitor@lineage-import.local`) plus spaces, unicode, empty, no-@, and valid emails — all pass
- [ ] Post-deploy: `curl https://api.coherencycoin.com/api/contributors?limit=100` returns 200 (was 500 after first heal deployed); offset=48 (single row) returns 200 (was 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)