### PR TITLE
Audit vision image candidates

### DIFF
--- a/api/tests/test_audit_vision_image_candidates.py
+++ b/api/tests/test_audit_vision_image_candidates.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = ROOT / "scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import audit_vision_image_candidates as audit_candidates  # noqa: E402
+
+
+def _write_png(path: Path, width: int, height: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + struct.pack(">I", 13)
+        + b"IHDR"
+        + struct.pack(">II", width, height)
+        + b"\x08\x02\x00\x00\x00"
+        + b"\x00\x00\x00\x00"
+        + b"padding" * 20
+    )
+
+
+def test_audit_records_reports_present_candidate(tmp_path: Path) -> None:
+    candidate_dir = tmp_path / "candidates"
+    rel_path = "web/public/visuals/generated/lc-space-0.jpg"
+    candidate = candidate_dir / rel_path
+    _write_png(candidate, 512, 384)
+
+    report = audit_candidates.audit_records(
+        [{"id": "lc-space-0", "path": rel_path, "prompt": "living space"}],
+        candidate_dir,
+        profile_id="fast-sample-v1",
+        min_bytes=64,
+    )
+
+    assert report["summary"] == {
+        "total": 1,
+        "present": 1,
+        "missing": 0,
+        "too_small": 0,
+        "unreadable_dimensions": 0,
+        "pass": True,
+    }
+    item = report["items"][0]
+    assert item["width"] == 512
+    assert item["height"] == 384
+    assert item["profile"] == "fast-sample-v1"
+    assert item["passes_min_bytes"] is True
+    assert item["passes_dimensions"] is True
+
+
+def test_audit_records_reports_missing_candidate(tmp_path: Path) -> None:
+    report = audit_candidates.audit_records(
+        [{"id": "lc-space-0", "path": "web/public/visuals/generated/lc-space-0.jpg", "prompt": "living space"}],
+        tmp_path / "candidates",
+        profile_id="fast-sample-v1",
+        min_bytes=64,
+    )
+
+    assert report["summary"]["present"] == 0
+    assert report["summary"]["missing"] == 1
+    assert report["summary"]["pass"] is False
+    assert report["items"][0]["exists"] is False
+
+
+def test_select_records_matches_mirror_path() -> None:
+    records = [
+        {
+            "id": "life-morning-circle",
+            "path": "docs/visuals/life-morning-circle.png",
+            "mirror_paths": ["web/public/visuals/life-morning-circle.png"],
+        }
+    ]
+
+    selected = audit_candidates._select_records(
+        records,
+        "web/public/visuals/life-morning-circle.png",
+    )
+
+    assert selected == records

--- a/docs/system_audit/commit_evidence_2026-04-25_vision-candidate-audit.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_vision-candidate-audit.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/vision-candidate-audit-20260425",
+  "commit_scope": "Add an audit step for regenerated vision image candidates before production promotion.",
+  "files_owned": [
+    "api/tests/test_audit_vision_image_candidates.py",
+    "docs/system_audit/commit_evidence_2026-04-25_vision-candidate-audit.json",
+    "scripts/audit_vision_image_candidates.py",
+    "specs/vision-image-prompt-manifest.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_audit_vision_image_candidates.py tests/test_generate_visuals_manifest.py tests/test_check_generated_vision_assets.py",
+      "ruff check scripts/audit_vision_image_candidates.py api/tests/test_audit_vision_image_candidates.py",
+      "python3 -m py_compile scripts/audit_vision_image_candidates.py",
+      "python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --force",
+      "python3 scripts/audit_vision_image_candidates.py --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --min-bytes 1000",
+      "python3 scripts/check_generated_vision_assets.py --allow-untracked",
+      "python3 -m py_compile scripts/audit_vision_image_candidates.py scripts/generate_visuals.py scripts/plan_vision_image_regeneration.py scripts/check_generated_vision_assets.py scripts/export_vision_image_prompts.py",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Focused tests: 7 passed, 1 pytest config warning. Sample candidate generated at output/vision-quality/candidates/web/public/visuals/generated/lc-space-0.jpg, 73892 bytes, 512x512. Candidate audit passed with present=1, missing=0, too_small=0, unreadable_dimensions=0. Local PR guard passed with ready_for_push=True. Follow-through check passed with stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local candidate generation, audit validation, and pre-push guard pass; PR CI and public deploy validation pending."
+  },
+  "idea_ids": [
+    "living-collective-vision",
+    "vision-image-regeneration"
+  ],
+  "spec_ids": [
+    "vision-image-prompt-manifest"
+  ],
+  "task_ids": [
+    "vision-candidate-audit-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "quality-bar"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "sample candidate generation: OK (72KB)",
+    "candidate audit summary: pass=True, present=1, missing=0",
+    "candidate dimensions: 512x512",
+    "candidate output removed before commit to keep production assets unchanged",
+    "local guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T215708Z_codex-vision-candidate-audit-20260425.json",
+    "follow-through check: codex_open_prs=0, stale_codex_prs=0"
+  ],
+  "change_files": [
+    "api/tests/test_audit_vision_image_candidates.py",
+    "scripts/audit_vision_image_candidates.py",
+    "specs/vision-image-prompt-manifest.md"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Operators can ingest regenerated candidate images into an audit report with existence, size, dimensions, hashes, and prompt/profile provenance before promotion.",
+    "public_endpoints": [
+      "https://coherencycoin.com/vision"
+    ],
+    "test_flows": [
+      "Run public deploy verifier after merge.",
+      "Sense pulse and pipeline status after deploy."
+    ]
+  }
+}

