### PR TITLE
tend: hydrate retry task cards

### DIFF
--- a/api/app/services/agent_routing/prompt_templates_loader.py
+++ b/api/app/services/agent_routing/prompt_templates_loader.py
@@ -291,6 +291,9 @@ def build_default_task_card_context(
             ctx[field] = formatted
 
     if card:
+        for field in ("goal", "files_allowed", "done_when", "commands", "constraints"):
+            if field in card and card.get(field) and not ctx.get(field):
+                ctx[field] = card[field]
         ctx["task_card"] = card
         ctx.setdefault("task_card_autofill", {"source": "prompt_templates", "version": data.get("config_version", "")})
     return ctx

--- a/api/app/services/pipeline_advance_service.py
+++ b/api/app/services/pipeline_advance_service.py
@@ -151,6 +151,40 @@ _PHASE_TASK_TYPE: dict[str, TaskType] = {
     "reflect": TaskType.REFLECT,         # Hermes Learning Loop: reflect phase task type
 }
 
+_TASK_CARD_CONTEXT_KEYS = (
+    "goal",
+    "files_allowed",
+    "done_when",
+    "commands",
+    "constraints",
+    "task_card",
+    "spec_path",
+    "spec_file",
+    "spec_id",
+    "idea_name",
+)
+
+
+def _with_task_card_context(
+    *,
+    source_task: dict[str, Any],
+    task_type: TaskType,
+    direction: str,
+    context: dict[str, Any],
+) -> dict[str, Any]:
+    """Carry source task-card shape and fill configured defaults for follow-up tasks."""
+    next_context = dict(context)
+    source_context = source_task.get("context") if isinstance(source_task.get("context"), dict) else {}
+    for key in _TASK_CARD_CONTEXT_KEYS:
+        value = source_context.get(key)
+        if value and not next_context.get(key):
+            next_context[key] = value
+    try:
+        from app.services.agent_routing.prompt_templates_loader import build_default_task_card_context
+        return build_default_task_card_context(task_type, direction, next_context)
+    except Exception:
+        return next_context
+
 # Minimum output length to consider a task genuinely completed.
 # Text-only providers (openrouter/free) often claim completion with 0 output.
 def _min_output_chars_map() -> dict[str, int]:
@@ -852,6 +886,12 @@ def maybe_retry(task: dict[str, Any]) -> dict[str, Any] | None:
             retry_context["executor"] = phase_pref
     except Exception:
         pass
+    retry_context = _with_task_card_context(
+        source_task=task,
+        task_type=task_type_enum,
+        direction=direction,
+        context=retry_context,
+    )
 
     try:
         created = agent_service.create_task(AgentTaskCreate(
@@ -980,20 +1020,28 @@ def _escalate_or_autofix(
             original_direction = task.get("direction", "")
             # Take just the first paragraph as the focused direction
             simplified = original_direction.split("\n\n")[0][:500]
+            followup_direction = (
+                f"{simplified}\n\n"
+                f"Keep the scope minimal — implement only the core requirement. "
+                f"Skip optional features. This is a simplified retry after timeout."
+            )
+            followup_task_type = _PHASE_TASK_TYPE.get(task_type, TaskType.IMPL)
+            followup_context = _with_task_card_context(
+                source_task=task,
+                task_type=followup_task_type,
+                direction=followup_direction,
+                context={
+                    "idea_id": idea_id,
+                    "auto_fix": "split",
+                    "original_task_id": task.get("id", ""),
+                    "retry_count": 0,  # Fresh retry count for the simplified version
+                },
+            )
             try:
                 created = agent_service.create_task(AgentTaskCreate(
-                    direction=(
-                        f"{simplified}\n\n"
-                        f"Keep the scope minimal — implement only the core requirement. "
-                        f"Skip optional features. This is a simplified retry after timeout."
-                    ),
-                    task_type=_PHASE_TASK_TYPE.get(task_type, TaskType.IMPL),
-                    context={
-                        "idea_id": idea_id,
-                        "auto_fix": "split",
-                        "original_task_id": task.get("id", ""),
-                        "retry_count": 0,  # Fresh retry count for the simplified version
-                    },
+                    direction=followup_direction,
+                    task_type=followup_task_type,
+                    context=followup_context,
                 ))
                 log.info("AUTO_FIX split task=%s → simplified task=%s", task.get("id", "?"), created.get("id", "?"))
                 return
@@ -1002,23 +1050,30 @@ def _escalate_or_autofix(
 
         elif action == "respec":
             # Create a new spec task that's more specific
+            followup_direction = (
+                f"Write a more detailed spec for '{idea_name}' ({idea_id}).\n\n"
+                f"A previous implementation attempt failed because the spec was unclear.\n"
+                f"This spec MUST include:\n"
+                f"1. Concrete acceptance criteria (what 'done' looks like)\n"
+                f"2. Specific files to create or modify\n"
+                f"3. At least one test scenario with expected input/output\n"
+                f"4. Verification command to prove it works"
+            )
+            followup_context = _with_task_card_context(
+                source_task=task,
+                task_type=TaskType.SPEC,
+                direction=followup_direction,
+                context={
+                    "idea_id": idea_id,
+                    "auto_fix": "respec",
+                    "original_task_id": task.get("id", ""),
+                },
+            )
             try:
                 created = agent_service.create_task(AgentTaskCreate(
-                    direction=(
-                        f"Write a more detailed spec for '{idea_name}' ({idea_id}).\n\n"
-                        f"A previous implementation attempt failed because the spec was unclear.\n"
-                        f"This spec MUST include:\n"
-                        f"1. Concrete acceptance criteria (what 'done' looks like)\n"
-                        f"2. Specific files to create or modify\n"
-                        f"3. At least one test scenario with expected input/output\n"
-                        f"4. Verification command to prove it works"
-                    ),
+                    direction=followup_direction,
                     task_type=TaskType.SPEC,
-                    context={
-                        "idea_id": idea_id,
-                        "auto_fix": "respec",
-                        "original_task_id": task.get("id", ""),
-                    },
+                    context=followup_context,
                 ))
                 log.info("AUTO_FIX respec for idea=%s → task=%s", idea_id, created.get("id", "?"))
                 return
@@ -1028,19 +1083,26 @@ def _escalate_or_autofix(
         elif action == "heal":
             # Create a heal task to fix the specific issue
             error_snippet = (task.get("output") or task.get("error_summary") or "")[:500]
+            followup_direction = (
+                f"Fix the failing code for '{idea_name}' ({idea_id}).\n\n"
+                f"Error from previous run:\n{error_snippet}\n\n"
+                f"Find the root cause, fix it, and verify the fix with tests."
+            )
+            followup_context = _with_task_card_context(
+                source_task=task,
+                task_type=TaskType.IMPL,
+                direction=followup_direction,
+                context={
+                    "idea_id": idea_id,
+                    "auto_fix": "heal",
+                    "original_task_id": task.get("id", ""),
+                },
+            )
             try:
                 created = agent_service.create_task(AgentTaskCreate(
-                    direction=(
-                        f"Fix the failing code for '{idea_name}' ({idea_id}).\n\n"
-                        f"Error from previous run:\n{error_snippet}\n\n"
-                        f"Find the root cause, fix it, and verify the fix with tests."
-                    ),
+                    direction=followup_direction,
                     task_type=TaskType.IMPL,
-                    context={
-                        "idea_id": idea_id,
-                        "auto_fix": "heal",
-                        "original_task_id": task.get("id", ""),
-                    },
+                    context=followup_context,
                 ))
                 log.info("AUTO_FIX heal for idea=%s → task=%s", idea_id, created.get("id", "?"))
                 return
@@ -1106,28 +1168,43 @@ def handle_decision(task: dict[str, Any], decision: str) -> dict[str, Any] | Non
         # Retry with simplified scope
         original = task.get("direction", "")
         simplified = original.split("\n\n")[0][:500]
+        followup_direction = (
+            f"{simplified}\n\n"
+            f"Keep scope minimal — core requirement only. Skip optional features."
+        )
+        followup_task_type = _PHASE_TASK_TYPE.get(task_type, TaskType.IMPL)
+        followup_context = _with_task_card_context(
+            source_task=task,
+            task_type=followup_task_type,
+            direction=followup_direction,
+            context={"idea_id": idea_id, "decision_action": "simplified_retry", "retry_count": 0},
+        )
         try:
             return agent_service.create_task(AgentTaskCreate(
-                direction=(
-                    f"{simplified}\n\n"
-                    f"Keep scope minimal — core requirement only. Skip optional features."
-                ),
-                task_type=_PHASE_TASK_TYPE.get(task_type, TaskType.IMPL),
-                context={"idea_id": idea_id, "decision_action": "simplified_retry", "retry_count": 0},
+                direction=followup_direction,
+                task_type=followup_task_type,
+                context=followup_context,
             ))
         except Exception:
             log.warning("DECISION A failed for %s", idea_id, exc_info=True)
 
     elif choice == "B":
         # Rewrite spec
+        followup_direction = (
+            f"Rewrite the spec for '{idea_name}' ({idea_id}) with concrete acceptance criteria.\n"
+            f"Include: specific files, test scenarios, verification commands."
+        )
+        followup_context = _with_task_card_context(
+            source_task=task,
+            task_type=TaskType.SPEC,
+            direction=followup_direction,
+            context={"idea_id": idea_id, "decision_action": "respec"},
+        )
         try:
             return agent_service.create_task(AgentTaskCreate(
-                direction=(
-                    f"Rewrite the spec for '{idea_name}' ({idea_id}) with concrete acceptance criteria.\n"
-                    f"Include: specific files, test scenarios, verification commands."
-                ),
+                direction=followup_direction,
                 task_type=TaskType.SPEC,
-                context={"idea_id": idea_id, "decision_action": "respec"},
+                context=followup_context,
             ))
         except Exception:
             log.warning("DECISION B failed for %s", idea_id, exc_info=True)

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -556,6 +556,68 @@ class TestAutoAdvanceFingerprint:
         ctx = created_tasks[0]["context"]
         assert ctx["task_fingerprint"] == "idea-fp-retry:impl:auto"
 
+    def test_retry_spec_hydrates_task_card_context(self, monkeypatch):
+        """Spec retries carry a full task card before create_task persists them."""
+        from app.services import pipeline_advance_service as pas
+        from app.services.agent_service_executor import task_card_validation
+        from app.services.agent_routing.prompt_templates_loader import reset_prompt_templates_cache
+        from app.services.task_dedup_service import IdeaPhaseHistory
+
+        monkeypatch.setenv("PROMPT_VARIANT", "a")
+        reset_prompt_templates_cache()
+        task = _task(task_type="spec", status="failed", idea_id="openclaw-node-bridge")
+
+        monkeypatch.setattr(
+            "app.services.task_dedup_service.check_idea_phase_history",
+            lambda idea_id, phase: IdeaPhaseHistory(failed_count=1),
+        )
+        monkeypatch.setattr(pas, "_build_failure_memory", lambda *_a, **_k: "")
+
+        captured: list[dict] = []
+
+        def fake_create(data):
+            captured.append({"direction": data.direction, "context": data.context})
+            return {"id": "t-retry-spec", "task_type": "spec", "status": "pending", "context": data.context}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "create_task", fake_create)
+
+        result = pas.maybe_retry(task)
+        assert result is not None
+        ctx = captured[0]["context"]
+        assert ctx["task_card"]["files_allowed"] == ["specs/openclaw-node-bridge.md"]
+        for field in ("goal", "files_allowed", "done_when", "commands", "constraints"):
+            assert ctx[field] == ctx["task_card"][field]
+        assert task_card_validation(ctx)["score"] == 1.0
+
+    def test_autofix_split_spec_hydrates_task_card_context(self, monkeypatch):
+        """Timeout split follow-ups do not become weak-card dormant work."""
+        from app.services import pipeline_advance_service as pas
+        from app.services.agent_service_executor import task_card_validation
+        from app.services.agent_routing.prompt_templates_loader import reset_prompt_templates_cache
+
+        monkeypatch.setenv("PROMPT_VARIANT", "a")
+        reset_prompt_templates_cache()
+        task = _task(task_type="spec", status="timed_out", idea_id="node-message-bus")
+        task["direction"] = "x" * 2200
+        task["output"] = "timeout while creating the spec"
+
+        captured: list[dict] = []
+
+        def fake_create(data):
+            captured.append({"task_type": data.task_type, "context": data.context})
+            return {"id": "t-split-spec", "task_type": "spec", "status": "pending", "context": data.context}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "create_task", fake_create)
+
+        pas._escalate_or_autofix(task, "spec", "node-message-bus", 2)
+        assert len(captured) == 1
+        ctx = captured[0]["context"]
+        assert ctx["auto_fix"] == "split"
+        assert ctx["task_card"]["files_allowed"] == ["specs/node-message-bus.md"]
+        assert task_card_validation(ctx)["score"] == 1.0
+
 
 # ── Scenario 2: Skip-ahead in auto-advance ───────────────────────────────
 

--- a/docs/system_audit/commit_evidence_2026-04-25_retry-task-card-circulation.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_retry-task-card-circulation.json
@@ -1,0 +1,89 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-retry-task-cards",
+  "commit_scope": "Hydrate retry, split, respec, and decision-created follow-up tasks with the same task-card context as fresh seeded work.",
+  "files_owned": [
+    "api/app/services/agent_routing/prompt_templates_loader.py",
+    "api/app/services/pipeline_advance_service.py",
+    "api/tests/test_task_dedup_service.py",
+    "docs/system_audit/commit_evidence_2026-04-25_retry-task-card-circulation.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_task_dedup_service.py -q",
+      "python3 -m py_compile api/app/services/pipeline_advance_service.py api/app/services/agent_routing/prompt_templates_loader.py",
+      "git fetch origin main && git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_retry-task-card-circulation.json"
+    ],
+    "summary": "24 task pipeline tests passed; changed services compiled successfully; branch rebased on origin/main; PR guard local_preflight=pass ready_for_push=True; follow-through stale_codex_prs=0; evidence validation passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local validation passes; pre-push guard, CI, merge, deploy, and live sensing remain pending."
+  },
+  "idea_ids": [
+    "runner-context-hygiene",
+    "pipeline-low-success-rate"
+  ],
+  "spec_ids": [
+    "retry-task-card-circulation"
+  ],
+  "task_ids": [
+    "health-retry-task-cards"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live retry/split tasks showed task_card_validation.score=0.0 while fresh smart-seeded tasks scored 1.0.",
+    "Regression tests cover spec retry and timeout split follow-up task-card hydration.",
+    "Focused pytest run: 24 passed.",
+    "PR guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T220302Z_codex-health-retry-task-cards.json"
+  ],
+  "change_files": [
+    "api/app/services/agent_routing/prompt_templates_loader.py",
+    "api/app/services/pipeline_advance_service.py",
+    "api/tests/test_task_dedup_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Pipeline retry, auto-fix split, respec, heal, and decision follow-up tasks preserve or autofill full task-card context so health sensors no longer see weak-card retry work.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks",
+      "https://api.coherencycoin.com/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Observe fresh retry/split-created spec tasks and confirm context.task_card_validation.score is 1.0.",
+      "Confirm weak-card retry/split tasks no longer accumulate in running/pending task inventory."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- mirror configured task-card defaults into top-level task context
- hydrate retry, auto-fix split/respec/heal, and decision follow-up tasks from source task-card context
- cover spec retry and timeout split follow-ups so weak-card retry work stops accumulating

## Validation
- cd api && python3 -m pytest tests/test_task_dedup_service.py -q
- python3 -m py_compile api/app/services/pipeline_advance_service.py api/app/services/agent_routing/prompt_templates_loader.py
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_retry-task-card-circulation.json