### PR TITLE
attune: super-ideas acknowledge their unshipped attempts

### DIFF
--- a/ideas/agent-cli.md
+++ b/ideas/agent-cli.md
@@ -36,3 +36,5 @@ Agents and developers interact with Coherence Network through raw API calls, whi
 - **coherence-mcp-server**: MCP server exposing ideas, specs, lineage, identity, contributions as typed tools for AI agents. Published on Smithery, Glama, PulseMCP for discovery. Agents can browse ideas, read specs, trace value lineage, and record contributions without leaving their IDE.
 - **coherence-cli-npm**: Node.js CLI with identity-first onboarding, idea browsing, staking, forking. Zero dependencies, works against public API. Published on npm as `coherence-cli` with global install support.
 - **cli-binary-name-conflict**: `cc` shadows Apple clang (`/usr/bin/cc`) on macOS. Developers who type `cc` expecting the Coherence CLI instead invoke the C compiler. Needs alias or rename to `coh` or `cn` to avoid the conflict.
+- **cli-mcp-surface**: unshipped attempt — cli mcp surface (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **cli-noninteractive-identity**: unshipped attempt — cli noninteractive identity (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/agent-pipeline.md
+++ b/ideas/agent-pipeline.md
@@ -42,3 +42,6 @@ Manual software development does not scale. A single human cannot spec, implemen
 - **split-review-into-phases**: Current review tries to verify code quality AND production deployment in one step, resulting in 60-80% failure rate. Split into: (1) code-review -- static analysis and spec compliance, (2) deploy -- push code to production environment, (3) verify-production -- confirm endpoints respond correctly, data persists, no regressions.
 - **pipeline-data-flow-fixes**: Phase auto-advance fires before push confirmation, causing tasks to advance before code is actually on the remote. Push failures are hardcoded as `execution_error` instead of the more specific `push_failed`, making diagnostics harder.
 - **validation-requires-production**: Review phase asks the provider to verify production behavior, but the provider cannot deploy. The runner itself must check endpoints after deploy -- providers verify code quality, the runner verifies production state.
+- **agent-sse-control-channel**: unshipped attempt — agent sse control channel (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **spec-verification-upgrade**: unshipped attempt — spec verification upgrade (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **test-backlog-cursor**: unshipped attempt — test backlog cursor (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/coherence-credit.md
+++ b/ideas/coherence-credit.md
@@ -40,3 +40,5 @@ Without a common unit of account, you cannot compare the cost of writing a spec 
 ## Absorbed Ideas
 
 - **market-driven-exchange-rates**: Replace hardcoded 1 ETH = 1000 CC with oracle-fed pricing. Fetch live prices from CoinGecko/Chainlink. CC value tracks real contribution value, not crypto speculation. Exchange rates update at most daily to prevent gaming.
+- **attention-economy-cc-flow**: unshipped attempt — attention economy cc flow (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **cc-flow-on-asset-use**: unshipped attempt — cc flow on asset use (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/contributor-experience.md
+++ b/ideas/contributor-experience.md
@@ -37,6 +37,8 @@ New contributors arrive and see a "Share your idea" prompt but have no context a
 
 - **ux-new-contributor-orientation**: Landing page needs context -- what is Coherence Network, what are ideas for, what does CC mean, why participate. "How it works" section (Share -> Grow -> Value) needs real examples, not abstract descriptions. Should show actual ideas that went from inception to completion with real CC payouts.
 - **identity-37-providers**: 37 identity providers across 6 categories (Social, Dev, Crypto/Web3, Professional, Identity, Platform). Contributors attributed via any existing account without registering. GitHub, Twitter, Discord, Ethereum wallet, LinkedIn -- any existing identity is sufficient.
+- **contributor-discovery**: unshipped attempt — contributor discovery (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **contributor-messaging**: unshipped attempt — contributor messaging (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
 
 ## Open Questions
 

--- a/ideas/data-infrastructure.md
+++ b/ideas/data-infrastructure.md
@@ -45,6 +45,8 @@ The original schema had 10+ separate tables (ideas, specs, tasks, contributors, 
 - **universal-node-edge-layer**: Replace 10+ tables with `nodes` (`id`, `type`, `name`, `properties` JSONB) + `edges` (`from_id`, `to_id`, `type`, `strength`). PostgreSQL JSONB chosen over Neo4j for operational simplicity -- one database to manage, not two. Graph queries use recursive CTEs instead of a separate graph database.
 - **concept-layer-foundation**: 184 universal concepts, 46 relationship types, 53 axes from the Living Codex ontology. Concepts are nodes; relationships are edges. The concept layer provides the vocabulary for coherence scoring -- how well does an idea align with the platform's conceptual framework?
 - **service-contract-registry**: `ServiceSpec`, `ServiceRef`, `IService` protocol with dependency validation and health reporting. Every service declares what it needs and what it provides. The registry validates that all dependencies are satisfied before startup.
+- **data-hygiene-db-monitoring**: unshipped attempt — data hygiene db monitoring (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **data-retention-summarization**: unshipped attempt — data retention summarization (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
 
 ## Open Questions
 

--- a/ideas/developer-experience.md
+++ b/ideas/developer-experience.md
@@ -36,3 +36,4 @@ Developer friction compounds. If tests are slow, developers skip them. If databa
 
 - **external-repo-milestone**: Create `coherence-external-proof` repo to demonstrate external enablement. The repo uses the public API to create ideas, record contributions, track lifecycle stages, and measure coherence scores for a completely unrelated project. If the platform cannot manage someone else's ideas, it is not ready for adoption.
 - **db-error-tracking**: Health endpoint reports `schema_ok` boolean. Startup database errors logged at ERROR level (not WARNING or INFO). Missing tables recorded as friction events with table name, expected schema, and timestamp. This turns invisible infrastructure failures into actionable alerts.
+- **documentation-developer-experience**: unshipped attempt — documentation developer experience (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/external-presence.md
+++ b/ideas/external-presence.md
@@ -57,3 +57,5 @@ A platform that lives only at one URL has a ceiling on reach. Contributors are o
 - **presence-modularization**: Modular public presences — shared fragments + build script.
 - **community-project-funder-match**: Match community projects with small funders.
 - **oss-interface-alignment**: Align OSS intelligence interfaces with runtime.
+- **creator-economy-bridge**: unshipped attempt — creator economy bridge (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **geolocation-awareness-geocoding**: unshipped attempt — geolocation awareness geocoding (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/knowledge-and-resonance.md
+++ b/ideas/knowledge-and-resonance.md
@@ -75,3 +75,5 @@ Without a concept layer, every idea is a bag of words. Similarity is keyword mat
 - **codex-digital-signatures**: ECDSA verification for concept authenticity.
 - **codex-llm-pipeline**: LLM concept processing pipeline — multi-provider AI analysis.
 - **codex-image-analysis**: Visual concept extraction — analyze images for concept networks.
+- **concept-as-idea-registration**: unshipped attempt — concept as idea registration (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **ucore-daily-engagement-skill**: unshipped attempt — ucore daily engagement skill (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/pipeline-reliability.md
+++ b/ideas/pipeline-reliability.md
@@ -48,3 +48,7 @@ The pipeline fails in multiple ways: provider timeouts, executor crashes, valida
 - **silent-failure-detection**: 9 failed tasks with `error_summary=None`. The runner must capture stderr, exit code, timeout info, and partial output for every failure. Silent failures are the most expensive kind -- you pay the CC cost and learn nothing.
 - **task-deduplication**: 799 spec tasks for 147 ideas. Before creating a new task, check completed_tasks table. If a task with the same idea_id and phase already exists and succeeded, skip it. If it failed, check error_category before retrying.
 - **data-driven-timeout-resume**: Replace fixed 300s timeouts with measurement-derived ones. Track P50, P90, P99 execution times per provider per task type. Set timeout at 2x P90. Resume from partial work on timeout instead of restarting.
+- **ci-pipeline**: unshipped attempt — ci pipeline (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **pipeline-deploy-phase**: unshipped attempt — pipeline deploy phase (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **runner-pipeline-health**: unshipped attempt — runner pipeline health (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **runner-self-update**: unshipped attempt — runner self update (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/portfolio-governance.md
+++ b/ideas/portfolio-governance.md
@@ -55,3 +55,4 @@ With 338 ideas in the system, the signal-to-noise ratio collapses unless every i
 - **grant-belief-graph**: Belief graph — per-user and per-contributor knowledge structure.
 - **grant-source-ingestion**: Grant source document ingestion — extract, normalize, operationalize.
 - **validation-quality-gates**: Validation quality gates that separate real value from noise.
+- **validation-categories**: unshipped attempt — validation categories (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)

--- a/ideas/user-surfaces.md
+++ b/ideas/user-surfaces.md
@@ -42,6 +42,11 @@ The platform has rich data (ideas, specs, tasks, contributions, coherence scores
 
 - **web-news-resonance-page**: `/news` page showing a daily resonance feed matched to ideas with relevance scores. External news articles and events are matched against active ideas to surface opportunities and threats. Helps contributors understand the broader context of their work.
 - **ux-homepage-readability**: Hero text nearly invisible on dark background. Warm amber palette (`#D4A574` on `#1a1a2e`) gives approximately 3.2:1 contrast ratio -- below the 4.5:1 WCAG AA minimum. Fix by either lightening the text or adding a semi-transparent background behind text blocks.
+- **ux-contributor-experience**: unshipped attempt — ux contributor experience (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **ux-my-portfolio**: unshipped attempt — ux my portfolio (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **ux-resonance-empty-state**: unshipped attempt — ux resonance empty state (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **ux-value-lineage-visualization**: unshipped attempt — ux value lineage visualization (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
+- **web-skeleton**: unshipped attempt — web skeleton (lineage: see `docs/lineage/unshipped-digest-2026-04-27.md`)
 
 ## Open Questions
 


### PR DESCRIPTION
Ingestion: the body's idea registry now reflects what's been attempted under each super-idea, not just what's shipped.

26 unshipped spec slugs added as absorbed-idea bullets across 11 super-ideas, each linking back to `docs/lineage/unshipped-digest-2026-04-27.md` for the lineage trail.

| super-idea | new entries |
|---|---|
| user-surfaces | 5 |
| pipeline-reliability | 4 |
| agent-pipeline | 3 |
| data-infrastructure / external-presence / coherence-credit / agent-cli / contributor-experience / knowledge-and-resonance | 2 each |
| developer-experience / portfolio-governance | 1 each |

5 candidates from the original 31 were filtered as residual noise (test-idea placeholder, idea-UUID slugs, follow-up questions caught as spec names).

The body's idea files now hold both the territory it has named AND the unfinished attempts at filling it. Visitors reading any super-idea see the full picture — what landed, what was tried, what's still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)