--- a/scripts/audit_vision_image_candidates.py
+++ b/scripts/audit_vision_image_candidates.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Audit regenerated vision image candidates before production promotion."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "docs" / "visuals" / "prompts.json"
+DEFAULT_CANDIDATE_DIR = REPO_ROOT / "output" / "vision-quality" / "candidates"
+DEFAULT_REPORT = REPO_ROOT / "output" / "vision-quality" / "candidate-audit.json"
+DEFAULT_MIN_BYTES = 8_000
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _rel(path: Path) -> str:
+    resolved = path if path.is_absolute() else REPO_ROOT / path
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def _records_from_manifest(path: Path) -> list[dict[str, Any]]:
+    payload = _load_json(path)
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError(f"manifest has no records list: {_rel(path)}")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _records_from_batch(path: Path) -> list[dict[str, Any]]:
+    payload = _load_json(path)
+    records = payload.get("records")
+    if not isinstance(records, list):
+        raise ValueError(f"batch has no records list: {_rel(path)}")
+    return [record for record in records if isinstance(record, dict)]
+
+
+def _select_records(records: list[dict[str, Any]], only_path: str | None) -> list[dict[str, Any]]:
+    if not only_path:
+        return records
+    selected: list[dict[str, Any]] = []
+    for record in records:
+        aliases = [
+            str(record.get("id") or ""),
+            str(record.get("path") or ""),
+            *[str(path) for path in record.get("mirror_paths") or []],
+        ]
+        if only_path in aliases:
+            selected.append(record)
+    return selected
+
+
+def _candidate_path(record: dict[str, Any], candidate_dir: Path) -> Path:
+    base = candidate_dir if candidate_dir.is_absolute() else REPO_ROOT / candidate_dir
+    return base / str(record.get("path") or "")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _png_dimensions(raw: bytes) -> tuple[int, int] | None:
+    if raw[:8] != b"\x89PNG\r\n\x1a\n" or len(raw) < 24:
+        return None
+    width, height = struct.unpack(">II", raw[16:24])
+    return int(width), int(height)
+
+
+def _jpeg_dimensions(raw: bytes) -> tuple[int, int] | None:
+    if raw[:2] != b"\xff\xd8":
+        return None
+    index = 2
+    while index + 9 < len(raw):
+        if raw[index] != 0xFF:
+            index += 1
+            continue
+        marker = raw[index + 1]
+        index += 2
+        if marker in {0xD8, 0xD9}:
+            continue
+        if index + 2 > len(raw):
+            return None
+        segment_length = int.from_bytes(raw[index : index + 2], "big")
+        if segment_length < 2 or index + segment_length > len(raw):
+            return None
+        if 0xC0 <= marker <= 0xC3 and segment_length >= 7:
+            height = int.from_bytes(raw[index + 3 : index + 5], "big")
+            width = int.from_bytes(raw[index + 5 : index + 7], "big")
+            return width, height
+        index += segment_length
+    return None
+
+
+def image_dimensions(path: Path) -> tuple[int, int] | None:
+    raw = path.read_bytes()
+    return _png_dimensions(raw) or _jpeg_dimensions(raw)
+
+
+def audit_records(
+    records: list[dict[str, Any]],
+    candidate_dir: Path,
+    *,
+    profile_id: str | None,
+    min_bytes: int,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    missing = 0
+    too_small = 0
+    unreadable_dimensions = 0
+
+    for record in records:
+        candidate = _candidate_path(record, candidate_dir)
+        item: dict[str, Any] = {
+            "id": record.get("id"),
+            "source_path": record.get("path"),
+            "candidate_path": _rel(candidate),
+            "profile": profile_id,
+            "prompt_sha256": hashlib.sha256(
+                str(record.get("prompt") or "").encode("utf-8")
+            ).hexdigest(),
+            "exists": candidate.exists(),
+        }
+        if not candidate.exists():
+            missing += 1
+            items.append(item)
+            continue
+
+        size_bytes = candidate.stat().st_size
+        dims = image_dimensions(candidate)
+        item["size_bytes"] = size_bytes
+        item["sha256"] = _sha256(candidate)
+        item["width"] = dims[0] if dims else None
+        item["height"] = dims[1] if dims else None
+        item["passes_min_bytes"] = size_bytes >= min_bytes
+        item["passes_dimensions"] = dims is not None
+        if size_bytes < min_bytes:
+            too_small += 1
+        if dims is None:
+            unreadable_dimensions += 1
+        items.append(item)
+
+    fail_count = missing + too_small + unreadable_dimensions
+    return {
+        "schema_version": 1,
+        "candidate_dir": _rel(candidate_dir),
+        "profile": profile_id,
+        "min_bytes": min_bytes,
+        "summary": {
+            "total": len(records),
+            "present": len(records) - missing,
+            "missing": missing,
+            "too_small": too_small,
+            "unreadable_dimensions": unreadable_dimensions,
+            "pass": fail_count == 0,
+        },
+        "items": items,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit regenerated vision image candidates")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--batch-file", type=Path)
+    parser.add_argument("--candidate-dir", type=Path, default=DEFAULT_CANDIDATE_DIR)
+    parser.add_argument("--only-path")
+    parser.add_argument("--profile")
+    parser.add_argument("--min-bytes", type=int, default=DEFAULT_MIN_BYTES)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--allow-missing", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        records = _records_from_batch(args.batch_file) if args.batch_file else _records_from_manifest(args.manifest)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    records = _select_records(records, args.only_path)
+    if args.only_path and not records:
+        print(f"No manifest record matched: {args.only_path}", file=sys.stderr)
+        return 1
+
+    report = audit_records(
+        records,
+        args.candidate_dir,
+        profile_id=args.profile,
+        min_bytes=args.min_bytes,
+    )
+    report_path = args.report if args.report.is_absolute() else REPO_ROOT / args.report
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    summary = report["summary"]
+    print(
+        "Vision candidate audit: "
+        f"{summary['present']}/{summary['total']} present, "
+        f"missing={summary['missing']}, too_small={summary['too_small']}, "
+        f"unreadable_dimensions={summary['unreadable_dimensions']} -> {_rel(report_path)}"
+    )
+    if args.allow_missing and summary["missing"] and not summary["too_small"] and not summary["unreadable_dimensions"]:
+        return 0
+    return 0 if summary["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/vision-image-prompt-manifest.md
+++ b/specs/vision-image-prompt-manifest.md
@@ -8,11 +8,14 @@ source:
     symbols: [dynamic prompt profiles]
   - file: scripts/generate_visuals.py
     symbols: [generate_from_manifest(), compose_manifest_prompt()]
+  - file: scripts/audit_vision_image_candidates.py
+    symbols: [audit_records()]
 requirements:
   - "Every current Living Collective vision image has a persistent prompt record."
   - "Prompt validation fails when an image lacks a prompt record or has an empty prompt."
   - "Regeneration can target one stable image path or deterministic prompt batch."
   - "Regeneration can write review candidates under a separate output directory before production assets are replaced."
+  - "Candidate image batches can be audited for existence, size, dimensions, and prompt/profile provenance before promotion."
 done_when:
   - "Prompt manifest covers all current vision images."
   - "Asset validation includes prompt-record coverage."
@@ -43,6 +46,7 @@ Living Collective vision images must be regenerable from source-controlled promp
 - `scripts/export_vision_image_prompts.py` — migration/audit exporter for prompt records.
 - `scripts/check_generated_vision_assets.py` — asset and prompt-record validation.
 - `scripts/generate_visuals.py` — manifest-driven regeneration mode.
+- `scripts/audit_vision_image_candidates.py` — candidate-output audit before production promotion.
 - `scripts/plan_vision_image_regeneration.py` — deterministic batch planner.
 - `specs/vision-image-prompt-manifest.md` — this spec.
 
@@ -52,6 +56,7 @@ Living Collective vision images must be regenerable from source-controlled promp
 - `python3 scripts/check_generated_vision_assets.py --allow-untracked` passes and reports prompt-record validation.
 - `python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --dry-run --force` targets one stable image from the manifest.
 - `python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force` targets one stable candidate path with a dynamic profile.
+- `python3 scripts/audit_vision_image_candidates.py --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --allow-missing` writes a candidate audit report.
 - `python3 scripts/plan_vision_image_regeneration.py --batch-size 50 --out-dir output/vision-quality/batches` writes deterministic batch files.
 
 ## Verification
@@ -61,8 +66,9 @@ python3 scripts/export_vision_image_prompts.py
 python3 scripts/check_generated_vision_assets.py --allow-untracked
 python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --dry-run --force
 python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --dry-run --force
+python3 scripts/audit_vision_image_candidates.py --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --allow-missing
 python3 scripts/plan_vision_image_regeneration.py --batch-size 50 --out-dir output/vision-quality/batches
-python3 -m py_compile scripts/export_vision_image_prompts.py scripts/plan_vision_image_regeneration.py scripts/generate_visuals.py scripts/check_generated_vision_assets.py
+python3 -m py_compile scripts/export_vision_image_prompts.py scripts/plan_vision_image_regeneration.py scripts/generate_visuals.py scripts/check_generated_vision_assets.py scripts/audit_vision_image_candidates.py
 ```
 
 ## Out of Scope


### PR DESCRIPTION
## Summary
- add candidate audit script for regenerated vision images
- report candidate existence, size, dimensions, hashes, and prompt/profile provenance
- document the candidate audit step in the vision prompt manifest spec

## Validation
- make prompt-gate
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -v tests/test_audit_vision_image_candidates.py tests/test_generate_visuals_manifest.py tests/test_check_generated_vision_assets.py
- ruff check scripts/audit_vision_image_candidates.py api/tests/test_audit_vision_image_candidates.py
- python3 scripts/generate_visuals.py --from-manifest --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --out-dir output/vision-quality/candidates --force
- python3 scripts/audit_vision_image_candidates.py --only-path web/public/visuals/generated/lc-space-0.jpg --profile fast-sample-v1 --min-bytes 1000
- python3 scripts/check_generated_vision_assets.py --allow-untracked
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence