### PR TITLE
tend: Connected Frequencies — multi-dimensional, named, linked by kind

### DIFF
--- a/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
+++ b/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
@@ -2,6 +2,156 @@ import Link from "next/link";
 import { displayName, EDGE_LABELS } from "@/lib/vision-utils";
 import type { Edge } from "@/lib/types/vision";
 
+/* ── Multi-dimensional routing + grouping ─────────────────────────────── */
+
+type GroupKey =
+  | "concepts"
+  | "people"
+  | "communities"
+  | "places"
+  | "gatherings"
+  | "practices"
+  | "works"
+  | "ideas"
+  | "specs"
+  | "other";
+
+/**
+ * Extract the type prefix from a node id. The graph uses two shapes:
+ * - colon-separated: `contributor:xxx`, `community:xxx`, `event:xxx`
+ * - hyphen-separated: `asset-xxx`, `scene-xxx`, `network-xxx`
+ * Both are canonical; we normalise here so grouping catches every form.
+ */
+function idPrefix(id: string): string {
+  if (id.startsWith("lc-")) return "lc";
+  const colonIdx = id.indexOf(":");
+  if (colonIdx > 0) return id.slice(0, colonIdx);
+  const hyphenIdx = id.indexOf("-");
+  if (hyphenIdx > 0) return id.slice(0, hyphenIdx);
+  return id;
+}
+
+function groupFor(id: string): GroupKey {
+  const p = idPrefix(id);
+  switch (p) {
+    case "lc": return "concepts";
+    case "contributor": return "people";
+    case "community":
+    case "network":
+    case "network-org": return "communities";
+    case "scene":
+    case "venue":
+    case "place": return "places";
+    case "event":
+    case "gathering": return "gatherings";
+    case "practice":
+    case "skill": return "practices";
+    case "asset": return "works";
+    case "idea": return "ideas";
+    case "spec": return "specs";
+    default: return "other";
+  }
+}
+
+function hrefFor(id: string): string {
+  const p = idPrefix(id);
+  if (p === "lc") return `/vision/${id}`;
+  if (p === "contributor") return `/profile/${encodeURIComponent(id)}`;
+  if (p === "asset") return `/assets/${encodeURIComponent(id)}`;
+  if (p === "idea") return `/ideas/${encodeURIComponent(id)}`;
+  if (p === "spec") return `/specs/${encodeURIComponent(id)}`;
+  return `/nodes/${encodeURIComponent(id)}`;
+}
+
+const GROUP_META: Record<GroupKey, { label: string; accent: string }> = {
+  concepts: { label: "Concepts", accent: "amber" },
+  people: { label: "People", accent: "rose" },
+  communities: { label: "Communities", accent: "purple" },
+  places: { label: "Places", accent: "teal" },
+  gatherings: { label: "Gatherings", accent: "purple" },
+  practices: { label: "Practices", accent: "emerald" },
+  works: { label: "Works", accent: "blue" },
+  ideas: { label: "Ideas", accent: "emerald" },
+  specs: { label: "Specs", accent: "cyan" },
+  other: { label: "Other", accent: "stone" },
+};
+
+const GROUP_ORDER: GroupKey[] = [
+  "concepts",
+  "people",
+  "communities",
+  "places",
+  "gatherings",
+  "practices",
+  "works",
+  "ideas",
+  "specs",
+  "other",
+];
+
+const ACCENT_CLASSES: Record<string, { bg: string; text: string; border: string; hover: string }> = {
+  amber: {
+    bg: "bg-amber-500/10",
+    text: "text-amber-300/80",
+    border: "border-amber-500/20",
+    hover: "hover:text-amber-300 hover:border-amber-500/40",
+  },
+  rose: {
+    bg: "bg-rose-500/10",
+    text: "text-rose-300/80",
+    border: "border-rose-500/20",
+    hover: "hover:text-rose-300 hover:border-rose-500/40",
+  },
+  purple: {
+    bg: "bg-purple-500/10",
+    text: "text-purple-300/80",
+    border: "border-purple-500/20",
+    hover: "hover:text-purple-300 hover:border-purple-500/40",
+  },
+  teal: {
+    bg: "bg-teal-500/10",
+    text: "text-teal-300/80",
+    border: "border-teal-500/20",
+    hover: "hover:text-teal-300 hover:border-teal-500/40",
+  },
+  emerald: {
+    bg: "bg-emerald-500/10",
+    text: "text-emerald-300/80",
+    border: "border-emerald-500/20",
+    hover: "hover:text-emerald-300 hover:border-emerald-500/40",
+  },
+  blue: {
+    bg: "bg-blue-500/10",
+    text: "text-blue-300/80",
+    border: "border-blue-500/20",
+    hover: "hover:text-blue-300 hover:border-blue-500/40",
+  },
+  cyan: {
+    bg: "bg-cyan-500/10",
+    text: "text-cyan-300/80",
+    border: "border-cyan-500/20",
+    hover: "hover:text-cyan-300 hover:border-cyan-500/40",
+  },
+  stone: {
+    bg: "bg-stone-500/10",
+    text: "text-stone-400/80",
+    border: "border-stone-700/30",
+    hover: "hover:text-stone-300 hover:border-stone-600/40",
+  },
+};
+
+function edgeLabel(edgeType: string): string {
+  return EDGE_LABELS[edgeType] || edgeType;
+}
+
+/* ── Component ────────────────────────────────────────────────────────── */
+
+type Touch = {
+  targetId: string;
+  edgeType: string;
+  direction: "out" | "in";
+};
+
 export function ConnectedConcepts({
   outgoing,
   incoming,
@@ -13,56 +163,118 @@ export function ConnectedConcepts({
   nameMap: Record<string, string>;
   mode: "full" | "compact";
 }) {
-  if (outgoing.length === 0 && incoming.length === 0) return null;
+  // Fold outgoing + incoming into a single "touches" list keyed by target.
+  // A visitor doesn't need to reason about edge direction to understand
+  // that two concepts are connected; direction only matters for the
+  // edge-type label (extends vs. extended-by, etc.).
+  const touchesByTarget = new Map<string, Touch[]>();
+  const addTouch = (target: string, edgeType: string, direction: "out" | "in") => {
+    if (!touchesByTarget.has(target)) touchesByTarget.set(target, []);
+    touchesByTarget.get(target)!.push({ targetId: target, edgeType, direction });
+  };
+  for (const e of outgoing) addTouch(e.to, e.type, "out");
+  for (const e of incoming) addTouch(e.from, e.type, "in");
+
+  // Group targets by kind (concept / person / place / ...).
+  const grouped: Record<GroupKey, string[]> = {
+    concepts: [],
+    people: [],
+    communities: [],
+    places: [],
+    gatherings: [],
+    practices: [],
+    works: [],
+    ideas: [],
+    specs: [],
+    other: [],
+  };
+  for (const target of touchesByTarget.keys()) {
+    grouped[groupFor(target)].push(target);
+  }
+  // Sort targets alphabetically by display name inside each group.
+  for (const key of Object.keys(grouped) as GroupKey[]) {
+    grouped[key].sort((a, b) =>
+      displayName(a, nameMap).localeCompare(displayName(b, nameMap)),
+    );
+  }
+
+  if (touchesByTarget.size === 0) return null;
 
   if (mode === "compact") {
+    // Compact mode: single row of chips across all groups, lightly
+    // color-coded by group so the eye can still sort them at a glance.
+    const allTargets: string[] = [];
+    for (const key of GROUP_ORDER) allTargets.push(...grouped[key]);
     return (
       <div className="flex flex-wrap gap-2 p-4 rounded-xl border border-stone-800/30 bg-stone-900/20">
         <span className="text-xs text-stone-600 mr-2">Connected:</span>
-        {outgoing.map((e) => (
-          <Link key={e.id} href={`/vision/${e.to}`}
-            className="text-xs px-2 py-1 rounded-full border border-stone-700/30 text-stone-500 hover:text-amber-300/70 hover:border-amber-500/20 transition-colors">
-            {displayName(e.to, nameMap)}
-          </Link>
-        ))}
-        {incoming.map((e) => (
-          <Link key={e.id} href={`/vision/${e.from}`}
-            className="text-xs px-2 py-1 rounded-full border border-stone-700/30 text-stone-500 hover:text-teal-300/70 hover:border-teal-500/20 transition-colors">
-            {displayName(e.from, nameMap)}
-          </Link>
-        ))}
+        {allTargets.map((id) => {
+          const accent = GROUP_META[groupFor(id)].accent;
+          const c = ACCENT_CLASSES[accent];
+          return (
+            <Link
+              key={id}
+              href={hrefFor(id)}
+              className={`text-xs px-2 py-1 rounded-full border transition-colors ${c.text} ${c.border} ${c.hover}`}
+            >
+              {displayName(id, nameMap)}
+            </Link>
+          );
+        })}
       </div>
     );
   }
 
   return (
-    <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-4">
-      <h2 className="text-lg font-light text-stone-300">Connected Frequencies</h2>
-      <div className="space-y-2">
-        {outgoing.map((e) => (
-          <Link key={e.id} href={`/vision/${e.to}`}
-            className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-stone-800/40 transition-colors group">
-            <span className="text-xs text-amber-400/60 font-medium min-w-[120px]">
-              {EDGE_LABELS[e.type] || e.type}
-            </span>
-            <span className="text-stone-300 group-hover:text-amber-300/80 transition-colors">
-              {displayName(e.to, nameMap)}
-            </span>
-            <span className="text-stone-700 ml-auto">&rarr;</span>
-          </Link>
-        ))}
-        {incoming.map((e) => (
-          <Link key={e.id} href={`/vision/${e.from}`}
-            className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-stone-800/40 transition-colors group">
-            <span className="text-xs text-teal-400/60 font-medium min-w-[120px]">
-              {EDGE_LABELS[e.type] || e.type}
-            </span>
-            <span className="text-stone-300 group-hover:text-teal-300/80 transition-colors">
-              {displayName(e.from, nameMap)}
-            </span>
-            <span className="text-stone-700 ml-auto">&larr;</span>
-          </Link>
-        ))}
+    <section className="rounded-2xl border border-stone-800/40 bg-stone-900/30 p-6 space-y-5">
+      <div>
+        <h2 className="text-lg font-light text-stone-300">Connected Frequencies</h2>
+        <p className="text-xs text-stone-500 mt-1">
+          The people, places, works, and concepts the graph shows connected to this one.
+        </p>
+      </div>
+
+      <div className="space-y-5">
+        {GROUP_ORDER.map((key) => {
+          const targets = grouped[key];
+          if (targets.length === 0) return null;
+          const meta = GROUP_META[key];
+          const c = ACCENT_CLASSES[meta.accent];
+          return (
+            <div key={key} className="space-y-2">
+              <p
+                className={`text-[11px] uppercase tracking-[0.18em] font-medium ${c.text}`}
+              >
+                {meta.label} · {targets.length}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {targets.map((id) => {
+                  const touches = touchesByTarget.get(id) || [];
+                  // Prefer outgoing edge-type as the primary label; fall
+                  // back to incoming. Multiple edge types between the same
+                  // two nodes are rare; if present, show the first.
+                  const primary = touches[0];
+                  const label = edgeLabel(primary.edgeType);
+                  return (
+                    <Link
+                      key={id}
+                      href={hrefFor(id)}
+                      className={`group inline-flex items-center gap-2 px-3 py-1.5 rounded-full border transition-colors ${c.border} ${c.bg} ${c.hover}`}
+                      title={label}
+                    >
+                      <span className={`text-sm ${c.text}`}>
+                        {displayName(id, nameMap)}
+                      </span>
+                      <span className="text-[10px] text-stone-500 group-hover:text-stone-400">
+                        {label}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -189,12 +189,6 @@ export default async function VisionConceptPage({
   const isLC = concept.domains?.includes("living-collective");
   if (!isLC) redirect(`/concepts/${conceptId}`);
 
-  // Name map for all LC concepts
-  const nameMap: Record<string, string> = {};
-  for (const c of allLC) {
-    if (c.id && c.name) nameMap[c.id] = c.name;
-  }
-
   // Frequency siblings (other concepts at the same Hz)
   const myHz = concept.sacred_frequency?.hz;
   const frequencySiblings = myHz
@@ -202,10 +196,55 @@ export default async function VisionConceptPage({
     : [];
 
   const visual = concept.visual_path;
-  const lcEdges = edges.filter((e) => e.from.startsWith("lc-") || e.to.startsWith("lc-"));
-  const outgoing = lcEdges.filter((e) => e.from === conceptId);
-  const incoming = lcEdges.filter((e) => e.to === conceptId);
+  // Keep every edge whose target is a real presence — drop the KB auto-
+  // generated visuals and the platform renderer components that just
+  // add noise to the Connected Frequencies directory.
+  const relevantEdges = edges.filter((e) => {
+    if (e.from.startsWith("visual-lc-") || e.to.startsWith("visual-lc-")) return false;
+    if (e.from.startsWith("renderer-") || e.to.startsWith("renderer-")) return false;
+    return true;
+  });
+  const outgoing = relevantEdges.filter((e) => e.from === conceptId);
+  const incoming = relevantEdges.filter((e) => e.to === conceptId);
   const hasStory = !!concept.story_content;
+
+  // Build a nameMap that covers every touch. Start with the LC concept
+  // map (cheap — one list endpoint), then resolve every non-concept
+  // target (contributors, assets, communities, events) in parallel so
+  // Connected Frequencies can render real names instead of raw ids.
+  const nameMap: Record<string, string> = {};
+  for (const c of allLC) {
+    if (c.id && c.name) nameMap[c.id] = c.name;
+  }
+  const unresolvedTargets = new Set<string>();
+  for (const e of relevantEdges) {
+    for (const target of [e.from, e.to]) {
+      if (target !== conceptId && !nameMap[target] && !target.startsWith("lc-")) {
+        unresolvedTargets.add(target);
+      }
+    }
+  }
+  if (unresolvedTargets.size > 0) {
+    const base = getApiBase();
+    const resolved = await Promise.all(
+      Array.from(unresolvedTargets).map(async (id) => {
+        try {
+          const r = await fetch(
+            `${base}/api/graph/nodes/${encodeURIComponent(id)}`,
+            { next: { revalidate: 60 } },
+          );
+          if (!r.ok) return null;
+          const n = await r.json();
+          return { id, name: n?.name || n?.author_display_name || null };
+        } catch {
+          return null;
+        }
+      }),
+    );
+    for (const entry of resolved) {
+      if (entry?.name) nameMap[entry.id] = entry.name;
+    }
+  }
 
   return (
     <main>

--- a/web/app/vision/economy/page.tsx
+++ b/web/app/vision/economy/page.tsx
@@ -166,14 +166,47 @@ async function fetchAllLC(): Promise<LCConcept[]> {
 export default async function EconomyPage() {
   const [concept, edges, allLC] = await Promise.all([fetchConcept(), fetchEdges(), fetchAllLC()]);
 
+  const relevantEdges = edges.filter((e) => {
+    if (e.from.startsWith("visual-lc-") || e.to.startsWith("visual-lc-")) return false;
+    if (e.from.startsWith("renderer-") || e.to.startsWith("renderer-")) return false;
+    return true;
+  });
+  const outgoing = relevantEdges.filter((e) => e.from === CONCEPT_ID);
+  const incoming = relevantEdges.filter((e) => e.to === CONCEPT_ID);
+
   const nameMap: Record<string, string> = {};
   for (const c of allLC) {
     if (c.id && c.name) nameMap[c.id] = c.name;
   }
-
-  const lcEdges = edges.filter((e) => e.from.startsWith("lc-") || e.to.startsWith("lc-"));
-  const outgoing = lcEdges.filter((e) => e.from === CONCEPT_ID);
-  const incoming = lcEdges.filter((e) => e.to === CONCEPT_ID);
+  const unresolvedTargets = new Set<string>();
+  for (const e of relevantEdges) {
+    for (const target of [e.from, e.to]) {
+      if (target !== CONCEPT_ID && !nameMap[target] && !target.startsWith("lc-")) {
+        unresolvedTargets.add(target);
+      }
+    }
+  }
+  if (unresolvedTargets.size > 0) {
+    const base = getApiBase();
+    const resolved = await Promise.all(
+      Array.from(unresolvedTargets).map(async (id) => {
+        try {
+          const r = await fetch(
+            `${base}/api/graph/nodes/${encodeURIComponent(id)}`,
+            { next: { revalidate: 60 } },
+          );
+          if (!r.ok) return null;
+          const n = await r.json();
+          return { id, name: n?.name || n?.author_display_name || null };
+        } catch {
+          return null;
+        }
+      }),
+    );
+    for (const entry of resolved) {
+      if (entry?.name) nameMap[entry.id] = entry.name;
+    }
+  }
   const pageTitle = concept?.name || "The Living Economy";
 
   return (


### PR DESCRIPTION
## Summary

The "Connected Frequencies" section on `/vision/{concept}` was showing only concept-to-concept edges — on `lc-sensing`, that's 13 out of 68 real touches. Every other connection (9 contributors, 10 works, 6 places, 3 gatherings, 1 community, etc.) was silently filtered out. And on the few non-concept targets that did slip through, names fell back to the raw slug (`contributor:the-official-website-of-dr-joe-dispenza-00497d303c42`) because the `nameMap` was built only from the LC-concept list.

## v2 of the section

- **Every real edge participates.** Only `visual-lc-*` (KB auto-generated imagery) and `renderer-*` (platform components) are filtered — same pattern as `/people?kind=works`.
- **Grouped by kind:** Concepts · People · Communities · Places · Gatherings · Practices · Works · Ideas · Specs · Other. Each group color-coded, counts shown, empty groups hidden.
- **Every name resolved.** Non-concept targets are fetched from `/api/graph/nodes/{id}` in parallel (under 60s revalidate cache) so the visitor sees "Liquid Bloom", not `contributor:liquid-bloom-0ddab636c396`.
- **Routed by prefix.** `/vision/lc-*`, `/profile/contributor:*`, `/assets/asset:*`, `/ideas/idea:*`, `/specs/spec:*`, universal `/nodes/*` for anything else. No more 404s when a visitor clicks a scene chip.
- **Both id shapes tolerated.** Graph uses both colon (`contributor:xxx`) and hyphen (`scene-xxx`, `network-gen`) conventions; `idPrefix()` extracts either.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified on `/vision/lc-sensing` in dev preview: 11 concepts + 9 people + 1 community + 6 places + 3 gatherings + 13 works + 1 other render with real names and working links
- [x] Compact mode still works (used in StoryContent) — same color-coded chips