### PR TITLE
Gate spec-id implementation tasks

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -1384,9 +1384,11 @@ def _block_impl_without_active_spec(task_id: str, task: dict[str, Any]) -> bool:
     import re as _re_gate
 
     _ctx = task.get("context") or {}
-    _gate_idea_id = _ctx.get("idea_id", "")
+    _gate_idea_id = str(_ctx.get("idea_id", "") or "").strip()
+    _gate_spec_id = str(_ctx.get("spec_id", "") or "").strip()
+    _gate_label = _gate_idea_id or _gate_spec_id
     _gate_spec_path = _ctx.get("spec_path", "none") or "none"
-    if not _gate_idea_id or _gate_idea_id in ("unknown",):
+    if not _gate_label or _gate_label in ("unknown",):
         return False
 
     _repo_s = str(_get_repo_dir())
@@ -1396,12 +1398,12 @@ def _block_impl_without_active_spec(task_id: str, task: dict[str, Any]) -> bool:
         if _cand.exists():
             _resolved_spec = _cand
     if _resolved_spec is None:
-        _found = _glob_mod.glob(f"{_repo_s}/specs/*{_gate_idea_id}*.md")
+        _found = _glob_mod.glob(f"{_repo_s}/specs/*{_gate_label}*.md")
         _resolved_spec = Path(_found[0]) if _found else None
 
     if _resolved_spec is None:
         _msg = (
-            f"NO_SPEC_GATE: impl for '{_gate_idea_id}' has no spec "
+            f"NO_SPEC_GATE: impl for '{_gate_label}' has no spec "
             f"(spec_path={_gate_spec_path!r}). Seed a spec task first."
         )
         log.warning(_msg)
@@ -1424,7 +1426,7 @@ def _block_impl_without_active_spec(task_id: str, task: dict[str, Any]) -> bool:
         _sm = _re_gate.search(r"^status:\s*(\S+)", _spec_text, _re_gate.MULTILINE)
         if _sm and _sm.group(1).lower() == "done":
             _msg = (
-                f"DONE_SPEC_GATE: impl for '{_gate_idea_id}' targets "
+                f"DONE_SPEC_GATE: impl for '{_gate_label}' targets "
                 f"'{_resolved_spec.name}' (status=done). Nothing to implement."
             )
             log.warning(_msg)

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -27,6 +27,54 @@ def test_impl_without_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -
     assert body["context"]["failure_signature"] == "impl_without_active_spec"
 
 
+def test_impl_without_idea_id_uses_spec_id_for_spec_gate(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_runner,
+        "api",
+        lambda method, path, body=None: calls.append((method, path, body or {})) or {"status": body["status"]},
+    )
+
+    blocked = local_runner._block_impl_without_active_spec(
+        "task_spec_gap",
+        {"context": {"source": "spec_implementation_gap", "spec_id": "089", "spec_path": "specs/089-missing.md"}},
+    )
+
+    assert blocked is True
+    body = calls[0][2]
+    assert body["status"] == "needs_decision"
+    assert "NO_SPEC_GATE" in body["decision_prompt"]
+    assert body["context"]["failure_reason_bucket"] == "spec_gate"
+    assert body["context"]["failure_signature"] == "impl_without_active_spec"
+
+
+def test_impl_without_idea_id_blocks_done_spec_by_spec_id(monkeypatch, tmp_path: Path) -> None:
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    spec_path = spec_dir / "089-done.md"
+    spec_path.write_text("---\nstatus: done\n---\n", encoding="utf-8")
+    calls: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        local_runner,
+        "api",
+        lambda method, path, body=None: calls.append((method, path, body or {})) or {"status": body["status"]},
+    )
+
+    blocked = local_runner._block_impl_without_active_spec(
+        "task_done_spec_id",
+        {"context": {"source": "spec_implementation_gap", "spec_id": "089", "spec_path": "specs/089-done.md"}},
+    )
+
+    assert blocked is True
+    body = calls[0][2]
+    assert body["status"] == "needs_decision"
+    assert "DONE_SPEC_GATE" in body["decision_prompt"]
+    assert body["context"]["failure_reason_bucket"] == "done_spec_gate"
+    assert body["context"]["failure_signature"] == "impl_for_done_spec"
+
+
 def test_impl_for_done_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
     spec_dir = tmp_path / "specs"
     spec_dir.mkdir()

--- a/docs/system_audit/commit_evidence_2026-04-24_spec_id_impl_gate.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_spec_id_impl_gate.json
@@ -1,0 +1,70 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/digest-low-success-20260425",
+  "commit_scope": "Tighten local runner spec-state gate for inventory-created implementation tasks that carry spec_id without idea_id.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-24_spec_id_impl_gate.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_runner_spec_gate_guidance.py tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Focused tests: 13 passed, 1 pytest config warning. PR guard local_preflight=pass, ready_for_push=True. Follow-through check reported stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local focused tests pass; PR CI and public deploy validation pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "agent-pipeline-spec-gate"
+  ],
+  "task_ids": [
+    "digest-low-success-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live monitor issue derived-low_success_rate reported impl_without_active_spec and impl_for_done_spec signatures",
+    "focused pytest run: 13 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T200816Z_codex-digest-low-success-20260425.json"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "process_only"
+}


### PR DESCRIPTION
## Summary
- tighten local runner spec gate to use spec_id when idea_id is absent
- block inventory-created impl tasks for missing or done specs before provider execution
- add regression coverage for spec_id-only missing/done spec contexts

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_runner_spec_gate_guidance.py tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence