### PR TITLE
Serve public assets from standalone web builds

### DIFF
--- a/docs/system_audit/commit_evidence_2026-04-25_static-public-assets.json
+++ b/docs/system_audit/commit_evidence_2026-04-25_static-public-assets.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-04-25",
+  "thread_branch": "codex/static-assets-production-20260425",
+  "commit_scope": "Make standalone web builds carry public assets and make deploy verification catch HTML fallback responses for static assets.",
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-04-25_static-public-assets.json",
+    "scripts/verify_web_api_deploy.sh",
+    "web/package.json",
+    "web/scripts/prepare-standalone-assets.mjs"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "bash -n scripts/verify_web_api_deploy.sh",
+      "cd web && npm ci --allow-git=none",
+      "cd web && npm run build",
+      "test -f web/.next/standalone/public/assets/logo.svg && test -f web/.next/standalone/public/visuals/generated/lc-space-0.jpg && test -f web/.next/standalone/.next/static/BUILD_ID",
+      "cd web && HOSTNAME=127.0.0.1 PORT=3127 node .next/standalone/server.js",
+      "curl -sS -L -o /tmp/coherence-logo.svg -w '%{http_code} %{content_type} %{size_download}\\n' http://127.0.0.1:3127/assets/logo.svg",
+      "curl -sS -L -o /tmp/coherence-lc-space.jpg -w '%{http_code} %{content_type} %{size_download}\\n' http://127.0.0.1:3127/visuals/generated/lc-space-0.jpg",
+      "GATEWAY_PATIENCE_SECONDS=5 ./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com",
+      "python3 scripts/sync_kb_to_db.py lc-pulse --api-url http://127.0.0.1:18180 --api-key dev-key",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Web build passed and postbuild copied public assets plus .next/static into the standalone bundle. Local standalone server returned 200 image/svg+xml for /assets/logo.svg and 200 image/jpeg for /visuals/generated/lc-space-0.jpg. The updated public verifier currently fails against production because the pre-fix deployment returns HTML for logo.svg and 404 HTML for the generated JPEG. Local PR guard passed with ready_for_push=True after syncing lc-pulse into the local verification cache DB; follow-through passed with codex_open_prs=0 and stale_codex_prs=0."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks after push"
+    ],
+    "summary": "Pending PR creation."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Pending merge and public deploy verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local build and direct standalone asset serving pass; CI and post-merge public deploy validation are pending."
+  },
+  "idea_ids": [
+    "living-collective-vision",
+    "deployment-ci-ops"
+  ],
+  "spec_ids": [
+    "vision-image-prompt-manifest",
+    "public-deploy-contract"
+  ],
+  "task_ids": [
+    "static-public-assets-20260425"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "production-approval"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "deployment"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "production pre-fix logo.svg: HTTP 200 text/html; body looks like HTML fallback",
+    "production pre-fix lc-space-0.jpg: HTTP 404 text/html; HTML response preview",
+    "local standalone logo.svg: HTTP 200 image/svg+xml, 793 bytes, XML/SVG signature",
+    "local standalone lc-space-0.jpg: HTTP 200 image/jpeg, 112419 bytes, JPEG signature",
+    "web build: passed with existing Tailwind module-type warning",
+    "local guard report: docs/system_audit/pr_check_failures/pr_check_guard_20260424T224136Z_codex-static-assets-production-20260425.json",
+    "follow-through check: codex_open_prs=0, stale_codex_prs=0"
+  ],
+  "change_files": [
+    "scripts/verify_web_api_deploy.sh",
+    "web/package.json",
+    "web/scripts/prepare-standalone-assets.mjs"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -264,6 +264,68 @@ check_web_css_assets() {
   return 0
 }
 
+check_web_public_asset() {
+  local name="$1"
+  local path="$2"
+  local expected_kind="$3"
+  local url="${WEB_URL%/}${path}"
+  local slug
+  slug="$(echo "public_asset_${name}" | tr "[:upper:]" "[:lower:]" | tr -cs "a-z0-9" "_")"
+  local headers_file="$TMP_DIR/${slug}.headers.txt"
+  local body_file="$TMP_DIR/${slug}.body"
+
+  echo
+  echo "==> Web public asset (${name}): ${url}"
+
+  local status
+  status="$(run_with_retries_capture "$CURL_RETRIES" "$CURL_RETRY_SLEEP_SECONDS" curl -sS -L -D "$headers_file" -o "$body_file" -w "%{http_code}" \
+    --max-time "$CURL_MAX_TIME" \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    "$url" || true)"
+  local content_type
+  content_type="$(awk 'tolower($1) == "content-type:" { print $2 }' "$headers_file" | tail -n 1 | tr -d '\r')"
+  echo "HTTP status: ${status:-unknown}"
+  echo "Content-Type: ${content_type:-<missing>}"
+
+  if [[ -z "$status" || "$status" -lt 200 || "$status" -ge 400 ]]; then
+    echo "FAIL: public asset is not reachable"
+    head -c 120 "$body_file" || true
+    echo
+    return 1
+  fi
+
+  if python3 - "$body_file" "$expected_kind" <<'PY'
+import sys
+from pathlib import Path
+
+body = Path(sys.argv[1]).read_bytes()
+kind = sys.argv[2]
+
+if kind == "svg":
+    probe = body[:256].lstrip()
+    ok = probe.startswith(b"<svg") or probe.startswith(b"<?xml")
+elif kind == "jpeg":
+    ok = body.startswith(b"\xff\xd8\xff")
+else:
+    ok = False
+
+if not ok:
+    text_probe = body[:256].lower()
+    if b"<!doctype html" in text_probe or b"<html" in text_probe:
+        print("body looks like HTML fallback, not a public asset")
+    else:
+        print(f"body did not match expected {kind} signature")
+    raise SystemExit(1)
+PY
+  then
+    echo "PASS"
+    return 0
+  fi
+
+  echo "FAIL: public asset response bytes are not ${expected_kind}"
+  return 1
+}
+
 check_cors() {
   local api_health_url="$1"
   local web_origin="$2"
@@ -624,6 +686,8 @@ fi
 check_provider_readiness "${API_URL%/}/api/automation/usage/readiness" "$VERIFY_REQUIRE_PROVIDER_READINESS" || fail=1
 check_url "Public web root" "${WEB_URL%/}/" || fail=1
 check_web_css_assets "${WEB_URL%/}/" || fail=1
+check_web_public_asset "logo" "/assets/logo.svg" "svg" || fail=1
+check_web_public_asset "generated vision image" "/visuals/generated/lc-space-0.jpg" "jpeg" || fail=1
 check_url "Public web gates page" "${WEB_URL%/}/gates" || fail=1
 check_url "Public web API health page" "${WEB_URL%/}/api-health" || fail=1
 check_url "Public web API health proxy" "${WEB_URL%/}/api/health-proxy" || fail=1

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node scripts/prepare-standalone-assets.mjs",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",

--- a/web/scripts/prepare-standalone-assets.mjs
+++ b/web/scripts/prepare-standalone-assets.mjs
@@ -1,0 +1,28 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const standaloneDir = path.join(root, ".next", "standalone");
+const standaloneServer = path.join(standaloneDir, "server.js");
+
+if (!existsSync(standaloneServer)) {
+  process.exit(0);
+}
+
+const standaloneNextDir = path.join(standaloneDir, ".next");
+mkdirSync(standaloneNextDir, { recursive: true });
+
+const staticSource = path.join(root, ".next", "static");
+const staticTarget = path.join(standaloneNextDir, "static");
+if (existsSync(staticSource)) {
+  rmSync(staticTarget, { recursive: true, force: true });
+  cpSync(staticSource, staticTarget, { recursive: true });
+}
+
+const publicSource = path.join(root, "public");
+const publicTarget = path.join(standaloneDir, "public");
+if (existsSync(publicSource)) {
+  rmSync(publicTarget, { recursive: true, force: true });
+  cpSync(publicSource, publicTarget, { recursive: true });
+}


### PR DESCRIPTION
## Summary
- copy public assets and .next/static into Next standalone output after web builds
- add public asset byte-signature checks to deploy verification for logo SVG and generated vision JPEG
- record evidence for the static asset production repair

## Validation
- make prompt-gate
- cd web && npm ci --allow-git=none
- cd web && npm run build
- local standalone server returned 200 image/svg+xml for /assets/logo.svg and 200 image/jpeg for /visuals/generated/lc-space-0.jpg
- GATEWAY_PATIENCE_SECONDS=5 ./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com (expected pre-fix failure: public assets return HTML/404)
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict