### PR TITLE
tend: serialize runner seeding

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -4537,13 +4537,14 @@ def _legacy_reap_stale_tasks(max_age_minutes: int = 15) -> int:
 # Session-level skip cache: ideas we already marked stuck/partial this session.
 # Prevents thrashing the API every 15s on the same stuck ideas.
 _SEEDER_SKIP_CACHE: set[str] = set()
+_SEEDER_LOCK = threading.Lock()
 
 # R2: maximum tasks allowed per idea+phase before capping (task dedup spec)
 MAX_TASKS_PER_PHASE: int = 3
 MAX_SEED_ATTEMPTS_PER_CYCLE: int = 12
 
 
-def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
+def _seed_task_from_open_idea(_attempt: int = 0, _lock_held: bool = False) -> bool:
     """Generate a task from an open idea when the queue is empty.
 
     Smart seeding:
@@ -4556,6 +4557,15 @@ def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
     """
     import random as _random
 
+    if not _lock_held:
+        if not _SEEDER_LOCK.acquire(blocking=False):
+            log.info("SEED: another worker is already seeding — skipping this worker cycle")
+            return False
+        try:
+            return _seed_task_from_open_idea(_attempt=_attempt, _lock_held=True)
+        finally:
+            _SEEDER_LOCK.release()
+
     if _attempt >= MAX_SEED_ATTEMPTS_PER_CYCLE:
         log.info(
             "SEED: attempt budget exhausted (%d) — pausing until next cycle",
@@ -4564,7 +4574,7 @@ def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
         return False
 
     def _try_next() -> bool:
-        return _seed_task_from_open_idea(_attempt + 1)
+        return _seed_task_from_open_idea(_attempt=_attempt + 1, _lock_held=True)
 
     # Capacity check
     active = _count_active_tasks()

--- a/api/tests/test_runner_spec_gate_guidance.py
+++ b/api/tests/test_runner_spec_gate_guidance.py
@@ -77,6 +77,20 @@ def test_seed_attempt_budget_stops_recursive_capped_scan(monkeypatch) -> None:
     assert "capped-idea" in local_runner._SEEDER_SKIP_CACHE
 
 
+def test_seed_skips_when_another_worker_holds_lock(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(local_runner, "api", lambda method, path, body=None: calls.append((method, path, body)) or {})
+
+    acquired = local_runner._SEEDER_LOCK.acquire(blocking=False)
+    assert acquired is True
+    try:
+        assert local_runner._seed_task_from_open_idea() is False
+    finally:
+        local_runner._SEEDER_LOCK.release()
+
+    assert calls == []
+
+
 def test_impl_without_spec_becomes_needs_decision(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(local_runner, "_get_repo_dir", lambda: tmp_path)

--- a/docs/system_audit/commit_evidence_2026-04-25_single-seeder-circulation.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_single-seeder-circulation.json
@@ -1,0 +1,84 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-seeder-single-circulation",
+  "commit_scope": "Prevent parallel runner workers from entering smart seeding at the same time so empty-queue sensing stays single and energy-efficient.",
+  "files_owned": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py",
+    "docs/system_audit/commit_evidence_2026-04-25_single-seeder-circulation.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q",
+      "python3 -m py_compile api/scripts/local_runner.py",
+      "git fetch origin main && git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "12 runner spec-gate tests passed; local_runner.py compiled successfully. Branch rebased with autostash, PR guard local_preflight=pass ready_for_push=True, follow-through stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused validation passed; pre-push guard, PR CI, merge, deploy, and live runner sensing remain pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate",
+    "runner-energy-efficiency"
+  ],
+  "spec_ids": [
+    "single-seeder-circulation"
+  ],
+  "task_ids": [
+    "health-seeder-single-circulation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "live runner log showed both parallel workers entering the empty-queue seeder path",
+    "focused pytest run: 12 passed",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260424T213153Z_codex-health-seeder-single-circulation.json"
+  ],
+  "change_files": [
+    "api/scripts/local_runner.py",
+    "api/tests/test_runner_spec_gate_guidance.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "When two runner workers poll an empty queue, only one worker should enter smart seeding and the other should log a seeding skip.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks"
+    ],
+    "test_flows": [
+      "Restart local runner after deploy and confirm NODE_REGISTERED uses deployed SHA.",
+      "Observe local_runner.out for SEED single-worker skip or one bounded seed sequence per poll cycle."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- serialize smart seeding across parallel runner workers with a nonblocking seeder lock
- keep recursive try-next calls inside the same lock
- add a focused test proving a second worker skips without API calls while seeding is held

## Validation
- cd api && python3 -m pytest tests/test_runner_spec_gate_guidance.py -q
- python3 -m py_compile api/scripts/local_runner.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_single-seeder-circulation.json