### PR TITLE
Expose pipeline row status

### DIFF
--- a/api/app/services/agent_service_pipeline_status.py
+++ b/api/app/services/agent_service_pipeline_status.py
@@ -40,6 +40,7 @@ def _pipeline_task_status_item(task: dict[str, Any], now: datetime) -> tuple[str
 
     item = {
         "id": task.get("id"),
+        "status": st_val,
         "task_type": task.get("task_type"),
         "model": task.get("model"),
         "direction": (task.get("direction") or "")[:100],

--- a/api/tests/test_failure_taxonomy_service.py
+++ b/api/tests/test_failure_taxonomy_service.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from app.services import failure_taxonomy_service
 from app.services import pipeline_policy_service
-from app.services.agent_service_pipeline_status import _pipeline_queue_diagnostics
+from app.services.agent_service_pipeline_status import (
+    _pipeline_queue_diagnostics,
+    _pipeline_task_status_item,
+)
 from app.services.agent_service_store import _store
 from app.services.agent_service_task_derive import failure_classification
 
@@ -169,3 +174,23 @@ def test_pipeline_diagnostics_reports_zero_output_resolved_tasks() -> None:
         {"task_id": "task_hollow_completed", "task_type": "impl", "status": "completed"},
         {"task_id": "task_hollow_failed", "task_type": "spec", "status": "failed"},
     ]
+
+
+def test_pipeline_task_status_item_includes_status() -> None:
+    status, item = _pipeline_task_status_item(
+        {
+            "id": "task_needs_decision",
+            "status": "needs_decision",
+            "task_type": "impl",
+            "model": "claude/claude-sonnet-4-6",
+            "direction": "Needs operator decision",
+            "created_at": None,
+            "updated_at": None,
+            "started_at": None,
+            "claimed_by": None,
+        },
+        now=datetime.now(timezone.utc),
+    )
+
+    assert status == "needs_decision"
+    assert item["status"] == "needs_decision"

--- a/docs/system_audit/commit_evidence_2026-04-24_pipeline_row_status.json
+++ b/docs/system_audit/commit_evidence_2026-04-24_pipeline_row_status.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-04-24",
+  "thread_branch": "codex/pipeline-row-status-20260425",
+  "commit_scope": "Expose explicit task status on pipeline status rows so recent non-running rows are not mistaken for completed work.",
+  "files_owned": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py",
+    "docs/system_audit/commit_evidence_2026-04-24_pipeline_row_status.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Focused tests: 12 passed, 1 pytest config warning. Local PR guard passed with ready_for_push=True. Follow-through check passed with stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local tests and pre-push guard pass; PR CI and public deploy validation pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "pipeline-row-status"
+  ],
+  "task_ids": [
+    "pipeline-row-status-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live status-report recent_completed rows showed output_len=0 without explicit row status",
+    "focused pytest run: 12 passed",
+    "local guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T211954Z_codex-pipeline-row-status-20260425.json",
+    "follow-through check: codex_open_prs=0, stale_codex_prs=0"
+  ],
+  "change_files": [
+    "api/app/services/agent_service_pipeline_status.py",
+    "api/tests/test_failure_taxonomy_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public status-report running, pending, and recent non-running rows should include explicit status fields.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/status-report"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense status-report row status fields after deploy."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit status to pipeline status rows
- add regression coverage for non-completed row status exposure
- record local validation and guard evidence

## Validation
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_failure_taxonomy_service.py tests/test_agent_monitor_helpers.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-24_pipeline_row_status.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence