### PR TITLE
ops(dependabot): group react + next peer-dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,16 @@ updates:
       time: "08:20"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    groups:
+      # Peer-deps that must move together — solo bumps fail with ERESOLVE
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      next:
+        patterns:
+          - "next"
+          - "@next/*"
+          - "eslint-config-next"


### PR DESCRIPTION
## Summary

Adds dependabot grouping for react/react-dom (and the @types) plus next.js family. Solo bumps of either side fail CI with ERESOLVE because peer-dep resolution requires both packages at the same version.

## Why

PRs #867 (react-dom 19.2.4→19.2.5) and #869 (react 19.2.4→19.2.5) each failed `validate-thread-process` independently — npm install can't reconcile `react-dom@19.2.5` against `react@19.2.4`. Grouping ensures the next dependabot run proposes both as one PR.

## After this lands

I'll close #867 and #869 as superseded; dependabot will re-open them grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)