### PR TITLE
tend: route translator and news config through spine

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -356,6 +356,21 @@ def _default_config() -> dict[str, Any]:
             "failed_alert_max_per_window": 5,
             "failed_alert_window_seconds": 3600,
         },
+        "translator": {
+            "backend": "libretranslate",
+            "libretranslate_url": "https://libretranslate.com",
+            "libretranslate_key": None,
+            "anthropic_api_key": None,
+            "anthropic_api_url": "https://api.anthropic.com/v1/messages",
+            "anthropic_model": "claude-haiku-4-5-20251001",
+            "timeout_seconds": 120,
+        },
+        "news": {
+            "sources_path": "config/news-sources.json",
+            "cache_ttl_seconds": 900,
+            "fetch_timeout_seconds": 15.0,
+            "user_agent": "CoherenceNetwork/1.0",
+        },
         "storage": {
             "graph_store_path": None,
             "idea_portfolio_path": None,

--- a/api/app/services/news_ingestion_service.py
+++ b/api/app/services/news_ingestion_service.py
@@ -1,23 +1,25 @@
 """News ingestion service: fetches RSS feeds and caches results.
 
-Sources are loaded from config/news-sources.json (configurable via API).
-Falls back to a minimal default set if the config file is missing.
+Sources are loaded from the configured JSON source list and are editable via
+the API. If the source file is missing or unreadable, the service returns an
+empty source list rather than carrying hidden feed data in code.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass, field, asdict
-from datetime import datetime, timezone
+from dataclasses import asdict, dataclass
+from datetime import timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Optional
 
 import httpx
+
+from app.config_loader import get_float, get_int, get_str
 
 logger = logging.getLogger(__name__)
 
@@ -25,27 +27,18 @@ logger = logging.getLogger(__name__)
 # Source configuration — loaded from config file, editable via API
 # ---------------------------------------------------------------------------
 
-# Default location of the on-disk source list. Resolved lazily so that tests
-# (and any other consumer that wants isolation) can point NEWS_SOURCES_CONFIG
-# at a temp file at runtime — the previous module-level constant captured the
-# value at import time, so per-test env-var overrides were silently ignored
-# and the in-tree config/news-sources.json got polluted on every test run.
-_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent.parent.parent / "config" / "news-sources.json"
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DEFAULT_CONFIG_PATH = _REPO_ROOT / "config" / "news-sources.json"
 
 
 def _config_path() -> Path:
-    return Path(os.environ.get("NEWS_SOURCES_CONFIG", str(_DEFAULT_CONFIG_PATH)))
-
-
-_DEFAULT_SOURCES: list[dict] = [
-    {"id": "hackernews", "name": "Hacker News", "type": "rss", "url": "https://news.ycombinator.com/rss", "categories": ["technology", "programming"], "is_active": True, "update_interval_minutes": 60, "priority": 1},
-    {"id": "techcrunch", "name": "TechCrunch", "type": "rss", "url": "https://techcrunch.com/feed/", "categories": ["technology", "startups"], "is_active": True, "update_interval_minutes": 60, "priority": 2},
-    {"id": "arstechnica", "name": "Ars Technica", "type": "rss", "url": "https://feeds.arstechnica.com/arstechnica/index", "categories": ["technology", "science"], "is_active": True, "update_interval_minutes": 60, "priority": 3},
-]
+    configured = get_str("news", "sources_path", default=str(_DEFAULT_CONFIG_PATH)).strip()
+    path = Path(configured or str(_DEFAULT_CONFIG_PATH))
+    return path if path.is_absolute() else _REPO_ROOT / path
 
 
 def _load_sources() -> list[dict]:
-    """Load news sources from config file, falling back to defaults."""
+    """Load news sources from config file."""
     cfg = _config_path()
     if cfg.exists():
         try:
@@ -54,8 +47,10 @@ def _load_sources() -> list[dict]:
             logger.info("Loaded %d news sources (%d active) from %s", len(sources), len(active), cfg)
             return sources
         except Exception as e:
-            logger.warning("Failed to load %s: %s — using defaults", cfg, e)
-    return list(_DEFAULT_SOURCES)
+            logger.warning("Failed to load %s: %s — using empty source list", cfg, e)
+    else:
+        logger.info("News source config %s not found — using empty source list", cfg)
+    return []
 
 
 def _save_sources(sources: list[dict]) -> None:
@@ -69,7 +64,7 @@ def _save_sources(sources: list[dict]) -> None:
 # Module-level source list — reloaded on mutation
 _sources: list[dict] = _load_sources()
 
-CACHE_TTL_SECONDS = 900  # 15 minutes
+CACHE_TTL_SECONDS = get_int("news", "cache_ttl_seconds", default=900)
 
 
 # ---------------------------------------------------------------------------
@@ -227,10 +222,12 @@ async def fetch_feeds(force_refresh: bool = False) -> list[NewsItem]:
 
     active_sources = [s for s in _sources if s.get("is_active", True) and s.get("type") == "rss"]
     all_items: list[NewsItem] = []
-    async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+    timeout = get_float("news", "fetch_timeout_seconds", default=15.0)
+    user_agent = get_str("news", "user_agent", default="CoherenceNetwork/1.0")
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
         for source in active_sources:
             try:
-                resp = await client.get(source["url"], headers={"User-Agent": "CoherenceNetwork/1.0"})
+                resp = await client.get(source["url"], headers={"User-Agent": user_agent})
                 resp.raise_for_status()
                 parsed = _parse_rss(resp.text, source.get("name", source["id"]))
                 all_items.extend(parsed)

--- a/api/app/services/translator_backends.py
+++ b/api/app/services/translator_backends.py
@@ -9,13 +9,13 @@ Two backends ship:
 
 - **LibreTranslateBackend** (default) — free, open-source, no API key.
   Calls a LibreTranslate instance (public ``libretranslate.com`` by default,
-  self-hosted if ``COHERENCE_LIBRETRANSLATE_URL`` is set). Post-processes the
+  self-hosted if ``config.translator.libretranslate_url`` is set). Post-processes the
   translation to substitute the per-language glossary's felt-sense equivalents
   for anchor terms ("tending" → "hüten"), so the frequency carries through
   even though LibreTranslate is not prompt-aware.
 
 - **AnthropicAttunementBackend** (optional) — Claude via httpx. Used when
-  ``ANTHROPIC_API_KEY`` is present in the keystore or env; higher translation
+  the Anthropic key is present in the keystore or config; higher translation
   quality and native prompt steering, but requires a paid key.
 
 ``register_default_backend()`` prefers LibreTranslate (zero-config, free) and
@@ -27,13 +27,14 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+from app.config_loader import get_int, get_str
 
 # ---------------------------------------------------------------------------
 # Anthropic (optional, paid)
@@ -79,9 +80,9 @@ def resolve_anthropic_key() -> str | None:
     key = _read_keystore_key()
     if key:
         return key
-    env = os.getenv("ANTHROPIC_API_KEY")
-    if env and env.strip():
-        return env.strip()
+    configured = get_str("translator", "anthropic_api_key", default="").strip()
+    if configured:
+        return configured
     return None
 
 
@@ -100,7 +101,7 @@ class LibreTranslateBackend:
 
     The public endpoint ``libretranslate.com`` rate-limits anonymous callers
     but works for the gentle pace of on-demand view attunement. For heavier
-    use, self-host LibreTranslate and set ``COHERENCE_LIBRETRANSLATE_URL``.
+    use, set ``config.translator.libretranslate_url`` to a self-hosted instance.
     """
 
     base_url: str = DEFAULT_LIBRETRANSLATE_URL
@@ -217,13 +218,14 @@ def _apply_glossary(text: str, glossary: list[tuple[str, str]]) -> str:
 class AnthropicAttunementBackend:
     """Calls Anthropic Messages API to attune source text into a target lang.
 
-    Requires ``ANTHROPIC_API_KEY``. Higher translation quality and glossary
+    Requires an Anthropic key from the keystore or config. Higher translation quality and glossary
     is carried via the system prompt (not post-substitution), so terms land
     in grammatical context rather than as raw replacements.
     """
 
     api_key: str
     model: str = DEFAULT_ANTHROPIC_MODEL
+    api_url: str = ANTHROPIC_API_URL
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
     max_output_tokens: int = 8000
 
@@ -271,7 +273,7 @@ class AnthropicAttunementBackend:
             "content-type": "application/json",
         }
         with httpx.Client(timeout=self.timeout_seconds) as client:
-            resp = client.post(ANTHROPIC_API_URL, headers=headers, json=body)
+            resp = client.post(self.api_url, headers=headers, json=body)
             resp.raise_for_status()
             data: Any = resp.json()
         parts = data.get("content") if isinstance(data, dict) else None
@@ -315,8 +317,8 @@ def register_default_backend() -> str | None:
     """Install the best available backend. Returns the backend name or None.
 
     Resolution order:
-      1. ``COHERENCE_TRANSLATOR=anthropic`` (explicit) + key present → Anthropic
-      2. ``COHERENCE_TRANSLATOR=libretranslate`` (explicit) → LibreTranslate
+      1. ``config.translator.backend=anthropic`` (explicit) + key present → Anthropic
+      2. ``config.translator.backend=libretranslate`` (explicit) → LibreTranslate
       3. Default: LibreTranslate (free, no key)
 
     Called at app startup; safe to call multiple times (no-op when set).
@@ -326,21 +328,38 @@ def register_default_backend() -> str | None:
     if translator_service.has_backend():
         return None
 
-    choice = (os.getenv("COHERENCE_TRANSLATOR") or "").strip().lower()
+    choice = get_str("translator", "backend", default="libretranslate").strip().lower()
 
     if choice == "anthropic":
         key = resolve_anthropic_key()
         if key:
-            model = os.getenv("COHERENCE_TRANSLATOR_MODEL") or DEFAULT_ANTHROPIC_MODEL
-            translator_service.set_backend(AnthropicAttunementBackend(api_key=key, model=model))
+            model = get_str("translator", "anthropic_model", default=DEFAULT_ANTHROPIC_MODEL).strip()
+            api_url = get_str("translator", "anthropic_api_url", default=ANTHROPIC_API_URL).strip()
+            timeout = get_int("translator", "timeout_seconds", default=DEFAULT_TIMEOUT_SECONDS)
+            translator_service.set_backend(
+                AnthropicAttunementBackend(
+                    api_key=key,
+                    model=model or DEFAULT_ANTHROPIC_MODEL,
+                    api_url=api_url or ANTHROPIC_API_URL,
+                    timeout_seconds=timeout,
+                )
+            )
             return "anthropic"
-        _logger.warning("COHERENCE_TRANSLATOR=anthropic but no key found — falling back to LibreTranslate")
+        _logger.warning("translator backend is anthropic but no key found — falling back to LibreTranslate")
+        choice = "libretranslate"
 
     if choice == "libretranslate" or choice == "":
-        url = os.getenv("COHERENCE_LIBRETRANSLATE_URL") or DEFAULT_LIBRETRANSLATE_URL
-        api_key = os.getenv("COHERENCE_LIBRETRANSLATE_KEY") or None
-        translator_service.set_backend(LibreTranslateBackend(base_url=url, api_key=api_key))
+        url = get_str("translator", "libretranslate_url", default=DEFAULT_LIBRETRANSLATE_URL).strip()
+        api_key = get_str("translator", "libretranslate_key", default="").strip() or None
+        timeout = get_int("translator", "timeout_seconds", default=DEFAULT_TIMEOUT_SECONDS)
+        translator_service.set_backend(
+            LibreTranslateBackend(
+                base_url=url or DEFAULT_LIBRETRANSLATE_URL,
+                api_key=api_key,
+                timeout_seconds=timeout,
+            )
+        )
         return "libretranslate"
 
-    _logger.warning("Unknown COHERENCE_TRANSLATOR=%r; no backend installed", choice)
+    _logger.warning("Unknown translator backend=%r; no backend installed", choice)
     return None

--- a/api/config/api.json
+++ b/api/config/api.json
@@ -45,6 +45,25 @@
     "failed_alert_window_seconds": 3600
   },
 
+  "translator": {
+    "_doc": "View attunement backend selection. Secrets belong in ~/.coherence-network/config.json or keys.json.",
+    "backend": "libretranslate",
+    "libretranslate_url": "https://libretranslate.com",
+    "libretranslate_key": null,
+    "anthropic_api_key": null,
+    "anthropic_api_url": "https://api.anthropic.com/v1/messages",
+    "anthropic_model": "claude-haiku-4-5-20251001",
+    "timeout_seconds": 120
+  },
+
+  "news": {
+    "_doc": "News ingestion source list and fetch behavior.",
+    "sources_path": "config/news-sources.json",
+    "cache_ttl_seconds": 900,
+    "fetch_timeout_seconds": 15.0,
+    "user_agent": "CoherenceNetwork/1.0"
+  },
+
   "storage": {
     "_doc": "File paths for local storage (dev mode). Production uses database.url.",
     "graph_store_path": null,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -231,16 +231,6 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     # Ideas now live in graph_nodes (unified DB) — don't set file-based portfolio path
     os.environ.pop("IDEA_PORTFOLIO_PATH", None)
     os.environ["AGENT_TASKS_USE_DB"] = "0"
-    # Point news ingestion at a per-test config file. The service used to
-    # cache the path at import time, so this env var was silently ignored
-    # and tests dirtied the in-tree config/news-sources.json.
-    os.environ["NEWS_SOURCES_CONFIG"] = str(tmp_path / "news_sources.json")
-    try:
-        from app.services import news_ingestion_service
-        news_ingestion_service._sources = news_ingestion_service._load_sources()
-    except Exception:
-        pass
-
     # Disable the in-process TTL cache (app.core.ttl_cache.ttl_cached)
     # so tests always see fresh computation. Without this, a stale flow
     # aggregation from test A can leak into test B.
@@ -257,6 +247,7 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     config_loader._CONFIG.setdefault("agent_executor", {})["policy_enabled"] = True
     config_loader._CONFIG.setdefault("runtime", {})["events_path"] = str(tmp_path / "runtime_events.json")
     config_loader._CONFIG.setdefault("runtime", {})["idea_map_path"] = str(tmp_path / "runtime_idea_map.json")
+    config_loader._CONFIG.setdefault("news", {})["sources_path"] = str(tmp_path / "news_sources.json")
     config_loader._CONFIG.setdefault("agent_lifecycle", {})["telemetry_enabled"] = True
     config_loader._CONFIG.setdefault("agent_lifecycle", {})["jsonl_enabled"] = True
     config_loader._CONFIG.setdefault("agent_lifecycle", {})["subscribers"] = "runtime"
@@ -271,11 +262,18 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
             "agent_execute_token": None,
             "runtime_events_path": str(tmp_path / "runtime_events.json"),
             "runtime_idea_map_path": str(tmp_path / "runtime_idea_map.json"),
+            "news_sources_path": str(tmp_path / "news_sources.json"),
             "agent_lifecycle_telemetry_enabled": True,
             "agent_lifecycle_jsonl_enabled": True,
             "agent_lifecycle_subscribers": "runtime",
         }
     )
+
+    try:
+        from app.services import news_ingestion_service
+        news_ingestion_service._sources = news_ingestion_service._load_sources()
+    except Exception:
+        pass
 
     # Reset the unified engine — all services delegate to this
     unified_db.reset_engine()

--- a/api/tests/test_external_presence.py
+++ b/api/tests/test_external_presence.py
@@ -10,11 +10,14 @@ Covers done_when criteria:
 from __future__ import annotations
 
 from uuid import uuid4
+import json
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app import config_loader
 from app.main import app
+from app.services import news_ingestion_service
 
 AUTH = {"X-API-Key": "dev-key"}
 BASE = "http://test"
@@ -53,6 +56,35 @@ async def test_news_sources_returns_list():
         body = r.json()
         assert "count" in body
         assert isinstance(body["sources"], list)
+
+
+def test_news_sources_load_from_config_path(tmp_path):
+    """News source data lives in configured JSON, not hidden service defaults."""
+    source_path = tmp_path / "news_sources.json"
+    source_path.write_text(
+        json.dumps([
+            {
+                "id": "configured-feed",
+                "name": "Configured Feed",
+                "type": "rss",
+                "url": "https://example.com/feed.xml",
+                "is_active": True,
+            }
+        ]),
+        encoding="utf-8",
+    )
+    config_loader.set_config_value("news", "sources_path", str(source_path))
+
+    loaded = news_ingestion_service._load_sources()
+
+    assert [row["id"] for row in loaded] == ["configured-feed"]
+
+
+def test_missing_news_sources_config_returns_empty_list(tmp_path):
+    """Missing source config should be visible as empty, not a hard-coded feed list."""
+    config_loader.set_config_value("news", "sources_path", str(tmp_path / "missing.json"))
+
+    assert news_ingestion_service._load_sources() == []
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_libretranslate_backend.py
+++ b/api/tests/test_libretranslate_backend.py
@@ -8,12 +8,10 @@ when LibreTranslate rendered them as something else.
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from app.services.translator_backends import (
+    AnthropicAttunementBackend,
     LibreTranslateBackend,
     _apply_glossary,
     register_default_backend,
@@ -86,15 +84,41 @@ def test_preserves_image_syntax():
     assert "hüten" in out
 
 
-def test_register_default_prefers_libretranslate_without_key(monkeypatch):
-    """With no COHERENCE_TRANSLATOR set and no anthropic key, installs LibreTranslate."""
+def test_register_default_prefers_libretranslate_without_key():
+    """With default translator config and no Anthropic key, installs LibreTranslate."""
     # Clean slate
     translator_service.set_backend(None)
-    monkeypatch.delenv("COHERENCE_TRANSLATOR", raising=False)
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     # Avoid picking up a real keystore by faking Path.home()
     with patch("app.services.translator_backends._read_keystore_key", return_value=None):
         name = register_default_backend()
     assert name == "libretranslate"
     assert translator_service.has_backend() is True
+    translator_service.set_backend(None)
+
+
+def test_register_default_uses_translator_config_for_anthropic():
+    translator_service.set_backend(None)
+
+    values = {
+        ("translator", "backend"): "anthropic",
+        ("translator", "anthropic_model"): "claude-test",
+        ("translator", "anthropic_api_url"): "https://anthropic.test/messages",
+    }
+
+    def fake_get_str(section: str, key: str, default: str = "") -> str:
+        return values.get((section, key), default)
+
+    with (
+        patch("app.services.translator_backends.get_str", side_effect=fake_get_str),
+        patch("app.services.translator_backends.get_int", return_value=17),
+        patch("app.services.translator_backends._read_keystore_key", return_value="key-test"),
+    ):
+        name = register_default_backend()
+
+    assert name == "anthropic"
+    backend = translator_service._BACKEND  # type: ignore[attr-defined]
+    assert isinstance(backend, AnthropicAttunementBackend)
+    assert backend.model == "claude-test"
+    assert backend.api_url == "https://anthropic.test/messages"
+    assert backend.timeout_seconds == 17
     translator_service.set_backend(None)

--- a/docs/system_audit/commit_evidence_2026-04-24_root-hardcoding-fallbacks.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_root-hardcoding-fallbacks.json
@@ -1,0 +1,118 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/root-hardcoding-fallbacks",
+  "commit_scope": "Move translator backend selection and news source configuration out of app-code env fallbacks and embedded service data, keeping the settings on the config-loader spine.",
+  "files_owned": [
+    "api/app/config_loader.py",
+    "api/app/services/news_ingestion_service.py",
+    "api/app/services/translator_backends.py",
+    "api/config/api.json",
+    "api/tests/conftest.py",
+    "api/tests/test_external_presence.py",
+    "api/tests/test_libretranslate_backend.py",
+    "docs/system_audit/commit_evidence_2026-04-24_root-hardcoding-fallbacks.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "cd api && ruff check app/services/news_ingestion_service.py app/services/translator_backends.py app/config_loader.py tests/test_libretranslate_backend.py tests/test_external_presence.py tests/conftest.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_libretranslate_backend.py tests/test_flow_multilingual.py tests/test_external_presence.py",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "rg -n \"os\\.getenv|os\\.environ|getenv\\(|NEWS_SOURCES_CONFIG|COHERENCE_TRANSLATOR|COHERENCE_LIBRETRANSLATE\" api/app/services/news_ingestion_service.py api/app/services/translator_backends.py",
+      "git grep -n -E 'os\\.getenv|os\\.environ\\.get|environ\\[|getenv\\(' origin/main -- api/app | wc -l",
+      "rg -n \"os\\.getenv|os\\.environ\\.get|environ\\[|getenv\\(\" api/app --glob '!**/__pycache__/**' | wc -l"
+    ],
+    "observations": {
+      "api_app_env_read_matches_before": 149,
+      "api_app_env_read_matches_after": 143,
+      "touched_services_direct_env_reads_after": 0,
+      "targeted_tests": "45 passed",
+      "local_pr_guard": "pass",
+      "followthrough_guard": "pass",
+      "runtime_web_guard": "pass"
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Translator and news ingestion behavior remains configurable, but app code no longer reads translator/news env fallbacks or carries hidden default RSS source data.",
+    "public_endpoints": [
+      "/api/health",
+      "/api/news/sources",
+      "/api/concepts"
+    ],
+    "test_flows": [
+      "Translator defaults install LibreTranslate through config defaults",
+      "Configured Anthropic translator selection uses config values",
+      "News source data loads from the configured JSON source path",
+      "Missing news source config returns an honest empty source list"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Root config/data cleanup is locally validated through full local PR guard and follow-through guard; branch still needs PR checks, deployment, and public sensing."
+  },
+  "idea_ids": [
+    "repository-health",
+    "external-presence",
+    "living-collective"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "external-presence-bots-and-news",
+    "multilingual-living-views"
+  ],
+  "task_ids": [
+    "root-hardcoding-fallbacks-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture-attunement"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/services/translator_backends.py",
+    "api/app/services/news_ingestion_service.py",
+    "api/app/config_loader.py",
+    "api/config/api.json",
+    "api/tests/test_libretranslate_backend.py",
+    "api/tests/test_external_presence.py"
+  ],
+  "change_files": [
+    "api/app/config_loader.py",
+    "api/app/services/news_ingestion_service.py",
+    "api/app/services/translator_backends.py",
+    "api/config/api.json",
+    "api/tests/conftest.py",
+    "api/tests/test_external_presence.py",
+    "api/tests/test_libretranslate_backend.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Walk
- Move translator backend selection and endpoint/key knobs from app-code env reads into `config_loader` / `api/config/api.json`.
- Move news source path/cache/fetch knobs into config and remove hidden default RSS feed data from `news_ingestion_service.py`.
- Keep test isolation on the same config path instead of `NEWS_SOURCES_CONFIG`.

## Evidence
- `cd api && ruff check app/services/news_ingestion_service.py app/services/translator_backends.py app/config_loader.py tests/test_libretranslate_backend.py tests/test_external_presence.py tests/conftest.py`
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_libretranslate_backend.py tests/test_flow_multilingual.py tests/test_external_presence.py`
- `THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`

## Reflect
This is a Root cleanup movement: app-code env-read matches drop from 149 to 143, and the touched translator/news services have zero direct env reads after the change. Remaining env surface still needs continued tending.