### PR TITLE
tend: presence stories render on /profile (+ URL-decode fix + MePage null-guards)

### DIFF
--- a/web/app/profile/[contributorId]/_components/PresenceStory.tsx
+++ b/web/app/profile/[contributorId]/_components/PresenceStory.tsx
@@ -1,0 +1,102 @@
+import { inlineMarkdownToHtml } from "@/lib/vision-utils";
+
+/**
+ * Renders a presence's story (markdown stored on the node's description)
+ * as warm, readable prose — the contributor's own voice presented first,
+ * before any metrics or keys. Supports paragraphs, ## and ### headings,
+ * > blockquotes, inline bold / italic / links.
+ *
+ * The first `# Title` heading is stripped — the page already shows the
+ * contributor's name as h1, so repeating it inline would read like a
+ * rendering bug.
+ */
+export function PresenceStory({
+  content,
+  displayName,
+}: {
+  content: string | null | undefined;
+  displayName: string;
+}) {
+  if (!content || !content.trim()) return null;
+
+  // Strip leading `# Heading` if it matches the display name (or any single
+  // h1 at the top of the content — the page already shows the name).
+  let body = content.trim();
+  if (body.startsWith("# ")) {
+    const firstLineEnd = body.indexOf("\n");
+    body = body.slice(firstLineEnd === -1 ? body.length : firstLineEnd + 1).trimStart();
+  }
+
+  // Also drop any YAML frontmatter if it leaked through
+  if (body.startsWith("---\n")) {
+    const end = body.indexOf("\n---\n", 4);
+    if (end !== -1) body = body.slice(end + 5).trimStart();
+  }
+
+  const blocks = body.split(/\n\n+/);
+
+  return (
+    <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-6 sm:p-8 space-y-5">
+      <p className="text-xs uppercase tracking-widest text-muted-foreground">
+        Presence
+      </p>
+      <div className="space-y-5 max-w-3xl">
+        {blocks.map((block, i) => {
+          const trimmed = block.trim();
+          if (!trimmed) return null;
+
+          if (trimmed.startsWith("## ")) {
+            return (
+              <h2
+                key={i}
+                className="text-xl font-light text-stone-300 pt-3 pb-1"
+              >
+                {trimmed.slice(3)}
+              </h2>
+            );
+          }
+          if (trimmed.startsWith("### ")) {
+            return (
+              <h3
+                key={i}
+                className="text-base font-light text-stone-400 pt-2 pb-1"
+              >
+                {trimmed.slice(4)}
+              </h3>
+            );
+          }
+          if (trimmed.startsWith("> ")) {
+            const quoteText = trimmed
+              .split("\n")
+              .map((l) => l.replace(/^>\s?/, ""))
+              .join(" ");
+            return (
+              <blockquote
+                key={i}
+                className="border-l-2 border-amber-500/30 pl-4 italic text-foreground/80 leading-relaxed"
+                dangerouslySetInnerHTML={{
+                  __html: inlineMarkdownToHtml(quoteText),
+                }}
+              />
+            );
+          }
+          if (trimmed === "---") {
+            return <hr key={i} className="border-border/30 my-2" />;
+          }
+
+          // Regular paragraph — join wrapped lines into one flowing paragraph
+          const paragraphText = trimmed.replace(/\n/g, " ");
+          return (
+            <p
+              key={i}
+              className="text-base text-foreground/85 leading-relaxed"
+              dangerouslySetInnerHTML={{
+                __html: inlineMarkdownToHtml(paragraphText),
+              }}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/app/profile/[contributorId]/page.tsx
+++ b/web/app/profile/[contributorId]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getApiBase } from "@/lib/api";
 import { FrequencySpectrum } from "./_components/FrequencySpectrum";
+import { PresenceStory } from "./_components/PresenceStory";
 
 export const dynamic = "force-dynamic";
 
@@ -158,7 +159,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ contributorId: string }>;
 }): Promise<Metadata> {
-  const { contributorId } = await params;
+  const contributorId = decodeURIComponent((await params).contributorId);
   const contributor = await fetchContributorNode(contributorId);
   const name = contributor?.author_display_name || contributor?.name || contributorId;
   const lede = contributor?.offering || contributor?.skills
@@ -176,7 +177,13 @@ export default async function ContributorProfilePage({
 }: {
   params: Promise<{ contributorId: string }>;
 }) {
-  const { contributorId } = await params;
+  const rawContributorId = (await params).contributorId;
+  // Next.js delivers dynamic params still URL-encoded. Node ids here
+  // commonly contain a colon (contributor:liquid-bloom-xxx), which
+  // arrives as contributor%3A... — failing the "starts with
+  // contributor:" check and cascading into a 404. Decode once, up
+  // front, so every downstream fetch and comparison sees the real id.
+  const contributorId = decodeURIComponent(rawContributorId);
 
   const [contributor, publicKeyData, profile, assets] = await Promise.all([
     fetchContributorNode(contributorId),
@@ -258,6 +265,14 @@ export default async function ContributorProfilePage({
           </p>
         )}
       </section>
+
+      {/* ── Presence — their voice, first. The markdown story saved to the
+         contributor's description; rendered as warm prose before any
+         metrics or keys so a visitor meets the person before the profile. */}
+      <PresenceStory
+        content={contributor?.description as string | undefined}
+        displayName={displayName}
+      />
 
       {/* ── Living Frequency Spectrum — shaped by attention ──── */}
       <FrequencySpectrum contributorId={contributorId} />

--- a/web/components/MePage.tsx
+++ b/web/components/MePage.tsx
@@ -311,10 +311,10 @@ export function MePage() {
                   {m.when ? `, ${m.when}` : ""}
                   .
                 </p>
-                {m.hosts.length > 0 && (
+                {(m.hosts?.length ?? 0) > 0 && (
                   <p className="text-muted-foreground">
                     {t("me.metAtHosts")}{" "}
-                    {m.hosts.map((h, i) => (
+                    {(m.hosts ?? []).map((h, i) => (
                       <span key={h.id}>
                         {h.canonical_url ? (
                           <a
@@ -328,7 +328,7 @@ export function MePage() {
                         ) : (
                           <span className="text-foreground">{h.name}</span>
                         )}
-                        {i < m.hosts.length - 1 ? ", " : "."}
+                        {i < (m.hosts?.length ?? 0) - 1 ? ", " : "."}
                       </span>
                     ))}
                   </p>
@@ -336,10 +336,10 @@ export function MePage() {
                 {m.teaching_note && (
                   <p className="text-muted-foreground italic">{m.teaching_note}</p>
                 )}
-                {m.resonates_with.length > 0 && (
+                {(m.resonates_with?.length ?? 0) > 0 && (
                   <p className="text-muted-foreground">
                     {t("me.metAtResonance")}{" "}
-                    {m.resonates_with.map((r, i) => (
+                    {(m.resonates_with ?? []).map((r, i) => (
                       <span key={r.concept_id}>
                         <a
                           href={`/vision/${encodeURIComponent(r.concept_id)}`}
@@ -347,7 +347,7 @@ export function MePage() {
                         >
                           {r.name || humanizeConceptId(r.concept_id)}
                         </a>
-                        {i < m.resonates_with.length - 1 ? ", " : "."}
+                        {i < (m.resonates_with?.length ?? 0) - 1 ? ", " : "."}
                       </span>
                     ))}
                   </p>


### PR DESCRIPTION
## Summary

Three small heals so the presence-stories synced to the graph actually reach visitors on /profile, plus one regression repair on /me.

1. **New `<PresenceStory>` component** mounted on `/profile/[contributorId]`. Renders the node's `description` markdown as warm prose. The surface where each presence meets a visitor *in their own voice* — before any metrics, keys, or assets.
2. **URL-decode fix** — `/profile/[contributorId]` was silently 404'ing for every presence node (all have colons in their id: `contributor:liquid-bloom-xxx`). Next.js delivers the dynamic param still URL-encoded (`contributor%3A...`), so the `startsWith("contributor:")` check failed, the code prepended *another* `contributor:`, and the API 404'd. Decode once at the top.
3. **MePage null-guards** — `<MePage>` crashed on meetings whose records pre-date the `hosts`/`resonates_with` fields. `?.length ?? 0` and `?? []`.

## Verified locally

- `/profile/contributor:liquid-bloom-0ddab636c396` now renders his full story: "CONTRIBUTOR PROFILE / Liquid Bloom / PRESENCE / *To stand inside a Liquid Bloom set is to enter what Amani Friend calls a sonic sanctuary — a held space where **sound can be prayer, medicine, and celebration all at once**...*"
- MePage no longer crashes on old meeting records.

## Test plan

- [x] TSC clean
- [x] Preview: /profile renders Liquid Bloom story in his own voice
- [ ] Post-deploy: visit each of the 8 presences' /profile pages on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)