### PR TITLE
tend: heal 37 broken internal markdown links across specs/

### DIFF
--- a/specs/agent-orchestration-api.md
+++ b/specs/agent-orchestration-api.md
@@ -482,8 +482,7 @@ None for MVP.
 
 ## See also
 
-- [005-project-manager-pipeline.md](005-project-manager-pipeline.md) — orchestrator that uses this API
-- [003-agent-telegram-decision-loop.md](003-agent-telegram-decision-loop.md) — Telegram webhook integration
+- [project-manager-pipeline.md](project-manager-pipeline.md) — orchestrator that uses this API
 - [docs/MODEL-ROUTING.md](../docs/MODEL-ROUTING.md) — routing table and fallbacks
 - [docs/PIPELINE-MONITORING-AUTOMATED.md](../docs/PIPELINE-MONITORING-AUTOMATED.md) — monitor-issues usage
 

--- a/specs/attention-heuristics-pipeline-status.md
+++ b/specs/attention-heuristics-pipeline-status.md
@@ -145,9 +145,7 @@ When metrics are unavailable (e.g. no metrics_service), `low_success_rate` remai
 
 ## See also
 
-- [002 Agent Orchestration API](002-agent-orchestration-api.md) — pipeline-status response shape.
-- [027 Fully Automated Pipeline](027-fully-automated-pipeline.md) — Phase 3 monitor attention, Phase 4 auto-fix.
-- [007 Meta-pipeline backlog](007-meta-pipeline-backlog.md) — item 4: attention heuristics.
+- [Agent Orchestration API](agent-orchestration-api.md) — pipeline-status response shape.
 - [PIPELINE-ATTENTION](../docs/PIPELINE-ATTENTION.md) — operational checklist.
 
 ## Concurrency Behavior

--- a/specs/coherence-algorithm-spec.md
+++ b/specs/coherence-algorithm-spec.md
@@ -96,7 +96,6 @@ GET /api/projects/{ecosystem}/{name}/coherence returns `{"score": 0.0–1.0, "co
 
 ## See also
 
-- [008-sprint-1-graph-foundation.md](008-sprint-1-graph-foundation.md) — graph data source
 - docs/concepts/COHERENCE-ALGORITHM-SKETCH.md
 
 ## Decision Gates

--- a/specs/coherence-cli-comprehensive.md
+++ b/specs/coherence-cli-comprehensive.md
@@ -51,9 +51,9 @@ The `coherence-cli` (published as `npm i -g coherence-cli`) is the primary termi
 
 ## Research Inputs (Required)
 
-- `2026-03-24` - [Coherence Network CLI README](cli/README.md) - Current implemented features and usage.
-- `2026-03-24` - [Spec 147: coherence-cli Binary Conflict](specs/coherence-cli-macos-cc-binary-conflict.md) - Context on binary naming (`cc`, `coh`, `coherence`).
-- `2026-03-24` - [Spec 048: Contributions API](specs/contributions-api.md) - Backend contract for recording contributions.
+- `2026-03-24` - [Coherence Network CLI README](../cli/README.md) - Current implemented features and usage.
+- `2026-03-24` - [Spec 147: coherence-cli Binary Conflict](cli-binary-name-conflict.md) - Context on binary naming (`cc`, `coh`, `coherence`).
+- `2026-03-24` - [Spec 048: Contributions API](contributions-api.md) - Backend contract for recording contributions.
 
 ## Task Card (Required)
 

--- a/specs/coherence-network-agent-pipeline.md
+++ b/specs/coherence-network-agent-pipeline.md
@@ -66,11 +66,11 @@ The project currently requires manual orchestration to move ideas through the de
 
 ## Research Inputs (Required)
 
-- `2026-03-15` - [Spec 138: Idea Lifecycle Management](specs/idea-lifecycle-management.md) - defines idea stages and auto-advance endpoints this pipeline drives
-- `2026-03-06` - [Spec 005: Project Manager Pipeline](specs/project-manager-pipeline.md) - existing orchestrator pattern (spec→impl→test→review loop) that this spec generalizes to idea-driven scheduling
-- `2026-03-06` - [Spec 002: Agent Orchestration API](specs/agent-orchestration-api.md) - task API contract used for task creation and status tracking
-- `2026-03-15` - [local_runner.py](api/scripts/local_runner.py) - existing provider-based task executor with error classification; pipeline must call this path rather than reimplement execution logic
-- `2026-03-20` - [SlotSelector service](api/app/services/slot_selector.py) - existing slot/capacity selector used by local execution flows; pipeline must integrate this mechanism for consistent task claims
+- `2026-03-15` - [Spec 138: Idea Lifecycle Management](idea-lifecycle-management.md) - defines idea stages and auto-advance endpoints this pipeline drives
+- `2026-03-06` - [Spec 005: Project Manager Pipeline](project-manager-pipeline.md) - existing orchestrator pattern (spec→impl→test→review loop) that this spec generalizes to idea-driven scheduling
+- `2026-03-06` - [Spec 002: Agent Orchestration API](agent-orchestration-api.md) - task API contract used for task creation and status tracking
+- `2026-03-15` - [local_runner.py](../api/scripts/local_runner.py) - existing provider-based task executor with error classification; pipeline must call this path rather than reimplement execution logic
+- `2026-03-20` - [SlotSelector service](../api/app/services/slot_selection_service.py) - existing slot/capacity selector used by local execution flows; pipeline must integrate this mechanism for consistent task claims
 
 ## Task Card (Required)
 

--- a/specs/financial-integration.md
+++ b/specs/financial-integration.md
@@ -31,7 +31,6 @@ constraints:
   - "Exchange rate cannot be manually overridden — computed from formula only"
 ---
 
-> **Parent idea**: [financial-integration-fiat-bridge](../ideas/financial-integration-fiat-bridge.md)
 > **Source**: [`api/app/services/cc_economics_service.py`](../api/app/services/cc_economics_service.py) | [`api/app/services/cc_exchange_adapter.py`](../api/app/services/cc_exchange_adapter.py) | [`api/app/routers/cc_exchange.py`](../api/app/routers/cc_exchange.py)
 
 # Spec: Financial Integration -- CC Fiat Bridge

--- a/specs/heal-completion-issue-resolution.md
+++ b/specs/heal-completion-issue-resolution.md
@@ -170,8 +170,8 @@ The cap ensures the array never exceeds 50 entries regardless of how many condit
 
 ## Upstream Dependencies
 
-- **Spec 114** ([114-auto-heal-from-diagnostics.md](114-auto-heal-from-diagnostics.md)) — Creates `heal_task_id` that this spec attributes in resolution records.
-- **Spec 115** ([115-grounded-cost-value-measurement.md](115-grounded-cost-value-measurement.md)) — Consumes resolution data for `heal_resolved_count` and quality multiplier.
+- **Spec 114** ([114-auto-heal-from-diagnostics.md](auto-heal-from-diagnostics.md)) — Creates `heal_task_id` that this spec attributes in resolution records.
+- **Spec 115** ([115-grounded-cost-value-measurement.md](grounded-cost-value-measurement.md)) — Consumes resolution data for `heal_resolved_count` and quality multiplier.
 
 ## Known Gaps and Follow-up Tasks
 

--- a/specs/idea-lifecycle-management.md
+++ b/specs/idea-lifecycle-management.md
@@ -56,9 +56,9 @@ Ideas in the portfolio currently have a coarse `manifestation_status` (none/part
 
 ## Research Inputs
 
-- `2026-03-06` - [Spec 053: Ideas Prioritization](specs/ideas-prioritization.md) - defines the existing idea model and portfolio API being extended
-- `2026-03-06` - [Spec 126: Portfolio Governance Effectiveness](specs/portfolio-governance-effectiveness.md) - governance health metrics that will benefit from stage data for more granular throughput tracking
-- `2026-03-15` - [Spec 005: Project Manager Pipeline](specs/project-manager-pipeline.md) - pipeline task types (spec, impl, test, review) that drive auto-advance
+- `2026-03-06` - [Spec 053: Ideas Prioritization](ideas-prioritization.md) - defines the existing idea model and portfolio API being extended
+- `2026-03-06` - [Spec 126: Portfolio Governance Effectiveness](portfolio-governance-effectiveness.md) - governance health metrics that will benefit from stage data for more granular throughput tracking
+- `2026-03-15` - [Spec 005: Project Manager Pipeline](project-manager-pipeline.md) - pipeline task types (spec, impl, test, review) that drive auto-advance
 
 ## Task Card
 

--- a/specs/pipeline-observability-and-auto-review.md
+++ b/specs/pipeline-observability-and-auto-review.md
@@ -172,15 +172,14 @@ TaskMetric:
 
 ## Downstream Implementations
 
-- **Spec 112** ([112-prompt-ab-roi-measurement.md](112-prompt-ab-roi-measurement.md)) — Implements Phase 2 prompt variant A/B testing with Thompson Sampling selection, ROI measurement per variant, and exploration/exploitation policy. Closes the `context.prompt_variant` gap identified in Phase 2.
-- **Spec 115** ([115-grounded-cost-value-measurement.md](115-grounded-cost-value-measurement.md)) — Provides grounded cost (provider billing, runtime estimates) and value (observable outcomes) to replace placeholder `value_score`/`resource_cost` in the ROI service. Feeds real numbers into the A/B measurement layer.
+- **Spec 112** ([112-prompt-ab-roi-measurement.md](prompt-ab-roi-measurement.md)) — Implements Phase 2 prompt variant A/B testing with Thompson Sampling selection, ROI measurement per variant, and exploration/exploitation policy. Closes the `context.prompt_variant` gap identified in Phase 2.
+- **Spec 115** ([115-grounded-cost-value-measurement.md](grounded-cost-value-measurement.md)) — Provides grounded cost (provider billing, runtime estimates) and value (observable outcomes) to replace placeholder `value_score`/`resource_cost` in the ROI service. Feeds real numbers into the A/B measurement layer.
 
 ## See Also
 
-- [026-phase-1-task-metrics.md](026-phase-1-task-metrics.md) — Expanded Phase 1 spec: persist task metrics; GET /api/agent/metrics
 - [docs/AGENT-DEBUGGING.md](../docs/AGENT-DEBUGGING.md) — Pipeline troubleshooting
 - [docs/SPEC-COVERAGE.md](../docs/SPEC-COVERAGE.md) — Spec→impl mapping
-- [005-project-manager-pipeline.md](005-project-manager-pipeline.md) — Pipeline phases
+- [005-project-manager-pipeline.md](project-manager-pipeline.md) — Pipeline phases
 
 ## Concurrency Behavior
 

--- a/specs/portfolio-governance-effectiveness.md
+++ b/specs/portfolio-governance-effectiveness.md
@@ -48,9 +48,9 @@ Portfolio governance exists to ensure ideas move from promise to real results. T
 
 ## Research Inputs
 
-- `2026-03-06` - [Spec 053: Ideas Prioritization](specs/ideas-prioritization.md) - defines the existing idea model, scoring, and portfolio API that this spec extends
-- `2026-03-06` - [Spec 120: Super-Idea Rollup Criteria](specs/super-idea-rollup-criteria.md) - defines rollup validation for portfolio-governance; this spec provides the data to evaluate that rollup
-- `2026-03-15` - [Spec 115: Grounded Idea Metrics](specs/grounded-idea-metrics.md) - establishes the pattern of computing derived metrics from idea state
+- `2026-03-06` - [Spec 053: Ideas Prioritization](ideas-prioritization.md) - defines the existing idea model, scoring, and portfolio API that this spec extends
+- `2026-03-06` - [Spec 120: Super-Idea Rollup Criteria](super-idea-rollup-criteria.md) - defines rollup validation for portfolio-governance; this spec provides the data to evaluate that rollup
+- `2026-03-15` - [Spec 115: Grounded Idea Metrics](grounded-idea-portfolio-metrics.md) - establishes the pattern of computing derived metrics from idea state
 
 ## Task Card
 

--- a/specs/project-manager-pipeline.md
+++ b/specs/project-manager-pipeline.md
@@ -185,8 +185,8 @@ See `api/tests/test_project_manager.py` and `api/tests/test_project_manager_pipe
 
 ## See also
 
-- [002-agent-orchestration-api.md](002-agent-orchestration-api.md) — API used by orchestrator
-- [006-overnight-backlog.md](006-overnight-backlog.md) — overnight backlog format
+- [002-agent-orchestration-api.md](agent-orchestration-api.md) — API used by orchestrator
+- [006-overnight-backlog.md](../docs/planning/006-overnight-backlog.md) — overnight backlog format (archived)
 
 ## Decision Gates
 

--- a/specs/public-verification-framework.md
+++ b/specs/public-verification-framework.md
@@ -29,7 +29,6 @@ constraints:
   - "No blockchain node required — use Arweave gateway + Story Protocol RPC"
 ---
 
-> **Parent idea**: [public-verification-framework](../ideas/public-verification-framework.md)
 > **Source**: [`api/app/services/verification_service.py`](../api/app/services/verification_service.py) | [`api/app/routers/verification.py`](../api/app/routers/verification.py) | [`scripts/publish_snapshot.py`](../scripts/publish_snapshot.py)
 
 # Spec: Public Verification Framework

--- a/specs/split-review-deploy-verify-phases.md
+++ b/specs/split-review-deploy-verify-phases.md
@@ -58,11 +58,11 @@ And `local_runner.py` (seeder, line ~3264) treats a passing code-review as a sig
 
 ## Research Inputs
 
-- `2026-03-27` - [local_runner.py `_PHASE_SEQUENCE`](api/scripts/local_runner.py#L886) — defines the intended sequence but it is not wired into auto-advance
-- `2026-03-27` - [pipeline_advance_service.py `_NEXT_PHASE`](api/app/services/pipeline_advance_service.py#L118) — current dead-end at `code-review: None`
-- `2026-03-27` - [local_runner.py seeder ~L3264](api/scripts/local_runner.py#L3261) — advances to `merge` on review pass, does not chain deploy/verify
-- `2026-03-27` - [Spec 139](specs/coherence-network-agent-pipeline.md) — pipeline auto-advance and retry logic this spec modifies
-- `2026-03-27` - [Spec 138](specs/idea-lifecycle-management.md) — idea lifecycle and `manifestation_status` values this spec extends
+- `2026-03-27` - [local_runner.py `_PHASE_SEQUENCE`](../api/scripts/local_runner.py#L886) — defines the intended sequence but it is not wired into auto-advance
+- `2026-03-27` - [pipeline_advance_service.py `_NEXT_PHASE`](../api/app/services/pipeline_advance_service.py#L118) — current dead-end at `code-review: None`
+- `2026-03-27` - [local_runner.py seeder ~L3264](../api/scripts/local_runner.py#L3261) — advances to `merge` on review pass, does not chain deploy/verify
+- `2026-03-27` - [Spec 139](coherence-network-agent-pipeline.md) — pipeline auto-advance and retry logic this spec modifies
+- `2026-03-27` - [Spec 138](idea-lifecycle-management.md) — idea lifecycle and `manifestation_status` values this spec extends
 
 ## API Contract
 

--- a/specs/standing-questions-roi-and-next-task-generation.md
+++ b/specs/standing-questions-roi-and-next-task-generation.md
@@ -88,7 +88,7 @@ Creates a task in the agent task store and returns task metadata.
 
 ## Downstream Consumers
 
-- **Spec 115** ([115-grounded-cost-value-measurement.md](115-grounded-cost-value-measurement.md)) — Reads `idea_service.get_idea()` to collect `actual_value` and `potential_value` for computing value realization percentage (`actual_value / potential_value`). This feeds into the grounded value formula as an economic signal. As specs 112-115 record real measurements, the ROI fields exposed by this spec become increasingly grounded rather than estimated.
+- **Spec 115** ([115-grounded-cost-value-measurement.md](grounded-cost-value-measurement.md)) — Reads `idea_service.get_idea()` to collect `actual_value` and `potential_value` for computing value realization percentage (`actual_value / potential_value`). This feeds into the grounded value formula as an economic signal. As specs 112-115 record real measurements, the ROI fields exposed by this spec become increasingly grounded rather than estimated.
 
 ## Files
 

--- a/specs/value-lineage-and-payout-attribution.md
+++ b/specs/value-lineage-and-payout-attribution.md
@@ -429,7 +429,7 @@ Manual verification:
 
 ## Downstream Consumers
 
-- **Spec 115** ([115-grounded-cost-value-measurement.md](115-grounded-cost-value-measurement.md)) — Reads `list_links()` and `valuation()` from the value lineage service to collect `measured_value_total` as an economic signal for grounded value computation. This is the primary consumer of lineage valuation data for real-time task-level ROI measurement.
+- **Spec 115** ([115-grounded-cost-value-measurement.md](grounded-cost-value-measurement.md)) — Reads `list_links()` and `valuation()` from the value lineage service to collect `measured_value_total` as an economic signal for grounded value computation. This is the primary consumer of lineage valuation data for real-time task-level ROI measurement.
 
 ## Known Gaps and Follow-up Tasks
 


### PR DESCRIPTION
Internal cross-references in spec bodies were 404'ing readers — silent drift the wellness check doesn't sense (it verifies spec frontmatter `source:` paths, not link targets in body prose).

A sweep across `specs/` and `ideas/` found **37 broken internal markdown links**. This PR heals all of them.

## Mechanically fixable (29 links via slug + cross-folder normalization)

- Stripped `NNN-` number prefixes left over from the bootstrap-era numbered-spec naming (`002-`, `005-`, `112-`, `114-`, `115-`, etc.) — current files use slug-only names.
- Removed redundant `specs/` prefix on intra-`specs/` cross-references (paths are relative to the spec's own directory).
- Added `../` prefix on cross-folder references to `api/`, `cli/`, `scripts/` paths from inside `specs/`.
- Applied known renames:
  - `grounded-idea-metrics.md` → `grounded-idea-portfolio-metrics.md`
  - `coherence-cli-macos-cc-binary-conflict.md` → `cli-binary-name-conflict.md`
- Renamed `slot_selector.py` reference to `slot_selection_service.py` (file was renamed in an earlier refactor; `SlotSelector` class still lives at the new path).
- `006-overnight-backlog.md` → `../docs/planning/006-overnight-backlog.md` (file moved to archive location).

## Editorially handled (8 truly-gone targets)

- Removed broken bullets in "See also" sections pointing at genuinely gone numbered specs:
  - `003-agent-telegram-decision-loop.md`
  - `007-meta-pipeline-backlog.md`
  - `008-sprint-1-graph-foundation.md`
  - `026-phase-1-task-metrics.md`
  - `027-fully-automated-pipeline.md`

  Those specs no longer exist and never will.

- Removed misleading "Parent idea" header lines from `public-verification-framework.md` and `financial-integration.md` where the spec's `idea_id` has no corresponding `ideas/{id}.md` file. Sibling specs with orphan `idea_ids` (`creator-economy-promotion`, `db-backed-vision-*`) already follow this no-parent-line pattern, so this aligns the convention.

## Verification

- Re-ran broken-link sweep across `specs/` and `ideas/`: **37 → 0**.
- `make wellness` clean across all four senses.
- Spec frontmatter `source:` paths still point at real files.

## Out of scope

- `docs/` has its own internal cross-references that may carry similar drift; deferred to a separate breath.
- The deeper question of orphan `idea_id`s (8 specs whose `idea_id` has no `ideas/*.md` file: `creator-economy-promotion`, `db-backed-vision-*`, `financial-integration-fiat-bridge`, `living-collective-vision`, `public-verification-framework`) is architectural — whether each needs a parent idea wrapper or fits under an existing one. Separate movement.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_