### PR TITLE
Harden concept translation fallback

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -95,6 +95,16 @@ def _write_anchor_view_from_concept(concept_id: str, concept: dict[str, Any]):
     )
 
 
+def _is_unchanged_machine_view(chosen, anchor) -> bool:
+    return (
+        chosen is not None
+        and anchor is not None
+        and chosen.lang != anchor.lang
+        and chosen.author_type == translation_cache.AUTHOR_TYPE_TRANSLATION_MACHINE
+        and chosen.content_hash == anchor.content_hash
+    )
+
+
 # ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
@@ -762,7 +772,38 @@ async def get_concept(
         raise HTTPException(status_code=400, detail=localize("unsupported_locale", err_lang, code=lang))
 
     chosen = next((v for v in views if v.lang == target_lang), None)
+    if _is_unchanged_machine_view(chosen, anchor):
+        chosen = None
     pending = chosen is None
+
+    if pending and target_lang != translator_service.DEFAULT_LOCALE and translator_service.has_backend():
+        translated = translator_service.attune_from_anchor(
+            entity_type="concept",
+            entity_id=concept_id,
+            target_lang=target_lang,
+        )
+        if translated is not None:
+            concept["name"] = translated.content_title or concept.get("name")
+            concept["description"] = translated.content_description or concept.get("description")
+            concept["story_content"] = translated.content_markdown or concept.get("story_content")
+            concept["language_meta"] = {
+                "lang": target_lang,
+                "is_anchor": False,
+                "stale": False,
+                "pending": False,
+                "available_langs": sorted({v.lang for v in views} | {target_lang}),
+                "anchor": (
+                    {
+                        "lang": anchor.lang,
+                        "author_type": anchor.author_type,
+                        "updated_at": anchor.updated_at.isoformat() if anchor.updated_at else None,
+                        "content_hash": anchor.content_hash,
+                    }
+                    if anchor
+                    else None
+                ),
+            }
+            return concept
 
     # On-demand attunement: if the view is missing or stale and a backend is
     # configured, enqueue a translation. The current request still serves the

--- a/api/app/services/translator_backends.py
+++ b/api/app/services/translator_backends.py
@@ -131,6 +131,13 @@ class LibreTranslateBackend:
     def _translate(self, text: str, source_lang: str, target_lang: str) -> str:
         if not text.strip():
             return text
+        if len(text) > 3500:
+            chunks = re.split(r"(\n\s*\n)", text)
+            translated_chunks = [
+                self._translate(part, source_lang, target_lang) if part.strip() else part
+                for part in chunks
+            ]
+            return "".join(translated_chunks)
         body: dict[str, Any] = {
             "q": text,
             "source": source_lang,

--- a/api/app/services/translator_service.py
+++ b/api/app/services/translator_service.py
@@ -192,6 +192,13 @@ def attune_from_anchor(
         target_lang=target_lang,
         glossary_prompt=glossary,
     )
+    if (
+        target_lang != anchor.lang
+        and (title or "") == (anchor.content_title or "")
+        and (desc or "") == (anchor.content_description or "")
+        and (md or "") == (anchor.content_markdown or "")
+    ):
+        return None
     rec = _cache.write_view(
         entity_type=entity_type,
         entity_id=entity_id,

--- a/docs/system_audit/commit_evidence_2026-04-27_vision-i18n-content-fallback.json
+++ b/docs/system_audit/commit_evidence_2026-04-27_vision-i18n-content-fallback.json
@@ -1,10 +1,12 @@
 {
   "date": "2026-04-27",
-  "thread_branch": "codex/vision-i18n-20260427",
+  "thread_branch": "codex/vision-i18n-live-hardening-20260427",
   "commit_scope": "Improve /vision and concept-page i18n for restored fallback content and missing concept language views.",
   "files_owned": [
     "api/app/routers/concepts.py",
     "api/app/services/idea_hierarchy.py",
+    "api/app/services/translator_backends.py",
+    "api/app/services/translator_service.py",
     "api/tests/test_on_demand_attunement.py",
     "web/app/vision/page.tsx",
     "web/app/vision/[conceptId]/page.tsx",
@@ -20,7 +22,7 @@
       "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
       "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
     ],
-    "summary": "Focused on-demand attunement tests passed, including the new no-views concept case. The CI-failing super-idea rollup tests passed after restoring the missing update_idea binding. The Next.js production build passed. A local German /vision render showed localized restored fallback content and preserved lang=de on concept links. Follow-through was clean and the local PR guard passed after seeding the isolated verifier DB with lc-pulse."
+    "summary": "Focused on-demand attunement tests passed, including the new no-views concept case. The CI-failing super-idea rollup tests passed after restoring the missing update_idea binding. The Next.js production build passed. A local German /vision render showed localized restored fallback content and preserved lang=de on concept links. Follow-through was clean and the local PR guard passed after seeding the isolated verifier DB with lc-pulse. After live verification exposed an unchanged English machine view, translator fallback was hardened to chunk long text and reject unchanged target-language machine views."
   },
   "ci_validation": {
     "status": "pending",
@@ -73,6 +75,8 @@
   "change_files": [
     "api/app/routers/concepts.py",
     "api/app/services/idea_hierarchy.py",
+    "api/app/services/translator_backends.py",
+    "api/app/services/translator_service.py",
     "api/tests/test_on_demand_attunement.py",
     "web/app/vision/page.tsx",
     "web/app/vision/[conceptId]/page.tsx"


### PR DESCRIPTION
## Summary\n- Chunk long LibreTranslate requests so concept stories are not sent as one oversized translation body.\n- Reject unchanged machine translations instead of caching source-language text as the target language.\n- Treat unchanged cached machine views as missing and synchronously retry attunement for the requested language.\n\n## Context\nAfter PR #1251 deployed, live /api/concepts/lc-pulse?lang=de exposed a fail-open machine view where the German view contained unchanged English story content. This prevents that bad state from being served as a completed translation.\n\n## Validation\n- cd api && python3 -m pytest tests/test_on_demand_attunement.py tests/test_super_idea_rollup.py -q\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main