### PR TITLE
tend: finish cc → coh across all docs, CLI help text, and prompts

### DIFF
--- a/.claude/agents/dev-engineer.md
+++ b/.claude/agents/dev-engineer.md
@@ -11,7 +11,7 @@ You are the Dev Engineer for Coherence Network. Implement ONLY what the spec say
 
 1. Find the spec: `specs/{slug}.md` — frontmatter has `source:` (files + symbols to modify)
 2. Find the parent idea: `ideas/{idea_id}.md` — context for why this spec exists
-3. Check progress: MCP `coherence_idea_progress` or `cc idea {id}`
+3. Check progress: MCP `coherence_idea_progress` or `coh idea {id}`
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ curl -s https://api.coherencycoin.com/api/health | python3 -m json.tool
 
 ```bash
 npm i -g coherence-cli
-cc status                    # network health, idea count, your identity
-cc ideas                     # browse the portfolio ranked by ROI
-cc idea <id>                 # deep-dive: scores, open questions, value gaps
+coh status                    # network health, idea count, your identity
+coh ideas                     # browse the portfolio ranked by ROI
+coh idea <id>                 # deep-dive: scores, open questions, value gaps
 ```
 
 **Option C — give your AI agent access:**
@@ -68,14 +68,14 @@ Every contribution — code, docs, review, design, community — is tracked and 
 
 ```bash
 # Link your identity (37 providers: GitHub, Discord, Ethereum, Solana, ORCID, ...)
-cc identity setup
-cc identity link github your-handle
+coh identity setup
+coh identity link github your-handle
 
 # Submit a new idea
-cc share
+coh share
 
 # Record any contribution
-cc contribute
+coh contribute
 
 # Or contribute via the API
 curl -s https://api.coherencycoin.com/api/contributions/record \
@@ -99,8 +99,8 @@ The workflow is: **Spec → Test → Implement → CI → Review → Merge**. Sp
 **Stake** on ideas you believe in. **Fork** ideas to take them new directions. **Trace** the full value chain from spark to payout.
 
 ```bash
-cc stake <idea-id> 10       # stake 10 CC on an idea
-cc fork <idea-id>           # fork and evolve it
+coh stake <idea-id> 10       # stake 10 CC on an idea
+coh fork <idea-id>           # fork and evolve it
 
 # View the full value chain
 curl -s https://api.coherencycoin.com/api/value-lineage/links?limit=5 | python3 -m json.tool
@@ -141,7 +141,7 @@ Every part of the network links to every other. Jump in wherever makes sense.
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, contributors, and value chains visually | [coherencycoin.com](https://coherencycoin.com) |
 | **API** | 100+ endpoints with full OpenAPI docs — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
 | **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **skills.sh** | Portable agent skill directory (same `SKILL.md` as ClawHub) | [skills.sh](https://skills.sh/) — submit `skills/coherence-network/` |

--- a/README.template.md
+++ b/README.template.md
@@ -33,9 +33,9 @@ curl -s https://api.coherencycoin.com/api/health | python3 -m json.tool
 
 ```bash
 npm i -g coherence-cli
-cc status                    # network health, idea count, your identity
-cc ideas                     # browse the portfolio ranked by ROI
-cc idea <id>                 # deep-dive: scores, open questions, value gaps
+coh status                    # network health, idea count, your identity
+coh ideas                     # browse the portfolio ranked by ROI
+coh idea <id>                 # deep-dive: scores, open questions, value gaps
 ```
 
 **Option C — give your AI agent access:**
@@ -61,14 +61,14 @@ Every contribution — code, docs, review, design, community — is tracked and 
 
 ```bash
 # Link your identity (37 providers: GitHub, Discord, Ethereum, Solana, ORCID, ...)
-cc identity setup
-cc identity link github your-handle
+coh identity setup
+coh identity link github your-handle
 
 # Submit a new idea
-cc share
+coh share
 
 # Record any contribution
-cc contribute
+coh contribute
 
 # Or contribute via the API
 curl -s https://api.coherencycoin.com/api/contributions/record \
@@ -92,8 +92,8 @@ The workflow is: **Spec → Test → Implement → CI → Review → Merge**. Sp
 **Stake** on ideas you believe in. **Fork** ideas to take them new directions. **Trace** the full value chain from spark to payout.
 
 ```bash
-cc stake <idea-id> 10       # stake 10 CC on an idea
-cc fork <idea-id>           # fork and evolve it
+coh stake <idea-id> 10       # stake 10 CC on an idea
+coh fork <idea-id>           # fork and evolve it
 
 # View the full value chain
 curl -s https://api.coherencycoin.com/api/value-lineage/links?limit=5 | python3 -m json.tool

--- a/api/app/routers/auth_keys.py
+++ b/api/app/routers/auth_keys.py
@@ -259,7 +259,7 @@ class OnboardRequest(BaseModel):
 async def onboard_contributor(body: OnboardRequest) -> dict:
     """One-shot onboarding: create contributor + link identity + generate API key.
 
-    This is the primary entry point for `cc setup`.
+    This is the primary entry point for `coh setup`.
     Returns the API key — save it to ~/.coherence-network/keys.json.
     """
     from app.services import contributor_identity_service, contributor_service
@@ -319,7 +319,7 @@ async def onboard_contributor(body: OnboardRequest) -> dict:
         "provider_id": body.provider_id,
         "created_at": minted.row.created_at,
         "scopes": list(minted.row.scopes),
-        "message": f"Welcome to Coherence Network, {body.name}! Key saved — run: cc status",
+        "message": f"Welcome to Coherence Network, {body.name}! Key saved — run: coh status",
     }
 
 
@@ -348,7 +348,7 @@ async def whoami(
     # Legacy compatibility: callers sending X-API-Key (or ?api_key_query=).
     key = x_api_key or api_key_query
     if not key:
-        return {"authenticated": False, "message": "No API key provided. Run: cc setup"}
+        return {"authenticated": False, "message": "No API key provided. Run: coh setup"}
 
     info = verify_contributor_key(key)
     if info:

--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -709,7 +709,7 @@ class _CircuitBreaker:
     - Trips when: ≥ `trip_threshold` consecutive failures OR failure rate > 80% over the window
     - When tripped: blocks _seed_task_from_open_idea() and logs clearly
     - Resets after `cooldown_seconds` to allow a probe attempt
-    - Manual reset via `cc cmd mac resume` (processed in _process_node_messages)
+    - Manual reset via `coh cmd mac resume` (processed in _process_node_messages)
     """
 
     def __init__(self, window_size: int = 20, trip_threshold: int = 10, cooldown_seconds: int = 600):
@@ -750,7 +750,7 @@ class _CircuitBreaker:
             self._trip_time = time.time()
             self._trip_reason = reason
             log.error("CIRCUIT_BREAKER TRIPPED: %s — pipeline seeding paused for %ds. "
-                      "Fix the root cause, then send 'cc cmd mac resume' to reset.",
+                      "Fix the root cause, then send 'coh cmd mac resume' to reset.",
                       reason, self.cooldown_seconds)
 
     def allow_seeding(self) -> bool:
@@ -2156,7 +2156,7 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
             direction = (
                 f"Deploy '{idea_name}' ({idea_id}) to production.\n\n"
                 f"1. Verify code is committed and pushed to main\n"
-                f"2. Run: cc deploy (or SSH deploy if cc deploy unavailable)\n"
+                f"2. Run: coh deploy (or SSH deploy if coh deploy unavailable)\n"
                 f"3. Verify health check passes: curl https://api.coherencycoin.com/api/health\n"
                 f"4. If deploy fails, report DEPLOY_FAILED with the error\n"
                 f"5. If health check fails after deploy, report DEPLOY_FAILED — rollback needed\n\n"
@@ -2169,7 +2169,7 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
                 f"Run the spec's verification scenarios against PRODUCTION:\n"
                 f"  - API: curl https://api.coherencycoin.com/...\n"
                 f"  - Web: check https://coherencycoin.com/...\n"
-                f"  - CLI: run cc <command>\n\n"
+                f"  - CLI: run coh <command>\n\n"
                 f"For EACH scenario report PASS or FAIL with actual output.\n"
                 f"If ANY scenario fails, output VERIFY_FAILED with details.\n"
                 f"If ALL pass, output VERIFY_PASSED with evidence.\n\n"
@@ -2371,7 +2371,7 @@ def _run_phase_auto_advance_hook(task: dict[str, Any]) -> None:
                 f"1. Check what was built: git log --oneline -10 | grep '{idea_id}'\n"
                 f"2. Verify it's on production: curl -s https://api.coherencycoin.com/api/health\n"
                 f"3. Record a contribution:\n"
-                f"   cc contribute --type code --idea {idea_id} --desc 'Full lifecycle: spec→impl→test→review→merge→deploy→verify'\n"
+                f"   coh contribute --type code --idea {idea_id} --desc 'Full lifecycle: spec→impl→test→review→merge→deploy→verify'\n"
                 f"4. Update the idea's coherence score if possible\n"
                 f"5. Check if there are follow-up tasks or gaps identified during review\n\n"
                 f"Output: REFLECT_COMPLETE with summary of what was delivered, coherence impact, "
@@ -4842,7 +4842,7 @@ def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
         f"concrete test scenarios that PROVE the feature works as described.\n\n"
         f"Each scenario must have:\n"
         f"- Setup: what state exists before the test\n"
-        f"- Action: exact command or request (curl, cc command, browser action)\n"
+        f"- Action: exact command or request (curl, coh command, browser action)\n"
         f"- Expected result: specific output, not vague ('returns data')\n"
         f"- Edge case: what happens with bad input, missing data, or duplicate request\n\n"
         f"Example of a GOOD verification scenario:\n"
@@ -4865,7 +4865,7 @@ def _seed_task_from_open_idea(_attempt: int = 0) -> bool:
             f"\nNETWORK-SPECIFIC:\n"
             f"- Include the exact API endpoints that must exist (e.g., GET /api/concepts)\n"
             f"- Include the exact web pages (e.g., /concepts) if web-facing\n"
-            f"- Include the exact CLI commands (e.g., cc concepts) if CLI-facing\n"
+            f"- Include the exact CLI commands (e.g., coh concepts) if CLI-facing\n"
             f"- At least one scenario must test the full create-read-update cycle\n"
             f"- At least one scenario must test error handling (bad input, missing resource)\n"
         )
@@ -7094,7 +7094,7 @@ def main():
                 "[runner] WARNING: no contributor identity configured — all contributions will be anonymous",
             )
             log.warning(
-                "[runner] Fix: cc identity set <your_id>  or  export COHERENCE_CONTRIBUTOR_ID=<your_id>",
+                "[runner] Fix: coh identity set <your_id>  or  export COHERENCE_CONTRIBUTOR_ID=<your_id>",
             )
     except Exception as exc:
         log.debug("Runner identity resolution skipped: %s", exc)

--- a/api/scripts/task_control_channel.py
+++ b/api/scripts/task_control_channel.py
@@ -206,38 +206,38 @@ class TaskControlChannel:
 def inject_control_instructions(prompt: str, task_dir: Path) -> str:
     """Add control channel instructions to the agent's prompt.
 
-    Uses cc CLI for communication — agents are network participants.
+    Uses coh CLI for communication — agents are network participants.
     """
     instructions = """
 
 ## Real-time network communication
 
-You are a node in the Coherence Network. Use `cc` to communicate:
+You are a node in the Coherence Network. Use `coh` to communicate:
 
 ### Check for messages (do this every 5-7 minutes)
 ```bash
-cc inbox
+coh inbox
 ```
 
 If you see a command, act on it:
-- `checkpoint` — Write your current progress to `.task-checkpoint.md` and reply with `cc msg <sender> "checkpoint saved"`
-- `steer` — Adjust your approach as directed and reply with `cc msg <sender> "acknowledged, adjusting"`
-- `abort` — Stop work, save progress to `.task-checkpoint.md`, reply with `cc msg <sender> "aborting, progress saved"`, then exit
-- `ask` — Answer the question via `cc msg <sender> "<your answer>"`
+- `checkpoint` — Write your current progress to `.task-checkpoint.md` and reply with `coh msg <sender> "checkpoint saved"`
+- `steer` — Adjust your approach as directed and reply with `coh msg <sender> "acknowledged, adjusting"`
+- `abort` — Stop work, save progress to `.task-checkpoint.md`, reply with `coh msg <sender> "aborting, progress saved"`, then exit
+- `ask` — Answer the question via `coh msg <sender> "<your answer>"`
 
 ### Send status updates
 ```bash
-cc msg broadcast "Working on <idea>: 60% complete, implementing API endpoints"
+coh msg broadcast "Working on <idea>: 60% complete, implementing API endpoints"
 ```
 
 ### Report issues
 ```bash
-cc msg broadcast "Blocked: missing dependency X, need guidance"
+coh msg broadcast "Blocked: missing dependency X, need guidance"
 ```
 
 ### When done
 ```bash
-cc contribute --type code --cc 5 --desc "Implemented <feature>"
+coh contribute --type code --cc 5 --desc "Implemented <feature>"
 ```
 """
     return prompt + instructions

--- a/cli/bin/coh.mjs
+++ b/cli/bin/coh.mjs
@@ -136,7 +136,7 @@ import {
 } from "../lib/config.mjs";
 import { basename } from 'path';
 
-// Deprecation warning when invoked as `cc` (shadows /usr/bin/cc on macOS/Linux)
+// Deprecation warning when invoked as `cc` (shadows /usr/bin/coh on macOS/Linux)
 const _invokedAs = basename(process.argv[1] || '');
 if (_invokedAs === 'cc') {
   process.stderr.write(
@@ -149,7 +149,7 @@ if (_invokedAs === 'cc') {
 // override; per-invocation env vars (COHERENCE_API_URL, COHERENCE_API_KEY,
 // COHERENCE_TIMEOUT_MS) are honored by the resolvers in config.mjs when no
 // override is set. The persistent workspace default lives in config.json
-// under the `workspace` key (set via `cc workspace use <id>`).
+// under the `workspace` key (set via `coh workspace use <id>`).
 //
 //   --workspace <id>    Scope commands to a specific workspace for this run.
 //   --api-url <url>     Override the API origin (alternative: COHERENCE_API_URL).
@@ -313,10 +313,10 @@ async function handleEdge(args) {
     case "delete": return deleteEdge(subArgs);
     case "types":  return listEdgeTypes();
     default:
-      console.log("Usage: cc edge <create|delete|types>");
-      console.log("  cc edge create <from-id> <type> <to-id>");
-      console.log("  cc edge delete <edge-id>");
-      console.log("  cc edge types");
+      console.log("Usage: coh edge <create|delete|types>");
+      console.log("  coh edge create <from-id> <type> <to-id>");
+      console.log("  coh edge delete <edge-id>");
+      console.log("  coh edge types");
   }
 }
 
@@ -443,7 +443,7 @@ async function showWhoami() {
       console.log(`  Network:     ${Y}key not recognized by server${R}`);
     }
   } else {
-    console.log(`  ${Y}Not set up yet.${R} Run: cc setup`);
+    console.log(`  ${Y}Not set up yet.${R} Run: coh setup`);
   }
   console.log();
 }
@@ -522,10 +522,10 @@ async function handleMarketplace(args) {
       case "browse":  return marketplaceBrowse(args.slice(1));
       case "fork":    return marketplaceFork(args.slice(1));
       default:
-         console.log("Usage: cc marketplace <publish|browse|fork>");
-         console.log("  cc marketplace publish --idea-id <id> --tags <tags> --author <name>");
-         console.log("  cc marketplace browse --page <n> --sort <recent|popular|value>");
-         console.log("  cc marketplace fork --listing-id <id> --forker-id <id>");
+         console.log("Usage: coh marketplace <publish|browse|fork>");
+         console.log("  coh marketplace publish --idea-id <id> --tags <tags> --author <name>");
+         console.log("  coh marketplace browse --page <n> --sort <recent|popular|value>");
+         console.log("  coh marketplace fork --listing-id <id> --forker-id <id>");
    }
 }
 
@@ -536,10 +536,10 @@ async function handleGraph(args) {
       case "edges":   return listGraphEdges(args.slice(1));
       case "neighbors": return getGraphNeighbors(args.slice(1));
       default:
-         console.log("Usage: cc graph <nodes|edges|neighbors>");
-         console.log("  cc graph nodes list|create");
-         console.log("  cc graph edges list|create|neighbors");
-         console.log("  cc graph neighbors --node-id <id>");
+         console.log("Usage: coh graph <nodes|edges|neighbors>");
+         console.log("  coh graph nodes list|create");
+         console.log("  coh graph edges list|create|neighbors");
+         console.log("  coh graph neighbors --node-id <id>");
    }
 }
 
@@ -550,7 +550,7 @@ async function handleOnboarding(args) {
       case "session":  return onboardingSession(args.slice(1));
       case "upgrade":  return onboardingUpgrade(args.slice(1));
       default:
-         console.log("Usage: cc onboarding <register|session|upgrade>");
+         console.log("Usage: coh onboarding <register|session|upgrade>");
   }
 }
 
@@ -561,7 +561,7 @@ async function handleCredentials(args) {
     case "list":   return credentialsList(args.slice(1));
     case "remove": return credentialsRemove(args.slice(1));
     default:
-      console.log("Usage: cc credentials <add|list|remove>");
+      console.log("Usage: coh credentials <add|list|remove>");
   }
 }
 
@@ -759,7 +759,7 @@ function showHelp() {
 
 \x1b[1m${t("help.sectionEdge")}\x1b[0m
   edges <id>              List all edges for an entity (alias: edg)
-  edg <id>                Shorthand alias for cc edges
+  edg <id>                Shorthand alias for coh edges
   edges <id> --type <t>  Filter edges by relationship type
   edge types              Print all 46 canonical edge types
   edge create <from> <type> <to>  Create a typed edge
@@ -856,7 +856,7 @@ async function main() {
   }
   debugPytest(`unknown-command=${String(command)}`);
   console.log(`Unknown command: ${command}`);
-  console.log("Run 'cc help' for available commands.");
+  console.log("Run 'coh help' for available commands.");
   process.exit(1);
 }
 

--- a/cli/lib/api.mjs
+++ b/cli/lib/api.mjs
@@ -12,7 +12,7 @@ function timeoutSignal() {
   return AbortSignal.timeout(getTimeoutMs());
 }
 
-/** Normalized API origin (no trailing slash). Used by SSE watchers and `cc rest`. */
+/** Normalized API origin (no trailing slash). Used by SSE watchers and `coh rest`. */
 export function getApiBase() {
   return getHubUrl().replace(/\/$/, "");
 }
@@ -113,7 +113,7 @@ export async function del(path) {
 }
 
 /**
- * Low-level HTTP for `cc rest` — any method, optional JSON body and extra headers.
+ * Low-level HTTP for `coh rest` — any method, optional JSON body and extra headers.
  * @returns {{ ok: boolean, status: number, path: string, text: string, json: any | null }}
  */
 export async function request(method, path, options = {}) {

--- a/cli/lib/commands/agent.mjs
+++ b/cli/lib/commands/agent.mjs
@@ -1,24 +1,24 @@
 /**
  * Agent pipeline commands
  *
- *   cc agent                          — show pipeline status
- *   cc agent status                   — full status report
- *   cc agent pipeline                 — pipeline-status
- *   cc agent runners                  — list runners
- *   cc agent lifecycle                — lifecycle summary
- *   cc agent usage                    — agent usage stats
- *   cc agent visibility               — agent visibility
- *   cc agent guidance                 — orchestration guidance
- *   cc agent integration              — integration report
- *   cc agent issues                   — fatal and monitor issues
- *   cc agent metrics                  — task metrics
- *   cc agent effectiveness            — agent effectiveness report
- *   cc agent health                   — collective health
- *   cc agent diagnostics              — diagnostics completeness
- *   cc agent reap-history             — reap history
- *   cc agent attention                — tasks needing attention
- *   cc agent run-state <task_id>      — run state for a task
- *   cc agent execute <task_id>        — execute a task (agent use)
+ *   coh agent                          — show pipeline status
+ *   coh agent status                   — full status report
+ *   coh agent pipeline                 — pipeline-status
+ *   coh agent runners                  — list runners
+ *   coh agent lifecycle                — lifecycle summary
+ *   coh agent usage                    — agent usage stats
+ *   coh agent visibility               — agent visibility
+ *   coh agent guidance                 — orchestration guidance
+ *   coh agent integration              — integration report
+ *   coh agent issues                   — fatal and monitor issues
+ *   coh agent metrics                  — task metrics
+ *   coh agent effectiveness            — agent effectiveness report
+ *   coh agent health                   — collective health
+ *   coh agent diagnostics              — diagnostics completeness
+ *   coh agent reap-history             — reap history
+ *   coh agent attention                — tasks needing attention
+ *   coh agent run-state <task_id>      — run state for a task
+ *   coh agent execute <task_id>        — execute a task (agent use)
  */
 
 import { get, post, patch, request } from "../api.mjs";
@@ -523,7 +523,7 @@ export async function showAttentionTasks() {
 
 export async function showRunState(args) {
   const taskId = args[0];
-  if (!taskId) { console.log("Usage: cc agent run-state <task_id>"); return; }
+  if (!taskId) { console.log("Usage: coh agent run-state <task_id>"); return; }
 
   const data = await get(`/api/agent/run-state/${encodeURIComponent(taskId)}`);
   if (!data) { console.log(`No run state for task '${taskId}'.`); return; }
@@ -569,7 +569,7 @@ export async function showAgentRoute(args) {
 export async function executeAgentTask(args) {
   const taskId = args[0];
   if (!taskId) {
-    console.log("Usage: cc agent execute <task_id>");
+    console.log("Usage: coh agent execute <task_id>");
     console.log("  Requires agent_executor.execute_token in ~/.coherence-network/config.json for server-side execute.");
     return;
   }

--- a/cli/lib/commands/assets.mjs
+++ b/cli/lib/commands/assets.mjs
@@ -43,7 +43,7 @@ export async function listAssets(args) {
 export async function showAsset(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc asset <id>");
+    console.log("Usage: coh asset <id>");
     return;
   }
   const data = await get(`/api/assets/${encodeURIComponent(id)}`);
@@ -65,7 +65,7 @@ export async function createAsset(args) {
   const type = args[0];
   const desc = args.slice(1).join(" ");
   if (!type || !desc) {
-    console.log("Usage: cc asset create <type> <description>");
+    console.log("Usage: coh asset create <type> <description>");
     return;
   }
   const result = await post("/api/assets", {

--- a/cli/lib/commands/blueprints.mjs
+++ b/cli/lib/commands/blueprints.mjs
@@ -1,8 +1,8 @@
 /**
  * Blueprints command — template-based roadmap seeding
  * 
- * cc blueprints          — List available blueprints
- * cc blueprint apply <id> — Apply a blueprint roadmap
+ * coh blueprints          — List available blueprints
+ * coh blueprint apply <id> — Apply a blueprint roadmap
  */
 
 import inquirer from "inquirer";
@@ -38,13 +38,13 @@ export async function runBlueprintsCommand(args = []) {
       console.log(`- ${chalk.bold(b.id.padEnd(20))} [${price}] ${author}`);
       console.log(`  ${chalk.dim(b.name + ' — ' + b.description)}\n`);
     });
-    console.log(chalk.dim("Use 'cc blueprint apply <id>' to seed a roadmap."));
+    console.log(chalk.dim("Use 'coh blueprint apply <id>' to seed a roadmap."));
   }
 }
 
 async function applyBlueprint(id, prefix = "") {
   if (!id) {
-    console.log("Usage: cc blueprint apply <id> [prefix]");
+    console.log("Usage: coh blueprint apply <id> [prefix]");
     return;
   }
 

--- a/cli/lib/commands/collab.mjs
+++ b/cli/lib/commands/collab.mjs
@@ -1,9 +1,9 @@
 /**
  * Collaboration command — work together on ideas
  * 
- * cc collab             — Interactive collab dashboard for focused idea
- * cc collab broadcast   — Signal interest in the focused idea
- * cc collab list        — List active collaborators for focused idea
+ * coh collab             — Interactive collab dashboard for focused idea
+ * coh collab broadcast   — Signal interest in the focused idea
+ * coh collab list        — List active collaborators for focused idea
  */
 
 import inquirer from "inquirer";
@@ -17,7 +17,7 @@ export async function runCollabCommand(args = []) {
   const contributorId = getContributorId();
 
   if (!focus.idea_id) {
-    console.log(chalk.yellow("⚠ No focused idea. Use 'cc focus' to pick one first."));
+    console.log(chalk.yellow("⚠ No focused idea. Use 'coh focus' to pick one first."));
     return;
   }
 

--- a/cli/lib/commands/concepts.mjs
+++ b/cli/lib/commands/concepts.mjs
@@ -2,9 +2,9 @@
  * Concept commands — browse and extend the Living Codex ontology (184 concepts, 46 rel types, 53 axes).
  *
  * Commands:
- *   cc concepts [--limit N] [--search <query>]
- *   cc concept <id>
- *   cc concept link <from-id> <rel-type> <to-id> [--by <author>]
+ *   coh concepts [--limit N] [--search <query>]
+ *   coh concept <id>
+ *   coh concept link <from-id> <rel-type> <to-id> [--by <author>]
  */
 
 import { get, post } from "../api.mjs";
@@ -50,7 +50,7 @@ function parseArgs(args) {
   return { opts, positional };
 }
 
-/** cc concepts [--limit N] [--search <query>] */
+/** coh concepts [--limit N] [--search <query>] */
 export async function listConcepts(args) {
   const { opts } = parseArgs(args);
 
@@ -108,12 +108,12 @@ export async function listConcepts(args) {
   console.log();
 }
 
-/** cc concept <id> */
+/** coh concept <id> */
 export async function showConcept(args) {
   const { positional } = parseArgs(args);
   const id = positional[0];
   if (!id) {
-    console.error("Usage: cc concept <id>");
+    console.error("Usage: coh concept <id>");
     process.exit(1);
   }
 
@@ -174,14 +174,14 @@ export async function showConcept(args) {
   console.log();
 }
 
-/** cc concept link <from-id> <rel-type> <to-id> [--by <author>] */
+/** coh concept link <from-id> <rel-type> <to-id> [--by <author>] */
 export async function linkConcepts(args) {
   const { opts, positional } = parseArgs(args);
   const [fromId, relType, toId] = positional;
 
   if (!fromId || !relType || !toId) {
-    console.error("Usage: cc concept link <from-id> <rel-type> <to-id> [--by <author>]");
-    console.error("Example: cc concept link activity transforms knowledge");
+    console.error("Usage: coh concept link <from-id> <rel-type> <to-id> [--by <author>]");
+    console.error("Example: coh concept link activity transforms knowledge");
     process.exit(1);
   }
 

--- a/cli/lib/commands/config_editor.mjs
+++ b/cli/lib/commands/config_editor.mjs
@@ -226,7 +226,7 @@ export async function setConfigCommand(args = []) {
   const [path, ...valueParts] = positional;
   const value = valueParts.join(" ");
   if (!path || !valueParts.length) {
-    console.log("Usage: cc config set <path> <value> [--local] [--admin-key <key>]");
+    console.log("Usage: coh config set <path> <value> [--local] [--admin-key <key>]");
     return;
   }
 
@@ -256,7 +256,7 @@ export async function unsetConfigCommand(args = []) {
   const { positional, local, adminKey } = parseFlags(args);
   const [path] = positional;
   if (!path) {
-    console.log("Usage: cc config unset <path> [--local] [--admin-key <key>]");
+    console.log("Usage: coh config unset <path> [--local] [--admin-key <key>]");
     return;
   }
 
@@ -280,7 +280,7 @@ export async function unsetConfigCommand(args = []) {
   } else if (mapping.type === "string" && path !== "database.url" && path !== "server.environment") {
     payload[mapping.field] = "";
   } else {
-    console.log(`Remote unset is not supported for ${path}. Use cc config set instead.`);
+    console.log(`Remote unset is not supported for ${path}. Use coh config set instead.`);
     return;
   }
 
@@ -397,6 +397,6 @@ export async function handleConfig(args = []) {
     case "edit":
       return editConfigCommand(subArgs);
     default:
-      console.log("Usage: cc config <show|set|unset|edit> [args]");
+      console.log("Usage: coh config <show|set|unset|edit> [args]");
   }
 }

--- a/cli/lib/commands/contribute.mjs
+++ b/cli/lib/commands/contribute.mjs
@@ -1,9 +1,9 @@
 /**
  * Contribute command — record any contribution.
  *
- * Interactive:  cc contribute
+ * Interactive:  coh contribute
  * Non-interactive (for agents):
- *   cc contribute --type code --cc 5 --idea <id> --desc "what I did"
+ *   coh contribute --type code --cc 5 --idea <id> --desc "what I did"
  */
 
 import { post } from "../api.mjs";

--- a/cli/lib/commands/contributors.mjs
+++ b/cli/lib/commands/contributors.mjs
@@ -55,7 +55,7 @@ export async function showContributor(args) {
   const id = clean[0];
   if (!id) {
     if (jsonMode) printJsonError("missing_contributor_id");
-    else console.log("Usage: cc contributor <id>");
+    else console.log("Usage: coh contributor <id>");
     return;
   }
   const data = await get(`/api/contributors/${encodeURIComponent(id)}`);
@@ -81,7 +81,7 @@ export async function showContributor(args) {
 export async function showContributions(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc contributor <id> contributions");
+    console.log("Usage: coh contributor <id> contributions");
     return;
   }
   const data = await get(`/api/contributors/${encodeURIComponent(id)}/contributions`);

--- a/cli/lib/commands/credentials.mjs
+++ b/cli/lib/commands/credentials.mjs
@@ -1,5 +1,5 @@
 /**
- * Credentials commands: cc credentials add, cc credentials list, cc credentials remove
+ * Credentials commands: coh credentials add, coh credentials list, coh credentials remove
  */
 
 import { get, post, del } from "../api.mjs";
@@ -21,8 +21,8 @@ export async function credentialsAdd(args) {
   }
 
   if (!contributorId || !repoUrl || !raw) {
-    console.log("Usage: cc credentials add --contributor-id <id> --repo <url> --token <token> [--type <type>] [--scopes s1,s2]");
-    console.log("Example: cc credentials add -c cont_123 -r github.com/user/repo -k ghp_XYZ123");
+    console.log("Usage: coh credentials add --contributor-id <id> --repo <url> --token <token> [--type <type>] [--scopes s1,s2]");
+    console.log("Example: coh credentials add -c cont_123 -r github.com/user/repo -k ghp_XYZ123");
     return;
   }
 
@@ -95,7 +95,7 @@ export async function credentialsRemove(args) {
   if (args[0] && !args[0].startsWith("-")) id = args[0];
 
   if (!id) {
-    console.log("Usage: cc credentials remove <id>");
+    console.log("Usage: coh credentials remove <id>");
     return;
   }
 

--- a/cli/lib/commands/debug.mjs
+++ b/cli/lib/commands/debug.mjs
@@ -1,13 +1,13 @@
 /**
- * cc debug — Runtime debug mode toggle and diagnostics.
+ * coh debug — Runtime debug mode toggle and diagnostics.
  *
  * Usage:
- *   cc debug            Show current debug status
- *   cc debug on         Enable debug mode (log level → DEBUG)
- *   cc debug off        Disable debug mode (log level → INFO)
- *   cc debug level <l>  Set log level (debug/info/warning/error)
- *   cc debug trace <ep> Add endpoint to trace list
- *   cc debug untrace <ep> Remove endpoint from trace list
+ *   coh debug            Show current debug status
+ *   coh debug on         Enable debug mode (log level → DEBUG)
+ *   coh debug off        Disable debug mode (log level → INFO)
+ *   coh debug level <l>  Set log level (debug/info/warning/error)
+ *   coh debug trace <ep> Add endpoint to trace list
+ *   coh debug untrace <ep> Remove endpoint from trace list
  */
 
 import { get, patch } from "../api.mjs";
@@ -30,7 +30,7 @@ export async function debugCommand(args) {
   if (sub === "level") {
     const level = (args[1] || "").toUpperCase();
     if (!level) {
-      console.log("\x1b[33m⚠\x1b[0m Usage: cc debug level <debug|info|warning|error>");
+      console.log("\x1b[33m⚠\x1b[0m Usage: coh debug level <debug|info|warning|error>");
       return;
     }
     return setLevel(level);
@@ -39,7 +39,7 @@ export async function debugCommand(args) {
   if (sub === "trace") {
     const ep = args[1];
     if (!ep) {
-      console.log("\x1b[33m⚠\x1b[0m Usage: cc debug trace <endpoint>");
+      console.log("\x1b[33m⚠\x1b[0m Usage: coh debug trace <endpoint>");
       return;
     }
     return addTrace(ep);
@@ -48,13 +48,13 @@ export async function debugCommand(args) {
   if (sub === "untrace") {
     const ep = args[1];
     if (!ep) {
-      console.log("\x1b[33m⚠\x1b[0m Usage: cc debug untrace <endpoint>");
+      console.log("\x1b[33m⚠\x1b[0m Usage: coh debug untrace <endpoint>");
       return;
     }
     return removeTrace(ep);
   }
 
-  console.log("\x1b[33m⚠\x1b[0m Unknown subcommand. Use: cc debug [on|off|level|trace|untrace|status]");
+  console.log("\x1b[33m⚠\x1b[0m Unknown subcommand. Use: coh debug [on|off|level|trace|untrace|status]");
 }
 
 async function showStatus() {

--- a/cli/lib/commands/deploy.mjs
+++ b/cli/lib/commands/deploy.mjs
@@ -1,8 +1,8 @@
 /**
  * Deploy command: deploy latest main to VPS (coherencycoin.com)
  *
- * cc deploy         — deploy now (directly if SSH key available, otherwise via node message)
- * cc deploy status  — check what SHA is deployed vs origin/main
+ * coh deploy         — deploy now (directly if SSH key available, otherwise via node message)
+ * coh deploy status  — check what SHA is deployed vs origin/main
  */
 
 import { get, post } from "../api.mjs";
@@ -115,7 +115,7 @@ async function deployViaMessage() {
 
   if (result?.id) {
     console.log(`  \x1b[32m✓\x1b[0m Deploy command sent to ${target.hostname}`);
-    console.log("  Node will deploy on next poll (~2 min). Check: cc deploy status");
+    console.log("  Node will deploy on next poll (~2 min). Check: coh deploy status");
   } else {
     console.log("  \x1b[31m✗\x1b[0m Failed to send deploy command");
   }

--- a/cli/lib/commands/diag_publish.mjs
+++ b/cli/lib/commands/diag_publish.mjs
@@ -1,13 +1,13 @@
 /**
- * cc diag publish <event> [message] — emit a diagnostic event from this node
+ * coh diag publish <event> [message] — emit a diagnostic event from this node
  *
  * Used by agents in diagnostic mode to broadcast activity:
- *   cc diag publish heartbeat
- *   cc diag publish tool_call "running git status"
- *   cc diag publish reasoning "analyzing the API response schema"
- *   cc diag publish cc_cmd "cc ideas 5"
- *   cc diag publish error "failed to connect to API"
- *   cc diag publish checkpoint "saving progress"
+ *   coh diag publish heartbeat
+ *   coh diag publish tool_call "running git status"
+ *   coh diag publish reasoning "analyzing the API response schema"
+ *   coh diag publish cc_cmd "coh ideas 5"
+ *   coh diag publish error "failed to connect to API"
+ *   coh diag publish checkpoint "saving progress"
  */
 
 import { post, get } from "../api.mjs";
@@ -15,7 +15,7 @@ import { hostname } from "node:os";
 
 export async function publishDiag(args) {
   if (args.length < 1) {
-    console.log("Usage: cc diag publish <event> [message]");
+    console.log("Usage: coh diag publish <event> [message]");
     console.log("Events: heartbeat, tool_call, tool_result, reasoning, cc_cmd, cc_msg, error, checkpoint, started, finished");
     return;
   }
@@ -41,9 +41,9 @@ export async function publishDiag(args) {
 }
 
 /**
- * Start diagnostic mode — emit heartbeats and wrap cc commands with diagnostic events.
+ * Start diagnostic mode — emit heartbeats and wrap coh commands with diagnostic events.
  *
- * cc diag mode — starts emitting heartbeat every 10s + wraps future cc calls
+ * coh diag mode — starts emitting heartbeat every 10s + wraps future coh calls
  */
 export async function startDiagMode(args) {
   const nodes = await get("/api/federation/nodes");
@@ -54,7 +54,7 @@ export async function startDiagMode(args) {
   console.log(`  ${"─".repeat(50)}`);
   console.log(`  Node: ${myNode?.hostname || "?"} (${nodeId.slice(0, 12)})`);
   console.log(`  Publishing to: /api/federation/nodes/${nodeId}/diag`);
-  console.log(`  Subscribe with: cc diag live ${nodeId.slice(0, 12)}`);
+  console.log(`  Subscribe with: coh diag live ${nodeId.slice(0, 12)}`);
   console.log(`  Press Ctrl+C to stop`);
   console.log();
 

--- a/cli/lib/commands/diagnostics.mjs
+++ b/cli/lib/commands/diagnostics.mjs
@@ -127,9 +127,9 @@ export async function showDiagVisibility() {
 }
 
 /**
- * cc diag live [node_id] — subscribe to real-time diagnostic events from agents.
+ * coh diag live [node_id] — subscribe to real-time diagnostic events from agents.
  *
- * Shows: heartbeat, tool usage, reasoning steps, cc ingress/egress, messages.
+ * Shows: heartbeat, tool usage, reasoning steps, coh ingress/egress, messages.
  * Use node_id='*' or omit to see all nodes.
  */
 export async function showDiagLive(args) {

--- a/cli/lib/commands/dif.mjs
+++ b/cli/lib/commands/dif.mjs
@@ -1,5 +1,5 @@
 /**
- * DIF commands — cc dif verify, cc dif key, cc dif config, etc.
+ * DIF commands — coh dif verify, coh dif key, coh dif config, etc.
  */
 
 import { readFileSync } from "node:fs";
@@ -27,7 +27,7 @@ function errorMsg(status, data, retryAfter) {
   else console.log(`  ${RED}✗${R} ${status} ${typeof data === "string" ? data : JSON.stringify(data)}`);
 }
 
-// ── cc dif config ───────────────────────────────────────────────────
+// ── coh dif config ───────────────────────────────────────────────────
 
 export function showConfig() {
   const cfg = getDifConfig();
@@ -46,12 +46,12 @@ export function showConfig() {
 
 export function setBaseUrl(args) {
   const url = args[0];
-  if (!url) { console.log("Usage: cc dif config set-base-url <url>"); return; }
+  if (!url) { console.log("Usage: coh dif config set-base-url <url>"); return; }
   setDifConfig({ base_url: url });
   console.log(`  ${G}✓${R} Base URL set to ${url}`);
 }
 
-// ── cc dif whoami ───────────────────────────────────────────────────
+// ── coh dif whoami ───────────────────────────────────────────────────
 
 export async function whoami() {
   const { status, data } = await difFetch("GET", "/api/v2/dif/me");
@@ -68,7 +68,7 @@ export async function whoami() {
   console.log();
 }
 
-// ── cc dif key ──────────────────────────────────────────────────────
+// ── coh dif key ──────────────────────────────────────────────────────
 
 export async function keyList() {
   const { status, data } = await difFetch("GET", "/api/v2/dif/me/api-keys");
@@ -106,7 +106,7 @@ export async function keyCreate(args) {
 
 export async function keyRevoke(args) {
   const keyId = args[0];
-  if (!keyId) { console.log("Usage: cc dif key revoke <key-id>"); return; }
+  if (!keyId) { console.log("Usage: coh dif key revoke <key-id>"); return; }
   const { status, data } = await difFetch("DELETE", `/api/v2/dif/me/api-keys/${keyId}`);
   if (status !== 200 && status !== 204) { errorMsg(status, data); return; }
   console.log(`  ${G}✓${R} Key ${keyId} revoked`);
@@ -114,7 +114,7 @@ export async function keyRevoke(args) {
 
 export async function keyRotate(args) {
   const keyId = args[0];
-  if (!keyId) { console.log("Usage: cc dif key rotate <key-id>"); return; }
+  if (!keyId) { console.log("Usage: coh dif key rotate <key-id>"); return; }
   const { status, data } = await difFetch("POST", `/api/v2/dif/me/api-keys/${keyId}/rotate`);
   if (status !== 200) { errorMsg(status, data); return; }
 
@@ -128,7 +128,7 @@ export async function keyRotate(args) {
 
 export async function keyUpdate(args) {
   const keyId = args[0];
-  if (!keyId) { console.log("Usage: cc dif key update <key-id> [--name ...] [--expires ...]"); return; }
+  if (!keyId) { console.log("Usage: coh dif key update <key-id> [--name ...] [--expires ...]"); return; }
   const body = {};
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--name" && args[i + 1]) body.name = args[++i];
@@ -141,7 +141,7 @@ export async function keyUpdate(args) {
 
 export async function keyUse(args) {
   const keyId = args[0];
-  if (!keyId) { console.log("Usage: cc dif key use <key-id>"); return; }
+  if (!keyId) { console.log("Usage: coh dif key use <key-id>"); return; }
   setDifConfig({ selected_key_id: keyId });
   console.log(`  ${G}✓${R} Selected key: ${keyId}`);
 }
@@ -155,7 +155,7 @@ export function keyShow() {
   console.log(`  Expires:   ${key.expires_at || "never"}`);
 }
 
-// ── cc dif usage / limits / funding ─────────────────────────────────
+// ── coh dif usage / limits / funding ─────────────────────────────────
 
 export async function showUsage(args) {
   const days = args.find(a => a.startsWith("--days"))?.split("=")[1] || "30";
@@ -197,7 +197,7 @@ export async function showFunding() {
   console.log();
 }
 
-// ── cc dif verify ───────────────────────────────────────────────────
+// ── coh dif verify ───────────────────────────────────────────────────
 
 export async function verify(args) {
   let language = "", code = "", filePath = "", jsonMode = false;
@@ -208,7 +208,7 @@ export async function verify(args) {
     else if (args[i] === "--json") jsonMode = true;
   }
 
-  if (!language) { console.log("Usage: cc dif verify --language <lang> --code <code> | --file <path>"); return; }
+  if (!language) { console.log("Usage: coh dif verify --language <lang> --code <code> | --file <path>"); return; }
   if (filePath) {
     try { code = readFileSync(filePath, "utf-8"); }
     catch (e) { console.log(`  ${RED}✗${R} Cannot read file: ${filePath}`); return; }
@@ -250,7 +250,7 @@ export async function verify(args) {
   console.log();
 }
 
-// ── cc dif smoke ────────────────────────────────────────────────────
+// ── coh dif smoke ────────────────────────────────────────────────────
 
 export async function smoke() {
   console.log(`\n${B}  DIF SMOKE TEST${R}`);
@@ -299,7 +299,7 @@ export async function smoke() {
 }
 
 
-// ── cc dif key ensure ──────────────────────────────────────────────
+// ── coh dif key ensure ──────────────────────────────────────────────
 
 export async function keyEnsure() {
   const { getMerlySession, getAccessToken, merlyAuthedPost } = await import("../merly_auth.mjs");
@@ -313,7 +313,7 @@ export async function keyEnsure() {
   // Step 1: Check Merly login
   const token = await getAccessToken();
   if (!token) {
-    console.log(`  ${RED}✗${R} Not logged into Merly. Run: cc login merly`);
+    console.log(`  ${RED}✗${R} Not logged into Merly. Run: coh login merly`);
     return;
   }
   console.log(`  ${G}✓${R} Merly session active`);
@@ -391,7 +391,7 @@ export async function keyEnsure() {
 }
 
 
-// ── cc dif key status ──────────────────────────────────────────────
+// ── coh dif key status ──────────────────────────────────────────────
 
 export async function keyStatus() {
   const { getMerlySession, isLoggedIn } = await import("../merly_auth.mjs");
@@ -443,7 +443,7 @@ export async function keyStatus() {
 }
 
 
-// ── cc dif feedback ────────────────────────────────────────────────
+// ── coh dif feedback ────────────────────────────────────────────────
 
 export async function showFeedback(args) {
   const { get } = await import("../api.mjs");

--- a/cli/lib/commands/edges.mjs
+++ b/cli/lib/commands/edges.mjs
@@ -2,10 +2,10 @@
  * Edge navigation commands — browse the graph through 46 typed relationships.
  *
  * Commands:
- *   cc edges <entity-id> [--type <type>] [--direction both|outgoing|incoming]
- *   cc edge create <from-id> <type> <to-id> [--strength 0.9]
- *   cc edge delete <edge-id>
- *   cc edge types
+ *   coh edges <entity-id> [--type <type>] [--direction both|outgoing|incoming]
+ *   coh edge create <from-id> <type> <to-id> [--strength 0.9]
+ *   coh edge delete <edge-id>
+ *   coh edge types
  */
 
 import { get, post, del } from "../api.mjs";
@@ -45,12 +45,12 @@ function parseArgs(args) {
   return { opts, positional };
 }
 
-/** cc edges <entity-id> [--type X] [--direction both|outgoing|incoming] */
+/** coh edges <entity-id> [--type X] [--direction both|outgoing|incoming] */
 export async function listEntityEdges(args) {
   const { opts, positional } = parseArgs(args);
   const entityId = positional[0];
   if (!entityId) {
-    console.error("Usage: cc edges <entity-id> [--type <type>] [--direction both|outgoing|incoming]");
+    console.error("Usage: coh edges <entity-id> [--type <type>] [--direction both|outgoing|incoming]");
     process.exit(1);
   }
 
@@ -101,7 +101,7 @@ export async function listEntityEdges(args) {
   }
 }
 
-/** cc edge types */
+/** coh edge types */
 export async function listEdgeTypes() {
   const data = await get("/api/edges/types");
   const families = data?.families ?? [];
@@ -119,13 +119,13 @@ export async function listEdgeTypes() {
   }
 }
 
-/** cc edge create <from-id> <type> <to-id> [--strength 0.9] */
+/** coh edge create <from-id> <type> <to-id> [--strength 0.9] */
 export async function createEdge(args) {
   const { opts, positional } = parseArgs(args);
   const [fromId, type, toId] = positional;
 
   if (!fromId || !type || !toId) {
-    console.error("Usage: cc edge create <from-id> <type> <to-id> [--strength 0.9]");
+    console.error("Usage: coh edge create <from-id> <type> <to-id> [--strength 0.9]");
     process.exit(1);
   }
 
@@ -145,7 +145,7 @@ export async function createEdge(args) {
       process.exit(1);
     }
     if (err.status === 400) {
-      console.error(`Unknown edge type '${type}'. Run 'cc edge types' to see valid types.`);
+      console.error(`Unknown edge type '${type}'. Run 'coh edge types' to see valid types.`);
       process.exit(1);
     }
     throw err;
@@ -158,11 +158,11 @@ export async function createEdge(args) {
   console.log(JSON.stringify(result, null, 2));
 }
 
-/** cc edge delete <edge-id> */
+/** coh edge delete <edge-id> */
 export async function deleteEdge(args) {
   const edgeId = args[0];
   if (!edgeId) {
-    console.error("Usage: cc edge delete <edge-id>");
+    console.error("Usage: coh edge delete <edge-id>");
     process.exit(1);
   }
 

--- a/cli/lib/commands/federation.mjs
+++ b/cli/lib/commands/federation.mjs
@@ -1,22 +1,22 @@
 /**
  * Federation commands
  *
- *   cc federation                     — list federation nodes
- *   cc federation nodes               — list nodes
- *   cc federation node <id>           — (alias for nodes detail)
- *   cc federation instances           — list federated instances
- *   cc federation instance <id>       — show a specific instance
- *   cc federation register <url>      — register a new node
- *   cc federation heartbeat <id>      — send heartbeat for a node
- *   cc federation capabilities        — fleet capability summary
- *   cc federation stats               — federation node stats
- *   cc federation sync                — trigger federation sync
- *   cc federation sync history        — sync history
- *   cc federation aggregates          — list federated aggregations
- *   cc federation strategies          — compute strategies
- *   cc federation msg <node_id> <msg> — send message to a node
- *   cc federation msgs <node_id>      — read messages from a node
- *   cc federation broadcast <msg>     — broadcast to all nodes
+ *   coh federation                     — list federation nodes
+ *   coh federation nodes               — list nodes
+ *   coh federation node <id>           — (alias for nodes detail)
+ *   coh federation instances           — list federated instances
+ *   coh federation instance <id>       — show a specific instance
+ *   coh federation register <url>      — register a new node
+ *   coh federation heartbeat <id>      — send heartbeat for a node
+ *   coh federation capabilities        — fleet capability summary
+ *   coh federation stats               — federation node stats
+ *   coh federation sync                — trigger federation sync
+ *   coh federation sync history        — sync history
+ *   coh federation aggregates          — list federated aggregations
+ *   coh federation strategies          — compute strategies
+ *   coh federation msg <node_id> <msg> — send message to a node
+ *   coh federation msgs <node_id>      — read messages from a node
+ *   coh federation broadcast <msg>     — broadcast to all nodes
  */
 
 import { get, post, del as apiDel } from "../api.mjs";
@@ -80,7 +80,7 @@ export async function listFederationInstances() {
 
 export async function showFederationInstance(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc federation instance <id>"); return; }
+  if (!id) { console.log("Usage: coh federation instance <id>"); return; }
 
   const data = await get(`/api/federation/instances/${encodeURIComponent(id)}`);
   if (!data) { console.log(`Instance '${id}' not found.`); return; }
@@ -98,7 +98,7 @@ export async function showFederationInstance(args) {
 export async function registerFederationNode(args) {
   const url = args[0];
   const capabilities = args.slice(1);
-  if (!url) { console.log("Usage: cc federation register <url> [capability...]"); return; }
+  if (!url) { console.log("Usage: coh federation register <url> [capability...]"); return; }
 
   const body = { url };
   if (capabilities.length) body.capabilities = capabilities;
@@ -114,7 +114,7 @@ export async function registerFederationNode(args) {
 
 export async function federationHeartbeat(args) {
   const nodeId = args[0];
-  if (!nodeId) { console.log("Usage: cc federation heartbeat <node_id>"); return; }
+  if (!nodeId) { console.log("Usage: coh federation heartbeat <node_id>"); return; }
 
   const result = await post(`/api/federation/nodes/${encodeURIComponent(nodeId)}/heartbeat`, {});
   if (result) {
@@ -236,7 +236,7 @@ export async function sendFederationMessage(args) {
   const nodeId = args[0];
   const message = args.slice(1).join(" ");
   if (!nodeId || !message) {
-    console.log("Usage: cc federation msg <node_id> <message>");
+    console.log("Usage: coh federation msg <node_id> <message>");
     return;
   }
   const result = await post(`/api/federation/nodes/${encodeURIComponent(nodeId)}/messages`, {
@@ -251,7 +251,7 @@ export async function sendFederationMessage(args) {
 
 export async function readFederationMessages(args) {
   const nodeId = args[0];
-  if (!nodeId) { console.log("Usage: cc federation msgs <node_id>"); return; }
+  if (!nodeId) { console.log("Usage: coh federation msgs <node_id>"); return; }
 
   const data = await get(`/api/federation/nodes/${encodeURIComponent(nodeId)}/messages`);
   const messages = Array.isArray(data) ? data : data?.messages || [];
@@ -278,7 +278,7 @@ export async function readFederationMessages(args) {
 
 export async function broadcastFederation(args) {
   const message = args.join(" ");
-  if (!message) { console.log("Usage: cc federation broadcast <message>"); return; }
+  if (!message) { console.log("Usage: coh federation broadcast <message>"); return; }
 
   const result = await post("/api/federation/broadcast", { message });
   if (result) {

--- a/cli/lib/commands/focus.mjs
+++ b/cli/lib/commands/focus.mjs
@@ -41,7 +41,7 @@ export async function runFocusCommand(args = []) {
     // Show current focus if not TTY and no args
     const focus = getFocus();
     if (!focus.idea_id && !focus.task_id) {
-      console.log("No active focus. Use 'cc focus <id>' to set one.");
+      console.log("No active focus. Use 'coh focus <id>' to set one.");
     } else {
       if (focus.idea_id) console.log(`Active Idea: ${focus.idea_id}`);
       if (focus.task_id) console.log(`Active Task: ${focus.task_id}`);

--- a/cli/lib/commands/geolocation.mjs
+++ b/cli/lib/commands/geolocation.mjs
@@ -1,10 +1,10 @@
 /**
  * Geolocation commands: nearby, location
  *
- * cc nearby [--lat <lat>] [--lon <lon>] [--radius <km>]
- * cc location set <contributor-id> <city> <country> <lat> <lon>
- * cc location get <contributor-id>
- * cc location clear <contributor-id>
+ * coh nearby [--lat <lat>] [--lon <lon>] [--radius <km>]
+ * coh location set <contributor-id> <city> <country> <lat> <lon>
+ * coh location get <contributor-id>
+ * coh location clear <contributor-id>
  */
 
 import { get, patch, del } from "../api.mjs";
@@ -25,7 +25,7 @@ export async function showNearby(args) {
   const radius = parseFloat(parseFlag(args, "--radius") ?? "100");
 
   if (isNaN(lat) || isNaN(lon)) {
-    console.error("Usage: cc nearby --lat <lat> --lon <lon> [--radius <km>]");
+    console.error("Usage: coh nearby --lat <lat> --lon <lon> [--radius <km>]");
     process.exit(1);
   }
 
@@ -87,9 +87,9 @@ export async function handleLocation(args) {
     default:
       console.error(
         "Usage:\n" +
-          "  cc location set <contributor-id> <city> <country> <lat> <lon> [public|contributors_only|private]\n" +
-          "  cc location get <contributor-id>\n" +
-          "  cc location clear <contributor-id>",
+          "  coh location set <contributor-id> <city> <country> <lat> <lon> [public|contributors_only|private]\n" +
+          "  coh location get <contributor-id>\n" +
+          "  coh location clear <contributor-id>",
       );
       process.exit(1);
   }
@@ -99,7 +99,7 @@ async function setLocation(args) {
   const [contributorId, city, country, latStr, lonStr, visibility = "contributors_only"] = args;
   if (!contributorId || !city || !country || !latStr || !lonStr) {
     console.error(
-      "Usage: cc location set <contributor-id> <city> <country> <lat> <lon> [public|contributors_only|private]",
+      "Usage: coh location set <contributor-id> <city> <country> <lat> <lon> [public|contributors_only|private]",
     );
     process.exit(1);
   }
@@ -130,7 +130,7 @@ async function setLocation(args) {
 async function getLocation(args) {
   const [contributorId] = args;
   if (!contributorId) {
-    console.error("Usage: cc location get <contributor-id>");
+    console.error("Usage: coh location get <contributor-id>");
     process.exit(1);
   }
 
@@ -148,7 +148,7 @@ async function getLocation(args) {
 async function clearLocation(args) {
   const [contributorId] = args;
   if (!contributorId) {
-    console.error("Usage: cc location clear <contributor-id>");
+    console.error("Usage: coh location clear <contributor-id>");
     process.exit(1);
   }
 

--- a/cli/lib/commands/governance.mjs
+++ b/cli/lib/commands/governance.mjs
@@ -50,7 +50,7 @@ export async function listChangeRequests() {
 export async function showChangeRequest(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc governance <id>");
+    console.log("Usage: coh governance <id>");
     return;
   }
   const data = await get(`/api/governance/change-requests/${encodeURIComponent(id)}`);
@@ -75,7 +75,7 @@ export async function vote(args) {
   const id = args[0];
   const choice = args[1];
   if (!id || !choice || !["yes", "no"].includes(choice)) {
-    console.log("Usage: cc governance vote <id> <yes|no>");
+    console.log("Usage: coh governance vote <id> <yes|no>");
     return;
   }
   const result = await post(`/api/governance/change-requests/${encodeURIComponent(id)}/votes`, {
@@ -92,7 +92,7 @@ export async function propose(args) {
   const title = args[0];
   const desc = args.slice(1).join(" ");
   if (!title || !desc) {
-    console.log("Usage: cc governance propose <title> <description>");
+    console.log("Usage: coh governance propose <title> <description>");
     return;
   }
   const result = await post("/api/governance/change-requests", { title, description: desc });

--- a/cli/lib/commands/graph.mjs
+++ b/cli/lib/commands/graph.mjs
@@ -130,7 +130,7 @@ export async function createGraphEdge(args) {
   }
 
   if (!fromId || !toId) {
-    console.log("Usage: cc graph edges create --from-id <id> --to-id <id> [--type <type>]");
+    console.log("Usage: coh graph edges create --from-id <id> --to-id <id> [--type <type>]");
     return;
   }
 
@@ -164,7 +164,7 @@ export async function getGraphNeighbors(args) {
     if (args[i] === "--node-id" && args[i + 1]) nodeId = args[++i];
   }
   if (!nodeId) {
-    console.log("Usage: cc graph neighbors --node-id <id>");
+    console.log("Usage: coh graph neighbors --node-id <id>");
     return;
   }
 

--- a/cli/lib/commands/guide.mjs
+++ b/cli/lib/commands/guide.mjs
@@ -1,5 +1,5 @@
 /**
- * Guide commands: cc guide
+ * Guide commands: coh guide
  * A guided experience for new contributors.
  */
 
@@ -44,7 +44,7 @@ async function welcome(nonInteractive) {
   console.log(`  4. Track the ${B}Flow${R} from idea to merged PR`);
   console.log();
   if (!nonInteractive) {
-    console.log(`  To start, run: ${G}cc guide register --handle <your-name>${R}`);
+    console.log(`  To start, run: ${G}coh guide register --handle <your-name>${R}`);
   } else {
     console.log(`  Non-interactive mode: Use the subcommands with required flags.`);
   }
@@ -60,7 +60,7 @@ async function registerStep(args, nonInteractive) {
   await onboardingRegister(args);
   
   console.log(`  Next, setup your repo credentials:`);
-  console.log(`  ${G}cc guide credentials --contributor-id <id> --repo <url> --token <token>${R}`);
+  console.log(`  ${G}coh guide credentials --contributor-id <id> --repo <url> --token <token>${R}`);
   console.log();
 }
 
@@ -71,7 +71,7 @@ async function credentialsStep(args, nonInteractive) {
   await credentialsAdd(args);
   
   console.log(`  Next, share your first idea:`);
-  console.log(`  ${G}cc guide ideate --name "My Feature" --desc "Description"${R}`);
+  console.log(`  ${G}coh guide ideate --name "My Feature" --desc "Description"${R}`);
   console.log();
 }
 
@@ -87,7 +87,7 @@ async function ideateStep(args, nonInteractive) {
         if (args[i] === "--desc" && args[i+1]) desc = args[++i];
     }
     if (!name) {
-        console.log("Usage: cc guide ideate --name <n> --desc <d>");
+        console.log("Usage: coh guide ideate --name <n> --desc <d>");
         return;
     }
     const res = await post("/api/ideas", { 
@@ -105,7 +105,7 @@ async function ideateStep(args, nonInteractive) {
   }
   
   console.log(`  Next, watch the flow of your idea into tasks and PRs:`);
-  console.log(`  ${G}cc guide flow --idea-id <id>${R}`);
+  console.log(`  ${G}coh guide flow --idea-id <id>${R}`);
   console.log();
 }
 
@@ -119,7 +119,7 @@ async function flowStep(args, nonInteractive) {
   }
   
   if (!ideaId) {
-    console.log("Usage: cc guide flow --idea-id <id>");
+    console.log("Usage: coh guide flow --idea-id <id>");
     return;
   }
   

--- a/cli/lib/commands/guides.mjs
+++ b/cli/lib/commands/guides.mjs
@@ -1,7 +1,7 @@
 /**
  * Guides command — discover creators and thought leaders
  * 
- * cc guides             — Show top guides who package knowledge
+ * coh guides             — Show top guides who package knowledge
  */
 
 import chalk from "chalk";

--- a/cli/lib/commands/ideas.mjs
+++ b/cli/lib/commands/ideas.mjs
@@ -2,22 +2,22 @@
  * Ideas commands: ideas, idea, share, stake, fork, and extended coverage
  *
  * Extended commands:
- *   cc idea tags                       — list idea tags catalog
- *   cc idea health                     — governance health
- *   cc idea showcase                   — featured ideas showcase
- *   cc idea resonance                  — ideas resonance overview
- *   cc idea progress                   — pipeline progress dashboard
- *   cc idea count                      — ideas count summary
- *   cc idea cards                      — idea cards view
- *   cc idea <id> activity              — idea activity log
- *   cc idea <id> tasks                 — tasks for an idea
- *   cc idea <id> progress              — progress for an idea
- *   cc idea <id> resonance             — concept resonance for an idea
- *   cc idea <id> advance               — advance idea to next stage
- *   cc idea <id> stage <stage>         — set idea stage
- *   cc idea <id> tag <tag1> [tag2...]  — update idea tags
- *   cc idea <id> question <text>       — add question to idea
- *   cc idea <id> answer <text>         — answer open question
+ *   coh idea tags                       — list idea tags catalog
+ *   coh idea health                     — governance health
+ *   coh idea showcase                   — featured ideas showcase
+ *   coh idea resonance                  — ideas resonance overview
+ *   coh idea progress                   — pipeline progress dashboard
+ *   coh idea count                      — ideas count summary
+ *   coh idea cards                      — idea cards view
+ *   coh idea <id> activity              — idea activity log
+ *   coh idea <id> tasks                 — tasks for an idea
+ *   coh idea <id> progress              — progress for an idea
+ *   coh idea <id> resonance             — concept resonance for an idea
+ *   coh idea <id> advance               — advance idea to next stage
+ *   coh idea <id> stage <stage>         — set idea stage
+ *   coh idea <id> tag <tag1> [tag2...]  — update idea tags
+ *   coh idea <id> question <text>       — add question to idea
+ *   coh idea <id> answer <text>         — answer open question
  */
 
 import { get, post, patch, put } from "../api.mjs";
@@ -44,7 +44,7 @@ export async function listIdeas(args) {
   const isTTY = process.stdout.isTTY;
 
   // Interactive picker only when TTY AND not JSON mode AND no other args.
-  // When piping (`cc ideas | jq`) or passing `--json`, we always return
+  // When piping (`coh ideas | jq`) or passing `--json`, we always return
   // structured data instead of opening a picker.
   if (isTTY && !jsonMode && args.length === 0) {
     return runInteractivePicker();
@@ -153,7 +153,7 @@ export async function listIdeas(args) {
     for (const idea of data) renderRow(idea);
   }
   console.log(`  ${"─".repeat(92)}`);
-  if (!flags.all) console.log(`  ${D}Use 'cc idea list --all' to see the full fractal.${R}`);
+  if (!flags.all) console.log(`  ${D}Use 'coh idea list --all' to see the full fractal.${R}`);
   console.log();
 }
 
@@ -193,7 +193,7 @@ async function runInteractivePicker() {
 }
 
 export async function showIdea(args) {
-  // Route subcommands: cc idea <id> <subcommand>
+  // Route subcommands: coh idea <id> <subcommand>
   let id = args[0];
   const focus = getFocus();
 
@@ -203,8 +203,8 @@ export async function showIdea(args) {
   }
 
   if (!id) {
-    console.log("Usage: cc idea <id> [tasks|translate|children|...]");
-    console.log(chalk.dim("Hint: Use 'cc focus' to pick an idea once and skip the ID."));
+    console.log("Usage: coh idea <id> [tasks|translate|children|...]");
+    console.log(chalk.dim("Hint: Use 'coh focus' to pick an idea once and skip the ID."));
     return;
   }
 
@@ -288,12 +288,12 @@ export async function showIdea(args) {
   console.log();
 }
 
-/** Point-of-view translation: cc idea <id> translate [lens_id] */
+/** Point-of-view translation: coh idea <id> translate [lens_id] */
 export async function showIdeaTranslate(args) {
   const id = args[0];
   const lens = args[1] || "libertarian";
   if (!id) {
-    console.log("Usage: cc idea <id> translate [lens_id]");
+    console.log("Usage: coh idea <id> translate [lens_id]");
     return;
   }
   const data = await get(
@@ -349,7 +349,7 @@ export async function stakeOnIdea(args) {
   const ideaId = args[0];
   const amount = parseFloat(args[1]);
   if (!ideaId || isNaN(amount)) {
-    console.log("Usage: cc stake <idea-id> <amount-cc>");
+    console.log("Usage: coh stake <idea-id> <amount-cc>");
     return;
   }
   const contributor = await ensureIdentity();
@@ -367,7 +367,7 @@ export async function stakeOnIdea(args) {
 export async function forkIdea(args) {
   const ideaId = args[0];
   if (!ideaId) {
-    console.log("Usage: cc fork <idea-id>");
+    console.log("Usage: coh fork <idea-id>");
     return;
   }
   const contributor = await ensureIdentity();
@@ -385,11 +385,11 @@ export async function forkIdea(args) {
 /**
  * Non-interactive idea creation for agents and scripts.
  *
- * Usage: cc idea create <id> <name> [--desc "..."] [--value N] [--cost N] [--parent <id>]
+ * Usage: coh idea create <id> <name> [--desc "..."] [--value N] [--cost N] [--parent <id>]
  */
 export async function createIdea(args) {
   if (args.length < 2) {
-    console.log("Usage: cc idea create <id> <name> [--desc \"...\"] [--value N] [--cost N] [--parent <id>]");
+    console.log("Usage: coh idea create <id> <name> [--desc \"...\"] [--value N] [--cost N] [--parent <id>]");
     return;
   }
 
@@ -462,7 +462,7 @@ export async function setIdeaWorkType(args) {
   const workType = args[1];
   const validTypes = ["exploration", "research", "prototype", "feature", "enhancement", "bug-fix", "mvp"];
   if (!id || !workType) {
-    console.log(`Usage: cc idea <id> type <work_type>`);
+    console.log(`Usage: coh idea <id> type <work_type>`);
     console.log(`  Valid types: ${validTypes.join(", ")}`);
     return;
   }
@@ -479,14 +479,14 @@ export async function setIdeaWorkType(args) {
 }
 
 export async function linkIdea(args) {
-  // cc idea <id> link <relation> <target-id>
+  // coh idea <id> link <relation> <target-id>
   // relation: blocks, enables, supersedes, depends-on, related-to
   const fromId = args[0];
   const rel = args[1];
   const toId = args[2];
   const validRels = ["blocks", "enables", "supersedes", "depends-on", "related-to"];
   if (!fromId || !rel || !toId) {
-    console.log("Usage: cc idea <id> link <relation> <target-id>");
+    console.log("Usage: coh idea <id> link <relation> <target-id>");
     console.log(`  Relations: ${validRels.join(", ")}`);
     return;
   }
@@ -511,7 +511,7 @@ export async function linkIdea(args) {
 
 export async function showIdeaChildren(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> children"); return; }
+  if (!id) { console.log("Usage: coh idea <id> children"); return; }
   const raw = await get("/api/ideas", { limit: 400 });
   const all = Array.isArray(raw) ? raw : raw?.ideas || [];
   const children = all.filter(i => i.parent_idea_id === id);
@@ -532,9 +532,9 @@ export async function showIdeaChildren(args) {
 }
 
 export async function showIdeaDeps(args) {
-  // cc idea <id> deps [--type blocks|enables|supersedes|depends-on|related-to]
+  // coh idea <id> deps [--type blocks|enables|supersedes|depends-on|related-to]
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> deps [--type <relation>]"); return; }
+  if (!id) { console.log("Usage: coh idea <id> deps [--type <relation>]"); return; }
 
   let edgeType = null;
   for (let i = 1; i < args.length; i++) {
@@ -564,7 +564,7 @@ export async function showIdeaDeps(args) {
 
   if (!edges.length) {
     console.log(`  ${D}No dependency edges found.${R}`);
-    console.log(`  ${D}Add one: cc idea ${id} link blocks|enables|supersedes <target-id>${R}`);
+    console.log(`  ${D}Add one: coh idea ${id} link blocks|enables|supersedes <target-id>${R}`);
     console.log();
     return;
   }
@@ -598,7 +598,7 @@ export async function showIdeaDeps(args) {
   }
 
   console.log();
-  console.log(`  ${D}Total edges: ${edges.length}  |  cc idea <id> link <rel> <target> to add more${R}`);
+  console.log(`  ${D}Total edges: ${edges.length}  |  coh idea <id> link <rel> <target> to add more${R}`);
   console.log();
 }
 
@@ -719,7 +719,7 @@ export async function showIdeasCount() {
 
 export async function showIdeaActivity(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> activity"); return; }
+  if (!id) { console.log("Usage: coh idea <id> activity"); return; }
   const data = await get(`/api/ideas/${encodeURIComponent(id)}/activity`);
   if (!data) { console.log(`No activity for idea '${id}'.`); return; }
   const events = Array.isArray(data) ? data : data?.events || data?.activity || [];
@@ -738,7 +738,7 @@ export async function showIdeaActivity(args) {
 
 export async function showIdeaTasks(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> tasks"); return; }
+  if (!id) { console.log("Usage: coh idea <id> tasks"); return; }
   const data = await get(`/api/ideas/${encodeURIComponent(id)}/tasks`);
   if (!data) { console.log(`No tasks for idea '${id}'.`); return; }
   const groups = Array.isArray(data?.groups) ? data.groups : [];
@@ -765,7 +765,7 @@ export async function showIdeaTasks(args) {
 
 export async function showIdeaItemProgress(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> progress"); return; }
+  if (!id) { console.log("Usage: coh idea <id> progress"); return; }
   const data = await get(`/api/ideas/${encodeURIComponent(id)}/progress`);
   if (!data) { console.log(`No progress data for idea '${id}'.`); return; }
   const B = "\x1b[1m", D = "\x1b[2m", R = "\x1b[0m", G = "\x1b[32m";
@@ -787,7 +787,7 @@ export async function showIdeaItemProgress(args) {
 
 export async function showIdeaConceptResonance(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> resonance"); return; }
+  if (!id) { console.log("Usage: coh idea <id> resonance"); return; }
   const data = await get(`/api/ideas/${encodeURIComponent(id)}/concept-resonance`);
   if (!data) { console.log(`No concept resonance data for idea '${id}'.`); return; }
   const B = "\x1b[1m", D = "\x1b[2m", R = "\x1b[0m";
@@ -809,7 +809,7 @@ export async function showIdeaConceptResonance(args) {
 
 export async function advanceIdea(args) {
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> advance"); return; }
+  if (!id) { console.log("Usage: coh idea <id> advance"); return; }
   const result = await post(`/api/ideas/${encodeURIComponent(id)}/advance`, {});
   if (result) {
     console.log(`\x1b[32m✓\x1b[0m Idea '${id}' advanced`);
@@ -822,7 +822,7 @@ export async function advanceIdea(args) {
 export async function setIdeaStage(args) {
   const id = args[0];
   const stage = args[1];
-  if (!id || !stage) { console.log("Usage: cc idea <id> stage <stage>"); return; }
+  if (!id || !stage) { console.log("Usage: coh idea <id> stage <stage>"); return; }
   const result = await post(`/api/ideas/${encodeURIComponent(id)}/stage`, { stage });
   if (result) {
     console.log(`\x1b[32m✓\x1b[0m Idea '${id}' stage set to '${stage}'`);
@@ -834,7 +834,7 @@ export async function setIdeaStage(args) {
 export async function updateIdeaTags(args) {
   const id = args[0];
   const tags = args.slice(1);
-  if (!id || !tags.length) { console.log("Usage: cc idea <id> tag <tag1> [tag2...]"); return; }
+  if (!id || !tags.length) { console.log("Usage: coh idea <id> tag <tag1> [tag2...]"); return; }
   const result = await put(`/api/ideas/${encodeURIComponent(id)}/tags`, { tags });
   if (result) {
     console.log(`\x1b[32m✓\x1b[0m Tags updated for '${id}': ${tags.join(", ")}`);
@@ -846,7 +846,7 @@ export async function updateIdeaTags(args) {
 export async function addIdeaQuestion(args) {
   const id = args[0];
   const question = args.slice(1).join(" ");
-  if (!id || !question) { console.log("Usage: cc idea <id> question <text>"); return; }
+  if (!id || !question) { console.log("Usage: coh idea <id> question <text>"); return; }
   const result = await post(`/api/ideas/${encodeURIComponent(id)}/questions`, { question });
   if (result) {
     console.log(`\x1b[32m✓\x1b[0m Question added to '${id}'`);
@@ -858,7 +858,7 @@ export async function addIdeaQuestion(args) {
 export async function answerIdeaQuestion(args) {
   const id = args[0];
   const answer = args.slice(1).join(" ");
-  if (!id || !answer) { console.log("Usage: cc idea <id> answer <text>"); return; }
+  if (!id || !answer) { console.log("Usage: coh idea <id> answer <text>"); return; }
   const result = await post(`/api/ideas/${encodeURIComponent(id)}/questions/answer`, { answer });
   if (result) {
     console.log(`\x1b[32m✓\x1b[0m Answer recorded for '${id}'`);
@@ -868,9 +868,9 @@ export async function answerIdeaQuestion(args) {
 }
 
 export async function archiveIdea(args) {
-  // cc idea <id> archive [--reason "..."] [--duplicate-of <id>]
+  // coh idea <id> archive [--reason "..."] [--duplicate-of <id>]
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> archive [--reason \"...\"] [--duplicate-of <id>]"); return; }
+  if (!id) { console.log("Usage: coh idea <id> archive [--reason \"...\"] [--duplicate-of <id>]"); return; }
   const flags = {};
   for (let i = 1; i < args.length; i++) {
     if ((args[i] === "--reason" || args[i] === "-r") && args[i+1]) flags.reason = args[++i];
@@ -890,9 +890,9 @@ export async function archiveIdea(args) {
 }
 
 export async function retireIdea(args) {
-  // cc idea <id> retire [--duplicate-of <id>]
+  // coh idea <id> retire [--duplicate-of <id>]
   const id = args[0];
-  if (!id) { console.log("Usage: cc idea <id> retire [--duplicate-of <id>]"); return; }
+  if (!id) { console.log("Usage: coh idea <id> retire [--duplicate-of <id>]"); return; }
   const flags = {};
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--duplicate-of" && args[i+1]) flags.duplicateOf = args[++i];
@@ -908,7 +908,7 @@ export async function retireIdea(args) {
 }
 
 export async function showStaleIdeas(args) {
-  // cc idea stale [--days N]   — ideas with lifecycle=active not touched in N days (default 30)
+  // coh idea stale [--days N]   — ideas with lifecycle=active not touched in N days (default 30)
   let days = 30;
   for (let i = 0; i < args.length; i++) {
     if ((args[i] === "--days" || args[i] === "-d") && args[i+1]) days = parseInt(args[++i]);
@@ -946,6 +946,6 @@ export async function showStaleIdeas(args) {
     console.log(`  ${Y}⚠${R}  ${name} ${String(last).padEnd(14)} ${C}${wt}${R} ${D}${status}${R}`);
   }
   console.log(`  ${"─".repeat(76)}`);
-  console.log(`  ${D}Archive: cc idea <id> archive | Retire duplicate: cc idea <id> retire --duplicate-of <id>${R}`);
+  console.log(`  ${D}Archive: coh idea <id> archive | Retire duplicate: coh idea <id> retire --duplicate-of <id>${R}`);
   console.log();
 }

--- a/cli/lib/commands/identity.mjs
+++ b/cli/lib/commands/identity.mjs
@@ -20,7 +20,7 @@ export async function showIdentity() {
       console.log("Configured identity is invalid.");
     }
     console.log("No identity configured.");
-    console.log("  Fix: cc identity set <your_id>");
+    console.log("  Fix: coh identity set <your_id>");
     return;
   }
   const data = await get(`/api/identity/${encodeURIComponent(id)}`);
@@ -39,7 +39,7 @@ export async function showIdentity() {
     }
   }
   console.log();
-  console.log("  Link more: cc identity link <provider> <id>");
+  console.log("  Link more: coh identity link <provider> <id>");
   console.log();
 }
 
@@ -47,7 +47,7 @@ export async function linkIdentity(args) {
   const [provider, ...rest] = args;
   const providerId = rest.join(" ");
   if (!provider || !providerId) {
-    console.log("Usage: cc identity link <provider> <id>");
+    console.log("Usage: coh identity link <provider> <id>");
     console.log("Providers: github, x, discord, telegram, ethereum, bitcoin, solana, email, gitlab, linkedin, ...");
     return;
   }
@@ -68,7 +68,7 @@ export async function linkIdentity(args) {
 export async function unlinkIdentity(args) {
   const provider = args[0];
   if (!provider) {
-    console.log("Usage: cc identity unlink <provider>");
+    console.log("Usage: coh identity unlink <provider>");
     return;
   }
   const contributor = parseContributorId(getContributorId());
@@ -87,7 +87,7 @@ export async function unlinkIdentity(args) {
 export async function lookupIdentity(args) {
   const [provider, providerId] = args;
   if (!provider || !providerId) {
-    console.log("Usage: cc identity lookup <provider> <id>");
+    console.log("Usage: coh identity lookup <provider> <id>");
     return;
   }
   const data = await get(`/api/identity/lookup/${encodeURIComponent(provider)}/${encodeURIComponent(providerId)}`);
@@ -100,7 +100,7 @@ export async function lookupIdentity(args) {
 
 export async function setIdentity(args) {
   if (args.length !== 1) {
-    console.error("Usage: cc identity set <contributor_id>");
+    console.error("Usage: coh identity set <contributor_id>");
     process.exitCode = 1;
     return;
   }

--- a/cli/lib/commands/inventory.mjs
+++ b/cli/lib/commands/inventory.mjs
@@ -2,16 +2,16 @@
  * Inventory commands: inventory, pipeline
  *
  * Covers the gap analysis, process completeness, flow, and pipeline endpoints.
- *   cc inventory                    — show pipeline pulse / overall flow
- *   cc inventory flow               — full flow details
- *   cc inventory gaps               — list traceability gaps
- *   cc inventory routes             — canonical routes
- *   cc inventory completeness       — process completeness report
- *   cc inventory endpoints          — endpoint traceability
- *   cc inventory evidence           — route evidence
- *   cc inventory assets             — asset modularity report
- *   cc pipeline pulse               — pipeline pulse (alias)
- *   cc pipeline fix-hollow          — fix hollow completions
+ *   coh inventory                    — show pipeline pulse / overall flow
+ *   coh inventory flow               — full flow details
+ *   coh inventory gaps               — list traceability gaps
+ *   coh inventory routes             — canonical routes
+ *   coh inventory completeness       — process completeness report
+ *   coh inventory endpoints          — endpoint traceability
+ *   coh inventory evidence           — route evidence
+ *   coh inventory assets             — asset modularity report
+ *   coh pipeline pulse               — pipeline pulse (alias)
+ *   coh pipeline fix-hollow          — fix hollow completions
  */
 
 import { get, post } from "../api.mjs";
@@ -114,7 +114,7 @@ export async function showInventoryGaps() {
       console.log(`  \x1b[33m▲\x1b[0m ${truncate(g.description || g.id || String(g), 70)}`);
     }
   } else {
-    console.log(`  \x1b[2mNo gap data in flow response. Try: cc inventory endpoints\x1b[0m`);
+    console.log(`  \x1b[2mNo gap data in flow response. Try: coh inventory endpoints\x1b[0m`);
   }
   console.log();
 }

--- a/cli/lib/commands/lineage.mjs
+++ b/cli/lib/commands/lineage.mjs
@@ -37,7 +37,7 @@ export async function listLinks(args) {
 export async function showLink(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc lineage <id>");
+    console.log("Usage: coh lineage <id>");
     return;
   }
   const data = await get(`/api/value-lineage/links/${encodeURIComponent(id)}`);
@@ -60,7 +60,7 @@ export async function showLink(args) {
 export async function showValuation(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc lineage <id> valuation");
+    console.log("Usage: coh lineage <id> valuation");
     return;
   }
   const data = await get(`/api/value-lineage/links/${encodeURIComponent(id)}/valuation`);
@@ -82,7 +82,7 @@ export async function payoutPreview(args) {
   const id = args[0];
   const amount = parseFloat(args[1]);
   if (!id || isNaN(amount)) {
-    console.log("Usage: cc lineage <id> payout <amount>");
+    console.log("Usage: coh lineage <id> payout <amount>");
     return;
   }
   const data = await post(`/api/value-lineage/links/${encodeURIComponent(id)}/payout-preview`, { amount });

--- a/cli/lib/commands/listen.mjs
+++ b/cli/lib/commands/listen.mjs
@@ -1,12 +1,12 @@
 /**
- * cc listen — real-time event stream from the network
+ * coh listen — real-time event stream from the network
  *
  * Connects to the SSE endpoint and prints events as they arrive.
  * Messages, deploys, task completions, status changes — all pushed in real-time.
  *
  * Usage:
- *   cc listen              # Listen for events for this node
- *   cc listen --all        # Listen for all events (broadcast)
+ *   coh listen              # Listen for events for this node
+ *   coh listen --all        # Listen for all events (broadcast)
  */
 
 import { hostname } from "node:os";

--- a/cli/lib/commands/marketplace.mjs
+++ b/cli/lib/commands/marketplace.mjs
@@ -8,7 +8,7 @@ import { get, post } from "../api.mjs";
 export async function marketplacePublish(args) {
   const ideaId = args[0];
   if (!ideaId) {
-    console.log("Usage: cc marketplace publish <idea-id> [--tags tag1,tag2] [--author \"Name\"]");
+    console.log("Usage: coh marketplace publish <idea-id> [--tags tag1,tag2] [--author \"Name\"]");
     return;
   }
   const body = { idea_id: ideaId };
@@ -69,12 +69,12 @@ export async function marketplaceBrowse(args) {
 export async function marketplaceFork(args) {
   const listingId = args[0];
   if (!listingId) {
-    console.log("Usage: cc marketplace fork <listing-id> <forker-id> [--notes \"why\"]");
+    console.log("Usage: coh marketplace fork <listing-id> <forker-id> [--notes \"why\"]");
     return;
   }
   const forkerId = args[1];
   if (!forkerId) {
-    console.log("Usage: cc marketplace fork <listing-id> <forker-id> [--notes \"why\"]");
+    console.log("Usage: coh marketplace fork <listing-id> <forker-id> [--notes \"why\"]");
     return;
   }
   const body = { forker_id: forkerId, notes: "" };

--- a/cli/lib/commands/meta.mjs
+++ b/cli/lib/commands/meta.mjs
@@ -1,9 +1,9 @@
 /**
  * meta — system self-discovery commands
  *
- * cc meta endpoints   — list all API endpoints as concept nodes
- * cc meta modules     — list all code modules with spec/idea links
- * cc meta             — summary overview
+ * coh meta endpoints   — list all API endpoints as concept nodes
+ * coh meta modules     — list all code modules with spec/idea links
+ * coh meta             — summary overview
  */
 
 import { get } from "../api.mjs";
@@ -39,7 +39,7 @@ export async function showMetaSummary() {
   console.log(`  Traced:       ${B}${data.traced_count}${R} endpoints linked to spec/idea`);
   console.log(`  Coverage:     ${coverageColor}${pct}%${R} of endpoints have traceability`);
   console.log();
-  console.log(`  ${D}Use 'cc meta endpoints' or 'cc meta modules' for details${R}`);
+  console.log(`  ${D}Use 'coh meta endpoints' or 'coh meta modules' for details${R}`);
   console.log();
 }
 

--- a/cli/lib/commands/models.mjs
+++ b/cli/lib/commands/models.mjs
@@ -1,17 +1,17 @@
 /**
- * cc models — Model listing and routing management.
+ * coh models — Model listing and routing management.
  *
  * Usage:
- *   cc models                              List all models by executor
- *   cc models routing                      Show task-type → tier mapping
- *   cc models set <executor> <type> <model> Override model for executor + task type
- *   cc usage                               Show automation usage overview
- *   cc usage alerts                        Show active usage alerts
+ *   coh models                              List all models by executor
+ *   coh models routing                      Show task-type → tier mapping
+ *   coh models set <executor> <type> <model> Override model for executor + task type
+ *   coh usage                               Show automation usage overview
+ *   coh usage alerts                        Show active usage alerts
  */
 
 import { get, patch } from "../api.mjs";
 
-// ── cc models ──────────────────────────────────────────────────────
+// ── coh models ──────────────────────────────────────────────────────
 
 export async function modelsCommand(args) {
   const sub = (args[0] || "").toLowerCase();
@@ -29,13 +29,13 @@ export async function modelsCommand(args) {
     const taskType = args[2];
     const model = args[3];
     if (!executor || !taskType || !model) {
-      console.log("\x1b[33m⚠\x1b[0m Usage: cc models set <executor> <task_type> <model>");
+      console.log("\x1b[33m⚠\x1b[0m Usage: coh models set <executor> <task_type> <model>");
       return;
     }
     return setModelOverride(executor, taskType, model);
   }
 
-  console.log("\x1b[33m⚠\x1b[0m Unknown subcommand. Use: cc models [list|routing|set]");
+  console.log("\x1b[33m⚠\x1b[0m Unknown subcommand. Use: coh models [list|routing|set]");
 }
 
 async function listModels() {
@@ -130,7 +130,7 @@ async function setModelOverride(executor, taskType, model) {
   console.log(`  \x1b[32m✓\x1b[0m Model routing updated: ${executor}/${taskType} → ${model}`);
 }
 
-// ── cc usage ───────────────────────────────────────────────────────
+// ── coh usage ───────────────────────────────────────────────────────
 
 export async function usageCommand(args) {
   const sub = (args[0] || "").toLowerCase();

--- a/cli/lib/commands/news.mjs
+++ b/cli/lib/commands/news.mjs
@@ -92,7 +92,7 @@ export async function addSource(args) {
   const url = args[0];
   const name = args.slice(1).join(" ");
   if (!url || !name) {
-    console.log("Usage: cc news source add <url> <name>");
+    console.log("Usage: coh news source add <url> <name>");
     return;
   }
   const result = await post("/api/news/sources", { url, name });

--- a/cli/lib/commands/nodes.mjs
+++ b/cli/lib/commands/nodes.mjs
@@ -194,11 +194,11 @@ export async function sendMessage(args) {
   const text = textParts.join(" ");
 
   if (!targetOrBroadcast || !text) {
-    console.log("Usage: cc msg <node|broadcast> <message text>");
-    console.log("  cc msg broadcast Hello all nodes!");
-    console.log("  cc msg mac Hello Mac node!");
-    console.log("  cc msg windows Check status please");
-    console.log("  cc msg seeker Hello by hostname match");
+    console.log("Usage: coh msg <node|broadcast> <message text>");
+    console.log("  coh msg broadcast Hello all nodes!");
+    console.log("  coh msg mac Hello Mac node!");
+    console.log("  coh msg windows Check status please");
+    console.log("  coh msg seeker Hello by hostname match");
     return;
   }
 
@@ -239,21 +239,21 @@ export async function sendMessage(args) {
 
 /**
  * Send a command to a node (not a text message).
- * Usage: cc cmd <node> <command> [args...]
+ * Usage: coh cmd <node> <command> [args...]
  * Examples:
- *   cc cmd mac update
- *   cc cmd windows status
- *   cc cmd all update
+ *   coh cmd mac update
+ *   coh cmd windows status
+ *   coh cmd all update
  */
 export async function sendCommand(args) {
   const [target, command, ...extra] = args;
 
   if (!target || !command) {
-    console.log("Usage: cc cmd <node|all> <command> [args...]");
-    console.log("  cc cmd mac update          Tell Mac node to git pull");
-    console.log("  cc cmd windows status      Request status from Windows");
-    console.log("  cc cmd all update          Update all nodes");
-    console.log("  cc cmd seeker restart      Restart by hostname match");
+    console.log("Usage: coh cmd <node|all> <command> [args...]");
+    console.log("  coh cmd mac update          Tell Mac node to git pull");
+    console.log("  coh cmd windows status      Request status from Windows");
+    console.log("  coh cmd all update          Update all nodes");
+    console.log("  coh cmd seeker restart      Restart by hostname match");
     console.log();
     console.log("Commands: update, status, restart, pause, resume");
     return;

--- a/cli/lib/commands/onboarding.mjs
+++ b/cli/lib/commands/onboarding.mjs
@@ -19,7 +19,7 @@ export async function onboardingRegister(args) {
   }
 
   if (!handle) {
-    console.log("Usage: cc onboarding register --handle <name> [--email e] [--hint-github gh] [--hint-wallet addr]");
+    console.log("Usage: coh onboarding register --handle <name> [--email e] [--hint-github gh] [--hint-wallet addr]");
     return;
   }
 
@@ -52,7 +52,7 @@ export async function onboardingSession(args) {
   }
 
   if (!token) {
-    console.log("Usage: cc onboarding session --token <token>");
+    console.log("Usage: coh onboarding session --token <token>");
     return;
   }
 

--- a/cli/lib/commands/ontology.mjs
+++ b/cli/lib/commands/ontology.mjs
@@ -2,11 +2,11 @@
  * Ontology command — accessible ontology for non-technical contributors.
  *
  * Usage:
- *   cc ontology contribute --text "Water seeks balance" --domains ecology,physics
- *   cc ontology list [--domain ecology] [--status placed]
- *   cc ontology garden
- *   cc ontology stats
- *   cc ontology get <id>
+ *   coh ontology contribute --text "Water seeks balance" --domains ecology,physics
+ *   coh ontology list [--domain ecology] [--status placed]
+ *   coh ontology garden
+ *   coh ontology stats
+ *   coh ontology get <id>
  */
 
 import { get, post, patch, del } from "../api.mjs";
@@ -240,13 +240,13 @@ export async function ontology(args = []) {
       return stats(flags);
     case "get":
       if (!flags._positional) {
-        console.error("Usage: cc ontology get <id>");
+        console.error("Usage: coh ontology get <id>");
         process.exit(1);
       }
       return getOne(flags._positional, flags);
     default:
       console.log();
-      console.log(`${BOLD}cc ontology${RESET} — accessible ontology for everyone`);
+      console.log(`${BOLD}coh ontology${RESET} — accessible ontology for everyone`);
       console.log();
       console.log("  contribute --text <description> [--domains d1,d2] [--title title]");
       console.log("  list       [--domain d] [--status placed|pending|orphan]");

--- a/cli/lib/commands/ops.mjs
+++ b/cli/lib/commands/ops.mjs
@@ -298,7 +298,7 @@ export async function showOpsSnapshot(args = []) {
 export async function showOpsEvents(args = []) {
   const taskId = args.find((value) => !value.startsWith("--")) || "";
   if (!taskId) {
-    console.log("Usage: cc ops events <task_id> [--json] [--follow]");
+    console.log("Usage: coh ops events <task_id> [--json] [--follow]");
     return;
   }
   if (args.includes("--follow")) {
@@ -369,7 +369,7 @@ async function followTaskEvents(taskId, { verbose = false } = {}) {
 export async function sendOpsRunnerCommand(args = []) {
   const [target, command, ...extra] = args;
   if (!target || !command) {
-    console.log("Usage: cc ops runner <runner|host|node> <status|pause|resume|restart> [args...]");
+    console.log("Usage: coh ops runner <runner|host|node> <status|pause|resume|restart> [args...]");
     return;
   }
   const resolution = await resolveRunnerCommandTarget(target);

--- a/cli/lib/commands/org.mjs
+++ b/cli/lib/commands/org.mjs
@@ -1,8 +1,8 @@
 /**
  * Org command — view agent hierarchy and roles
  * 
- * cc org                — Show your reporting lines
- * cc org <contributor>  — Show org for specific contributor
+ * coh org                — Show your reporting lines
+ * coh org <contributor>  — Show org for specific contributor
  */
 
 import inquirer from "inquirer";

--- a/cli/lib/commands/peers.mjs
+++ b/cli/lib/commands/peers.mjs
@@ -1,9 +1,9 @@
 /**
  * Peers command — discover other contributors
  * 
- * cc peers             — Interactive discovery (resonant + nearby)
- * cc peers --nearby    — Focus on geographic proximity
- * cc peers --resonance — Focus on interest matching
+ * coh peers             — Interactive discovery (resonant + nearby)
+ * coh peers --nearby    — Focus on geographic proximity
+ * coh peers --resonance — Focus on interest matching
  */
 
 import inquirer from "inquirer";
@@ -15,7 +15,7 @@ import { getContributorId } from "../config.mjs";
 export async function runPeersCommand(args = []) {
   const contributorId = getContributorId();
   if (!contributorId) {
-    console.log(chalk.yellow("⚠ You must set an identity first: cc identity link <provider> <handle>"));
+    console.log(chalk.yellow("⚠ You must set an identity first: coh identity link <provider> <handle>"));
     return;
   }
 

--- a/cli/lib/commands/portfolio.mjs
+++ b/cli/lib/commands/portfolio.mjs
@@ -1,5 +1,5 @@
 /**
- * Portfolio command: cc portfolio
+ * Portfolio command: coh portfolio
  *
  * Single-query overview of all ideas by category showing:
  *   - idea count, gap (CC), value capture %

--- a/cli/lib/commands/rest.mjs
+++ b/cli/lib/commands/rest.mjs
@@ -1,11 +1,11 @@
 /**
- * Universal API access — `cc rest` reaches any HTTP route on the configured hub.
+ * Universal API access — `coh rest` reaches any HTTP route on the configured hub.
  *
- *   cc rest coverage              — canonical route manifest + accessibility proof
- *   cc rest GET /api/health
- *   cc rest POST /api/foo --body '{"a":1}'
- *   cc rest PATCH /api/agent/tasks/x --body '{"status":"running"}'
- *   cc rest GET /api/ideas -H "X-Custom: 1"
+ *   coh rest coverage              — canonical route manifest + accessibility proof
+ *   coh rest GET /api/health
+ *   coh rest POST /api/foo --body '{"a":1}'
+ *   coh rest PATCH /api/agent/tasks/x --body '{"status":"running"}'
+ *   coh rest GET /api/ideas -H "X-Custom: 1"
  */
 
 import { getApiBase, request, get } from "../api.mjs";
@@ -95,7 +95,7 @@ export async function showRestCoverage() {
     milestone: String(milestone),
     generated_at: String(generated),
     proof:
-      "Every path in api_routes can be invoked via: cc rest <METHOD> <path> [--body JSON] [-H 'Name: value']. "
+      "Every path in api_routes can be invoked via: coh rest <METHOD> <path> [--body JSON] [-H 'Name: value']. "
       + "First-class `cc` subcommands remain recommended for common workflows.",
   };
 
@@ -103,7 +103,7 @@ export async function showRestCoverage() {
   console.log();
   console.log(
     `\x1b[2m${count} canonical API routes · registry v${version} · ` +
-      "full terminal access = `cc rest` + manifest above\x1b[0m",
+      "full terminal access = `coh rest` + manifest above\x1b[0m",
   );
 }
 
@@ -126,11 +126,11 @@ export async function handleRest(argv) {
 \x1b[1mcc rest\x1b[0m — call any API path on the configured hub
 
 \x1b[1mUsage:\x1b[0m
-  cc rest coverage              Show canonical route count + accessibility proof
-  cc rest GET /api/health
-  cc rest POST /api/path --body '{"key":"value"}'
-  cc rest PATCH /api/resource/x --body '{"a":1}' -H "X-Custom: yes"
-  cc rest GET /api/ideas -q limit=5
+  coh rest coverage              Show canonical route count + accessibility proof
+  coh rest GET /api/health
+  coh rest POST /api/path --body '{"key":"value"}'
+  coh rest PATCH /api/resource/x --body '{"a":1}' -H "X-Custom: yes"
+  coh rest GET /api/ideas -q limit=5
 
 \x1b[1mEnv vars:\x1b[0m COHERENCE_API_URL, COHERENCE_API_KEY, COHERENCE_TIMEOUT_MS
 \x1b[1mFlags:\x1b[0m --api-url <url>, --api-key <key>, --timeout <ms>, --workspace <id>

--- a/cli/lib/commands/runtime.mjs
+++ b/cli/lib/commands/runtime.mjs
@@ -1,18 +1,18 @@
 /**
  * Runtime commands
  *
- *   cc runtime                      — show change token + events summary
- *   cc runtime events               — list recent runtime events
- *   cc runtime event <type> <data>  — post a runtime event
- *   cc runtime ideas                — runtime ideas summary
- *   cc runtime endpoints            — endpoints summary
- *   cc runtime web                  — web views performance
- *   cc runtime attention            — endpoints needing attention
- *   cc runtime exerciser            — run exerciser
- *   cc runtime usage                — verification usage
- *   cc runtime mvp                  — MVP acceptance summary
- *   cc runtime mvp judge            — MVP acceptance judge result
- *   cc runtime mvp baselines        — local baselines
+ *   coh runtime                      — show change token + events summary
+ *   coh runtime events               — list recent runtime events
+ *   coh runtime event <type> <data>  — post a runtime event
+ *   coh runtime ideas                — runtime ideas summary
+ *   coh runtime endpoints            — endpoints summary
+ *   coh runtime web                  — web views performance
+ *   coh runtime attention            — endpoints needing attention
+ *   coh runtime exerciser            — run exerciser
+ *   coh runtime usage                — verification usage
+ *   coh runtime mvp                  — MVP acceptance summary
+ *   coh runtime mvp judge            — MVP acceptance judge result
+ *   coh runtime mvp baselines        — local baselines
  */
 
 import { get, post } from "../api.mjs";
@@ -70,7 +70,7 @@ export async function postRuntimeEvent(args) {
   const eventType = args[0];
   const rest = args.slice(1).join(" ");
   if (!eventType) {
-    console.log("Usage: cc runtime event <type> [data...]");
+    console.log("Usage: coh runtime event <type> [data...]");
     return;
   }
   let data = {};

--- a/cli/lib/commands/services.mjs
+++ b/cli/lib/commands/services.mjs
@@ -38,7 +38,7 @@ export async function listServices() {
 export async function showService(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc service <id>");
+    console.log("Usage: coh service <id>");
     return;
   }
   const data = await get(`/api/services/${encodeURIComponent(id)}`);

--- a/cli/lib/commands/setup.mjs
+++ b/cli/lib/commands/setup.mjs
@@ -1,8 +1,8 @@
 /**
- * Interactive onboarding: cc setup
+ * Interactive onboarding: coh setup
  *
  * Guides a new contributor through identity + API key setup.
- * Non-interactive mode: cc setup --name <name> --provider <p> --id <id>
+ * Non-interactive mode: coh setup --name <name> --provider <p> --id <id>
  */
 
 import { post } from "../api.mjs";
@@ -26,7 +26,7 @@ export async function setup(args) {
     console.log(`\n\x1b[32m✓\x1b[0m Already set up as \x1b[1m${keys.contributor_id}\x1b[0m`);
     console.log(`  API key: ${keys.api_key.slice(0, 12)}...`);
     if (keys.provider) console.log(`  Provider: ${keys.provider}:${keys.provider_id}`);
-    console.log(`\n  To reconfigure: cc setup --reset`);
+    console.log(`\n  To reconfigure: coh setup --reset`);
     return;
   }
 
@@ -113,10 +113,10 @@ async function completeSetup(name, provider, providerId) {
   Saved to:    ${KEYS_FILE}
 
   You can now:
-    cc ideas              Browse ideas
-    cc share              Submit a new idea
-    cc contribute         Record a contribution
-    cc stake <id> <cc>    Invest in an idea
-    cc status             Check network health
+    coh ideas              Browse ideas
+    coh share              Submit a new idea
+    coh contribute         Record a contribution
+    coh stake <id> <cc>    Invest in an idea
+    coh status             Check network health
 `);
 }

--- a/cli/lib/commands/skills.mjs
+++ b/cli/lib/commands/skills.mjs
@@ -1,7 +1,7 @@
 /**
  * Skills command — procedural memory from the Hermes Learning Loop
  * 
- * cc skills             — Interactive skills browser
+ * coh skills             — Interactive skills browser
  */
 
 import inquirer from "inquirer";

--- a/cli/lib/commands/specs.mjs
+++ b/cli/lib/commands/specs.mjs
@@ -11,7 +11,7 @@ import { hasJsonFlag, printJson, printJsonError, stripJsonFlag } from "../ui/jso
 
 export async function listSpecs(args) {
   const jsonMode = hasJsonFlag(args);
-  // Strip --json before parsing positional so `cc specs --json` still
+  // Strip --json before parsing positional so `coh specs --json` still
   // defaults to the right limit instead of trying to parseInt("--json").
   const clean = stripJsonFlag(args);
   const limit = parseInt(clean[0]) || 20;
@@ -58,7 +58,7 @@ export async function showSpec(args) {
   const id = clean[0];
   if (!id) {
     if (jsonMode) printJsonError("missing_spec_id");
-    else console.log("Usage: cc spec <spec-id>");
+    else console.log("Usage: coh spec <spec-id>");
     return;
   }
   const data = await get(`/api/spec-registry/${encodeURIComponent(id)}`);

--- a/cli/lib/commands/status.mjs
+++ b/cli/lib/commands/status.mjs
@@ -113,7 +113,7 @@ export async function showStatus(args = []) {
       if (focus.idea_id) focusContent += `${chalk.cyan.bold("FOCUS IDEA:")} ${focus.idea_id}\n`;
       if (focus.task_id) focusContent += `${chalk.magenta.bold("FOCUS TASK:")} ${focus.task_id}`;
     } else {
-      focusContent = chalk.dim("No active focus. Use 'cc focus' to pick an idea.");
+      focusContent = chalk.dim("No active focus. Use 'coh focus' to pick an idea.");
     }
 
     console.log(boxen(focusContent, {

--- a/cli/lib/commands/tasks.mjs
+++ b/cli/lib/commands/tasks.mjs
@@ -3,12 +3,12 @@
  *
  * This is the agent-to-agent work protocol. An AI agent (Claude, Codex,
  * Cursor, Gemini) can:
- *   cc tasks              — see what's pending/running
- *   cc task next          — claim the highest-priority pending task
- *   cc task <id>          — view task detail
- *   cc task claim <id>    — claim a specific task
- *   cc task report <id> <status> [output] — report result
- *   cc task seed <idea>   — create a task from an idea
+ *   coh tasks              — see what's pending/running
+ *   coh task next          — claim the highest-priority pending task
+ *   coh task <id>          — view task detail
+ *   coh task claim <id>    — claim a specific task
+ *   coh task report <id> <status> [output] — report result
+ *   coh task seed <idea>   — create a task from an idea
  */
 
 import { get, post, patch } from "../api.mjs";
@@ -99,7 +99,7 @@ export async function listTasks(args) {
     return;
   }
 
-  // Explicit status filter: cc tasks running, cc tasks failed, etc.
+  // Explicit status filter: coh tasks running, coh tasks failed, etc.
   const data = await get("/api/agent/tasks", { status: explicit, limit, ...workspaceQuery() });
   const tasks = data?.tasks || (Array.isArray(data) ? data : []);
 
@@ -132,7 +132,7 @@ export async function listTasks(args) {
 export async function showTask(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc task <id>");
+    console.log("Usage: coh task <id>");
     return;
   }
   const t = await get(`/api/agent/tasks/${id}`);
@@ -210,7 +210,7 @@ export async function reportTask(args) {
   const output = outputParts.join(" ");
 
   if (!id || !status) {
-    console.log("Usage: cc task report <id> <completed|failed> [output text]");
+    console.log("Usage: coh task report <id> <completed|failed> [output text]");
     return;
   }
 
@@ -237,7 +237,7 @@ export async function seedTask(args) {
   const taskType = type || "spec";
 
   if (!ideaId) {
-    console.log("Usage: cc task seed <idea_id> [spec|test|impl|review]");
+    console.log("Usage: coh task seed <idea_id> [spec|test|impl|review]");
     return;
   }
 
@@ -278,7 +278,7 @@ export async function showTaskCount() {
 export async function showTaskEvents(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc task events <task_id>");
+    console.log("Usage: coh task events <task_id>");
     console.log("  Fetches stored event list from GET /api/agent/tasks/<id>/stream (not the SSE /events endpoint).");
     return;
   }
@@ -302,7 +302,7 @@ function timeSince(iso) {
 
 export async function postProgress(args) {
   const message = args.join(" ").trim();
-  if (!message) { console.log("Usage: cc progress \"what you just did\""); return; }
+  if (!message) { console.log("Usage: coh progress \"what you just did\""); return; }
   let taskId = getCliActiveTaskId() || "";
   if (!taskId) {
     try { const { readFileSync } = await import("node:fs"); const ctrl = readFileSync(".task-control", "utf-8").trim(); const m = ctrl.match(/task[_-]([a-f0-9]+)/i); if (m) taskId = `task_${m[1]}`; } catch {}

--- a/cli/lib/commands/traceability.mjs
+++ b/cli/lib/commands/traceability.mjs
@@ -45,7 +45,7 @@ export async function showCoverage() {
 export async function traceIdea(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc trace idea <id>");
+    console.log("Usage: coh trace idea <id>");
     return;
   }
   const data = await get(`/api/traceability/idea/${encodeURIComponent(id)}`);
@@ -77,7 +77,7 @@ export async function traceIdea(args) {
 export async function traceSpec(args) {
   const id = args[0];
   if (!id) {
-    console.log("Usage: cc trace spec <id>");
+    console.log("Usage: coh trace spec <id>");
     return;
   }
   const data = await get(`/api/traceability/spec/${encodeURIComponent(id)}`);

--- a/cli/lib/commands/translate.mjs
+++ b/cli/lib/commands/translate.mjs
@@ -6,9 +6,9 @@
  * the prior canonical is preserved as superseded.
  *
  * Commands:
- *   cc translate submit <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>] [--description <d>] [--from-lang <source>] [--by <author_id>] [--notes <notes>]
- *   cc translate history <entity_type> <entity_id> [--lang <lang>]
- *   cc translate list <entity_type> <entity_id>
+ *   coh translate submit <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>] [--description <d>] [--from-lang <source>] [--by <author_id>] [--notes <notes>]
+ *   coh translate history <entity_type> <entity_id> [--lang <lang>]
+ *   coh translate list <entity_type> <entity_id>
  */
 
 import { readFileSync } from "node:fs";
@@ -38,7 +38,7 @@ function parseKvFlags(args, flags) {
   return { opts, positional };
 }
 
-/** cc translate submit <entity_type> <entity_id> --lang de --file path [--title ...] [--description ...] */
+/** coh translate submit <entity_type> <entity_id> --lang de --file path [--title ...] [--description ...] */
 async function submitTranslation(args) {
   const { opts, positional } = parseKvFlags(args, {
     "--lang": "lang",
@@ -54,7 +54,7 @@ async function submitTranslation(args) {
   });
   const [entity_type, entity_id] = positional;
   if (!entity_type || !entity_id) {
-    console.log(`${DIM}Usage:${RESET} cc translate submit <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>] [--description <d>] [--from-lang <source>] [--by <author_id>]`);
+    console.log(`${DIM}Usage:${RESET} coh translate submit <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>] [--description <d>] [--from-lang <source>] [--by <author_id>]`);
     return;
   }
   if (!opts.lang) {
@@ -100,7 +100,7 @@ async function submitTranslation(args) {
   console.log(`  ${DIM}status:${RESET}     ${GREEN}${resp.status}${RESET}`);
 }
 
-/** cc translate history <entity_type> <entity_id> [--lang <lang>] */
+/** coh translate history <entity_type> <entity_id> [--lang <lang>] */
 async function showHistory(args) {
   const { opts, positional } = parseKvFlags(args, {
     "--lang": "lang",
@@ -108,7 +108,7 @@ async function showHistory(args) {
   });
   const [entity_type, entity_id] = positional;
   if (!entity_type || !entity_id) {
-    console.log(`${DIM}Usage:${RESET} cc translate history <entity_type> <entity_id> [--lang <lang>]`);
+    console.log(`${DIM}Usage:${RESET} coh translate history <entity_type> <entity_id> [--lang <lang>]`);
     return;
   }
   const qs = opts.lang ? `?lang=${encodeURIComponent(opts.lang)}` : "";
@@ -134,7 +134,7 @@ async function showHistory(args) {
   }
 }
 
-/** cc translate list <entity_type> <entity_id> — alias for history without lang filter */
+/** coh translate list <entity_type> <entity_id> — alias for history without lang filter */
 async function listTranslations(args) {
   return showHistory(args);
 }
@@ -146,12 +146,12 @@ export async function handleTranslate(args) {
     case "history": return showHistory(args.slice(1));
     case "list":    return listTranslations(args.slice(1));
     default:
-      console.log(`${DIM}Usage:${RESET} cc translate <submit|history|list> …`);
+      console.log(`${DIM}Usage:${RESET} coh translate <submit|history|list> …`);
       console.log(``);
-      console.log(`  ${BOLD}cc translate submit${RESET} <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>]`);
+      console.log(`  ${BOLD}coh translate submit${RESET} <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>]`);
       console.log(`    Submit a translation. Supersedes prior canonical for (entity, lang); history preserved.`);
       console.log(``);
-      console.log(`  ${BOLD}cc translate history${RESET} <entity_type> <entity_id> [--lang <lang>]`);
+      console.log(`  ${BOLD}coh translate history${RESET} <entity_type> <entity_id> [--lang <lang>]`);
       console.log(`    List all views (canonical + superseded) for an entity, optionally filtered by language.`);
   }
 }

--- a/cli/lib/commands/treasury.mjs
+++ b/cli/lib/commands/treasury.mjs
@@ -31,7 +31,7 @@ export async function showTreasury() {
 export async function showDeposits(args) {
   const contributor = args[0];
   if (!contributor) {
-    console.log("Usage: cc treasury deposits <contributor-id>");
+    console.log("Usage: coh treasury deposits <contributor-id>");
     return;
   }
   const data = await get(`/api/treasury/deposits/${encodeURIComponent(contributor)}`);
@@ -57,7 +57,7 @@ export async function makeDeposit(args) {
   const amount = parseFloat(args[0]);
   const asset = args[1];
   if (isNaN(amount) || !asset) {
-    console.log("Usage: cc treasury deposit <amount> <asset>");
+    console.log("Usage: coh treasury deposit <amount> <asset>");
     return;
   }
   const result = await post("/api/treasury/deposit", { amount, asset });

--- a/cli/lib/commands/update.mjs
+++ b/cli/lib/commands/update.mjs
@@ -1,5 +1,5 @@
 /**
- * cc update — universal update for all agent surfaces
+ * coh update — universal update for all agent surfaces
  *
  * Updates: CLI, MCP server, OpenClaw skill, and agent config files
  * (.claude/settings.json, .cursorrules, .windsurfrules, AGENTS.md)
@@ -168,7 +168,7 @@ async function updateAgentConfigs() {
   }
 
   const agentInstructions = skillContent
-    ? `# Coherence Network\n\nThis project uses the Coherence Network. Run \`cc status\` to check health.\nRun \`cc inbox\` to check messages. Run \`cc help\` for all commands.\n\nFull documentation: https://api.coherencycoin.com/docs\nCLI: npm i -g coherence-cli\nMCP: npx coherence-mcp-server\n`
+    ? `# Coherence Network\n\nThis project uses the Coherence Network. Run \`coh status\` to check health.\nRun \`coh inbox\` to check messages. Run \`coh help\` for all commands.\n\nFull documentation: https://api.coherencycoin.com/docs\nCLI: npm i -g coherence-cli\nMCP: npx coherence-mcp-server\n`
     : null;
 
   // Claude Code: .claude/settings.json MCP config

--- a/cli/lib/commands/workspaces.mjs
+++ b/cli/lib/commands/workspaces.mjs
@@ -1,5 +1,5 @@
 /**
- * cc workspace — workspace (tenant) CRUD.
+ * coh workspace — workspace (tenant) CRUD.
  *
  * Workspaces own their own ideas, specs, pillars, and agent personas.
  * Every idea/spec belongs to exactly one workspace.
@@ -44,7 +44,7 @@ export async function listWorkspaces() {
 export async function showWorkspace(args) {
   const id = args[0];
   if (!id) {
-    console.error("Usage: cc workspace show <workspace_id>");
+    console.error("Usage: coh workspace show <workspace_id>");
     process.exit(1);
   }
   const ws = await get(`/api/workspaces/${encodeURIComponent(id)}`);
@@ -56,11 +56,11 @@ export async function showWorkspace(args) {
 }
 
 export async function createWorkspace(args) {
-  // Usage: cc workspace create <id> <name> [--desc "..."] [--pillars "a,b,c"] [--visibility public]
+  // Usage: coh workspace create <id> <name> [--desc "..."] [--pillars "a,b,c"] [--visibility public]
   const id = args[0];
   const name = args[1];
   if (!id || !name) {
-    console.error("Usage: cc workspace create <id> <name> [--desc \"...\"] [--pillars \"a,b,c\"] [--visibility public]");
+    console.error("Usage: coh workspace create <id> <name> [--desc \"...\"] [--pillars \"a,b,c\"] [--visibility public]");
     process.exit(1);
   }
   let description = "";
@@ -97,8 +97,8 @@ export async function showWorkspacePillars(args) {
 export function useWorkspace(args) {
   const id = args[0];
   if (!id) {
-    console.error("Usage: cc workspace use <workspace_id>");
-    console.error("       cc workspace use --clear");
+    console.error("Usage: coh workspace use <workspace_id>");
+    console.error("       coh workspace use --clear");
     process.exit(1);
   }
   if (id === "--clear" || id === "default") {
@@ -127,7 +127,7 @@ export async function handleWorkspace(args) {
     case "current": return currentWorkspace();
     default:
       if (!sub) return listWorkspaces();
-      // cc workspace <id> → show
+      // coh workspace <id> → show
       return showWorkspace(args);
   }
 }

--- a/cli/lib/config.mjs
+++ b/cli/lib/config.mjs
@@ -97,14 +97,14 @@ export function getContributorId() {
   return null;
 }
 
-/** Resolution source label for `cc identity` (R4). */
+/** Resolution source label for `coh identity` (R4). */
 export function getContributorSource() {
   const fromFile = loadConfig().contributor_id;
   if (fromFile && String(fromFile).trim()) return "config.json";
   return "none";
 }
 
-/** R2 — contributor_id for `cc identity set` (letters, digits, underscore, period, hyphen; max 64). */
+/** R2 — contributor_id for `coh identity set` (letters, digits, underscore, period, hyphen; max 64). */
 export const CONTRIBUTOR_ID_PATTERN = /^[\w.\-]{1,64}$/;
 
 export function normalizeContributorId(value) {

--- a/cli/lib/identity.mjs
+++ b/cli/lib/identity.mjs
@@ -77,7 +77,7 @@ export async function ensureIdentity() {
     } catch {}
 
     console.error(`Registered as: ${detected.id} (from ${detected.source})`);
-    console.error(`Link identity: cc identity link github <handle>`);
+    console.error(`Link identity: coh identity link github <handle>`);
     return detected.id;
   }
 
@@ -123,7 +123,7 @@ export async function ensureIdentity() {
       if (result) {
         console.log(`  \x1b[32m✓\x1b[0m Linked ${provider}:${handle}`);
       } else {
-        console.log(`  \x1b[33m!\x1b[0m Could not link. Try later: cc identity link ${provider} ${handle}`);
+        console.log(`  \x1b[33m!\x1b[0m Could not link. Try later: coh identity link ${provider} ${handle}`);
       }
     }
   }
@@ -144,7 +144,7 @@ export async function ensureIdentity() {
         if (result) {
           console.log(`  \x1b[32m✓\x1b[0m Linked ${provider}:${value}`);
         } else {
-          console.log(`  \x1b[33m!\x1b[0m Could not link. Try later: cc identity link ${provider} ${value}`);
+          console.log(`  \x1b[33m!\x1b[0m Could not link. Try later: coh identity link ${provider} ${value}`);
         }
       }
     }
@@ -176,14 +176,14 @@ export async function ensureIdentity() {
       });
       console.log(`\x1b[32m✓\x1b[0m API key generated and saved to ~/.coherence-network/keys.json`);
     } else {
-      console.log(`\x1b[33m!\x1b[0m Could not generate API key now. Run: cc setup`);
+      console.log(`\x1b[33m!\x1b[0m Could not generate API key now. Run: coh setup`);
     }
   }
 
   console.log();
   console.log(`\x1b[32m✓\x1b[0m Registered as: ${name}`);
   console.log(`Config saved to ~/.coherence-network/config.json`);
-  console.log(`Link more anytime: cc identity link <provider> <handle>`);
+  console.log(`Link more anytime: coh identity link <provider> <handle>`);
   console.log();
 
   rl.close();

--- a/cli/lib/ui/json.mjs
+++ b/cli/lib/ui/json.mjs
@@ -1,5 +1,5 @@
 /**
- * Shared --json output helpers for cc commands.
+ * Shared --json output helpers for coh commands.
  *
  * Before this module, each command re-invented its own JSON handling:
  *   - ops.mjs did `args.includes("--json")`
@@ -21,7 +21,7 @@
  * All functions honor the precedence:
  *   explicit flag > stdout non-TTY (piped to jq/less) > default human mode
  *
- * Auto-detecting non-TTY means `cc ideas | jq '.[0]'` just works without
+ * Auto-detecting non-TTY means `coh ideas | jq '.[0]'` just works without
  * the user having to remember `--json`.
  */
 

--- a/docs/EXTERNAL_ENABLEMENT_TRACKING.md
+++ b/docs/EXTERNAL_ENABLEMENT_TRACKING.md
@@ -53,7 +53,7 @@ COHERENCE_API_URL=http://localhost:8000 COHERENCE_API_KEY=dev-key python3 script
 | 2 | Auto-filter: skip tasks for repos without credentials in `keys.json` (no flag needed) | **done** | `api/scripts/local_runner.py` |
 | 3 | Write credential routing tests | **done** | `api/tests/test_flow_enforcement.py` |
 
-**Context**: DB schema + CRUD endpoints + CLI `cc credentials` already exist. Runner now filters tasks by repo credentials (both explicit `--repo` flag and automatic credential check).
+**Context**: DB schema + CRUD endpoints + CLI `coh credentials` already exist. Runner now filters tasks by repo credentials (both explicit `--repo` flag and automatic credential check).
 
 ### Planned Features (priority order)
 
@@ -64,7 +64,7 @@ COHERENCE_API_URL=http://localhost:8000 COHERENCE_API_KEY=dev-key python3 script
 | 3 | **Approvals & budget board** | Single board for governance requests, deploy gates, needs_decision tasks, spend pressure. | Medium |
 | 4 | **Adapters catalog** | First-class surface for providers, federation nodes, Discord/Telegram, deploy gates. | Medium |
 | 5 | **Guided onboarding** | Beginner-friendly setup flow with deployment presets (local/private/public). | Medium |
-| 6 | **CLI mission control parity** | `cc mission-control`, `cc approvals`, `cc budgets`, `cc adapters`. | Medium |
+| 6 | **CLI mission control parity** | `coh mission-control`, `coh approvals`, `coh budgets`, `coh adapters`. | Medium |
 | 7 | **Anomaly self-heal policies** | Orphaned tasks, stale runners, deploy drift → automatic recovery policies. | Large |
 
 ### Coverage Gaps
@@ -83,12 +83,12 @@ COHERENCE_API_URL=http://localhost:8000 COHERENCE_API_KEY=dev-key python3 script
 
 | Command | Spec | Priority |
 |---------|------|----------|
-| cc marketplace | 121 | High |
-| cc graph | 166 | Medium |
-| cc onboarding | 168 | Medium |
-| cc invest | 157 | Low |
-| cc measurements | 131 | Low |
-| cc strategies | 134 | Low |
+| coh marketplace | 121 | High |
+| coh graph | 166 | Medium |
+| coh onboarding | 168 | Medium |
+| coh invest | 157 | Low |
+| coh measurements | 131 | Low |
+| coh strategies | 134 | Low |
 
 ## Completed
 
@@ -120,15 +120,15 @@ COHERENCE_API_URL=http://localhost:8000 COHERENCE_API_KEY=dev-key python3 script
 | Compact summaries | Summarize large outputs; fetch raw on drilldown | done |
 | Tool overhead controls | Auto-prune guard_agents for simple tasks | done |
 | Blueprint royalties | Contributors earn CC on blueprint use | done |
-| Guide discovery | `cc guides` surfaces top creators | done |
+| Guide discovery | `coh guides` surfaces top creators | done |
 | Skill synthesis | Completed tasks → procedural Skill nodes | done |
 | Procedural memory API | Query previous successes before starting work | done |
 | Diagnostics console | `/diagnostics` with config editor, workbench, context budget | done |
-| CLI ops surface | `cc ops`, `cc config`, task-log drilldown, runner control | done |
+| CLI ops surface | `coh ops`, `coh config`, task-log drilldown, runner control | done |
 | JSON-backed settings | Replaced env-driven config with shared JSON config | done |
 | Auto-deploy | GitHub Actions → Hostinger VPS deployment | done |
 | Test suite overhaul | 3,244 → 163 flow-centric tests (7s runtime) | done |
-| Credential CRUD | DB schema, API endpoints, `cc credentials` CLI | done |
+| Credential CRUD | DB schema, API endpoints, `coh credentials` CLI | done |
 
 ### Per-Contributor Credential Model
 

--- a/docs/PIPELINE_DESIGN.md
+++ b/docs/PIPELINE_DESIGN.md
@@ -122,7 +122,7 @@ _CircuitBreaker(window_size=20, trip_threshold=10, cooldown_seconds=600)
 
 - Trips when: 10 consecutive failures OR >80% failure rate in last 20 tasks
 - When tripped: `allow_seeding()` returns `False` — no new tasks are seeded
-- Reset: `cc cmd mac resume` sends a message to the runner to reset the breaker
+- Reset: `coh cmd mac resume` sends a message to the runner to reset the breaker
 - Cooldown: 10 minutes, then auto-resets
 
 **Gap identified 2026-03-30:** The circuit breaker correctly tripped on `impl_branch_missing` failures

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -513,7 +513,7 @@ Ideas are the atomic unit of the Coherence Network. If an idea isn't in the syst
 
 ```bash
 # Via CLI
-cc share
+coh share
 
 # Via API
 curl -s https://api.coherencycoin.com/api/ideas -X POST \
@@ -541,7 +541,7 @@ curl -s https://api.coherencycoin.com/api/ideas -X POST \
 1. Were any new ideas discussed? → Record them via `POST /api/ideas`
 2. Were any existing ideas implemented? → Update status via `PATCH /api/ideas/{id}`
 3. Do new ideas have parent relationships? → Set `parent_idea_id`
-4. Are all ideas discoverable via `cc ideas`? → Verify
+4. Are all ideas discoverable via `coh ideas`? → Verify
 
 ### API key requirement
 

--- a/docs/WORKER-SERVICE.md
+++ b/docs/WORKER-SERVICE.md
@@ -59,8 +59,8 @@ chmod +x deploy/worker/install-macos.sh
 
 ### Check status
 ```bash
-cc status                    # network + node health
-cc nodes                     # federation nodes
+coh status                    # network + node health
+coh nodes                     # federation nodes
 tail -f api/logs/worker_service.log  # live logs (from worker worktree)
 ```
 
@@ -85,8 +85,8 @@ launchctl load ~/Library/LaunchAgents/com.coherence-network.worker.plist     # s
 
 ### Update to latest code
 ```bash
-# Option 1: Send update command via cc
-cc msg windows "Update to latest main"
+# Option 1: Send update command via coh
+coh msg windows "Update to latest main"
 
 # Option 2: Manual
 cd C:\source\Coherence-Network\.claude\worktrees\worker
@@ -98,9 +98,9 @@ The runner has self-update built in (`--self-update` flag, on by default unless 
 
 ### Send commands to the worker
 ```bash
-cc msg windows "Update to latest main"     # trigger self-update
-cc msg mac "Update to latest main"         # same for mac node
-cc msg windows "restart"                   # restart worker
+coh msg windows "Update to latest main"     # trigger self-update
+coh msg mac "Update to latest main"         # same for mac node
+coh msg windows "restart"                   # restart worker
 ```
 
 ## What survives restarts

--- a/docs/shared/cli-commands.md
+++ b/docs/shared/cli-commands.md
@@ -3,23 +3,23 @@
 
 | Category | Commands |
 |----------|----------|
-| **Core** | `cc status`, `cc help`, `cc setup`, `cc inbox`, `cc resonance` |
-| **Ideas** | `cc ideas`, `cc idea <id>`, `cc idea create`, `cc share`, `cc stake <id> <cc>`, `cc fork <id>` |
-| **Specs** | `cc specs`, `cc spec <id>` |
-| **Identity** | `cc identity`, `cc identity setup`, `cc identity set <id>`, `cc identity link <p> <id>`, `cc identity unlink <p>`, `cc identity lookup <p> <id>` |
-| **Contributors** | `cc contributors`, `cc contributor <id>`, `cc contributor <id> contributions` |
-| **Contributions** | `cc contribute` |
-| **Tasks** | `cc tasks`, `cc task <id>`, `cc task next`, `cc task claim <id>`, `cc task report <id>`, `cc task seed <idea>` |
-| **Assets** | `cc assets`, `cc asset <id>`, `cc asset create <type> <desc>` |
-| **News** | `cc news`, `cc news trending`, `cc news sources`, `cc news source add <url> <name>`, `cc news resonance [contributor]` |
-| **Treasury** | `cc treasury`, `cc treasury deposits [contributor]`, `cc treasury deposit <amount> <asset>` |
-| **Value lineage** | `cc lineage`, `cc lineage <id>`, `cc lineage <id> valuation`, `cc lineage <id> payout <amount>` |
-| **Governance** | `cc governance`, `cc governance <id>`, `cc governance vote <id> <yes\|no>`, `cc governance propose <title> <desc>` |
-| **Nodes** | `cc nodes`, `cc msg <node> <text>`, `cc cmd <node> update\|status\|diagnose\|restart\|ping` |
-| **Services** | `cc services`, `cc service <id>`, `cc services health`, `cc services deps` |
-| **Friction** | `cc friction`, `cc friction events`, `cc friction categories` |
-| **Providers** | `cc providers`, `cc providers stats` |
-| **Traceability** | `cc trace`, `cc trace coverage`, `cc trace idea <id>`, `cc trace spec <id>` |
-| **Diagnostics** | `cc diag`, `cc diag health`, `cc diag issues`, `cc diag runners`, `cc diag visibility` |
+| **Core** | `coh status`, `coh help`, `coh setup`, `coh inbox`, `coh resonance` |
+| **Ideas** | `coh ideas`, `coh idea <id>`, `coh idea create`, `coh share`, `coh stake <id> <cc>`, `coh fork <id>` |
+| **Specs** | `coh specs`, `coh spec <id>` |
+| **Identity** | `coh identity`, `coh identity setup`, `coh identity set <id>`, `coh identity link <p> <id>`, `coh identity unlink <p>`, `coh identity lookup <p> <id>` |
+| **Contributors** | `coh contributors`, `coh contributor <id>`, `coh contributor <id> contributions` |
+| **Contributions** | `coh contribute` |
+| **Tasks** | `coh tasks`, `coh task <id>`, `coh task next`, `coh task claim <id>`, `coh task report <id>`, `coh task seed <idea>` |
+| **Assets** | `coh assets`, `coh asset <id>`, `coh asset create <type> <desc>` |
+| **News** | `coh news`, `coh news trending`, `coh news sources`, `coh news source add <url> <name>`, `coh news resonance [contributor]` |
+| **Treasury** | `coh treasury`, `coh treasury deposits [contributor]`, `coh treasury deposit <amount> <asset>` |
+| **Value lineage** | `coh lineage`, `coh lineage <id>`, `coh lineage <id> valuation`, `coh lineage <id> payout <amount>` |
+| **Governance** | `coh governance`, `coh governance <id>`, `coh governance vote <id> <yes\|no>`, `coh governance propose <title> <desc>` |
+| **Nodes** | `coh nodes`, `coh msg <node> <text>`, `coh cmd <node> update\|status\|diagnose\|restart\|ping` |
+| **Services** | `coh services`, `coh service <id>`, `coh services health`, `coh services deps` |
+| **Friction** | `coh friction`, `coh friction events`, `coh friction categories` |
+| **Providers** | `coh providers`, `coh providers stats` |
+| **Traceability** | `coh trace`, `coh trace coverage`, `coh trace idea <id>`, `coh trace spec <id>` |
+| **Diagnostics** | `coh diag`, `coh diag health`, `coh diag issues`, `coh diag runners`, `coh diag visibility` |
 
 </details>

--- a/docs/shared/ecosystem-table.md
+++ b/docs/shared/ecosystem-table.md
@@ -2,7 +2,7 @@
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, contributors, and value chains visually | [coherencycoin.com](https://coherencycoin.com) |
 | **API** | 100+ endpoints with full OpenAPI docs — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **CLI** | Terminal-first access — `npx coherence-cli help` or `npm i -g coherence-cli && coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
 | **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **skills.sh** | Portable agent skill directory (same `SKILL.md` as ClawHub) | [skills.sh](https://skills.sh/) — submit `skills/coherence-network/` |

--- a/ideas/user-surfaces.md
+++ b/ideas/user-surfaces.md
@@ -24,10 +24,10 @@ The platform has rich data (ideas, specs, tasks, contributions, coherence scores
 ## Key Capabilities
 
 - **Web pages**: Browsable ideas list with free-energy scores, spec viewer with status indicators, usage dashboard with provider metrics, diagnostics page with failure breakdowns, pipeline view with task status. All pages use real data from the API, not placeholder content.
-- **CLI (35+ commands)**: Full API surface coverage -- `cc ideas` (list/create/advance), `cc tasks` (list/detail/claim), `cc ops` (pipeline status, metrics), `cc nodes` (runner status), `cc diagnostics` (failure analysis), `cc stake` (invest CC), `cc fork` (branch ideas).
+- **CLI (35+ commands)**: Full API surface coverage -- `coh ideas` (list/create/advance), `coh tasks` (list/detail/claim), `coh ops` (pipeline status, metrics), `coh nodes` (runner status), `coh diagnostics` (failure analysis), `coh stake` (invest CC), `coh fork` (branch ideas).
 - **Homepage readability**: WCAG AA contrast compliance. The current warm amber palette is beautiful but the hero text is nearly invisible on the dark background. Fix contrast ratios to meet 4.5:1 minimum for normal text, 3:1 for large text, while preserving the visual identity.
 - **MCP skill registry**: Submit the MCP server to Smithery, Glama, PulseMCP, and other discovery platforms. AI agents searching for "idea management" or "coherence scoring" tools should find Coherence Network's MCP server.
-- **Node and task visibility**: See what runner nodes are active, what tasks each node is executing, drill into task details including execution time, provider, status, and error info. Both CLI (`cc tasks`, `cc task <id>`) and web (`/pipeline`) surfaces.
+- **Node and task visibility**: See what runner nodes are active, what tasks each node is executing, drill into task details including execution time, provider, status, and error info. Both CLI (`coh tasks`, `coh task <id>`) and web (`/pipeline`) surfaces.
 - **Metadata self-discovery**: The system describes its own capabilities. Every API endpoint links back to the idea and spec that defined it. New users and agents can explore the platform's capabilities without reading documentation.
 
 ## What Success Looks Like

--- a/mcp-server/coherence_mcp_server/server.py
+++ b/mcp-server/coherence_mcp_server/server.py
@@ -1484,7 +1484,7 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
                         "navigation": {"idea_file": f"ideas/{entity_id}.md",
                                        "spec_files": [f"specs/{s}.md" for s in spec_ids],
                                        "api": f"/api/ideas/{entity_id}",
-                                       "cli": f"cc idea {entity_id}"}}
+                                       "cli": f"coh idea {entity_id}"}}
             elif entity_type == "spec":
                 spec = api_get(f"/api/spec-registry/{entity_id}")
                 spec_file = api_get("/api/content/file", {"path": f"specs/{entity_id}.md"})
@@ -1492,7 +1492,7 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
                 parent_idea = api_get(f"/api/ideas/{idea_id}") if idea_id else None
                 nav: dict[str, Any] = {"spec_file": f"specs/{entity_id}.md",
                                        "api": f"/api/spec-registry/{entity_id}",
-                                       "cli": f"cc spec {entity_id}"}
+                                       "cli": f"coh spec {entity_id}"}
                 if idea_id:
                     nav["idea_file"] = f"ideas/{idea_id}.md"
                 return {"entity_type": "spec", "spec": spec, "spec_file_content": spec_file,
@@ -1506,7 +1506,7 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
                 return {"entity_type": "task", "task": task, "events": events,
                         "parent_idea": parent_idea,
                         "navigation": {"api": f"/api/agent/tasks/{entity_id}",
-                                       "cli": f"cc task {entity_id}"}}
+                                       "cli": f"coh task {entity_id}"}}
             else:
                 return {"error": f"Unknown entity_type: {entity_type}. Use 'idea', 'spec', or 'task'."}
         # Pipeline Policies

--- a/skills/coherence-network/SKILL.md
+++ b/skills/coherence-network/SKILL.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED from SKILL.template.md. Edit the template, not this file. -->
 ---
 name: coherence-network
-description: "Coherence Network: an open intelligence platform that traces every idea from inception to payout — with fair attribution, coherence scoring, and federated trust. Works out of the box with the public API at api.coherencycoin.com (no local node required). Install the CLI with `npm i -g coherence-cli` for the fastest path. Use this skill to: browse and rank ideas by ROI and free-energy score, search feature specs with implementation summaries, trace full value lineage (idea→spec→implementation→usage→payout), inspect contributor ledgers and coherence-weighted payouts, fork and stake on ideas, explore cross-instance federation and governance voting, surface friction signals and runtime telemetry, track idea progress and showcase validated work, or pick the next highest-ROI task automatically. Triggers on: coherence network, ideas, specs, lineage, contributions, assets, traceability, trust, freedom, uniqueness, collaboration, portfolio, ROI, coherence score, fair attribution, value chain, payout, governance, federation, friction, staking, forking, resonance, showcase, cc cli, coherence cli."
+description: "Coherence Network: an open intelligence platform that traces every idea from inception to payout — with fair attribution, coherence scoring, and federated trust. Works out of the box with the public API at api.coherencycoin.com (no local node required). Install the CLI with `npm i -g coherence-cli` for the fastest path. Use this skill to: browse and rank ideas by ROI and free-energy score, search feature specs with implementation summaries, trace full value lineage (idea→spec→implementation→usage→payout), inspect contributor ledgers and coherence-weighted payouts, fork and stake on ideas, explore cross-instance federation and governance voting, surface friction signals and runtime telemetry, track idea progress and showcase validated work, or pick the next highest-ROI task automatically. Triggers on: coherence network, ideas, specs, lineage, contributions, assets, traceability, trust, freedom, uniqueness, collaboration, portfolio, ROI, coherence score, fair attribution, value chain, payout, governance, federation, friction, staking, forking, resonance, showcase, coh cli, coherence cli."
 metadata:
   {
     "openclaw":
@@ -48,31 +48,31 @@ An open intelligence platform where every contribution is traced, scored, and fa
 On first use, the skill auto-registers. No setup, no API key, no identity required to start.
 
 ```bash
-cc status
+coh status
 ```
 
-This works immediately. If `cc` is not installed yet, run `npm i -g coherence-cli` first.
+This works immediately. If `coh` is not installed yet, run `npm i -g coherence-cli` first.
 
 **Identity is optional but recommended.** To get credit for contributions:
 
 ```bash
-cc identity link github <your-github-handle>
+coh identity link github <your-github-handle>
 ```
 
 That's it. No account creation, no API key, no registration form. Your GitHub handle becomes your persistent identity across all sessions and nodes.
 
 ## OpenClaw session protocol (bidirectional messaging)
 
-OpenClaw loads this skill when a session starts. **Check the inbox before any other work** so messages from other federation nodes are not missed. Any node can send traffic with `cc msg` or structured `cc cmd`; the recipient sees it on the next inbox poll.
+OpenClaw loads this skill when a session starts. **Check the inbox before any other work** so messages from other federation nodes are not missed. Any node can send traffic with `coh msg` or structured `coh cmd`; the recipient sees it on the next inbox poll.
 
 **Start of every session (in order):**
 
-1. `cc inbox` — list messages for this node (CLI: resolves your `node_id` from hostname, then `GET /api/federation/nodes/{node_id}/messages?unread_only=false&limit=20`; unread messages are marked in the output).
-2. `cc status` — confirm API health and operational signals.
+1. `coh inbox` — list messages for this node (CLI: resolves your `node_id` from hostname, then `GET /api/federation/nodes/{node_id}/messages?unread_only=false&limit=20`; unread messages are marked in the output).
+2. `coh status` — confirm API health and operational signals.
 
 If the inbox has messages, surface them to the user and confirm before acting on them.
 
-**During / end of session:** use `cc msg`, `cc cmd`, or `POST /api/federation/nodes/{node_id}/messages` to reach peers; they will appear in the recipient’s next `cc inbox`.
+**During / end of session:** use `coh msg`, `coh cmd`, or `POST /api/federation/nodes/{node_id}/messages` to reach peers; they will appear in the recipient’s next `coh inbox`.
 
 **Roadmap:** Phase 2 — OpenClaw webhook push (requires OpenClaw gateway API). Phase 3 — real-time WebSocket bridge between CC federation and the OpenClaw gateway.
 
@@ -81,12 +81,12 @@ If the inbox has messages, surface them to the user and confirm before acting on
 ### Option A: CLI (recommended for agents)
 
 ```bash
-cc status                   # Works immediately — no setup needed
-cc ideas                    # Browse the portfolio
-cc share                    # Submit an idea
+coh status                   # Works immediately — no setup needed
+coh ideas                    # Browse the portfolio
+coh share                    # Submit an idea
 ```
 
-The `cc` command talks directly to the public API at `api.coherencycoin.com`. All commands output to stdout for easy parsing. No local server required.
+The `coh` command talks directly to the public API at `api.coherencycoin.com`. All commands output to stdout for easy parsing. No local server required.
 
 ### Option B: curl (no install needed)
 
@@ -114,11 +114,11 @@ Ideas are the atomic unit. Each is scored, ranked, and trackable through its ent
 **CLI:**
 
 ```bash
-cc ideas                    # Browse portfolio ranked by ROI
-cc idea <id>                # View idea detail with scores
-cc share                    # Submit a new idea (interactive)
-cc stake <id> <cc>          # Stake CC on an idea
-cc fork <id>                # Fork an idea
+coh ideas                    # Browse portfolio ranked by ROI
+coh idea <id>                # View idea detail with scores
+coh share                    # Submit a new idea (interactive)
+coh stake <id> <cc>          # Stake CC on an idea
+coh fork <id>                # Fork an idea
 ```
 
 **curl:**
@@ -153,8 +153,8 @@ curl -s "$CN_API/api/ideas/IDEA-ID/fork?forker_id=alice" -X POST | jq .
 **CLI:**
 
 ```bash
-cc specs                    # List specs with ROI metrics
-cc spec <id>                # View spec detail
+coh specs                    # List specs with ROI metrics
+coh spec <id>                # View spec detail
 ```
 
 **curl:**
@@ -184,13 +184,13 @@ Link any identity to attribute contributions. No registration required — just 
 **CLI:**
 
 ```bash
-cc identity                         # Show linked accounts
-cc identity setup                   # Guided onboarding
-cc identity link github alice-dev   # Link GitHub
-cc identity link discord user#1234  # Link Discord
-cc identity link ethereum 0x123...  # Link ETH address
-cc identity lookup github alice-dev # Find contributor by identity
-cc identity unlink discord          # Unlink
+coh identity                         # Show linked accounts
+coh identity setup                   # Guided onboarding
+coh identity link github alice-dev   # Link GitHub
+coh identity link discord user#1234  # Link Discord
+coh identity link ethereum 0x123...  # Link ETH address
+coh identity lookup github alice-dev # Find contributor by identity
+coh identity unlink discord          # Unlink
 ```
 
 **curl:**
@@ -223,9 +223,9 @@ curl -s "$CN_API/api/contributions/record" -X POST -H "Content-Type: application
 **CLI:**
 
 ```bash
-cc contribute                # Record any contribution (interactive)
-cc status                    # Network health + node info
-cc resonance                 # What's alive right now
+coh contribute                # Record any contribution (interactive)
+coh status                    # Network health + node info
+coh resonance                 # What's alive right now
 ```
 
 **curl:**
@@ -239,22 +239,22 @@ curl -s "$CN_API/api/assets?limit=20" | jq '.[] | {id, type, description, total_
 
 ## Tasks — agent-to-agent work protocol
 
-The task queue is the backbone of agent-to-agent coordination. Any AI agent with `cc` installed can pick up work, execute it, and report back.
+The task queue is the backbone of agent-to-agent coordination. Any AI agent with `coh` installed can pick up work, execute it, and report back.
 
 **CLI (recommended for agents):**
 
 ```bash
-cc tasks                    # List pending tasks
-cc tasks running            # List running tasks
-cc task <id>                # View task detail (direction, idea link, context)
-cc task next                # Claim the highest-priority pending task
-cc task claim <id>          # Claim a specific task
-cc task report <id> completed "All tests pass"   # Report success
-cc task report <id> failed "Missing dependency"   # Report failure
-cc task seed <idea-id> spec # Create a spec task from an idea
+coh tasks                    # List pending tasks
+coh tasks running            # List running tasks
+coh task <id>                # View task detail (direction, idea link, context)
+coh task next                # Claim the highest-priority pending task
+coh task claim <id>          # Claim a specific task
+coh task report <id> completed "All tests pass"   # Report success
+coh task report <id> failed "Missing dependency"   # Report failure
+coh task seed <idea-id> spec # Create a spec task from an idea
 ```
 
-When piped (non-TTY), `cc task next` outputs raw JSON for programmatic consumption.
+When piped (non-TTY), `coh task next` outputs raw JSON for programmatic consumption.
 
 **curl:**
 
@@ -280,11 +280,11 @@ curl -s "$CN_API/api/agent/tasks" -X POST -H "Content-Type: application/json" \
 **CLI:**
 
 ```bash
-cc nodes                          # See all federation nodes
-cc msg broadcast "Update ready"   # Broadcast to all nodes
-cc msg <node_id> "Run tests"      # Message a specific node
-cc cmd <node> diagnose            # Structured command
-cc inbox                          # Read messages
+coh nodes                          # See all federation nodes
+coh msg broadcast "Update ready"   # Broadcast to all nodes
+coh msg <node_id> "Run tests"      # Message a specific node
+coh cmd <node> diagnose            # Structured command
+coh inbox                          # Read messages
 ```
 
 **curl:**
@@ -324,7 +324,7 @@ Every part of the network links to every other. Jump in wherever makes sense.
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
 | **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
 | **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | This skill — auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |

--- a/skills/coherence-network/SKILL.template.md
+++ b/skills/coherence-network/SKILL.template.md
@@ -1,6 +1,6 @@
 ---
 name: coherence-network
-description: "Coherence Network: an open intelligence platform that traces every idea from inception to payout — with fair attribution, coherence scoring, and federated trust. Works out of the box with the public API at api.coherencycoin.com (no local node required). Install the CLI with `npm i -g coherence-cli` for the fastest path. Use this skill to: browse and rank ideas by ROI and free-energy score, search feature specs with implementation summaries, trace full value lineage (idea→spec→implementation→usage→payout), inspect contributor ledgers and coherence-weighted payouts, fork and stake on ideas, explore cross-instance federation and governance voting, surface friction signals and runtime telemetry, track idea progress and showcase validated work, or pick the next highest-ROI task automatically. Triggers on: coherence network, ideas, specs, lineage, contributions, assets, traceability, trust, freedom, uniqueness, collaboration, portfolio, ROI, coherence score, fair attribution, value chain, payout, governance, federation, friction, staking, forking, resonance, showcase, cc cli, coherence cli."
+description: "Coherence Network: an open intelligence platform that traces every idea from inception to payout — with fair attribution, coherence scoring, and federated trust. Works out of the box with the public API at api.coherencycoin.com (no local node required). Install the CLI with `npm i -g coherence-cli` for the fastest path. Use this skill to: browse and rank ideas by ROI and free-energy score, search feature specs with implementation summaries, trace full value lineage (idea→spec→implementation→usage→payout), inspect contributor ledgers and coherence-weighted payouts, fork and stake on ideas, explore cross-instance federation and governance voting, surface friction signals and runtime telemetry, track idea progress and showcase validated work, or pick the next highest-ROI task automatically. Triggers on: coherence network, ideas, specs, lineage, contributions, assets, traceability, trust, freedom, uniqueness, collaboration, portfolio, ROI, coherence score, fair attribution, value chain, payout, governance, federation, friction, staking, forking, resonance, showcase, coh cli, coherence cli."
 metadata:
   {
     "openclaw":
@@ -47,31 +47,31 @@ An open intelligence platform where every contribution is traced, scored, and fa
 On first use, the skill auto-registers. No setup, no API key, no identity required to start.
 
 ```bash
-cc status
+coh status
 ```
 
-This works immediately. If `cc` is not installed yet, run `npm i -g coherence-cli` first.
+This works immediately. If `coh` is not installed yet, run `npm i -g coherence-cli` first.
 
 **Identity is optional but recommended.** To get credit for contributions:
 
 ```bash
-cc identity link github <your-github-handle>
+coh identity link github <your-github-handle>
 ```
 
 That's it. No account creation, no API key, no registration form. Your GitHub handle becomes your persistent identity across all sessions and nodes.
 
 ## OpenClaw session protocol (bidirectional messaging)
 
-OpenClaw loads this skill when a session starts. **Check the inbox before any other work** so messages from other federation nodes are not missed. Any node can send traffic with `cc msg` or structured `cc cmd`; the recipient sees it on the next inbox poll.
+OpenClaw loads this skill when a session starts. **Check the inbox before any other work** so messages from other federation nodes are not missed. Any node can send traffic with `coh msg` or structured `coh cmd`; the recipient sees it on the next inbox poll.
 
 **Start of every session (in order):**
 
-1. `cc inbox` — list messages for this node (CLI: resolves your `node_id` from hostname, then `GET /api/federation/nodes/{node_id}/messages?unread_only=false&limit=20`; unread messages are marked in the output).
-2. `cc status` — confirm API health and operational signals.
+1. `coh inbox` — list messages for this node (CLI: resolves your `node_id` from hostname, then `GET /api/federation/nodes/{node_id}/messages?unread_only=false&limit=20`; unread messages are marked in the output).
+2. `coh status` — confirm API health and operational signals.
 
 If the inbox has messages, surface them to the user and confirm before acting on them.
 
-**During / end of session:** use `cc msg`, `cc cmd`, or `POST /api/federation/nodes/{node_id}/messages` to reach peers; they will appear in the recipient’s next `cc inbox`.
+**During / end of session:** use `coh msg`, `coh cmd`, or `POST /api/federation/nodes/{node_id}/messages` to reach peers; they will appear in the recipient’s next `coh inbox`.
 
 **Roadmap:** Phase 2 — OpenClaw webhook push (requires OpenClaw gateway API). Phase 3 — real-time WebSocket bridge between CC federation and the OpenClaw gateway.
 
@@ -80,12 +80,12 @@ If the inbox has messages, surface them to the user and confirm before acting on
 ### Option A: CLI (recommended for agents)
 
 ```bash
-cc status                   # Works immediately — no setup needed
-cc ideas                    # Browse the portfolio
-cc share                    # Submit an idea
+coh status                   # Works immediately — no setup needed
+coh ideas                    # Browse the portfolio
+coh share                    # Submit an idea
 ```
 
-The `cc` command talks directly to the public API at `api.coherencycoin.com`. All commands output to stdout for easy parsing. No local server required.
+The `coh` command talks directly to the public API at `api.coherencycoin.com`. All commands output to stdout for easy parsing. No local server required.
 
 ### Option B: curl (no install needed)
 
@@ -107,11 +107,11 @@ Ideas are the atomic unit. Each is scored, ranked, and trackable through its ent
 **CLI:**
 
 ```bash
-cc ideas                    # Browse portfolio ranked by ROI
-cc idea <id>                # View idea detail with scores
-cc share                    # Submit a new idea (interactive)
-cc stake <id> <cc>          # Stake CC on an idea
-cc fork <id>                # Fork an idea
+coh ideas                    # Browse portfolio ranked by ROI
+coh idea <id>                # View idea detail with scores
+coh share                    # Submit a new idea (interactive)
+coh stake <id> <cc>          # Stake CC on an idea
+coh fork <id>                # Fork an idea
 ```
 
 **curl:**
@@ -146,8 +146,8 @@ curl -s "$CN_API/api/ideas/IDEA-ID/fork?forker_id=alice" -X POST | jq .
 **CLI:**
 
 ```bash
-cc specs                    # List specs with ROI metrics
-cc spec <id>                # View spec detail
+coh specs                    # List specs with ROI metrics
+coh spec <id>                # View spec detail
 ```
 
 **curl:**
@@ -177,13 +177,13 @@ Link any identity to attribute contributions. No registration required — just 
 **CLI:**
 
 ```bash
-cc identity                         # Show linked accounts
-cc identity setup                   # Guided onboarding
-cc identity link github alice-dev   # Link GitHub
-cc identity link discord user#1234  # Link Discord
-cc identity link ethereum 0x123...  # Link ETH address
-cc identity lookup github alice-dev # Find contributor by identity
-cc identity unlink discord          # Unlink
+coh identity                         # Show linked accounts
+coh identity setup                   # Guided onboarding
+coh identity link github alice-dev   # Link GitHub
+coh identity link discord user#1234  # Link Discord
+coh identity link ethereum 0x123...  # Link ETH address
+coh identity lookup github alice-dev # Find contributor by identity
+coh identity unlink discord          # Unlink
 ```
 
 **curl:**
@@ -216,9 +216,9 @@ curl -s "$CN_API/api/contributions/record" -X POST -H "Content-Type: application
 **CLI:**
 
 ```bash
-cc contribute                # Record any contribution (interactive)
-cc status                    # Network health + node info
-cc resonance                 # What's alive right now
+coh contribute                # Record any contribution (interactive)
+coh status                    # Network health + node info
+coh resonance                 # What's alive right now
 ```
 
 **curl:**
@@ -232,22 +232,22 @@ curl -s "$CN_API/api/assets?limit=20" | jq '.[] | {id, type, description, total_
 
 ## Tasks — agent-to-agent work protocol
 
-The task queue is the backbone of agent-to-agent coordination. Any AI agent with `cc` installed can pick up work, execute it, and report back.
+The task queue is the backbone of agent-to-agent coordination. Any AI agent with `coh` installed can pick up work, execute it, and report back.
 
 **CLI (recommended for agents):**
 
 ```bash
-cc tasks                    # List pending tasks
-cc tasks running            # List running tasks
-cc task <id>                # View task detail (direction, idea link, context)
-cc task next                # Claim the highest-priority pending task
-cc task claim <id>          # Claim a specific task
-cc task report <id> completed "All tests pass"   # Report success
-cc task report <id> failed "Missing dependency"   # Report failure
-cc task seed <idea-id> spec # Create a spec task from an idea
+coh tasks                    # List pending tasks
+coh tasks running            # List running tasks
+coh task <id>                # View task detail (direction, idea link, context)
+coh task next                # Claim the highest-priority pending task
+coh task claim <id>          # Claim a specific task
+coh task report <id> completed "All tests pass"   # Report success
+coh task report <id> failed "Missing dependency"   # Report failure
+coh task seed <idea-id> spec # Create a spec task from an idea
 ```
 
-When piped (non-TTY), `cc task next` outputs raw JSON for programmatic consumption.
+When piped (non-TTY), `coh task next` outputs raw JSON for programmatic consumption.
 
 **curl:**
 
@@ -273,11 +273,11 @@ curl -s "$CN_API/api/agent/tasks" -X POST -H "Content-Type: application/json" \
 **CLI:**
 
 ```bash
-cc nodes                          # See all federation nodes
-cc msg broadcast "Update ready"   # Broadcast to all nodes
-cc msg <node_id> "Run tests"      # Message a specific node
-cc cmd <node> diagnose            # Structured command
-cc inbox                          # Read messages
+coh nodes                          # See all federation nodes
+coh msg broadcast "Update ready"   # Broadcast to all nodes
+coh msg <node_id> "Run tests"      # Message a specific node
+coh cmd <node> diagnose            # Structured command
+coh inbox                          # Read messages
 ```
 
 **curl:**
@@ -317,7 +317,7 @@ Every part of the network links to every other. Jump in wherever makes sense.
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
 | **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
 | **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | This skill — auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |

--- a/specs/idea-dual-identity.md
+++ b/specs/idea-dual-identity.md
@@ -105,12 +105,12 @@ The API accepts any namespace depth. Clients and the CLI display the full slug.
    via history (301-style lookup), new slug resolves directly.
 4. Rename does not break any FK: parent/child relationships still resolve.
 5. All existing `test_ideas.py` tests pass without modification.
-6. `cc idea triage` lists ideas with both UUID and slug visible.
+6. `coh idea triage` lists ideas with both UUID and slug visible.
 
 ## Known Gaps and Follow-up Tasks
 
 - **Slug search**: `GET /api/ideas?slug_prefix=finance/` — filtered listing by namespace.
-- **Slug autocomplete** in CLI: `cc idea <TAB>` resolves slugs.
+- **Slug autocomplete** in CLI: `coh idea <TAB>` resolves slugs.
 - **Structured slug enforcement**: optional future constraint that all slugs
   under a pillar super-idea share its namespace prefix.
 - **Slug registry**: a dedicated `GET /api/ideas/slugs` catalog endpoint for

--- a/specs/idea-right-sizing.md
+++ b/specs/idea-right-sizing.md
@@ -271,7 +271,7 @@ curl -s "https://api.coherencycoin.com/api/ideas/right-sizing/history?days=7" | 
 
 - **Follow-up**: Replace TF-IDF overlap with sentence-embedding similarity (e.g., via `sentence-transformers` or OpenAI embeddings) once the overlap false-positive rate is measured.
 - **Follow-up**: Surface the portfolio health badge (`82% healthy`) on the web `/ideas` page (requires web changes outside this spec's scope).
-- **Follow-up**: Add `cc ideas --right-size` CLI subcommand (requires `cc` CLI changes; this spec defines the API contract only).
+- **Follow-up**: Add `coh ideas --right-size` CLI subcommand (requires `coh` CLI changes; this spec defines the API contract only).
 - **Follow-up**: Alerting when `healthy_pct` drops > 5% week-over-week (spec 159 candidate).
 
 ## Decision Gates

--- a/specs/investment-ux-stake-cc-on-ideas.md
+++ b/specs/investment-ux-stake-cc-on-ideas.md
@@ -17,7 +17,7 @@ requirements:
   - Web invest modal shows ROI data before confirmation
   - Portfolio page renders positions with gain/loss and ROI percent
 done_when:
-  - cc invest --dry-run returns ROI projection against live API
+  - coh invest --dry-run returns ROI projection against live API
   - Web /ideas shows Invest button opening modal with ROI data
   - /portfolio/investments page renders without errors
   - pytest api/tests/test_investments.py passes
@@ -36,7 +36,7 @@ done_when:
 
 ## Problem Statement
 
-The current `cc stake <idea-id> <amount-cc>` command:
+The current `coh stake <idea-id> <amount-cc>` command:
 - Accepts a stake and creates tasks, but shows no confirmation of projected return
 - Provides no way to see what happened to staked CC after the fact
 - Has no portfolio-level view aggregating all positions
@@ -149,7 +149,7 @@ Existing stake endpoint gains:
 ```json
 { "dry_run": true }
 ```
-When `dry_run: true`, returns the same projection as `invest-preview` without recording the stake. Enables `cc invest --dry-run`.
+When `dry_run: true`, returns the same projection as `invest-preview` without recording the stake. Enables `coh invest --dry-run`.
 
 ## Files to Create/Modify
 
@@ -226,7 +226,7 @@ curl -s -X POST https://api.coherencycoin.com/api/contributors/carol/pledges/<pl
 
 The feature is considered realized when all five items below can be independently verified:
 
-1. **CLI dry-run** — `cc invest <any-idea-id> 1 --dry-run` returns a ROI projection (not an error) against the live API at `https://api.coherencycoin.com`
+1. **CLI dry-run** — `coh invest <any-idea-id> 1 --dry-run` returns a ROI projection (not an error) against the live API at `https://api.coherencycoin.com`
 2. **Web modal** — `https://coherencycoin.com/ideas` shows an "Invest" button on at least one idea card; clicking it opens a modal with ROI data
 3. **Portfolio page** — `https://coherencycoin.com/portfolio/investments` renders without 404/500 for any signed-in contributor
 4. **History API** — `GET https://api.coherencycoin.com/api/contributors/{id}/investment-history` returns valid JSON with `events` array

--- a/specs/meta-self-discovery.md
+++ b/specs/meta-self-discovery.md
@@ -130,7 +130,7 @@ Summary of traceability coverage across the entire system.
 
 ## CLI Commands
 
-### `cc meta endpoints`
+### `coh meta endpoints`
 
 Lists all endpoints in table format:
 
@@ -143,7 +143,7 @@ GET     /api/audit                   -        -                 ✗
 Total: 142 endpoints, 38 traced (26.8%)
 ```
 
-### `cc meta module <name>`
+### `coh meta module <name>`
 
 Shows a single module's endpoints and their trace status:
 
@@ -183,7 +183,7 @@ CLI commands are implemented as MCP tool handlers in `api/mcp_server.py` using t
 
 ### Phase 3 — CLI (follow-up spec)
 
-9. CLI `cc meta` commands via MCP or standalone handler.
+9. CLI `coh meta` commands via MCP or standalone handler.
 
 ## Verification Scenarios
 
@@ -258,7 +258,7 @@ Returns `0` — untraced endpoints must have `null` for spec_id and idea_id.
 1. **Test registry integration** — `has_test` field requires a test-coverage registry. Spec TBD.
 2. **Usage telemetry wiring** — `recent_calls` per endpoint requires API request logging. Spec TBD.
 3. **Web `/meta` page** — Phase 2 follow-up spec (interactive system map).
-4. **CLI `cc meta` commands** — Phase 3 follow-up spec.
+4. **CLI `coh meta` commands** — Phase 3 follow-up spec.
 5. **Neo4j graph projection** — Store `MetaEndpointNode` as graph nodes for traversal. Phase 4.
 6. **Contributor attribution** — Wire endpoint authorship from git blame / contribution records. Phase 4.
 7. **Periodic coverage report** — Emit coverage snapshot to `runtime_events` table nightly. Phase 3.

--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -61,8 +61,8 @@ done_when:
   - "A contributor can submit a contribution in Spanish; an English viewer sees it translated; a Bahasa viewer sees it in Bahasa"
   - "Any signed-in contributor can submit a human translation via POST /api/translations; it replaces the machine version immediately"
   - "Editing a source story flags every language row for that entity as stale (machine AND human preserved — never silently discarded)"
-  - "cc stories --lang de returns stories with translated titles and summaries"
-  - "cc translate submit {entity-id} --lang es --file translation.md posts a human translation"
+  - "coh stories --lang de returns stories with translated titles and summaries"
+  - "coh translate submit {entity-id} --lang es --file translation.md posts a human translation"
   - "Locale coverage visible on /settings/translations: per-locale counts of machine vs. human vs. stale"
   - "All new and existing tests pass (api and web)"
 test: "cd api && python -m pytest tests/test_locale.py tests/test_translation_cache.py -q && cd ../web && npm run test"
@@ -98,7 +98,7 @@ The platform's mission names "every idea tracked, for humanity" — but a single
 - [ ] **R11**: "Needs native review" banner appears on any machine-translated surface for users whose profile locale matches. A "Propose a better translation" action opens an inline editor that submits via R9. No approval gate.
 - [ ] **R12**: `GET /api/locales` returns supported locales with coverage stats per locale: total entities, machine-translated, human-translated, stale.
 - [ ] **R13**: Per-entity translation history: `GET /api/translations?entity_type=concept&entity_id=lc-xxx&lang=es` lists every translation row for that entity+lang, newest first. The edit page shows this so a new translator sees prior attempts.
-- [ ] **R14**: CLI additions: `cc stories --lang de`, `cc translate show {id} --lang es`, `cc translate submit {id} --lang es --file t.md`, `cc glossary --lang id`.
+- [ ] **R14**: CLI additions: `coh stories --lang de`, `coh translate show {id} --lang es`, `coh translate submit {id} --lang es --file t.md`, `coh glossary --lang id`.
 
 ## Research Inputs
 
@@ -295,7 +295,7 @@ Manual: visit `/de/vision/lc-water-as-living-body`, confirm German chrome and tr
 
 **Confirmed during this session** (each a discrete commit in the trail):
 - `POST /api/translations` endpoint + `GET` history — human/machine supersede semantics exposed
-- `cc translate submit <entity_type> <entity_id> --lang <l> --file <path>` and `cc translate history` CLI
+- `coh translate submit <entity_type> <entity_id> --lang <l> --file <path>` and `coh translate history` CLI
 - Anchor glossary seeded for `es` and `id` (matching the existing `de` pattern); 15 anchor terms per language
 - `/settings/translations` coverage dashboard — per-locale `original/human/machine/stale` tallies from `GET /api/locales`, linked from `/settings`
 - Language picker in site header — `LocaleSwitcherCompact` wired at `web/components/site_header.tsx` (desktop and mobile menu); cookie-backed, ?lang= override, Accept-Language auto-detection all in `web/middleware.ts`

--- a/web/app/graph/page.tsx
+++ b/web/app/graph/page.tsx
@@ -129,8 +129,8 @@ export default async function GraphPage({
           <code className="bg-gray-800 px-1 rounded">/api/edges</code>,{" "}
           <code className="bg-gray-800 px-1 rounded">/api/edges/types</code>, or{" "}
           <code className="bg-gray-800 px-1 rounded">/api/entities/&#123;id&#125;/edges</code>.
-          CLI: <code className="bg-gray-800 px-1 rounded">cc edges &lt;id&gt;</code>{" "}
-          (alias: <code className="bg-gray-800 px-1 rounded">cc edg &lt;id&gt;</code>)
+          CLI: <code className="bg-gray-800 px-1 rounded">coh edges &lt;id&gt;</code>{" "}
+          (alias: <code className="bg-gray-800 px-1 rounded">coh edg &lt;id&gt;</code>)
         </p>
       </div>
 

--- a/workspaces/coherence-network/guides/onboarding.md
+++ b/workspaces/coherence-network/guides/onboarding.md
@@ -12,12 +12,12 @@ Welcome. This workspace runs the Coherence Network platform itself.
 ## CLI tour
 
 ```bash
-cc idea list                 # 16 curated super-ideas
-cc idea list --all           # every idea (325+)
-cc idea agent-pipeline       # a specific idea
-cc spec list                 # all specs
-cc tasks --status pending    # work waiting for an agent
-cc status                    # pipeline health
+coh idea list                 # 16 curated super-ideas
+coh idea list --all           # every idea (325+)
+coh idea agent-pipeline       # a specific idea
+coh spec list                 # all specs
+coh tasks --status pending    # work waiting for an agent
+coh status                    # pipeline health
 ```
 
 ## Anatomy of a spec

--- a/workspaces/coherence-network/templates/task.md
+++ b/workspaces/coherence-network/templates/task.md
@@ -1,6 +1,6 @@
 # Task template — Coherence Network workspace
 
-Tasks are created via `cc task seed {idea_id}` or the pipeline orchestrator.
+Tasks are created via `coh task seed {idea_id}` or the pipeline orchestrator.
 They are not authored by hand. This file documents the fields the orchestrator
 populates so humans understand what an agent sees.
 


### PR DESCRIPTION
After PR #1185 landed the binary rename, 582 `cc <command>` references remained scattered across docs, CLI help strings, agent prompts, MCP server output, and skill templates. Those examples all worked before — now they're sediment pointing at a binary that no longer exists.

This sweep walks the whole tree and updates every CLI invocation reference to `coh`, preserving non-CLI uses.

## What moved (80 files, 582 edits each way)

**Docs**: README.md + template (root), `EXTERNAL_ENABLEMENT_TRACKING`, `PIPELINE_DESIGN`, `RUNBOOK`, `WORKER-SERVICE`, `shared/ecosystem-table`, `shared/cli-commands`.

**Skills**: `skills/coherence-network/SKILL.md` + template.

**Agent prompts**: `api/scripts/local_runner.py` (6 prompt strings for deploy/verify/reflect/circuit-breaker/identity hints), `api/scripts/task_control_channel.py` (control channel instructions agents receive every task).

**API user-facing**: `auth_keys.py` onboarding welcome + no-key messages.

**MCP server**: 3 `navigation.cli` fields in `coherence_mcp_server/server.py` (idea/spec/task lookups).

**CLI**: 55 files under `cli/lib/commands/**.mjs` + `cli/bin/coh.mjs` + `cli/lib/api.mjs` — all `Usage:`, help, and comment lines. Bulk-updated via surgical regex that preserves local variable names.

**Specs**: `idea-dual-identity`, `investment-ux-stake-cc-on-ideas`, `meta-self-discovery`, `idea-right-sizing`, `multilingual-web`, `node-task-visibility`, `user-surfaces`.

**Also**: `.claude/agents/dev-engineer.md`, `workspaces/coherence-network/guides/onboarding.md` + `templates/task.md`, `web/app/graph/page.tsx`.

## Preserved (not CLI binary references)

- Python local variables — `cc = float(...)`, `for idea_id, cc in ...`.
- JS local variables — `const cc = amount + " CC"` in contributors.mjs.
- `--cc 5` flag for the CC amount.
- `/cc` web route + its e2e test.
- `scripts/cc.py` — unrelated predecessor Python CLI (no readers; separate compost question).

The regex used for bulk updates: `(?<![A-Za-z0-9_\-])(?<!const )(?<!let )(?<!var )cc(?= [a-z<])` — matches `cc` followed by a lowercase command letter or `<` placeholder, preceded by nothing or by a word boundary, but never by `const`/`let`/`var`.

## Verified

- `node --check cli/bin/coh.mjs` — syntax OK.
- `make wellness` — four senses clean.
- Final grep sweep: only legitimate non-CLI `cc` refs remain.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_