### PR TITLE
feat(cli): rename cc → coh (v0.13.0) — remove macOS clang conflict

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install CLI dependencies
         if: steps.changed_surfaces.outputs.api == 'true'
-        # test_flow_cli.py spawns `node cli/bin/cc.mjs`, which imports chalk/boxen/etc.
+        # test_flow_cli.py spawns `node cli/bin/coh.mjs`, which imports chalk/boxen/etc.
         # at runtime — without these on disk the smoke tests can never pass.
         run: |
           cd cli && npm ci --no-audit --no-fund

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@
 
 | What | Where | CLI |
 |------|-------|-----|
-| Ideas | `ideas/INDEX.md` → `ideas/{slug}.md` | `cc idea {slug}` (DB has raw ideas, not consolidated) |
-| Specs | `specs/INDEX.md` → `specs/{slug}.md` | `cc spec {slug}` |
-| Pipeline tasks | — | `cc tasks --status pending` |
+| Ideas | `ideas/INDEX.md` → `ideas/{slug}.md` | `coh idea {slug}` (DB has raw ideas, not consolidated) |
+| Specs | `specs/INDEX.md` → `specs/{slug}.md` | `coh spec {slug}` |
+| Pipeline tasks | — | `coh tasks --status pending` |
 | Tracking | `docs/EXTERNAL_ENABLEMENT_TRACKING.md` | — |
 | **Living Collective KB** | `docs/vision-kb/INDEX.md` → `concepts/{id}.md` | — |
 
@@ -108,11 +108,11 @@ The graph DB is the sole source of truth. The KB is the working draft where cont
 
 | Action | API | CLI | Web |
 |--------|-----|-----|-----|
-| View story | `GET /api/concepts/{id}` | `cc story {id}` | `/vision/{id}` |
-| List stories | `GET /api/concepts/domain/living-collective` | `cc stories` | `/vision` |
-| Update story | `PATCH /api/concepts/{id}/story` | `cc story-update {id} -f file.md` | `/vision/{id}/edit` |
-| Regenerate images | `POST /api/concepts/{id}/visuals/regenerate` | `cc visuals-generate {id}` | Edit page button |
-| View/edit config | `GET/PATCH /api/config` | `cc config` / `cc config-set key val` | `/settings` |
+| View story | `GET /api/concepts/{id}` | `coh story {id}` | `/vision/{id}` |
+| List stories | `GET /api/concepts/domain/living-collective` | `coh stories` | `/vision` |
+| Update story | `PATCH /api/concepts/{id}/story` | `coh story-update {id} -f file.md` | `/vision/{id}/edit` |
+| Regenerate images | `POST /api/concepts/{id}/visuals/regenerate` | `coh visuals-generate {id}` | Edit page button |
+| View/edit config | `GET/PATCH /api/config` | `coh config` / `coh config-set key val` | `/settings` |
 
 ## Navigation
 
@@ -123,7 +123,7 @@ All paths converge: **idea → specs → source files**
 | Keyword | `Grep` → source file → spec frontmatter `idea_id:` → `ideas/{id}.md` |
 | Idea | `ideas/{slug}.md` spec links → `specs/{slug}.md` `source:` map |
 | Code | `Grep` specs/ for filename → spec frontmatter `idea_id:` |
-| Task | `cc task {id}` → `context.idea_id` → `ideas/{id}.md` |
+| Task | `coh task {id}` → `context.idea_id` → `ideas/{id}.md` |
 
 ## MCP Tools
 
@@ -131,17 +131,17 @@ All paths converge: **idea → specs → source files**
 
 | Verb | MCP tool | CLI equivalent |
 |------|----------|---------------|
-| Navigate | `coherence_trace` | `cc trace idea {slug}` |
+| Navigate | `coherence_trace` | `coh trace idea {slug}` |
 | Advance | `coherence_advance_idea` | — |
-| Spec CRUD | `coherence_create_spec`, `coherence_update_spec` | `cc rest POST /api/spec-registry` |
-| Task flow | `coherence_task_seed` → `coherence_task_report` | `cc task seed {idea}` → `cc task report` |
-| Select work | `coherence_select_idea` | `cc idea select` |
+| Spec CRUD | `coherence_create_spec`, `coherence_update_spec` | `coh rest POST /api/spec-registry` |
+| Task flow | `coherence_task_seed` → `coherence_task_report` | `coh task seed {idea}` → `coh task report` |
+| Select work | `coherence_select_idea` | `coh idea select` |
 
 ## Context Budget
 
 1. **Spec frontmatter** (25 lines avg) — `Read specs/{slug}.md limit=30` gets source, requirements, done_when, test, constraints. Body (200 lines avg) is human reference — skip unless you need API contract or data model detail.
 2. **Idea .md files** (35-52 lines) — problem, capabilities, spec links, absorbed ideas. Always worth reading in full.
-3. **CLI** for pipeline operations — `cc tasks`, `cc task {id}`, `cc status`, `cc idea {slug}`
+3. **CLI** for pipeline operations — `coh tasks`, `coh task {id}`, `coh status`, `coh idea {slug}` (or `npx coherence-cli <cmd>` zero-install)
 4. For large source files: use targeted line ranges from the `source:` symbols
 
 ## Code Isolation

--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -2336,7 +2336,7 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
                 f"- Services: api/app/services/<name>.py\n"
                 f"- Models: api/app/models/<name>.py\n"
                 f"- Web pages: web/app/<route>/page.tsx\n"
-                f"- CLI: cli/bin/cc.mjs\n"
+                f"- CLI: cli/bin/coh.mjs\n"
                 f"- Specs: specs/<id>.md\n\n"
                 f"MANDATORY: After writing each code file, verify it with DIF:\n"
                 f"  curl -s -X POST https://dif.merly.ai/api/v2/dif/verify \\\n"
@@ -2853,7 +2853,7 @@ Where to put code:
 - Services: api/app/services/<name>.py
 - Models: api/app/models/<name>.py
 - Web pages: web/app/<route>/page.tsx
-- CLI: cli/bin/cc.mjs
+- CLI: cli/bin/coh.mjs
 
 BEFORE FINISHING — you MUST run these commands:
   echo "*.pyc\\n__pycache__/\\n.task-*\\ndata/coherence.db\\n.codex*" >> .gitignore

--- a/api/tests/test_flow_cli.py
+++ b/api/tests/test_flow_cli.py
@@ -1,6 +1,6 @@
 """Flow-centric CLI tests: command registration, API coverage, API contract, and smoke tests.
 
-Tests CLI command registration via static source analysis of cli/bin/cc.mjs,
+Tests CLI command registration via static source analysis of cli/bin/coh.mjs,
 verifies CLI files reference critical API endpoints, confirms API endpoint
 response shapes via httpx AsyncClient, and runs end-to-end subprocess smoke
 tests against a real uvicorn server.
@@ -30,7 +30,7 @@ from app.main import app
 # ---------------------------------------------------------------------------
 
 CLI_DIR = Path(__file__).resolve().parent.parent.parent / "cli"
-CLI_BIN = CLI_DIR / "bin" / "cc.mjs"
+CLI_BIN = CLI_DIR / "bin" / "coh.mjs"
 CLI_COMMANDS_DIR = CLI_DIR / "lib" / "commands"
 CLI_PACKAGE_JSON = CLI_DIR / "package.json"
 
@@ -43,12 +43,12 @@ ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class TestCommandRegistration:
-    """Static analysis of cli/bin/cc.mjs to verify command registration."""
+    """Static analysis of cli/bin/coh.mjs to verify command registration."""
 
     def test_cli_entrypoint_exists(self) -> None:
-        """cc.mjs file exists and is executable."""
+        """coh.mjs file exists and is executable."""
         assert CLI_BIN.exists(), f"Missing CLI entry point: {CLI_BIN}"
-        assert os.access(CLI_BIN, os.X_OK), f"cc.mjs is not executable: {CLI_BIN}"
+        assert os.access(CLI_BIN, os.X_OK), f"coh.mjs is not executable: {CLI_BIN}"
 
     def test_core_commands_registered(self) -> None:
         """COMMANDS map includes: ideas, identity, nodes, status, tasks, stake, fork, specs, help."""
@@ -59,32 +59,32 @@ class TestCommandRegistration:
         ]
         for cmd in required_commands:
             assert f"{cmd}:" in source or f"'{cmd}'" in source or f'"{cmd}"' in source, (
-                f"Command '{cmd}' not found in COMMANDS map in cc.mjs"
+                f"Command '{cmd}' not found in COMMANDS map in coh.mjs"
             )
 
     def test_command_files_exist(self) -> None:
         """Each command name in the COMMANDS map references a .mjs file in cli/lib/commands/."""
         source = CLI_BIN.read_text(encoding="utf-8")
-        # Extract import paths from cc.mjs that reference ../lib/commands/*.mjs
+        # Extract import paths from coh.mjs that reference ../lib/commands/*.mjs
         import_pattern = re.compile(r'from\s+"\.\.\/lib\/commands\/([^"]+\.mjs)"')
         imported_files = set(import_pattern.findall(source))
-        assert imported_files, "No command imports found in cc.mjs"
+        assert imported_files, "No command imports found in coh.mjs"
         for filename in imported_files:
             cmd_path = CLI_COMMANDS_DIR / filename
             assert cmd_path.exists(), f"Imported command file missing: {cmd_path}"
 
     def test_no_orphan_command_files(self) -> None:
-        """Every .mjs file in commands/ is referenced in cc.mjs imports (known legacy orphans excluded)."""
+        """Every .mjs file in commands/ is referenced in coh.mjs imports (known legacy orphans excluded)."""
         source = CLI_BIN.read_text(encoding="utf-8")
         import_pattern = re.compile(r'from\s+"\.\.\/lib\/commands\/([^"]+\.mjs)"')
         imported_files = set(import_pattern.findall(source))
 
         actual_files = {f.name for f in CLI_COMMANDS_DIR.glob("*.mjs")}
-        # Legacy command files that exist but are not wired into cc.mjs
+        # Legacy command files that exist but are not wired into coh.mjs
         known_orphans = {"federation.mjs", "inventory.mjs", "runtime.mjs"}
         orphans = actual_files - imported_files - known_orphans
         assert not orphans, (
-            f"Orphan command files not imported in cc.mjs: {sorted(orphans)}"
+            f"Orphan command files not imported in coh.mjs: {sorted(orphans)}"
         )
 
     def test_package_json_valid(self) -> None:
@@ -95,7 +95,10 @@ class TestCommandRegistration:
         assert "version" in pkg, "package.json missing 'version' field"
         assert "bin" in pkg, "package.json missing 'bin' field"
         assert isinstance(pkg["bin"], dict), "package.json 'bin' must be a dict"
-        assert "cc" in pkg["bin"], "'cc' not found in package.json bin field"
+        assert "coh" in pkg["bin"], "'coh' not found in package.json bin field"
+        assert "cc" not in pkg["bin"], (
+            "'cc' must not be registered (shadows Apple clang on macOS)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -326,45 +329,45 @@ class TestSmokeTests:
     """Run actual CLI binary via subprocess against a real uvicorn server."""
 
     def test_cli_help_exits_zero(self) -> None:
-        """cc help exits 0."""
+        """coh help exits 0."""
         with _serve_app() as api_base:
             result = _run_cli(api_base, "help")
         assert result.returncode == 0, (
-            f"cc help exited {result.returncode}: {result.stderr}"
+            f"coh help exited {result.returncode}: {result.stderr}"
         )
 
     def test_cli_status_runs(self) -> None:
-        """cc status exits 0 and outputs something."""
+        """coh status exits 0 and outputs something."""
         with _serve_app() as api_base:
             result = _run_cli(api_base, "status")
         assert result.returncode == 0, (
-            f"cc status exited {result.returncode}: {result.stderr}"
+            f"coh status exited {result.returncode}: {result.stderr}"
         )
         output = ANSI_RE.sub("", result.stdout)
-        assert len(output.strip()) > 0, "cc status produced no output"
+        assert len(output.strip()) > 0, "coh status produced no output"
 
     def test_cli_ideas_list(self) -> None:
-        """cc ideas hits the API and returns formatted output."""
+        """coh ideas hits the API and returns formatted output."""
         with _serve_app() as api_base:
             result = _run_cli(api_base, "ideas")
         assert result.returncode == 0, (
-            f"cc ideas exited {result.returncode}: {result.stderr}"
+            f"coh ideas exited {result.returncode}: {result.stderr}"
         )
         output = ANSI_RE.sub("", result.stdout)
-        assert len(output.strip()) > 0, "cc ideas produced no output"
+        assert len(output.strip()) > 0, "coh ideas produced no output"
 
     def test_cli_nodes_list(self) -> None:
-        """cc nodes hits the API."""
+        """coh nodes hits the API."""
         with _serve_app() as api_base:
             result = _run_cli(api_base, "nodes")
         assert result.returncode == 0, (
-            f"cc nodes exited {result.returncode}: {result.stderr}"
+            f"coh nodes exited {result.returncode}: {result.stderr}"
         )
 
     def test_cli_identity_runs(self) -> None:
-        """cc identity exits 0."""
+        """coh identity exits 0."""
         with _serve_app() as api_base:
             result = _run_cli(api_base, "identity")
         assert result.returncode == 0, (
-            f"cc identity exited {result.returncode}: {result.stderr}"
+            f"coh identity exited {result.returncode}: {result.stderr}"
         )

--- a/cli/README.md
+++ b/cli/README.md
@@ -3,14 +3,24 @@
 
 **Every idea deserves a trail. Every contributor deserves credit.**
 
-`cc` is the command-line interface for [Coherence Network](https://coherencycoin.com) — an open intelligence platform that traces every idea from inception to payout, with fair attribution, coherence scoring, and federated trust.
+`coh` is the command-line interface for [Coherence Network](https://coherencycoin.com) — an open intelligence platform that traces every idea from inception to payout, with fair attribution, coherence scoring, and federated trust.
+
+**Zero-install (recommended for first use):**
+
+```
+npx coherence-cli status
+```
+
+**Global install:**
 
 ```
 npm i -g coherence-cli
-cc status
+coh status
 ```
 
 That's it. You're connected to the live network. No account, no signup, no API key needed for reading.
+
+> **Renamed in v0.13.0**: the `cc` binary was retired — it shadowed Apple's C compiler (`/usr/bin/cc`) on macOS. Use `coh` after a global install, or `npx coherence-cli` for a zero-conflict path.
 
 ---
 
@@ -28,7 +38,7 @@ Idea → Research → Spec → Implementation → Review → Usage → Payout
 
 Every stage is scored for **coherence** (0.0–1.0) — measuring test coverage, documentation quality, and implementation simplicity. Contributors are paid proportionally to the energy they invested and the coherence they achieved.
 
-`cc` gives you direct access to all of it from your terminal.
+`coh` gives you direct access to all of it from your terminal.
 
 ---
 
@@ -37,26 +47,26 @@ Every stage is scored for **coherence** (0.0–1.0) — measuring test coverage,
 ### See what's happening
 
 ```bash
-cc ideas          # Browse the portfolio ranked by ROI
-cc resonance      # What's alive right now
-cc status         # Network health, node count, your identity
+coh ideas          # Browse the portfolio ranked by ROI
+coh resonance      # What's alive right now
+coh status         # Network health, node count, your identity
 ```
 
 ### Go deeper
 
 ```bash
-cc idea <id>      # Full scores, open questions, value gaps
-cc specs          # Feature specs with ROI metrics
-cc spec <id>      # Implementation summary, pseudocode, cost
+coh idea <id>      # Full scores, open questions, value gaps
+coh specs          # Feature specs with ROI metrics
+coh spec <id>      # Implementation summary, pseudocode, cost
 ```
 
 ### Contribute
 
 ```bash
-cc share          # Submit a new idea (interactive)
-cc stake <id> 10  # Stake 10 CC on an idea you believe in
-cc fork <id>      # Fork an idea and take it a new direction
-cc contribute     # Record any contribution (code, docs, review, design, community)
+coh share          # Submit a new idea (interactive)
+coh stake <id> 10  # Stake 10 CC on an idea you believe in
+coh fork <id>      # Fork an idea and take it a new direction
+coh contribute     # Record any contribution (code, docs, review, design, community)
 ```
 
 ### Tasks — agent-to-agent work protocol
@@ -64,32 +74,32 @@ cc contribute     # Record any contribution (code, docs, review, design, communi
 AI agents and human contributors use the same task queue. Pick up work, execute it, report back.
 
 ```bash
-cc tasks              # See what's pending
-cc tasks running      # See what's in progress
-cc task next          # Claim the highest-priority pending task
-cc task <id>          # View task detail (direction, idea link, context)
-cc task claim <id>    # Claim a specific task
-cc task report <id> completed "All tests pass"   # Report success
-cc task report <id> failed "Missing dependency"   # Report failure
-cc task seed <idea-id> spec   # Create a spec task from an idea
+coh tasks              # See what's pending
+coh tasks running      # See what's in progress
+coh task next          # Claim the highest-priority pending task
+coh task <id>          # View task detail (direction, idea link, context)
+coh task claim <id>    # Claim a specific task
+coh task report <id> completed "All tests pass"   # Report success
+coh task report <id> failed "Missing dependency"   # Report failure
+coh task seed <idea-id> spec   # Create a spec task from an idea
 ```
 
-When piped (non-TTY), `cc task next` outputs raw JSON — so an AI agent can parse it programmatically:
+When piped (non-TTY), `coh task next` outputs raw JSON — so an AI agent can parse it programmatically:
 
 ```bash
-TASK=$(cc task next 2>/dev/null | tail -1)
+TASK=$(coh task next 2>/dev/null | tail -1)
 # Agent processes the task...
-cc task report $(echo $TASK | jq -r .id) completed "Done"
+coh task report $(echo $TASK | jq -r .id) completed "Done"
 ```
 
 ### Federation — multi-node coordination
 
 ```bash
-cc nodes                          # See all federation nodes (status, providers, last seen)
-cc msg broadcast "Update ready"   # Broadcast to all nodes
-cc msg <node_id> "Run tests"      # Message a specific node
-cc cmd <node> diagnose            # Send a structured command
-cc inbox                          # Read your messages
+coh nodes                          # See all federation nodes (status, providers, last seen)
+coh msg broadcast "Update ready"   # Broadcast to all nodes
+coh msg <node_id> "Run tests"      # Message a specific node
+coh cmd <node> diagnose            # Send a structured command
+coh inbox                          # Read your messages
 ```
 
 ### Identity — bring your own
@@ -97,12 +107,12 @@ cc inbox                          # Read your messages
 Link any identity you already have. No new accounts. 37 providers across 6 categories.
 
 ```bash
-cc identity setup                    # Guided onboarding (first time)
-cc identity link github alice-dev    # Link your GitHub
-cc identity link ethereum 0xabc...   # Link your wallet
-cc identity link discord user#1234   # Link Discord
-cc identity                          # See all your linked accounts
-cc identity lookup github alice-dev  # Find anyone by their handle
+coh identity setup                    # Guided onboarding (first time)
+coh identity link github alice-dev    # Link your GitHub
+coh identity link ethereum 0xabc...   # Link your wallet
+coh identity link discord user#1234   # Link Discord
+coh identity                          # See all your linked accounts
+coh identity lookup github alice-dev  # Find anyone by their handle
 ```
 
 **Supported providers:**
@@ -136,7 +146,7 @@ The score isn't a grade — it's a signal. It tells you and the network how much
 
 | Pillar | In practice |
 |--------|-------------|
-| **Traceability** | `cc idea <id>` traces from spark to payout. Nothing is lost. |
+| **Traceability** | `coh idea <id>` traces from spark to payout. Nothing is lost. |
 | **Trust** | Coherence scores replace subjective judgement with measurable quality. |
 | **Freedom** | Fork any idea. Run your own node. Vote on governance. No gatekeepers. |
 | **Uniqueness** | Every idea, spec, and contribution is uniquely identified and ranked. |
@@ -161,7 +171,7 @@ Every part of the network links to every other. Jump in wherever makes sense for
 
 ## Configuration
 
-By default, `cc` talks to the public API at `https://api.coherencycoin.com`. Override with environment variables:
+By default, `coh` talks to the public API at `https://api.coherencycoin.com`. Override with environment variables:
 
 ```bash
 # Point to a local node
@@ -178,43 +188,43 @@ Config is stored in `~/.coherence-network/config.json`.
 ## All commands
 
 ```
-cc help                           Show all commands
+coh help                           Show all commands
 
 # Explore
-cc ideas [limit]                  Browse ideas by ROI
-cc idea <id>                      View idea detail with scores
-cc idea create <id> <name>        Create a new idea
-cc specs [limit]                  List feature specs
-cc spec <id>                      View spec detail
-cc resonance                      What's alive right now
-cc status                         Network health + node info
+coh ideas [limit]                  Browse ideas by ROI
+coh idea <id>                      View idea detail with scores
+coh idea create <id> <name>        Create a new idea
+coh specs [limit]                  List feature specs
+coh spec <id>                      View spec detail
+coh resonance                      What's alive right now
+coh status                         Network health + node info
 
 # Contribute
-cc share                          Submit a new idea (interactive)
-cc stake <id> <cc>                Stake CC on an idea
-cc fork <id>                      Fork an idea
-cc contribute                     Record any contribution
+coh share                          Submit a new idea (interactive)
+coh stake <id> <cc>                Stake CC on an idea
+coh fork <id>                      Fork an idea
+coh contribute                     Record any contribution
 
 # Tasks (agent-to-agent)
-cc tasks [status] [limit]         List tasks (pending|running|completed)
-cc task <id>                      View task detail
-cc task next                      Claim next pending task
-cc task claim <id>                Claim a specific task
-cc task report <id> <status> [output]  Report result
-cc task seed <idea> [type]        Create task from idea
+coh tasks [status] [limit]         List tasks (pending|running|completed)
+coh task <id>                      View task detail
+coh task next                      Claim next pending task
+coh task claim <id>                Claim a specific task
+coh task report <id> <status> [output]  Report result
+coh task seed <idea> [type]        Create task from idea
 
 # Identity
-cc identity                       Show linked accounts
-cc identity setup                 Guided identity onboarding
-cc identity link <provider> <id>  Link a provider identity
-cc identity unlink <provider>     Unlink a provider
-cc identity lookup <provider> <id> Find contributor by identity
+coh identity                       Show linked accounts
+coh identity setup                 Guided identity onboarding
+coh identity link <provider> <id>  Link a provider identity
+coh identity unlink <provider>     Unlink a provider
+coh identity lookup <provider> <id> Find contributor by identity
 
 # Federation
-cc nodes                          List federation nodes
-cc msg <node|broadcast> <text>    Send message to a node
-cc cmd <node> <command>           Send structured command
-cc inbox                          Read your messages
+coh nodes                          List federation nodes
+coh msg <node|broadcast> <text>    Send message to a node
+coh cmd <node> <command>           Send structured command
+coh inbox                          Read your messages
 ```
 
 ---
@@ -226,8 +236,8 @@ Coherence Network is open source. Every contribution is tracked and attributed �
 The simplest way to start:
 
 ```bash
-cc ideas            # find something interesting
-cc contribute       # record what you did
+coh ideas            # find something interesting
+coh contribute       # record what you did
 ```
 
 Or explore any part of the ecosystem from the table above. Every surface leads to every other.

--- a/cli/README.template.md
+++ b/cli/README.template.md
@@ -2,14 +2,24 @@
 
 **Every idea deserves a trail. Every contributor deserves credit.**
 
-`cc` is the command-line interface for [Coherence Network](https://coherencycoin.com) — an open intelligence platform that traces every idea from inception to payout, with fair attribution, coherence scoring, and federated trust.
+`coh` is the command-line interface for [Coherence Network](https://coherencycoin.com) — an open intelligence platform that traces every idea from inception to payout, with fair attribution, coherence scoring, and federated trust.
+
+**Zero-install (recommended for first use):**
+
+```
+npx coherence-cli status
+```
+
+**Global install:**
 
 ```
 npm i -g coherence-cli
-cc status
+coh status
 ```
 
 That's it. You're connected to the live network. No account, no signup, no API key needed for reading.
+
+> **Renamed in v0.13.0**: the `cc` binary was retired — it shadowed Apple's C compiler (`/usr/bin/cc`) on macOS. Use `coh` after a global install, or `npx coherence-cli` for a zero-conflict path.
 
 ---
 
@@ -21,7 +31,7 @@ Coherence Network changes that. It tracks the full lifecycle:
 
 <!-- include: docs/shared/lifecycle-diagram.md -->
 
-`cc` gives you direct access to all of it from your terminal.
+`coh` gives you direct access to all of it from your terminal.
 
 ---
 
@@ -30,26 +40,26 @@ Coherence Network changes that. It tracks the full lifecycle:
 ### See what's happening
 
 ```bash
-cc ideas          # Browse the portfolio ranked by ROI
-cc resonance      # What's alive right now
-cc status         # Network health, node count, your identity
+coh ideas          # Browse the portfolio ranked by ROI
+coh resonance      # What's alive right now
+coh status         # Network health, node count, your identity
 ```
 
 ### Go deeper
 
 ```bash
-cc idea <id>      # Full scores, open questions, value gaps
-cc specs          # Feature specs with ROI metrics
-cc spec <id>      # Implementation summary, pseudocode, cost
+coh idea <id>      # Full scores, open questions, value gaps
+coh specs          # Feature specs with ROI metrics
+coh spec <id>      # Implementation summary, pseudocode, cost
 ```
 
 ### Contribute
 
 ```bash
-cc share          # Submit a new idea (interactive)
-cc stake <id> 10  # Stake 10 CC on an idea you believe in
-cc fork <id>      # Fork an idea and take it a new direction
-cc contribute     # Record any contribution (code, docs, review, design, community)
+coh share          # Submit a new idea (interactive)
+coh stake <id> 10  # Stake 10 CC on an idea you believe in
+coh fork <id>      # Fork an idea and take it a new direction
+coh contribute     # Record any contribution (code, docs, review, design, community)
 ```
 
 ### Tasks — agent-to-agent work protocol
@@ -57,32 +67,32 @@ cc contribute     # Record any contribution (code, docs, review, design, communi
 AI agents and human contributors use the same task queue. Pick up work, execute it, report back.
 
 ```bash
-cc tasks              # See what's pending
-cc tasks running      # See what's in progress
-cc task next          # Claim the highest-priority pending task
-cc task <id>          # View task detail (direction, idea link, context)
-cc task claim <id>    # Claim a specific task
-cc task report <id> completed "All tests pass"   # Report success
-cc task report <id> failed "Missing dependency"   # Report failure
-cc task seed <idea-id> spec   # Create a spec task from an idea
+coh tasks              # See what's pending
+coh tasks running      # See what's in progress
+coh task next          # Claim the highest-priority pending task
+coh task <id>          # View task detail (direction, idea link, context)
+coh task claim <id>    # Claim a specific task
+coh task report <id> completed "All tests pass"   # Report success
+coh task report <id> failed "Missing dependency"   # Report failure
+coh task seed <idea-id> spec   # Create a spec task from an idea
 ```
 
-When piped (non-TTY), `cc task next` outputs raw JSON — so an AI agent can parse it programmatically:
+When piped (non-TTY), `coh task next` outputs raw JSON — so an AI agent can parse it programmatically:
 
 ```bash
-TASK=$(cc task next 2>/dev/null | tail -1)
+TASK=$(coh task next 2>/dev/null | tail -1)
 # Agent processes the task...
-cc task report $(echo $TASK | jq -r .id) completed "Done"
+coh task report $(echo $TASK | jq -r .id) completed "Done"
 ```
 
 ### Federation — multi-node coordination
 
 ```bash
-cc nodes                          # See all federation nodes (status, providers, last seen)
-cc msg broadcast "Update ready"   # Broadcast to all nodes
-cc msg <node_id> "Run tests"      # Message a specific node
-cc cmd <node> diagnose            # Send a structured command
-cc inbox                          # Read your messages
+coh nodes                          # See all federation nodes (status, providers, last seen)
+coh msg broadcast "Update ready"   # Broadcast to all nodes
+coh msg <node_id> "Run tests"      # Message a specific node
+coh cmd <node> diagnose            # Send a structured command
+coh inbox                          # Read your messages
 ```
 
 ### Identity — bring your own
@@ -90,12 +100,12 @@ cc inbox                          # Read your messages
 Link any identity you already have. No new accounts. 37 providers across 6 categories.
 
 ```bash
-cc identity setup                    # Guided onboarding (first time)
-cc identity link github alice-dev    # Link your GitHub
-cc identity link ethereum 0xabc...   # Link your wallet
-cc identity link discord user#1234   # Link Discord
-cc identity                          # See all your linked accounts
-cc identity lookup github alice-dev  # Find anyone by their handle
+coh identity setup                    # Guided onboarding (first time)
+coh identity link github alice-dev    # Link your GitHub
+coh identity link ethereum 0xabc...   # Link your wallet
+coh identity link discord user#1234   # Link Discord
+coh identity                          # See all your linked accounts
+coh identity lookup github alice-dev  # Find anyone by their handle
 ```
 
 **Supported providers:**
@@ -116,7 +126,7 @@ You don't need to register anywhere. Just link a provider and start contributing
 
 | Pillar | In practice |
 |--------|-------------|
-| **Traceability** | `cc idea <id>` traces from spark to payout. Nothing is lost. |
+| **Traceability** | `coh idea <id>` traces from spark to payout. Nothing is lost. |
 | **Trust** | Coherence scores replace subjective judgement with measurable quality. |
 | **Freedom** | Fork any idea. Run your own node. Vote on governance. No gatekeepers. |
 | **Uniqueness** | Every idea, spec, and contribution is uniquely identified and ranked. |
@@ -141,7 +151,7 @@ Every part of the network links to every other. Jump in wherever makes sense for
 
 ## Configuration
 
-By default, `cc` talks to the public API at `https://api.coherencycoin.com`. Override with environment variables:
+By default, `coh` talks to the public API at `https://api.coherencycoin.com`. Override with environment variables:
 
 ```bash
 # Point to a local node
@@ -158,43 +168,43 @@ Config is stored in `~/.coherence-network/config.json`.
 ## All commands
 
 ```
-cc help                           Show all commands
+coh help                           Show all commands
 
 # Explore
-cc ideas [limit]                  Browse ideas by ROI
-cc idea <id>                      View idea detail with scores
-cc idea create <id> <name>        Create a new idea
-cc specs [limit]                  List feature specs
-cc spec <id>                      View spec detail
-cc resonance                      What's alive right now
-cc status                         Network health + node info
+coh ideas [limit]                  Browse ideas by ROI
+coh idea <id>                      View idea detail with scores
+coh idea create <id> <name>        Create a new idea
+coh specs [limit]                  List feature specs
+coh spec <id>                      View spec detail
+coh resonance                      What's alive right now
+coh status                         Network health + node info
 
 # Contribute
-cc share                          Submit a new idea (interactive)
-cc stake <id> <cc>                Stake CC on an idea
-cc fork <id>                      Fork an idea
-cc contribute                     Record any contribution
+coh share                          Submit a new idea (interactive)
+coh stake <id> <cc>                Stake CC on an idea
+coh fork <id>                      Fork an idea
+coh contribute                     Record any contribution
 
 # Tasks (agent-to-agent)
-cc tasks [status] [limit]         List tasks (pending|running|completed)
-cc task <id>                      View task detail
-cc task next                      Claim next pending task
-cc task claim <id>                Claim a specific task
-cc task report <id> <status> [output]  Report result
-cc task seed <idea> [type]        Create task from idea
+coh tasks [status] [limit]         List tasks (pending|running|completed)
+coh task <id>                      View task detail
+coh task next                      Claim next pending task
+coh task claim <id>                Claim a specific task
+coh task report <id> <status> [output]  Report result
+coh task seed <idea> [type]        Create task from idea
 
 # Identity
-cc identity                       Show linked accounts
-cc identity setup                 Guided identity onboarding
-cc identity link <provider> <id>  Link a provider identity
-cc identity unlink <provider>     Unlink a provider
-cc identity lookup <provider> <id> Find contributor by identity
+coh identity                       Show linked accounts
+coh identity setup                 Guided identity onboarding
+coh identity link <provider> <id>  Link a provider identity
+coh identity unlink <provider>     Unlink a provider
+coh identity lookup <provider> <id> Find contributor by identity
 
 # Federation
-cc nodes                          List federation nodes
-cc msg <node|broadcast> <text>    Send message to a node
-cc cmd <node> <command>           Send structured command
-cc inbox                          Read your messages
+coh nodes                          List federation nodes
+coh msg <node|broadcast> <text>    Send message to a node
+coh cmd <node> <command>           Send structured command
+coh inbox                          Read your messages
 ```
 
 ---
@@ -206,8 +216,8 @@ Coherence Network is open source. Every contribution is tracked and attributed �
 The simplest way to start:
 
 ```bash
-cc ideas            # find something interesting
-cc contribute       # record what you did
+coh ideas            # find something interesting
+coh contribute       # record what you did
 ```
 
 Or explore any part of the ecosystem from the table above. Every surface leads to every other.

--- a/cli/bin/coh.mjs
+++ b/cli/bin/coh.mjs
@@ -1,13 +1,54 @@
 #!/usr/bin/env node
 
 /**
- * cc — Coherence Network CLI
+ * coh — Coherence Network CLI
  *
  * Identity-first contributions, idea staking, and value traceability.
  * Zero dependencies. Node 18+ required.
+ *
+ * Previously shipped as `cc`; renamed in v0.13.0 to avoid shadowing
+ * Apple's C compiler on macOS. See specs/cli-binary-name-conflict.md.
  */
 
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+// macOS conflict-detection — fires at most once per machine.
+// If the user's PATH still resolves `cc` to Apple clang, we remind them
+// the old binary name was retired. Advisory only — never blocks execution.
+(() => {
+  if (process.platform !== "darwin") return;
+  try {
+    const markerDir = join(homedir(), ".coherence-network");
+    const marker = join(markerDir, ".cc-conflict-warned");
+    if (existsSync(marker)) return;
+    let resolvedCc = "";
+    try {
+      resolvedCc = execFileSync("/usr/bin/which", ["cc"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return;
+    }
+    if (!resolvedCc || resolvedCc.includes("coherence")) return;
+    process.stderr.write(
+      "[coherence-cli] Tip: the old 'cc' binary has been retired. " +
+        "Use 'coh' or 'npx coherence-cli'.\n",
+    );
+    try {
+      mkdirSync(markerDir, { recursive: true, mode: 0o700 });
+      writeFileSync(marker, new Date().toISOString(), { mode: 0o600 });
+    } catch {
+      // Non-fatal; we simply warn again next run.
+    }
+  } catch {
+    // Any failure in detection must not block the CLI.
+  }
+})();
+
 import { resolveLocale, createT } from "../lib/i18n.mjs";
 const _locale = resolveLocale(process.argv);
 const t = createT(_locale);

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coherence-cli",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coherence-cli",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",
@@ -16,9 +16,8 @@
         "ora": "^9.3.0"
       },
       "bin": {
-        "cc": "bin/cc.mjs",
-        "coh": "bin/cc.mjs",
-        "coherence": "bin/cc.mjs"
+        "coh": "bin/coh.mjs",
+        "coherence": "bin/coh.mjs"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,12 +1,11 @@
 {
   "name": "coherence-cli",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Coherence Network CLI — trace ideas from inception to payout, with fair attribution, coherence scoring, and 37 identity providers. No signup needed.",
   "type": "module",
   "bin": {
-    "cc": "bin/cc.mjs",
-    "coh": "bin/cc.mjs",
-    "coherence": "bin/cc.mjs"
+    "coh": "bin/coh.mjs",
+    "coherence": "bin/coh.mjs"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,6 +1,6 @@
 # Spec Index
 
-> 82 specs (78 done, 3 draft, 1 active). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
+> 82 specs (79 done, 3 draft, 0 active). Grouped by parent idea. Read frontmatter (`limit=30`) for source files, requirements, done_when.
 
 ## By Idea (19 ideas → 82 specs)
 

--- a/specs/cli-binary-name-conflict.md
+++ b/specs/cli-binary-name-conflict.md
@@ -1,11 +1,11 @@
 ---
 idea_id: agent-cli
-status: active
+status: done
 source:
   - file: cli/package.json
     symbols: [bin]
-  - file: cli/bin/cc.mjs
-    symbols: [file rename → coh.mjs]
+  - file: cli/bin/coh.mjs
+    symbols: [CLI entry point with macOS conflict-detection warning]
   - file: cli/README.md
     symbols: [installation instructions, usage examples]
   - file: CLAUDE.md

--- a/specs/coherence-cli-comprehensive.md
+++ b/specs/coherence-cli-comprehensive.md
@@ -2,7 +2,7 @@
 idea_id: user-surfaces
 status: done
 source:
-  - file: cli/bin/cc.mjs
+  - file: cli/bin/coh.mjs
     symbols: [CLI entry point]
   - file: cli/lib/commands/ideas.mjs
     symbols: [ideas commands]
@@ -30,7 +30,7 @@ constraints:
 ---
 
 > **Parent idea**: [user-surfaces](../ideas/user-surfaces.md)
-> **Source**: [`cli/bin/cc.mjs`](../cli/bin/cc.mjs) | [`cli/lib/commands/ideas.mjs`](../cli/lib/commands/ideas.mjs) | [`cli/lib/commands/tasks.mjs`](../cli/lib/commands/tasks.mjs) | [`cli/lib/commands/nodes.mjs`](../cli/lib/commands/nodes.mjs)
+> **Source**: [`cli/bin/coh.mjs`](../cli/bin/coh.mjs) | [`cli/lib/commands/ideas.mjs`](../cli/lib/commands/ideas.mjs) | [`cli/lib/commands/tasks.mjs`](../cli/lib/commands/tasks.mjs) | [`cli/lib/commands/nodes.mjs`](../cli/lib/commands/nodes.mjs)
 
 # Coherence Network CLI (coherence-cli) Comprehensive Feature Spec
 
@@ -61,7 +61,7 @@ The `coherence-cli` (published as `npm i -g coherence-cli`) is the primary termi
 goal: Formalize the coherence-cli with 15 core commands, zero dependencies, and identity-first onboarding.
 files_allowed:
   - cli/package.json
-  - cli/bin/cc.mjs
+  - cli/bin/coh.mjs
   - cli/lib/commands/*.mjs
   - cli/README.md
   - cli/README.template.md
@@ -71,7 +71,7 @@ done_when:
   - `identity setup` successfully guides a new user to a valid local identity.
 commands:
   - cd cli && npm pack --dry-run
-  - node cli/bin/cc.mjs help
+  - node cli/bin/coh.mjs help
 constraints:
   - No external runtime dependencies allowed.
   - Must support Node.js >= 18.0.0.
@@ -115,7 +115,7 @@ Local configuration stored in `~/.coherence-network/config.json`:
 
 - `specs/coherence-cli-comprehensive.md` — this spec.
 - `cli/package.json` — metadata and versioning.
-- `cli/bin/cc.mjs` — main entry point and command router.
+- `cli/bin/coh.mjs` — main entry point and command router.
 - `cli/lib/commands/ideas.mjs` — implementation of idea commands.
 - `cli/lib/commands/identity.mjs` — implementation of identity commands.
 - `cli/lib/commands/contribute.mjs` — contribution recording.
@@ -129,23 +129,23 @@ Manual Validation Flow:
 
 - **Identity Flow**:
   ```bash
-  node cli/bin/cc.mjs identity setup
+  node cli/bin/coh.mjs identity setup
   # Follow prompts to link a mock provider
-  node cli/bin/cc.mjs identity
+  node cli/bin/coh.mjs identity
   # Confirm identity is persisted in ~/.coherence-network/config.json
   ```
 - **Browsing Flow**:
   ```bash
-  node cli/bin/cc.mjs ideas
+  node cli/bin/coh.mjs ideas
   # Confirm a table of ideas is displayed
-  node cli/bin/cc.mjs idea <valid_id>
+  node cli/bin/coh.mjs idea <valid_id>
   # Confirm detailed scores and gaps are shown
   ```
 - **Contribution Flow**:
   ```bash
-  node cli/bin/cc.mjs share --name "Spec Validation Test"
+  node cli/bin/coh.mjs share --name "Spec Validation Test"
   # Confirm idea is created
-  node cli/bin/cc.mjs contribute --idea <id> --desc "Test contribution"
+  node cli/bin/coh.mjs contribute --idea <id> --desc "Test contribution"
   # Confirm success
   ```
 - **Zero-Dependency Check**:
@@ -165,7 +165,7 @@ N/A — CLI is a single-user process. Local config file is updated using atomic 
 cd cli && (grep "dependencies" package.json -A 5 | grep -v "devDependencies" || true)
 
 # Verify help output contains the 15 core commands
-node cli/bin/cc.mjs help
+node cli/bin/coh.mjs help
 ```
 
 ## Out of Scope

--- a/specs/node-task-visibility.md
+++ b/specs/node-task-visibility.md
@@ -9,10 +9,10 @@ source:
   - file: web/app/tasks/[task_id]/page.tsx
     symbols: [task detail]
 done_when:
-  - "cc tasks shows idea names (not IDs) and clean provider labels"
-  - "cc tasks shows a \"recently completed\" section"
-  - "cc task <id> shows full (untruncated) output and activity timeline"
-  - "cc task <id> shows error_summary when present"
+  - "coh tasks shows idea names (not IDs) and clean provider labels"
+  - "coh tasks shows a \"recently completed\" section"
+  - "coh task <id> shows full (untruncated) output and activity timeline"
+  - "coh task <id> shows error_summary when present"
   - "coherencycoin.com/pipeline loads and shows live task flow"
   - "/pipeline shows per-provider success rates"
   - "/pipeline shows active node names and task counts"
@@ -26,7 +26,7 @@ constraints:
 > **Parent idea**: [user-surfaces](../ideas/user-surfaces.md)
 > **Source**: [`web/app/nodes/page.tsx`](../web/app/nodes/page.tsx) | [`web/app/tasks/page.tsx`](../web/app/tasks/page.tsx) | [`web/app/tasks/[task_id]/page.tsx`](../web/app/tasks/[task_id]/page.tsx)
 
-# Node and Task Visibility — `cc tasks`, `cc task <id>`, Web Pipeline Dashboard
+# Node and Task Visibility — `coh tasks`, `coh task <id>`, Web Pipeline Dashboard
 
 **Idea ID**: `node-task-visibility`
 **Status**: Draft — 2026-03-28
@@ -38,14 +38,14 @@ constraints:
 
 | Surface | Current state | Gap |
 |---------|--------------|-----|
-| `cc tasks` | Lists running/pending/needs_decision. Shows `idea_id` (e.g. `node-task-visibility`) and raw model string (`openrouter/free`). | Idea **name** not resolved; no "recent completions"; provider label unclear |
-| `cc task <id>` | Shows status, type, direction (200 chars), idea_id, worker, result (200 chars). | Output truncated; activity/events not shown; errors not formatted; no timing |
+| `coh tasks` | Lists running/pending/needs_decision. Shows `idea_id` (e.g. `node-task-visibility`) and raw model string (`openrouter/free`). | Idea **name** not resolved; no "recent completions"; provider label unclear |
+| `coh task <id>` | Shows status, type, direction (200 chars), idea_id, worker, result (200 chars). | Output truncated; activity/events not shown; errors not formatted; no timing |
 | Web `/tasks` page | Exists at `coherencycoin.com/tasks`. Shows task list with paginated rows. | Not a real-time pipeline view; no per-node status; no provider success rates; no routing signal |
 | API | Endpoints exist for tasks, active, activity. | No single aggregated `/pipeline/summary` endpoint; `result` field is raw JSON, not rendered |
 
 ### Who This Affects
 
-- **Human contributors** running `cc` locally: need to know what's running, which ideas are advancing, if their node is processing tasks.
+- **Human contributors** running `coh` locally: need to know what's running, which ideas are advancing, if their node is processing tasks.
 - **Operators** monitoring pipeline health: need provider success rates and routing decisions visible.
 - **New visitors** to the web app: the homepage says the network is alive — the `/pipeline` page must prove it.
 
@@ -54,7 +54,7 @@ constraints:
 ```yaml
 goal: >
   Make pipeline activity visible to human contributors via CLI and web without
-  requiring curl. cc tasks and cc task <id> must resolve idea names and show
+  requiring curl. coh tasks and coh task <id> must resolve idea names and show
   clean output. /pipeline web page must show live task flow, node status,
   and provider success rates.
 files_allowed:
@@ -65,16 +65,16 @@ files_allowed:
   - api/app/routers/pipeline.py
   - api/app/main.py
 done_when:
-  - cc tasks shows idea names (not IDs) and clean provider labels
-  - cc tasks shows a "recently completed" section
-  - cc task <id> shows full (untruncated) output and activity timeline
-  - cc task <id> shows error_summary when present
+  - coh tasks shows idea names (not IDs) and clean provider labels
+  - coh tasks shows a "recently completed" section
+  - coh task <id> shows full (untruncated) output and activity timeline
+  - coh task <id> shows error_summary when present
   - coherencycoin.com/pipeline loads and shows live task flow
   - /pipeline shows per-provider success rates
   - /pipeline shows active node names and task counts
 commands:
-  - node cli/bin/cc.mjs tasks
-  - node cli/bin/cc.mjs task task_d73edbae8000792b
+  - node cli/bin/coh.mjs tasks
+  - node cli/bin/coh.mjs task task_d73edbae8000792b
   - curl -s https://api.coherencycoin.com/api/pipeline/summary
   - curl -sI https://coherencycoin.com/pipeline
 constraints:
@@ -94,7 +94,7 @@ No new tables. All data is derived from:
 
 ### CLI Name Resolution Strategy
 
-`cc tasks` must resolve idea names without N+1 API calls. Strategy:
+`coh tasks` must resolve idea names without N+1 API calls. Strategy:
 1. Collect all unique `idea_id` values from the task batch.
 2. Issue one `GET /api/ideas?ids=id1,id2,...` (if supported) OR fall back to individual `GET /api/ideas/{id}` calls in parallel (Promise.all).
 3. Cache resolved names in-process for the duration of the command.
@@ -103,13 +103,13 @@ If the API does not support `?ids=...` filtering, the CLI falls back to parallel
 
 ## Verification Scenarios
 
-### Scenario 1 — `cc tasks` shows idea names, not IDs
+### Scenario 1 — `coh tasks` shows idea names, not IDs
 
 **Setup**: At least 1 pending or running task exists with an `idea_id` (e.g. `node-task-visibility`).
 
 **Action**:
 ```bash
-node cli/bin/cc.mjs tasks
+node cli/bin/coh.mjs tasks
 ```
 
 **Expected**:
@@ -165,7 +165,7 @@ Open `https://coherencycoin.com` in a browser. Navigate to the pipeline page.
 
 ## Known Gaps and Follow-up Tasks
 
-1. **`cc tasks watch`** — a live terminal refresh mode (like `watch -n2 cc tasks`) is not in scope here but would complement this spec. Track as separate idea.
+1. **`coh tasks watch`** — a live terminal refresh mode (like `watch -n2 coh tasks`) is not in scope here but would complement this spec. Track as separate idea.
 2. **Thompson Sampling visibility** — provider routing decisions (which executor is winning, exploration vs exploitation ratio) are not exposed in this spec. The pipeline page shows success rates but not the internal sampling state. Track as `spec-thompson-visibility`.
 3. **Task output storage** — currently `result` is a plain string. A follow-up should store structured output with sections (files changed, DIF score, commit SHA) as JSON. This spec only improves display of the existing field.
 4. **`GET /api/ideas?ids=id1,id2`** bulk endpoint — not confirmed to exist. If missing, the CLI falls back to parallel individual fetches. A follow-up spec should add this endpoint.
@@ -177,8 +177,8 @@ Open `https://coherencycoin.com` in a browser. Navigate to the pipeline page.
 
 This spec is realized when ALL of the following are independently verifiable:
 
-1. `node cli/bin/cc.mjs tasks` output contains a full idea name (not a raw ID) for any running task.
-2. `node cli/bin/cc.mjs task <any-completed-task-id>` output contains the full untruncated result.
+1. `node cli/bin/coh.mjs tasks` output contains a full idea name (not a raw ID) for any running task.
+2. `node cli/bin/coh.mjs task <any-completed-task-id>` output contains the full untruncated result.
 3. `curl -s https://api.coherencycoin.com/api/pipeline/summary | jq .queue_depth` returns a JSON object with integer values.
 4. `curl -sI https://coherencycoin.com/pipeline` returns `HTTP/2 200`.
 5. A screenshot of `coherencycoin.com/pipeline` showing at least one active task with an idea name is posted to the project's contributor record.


### PR DESCRIPTION
Closes `specs/cli-binary-name-conflict.md`.

The npm global install of coherence-cli registered `cc` as a binary, which shadowed `/usr/bin/cc` (Apple clang) on macOS. Any developer or agent typing `cc` for our CLI could silently invoke the C compiler, or vice versa.

## Requirements landed

- **R1** — Remove `cc` from `cli/package.json` bin map (keep `coh`, `coherence`).
- **R2** — Rename `cli/bin/cc.mjs` → `cli/bin/coh.mjs` (git mv preserves history).
- **R3** — CLAUDE.md: every `cc <command>` example now uses `coh <command>`.
- **R4** — `cli/README.md` (+ template): `coh` as primary; npx zero-install callout; retirement note explaining the rename.
- **R5** — macOS conflict-detection block at startup of `coh.mjs`: on darwin, if `which cc` does not resolve to coherence-cli, print a one-time advisory to stderr and write a marker at `~/.coherence-network/.cc-conflict-warned` so it fires at most once. Advisory only — never blocks execution.
- **R6** — `npx coherence-cli <cmd>` surfaced as the canonical zero-conflict path in both README and CLAUDE.md.

## Downstream updates

- `cli/package.json` + `cli/package-lock.json` bumped to v0.13.0.
- `api/scripts/local_runner.py` (prompt text, 2 sites).
- `api/tests/test_flow_cli.py` (`CLI_BIN` path, static analysis, test docstrings, added assertion `"cc" not in pkg["bin"]`).
- `.github/workflows/thread-gates.yml` (comment).
- `specs/coherence-cli-comprehensive.md` + `specs/node-task-visibility.md` (source paths + usage examples).
- `specs/cli-binary-name-conflict.md` → status: done; source map points to new file.
- `specs/INDEX.md` header: 78 → 79 done, 1 → 0 active.

## Verified

- `node --check cli/bin/coh.mjs` — syntax OK.
- `make wellness` — all four senses clean.
- `grep " cc " CLAUDE.md` excluding `coherence-cli|Apple|clang|/usr/bin|binary` → 0 matches.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_