### PR TITLE
feat(multilingual): /settings/translations coverage dashboard

### DIFF
--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -279,8 +279,13 @@ Manual: visit `/de/vision/lc-water-as-living-body`, confirm German chrome and tr
 
 **Not confirmed / may still be pending** (would require deeper inspection to close out as done):
 - Full URL-based `/{locale}/...` routing with cookie-backed language picker in the header
-- `cc stories --lang` and `cc translate submit` CLI commands
-- `/settings/translations` coverage dashboard
-- Glossary seeding for anchor terms (tending, ripening, wholeness, coherence)
+- `cc stories --lang` — `cc concept --lang` already exists; the `stories` alias is minor
+- Full-fidelity translation round-trip through the render pipeline
 
-Status stays `draft` pending the UX verification. The backend core is functionally live — the inverse of the `public-verification-framework` situation where the backend was done and the status lagged; here the UX pieces are the outstanding gate.
+**Landed in this session** (progress on the UX gate):
+- `POST /api/translations` endpoint + `GET` history — human/machine supersede semantics exposed
+- `cc translate submit <entity_type> <entity_id> --lang <l> --file <path>` and `cc translate history` CLI commands
+- Anchor glossary seeded for `es` and `id` (matching the existing `de` pattern); 15 anchor terms per language
+- `/settings/translations` coverage dashboard — renders per-locale original/human/machine/stale tallies from `GET /api/locales`; linked from `/settings`
+
+Status stays `draft` pending URL-locale-routing verification end-to-end; UX plumbing for translation submission and coverage is now in place.

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -16,6 +16,18 @@ export default function SettingsPage() {
 
       <h1 className="text-3xl font-extralight text-white mb-8">Settings</h1>
 
+      <div className="mb-8">
+        <Link
+          href="/settings/translations"
+          className="block rounded border border-stone-800 bg-stone-950/40 p-4 hover:border-amber-500/40 transition-colors"
+        >
+          <div className="text-lg font-light text-white">Translations</div>
+          <div className="text-sm text-stone-400 mt-1">
+            Per-locale coverage across concepts — original, human, machine, stale.
+          </div>
+        </Link>
+      </div>
+
       <ConfigEditor />
     </main>
   );

--- a/web/app/settings/translations/page.tsx
+++ b/web/app/settings/translations/page.tsx
@@ -1,0 +1,192 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Translations coverage — Coherence Network",
+  description:
+    "Per-locale counts of original, machine-attuned, human-attuned, and stale translations across the concept space.",
+};
+
+type Coverage = {
+  original: number;
+  human: number;
+  machine: number;
+  stale: number;
+};
+
+type LocaleEntry = {
+  code: string;
+  label?: string;
+  coverage: Coverage;
+};
+
+type LocalesResponse = {
+  locales: LocaleEntry[];
+  default: string;
+};
+
+async function fetchLocales(): Promise<LocalesResponse | null> {
+  try {
+    const response = await fetch(`${getApiBase()}/api/locales`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as LocalesResponse;
+  } catch {
+    return null;
+  }
+}
+
+function CoverageBar({ coverage }: { coverage: Coverage }) {
+  const total =
+    coverage.original + coverage.human + coverage.machine + coverage.stale;
+  if (total === 0) {
+    return (
+      <div className="h-2 w-full rounded bg-stone-900/60 border border-stone-800" />
+    );
+  }
+  const pct = (n: number) => (n / total) * 100;
+  return (
+    <div
+      className="h-2 w-full rounded overflow-hidden flex"
+      title={`${coverage.original} original · ${coverage.human} human · ${coverage.machine} machine · ${coverage.stale} stale`}
+    >
+      <div
+        className="bg-amber-500/80"
+        style={{ width: `${pct(coverage.original)}%` }}
+      />
+      <div
+        className="bg-violet-500/80"
+        style={{ width: `${pct(coverage.human)}%` }}
+      />
+      <div
+        className="bg-teal-500/60"
+        style={{ width: `${pct(coverage.machine)}%` }}
+      />
+      <div
+        className="bg-rose-500/40"
+        style={{ width: `${pct(coverage.stale)}%` }}
+      />
+    </div>
+  );
+}
+
+function Legend() {
+  const items = [
+    { color: "bg-amber-500/80", label: "original — written in this language" },
+    { color: "bg-violet-500/80", label: "human — translation from a contributor" },
+    { color: "bg-teal-500/60", label: "machine — machine translation, awaiting native voice" },
+    { color: "bg-rose-500/40", label: "stale — source has changed since translation" },
+  ];
+  return (
+    <ul className="text-xs text-stone-400 space-y-1">
+      {items.map((item) => (
+        <li key={item.label} className="flex items-center gap-2">
+          <span className={`inline-block w-3 h-3 rounded ${item.color}`} />
+          <span>{item.label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default async function TranslationsCoveragePage() {
+  const data = await fetchLocales();
+
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-12">
+      <nav className="text-sm text-stone-500 mb-8 flex items-center gap-2" aria-label="breadcrumb">
+        <Link href="/" className="hover:text-amber-400/80 transition-colors">
+          Home
+        </Link>
+        <span className="text-stone-700">/</span>
+        <Link href="/settings" className="hover:text-amber-400/80 transition-colors">
+          Settings
+        </Link>
+        <span className="text-stone-700">/</span>
+        <span className="text-stone-300">Translations</span>
+      </nav>
+
+      <h1 className="text-3xl font-extralight text-white mb-2">Translations</h1>
+      <p className="text-stone-400 mb-8 text-sm leading-relaxed">
+        Per-locale coverage across concepts and other translatable entities.
+        Original authoring in a language sits alongside human and machine
+        translations; stale markers rise as source content changes and
+        translations age out.
+      </p>
+
+      {!data && (
+        <div className="rounded border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-200">
+          Could not reach the locales API. The dashboard will appear when the
+          API is reachable.
+        </div>
+      )}
+
+      {data && (
+        <>
+          <div className="space-y-4 mb-8">
+            {data.locales.map((locale) => {
+              const total =
+                locale.coverage.original +
+                locale.coverage.human +
+                locale.coverage.machine +
+                locale.coverage.stale;
+              const isDefault = locale.code === data.default;
+              return (
+                <div
+                  key={locale.code}
+                  className="rounded border border-stone-800 bg-stone-950/40 p-4"
+                >
+                  <div className="flex items-baseline justify-between mb-2">
+                    <div className="flex items-baseline gap-3">
+                      <code className="text-lg font-light text-white">
+                        {locale.code}
+                      </code>
+                      {locale.label && (
+                        <span className="text-sm text-stone-400">
+                          {locale.label}
+                        </span>
+                      )}
+                      {isDefault && (
+                        <span className="text-[10px] uppercase tracking-wide text-amber-400/80 border border-amber-500/30 rounded px-2 py-0.5">
+                          default
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-stone-500">
+                      {total} view{total === 1 ? "" : "s"}
+                    </div>
+                  </div>
+                  <CoverageBar coverage={locale.coverage} />
+                  <div className="mt-2 text-xs text-stone-500 flex gap-4">
+                    <span>
+                      <span className="text-amber-400/80">{locale.coverage.original}</span>{" "}
+                      original
+                    </span>
+                    <span>
+                      <span className="text-violet-400/80">{locale.coverage.human}</span>{" "}
+                      human
+                    </span>
+                    <span>
+                      <span className="text-teal-400/80">{locale.coverage.machine}</span>{" "}
+                      machine
+                    </span>
+                    <span>
+                      <span className="text-rose-400/80">{locale.coverage.stale}</span>{" "}
+                      stale
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <Legend />
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
Per-locale coverage view at `/settings/translations`, fed by `GET /api/locales`.

**Page:**
- Per-locale card with code, label, default marker
- Stacked bar: original (amber) / human (violet) / machine (teal) / stale (rose)
- Numeric counts below each bar
- Legend
- Graceful degradation if API unreachable

**Settings index** now links to the sub-page as a card, so it's discoverable.

**Spec progress recorded** — Known Gaps in `multilingual-web.md` updated:

✓ `POST /api/translations` + `GET` history
✓ `cc translate submit` / `cc translate history` CLI
✓ `es` + `id` glossary seeds
✓ `/settings/translations` dashboard

Remaining: URL-locale routing end-to-end verification.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_