### PR TITLE
tend: route persistence friction config through spine

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -110,6 +110,13 @@ def _default_runtime_config() -> dict[str, Any]:
         "automation_usage": {
             "endpoint_cache_max_workers": 4,
             "quality_awareness_ttl_seconds": 300.0,
+            "snapshots_path": None,
+            "use_db": True,
+            "purge_imported_files": True,
+            "max_snapshots": 800,
+        },
+        "persistence_contract": {
+            "required": "auto",
         },
         "metrics": {
             "file_path": None,

--- a/api/app/services/automation_usage_service.py
+++ b/api/app/services/automation_usage_service.py
@@ -214,9 +214,6 @@ def _dedupe_preserve_order(items: list[str]) -> list[str]:
 
 
 def _snapshots_path() -> Path:
-    explicit = str(os.getenv("AUTOMATION_USAGE_SNAPSHOTS_PATH", "")).strip()
-    if explicit:
-        return Path(explicit)
     configured = get_str("automation_usage", "snapshots_path")
     if configured:
         return Path(configured)
@@ -224,9 +221,6 @@ def _snapshots_path() -> Path:
 
 
 def _use_db_snapshots() -> bool:
-    explicit = os.getenv("AUTOMATION_USAGE_USE_DB")
-    if explicit is not None:
-        return explicit.strip().lower() in {"1", "true", "yes", "on"}
     if get_str("automation_usage", "snapshots_path"):
         return False
     return get_bool("automation_usage", "use_db", True)
@@ -358,7 +352,7 @@ def _endpoint_cache_meta_key(endpoint: str, params: dict[str, Any] | None = None
         database_url("telemetry") or "",
         database_url(None) or "",
         get_str("runtime", "events_path") or "",
-        str(os.getenv("PYTEST_CURRENT_TEST") or ""),
+        get_str("api", "test_context_id", ""),
     ]
     scope_digest = hashlib.sha1("||".join(scope_parts).encode("utf-8")).hexdigest()[:12]
     canonical = json.dumps(params or {}, sort_keys=True, separators=(",", ":"), default=str)

--- a/api/app/services/friction_service.py
+++ b/api/app/services/friction_service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,46 +22,24 @@ def _default_path() -> Path:
 
 
 def friction_file_path() -> Path:
-    explicit = str(os.getenv("FRICTION_EVENTS_PATH", "")).strip()
-    if explicit:
-        return Path(explicit)
     configured = get_str("friction", "events_path")
     return Path(configured) if configured else _default_path()
 
 
 def report_window_limit_days() -> int:
     """Return the safe report horizon for the current friction event backend."""
-    if str(os.getenv("FRICTION_EVENTS_PATH", "")).strip():
-        return 365
     if get_str("friction", "events_path"):
         return 365
     return 90
 
 
 def _use_db_events() -> bool:
-    explicit_use_db = str(os.getenv("FRICTION_USE_DB", "")).strip().lower()
-    if explicit_use_db in {"1", "true", "yes", "on"}:
-        return True
-    if explicit_use_db in {"0", "false", "no", "off"}:
-        return False
-    if str(os.getenv("FRICTION_EVENTS_PATH", "")).strip():
-        return False
-    override = get_str("friction", "use_db")
-    if override:
-        override = override.strip().lower()
-        if override in {"1", "true", "yes", "on"}:
-            return True
-        if override in {"0", "false", "no", "off"}:
-            return False
     if get_str("friction", "events_path"):
         return False
-    return True
+    return get_bool("friction", "use_db", True)
 
 
 def monitor_issues_file_path() -> Path:
-    explicit = str(os.getenv("MONITOR_ISSUES_PATH", "")).strip()
-    if explicit:
-        return Path(explicit)
     configured = get_str("monitor", "issues_path")
     if configured:
         return Path(configured)
@@ -70,9 +47,6 @@ def monitor_issues_file_path() -> Path:
 
 
 def github_actions_health_file_path() -> Path:
-    explicit = str(os.getenv("GITHUB_ACTIONS_HEALTH_PATH", "")).strip()
-    if explicit:
-        return Path(explicit)
     configured = get_str("github_actions", "health_path")
     if configured:
         return Path(configured)

--- a/api/app/services/persistence_contract_service.py
+++ b/api/app/services/persistence_contract_service.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from typing import Any
 
 from app.adapters.postgres_store import PostgresGraphStore
+from app.config_loader import database_url, get_str
 from app.services import (
     commit_evidence_service,
     idea_registry_service,
@@ -17,17 +17,15 @@ from app.services import (
 
 
 def contract_required() -> bool:
-    raw = (
-        os.getenv("GLOBAL_PERSISTENCE_REQUIRED")
-        or os.getenv("PERSISTENCE_CONTRACT_REQUIRED")
-        or "auto"
-    ).strip().lower()
+    raw = get_str("persistence_contract", "required", "auto").strip().lower()
     if raw in {"1", "true", "yes", "on"}:
         return True
     if raw in {"0", "false", "no", "off"}:
         return False
-    # Auto-mode: enforce whenever a primary database is configured (typical production path).
-    return bool(os.getenv("DATABASE_URL", "").strip())
+    # Auto-mode: enforce whenever the primary persistence spine is a real
+    # service database. The checked-in SQLite default keeps local dev relaxed.
+    configured = database_url(None).strip().lower()
+    return bool(configured and not configured.startswith(("sqlite:", "sqlite+")))
 
 
 def evaluate(app: Any) -> dict[str, Any]:
@@ -77,7 +75,7 @@ def evaluate(app: Any) -> dict[str, Any]:
     usage_provider_info = {
         "ok": telemetry_info.get("backend") == "postgresql",
         "backend": telemetry_info.get("backend"),
-        "snapshots_path_override": bool(os.getenv("AUTOMATION_USAGE_SNAPSHOTS_PATH", "").strip()),
+        "snapshots_path_override": bool(get_str("automation_usage", "snapshots_path", "").strip()),
         "note": "provider usage snapshots + friction telemetry backend",
     }
     if required and not usage_provider_info["ok"]:

--- a/api/config/api.json
+++ b/api/config/api.json
@@ -134,7 +134,16 @@
   "automation_usage": {
     "_doc": "Automation usage service configuration.",
     "endpoint_cache_max_workers": 4,
-    "quality_awareness_ttl_seconds": 300.0
+    "quality_awareness_ttl_seconds": 300.0,
+    "snapshots_path": null,
+    "use_db": true,
+    "purge_imported_files": true,
+    "max_snapshots": 800
+  },
+
+  "persistence_contract": {
+    "_doc": "Global persistence enforcement. true/false force behavior; auto enforces only when a non-SQLite primary database is configured.",
+    "required": "auto"
   },
 
   "route_registry": {

--- a/api/tests/test_persistence_contract_config.py
+++ b/api/tests/test_persistence_contract_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from app.services import automation_usage_service, friction_service, persistence_contract_service
+
+
+def test_persistence_contract_auto_ignores_dev_sqlite(set_config) -> None:
+    set_config("persistence_contract", "required", "auto")
+    set_config("database", "url", "sqlite:///data/coherence.db")
+
+    assert persistence_contract_service.contract_required() is False
+
+
+def test_persistence_contract_auto_requires_service_database(set_config) -> None:
+    set_config("persistence_contract", "required", "auto")
+    set_config("database", "url", "postgresql://user:pass@example.test/coherence")
+
+    assert persistence_contract_service.contract_required() is True
+
+
+def test_persistence_contract_required_comes_from_config_not_env(set_config, monkeypatch) -> None:
+    monkeypatch.setenv("GLOBAL_PERSISTENCE_REQUIRED", "1")
+    set_config("persistence_contract", "required", False)
+    set_config("database", "url", "sqlite:///data/coherence.db")
+
+    assert persistence_contract_service.contract_required() is False
+
+
+def test_automation_usage_snapshot_path_comes_from_config(set_config, tmp_path) -> None:
+    snapshots_path = tmp_path / "usage_snapshots.json"
+    set_config("automation_usage", "snapshots_path", str(snapshots_path))
+    set_config("automation_usage", "use_db", True)
+
+    assert automation_usage_service._snapshots_path() == snapshots_path
+    assert automation_usage_service._use_db_snapshots() is False
+
+
+def test_automation_usage_use_db_comes_from_config(set_config) -> None:
+    set_config("automation_usage", "snapshots_path", None)
+    set_config("automation_usage", "use_db", False)
+
+    assert automation_usage_service._use_db_snapshots() is False
+
+
+def test_friction_paths_come_from_config(set_config, tmp_path) -> None:
+    friction_path = tmp_path / "friction.jsonl"
+    monitor_path = tmp_path / "monitor.json"
+    github_path = tmp_path / "github.json"
+    set_config("friction", "events_path", str(friction_path))
+    set_config("monitor", "issues_path", str(monitor_path))
+    set_config("github_actions", "health_path", str(github_path))
+
+    assert friction_service.friction_file_path() == friction_path
+    assert friction_service.monitor_issues_file_path() == monitor_path
+    assert friction_service.github_actions_health_file_path() == github_path
+    assert friction_service.report_window_limit_days() == 365
+    assert friction_service._use_db_events() is False
+
+
+def test_friction_use_db_comes_from_config(set_config) -> None:
+    set_config("friction", "events_path", None)
+    set_config("friction", "use_db", False)
+
+    assert friction_service._use_db_events() is False

--- a/docs/system_audit/commit_evidence_2026-04-24_root-config-persistence-friction.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_root-config-persistence-friction.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/root-config-integrity-next",
+  "commit_scope": "Route persistence contract, automation usage snapshot storage, and friction ledger path toggles through config instead of app environment fallbacks.",
+  "files_owned": [
+    "api/app/config_loader.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/friction_service.py",
+    "api/app/services/persistence_contract_service.py",
+    "api/config/api.json",
+    "api/tests/test_persistence_contract_config.py",
+    "docs/system_audit/commit_evidence_2026-04-24_root-config-persistence-friction.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_persistence_contract_config.py -q",
+      "cd api && python3 -m ruff check app/services/persistence_contract_service.py app/services/automation_usage_service.py app/services/friction_service.py app/config_loader.py tests/test_persistence_contract_config.py",
+      "git diff --check",
+      "rg -n \"os\\.getenv|os\\.environ\\.get|environ\\[|getenv\\(\" api/app/services/persistence_contract_service.py api/app/services/friction_service.py api/app/config_loader.py",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Persistence and friction health behavior keeps the same public shape while configuration comes from api/config plus user overlay instead of ambient app env fallbacks.",
+    "public_endpoints": [
+      "/health",
+      "/health/persistence-contract",
+      "/api/friction/summary",
+      "/api/automation/usage"
+    ],
+    "test_flows": [
+      "Persistence contract auto mode ignores dev SQLite and enforces for PostgreSQL",
+      "Automation usage snapshot path and DB storage toggles come from config",
+      "Friction, monitor, and GitHub Actions health paths come from config"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Local validation is complete; standard PR gates, CI, deployment, and live sensing still need to run."
+  },
+  "idea_ids": [
+    "repository-health",
+    "root-config-integrity"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "root-config-spine"
+  ],
+  "task_ids": [
+    "root-config-persistence-friction-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture-attunement"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/tests/test_persistence_contract_config.py",
+    "targeted pytest and ruff outputs in thread",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T095616Z_codex-root-config-integrity-next.json",
+    "app env-read scan: 143 to 131 matches"
+  ],
+  "change_files": [
+    "api/app/config_loader.py",
+    "api/app/services/automation_usage_service.py",
+    "api/app/services/friction_service.py",
+    "api/app/services/persistence_contract_service.py",
+    "api/config/api.json",
+    "api/tests/test_persistence_contract_config.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- move persistence contract requiredness from app env fallbacks to config-backed auto/force behavior
- move automation usage snapshot path/use-db toggles and friction/monitor/GitHub health paths to config
- add focused tests proving config controls persistence, automation snapshot storage, and friction paths

## Validation
- cd api && python3 -m pytest tests/test_persistence_contract_config.py -q
- cd api && python3 -m ruff check app/services/persistence_contract_service.py app/services/automation_usage_service.py app/services/friction_service.py app/config_loader.py tests/test_persistence_contract_config.py
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_root-config-persistence-friction.json

## Sensing
- app env-read scan moved from 143 to 131 matches
- maintainability audit inside PR guard reports layer_violations=0
