### PR TITLE
ops: disable daily firing of asset_value_update until scripts exist

### DIFF
--- a/.github/workflows/asset_value_update.yml
+++ b/.github/workflows/asset_value_update.yml
@@ -1,8 +1,8 @@
 name: Update External Asset Values
 
 on:
-  schedule:
-    - cron: '22 7 * * *'  # daily (was every 6h)
+  # Daily schedule disabled until updater scripts (scripts/asset_tracking/update_asset_value.py)
+  # are implemented. Manual dispatch still works.
   workflow_dispatch:  # Manual trigger
 
 jobs:


### PR DESCRIPTION
Disables the cron trigger on `asset_value_update.yml` until `scripts/asset_tracking/update_asset_value.py` and `scripts/utilities/asset_value_report.py` are actually implemented. Daily firing was creating issue #184 every run with no value.

Manual dispatch (`workflow_dispatch`) still works for when someone wants to invoke the workflow intentionally after scripts are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)