### PR TITLE
feat(asset-renderer): render-session + postRenderEvent (R10, R4 client)

### DIFF
--- a/web/lib/render-session.ts
+++ b/web/lib/render-session.ts
@@ -1,0 +1,131 @@
+/**
+ * Render session — tracks lifecycle of one asset render.
+ *
+ * Covers spec R10 (5s onReady timeout) and the engagement → CC pool
+ * pipeline. Pure logic, no React — the AssetRenderer component
+ * instantiates a session and wires its callbacks to React lifecycle.
+ *
+ * Usage:
+ *   const session = createRenderSession({
+ *     assetId: "asset:abc",
+ *     rendererId: "builtin-markdown-v1",
+ *     readerId: "contributor:charlie",
+ *     onTimeout: () => setShowFallback(true),
+ *   });
+ *   // inside renderer: session.markReady()
+ *   // every N seconds while visible: session.trackEngagement(seconds)
+ *   // on unmount: POST session.getEventPayload()
+ */
+
+export interface RenderSessionOptions {
+  assetId: string;
+  rendererId: string;
+  readerId: string;
+  /** Milliseconds to wait for markReady() before firing onTimeout. Default 5000 per spec R10. */
+  timeoutMs?: number;
+  /** Fires if markReady() is not called within timeoutMs. */
+  onTimeout?: () => void;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Injectable setTimeout for tests. Defaults to globalThis.setTimeout. */
+  setTimeoutFn?: typeof setTimeout;
+  /** Injectable clearTimeout for tests. Defaults to globalThis.clearTimeout. */
+  clearTimeoutFn?: typeof clearTimeout;
+}
+
+export interface RenderEventPayload {
+  asset_id: string;
+  renderer_id: string;
+  reader_id: string;
+  duration_ms: number;
+}
+
+export interface RenderSession {
+  markReady(): void;
+  trackEngagement(seconds: number): void;
+  getEventPayload(): RenderEventPayload;
+  isReady(): boolean;
+  hasTimedOut(): boolean;
+  dispose(): void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export function createRenderSession(options: RenderSessionOptions): RenderSession {
+  const now = options.now ?? Date.now;
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const startedAt = now();
+  let ready = false;
+  let timedOut = false;
+  let engagementSeconds = 0;
+  let disposed = false;
+
+  const timer = setTimeoutFn(() => {
+    if (!ready && !disposed) {
+      timedOut = true;
+      options.onTimeout?.();
+    }
+  }, timeoutMs);
+
+  return {
+    markReady() {
+      if (disposed) return;
+      ready = true;
+      clearTimeoutFn(timer);
+    },
+    trackEngagement(seconds: number) {
+      if (disposed) return;
+      engagementSeconds = Math.max(engagementSeconds, seconds);
+    },
+    getEventPayload(): RenderEventPayload {
+      // Prefer engagement-reported seconds when available; fall back to wall time.
+      const wallMs = now() - startedAt;
+      const engagementMs = engagementSeconds * 1000;
+      const durationMs = engagementMs > 0 ? engagementMs : wallMs;
+      return {
+        asset_id: options.assetId,
+        renderer_id: options.rendererId,
+        reader_id: options.readerId,
+        duration_ms: Math.max(0, Math.floor(durationMs)),
+      };
+    },
+    isReady() {
+      return ready;
+    },
+    hasTimedOut() {
+      return timedOut;
+    },
+    dispose() {
+      disposed = true;
+      clearTimeoutFn(timer);
+    },
+  };
+}
+
+/**
+ * POST a render event payload to /api/render-events.
+ *
+ * The caller (AssetRenderer component on unmount) invokes this with
+ * the payload returned by session.getEventPayload(). Returns the
+ * attributed RenderEvent on success, or null on transport failure —
+ * a failed log is not a user-facing error; the content was still seen.
+ */
+export async function postRenderEvent(
+  payload: RenderEventPayload,
+  apiBase: string = "",
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(`${apiBase}/api/render-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/web/tests/render-session.test.ts
+++ b/web/tests/render-session.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createRenderSession, postRenderEvent } from "../lib/render-session";
+
+function makeFakeTimers() {
+  let currentTime = 0;
+  const timers: Array<{ id: number; fireAt: number; cb: () => void }> = [];
+  let nextId = 1;
+  return {
+    now: () => currentTime,
+    setTimeout: ((cb: () => void, ms: number) => {
+      const id = nextId++;
+      timers.push({ id, fireAt: currentTime + ms, cb });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout,
+    clearTimeout: ((id: ReturnType<typeof setTimeout>) => {
+      const idx = timers.findIndex((t) => t.id === (id as unknown as number));
+      if (idx !== -1) timers.splice(idx, 1);
+    }) as typeof clearTimeout,
+    advance(ms: number) {
+      currentTime += ms;
+      // Fire any timers whose time has come
+      const toFire = timers.filter((t) => t.fireAt <= currentTime);
+      for (const t of toFire) {
+        const idx = timers.indexOf(t);
+        if (idx !== -1) timers.splice(idx, 1);
+      }
+      for (const t of toFire) t.cb();
+    },
+  };
+}
+
+describe("createRenderSession", () => {
+  it("fires onTimeout if markReady is not called within 5s (R10)", () => {
+    const clock = makeFakeTimers();
+    const onTimeout = vi.fn();
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      onTimeout,
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    clock.advance(5001);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(session.hasTimedOut()).toBe(true);
+    expect(session.isReady()).toBe(false);
+  });
+
+  it("does not fire onTimeout if markReady is called in time", () => {
+    const clock = makeFakeTimers();
+    const onTimeout = vi.fn();
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      onTimeout,
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    clock.advance(100);
+    session.markReady();
+    clock.advance(10000);
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(session.hasTimedOut()).toBe(false);
+    expect(session.isReady()).toBe(true);
+  });
+
+  it("uses custom timeoutMs when provided", () => {
+    const clock = makeFakeTimers();
+    const onTimeout = vi.fn();
+    createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      timeoutMs: 1000,
+      onTimeout,
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    clock.advance(500);
+    expect(onTimeout).not.toHaveBeenCalled();
+    clock.advance(600);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("engagement duration prefers trackEngagement over wall time when reported", () => {
+    const clock = makeFakeTimers();
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    session.markReady();
+    clock.advance(10_000);
+    session.trackEngagement(7);
+    clock.advance(5_000);
+    // Engagement reported 7s; wall time elapsed is 15s. Engagement wins.
+    const payload = session.getEventPayload();
+    expect(payload.duration_ms).toBe(7_000);
+  });
+
+  it("engagement tracking only moves forward, not backward", () => {
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+    });
+    session.markReady();
+    session.trackEngagement(10);
+    session.trackEngagement(5); // lower value — should not overwrite
+    const payload = session.getEventPayload();
+    expect(payload.duration_ms).toBe(10_000);
+  });
+
+  it("getEventPayload falls back to wall time when no engagement reported", () => {
+    const clock = makeFakeTimers();
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    session.markReady();
+    clock.advance(3_500);
+    const payload = session.getEventPayload();
+    expect(payload.duration_ms).toBe(3_500);
+  });
+
+  it("dispose prevents onTimeout from firing after unmount", () => {
+    const clock = makeFakeTimers();
+    const onTimeout = vi.fn();
+    const session = createRenderSession({
+      assetId: "a1",
+      rendererId: "r1",
+      readerId: "u1",
+      onTimeout,
+      now: clock.now,
+      setTimeoutFn: clock.setTimeout,
+      clearTimeoutFn: clock.clearTimeout,
+    });
+    session.dispose();
+    clock.advance(10_000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("payload carries asset, renderer, and reader ids", () => {
+    const session = createRenderSession({
+      assetId: "asset:42",
+      rendererId: "gltf-viewer-v1",
+      readerId: "contributor:charlie",
+    });
+    session.markReady();
+    session.trackEngagement(1);
+    const payload = session.getEventPayload();
+    expect(payload.asset_id).toBe("asset:42");
+    expect(payload.renderer_id).toBe("gltf-viewer-v1");
+    expect(payload.reader_id).toBe("contributor:charlie");
+  });
+});
+
+describe("postRenderEvent", () => {
+  it("returns parsed body on success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "evt-1", cc_pool: "0.15" }),
+    });
+    // @ts-expect-error test stub
+    globalThis.fetch = fetchMock;
+    const result = await postRenderEvent({
+      asset_id: "a",
+      renderer_id: "r",
+      reader_id: "u",
+      duration_ms: 1000,
+    });
+    expect(result).toEqual({ id: "evt-1", cc_pool: "0.15" });
+  });
+
+  it("returns null on network failure", async () => {
+    // @ts-expect-error test stub
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network"));
+    const result = await postRenderEvent({
+      asset_id: "a",
+      renderer_id: "r",
+      reader_id: "u",
+      duration_ms: 1000,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-2xx response", async () => {
+    // @ts-expect-error test stub
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const result = await postRenderEvent({
+      asset_id: "a",
+      renderer_id: "r",
+      reader_id: "u",
+      duration_ms: 1000,
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Pure session lifecycle + POST helper. The AssetRenderer React wrapper (next PR) binds this to React lifecycle.

**`createRenderSession`** — session manager for one render:
- `markReady()` — cancel the timeout (spec R10)
- `trackEngagement(s)` — monotonic seconds
- `getEventPayload()` — body for POST /api/render-events
- `dispose()` — unmount cleanup

Engagement takes max of reported values; payload prefers engagement-reported duration over wall time.

**`postRenderEvent`** — POSTs to `/api/render-events`, returns the attributed event or null (silent on failure; a failed log isn't user-facing).

**11 vitest tests**: timeout fires at 5s, doesn't fire when ready in time, custom timeout, engagement preferred over wall time, monotonic engagement, wall-time fallback, dispose prevents timeout, payload ids preserved, POST success/network-fail/non-2xx.

Clock and setTimeout are **injectable** for deterministic tests — no fake timers, no flakiness.

Covers spec R10 (5s onReady timeout) and the client half of R4 (POST render event).

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_