### PR TITLE
tend: seed structured task cards

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -63,6 +63,54 @@ def _get_repo_dir() -> Path:
 _REPO_DIR = _ORIGINAL_REPO_DIR
 _LOG_DIR = _API_DIR / "logs"
 
+
+def _task_card_context(
+    *,
+    goal: str,
+    files_allowed: list[str],
+    done_when: list[str],
+    commands: list[str],
+    constraints: list[str],
+) -> dict[str, Any]:
+    """Return task-card fields both nested and top-level for API validation."""
+    card = {
+        "goal": goal,
+        "files_allowed": files_allowed,
+        "done_when": done_when,
+        "commands": commands,
+        "constraints": constraints,
+    }
+    return {**card, "task_card": dict(card)}
+
+
+def _extract_spec_task_files(spec_text: str, fallback_spec_path: str) -> list[str]:
+    """Extract exact-ish implementation file paths from spec source/files_allowed blocks."""
+    files: list[str] = []
+    in_files_allowed = False
+    for raw_line in spec_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_-]*:", line) and not line.startswith(("file:", "files_allowed:")):
+            in_files_allowed = False
+        if line.startswith("files_allowed:"):
+            in_files_allowed = True
+            continue
+        candidate = ""
+        if line.startswith("- file:"):
+            candidate = line.split(":", 1)[1].strip()
+        elif line.startswith("file:"):
+            candidate = line.split(":", 1)[1].strip()
+        elif in_files_allowed and line.startswith("- "):
+            candidate = line[2:].strip()
+        if candidate:
+            candidate = candidate.strip("'\"")
+            if candidate and not candidate.startswith(("#", "http://", "https://")) and candidate not in files:
+                files.append(candidate)
+        if len(files) >= 20:
+            break
+    return files or ([fallback_spec_path] if fallback_spec_path else [])
+
 # ── Runner config — single source of truth, no env vars ──────────────
 _RUNNER_CONFIG: dict[str, Any] = {}
 
@@ -2199,6 +2247,7 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
             spec_ref = ""
             resolved_spec_path = ""
             spec_status = ""
+            spec_text = ""
             task_context = task.get("context") if isinstance(task.get("context"), dict) else {}
             context_spec_path = ""
             try:
@@ -2258,6 +2307,24 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
             extra_context["spec_path"] = context_spec_path or resolved_spec_path or "none"
             if task_context.get("spec_branch"):
                 extra_context["spec_branch"] = task_context["spec_branch"]
+            impl_spec_path = str(extra_context["spec_path"])
+            extra_context.update(_task_card_context(
+                goal=f"Implement {idea_name} according to {impl_spec_path}",
+                files_allowed=_extract_spec_task_files(spec_text, impl_spec_path),
+                done_when=[
+                    "Implementation matches the active spec acceptance criteria",
+                    "Changed code is committed with focused verification output",
+                    "No files outside the spec source/files_allowed scope are modified",
+                ],
+                commands=[
+                    "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+                ],
+                constraints=[
+                    "Use the active spec as the implementation contract",
+                    "Do not advance when the spec is missing, stale, or marked done",
+                    "Keep changes limited to the spec-listed implementation files",
+                ],
+            ))
 
             direction = (
                 f"Implement '{idea_name}' ({idea_id}).\n\n"
@@ -4830,6 +4897,44 @@ def _seed_task_from_open_idea() -> bool:
         "seed_generated": True,
         "seed_source": "local_runner_smart_seed",
     }
+    if task_type == "spec":
+        spec_path = f"specs/{idea_id}.md"
+        seed_ctx.update(_task_card_context(
+            goal=f"Write an executable spec for {idea_name}",
+            files_allowed=[spec_path],
+            done_when=[
+                f"{spec_path} exists",
+                "Spec includes goal, source files, requirements, done_when, verification scenarios, and constraints",
+                "Verification scenarios include exact commands or requests with expected output",
+            ],
+            commands=[
+                "python3 scripts/validate_spec_quality.py --base origin/main --head HEAD",
+            ],
+            constraints=[
+                f"Only create or edit {spec_path}",
+                "Keep the spec concrete enough for implementation without extra discovery",
+                "Follow CLAUDE.md",
+            ],
+        ))
+    elif task_type == "impl":
+        spec_path = f"specs/{idea_id}.md"
+        seed_ctx.update(_task_card_context(
+            goal=f"Implement {idea_name} from {spec_path}",
+            files_allowed=[spec_path],
+            done_when=[
+                "Implementation satisfies the spec done_when criteria",
+                "Relevant tests or verification commands pass",
+                "Changes are committed for runner push/PR handling",
+            ],
+            commands=[
+                "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+            ],
+            constraints=[
+                "Read the spec before editing implementation files",
+                "Only modify files allowed by the spec",
+                "Stop with IMPL_BLOCKED if the spec is missing or too vague",
+            ],
+        ))
     if workspace_git_url_seed:
         seed_ctx["workspace_git_url"] = workspace_git_url_seed
 

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -5,6 +5,37 @@ from pathlib import Path
 from scripts import local_runner
 
 
+def test_task_card_context_populates_nested_and_top_level_fields() -> None:
+    context = local_runner._task_card_context(
+        goal="Write an executable spec",
+        files_allowed=["specs/example.md"],
+        done_when=["spec exists"],
+        commands=["python3 scripts/validate_spec_quality.py --base origin/main --head HEAD"],
+        constraints=["only edit specs/example.md"],
+    )
+
+    assert context["goal"] == "Write an executable spec"
+    assert context["files_allowed"] == ["specs/example.md"]
+    assert context["task_card"]["goal"] == context["goal"]
+    assert context["task_card"]["files_allowed"] == context["files_allowed"]
+
+
+def test_extract_spec_task_files_prefers_spec_source_files() -> None:
+    spec_text = """---
+source:
+  - file: api/app/routers/assets.py
+    symbols: [router]
+files_allowed:
+  - api/app/services/assets.py
+---
+"""
+
+    assert local_runner._extract_spec_task_files(spec_text, "specs/assets.md") == [
+        "api/app/routers/assets.py",
+        "api/app/services/assets.py",
+    ]
+
+
 def test_impl_without_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
@@ -176,7 +207,10 @@ def test_spec_phase_does_not_enqueue_impl_for_done_spec(monkeypatch, tmp_path: P
 def test_spec_phase_enqueues_impl_with_durable_spec_branch(monkeypatch, tmp_path: Path) -> None:
     spec_dir = tmp_path / "specs"
     spec_dir.mkdir()
-    (spec_dir / "active-idea.md").write_text("---\nstatus: active\n---\n", encoding="utf-8")
+    (spec_dir / "active-idea.md").write_text(
+        "---\nstatus: active\nsource:\n  - file: api/app/routers/active.py\n---\n",
+        encoding="utf-8",
+    )
     calls: list[tuple[str, str, dict | None]] = []
     monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)
     monkeypatch.setattr(local_runner, "_append_idea_event", lambda *args, **kwargs: None)
@@ -211,3 +245,9 @@ def test_spec_phase_enqueues_impl_with_durable_spec_branch(monkeypatch, tmp_path
     context = created[0][2]["context"]
     assert context["spec_path"] == "specs/active-idea.md"
     assert context["spec_branch"] == "task/spec-task-id"
+    assert context["goal"] == "Implement Active Idea according to specs/active-idea.md"
+    assert context["files_allowed"] == ["api/app/routers/active.py"]
+    assert context["task_card"]["done_when"]
+    assert context["task_card"]["commands"] == [
+        "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ]

--- a/docs/system_audit/commit_evidence_2026-04-25_seed-task-card-context.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_seed-task-card-context.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-seed-task-cards",
+  "commit_scope": "Give runner-seeded and auto-advanced tasks structured task-card context so validation guides execution instead of producing weak-card friction.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-25_seed-task-card-context.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "python3 -m py_compile api/scripts/local_runner.py",
+      "git fetch origin main && git rebase origin/main",
+      "git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "10 runner spec-gate tests passed; local_runner.py compiled successfully. Branch rebased with autostash after dirty-worktree guard, PR guard local_preflight=pass ready_for_push=True, follow-through stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local tests pass; pre-push guard, PR CI, merge, deploy, and live sensing remain pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate",
+    "runner-context-hygiene"
+  ],
+  "spec_ids": [
+    "seed-task-card-context"
+  ],
+  "task_ids": [
+    "health-seed-task-cards"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live monitor issue reported low_success_rate with weak task-card context hygiene",
+    "runner-created tasks showed task_card_validation score=0.0 for missing goal/files_allowed/done_when/commands/constraints",
+    "focused pytest run: 10 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T210924Z_codex-health-seed-task-cards.json"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "New runner-seeded spec and impl tasks should carry structured task_card, top-level files_allowed, and nonzero task_card_validation scores.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks",
+      "https://api.coherencycoin.com/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Create or observe a runner-seeded spec task and confirm context.task_card_validation.score is greater than 0.",
+      "Confirm weak_task_card friction no longer appears for fresh runner seed tasks."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add structured task-card context for runner smart-seeded spec/impl tasks
- derive impl file scope from active spec source/files_allowed entries during phase auto-advance
- cover task-card context and durable spec handoff with focused runner tests

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- python3 -m py_compile api/scripts/local_runner.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_seed-task-card-context.json