### PR TITLE
tend: concepts are one layer — fold Codex bare-ids into Concepts group

### DIFF
--- a/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
+++ b/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
@@ -49,7 +49,14 @@ function groupFor(id: string): GroupKey {
     case "asset": return "works";
     case "idea": return "ideas";
     case "spec": return "specs";
-    default: return "other";
+    default:
+      // Living Codex concepts arrive as bare lowercase ids (e.g. "wisdom",
+      // "consciousness", "memory") with no colon or hyphen prefix. They're
+      // the same kind of thing as lc-* concepts — same ontology layer, same
+      // kind of entity to a visitor — so they fold into the "concepts"
+      // group rather than splitting into a separate "other" bucket.
+      if (/^[a-z][a-z0-9-]*$/.test(id) && !id.includes(":")) return "concepts";
+      return "other";
   }
 }
 
@@ -60,6 +67,11 @@ function hrefFor(id: string): string {
   if (p === "asset") return `/assets/${encodeURIComponent(id)}`;
   if (p === "idea") return `/ideas/${encodeURIComponent(id)}`;
   if (p === "spec") return `/specs/${encodeURIComponent(id)}`;
+  // Bare-id Codex concepts (e.g. "consciousness", "memory", "social-justice")
+  // live at /concepts/{id}. They land here only when no known type prefix
+  // matched above — routing by group keeps scenes/communities/events/etc.
+  // on the universal /nodes/ page where they belong.
+  if (groupFor(id) === "concepts") return `/concepts/${encodeURIComponent(id)}`;
   return `/nodes/${encodeURIComponent(id)}`;
 }
 


### PR DESCRIPTION
## Summary

The Connected Frequencies section was splitting the same conceptual layer into two groups: `lc-*` concepts went to "Concepts", bare-id Codex concepts (e.g. `consciousness`, `memory`, `social-justice`) went to "Other". Same kind of thing, different ontology, treated as separate — fragmentation in the visitor's frame.

Now concepts are one layer:
- Bare-id Codex concepts fold into the Concepts group alongside `lc-*` concepts, same chip color, same group heading.
- Their hrefs route to `/concepts/{id}` (Codex concept page) rather than `/nodes/{id}` (catch-all that hid their concept-ness) or `/vision/{id}` (LC-specific).
- `hrefFor` now uses `groupFor(id)` to decide routing — so scenes/events/communities still land on `/nodes/*`, they don't accidentally get the `/concepts/` route.

## Related graph-side hygiene (direct API, not in this diff)

- **Migrated Anne Tucker fossil** (`contributor:anne-tucker-is-a-healer-channeling-mothe-dbce0b7bf8f1`) → clean canonical `contributor:anne-tucker`. Name, description, canonical_url, YouTube presence preserved. One meaningful edge (`manages` her own retreat) recreated with canonical edge type; 12 auto-generated low-signal concept edges released.
- **Composted 4 bare Codex concepts** that duplicated LC canonicals: `space`, `field`, `energy`, `health-domain`. The lc-* versions carry the whole concept.
- **Composted 12 truly-dead legacy nodes**: 1 stale CI sensing event, 1 schema artifact, 10 `kw-*` legacy keyword-seeds.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified on `/vision/lc-sensing` dev preview: 6 groups (Concepts · 12 / People · 8 / Communities · 1 / Places · 6 / Gatherings · 3 / Works · 13), no "Other", bare `consciousness` shows up among Concepts with `/concepts/consciousness` href, scenes correctly route to `/nodes/scene-*`.