### PR TITLE
tend: route db task stores through config spine

### DIFF
--- a/api/app/services/agent_task_store_service.py
+++ b/api/app/services/agent_task_store_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -12,7 +11,7 @@ from sqlalchemy import DateTime, Integer, String, Text, create_engine, func, ins
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, load_only, mapped_column, sessionmaker
 from sqlalchemy.pool import NullPool
 
-from app.config_loader import get_bool, get_str
+from app.config_loader import database_url, get_bool, get_str
 
 
 class Base(DeclarativeBase):
@@ -51,34 +50,19 @@ _SCHEMA_INITIALIZED = False
 _SCHEMA_INITIALIZED_URL = ""
 
 
-def _truthy(raw: str | None) -> bool:
-    if raw is None:
-        return False
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
 def _database_url() -> str:
-    url = (
-        os.getenv("AGENT_TASKS_DATABASE_URL")
-        or os.getenv("DATABASE_URL")
-        or get_str("agent_tasks", "database_url")
-        or ""
-    ).strip()
-    return url
+    explicit = get_str("agent_tasks", "database_url", "").strip()
+    return explicit or database_url("agent_tasks").strip()
 
 
 def enabled() -> bool:
-    persist_override = os.getenv("AGENT_TASKS_PERSIST", "").strip().lower()
-    if persist_override in {"0", "false", "no", "off"}:
+    if not get_bool("agent_tasks", "persist", default=True):
         return False
-    use_db_override = os.getenv("AGENT_TASKS_USE_DB", "").strip().lower()
-    if use_db_override in {"0", "false", "no", "off"}:
+    if not get_bool("agent_tasks", "use_db", default=True):
         return False
     if not _database_url():
         return False
-    if use_db_override in {"1", "true", "yes", "on"}:
-        return True
-    return get_bool("agent_tasks", "use_db", default=True)
+    return True
 
 
 def _create_engine(url: str):

--- a/api/app/services/unified_db.py
+++ b/api/app/services/unified_db.py
@@ -4,14 +4,12 @@ Spec 118: Replaces 4 separate SQLite DBs and 5 JSON stores with one DB.
 All services import from here instead of managing their own connections.
 
 Configuration:
-  - DATABASE_URL env var overrides for production (e.g. PostgreSQL).
+  - api/config/api.json and ~/.coherence-network/config.json provide database.url.
   - Otherwise defaults to sqlite:///data/coherence.db (works out of the box).
-  - IDEA_PORTFOLIO_PATH is honored for test isolation (derives .db path from it).
 """
 
 from __future__ import annotations
 
-import os
 import threading
 from contextlib import contextmanager
 from pathlib import Path
@@ -58,33 +56,18 @@ def database_url() -> str:
 
     Priority:
       1. api/config/api.json → database.url
-      2. DATABASE_URL env var (legacy — Docker/CI override)
-      3. IDEA_PORTFOLIO_PATH → derived .db path (test isolation)
-      4. sqlite:///data/coherence.db (default)
+      2. ~/.coherence-network/config.json overlay
+      3. sqlite:///data/coherence.db (default)
     """
-    # Config file first
     try:
-        from app.config_loader import api_config
-        config_url = api_config("database", "url")
-        if config_url and config_url != "sqlite:///data/coherence.db":
-            return str(config_url).strip()
-    except ImportError:
-        pass
+        from app.config_loader import database_url as configured_database_url
 
-    # Legacy env var (Docker/CI)
-    configured = os.getenv("DATABASE_URL")
-    if configured:
-        return str(configured).strip()
-    # Test isolation via IDEA_PORTFOLIO_PATH
-    portfolio_path = os.getenv("IDEA_PORTFOLIO_PATH")
-    if portfolio_path:
-        p = Path(portfolio_path)
-        sqlite_path = p.with_suffix(".db") if p.suffix.lower() == ".json" else Path(f"{p}.db")
+        return configured_database_url().strip()
+    except ImportError:
+        sqlite_path = _default_sqlite_path()
         sqlite_path.parent.mkdir(parents=True, exist_ok=True)
         return f"sqlite+pysqlite:///{sqlite_path}"
-    sqlite_path = _default_sqlite_path()
-    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
-    return f"sqlite+pysqlite:///{sqlite_path}"
+
 
 
 def _create_engine(url: str):

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -212,7 +212,7 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     """Reset unified DB engine and service caches between tests.
 
     Each test gets a clean engine and a unique, isolated SQLite database
-    in tmp_path so env-var changes take effect and state never leaks.
+    in tmp_path through config_loader so state never leaks.
     """
     from app import config_loader
     import app.services.config_service as cs_module
@@ -225,9 +225,8 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     )
     from app.services.agent_routing import model_routing_loader
 
-    # Use an isolated DB for each test
+    # Use an isolated DB for each test through the config spine.
     db_file = tmp_path / "test_coherence.db"
-    os.environ["DATABASE_URL"] = f"sqlite+pysqlite:///{db_file}"
     # Ideas now live in graph_nodes (unified DB) — don't set file-based portfolio path
     os.environ.pop("IDEA_PORTFOLIO_PATH", None)
     os.environ["AGENT_TASKS_USE_DB"] = "0"
@@ -239,9 +238,11 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     # Reset config to its baseline first, then apply per-test overrides to the
     # loaded config so later cache invalidations preserve those defaults.
     cs_module.reset_config_cache()
+    config_loader._CONFIG.setdefault("database", {})["url"] = f"sqlite+pysqlite:///{db_file}"
     config_loader._CONFIG.setdefault("api", {})["testing"] = True
     config_loader._CONFIG.setdefault("api", {})["test_context_id"] = request.node.nodeid
     config_loader._CONFIG.setdefault("agent_tasks", {})["persist"] = False
+    config_loader._CONFIG.setdefault("agent_tasks", {})["use_db"] = False
     config_loader._CONFIG.setdefault("agent_executor", {})["execute_token_allow_unauth"] = True
     config_loader._CONFIG.setdefault("agent_executor", {})["execute_token"] = None
     config_loader._CONFIG.setdefault("agent_executor", {})["policy_enabled"] = True
@@ -256,6 +257,7 @@ def _reset_service_caches_between_tests(tmp_path: Path, request: pytest.FixtureR
     cs_module._CACHE.update(
         {
             "agent_tasks_persist": False,
+            "agent_tasks_use_db": False,
             "agent_executor_execute_token_allow_unauth": True,
             "agent_execute_token_allow_unauth": True,
             "agent_executor_execute_token": None,

--- a/api/tests/test_persistence_contract_config.py
+++ b/api/tests/test_persistence_contract_config.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from app.services import automation_usage_service, friction_service, persistence_contract_service
+from app.services import (
+    agent_task_store_service,
+    automation_usage_service,
+    friction_service,
+    persistence_contract_service,
+    unified_db,
+)
 from app.services.telemetry_persistence_service import db as telemetry_service_db
 
 
@@ -69,3 +75,32 @@ def test_telemetry_persistence_service_uses_unified_database_url(set_config, mon
     set_config("database", "url", "postgresql://user:pass@example.test/coherence")
 
     assert telemetry_service_db.database_url() == "postgresql://user:pass@example.test/coherence"
+
+
+def test_unified_database_url_comes_from_config_not_env(set_config, monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///tmp/legacy-unified.db")
+    monkeypatch.setenv("IDEA_PORTFOLIO_PATH", "/tmp/legacy-ideas.json")
+    set_config("database", "url", "postgresql://user:pass@example.test/coherence")
+
+    assert unified_db.database_url() == "postgresql://user:pass@example.test/coherence"
+
+
+def test_agent_task_store_uses_config_database_url_not_env(set_config, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_TASKS_DATABASE_URL", "sqlite+pysqlite:///tmp/legacy-agent-tasks.db")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+pysqlite:///tmp/legacy-main.db")
+    set_config("agent_tasks", "database_url", "postgresql://user:pass@example.test/agent_tasks")
+    set_config("agent_tasks", "persist", True)
+    set_config("agent_tasks", "use_db", True)
+
+    assert agent_task_store_service._database_url() == "postgresql://user:pass@example.test/agent_tasks"
+    assert agent_task_store_service.enabled() is True
+
+
+def test_agent_task_store_enablement_comes_from_config(set_config, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_TASKS_PERSIST", "1")
+    monkeypatch.setenv("AGENT_TASKS_USE_DB", "1")
+    set_config("agent_tasks", "database_url", "postgresql://user:pass@example.test/agent_tasks")
+    set_config("agent_tasks", "persist", False)
+    set_config("agent_tasks", "use_db", True)
+
+    assert agent_task_store_service.enabled() is False

--- a/docs/system_audit/commit_evidence_2026-04-24_unified-db-agent-task-config-spine.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_unified-db-agent-task-config-spine.json
@@ -1,0 +1,99 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/root-unified-db-config-spine",
+  "commit_scope": "Move unified DB and agent task store database discovery from app env fallbacks to the config spine.",
+  "files_owned": [
+    "api/app/services/agent_task_store_service.py",
+    "api/app/services/unified_db.py",
+    "api/tests/conftest.py",
+    "api/tests/test_persistence_contract_config.py",
+    "docs/system_audit/commit_evidence_2026-04-24_unified-db-agent-task-config-spine.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_persistence_contract_config.py -q",
+      "cd api && python3 -m pytest tests/test_flow_agent_lifecycle.py tests/test_agent_task_claims.py tests/test_flow_workspaces.py -q",
+      "cd api && python3 -m pytest tests/test_persistence_contract_config.py tests/test_runtime_mode_and_events.py -q",
+      "cd api && python3 -m ruff check app/services/unified_db.py app/services/agent_task_store_service.py tests/conftest.py tests/test_persistence_contract_config.py",
+      "rg -n \"os\\.getenv|os\\.environ\\.get|environ\\[|getenv\\(\" api/app/services/unified_db.py api/app/services/agent_task_store_service.py",
+      "git diff --check",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Unified DB and agent task store use config-backed database URLs and ignore legacy env fallbacks while preserving task API behavior.",
+    "public_endpoints": [
+      "/api/health/persistence",
+      "/api/agent/tasks",
+      "/api/runtime/endpoints/summary"
+    ],
+    "test_flows": [
+      "Unified database URL ignores DATABASE_URL and IDEA_PORTFOLIO_PATH env when config is set",
+      "Agent task store URL and enablement ignore legacy env toggles when config is set",
+      "Agent task lifecycle, claims, workspace, and runtime mode tests pass"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Targeted validation is complete; standard PR guard, CI, deployment, and live sensing still need to pass."
+  },
+  "idea_ids": [
+    "repository-health",
+    "root-config-integrity"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "root-config-spine"
+  ],
+  "task_ids": [
+    "unified-db-agent-task-config-spine-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture-attunement"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/services/unified_db.py",
+    "api/app/services/agent_task_store_service.py",
+    "api/tests/test_persistence_contract_config.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T104501Z_codex-root-unified-db-config-spine.json",
+    "app env-read scan: 129 to 123 matches"
+  ],
+  "change_files": [
+    "api/app/services/agent_task_store_service.py",
+    "api/app/services/unified_db.py",
+    "api/tests/conftest.py",
+    "api/tests/test_persistence_contract_config.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- remove legacy app env fallback discovery from unified_db
- route agent task store database URL and enablement through config
- move test DB isolation onto config_loader so tests still use unique SQLite stores without runtime env coupling

## Validation
- cd api && python3 -m pytest tests/test_persistence_contract_config.py -q
- cd api && python3 -m pytest tests/test_flow_agent_lifecycle.py tests/test_agent_task_claims.py tests/test_flow_workspaces.py -q
- cd api && python3 -m pytest tests/test_persistence_contract_config.py tests/test_runtime_mode_and_events.py -q
- cd api && python3 -m ruff check app/services/unified_db.py app/services/agent_task_store_service.py tests/conftest.py tests/test_persistence_contract_config.py
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_unified-db-agent-task-config-spine.json

## Sensing
- app env-read scan moved from 129 to 123 matches
- unified_db.py and agent_task_store_service.py now have zero app env reads
- maintainability audit reports layer_violations=0
