### PR TITLE
Classify compacted failure outputs

### DIFF
--- a/api/app/services/pipeline_policy_service.py
+++ b/api/app/services/pipeline_policy_service.py
@@ -221,6 +221,20 @@ _CODE_DEFAULTS: dict[str, Any] = {
             "action": "Reject the hollow completion and retry with an exact file scope and verification command.",
         },
         {
+            "regex": "compact[_ -]?summary[_ -]?original[_ -]?chars|original_chars_start|context compact(?:ed|ion)",
+            "bucket": "context_compaction",
+            "signature": "context_compaction_summary_leaked",
+            "summary": "Failure output is a compacted context summary instead of task evidence.",
+            "action": "Retry from the persisted task card with a fresh context budget and require concrete artifact/test evidence.",
+        },
+        {
+            "regex": "now[_ -]?researching[_ -]?the[_ -]?idea|will[_ -]?start[_ -]?searching|i(?:'|’)?ll[_ -]?start[_ -]?searching|starting[_ -]?research",
+            "bucket": "no_code",
+            "signature": "progress_only_no_artifact",
+            "summary": "Provider returned progress narration without a concrete artifact, diff, or verification result.",
+            "action": "Reject the run as no-artifact output and retry with exact files_allowed plus done_when evidence.",
+        },
+        {
             "regex": "merge conflict|rebase|conflict \\(content\\)",
             "bucket": "git_conflict",
             "signature": "git_conflict_or_rebase",

--- a/api/tests/test_failure_taxonomy_service.py
+++ b/api/tests/test_failure_taxonomy_service.py
@@ -48,6 +48,24 @@ def test_failure_taxonomy_names_spec_gate_and_hollow_success(monkeypatch) -> Non
     assert hollow["signature"] == "provider_claimed_success_no_diff"
 
 
+def test_failure_taxonomy_names_compaction_and_progress_only_outputs(monkeypatch) -> None:
+    monkeypatch.setattr(pipeline_policy_service, "get_policy", lambda key, default: default)
+    failure_taxonomy_service._compiled_patterns = None
+    failure_taxonomy_service._compiled_from_id = None
+
+    compacted = failure_taxonomy_service.classify_failure(
+        failure_class="other_compact_summary_original_chars_start_a2f76de1"
+    )
+    progress_only = failure_taxonomy_service.classify_failure(
+        failure_class="other_now_researching_the_idea_and_9bad7518"
+    )
+
+    assert compacted["bucket"] == "context_compaction"
+    assert compacted["signature"] == "context_compaction_summary_leaked"
+    assert progress_only["bucket"] == "no_code"
+    assert progress_only["signature"] == "progress_only_no_artifact"
+
+
 def test_failure_classification_can_re_digest_stored_signature(monkeypatch) -> None:
     monkeypatch.setattr(pipeline_policy_service, "get_policy", lambda key, default: default)
     failure_taxonomy_service._compiled_patterns = None

--- a/docs/system_audit/commit_evidence_2026-04-24_failure_taxonomy_digest.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_failure_taxonomy_digest.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/hollow-impl-completion-20260425",
+  "commit_scope": "Classify compacted-context and progress-only task failures so low-success-rate diagnostics stop collapsing into generic other buckets.",
+  "files_owned": [
+    "api/app/services/pipeline_policy_service.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "docs/system_audit/commit_evidence_2026-04-24_failure_taxonomy_digest.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py"
+      ,
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Initial focused run failed because progress-only regex did not match stored underscore signatures; regex was tightened and rerun passed with 9 passed, 1 pytest config warning. PR guard local_preflight=pass, ready_for_push=True. Follow-through check reported stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local tests pass; pre-push guard, PR CI, and public deploy validation pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "failure-taxonomy-diagnostics"
+  ],
+  "task_ids": [
+    "hollow-impl-completion-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live monitor issue derived-low_success_rate: recent_failed_reasons other x6, spec_gate x5, done_spec_gate x1",
+    "live status-report recent signatures included other_compact_summary_original_chars_start_* and other_now_researching_the_idea_*",
+    "focused pytest run: 9 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T202113Z_codex-hollow-impl-completion-20260425.json"
+  ],
+  "change_files": [
+    "api/app/services/pipeline_policy_service.py",
+    "api/tests/test_failure_taxonomy_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public monitor diagnostics should classify compacted-context failures as context_compaction and progress-only outputs as no_code/progress_only_no_artifact after deploy.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/monitor-issues",
+      "https://api.coherencycoin.com/api/agent/status-report"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense monitor/status-report diagnostics after deploy."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- classify compacted-context failure signatures as context_compaction
- classify progress-only task outputs as no_code/progress_only_no_artifact
- add regression coverage for both live low-success-rate signature shapes

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence