### PR TITLE
tend: make spec handoff durable

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -2168,10 +2168,11 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
             spec_ref = ""
             resolved_spec_path = ""
             spec_status = ""
+            task_context = task.get("context") if isinstance(task.get("context"), dict) else {}
+            context_spec_path = ""
             try:
                 import glob as _glob
                 spec_files = []
-                task_context = task.get("context") if isinstance(task.get("context"), dict) else {}
                 context_spec = task_context.get("spec_file") or task_context.get("spec_path")
                 if context_spec:
                     exact_context = (
@@ -2197,7 +2198,13 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
                         spec_content = spec_text[:600]
                     status_match = re.search(r"^status:\s*(\S+)", spec_text, re.MULTILINE)
                     spec_status = status_match.group(1).strip().lower() if status_match else ""
-                    spec_ref = f"\n\nSpec ({resolved_spec_path}):\n```\n{spec_content}\n```\n(Full spec at {resolved_spec_path})\n"
+                    try:
+                        context_spec_path = str(
+                            Path(resolved_spec_path).resolve().relative_to(_get_repo_dir().resolve())
+                        )
+                    except ValueError:
+                        context_spec_path = resolved_spec_path
+                    spec_ref = f"\n\nSpec ({context_spec_path}):\n```\n{spec_content}\n```\n(Full spec at {context_spec_path})\n"
             except Exception as exc:
                 log.warning("AUTO_PHASE spec resolve failed idea=%s error=%s", idea_id, exc)
             if not resolved_spec_path:
@@ -2217,7 +2224,9 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
                     "spec_path": resolved_spec_path,
                 })
                 return
-            extra_context["spec_path"] = resolved_spec_path or "none"
+            extra_context["spec_path"] = context_spec_path or resolved_spec_path or "none"
+            if task_context.get("spec_branch"):
+                extra_context["spec_branch"] = task_context["spec_branch"]
 
             direction = (
                 f"Implement '{idea_name}' ({idea_id}).\n\n"
@@ -4116,10 +4125,10 @@ def run_one(task: dict, dry_run: bool = False, provider_override: str | None = N
     if success and reported:
         # Only advance phases if the task produced meaningful output
         if len(output_stripped) >= min_chars:
-            # Fix 4: impl/test phase advance is deferred to _worker_loop (after push confirmation).
+            # Fix 4: file-producing phase advance is deferred to _worker_loop (after push confirmation).
             # _worker_loop calls _run_phase_auto_advance_hook only after _push_branch_to_origin
             # returns True, preventing phantom phase advance when the push subsequently fails.
-            if task_type not in ("impl", "test"):
+            if task_type not in ("spec", "impl", "test"):
                 _run_phase_auto_advance_hook(task)
             _auto_record_contribution(task, provider, duration)
         else:
@@ -6436,6 +6445,7 @@ def _worker_loop(worker_id: int, dry_run: bool = False) -> None:
             # Create worktree — for test/review phases, checkout the impl PR branch
             task_type = task.get("task_type", "spec")
             impl_branch = ctx.get("impl_branch", "")
+            spec_branch = ctx.get("spec_branch", "")
             workspace_git_url = ctx.get("workspace_git_url", "")
 
             # HARD GATE: test/code-review/review REQUIRE impl_branch.
@@ -6463,7 +6473,12 @@ def _worker_loop(worker_id: int, dry_run: bool = False) -> None:
                 # (DG-010): counting seeder mistakes as provider failures trips the breaker unfairly.
                 continue
 
-            base_branch = impl_branch if task_type in ("test", "code-review", "review") else None
+            if task_type in ("test", "code-review", "review"):
+                base_branch = impl_branch
+            elif task_type == "impl" and spec_branch:
+                base_branch = spec_branch
+            else:
+                base_branch = None
             wt = _create_worktree(task_id, base_branch=base_branch, idea_id=idea_id,
                                   workspace_git_url=workspace_git_url)
             pushed = False
@@ -6526,11 +6541,23 @@ def _worker_loop(worker_id: int, dry_run: bool = False) -> None:
                                     ctx = {**ctx, "impl_branch": impl_branch_name}
                                     if isinstance(task.get("context"), dict):
                                         task["context"]["impl_branch"] = impl_branch_name
+                            elif task_type == "spec":
+                                spec_branch_name = f"task/{task_id[:16]}"
+                                branch_patch_result = api("PATCH", f"/api/agent/tasks/{task_id}", {
+                                    "context": {**ctx, "spec_branch": spec_branch_name},
+                                })
+                                if branch_patch_result:
+                                    log.info("SPEC_BRANCH_SET task=%s branch=%s", task_id[:16], spec_branch_name)
+                                else:
+                                    log.warning("SPEC_BRANCH_PATCH_FAILED task=%s branch=%s", task_id[:16], spec_branch_name)
+                                ctx = {**ctx, "spec_branch": spec_branch_name}
+                                if isinstance(task.get("context"), dict):
+                                    task["context"]["spec_branch"] = spec_branch_name
                             # Create PR after successful branch push for impl tasks
                             if task_type == "impl":
                                 _create_pr_for_branch(task_id, task, wt)
-                            # Fix 4: phase advance only fires after push is confirmed for impl/test
-                            if task_type in ("impl", "test"):
+                            # Fix 4: phase advance only fires after push is confirmed for file-producing phases
+                            if task_type in ("spec", "impl", "test"):
                                 _run_phase_auto_advance_hook(task)
                     elif not ok and diff and task_type in ("impl", "test"):
                         # Timed out but produced real code — save the work, push branch

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -171,3 +171,43 @@ def test_spec_phase_does_not_enqueue_impl_for_done_spec(monkeypatch, tmp_path: P
     )
 
     assert not [call for call in calls if call[0] == "POST" and call[1] == "/api/agent/tasks"]
+
+
+def test_spec_phase_enqueues_impl_with_durable_spec_branch(monkeypatch, tmp_path: Path) -> None:
+    spec_dir = tmp_path / "specs"
+    spec_dir.mkdir()
+    (spec_dir / "active-idea.md").write_text("---\nstatus: active\n---\n", encoding="utf-8")
+    calls: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(local_runner, "_append_idea_event", lambda *args, **kwargs: None)
+
+    def fake_api(method: str, path: str, body: dict | None = None):
+        calls.append((method, path, body))
+        if path == "/api/ideas/active-idea/tasks":
+            return {
+                "groups": [
+                    {"task_type": "spec", "count": 1, "status_counts": {"completed": 1}},
+                ],
+                "tasks": [],
+            }
+        if path == "/api/ideas/active-idea":
+            return {"id": "active-idea", "name": "Active Idea", "description": ""}
+        return {}
+
+    monkeypatch.setattr(local_runner, "api", fake_api)
+
+    local_runner._run_phase_auto_advance_hook(
+        {
+            "task_type": "spec",
+            "context": {
+                "idea_id": "active-idea",
+                "spec_branch": "task/spec-task-id",
+            },
+        }
+    )
+
+    created = [call for call in calls if call[0] == "POST" and call[1] == "/api/agent/tasks"]
+    assert len(created) == 1
+    context = created[0][2]["context"]
+    assert context["spec_path"] == "specs/active-idea.md"
+    assert context["spec_branch"] == "task/spec-task-id"

--- a/docs/system_audit/commit_evidence_2026-04-25_durable-spec-handoff.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_durable-spec-handoff.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-durable-spec-handoff",
+  "commit_scope": "Make spec-to-impl phase advance durable by pushing spec task branches before creating implementation tasks and passing that branch to the implementation worktree.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-25_durable-spec-handoff.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "cd api && python3 -m py_compile scripts/local_runner.py",
+      "cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_durable-spec-handoff.json",
+      "git diff --check",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deployment, and live sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "repository-architecture-health",
+    "pipeline-monitoring"
+  ],
+  "task_ids": [
+    "durable-spec-handoff-2026-04-25"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live needs_decision tasks showed impl tasks carrying spec_path values under transient .worktrees/task-* directories",
+    "api/scripts/local_runner.py previously advanced spec tasks before worker-loop branch push",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T202147Z_codex-health-durable-spec-handoff.json",
+    "Local worktree web validation passed with 58 interface parity checks and zero failures"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "process_only"
+}


### PR DESCRIPTION
## Summary
- defer spec phase auto-advance until the worker confirms the spec branch was pushed
- pass spec_branch and relative spec_path into generated impl tasks
- let impl worktrees start from the spec branch so the spec is durable tissue, not a transient worktree path

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- cd api && python3 -m py_compile scripts/local_runner.py
- cd api && python3 -m ruff check tests/test_runner_spec_gate_guidance.py
- git diff --check
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh