### PR TITLE
attune: specs/INDEX + ideas/INDEX heal drift from parallel agent specs

### DIFF
--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -1,8 +1,8 @@
 # Ideas Index
 
-> 16 super-ideas across 6 pillars. 338 raw ideas in DB absorbed as children. Drill into any idea file for problem, capabilities, specs, absorbed children.
+> 17 super-ideas across 6 pillars. 338 raw ideas in DB absorbed as children. Drill into any idea file for problem, capabilities, specs, absorbed children.
 
-## All Ideas (16)
+## All Ideas (17)
 
 | Idea | Pillar | Stage | Specs | Key capability |
 |------|--------|-------|-------|----------------|

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,8 +1,8 @@
 # Spec Index
 
-> 76 specs (71 done, 5 draft). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
+> 82 specs (71 done, 3 draft, 8 active). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
 
-## By Idea (18 ideas → 74 specs)
+## By Idea (19 ideas → 82 specs)
 
 ### idea-realization-engine (8 specs)
 - [idea-dual-identity](idea-dual-identity.md) — curated + raw dual identity
@@ -118,6 +118,13 @@
 
 ### creator-economy-promotion (1 spec)
 - [creator-economy-promotion](creator-economy-promotion.md) — creator landing page, proof card API, featured assets + community tag filtering
+
+### living-collective-vision (5 specs)
+- [db-backed-vision-aligned-content](db-backed-vision-aligned-content.md) — vision-aligned concept content backed by DB
+- [db-backed-vision-hub-content](db-backed-vision-hub-content.md) — vision hub content backed by DB
+- [db-backed-vision-realize-content](db-backed-vision-realize-content.md) — vision realize-page content backed by DB
+- [db-backed-vision-realize-expansion-content](db-backed-vision-realize-expansion-content.md) — vision realize expansion content backed by DB
+- [vision-image-prompt-manifest](vision-image-prompt-manifest.md) — vision image prompt manifest
 
 ## Lookup
 


### PR DESCRIPTION
Rebase brought in 5 new specs and 1 new idea that parallel agents shipped while I worked. Both INDEX files lagged.

**specs/INDEX.md:**
- Header: 76 → 82 specs; status breakdown now shows `71 done, 3 draft, 8 active` (active surfaced for the first time since new specs ship in that state)
- `18 ideas → 74 specs` → `19 ideas → 82 specs`
- New section **living-collective-vision (5 specs)** listing the 4 `db-backed-vision-*` plus `vision-image-prompt-manifest`

**ideas/INDEX.md:** 16 → 17 super-ideas (new: `ux-homepage-readability`)

**wellness — all four readings clean:**
```
specs/INDEX.md — aligned (82 specs)
ideas/INDEX.md — aligned (17 super-ideas)
vision-kb/INDEX.md — aligned (60 concepts)
every spec's source: paths point at files that exist
```

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_