### PR TITLE
tend: make external proof auth advisory

### DIFF
--- a/.github/workflows/external-proof.yml
+++ b/.github/workflows/external-proof.yml
@@ -40,5 +40,14 @@ jobs:
             echo "::warning::COHERENCE_API_KEY secret not set; running dry-run instead"
             python3 scripts/external_proof_demo.py --dry-run
           else
+            set +e
             python3 scripts/external_proof_demo.py
+            status=$?
+            set -e
+            if [ "$status" -eq 2 ] && [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+              echo "::warning::COHERENCE_API_KEY was rejected by the live API; running dry-run so deploy proof stays advisory until the secret is rotated"
+              python3 scripts/external_proof_demo.py --dry-run
+            else
+              exit "$status"
+            fi
           fi

--- a/api/tests/test_external_proof_demo.py
+++ b/api/tests/test_external_proof_demo.py
@@ -60,3 +60,27 @@ def test_external_proof_headers_include_public_api_key_header() -> None:
     assert headers["X-API-Key"] == "dev-key"
     assert headers["Authorization"] == "Bearer dev-key"
     assert headers["Content-Type"] == "application/json"
+
+
+def test_external_proof_auth_failure_has_distinct_exit_code() -> None:
+    module = _load_external_proof_module()
+
+    class Response:
+        ok = False
+        status_code = 401
+        text = '{"detail":"Invalid or missing X-API-Key header"}'
+
+    class Requests:
+        @staticmethod
+        def request(*args, **kwargs):
+            return Response()
+
+    runner = module.ProofRunner("https://api.example.test", "stale-key", dry_run=False)
+    runner.requests = Requests()
+
+    try:
+        runner._call("POST", "/api/ideas/idea-123/stage", {"stage": "spec"})
+    except SystemExit as exc:
+        assert exc.code == module.AUTH_FAILED_EXIT
+    else:
+        raise AssertionError("expected auth failure to exit distinctly")

--- a/docs/system_audit/commit_evidence_2026-04-25_external-proof-auth-guidance.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_external-proof-auth-guidance.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-external-proof-guidance",
+  "commit_scope": "Make External proof distinguish stale API-key auth from product regressions and keep push deployments advisory when the GitHub secret is rejected.",
+  "files_owned": [
+    ".github/workflows/external-proof.yml",
+    "scripts/external_proof_demo.py",
+    "api/tests/test_external_proof_demo.py",
+    "docs/system_audit/commit_evidence_2026-04-25_external-proof-auth-guidance.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_external_proof_demo.py -q",
+      "python3 scripts/external_proof_demo.py --dry-run",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_external-proof-auth-guidance.json",
+      "git diff --check",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Focused validation is passing; full local gate, CI, deployment, and live sensing still need to complete."
+  },
+  "idea_ids": [
+    "repository-health",
+    "pipeline-proprioception"
+  ],
+  "spec_ids": [
+    "external-repo-milestone"
+  ],
+  "task_ids": [
+    "external-proof-auth-guidance-2026-04-25"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "live-sensing"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "External proof run 24910877082 failed with HTTP 401 Invalid or missing X-API-Key header after public idea creation",
+    ".github/workflows/external-proof.yml previously only downgraded missing secrets, not rejected stale secrets",
+    "api/tests/test_external_proof_demo.py",
+    "PR guard report docs/system_audit/pr_check_failures/pr_check_guard_20260424T204404Z_codex-health-external-proof-guidance.json"
+  ],
+  "change_files": [
+    ".github/workflows/external-proof.yml",
+    "scripts/external_proof_demo.py",
+    "api/tests/test_external_proof_demo.py"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/external_proof_demo.py
+++ b/scripts/external_proof_demo.py
@@ -20,6 +20,7 @@ Usage:
 Exit codes:
     0  — all checkpoints passed
     1  — any API call failed or env vars missing
+    2  — configured API key was rejected by a protected endpoint
 
 Dependencies: requests (or any HTTP client). Stdlib-only if possible
 by keeping requests usage minimal.
@@ -34,6 +35,9 @@ import json
 import os
 import sys
 from typing import Any, Dict, Optional
+
+
+AUTH_FAILED_EXIT = 2
 
 
 def _idea_create_payload() -> Dict[str, Any]:
@@ -105,6 +109,17 @@ class ProofRunner:
             method, url, headers=self._headers(), json=body, timeout=30
         )
         if not response.ok:
+            if response.status_code == 401:
+                print(
+                    "[AUTH-FAILED] COHERENCE_API_KEY was rejected by the live API. "
+                    "Rotate the GitHub Actions secret or run with --dry-run.",
+                    file=sys.stderr,
+                )
+                print(
+                    f"[FAIL] HTTP {response.status_code} — {response.text[:500]}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(AUTH_FAILED_EXIT)
             print(
                 f"[FAIL] HTTP {response.status_code} — {response.text[:500]}",
                 file=sys.stderr,


### PR DESCRIPTION
## Summary
- classify rejected COHERENCE_API_KEY as a distinct auth failure exit code in external_proof_demo.py
- keep manual External proof strict, but downgrade stale-secret auth failure on push to a warning plus dry-run
- add regression coverage for the distinct auth exit code

## Validation
- cd api && python3 -m pytest tests/test_external_proof_demo.py -q
- python3 scripts/external_proof_demo.py --dry-run
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_external-proof-auth-guidance.json