### PR TITLE
Prioritize low-success guidance

### DIFF
--- a/api/app/routers/agent_monitor_helpers.py
+++ b/api/app/routers/agent_monitor_helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from app.routers.agent_helpers import issue_priority_map
 from app.services import agent_service
+from app.services.agent_monitor_guidance_service import low_success_rate_suggested_action
 from app.services.config_service import get_config
 
 logger = logging.getLogger(__name__)
@@ -215,20 +216,17 @@ def low_success_rate_context(status: dict[str, Any] | None = None) -> tuple[str,
         if type_rate < 0.8:
             weak_types.append((str(task_type), type_completed, type_failed, type_rate))
     weak_types.sort(key=lambda item: (-item[2], item[3], item[0]))
+    diagnostics = status.get("diagnostics") if isinstance(status, dict) and isinstance(status.get("diagnostics"), dict) else {}
     if weak_types:
         fragments = [
             f"{task_type} {int(round(type_rate * 100))}% ({type_completed}/{type_failed})"
             for task_type, type_completed, type_failed, type_rate in weak_types[:3]
         ]
         message = f"{message} Weak task types: {', '.join(fragments)}."
-        suggested = (
-            f"Digest recent {weak_types[0][0]} failures first: inspect failure signatures, "
-            "then tighten routing/task-card gates or requeue only scoped work with evidence."
-        )
+        suggested = low_success_rate_suggested_action(diagnostics, weak_types[0][0])
     else:
-        suggested = "Run targeted prompt/model diagnostics and capture remediation in the meta pipeline."
+        suggested = low_success_rate_suggested_action(diagnostics, "prompt/model")
 
-    diagnostics = status.get("diagnostics") if isinstance(status, dict) and isinstance(status.get("diagnostics"), dict) else {}
     if diagnostics:
         reason_fragments = _diagnostic_count_fragments(diagnostics, "recent_failed_reasons", "reason")
         signature_fragments = _diagnostic_count_fragments(diagnostics, "recent_failed_signatures", "signature", limit=2)

--- a/api/app/services/agent_monitor_guidance_service.py
+++ b/api/app/services/agent_monitor_guidance_service.py
@@ -1,0 +1,39 @@
+"""Guidance text helpers for agent monitor issues."""
+
+from typing import Any
+
+
+def low_success_rate_suggested_action(
+    diagnostics: dict[str, Any],
+    fallback_task_type: str,
+) -> str:
+    rows = diagnostics.get("recent_failed_reasons") if isinstance(diagnostics.get("recent_failed_reasons"), list) else []
+    top_reason = ""
+    for row in rows:
+        count = row.get("count") if isinstance(row, dict) else 0
+        try:
+            normalized_count = int(count or 0)
+        except (TypeError, ValueError):
+            normalized_count = 0
+        if isinstance(row, dict) and str(row.get("reason") or "").strip() and normalized_count > 0:
+            top_reason = str(row.get("reason") or "").strip()
+            break
+
+    reason_actions = {
+        "context_compaction": "Fix recent context_compaction failures first: retry from persisted task cards with a fresh context budget and require artifact/test evidence.",
+        "spec_gate": "Fix recent spec_gate failures first: stop unspecced implementation work, create or activate the required specs, and requeue only scoped work with evidence.",
+        "no_code": "Fix recent no-artifact failures first: reject progress-only or empty completions, then retry with exact files_allowed and done_when verification.",
+        "empty_output": "Fix recent no-artifact failures first: reject progress-only or empty completions, then retry with exact files_allowed and done_when verification.",
+        "done_spec_gate": "Fix recent done_spec_gate failures first: verify existing artifacts or select unfinished specs instead of retrying completed specs.",
+    }
+    if top_reason in reason_actions:
+        return reason_actions[top_reason]
+    if top_reason:
+        return (
+            f"Digest recent {top_reason} failures first: inspect failure signatures, "
+            "then tighten routing/task-card gates or requeue only scoped work with evidence."
+        )
+    return (
+        f"Digest recent {fallback_task_type} failures first: inspect failure signatures, "
+        "then tighten routing/task-card gates or requeue only scoped work with evidence."
+    )

--- a/api/tests/test_agent_monitor_helpers.py
+++ b/api/tests/test_agent_monitor_helpers.py
@@ -114,4 +114,44 @@ def test_low_success_rate_issue_digests_metrics(monkeypatch) -> None:
     assert "impl 42% (8/11)" in issues[0]["message"]
     assert "Recent failure buckets: spec_gate x6, no_code x2" in issues[0]["message"]
     assert "Top signatures: impl_without_active_spec x6" in issues[0]["message"]
-    assert "Digest recent impl failures first" in issues[0]["suggested_action"]
+    assert "Fix recent spec_gate failures first" in issues[0]["suggested_action"]
+
+
+def test_low_success_rate_issue_prioritizes_context_compaction_guidance(monkeypatch) -> None:
+    def fake_aggregates() -> dict:
+        return {
+            "success_rate": {"completed": 184, "failed": 70, "total": 254, "rate": 0.72},
+            "by_task_type": {
+                "impl": {"completed": 8, "failed": 55, "success_rate": 0.13},
+                "spec": {"completed": 176, "failed": 14, "success_rate": 0.93},
+            },
+        }
+
+    import app.services.metrics_service as metrics_service
+
+    monkeypatch.setattr(metrics_service, "get_aggregates", fake_aggregates)
+    status = {
+        "running": [{"id": "task_running", "running_seconds": 1}],
+        "pending": [],
+        "attention": {"low_success_rate": True},
+        "diagnostics": {
+            "recent_failed_reasons": [
+                {"reason": "context_compaction", "count": 4},
+                {"reason": "no_code", "count": 2},
+            ],
+            "recent_failed_signatures": [
+                {"signature": "context_compaction_summary_leaked", "count": 4},
+                {"signature": "progress_only_no_artifact", "count": 2},
+            ],
+        },
+    }
+
+    issues = agent_monitor_helpers.derive_monitor_issues_from_pipeline_status(
+        status,
+        now=datetime.now(timezone.utc),
+    )
+
+    assert [issue["condition"] for issue in issues] == ["low_success_rate"]
+    assert "Recent failure buckets: context_compaction x4, no_code x2" in issues[0]["message"]
+    assert "Top signatures: context_compaction_summary_leaked x4" in issues[0]["message"]
+    assert "Fix recent context_compaction failures first" in issues[0]["suggested_action"]

--- a/docs/system_audit/commit_evidence_2026-04-24_low_success_guidance.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_low_success_guidance.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/low-success-guidance-20260425",
+  "commit_scope": "Make low-success-rate monitor guidance follow the dominant recent failure reason instead of always naming the weakest 7-day task type.",
+  "files_owned": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/app/services/agent_monitor_guidance_service.py",
+    "api/tests/test_agent_monitor_helpers.py",
+    "docs/system_audit/commit_evidence_2026-04-24_low_success_guidance.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py",
+      "python3 api/scripts/run_maintainability_audit.py --output api/logs/maintainability_audit_report.worktree_guard.json --fail-on-regression",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "10 passed, 1 pytest config warning. Initial PR guard detected maintainability regression after router helper growth; logic was moved into a small service module and maintainability audit then reported regression=no. Final PR guard local_preflight=pass, ready_for_push=True; follow-through stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local tests pass; pre-push guard, PR CI, and public deploy validation pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "monitor-guidance-diagnostics"
+  ],
+  "task_ids": [
+    "low-success-guidance-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live monitor issue derived-low_success_rate: recent_failed_reasons spec_gate x5, context_compaction x4, no_code x2",
+    "focused pytest run: 10 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T204017Z_codex-low-success-guidance-20260425.json"
+  ],
+  "change_files": [
+    "api/app/routers/agent_monitor_helpers.py",
+    "api/app/services/agent_monitor_guidance_service.py",
+    "api/tests/test_agent_monitor_helpers.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public low_success_rate suggested_action should prioritize the dominant recent diagnostic reason, such as context_compaction, instead of only the weakest 7-day task type.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/monitor-issues",
+      "https://api.coherencycoin.com/api/agent/status-report"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense monitor/status-report diagnostics after deploy."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- make low-success-rate suggested actions prioritize the dominant recent diagnostic reason
- add compact guidance service to keep monitor helper below maintainability thresholds
- add regression coverage for context_compaction-driven guidance

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_agent_monitor_helpers.py tests/test_failure_taxonomy_service.py
- python3 api/scripts/run_maintainability_audit.py --output api/logs/maintainability_audit_report.worktree_guard.json --fail-on-regression
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence