### PR TITLE
feat(multilingual): POST /api/translations fills the spec gap

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -733,6 +733,8 @@ from app.routers import render_events as render_events_router
 app.include_router(render_events_router.router, prefix="/api", tags=["render-events"])
 from app.routers import memory as memory_router
 app.include_router(memory_router.router, prefix="/api", tags=["memory"])
+from app.routers import translations as translations_router
+app.include_router(translations_router.router, prefix="/api", tags=["translations"])
 app.include_router(concepts.router, prefix="/api", tags=["concepts"])
 app.include_router(locales_router.router, prefix="/api", tags=["locales"])
 app.include_router(entity_views_router.router, prefix="/api", tags=["locales"])

--- a/api/app/routers/translations.py
+++ b/api/app/routers/translations.py
@@ -1,0 +1,146 @@
+"""Translations router — POST human or machine translations for any entity.
+
+Fills the spec gap in `multilingual-web` R8: anyone signed-in can
+submit a translation and it becomes canonical immediately; the prior
+canonical is preserved as superseded (history is the moderation
+surface, not a review queue).
+
+The underlying service (`translation_cache_service.write_view`) already
+implements supersede semantics, content-hash tracking, and status
+transitions. This router exposes it over HTTP.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.services import translation_cache_service
+
+router = APIRouter(prefix="/translations", tags=["translations"])
+
+
+class TranslationSubmit(BaseModel):
+    """Payload for POST /api/translations."""
+
+    entity_type: str = Field(description="concept, idea, contribution, story, etc.")
+    entity_id: str
+    lang: str = Field(description="Target language code: de, es, id, en, etc.")
+    content_title: str
+    content_description: str = ""
+    content_markdown: str
+    author_type: str = Field(
+        default="translation_human",
+        description="translation_human | translation_machine | contributor",
+    )
+    author_id: Optional[str] = None
+    translator_model: Optional[str] = None
+    translated_from_lang: Optional[str] = None
+    translated_from_hash: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class TranslationView(BaseModel):
+    """Response body — the newly-canonical translation view."""
+
+    id: str
+    entity_type: str
+    entity_id: str
+    lang: str
+    content_title: str
+    content_description: str
+    content_markdown: str
+    content_hash: str
+    author_type: str
+    author_id: Optional[str]
+    translator_model: Optional[str]
+    translated_from_lang: Optional[str]
+    translated_from_hash: Optional[str]
+    status: str
+    notes: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+class TranslationListResponse(BaseModel):
+    items: List[TranslationView]
+    total: int
+
+
+def _record_to_view(rec) -> TranslationView:
+    return TranslationView(
+        id=rec.id,
+        entity_type=rec.entity_type,
+        entity_id=rec.entity_id,
+        lang=rec.lang,
+        content_title=rec.content_title,
+        content_description=rec.content_description,
+        content_markdown=rec.content_markdown,
+        content_hash=rec.content_hash,
+        author_type=rec.author_type,
+        author_id=rec.author_id,
+        translator_model=rec.translator_model,
+        translated_from_lang=rec.translated_from_lang,
+        translated_from_hash=rec.translated_from_hash,
+        status=rec.status,
+        notes=rec.notes,
+        created_at=rec.created_at,
+        updated_at=rec.updated_at,
+    )
+
+
+@router.post(
+    "",
+    response_model=TranslationView,
+    status_code=201,
+    summary="Submit a translation (human or machine); supersedes any prior canonical",
+)
+async def submit_translation(body: TranslationSubmit) -> TranslationView:
+    """Submit a translation for an entity. Becomes canonical immediately.
+
+    Any prior canonical view for the same (entity, lang) is preserved
+    as superseded — history is the moderation surface, not a review
+    queue (spec R8).
+    """
+    try:
+        rec = translation_cache_service.write_view(
+            entity_type=body.entity_type,
+            entity_id=body.entity_id,
+            lang=body.lang,
+            content_title=body.content_title,
+            content_description=body.content_description,
+            content_markdown=body.content_markdown,
+            author_type=body.author_type,
+            author_id=body.author_id,
+            translator_model=body.translator_model,
+            translated_from_lang=body.translated_from_lang,
+            translated_from_hash=body.translated_from_hash,
+            notes=body.notes,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    return _record_to_view(rec)
+
+
+@router.get(
+    "/{entity_type}/{entity_id}",
+    response_model=TranslationListResponse,
+    summary="List all translation views (canonical + superseded) for an entity",
+)
+async def list_translations_for_entity(
+    entity_type: str,
+    entity_id: str,
+    lang: Optional[str] = None,
+) -> TranslationListResponse:
+    """Return every translation view for an entity across languages.
+    If `lang` is given, filter to that language's history.
+    """
+    if lang is not None:
+        rows = translation_cache_service.list_history(entity_type, entity_id, lang)
+    else:
+        rows = translation_cache_service.all_canonical_views(entity_type, entity_id)
+    items = [_record_to_view(r) for r in rows]
+    return TranslationListResponse(items=items, total=len(items))

--- a/api/tests/test_translations_router.py
+++ b/api/tests/test_translations_router.py
@@ -1,0 +1,128 @@
+"""Tests for POST /api/translations and GET /api/translations/{entity_type}/{entity_id}.
+
+Covers the multilingual-web spec gap: anyone signed-in can submit a
+translation and it becomes canonical immediately; prior canonical is
+preserved as superseded.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _payload(**overrides):
+    base = {
+        "entity_type": "concept",
+        "entity_id": "lc-test-concept",
+        "lang": "de",
+        "content_title": "Der Puls",
+        "content_description": "Eine kurze Beschreibung",
+        "content_markdown": "# Der Puls\n\nDer Puls ist der Herzschlag des Feldes.",
+        "author_type": "translation_human",
+        "author_id": "contributor:alice",
+        "translated_from_lang": "en",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_submit_translation_returns_201_canonical(client):
+    response = client.post("/api/translations", json=_payload())
+    assert response.status_code == 201
+    body = response.json()
+    assert body["entity_type"] == "concept"
+    assert body["lang"] == "de"
+    assert body["content_title"] == "Der Puls"
+    assert body["author_type"] == "translation_human"
+    assert body["status"] == "canonical"
+    assert body["content_hash"] != ""
+
+
+def test_human_submission_supersedes_prior_canonical(client):
+    first = client.post(
+        "/api/translations",
+        json=_payload(
+            entity_id="lc-supersede-test",
+            content_markdown="# v1",
+            author_type="translation_machine",
+            translator_model="test-model",
+        ),
+    ).json()
+    assert first["status"] == "canonical"
+    assert first["author_type"] == "translation_machine"
+
+    second = client.post(
+        "/api/translations",
+        json=_payload(
+            entity_id="lc-supersede-test",
+            content_markdown="# v2 — human voice",
+            author_type="translation_human",
+            author_id="contributor:bob",
+        ),
+    ).json()
+    assert second["status"] == "canonical"
+    assert second["author_type"] == "translation_human"
+    assert second["content_markdown"] != first["content_markdown"]
+
+    # The history endpoint should now return both; first is superseded
+    history = client.get(
+        "/api/translations/concept/lc-supersede-test",
+        params={"lang": "de"},
+    ).json()
+    assert history["total"] >= 2
+    canonicals = [v for v in history["items"] if v["status"] == "canonical"]
+    superseded = [v for v in history["items"] if v["status"] == "superseded"]
+    assert len(canonicals) == 1
+    assert canonicals[0]["author_type"] == "translation_human"
+    assert any(v["author_type"] == "translation_machine" for v in superseded)
+
+
+def test_list_translations_across_languages(client):
+    for lang in ("de", "es", "id"):
+        client.post(
+            "/api/translations",
+            json=_payload(
+                entity_id="lc-multi-lang",
+                lang=lang,
+                content_markdown=f"# content in {lang}",
+            ),
+        )
+    response = client.get("/api/translations/concept/lc-multi-lang")
+    assert response.status_code == 200
+    langs = {v["lang"] for v in response.json()["items"]}
+    assert {"de", "es", "id"}.issubset(langs)
+
+
+def test_submit_rejects_missing_entity_id(client):
+    payload = _payload()
+    del payload["entity_id"]
+    response = client.post("/api/translations", json=payload)
+    assert response.status_code == 422
+
+
+def test_submit_rejects_missing_content_markdown(client):
+    payload = _payload()
+    del payload["content_markdown"]
+    response = client.post("/api/translations", json=payload)
+    assert response.status_code == 422
+
+
+def test_list_history_filters_to_single_lang(client):
+    client.post(
+        "/api/translations",
+        json=_payload(entity_id="lc-lang-filter", lang="de", content_markdown="de"),
+    )
+    client.post(
+        "/api/translations",
+        json=_payload(entity_id="lc-lang-filter", lang="es", content_markdown="es"),
+    )
+    de_history = client.get(
+        "/api/translations/concept/lc-lang-filter", params={"lang": "de"}
+    ).json()
+    assert all(v["lang"] == "de" for v in de_history["items"])


### PR DESCRIPTION
The `translation_cache_service.write_view()` already had human/machine supersede semantics shipped; what was missing was the HTTP surface to invoke it (spec R8).

**New router** `api/app/routers/translations.py`:
- `POST /api/translations` — submit a translation; supersedes prior canonical
- `GET /api/translations/{entity_type}/{entity_id}[?lang=]` — list views (canonical + superseded)

**Payload:** `entity_type, entity_id, lang, content_title, content_description, content_markdown, author_type (translation_human | translation_machine | contributor), author_id, translator_model, translated_from_lang, translated_from_hash, notes`

**6 route tests:** returns 201 canonical, human supersedes prior canonical (history preserves prior), list across languages, missing-field 422s, lang filter on history.

Router mounted. No behavior change to the existing service — this is the surface that was missing.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_