### PR TITLE
tend: let *_composted short-circuit auto-retry

### DIFF
--- a/api/app/services/pipeline_advance_service.py
+++ b/api/app/services/pipeline_advance_service.py
@@ -750,6 +750,17 @@ def maybe_retry(task: dict[str, Any]) -> dict[str, Any] | None:
         )
         return None
 
+    # Manual compost: operators release sediment to timed_out with an
+    # error_category ending in `_composted`. Do not retry or escalate —
+    # the whole point of composting is to let the phase clear without
+    # spawning a fresh needs_decision entry to replace what we just cleared.
+    if error_category.endswith("_composted"):
+        log.info(
+            "AUTO_RETRY skip — %s for %s manually composted (category=%s)",
+            task_type, idea_id, error_category,
+        )
+        return None
+
     # R4: dedup gate — check phase history before retrying
     from app.services.task_dedup_service import check_idea_phase_history
     history = check_idea_phase_history(idea_id, task_type)

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -460,6 +460,34 @@ class TestAutoAdvanceFingerprint:
         ctx = created_tasks[0]["context"]
         assert ctx["task_fingerprint"] == "idea-fp:impl:auto"
 
+    def test_retry_skips_composted_tasks(self, monkeypatch):
+        """maybe_retry returns None without creating any task when error_category
+        ends in `_composted`. Composting is a manual operator action to release
+        sediment; re-escalating would immediately refuel the pile being cleared.
+        """
+        from app.services import pipeline_advance_service as pas
+
+        task = _task(task_type="impl", status="timed_out", idea_id="idea-composted")
+        task["error_category"] = "retry_exhausted_composted"
+
+        created: list[dict] = []
+
+        def fake_create(data):
+            created.append(data)
+            return {"id": "should-not-happen"}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "create_task", fake_create)
+        # Escalation path would also call these — ensure neither fires.
+        escalated: list = []
+        monkeypatch.setattr(pas, "_escalate_or_autofix",
+                            lambda *a, **k: escalated.append(a))
+
+        result = pas.maybe_retry(task)
+        assert result is None
+        assert created == []
+        assert escalated == []
+
     def test_retry_caps_oversized_direction(self, monkeypatch):
         """maybe_retry truncates direction+partial_work so the new task stays
         under the 3000-char OVERSIZED_DIRECTION gate (DG-002).


### PR DESCRIPTION
## Summary
When an operator PATCHes a task to \`timed_out\` with \`error_category\` ending in \`_composted\`, the agent_tasks_routes endpoint was firing \`maybe_retry\` → \`_escalate_or_autofix\`, spawning a fresh \`needs_decision\` task to replace the one just cleared. Composting 110 escalations this breath generated ~110 new escalations; net sediment stayed flat.

Short-circuit \`maybe_retry\` when \`error_category\` ends in \`_composted\`. The manual compost verb is now honest — it releases sediment without refueling the pile.

## Test plan
- [x] \`pytest tests/test_task_dedup_service.py tests/test_flow_enforcement.py\` — 26 passed
- [ ] After deploy: re-run compost script; needs_decision count should drop monotonically

🤖 Generated with [Claude Code](https://claude.com/claude-code)