### PR TITLE
tend: heal multilingual-web source drift + wellness surfaces spec-source drift

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -136,6 +136,55 @@ def sense_metabolism() -> list[str]:
     return findings
 
 
+def sense_spec_sources() -> list[str]:
+    """Do the paths spec frontmatter 'source:' points at actually exist?
+
+    Missing paths are signal, not failure. Some specs name future targets
+    (scripts to be written, services-to-be-built); those show as drift
+    here but are acknowledged in the spec's Known Gaps section. This
+    reading exists so surprise drift can't hide.
+    """
+    findings: list[dict[str, str]] = []
+    specs_dir = ROOT / "specs"
+    if not specs_dir.is_dir():
+        return ["  specs/ directory not found"]
+
+    for spec in sorted(specs_dir.glob("*.md")):
+        if spec.name in ("INDEX.md", "TEMPLATE.md"):
+            continue
+        text = spec.read_text()
+        # Truncate scan to the frontmatter section (between first two '---' lines)
+        head, *rest = text.split("---", 2)
+        if not rest:
+            continue
+        frontmatter = rest[0] if len(rest) == 1 else rest[0]
+        for m in re.finditer(r"^\s*-\s*file:\s*(\S+)", frontmatter, re.MULTILINE):
+            path = m.group(1).strip()
+            if path.startswith("..") or "://" in path or path.startswith("specs/"):
+                continue
+            if not (ROOT / path).exists():
+                findings.append({"spec": spec.name, "path": path})
+
+    if not findings:
+        return ["  every spec's source: paths point at files that exist"]
+
+    by_spec: dict[str, list[str]] = {}
+    for f in findings:
+        by_spec.setdefault(f["spec"], []).append(f["path"])
+
+    lines = [
+        f"  {len(findings)} source paths missing across {len(by_spec)} spec(s)"
+    ]
+    for spec_name in sorted(by_spec):
+        paths = by_spec[spec_name]
+        lines.append(f"    · {spec_name} — {len(paths)} missing")
+        for p in paths[:3]:
+            lines.append(f"      → {p}")
+        if len(paths) > 3:
+            lines.append(f"      → (+{len(paths) - 3} more)")
+    return lines
+
+
 def main() -> int:
     print("# Wellness check\n")
     print("A gentle sensing. Not an audit. Drift is the signal,")
@@ -153,6 +202,11 @@ def main() -> int:
 
     print("## Metabolism — composting-in-progress\n")
     for line in sense_metabolism():
+        print(line)
+    print()
+
+    print("## Source maps — do specs point at files that exist?\n")
+    for line in sense_spec_sources():
         print(line)
     print()
 

--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -5,23 +5,39 @@ source:
   - file: web/app/layout.tsx
     symbols: [RootLayout]
   - file: web/middleware.ts
-    symbols: [middleware (new)]
+    symbols: [middleware]
   - file: web/next.config.ts
     symbols: [nextConfig]
-  - file: api/app/models/locale.py
-    symbols: [SupportedLocale, ContentTranslation, GlossaryEntry (new)]
-  - file: api/app/services/translation_cache.py
-    symbols: [get_or_translate(), invalidate_for_entity(), select_canonical() (new)]
-  - file: api/app/services/translator.py
-    symbols: [translate_markdown(), build_glossary_prompt() (new)]
-  - file: api/app/routers/locale.py
-    symbols: [list_locales, get_glossary, upsert_glossary_entry (new)]
+  - file: api/app/models/translation.py
+    symbols: [EntityView, GlossaryEntry]
+  - file: api/app/models/lens_translation.py
+    symbols: [LensTranslation]
+  - file: api/app/services/translation_cache_service.py
+    symbols: [write_view, canonical_view, all_canonical_views, find_anchor, is_stale, list_history, glossary_for, upsert_glossary_entry]
+  - file: api/app/services/translator_service.py
+    symbols: [translate_markdown, build_glossary_prompt, SUPPORTED_LOCALES]
+  - file: api/app/services/concept_translation_service.py
+    symbols: [translate_concept, get_cached_translation]
+  - file: api/app/services/lens_translation_service.py
+    symbols: [translate_via_lens]
+  - file: api/app/routers/locales.py
+    symbols: [list_locales, get_glossary, patch_glossary]
   - file: api/app/routers/translations.py
-    symbols: [submit_translation, list_translations_for_entity (new)]
+    symbols: [submit_translation, list_translations_for_entity]
   - file: api/app/routers/concepts.py
-    symbols: [get_concept — extend with lang param, support non-English source_lang]
+    symbols: [get_concept]
   - file: api/app/routers/contributions.py
-    symbols: [create_contribution — accept source_lang; get_contribution — accept lang]
+    symbols: [create_contribution, get_contribution]
+  - file: cli/lib/commands/translate.mjs
+    symbols: [handleTranslate, submitTranslation, showHistory]
+  - file: web/app/settings/translations/page.tsx
+    symbols: [TranslationsCoveragePage]
+  - file: docs/vision-kb/glossary/de.md
+    symbols: [anchor terms for German]
+  - file: docs/vision-kb/glossary/es.md
+    symbols: [anchor terms for Spanish]
+  - file: docs/vision-kb/glossary/id.md
+    symbols: [anchor terms for Indonesian]
 requirements:
   - "Web supports locales: en (default), de, es, id — URL-based /{locale}/... routing"
   - "next-intl drives UI chrome strings from web/messages/{locale}.json"


### PR DESCRIPTION
Two movements — the same finding from two angles:

**1. `multilingual-web.md` source paths match reality.**
The spec was written against proposed filenames (`locale.py`, `translation_cache.py`, `translator.py`, `locale.py`); the code shipped with slightly different names (`locales.py`, `translation_cache_service.py`, `translator_service.py`, etc.). Source map now points at the real files, including what this session landed (`translate.mjs` CLI, settings translations page, glossary files).

**2. `wellness_check.py` senses spec-source drift.**
New reading: "Source maps — do specs point at files that exist?" Lists any spec whose frontmatter `source:` paths don't exist on disk, with up to 3 examples per spec. The reading exists so surprise drift can't hide — it's not a gate.

**Current reading after this PR:**
```
12 source paths missing across 3 spec(s)
  · external-repo-milestone.md — 1 missing
    → scripts/external_proof_demo.py
  · public-verification-framework.md — 1 missing
    → scripts/publish_snapshot.py
  · story-protocol-integration.md — 10 missing
    → api/app/services/ip_registration_service.py
    → api/app/services/permanent_storage_service.py
    → api/app/services/settlement_service.py
    → (+7 more)
```

All 12 are aspirational target files acknowledged in the respective spec's Known Gaps. Down from 16 before this PR.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_