### PR TITLE
tend: link producers collapse onto /nodes/{id}

### DIFF
--- a/web/app/profile/[contributorId]/page.tsx
+++ b/web/app/profile/[contributorId]/page.tsx
@@ -142,12 +142,9 @@ function fingerprint(hex: string): string {
 
 type ResolvedDim = { label: string; href: string | null; nodeType: string | null };
 
-function hrefForNode(id: string, nodeType: string | null): string | null {
-  if (id.startsWith("contributor:")) return `/profile/${encodeURIComponent(id)}`;
-  if (id.startsWith("asset:")) return `/assets/${encodeURIComponent(id)}`;
-  if (id.startsWith("idea:")) return `/ideas/${encodeURIComponent(id)}`;
-  if (id.startsWith("spec:")) return `/specs/${encodeURIComponent(id)}`;
-  if (id.startsWith("lc-") || nodeType === "concept") return `/vision/${encodeURIComponent(id)}`;
+function hrefForNode(id: string): string {
+  // Every node id routes through the universal /nodes/[id] viewer,
+  // which picks the right typed page inline.
   return `/nodes/${encodeURIComponent(id)}`;
 }
 
@@ -183,13 +180,13 @@ async function resolveDimension(dim: string): Promise<ResolvedDim> {
       next: { revalidate: 60 },
     });
     if (!res.ok) {
-      return { label: dim, href: hrefForNode(dim, null), nodeType: null };
+      return { label: dim, href: hrefForNode(dim), nodeType: null };
     }
     const node = await res.json();
     const name = node?.name || node?.author_display_name || dim;
-    return { label: name, href: hrefForNode(dim, node?.type ?? null), nodeType: node?.type ?? null };
+    return { label: name, href: hrefForNode(dim), nodeType: node?.type ?? null };
   } catch {
-    return { label: dim, href: hrefForNode(dim, null), nodeType: null };
+    return { label: dim, href: hrefForNode(dim), nodeType: null };
   }
 }
 

--- a/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
+++ b/web/app/vision/[conceptId]/_components/ConnectedConcepts.tsx
@@ -61,17 +61,10 @@ function groupFor(id: string): GroupKey {
 }
 
 function hrefFor(id: string): string {
-  const p = idPrefix(id);
-  if (p === "lc") return `/vision/${id}`;
-  if (p === "contributor") return `/profile/${encodeURIComponent(id)}`;
-  if (p === "asset") return `/assets/${encodeURIComponent(id)}`;
-  if (p === "idea") return `/ideas/${encodeURIComponent(id)}`;
-  if (p === "spec") return `/specs/${encodeURIComponent(id)}`;
-  // Bare-id Codex concepts (e.g. "consciousness", "memory", "social-justice")
-  // live at /concepts/{id}. They land here only when no known type prefix
-  // matched above — routing by group keeps scenes/communities/events/etc.
-  // on the universal /nodes/ page where they belong.
-  if (groupFor(id) === "concepts") return `/concepts/${encodeURIComponent(id)}`;
+  // Every node id — lc concept, bare Codex concept, contributor, asset,
+  // scene, event, idea, spec — routes through the universal /nodes/[id]
+  // viewer, which picks the right typed page inline. Callers don't need
+  // to know a node's shape to link to it.
   return `/nodes/${encodeURIComponent(id)}`;
 }
 


### PR DESCRIPTION
## Summary

Two link producers — `ConnectedConcepts.hrefFor` and profile page's `hrefForNode` — were doing their own prefix-based routing in parallel to `/nodes/[id]`. Now they both just route through `/nodes/{encodeURIComponent(id)}` and let the universal viewer pick the right shape.

One source of truth for "where does this node open?" — the `/nodes/[id]` page itself. Callers don't need to know a node's type to link to it.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Preview: ConnectedConcepts chips on /vision/lc-wisdom all point to /nodes/
- [x] Profile page dimension links resolve through /nodes/ correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>