### PR TITLE
fix(ux-homepage-readability): fix light-mode primary contrast (3.3→4.78:1)

### DIFF
--- a/api/tests/test_homepage_contrast.py
+++ b/api/tests/test_homepage_contrast.py
@@ -1,0 +1,181 @@
+"""
+WCAG AA contrast tests for homepage CSS palette (ux-homepage-readability).
+
+Parses the CSS variable values directly from globals.css and asserts
+≥4.5:1 contrast for all foreground/background pairs.
+"""
+import math
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# WCAG helpers
+# ---------------------------------------------------------------------------
+
+def _hsl_to_rgb(h: float, s: float, l: float) -> tuple[float, float, float]:
+    s /= 100
+    l /= 100
+    c = (1 - abs(2 * l - 1)) * s
+    x = c * (1 - abs((h / 60) % 2 - 1))
+    m = l - c / 2
+    hi = int(h / 60) % 6
+    if hi == 0:
+        r, g, b = c, x, 0
+    elif hi == 1:
+        r, g, b = x, c, 0
+    elif hi == 2:
+        r, g, b = 0, c, x
+    elif hi == 3:
+        r, g, b = 0, x, c
+    elif hi == 4:
+        r, g, b = x, 0, c
+    else:
+        r, g, b = c, 0, x
+    return (r + m, g + m, b + m)
+
+
+def _linearize(c: float) -> float:
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _luminance(r: float, g: float, b: float) -> float:
+    return 0.2126 * _linearize(r) + 0.7152 * _linearize(g) + 0.0722 * _linearize(b)
+
+
+def contrast_ratio(h1: float, s1: float, l1: float,
+                   h2: float, s2: float, l2: float) -> float:
+    lum1 = _luminance(*_hsl_to_rgb(h1, s1, l1))
+    lum2 = _luminance(*_hsl_to_rgb(h2, s2, l2))
+    lighter = max(lum1, lum2)
+    darker = min(lum1, lum2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _parse_css_var(css_text: str, var_name: str) -> tuple[float, float, float]:
+    """Extract HSL triple from a CSS variable definition."""
+    pattern = rf"--{re.escape(var_name)}:\s*([\d.]+)\s+([\d.]+)%\s+([\d.]+)%"
+    matches = list(re.finditer(pattern, css_text))
+    if not matches:
+        raise ValueError(f"CSS variable --{var_name} not found")
+    h, s, l = matches[0].group(1), matches[0].group(2), matches[0].group(3)
+    return float(h), float(s), float(l)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def dark_vars(globals_css: str) -> dict[str, tuple[float, float, float]]:
+    """Extract dark-mode CSS variable values (the :root / :root.dark block)."""
+    # Dark-mode block ends before ':root.light' or ':root.dark' (re-definition)
+    dark_section = globals_css.split(":root.light")[0]
+    return {
+        "background": _parse_css_var(dark_section, "background"),
+        "foreground": _parse_css_var(dark_section, "foreground"),
+        "primary": _parse_css_var(dark_section, "primary"),
+        "primary-foreground": _parse_css_var(dark_section, "primary-foreground"),
+        "muted": _parse_css_var(dark_section, "muted"),
+        "muted-foreground": _parse_css_var(dark_section, "muted-foreground"),
+    }
+
+
+@pytest.fixture(scope="module")
+def light_vars(globals_css: str) -> dict[str, tuple[float, float, float]]:
+    """Extract light-mode CSS variable values from the :root.light block."""
+    m = re.search(r":root\.light\s*\{([^}]+)\}", globals_css, re.DOTALL)
+    if not m:
+        raise ValueError(":root.light block not found in globals.css")
+    block = m.group(1)
+    return {
+        "background": _parse_css_var(block, "background"),
+        "foreground": _parse_css_var(block, "foreground"),
+        "card": _parse_css_var(block, "card"),
+        "card-foreground": _parse_css_var(block, "card-foreground"),
+        "primary": _parse_css_var(block, "primary"),
+        "primary-foreground": _parse_css_var(block, "primary-foreground"),
+        "muted": _parse_css_var(block, "muted"),
+        "muted-foreground": _parse_css_var(block, "muted-foreground"),
+    }
+
+
+@pytest.fixture(scope="module")
+def globals_css() -> str:
+    css_path = Path(__file__).parents[2] / "web" / "app" / "globals.css"
+    return css_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# WCAG AA assertions — dark mode
+# ---------------------------------------------------------------------------
+
+WCAG_AA = 4.5
+
+
+class TestDarkModeContrast:
+    def test_foreground_on_background(self, dark_vars):
+        r = contrast_ratio(*dark_vars["foreground"], *dark_vars["background"])
+        assert r >= WCAG_AA, f"dark foreground/bg: {r:.3f} < 4.5"
+
+    def test_primary_on_background(self, dark_vars):
+        r = contrast_ratio(*dark_vars["primary"], *dark_vars["background"])
+        assert r >= WCAG_AA, f"dark primary/bg: {r:.3f} < 4.5"
+
+    def test_primary_foreground_on_primary(self, dark_vars):
+        r = contrast_ratio(*dark_vars["primary-foreground"], *dark_vars["primary"])
+        assert r >= WCAG_AA, f"dark primary-fg/primary: {r:.3f} < 4.5"
+
+    def test_muted_foreground_on_background(self, dark_vars):
+        r = contrast_ratio(*dark_vars["muted-foreground"], *dark_vars["background"])
+        assert r >= WCAG_AA, f"dark muted-fg/bg: {r:.3f} < 4.5"
+
+    def test_muted_foreground_on_muted(self, dark_vars):
+        r = contrast_ratio(*dark_vars["muted-foreground"], *dark_vars["muted"])
+        assert r >= WCAG_AA, f"dark muted-fg/muted: {r:.3f} < 4.5"
+
+    def test_foreground_minimum_luminance_difference(self, dark_vars):
+        """Foreground must be visually distinct from background (not just AA)."""
+        r = contrast_ratio(*dark_vars["foreground"], *dark_vars["background"])
+        assert r >= 7.0, f"dark foreground/bg is only {r:.3f}:1, expected ≥7:1 for AAA"
+
+
+# ---------------------------------------------------------------------------
+# WCAG AA assertions — light mode
+# ---------------------------------------------------------------------------
+
+class TestLightModeContrast:
+    def test_foreground_on_background(self, light_vars):
+        r = contrast_ratio(*light_vars["foreground"], *light_vars["background"])
+        assert r >= WCAG_AA, f"light foreground/bg: {r:.3f} < 4.5"
+
+    def test_primary_on_background(self, light_vars):
+        r = contrast_ratio(*light_vars["primary"], *light_vars["background"])
+        assert r >= WCAG_AA, f"light primary/bg: {r:.3f} < 4.5"
+
+    def test_primary_foreground_on_primary(self, light_vars):
+        r = contrast_ratio(*light_vars["primary-foreground"], *light_vars["primary"])
+        assert r >= WCAG_AA, f"light primary-fg/primary: {r:.3f} < 4.5"
+
+    def test_muted_foreground_on_background(self, light_vars):
+        r = contrast_ratio(*light_vars["muted-foreground"], *light_vars["background"])
+        assert r >= WCAG_AA, f"light muted-fg/bg: {r:.3f} < 4.5"
+
+    def test_muted_foreground_on_card(self, light_vars):
+        r = contrast_ratio(*light_vars["muted-foreground"], *light_vars["card"])
+        assert r >= WCAG_AA, f"light muted-fg/card: {r:.3f} < 4.5"
+
+    def test_card_foreground_on_card(self, light_vars):
+        r = contrast_ratio(*light_vars["card-foreground"], *light_vars["card"])
+        assert r >= WCAG_AA, f"light card-fg/card: {r:.3f} < 4.5"
+
+    def test_foreground_on_background_strong(self, light_vars):
+        """Main body text should exceed AAA (7:1) for max readability."""
+        r = contrast_ratio(*light_vars["foreground"], *light_vars["background"])
+        assert r >= 7.0, f"light foreground/bg is only {r:.3f}:1, expected ≥7:1 for AAA"
+
+    def test_primary_lightness_ceiling(self, light_vars):
+        """Primary L% must be ≤35 to guarantee ≥4.5:1 on warm off-white background."""
+        _, _, l = light_vars["primary"]
+        assert l <= 35, f"light --primary L={l}% exceeds ceiling of 35% — contrast will fail"

--- a/ideas/ux-homepage-readability.md
+++ b/ideas/ux-homepage-readability.md
@@ -1,0 +1,30 @@
+# Homepage Readability — text nearly invisible on dark background
+
+**ID**: ux-homepage-readability
+**Parent**: user-surfaces
+**Status**: implemented
+
+## Problem
+
+Primary interactive elements (buttons, links, chart accents) used `hsl(36 72% 42%)` in light mode — a warm gold that renders at only ~3.3:1 contrast against the warm off-white background `hsl(42 40% 96%)`. WCAG AA requires ≥4.5:1 for normal text and interactive controls.
+
+Dark mode was already compliant (primary at L=58% gives 7.7:1 on `hsl(24 22% 11%)`).
+
+## Fix
+
+Lowered light-mode `--primary`, `--ring`, and `--chart-1` from L=42% to L=34%, giving a measured contrast of **~4.78:1** on the warm off-white background — comfortably above the 4.5:1 threshold.
+
+| Token | Before | After | Contrast (on bg) |
+|-------|--------|-------|-----------------|
+| `--primary` (light) | `36 72% 42%` | `36 72% 34%` | 3.33 → 4.78 |
+| `--ring` (light) | `36 72% 42%` | `36 72% 34%` | 3.33 → 4.78 |
+| `--chart-1` (light) | `36 72% 42%` | `36 72% 34%` | 3.33 → 4.78 |
+
+## Evidence
+
+`api/tests/test_homepage_contrast.py` — 14 WCAG AA assertions covering dark + light palettes. All pass.
+
+## Files Modified
+
+- `web/app/globals.css` — `:root.light` token values
+- `api/tests/test_homepage_contrast.py` — regression tests

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -40,13 +40,13 @@
     --card-foreground: 24 26% 16%;
     --popover: 42 30% 97%;
     --popover-foreground: 24 26% 16%;
-    /* Darker gold so primary text passes AA on light bg (≥4.5:1) */
-    --primary: 36 72% 42%;
+    /* Darker gold so primary text passes AA on light bg (~4.78:1 on hsl(42 40% 96%)) */
+    --primary: 36 72% 34%;
     --primary-foreground: 42 40% 97%;
     --secondary: 36 22% 88%;
     --secondary-foreground: 24 22% 18%;
     --muted: 36 20% 90%;
-    /* muted-foreground: 28 18% 38% ≈ #6b5d4a — passes AA on card/bg */
+    /* muted-foreground: 28 18% 38% ≈ #6b5d4a — passes AA on card/bg (~5.58:1) */
     --muted-foreground: 28 18% 38%;
     --accent: 36 28% 85%;
     --accent-foreground: 24 22% 18%;
@@ -54,8 +54,8 @@
     --destructive-foreground: 0 0% 98%;
     --border: 36 20% 82%;
     --input: 36 20% 82%;
-    --ring: 36 72% 42%;
-    --chart-1: 36 72% 42%;
+    --ring: 36 72% 34%;
+    --chart-1: 36 72% 34%;
     --chart-2: 158 38% 32%;
     --chart-3: 45 65% 38%;
     --chart-4: 12 60% 48%;


### PR DESCRIPTION
fixes contrast accessibility issue on homepage

## Summary
- Adjusts the light-mode primary color token so the contrast ratio meets WCAG AA (4.78:1, up from 3.3:1)

## Test plan
- [ ] Visual regression: primary button text readable in light mode
- [ ] Contrast ratio ≥ 4.5:1 verified via browser DevTools accessibility panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)