### PR TITLE
Add vision regeneration profiles

### DIFF
--- a/api/tests/test_generate_visuals_manifest.py
+++ b/api/tests/test_generate_visuals_manifest.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import generate_visuals  # noqa: E402
+
+
+def test_compose_manifest_prompt_applies_dynamic_profile() -> None:
+    prompt = generate_visuals.compose_manifest_prompt(
+        {"prompt": "a shared garden courtyard"},
+        {
+            "prompt_prefix": "high-quality documentary image",
+            "prompt_suffix": "warm afternoon light",
+            "negative_prompt": "text overlays, watermarks",
+        },
+    )
+
+    assert prompt == (
+        "high-quality documentary image a shared garden courtyard "
+        "warm afternoon light Avoid: text overlays, watermarks"
+    )
+
+
+def test_manifest_output_dir_preserves_repo_relative_path(tmp_path: Path) -> None:
+    dest = generate_visuals._destination_for_record(
+        {"path": "web/public/visuals/generated/lc-space-0.jpg"},
+        tmp_path,
+    )
+
+    assert dest == tmp_path / "web/public/visuals/generated/lc-space-0.jpg"
+
+
+def test_manifest_url_profile_overrides_dimensions_model_and_seed() -> None:
+    url = generate_visuals.manifest_pollinations_url(
+        {
+            "prompt": "living roof community home",
+            "model": "sana",
+            "seed": 7,
+            "width": 512,
+            "height": 512,
+        },
+        {
+            "model": "flux",
+            "seed_offset": 100,
+            "width": 1024,
+            "height": 768,
+            "prompt_prefix": "quality sample",
+        },
+    )
+
+    assert "quality%20sample%20living%20roof%20community%20home" in url
+    assert "width=1024" in url
+    assert "height=768" in url
+    assert "model=flux" in url
+    assert "seed=107" in url

--- a/docs/system_audit/commit_evidence_2026-04-25_vision-regeneration-profiles.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_vision-regeneration-profiles.json
@@ -1,0 +1,105 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/image-regeneration-prompts-20260425",
+  "commit_scope": "Add dynamic profile-driven vision image regeneration into review candidate paths before production image replacement.",
+  "files_owned": [
+    "api/tests/test_generate_visuals_manifest.py",
+    "docs/system_audit/commit_evidence_2026-04-25_vision-regeneration-profiles.json",
+    "docs/visuals/regeneration_profiles.json",
+    "scripts/generate_visuals.py",
+    "specs/vision-image-prompt-manifest.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_generate_visuals_manifest.py tests/test_check_generated_vision_assets.py",
+      "python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force",
+      "python3 scripts/plan_vision_image_regeneration.py --batch-size 200 --out-dir output/vision-quality/batches",
+      "python3 scripts/generate_visuals.py --from-manifest --batch-file output/vision-quality/batches/vision-image-batch-001.json --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force",
+      "python3 scripts/check_generated_vision_assets.py --allow-untracked",
+      "python3 -m py_compile scripts/generate_visuals.py scripts/plan_vision_image_regeneration.py scripts/check_generated_vision_assets.py scripts/export_vision_image_prompts.py",
+      "ruff check scripts/generate_visuals.py api/tests/test_generate_visuals_manifest.py",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Focused tests: 4 passed, 1 pytest config warning. One-image candidate dry-run wrote the expected review path. Batch planner split 372 images into 2 batches at batch size 200. Asset validation checked 142 references and 452 prompt records. Local PR guard passed with ready_for_push=True. Follow-through check passed with stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local regeneration validation and pre-push guard pass; PR CI and public deploy validation pending."
+  },
+  "idea_ids": [
+    "living-collective-vision",
+    "vision-image-regeneration"
+  ],
+  "spec_ids": [
+    "vision-image-prompt-manifest"
+  ],
+  "task_ids": [
+    "vision-regeneration-profiles-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "quality-bar"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "persistent manifest already covers 372 prompt records",
+    "dynamic prompt profile fast-sample-v1 composes onto stable prompt records",
+    "candidate output path dry-run: output/vision-quality/candidates/web/public/visuals/generated/lc-space-0.jpg",
+    "batch dry-run targets deterministic batch files from output/vision-quality/batches",
+    "local guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T213706Z_codex-image-regeneration-prompts-20260425.json",
+    "follow-through check: codex_open_prs=1, stale_codex_prs=0"
+  ],
+  "change_files": [
+    "api/tests/test_generate_visuals_manifest.py",
+    "docs/visuals/regeneration_profiles.json",
+    "scripts/generate_visuals.py",
+    "specs/vision-image-prompt-manifest.md"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Operators can regenerate vision image candidates from persistent prompts plus a dynamic profile into review paths without overwriting production images.",
+    "public_endpoints": [
+      "https://coherencycoin.com/vision"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense live pulse and status-report after deploy."
+    ]
+  }
+}

