### PR TITLE
Normalize awareness runtime node ids

### DIFF
--- a/api/tests/test_awareness_node_daemon.py
+++ b/api/tests/test_awareness_node_daemon.py
@@ -53,10 +53,11 @@ def test_run_once_registers_heartbeats_announces_and_polls() -> None:
     assert result["identity"]["life_state"]["dynamic"] is True
     assert result["live_data"]["wake_reason"] == "test wake"
     assert result["messages"]["count"] == 1
+    node_id = daemon.runtime_node_id(profile)
     assert calls[0][0:2] == ("POST", "/api/federation/nodes")
-    assert calls[1][0:2] == ("POST", "/api/federation/nodes/codex-node-local/heartbeat")
-    assert calls[2][0:2] == ("POST", "/api/federation/nodes/codex-node-local/messages")
-    assert calls[3][0:2] == ("GET", "/api/federation/nodes/codex-node-local/messages")
+    assert calls[1][0:2] == ("POST", f"/api/federation/nodes/{node_id}/heartbeat")
+    assert calls[2][0:2] == ("POST", f"/api/federation/nodes/{node_id}/messages")
+    assert calls[3][0:2] == ("GET", f"/api/federation/nodes/{node_id}/messages")
 
 
 def test_each_profile_can_identify_where_when_and_why_it_woke() -> None:
@@ -76,7 +77,8 @@ def test_each_profile_can_identify_where_when_and_why_it_woke() -> None:
         assert card["origin_profile"]["agent_id"] == profile.agent_id
         assert card["life_state"]["kind"] == "runtime_presence"
         assert card["life_state"]["model_calls"] == 0
-        assert card["where"]["node_id"] == profile.node_id[:16]
+        assert card["where"]["node_id"] == daemon.runtime_node_id(profile)
+        assert len(card["where"]["node_id"]) == 16
         assert card["where"]["api_base"] == "https://api.example.test"
         assert card["woke_at"] == "2026-04-27T00:00:00Z"
         assert card["wake_reason"] == "asked to identify itself"
@@ -84,3 +86,20 @@ def test_each_profile_can_identify_where_when_and_why_it_woke() -> None:
         assert profile.display_name in text
         assert "asked to identify itself" in text
         assert "profile is origin" in text
+
+
+def test_short_origin_node_ids_are_expanded_to_runtime_node_ids() -> None:
+    profile = daemon.AgentProfile(
+        agent_id="grok",
+        display_name="Grok",
+        node_id="grok-local-node",
+        providers=["grok"],
+        voice="curious",
+        memory={"temp": "thread", "persistent": "coherence-network", "static": "repo"},
+        no_model_actions=["register", "heartbeat", "announce", "poll_messages"],
+    )
+
+    node_id = daemon.runtime_node_id(profile)
+
+    assert len(node_id) == 16
+    assert node_id.startswith("groklocalnode")

--- a/docs/system_audit/commit_evidence_2026-04-27_agent-runtime-node-normalization.json
+++ b/docs/system_audit/commit_evidence_2026-04-27_agent-runtime-node-normalization.json
@@ -1,0 +1,73 @@
+{
+  "date": "2026-04-27",
+  "thread_branch": "codex/agent-identity-self-report-20260427",
+  "commit_scope": "Normalize awareness agent origin node ids into valid runtime node ids.",
+  "files_owned": [
+    "scripts/awareness_node_daemon.py",
+    "api/tests/test_awareness_node_daemon.py",
+    "specs/close-awareness-gaps.md",
+    "docs/system_audit/commit_evidence_2026-04-27_agent-runtime-node-normalization.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python3 -m pytest tests/test_awareness_node_daemon.py -q",
+      "for p in codex claude grok; do python3 scripts/awareness_node_daemon.py --profile \"$p\" --once --dry-run --identify --wake-reason 'walking toward wholeness joy and vitality'; done",
+      "git diff --check"
+    ],
+    "summary": "Awareness daemon tests passed. Codex, Claude, and Grok dry-runs each produced a 16-character runtime node id, including Grok."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "Live Grok wake proof pending deploy."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; PR, CI, and deploy proof remain pending."
+  },
+  "idea_ids": [
+    "close-awareness-gaps"
+  ],
+  "spec_ids": [
+    "specs/close-awareness-gaps.md"
+  ],
+  "task_ids": [
+    "codex-thread-agent-runtime-node-normalization-20260427"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/tests/test_awareness_node_daemon.py",
+    "scripts/awareness_node_daemon.py dry-run identity output for codex, claude, and grok"
+  ],
+  "change_files": [
+    "scripts/awareness_node_daemon.py",
+    "api/tests/test_awareness_node_daemon.py",
+    "specs/close-awareness-gaps.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/awareness_node_daemon.py
+++ b/scripts/awareness_node_daemon.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -91,6 +92,16 @@ def _branch_name(repo_root: Path = REPO_ROOT) -> str:
     return branch or "unknown"
 
 
+def runtime_node_id(profile: AgentProfile) -> str:
+    """Return the 16-character node id required by the federation API."""
+    raw = "".join(ch for ch in profile.node_id.lower() if ch.isalnum())
+    if len(raw) >= 16:
+        return raw[:16]
+    seed = f"{profile.agent_id}:{profile.node_id}:{profile.display_name}"
+    suffix = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return (raw + suffix)[:16]
+
+
 def build_identity_card(
     profile: AgentProfile,
     *,
@@ -115,7 +126,7 @@ def build_identity_card(
             "providers": profile.providers,
         },
         "where": {
-            "node_id": profile.node_id[:16],
+            "node_id": runtime_node_id(profile),
             "api_base": api_base,
             "repo_root": str(repo_root),
             "branch": _branch_name(repo_root),
@@ -160,8 +171,9 @@ def run_once(
 ) -> dict[str, Any]:
     call = request_json or (lambda method, path, *, body=None, params=None: globals()["request_json"](api_base, method, path, body=body, params=params))
     identity = build_identity_card(profile, api_base=api_base, wake_reason=wake_reason)
+    node_id = runtime_node_id(profile)
     register_body = {
-        "node_id": profile.node_id[:16],
+        "node_id": node_id,
         "hostname": profile.display_name,
         "os_type": "vps",
         "providers": profile.providers,

--- a/specs/close-awareness-gaps.md
+++ b/specs/close-awareness-gaps.md
@@ -16,6 +16,7 @@ requirements:
   - "Stable local agent profiles exist for codex, claude, and grok without calling model providers."
   - "A local awareness node daemon registers, heartbeats, announces, and polls messages without model calls."
   - "Each agent profile is an origin point; live identity data reports who it is, where it is, when it woke, and why it woke."
+  - "Short or hyphenated origin node ids are normalized into valid 16-character runtime node ids."
 done_when:
   - "Focused tests pass for federation message readback, routing proof generation, and daemon profile/run behavior."
   - "The fact report script runs far enough to emit a report path without the removed _select_executor failure."
@@ -43,6 +44,7 @@ The network already carries presence, streams, and messages. The remaining local
 - [ ] **R5**: Add origin profiles for `codex`, `claude`, and `grok` with voice guidance, memory scope, and allowed no-model actions.
 - [ ] **R6**: Add a local awareness node daemon that registers, heartbeats, sends an optional announcement, and polls messages using HTTP only.
 - [ ] **R7**: Add a no-model identity card that treats the profile as `origin_profile` and reports live `who`, `where`, `woke_at`, `wake_reason`, memory scope, and voice guidance for each wake.
+- [ ] **R8**: Normalize origin node ids into valid runtime node ids so every profile wakes cleanly through the federation API.
 
 ## Files to Create/Modify
 
@@ -55,6 +57,7 @@ The network already carries presence, streams, and messages. The remaining local
 - `config/agent_profiles.json`
 - `docs/system_audit/commit_evidence_2026-04-27_close-awareness-gaps.json`
 - `docs/system_audit/commit_evidence_2026-04-27_agent-identity-self-report.json`
+- `docs/system_audit/commit_evidence_2026-04-27_agent-runtime-node-normalization.json`
 - `specs/close-awareness-gaps.md`
 
 ## Verification
@@ -74,6 +77,7 @@ python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md
 - `api/tests/test_awareness_node_daemon.py::test_load_profiles_contains_expected_agent_guidance`
 - `api/tests/test_awareness_node_daemon.py::test_run_once_registers_heartbeats_announces_and_polls`
 - `api/tests/test_awareness_node_daemon.py::test_each_profile_can_identify_where_when_and_why_it_woke`
+- `api/tests/test_awareness_node_daemon.py::test_short_origin_node_ids_are_expanded_to_runtime_node_ids`
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- normalize awareness origin node ids into valid 16-character runtime node ids
- keep origin profile intact while shaping the API-facing node id per wake
- add coverage for short Grok-style origin ids

## Validation
- cd api && python3 -m pytest tests/test_awareness_node_daemon.py -q
- for p in codex claude grok; do python3 scripts/awareness_node_daemon.py --profile "" --once --dry-run --identify --wake-reason 'walking toward wholeness joy and vitality'; done
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-04-27_agent-runtime-node-normalization.json
- python3 scripts/validate_spec_quality.py --file specs/close-awareness-gaps.md
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict