### PR TITLE
refactor(idea_service): extract standing-questions helpers (#163)

### DIFF
--- a/api/app/services/idea_service.py
+++ b/api/app/services/idea_service.py
@@ -143,10 +143,6 @@ def _resolve_idea_raw(id_or_slug: str, ideas: list) -> "Idea | None":
 # The DB is the sole source of truth for idea data; this set is only for
 # the is_internal_idea_id() classification heuristic.
 
-STANDING_QUESTION_TEXT = (
-    "How can we improve this idea, show whether it is working yet, "
-    "and make that proof clearer over time?"
-)
 
 _CACHE_LOCK = threading.Lock()
 _TRACKED_IDEA_CACHE: dict[str, Any] = {"expires_at": 0.0, "idea_ids": [], "cache_key": ""}
@@ -493,39 +489,12 @@ def _write_single_idea(idea: Idea, position: int) -> None:
     _invalidate_ideas_cache()
 
 
-def _ensure_standing_questions(ideas: list[Idea]) -> tuple[list[Idea], bool]:
-    changed = False
-    for idea in ideas:
-        if is_internal_idea_id(idea.id, idea.interfaces):
-            continue
-        has_standing = any(q.question == STANDING_QUESTION_TEXT for q in idea.open_questions)
-        if has_standing:
-            continue
-        default_value = 24.0 if idea.manifestation_status != ManifestationStatus.NONE else 20.0
-        default_cost = 2.0 if idea.manifestation_status != ManifestationStatus.NONE else 3.0
-        idea.open_questions.append(
-            IdeaQuestion(
-                question=STANDING_QUESTION_TEXT,
-                value_to_whole=default_value,
-                estimated_cost=default_cost,
-            )
-        )
-        changed = True
-    return ideas, changed
-
-
-def _prune_internal_standing_questions(ideas: list[Idea]) -> tuple[list[Idea], bool]:
-    changed = False
-    for idea in ideas:
-        if not is_internal_idea_id(idea.id, idea.interfaces):
-            continue
-        before = len(idea.open_questions)
-        if before == 0:
-            continue
-        idea.open_questions = [q for q in idea.open_questions if q.question != STANDING_QUESTION_TEXT]
-        if len(idea.open_questions) != before:
-            changed = True
-    return ideas, changed
+# Extracted to idea_standing_questions (#163)
+from app.services.idea_standing_questions import (  # noqa: E402,F401
+    STANDING_QUESTION_TEXT,
+    _ensure_standing_questions,
+    _prune_internal_standing_questions,
+)
 
 
 def _score(idea: Idea) -> float:

--- a/api/app/services/idea_standing_questions.py
+++ b/api/app/services/idea_standing_questions.py
@@ -1,0 +1,57 @@
+"""Standing-question maintenance for ideas.
+
+Extracted from idea_service.py (#163). The standing question — *"How can
+we improve this idea, show whether it is working yet, and make that
+proof clearer over time?"* — is the question every non-internal idea
+holds open for itself.
+
+Public surface (re-exported from idea_service):
+  STANDING_QUESTION_TEXT, _ensure_standing_questions,
+  _prune_internal_standing_questions
+"""
+
+from __future__ import annotations
+
+from app.models.idea import Idea, IdeaQuestion, ManifestationStatus
+from app.services.idea_internal_filter import is_internal_idea_id
+
+
+STANDING_QUESTION_TEXT = (
+    "How can we improve this idea, show whether it is working yet, "
+    "and make that proof clearer over time?"
+)
+
+
+def _ensure_standing_questions(ideas: list[Idea]) -> tuple[list[Idea], bool]:
+    changed = False
+    for idea in ideas:
+        if is_internal_idea_id(idea.id, idea.interfaces):
+            continue
+        has_standing = any(q.question == STANDING_QUESTION_TEXT for q in idea.open_questions)
+        if has_standing:
+            continue
+        default_value = 24.0 if idea.manifestation_status != ManifestationStatus.NONE else 20.0
+        default_cost = 2.0 if idea.manifestation_status != ManifestationStatus.NONE else 3.0
+        idea.open_questions.append(
+            IdeaQuestion(
+                question=STANDING_QUESTION_TEXT,
+                value_to_whole=default_value,
+                estimated_cost=default_cost,
+            )
+        )
+        changed = True
+    return ideas, changed
+
+
+def _prune_internal_standing_questions(ideas: list[Idea]) -> tuple[list[Idea], bool]:
+    changed = False
+    for idea in ideas:
+        if not is_internal_idea_id(idea.id, idea.interfaces):
+            continue
+        before = len(idea.open_questions)
+        if before == 0:
+            continue
+        idea.open_questions = [q for q in idea.open_questions if q.question != STANDING_QUESTION_TEXT]
+        if len(idea.open_questions) != before:
+            changed = True
+    return ideas, changed


### PR DESCRIPTION
Continuing the idea_service modularity reduction toward the 450-line threshold (#163).

This PR extracts the standing-question maintenance helpers (`_ensure_standing_questions`, `_prune_internal_standing_questions`) and the `STANDING_QUESTION_TEXT` constant they share into `idea_standing_questions.py`. Re-imported into idea_service for backward compat.

| | Before | After |
|---|---|---|
| `idea_service.py` | 2,191 | 2,160 |

321 tests pass.

## Cumulative progress on idea_service

| Step | PR | After |
|---|---|---|
| start | — | 2,524 |
| extract text helpers | #1237 | 2,481 |
| extract internal-id filter | #1238 | 2,423 |
| extract resonance helpers | #1238 | 2,347 |
| extract derive helper | #1238 | 2,223 |
| dedup constants | #1239 | 2,191 |
| extract standing questions | this PR | **2,160** |

**364 lines / 14% reduction** so far. Remaining work: cache + persistence + tracking subsystem (tightly coupled, needs careful unit-extraction), plus CRUD operations (~1,500 lines, biggest chunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)