### PR TITLE
tend: surface dormant pending backlog

### DIFF
--- a/api/app/routers/agent_monitor_helpers.py
+++ b/api/app/routers/agent_monitor_helpers.py
@@ -143,6 +143,18 @@ def actionable_pending_tasks(pending: list[Any]) -> list[dict[str, Any]]:
     return active
 
 
+def dormant_pending_tasks(pending: list[Any]) -> list[dict[str, Any]]:
+    window = pending_actionable_window_seconds()
+    dormant: list[dict[str, Any]] = []
+    for item in pending:
+        if not isinstance(item, dict):
+            continue
+        wait = wait_seconds(item.get("wait_seconds"))
+        if wait is not None and wait > window:
+            dormant.append(item)
+    return dormant
+
+
 def derive_monitor_issues_from_pipeline_status(status: dict[str, Any], *, now: datetime) -> list[dict[str, Any]]:
     running = status.get("running") if isinstance(status.get("running"), list) else []
     pending = status.get("pending") if isinstance(status.get("pending"), list) else []
@@ -150,6 +162,7 @@ def derive_monitor_issues_from_pipeline_status(status: dict[str, Any], *, now: d
     issues: list[dict[str, Any]] = []
 
     active_pending = actionable_pending_tasks(pending)
+    dormant_pending = dormant_pending_tasks(pending)
     wait_values = [wait_seconds(item.get("wait_seconds")) for item in active_pending]
     wait_seconds_list = [value for value in wait_values if value is not None]
     max_wait = max(wait_seconds_list) if wait_seconds_list else 0
@@ -163,6 +176,29 @@ def derive_monitor_issues_from_pipeline_status(status: dict[str, Any], *, now: d
                 "high",
                 f"No task running for {max_wait}s despite {len(active_pending)} actionable pending.",
                 "Restart agent runner and verify task claims progress.",
+                now=now,
+            )
+        )
+
+    if dormant_pending:
+        dormant_waits = [
+            value
+            for value in (wait_seconds(item.get("wait_seconds")) for item in dormant_pending)
+            if value is not None
+        ]
+        oldest_wait = max(dormant_waits) if dormant_waits else 0
+        issues.append(
+            derived_issue(
+                "dormant_pending_backlog",
+                "medium",
+                (
+                    f"{len(dormant_pending)} pending task(s) are dormant beyond "
+                    f"{pending_actionable_window_seconds()}s; oldest_wait={oldest_wait}s."
+                ),
+                (
+                    "Review dormant pending tasks, then release completed/obsolete rows, "
+                    "requeue still-valid work with fresh context, or restart a runner intentionally."
+                ),
                 now=now,
             )
         )
@@ -312,7 +348,7 @@ def build_fallback_status_report(
     running = status.get("running") if isinstance(status.get("running"), list) else []
     pending = status.get("pending") if isinstance(status.get("pending"), list) else []
     active_pending = actionable_pending_tasks(pending)
-    dormant_pending_count = max(0, len(pending) - len(active_pending))
+    dormant_pending_count = len(dormant_pending_tasks(pending))
     recent_completed = (
         status.get("recent_completed")
         if isinstance(status.get("recent_completed"), list)

--- a/api/tests/test_agent_monitor_helpers.py
+++ b/api/tests/test_agent_monitor_helpers.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from app.routers import agent_monitor_helpers
 
 
-def test_stale_pending_backlog_does_not_emit_runner_down_issue(set_config) -> None:
+def test_stale_pending_backlog_emits_dormant_tending_issue(set_config) -> None:
     set_config("pipeline", "pending_actionable_window_seconds", 86400)
     status = {
         "running": [],
@@ -20,7 +20,8 @@ def test_stale_pending_backlog_does_not_emit_runner_down_issue(set_config) -> No
         now=datetime.now(timezone.utc),
     )
 
-    assert [issue["condition"] for issue in issues] == []
+    assert [issue["condition"] for issue in issues] == ["dormant_pending_backlog"]
+    assert issues[0]["severity"] == "medium"
 
 
 def test_recent_pending_without_runner_still_emits_runner_down_issue(set_config) -> None:
@@ -42,7 +43,7 @@ def test_recent_pending_without_runner_still_emits_runner_down_issue(set_config)
     assert "1 actionable pending" in issues[0]["message"]
 
 
-def test_fallback_status_marks_dormant_pending_without_attention(set_config, monkeypatch) -> None:
+def test_fallback_status_marks_dormant_pending_as_attention(set_config, monkeypatch) -> None:
     set_config("pipeline", "pending_actionable_window_seconds", 86400)
     status = {
         "running": [],
@@ -58,10 +59,16 @@ def test_fallback_status_marks_dormant_pending_without_attention(set_config, mon
     payload = agent_monitor_helpers.build_fallback_status_report(
         now=datetime.now(timezone.utc),
         fallback_reason="missing_status_report_file",
-        monitor_payload={"issues": []},
+        monitor_payload={
+            "issues": agent_monitor_helpers.derive_monitor_issues_from_pipeline_status(
+                status,
+                now=datetime.now(timezone.utc),
+            )
+        },
         effectiveness=None,
     )
 
     assert payload["layer_1_orchestration"]["status"] == "ok"
     assert payload["layer_2_execution"]["dormant_pending_count"] == 1
     assert payload["layer_2_execution"]["actionable_pending_count"] == 0
+    assert payload["overall"]["needs_attention"] == ["dormant_pending_backlog"]

--- a/docs/system_audit/commit_evidence_2026-04-24_dormant-pending-backlog-tending.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_dormant-pending-backlog-tending.json
@@ -1,0 +1,95 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/tend-dormant-pending-backlog",
+  "commit_scope": "Surface dormant pending backlog as its own monitor attention signal so stale work is tended instead of hidden while still avoiding false runner-down alerts.",
+  "files_owned": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/tests/test_agent_monitor_helpers.py",
+    "docs/system_audit/commit_evidence_2026-04-24_dormant-pending-backlog-tending.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_agent_monitor_helpers.py -q",
+      "cd api && python3 -m ruff check app/routers/agent_monitor_helpers.py tests/test_agent_monitor_helpers.py",
+      "git diff --check && git diff --stat HEAD",
+      "cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_monitor_resolution.py -q",
+      "cd api && python3 -m pytest tests/test_flow_cli.py::TestAPIContract::test_pipeline_status_shape tests/test_flow_agent_lifecycle.py::test_agent_routing_and_metrics_flow -q",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_dormant-pending-backlog-tending.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Dormant pending tasks older than the actionable window should appear as dormant_pending_backlog attention in monitor issues and status reports, while fresh pending work without a runner still emits no_task_running.",
+    "public_endpoints": [
+      "/api/agent/monitor-issues",
+      "/api/agent/status-report",
+      "/api/agent/pipeline-status"
+    ],
+    "test_flows": [
+      "Old pending tasks emit dormant_pending_backlog instead of disappearing",
+      "Recent pending tasks without a runner still emit no_task_running",
+      "Fallback status reports carry dormant_pending_count and needs_attention"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Targeted local validation is complete; evidence validation, local PR guard, CI, deployment, and live sensing still need to pass."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "dormant-pending-backlog-tending-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/tests/test_agent_monitor_helpers.py",
+    "local pytest and ruff outputs in thread",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T144633Z_codex-tend-dormant-pending-backlog.json",
+    "live /api/agent/status-report previously showed dormant_pending=20 with no attention signal"
+  ],
+  "change_files": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/tests/test_agent_monitor_helpers.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- surface dormant pending tasks as a distinct `dormant_pending_backlog` monitor issue
- keep fresh pending work mapped to `no_task_running` so runner outage detection remains clear
- carry dormant backlog attention into fallback status reports

## Validation
- cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_monitor_resolution.py -q
- cd api && python3 -m pytest tests/test_flow_cli.py::TestAPIContract::test_pipeline_status_shape tests/test_flow_agent_lifecycle.py::test_agent_routing_and_metrics_flow -q
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_dormant-pending-backlog-tending.json