### PR TITLE
ops: nightly Postgres backup — close the volume-delete drift

### DIFF
--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Nightly Postgres backup for Coherence Network.
+#
+# Runs on the VPS (Hostinger, 187.77.152.42). Installed via cron:
+#   15 3 * * * /docker/coherence-network/repo/scripts/backup_postgres.sh
+#
+# Writes timestamped gzipped dumps to /docker/coherence-network/backups/
+# and prunes dumps older than $RETENTION_DAYS (default 30).
+#
+# Dumps are plain SQL (pg_dump -Fp) gzipped, readable by any Postgres 16+ psql.
+# Restore with: scripts/restore_postgres.sh <dump-file>
+#
+# Exits non-zero on any failure so cron emails/logs surface it.
+
+set -euo pipefail
+
+COMPOSE_DIR="${COMPOSE_DIR:-/docker/coherence-network}"
+BACKUP_DIR="${BACKUP_DIR:-/docker/coherence-network/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+DB_USER="${DB_USER:-coherence}"
+DB_NAME="${DB_NAME:-coherence}"
+POSTGRES_SERVICE="${POSTGRES_SERVICE:-postgres}"
+
+TS="$(date -u +%Y%m%d-%H%M%SZ)"
+OUT="${BACKUP_DIR}/coherence-${TS}.sql.gz"
+LOG="${BACKUP_DIR}/backup.log"
+
+mkdir -p "${BACKUP_DIR}"
+
+{
+  echo "[$(date -u +%FT%TZ)] backup starting -> ${OUT}"
+} >> "${LOG}"
+
+cd "${COMPOSE_DIR}"
+
+if ! docker compose exec -T "${POSTGRES_SERVICE}" \
+  pg_dump -U "${DB_USER}" -d "${DB_NAME}" -Fp --no-owner --no-privileges \
+  | gzip -9 > "${OUT}"; then
+  echo "[$(date -u +%FT%TZ)] ERROR: pg_dump failed" >> "${LOG}"
+  rm -f "${OUT}"
+  exit 1
+fi
+
+SIZE=$(du -h "${OUT}" | cut -f1)
+
+# Sanity check: dump must contain contribution_ledger data
+LEDGER_ROWS=$(gzip -cd "${OUT}" | awk '/^COPY public.contribution_ledger/,/^\\\.$/' | grep -c '^clr_' || true)
+
+if [[ "${LEDGER_ROWS}" -lt 1 ]]; then
+  echo "[$(date -u +%FT%TZ)] WARNING: dump contains 0 contribution_ledger rows — contribution_ledger may be empty, or dump format unexpected" >> "${LOG}"
+fi
+
+echo "[$(date -u +%FT%TZ)] backup ok size=${SIZE} contribution_ledger_rows=${LEDGER_ROWS}" >> "${LOG}"
+
+# Prune old dumps
+find "${BACKUP_DIR}" -maxdepth 1 -name 'coherence-*.sql.gz' -mtime "+${RETENTION_DAYS}" -print -delete >> "${LOG}" 2>&1 || true
+
+echo "${OUT}"

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Restore the Coherence Network Postgres from a backup dump.
+#
+# Usage on VPS:
+#   scripts/restore_postgres.sh /docker/coherence-network/backups/coherence-YYYYMMDD-HHMMSSZ.sql.gz
+#
+# DESTRUCTIVE: drops and recreates the target database before restoring.
+# The script refuses to run without CONFIRM=yes to protect against accidents.
+#
+# Recommended flow before restore:
+#   1. Take a fresh dump of the current state first (just in case):
+#        scripts/backup_postgres.sh
+#   2. Stop the api service so no writes race the restore:
+#        docker compose stop api
+#   3. Run this script with CONFIRM=yes
+#   4. Restart: docker compose start api
+
+set -euo pipefail
+
+DUMP="${1:-}"
+if [[ -z "${DUMP}" ]]; then
+  echo "usage: $0 <dump-file.sql.gz>" >&2
+  exit 2
+fi
+if [[ ! -f "${DUMP}" ]]; then
+  echo "dump not found: ${DUMP}" >&2
+  exit 2
+fi
+
+if [[ "${CONFIRM:-no}" != "yes" ]]; then
+  cat >&2 <<EOF
+This will DROP the coherence database and restore from:
+  ${DUMP}
+
+Set CONFIRM=yes and re-run to proceed:
+  CONFIRM=yes $0 ${DUMP}
+EOF
+  exit 2
+fi
+
+COMPOSE_DIR="${COMPOSE_DIR:-/docker/coherence-network}"
+DB_USER="${DB_USER:-coherence}"
+DB_NAME="${DB_NAME:-coherence}"
+POSTGRES_SERVICE="${POSTGRES_SERVICE:-postgres}"
+
+cd "${COMPOSE_DIR}"
+
+echo "[restore] dropping database ${DB_NAME}"
+docker compose exec -T "${POSTGRES_SERVICE}" psql -U "${DB_USER}" -d postgres \
+  -c "DROP DATABASE IF EXISTS ${DB_NAME};"
+docker compose exec -T "${POSTGRES_SERVICE}" psql -U "${DB_USER}" -d postgres \
+  -c "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
+
+echo "[restore] loading dump ${DUMP}"
+gzip -cd "${DUMP}" | docker compose exec -T "${POSTGRES_SERVICE}" \
+  psql -U "${DB_USER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 > /dev/null
+
+echo "[restore] verifying"
+docker compose exec -T "${POSTGRES_SERVICE}" psql -U "${DB_USER}" -d "${DB_NAME}" \
+  -c "SELECT 'contribution_ledger' AS tbl, COUNT(*) FROM contribution_ledger
+      UNION ALL SELECT 'graph_nodes', COUNT(*) FROM graph_nodes
+      UNION ALL SELECT 'graph_edges', COUNT(*) FROM graph_edges
+      UNION ALL SELECT 'contributors', COUNT(*) FROM contributors;"
+
+echo "[restore] done"


### PR DESCRIPTION
## Summary

This commit was deployed to the VPS on 2026-04-17 (cron `15 3 * * *`, first two dumps landed at ~90 MB each) but never landed on `main`. That is a real drift: if anyone re-deploys from `main`, the body loses its backup safety net silently.

Shipping the code so the source of truth matches what's actually running.

## What this installs

- `scripts/backup_postgres.sh` — `pg_dump -Fp | gzip` → `/docker/coherence-network/backups/`, sanity-checks the dump contains `contribution_ledger` rows, prunes anything older than 30 days
- `scripts/restore_postgres.sh` — `DROP` + `CREATE` + load, guarded by `CONFIRM=yes`, verifies row counts after restore

## State on the VPS (already true; this PR closes the source-of-truth drift)

- Cron installed at `15 3 * * *` UTC (5h before the 8am auto-deploy window)
- Two backup dumps already on disk (~90 MB each)
- Off-site copy in `~/.cache/local-instance/postgres-backups/`
- 4,964 `contribution_ledger` rows now safe from a `docker compose down -v`

## Original commit

`7ec10c4d` (Fri Apr 17 2026), originally on branch `claude/cool-wiles-9f71cb`. Rebased clean onto current main, no conflicts. Branch's stale unrelated web tinkering discarded (was 9-day-old browser dev artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)