### PR TITLE
feat(asset-renderer): web renderer SDK (R7)

### DIFF
--- a/web/lib/renderer-sdk.ts
+++ b/web/lib/renderer-sdk.ts
@@ -1,0 +1,96 @@
+/**
+ * Renderer SDK — the public interface for building compatible asset renderers.
+ *
+ * Community developers implement the RendererProps interface and register
+ * their component via registerRenderer(). The platform handles MIME type
+ * lookup, dynamic loading, sandboxing, CC attribution, and storage
+ * resolution — the renderer only has to display content and emit
+ * lifecycle signals.
+ *
+ * See specs/asset-renderer-plugin.md (R7).
+ */
+
+import type { ComponentType } from "react";
+
+/**
+ * Props every renderer receives from the platform.
+ *
+ * - contentUrl: Arweave/IPFS URL to the raw content the renderer should display.
+ * - metadata: format-specific metadata supplied at registration
+ *   (e.g. vertex count for a GLTF, page count for a PDF).
+ * - onReady: MUST be called within 5 seconds of mount. If the timeout
+ *   elapses, the platform shows a download fallback (spec R10).
+ * - onEngagement: periodic signal carrying seconds of active engagement.
+ *   The platform uses this to scale the CC pool for attribution.
+ */
+export interface RendererProps {
+  contentUrl: string;
+  metadata: Record<string, unknown>;
+  onReady: () => void;
+  onEngagement: (seconds: number) => void;
+}
+
+/**
+ * Config an SDK user provides when registering a renderer.
+ *
+ * - id: unique string like "gltf-viewer-v1".
+ * - mimeTypes: what MIME types this renderer handles.
+ * - component: the React component receiving RendererProps.
+ */
+export interface RendererConfig {
+  id: string;
+  mimeTypes: string[];
+  component: ComponentType<RendererProps>;
+}
+
+/**
+ * In-process registry of locally-registered renderers, keyed by MIME type.
+ * Populated by registerRenderer() and consumed by findRendererForMime().
+ *
+ * This is the *client-side* cache for renderers that are either built into
+ * the platform (markdown, image, pdf, html) or loaded at runtime from a
+ * remote component_url. It does NOT replace the server-side registry at
+ * POST /api/renderers/register — that's authoritative for attribution.
+ */
+const _registry: Map<string, RendererConfig> = new Map();
+
+/**
+ * Register a renderer. The platform calls this during built-in renderer
+ * bootstrap and when loading a remote component_url. SDK users building
+ * renderers in their own packages call this on module load.
+ */
+export function registerRenderer(config: RendererConfig): void {
+  if (!config.id) {
+    throw new Error("registerRenderer: id is required");
+  }
+  if (!config.mimeTypes || config.mimeTypes.length === 0) {
+    throw new Error("registerRenderer: at least one mime type is required");
+  }
+  for (const mime of config.mimeTypes) {
+    _registry.set(mime, config);
+  }
+}
+
+/**
+ * Find a locally-registered renderer for a MIME type. Returns undefined
+ * if none is registered — the caller should fall back to remote lookup
+ * via GET /api/renderers/for/{mime_type} or show a download surface.
+ */
+export function findRendererForMime(mimeType: string): RendererConfig | undefined {
+  return _registry.get(mimeType);
+}
+
+/**
+ * List all locally-registered renderers. Mostly for debugging and
+ * introspection; the platform's authoritative list is server-side.
+ */
+export function listRegisteredRenderers(): RendererConfig[] {
+  return Array.from(new Set(_registry.values()));
+}
+
+/**
+ * Testing hook. Not part of the public API.
+ */
+export function _resetRegistryForTests(): void {
+  _registry.clear();
+}

--- a/web/tests/renderer-sdk.test.ts
+++ b/web/tests/renderer-sdk.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerRenderer,
+  findRendererForMime,
+  listRegisteredRenderers,
+  _resetRegistryForTests,
+  type RendererConfig,
+  type RendererProps,
+} from "../lib/renderer-sdk";
+
+function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
+  return {
+    id: "test-renderer",
+    mimeTypes: ["text/plain"],
+    // @ts-expect-error — test stub, not a real component
+    component: (_props: RendererProps) => null,
+    ...overrides,
+  };
+}
+
+describe("renderer-sdk", () => {
+  beforeEach(() => {
+    _resetRegistryForTests();
+  });
+
+  it("registers a renderer under each of its mime types", () => {
+    registerRenderer(
+      makeConfig({ id: "gltf-viewer-v1", mimeTypes: ["model/gltf+json", "model/gltf-binary"] }),
+    );
+    expect(findRendererForMime("model/gltf+json")?.id).toBe("gltf-viewer-v1");
+    expect(findRendererForMime("model/gltf-binary")?.id).toBe("gltf-viewer-v1");
+  });
+
+  it("returns undefined for unregistered mime type", () => {
+    expect(findRendererForMime("audio/midi")).toBeUndefined();
+  });
+
+  it("rejects registration without id", () => {
+    expect(() => registerRenderer(makeConfig({ id: "" }))).toThrow();
+  });
+
+  it("rejects registration without mime types", () => {
+    expect(() => registerRenderer(makeConfig({ mimeTypes: [] }))).toThrow();
+  });
+
+  it("last registration for a mime type wins", () => {
+    registerRenderer(makeConfig({ id: "v1", mimeTypes: ["text/markdown"] }));
+    registerRenderer(makeConfig({ id: "v2", mimeTypes: ["text/markdown"] }));
+    expect(findRendererForMime("text/markdown")?.id).toBe("v2");
+  });
+
+  it("listRegisteredRenderers returns unique entries", () => {
+    registerRenderer(
+      makeConfig({ id: "multi", mimeTypes: ["text/plain", "text/markdown"] }),
+    );
+    const all = listRegisteredRenderers();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe("multi");
+  });
+});


### PR DESCRIPTION
`web/lib/renderer-sdk.ts` is the public contract community developers implement to build compatible asset renderers.

**Exports:**
- `RendererProps` — contentUrl, metadata, onReady, onEngagement
- `RendererConfig` — id, mimeTypes, component
- `registerRenderer(config)` — add to client-side registry
- `findRendererForMime(mimeType)` — lookup
- `listRegisteredRenderers()` — introspection

Client-side registry complements the server-side `/api/renderers` registry: server is authoritative for CC attribution, client-side is the dispatch table used at render time.

**6 vitest tests**: multi-mime registration, unregistered lookup, empty-id rejection, empty-mime rejection, last-write-wins, list uniqueness.

Spec R7 now has a concrete SDK surface.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_