### PR TITLE
tend: soften runner spec gates

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -1353,6 +1353,99 @@ def _complete_task_with_status(
     return False
 
 
+def _report_task_needs_decision(
+    task_id: str,
+    message: str,
+    *,
+    decision_prompt: str,
+    context_patch: dict | None = None,
+    error_category: str = "validation",
+) -> bool:
+    body: dict[str, Any] = {
+        "status": "needs_decision",
+        "output": message[:50000],
+        "decision_prompt": decision_prompt[:2000],
+        "error_summary": message[:500],
+        "error_category": error_category,
+    }
+    if context_patch:
+        body["context"] = context_patch
+    result = api("PATCH", f"/api/agent/tasks/{task_id}", body)
+    if result:
+        log.info("REPORTED task=%s status=needs_decision", task_id)
+        return True
+    log.error("REPORT FAILED task=%s status=needs_decision", task_id)
+    return False
+
+
+def _block_impl_without_active_spec(task_id: str, task: dict[str, Any]) -> bool:
+    """Return True when an impl task is blocked before execution by spec state."""
+    import glob as _glob_mod
+    import re as _re_gate
+
+    _ctx = task.get("context") or {}
+    _gate_idea_id = _ctx.get("idea_id", "")
+    _gate_spec_path = _ctx.get("spec_path", "none") or "none"
+    if not _gate_idea_id or _gate_idea_id in ("unknown",):
+        return False
+
+    _repo_s = str(_get_repo_dir())
+    _resolved_spec: "Path | None" = None
+    if _gate_spec_path != "none":
+        _cand = Path(_gate_spec_path) if Path(_gate_spec_path).is_absolute() else Path(_repo_s) / _gate_spec_path
+        if _cand.exists():
+            _resolved_spec = _cand
+    if _resolved_spec is None:
+        _found = _glob_mod.glob(f"{_repo_s}/specs/*{_gate_idea_id}*.md")
+        _resolved_spec = Path(_found[0]) if _found else None
+
+    if _resolved_spec is None:
+        _msg = (
+            f"NO_SPEC_GATE: impl for '{_gate_idea_id}' has no spec "
+            f"(spec_path={_gate_spec_path!r}). Seed a spec task first."
+        )
+        log.warning(_msg)
+        _report_task_needs_decision(
+            task_id,
+            _msg,
+            decision_prompt=(
+                "NO_SPEC_GATE: This impl task has no active spec. "
+                "Create/activate a spec for this idea, then requeue implementation."
+            ),
+            context_patch={
+                "failure_reason_bucket": "spec_gate",
+                "failure_signature": "impl_without_active_spec",
+            },
+        )
+        return True
+
+    try:
+        _spec_text = _resolved_spec.read_text(encoding="utf-8", errors="replace")
+        _sm = _re_gate.search(r"^status:\s*(\S+)", _spec_text, _re_gate.MULTILINE)
+        if _sm and _sm.group(1).lower() == "done":
+            _msg = (
+                f"DONE_SPEC_GATE: impl for '{_gate_idea_id}' targets "
+                f"'{_resolved_spec.name}' (status=done). Nothing to implement."
+            )
+            log.warning(_msg)
+            _report_task_needs_decision(
+                task_id,
+                _msg,
+                decision_prompt=(
+                    "DONE_SPEC_GATE: This impl task targets a spec already marked done. "
+                    "Verify the existing work, reopen the spec, or choose a different active spec."
+                ),
+                context_patch={
+                    "failure_reason_bucket": "done_spec_gate",
+                    "failure_signature": "impl_for_done_spec",
+                },
+            )
+            return True
+    except Exception as _ge:
+        log.debug("SPEC_GATE read error (continuing): %s", _ge)
+    return False
+
+
 _contribution_retry_queue: list[dict[str, Any]] = []
 _contribution_retry_lock = threading.Lock()
 _CONTRIBUTION_RETRY_CAP = 100
@@ -3677,46 +3770,10 @@ def run_one(task: dict, dry_run: bool = False, provider_override: str | None = N
         )
         return True
 
-    # Fast-fail gate: impl tasks without a spec, or against a 'done' spec, produce hollow output.
+    # Guidance gate: impl tasks without an active spec produce hollow output.
     # Must run here (not in build_prompt) because build_prompt() must return str, not bool.
-    if task_type == "impl":
-        import glob as _glob_mod, re as _re_gate
-        _ctx = task.get("context") or {}
-        _gate_idea_id = _ctx.get("idea_id", "")
-        _gate_spec_path = _ctx.get("spec_path", "none") or "none"
-        if _gate_idea_id and _gate_idea_id not in ("unknown",):
-            _repo_s = str(_get_repo_dir())
-            _resolved_spec: "Path | None" = None
-            if _gate_spec_path != "none":
-                _cand = Path(_gate_spec_path) if Path(_gate_spec_path).is_absolute() else Path(_repo_s) / _gate_spec_path
-                if _cand.exists():
-                    _resolved_spec = _cand
-            if _resolved_spec is None:
-                _found = _glob_mod.glob(f"{_repo_s}/specs/*{_gate_idea_id}*.md")
-                _resolved_spec = Path(_found[0]) if _found else None
-
-            if _resolved_spec is None:
-                _msg = (
-                    f"NO_SPEC_GATE: impl for '{_gate_idea_id}' has no spec "
-                    f"(spec_path={_gate_spec_path!r}). Seed a spec task first."
-                )
-                log.warning(_msg)
-                complete_task(task_id, _msg, False, {"failure_reason_bucket": "no_spec"})
-                return False
-
-            try:
-                _spec_text = _resolved_spec.read_text(encoding="utf-8", errors="replace")
-                _sm = _re_gate.search(r"^status:\s*(\S+)", _spec_text, _re_gate.MULTILINE)
-                if _sm and _sm.group(1).lower() == "done":
-                    _msg = (
-                        f"DONE_SPEC_GATE: impl for '{_gate_idea_id}' targets "
-                        f"'{_resolved_spec.name}' (status=done). Nothing to implement."
-                    )
-                    log.warning(_msg)
-                    complete_task(task_id, _msg, False, {"failure_reason_bucket": "spec_already_done"})
-                    return False
-            except Exception as _ge:
-                log.debug("SPEC_GATE read error (continuing): %s", _ge)
+    if task_type == "impl" and _block_impl_without_active_spec(task_id, task):
+        return False
 
     # Execute
     prompt = build_prompt(task)

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import local_runner
+
+
+def test_impl_without_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_runner,
+        "api",
+        lambda method, path, body=None: calls.append((method, path, body or {})) or {"status": body["status"]},
+    )
+
+    blocked = local_runner._block_impl_without_active_spec(
+        "task_no_spec",
+        {"context": {"idea_id": "missing-spec", "spec_path": "none"}},
+    )
+
+    assert blocked is True
+    body = calls[0][2]
+    assert body["status"] == "needs_decision"
+    assert "NO_SPEC_GATE" in body["decision_prompt"]
+    assert body["context"]["failure_reason_bucket"] == "spec_gate"
+    assert body["context"]["failure_signature"] == "impl_without_active_spec"
+
+
+def test_impl_for_done_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    spec_path = spec_dir / "done-idea.md"
+    spec_path.write_text("---\nstatus: done\n---\n", encoding="utf-8")
+    calls: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_runner,
+        "api",
+        lambda method, path, body=None: calls.append((method, path, body or {})) or {"status": body["status"]},
+    )
+
+    blocked = local_runner._block_impl_without_active_spec(
+        "task_done_spec",
+        {"context": {"idea_id": "done-idea", "spec_path": "specs/done-idea.md"}},
+    )
+
+    assert blocked is True
+    body = calls[0][2]
+    assert body["status"] == "needs_decision"
+    assert "DONE_SPEC_GATE" in body["decision_prompt"]
+    assert body["context"]["failure_reason_bucket"] == "done_spec_gate"
+    assert body["context"]["failure_signature"] == "impl_for_done_spec"
+
+
+def test_impl_with_active_spec_continues(monkeypatch, tmp_path: Path) -> None:
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    spec_path = spec_dir / "active-idea.md"
+    spec_path.write_text("---\nstatus: active\n---\n", encoding="utf-8")
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+
+    blocked = local_runner._block_impl_without_active_spec(
+        "task_active_spec",
+        {"context": {"idea_id": "active-idea", "spec_path": "specs/active-idea.md"}},
+    )
+
+    assert blocked is False

--- a/docs/system_audit/commit_evidence_2026-04-24_runner-spec-gate-guidance.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_runner-spec-gate-guidance.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/health-runner-spec-gate-guidance",
+  "commit_scope": "Change the local runner impl/spec gate from failed-task churn to needs_decision guidance for missing or already-done specs.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-24_runner-spec-gate-guidance.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "cd api && python3 -m py_compile scripts/local_runner.py",
+      "cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py",
+      "git diff --check",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_runner-spec-gate-guidance.json"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deployment, and live sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "runner-spec-gate-guidance-2026-04-24"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live monitor after PR #1160 reported recent_failed_reasons spec_gate x7 and done_spec_gate x3",
+    "api/scripts/local_runner.py previously called complete_task(... success=False) for NO_SPEC_GATE and DONE_SPEC_GATE",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T165119Z_codex-health-runner-spec-gate-guidance.json"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "process_only"
+}


### PR DESCRIPTION
## Summary
- change local runner NO_SPEC_GATE and DONE_SPEC_GATE from failed completions to needs_decision guidance
- preserve clear decision prompts and taxonomy context for spec_gate/done_spec_gate blocks
- add focused runner tests for missing, done, and active spec paths

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- cd api && python3 -m py_compile scripts/local_runner.py
- cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py
- git diff --check
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_runner-spec-gate-guidance.json