### PR TITLE
tend: digest failure signatures

### DIFF
--- a/api/app/routers/agent_monitor_helpers.py
+++ b/api/app/routers/agent_monitor_helpers.py
@@ -155,7 +155,30 @@ def dormant_pending_tasks(pending: list[Any]) -> list[dict[str, Any]]:
     return dormant
 
 
-def low_success_rate_context() -> tuple[str, str]:
+def _diagnostic_count_fragments(
+    diagnostics: dict[str, Any],
+    key: str,
+    label_key: str,
+    *,
+    limit: int = 3,
+) -> list[str]:
+    rows = diagnostics.get(key) if isinstance(diagnostics.get(key), list) else []
+    fragments: list[str] = []
+    for row in rows[:limit]:
+        if not isinstance(row, dict):
+            continue
+        label = str(row.get(label_key) or "").strip()
+        count = row.get("count")
+        try:
+            normalized_count = int(count)
+        except (TypeError, ValueError):
+            normalized_count = 0
+        if label and normalized_count > 0:
+            fragments.append(f"{label} x{normalized_count}")
+    return fragments
+
+
+def low_success_rate_context(status: dict[str, Any] | None = None) -> tuple[str, str]:
     """Summarize current task-metric failure shape for monitor issue text."""
     try:
         from app.services.metrics_service import get_aggregates
@@ -204,6 +227,15 @@ def low_success_rate_context() -> tuple[str, str]:
         )
     else:
         suggested = "Run targeted prompt/model diagnostics and capture remediation in the meta pipeline."
+
+    diagnostics = status.get("diagnostics") if isinstance(status, dict) and isinstance(status.get("diagnostics"), dict) else {}
+    if diagnostics:
+        reason_fragments = _diagnostic_count_fragments(diagnostics, "recent_failed_reasons", "reason")
+        signature_fragments = _diagnostic_count_fragments(diagnostics, "recent_failed_signatures", "signature", limit=2)
+        if reason_fragments:
+            message = f"{message} Recent failure buckets: {', '.join(reason_fragments)}."
+        if signature_fragments:
+            message = f"{message} Top signatures: {', '.join(signature_fragments)}."
     return message, suggested
 
 
@@ -286,7 +318,7 @@ def derive_monitor_issues_from_pipeline_status(status: dict[str, Any], *, now: d
             )
         )
     if bool(att.get("low_success_rate")):
-        message, suggested_action = low_success_rate_context()
+        message, suggested_action = low_success_rate_context(status)
         issues.append(
             derived_issue(
                 "low_success_rate",
@@ -469,6 +501,7 @@ def build_fallback_status_report(
         "status": "needs_attention" if execution_needs_attention else "ok",
         "running": running,
         "pending": pending,
+        "diagnostics": status.get("diagnostics") if isinstance(status.get("diagnostics"), dict) else {},
         "actionable_pending_count": len(active_pending),
         "dormant_pending_count": dormant_pending_count,
         "recent_completed": recent_completed,

--- a/api/app/services/agent_service_pipeline_status.py
+++ b/api/app/services/agent_service_pipeline_status.py
@@ -6,7 +6,6 @@ from typing import Any
 from app.services.agent_service_store import _ensure_store_loaded, _store
 from app.services.agent_service_task_derive import (
     failure_classification,
-    failure_reason_bucket,
     status_value,
     task_output_text,
     task_type_name,
@@ -172,24 +171,32 @@ def _pipeline_queue_diagnostics(
     for item in running:
         key = task_type_name(item.get("task_type")) or "unknown"
         running_by_task_type[key] = running_by_task_type.get(key, 0) + 1
-    reason_counts = {}
-    recent_failed = []
+    reason_counts: dict[str, int] = {}
+    signature_counts: dict[str, int] = {}
+    recent_failed: list[dict[str, Any]] = []
     for completed_item in completed[:12]:
         task = _store.get(completed_item["id"]) or {}
         if status_value(task.get("status")) != "failed":
             continue
-        reason = failure_reason_bucket(task)
+        classified = failure_classification(task)
+        reason = classified["bucket"]
         reason_counts[reason] = reason_counts.get(reason, 0) + 1
         ctx = task.get("context") or {}
         failure_signature = str(ctx.get("failure_signature") or "").strip() if isinstance(ctx, dict) else ""
+        signature = classified.get("signature") or failure_signature
+        if signature:
+            signature_counts[signature] = signature_counts.get(signature, 0) + 1
         recent_failed.append({
             "task_id": task.get("id"),
             "task_type": task_type_name(task.get("task_type")) or "unknown",
             "reason": reason,
-            "signature": failure_signature or failure_classification(task).get("signature", ""),
+            "signature": signature,
         })
     recent_failed_reasons = [
         {"reason": r, "count": c} for r, c in sorted(reason_counts.items(), key=lambda row: (-row[1], row[0]))
+    ]
+    recent_failed_signatures = [
+        {"signature": r, "count": c} for r, c in sorted(signature_counts.items(), key=lambda row: (-row[1], row[0]))
     ]
     total_pending = sum(pending_by_task_type.values())
     dominant_pending_type = ""
@@ -202,7 +209,9 @@ def _pipeline_queue_diagnostics(
         "pending_by_task_type": pending_by_task_type,
         "running_by_task_type": running_by_task_type,
         "recent_failed_count": len(recent_failed),
+        "recent_failed": recent_failed[:5],
         "recent_failed_reasons": recent_failed_reasons,
+        "recent_failed_signatures": recent_failed_signatures,
         "queue_mix_warning": queue_mix_warning,
         "dominant_pending_task_type": dominant_pending_type,
         "dominant_pending_share": dominant_pending_share,

--- a/api/app/services/agent_service_task_derive.py
+++ b/api/app/services/agent_service_task_derive.py
@@ -228,7 +228,13 @@ def failure_classification(task: dict[str, Any], *, output_text: str | None = No
             if maybe:
                 detail = maybe
                 break
-    failure_class = str((context or {}).get("last_failure_class") or (context or {}).get("failure_class") or "")
+    class_parts = [
+        str((context or {}).get("last_failure_class") or "").strip(),
+        str((context or {}).get("failure_class") or "").strip(),
+        str((context or {}).get("failure_signature") or "").strip(),
+        str((context or {}).get("failure_summary") or "").strip(),
+    ]
+    failure_class = "\n".join(part for part in class_parts if part)
     return failure_taxonomy_service.classify_failure(
         output_text=output_value,
         result_error=detail,

--- a/api/app/services/pipeline_policy_service.py
+++ b/api/app/services/pipeline_policy_service.py
@@ -59,6 +59,8 @@ _CACHE_TTL_SECONDS = 60.0
 _cache: dict[str, Any] = {}
 _cache_loaded_at: float = 0.0
 _cache_lock = threading.Lock()
+_failure_patterns_cache_source_id: int | None = None
+_failure_patterns_cache: list[dict[str, str]] | None = None
 
 
 def _now() -> datetime:
@@ -66,10 +68,12 @@ def _now() -> datetime:
 
 
 def invalidate_cache() -> None:
-    global _cache_loaded_at
+    global _cache_loaded_at, _failure_patterns_cache_source_id, _failure_patterns_cache
     with _cache_lock:
         _cache.clear()
         _cache_loaded_at = 0.0
+        _failure_patterns_cache_source_id = None
+        _failure_patterns_cache = None
 
 
 def _refresh_cache_if_stale() -> dict[str, Any]:
@@ -194,6 +198,27 @@ _CODE_DEFAULTS: dict[str, Any] = {
             "signature": "timeout_runtime_or_dependency",
             "summary": "Execution timed out before completion.",
             "action": "Reduce task scope, keep one concrete goal, and rerun targeted verification commands.",
+        },
+        {
+            "regex": "done[_ -]?spec[_ -]?gate|done_spec_gate|impl_for_done_spec",
+            "bucket": "done_spec_gate",
+            "signature": "impl_for_done_spec",
+            "summary": "Implementation task targeted a spec that is already done.",
+            "action": "Do not retry as implementation; verify the existing artifact or select unfinished work.",
+        },
+        {
+            "regex": "no[_ -]?spec[_ -]?gate|spec[_ -]?gate|impl_without_active_spec",
+            "bucket": "spec_gate",
+            "signature": "impl_without_active_spec",
+            "summary": "Implementation task was blocked because the active-spec gate was not satisfied.",
+            "action": "Create or activate the required spec before requeueing implementation work.",
+        },
+        {
+            "regex": "provider claimed success but produced no code changes|claimed success.*no code changes|produced no meaningful output",
+            "bucket": "no_code",
+            "signature": "provider_claimed_success_no_diff",
+            "summary": "Provider claimed success without producing a meaningful code diff.",
+            "action": "Reject the hollow completion and retry with an exact file scope and verification command.",
         },
         {
             "regex": "merge conflict|rebase|conflict \\(content\\)",
@@ -327,7 +352,7 @@ def delete_policy(key: str) -> bool:
 
 def list_policies() -> list[dict[str, Any]]:
     """List all policies (DB + code defaults merged)."""
-    cache = _refresh_cache_if_stale()
+    _refresh_cache_if_stale()
     # Start with code defaults
     merged: dict[str, dict[str, Any]] = {}
     for key, value in _CODE_DEFAULTS.items():
@@ -381,7 +406,7 @@ def seed_defaults() -> int:
                 session.add(PipelinePolicyRecord(
                     key=key,
                     value_json=json.dumps(value, default=str),
-                    description=f"Auto-seeded from code default",
+                    description="Auto-seeded from code default",
                     updated_by="system:seed",
                     created_at=now,
                     updated_at=now,
@@ -422,7 +447,26 @@ def get_pass_gate_tokens() -> dict[str, str]:
 
 def get_failure_patterns() -> list[dict[str, str]]:
     """Get failure classification patterns."""
-    return get_policy("failure_patterns", _CODE_DEFAULTS["failure_patterns"])
+    global _failure_patterns_cache_source_id, _failure_patterns_cache
+    active = get_policy("failure_patterns", _CODE_DEFAULTS["failure_patterns"])
+    if not isinstance(active, list):
+        active = []
+    active_id = id(active)
+    if _failure_patterns_cache is not None and _failure_patterns_cache_source_id == active_id:
+        return _failure_patterns_cache
+    merged: list[dict[str, str]] = []
+    seen_signatures: set[str] = set()
+    for entry in active + _CODE_DEFAULTS["failure_patterns"]:
+        if not isinstance(entry, dict):
+            continue
+        signature = str(entry.get("signature") or "").strip()
+        if not signature or signature in seen_signatures:
+            continue
+        merged.append(entry)
+        seen_signatures.add(signature)
+    _failure_patterns_cache_source_id = active_id
+    _failure_patterns_cache = merged
+    return merged
 
 
 def get_no_retry_categories() -> list[str]:

--- a/api/tests/test_agent_monitor_helpers.py
+++ b/api/tests/test_agent_monitor_helpers.py
@@ -92,6 +92,15 @@ def test_low_success_rate_issue_digests_metrics(monkeypatch) -> None:
         "running": [{"id": "task_running", "running_seconds": 1}],
         "pending": [],
         "attention": {"low_success_rate": True},
+        "diagnostics": {
+            "recent_failed_reasons": [
+                {"reason": "spec_gate", "count": 6},
+                {"reason": "no_code", "count": 2},
+            ],
+            "recent_failed_signatures": [
+                {"signature": "impl_without_active_spec", "count": 6},
+            ],
+        },
     }
 
     issues = agent_monitor_helpers.derive_monitor_issues_from_pipeline_status(
@@ -103,4 +112,6 @@ def test_low_success_rate_issue_digests_metrics(monkeypatch) -> None:
     assert "65%" in issues[0]["message"]
     assert "22 completed / 12 failed / 34 resolved" in issues[0]["message"]
     assert "impl 42% (8/11)" in issues[0]["message"]
+    assert "Recent failure buckets: spec_gate x6, no_code x2" in issues[0]["message"]
+    assert "Top signatures: impl_without_active_spec x6" in issues[0]["message"]
     assert "Digest recent impl failures first" in issues[0]["suggested_action"]

--- a/api/tests/test_failure_taxonomy_service.py
+++ b/api/tests/test_failure_taxonomy_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from app.services import failure_taxonomy_service
+from app.services import pipeline_policy_service
+from app.services.agent_service_task_derive import failure_classification
+
+
+def test_failure_patterns_merge_code_defaults_with_database_override(monkeypatch) -> None:
+    monkeypatch.setattr(
+        pipeline_policy_service,
+        "get_policy",
+        lambda key, default: [
+            {
+                "regex": "custom-provider-error",
+                "bucket": "provider_error",
+                "signature": "custom_provider_error",
+                "summary": "Custom provider error.",
+                "action": "Use the custom provider repair path.",
+            }
+        ],
+    )
+
+    patterns = pipeline_policy_service.get_failure_patterns()
+    signatures = {row["signature"] for row in patterns}
+
+    assert "custom_provider_error" in signatures
+    assert "impl_without_active_spec" in signatures
+    assert "provider_claimed_success_no_diff" in signatures
+
+
+def test_failure_taxonomy_names_spec_gate_and_hollow_success(monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_policy_service, "get_policy", lambda key, default: default)
+    failure_taxonomy_service._compiled_patterns = None
+    failure_taxonomy_service._compiled_from_id = None
+
+    spec_gate = failure_taxonomy_service.classify_failure(
+        failure_class="other_spec_gate_impl_for_cli_87995841"
+    )
+    hollow = failure_taxonomy_service.classify_failure(
+        output_text="Provider claimed success but produced no code changes"
+    )
+
+    assert spec_gate["bucket"] == "spec_gate"
+    assert spec_gate["signature"] == "impl_without_active_spec"
+    assert hollow["bucket"] == "no_code"
+    assert hollow["signature"] == "provider_claimed_success_no_diff"
+
+
+def test_failure_classification_can_re_digest_stored_signature(monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_policy_service, "get_policy", lambda key, default: default)
+    failure_taxonomy_service._compiled_patterns = None
+    failure_taxonomy_service._compiled_from_id = None
+
+    classified = failure_classification({
+        "output": "",
+        "context": {
+            "failure_reason_bucket": "other",
+            "failure_signature": "other_done_spec_gate_impl_for_5620d8da",
+        },
+    })
+
+    assert classified["bucket"] == "done_spec_gate"
+    assert classified["signature"] == "impl_for_done_spec"

--- a/docs/system_audit/commit_evidence_2026-04-24_failure-signature-digest.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_failure-signature-digest.json
@@ -1,0 +1,104 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/health-digest-failure-signatures",
+  "commit_scope": "Make failed-task diagnostics name spec-gate and hollow-success signatures, then surface recent failure buckets and signatures in the low_success_rate monitor issue.",
+  "files_owned": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/app/services/agent_service_task_derive.py",
+    "api/app/services/pipeline_policy_service.py",
+    "api/tests/test_agent_monitor_helpers.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "docs/system_audit/commit_evidence_2026-04-24_failure-signature-digest.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py -q",
+      "cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_monitor_resolution.py tests/test_failure_taxonomy_service.py -q",
+      "cd api && python3 -m ruff check app/routers/agent_monitor_helpers.py app/services/agent_service_pipeline_status.py app/services/agent_service_task_derive.py app/services/pipeline_policy_service.py tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py",
+      "git diff --check",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_failure-signature-digest.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "When low_success_rate is active, /api/agent/monitor-issues should include recent failure buckets and top signatures such as spec_gate or impl_without_active_spec, even when active DB policy rows predate the code taxonomy.",
+    "public_endpoints": [
+      "/api/agent/monitor-issues",
+      "/api/agent/status-report",
+      "/api/pipeline/policies/failure_patterns"
+    ],
+    "test_flows": [
+      "DB-backed failure patterns inherit missing code-default signatures",
+      "Stored fallback signatures can be re-digested out of the generic other bucket",
+      "Derived low_success_rate issue includes recent failure buckets and top signatures"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deploy, and public sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "failure-signature-digest-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live /api/agent/monitor-issues reported only low_success_rate after dormant/orphan issues cleared",
+    "Live failed-task samples had context.failure_signature values including other_spec_gate_impl_* and other_done_spec_gate_impl_* while bucket remained other",
+    "api/app/services/pipeline_policy_service.py",
+    "api/app/services/agent_service_task_derive.py",
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/app/routers/agent_monitor_helpers.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T162524Z_codex-health-digest-failure-signatures.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/app/services/agent_service_task_derive.py",
+    "api/app/services/pipeline_policy_service.py",
+    "api/tests/test_agent_monitor_helpers.py",
+    "api/tests/test_failure_taxonomy_service.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- add concrete taxonomy signatures for spec-gate, done-spec-gate, and hollow provider success failures
- merge missing code-default failure signatures into DB-backed failure policy reads
- surface recent failure buckets and top signatures in low_success_rate monitor issues and fallback status diagnostics

## Validation
- cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py -q
- cd api && python3 -m pytest tests/test_agent_monitor_helpers.py tests/test_monitor_resolution.py tests/test_failure_taxonomy_service.py -q
- cd api && python3 -m ruff check app/routers/agent_monitor_helpers.py app/services/agent_service_pipeline_status.py app/services/agent_service_task_derive.py app/services/pipeline_policy_service.py tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py
- git diff --check
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_failure-signature-digest.json