### PR TITLE
tend: keep spec failures in spec lane

### DIFF
--- a/api/app/services/pipeline_advance_service.py
+++ b/api/app/services/pipeline_advance_service.py
@@ -971,8 +971,22 @@ def _classify_failure(task: dict[str, Any]) -> dict[str, Any]:
         analysis["fix_action"] = "respec"
         analysis["fix_description"] = "Create a new spec task with more specific requirements."
 
+    # Pattern: spec failed validation; repair the spec, do not create impl/heal work.
+    elif task_type == "spec" and (
+        "fail" in combined
+        or "error" in combined
+        or "validation" in combined
+        or "missing" in combined
+        or "not found" in combined
+    ):
+        analysis["failure_type"] = "spec_validation_failed"
+        analysis["reason"] = "Spec task failed before producing an active implementation contract."
+        analysis["auto_fixable"] = True
+        analysis["fix_action"] = "respec"
+        analysis["fix_description"] = "Create a new spec task with clearer acceptance criteria and verification."
+
     # Pattern: test failures in impl or test phase
-    elif "test" in combined and ("fail" in combined or "error" in combined or "assert" in combined):
+    elif task_type != "spec" and "test" in combined and ("fail" in combined or "error" in combined or "assert" in combined):
         analysis["failure_type"] = "test_failure"
         analysis["reason"] = "Tests are failing — likely a bug in the implementation."
         analysis["auto_fixable"] = True
@@ -980,7 +994,7 @@ def _classify_failure(task: dict[str, Any]) -> dict[str, Any]:
         analysis["fix_description"] = "Create a heal task to fix the failing tests."
 
     # Pattern: import/dependency error
-    elif "import" in combined and "error" in combined or "modulenotfounderror" in combined:
+    elif task_type != "spec" and (("import" in combined and "error" in combined) or "modulenotfounderror" in combined):
         analysis["failure_type"] = "missing_dependency"
         analysis["reason"] = "Missing import or dependency."
         analysis["auto_fixable"] = True

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -646,6 +646,54 @@ class TestAutoAdvanceFingerprint:
         assert ctx["task_card"]["files_allowed"] == ["specs/node-message-bus.md"]
         assert task_card_validation(ctx)["score"] == 1.0
 
+    def test_failed_spec_with_test_words_respecs_instead_of_heal(self):
+        """Spec-phase validation failures must not create impl heal tasks."""
+        from app.services import pipeline_advance_service as pas
+
+        task = _task(
+            task_type="spec",
+            status="failed",
+            idea_id="spec-validation",
+            output="Acceptance Tests section missing; validation failed with expected test command not found.",
+        )
+
+        analysis = pas._classify_failure(task)
+        assert analysis["failure_type"] == "spec_validation_failed"
+        assert analysis["fix_action"] == "respec"
+
+    def test_autofix_failed_spec_creates_respec_task_not_impl_heal(self, monkeypatch):
+        """Spec failures that mention tests stay in the spec lane."""
+        from app.models.agent import TaskType
+        from app.services import pipeline_advance_service as pas
+        from app.services.agent_service_executor import task_card_validation
+        from app.services.agent_routing.prompt_templates_loader import reset_prompt_templates_cache
+
+        monkeypatch.setenv("PROMPT_VARIANT", "a")
+        reset_prompt_templates_cache()
+        task = _task(
+            task_type="spec",
+            status="failed",
+            idea_id="spec-validation",
+            output="Acceptance Tests section missing; validation failed with expected test command not found.",
+        )
+
+        captured: list[dict] = []
+
+        def fake_create(data):
+            captured.append({"task_type": data.task_type, "context": data.context})
+            return {"id": "t-respec", "task_type": "spec", "status": "pending", "context": data.context}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "create_task", fake_create)
+
+        pas._escalate_or_autofix(task, "spec", "spec-validation", 2)
+        assert len(captured) == 1
+        assert captured[0]["task_type"] == TaskType.SPEC
+        ctx = captured[0]["context"]
+        assert ctx["auto_fix"] == "respec"
+        assert ctx["task_card"]["files_allowed"] == ["specs/spec-validation.md"]
+        assert task_card_validation(ctx)["score"] == 1.0
+
 
 # ── Scenario 2: Skip-ahead in auto-advance ───────────────────────────────
 

--- a/docs/system_audit/commit_evidence_2026-04-25_spec-gate-heal-routing.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_spec-gate-heal-routing.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/health-spec-gate-heal-routing",
+  "commit_scope": "Keep failed spec validation follow-ups in the spec lane so auto-heal does not create impl work before an active spec exists.",
+  "files_owned": [
+    "api/app/services/pipeline_advance_service.py",
+    "api/tests/test_task_dedup_service.py",
+    "docs/system_audit/commit_evidence_2026-04-25_spec-gate-heal-routing.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_task_dedup_service.py -q",
+      "python3 -m py_compile api/app/services/pipeline_advance_service.py",
+      "git fetch origin main && git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_spec-gate-heal-routing.json"
+    ],
+    "summary": "27 task pipeline tests passed; pipeline_advance_service.py compiled successfully; branch rebased on origin/main; direct runtime/web contract passed after transient guard failure; PR guard rerun local_preflight=pass ready_for_push=True; follow-through stale_codex_prs=0; evidence validation passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local validation passes; pre-push guard, CI, merge, deploy, and live sensing remain pending."
+  },
+  "idea_ids": [
+    "pipeline-low-success-rate",
+    "runner-context-hygiene"
+  ],
+  "spec_ids": [
+    "spec-gate-heal-routing"
+  ],
+  "task_ids": [
+    "health-spec-gate-heal-routing"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Live monitor issue reported spec_gate failures with impl_without_active_spec signatures.",
+    "Live task_b256bd91ac1f79fb showed auto_fix=heal impl follow-up with spec-only task_card and NO_SPEC_GATE.",
+    "Regression tests cover spec output mentioning tests/validation and assert respec rather than impl heal.",
+    "Focused pytest run: 27 passed.",
+    "Transient guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T221427Z_codex-health-spec-gate-heal-routing.json",
+    "Passing guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T221651Z_codex-health-spec-gate-heal-routing.json"
+  ],
+  "change_files": [
+    "api/app/services/pipeline_advance_service.py",
+    "api/tests/test_task_dedup_service.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Failed spec-validation tasks create respec follow-ups instead of impl heal tasks, reducing NO_SPEC_GATE retries caused by missing active specs.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks",
+      "https://api.coherencycoin.com/api/agent/monitor-issues"
+    ],
+    "test_flows": [
+      "Observe future spec validation failures and confirm auto_fix=respec with task_type=spec.",
+      "Confirm impl_without_active_spec failures stop growing from spec-phase auto-heal follow-ups."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- classify failed spec validation as respec work, even when the output mentions tests
- keep test/import heal routing out of the spec phase
- add regressions proving failed spec tasks create spec respec follow-ups, not impl heal tasks that hit NO_SPEC_GATE

## Validation
- cd api && python3 -m pytest tests/test_task_dedup_service.py -q
- python3 -m py_compile api/app/services/pipeline_advance_service.py
- THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-25_spec-gate-heal-routing.json