### PR TITLE
tend: heal scraped wounds + filter KB visuals from Works directory

### DIFF
--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -654,6 +654,7 @@ def _extract_creations(
     found: list[Creation] = []
     seen_keys: set[tuple[str, str]] = set()
 
+    from html import unescape as _html_unescape
     for item in _iter_jsonld_items(parsed.json_ld_chunks):
         if not isinstance(item, dict):
             continue
@@ -663,7 +664,10 @@ def _extract_creations(
         kind = _JSON_LD_CREATION_TYPES.get(str(raw_type).lower())
         if not kind:
             continue
-        name = (item.get("name") or item.get("headline") or "").strip()
+        # WordPress sites (and others) emit titles with HTML entities
+        # ("Hatha Flow &#038; Sound"). Decode once at the boundary so they
+        # never reach the graph as literal "&#038;".
+        name = _html_unescape((item.get("name") or item.get("headline") or "")).strip()
         if not name:
             continue
         url = item.get("url") or item.get("@id")
@@ -688,8 +692,9 @@ def _extract_creations(
             return found
 
     if not found:
+        from html import unescape as _html_unescape
         og_type = parsed.og.get("og:type", "").lower()
-        og_title = parsed.og.get("og:title", "").strip()
+        og_title = _html_unescape(parsed.og.get("og:title", "")).strip()
         og_kind: str | None = None
         if og_title:
             if "music.album" in og_type:

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -31,6 +31,7 @@ type PresenceNode = {
   image_url?: string | null;
   provider?: string;
   contributor_type?: string;
+  asset_type?: string;
 };
 
 async function fetchType(type: string, limit = 200): Promise<PresenceNode[]> {
@@ -48,11 +49,11 @@ async function fetchType(type: string, limit = 200): Promise<PresenceNode[]> {
 }
 
 function filterScannable(items: PresenceNode[]): PresenceNode[] {
-  // Skip test/system/visitor contributors — keep only real presences.
-  // SYSTEM + AGENT contributor_types are work-ledger identities
-  // (runners, pipeline bots, Claude agents); they live under
-  // /contributors where the ledger lens fits. Presences are humans +
-  // communities + places + gatherings + practices + works only.
+  // Skip test/system/visitor identities and KB-system assets. A
+  // visitor in /people wants to find humans, communities, places,
+  // gatherings, and the works people put into the world — not
+  // runner pipelines, auto-generated concept imagery, or platform
+  // renderer components.
   return items.filter((n) => {
     if (!n.name) return false;
     if (n.id.includes(":wanderer-")) return false;
@@ -60,6 +61,12 @@ function filterScannable(items: PresenceNode[]): PresenceNode[] {
     if (n.id.includes(":test-")) return false;
     const ct = (n.contributor_type || "").toUpperCase();
     if (ct === "SYSTEM" || ct === "AGENT") return false;
+
+    // Asset filters: hide platform tissue that clutters the Works directory
+    const at = (n.asset_type || "").toUpperCase();
+    if (at === "RENDERER") return false; // Image Viewer v1, Audio Player v1, ...
+    if (n.id.startsWith("visual-lc-")) return false; // KB auto-generated concept visuals
+
     return true;
   });
 }


### PR DESCRIPTION
## Summary

A hygiene sweep surfaced by a visitor's-eye view: /people?kind=works was showing 200 entries, most of which were platform tissue — 250 KB auto-generated concept visuals ("lc-w-wu-wei story visual 0" etc.) and 6 internal renderer components ("Image Viewer v1", "Audio Player v1", "GLTF 3D Viewer v1") interleaved with real human works. Also several names stored as raw HTML entities from WordPress-style scrapes ("Hatha Flow &#038; Sound").

**Two roots tended:**

1. **Scraped HTML entities**. `inspired_by_service.extract_creations` now calls `html.unescape` on both JSON-LD names and OpenGraph title fallbacks before the string reaches the graph. New ingests land clean. Existing wounds healed directly on prod (6 assets).

2. **KB visuals + renderer components cluttering Works**. `filterScannable` now excludes `id.startsWith("visual-lc-")` (KB auto-generated imagery) and `asset_type === "RENDERER"` (internal components). Works count: **200 → 40** real entries.

**Direct-on-graph heals** (not in this diff, applied via PATCH/DELETE against prod):
- Deleted 8 wounded contributor nodes: "Smoke Test", "Home", "Threads", "should-never-succeed", "milestone-agent", the "The Official Website of Dr Joe Dispenza" fossil, a URL-as-name Avalon contributor, and "test-never-persist-test-fp-delete-me".
- Deleted 2 malformed doubled-prefix placeholder wrappers (`contributor:contributor-ubbe-maclean-*`, `contributor:contributor-shawn-heinrichs-*`). The clean `contributor:ubbe-maclean-placeholder` + `contributor:shawn-heinrichs-placeholder` remain as held-open placeholders.
- Deleted the Vali Soul Sanctuary duplicate; kept `community:vali-soul-sanctuary-boulder` as canonical.
- Unified `urs` into `contributor:seeker71`: name → "Urs Muff", public key + `key_registered_at` migrated, `urs` deleted.
- Healed "EMC2 Music Festival 2026 @ EMC2 Music Festival 2026" → "EMC2 Music Festival 2026".

## Test plan
- [x] 26 targeted tests pass (inspired_by + flow core + sensing graph)
- [x] `npx tsc --noEmit` clean
- [x] Visual check: /people?kind=works now shows 40 real entries, all with human-readable names
- [x] Fuzzy-duplicate + id-as-name audit: 0 remaining