### PR TITLE
tend: stop auto-advance from escalating the wrong task

### DIFF
--- a/api/app/services/pipeline_advance_service.py
+++ b/api/app/services/pipeline_advance_service.py
@@ -473,11 +473,19 @@ def maybe_advance(task: dict[str, Any]) -> dict[str, Any] | None:
             log.info("AUTO_ADVANCE skip — %s task already active for %s", candidate, idea_id)
             return None
         if history.retry_budget_left <= 0 and history.completed_count == 0:
+            # The downstream phase is exhausted, but `task` is the
+            # just-completed PREDECESSOR (e.g. spec). Calling
+            # _escalate_or_autofix(task, ...) would mark that working
+            # predecessor as needs_decision with a misleading prompt about
+            # the wrong phase ("Task 'impl' for X failed 4 times" attached
+            # to a successful spec task). The exhausted phase's own tasks
+            # already carry their needs_decision state from maybe_retry's
+            # escalation path. Just stop advancing — don't double-escalate.
             log.warning(
-                "AUTO_ADVANCE escalate — %s for %s has %d failures, no completions, retry budget exhausted",
+                "AUTO_ADVANCE skip — %s for %s exhausted (%d failures, 0 completions); "
+                "downstream tasks already escalated, not re-marking predecessor",
                 candidate, idea_id, history.failed_count,
             )
-            _escalate_or_autofix(task, candidate, idea_id, history.failed_count)
             return None
         # This phase is eligible
         break

--- a/api/tests/test_task_dedup_service.py
+++ b/api/tests/test_task_dedup_service.py
@@ -413,6 +413,65 @@ class TestAutoRetryDedupGate:
 
 class TestAutoAdvanceFingerprint:
 
+    def test_advance_does_not_escalate_predecessor_when_next_phase_exhausted(self, monkeypatch):
+        """When auto-advance walks to a downstream phase that's exhausted its
+        retry budget, it must NOT mark the just-completed predecessor task as
+        needs_decision. The exhausted phase's own tasks already carry their
+        escalation state from maybe_retry; double-escalating onto the wrong
+        task type produces misleading prompts ("Task 'impl' for X failed 4
+        times" attached to a successful spec) and pollutes the predecessor
+        phase's count, eventually capping it too.
+        """
+        from app.services import pipeline_advance_service as pas
+        from app.services.task_dedup_service import IdeaPhaseHistory
+
+        # A spec task just completed (use default _LONG_SPEC_OUTPUT so the
+        # HOLLOW_COMPLETION gate doesn't block advance before our check)
+        task = _task(
+            task_type="spec",
+            status="completed",
+            idea_id="idea-exhausted-impl",
+        )
+
+        # impl phase: 4 failures, 0 completions, retry budget exhausted
+        def fake_history(idea_id, phase):
+            if phase == "impl":
+                return IdeaPhaseHistory(failed_count=4, completed_count=0)
+            return IdeaPhaseHistory()
+
+        monkeypatch.setattr(
+            "app.services.task_dedup_service.check_idea_phase_history",
+            fake_history,
+        )
+
+        update_calls: list = []
+        create_calls: list = []
+
+        def fake_update(task_id, **kwargs):
+            update_calls.append((task_id, kwargs))
+            return {"id": task_id, **kwargs}
+
+        def fake_create(data):
+            create_calls.append(data)
+            return {"id": "should-not-create", "task_type": data.task_type, "context": data.context}
+
+        from app.services import agent_service as _as
+        monkeypatch.setattr(_as, "update_task", fake_update)
+        monkeypatch.setattr(_as, "create_task", fake_create)
+        monkeypatch.setattr(_as, "list_tasks", lambda **_k: ([], 0, 0))
+
+        result = pas.maybe_advance(task)
+
+        # Should not advance, should not escalate the spec task
+        assert result is None
+        assert update_calls == [], (
+            f"predecessor (spec) was modified — escalation leaked onto wrong task: {update_calls}"
+        )
+        # Should also not auto-fix (no new task should be created from this path)
+        assert create_calls == [], (
+            f"unexpected task created when downstream phase is exhausted: {create_calls}"
+        )
+
     def test_advance_sets_fingerprint(self, monkeypatch):
         """maybe_advance creates task with deterministic fingerprint (R8)."""
         from app.services import pipeline_advance_service as pas


### PR DESCRIPTION
## Summary
\`maybe_advance\` walks downstream from a completed task. When it finds the next phase has exhausted retry budget, it called \`_escalate_or_autofix(task, candidate, ...)\` — but \`task\` is the just-completed PREDECESSOR (e.g. spec) and \`candidate\` is the EXHAUSTED downstream phase (e.g. impl).

The escalation marked the working spec task as \`needs_decision\` with the misleading prompt \"Task 'impl' for X failed 4 times\" — and counted against the spec phase's cap.

Observed in production: \`cross-linked-presences\` had 3 completed spec tasks + 9 needs_decision spec tasks, all carrying impl-flavored prompts. Each successful spec retry triggered another false escalation onto a working task. Across the fleet this generated ~120 spurious \`needs_decision\` entries per breath.

The exhausted phase's own tasks already carry their \`needs_decision\` state from \`maybe_retry\`'s escalation path. Removed the second escalation in auto-advance — it just stops walking now.

## Test plan
- [x] \`pytest tests/test_task_dedup_service.py tests/test_flow_enforcement.py\` — 31 passed
- [x] New regression: \`test_advance_does_not_escalate_predecessor_when_next_phase_exhausted\`
- [ ] Post-deploy: needs_decision count stays flat or drops while pipeline continues to ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)