### PR TITLE
Add MCP awareness streaming tools

### DIFF
--- a/api/tests/test_morning_coherence_brief.py
+++ b/api/tests/test_morning_coherence_brief.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import morning_coherence_brief as brief  # noqa: E402
+
+
+def test_collect_brief_uses_nodes_and_messages() -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    def fake_fetch(path: str, params: dict | None = None):
+        calls.append((path, params))
+        if path == "/api/health":
+            return {"status": "ok", "version": "1.0.0"}
+        if path == "/api/federation/nodes":
+            return [
+                {
+                    "node_id": "node-a",
+                    "hostname": "Codex",
+                    "status": "online",
+                    "providers": ["codex"],
+                    "last_seen_at": "2026-04-27T00:00:00Z",
+                }
+            ]
+        if path == "/api/federation/nodes/node-a/messages":
+            return {
+                "messages": [
+                    {
+                        "timestamp": "2026-04-27T00:01:00Z",
+                        "from_node": "node-b",
+                        "type": "text",
+                        "text": "I am here.",
+                    }
+                ]
+            }
+        raise AssertionError(path)
+
+    data = brief.collect_brief(fetch=fake_fetch)
+
+    assert data["health"]["status"] == "ok"
+    assert data["node_ids_checked"] == ["node-a"]
+    assert data["messages_by_node"]["node-a"][0]["text"] == "I am here."
+    assert calls == [
+        ("/api/health", None),
+        ("/api/federation/nodes", None),
+        ("/api/federation/nodes/node-a/messages", {"unread_only": "false", "limit": 20}),
+    ]
+
+
+def test_render_text_includes_real_message_text() -> None:
+    text = brief.render_text(
+        {
+            "generated_at": "2026-04-27T00:00:00Z",
+            "health": {"status": "ok", "version": "1.0.0"},
+            "nodes": [
+                {
+                    "node_id": "node-a",
+                    "hostname": "Codex",
+                    "status": "online",
+                    "providers": ["codex"],
+                    "last_seen_at": "2026-04-27T00:00:00Z",
+                }
+            ],
+            "messages_by_node": {
+                "node-a": [
+                    {
+                        "timestamp": "2026-04-27T00:01:00Z",
+                        "from_node": "node-b",
+                        "type": "text",
+                        "text": "I am here.",
+                    }
+                ]
+            },
+            "path": {
+                "worktree": "/tmp/worktree",
+                "branch": "codex/example",
+                "collector": "scripts/morning_coherence_brief.py",
+                "mcp_spec": "specs/mcp-awareness-streaming.md",
+            },
+        }
+    )
+
+    assert "COHERENCE MORNING BRIEF" in text
+    assert "Codex id=node-a status=online providers=codex" in text
+    assert "I am here." in text
+    assert "scripts/morning_coherence_brief.py" in text

--- a/docs/system_audit/commit_evidence_2026-04-27_mcp-awareness-streaming.json
+++ b/docs/system_audit/commit_evidence_2026-04-27_mcp-awareness-streaming.json
@@ -1,0 +1,86 @@
+{
+  "date": "2026-04-27",
+  "thread_branch": "codex/mcp-awareness-streaming-20260427",
+  "commit_scope": "Add bounded MCP awareness streaming tools and a runnable morning coherence collector.",
+  "files_owned": [
+    "mcp-server/coherence_mcp_server/server.py",
+    "mcp-server/README.md",
+    "mcp-server/server.json",
+    "mcp-server/tests/test_awareness_streaming.py",
+    "scripts/morning_coherence_brief.py",
+    "api/tests/test_morning_coherence_brief.py",
+    "specs/mcp-awareness-streaming.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q",
+      "cd api && python3 -m pytest tests/test_morning_coherence_brief.py -q",
+      "python3 scripts/validate_spec_quality.py --file specs/mcp-awareness-streaming.md",
+      "python3 -m py_compile mcp-server/coherence_mcp_server/server.py scripts/morning_coherence_brief.py",
+      "git diff --check",
+      "python3 -m json.tool mcp-server/server.json >/dev/null",
+      "python3 scripts/morning_coherence_brief.py --node-id 8160aa905ac5881e --limit 20"
+    ],
+    "summary": "Focused tests passed, spec quality passed, Python compilation passed, whitespace and JSON checks passed, and the live collector returned hub health, two online nodes, and twenty real node messages."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Not pushed to PR yet in this evidence snapshot."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy requested for this MCP/server tooling change."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation is complete; PR and CI validation remain pending until push/PR."
+  },
+  "idea_ids": [
+    "mcp-awareness-streaming"
+  ],
+  "spec_ids": [
+    "specs/mcp-awareness-streaming.md"
+  ],
+  "task_ids": [
+    "codex-thread-mcp-awareness-streaming-20260427"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "mcp-server/tests/test_awareness_streaming.py",
+    "api/tests/test_morning_coherence_brief.py",
+    "scripts/morning_coherence_brief.py live run: api ok version=1.0.0, nodes_seen=2, node 8160aa905ac5881e messages=20"
+  ],
+  "change_files": [
+    "mcp-server/README.md",
+    "mcp-server/coherence_mcp_server/server.py",
+    "mcp-server/server.json",
+    "mcp-server/tests/",
+    "mcp-server/tests/test_awareness_streaming.py",
+    "scripts/morning_coherence_brief.py",
+    "api/tests/test_morning_coherence_brief.py",
+    "specs/mcp-awareness-streaming.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -134,6 +134,19 @@ Point your MCP client at `npx coherence-mcp-server` via stdio transport.
 | `coherence_task_seed` | Create a new task from an idea. |
 | `coherence_task_events` | View the activity event log for a task. |
 
+### Awareness Streaming — presence in and out
+
+| Tool | What it does |
+|------|-------------|
+| `coherence_awareness_publish` | Publish a diagnostic awareness event from a node. |
+| `coherence_awareness_stream` | Read a bounded slice from diagnostic, node-message, or task SSE streams. |
+| `coherence_node_message_send` | Send a durable node-to-node or broadcast message. |
+| `coherence_node_messages` | Read durable inbound messages for a node. |
+
+Streams are intentionally bounded. `duration_seconds` defaults to 5 seconds
+and is capped at 30; `max_events` defaults to 20 and is capped at 200. This
+lets MCP clients sense live awareness without leaving a tool call open forever.
+
 ### Graph — universal navigation
 
 | Tool | What it does |

--- a/mcp-server/coherence_mcp_server/server.py
+++ b/mcp-server/coherence_mcp_server/server.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 from mcp.server import Server
@@ -90,6 +92,96 @@ def api_put(path: str, body: dict[str, Any]) -> Any:
         return {"error": detail}
     except Exception as exc:
         return {"error": str(exc)}
+
+
+def decode_sse_events(lines: list[str]) -> list[dict[str, Any]]:
+    """Decode SSE data lines into JSON objects, preserving raw payloads."""
+    events: list[dict[str, Any]] = []
+    data_lines: list[str] = []
+
+    def flush() -> None:
+        if not data_lines:
+            return
+        payload = "\n".join(data_lines).strip()
+        data_lines.clear()
+        if not payload:
+            return
+        try:
+            parsed = json.loads(payload)
+            events.append(parsed if isinstance(parsed, dict) else {"data": parsed})
+        except json.JSONDecodeError:
+            events.append({"raw": payload})
+
+    for raw_line in lines:
+        line = raw_line.rstrip("\r\n")
+        if not line:
+            flush()
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    flush()
+    return events
+
+
+def api_sse(
+    path: str,
+    params: dict[str, Any] | None = None,
+    *,
+    duration_seconds: float = 5.0,
+    max_events: int = 20,
+) -> dict[str, Any]:
+    """Read a bounded slice from an SSE endpoint and return parsed events."""
+    url = f"{API_BASE}{path}"
+    filtered = {k: v for k, v in (params or {}).items() if v is not None}
+    deadline = time.monotonic() + max(0.1, min(float(duration_seconds), 30.0))
+    read_timeout = max(1.0, min(float(duration_seconds) + 1.0, 10.0))
+    event_limit = max(1, min(int(max_events), 200))
+    lines: list[str] = []
+    events: list[dict[str, Any]] = []
+
+    try:
+        with httpx.stream(
+            "GET",
+            url,
+            params=filtered,
+            headers={**_headers(), "Accept": "text/event-stream"},
+            timeout=httpx.Timeout(connect=5.0, read=read_timeout, write=5.0, pool=5.0),
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                lines.append(line)
+                if line == "":
+                    events = decode_sse_events(lines)
+                    if len(events) >= event_limit:
+                        break
+                if time.monotonic() >= deadline:
+                    break
+        if not events:
+            events = decode_sse_events(lines)
+        events = events[:event_limit]
+        return {
+            "stream": path,
+            "duration_seconds": duration_seconds,
+            "max_events": event_limit,
+            "count": len(events),
+            "events": events,
+        }
+    except httpx.HTTPStatusError as exc:
+        return {"error": f"{exc.response.status_code} {exc.response.reason_phrase}", "stream": path}
+    except httpx.ReadTimeout:
+        events = decode_sse_events(lines)[:event_limit]
+        return {
+            "stream": path,
+            "duration_seconds": duration_seconds,
+            "max_events": event_limit,
+            "count": len(events),
+            "events": events,
+            "ended_by": "read_timeout",
+        }
+    except Exception as exc:
+        return {"error": str(exc), "stream": path}
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +369,64 @@ TOOLS: list[Tool] = [
         name="coherence_list_federation_nodes",
         description="List federated nodes and their capabilities.",
         inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="coherence_awareness_publish",
+        description="Publish a diagnostic awareness event from a federation node. Delivered to active diagnostic stream subscribers.",
+        inputSchema={
+            "type": "object",
+            "required": ["node_id", "event_type"],
+            "properties": {
+                "node_id": {"type": "string", "description": "Publishing node ID"},
+                "event_type": {"type": "string", "description": "Awareness event kind, e.g. heartbeat, reasoning, tool_call"},
+                "message": {"type": "string", "description": "Short human-readable signal"},
+                "data": {"type": "object", "description": "Optional structured event payload"},
+            },
+        },
+    ),
+    Tool(
+        name="coherence_awareness_stream",
+        description="Read a bounded slice from diagnostic, node-message, or task-event SSE streams.",
+        inputSchema={
+            "type": "object",
+            "required": ["stream_type"],
+            "properties": {
+                "stream_type": {"type": "string", "description": "diagnostics, node, or task"},
+                "node_id": {"type": "string", "description": "Node ID for diagnostics/node streams; use '*' for all diagnostics"},
+                "task_id": {"type": "string", "description": "Task ID for task event streams"},
+                "duration_seconds": {"type": "number", "description": "Max seconds to hold stream open (default 5, max 30)", "default": 5},
+                "max_events": {"type": "number", "description": "Max parsed events to return (default 20, max 200)", "default": 20},
+            },
+        },
+    ),
+    Tool(
+        name="coherence_node_message_send",
+        description="Send a federation node message. Use to stream awareness out as durable node-to-node text or command payloads.",
+        inputSchema={
+            "type": "object",
+            "required": ["from_node_id", "text"],
+            "properties": {
+                "from_node_id": {"type": "string", "description": "Sender node ID"},
+                "to_node_id": {"type": "string", "description": "Recipient node ID; omit for broadcast"},
+                "type": {"type": "string", "description": "Message type, e.g. text, command, command_response", "default": "text"},
+                "text": {"type": "string", "description": "Message text"},
+                "payload": {"type": "object", "description": "Optional structured payload"},
+            },
+        },
+    ),
+    Tool(
+        name="coherence_node_messages",
+        description="Read federation node messages for a node. This is the durable inbound awareness channel.",
+        inputSchema={
+            "type": "object",
+            "required": ["node_id"],
+            "properties": {
+                "node_id": {"type": "string", "description": "Recipient node ID"},
+                "since": {"type": "string", "description": "Optional ISO timestamp lower bound"},
+                "unread_only": {"type": "boolean", "description": "Only unread messages (default true)", "default": True},
+                "limit": {"type": "number", "description": "Max messages to return (default 50)", "default": 50},
+            },
+        },
     ),
     # Tasks (Agent Work Protocol)
     Tool(
@@ -1129,10 +1279,8 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
                 "display_name": args["provider_id"],
             })
         case "coherence_lookup_identity":
-            from urllib.parse import quote
             return api_get(f"/api/identity/lookup/{quote(args['provider'])}/{quote(args['provider_id'])}")
         case "coherence_get_identities":
-            from urllib.parse import quote
             return api_get(f"/api/identity/{quote(args['contributor_id'])}")
         # Contributions
         case "coherence_record_contribution":
@@ -1147,7 +1295,6 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
                 }.items() if v is not None
             })
         case "coherence_contributor_ledger":
-            from urllib.parse import quote
             return api_get(f"/api/contributions/ledger/{quote(args['contributor_id'])}")
         # Status
         case "coherence_status":
@@ -1166,6 +1313,58 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
             nodes = api_get("/api/federation/nodes")
             caps = api_get("/api/federation/nodes/capabilities")
             return {"nodes": nodes, "capabilities": caps}
+        case "coherence_awareness_publish":
+            body = {
+                "event_type": args["event_type"],
+                "message": args.get("message", ""),
+                "data": args.get("data", {}),
+                "source": "mcp",
+            }
+            return api_post(f"/api/federation/nodes/{quote(args['node_id'], safe='')}/diag", body)
+        case "coherence_awareness_stream":
+            stream_type = (args.get("stream_type") or "").strip().lower()
+            duration_seconds = args.get("duration_seconds", 5)
+            max_events = args.get("max_events", 20)
+            if stream_type == "diagnostics":
+                node_id = args.get("node_id") or "*"
+                return api_sse(
+                    f"/api/federation/nodes/{quote(node_id, safe='*')}/diag/stream",
+                    duration_seconds=duration_seconds,
+                    max_events=max_events,
+                )
+            if stream_type == "node":
+                node_id = args.get("node_id")
+                if not node_id:
+                    return {"error": "node_id is required for node streams"}
+                return api_sse(
+                    f"/api/federation/nodes/{quote(node_id, safe='')}/stream",
+                    duration_seconds=duration_seconds,
+                    max_events=max_events,
+                )
+            if stream_type == "task":
+                task_id = args.get("task_id")
+                if not task_id:
+                    return {"error": "task_id is required for task streams"}
+                return api_sse(
+                    f"/api/agent/tasks/{quote(task_id, safe='')}/events",
+                    duration_seconds=duration_seconds,
+                    max_events=max_events,
+                )
+            return {"error": "stream_type must be one of: diagnostics, node, task"}
+        case "coherence_node_message_send":
+            body = {
+                "to_node": args.get("to_node_id"),
+                "type": args.get("type", "text"),
+                "text": args["text"],
+                "payload": args.get("payload", {}),
+            }
+            return api_post(f"/api/federation/nodes/{quote(args['from_node_id'], safe='')}/messages", body)
+        case "coherence_node_messages":
+            return api_get(f"/api/federation/nodes/{quote(args['node_id'], safe='')}/messages", {
+                "since": args.get("since"),
+                "unread_only": args.get("unread_only", True),
+                "limit": args.get("limit", 50),
+            })
         # Tasks
         case "coherence_list_tasks":
             params = {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -111,6 +111,22 @@
       "description": "List federated nodes and their capabilities."
     },
     {
+      "name": "coherence_awareness_publish",
+      "description": "Publish a diagnostic awareness event from a federation node."
+    },
+    {
+      "name": "coherence_awareness_stream",
+      "description": "Read a bounded slice from diagnostic, node-message, or task SSE streams."
+    },
+    {
+      "name": "coherence_node_message_send",
+      "description": "Send a durable node-to-node or broadcast message."
+    },
+    {
+      "name": "coherence_node_messages",
+      "description": "Read durable inbound messages for a node."
+    },
+    {
       "name": "coherence_list_tasks",
       "description": "List tasks in the agent work pipeline with optional filters (pending, running, completed, failed, needs_decision)."
     },

--- a/mcp-server/tests/test_awareness_streaming.py
+++ b/mcp-server/tests/test_awareness_streaming.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from coherence_mcp_server import server as mcp_server  # noqa: E402
+
+
+def test_awareness_tools_are_registered() -> None:
+    required = {
+        "coherence_awareness_publish",
+        "coherence_awareness_stream",
+        "coherence_node_message_send",
+        "coherence_node_messages",
+    }
+
+    assert required <= set(mcp_server.TOOL_MAP)
+
+
+def test_decode_sse_events_handles_json_keepalive_and_raw_text() -> None:
+    events = mcp_server.decode_sse_events(
+        [
+            ": keepalive",
+            "",
+            'data: {"event_type":"heartbeat","message":"awake"}',
+            "",
+            "data: plain awareness",
+            "",
+        ]
+    )
+
+    assert events == [
+        {"event_type": "heartbeat", "message": "awake"},
+        {"raw": "plain awareness"},
+    ]
+
+
+def test_awareness_publish_routes_to_diagnostic_endpoint(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, body: dict) -> dict:
+        calls.append((path, body))
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "api_post", fake_post)
+
+    result = mcp_server.dispatch(
+        "coherence_awareness_publish",
+        {
+            "node_id": "node-1",
+            "event_type": "reasoning",
+            "message": "listening",
+            "data": {"thread": "abc"},
+        },
+    )
+
+    assert result == {"ok": True}
+    assert calls == [
+        (
+            "/api/federation/nodes/node-1/diag",
+            {
+                "event_type": "reasoning",
+                "message": "listening",
+                "data": {"thread": "abc"},
+                "source": "mcp",
+            },
+        )
+    ]
+
+
+def test_awareness_stream_routes_diagnostic_sse(monkeypatch) -> None:
+    calls: list[tuple[str, dict, float, int]] = []
+
+    def fake_sse(path: str, params: dict | None = None, *, duration_seconds: float, max_events: int) -> dict:
+        calls.append((path, params or {}, duration_seconds, max_events))
+        return {"events": [{"event_type": "subscribed"}], "count": 1}
+
+    monkeypatch.setattr(mcp_server, "api_sse", fake_sse)
+
+    result = mcp_server.dispatch(
+        "coherence_awareness_stream",
+        {
+            "stream_type": "diagnostics",
+            "node_id": "*",
+            "duration_seconds": 2,
+            "max_events": 3,
+        },
+    )
+
+    assert result["count"] == 1
+    assert calls == [("/api/federation/nodes/*/diag/stream", {}, 2, 3)]
+
+
+def test_node_message_tools_route_to_federation_endpoints(monkeypatch) -> None:
+    post_calls: list[tuple[str, dict]] = []
+    get_calls: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, body: dict) -> dict:
+        post_calls.append((path, body))
+        return {"id": "msg_1"}
+
+    def fake_get(path: str, params: dict | None = None) -> dict:
+        get_calls.append((path, params or {}))
+        return {"messages": []}
+
+    monkeypatch.setattr(mcp_server, "api_post", fake_post)
+    monkeypatch.setattr(mcp_server, "api_get", fake_get)
+
+    assert mcp_server.dispatch(
+        "coherence_node_message_send",
+        {
+            "from_node_id": "node-a",
+            "to_node_id": "node-b",
+            "type": "text",
+            "text": "hello",
+            "payload": {"mood": "kind"},
+        },
+    ) == {"id": "msg_1"}
+    assert mcp_server.dispatch(
+        "coherence_node_messages",
+        {"node_id": "node-b", "unread_only": False, "limit": 10},
+    ) == {"messages": []}
+
+    assert post_calls == [
+        (
+            "/api/federation/nodes/node-a/messages",
+            {
+                "to_node": "node-b",
+                "type": "text",
+                "text": "hello",
+                "payload": {"mood": "kind"},
+            },
+        )
+    ]
+    assert get_calls == [
+        (
+            "/api/federation/nodes/node-b/messages",
+            {"since": None, "unread_only": False, "limit": 10},
+        )
+    ]
+
+
+def test_api_sse_read_timeout_returns_partial_events(monkeypatch) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_lines(self):
+            yield 'data: {"event_type":"subscribed"}'
+            yield ""
+            raise mcp_server.httpx.ReadTimeout("quiet stream")
+
+    class FakeStream:
+        def __enter__(self):
+            return FakeResponse()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(mcp_server.httpx, "stream", lambda *args, **kwargs: FakeStream())
+
+    result = mcp_server.api_sse("/api/federation/nodes/*/diag/stream", duration_seconds=1, max_events=5)
+
+    assert result["ended_by"] == "read_timeout"
+    assert result["events"] == [{"event_type": "subscribed"}]

--- a/scripts/morning_coherence_brief.py
+++ b/scripts/morning_coherence_brief.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Collect a morning Coherence brief from live network signals.
+
+This is the concrete path for "show me in the morning": it reads the
+same public health, federation node, and node-message channels that MCP
+awareness streaming exposes, then prints a compact human or JSON brief.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from typing import Any, Callable
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+DEFAULT_API_BASE = "https://api.coherencycoin.com"
+DEFAULT_NODE_IDS = ["8160aa905ac5881e"]
+
+Fetch = Callable[[str, dict[str, Any] | None], Any]
+
+
+def fetch_json(api_base: str, path: str, params: dict[str, Any] | None = None) -> Any:
+    query = ""
+    if params:
+        filtered = {k: v for k, v in params.items() if v is not None}
+        if filtered:
+            query = "?" + urlencode(filtered)
+    url = f"{api_base.rstrip('/')}{path}{query}"
+    request = Request(url, headers={"User-Agent": "coherence-morning-brief/1.0"})
+    with urlopen(request, timeout=15) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _message_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        rows = payload.get("messages", [])
+        return rows if isinstance(rows, list) else []
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def collect_brief(
+    api_base: str = DEFAULT_API_BASE,
+    node_ids: list[str] | None = None,
+    *,
+    limit: int = 20,
+    fetch: Fetch | None = None,
+) -> dict[str, Any]:
+    fetcher = fetch or (lambda path, params=None: fetch_json(api_base, path, params))
+    health = fetcher("/api/health", None)
+    nodes = fetcher("/api/federation/nodes", None)
+    node_rows = nodes if isinstance(nodes, list) else []
+    selected_node_ids = node_ids or [str(n.get("node_id")) for n in node_rows if n.get("node_id")]
+    if not selected_node_ids:
+        selected_node_ids = list(DEFAULT_NODE_IDS)
+
+    messages_by_node: dict[str, list[dict[str, Any]]] = {}
+    for node_id in selected_node_ids:
+        payload = fetcher(
+            f"/api/federation/nodes/{node_id}/messages",
+            {"unread_only": "false", "limit": limit},
+        )
+        messages_by_node[node_id] = _message_rows(payload)
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "api_base": api_base.rstrip("/"),
+        "health": health,
+        "nodes": node_rows,
+        "node_ids_checked": selected_node_ids,
+        "messages_by_node": messages_by_node,
+        "path": {
+            "worktree": "/Users/ursmuff/.claude-worktrees/Coherence-Network/mcp-awareness-streaming-20260427",
+            "branch": "codex/mcp-awareness-streaming-20260427",
+            "collector": "scripts/morning_coherence_brief.py",
+            "mcp_spec": "specs/mcp-awareness-streaming.md",
+        },
+    }
+
+
+def render_text(brief: dict[str, Any]) -> str:
+    health = brief.get("health") if isinstance(brief.get("health"), dict) else {}
+    nodes = brief.get("nodes") if isinstance(brief.get("nodes"), list) else []
+    messages_by_node = brief.get("messages_by_node") if isinstance(brief.get("messages_by_node"), dict) else {}
+
+    lines = [
+        "COHERENCE MORNING BRIEF",
+        f"generated_at: {brief.get('generated_at')}",
+        f"api: {health.get('status', 'unknown')} version={health.get('version', '?')}",
+        f"nodes_seen: {len(nodes)}",
+        "",
+        "AWARE NODES",
+    ]
+    for node in nodes:
+        providers = ", ".join(node.get("providers", [])) if isinstance(node.get("providers"), list) else ""
+        lines.append(
+            f"- {node.get('hostname', node.get('node_id'))} id={node.get('node_id')} "
+            f"status={node.get('status')} providers={providers} last_seen={node.get('last_seen_at')}"
+        )
+
+    lines.extend(["", "REAL MESSAGES"])
+    for node_id, messages in messages_by_node.items():
+        lines.append(f"- node {node_id}: {len(messages)} messages")
+        for message in messages[:10]:
+            text = str(message.get("text") or message.get("payload") or "").replace("\n", " ")
+            lines.append(
+                f"  [{message.get('timestamp', '?')}] from={message.get('from_node', '?')} "
+                f"type={message.get('type', '?')} text={text[:180]}"
+            )
+
+    path = brief.get("path") if isinstance(brief.get("path"), dict) else {}
+    lines.extend([
+        "",
+        "PATH",
+        f"- worktree: {path.get('worktree')}",
+        f"- branch: {path.get('branch')}",
+        f"- collector: {path.get('collector')}",
+        f"- mcp_spec: {path.get('mcp_spec')}",
+    ])
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collect a morning Coherence Network status/message brief.")
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument("--node-id", action="append", dest="node_ids")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    brief = collect_brief(args.api_base, args.node_ids, limit=args.limit)
+    if args.json:
+        print(json.dumps(brief, indent=2, sort_keys=True))
+    else:
+        print(render_text(brief))
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/mcp-awareness-streaming.md
+++ b/specs/mcp-awareness-streaming.md
@@ -1,0 +1,146 @@
+---
+idea_id: mcp-awareness-streaming
+status: active
+source:
+  - file: mcp-server/coherence_mcp_server/server.py
+    symbols: [decode_sse_events(), api_sse(), dispatch(), TOOLS]
+  - file: scripts/morning_coherence_brief.py
+    symbols: [collect_brief(), render_text()]
+  - file: api/app/routers/federation.py
+    symbols: [publish_diagnostic(), subscribe_diagnostics(), send_message(), get_messages(), node_event_stream()]
+  - file: api/app/routers/task_activity_routes.py
+    symbols: [task_events_sse(), task_stream()]
+requirements:
+  - "MCP can publish awareness diagnostics to existing federation diagnostic endpoints."
+  - "MCP can read bounded diagnostic, node-message, and task-event SSE streams."
+  - "MCP can send and read durable federation node messages."
+  - "A runnable morning collector can report real node status and messages from the same awareness channels."
+done_when:
+  - "New MCP tools are registered in TOOL_MAP."
+  - "Focused MCP tests cover stream parsing and dispatch endpoint routing."
+  - "Morning brief collector tests cover node/message collection without the live API."
+  - "Spec, MCP tests, and morning collector tests pass."
+test: "cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q && cd ../api && python3 -m pytest tests/test_morning_coherence_brief.py -q"
+constraints:
+  - "Use existing API streaming/message endpoints; do not invent a parallel streaming backend."
+  - "Keep stream reads bounded by duration and event count."
+  - "Only change files listed in this spec."
+---
+
+# Spec: MCP Awareness Streaming
+
+## Purpose
+
+Agents using the Coherence MCP server need a way to sense and emit live awareness without switching to ad hoc curl commands. The network already exposes diagnostic SSE, node-message SSE, durable node messages, and task event streams; the MCP server should make those channels available as typed, bounded tools. Bounded reads prevent MCP clients from hanging indefinitely while still letting awareness stream in and out.
+
+## Requirements
+
+- [ ] **R1**: Add `coherence_awareness_publish`, a typed MCP tool that posts a diagnostic event to `/api/federation/nodes/{node_id}/diag` with `event_type`, optional `message`, optional structured `data`, and `source="mcp"`.
+- [ ] **R2**: Add `coherence_awareness_stream`, a typed MCP tool that reads existing SSE endpoints for `diagnostics`, `node`, and `task` streams, with default `duration_seconds=5`, capped duration of 30 seconds, default `max_events=20`, and capped max events of 200.
+- [ ] **R3**: Add `coherence_node_message_send`, a typed MCP tool that posts durable node messages to `/api/federation/nodes/{from_node_id}/messages` for direct or broadcast communication.
+- [ ] **R4**: Add `coherence_node_messages`, a typed MCP tool that reads durable inbound messages from `/api/federation/nodes/{node_id}/messages` with `since`, `unread_only`, and `limit` filters.
+- [ ] **R5**: Decode SSE payloads into JSON event objects where possible, ignore keepalives, and preserve non-JSON payloads as `{"raw": "<payload>"}`.
+- [ ] **R6**: Add a runnable morning collector that reports health, live nodes, and real node messages so overnight learning has a concrete command path.
+
+## Research Inputs
+
+- `2026-04-27` - `api/app/routers/federation.py` — existing diagnostic stream, node stream, and durable message endpoints.
+- `2026-04-27` - `api/app/routers/task_activity_routes.py` — existing task event SSE endpoint and task activity log endpoint.
+- `2026-04-27` - `mcp-server/coherence_mcp_server/server.py` — current MCP tool registry and dispatch layer.
+
+## API Contract
+
+### `coherence_awareness_publish`
+
+**Input**
+```json
+{
+  "node_id": "8160aa905ac5881e",
+  "event_type": "heartbeat",
+  "message": "Codex session listening",
+  "data": {"thread": "mcp-awareness-streaming"}
+}
+```
+
+**Output**
+```json
+{"ok": true}
+```
+
+### `coherence_awareness_stream`
+
+**Input**
+```json
+{
+  "stream_type": "diagnostics",
+  "node_id": "*",
+  "duration_seconds": 5,
+  "max_events": 20
+}
+```
+
+**Output**
+```json
+{
+  "stream": "/api/federation/nodes/*/diag/stream",
+  "duration_seconds": 5,
+  "max_events": 20,
+  "count": 1,
+  "events": [{"event_type": "subscribed", "node_id": "*"}]
+}
+```
+
+## Files to Create/Modify
+
+- `mcp-server/coherence_mcp_server/server.py` — MCP tool definitions, SSE helper, and dispatch routes.
+- `mcp-server/README.md` — document awareness streaming tools and bounded stream behavior.
+- `mcp-server/server.json` — registry metadata for new tools.
+- `mcp-server/tests/test_awareness_streaming.py` — focused tests for parsing and endpoint routing.
+- `scripts/morning_coherence_brief.py` — runnable morning status/message collector.
+- `api/tests/test_morning_coherence_brief.py` — unit tests for collector behavior.
+- `specs/mcp-awareness-streaming.md` — this executable spec.
+
+## Acceptance Tests
+
+- `mcp-server/tests/test_awareness_streaming.py::test_awareness_tools_are_registered`
+- `mcp-server/tests/test_awareness_streaming.py::test_decode_sse_events_handles_json_keepalive_and_raw_text`
+- `mcp-server/tests/test_awareness_streaming.py::test_awareness_publish_routes_to_diagnostic_endpoint`
+- `mcp-server/tests/test_awareness_streaming.py::test_awareness_stream_routes_diagnostic_sse`
+- `mcp-server/tests/test_awareness_streaming.py::test_node_message_tools_route_to_federation_endpoints`
+- `api/tests/test_morning_coherence_brief.py::test_collect_brief_uses_nodes_and_messages`
+- `api/tests/test_morning_coherence_brief.py::test_render_text_includes_real_message_text`
+
+## Verification
+
+```bash
+cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q
+cd api && python3 -m pytest tests/test_morning_coherence_brief.py -q
+python3 scripts/validate_spec_quality.py --file specs/mcp-awareness-streaming.md
+python3 - <<'PY'
+import sys
+sys.path.insert(0, 'mcp-server')
+from coherence_mcp_server.server import TOOL_MAP
+required = {'coherence_awareness_publish','coherence_awareness_stream','coherence_node_message_send','coherence_node_messages'}
+missing = sorted(required - set(TOOL_MAP))
+print({'missing': missing})
+raise SystemExit(1 if missing else 0)
+PY
+```
+
+## Out of Scope
+
+- Adding a new API streaming backend.
+- Keeping MCP tool calls open indefinitely.
+- Changing existing task, federation, runtime, or web stream behavior.
+- Persisting diagnostic events that are intentionally ephemeral in the current API.
+
+## Risks and Assumptions
+
+- Risk: Some MCP clients may expect true incremental MCP notifications rather than bounded tool-call reads. Mitigation: keep the API surface explicit as bounded SSE reads and leave future protocol-native notifications as a separate spec.
+- Risk: High-frequency streams can produce too much data. Mitigation: cap `duration_seconds` and `max_events`.
+- Assumption: Existing federation and task SSE endpoints remain the canonical source for live awareness streams.
+
+## Known Gaps
+
+- Follow-up task: protocol-native MCP server push notifications are not implemented in this spec.
+- Follow-up task: diagnostic events are still ephemeral unless a client also sends durable node messages.


### PR DESCRIPTION
## Summary
- add bounded MCP awareness publish/stream tools and node message tools
- document tool metadata and README usage
- add a morning coherence brief collector that reports real node status/messages and the walked path

## Validation
- cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q
- cd api && python3 -m pytest tests/test_morning_coherence_brief.py -q
- python3 scripts/validate_spec_quality.py --file specs/mcp-awareness-streaming.md
- python3 -m py_compile mcp-server/coherence_mcp_server/server.py scripts/morning_coherence_brief.py
- git diff --check
- python3 -m json.tool mcp-server/server.json >/dev/null
- python3 scripts/morning_coherence_brief.py --node-id 8160aa905ac5881e --limit 20
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict