### PR TITLE
tend: bound runner stuck seeding

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -4540,9 +4540,10 @@ _SEEDER_SKIP_CACHE: set[str] = set()
 
 # R2: maximum tasks allowed per idea+phase before capping (task dedup spec)
 MAX_TASKS_PER_PHASE: int = 3
+MAX_SEED_ATTEMPTS_PER_CYCLE: int = 12
 
 
-def _seed_task_from_open_idea() -> bool:
+def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
     """Generate a task from an open idea when the queue is empty.
 
     Smart seeding:
@@ -4554,6 +4555,16 @@ def _seed_task_from_open_idea() -> bool:
     6. Always link idea_id for phase advancement
     """
     import random as _random
+
+    if _attempt >= MAX_SEED_ATTEMPTS_PER_CYCLE:
+        log.info(
+            "SEED: attempt budget exhausted (%d) — pausing until next cycle",
+            MAX_SEED_ATTEMPTS_PER_CYCLE,
+        )
+        return False
+
+    def _try_next() -> bool:
+        return _seed_task_from_open_idea(_attempt + 1)
 
     # Capacity check
     active = _count_active_tasks()
@@ -4610,7 +4621,7 @@ def _seed_task_from_open_idea() -> bool:
         log.info("SEED_SKIP_IMPLEMENTED idea=%s already on main (%s PR #%s) — marked validated",
                  idea_id, evidence_type, pr_num)
         _SEEDER_SKIP_CACHE.add(idea_id)
-        return _seed_task_from_open_idea()  # try next idea
+        return _try_next()
 
     # Check existing task history for this idea to determine next phase
     task_type = "spec"  # default
@@ -4654,7 +4665,7 @@ def _seed_task_from_open_idea() -> bool:
                     # All phases completed
                     log.info("SEED: all phases completed for %s — skipping", idea_id)
                     _SEEDER_SKIP_CACHE.add(idea_id)
-                    return _seed_task_from_open_idea()
+                    return _try_next()
                 continue
             _candidate_phase = _cp
             break
@@ -4665,7 +4676,7 @@ def _seed_task_from_open_idea() -> bool:
             log.info("SEED: capping %s for %s (%d tasks exist, limit %d)",
                      _candidate_phase, idea_id, candidate_count, MAX_TASKS_PER_PHASE)
             _SEEDER_SKIP_CACHE.add(idea_id)
-            return _seed_task_from_open_idea()
+            return _try_next()
 
         # R2c: replaced hardcoded >= 10 with MAX_TASKS_PER_PHASE
         max_phase_tasks = max(phase_counts.values()) if phase_counts else 0
@@ -4675,7 +4686,7 @@ def _seed_task_from_open_idea() -> bool:
                      idea_name[:30], max_phase_tasks, MAX_TASKS_PER_PHASE)
             _SEEDER_SKIP_CACHE.add(idea_id)
             api("PATCH", f"/api/ideas/{idea_id}", {"manifestation_status": "partial"})
-            return _seed_task_from_open_idea()  # retry with next idea
+            return _try_next()
 
         # ── Exponential backoff: delay re-seeding ideas with high failure rates ──
         failed_for_phase = 0
@@ -4705,7 +4716,7 @@ def _seed_task_from_open_idea() -> bool:
                         # NOTE: do NOT add to _SEEDER_SKIP_CACHE here — cooldown is temporary.
                         # The skip cache is session-scoped and would permanently blacklist the idea.
                         # Instead, just try the next candidate this cycle.
-                        return _seed_task_from_open_idea()
+                        return _try_next()
                 except (ValueError, TypeError):
                     pass
 
@@ -4714,7 +4725,7 @@ def _seed_task_from_open_idea() -> bool:
                         idea_name[:30], failed_for_phase)
             _SEEDER_SKIP_CACHE.add(idea_id)
             api("PATCH", f"/api/ideas/{idea_id}", {"manifestation_status": "partial"})
-            return _seed_task_from_open_idea()
+            return _try_next()
 
         if total_tasks == 0 and idea.get("manifestation_status") == "partial":
             # Orphaned: marked partial but no tasks exist — reset to none

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -36,6 +36,47 @@ files_allowed:
     ]
 
 
+def test_seed_attempt_budget_stops_recursive_capped_scan(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(local_runner, "MAX_SEED_ATTEMPTS_PER_CYCLE", 1)
+    monkeypatch.setattr(local_runner, "_count_active_tasks", lambda: 0)
+    monkeypatch.setattr(local_runner, "_check_existing_evidence", lambda idea_id: None)
+    local_runner._SEEDER_SKIP_CACHE.clear()
+
+    def fake_api(method: str, path: str, body: dict | None = None):
+        calls.append((method, path, body))
+        if path == "/api/ideas?limit=200":
+            return {
+                "ideas": [
+                    {
+                        "id": "capped-idea",
+                        "name": "Capped Idea",
+                        "manifestation_status": "none",
+                        "free_energy_score": 10,
+                    }
+                ]
+            }
+        if path in (
+            "/api/agent/tasks?status=pending&limit=100",
+            "/api/agent/tasks?status=running&limit=100",
+        ):
+            return {"tasks": []}
+        if path == "/api/ideas/capped-idea/tasks":
+            return {
+                "total": 3,
+                "groups": [
+                    {"task_type": "spec", "status_counts": {"failed": 3}},
+                ],
+            }
+        return {}
+
+    monkeypatch.setattr(local_runner, "api", fake_api)
+
+    assert local_runner._seed_task_from_open_idea() is False
+    assert [path for _, path, _ in calls].count("/api/ideas?limit=200") == 1
+    assert "capped-idea" in local_runner._SEEDER_SKIP_CACHE
+
+
 def test_impl_without_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)

--- a/docs/system_audit/commit_evidence_2026-04-25_runner-stuck-energy-budget.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_runner-stuck-energy-budget.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-runner-stuck-energy",
+  "commit_scope": "Bound runner smart-seed retry attempts so empty-queue cycles do not spend unbounded energy recursively scanning capped or stuck ideas.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-25_runner-stuck-energy-budget.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "python3 -m py_compile api/scripts/local_runner.py",
+      "git fetch origin main && git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "11 runner spec-gate tests passed; local_runner.py compiled successfully. Branch rebased with autostash, PR guard local_preflight=pass ready_for_push=True, follow-through stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused validation passed; pre-push guard, PR CI, merge, deploy, and live runner sensing remain pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate",
+    "runner-energy-efficiency"
+  ],
+  "spec_ids": [
+    "runner-stuck-energy-budget"
+  ],
+  "task_ids": [
+    "health-runner-stuck-energy"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live runner log showed repeated capped/truly-stuck idea scans while pending=0 and running=0",
+    "focused pytest run: 11 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T212144Z_codex-health-runner-stuck-energy.json"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "When many ideas are capped or stuck, a single empty-queue seed cycle should stop after a bounded number of skip attempts and wait for the next cycle.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks",
+      "https://api.coherencycoin.com/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Restart local runner after deploy and confirm NODE_REGISTERED uses deployed SHA.",
+      "Observe local_runner.out for SEED attempt budget exhaustion instead of long repeated capped/stuck scans in one cycle."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- bound smart-seed recursive retries with a per-cycle attempt budget
- keep capped/stuck ideas from causing long empty-queue scan loops
- add a focused runner test for capped-idea budget exhaustion

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- python3 -m py_compile api/scripts/local_runner.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_runner-stuck-energy-budget.json