### PR TITLE
refactor(idea_service): extract pure text helpers (#163, ongoing)

### DIFF
--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -67,7 +67,14 @@ from app.services.app_mode import debug_audit_enabled, running_under_test
 logger = logging.getLogger(__name__)
 
 
-_TAG_SLUG_PATTERN = re.compile(r"[^a-z0-9-]")
+# normalize_tags / validate_raw_tags / slugify moved to idea_text_helpers.py;
+# re-imported below for backward compat (#163 modularity drift)
+from app.services.idea_text_helpers import (  # noqa: E402,F401
+    _TAG_SLUG_PATTERN,
+    normalize_tags,
+    slugify,
+    validate_raw_tags,
+)
 
 
 def is_idea_external(idea_id: str) -> bool:
@@ -94,58 +101,8 @@ def get_workspace_git_url(idea_id: str) -> str | None:
     return None
 
 
-def normalize_tags(raw_tags: list[str]) -> list[str]:
-    """Normalize tags: trim, lowercase, slugify, deduplicate, sort ascending."""
-    seen: set[str] = set()
-    result: list[str] = []
-    for raw in raw_tags:
-        tag = raw.strip().lower()
-        tag = re.sub(r"\s+", "-", tag)
-        tag = _TAG_SLUG_PATTERN.sub("", tag)
-        tag = tag.strip("-")
-        if tag and tag not in seen:
-            seen.add(tag)
-            result.append(tag)
-    return sorted(result)
 
 
-def validate_raw_tags(raw_tags: list[str]) -> tuple[list[str], bool]:
-    """Validate and normalize tags. Returns (normalized, is_valid).
-
-    is_valid is False when a non-empty raw tag normalizes to empty string.
-    """
-    normalized = []
-    for raw in raw_tags:
-        stripped = raw.strip()
-        if not stripped:
-            continue  # silently drop empty/whitespace-only tags
-        tag = stripped.lower()
-        tag = re.sub(r"\s+", "-", tag)
-        tag = _TAG_SLUG_PATTERN.sub("", tag)
-        tag = tag.strip("-")
-        if not tag:
-            return [], False  # non-empty raw → empty after normalization = invalid
-        normalized.append(tag)
-    return normalize_tags(normalized), True
-
-
-def slugify(text: str) -> str:
-    """Convert free-form text to a URL-safe slug.
-
-    Rules: lowercase → strip non-alphanum/slash/hyphen → collapse hyphens →
-    strip leading/trailing hyphens per segment → max 80 chars.
-    Slashes are preserved to allow namespaced slugs like 'finance/cc-minting'.
-    """
-    import unicodedata
-    # Normalize unicode
-    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode()
-    text = text.lower()
-    # Replace spaces and non-slug chars (keeping / for namespacing) with -
-    text = re.sub(r"[^a-z0-9/]+", "-", text)
-    # Clean up per-segment
-    segments = [re.sub(r"-+", "-", s).strip("-") for s in text.split("/")]
-    slug = "/".join(s for s in segments if s)
-    return slug[:80]
 
 
 def _resolve_idea_raw(id_or_slug: str, ideas: list) -> "Idea | None":

--- a/api/app/services/idea_text_helpers.py
+++ b/api/app/services/idea_text_helpers.py
@@ -1,0 +1,67 @@
+"""Pure text helpers for idea identifiers — tag normalization and slugify.
+
+Extracted from idea_service.py to reduce that module under the modularity
+threshold (#163). These are pure functions with no idea-state dependencies.
+Re-exported from idea_service for backward compat.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+_TAG_SLUG_PATTERN = re.compile(r"[^a-z0-9-]")
+
+
+def normalize_tags(raw_tags: list[str]) -> list[str]:
+    """Normalize tags: trim, lowercase, slugify, deduplicate, sort ascending."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in raw_tags:
+        tag = raw.strip().lower()
+        tag = re.sub(r"\s+", "-", tag)
+        tag = _TAG_SLUG_PATTERN.sub("", tag)
+        tag = tag.strip("-")
+        if tag and tag not in seen:
+            seen.add(tag)
+            result.append(tag)
+    return sorted(result)
+
+
+def validate_raw_tags(raw_tags: list[str]) -> tuple[list[str], bool]:
+    """Validate and normalize tags. Returns (normalized, is_valid).
+
+    is_valid is False when a non-empty raw tag normalizes to empty string.
+    """
+    normalized = []
+    for raw in raw_tags:
+        stripped = raw.strip()
+        if not stripped:
+            continue  # silently drop empty/whitespace-only tags
+        tag = stripped.lower()
+        tag = re.sub(r"\s+", "-", tag)
+        tag = _TAG_SLUG_PATTERN.sub("", tag)
+        tag = tag.strip("-")
+        if not tag:
+            return [], False  # non-empty raw → empty after normalization = invalid
+        normalized.append(tag)
+    return normalize_tags(normalized), True
+
+
+def slugify(text: str) -> str:
+    """Convert free-form text to a URL-safe slug.
+
+    Rules: lowercase → strip non-alphanum/slash/hyphen → collapse hyphens →
+    strip leading/trailing hyphens per segment → max 80 chars.
+    Slashes are preserved to allow namespaced slugs like 'finance/cc-minting'.
+    """
+    # Normalize unicode
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode()
+    text = text.lower()
+    # Replace spaces and non-slug chars (keeping / for namespacing) with -
+    text = re.sub(r"[^a-z0-9/]+", "-", text)
+    # Clean up per-segment
+    segments = [re.sub(r"-+", "-", s).strip("-") for s in text.split("/")]
+    slug = "/".join(s for s in segments if s)
+    return slug[:80]


### PR DESCRIPTION
First of several extractions to bring `idea_service.py` under the 450-line modularity threshold (issue #163; current size 2,524 lines).

This PR extracts pure text helpers (`normalize_tags`, `validate_raw_tags`, `slugify`, `_TAG_SLUG_PATTERN`) into `idea_text_helpers.py`. Public API preserved via re-import.

| | Before | After |
|---|---|---|
| `idea_service.py` | 2,524 | 2,481 |

321 tests pass. The remaining ~2,000 lines split continues in subsequent extractions — internal-id filters, resonance helpers, persistence layer, CRUD operations. Each safe extraction is its own PR rather than one big bang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)