### PR TITLE
feat(asset-renderer): renderer resolver — local first, remote fallback (R3)

### DIFF
--- a/web/lib/renderer-resolver.ts
+++ b/web/lib/renderer-resolver.ts
@@ -1,0 +1,80 @@
+/**
+ * Renderer resolver — given a MIME type, find the renderer to use.
+ *
+ * Resolution order (spec R3):
+ *   1. Local client-side registry (built-in renderers + any loaded
+ *      bundles already registered via registerRenderer()).
+ *   2. Remote server registry at GET /api/renderers/for/{mime_type}
+ *      — returns a descriptor with component_url; the caller
+ *      dynamically imports the bundle.
+ *   3. Null — the caller should show a download fallback.
+ *
+ * This module is pure resolution logic. The actual dynamic-import
+ * loading of remote component_urls, the 5s onReady timeout (R10), and
+ * the sandbox container (R8) live in the AssetRenderer wrapper
+ * component, which consumes the descriptor returned from here.
+ */
+
+import { findRendererForMime, type RendererConfig } from "./renderer-sdk";
+
+export type LocalRendererDescriptor = {
+  source: "local";
+  config: RendererConfig;
+};
+
+export type RemoteRendererDescriptor = {
+  source: "remote";
+  id: string;
+  name: string;
+  componentUrl: string;
+  version: string;
+};
+
+export type RendererDescriptor = LocalRendererDescriptor | RemoteRendererDescriptor;
+
+type RemoteRendererFetcher = (mimeType: string) => Promise<RemoteRendererDescriptor | null>;
+
+/**
+ * Default remote fetcher. Hits GET /api/renderers/for/{mime_type}
+ * and returns a RemoteRendererDescriptor, or null on 404.
+ */
+async function defaultFetchRemoteRenderer(
+  mimeType: string,
+): Promise<RemoteRendererDescriptor | null> {
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+  const url = `${apiBase}/api/renderers/for/${encodeURIComponent(mimeType)}`;
+  try {
+    const response = await fetch(url);
+    if (response.status === 404) return null;
+    if (!response.ok) return null;
+    const data = await response.json();
+    return {
+      source: "remote",
+      id: data.id,
+      name: data.name,
+      componentUrl: data.component_url,
+      version: data.version,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a renderer for a given MIME type. Checks the local registry
+ * first; falls back to the server registry. Returns null if neither
+ * has a match (the caller should show a download surface per spec R3).
+ *
+ * The `fetcher` parameter is injectable for tests.
+ */
+export async function resolveRendererForMime(
+  mimeType: string,
+  fetcher: RemoteRendererFetcher = defaultFetchRemoteRenderer,
+): Promise<RendererDescriptor | null> {
+  const local = findRendererForMime(mimeType);
+  if (local) {
+    return { source: "local", config: local };
+  }
+  const remote = await fetcher(mimeType);
+  return remote;
+}

--- a/web/tests/renderer-resolver.test.ts
+++ b/web/tests/renderer-resolver.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import {
+  registerRenderer,
+  _resetRegistryForTests,
+} from "../lib/renderer-sdk";
+import {
+  resolveRendererForMime,
+  type RemoteRendererDescriptor,
+} from "../lib/renderer-resolver";
+
+describe("resolveRendererForMime", () => {
+  beforeEach(() => {
+    _resetRegistryForTests();
+  });
+
+  it("returns local descriptor when MIME is in the local registry", async () => {
+    registerRenderer({
+      id: "local-md-v1",
+      mimeTypes: ["text/markdown"],
+      // @ts-expect-error stub
+      component: () => null,
+    });
+    const descriptor = await resolveRendererForMime("text/markdown");
+    expect(descriptor).not.toBeNull();
+    expect(descriptor!.source).toBe("local");
+    if (descriptor!.source === "local") {
+      expect(descriptor!.config.id).toBe("local-md-v1");
+    }
+  });
+
+  it("falls back to remote fetcher when local has no match", async () => {
+    const remoteResult: RemoteRendererDescriptor = {
+      source: "remote",
+      id: "gltf-v1",
+      name: "GLTF Viewer",
+      componentUrl: "https://cdn.example.com/gltf.js",
+      version: "1.0.0",
+    };
+    const fetcher = vi.fn().mockResolvedValue(remoteResult);
+    const descriptor = await resolveRendererForMime("model/gltf+json", fetcher);
+    expect(fetcher).toHaveBeenCalledWith("model/gltf+json");
+    expect(descriptor).toEqual(remoteResult);
+  });
+
+  it("returns null when neither local nor remote has a match", async () => {
+    const fetcher = vi.fn().mockResolvedValue(null);
+    const descriptor = await resolveRendererForMime("audio/midi", fetcher);
+    expect(descriptor).toBeNull();
+  });
+
+  it("does not call remote fetcher when local has a match", async () => {
+    registerRenderer({
+      id: "local-png",
+      mimeTypes: ["image/png"],
+      // @ts-expect-error stub
+      component: () => null,
+    });
+    const fetcher = vi.fn().mockResolvedValue(null);
+    await resolveRendererForMime("image/png", fetcher);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`web/lib/renderer-resolver.ts` resolves a renderer for a MIME type:

1. Check the client-side registry (built-ins + SDK-registered)
2. Fall back to `GET /api/renderers/for/{mime_type}`
3. Return null — caller shows download surface

Returns a discriminated union:
- `LocalRendererDescriptor { source: "local", config }` — already imported
- `RemoteRendererDescriptor { source: "remote", componentUrl, ... }` — needs dynamic import
- `null` — no renderer

Remote fetcher is injectable for tests.

**4 vitest tests**: local match, remote fallback, null fallback, local-match-skips-remote.

Spec R3 resolution layer is done. Dynamic import + sandbox container + 5s onReady timeout (R8, R10) are the AssetRenderer wrapper, next PR.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_