### PR TITLE
attune: 7 specs active → done (status matches landed implementations)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,6 +1,6 @@
 # Spec Index
 
-> 82 specs (71 done, 3 draft, 8 active). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
+> 82 specs (78 done, 3 draft, 1 active). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
 
 ## By Idea (19 ideas → 82 specs)
 

--- a/specs/creator-economy-promotion.md
+++ b/specs/creator-economy-promotion.md
@@ -1,6 +1,6 @@
 ---
 idea_id: creator-economy-promotion
-status: active
+status: done
 source:
   - file: api/app/routers/creator_economy.py
     symbols: [get_creator_stats(), get_asset_proof_card(), list_featured_assets()]

--- a/specs/db-backed-vision-aligned-content.md
+++ b/specs/db-backed-vision-aligned-content.md
@@ -1,6 +1,6 @@
 ---
 idea_id: db-backed-vision-aligned-content
-status: active
+status: done
 source:
   - file: api/app/services/vision_content_service.py
     symbols: [get_aligned_content()]

--- a/specs/db-backed-vision-hub-content.md
+++ b/specs/db-backed-vision-hub-content.md
@@ -1,6 +1,6 @@
 ---
 idea_id: db-backed-vision-hub-content
-status: active
+status: done
 source:
   - file: api/app/services/vision_content_service.py
     symbols: [get_hub_content()]

--- a/specs/db-backed-vision-realize-content.md
+++ b/specs/db-backed-vision-realize-content.md
@@ -1,6 +1,6 @@
 ---
 idea_id: db-backed-vision-realize-content
-status: active
+status: done
 source:
   - file: api/app/services/vision_content_service.py
     symbols: [get_realize_content()]

--- a/specs/db-backed-vision-realize-expansion-content.md
+++ b/specs/db-backed-vision-realize-expansion-content.md
@@ -1,6 +1,6 @@
 ---
 idea_id: db-backed-vision-realize-expansion-content
-status: active
+status: done
 source:
   - file: api/app/services/vision_content_service.py
     symbols: [get_realize_content()]

--- a/specs/external-repo-milestone.md
+++ b/specs/external-repo-milestone.md
@@ -1,6 +1,6 @@
 ---
 idea_id: developer-experience
-status: active
+status: done
 source:
   - file: scripts/external_proof_demo.py
     symbols: [_idea_create_payload, run_idea_lifecycle, record_contribution, check_coherence_score]

--- a/specs/vision-image-prompt-manifest.md
+++ b/specs/vision-image-prompt-manifest.md
@@ -1,6 +1,6 @@
 ---
 idea_id: living-collective-vision
-status: active
+status: done
 source:
   - file: docs/visuals/prompts.json
     symbols: [vision image prompt records]


### PR DESCRIPTION
Seven specs whose source files, tests, and done_when items are all live were still reading `status: active`. Aligning the frontmatter to reality so proprioception matches the body.

**Promoted to done:**
- `creator-economy-promotion` — routers, service, models, web pages, 14 tests
- `external-repo-milestone` — script + CI workflow + tracking doc all live
- `db-backed-vision-aligned-content` — service + router + 2 tests
- `db-backed-vision-hub-content` — service + router + 2 tests
- `db-backed-vision-realize-content` — service + router + 2 tests
- `db-backed-vision-realize-expansion-content` — service + router + 1 test
- `vision-image-prompt-manifest` — manifest covers 142 refs + 452 records; `check_generated_vision_assets.py` passes

**specs/INDEX.md header**: 71 → 78 done, 8 → 1 active.

**Remaining non-done after this:**
- 3 drafts (financial-integration, multilingual-web, story-protocol-integration — partner-gated)
- 1 active (cli-binary-name-conflict — `cli/bin/cc.mjs` still exists, CLAUDE.md still has `cc ` references)

No code change. Status-only attune.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_