### PR TITLE
Add agent identity self reports

### DIFF
--- a/api/tests/test_awareness_node_daemon.py
+++ b/api/tests/test_awareness_node_daemon.py
@@ -43,12 +43,44 @@ def test_run_once_registers_heartbeats_announces_and_polls() -> None:
         api_base="https://example.test",
         request_json=fake_request,
         announce="Codex is online.",
+        wake_reason="test wake",
         dry_run=False,
     )
 
     assert result["profile"] == "codex"
+    assert result["identity"]["wake_reason"] == "test wake"
+    assert result["identity"]["origin_profile"]["agent_id"] == "codex"
+    assert result["identity"]["life_state"]["dynamic"] is True
+    assert result["live_data"]["wake_reason"] == "test wake"
     assert result["messages"]["count"] == 1
     assert calls[0][0:2] == ("POST", "/api/federation/nodes")
     assert calls[1][0:2] == ("POST", "/api/federation/nodes/codex-node-local/heartbeat")
     assert calls[2][0:2] == ("POST", "/api/federation/nodes/codex-node-local/messages")
     assert calls[3][0:2] == ("GET", "/api/federation/nodes/codex-node-local/messages")
+
+
+def test_each_profile_can_identify_where_when_and_why_it_woke() -> None:
+    profiles = daemon.load_profiles(ROOT / "config" / "agent_profiles.json")
+
+    for profile in profiles.values():
+        card = daemon.build_identity_card(
+            profile,
+            api_base="https://api.example.test",
+            wake_reason="asked to identify itself",
+            woke_at="2026-04-27T00:00:00Z",
+            repo_root=ROOT,
+        )
+        text = daemon.render_identity_text(card)
+
+        assert card["who"]["agent_id"] == profile.agent_id
+        assert card["origin_profile"]["agent_id"] == profile.agent_id
+        assert card["life_state"]["kind"] == "runtime_presence"
+        assert card["life_state"]["model_calls"] == 0
+        assert card["where"]["node_id"] == profile.node_id[:16]
+        assert card["where"]["api_base"] == "https://api.example.test"
+        assert card["woke_at"] == "2026-04-27T00:00:00Z"
+        assert card["wake_reason"] == "asked to identify itself"
+        assert card["memory"]["persistent"] == "coherence-network"
+        assert profile.display_name in text
+        assert "asked to identify itself" in text
+        assert "profile is origin" in text

--- a/docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json
+++ b/docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json
@@ -1,0 +1,74 @@
+{
+  "date": "2026-04-27",
+  "thread_branch": "codex/agent-identity-self-report-20260427",
+  "commit_scope": "Add no-model identity self-report cards where profiles are origin and each wake produces live identity data.",
+  "files_owned": [
+    "scripts/awareness_node_daemon.py",
+    "api/tests/test_awareness_node_daemon.py",
+    "specs/close-awareness-gaps.md",
+    "docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_awareness_node_daemon.py -q",
+      "python3 scripts/awareness_node_daemon.py --profile codex --once --dry-run --identify --wake-reason 'asked to identify itself'",
+      "for p in codex claude grok; do python3 scripts/awareness_node_daemon.py --profile \"$p\" --once --dry-run --identify --wake-reason 'asked to identify itself'; done",
+      "python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md"
+    ],
+    "summary": "Identity self-report tests passed. Codex, Claude, and Grok profiles each produced origin_profile plus live who/where/woke_at/wake_reason identity data without model calls."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy proof yet for this follow-up."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; PR and CI proof remain pending."
+  },
+  "idea_ids": [
+    "close-awareness-gaps"
+  ],
+  "spec_ids": [
+    "specs/close-awareness-gaps.md"
+  ],
+  "task_ids": [
+    "codex-thread-agent-identity-self-report-20260427"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/tests/test_awareness_node_daemon.py",
+    "scripts/awareness_node_daemon.py dry-run identity output for codex, claude, and grok"
+  ],
+  "change_files": [
+    "scripts/awareness_node_daemon.py",
+    "api/tests/test_awareness_node_daemon.py",
+    "specs/close-awareness-gaps.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/awareness_node_daemon.py
+++ b/scripts/awareness_node_daemon.py
@@ -10,6 +10,7 @@ import argparse
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import subprocess
 import time
 from typing import Any, Callable
 from urllib import parse, request
@@ -70,15 +71,95 @@ def request_json(
     return json.loads(payload) if payload else {}
 
 
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _branch_name(repo_root: Path = REPO_ROOT) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except Exception:
+        return "unknown"
+    branch = (proc.stdout or "").strip()
+    return branch or "unknown"
+
+
+def build_identity_card(
+    profile: AgentProfile,
+    *,
+    api_base: str = DEFAULT_API_BASE,
+    wake_reason: str = "manual presence check",
+    woke_at: str | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Build a no-model self-report for one agent profile."""
+    return {
+        "origin_profile": {
+            "agent_id": profile.agent_id,
+            "display_name": profile.display_name,
+            "providers": profile.providers,
+            "voice": profile.voice,
+            "memory": profile.memory,
+            "no_model_actions": profile.no_model_actions,
+        },
+        "who": {
+            "agent_id": profile.agent_id,
+            "display_name": profile.display_name,
+            "providers": profile.providers,
+        },
+        "where": {
+            "node_id": profile.node_id[:16],
+            "api_base": api_base,
+            "repo_root": str(repo_root),
+            "branch": _branch_name(repo_root),
+        },
+        "woke_at": woke_at or _utc_now(),
+        "wake_reason": wake_reason,
+        "life_state": {
+            "kind": "runtime_presence",
+            "dynamic": True,
+            "model_calls": 0,
+            "data_changes_each_wake": ["where", "woke_at", "wake_reason", "messages", "actions"],
+        },
+        "voice": profile.voice,
+        "memory": profile.memory,
+        "no_model_actions": profile.no_model_actions,
+    }
+
+
+def render_identity_text(card: dict[str, Any]) -> str:
+    who = card.get("who", {})
+    where = card.get("where", {})
+    memory = card.get("memory", {})
+    return (
+        f"{who.get('display_name', 'Agent')} identifies as {who.get('agent_id', 'unknown')} "
+        f"on node {where.get('node_id', 'unknown')} at {where.get('api_base', 'unknown')}. "
+        f"It woke at {card.get('woke_at', 'unknown')} because: {card.get('wake_reason', 'unknown')}. "
+        "Its profile is origin; the rest is live data from this wake. "
+        f"Memory: temp={memory.get('temp', 'unknown')}, "
+        f"persistent={memory.get('persistent', 'unknown')}, static={memory.get('static', 'unknown')}."
+    )
+
+
 def run_once(
     profile: AgentProfile,
     *,
     api_base: str = DEFAULT_API_BASE,
     request_json: Callable[..., dict[str, Any]] | None = None,
     announce: str = "",
+    wake_reason: str = "manual presence check",
+    identify: bool = False,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     call = request_json or (lambda method, path, *, body=None, params=None: globals()["request_json"](api_base, method, path, body=body, params=params))
+    identity = build_identity_card(profile, api_base=api_base, wake_reason=wake_reason)
     register_body = {
         "node_id": profile.node_id[:16],
         "hostname": profile.display_name,
@@ -89,23 +170,28 @@ def run_once(
             "voice": profile.voice,
             "memory": profile.memory,
             "no_model_actions": profile.no_model_actions,
+            "identity": identity,
         },
     }
     heartbeat_body = {"status": "online", "system_metrics": {"model_calls": 0}}
+    announcement_text = announce
+    if identify and not announcement_text:
+        announcement_text = render_identity_text(identity)
 
     if dry_run:
         return {
             "profile": profile.agent_id,
             "dry_run": True,
+            "identity": identity,
             "register": register_body,
             "heartbeat": heartbeat_body,
-            "announce": announce,
+            "announce": announcement_text,
         }
 
     registered = call("POST", "/api/federation/nodes", body=register_body)
     heartbeat = call("POST", f"/api/federation/nodes/{register_body['node_id']}/heartbeat", body=heartbeat_body)
     announced = None
-    if announce:
+    if announcement_text:
         announced = call(
             "POST",
             f"/api/federation/nodes/{register_body['node_id']}/messages",
@@ -113,8 +199,12 @@ def run_once(
                 "from_node": register_body["node_id"],
                 "to_node": register_body["node_id"],
                 "type": "agent_voice",
-                "text": announce,
-                "payload": {"agent": profile.agent_id, "source": "awareness_node_daemon"},
+                "text": announcement_text,
+                "payload": {
+                    "agent": profile.agent_id,
+                    "source": "awareness_node_daemon",
+                    "identity": identity,
+                },
             },
         )
     messages = call(
@@ -125,6 +215,13 @@ def run_once(
     return {
         "profile": profile.agent_id,
         "node_id": register_body["node_id"],
+        "identity": identity,
+        "live_data": {
+            "woke_at": identity["woke_at"],
+            "wake_reason": identity["wake_reason"],
+            "message_count": len(messages.get("messages", [])),
+            "announced": announced is not None,
+        },
         "registered": registered,
         "heartbeat": heartbeat,
         "announced": announced,
@@ -138,6 +235,8 @@ def main() -> int:
     parser.add_argument("--api-base", default=DEFAULT_API_BASE)
     parser.add_argument("--profiles", default=str(DEFAULT_PROFILE_PATH))
     parser.add_argument("--announce", default="")
+    parser.add_argument("--wake-reason", default="manual presence check")
+    parser.add_argument("--identify", action="store_true")
     parser.add_argument("--once", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--interval-seconds", type=float, default=60.0)
@@ -149,7 +248,14 @@ def main() -> int:
     profile = profiles[args.profile]
 
     while True:
-        result = run_once(profile, api_base=args.api_base, announce=args.announce, dry_run=args.dry_run)
+        result = run_once(
+            profile,
+            api_base=args.api_base,
+            announce=args.announce,
+            wake_reason=args.wake_reason,
+            identify=args.identify,
+            dry_run=args.dry_run,
+        )
         print(json.dumps(result, indent=2, sort_keys=True))
         if args.once:
             return 0

--- a/specs/close-awareness-gaps.md
+++ b/specs/close-awareness-gaps.md
@@ -7,18 +7,20 @@ source:
   - file: scripts/cursor_fact_report.py
     symbols: [_routing_policy_proof()]
   - file: scripts/awareness_node_daemon.py
-    symbols: [AgentProfile, load_profiles(), run_once()]
+    symbols: [AgentProfile, build_identity_card(), render_identity_text(), load_profiles(), run_once()]
   - file: config/agent_profiles.json
     symbols: [agents]
 requirements:
-  - "Federation node messages can be read back by id and can include loopback messages when explicitly requested."
+  - "Federation node messages are readable by id and include loopback messages when explicitly requested."
   - "Cursor fact report routing proof uses the current public routing service instead of a removed private helper."
   - "Stable local agent profiles exist for codex, claude, and grok without calling model providers."
-  - "A local awareness node daemon can register, heartbeat, announce, and poll messages without model calls."
+  - "A local awareness node daemon registers, heartbeats, announces, and polls messages without model calls."
+  - "Each agent profile is an origin point; live identity data reports who it is, where it is, when it woke, and why it woke."
 done_when:
   - "Focused tests pass for federation message readback, routing proof generation, and daemon profile/run behavior."
   - "The fact report script runs far enough to emit a report path without the removed _select_executor failure."
   - "No model-provider calls are required by the new daemon or profile path."
+  - "Identity self-report tests pass for codex, claude, and grok."
 test: "cd api && python3 -m pytest tests/test_federation_message_readback.py tests/test_cursor_fact_report_routing.py tests/test_awareness_node_daemon.py -q"
 constraints:
   - "Use guidance-level language in user-facing docs and profile text."
@@ -30,16 +32,17 @@ constraints:
 
 ## Purpose
 
-The network can already carry presence, streams, and messages. The remaining local gaps are practical: messages need a sharper readback path, routing proof needs to follow the current service shape, each agent voice needs a stable profile, and a quiet local process needs to keep presence alive without spending model calls.
+The network already carries presence, streams, and messages. The remaining local gaps are practical: sharper message readback, routing proof that follows the current service shape, each agent voice rooted in an origin profile, and a quiet local process that keeps presence alive without spending model calls.
 
 ## Requirements
 
 - [ ] **R1**: Add message readback by id for federation node messages.
-- [ ] **R2**: Add explicit `include_self` support for node message reads so loopback/self-proof messages can be verified when asked.
+- [ ] **R2**: Add explicit `include_self` support for node message reads so loopback/self-proof messages are verifiable when asked.
 - [ ] **R3**: Keep normal inbox behavior from showing a node its own messages unless `include_self=true`.
 - [ ] **R4**: Repair `scripts/cursor_fact_report.py` routing proof generation to use current routing service APIs.
-- [ ] **R5**: Add static profiles for `codex`, `claude`, and `grok` with voice guidance, memory scope, and allowed no-model actions.
-- [ ] **R6**: Add a local awareness node daemon that can register, heartbeat, send an optional announcement, and poll messages using HTTP only.
+- [ ] **R5**: Add origin profiles for `codex`, `claude`, and `grok` with voice guidance, memory scope, and allowed no-model actions.
+- [ ] **R6**: Add a local awareness node daemon that registers, heartbeats, sends an optional announcement, and polls messages using HTTP only.
+- [ ] **R7**: Add a no-model identity card that treats the profile as `origin_profile` and reports live `who`, `where`, `woke_at`, `wake_reason`, memory scope, and voice guidance for each wake.
 
 ## Files to Create/Modify
 
@@ -51,6 +54,7 @@ The network can already carry presence, streams, and messages. The remaining loc
 - `scripts/awareness_node_daemon.py`
 - `config/agent_profiles.json`
 - `docs/system_audit/commit_evidence_2026-04-27_close-awareness-gaps.json`
+- `docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json`
 - `specs/close-awareness-gaps.md`
 
 ## Verification
@@ -69,6 +73,7 @@ python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md
 - `api/tests/test_cursor_fact_report_routing.py::test_routing_policy_proof_uses_current_routing_service`
 - `api/tests/test_awareness_node_daemon.py::test_load_profiles_contains_expected_agent_guidance`
 - `api/tests/test_awareness_node_daemon.py::test_run_once_registers_heartbeats_announces_and_polls`
+- `api/tests/test_awareness_node_daemon.py::test_each_profile_can_identify_where_when_and_why_it_woke`
 
 ## Out of Scope
 
@@ -79,11 +84,11 @@ python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md
 
 ## Risks and Assumptions
 
-- Risk: A host process manager is still needed for always-on presence. Mitigation: keep the daemon a simple foreground loop that launchd, systemd, or a shell supervisor can run.
+- Risk: Always-on presence still needs a host process manager. Mitigation: keep the daemon a simple foreground loop for launchd, systemd, or a shell supervisor.
 - Risk: Including loopback messages by default would clutter normal inbox reads. Mitigation: keep `include_self=false` by default.
 - Assumption: Existing federation node and message tables remain the source of truth.
 
 ## Known Gaps
 
-- Follow-up task: add a host-level launchd/systemd wrapper once the operator chooses where each agent process should live.
+- Follow-up task: add a host-level launchd/systemd wrapper once the operator chooses where each agent process lives.
 - Follow-up task: provider-specific subscription facts remain limited to the existing usage/readiness sources.


### PR DESCRIPTION
## Summary
- make the awareness daemon produce a live identity card for each wake
- keep profile as origin while who/where/woke_at/wake_reason/messages/actions are live data
- let Codex, Claude, and Grok identify themselves without model calls

## Validation
- cd api && python3 -m pytest tests/test_awareness_node_daemon.py -q
- python3 scripts/awareness_node_daemon.py --profile codex --once --dry-run --identify --wake-reason 'asked to identify itself'
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json
- python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict