### PR TITLE
tend: stop unspecced impl advance

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -2165,23 +2165,56 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
             # Read the spec content directly to give the provider full context
             spec_ref = ""
             resolved_spec_path = ""
+            spec_status = ""
             try:
                 import glob as _glob
-                # Exact match first, then glob fallback
-                exact = _get_repo_dir() / "specs" / f"{idea_id}.md"
-                if exact.exists():
-                    spec_files = [str(exact)]
-                else:
-                    spec_files = _glob.glob(str(_get_repo_dir() / "specs" / f"*{idea_id}*"))
+                spec_files = []
+                task_context = task.get("context") if isinstance(task.get("context"), dict) else {}
+                context_spec = task_context.get("spec_file") or task_context.get("spec_path")
+                if context_spec:
+                    exact_context = (
+                        Path(context_spec)
+                        if Path(context_spec).is_absolute()
+                        else _get_repo_dir() / str(context_spec)
+                    )
+                    if exact_context.exists():
+                        spec_files = [str(exact_context)]
+                if not spec_files:
+                    # Exact match first, then glob fallback
+                    exact = _get_repo_dir() / "specs" / f"{idea_id}.md"
+                    if exact.exists():
+                        spec_files = [str(exact)]
+                    else:
+                        spec_files = _glob.glob(str(_get_repo_dir() / "specs" / f"*{idea_id}*"))
                 if spec_files:
                     resolved_spec_path = spec_files[0]
                     with open(resolved_spec_path, "r", encoding="utf-8", errors="replace") as sf:
+                        spec_text = sf.read()
                         # DG-002 fix: cap spec content to keep total direction < 3000 chars.
                         # Spec path is stored in context so the provider can read the full file.
-                        spec_content = sf.read()[:600]
+                        spec_content = spec_text[:600]
+                    status_match = re.search(r"^status:\s*(\S+)", spec_text, re.MULTILINE)
+                    spec_status = status_match.group(1).strip().lower() if status_match else ""
                     spec_ref = f"\n\nSpec ({resolved_spec_path}):\n```\n{spec_content}\n```\n(Full spec at {resolved_spec_path})\n"
-            except Exception:
-                pass
+            except Exception as exc:
+                log.warning("AUTO_PHASE spec resolve failed idea=%s error=%s", idea_id, exc)
+            if not resolved_spec_path:
+                log.warning("AUTO_PHASE skip impl — no active spec found for %s", idea_id)
+                _append_idea_event(idea_id, "phase_advance_blocked", {
+                    "from_phase": task_type,
+                    "to_phase": next_phase,
+                    "reason": "missing_active_spec",
+                })
+                return
+            if spec_status == "done":
+                log.warning("AUTO_PHASE skip impl — spec already done for %s path=%s", idea_id, resolved_spec_path)
+                _append_idea_event(idea_id, "phase_advance_blocked", {
+                    "from_phase": task_type,
+                    "to_phase": next_phase,
+                    "reason": "done_spec",
+                    "spec_path": resolved_spec_path,
+                })
+                return
             extra_context["spec_path"] = resolved_spec_path or "none"
 
             direction = (

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -66,3 +66,60 @@ def test_impl_with_active_spec_continues(monkeypatch, tmp_path: Path) -> None:
     )
 
     assert blocked is False
+
+
+def test_spec_phase_does_not_enqueue_impl_without_spec(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(local_runner, "_append_idea_event", lambda *args, **kwargs: None)
+
+    def fake_api(method: str, path: str, body: dict | None = None):
+        calls.append((method, path, body))
+        if path == "/api/ideas/missing-spec/tasks":
+            return {
+                "groups": [
+                    {"task_type": "spec", "count": 1, "status_counts": {"completed": 1}},
+                ],
+                "tasks": [],
+            }
+        if path == "/api/ideas/missing-spec":
+            return {"id": "missing-spec", "name": "Missing Spec", "description": ""}
+        return {}
+
+    monkeypatch.setattr(local_runner, "api", fake_api)
+
+    local_runner._run_phase_auto_advance_hook(
+        {"task_type": "spec", "context": {"idea_id": "missing-spec"}}
+    )
+
+    assert not [call for call in calls if call[0] == "POST" and call[1] == "/api/agent/tasks"]
+
+
+def test_spec_phase_does_not_enqueue_impl_for_done_spec(monkeypatch, tmp_path: Path) -> None:
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    (spec_dir / "done-idea.md").write_text("---\nstatus: done\n---\n", encoding="utf-8")
+    calls: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(local_runner, "_append_idea_event", lambda *args, **kwargs: None)
+
+    def fake_api(method: str, path: str, body: dict | None = None):
+        calls.append((method, path, body))
+        if path == "/api/ideas/done-idea/tasks":
+            return {
+                "groups": [
+                    {"task_type": "spec", "count": 1, "status_counts": {"completed": 1}},
+                ],
+                "tasks": [],
+            }
+        if path == "/api/ideas/done-idea":
+            return {"id": "done-idea", "name": "Done Idea", "description": ""}
+        return {}
+
+    monkeypatch.setattr(local_runner, "api", fake_api)
+
+    local_runner._run_phase_auto_advance_hook(
+        {"task_type": "spec", "context": {"idea_id": "done-idea"}}
+    )
+
+    assert not [call for call in calls if call[0] == "POST" and call[1] == "/api/agent/tasks"]

--- a/docs/system_audit/commit_evidence_2026-04-25_stop-unspecced-impl-advance.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_stop-unspecced-impl-advance.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-stop-unspecced-impl",
+  "commit_scope": "Stop the local runner from auto-enqueueing implementation tasks when the completed spec phase did not produce an active spec.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-25_stop-unspecced-impl-advance.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "cd api && python3 -m py_compile scripts/local_runner.py",
+      "cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py",
+      "git diff --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_stop-unspecced-impl-advance.json",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deployment, and live sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "stop-unspecced-impl-advance-2026-04-25"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live monitor after PR #1161 still reported recent failure signatures impl_without_active_spec x5 and impl_for_done_spec x3",
+    "api/scripts/local_runner.py previously set spec_path to none and still POSTed an impl task",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T200844Z_codex-health-stop-unspecced-impl.json",
+    "Local verifier rerun passed after first-run automation usage cache warmup"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "process_only"
+}


### PR DESCRIPTION
## Summary
- stop local runner phase auto-advance from enqueueing impl when no active spec file exists
- treat specs marked status: done as non-implementable at the advance source
- add regression coverage for missing and done spec phase advances

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- cd api && python3 -m py_compile scripts/local_runner.py
- cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py
- git diff --check
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh