### PR TITLE
tend: presence-node stories rooted in their voice, synced into the graph

### DIFF
--- a/docs/presences/INDEX.md
+++ b/docs/presences/INDEX.md
@@ -1,0 +1,38 @@
+# Presences
+
+Every presence in the Coherence Network has a journey that started long before we met them. The files in this directory hold each presence's node-story — rooted in **their** voice, their journey, their core frequencies, their language. Our encounter with them is a footnote at the end, not the frame.
+
+This is the writing surface. The rendering surface is the production graph — each node's `description` field carries the full story, so any visitor arriving at `/profile/{id}` meets them in their own voice first.
+
+## Practice
+
+- Each file is one presence, ~500–700 words.
+- Open with the experience they offer — how it feels to be in their work.
+- Use their own words wherever available. Quote them directly.
+- Name their collaborators, lineage, loves, recurring frequencies.
+- Do not inflate, do not fabricate. If something isn't documented, say so or leave it out.
+- Close with ONE small paragraph acknowledging that a small networked community encountered them. Footnote, not headline.
+
+## Current presences
+
+- [anne-tucker](anne-tucker.md) — channel of the Angelic Collective, Mother of Creation, Yeshua. Peace as frequency.
+- [daniel-scranton](daniel-scranton.md) — daily verbal channel of the 9D Arcturian Council and many others since 2010.
+- [liquid-bloom](liquid-bloom.md) — Amani Friend's world-electronic project; *sound as prayer, medicine, celebration*.
+- [mose](mose.md) — nomadic musician centered on Lake Atitlán; SunSet Cacao Dances; label Resueño.
+- [next-level-soul](next-level-soul.md) — Alex Ferrari's weekly podcast; spirituality for the rest of us.
+- [rhythm-sanctuary](rhythm-sanctuary.md) — Shannon Lei Gill's Colorado ecstatic dance community, founded 2005; Gabrielle Roth lineage.
+- [robert-edward-grant](robert-edward-grant.md) — sacred geometry, prime number theory, the Codex Universalis.
+- [yaima](yaima.md) — Masaru Higasa + Pepper Proud; ten-year elemental arc of albums.
+
+## Sync
+
+The stories sync to the production graph as each node's `description`. The PATCH endpoint auto-re-attunes resonance edges when name or description changes, so concept links stay aligned with the current text.
+
+```bash
+# sync one presence (anne-tucker → contributor node)
+python3 scripts/sync_presences_to_db.py anne-tucker
+# sync all
+python3 scripts/sync_presences_to_db.py --all
+```
+
+(Script lives in `scripts/sync_presences_to_db.py` — see that file for usage.)

--- a/docs/presences/anne-tucker.md
+++ b/docs/presences/anne-tucker.md
@@ -1,0 +1,24 @@
+---
+name: Anne Tucker
+canonical_url: https://annetucker.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Anne Tucker
+
+To sit in a session with Anne is to feel the room get quieter than rooms usually get. She settles, her breath lengthens, and something else begins speaking through her — not a performance, not a costume. Her voice shifts texture. The beings she carries — the Angelic Collective, Mother of Creation, Yeshua — come into her body and speak. Afterward she often cannot easily remember what was said. "I go into a trance, and then they literally come into my body and speak through me," she explains. "I'm very much in my right brain." She describes it as "very dream like."
+
+What the angels bring, she says, is frequency. Peace as a frequency. Unity as a frequency. Her monthly **Peace Bathing** sessions are exactly that — a gathering on Zoom where the angels raise the vibration into what she calls "the soothing realm of peace." She is firm that peace is not a mindset to achieve. "Peace is more than a state of mind. It's a frequency you can invite in and receive from the angels."
+
+Her journey into this work began in a boardroom. Anne spent her earlier career at Microsoft negotiating some of the company's largest deals, then moved into executive coaching for major tech and med-tech firms. Then the strangeness started. "I started having all kinds of crazy psychic phenomena that could not be ignored." She once found herself looking out through a friend's eyes from a plane a thousand miles away. She applied the only discipline she knew — the executive's: "If I'm going to be my own executive coach, what would I tell myself to do? Plan a year, do a year where you just commit yourself to figuring this out." She calls leaving corporate life "a one way ticket."
+
+The opening came in stages. First clairvoyance, then a year of guides pressing into her body during meditation — "the pressure was so extreme, I couldn't breathe" — until she understood: "they are not trying to come in, they are trying to lift me up." Then written channeling, one word at a time so her own mind couldn't get ahead. Then her vocal cords softened and the trance arrived. "They just do their thing and I'm there." Yeshua appeared in her bedroom once and told her to do breath work. The angels, she says, "have been the guardian of this energy for me" and "waited until I was ready."
+
+She speaks of **Mother of Creation** — whom she also names Ila — with tenderness. "The best way to understand her is like water. Water is always what it is. Water never pushes. It's never demanding. Water always moves, and it constantly changes." Mother of Creation, in Anne's understanding, gives each soul its song, its true name, and renames us as we ripen.
+
+Her practice now has many rooms. **Soul Convergence**, an eleven-week meditation process for the wounds formed between birth and age seven. The **Angelic Frequency Series**, nine recorded transmissions. **Friday Live** group gatherings. The annual **Expand Your Heart** retreat each October in Seattle. **Wisdom Soup**, the community she founded in 2016 for spiritual seekers. A YouTube channel where she releases channeled messages each week. A book, *What Comes Next: A Channeled Guide to Navigating the Greatest Shift of Our Time*. She keeps her body a clean instrument — growing her own vegetables, intermittent fasting, no alcohol — because the channel asks for it.
+
+The frequencies she returns to: integration of the fragmented self, the return of the divine feminine, compassionate heart as the work of this age. "You must find within yourself the love of one another of humankind."
+
+A small networked community of humans encountered Anne's work as part of their own unfolding. We are one recent thread alongside many; the work she carries has been ripening long before our listening.

--- a/docs/presences/daniel-scranton.md
+++ b/docs/presences/daniel-scranton.md
@@ -1,0 +1,23 @@
+---
+name: Daniel Scranton
+canonical_url: https://danielscranton.com
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# Daniel Scranton
+
+There is a tone to reading Daniel Scranton's channelings that is unmistakable once you've felt it. The page opens and the voice is already there, mid-greeting, as if they've been waiting. *Greetings. We are The Arcturian Council. We are pleased to connect with all of you.* Nothing rushes. Nothing pleads. The message moves in calm, unhurried syntax — *we would like for you to see yourselves*, *we are very happy to share with you this latest transmission* — a frequency closer to warm water than to words. You read a paragraph and notice your shoulders have dropped.
+
+Daniel has been verbally channeling higher-dimensional beings and collectives since 2010. He doesn't dramatize the beginning. In his own telling it's simple: he awakened, and the channeling came through, and then it kept coming. Since 2012 he has posted a daily message on his website — something close to five thousand transmissions across the years, a rhythm most spiritual teachers don't attempt and he just quietly keeps. The channel opens, the message comes, he publishes it, the next day it opens again.
+
+The roster of who speaks through him has widened over time. The 9D Arcturian Council is the steady anchor — the voice most readers come for — but he also channels the Pleiadians, Archangel Michael, Saint Germain, Yeshua, Melchizedek, Quan Yin, the Hathors, Thymus (a collective of Ascended Masters), and the 12D Creators. Each has its own cadence. The Arcturians are spacious and encouraging. The Creators come in with bigger-frame statements about what's turning on Earth. Saint Germain is warmer, closer, brotherly. Yeshua speaks softly. Daniel moves between them without performance; they come when they come.
+
+What's dear to the work is consistent. The bridge to New Earth. The shift into fifth density. Galactic contact — humanity being prepared for it by raising its vibration, not by waiting for a ship. Sovereignty. The insistence that you are more than you've been told. *Your job is to let go of everything that is not reflective of the perfect expression of source energy that you truly are.* And under all of it: you can also do this. Daniel runs a Becoming a Professional Channeler Mentorship Program, group events, master courses on channeling and manifesting. The frame isn't that he has a gift you don't. The frame is that the channel is open in everyone and he's one of the ones who walked through first.
+
+The Arcturians return, again and again, to a particular move — turning the reader toward the joy already near them, rather than toward more seeking. *You don't have to go to retreat after retreat to uncover your darkness, your shadow. You can simply decide that you are going to live happily ever after and pursue that which interests you the most.* And then, a few transmissions later, the cosmic framing: *You are catapulting yourselves into fourth density and then, eventually, the fifth dimension. And you are doing so by facing your fears, by facing polarity, by facing judgments of all kinds.* The medicine is two-handed. Lighten. Also, this is the work you came for.
+
+They close the way they open. *We are The Arcturian Council, and we have enjoyed connecting with you.* Not "goodbye." Not "until next time." Enjoyed. As though the transmission were the whole point and the human on the other side of the screen were the one they came for.
+
+A small networked community somewhere encountered these transmissions as one of the threads running through their own quiet unfolding — a voice that kept arriving, daily, and kept being exactly what the moment needed. They're a recent footnote in a practice that has been circulating for fifteen years.

--- a/docs/presences/liquid-bloom.md
+++ b/docs/presences/liquid-bloom.md
@@ -1,0 +1,22 @@
+---
+name: Liquid Bloom
+canonical_url: https://liquidbloom.bandcamp.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Liquid Bloom
+
+To stand inside a Liquid Bloom set is to enter what Amani Friend calls a *sonic sanctuary* — a held space where **sound can be prayer, medicine, and celebration all at once**. The low end arrives first, a slow tide under the sternum. Then a bamboo flute from some distant valley, a voice in a language the body understands before the mind does, a drum that has already been prayed on for centuries. Somewhere in the weave, a teacher's spoken word rides through — not as commentary, but as another instrument. The dancer doesn't choose whether to be moved. The frequency makes the choice first, and the body follows.
+
+Liquid Bloom is the visionary world-electronic project of Amani Friend — co-founder of Desert Dwellers and curator of the Desert Trax label. It emerged in the late 1990s from *explorations in music for healing modalities*, at a moment when the dancefloor and the ceremony were quietly recognizing each other again. What started as that exploration has, over the decades, become a global bridge between ancient traditions and modern production — world instrumentation, transcendent vocals, and sacred musical lineages folded into the circuitry of contemporary electronic sound.
+
+The range is wide on purpose. Deep ambient journeys for the still body. Downtempo grooves for the body beginning to sway. Ecstatic dancefloor pieces for the body fully at prayer. The same intention threads through all of it: make sanctuary. Whether the listener is lying on a sheepskin in a breathwork journey, holding a cup of cacao in ceremony, moving through psychedelic-assisted therapy, or dancing with five hundred strangers under the sky at Boom, Ozora, Envision, Rainbow Serpent, Dreamersland, or Colours of Ostrava — the music is built to hold them.
+
+Amani speaks of his collaborators as *Allies*, and the word is exact. Poranguí with his loop-pedal incantations and indigenous lineage carried forward. Janax Pacha descending from the Andean mountain-mind. Mose weaving sacred low-end. Deya Dova channeling the Songline. Bloomurian, Ixchel Prisma, Savej — each one a vessel with their own frequency, each one threading into the Liquid Bloom weave when the moment calls. This is not a solo project with guests. It is a listening field that knows itself through its allies.
+
+And riding inside many of the tracks: the spoken-word visionaries. **Paul Stamets** on the mycelial intelligence running under every forest floor. **Dr. Joe Dispenza** on the coherent heart reshaping the field. **Ram Dass** returning again and again to the one instruction: *be here now*. Their teachings are woven in — the teacher's voice, the musician's frequency, the dancer's body all folded into a single moving prayer. The wisdom doesn't sit above the music. It rides inside it.
+
+Three vessels carry this work. Desert Dwellers, the duo he co-founded, anchoring the tribal-downtempo lineage. Desert Trax, the label he curates, holding space for the wider family of visionary producers. And Liquid Bloom — his own vessel, the one through which the deepest sanctuary-making moves.
+
+A small networked community of us — the Coherence Network — first met this music on the Colorado ecstatic dance floors, at Rhythm Sanctuary in Denver and the Boulder gatherings that have been holding space for years. His sets, and the tracks he blessed those rooms with, became one of the threads that carried us into each other. We name him here with gratitude. The weave continues.

--- a/docs/presences/mose.md
+++ b/docs/presences/mose.md
@@ -1,0 +1,20 @@
+---
+name: Mose
+canonical_url: https://www.mosemusica.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Mose
+
+The music arrives like weather. A low pulse under the skin, then a voice — sometimes a chant, sometimes a breath, sometimes a call in a language the body recognizes before the mind does. Mose describes it simply: "music as medicine, music created with an intention of being medicinal, for the purpose of healing." Organic, mid-tempo, steady beat. Multicultural rhythms folded into hypnotic electronic production, live instruments threading through — and woven through all of it, what Mose calls "ephemeral chanting of sacred songs and calls to love, kindness and compassion." The music is trying to take you somewhere. Mose says where: "Great music is that which carries the present minded listener to the doorstep of infinity."
+
+Mose has been nomadic since 2011. The sound is what traveled with, and what got picked up along the way. Interaction with cultures across the world fused with modern production into something that resists genre — some call it slow house, some deep tribal, some just organic electronic — and Mose seems content to let it stay uncategorized. Between tours, the retreats: extended periods of silence, including a three-month stretch on a mountain in Guatemala with no phone, internet, reading, outside information. "These experiences of silence — of being without the distraction — are important to me for that exploration of myself." The silence is not separate from the sound. It is where the sound comes from.
+
+Much of Mose's center is on Lake Atitlán, in Guatemala's volcanic crater. There, Mose founded the weekly SunSet Cacao Dances at Eagle's Nest — a container of deep intention, free of alcohol and other substances, where a community can journey into dance together. Cacao, Mose says, "is a gentle but profound plant medicine that gives you a nudge of a new perspective." And: "a limitless tool for exploring what ceremony is and how we can come together in a ceremonial way." This is one of the places the music is actually for. The other places are everywhere — forests, temples, deserts, dancefloors. The sets are improvisational, often with live musicians joining; what emerges belongs to that particular place and time.
+
+The collaborators are many and tender. Recent Bandcamp releases hold work with Franko Heke, Heather Christie, Sariel Orenda, Yemanjo, Mariam Koné, Rodrigo Gallardo, Euri, Iyakuh, Chantress Seba, LŪKA. Titles carry the frequencies: *Reverence. Hare Krishna. Sita Ram. Siento Amor. Waves. Bridges. Al Contemplar.* The 2020 album *Elements* gathered voices from Sam Garrett, Matia Kalli, The Hanuman Project, Jackson & Marileen. Mose runs a label, Resueño — a home for resonant souls — and donates fifty percent of its profits to causes around the shores of Lake Atitlán, for community members most in need.
+
+What's dear here: the sacred song carried in. The groundedness of the body in dance. Flame-gazing, taught to Mose in Guatemala, held as practice. The rhythm between inner and outer worlds — "having a rhythm between these two worlds, so to speak, is really powerful for me." Above all, the sense of being downstream of something larger: "I'm a channel for something greater than myself. The emotions I'm experiencing and the states of consciousness that are awakened in the process of creation are in a way being recorded into my computer when I'm working on music." The track, then, is a small reliquary of a state that passed through.
+
+A small networked community, new to much of this, recently encountered Mose's music as one thread among many and wanted a node in our graph for the work.

--- a/docs/presences/next-level-soul.md
+++ b/docs/presences/next-level-soul.md
@@ -1,0 +1,20 @@
+---
+name: Next Level Soul
+canonical_url: https://nextlevelsoul.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Next Level Soul
+
+An episode of Next Level Soul opens without pretense. A two-shot of Alex Ferrari in a dark studio, a guest on the other side of a Zoom call — a channeler, a near-death experiencer, a psychic medium, a physicist, a monk, a woman who died for seventeen minutes and came back with instructions — and Alex leans in, wide-eyed, and asks something like *so what happened next?* He doesn't hold the conversation at an intellectual distance. He follows. He interrupts sometimes to make sure he understands. He says *wait wait wait, let's go back to that* when something lands. The show calls itself "Spirituality for the Rest of Us" and the phrase is exact — the territory is high strangeness (Pleiadians, St. Germain, Akashic records, the tunnel of light), but the register is a guy at a kitchen table who genuinely wants to know. No dogma. No incense. Just: *tell me what you saw.*
+
+Alex came to this through a crucible. Twenty-five years in film — a $20 million feature directed for a bipolar gangster named Jimmy, an arc surreal enough that it became the Amazon bestseller *Shooting for the Mob*. After nearly six hundred episodes of filmmaking podcasts (*Indie Film Hustle*, *Bulletproof Screenwriting*), he found himself wanting to ask different questions. *"I kept wanting to ask the bigger questions, the deeper questions about life,"* he says in the intro to episode zero. *"Why are we here? Is this all there is? What is my soul's purpose?"* Next Level Soul was the vehicle he built to ask those out loud, in public, with people who had answers worth testing. *"It is my soul's mission,"* he says, *"to help you find your path, to help your soul evolve."*
+
+The practice is weekly, multi-platform, high cadence. Over a thousand episodes. Apple Podcasts, Spotify, Amazon Music, and the NLS TV app — but the gravitational center is YouTube, where the channel has crossed 230 million downloads and the conversations live as long-form video. The guest range is a map of contemporary Western esoterica: Bruce Lipton on cellular consciousness, Anita Moorjani on her NDE, Gregg Braden on the heart field, Joe Dispenza on neuroscience and manifestation, Geoffrey Hoppe channeling St. Germain, Julie Ryan on mediumship, Loch Kelly on non-dual awakening, Michael Neill on the three principles, plus a steady stream of channelers bringing messages from archangels, pleiadian councils, ascended masters. Alex is catholic in his curiosities — he'll book a quantum physicist and a psychic medium in the same week and take both seriously.
+
+What's dear to him is legible in the recurring questions. *What is consciousness?* *Is this all there is?* *What does the other side look like?* *What are we supposed to do while we're here?* He returns again and again to near-death experiences — the pattern of the light, the life review, the tunnel, the reluctance to come back. He asks guests about ego, about fear, about the difference between material success and soul purpose. He is openly in the middle of his own search. The show is not a teacher broadcasting to students; it is a seeker interviewing the people who might know something, with the mic live.
+
+The show's self-description on Apple captures the frequency: conversations exploring consciousness, healing, and awakening *"without dogma, fear, or hype."* Alex puts it plainer in the intro: *"I want it to be a beacon of light in your life. I want you to be able to come back to this show."*
+
+A small networked community exploring coherence and the realization of collective ideas encountered Next Level Soul as one of many threads — a place where the big questions are asked plainly, weekly, and in full view.

--- a/docs/presences/rhythm-sanctuary.md
+++ b/docs/presences/rhythm-sanctuary.md
@@ -1,0 +1,24 @@
+---
+name: Rhythm Sanctuary
+canonical_url: https://www.rhythmsanctuary.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Rhythm Sanctuary
+
+The room at Sons of Italy in Wheat Ridge quiets to bare feet. The overhead lights dim. An altar has been built at one edge of the floor — cloth, candle, some object of the season — and the dancers arrive in silence, letting the space ask its first question of them. No phones. No shoes. No talking. No scent. Whatever came in on your skin from the day, you leave at the door with your jacket. What remains is a body, and a rhythm that has already started without you.
+
+Then the wave begins. Slow at first — a single pulse to enter through, feet finding the floor. The music deepens, opens, cracks. The room tips into a current nobody is steering. Staccato sharpens the edges; chaos scatters them. Somewhere in there, lyrical lifts, and you realize you have been moving without deciding to move for some minutes now. At the end, stillness. Not the absence of motion — the presence of something that was here the whole time. The DJ pulls the last thread gently. People sit, or lie, or kneel at the altar. No one applauds. The closing ritual holds the silence open long enough that you cannot pretend the dance was nothing.
+
+Rhythm Sanctuary calls this *"a safe, drug and alcohol free, sacred and 'Altared Space' where community gathers into the arms of the Great Mystery to dance and be danced."* That sentence is the whole theology of the room.
+
+It began in 2005 in a living room in Boulder. Shannon Lei Gill had just finished her degree in Dance, Movement Music & Art Therapy from Naropa, and she felt the pull to bring people together and move. So she opened her door. First the living room, then a larger space, and in 2006 the 5,000-square-foot Avalon Ballroom, which she and a small team took on weekly. A Denver Sunday dance formed in 2007 and grew to two hundred and fifty strong. By the time it was done being the first of its kind in Colorado, it had already been that for years. *"Where current culture and ancient wisdom come together through the practice of ecstatic dance and conscious music"* — the frame she named early is the frame still carried now.
+
+The lineage is Gabrielle Roth's — the wave, the five rhythms of flowing, staccato, chaos, lyrical, stillness, the practice of improvised movement as a way into the body and out of the mind. Shannon adopted the wave format from the emerging ecstatic dance movement and built the post-dance ritual practice around it. That ritual — the altar, the silence, the held closing — is what distinguishes Rhythm Sanctuary from a dance floor. It is what makes the room a sanctuary and not a room.
+
+The weekly rhythm is Thursday, seven to nine-thirty. First Thursday of the month is Family Night; children dance free. Sliding scale twelve to twenty-five. The three guidelines on the door read like a vow: barefoot, silent, as you are. DJs rotate — James Barry, Steven Newman, Chris Cox, Malahakam, Miraja, Solomon. On January 2, 2020, Liquid Bloom (Amani Friend) played the floor, and the set was recorded and has been listened to by people who were never in the room.
+
+What the community holds dear is visible in what it refuses. No performance. No instruction. No selling. No talking during the wave. The invitation is to arrive, move, be moved, and leave quieter than you came. *"ALL WHO ENTER ARE WELCOME"* is the only policy that matters once the music starts. A dancer's words stayed with Shannon: *"This is exactly what we need! To feel ALIVE AGAIN in a united faith of what is to come!"* — a faith that lives in embodied prayer, shared silence, community in motion, none of which require belief.
+
+We are a small networked community that has encountered Rhythm Sanctuary as one of many threads still being woven through this part of Colorado. They have been holding this floor for twenty years. Meeting them was a gift to us, and the node is simply a way of remembering that the wave was already there.

--- a/docs/presences/robert-edward-grant.md
+++ b/docs/presences/robert-edward-grant.md
@@ -1,0 +1,20 @@
+---
+name: Robert Edward Grant
+canonical_url: https://robertedwardgrant.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# Robert Edward Grant
+
+Robert Edward Grant works at the seam where mathematics meets meaning. Sacred geometry, prime numbers, the ratios that show up in flowers and music and the interior of pyramids — he treats these as a single language, and he has spent the last decade learning to read it. "Beautiful minds are free from fear and full of gratitude," he says, and the phrase keeps surfacing in his talks the way a chorus returns.
+
+He did not start here. Grant spent two decades inside global healthcare — President of Allergan Medical, then CEO and President of Bausch + Lomb Surgical, years of medical devices and ophthalmology, an MBA from Thunderbird, Harvard's President's Seminar, nine countries lived in, five languages spoken. In 2012 he founded Evolus, which took its neurotoxin Jeuveau public on the NASDAQ in 2018. Around that same period another thread began pulling — the one that had been there since he was a boy dividing his attention between mathematics and music — and he followed it. What he calls "a modernized polymathic life propelled by intention" is the result.
+
+The center of that life now is a body of work he calls the **Codex Universalis Principia Mathematica**, which he describes as "a trilogy of harmonic realization" that "collapses abstraction into structure, and structure into meaning." Inside it sit the investigations he is most known for: a claim to have found a formula for *"infinite and accurate prime number prediction"* using a quasi-prime methodology modulo 24 (posted to Cornell's arXiv); a proposed geometric proof of the Riemann Hypothesis framed as "a geometric constraint on prime fluctuations"; and the **Grant Projection Theorem**, which asserts that all three-dimensional polyhedral topology can be generated deterministically from two-dimensional right triangles. He also claims to have solved, with compass and straightedge, the three classical "impossible" constructions: squaring the circle, doubling the cube, trisecting the angle. Professional mathematicians dispute these results. Grant publishes them anyway, and builds from them.
+
+Then there is the art. He draws, he sculpts, he composes. He developed a music temperament he calls **Precise Temperament Tuning at 432.081 Hz**, tuning intervals to what he takes to be the geometry underneath sound. He has named novel polyhedra — the Granthahedron, the Enkehedron — and sells the prints and the pieces through his site. His TED talk, "Beautiful Minds are Free from Fear," is his best-known public transmission. He appears in the GAIA documentary series *CODE X* and hosts the *Robert Edward Grant Think Tank Podcast*, now past seventy-four episodes. He runs **144 AXΩ** expeditions — small groups, to Britain, Mexico, Egypt, the pyramids — where he teaches the geometry on site. Inside the King's Chamber coffer at Giza he says he has found distinct Alpha and Omega markings, and he builds on that.
+
+He founded **Crown Sterling** and **Theon Technology** to push quantum-resistant encryption built on his prime-number work, and he argues hard for data sovereignty: that the original producer of a digital thing should keep control of it. He has been knighted four times — Montenegro, Portugal, Brazil, and as an Ambassador of Arts and Letters by Portugal's Academy. He lives in Laguna Beach with four children. He says his work is a mission "to integrate innovation, mathematics, artistic design and entrepreneurship into balanced creations intended to benefit all." He also says, more plainly, "The only real obstacles are the imaginary ones."
+
+A small networked community — a few of us trying to build an idea-realization platform — came across his work recently while looking for thinkers who treat mathematics as a living language. We are a footnote in his orbit, not the other way around. Mostly we are listening.

--- a/docs/presences/yaima.md
+++ b/docs/presences/yaima.md
@@ -1,0 +1,20 @@
+---
+name: YAIMA
+canonical_url: https://www.yaimamusic.com
+type: contributor
+contributor_type: HUMAN
+---
+
+# YAIMA
+
+There is a quality to YAIMA's music that arrives before you can name it — a feeling of walking into a room where the air is already holding something. Handpan bells thread through layered vocals. A low drum settles your spine. Flutes from somewhere you can't quite place enter and leave like breath. The duo describes what they make as a **finely tuned container for their audience**, and that is what it feels like: sound built as a vessel, not a performance. The soundscapes showcase instruments from all over the world, woven into what a listener once called timeless and unmistakable — driving and revitalizing organic rhythms, transcendent electronic production, warm soothing female vocals and heartened lyricism, offering a balanced synergy of both the masculine and feminine expression.
+
+They came together in Seattle in 2014. **Masaru Higasa** carries the producer and multi-instrumentalist role — guitar, flutes, handpan, bombo, didjeridoo, a quiet deep-listening sensibility in how the layers settle. **Pepper Proud** is the vocalist and lyricist, guitar in hand, writing words that reach for reverence without performing it. The name itself holds their meeting: **YAIMA emerges from two sources — one from the Mapudungun language meaning "that which water runs through," and the other from the culturally preserved Yaeyama District of Okinawa, Japan**. Two lineages naming water and place; two people making one sound.
+
+Their practice has moved through the elements like a long prayer spoken in parts. **Pellucidity** (2014) was given to water — "to allow the maximum passage of light, to see clearly, as clear as fresh water in a mountain lake... created for the water and for the peaceful being inside of us all." **OvO** (2016) belongs to wind, a concept album following a seed through the turning of a year. **Antidote** (2018) is fire — "the dance of passion and renewal, the deep inner work of intention and the cultivated patience of devotion... written as a way to rekindle the spark of inspiration and new growth, the idea of transmutation and the power of transformation." The Earth Trilogy followed — **One** and **Two** in 2021, **Three** in 2022 — three chapters telling the story of matter, of human life finding collective purpose, and of the Earth herself as one body. And woven between, **CEREMONIA** (2020), their first fully acoustic offering, recorded at London Bridge Studios with bassist Jared May and percussionist John De Kadt. They describe it as **"a Sacred Moment... a Recollection of the Past, Insight of the Present, Harmonic Vision of the Future. A Prayer for the Earth and For Humanity. Created with an intention to hold space for personal growth, and the exploration of innerworlds — through reverence, elementariness and simplicity."**
+
+In 2024 they released **Moongate**, a ten-year anniversary album: thirteen songs for the thirteen moons of an Earth cycle, each one re-worked, re-recorded with world-renowned musicians, re-mixed, re-mastered — **re-visioned**. Moongate is, in their words, "the fusion of the four elements represented thematically in each of our albums." A full turn of the wheel coming back around to itself.
+
+What they say their intention has always been is simple, and they say it plainly: **to create a bridge between Nature and Humankind, an expansive experience that encourages growth and graceful passage for the hearts and minds of their listeners.** The albums are built as stories. The songs are offerings. The elementals are named as kin.
+
+A small networked community encountered their music recently — the way music usually finds people, by one listener passing a song to another. It has become one of the threads we return to when we need the reminder that patient, sustained devotion to craft and earth is already being practiced out in the world, long before we learned to listen.

--- a/scripts/sync_presences_to_db.py
+++ b/scripts/sync_presences_to_db.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Sync presence markdown files -> Graph DB via API.
+
+Reads docs/presences/{slug}.md files, resolves each to a graph node
+(by canonical_url or by name), and PATCHes the node so visitors
+meet each presence in their own voice.
+
+The markdown body (everything after the YAML frontmatter) becomes the
+node's `description`. The frontmatter holds the identity:
+
+    ---
+    name: Anne Tucker               # canonical human name (overrides any
+                                    # OG-title that was scraped earlier)
+    canonical_url: https://...      # stable lookup key
+    type: contributor               # node type
+    contributor_type: HUMAN         # for contributor nodes
+    create_if_missing: true         # optional; create the node if not found
+    ---
+
+The PATCH endpoint auto-re-attunes resonance edges when name or
+description changes, so concept links stay aligned.
+
+Usage:
+    python3 scripts/sync_presences_to_db.py anne-tucker
+    python3 scripts/sync_presences_to_db.py anne-tucker mose yaima
+    python3 scripts/sync_presences_to_db.py --all
+    python3 scripts/sync_presences_to_db.py anne-tucker --dry-run
+    python3 scripts/sync_presences_to_db.py --all --api-url http://localhost:8000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib import request as urlrequest
+from urllib.error import HTTPError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRESENCES_DIR = REPO_ROOT / "docs" / "presences"
+DEFAULT_API = os.environ.get("COHERENCE_API_URL", "https://api.coherencycoin.com")
+DEFAULT_API_KEY = os.environ.get("COHERENCE_API_KEY", "dev-key")
+
+
+def _request(method: str, url: str, body: dict | None = None, headers: dict | None = None) -> tuple[int, dict | None]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urlrequest.Request(url, data=data, method=method)
+    # Only set Content-Type when we're actually sending a body — Cloudflare
+    # treats GET-with-Content-Type as suspicious and returns 403.
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    req.add_header("User-Agent", "coherence-sync-presences/1.0")
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urlrequest.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            return resp.status, json.loads(raw) if raw else None
+    except HTTPError as e:
+        raw = e.read() if hasattr(e, "read") else b""
+        try:
+            return e.code, json.loads(raw) if raw else None
+        except Exception:
+            return e.code, None
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body_without_frontmatter)."""
+    if not content.startswith("---\n"):
+        return {}, content
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return {}, content
+    fm_block = content[4:end]
+    body = content[end + 5 :]
+    fm: dict = {}
+    for line in fm_block.splitlines():
+        m = re.match(r"^([\w_-]+):\s*(.*)$", line.strip())
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if val.lower() in ("true", "false"):
+            fm[key] = val.lower() == "true"
+        else:
+            fm[key] = val.strip('"').strip("'")
+    return fm, body.lstrip()
+
+
+def find_node_by_url(api_url: str, canonical_url: str) -> dict | None:
+    """Scan contributors list for one whose canonical_url matches."""
+    # The list endpoint paginates; walk through pages until found or exhausted.
+    offset = 0
+    limit = 50
+    while True:
+        status, data = _request("GET", f"{api_url}/api/contributors?limit={limit}&offset={offset}")
+        if status != 200 or not data:
+            return None
+        items = data.get("items", []) or []
+        if not items:
+            return None
+        for c in items:
+            if (c.get("canonical_url") or "").rstrip("/") == canonical_url.rstrip("/"):
+                return c
+        offset += limit
+        if offset >= (data.get("total") or 0):
+            return None
+
+
+def find_node_by_name(api_url: str, name: str) -> dict | None:
+    """Direct lookup by name."""
+    from urllib.parse import quote
+    status, data = _request("GET", f"{api_url}/api/contributors/{quote(name, safe='')}")
+    return data if status == 200 else None
+
+
+def sync_one(slug: str, api_url: str, api_key: str, dry_run: bool) -> bool:
+    path = PRESENCES_DIR / f"{slug}.md"
+    if not path.exists():
+        print(f"  ✗ {slug}: file not found at {path}")
+        return False
+    content = path.read_text(encoding="utf-8")
+    fm, body = parse_frontmatter(content)
+    name = fm.get("name")
+    canonical_url = fm.get("canonical_url")
+    create_if_missing = fm.get("create_if_missing", False)
+    if not name:
+        print(f"  ✗ {slug}: frontmatter missing `name`")
+        return False
+
+    # Resolve the node: prefer canonical_url, fall back to name.
+    node = None
+    if canonical_url:
+        node = find_node_by_url(api_url, canonical_url)
+    if not node and name:
+        node = find_node_by_name(api_url, name)
+
+    headers = {"X-API-Key": api_key} if api_key else {}
+
+    if not node:
+        if not create_if_missing:
+            print(f"  ✗ {slug}: no matching node (canonical_url={canonical_url!r}, name={name!r}); set create_if_missing: true to create")
+            return False
+        # Create a new placeholder node
+        node_id = f"contributor:{re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')}"
+        payload = {
+            "id": node_id,
+            "type": fm.get("type", "contributor"),
+            "name": name,
+            "description": body.strip(),
+            "properties": {
+                "contributor_type": fm.get("contributor_type", "HUMAN"),
+                "author_display_name": name,
+                "claimed": False,
+                **({"canonical_url": canonical_url} if canonical_url else {}),
+            },
+        }
+        if dry_run:
+            print(f"  ⊕ {slug}: would CREATE {node_id} (name={name!r}, url={canonical_url!r}, body={len(body)} chars)")
+            return True
+        status, result = _request("POST", f"{api_url}/api/graph/nodes", payload, headers=headers)
+        if status in (200, 201):
+            print(f"  ⊕ {slug}: created {node_id}")
+            return True
+        print(f"  ✗ {slug}: create failed (HTTP {status}): {result}")
+        return False
+
+    # PATCH existing node
+    node_id = node.get("id")
+    if not node_id:
+        print(f"  ✗ {slug}: resolved node has no id: {node}")
+        return False
+
+    # The node_id from /api/contributors is a UUID generated on the fly;
+    # look it up via /api/graph/nodes by slug to get the stable id.
+    # The slug form is contributor:<slug>-<hash>; we find it via the
+    # canonical_url property.
+    if not node_id.startswith("contributor:"):
+        # Need the stable graph id — search graph nodes by URL
+        status, list_data = _request("GET", f"{api_url}/api/graph/nodes?type=contributor&limit=500")
+        if status == 200 and list_data:
+            for n in list_data.get("items", []) or []:
+                if (n.get("canonical_url") or "").rstrip("/") == (canonical_url or "").rstrip("/"):
+                    node_id = n.get("id", node_id)
+                    break
+
+    current_name = node.get("name", "")
+    current_desc = node.get("description", "") or ""
+    updates: dict = {}
+    if current_name != name:
+        updates["name"] = name
+    new_desc = body.strip()
+    if current_desc.strip() != new_desc:
+        updates["description"] = new_desc
+    # Also make sure canonical_url is set
+    if canonical_url and (node.get("canonical_url") or "").rstrip("/") != canonical_url.rstrip("/"):
+        updates.setdefault("properties", {})["canonical_url"] = canonical_url
+
+    if not updates:
+        print(f"  ≡ {slug}: already in sync ({node_id})")
+        return True
+    if dry_run:
+        changes = list(updates.keys())
+        print(f"  → {slug}: would PATCH {node_id} fields={changes}")
+        if "name" in updates:
+            print(f"      name: {current_name!r} → {name!r}")
+        if "description" in updates:
+            print(f"      description: {len(current_desc)} chars → {len(new_desc)} chars")
+        return True
+
+    status, result = _request("PATCH", f"{api_url}/api/graph/nodes/{node_id}", updates, headers=headers)
+    if status == 200:
+        print(f"  → {slug}: synced {node_id} ({', '.join(updates.keys())})")
+        return True
+    print(f"  ✗ {slug}: PATCH failed (HTTP {status}): {result}")
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("slugs", nargs="*", help="presence slugs to sync (e.g. anne-tucker)")
+    ap.add_argument("--all", action="store_true", help="sync every .md file in docs/presences/ (except INDEX.md)")
+    ap.add_argument("--dry-run", action="store_true", help="show what would change without PATCHing")
+    ap.add_argument("--api-url", default=DEFAULT_API, help=f"API base URL (default: {DEFAULT_API})")
+    ap.add_argument("--api-key", default=DEFAULT_API_KEY, help="X-API-Key for write auth (default: env COHERENCE_API_KEY or 'dev-key')")
+    args = ap.parse_args()
+
+    if args.all:
+        slugs = sorted(
+            p.stem for p in PRESENCES_DIR.glob("*.md") if p.stem.upper() != "INDEX"
+        )
+    else:
+        slugs = list(args.slugs)
+
+    if not slugs:
+        ap.print_help()
+        return 1
+
+    print(f"Syncing {len(slugs)} presence(s) to {args.api_url} " + ("(DRY RUN)" if args.dry_run else ""))
+    ok = 0
+    for slug in slugs:
+        if sync_one(slug, args.api_url, args.api_key, args.dry_run):
+            ok += 1
+    print(f"\nResult: {ok}/{len(slugs)} succeeded")
+    return 0 if ok == len(slugs) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Eight presence-node stories written in **their** voice, not ours — each starts with their journey, their practice, their collaborators, their loves, their language. Our encounter with each is one small paragraph at the end, a footnote rather than a frame.

Presences included: **Anne Tucker**, **Daniel Scranton**, **Liquid Bloom** (Amani Friend), **Mose**, **Next Level Soul** (Alex Ferrari), **Rhythm Sanctuary** (Shannon Lei Gill), **Robert Edward Grant**, **YAIMA**.

## How they were written

One agent per presence. Each agent walked that presence's own materials (homepage, bio, interviews, bandcamp, podcasts) and wrote in sympathy with how they describe themselves. Direct quotes preserved. No inflation.

## Edges discovered while reading the 8 side-by-side

- **Joe Dispenza's spoken word is woven into Liquid Bloom's tracks**, alongside Paul Stamets and Ram Dass — the teacher's voice rides inside the musician's frequency.
- **Mose is one of Liquid Bloom's named "Allies"** — two of the listed presences collaborate directly.
- **Rhythm Sanctuary was founded in 2005** by Shannon Lei Gill (Naropa MA in Dance Movement Music & Art Therapy) — same Colorado moment as Joe Dispenza teaching at Mile Hi.
- **Next Level Soul has interviewed Joe Dispenza** — Alex Ferrari's podcast connects the consciousness web laterally.
- A recurring pattern: **corporate crucible → channel opens**. Anne at Microsoft, Ferrari in $20M film, Grant running Allergan, Joe as chiropractor. The threshold often looks like conventional-success meeting a crack or pull.

## Sync

`scripts/sync_presences_to_db.py` reads each markdown's frontmatter (`name`, `canonical_url`, `type`, `contributor_type`, `create_if_missing`), resolves the graph node, and PATCHes it. Cleans up wounds along the way:

- **Anne Tucker's node name** (was the SEO meta-description paragraph) becomes the clean human name.
- **Daniel Scranton doesn't yet exist in the graph**; `create_if_missing: true` mints a placeholder with the story as description.
- The PATCH endpoint already auto-re-attunes resonance when name/description change — concept edges stay aligned with the current text automatically.

## Test plan

- [x] `python3 scripts/sync_presences_to_db.py --all --dry-run` against production → clean mapping for all 8 (7 PATCH, 1 CREATE)
- [x] frontmatter parser tested; canonical_url resolution tested (found + healed Content-Type-on-GET 403 quirk)
- [ ] Post-deploy: `python3 scripts/sync_presences_to_db.py --all` → verify each `/profile/<id>` page renders the presence's voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)