### PR TITLE
tend: external proof reads /coherence/score (aggregate, not per-idea)

### DIFF
--- a/scripts/external_proof_demo.py
+++ b/scripts/external_proof_demo.py
@@ -182,7 +182,13 @@ class ProofRunner:
         self.pass_("contribution recorded")
 
     def check_coherence_score(self) -> None:
-        result = self._call("GET", f"/api/coherence/{self.idea_id}")
+        # The live endpoint is the aggregate system coherence at
+        # `/api/coherence/score` — there's no per-idea coherence endpoint,
+        # since coherence in this system is a network-level signal, not
+        # an idea-level one. The proof verifies the score is readable
+        # and in range; the idea-specific score travels on the idea
+        # response itself (`free_energy_score`, `selection_weight`).
+        result = self._call("GET", "/api/coherence/score")
         if not self.dry_run:
             score = result.get("score")
             if not isinstance(score, (int, float)) or not (0.0 <= score <= 1.0):


### PR DESCRIPTION
## Summary
- Script was calling `GET /api/coherence/{idea_id}` → 404. There's no per-idea coherence endpoint; coherence here is a network-level signal.
- Switched to `GET /api/coherence/score` — the actual route in `api/app/routers/coherence.py`.
- Idea-specific scores (`free_energy_score`, `selection_weight`) already ride on the idea response.

## Test plan
- [x] `pytest api/tests/test_external_proof_demo.py` — 5/5 pass
- [x] End-to-end against live prod with admin key — all 5 checkpoints pass, idea auto-archived
- [ ] External proof CI on main post-merge — strict mode green

🤖 Generated with [Claude Code](https://claude.com/claude-code)