### PR TITLE
tend: package news source config with api

### DIFF
--- a/api/app/services/news_ingestion_service.py
+++ b/api/app/services/news_ingestion_service.py
@@ -27,14 +27,14 @@ logger = logging.getLogger(__name__)
 # Source configuration — loaded from config file, editable via API
 # ---------------------------------------------------------------------------
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-_DEFAULT_CONFIG_PATH = _REPO_ROOT / "config" / "news-sources.json"
+_API_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_CONFIG_PATH = _API_ROOT / "config" / "news-sources.json"
 
 
 def _config_path() -> Path:
     configured = get_str("news", "sources_path", default=str(_DEFAULT_CONFIG_PATH)).strip()
     path = Path(configured or str(_DEFAULT_CONFIG_PATH))
-    return path if path.is_absolute() else _REPO_ROOT / path
+    return path if path.is_absolute() else _API_ROOT / path
 
 
 def _load_sources() -> list[dict]:

--- a/api/config/news-sources.json
+++ b/api/config/news-sources.json
@@ -1,0 +1,995 @@
+[
+  {
+    "id": "nature-science",
+    "name": "Nature - Scientific Discoveries",
+    "type": "rss",
+    "url": "https://www.nature.com/nature.rss",
+    "categories": [
+      "science",
+      "research",
+      "discovery",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 1
+  },
+  {
+    "id": "sciam-science",
+    "name": "Scientific American",
+    "type": "rss",
+    "url": "https://rss.sciam.com/ScientificAmerican-Global",
+    "categories": [
+      "science",
+      "research",
+      "consciousness",
+      "discovery"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 2
+  },
+  {
+    "id": "quanta-magazine",
+    "name": "Quanta Magazine",
+    "type": "rss",
+    "url": "https://api.quantamagazine.org/feed/",
+    "categories": [
+      "science",
+      "mathematics",
+      "physics",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 3
+  },
+  {
+    "id": "science-daily",
+    "name": "Science Daily",
+    "type": "rss",
+    "url": "https://www.sciencedaily.com/rss/all.xml",
+    "categories": [
+      "science",
+      "research",
+      "technology",
+      "discovery"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 90,
+    "priority": 4
+  },
+  {
+    "id": "new-scientist",
+    "name": "New Scientist",
+    "type": "rss",
+    "url": "https://www.newscientist.com/feed/home/",
+    "categories": [
+      "science",
+      "technology",
+      "research",
+      "innovation"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 5
+  },
+  {
+    "id": "mit-technology-review",
+    "name": "MIT Technology Review",
+    "type": "rss",
+    "url": "https://www.technologyreview.com/feed/",
+    "categories": [
+      "technology",
+      "innovation",
+      "research",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 6
+  },
+  {
+    "id": "ieee-spectrum",
+    "name": "IEEE Spectrum",
+    "type": "rss",
+    "url": "https://spectrum.ieee.org/rss/fulltext",
+    "categories": [
+      "engineering",
+      "technology",
+      "innovation",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 1
+  },
+  {
+    "id": "arstechnica-tech",
+    "name": "Ars Technica",
+    "type": "rss",
+    "url": "https://feeds.arstechnica.com/arstechnica/index/",
+    "categories": [
+      "technology",
+      "engineering",
+      "innovation",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 90,
+    "priority": 2
+  },
+  {
+    "id": "hacker-news",
+    "name": "Hacker News",
+    "type": "api",
+    "url": "https://hacker-news.firebaseio.com/v0/",
+    "categories": [
+      "technology",
+      "programming",
+      "innovation",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 3
+  },
+  {
+    "id": "techcrunch",
+    "name": "TechCrunch",
+    "type": "rss",
+    "url": "https://techcrunch.com/feed/",
+    "categories": [
+      "technology",
+      "startups",
+      "innovation",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 4
+  },
+  {
+    "id": "wired-tech",
+    "name": "Wired Technology",
+    "type": "rss",
+    "url": "https://www.wired.com/feed/rss",
+    "categories": [
+      "technology",
+      "innovation",
+      "culture",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 5
+  },
+  {
+    "id": "lions-roar-spirituality",
+    "name": "Lions Roar - Buddhist Wisdom",
+    "type": "rss",
+    "url": "https://www.lionsroar.com/feed/",
+    "categories": [
+      "spirituality",
+      "mindfulness",
+      "consciousness",
+      "wisdom"
+    ],
+    "ontology_levels": [
+      "L3-L4"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 1
+  },
+  {
+    "id": "tricycle-buddhism",
+    "name": "Tricycle - Buddhist Teachings",
+    "type": "rss",
+    "url": "https://tricycle.org/feed/",
+    "categories": [
+      "spirituality",
+      "buddhism",
+      "mindfulness",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L3-L4"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 2
+  },
+  {
+    "id": "mindful-org",
+    "name": "Mindful.org",
+    "type": "rss",
+    "url": "https://www.mindful.org/feed/",
+    "categories": [
+      "mindfulness",
+      "meditation",
+      "consciousness",
+      "wellness"
+    ],
+    "ontology_levels": [
+      "L3-L4"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 3
+  },
+  {
+    "id": "consciousness-research",
+    "name": "Consciousness Research Network",
+    "type": "rss",
+    "url": "https://consciousness-research.org/feed/",
+    "categories": [
+      "consciousness",
+      "research",
+      "spirituality",
+      "science"
+    ],
+    "ontology_levels": [
+      "L3-L4"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 4
+  },
+  {
+    "id": "integral-life",
+    "name": "Integral Life",
+    "type": "rss",
+    "url": "https://integrallife.com/feed/",
+    "categories": [
+      "consciousness",
+      "spirituality",
+      "evolution",
+      "wisdom"
+    ],
+    "ontology_levels": [
+      "L3-L4"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 5
+  },
+  {
+    "id": "global-citizen-unity",
+    "name": "Global Citizen - Unity Consciousness",
+    "type": "rss",
+    "url": "https://www.globalcitizen.org/en/feed/",
+    "categories": [
+      "unity",
+      "global",
+      "consciousness",
+      "collaboration"
+    ],
+    "ontology_levels": [
+      "L5-L6"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 1
+  },
+  {
+    "id": "un-news-unity",
+    "name": "UN News - International Cooperation",
+    "type": "rss",
+    "url": "https://news.un.org/en/rss",
+    "categories": [
+      "unity",
+      "international",
+      "cooperation",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L5-L6"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 2
+  },
+  {
+    "id": "world-economic-forum",
+    "name": "World Economic Forum",
+    "type": "rss",
+    "url": "https://www.weforum.org/feeds/",
+    "categories": [
+      "global",
+      "collaboration",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L5-L6"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 3
+  },
+  {
+    "id": "global-issues",
+    "name": "Global Issues",
+    "type": "rss",
+    "url": "https://www.globalissues.org/news/rss",
+    "categories": [
+      "global",
+      "unity",
+      "consciousness",
+      "collaboration"
+    ],
+    "ontology_levels": [
+      "L5-L6"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 4
+  },
+  {
+    "id": "bbc-world",
+    "name": "BBC World News",
+    "type": "rss",
+    "url": "http://feeds.bbci.co.uk/news/world/rss.xml",
+    "categories": [
+      "world",
+      "international",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L7-L8"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 30,
+    "priority": 1
+  },
+  {
+    "id": "reuters-world",
+    "name": "Reuters World News",
+    "type": "rss",
+    "url": "https://feeds.reuters.com/Reuters/worldNews",
+    "categories": [
+      "world",
+      "international",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L7-L8"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 30,
+    "priority": 2
+  },
+  {
+    "id": "guardian-world",
+    "name": "The Guardian World",
+    "type": "rss",
+    "url": "https://www.theguardian.com/world/rss",
+    "categories": [
+      "world",
+      "international",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L7-L8"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 45,
+    "priority": 3
+  },
+  {
+    "id": "al-jazeera-world",
+    "name": "Al Jazeera World",
+    "type": "rss",
+    "url": "https://www.aljazeera.com/xml/rss/all.xml",
+    "categories": [
+      "world",
+      "international",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L7-L8"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 4
+  },
+  {
+    "id": "bloomberg-finance",
+    "name": "Bloomberg Finance",
+    "type": "rss",
+    "url": "https://feeds.bloomberg.com/markets/news.rss",
+    "categories": [
+      "finance",
+      "economics",
+      "consciousness",
+      "abundance"
+    ],
+    "ontology_levels": [
+      "L9-L10"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 30,
+    "priority": 1
+  },
+  {
+    "id": "reuters-business",
+    "name": "Reuters Business",
+    "type": "rss",
+    "url": "https://feeds.reuters.com/reuters/businessNews",
+    "categories": [
+      "finance",
+      "business",
+      "consciousness",
+      "abundance"
+    ],
+    "ontology_levels": [
+      "L9-L10"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 30,
+    "priority": 2
+  },
+  {
+    "id": "financial-times",
+    "name": "Financial Times",
+    "type": "rss",
+    "url": "https://www.ft.com/rss/home",
+    "categories": [
+      "finance",
+      "economics",
+      "consciousness",
+      "abundance"
+    ],
+    "ontology_levels": [
+      "L9-L10"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 3
+  },
+  {
+    "id": "wall-street-journal",
+    "name": "Wall Street Journal",
+    "type": "rss",
+    "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+    "categories": [
+      "finance",
+      "markets",
+      "consciousness",
+      "abundance"
+    ],
+    "ontology_levels": [
+      "L9-L10"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 4
+  },
+  {
+    "id": "webmd-health",
+    "name": "WebMD Health News",
+    "type": "rss",
+    "url": "https://rssfeeds.webmd.com/rss/rss.aspx?RSSSource=RSS_PUBLIC",
+    "categories": [
+      "health",
+      "wellness",
+      "consciousness",
+      "healing"
+    ],
+    "ontology_levels": [
+      "L11-L12"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 1
+  },
+  {
+    "id": "medical-news-today",
+    "name": "Medical News Today",
+    "type": "rss",
+    "url": "https://www.medicalnewstoday.com/rss",
+    "categories": [
+      "health",
+      "medicine",
+      "consciousness",
+      "healing"
+    ],
+    "ontology_levels": [
+      "L11-L12"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 2
+  },
+  {
+    "id": "mayo-clinic-health",
+    "name": "Mayo Clinic Health",
+    "type": "rss",
+    "url": "https://www.mayoclinic.org/rss/all-mayo-clinic-news",
+    "categories": [
+      "health",
+      "wellness",
+      "consciousness",
+      "healing"
+    ],
+    "ontology_levels": [
+      "L11-L12"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 3
+  },
+  {
+    "id": "environmental-news-network",
+    "name": "Environmental News Network",
+    "type": "rss",
+    "url": "https://www.enn.com/rss.xml",
+    "categories": [
+      "environment",
+      "sustainability",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L13-L14"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 1
+  },
+  {
+    "id": "treehugger-environment",
+    "name": "TreeHugger Environment",
+    "type": "rss",
+    "url": "https://www.treehugger.com/feeds/all.rss",
+    "categories": [
+      "environment",
+      "sustainability",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L13-L14"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 2
+  },
+  {
+    "id": "national-geographic-environment",
+    "name": "National Geographic Environment",
+    "type": "rss",
+    "url": "https://feeds.nationalgeographic.com/ng/News/News_Environment",
+    "categories": [
+      "environment",
+      "nature",
+      "consciousness",
+      "unity"
+    ],
+    "ontology_levels": [
+      "L13-L14"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 3
+  },
+  {
+    "id": "space-cosmic-consciousness",
+    "name": "Space.com - Cosmic Consciousness",
+    "type": "rss",
+    "url": "https://www.space.com/feeds/all",
+    "categories": [
+      "cosmology",
+      "consciousness",
+      "universe",
+      "exploration"
+    ],
+    "ontology_levels": [
+      "L15-L16"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 1
+  },
+  {
+    "id": "phys-org-cosmology",
+    "name": "Phys.org - Physics & Cosmology",
+    "type": "rss",
+    "url": "https://phys.org/rss-feed/",
+    "categories": [
+      "cosmology",
+      "physics",
+      "science",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L15-L16"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 2
+  },
+  {
+    "id": "nasa-space-news",
+    "name": "NASA Space News",
+    "type": "rss",
+    "url": "https://www.nasa.gov/rss/dyn/breaking_news.rss",
+    "categories": [
+      "space",
+      "cosmology",
+      "consciousness",
+      "exploration"
+    ],
+    "ontology_levels": [
+      "L15-L16"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 180,
+    "priority": 3
+  },
+  {
+    "id": "quantum-magazine",
+    "name": "Quantum Magazine",
+    "type": "rss",
+    "url": "https://www.quantamagazine.org/feed/",
+    "categories": [
+      "quantum",
+      "physics",
+      "consciousness",
+      "cosmology"
+    ],
+    "ontology_levels": [
+      "L15-L16"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 240,
+    "priority": 4
+  },
+  {
+    "id": "artsy-art-news",
+    "name": "Artsy Art News",
+    "type": "rss",
+    "url": "https://www.artsy.net/rss/news",
+    "categories": [
+      "art",
+      "culture",
+      "consciousness",
+      "creativity"
+    ],
+    "ontology_levels": [
+      "L17-L18"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 1
+  },
+  {
+    "id": "hyperallergic-art",
+    "name": "Hyperallergic Art",
+    "type": "rss",
+    "url": "https://hyperallergic.com/feed/",
+    "categories": [
+      "art",
+      "culture",
+      "consciousness",
+      "creativity"
+    ],
+    "ontology_levels": [
+      "L17-L18"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 2
+  },
+  {
+    "id": "artnews-culture",
+    "name": "ARTnews Culture",
+    "type": "rss",
+    "url": "https://www.artnews.com/feed/",
+    "categories": [
+      "art",
+      "culture",
+      "consciousness",
+      "creativity"
+    ],
+    "ontology_levels": [
+      "L17-L18"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 3
+  },
+  {
+    "id": "philosophy-now",
+    "name": "Philosophy Now",
+    "type": "rss",
+    "url": "https://philosophynow.org/rss",
+    "categories": [
+      "philosophy",
+      "wisdom",
+      "consciousness",
+      "truth"
+    ],
+    "ontology_levels": [
+      "L19-L20"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 480,
+    "priority": 1
+  },
+  {
+    "id": "ieet-future-consciousness",
+    "name": "IEET Future Consciousness",
+    "type": "rss",
+    "url": "https://ieet.org/index.php/IEET2/rss",
+    "categories": [
+      "philosophy",
+      "future",
+      "consciousness",
+      "wisdom"
+    ],
+    "ontology_levels": [
+      "L19-L20"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 2
+  },
+  {
+    "id": "big-think-wisdom",
+    "name": "Big Think Wisdom",
+    "type": "rss",
+    "url": "https://bigthink.com/feed/",
+    "categories": [
+      "philosophy",
+      "wisdom",
+      "consciousness",
+      "truth"
+    ],
+    "ontology_levels": [
+      "L19-L20"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 300,
+    "priority": 3
+  },
+  {
+    "id": "x-tech",
+    "name": "X (Twitter) \u2014 Tech & AI",
+    "type": "api",
+    "url": "https://api.twitter.com/2/lists/{list_id}/tweets",
+    "categories": [
+      "technology",
+      "ai",
+      "startups"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": false,
+    "update_interval_minutes": 30,
+    "priority": 10,
+    "auth_required": "x_bearer_token"
+  },
+  {
+    "id": "x-science",
+    "name": "X (Twitter) \u2014 Science",
+    "type": "api",
+    "url": "https://api.twitter.com/2/lists/{list_id}/tweets",
+    "categories": [
+      "science",
+      "research"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": false,
+    "update_interval_minutes": 30,
+    "priority": 10,
+    "auth_required": "x_bearer_token"
+  },
+  {
+    "id": "reddit-ai",
+    "name": "Reddit r/artificial",
+    "type": "rss",
+    "url": "https://www.reddit.com/r/artificial/.rss",
+    "categories": [
+      "ai",
+      "technology"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 60,
+    "priority": 15
+  },
+  {
+    "id": "reddit-philosophy",
+    "name": "Reddit r/philosophy",
+    "type": "rss",
+    "url": "https://www.reddit.com/r/philosophy/.rss",
+    "categories": [
+      "philosophy",
+      "consciousness"
+    ],
+    "ontology_levels": [
+      "L19-L20"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 20
+  },
+  {
+    "id": "reddit-futurology",
+    "name": "Reddit r/Futurology",
+    "type": "rss",
+    "url": "https://www.reddit.com/r/Futurology/.rss",
+    "categories": [
+      "future",
+      "technology",
+      "science"
+    ],
+    "ontology_levels": [
+      "L15-L16"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 20
+  },
+  {
+    "id": "reddit-opensource",
+    "name": "Reddit r/opensource",
+    "type": "rss",
+    "url": "https://www.reddit.com/r/opensource/.rss",
+    "categories": [
+      "technology",
+      "collaboration",
+      "programming"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 20
+  },
+  {
+    "id": "youtube-rss-veritasium",
+    "name": "Veritasium (YouTube)",
+    "type": "rss",
+    "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCHnyfMqiRRG1u-2MsSQLbXA",
+    "categories": [
+      "science",
+      "discovery"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 480,
+    "priority": 30
+  },
+  {
+    "id": "youtube-rss-3b1b",
+    "name": "3Blue1Brown (YouTube)",
+    "type": "rss",
+    "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCYO_jab_esuFRV4b17AJtAw",
+    "categories": [
+      "mathematics",
+      "science"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 480,
+    "priority": 30
+  },
+  {
+    "id": "mastodon-fosstodon",
+    "name": "Fosstodon (Mastodon)",
+    "type": "rss",
+    "url": "https://fosstodon.org/@fosstodon.rss",
+    "categories": [
+      "technology",
+      "collaboration"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 120,
+    "priority": 25
+  },
+  {
+    "id": "bluesky-science",
+    "name": "Bluesky Science Feed",
+    "type": "api",
+    "url": "https://bsky.app/profile/science.bsky.social/feed",
+    "categories": [
+      "science",
+      "research"
+    ],
+    "ontology_levels": [
+      "L0-L2"
+    ],
+    "is_active": false,
+    "update_interval_minutes": 60,
+    "priority": 15,
+    "auth_required": "bluesky_token"
+  },
+  {
+    "id": "linkedin-pulse",
+    "name": "LinkedIn Pulse (API)",
+    "type": "api",
+    "url": "https://api.linkedin.com/v2/shares",
+    "categories": [
+      "business",
+      "technology",
+      "innovation"
+    ],
+    "ontology_levels": [
+      "L9-L10"
+    ],
+    "is_active": false,
+    "update_interval_minutes": 120,
+    "priority": 20,
+    "auth_required": "linkedin_token"
+  },
+  {
+    "id": "github-trending",
+    "name": "GitHub Trending",
+    "type": "api",
+    "url": "https://api.github.com/search/repositories?q=created:>2026-03-01&sort=stars",
+    "categories": [
+      "technology",
+      "programming",
+      "collaboration"
+    ],
+    "ontology_levels": [
+      "L1-L3"
+    ],
+    "is_active": true,
+    "update_interval_minutes": 360,
+    "priority": 15
+  }
+]

--- a/api/tests/test_external_presence.py
+++ b/api/tests/test_external_presence.py
@@ -80,6 +80,18 @@ def test_news_sources_load_from_config_path(tmp_path):
     assert [row["id"] for row in loaded] == ["configured-feed"]
 
 
+def test_news_default_source_config_is_packaged_with_api():
+    """Default relative source path resolves inside api/config for deployment."""
+    config_loader.set_config_value("news", "sources_path", "config/news-sources.json")
+
+    path = news_ingestion_service._config_path()
+
+    assert path.name == "news-sources.json"
+    assert path.parent.name == "config"
+    assert path.parent.parent.name == "api"
+    assert path.exists()
+
+
 def test_missing_news_sources_config_returns_empty_list(tmp_path):
     """Missing source config should be visible as empty, not a hard-coded feed list."""
     config_loader.set_config_value("news", "sources_path", str(tmp_path / "missing.json"))

--- a/docs/system_audit/commit_evidence_2026-04-24_news-source-config-packaging.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_news-source-config-packaging.json
@@ -1,0 +1,97 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/news-source-config-packaging",
+  "commit_scope": "Package news source configuration with the API and resolve the default source path relative to the API package so deployed containers can load configured feeds without hard-coded service defaults.",
+  "files_owned": [
+    "api/app/services/news_ingestion_service.py",
+    "api/config/news-sources.json",
+    "api/tests/test_external_presence.py",
+    "docs/system_audit/commit_evidence_2026-04-24_news-source-config-packaging.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "cd api && ruff check app/services/news_ingestion_service.py tests/test_external_presence.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_external_presence.py",
+      "python3 -m json.tool api/config/news-sources.json >/dev/null",
+      "python3 - <<'PY'\nfrom pathlib import Path\nprint(len(__import__('json').loads(Path('api/config/news-sources.json').read_text())))\nPY",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "observations": {
+      "packaged_news_source_count": 56,
+      "targeted_tests": "9 passed",
+      "local_pr_guard": "pass",
+      "followthrough_guard": "pass"
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public /api/news/sources should load configured packaged feeds instead of returning an empty list after the hard-coded defaults were removed.",
+    "public_endpoints": [
+      "/api/health",
+      "/api/news/sources"
+    ],
+    "test_flows": [
+      "Default news source config resolves inside api/config",
+      "Packaged news source JSON parses and contains configured feeds"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Packaging fix is locally validated through full local PR guard and follow-through guard; branch still needs PR checks, deployment, and public sensing."
+  },
+  "idea_ids": [
+    "external-presence",
+    "repository-health"
+  ],
+  "spec_ids": [
+    "external-presence-bots-and-news",
+    "repository-architecture-health"
+  ],
+  "task_ids": [
+    "news-source-config-packaging-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture-attunement"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/services/news_ingestion_service.py",
+    "api/config/news-sources.json",
+    "api/tests/test_external_presence.py"
+  ],
+  "change_files": [
+    "api/app/services/news_ingestion_service.py",
+    "api/config/news-sources.json",
+    "api/tests/test_external_presence.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Walk
- Package `news-sources.json` under `api/config` so the API container can load configured news feeds.
- Resolve the default news source path relative to the API package root instead of the repo root.
- Add a test proving the default relative path resolves to packaged `api/config/news-sources.json`.

## Evidence
- `cd api && ruff check app/services/news_ingestion_service.py tests/test_external_presence.py`
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_external_presence.py`
- `python3 -m json.tool api/config/news-sources.json >/dev/null`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`

## Reflect
Follow-up from live sensing: removing hard-coded service defaults was correct, but the data needed to be packaged with the API body rather than left at repo-root only.