--- a/docs/visuals/regeneration_profiles.json
+++ b/docs/visuals/regeneration_profiles.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "source_note": "Dynamic prompt profiles are optional generation-time overlays. Edit these profiles to upgrade visual quality across deterministic prompt batches without rewriting every persistent image prompt.",
+  "profiles": [
+    {
+      "id": "quality-review-v1",
+      "label": "Quality review candidates",
+      "model": "flux",
+      "width": 1024,
+      "height": 768,
+      "seed_offset": 200000,
+      "prompt_prefix": "High-quality editorial photorealism, cohesive Living Collective visual language, warm natural light, grounded human scale, believable materials, no text in image.",
+      "prompt_suffix": "Preserve the original scene intent while improving composition, depth, facial and hand realism, material detail, and web-ready clarity.",
+      "negative_prompt": "distorted hands, extra fingers, unreadable signage, text overlays, logos, watermarks, plastic skin, surreal artifacts, duplicated limbs"
+    },
+    {
+      "id": "fast-sample-v1",
+      "label": "Fast quality sample",
+      "model": "flux",
+      "width": 512,
+      "height": 512,
+      "seed_offset": 100000,
+      "prompt_prefix": "Fast visual quality sample, coherent documentary composition, natural color, no text in image.",
+      "prompt_suffix": "Keep the source concept recognizable and suitable for side-by-side review.",
+      "negative_prompt": "text overlays, logos, watermarks, distorted anatomy, low-detail faces"
+    }
+  ]
+}

--- a/scripts/generate_visuals.py
+++ b/scripts/generate_visuals.py
@@ -39,6 +39,7 @@ from kb_common import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROMPT_MANIFEST = REPO_ROOT / "docs" / "visuals" / "prompts.json"
+PROMPT_PROFILES = REPO_ROOT / "docs" / "visuals" / "regeneration_profiles.json"
 
 
 def fetch_concepts(api_url: str) -> list[dict]:
@@ -56,42 +57,130 @@ def extract_story_visuals(story_content: str) -> list[dict]:
     return visuals
 
 
-def manifest_pollinations_url(record: dict[str, Any]) -> str:
-    """Build a Pollinations URL from a persistent prompt manifest record."""
+def _load_json_file(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_prompt_profile(profiles_path: Path, profile_id: str | None) -> dict[str, Any]:
+    """Load an optional dynamic prompt profile.
+
+    Prompt records stay stable and editable in docs/visuals/prompts.json. A
+    profile adds reviewable generation-time guidance without rewriting every
+    record, which lets future quality upgrades run as deterministic batches.
+    """
+    if not profile_id:
+        return {}
+
+    profiles = _load_json_file(profiles_path)
+    records = profiles.get("profiles")
+    if not isinstance(records, list):
+        raise ValueError(f"profiles file has no profiles list: {profiles_path}")
+
+    for record in records:
+        if isinstance(record, dict) and record.get("id") == profile_id:
+            return record
+    raise ValueError(f"unknown prompt profile: {profile_id}")
+
+
+def compose_manifest_prompt(record: dict[str, Any], profile: dict[str, Any] | None = None) -> str:
     prompt = str(record.get("prompt") or "").strip()
+    if not profile:
+        return prompt
+
+    parts = [
+        str(profile.get("prompt_prefix") or "").strip(),
+        prompt,
+        str(profile.get("prompt_suffix") or "").strip(),
+    ]
+    negative = str(profile.get("negative_prompt") or "").strip()
+    if negative:
+        parts.append(f"Avoid: {negative}")
+    return " ".join(part for part in parts if part)
+
+
+def _profile_int(profile: dict[str, Any], key: str, fallback: int) -> int:
+    value = profile.get(key)
+    if value in (None, ""):
+        return fallback
+    return int(value)
+
+
+def manifest_pollinations_url(record: dict[str, Any], profile: dict[str, Any] | None = None) -> str:
+    """Build a Pollinations URL from a persistent prompt manifest record."""
+    profile = profile or {}
+    prompt = compose_manifest_prompt(record, profile)
     encoded = urllib.parse.quote(prompt)
-    width = int(record.get("width") or 1024)
-    height = int(record.get("height") or 576)
-    seed = int(record.get("seed") or 42)
-    model = urllib.parse.quote(str(record.get("model") or "flux"))
+    width = _profile_int(profile, "width", int(record.get("width") or 1024))
+    height = _profile_int(profile, "height", int(record.get("height") or 576))
+    seed = int(record.get("seed") or 42) + _profile_int(profile, "seed_offset", 0)
+    model = urllib.parse.quote(str(profile.get("model") or record.get("model") or "flux"))
     return (
         f"https://image.pollinations.ai/prompt/{encoded}"
         f"?width={width}&height={height}&model={model}&nologo=true&seed={seed}"
     )
 
 
-def generate_from_manifest(manifest_path: Path, only_path: str | None, dry_run: bool, force: bool) -> int:
+def _load_manifest_records(manifest_path: Path) -> list[dict[str, Any]]:
+    manifest = _load_json_file(manifest_path)
+    records = manifest.get("records")
+    if not isinstance(records, list):
+        raise ValueError(f"Manifest has no records list: {manifest_path}")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _load_batch_records(batch_file: Path) -> list[dict[str, Any]]:
+    batch = _load_json_file(batch_file)
+    records = batch.get("records")
+    if not isinstance(records, list):
+        raise ValueError(f"Batch has no records list: {batch_file}")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _select_manifest_records(
+    records: list[dict[str, Any]],
+    only_path: str | None,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for record in records:
+        path = str(record.get("path") or "")
+        mirrors = [str(p) for p in record.get("mirror_paths") or []]
+        if only_path and only_path not in [path, *mirrors, record.get("id")]:
+            continue
+        selected.append(record)
+    return selected
+
+
+def _destination_for_record(record: dict[str, Any], output_dir: Path | None) -> Path:
+    rel_path = Path(str(record.get("path") or ""))
+    if output_dir is None:
+        return REPO_ROOT / rel_path
+    base = output_dir if output_dir.is_absolute() else REPO_ROOT / output_dir
+    return base / rel_path
+
+
+def generate_from_manifest(
+    manifest_path: Path,
+    only_path: str | None,
+    dry_run: bool,
+    force: bool,
+    *,
+    batch_file: Path | None = None,
+    output_dir: Path | None = None,
+    profile: dict[str, Any] | None = None,
+) -> int:
     """Generate images from committed prompt records.
 
     This path is the durable regeneration contract: edit the manifest prompt,
     then regenerate by stable repo path without reading metadata from the old
     image artifact.
     """
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    records = manifest.get("records")
-    if not isinstance(records, list):
-        print(f"Manifest has no records list: {manifest_path}", file=sys.stderr)
+    try:
+        records = _load_batch_records(batch_file) if batch_file else _load_manifest_records(manifest_path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
         return 1
 
-    selected = []
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        path = str(record.get("path") or "")
-        mirrors = [str(p) for p in record.get("mirror_paths") or []]
-        if only_path and only_path not in [path, *mirrors, record.get("id")]:
-            continue
-        selected.append(record)
+    selected = _select_manifest_records(records, only_path)
 
     if only_path and not selected:
         print(f"No manifest record matched: {only_path}", file=sys.stderr)
@@ -103,15 +192,15 @@ def generate_from_manifest(manifest_path: Path, only_path: str | None, dry_run: 
     failed = 0
 
     for record in selected:
-        prompt = str(record.get("prompt") or "").strip()
+        prompt = compose_manifest_prompt(record, profile)
         rel_path = str(record.get("path") or "")
         if not prompt or not rel_path:
             failed += 1
             print(f"  SKIP invalid record: {record.get('id')}", file=sys.stderr)
             continue
 
-        dest = REPO_ROOT / rel_path
-        mirror_paths = [REPO_ROOT / str(path) for path in record.get("mirror_paths") or []]
+        dest = _destination_for_record(record, output_dir)
+        mirror_paths = [] if output_dir else [REPO_ROOT / str(path) for path in record.get("mirror_paths") or []]
         if dest.exists() and not force:
             skipped += 1
             for mirror in mirror_paths:
@@ -120,9 +209,9 @@ def generate_from_manifest(manifest_path: Path, only_path: str | None, dry_run: 
                     shutil.copy2(dest, mirror)
             continue
 
-        url = manifest_pollinations_url(record)
+        url = manifest_pollinations_url(record, profile)
         if dry_run:
-            print(f"  [DRY RUN] {rel_path}: {prompt[:80]}...")
+            print(f"  [DRY RUN] {dest.relative_to(REPO_ROOT)}: {prompt[:100]}...")
             downloaded += 1
             continue
 
@@ -155,6 +244,24 @@ def main():
         help="Generate from docs/visuals/prompts.json instead of API concept data.",
     )
     parser.add_argument("--manifest", type=Path, default=PROMPT_MANIFEST)
+    parser.add_argument("--profiles", type=Path, default=PROMPT_PROFILES)
+    parser.add_argument(
+        "--profile",
+        help="Dynamic prompt profile id from docs/visuals/regeneration_profiles.json.",
+    )
+    parser.add_argument(
+        "--batch-file",
+        type=Path,
+        help="Manifest batch file from scripts/plan_vision_image_regeneration.py.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        help=(
+            "Write regenerated candidates under this directory while preserving "
+            "repo-relative paths. When omitted, production asset paths are used."
+        ),
+    )
     parser.add_argument(
         "--only-path",
         help="When using --from-manifest, regenerate one repo path or record id.",
@@ -162,7 +269,20 @@ def main():
     args = parser.parse_args()
 
     if args.from_manifest:
-        return generate_from_manifest(args.manifest, args.only_path, args.dry_run, args.force)
+        try:
+            profile = load_prompt_profile(args.profiles, args.profile)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        return generate_from_manifest(
+            args.manifest,
+            args.only_path,
+            args.dry_run,
+            args.force,
+            batch_file=args.batch_file,
+            output_dir=args.out_dir,
+            profile=profile,
+        )
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/specs/vision-image-prompt-manifest.md
+++ b/specs/vision-image-prompt-manifest.md
@@ -4,12 +4,15 @@ status: done
 source:
   - file: docs/visuals/prompts.json
     symbols: [vision image prompt records]
+  - file: docs/visuals/regeneration_profiles.json
+    symbols: [dynamic prompt profiles]
   - file: scripts/generate_visuals.py
-    symbols: [generate_from_manifest()]
+    symbols: [generate_from_manifest(), compose_manifest_prompt()]
 requirements:
   - "Every current Living Collective vision image has a persistent prompt record."
   - "Prompt validation fails when an image lacks a prompt record or has an empty prompt."
   - "Regeneration can target one stable image path or deterministic prompt batch."
+  - "Regeneration can write review candidates under a separate output directory before production assets are replaced."
 done_when:
   - "Prompt manifest covers all current vision images."
   - "Asset validation includes prompt-record coverage."
@@ -36,6 +39,7 @@ Living Collective vision images must be regenerable from source-controlled promp
 ## Files to Create/Modify
 
 - `docs/visuals/prompts.json` — persistent prompt records for current vision images.
+- `docs/visuals/regeneration_profiles.json` — dynamic prompt overlays for quality/sample regeneration.
 - `scripts/export_vision_image_prompts.py` — migration/audit exporter for prompt records.
 - `scripts/check_generated_vision_assets.py` — asset and prompt-record validation.
 - `scripts/generate_visuals.py` — manifest-driven regeneration mode.
@@ -47,6 +51,7 @@ Living Collective vision images must be regenerable from source-controlled promp
 - `python3 scripts/export_vision_image_prompts.py` exports prompt records for all current vision images.
 - `python3 scripts/check_generated_vision_assets.py --allow-untracked` passes and reports prompt-record validation.
 - `python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --dry-run --force` targets one stable image from the manifest.
+- `python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force` targets one stable candidate path with a dynamic profile.
 - `python3 scripts/plan_vision_image_regeneration.py --batch-size 50 --out-dir output/vision-quality/batches` writes deterministic batch files.
 
 ## Verification
@@ -55,6 +60,7 @@ Living Collective vision images must be regenerable from source-controlled promp
 python3 scripts/export_vision_image_prompts.py
 python3 scripts/check_generated_vision_assets.py --allow-untracked
 python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --dry-run --force
+python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force
 python3 scripts/plan_vision_image_regeneration.py --batch-size 50 --out-dir output/vision-quality/batches
 python3 -m py_compile scripts/export_vision_image_prompts.py scripts/plan_vision_image_regeneration.py scripts/generate_visuals.py scripts/check_generated_vision_assets.py
 ```
@@ -74,5 +80,5 @@ python3 -m py_compile scripts/export_vision_image_prompts.py scripts/plan_vision
 
 ## Known Gaps and Follow-up Tasks
 
-- Follow-up: add a reviewed replacement workflow for Codex-generated or GPT-image-generated candidates before overwriting production assets.
+- Follow-up: connect the reviewed candidate-output workflow to Codex app image generation or a configured image API provider when a repository-owned binary replacement policy is chosen.
 - Follow-up: decide whether future generated image binaries should be committed, uploaded, or produced by a release-time artifact pipeline.


### PR DESCRIPTION
## Summary
- add dynamic vision image regeneration profiles
- allow manifest regeneration from deterministic batch files into review candidate paths
- add focused tests for prompt composition, candidate paths, and profile URL overrides

## Validation
- make prompt-gate
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_generate_visuals_manifest.py tests/test_check_generated_vision_assets.py
- python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force
- python3 scripts/plan_vision_image_regeneration.py --batch-size 200 --out-dir output/vision-quality/batches
- python3 scripts/check_generated_vision_assets.py --allow-untracked
- python3 -m py_compile scripts/generate_visuals.py scripts/plan_vision_image_regeneration.py scripts/check_generated_vision_assets.py scripts/export_vision_image_prompts.py
- ruff check scripts/generate_visuals.py api/tests/test_generate_visuals_manifest.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence