### PR TITLE
tend: cap auto-retry direction under OVERSIZED_DIRECTION gate

### DIFF
--- a/api/app/services/pipeline_advance_service.py
+++ b/api/app/services/pipeline_advance_service.py
@@ -781,7 +781,27 @@ def maybe_retry(task: dict[str, Any]) -> dict[str, Any] | None:
     failed_provider = task.get("model", "") or context.get("provider", "")
     partial_work = _extract_partial_work(task)
 
+    # DG-002 cap: API rejects directions >3000 chars (OVERSIZED_DIRECTION gate
+    # in agent_service_crud.py). Budget the retry direction so the sum of
+    # original + partial_work + failure_memory stays under 2900, leaving
+    # margin for safety. Keep failure_memory intact (it's small, ≤800, and
+    # highest signal), then truncate partial_work, then original direction.
+    _MAX_RETRY_DIRECTION = 2900
+    failure_memory = _build_failure_memory(idea_id, task_type)
+
     if partial_work:
+        # Reserve space: original direction + framing overhead + failure_memory
+        framing_overhead = 200  # "--- PARTIAL WORK ---" blocks + newlines
+        failure_budget = len(failure_memory) + 2 if failure_memory else 0
+        original_budget = min(len(direction), 1400)
+        partial_budget = max(
+            200,
+            _MAX_RETRY_DIRECTION - original_budget - framing_overhead - failure_budget,
+        )
+        if len(direction) > original_budget:
+            direction = direction[:original_budget] + "\n…[direction truncated]"
+        if len(partial_work) > partial_budget:
+            partial_work = partial_work[:partial_budget] + "\n…[partial work truncated]"
         direction = (
             f"{direction}\n\n"
             f"--- PARTIAL WORK FROM PREVIOUS ATTEMPT ---\n"
@@ -793,9 +813,16 @@ def maybe_retry(task: dict[str, Any]) -> dict[str, Any] | None:
 
     # AutoAgent-inspired: inject failure pattern memory so retries learn
     # from past mistakes instead of blindly repeating them.
-    failure_memory = _build_failure_memory(idea_id, task_type)
     if failure_memory:
         direction = f"{direction}\n\n{failure_memory}"
+
+    # Final safety cap — any path above must still respect the gate.
+    if len(direction) > _MAX_RETRY_DIRECTION:
+        log.warning(
+            "AUTO_RETRY direction %d chars exceeds cap %d for idea=%s phase=%s — hard truncating",
+            len(direction), _MAX_RETRY_DIRECTION, idea_id, task_type,
+        )
+        direction = direction[:_MAX_RETRY_DIRECTION] + "\n…[retry direction truncated]"
 
     task_type_enum = _PHASE_TASK_TYPE.get(task_type, TaskType.IMPL)
 

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -460,6 +460,61 @@ class TestAutoAdvanceFingerprint:
         ctx = created_tasks[0]["context"]
         assert ctx["task_fingerprint"] == "idea-fp:impl:auto"
 
+    def test_retry_caps_oversized_direction(self, monkeypatch):
+        """maybe_retry truncates direction+partial_work so the new task stays
+        under the 3000-char OVERSIZED_DIRECTION gate (DG-002).
+
+        Regression: before this cap, a 2900-char original direction + 5000-char
+        git-diff partial + 800-char failure memory produced ~8700-char retry
+        directions that the API rejected to needs_decision, piling up sediment.
+        """
+        from app.services import pipeline_advance_service as pas
+        from app.services.task_dedup_service import IdeaPhaseHistory
+
+        # Original direction at the seed-time cap (2900 chars)
+        original = "x" * 2900
+        # Partial work from huge git diff (up to 5000 chars)
+        huge_diff = "diff --git a/f\n" + ("+line\n" * 1000)
+        task = _task(
+            task_type="impl",
+            status="timed_out",
+            idea_id="idea-oversized",
+            extra_context={"diff_content": huge_diff},
+        )
+        task["direction"] = original
+
+        monkeypatch.setattr(
+            "app.services.task_dedup_service.check_idea_phase_history",
+            lambda idea_id, phase: IdeaPhaseHistory(failed_count=1),
+        )
+        # Max-size failure memory to stress the budget
+        monkeypatch.setattr(pas, "_build_failure_memory", lambda *_a, **_k: "f" * 800)
+
+        captured: list[dict] = []
+
+        def fake_create(data):
+            captured.append({"direction": data.direction, "context": data.context})
+            return {"id": "t-capped", "task_type": "impl", "status": "pending",
+                    "context": data.context}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "create_task", fake_create)
+        monkeypatch.setattr(_as, "list_tasks", lambda **_k: ([], 0, 0))
+
+        result = pas.maybe_retry(task)
+        assert result is not None
+        assert len(captured) == 1
+        retry_direction = captured[0]["direction"]
+        # Must stay under the API gate
+        assert len(retry_direction) <= 3000, (
+            f"retry direction is {len(retry_direction)} chars — "
+            f"OVERSIZED_DIRECTION gate would reject it"
+        )
+        # Partial-work framing must survive the truncation
+        assert "PARTIAL WORK FROM PREVIOUS ATTEMPT" in retry_direction
+        # Failure memory must survive (it's smallest, highest-signal)
+        assert "f" * 100 in retry_direction
+
     def test_retry_sets_fingerprint(self, monkeypatch):
         """maybe_retry creates task with deterministic fingerprint (R8)."""
         from app.services import pipeline_advance_service as pas


### PR DESCRIPTION
## Summary
- `maybe_retry` in `pipeline_advance_service.py` appended partial work (up to 5000-char git diff) + failure memory (up to 800 chars) to the already-seed-capped 2900-char original direction. Sum blew past the API's 3000-char OVERSIZED_DIRECTION gate, routing retries to `needs_decision` and piling up sediment (~70 tasks at peak).
- Budget the assembled retry direction to 2900 chars: original gets up to 1400, `failure_memory` stays intact (highest signal, smallest), `partial_work` consumes the remainder with a 200-char floor. Final hard cap catches any edge case.
- Regression test in `TestAutoAdvanceFingerprint::test_retry_caps_oversized_direction` covers worst-case inputs (2900 original + 5000 diff + 800 memory).

## Test plan
- [x] `pytest tests/test_task_dedup_service.py tests/test_flow_enforcement.py` — 25 passed
- [ ] After merge + deploy: verify seeded retry tasks show `direction` length ≤ 3000 and no new `OVERSIZED_DIRECTION` entries in `needs_decision`
- [ ] Compost remaining 70 pre-fix oversized tasks to `timed_out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)