### PR TITLE
feat(story-protocol): partner-gated stubs close the last source drift

### DIFF
--- a/api/app/services/ip_registration_service.py
+++ b/api/app/services/ip_registration_service.py
@@ -1,0 +1,103 @@
+"""IP registration service — Story Protocol SDK integration (pending).
+
+Per specs/story-protocol-integration.md R1. The spec describes async
+registration of an asset as an IP Asset on Story Protocol, returning
+an IP Asset ID stored on the asset's graph node.
+
+**Not yet wired.** The real implementation requires the Story Protocol
+SDK and a partner-selection gate:
+  - Which chain? Story Protocol's own L2 on Base? Sepolia for testing?
+  - Which signer? Platform-owned hot wallet or per-contributor wallet?
+  - Which royalty module config? Default split vs configurable?
+
+Until those decisions land, this module provides the function
+signatures the rest of the system can import and call. Functions
+raise `IpRegistrationPending` with a clear message so callers can
+either check `is_ready()` first or catch the exception and fall
+back to marking the asset's `ip_status` as `pending`.
+
+Once partner selection completes:
+  - Replace `IpRegistrationPending` raises with real SDK calls
+  - Implement `register_ip_asset()` to call `sp.register_ip(...)`
+  - Implement `get_ip_status()` to query the chain
+  - Implement `record_derivative()` to wire the royalty module
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class IpRegistrationPending(Exception):
+    """Raised when IP registration is invoked before Story Protocol
+    SDK integration lands."""
+
+
+@dataclass(frozen=True)
+class IpRegistrationResult:
+    """Shape the real implementation will return."""
+
+    sp_ip_id: str
+    tx_hash: str
+    royalty_module_address: Optional[str]
+    registered_at: str  # ISO 8601
+
+
+def is_ready() -> bool:
+    """Return True once the Story Protocol SDK is wired and a signer
+    is configured. Returns False for the current partner-gated state.
+    """
+    return False
+
+
+def register_ip_asset(
+    asset_id: str,
+    creator_id: str,
+    *,
+    content_hash: str,
+    metadata: Optional[dict] = None,
+) -> IpRegistrationResult:
+    """Register an asset as an IP Asset on Story Protocol.
+
+    Returns an IpRegistrationResult with the on-chain IP Asset ID,
+    transaction hash, and royalty module address. The caller stores
+    `sp_ip_id` on the asset's graph node under property `sp_ip_id`
+    and flips `ip_status` from `pending` to `registered`.
+    """
+    raise IpRegistrationPending(
+        "Story Protocol SDK integration is pending partner selection. "
+        "See specs/story-protocol-integration.md R1 for the contract."
+    )
+
+
+def get_ip_status(sp_ip_id: str) -> dict:
+    """Query the on-chain status of a registered IP Asset.
+
+    Returns a dict with fields the settlement service reads to confirm
+    the asset's IP Asset is confirmed and accruing royalties.
+    """
+    raise IpRegistrationPending(
+        "Story Protocol SDK integration is pending partner selection."
+    )
+
+
+def record_derivative(
+    child_asset_id: str,
+    parent_sp_ip_id: str,
+    *,
+    royalty_split_parent: float = 0.15,
+    royalty_split_child: float = 0.85,
+) -> IpRegistrationResult:
+    """Register a derivative work with the royalty module.
+
+    Configures the parent/child royalty split so future CC flows
+    attribute proportionally. Default 15%/85% per spec R7.
+    """
+    if abs(royalty_split_parent + royalty_split_child - 1.0) > 0.001:
+        raise ValueError(
+            "royalty_split_parent + royalty_split_child must sum to 1.0"
+        )
+    raise IpRegistrationPending(
+        "Story Protocol royalty module integration is pending partner selection."
+    )

--- a/api/app/services/permanent_storage_service.py
+++ b/api/app/services/permanent_storage_service.py
@@ -1,0 +1,129 @@
+"""Permanent storage service — Arweave + IPFS bundler integration (pending).
+
+Per specs/story-protocol-integration.md R3. The spec describes
+permanent upload of asset content to Arweave via a bundler (Irys/
+Bundlr) and content-addressed retrieval via IPFS. The resulting
+`arweave_tx_id` and `ipfs_cid` are stored on the asset's graph node.
+
+**Not yet wired.** The real implementation requires bundler service
+selection and a platform-owned funding wallet:
+  - Which bundler? Irys (formerly Bundlr) vs direct Arweave node
+  - Which IPFS gateway? Pinata / Web3.Storage / self-hosted
+  - Funding model? Platform pays bundler in AR / USDC per upload?
+  - Max file size? 50MB proposed in spec; larger needs chunked upload
+
+Until those decisions land, this module provides the function
+signatures so the rest of the system can import and call. Functions
+raise `PermanentStoragePending` with a clear message so callers
+can mark the asset's storage refs as `pending` and retry once
+the service is live.
+
+Content integrity verification (`verify_content_integrity`) already
+exists in `story_protocol_bridge.verify_content_integrity()` and
+does NOT depend on the storage service — it can be called today
+against any already-stored `arweave_tx_id` or local content hash.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+class PermanentStoragePending(Exception):
+    """Raised when a permanent storage upload is invoked before the
+    bundler/IPFS integration lands."""
+
+
+@dataclass(frozen=True)
+class PermanentStorageResult:
+    """Shape the real implementation will return."""
+
+    arweave_tx_id: Optional[str]
+    ipfs_cid: Optional[str]
+    content_hash: str  # sha256:<hex>
+    uploaded_at: str   # ISO 8601
+    size_bytes: int
+
+
+def is_ready() -> bool:
+    """Return True once the Arweave bundler client and IPFS gateway
+    are configured. Returns False for the current partner-gated state.
+    """
+    return False
+
+
+def upload_to_arweave(
+    content: bytes,
+    *,
+    mime_type: str,
+    tags: Optional[dict] = None,
+) -> str:
+    """Upload raw content to Arweave via the configured bundler.
+
+    Returns the Arweave transaction ID on success. The caller is
+    responsible for computing the SHA-256 hash and storing it on
+    the asset node alongside the returned tx_id.
+    """
+    raise PermanentStoragePending(
+        "Arweave bundler integration is pending partner selection. "
+        "See specs/story-protocol-integration.md R3 for the contract."
+    )
+
+
+def upload_to_ipfs(
+    content: bytes,
+    *,
+    mime_type: str,
+) -> str:
+    """Upload content to IPFS via the configured gateway.
+
+    Returns the content identifier (CID) on success.
+    """
+    raise PermanentStoragePending(
+        "IPFS gateway integration is pending partner selection."
+    )
+
+
+def upload(
+    content: bytes,
+    *,
+    mime_type: str,
+    tags: Optional[dict] = None,
+) -> PermanentStorageResult:
+    """Upload to both Arweave and IPFS in parallel; return the
+    combined result.
+
+    This is the recommended entry point — it ensures both storage
+    tiers are populated so the asset has permanent (Arweave) and
+    retrievable (IPFS) paths.
+    """
+    raise PermanentStoragePending(
+        "Permanent storage integration is pending partner selection."
+    )
+
+
+def verify_content_integrity(
+    expected_content_hash: str,
+    arweave_tx_id: Optional[str] = None,
+    ipfs_cid: Optional[str] = None,
+) -> dict:
+    """Fetch content from permanent storage and verify its SHA-256
+    hash matches the expected value.
+
+    Returns a dict with `arweave_match`, `ipfs_match`, and `overall_ok`.
+    Both `arweave_tx_id` and `ipfs_cid` are optional — pass what's
+    available. If neither is provided, raises ValueError.
+
+    The hashing half of this check is already implemented in
+    `app.services.story_protocol_bridge.verify_content_integrity()`
+    — once fetch is live, this function just fetches bytes from
+    the two sources and hands them to the bridge's pure hasher.
+    """
+    if arweave_tx_id is None and ipfs_cid is None:
+        raise ValueError(
+            "at least one of arweave_tx_id or ipfs_cid must be provided"
+        )
+    raise PermanentStoragePending(
+        "Permanent storage integration is pending partner selection."
+    )

--- a/web/app/assets/upload/page.tsx
+++ b/web/app/assets/upload/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Upload Asset — Coherence Network",
+  description:
+    "Register any digital asset with a MIME type and permanent storage. Full upload awaits Arweave integration.",
+};
+
+export default function AssetUploadPage() {
+  return (
+    <main className="max-w-2xl mx-auto px-6 py-12">
+      <nav
+        className="text-sm text-stone-500 mb-8 flex items-center gap-2"
+        aria-label="breadcrumb"
+      >
+        <Link href="/" className="hover:text-amber-400/80 transition-colors">
+          Home
+        </Link>
+        <span className="text-stone-700">/</span>
+        <span className="text-stone-300">Upload</span>
+      </nav>
+
+      <h1 className="text-3xl font-extralight text-white mb-4">
+        Upload an asset
+      </h1>
+      <p className="text-stone-400 text-sm leading-relaxed mb-8">
+        The asset-renderer system accepts any MIME type. Permanent storage
+        (Arweave + IPFS) and on-chain IP registration (Story Protocol) are
+        pending partner integration — for now, registration via the public{" "}
+        <code className="text-stone-300">POST /api/assets/register</code>{" "}
+        endpoint records the asset with its MIME type and content hash; the
+        file hosting is handled externally.
+      </p>
+
+      <div className="rounded border border-amber-500/30 bg-amber-500/5 p-5 mb-8">
+        <div className="text-amber-200 font-light mb-2">
+          Pending Arweave + Story Protocol wiring
+        </div>
+        <p className="text-sm text-stone-300 leading-relaxed">
+          Direct-upload-from-browser is gated on two partner decisions:
+        </p>
+        <ul className="list-disc list-inside mt-3 space-y-1 text-sm text-stone-400">
+          <li>
+            Arweave bundler (Irys / Bundlr) — selection + funding wallet
+          </li>
+          <li>
+            Story Protocol SDK — chain selection + signer configuration
+          </li>
+        </ul>
+        <p className="text-sm text-stone-400 mt-3">
+          See <code className="text-stone-300">specs/story-protocol-integration.md</code> R1 + R3.
+          The service stubs{" "}
+          <code className="text-stone-300">
+            api/app/services/ip_registration_service.py
+          </code>{" "}
+          and{" "}
+          <code className="text-stone-300">
+            api/app/services/permanent_storage_service.py
+          </code>{" "}
+          define the exact interface partner integration will fill.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <h2 className="text-lg font-light text-stone-300">Today's path</h2>
+        <p className="text-sm text-stone-400 leading-relaxed">
+          Host your content on Arweave / IPFS / GitHub / your own server, then
+          register the asset with its hash and URLs via the API. The full
+          attribution chain works against that registration — renderer
+          resolution, render events, evidence, settlement, and the proof card.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/creators/submit"
+            className="rounded border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-amber-200 hover:bg-amber-500/20 transition-colors text-sm"
+          >
+            Submit a creator asset →
+          </Link>
+          <Link
+            href="/creators"
+            className="rounded border border-stone-700 bg-stone-900/50 px-4 py-2 text-stone-200 hover:border-amber-500/40 transition-colors text-sm"
+          >
+            Creators landing
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/app/settlement/page.tsx
+++ b/web/app/settlement/page.tsx
@@ -1,0 +1,182 @@
+import Link from "next/link";
+
+import { getApiBase } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Settlement — Coherence Network",
+  description:
+    "Daily CC settlement batches — render aggregates, evidence multipliers, concept pools.",
+};
+
+type ConceptPool = {
+  concept_id: string;
+  cc_amount: string | number;
+};
+
+type SettlementEntry = {
+  asset_id: string;
+  read_count: number;
+  base_cc_pool: string | number;
+  evidence_multiplier: string | number;
+  effective_cc_pool: string | number;
+  cc_to_asset_creator: string | number;
+  cc_to_renderer_creators: string | number;
+  cc_to_host_nodes: string | number;
+  concept_pools: ConceptPool[];
+};
+
+type SettlementBatch = {
+  id: string;
+  batch_date: string;
+  entries: SettlementEntry[];
+  total_read_count: number;
+  total_cc_distributed: string | number;
+  computed_at: string;
+};
+
+async function fetchBatches(): Promise<SettlementBatch[] | null> {
+  try {
+    const response = await fetch(`${getApiBase()}/api/settlement?limit=30`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as SettlementBatch[];
+  } catch {
+    return null;
+  }
+}
+
+function formatCc(value: string | number): string {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "CC 0.0000";
+  return `CC ${n.toFixed(4)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function BatchCard({ batch }: { batch: SettlementBatch }) {
+  return (
+    <div className="rounded border border-stone-800 bg-stone-950/40 p-4">
+      <div className="flex items-baseline justify-between mb-3">
+        <div>
+          <div className="text-lg font-light text-white">
+            {formatDate(batch.batch_date)}
+          </div>
+          <div className="text-xs text-stone-500">
+            {batch.total_read_count} read
+            {batch.total_read_count === 1 ? "" : "s"} across{" "}
+            {batch.entries.length} asset
+            {batch.entries.length === 1 ? "" : "s"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-amber-400/80 font-light">
+            {formatCc(batch.total_cc_distributed)}
+          </div>
+          <div className="text-xs text-stone-500 uppercase tracking-wide">
+            distributed
+          </div>
+        </div>
+      </div>
+      {batch.entries.length > 0 && (
+        <div className="space-y-1 text-xs">
+          {batch.entries.slice(0, 8).map((e) => (
+            <div
+              key={e.asset_id}
+              className="flex items-center justify-between text-stone-400"
+            >
+              <span className="truncate">{e.asset_id}</span>
+              <span className="flex items-center gap-3">
+                <span>{e.read_count} reads</span>
+                {Number(e.evidence_multiplier) > 1 && (
+                  <span className="text-amber-400/80">
+                    ×{Number(e.evidence_multiplier).toFixed(1)}
+                  </span>
+                )}
+                <span className="text-stone-300">
+                  {formatCc(e.effective_cc_pool)}
+                </span>
+              </span>
+            </div>
+          ))}
+          {batch.entries.length > 8 && (
+            <div className="text-stone-600 text-xs">
+              + {batch.entries.length - 8} more
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default async function SettlementDashboardPage() {
+  const batches = await fetchBatches();
+
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-12">
+      <nav
+        className="text-sm text-stone-500 mb-8 flex items-center gap-2"
+        aria-label="breadcrumb"
+      >
+        <Link href="/" className="hover:text-amber-400/80 transition-colors">
+          Home
+        </Link>
+        <span className="text-stone-700">/</span>
+        <span className="text-stone-300">Settlement</span>
+      </nav>
+
+      <h1 className="text-3xl font-extralight text-white mb-2">Settlement</h1>
+      <p className="text-stone-400 text-sm leading-relaxed mb-8">
+        Daily CC distribution batches. Each batch aggregates render events,
+        applies the evidence-verification multiplier (up to 5× per verified
+        asset), and splits CC across asset creator, renderer creator, and host
+        node shares — then distributes the creator's share across the asset's
+        concept pools by tag weight.
+      </p>
+
+      {!batches && (
+        <div className="rounded border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-200">
+          Could not reach the settlement API.
+        </div>
+      )}
+
+      {batches && batches.length === 0 && (
+        <div className="rounded border border-stone-800 bg-stone-950/40 p-6 text-stone-400 text-sm">
+          No settlement batches computed yet. A batch is produced each day the
+          daily settlement job runs (<code>POST /api/settlement/run</code>).
+          Once render events accumulate against an asset, the first batch will
+          appear here.
+        </div>
+      )}
+
+      {batches && batches.length > 0 && (
+        <div className="space-y-4">
+          {batches.map((batch) => (
+            <BatchCard key={batch.id} batch={batch} />
+          ))}
+        </div>
+      )}
+
+      <p className="text-xs text-stone-500 mt-8">
+        Settlement math lives at{" "}
+        <code className="text-stone-400">
+          api/app/services/settlement_service.py
+        </code>
+        . See <code className="text-stone-400">story-protocol-integration.md</code> R8.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes the last four source paths flagged by wellness. **Zero drift** after this PR — every spec's `source:` path points at a real file.

**Two service stubs (partner-gated with honest exceptions):**

- `api/app/services/ip_registration_service.py` — `IpRegistrationPending` exception, `is_ready()` returns False until SDK wired, signatures for `register_ip_asset()`, `get_ip_status()`, `record_derivative()` with default 15%/85% royalty split per spec R7
- `api/app/services/permanent_storage_service.py` — `PermanentStoragePending` exception, `upload_to_arweave()`, `upload_to_ipfs()`, combined `upload()`, and `verify_content_integrity()` (notes that the hashing half is already live in `story_protocol_bridge`)

Each raises with the spec reference so callers can catch and fall back rather than hitting an opaque import error.

**Two web pages:**

- `web/app/assets/upload/page.tsx` — transparent "Pending Arweave + Story Protocol wiring" page that names the two gates, points to the stub modules, and directs readers to `/creators/submit` for the working registration path today
- `web/app/settlement/page.tsx` — daily-batch dashboard fed by `GET /api/settlement?limit=30`. Each card shows date, read count, distributed CC, per-asset entries with evidence multiplier highlighted when >1. Graceful empty + API-unreachable states.

**wellness:**
```
## Source maps — do specs point at files that exist?
  every spec's source: paths point at files that exist
```

The reading that started at 16 missing paths is fully clear. Every one of those 16 paths either got a real implementation, an honest partner-gated stub, or a scaffold page — none silently missing.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_