### PR TITLE
tend: widen failed signature sensing

### DIFF
--- a/api/app/services/agent_service_pipeline_status.py
+++ b/api/app/services/agent_service_pipeline_status.py
@@ -174,10 +174,7 @@ def _pipeline_queue_diagnostics(
     reason_counts: dict[str, int] = {}
     signature_counts: dict[str, int] = {}
     recent_failed: list[dict[str, Any]] = []
-    for completed_item in completed[:12]:
-        task = _store.get(completed_item["id"]) or {}
-        if status_value(task.get("status")) != "failed":
-            continue
+    for task in _recent_failed_tasks(limit=12):
         classified = failure_classification(task)
         reason = classified["bucket"]
         reason_counts[reason] = reason_counts.get(reason, 0) + 1
@@ -216,6 +213,22 @@ def _pipeline_queue_diagnostics(
         "dominant_pending_task_type": dominant_pending_type,
         "dominant_pending_share": dominant_pending_share,
     }
+
+
+def _task_updated_timestamp(task: dict[str, Any]) -> float:
+    value = task.get("updated_at") or task.get("created_at")
+    if hasattr(value, "timestamp"):
+        try:
+            return float(value.timestamp())
+        except Exception:
+            return 0.0
+    return 0.0
+
+
+def _recent_failed_tasks(*, limit: int) -> list[dict[str, Any]]:
+    failed = [task for task in _store.values() if status_value(task.get("status")) == "failed"]
+    failed.sort(key=_task_updated_timestamp, reverse=True)
+    return failed[:limit]
 
 
 def get_pipeline_status(now_utc=None) -> dict[str, Any]:

--- a/api/tests/test_failure_taxonomy_service.py
+++ b/api/tests/test_failure_taxonomy_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from app.services import failure_taxonomy_service
 from app.services import pipeline_policy_service
+from app.services.agent_service_pipeline_status import _pipeline_queue_diagnostics
+from app.services.agent_service_store import _store
 from app.services.agent_service_task_derive import failure_classification
 
 
@@ -61,3 +63,39 @@ def test_failure_classification_can_re_digest_stored_signature(monkeypatch) -> N
 
     assert classified["bucket"] == "done_spec_gate"
     assert classified["signature"] == "impl_for_done_spec"
+
+
+def test_pipeline_diagnostics_reads_recent_failed_tasks_outside_activity_window(monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_policy_service, "get_policy", lambda key, default: default)
+    failure_taxonomy_service._compiled_patterns = None
+    failure_taxonomy_service._compiled_from_id = None
+    original_store = dict(_store)
+    try:
+        _store.clear()
+        _store["task_failed"] = {
+            "id": "task_failed",
+            "status": "failed",
+            "task_type": "impl",
+            "created_at": None,
+            "updated_at": None,
+            "output": "",
+            "context": {
+                "failure_reason_bucket": "other",
+                "failure_signature": "other_spec_gate_impl_for_cli_87995841",
+            },
+        }
+
+        diagnostics = _pipeline_queue_diagnostics(
+            running=[],
+            pending=[],
+            completed=[{"id": f"task_completed_{idx}"} for idx in range(12)],
+        )
+    finally:
+        _store.clear()
+        _store.update(original_store)
+
+    assert diagnostics["recent_failed_count"] == 1
+    assert diagnostics["recent_failed_reasons"] == [{"reason": "spec_gate", "count": 1}]
+    assert diagnostics["recent_failed_signatures"] == [
+        {"signature": "impl_without_active_spec", "count": 1}
+    ]

--- a/docs/system_audit/commit_evidence_2026-04-24_recent-failed-window.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_recent-failed-window.json
@@ -1,0 +1,92 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/health-digest-failed-window",
+  "commit_scope": "Make pipeline diagnostics gather recent failed-task signatures directly from the task store instead of relying on the newest mixed activity window.",
+  "files_owned": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "docs/system_audit/commit_evidence_2026-04-24_recent-failed-window.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py -q",
+      "cd api && python3 -m ruff check app/services/agent_service_pipeline_status.py tests/test_failure_taxonomy_service.py",
+      "git diff --check",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_recent-failed-window.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "When low_success_rate is active, /api/agent/status-report diagnostics and /api/agent/monitor-issues should show recent failed-task buckets/signatures even if the latest general task activity contains running, pending, completed, or non-failed rows.",
+    "public_endpoints": [
+      "/api/agent/status-report",
+      "/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Pipeline diagnostics reads latest failed tasks directly from the task store",
+      "Stored other_spec_gate signatures re-digest into spec_gate and impl_without_active_spec",
+      "Low-success monitor can receive non-empty recent_failed_reasons from status diagnostics"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deployment, and live sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "recent-failed-window-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live /api/agent/status-report after PR #1157 showed recent_failed_count=0 while 7d metrics still had 36 failed tasks",
+    "Live /api/agent/monitor-issues after PR #1157 still omitted failure buckets because the diagnostic window was empty",
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T163747Z_codex-health-digest-failed-window.json"
+  ],
+  "change_files": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- gather recent failed-task diagnostics directly from the task store instead of the newest mixed activity window
- keep recent failure buckets/signatures available when low_success_rate is active but current activity is mostly running/pending/spec work
- add regression coverage for re-digesting stored spec-gate signatures outside the activity window

## Validation
- cd api && python3 -m pytest tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py -q
- cd api && python3 -m ruff check app/services/agent_service_pipeline_status.py tests/test_failure_taxonomy_service.py
- git diff --check
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_recent-failed-window.json