### PR TITLE
docs(lineage): unshipped specs grouped by parent super-idea

### DIFF
--- a/docs/lineage/unshipped-by-idea-2026-04-27.md
+++ b/docs/lineage/unshipped-by-idea-2026-04-27.md
@@ -1,0 +1,203 @@
+# Unshipped Specs — by parent super-idea
+
+Sensed 315 truly-unshipped specs against the body's idea taxonomy (16 super-ideas, 118 absorbed leaf-ideas).
+
+- **61 specs** match an existing super-idea (via direct, substring, or word-overlap matching)
+- **254 unmatched** — either new ideas the body hasn't named yet, or noise
+
+## Per super-idea — accumulated unshipped energy
+
+### [knowledge-and-resonance](../../ideas/knowledge-and-resonance.md) — 13 unshipped, 4 on main · *foundation*
+
+*Knowledge and Resonance*
+
+- `specs/163-resonance-navigation.md`
+- `specs/169-belief-system.md`
+- `specs/173-concept-resonance-kernel.md`
+- `specs/179-cross-domain-concept-resonance.md`
+- `specs/181-belief-systems-translation.md`
+- `specs/181-concept-translation-worldview-lenses.md`
+- `specs/182-concept-layer-crud.md`
+- `specs/185-accessible-ontology.md`
+- `specs/breath-cycle-phases.md`
+- `specs/coherence-algorithm-engine.md`
+- `specs/resonance-navigation.md`
+- `specs/runner-self-update.md`
+- `specs/ucore-event-streaming.md`
+
+### [federation-and-nodes](../../ideas/federation-and-nodes.md) — 10 unshipped, 2 on main · *network*
+
+*Federation and Nodes*
+
+- `specs/131-federation-measurement-push.md`
+- `specs/132-federation-node-identity.md`
+- `specs/134-federation-strategy-propagation.md`
+- `specs/142-federation-measurement-push-verification.md`
+- `specs/143-federated-instance-aggregation.md`
+- `specs/156-openclaw-bidirectional-messaging.md`
+- `specs/federation-aggregated-visibility-followup-how-can-we-improve-this-idea-show-whet.md`
+- `specs/federation-measurement-push.md`
+- `specs/federation-strategy-propagation.md`
+- `specs/openclaw-node-bridge.md`
+
+### [external-presence](../../ideas/external-presence.md) — 10 unshipped, 2 on main · *foundation*
+
+*External Presence and Ecosystem*
+
+- `specs/140-oss-interface-alignment.md`
+- `specs/141-community-project-funder-match-showcase-page.md`
+- `specs/151-configurable-news-sources.md`
+- `specs/163-discord-bot-channels-per-idea.md`
+- `specs/164-discord-bot-channels-per-idea.md`
+- `specs/167-social-platform-bots.md`
+- `specs/bot-telegram.md`
+- `specs/community-project-funder-match.md`
+- `specs/configurable-news-sources.md`
+- `specs/ucore-daily-engagement-skill.md`
+
+### [agent-pipeline](../../ideas/agent-pipeline.md) — 6 unshipped, 6 on main · *pipeline*
+
+*Agent Pipeline*
+
+- `specs/**Spec file**: `validation-requires-production` (same stem as `idea_id` for registry).md`
+- `specs/046-agent-debugging-pipeline-stuck-task-hangs.md`
+- `specs/073-walkable-flow-runtime-mismatch-fixes.md`
+- `specs/pipeline-data-flow-fixes.md`
+- `specs/split-review-into-phases.md`
+- `specs/validation-requires-production.md`
+
+### [pipeline-reliability](../../ideas/pipeline-reliability.md) — 3 unshipped, 10 on main · *pipeline*
+
+*Pipeline Reliability*
+
+- `specs/136-data-driven-timeout-dashboard.md`
+- `specs/silent-failure-detection.md`
+- `specs/smart-reap-diagnose-resume.md`
+
+### [data-infrastructure](../../ideas/data-infrastructure.md) — 3 unshipped, 8 on main · *foundation*
+
+*Data Infrastructure*
+
+- `specs/168-fractal-node-edge-primitives.md`
+- `specs/169-fractal-node-edge-primitives.md`
+- `specs/fractal-node-edge-primitives.md`
+
+### [idea-realization-engine](../../ideas/idea-realization-engine.md) — 3 unshipped, 8 on main · *realization*
+
+*Idea Realization Engine*
+
+- `specs/172-self-balancing-graph.md`
+- `specs/180-self-balancing-graph.md`
+- `specs/proof-based-validation.md`
+
+### [portfolio-governance](../../ideas/portfolio-governance.md) — 2 unshipped, 1 on main · *realization*
+
+*Portfolio Governance and Measurement*
+
+- `specs/113-public-validation-gates-api.md`
+- `specs/validation-quality-gates.md`
+
+### [user-surfaces](../../ideas/user-surfaces.md) — 2 unshipped, 6 on main · *surfaces*
+
+*User Surfaces*
+
+- `specs/150-homepage-readability-contrast.md`
+- `specs/web-news-resonance-page.md`
+
+### [value-attribution](../../ideas/value-attribution.md) — 2 unshipped, 9 on main · *economics*
+
+*Value Attribution*
+
+- `specs/agent-session-summary.md`
+- `specs/cross-linked-presences.md`
+
+### [developer-experience](../../ideas/developer-experience.md) — 2 unshipped, 2 on main · *surfaces*
+
+*Developer Experience*
+
+- `specs/db-error-tracking.md`
+- `specs/documentation-developer-experience.md`
+
+### [identity-and-onboarding](../../ideas/identity-and-onboarding.md) — 2 unshipped, 2 on main · *network*
+
+*Identity and Onboarding*
+
+- `specs/identity-37-providers.md`
+- `specs/ux-new-contributor-orientation.md`
+
+### [pipeline-optimization](../../ideas/pipeline-optimization.md) — 1 unshipped, 6 on main · *pipeline*
+
+*Pipeline Optimization*
+
+- `specs/ci-noise-reduction.md`
+
+### [agent-cli](../../ideas/agent-cli.md) — 1 unshipped, 3 on main · *pipeline*
+
+*Agent CLI and Interfaces*
+
+- `specs/coherence-cli-npm.md`
+
+### [contributor-experience](../../ideas/contributor-experience.md) — 1 unshipped, 1 on main · *network*
+
+*Contributor Experience*
+
+- `specs/ux-contributor-experience.md`
+
+## Unmatched (254)
+
+These specs don't match any existing super-idea or absorbed-idea slug. Either:
+- New ideas the body hasn't yet named (seed candidates for ideas/)
+- Highly specific specs that don't fit current taxonomy
+- Genuine noise from the broken pipeline
+
+- `specs/### 1.1 Spec file backfill (`scripts/backfill_spec_idea_links.py`).md`
+- `specs/### 1.1 Spec file backfill (`scripts/backfill_spec_idea_links.py`).md`
+- `specs/001-health-check.md`
+- `specs/003-agent-telegram-decision-loop.md`
+- `specs/004-ci-pipeline.md`
+- `specs/005-backlog.md`
+- `specs/005-project-manager-orchestrator.md`
+- `specs/006-overnight-backlog.md`
+- `specs/007-meta-pipeline-backlog.md`
+- `specs/007-sprint-0-landing.md`
+- `specs/008-sprint-1-graph-foundation.md`
+- `specs/009-api-error-handling.md`
+- `specs/010-request-validation.md`
+- `specs/011-pagination.md`
+- `specs/012-web-skeleton.md`
+- `specs/013-logging-audit.md`
+- `specs/014-deploy-readiness.md`
+- `specs/015-placeholder.md`
+- `specs/016-holdout-tests.md`
+- `specs/017-web-ci.md`
+- `specs/019-graph-store-abstraction.md`
+- `specs/020-sprint-2-coherence-api.md`
+- `specs/021-web-project-search-ui.md`
+- `specs/023-web-import-stack-ui.md`
+- `specs/024-pypi-indexing.md`
+- `specs/025-requirements-txt-import.md`
+- `specs/026-phase-1-task-metrics.md`
+- `specs/027-auto-update-framework.md`
+- `specs/027-fully-automated-pipeline.md`
+- `specs/028-parallel-by-phase-pipeline.md`
+- `specs/029-github-api-integration.md`
+- `specs/030-pipeline-full-automation.md`
+- `specs/030-spec-coverage-update.md`
+- `specs/031-setup-troubleshooting-venv.md`
+- `specs/033-readme-quick-start-qualify.md`
+- `specs/034-ops-runbook.md`
+- `specs/035-glossary.md`
+- `specs/036-check-pipeline-hierarchical-view.md`
+- `specs/037-post-tasks-invalid-task-type-422.md`
+- `specs/038-post-tasks-empty-direction-422.md`
+- `specs/039-pipeline-status-empty-state-200.md`
+- `specs/040-project-manager-load-backlog-malformed-test.md`
+- `specs/041-project-manager-state-file-flag-test.md`
+- `specs/042-project-manager-reset-clears-state-test.md`
+- `specs/043-agent-service-spec-task-type-local-model-test.md`
+- `specs/044-agent-service-test-task-type-local-model-test.md`
+- `specs/045-effectiveness-plan-progress-phase-6-7.md`
+- `specs/049-system-lineage-inventory-and-runtime-telemetry.md`
+- `specs/050-friction-analysis.md`
+- `specs/051-question-answering-and-minimum-e2e-flow.md`
+- *... + 204 more*


### PR DESCRIPTION
Third lens on the unshipped intent ledger.

| Lens | Lines | Grouping |
|---|---|---|
| Raw archive (#1220) | 62,123 | by canonical attempt — full spec content |
| Themes map (#1247) | 1,270 | by 1-2 word prefix |
| **By-idea map (this PR)** | **200** | **by parent super-idea** |

61 of 315 truly-unshipped specs matched to existing super-ideas (knowledge-and-resonance has the most: 13 unshipped attempts). 254 unmatched — seed candidates for new ideas, or noise to compost in a future tending pass.

Each unshipped spec links back to the raw archive, so anyone wanting full content fetches from there. The map gives the body one-read sight of where its unshipped energy clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)