### PR TITLE
tend: Frequency Profile resolves names + links; MePage null-guards

### DIFF
--- a/web/app/profile/[contributorId]/page.tsx
+++ b/web/app/profile/[contributorId]/page.tsx
@@ -135,21 +135,74 @@ function fingerprint(hex: string): string {
   return segments.join(":").toUpperCase();
 }
 
-/* ── Dimension color mapping ──────────────────────────────────────── */
+/* ── Dimension resolution ─────────────────────────────────────────── */
 
-const DIMENSION_COLORS: Record<string, { bg: string; text: string }> = {
-  concept: { bg: "bg-amber-500/15", text: "text-amber-400" },
-  keyword: { bg: "bg-blue-500/15", text: "text-blue-400" },
-  domain: { bg: "bg-purple-500/15", text: "text-purple-400" },
-  edge: { bg: "bg-emerald-500/15", text: "text-emerald-400" },
-  content: { bg: "bg-pink-500/15", text: "text-pink-400" },
-};
+type ResolvedDim = { label: string; href: string | null; nodeType: string | null };
 
-function dimensionColor(dim: string): { bg: string; text: string } {
-  const prefix = dim.split(":")[0]?.toLowerCase() || "";
-  return (
-    DIMENSION_COLORS[prefix] ?? { bg: "bg-stone-500/15", text: "text-stone-400" }
-  );
+function hrefForNode(id: string, nodeType: string | null): string | null {
+  if (id.startsWith("contributor:")) return `/profile/${encodeURIComponent(id)}`;
+  if (id.startsWith("asset:")) return `/assets/${encodeURIComponent(id)}`;
+  if (id.startsWith("idea:")) return `/ideas/${encodeURIComponent(id)}`;
+  if (id.startsWith("spec:")) return `/specs/${encodeURIComponent(id)}`;
+  if (id.startsWith("lc-") || nodeType === "concept") return `/vision/${encodeURIComponent(id)}`;
+  return `/nodes/${encodeURIComponent(id)}`;
+}
+
+function humanizeSynthetic(dim: string): string {
+  if (dim === "_living") return "Living text";
+  if (dim === "_source_backed") return "Source-backed";
+  const rest = dim.slice(1);
+  const colonIdx = rest.indexOf(":");
+  const prefix = colonIdx === -1 ? rest : rest.slice(0, colonIdx);
+  const value = colonIdx === -1 ? "" : rest.slice(colonIdx + 1);
+  const labels: Record<string, string> = {
+    domain: "Domain",
+    kw: "Keyword",
+    edge: "Edge",
+    type: "Type",
+    phase: "Phase",
+    hz: "Hz",
+    marker: "Marker",
+    extraction: "Extraction",
+    ingestion_policy: "Policy",
+  };
+  const label = labels[prefix] ?? prefix;
+  return value ? `${label}: ${value}` : label;
+}
+
+async function resolveDimension(dim: string): Promise<ResolvedDim> {
+  if (dim.startsWith("_")) {
+    return { label: humanizeSynthetic(dim), href: null, nodeType: null };
+  }
+  const base = getApiBase();
+  try {
+    const res = await fetch(`${base}/api/graph/nodes/${encodeURIComponent(dim)}`, {
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) {
+      return { label: dim, href: hrefForNode(dim, null), nodeType: null };
+    }
+    const node = await res.json();
+    const name = node?.name || node?.author_display_name || dim;
+    return { label: name, href: hrefForNode(dim, node?.type ?? null), nodeType: node?.type ?? null };
+  } catch {
+    return { label: dim, href: hrefForNode(dim, null), nodeType: null };
+  }
+}
+
+function dimensionColor(dim: string, nodeType: string | null): { bg: string; text: string } {
+  if (dim === "_living") return { bg: "bg-pink-500/15", text: "text-pink-400" };
+  if (dim === "_source_backed") return { bg: "bg-teal-500/15", text: "text-teal-400" };
+  if (dim.startsWith("_")) return { bg: "bg-stone-500/15", text: "text-stone-400" };
+  if (dim.startsWith("contributor:")) return { bg: "bg-rose-500/15", text: "text-rose-400" };
+  if (dim.startsWith("asset:")) return { bg: "bg-blue-500/15", text: "text-blue-400" };
+  if (dim.startsWith("idea:")) return { bg: "bg-emerald-500/15", text: "text-emerald-400" };
+  if (dim.startsWith("spec:")) return { bg: "bg-cyan-500/15", text: "text-cyan-400" };
+  if (dim.startsWith("community:") || dim.startsWith("event:") || dim.startsWith("gathering:")) {
+    return { bg: "bg-purple-500/15", text: "text-purple-400" };
+  }
+  if (dim.startsWith("lc-") || nodeType === "concept") return { bg: "bg-amber-500/15", text: "text-amber-400" };
+  return { bg: "bg-stone-500/15", text: "text-stone-400" };
 }
 
 /* ── Metadata ─────────────────────────────────────────────────────── */
@@ -191,6 +244,14 @@ export default async function ContributorProfilePage({
     fetchFrequencyProfile(contributorId),
     fetchAssets(contributorId),
   ]);
+
+  // Resolve each top dimension to a human label + href. Node-id dims
+  // (lc-sensing, contributor:xxx, asset:xxx, community:xxx) get a name
+  // fetched from /api/graph/nodes. Synthetic dims (_living, _domain:X)
+  // get a readable label. Done in parallel so 15 dims resolve together.
+  const resolvedDims = profile
+    ? await Promise.all(profile.top.map((d) => resolveDimension(d.dimension)))
+    : [];
 
   // A contributor exists when any of three signals land: the graph
   // node (source of truth), a registered public key, or a built-up
@@ -300,23 +361,36 @@ export default async function ContributorProfilePage({
 
         {profile ? (
           <>
-            {/* Dimension pills */}
+            {/* Dimension pills — resolved names, linked where a page exists */}
             <div className="flex flex-wrap gap-2">
-              {profile.top.map((dim) => {
-                const color = dimensionColor(dim.dimension);
-                return (
-                  <span
+              {profile.top.map((dim, i) => {
+                const resolved = resolvedDims[i] ?? { label: dim.dimension, href: null, nodeType: null };
+                const color = dimensionColor(dim.dimension, resolved.nodeType);
+                const chipClass = `inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${color.bg} ${color.text}`;
+                const inner = (
+                  <>
+                    <span>{resolved.label}</span>
+                    <span className="opacity-60 font-mono">{dim.strength.toFixed(2)}</span>
+                  </>
+                );
+                return resolved.href ? (
+                  <Link
                     key={dim.dimension}
-                    className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${color.bg} ${color.text}`}
+                    href={resolved.href}
+                    className={`${chipClass} hover:opacity-80 transition-opacity`}
                   >
-                    <span>{dim.dimension}</span>
-                    <span className="opacity-60">
-                      {(dim.strength * 100).toFixed(0)}%
-                    </span>
+                    {inner}
+                  </Link>
+                ) : (
+                  <span key={dim.dimension} className={chipClass}>
+                    {inner}
                   </span>
                 );
               })}
             </div>
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              Each dimension is a raw vector weight (0–1), not a share of the whole. Concept and entity weights come from graph neighbors — how strongly this contributor connects to each one. Domain, keyword, and type weights come from node properties. "Living text" and "source-backed" come from content analysis. Total magnitude is the L2 norm of the full vector.
+            </p>
 
             {/* Stats row */}
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 pt-2">

--- a/web/components/MePage.tsx
+++ b/web/components/MePage.tsx
@@ -389,7 +389,7 @@ export function MePage() {
           ) : (
             <>
               <FootprintProse fp={footprint} t={t} />
-              {trail && trail.concepts.length > 0 && (
+              {trail && (trail.concepts?.length ?? 0) > 0 && (
                 <TrailProse trail={trail} t={t} />
               )}
             </>
@@ -630,9 +630,9 @@ function TrailProse({
   trail: Trail;
   t: ReturnType<typeof useT>;
 }) {
-  if (trail.concepts.length === 0) return null;
+  if ((trail.concepts?.length ?? 0) === 0) return null;
 
-  const top = trail.concepts.slice(0, 5);
+  const top = (trail.concepts ?? []).slice(0, 5);
   const hasMore = trail.concept_count > top.length;
 
   return (

--- a/web/tests/render-session.test.ts
+++ b/web/tests/render-session.test.ts
@@ -174,7 +174,6 @@ describe("postRenderEvent", () => {
       ok: true,
       json: async () => ({ id: "evt-1", cc_pool: "0.15" }),
     });
-    // @ts-expect-error test stub
     globalThis.fetch = fetchMock;
     const result = await postRenderEvent({
       asset_id: "a",
@@ -186,7 +185,6 @@ describe("postRenderEvent", () => {
   });
 
   it("returns null on network failure", async () => {
-    // @ts-expect-error test stub
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("network"));
     const result = await postRenderEvent({
       asset_id: "a",
@@ -198,7 +196,6 @@ describe("postRenderEvent", () => {
   });
 
   it("returns null on non-2xx response", async () => {
-    // @ts-expect-error test stub
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     const result = await postRenderEvent({
       asset_id: "a",

--- a/web/tests/renderer-resolver.test.ts
+++ b/web/tests/renderer-resolver.test.ts
@@ -18,7 +18,6 @@ describe("resolveRendererForMime", () => {
     registerRenderer({
       id: "local-md-v1",
       mimeTypes: ["text/markdown"],
-      // @ts-expect-error stub
       component: () => null,
     });
     const descriptor = await resolveRendererForMime("text/markdown");
@@ -53,7 +52,6 @@ describe("resolveRendererForMime", () => {
     registerRenderer({
       id: "local-png",
       mimeTypes: ["image/png"],
-      // @ts-expect-error stub
       component: () => null,
     });
     const fetcher = vi.fn().mockResolvedValue(null);

--- a/web/tests/renderer-sdk.test.ts
+++ b/web/tests/renderer-sdk.test.ts
@@ -12,7 +12,6 @@ function makeConfig(overrides: Partial<RendererConfig> = {}): RendererConfig {
   return {
     id: "test-renderer",
     mimeTypes: ["text/plain"],
-    // @ts-expect-error — test stub, not a real component
     component: (_props: RendererProps) => null,
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- **Frequency Profile** on `/profile/[id]` now shows resolved names (not raw IDs) for every top dimension, with links to the right detail page. Concepts link to `/vision/lc-*`, contributors to `/profile/*`, assets to `/assets/*`, communities/events to `/nodes/*`. Synthetic dims (`_living`, `_domain:X`, `_kw:X`, `_edge:X`) get readable labels. Color-coded by node type so the eye can sort them at a glance.
- **Weight explanation** added below the pills: each is a raw vector component (0–1), not a share. Names where each weight comes from — graph neighbors, node properties, content analysis.
- **MePage null-guard** — `trail.concepts` could be undefined when the trail API returns early; now guarded so `/me` never crashes during render.
- **Typecheck heal** — three unused `@ts-expect-error` directives removed across `tests/render-session.test.ts`, `tests/renderer-resolver.test.ts`, `tests/renderer-sdk.test.ts`. The types got stricter; the suppressions were stale.

## Test plan
- [x] `npx tsc --noEmit` clean (previously 6 errors, now 0)
- [x] `/profile/contributor:liquid-bloom-*` renders 15 top dims with resolved names + working links
- [x] `/me` renders without throwing on missing trail.concepts
- [x] Witness breathing, 0 silences