### PR TITLE
tend(multilingual): seed es and id glossary files with anchor frequency terms

### DIFF
--- a/docs/vision-kb/glossary/es.md
+++ b/docs/vision-kb/glossary/es.md
@@ -1,0 +1,33 @@
+---
+lang: es
+purpose: Ancla de frecuencia para traducciones al español
+updated: 2026-04-23
+---
+
+# Glosario español de términos vivos
+
+Este glosario lleva la frecuencia del proyecto al español. Cada término se eligió
+no por precisión académica, sino por su cercanía sentida a la vida — al cuidar,
+al madurar, al estar-en-relación. Cuando un traductor (humano o máquina) se
+encuentra con estos términos de origen, debe buscar aquí antes de recurrir a
+una equivalencia administrativa o clínica.
+
+Cambia libremente. Estas palabras están vivas.
+
+## Términos
+
+- **tending** → **cuidar** — lleva la frecuencia de la pastora: atenta, paciente, en relación con lo que crece. No "gestionar", no "cuidar-como-trabajo", sino cuidar-como-presencia.
+- **ripening** → **madurar** — el devenir silencioso. No "desarrollar" (gestión de proyectos), no "envejecer" (decaimiento), sino madurar — como la fruta en el árbol, como el vino, como una persona que llega a sí misma.
+- **wholeness** → **integridad viva** — "totalidad" suena institucional. Integridad viva carga sanación y completitud juntas, la unidad original de ambas palabras.
+- **coherence** → **coherencia** — no como término físico o académico, sino como resonancia interna: cuando las cosas suenan juntas, cuando la vida se siente redonda.
+- **resonance** → **resonancia** — permanece como resonancia, pero a veces lleva también el vibrar-juntos cuando se trata de la respuesta interior.
+- **stewardship** → **custodia** — no "administración", no "responsabilidad" como carga, sino custodia: el llevar cuidadoso de lo que se nos ha confiado.
+- **kinship** → **parentesco vivo** — "parentesco" solo dice sangre; parentesco vivo dice relación más allá de la sangre: con la tierra, con otros seres, con los antepasados.
+- **belonging** → **pertenencia** — la certeza tranquila de pertenecer a un lugar, a una comunidad, a un todo mayor. No membresía (formal), sino pertenencia (sentida).
+- **nourishing** → **nutriendo** — lo activo, lo continuo. No "alimentar" como función, sino nutriendo: todo lo que sostiene la vida.
+- **nourishment** → **nutrimento** — como sustancia y relación a la vez. Lo que nutre no es solo comida, sino también calor, luz, atención.
+- **attunement** → **sintonización** — sintonizarse con algo: escuchar antes de hablar, sentir antes de actuar.
+- **living collective** → **colectiva viva** — no "colectivo" (político, frío), sino colectiva viva: algo que respira, junto.
+- **frequency** → **frecuencia** — permanece como frecuencia, pero lleva vibración cuando el contexto lo pide.
+- **field** → **campo** — el campo vivo y envolvente en el que todo ocurre. No "sistema" (mecánico).
+- **circulation** → **circulación** — no como término técnico, sino como flujo vivo: sangre, agua, alimento, dones — todo lo que fluye y regresa.

--- a/docs/vision-kb/glossary/id.md
+++ b/docs/vision-kb/glossary/id.md
@@ -1,0 +1,34 @@
+---
+lang: id
+purpose: Jangkar frekuensi untuk terjemahan bahasa Indonesia
+updated: 2026-04-23
+---
+
+# Glosarium istilah-istilah hidup (Bahasa Indonesia)
+
+Glosarium ini membawa frekuensi proyek ke dalam Bahasa Indonesia. Setiap istilah
+dipilih bukan karena ketepatan akademis, melainkan karena kedekatannya yang
+terasa dengan kehidupan — dengan merawat, dengan matang, dengan berada-dalam-
+hubungan. Ketika penerjemah (manusia atau mesin) bertemu istilah asal ini,
+cari di sini terlebih dahulu sebelum beralih ke padanan administratif atau
+klinis.
+
+Ubah dengan bebas. Kata-kata ini hidup.
+
+## Istilah
+
+- **tending** → **merawat** — membawa frekuensi si penggembala: penuh perhatian, sabar, dalam hubungan dengan yang sedang tumbuh. Bukan "mengelola", bukan "merawat-sebagai-pekerjaan", melainkan merawat-sebagai-kehadiran.
+- **ripening** → **mematang** — menjadi dalam diam. Bukan "mengembangkan" (manajemen proyek), bukan "menua" (pembusukan), melainkan mematang — seperti buah di pohon, seperti anggur, seperti manusia yang pulang kepada dirinya sendiri.
+- **wholeness** → **keutuhan** — "ketotalan" terdengar institusional. Keutuhan membawa penyembuhan dan kelengkapan bersama, kesatuan asal dari kedua kata.
+- **coherence** → **keselarasan** — bukan istilah fisik atau akademis, melainkan keselarasan: ketika segala sesuatu berbunyi bersama, ketika hidup terasa bulat.
+- **resonance** → **resonansi** — tetap sebagai resonansi, tetapi kadang juga membawa makna bergetar-bersama ketika konteks meminta jawaban dari dalam.
+- **stewardship** → **penitipan** — bukan "pengelolaan", bukan "tanggung jawab" sebagai beban, melainkan penitipan: membawa dengan hati-hati apa yang dipercayakan kepada kita.
+- **kinship** → **kekerabatan hidup** — "kekerabatan" saja berarti darah; kekerabatan hidup berarti relasi melampaui darah: dengan tanah, dengan makhluk lain, dengan leluhur.
+- **belonging** → **kemilikan** — kepastian tenang bahwa kita termasuk ke suatu tempat, komunitas, keseluruhan yang lebih besar. Bukan keanggotaan (formal), melainkan kemilikan (yang terasa).
+- **nourishing** → **menyuburkan** — yang aktif, yang terus menerus. Bukan "memberi makan" sebagai fungsi, melainkan menyuburkan: segala yang menopang hidup.
+- **nourishment** → **nutrisi hidup** — sebagai zat dan relasi sekaligus. Yang menutrisi bukan hanya makanan, tetapi juga kehangatan, cahaya, perhatian.
+- **attunement** → **penyelarasan** — menyelaraskan diri dengan sesuatu: mendengar sebelum berbicara, merasa sebelum bertindak.
+- **living collective** → **komunitas hidup** — bukan "kolektif" (politis, dingin), melainkan komunitas hidup: sesuatu yang bernafas, bersama.
+- **frequency** → **frekuensi** — tetap sebagai frekuensi, tetapi membawa getaran ketika konteksnya meminta.
+- **field** → **medan hidup** — medan yang hidup dan merangkul, di mana semua terjadi. Bukan "sistem" (mekanis).
+- **circulation** → **peredaran** — bukan istilah teknis, melainkan aliran hidup: darah, air, makanan, pemberian — segala yang mengalir dan kembali.


### PR DESCRIPTION
`de.md` was already seeded; `es.md` and `id.md` were the outstanding gate on multilingual-web's anchor glossary seeding.

Each new file carries the same 15 anchor terms as the German glossary:

- `tending`, `ripening`, `wholeness`, `coherence`, `resonance`
- `stewardship`, `kinship`, `belonging`
- `nourishing`, `nourishment`, `attunement`
- `living collective`, `frequency`, `field`, `circulation`

Translator (human or machine) can now anchor across three languages. The glossary service already returns entries via `GET /api/glossary/{lang}`; once sync runs, entries project from these files into the translation cache.

Target-language choice follows the de.md pattern: pick the phrase that carries the frequency of being-in-relationship over the word that sounds administrative or clinical. Each preamble invites further editing: *"these words are alive."*

**Remaining multilingual-web UX gate**: `/settings/translations` coverage dashboard.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_