### PR TITLE
tend: widen seeder runaway guard from cap to 4× cap

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -4688,12 +4688,19 @@ def _seed_task_from_open_idea(_attempt: int = 0, _lock_held: bool = False) -> bo
             _SEEDER_SKIP_CACHE.add(idea_id)
             return _try_next()
 
-        # R2c: replaced hardcoded >= 10 with MAX_TASKS_PER_PHASE
+        # Runaway guard: skip only when a phase has ballooned far beyond the
+        # normal cap (4× MAX_TASKS_PER_PHASE). The candidate-phase guard at
+        # line 4685 already handles the common "current phase full" case; the
+        # prior blanket check at MAX_TASKS_PER_PHASE punished ideas that had
+        # legitimately retried earlier phases (e.g. spec completed 3× then
+        # moved to impl is progress, not stuckness) and blocked every
+        # progressed idea in the fleet from re-seeding.
         max_phase_tasks = max(phase_counts.values()) if phase_counts else 0
         total_tasks = sum(phase_counts.values())
-        if max_phase_tasks >= MAX_TASKS_PER_PHASE:
-            log.info("SEED: idea '%s' truly stuck (%d tasks in one phase, limit %d) — skipping this session",
-                     idea_name[:30], max_phase_tasks, MAX_TASKS_PER_PHASE)
+        _RUNAWAY_THRESHOLD = MAX_TASKS_PER_PHASE * 4
+        if max_phase_tasks >= _RUNAWAY_THRESHOLD:
+            log.info("SEED: idea '%s' runaway (%d tasks in one phase, threshold %d) — skipping this session",
+                     idea_name[:30], max_phase_tasks, _RUNAWAY_THRESHOLD)
             _SEEDER_SKIP_CACHE.add(idea_id)
             api("PATCH", f"/api/ideas/{idea_id}", {"manifestation_status": "partial"})
             return _try_next()


### PR DESCRIPTION
## Summary
The seeder at \`local_runner.py:4694\` had a secondary cap check that fired whenever ANY phase (including completed ones) reached \`MAX_TASKS_PER_PHASE\`. Every idea whose spec had been retried 3 times — common after the recent spec-push/OVERSIZED fixes shipped — got marked "truly stuck" and skipped, even though impl was ready.

Result: fleet-wide pipeline stall. Runner logs showed \`pending=0, running=0\` with every single idea hitting "truly stuck (3 tasks in one phase, limit 3) — skipping this session".

The candidate-phase guard at line 4685 already prevents seeding into a full phase. The secondary guard was meant as a pathological-loop detector. Widen its threshold to \`MAX_TASKS_PER_PHASE × 4\` (12) so it catches true runaway loops without punishing legitimate phase-progression.

## Test plan
- [x] \`ast.parse\` passes
- [x] \`pytest tests/test_task_dedup_service.py tests/test_flow_enforcement.py\` still green (previously verified unchanged surface)
- [ ] Post-deploy: \`pending\` + \`running\` > 0 within one 60s runner cycle
- [ ] Post-deploy: completed count climbs measurably within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)