### PR TITLE
Expose zero-output resolved diagnostics

### DIFF
--- a/api/app/services/agent_service_pipeline_status.py
+++ b/api/app/services/agent_service_pipeline_status.py
@@ -174,6 +174,21 @@ def _pipeline_queue_diagnostics(
     reason_counts: dict[str, int] = {}
     signature_counts: dict[str, int] = {}
     recent_failed: list[dict[str, Any]] = []
+    recent_zero_output_resolved: list[dict[str, Any]] = []
+    for item in completed[:20]:
+        task = _store.get(item.get("id")) or {}
+        st = status_value(task.get("status"))
+        if st not in {"completed", "failed"}:
+            continue
+        if len(task_output_text(task).strip()) > 0:
+            continue
+        recent_zero_output_resolved.append(
+            {
+                "task_id": task.get("id"),
+                "task_type": task_type_name(task.get("task_type")) or "unknown",
+                "status": st,
+            }
+        )
     for task in _recent_failed_tasks(limit=12):
         classified = failure_classification(task)
         reason = classified["bucket"]
@@ -209,6 +224,8 @@ def _pipeline_queue_diagnostics(
         "recent_failed": recent_failed[:5],
         "recent_failed_reasons": recent_failed_reasons,
         "recent_failed_signatures": recent_failed_signatures,
+        "recent_zero_output_resolved_count": len(recent_zero_output_resolved),
+        "recent_zero_output_resolved": recent_zero_output_resolved[:5],
         "queue_mix_warning": queue_mix_warning,
         "dominant_pending_task_type": dominant_pending_type,
         "dominant_pending_share": dominant_pending_share,

--- a/api/tests/test_failure_taxonomy_service.py
+++ b/api/tests/test_failure_taxonomy_service.py
@@ -117,3 +117,55 @@ def test_pipeline_diagnostics_reads_recent_failed_tasks_outside_activity_window(
     assert diagnostics["recent_failed_signatures"] == [
         {"signature": "impl_without_active_spec", "count": 1}
     ]
+
+
+def test_pipeline_diagnostics_reports_zero_output_resolved_tasks() -> None:
+    original_store = dict(_store)
+    try:
+        _store.clear()
+        _store["task_hollow_completed"] = {
+            "id": "task_hollow_completed",
+            "status": "completed",
+            "task_type": "impl",
+            "created_at": None,
+            "updated_at": None,
+            "output": "",
+            "context": {},
+        }
+        _store["task_hollow_failed"] = {
+            "id": "task_hollow_failed",
+            "status": "failed",
+            "task_type": "spec",
+            "created_at": None,
+            "updated_at": None,
+            "output": "",
+            "context": {},
+        }
+        _store["task_non_hollow"] = {
+            "id": "task_non_hollow",
+            "status": "completed",
+            "task_type": "spec",
+            "created_at": None,
+            "updated_at": None,
+            "output": "Wrote specs/123-example.md",
+            "context": {},
+        }
+
+        diagnostics = _pipeline_queue_diagnostics(
+            running=[],
+            pending=[],
+            completed=[
+                {"id": "task_hollow_completed"},
+                {"id": "task_hollow_failed"},
+                {"id": "task_non_hollow"},
+            ],
+        )
+    finally:
+        _store.clear()
+        _store.update(original_store)
+
+    assert diagnostics["recent_zero_output_resolved_count"] == 2
+    assert diagnostics["recent_zero_output_resolved"] == [
+        {"task_id": "task_hollow_completed", "task_type": "impl", "status": "completed"},
+        {"task_id": "task_hollow_failed", "task_type": "spec", "status": "failed"},
+    ]

--- a/docs/system_audit/commit_evidence_2026-04-24_zero_output_resolved_diagnostics.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_zero_output_resolved_diagnostics.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/hollow-completion-status-20260425",
+  "commit_scope": "Expose zero-output resolved task rows in pipeline diagnostics so hollow completion debt is directly measurable.",
+  "files_owned": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "docs/system_audit/commit_evidence_2026-04-24_zero_output_resolved_diagnostics.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "11 passed, 1 pytest config warning. PR guard local_preflight=pass, ready_for_push=True. Follow-through check reported stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local tests pass; pre-push guard, PR CI, and public deploy validation pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "zero-output-resolved-diagnostics"
+  ],
+  "task_ids": [
+    "hollow-completion-status-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live status-report recent_completed rows showed output_len=0 while attention only surfaced low_success_rate",
+    "focused pytest run: 11 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T205540Z_codex-hollow-completion-status-20260425.json"
+  ],
+  "change_files": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public status-report diagnostics should include recent_zero_output_resolved_count and samples when zero-output completed or failed rows appear in the recent resolved window.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/status-report"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense status-report diagnostics after deploy."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add recent_zero_output_resolved diagnostics to pipeline status
- expose count and samples for completed/failed tasks with empty output in the recent resolved window
- add regression coverage for zero-output resolved diagnostics

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence