### PR TITLE
feat(story-protocol): evidence service + router — R9 has an HTTP surface

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -735,6 +735,8 @@ from app.routers import memory as memory_router
 app.include_router(memory_router.router, prefix="/api", tags=["memory"])
 from app.routers import translations as translations_router
 app.include_router(translations_router.router, prefix="/api", tags=["translations"])
+from app.routers import evidence as evidence_router
+app.include_router(evidence_router.router, prefix="/api", tags=["evidence"])
 app.include_router(concepts.router, prefix="/api", tags=["concepts"])
 app.include_router(locales_router.router, prefix="/api", tags=["locales"])
 app.include_router(entity_views_router.router, prefix="/api", tags=["locales"])

--- a/api/app/models/evidence.py
+++ b/api/app/models/evidence.py
@@ -1,0 +1,52 @@
+"""Evidence models — implementation evidence for assets, per story-protocol-integration R9.
+
+Evidence submission carries photo proof, optional GPS, and an
+attestation count. Verification uses the 2-of-3 factor rule from
+`story_protocol_bridge.verify_evidence()`. Verified evidence applies
+a 5x CC multiplier to the asset's next settlement period.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.services.story_protocol_bridge import GpsCoordinate
+
+
+class EvidenceCreate(BaseModel):
+    """Payload for POST /api/evidence."""
+
+    asset_id: str = Field(description="asset:<uuid> identifier")
+    submitter_id: str
+    photo_urls: List[str] = Field(default_factory=list)
+    gps: Optional[GpsCoordinate] = None
+    attestation_count: int = Field(default=0, ge=0)
+    description: str = ""
+
+
+class ImplementationEvidence(EvidenceCreate):
+    """Server-side evidence record."""
+
+    id: UUID = Field(default_factory=uuid4)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class EvidenceVerification(BaseModel):
+    """Outcome of running verification on a submitted evidence record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_id: UUID
+    asset_id: str
+    verified: bool
+    factors_satisfied: int
+    factors_required: int
+    has_photo_proof: bool
+    gps_within_radius: bool
+    attestation_met: bool
+    cc_multiplier_applicable: str  # Decimal serialized as str to avoid JSON float loss
+    verified_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/api/app/routers/evidence.py
+++ b/api/app/routers/evidence.py
@@ -1,0 +1,99 @@
+"""Evidence router — implementation evidence for asset CC-multiplier bonus.
+
+Endpoints:
+  POST /api/evidence                          - Submit evidence for an asset
+  POST /api/evidence/{evidence_id}/verify     - Run 2-of-3 factor verification
+  GET  /api/evidence/{evidence_id}            - Fetch one submission
+  GET  /api/evidence/asset/{asset_id}         - List submissions + verifications
+
+See specs/story-protocol-integration.md (R9).
+"""
+
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.models.evidence import (
+    EvidenceCreate,
+    EvidenceVerification,
+    ImplementationEvidence,
+)
+from app.services import evidence_service
+
+router = APIRouter(prefix="/evidence", tags=["evidence"])
+
+
+class EvidenceAssetView(BaseModel):
+    asset_id: str
+    submissions: List[ImplementationEvidence]
+    verifications: List[EvidenceVerification]
+    cc_multiplier_applicable: str
+
+
+@router.post(
+    "",
+    response_model=ImplementationEvidence,
+    status_code=201,
+    summary="Submit implementation evidence for an asset",
+)
+async def submit_evidence(body: EvidenceCreate) -> ImplementationEvidence:
+    """Store an evidence submission. Verification is a separate step —
+    callers POST to /api/evidence/{id}/verify when ready.
+    """
+    return evidence_service.submit_evidence(body)
+
+
+@router.post(
+    "/{evidence_id}/verify",
+    response_model=EvidenceVerification,
+    summary="Run 2-of-3 factor verification on a submission",
+)
+async def verify_evidence(evidence_id: UUID) -> EvidenceVerification:
+    """Runs the verification rule from story_protocol_bridge.
+    Verified evidence applies a 5× CC multiplier via the
+    applicable_multiplier_for_asset() lookup used by settlement.
+    """
+    result = evidence_service.run_verification(evidence_id)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"evidence '{evidence_id}' not found",
+        )
+    return result
+
+
+@router.get(
+    "/{evidence_id}",
+    response_model=ImplementationEvidence,
+    summary="Fetch an evidence submission",
+)
+async def get_evidence(evidence_id: UUID) -> ImplementationEvidence:
+    record = evidence_service.get_evidence(evidence_id)
+    if record is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"evidence '{evidence_id}' not found",
+        )
+    return record
+
+
+@router.get(
+    "/asset/{asset_id:path}",
+    response_model=EvidenceAssetView,
+    summary="List evidence submissions and verifications for an asset",
+)
+async def list_for_asset(asset_id: str) -> EvidenceAssetView:
+    """Returns every submission + every verification + the currently
+    applicable CC multiplier (highest among verified evidence).
+    """
+    multiplier = evidence_service.applicable_multiplier_for_asset(asset_id)
+    return EvidenceAssetView(
+        asset_id=asset_id,
+        submissions=evidence_service.list_evidence_for_asset(asset_id),
+        verifications=evidence_service.list_verifications_for_asset(asset_id),
+        cc_multiplier_applicable=str(multiplier),
+    )

--- a/api/app/services/evidence_service.py
+++ b/api/app/services/evidence_service.py
@@ -1,0 +1,129 @@
+"""Evidence service — submission, verification, and retrieval for asset implementation evidence.
+
+Per specs/story-protocol-integration.md R9. Delegates the actual
+verification math to `story_protocol_bridge.verify_evidence()` (the
+2-of-3 factor rule with haversine GPS radius and attestation
+threshold). This layer wraps it with storage, asset-id linkage, and
+known-community-coordinate context.
+
+Storage is in-process for this first slice, matching the pattern of
+other route-level slices landing against story-protocol. Graph-
+backed persistence is a follow-up.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from app.models.evidence import (
+    EvidenceCreate,
+    EvidenceVerification,
+    ImplementationEvidence,
+)
+from app.services.story_protocol_bridge import (
+    GpsCoordinate,
+    ImplementationEvidenceInput,
+    verify_evidence as _verify_evidence_raw,
+)
+
+
+# In-process stores, keyed by asset id.
+_EVIDENCE: Dict[str, List[ImplementationEvidence]] = defaultdict(list)
+_VERIFICATIONS: Dict[UUID, EvidenceVerification] = {}
+
+# Known community coordinates used for GPS-within-radius checks.
+# In production this list is read from the graph; for this slice it's
+# a small in-process seed that can be extended at runtime via
+# register_community_location().
+_KNOWN_COMMUNITIES: List[GpsCoordinate] = []
+
+
+def register_community_location(lat: float, lng: float) -> None:
+    """Add a known community coordinate for GPS-based evidence verification."""
+    _KNOWN_COMMUNITIES.append(GpsCoordinate(lat=lat, lng=lng))
+
+
+def submit_evidence(body: EvidenceCreate) -> ImplementationEvidence:
+    """Store an evidence submission. Does not verify — that's a separate
+    step so the submission can be inspected before verification runs.
+    """
+    evidence = ImplementationEvidence(**body.model_dump())
+    _EVIDENCE[body.asset_id].append(evidence)
+    return evidence
+
+
+def run_verification(evidence_id: UUID) -> Optional[EvidenceVerification]:
+    """Run 2-of-3 factor verification on a stored evidence record.
+
+    Returns None if the evidence_id is not found. Otherwise stores
+    and returns the verification result.
+    """
+    record = _find(evidence_id)
+    if record is None:
+        return None
+    factors = ImplementationEvidenceInput(
+        photo_urls=record.photo_urls,
+        gps=record.gps,
+        attestation_count=record.attestation_count,
+    )
+    raw = _verify_evidence_raw(factors, known_community_coords=_KNOWN_COMMUNITIES)
+    result = EvidenceVerification(
+        evidence_id=record.id,
+        asset_id=record.asset_id,
+        verified=raw.verified,
+        factors_satisfied=raw.factors_satisfied,
+        factors_required=raw.factors_required,
+        has_photo_proof=raw.has_photo_proof,
+        gps_within_radius=raw.gps_within_radius,
+        attestation_met=raw.attestation_met,
+        cc_multiplier_applicable=str(raw.cc_multiplier_applicable),
+    )
+    _VERIFICATIONS[record.id] = result
+    return result
+
+
+def get_evidence(evidence_id: UUID) -> Optional[ImplementationEvidence]:
+    return _find(evidence_id)
+
+
+def get_verification(evidence_id: UUID) -> Optional[EvidenceVerification]:
+    return _VERIFICATIONS.get(evidence_id)
+
+
+def list_evidence_for_asset(asset_id: str) -> List[ImplementationEvidence]:
+    return list(_EVIDENCE.get(asset_id, []))
+
+
+def list_verifications_for_asset(asset_id: str) -> List[EvidenceVerification]:
+    return [v for v in _VERIFICATIONS.values() if v.asset_id == asset_id]
+
+
+def applicable_multiplier_for_asset(asset_id: str) -> Decimal:
+    """Highest multiplier among verified evidence for this asset.
+
+    If no verified evidence exists, returns 1.0 (no multiplier).
+    Used by the settlement batch to apply the 5× bonus per R9.
+    """
+    verifications = list_verifications_for_asset(asset_id)
+    verified = [v for v in verifications if v.verified]
+    if not verified:
+        return Decimal("1")
+    return max(Decimal(v.cc_multiplier_applicable) for v in verified)
+
+
+def _find(evidence_id: UUID) -> Optional[ImplementationEvidence]:
+    for records in _EVIDENCE.values():
+        for r in records:
+            if r.id == evidence_id:
+                return r
+    return None
+
+
+def _reset_for_tests() -> None:
+    """Testing hook. Not part of the public API."""
+    _EVIDENCE.clear()
+    _VERIFICATIONS.clear()
+    _KNOWN_COMMUNITIES.clear()

--- a/api/tests/test_evidence_flow.py
+++ b/api/tests/test_evidence_flow.py
@@ -1,0 +1,151 @@
+"""Flow tests for /api/evidence — story-protocol-integration R9.
+
+Covers submission, verification, 2-of-3 threshold, GPS-within-radius,
+5x multiplier application, and per-asset view composition.
+"""
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import evidence_service
+
+
+@pytest.fixture
+def client():
+    evidence_service._reset_for_tests()
+    return TestClient(app)
+
+
+def _payload(**overrides):
+    base = {
+        "asset_id": "asset:a1",
+        "submitter_id": "contributor:alice",
+        "photo_urls": ["https://arweave.net/tx1"],
+        "gps": {"lat": 37.78, "lng": -122.41},
+        "attestation_count": 3,
+        "description": "Built the cob wall; see photos + community sign-off.",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_submit_evidence_returns_201_and_id(client):
+    response = client.post("/api/evidence", json=_payload())
+    assert response.status_code == 201
+    body = response.json()
+    assert body["asset_id"] == "asset:a1"
+    assert body["submitter_id"] == "contributor:alice"
+    assert "id" in body
+    assert body["photo_urls"] == ["https://arweave.net/tx1"]
+
+
+def test_verify_all_three_factors_true_when_community_registered(client):
+    evidence_service.register_community_location(37.785, -122.41)
+    submission = client.post("/api/evidence", json=_payload()).json()
+    result = client.post(f"/api/evidence/{submission['id']}/verify").json()
+    assert result["verified"] is True
+    assert result["factors_satisfied"] == 3
+    assert result["has_photo_proof"] is True
+    assert result["gps_within_radius"] is True
+    assert result["attestation_met"] is True
+    assert Decimal(result["cc_multiplier_applicable"]) == Decimal("5")
+
+
+def test_verify_two_factors_still_passes(client):
+    # photo + attestation; no GPS
+    submission = client.post(
+        "/api/evidence",
+        json=_payload(gps=None),
+    ).json()
+    result = client.post(f"/api/evidence/{submission['id']}/verify").json()
+    assert result["verified"] is True
+    assert result["factors_satisfied"] == 2
+
+
+def test_verify_one_factor_fails(client):
+    submission = client.post(
+        "/api/evidence",
+        json=_payload(gps=None, attestation_count=0),
+    ).json()
+    result = client.post(f"/api/evidence/{submission['id']}/verify").json()
+    assert result["verified"] is False
+    assert Decimal(result["cc_multiplier_applicable"]) == Decimal("1")
+
+
+def test_verify_unknown_evidence_returns_404(client):
+    response = client.post(
+        "/api/evidence/00000000-0000-0000-0000-000000000000/verify"
+    )
+    assert response.status_code == 404
+
+
+def test_list_for_asset_composes_submissions_and_multiplier(client):
+    evidence_service.register_community_location(37.78, -122.41)
+    first = client.post("/api/evidence", json=_payload(asset_id="asset:m1")).json()
+    client.post(f"/api/evidence/{first['id']}/verify")
+
+    # A second submission that fails verification
+    weak = client.post(
+        "/api/evidence",
+        json=_payload(
+            asset_id="asset:m1",
+            photo_urls=[],
+            gps=None,
+            attestation_count=1,
+        ),
+    ).json()
+    client.post(f"/api/evidence/{weak['id']}/verify")
+
+    view = client.get("/api/evidence/asset/asset:m1").json()
+    assert view["asset_id"] == "asset:m1"
+    assert len(view["submissions"]) == 2
+    assert len(view["verifications"]) == 2
+    # Highest applicable multiplier across verified evidence
+    assert Decimal(view["cc_multiplier_applicable"]) == Decimal("5")
+
+
+def test_list_for_asset_with_no_verified_returns_multiplier_one(client):
+    weak = client.post(
+        "/api/evidence",
+        json=_payload(
+            asset_id="asset:weak",
+            photo_urls=[],
+            gps=None,
+            attestation_count=1,
+        ),
+    ).json()
+    client.post(f"/api/evidence/{weak['id']}/verify")
+    view = client.get("/api/evidence/asset/asset:weak").json()
+    assert Decimal(view["cc_multiplier_applicable"]) == Decimal("1")
+
+
+def test_get_evidence_by_id_roundtrip(client):
+    submission = client.post("/api/evidence", json=_payload()).json()
+    response = client.get(f"/api/evidence/{submission['id']}")
+    assert response.status_code == 200
+    assert response.json()["id"] == submission["id"]
+
+
+def test_get_evidence_404(client):
+    response = client.get(
+        "/api/evidence/00000000-0000-0000-0000-000000000000"
+    )
+    assert response.status_code == 404
+
+
+def test_submit_rejects_missing_asset_id(client):
+    payload = _payload()
+    del payload["asset_id"]
+    response = client.post("/api/evidence", json=payload)
+    assert response.status_code == 422
+
+
+def test_submit_rejects_negative_attestation_count(client):
+    response = client.post(
+        "/api/evidence",
+        json=_payload(attestation_count=-1),
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
Closes 3 of the 10 missing source paths the wellness check flagged for `story-protocol-integration` (down from 10 missing to 7).

**New files:**
- `api/app/models/evidence.py` — `EvidenceCreate`, `ImplementationEvidence`, `EvidenceVerification`
- `api/app/services/evidence_service.py` — submit, run_verification, per-asset view, `applicable_multiplier_for_asset`, `register_community_location` runtime hook
- `api/app/routers/evidence.py` — four endpoints
- `api/tests/test_evidence_flow.py` — 11 flow tests

**Endpoints:**
- `POST /api/evidence` — submit implementation evidence
- `POST /api/evidence/{id}/verify` — run 2-of-3 factor verification
- `GET /api/evidence/{id}` — fetch submission
- `GET /api/evidence/asset/{asset_id}` — list submissions + verifications + current CC multiplier

**Verification math** stays in `story_protocol_bridge.verify_evidence()` — this layer wraps storage, asset linkage, and known-community-coordinate context around it. Default 5× multiplier per verified evidence (`EVIDENCE_CC_MULTIPLIER`).

`applicable_multiplier_for_asset(asset_id)` is the hook the future settlement batch reads to apply the bonus per R9 — no additional spec work when settlement lands; settlement just calls this function.

Storage in-process for this slice, matching other story-protocol landings. Graph-backed persistence is a follow-up gate.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_