### PR TITLE
tend: heal external proof — /advance for stage, PATCH for archive

### DIFF
--- a/api/tests/test_external_proof_demo.py
+++ b/api/tests/test_external_proof_demo.py
@@ -27,7 +27,7 @@ def test_external_proof_idea_payload_matches_public_contract() -> None:
     assert payload["workspace_id"] == "coherence-network"
 
 
-def test_external_proof_stage_calls_use_public_post_contract() -> None:
+def test_external_proof_lifecycle_calls_use_public_contract() -> None:
     module = _load_external_proof_module()
     runner = module.ProofRunner("https://api.example.test", "dev-key", dry_run=True)
     runner.idea_id = "idea-123"
@@ -36,8 +36,8 @@ def test_external_proof_stage_calls_use_public_post_contract() -> None:
     runner.archive_idea()
 
     assert runner.endpoints_exercised == [
-        "POST /api/ideas/idea-123/stage",
-        "POST /api/ideas/idea-123/stage",
+        "POST /api/ideas/idea-123/advance",
+        "PATCH /api/ideas/idea-123",
     ]
 
 

--- a/scripts/external_proof_demo.py
+++ b/scripts/external_proof_demo.py
@@ -142,8 +142,7 @@ class ProofRunner:
     def advance_stage(self) -> None:
         self._call(
             "POST",
-            f"/api/ideas/{self.idea_id}/stage",
-            {"stage": "spec"},
+            f"/api/ideas/{self.idea_id}/advance",
         )
         self.pass_("stage advanced")
 
@@ -182,12 +181,13 @@ class ProofRunner:
     def archive_idea(self) -> None:
         if self.idea_id is None:
             return
-        # Close/archive the test idea. The lifecycle endpoint varies
-        # across deployments; use the public stage setter for cleanup.
+        # "archived" is an IdeaLifecycle value, not an IdeaStage — the
+        # stage endpoint would reject it. Lifecycle lives on the idea
+        # object itself and is mutated via PATCH.
         self._call(
-            "POST",
-            f"/api/ideas/{self.idea_id}/stage",
-            {"stage": "archived"},
+            "PATCH",
+            f"/api/ideas/{self.idea_id}",
+            {"lifecycle": "archived"},
         )
         self.pass_("idea archived")
 


### PR DESCRIPTION
## Summary
- `/advance` is the correct stage-progression endpoint (no body). The script was POSTing to `/stage` with `{"stage":"spec"}` — wrong enum value and wrong endpoint-use.
- Archival lives on `IdeaLifecycle`, not `IdeaStage`. Switched to `PATCH /api/ideas/{id}` with `{"lifecycle":"archived"}` to match the contract.
- 401s from a stale CI secret had been masking both bugs across three prior fix commits.

## Context
CI secret rotation (GitHub Actions `COHERENCE_API_KEY` → prod's 43-char key from mounted `/root/.coherence-network/config.json`) was applied separately at 2026-04-24T20:36:29Z. This PR lets the script exercise the public contract correctly once the auth clears.

Leftover test idea `537fd351-710c-4cbd-a274-d5d9b7ba1545` on prod already archived manually via the corrected call.

## Test plan
- [x] `pytest api/tests/test_external_proof_demo.py -v` — 3/3 pass
- [x] `python3 scripts/external_proof_demo.py --dry-run` — 5 endpoints exercised, expected shape
- [ ] External proof CI run on main post-merge — full round-trip against live prod API
- [ ] Hostinger Auto Deploy verify
- [ ] Witness `pulse.coherencycoin.com/pulse/now` breathing after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)