### PR TITLE
feat(gitnexus): integration doc + measurement script for trial R2/R3

### DIFF
--- a/docs/integration/gitnexus-integration-experiment.md
+++ b/docs/integration/gitnexus-integration-experiment.md
@@ -1,0 +1,157 @@
+# GitNexus Integration — Experiment Setup & Agent Contract
+
+> **Status**: experiment in progress (per `specs/gitnexus-integration-experiment.md`).
+> **Decision pending**: adopt / drop / pivot at end of 30-task trial.
+
+[GitNexus](https://github.com/abhigyanpatwari/GitNexus) is a tree-sitter-powered code-intelligence engine that builds a property graph of every function call, import, class, and inheritance edge in a repository, and exposes 16 MCP tools for AI agents.
+
+This document is **the agent contract** for the trial: it defines when an agent should reach for GitNexus's tools versus our existing 60, and how to set up the sidecar.
+
+---
+
+## Why we're trying this
+
+Our agents work spec-to-file at the granularity of frontmatter `source:` paths. They don't have call-graph awareness. Symptom: a confident edit can silently break a downstream caller, surfacing only as a `*_composted` failure or a review-flagged regression. GitNexus addresses exactly this gap by precomputing blast-radius answers at index time.
+
+The trial is bounded — 30 paired tasks, then decide.
+
+## Setup
+
+### 1. Pin the GitNexus revision
+
+Trial uses GitNexus pinned at the SHA recorded in `scripts/measure_gitnexus_value.py::GITNEXUS_PIN`. If the upstream API shifts mid-trial, we want to know — re-pinning would invalidate the measurement window.
+
+### 2. Install on the runner host
+
+```bash
+# On the agent runner host (e.g., the VPS at 187.77.152.42 or each worker node)
+git clone https://github.com/abhigyanpatwari/GitNexus.git ~/gitnexus
+cd ~/gitnexus
+git checkout "$(cat /docker/coherence-network/repo/scripts/.gitnexus-pin)"
+npm install
+npm run build
+
+# Index this repository
+node dist/cli.js index /docker/coherence-network/repo
+
+# Start the sidecar MCP server (background, port 8765)
+node dist/cli.js mcp serve --port 8765 &
+```
+
+Verify: `curl -s http://localhost:8765/tools | jq '.tools | length'` returns `16`.
+
+### 3. Register with each agent
+
+**Claude Code** (`~/.claude.json` or `.mcp.json` per project):
+
+```json
+{
+  "mcpServers": {
+    "gitnexus": {
+      "url": "http://localhost:8765",
+      "type": "sse"
+    }
+  }
+}
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "gitnexus": {
+      "command": "node",
+      "args": ["/home/user/gitnexus/dist/cli.js", "mcp", "stdio"]
+    }
+  }
+}
+```
+
+**Local runner agents**: register via the MCP loader the runner already uses for `coherence-mcp-server` — point at `http://localhost:8765` as a second server, no code changes to the runner needed.
+
+### 4. Reindex on commit
+
+GitNexus's index can drift from `HEAD`. For the trial, reindex after every commit to the runner's working tree:
+
+```bash
+# Add to the runner's post-commit hook or pipeline-advance step
+node ~/gitnexus/dist/cli.js index /docker/coherence-network/repo --incremental
+```
+
+If the agent acts on a stale index, count it as a `pivot` signal in the measurement, not a setup bug to silence.
+
+---
+
+## Agent Contract — when to call which tool
+
+The body has two graph layers running in parallel during the trial. They serve different intents and don't merge. Use this table as a decision rule.
+
+| Question the agent has | Call this tool | Returns |
+|------------------------|----------------|---------|
+| **Structure-layer** (GitNexus) | | |
+| "What functions call `X`?" | `gitnexus.context` | callers + call sites + confidence |
+| "What breaks if I rename `X`?" | `gitnexus.impact` | blast-radius graph with depth + confidence |
+| "What does this file import?" | `gitnexus.context` | imports + re-exports + bindings |
+| "What classes extend `X`?" | `gitnexus.cypher` | inheritance subtree |
+| "Is there a function semantically like `Y`?" | `gitnexus.query` | hybrid search (BM25 + semantic + RRF) |
+| "What execution flow does `endpoint_X` participate in?" | `gitnexus.context` (process view) | upstream + downstream call chain |
+| **Meaning-layer** (our existing tools) | | |
+| "Which idea owns this work?" | `coherence_trace` | idea → spec → contributors |
+| "Which spec covers this file?" | `coherence_trace` (file → spec) | spec frontmatter `source:` match |
+| "Which contributor staked CC on this idea?" | `coherence_lineage` | CC stake graph |
+| "What's the next pending task in this idea?" | `coherence_task_seed` / `coherence_select_idea` | task queue |
+| "How is this concept used across ideas?" | `coherence_concept_*` | concept-resonance graph |
+
+**The discipline**: if the agent's question is "what code is connected to this code," GitNexus first. If the question is "what intent / contributor / value is connected to this code," our tools first. The two layers compose only at the agent's discretion — no pre-built joiners exist during the trial.
+
+### Concrete examples
+
+**Before editing `api/app/services/coherence_service.py::compute_score`:**
+
+1. `gitnexus.impact(symbol="compute_score")` → list of callers across the repo. The agent reads this to decide whether the edit is safe.
+2. `coherence_trace(file="api/app/services/coherence_service.py")` → which spec(s) reference this file, what `done_when` items rely on it. The agent uses this to plan tests.
+
+The two outputs are independent. Compose them in the agent's plan, not in a query.
+
+**Before renaming `Idea.coherence_score` field:**
+
+1. `gitnexus.cypher` → all references in the codebase, weighted by confidence.
+2. `coherence_trace(symbol="Idea.coherence_score")` → which spec frontmatter mentions this symbol.
+
+If GitNexus surfaces a caller that no spec covers, that's a finding regardless of the rename — surface it to the user.
+
+---
+
+## What we are measuring
+
+`scripts/measure_gitnexus_value.py` runs the same task batch twice (with vs. without GitNexus tools registered) and emits a comparison report. Metrics:
+
+- `composted_failures`: count of tasks ending in any `*_composted` status.
+- `heal_cycles`: total `heal` task type count across the batch.
+- `time_to_merge_minutes_median`: from task seed to PR merge.
+- `downstream_caller_misses`: review-flagged regressions where a reviewer notes "this broke caller X."
+
+Run during trial:
+
+```bash
+python3 scripts/measure_gitnexus_value.py --window-start 2026-04-27 --window-end 2026-05-27
+python3 scripts/measure_gitnexus_value.py --report-only   # render the comparison without re-collecting
+```
+
+---
+
+## Decision criteria (filled at trial end, recorded in the spec's `## Outcome` section)
+
+- **adopt** — the deltas show meaningful reduction in composted failures or downstream-caller misses, AND agent feedback is positive (tools are not just inflating context). Write a follow-up integration spec for permanent install + the meaning↔structure composition layer.
+- **drop** — deltas are flat or negative, OR agents ignored the contract and consumed extra tokens without using the tools. Uninstall and document why.
+- **pivot** — the structural intelligence helps but the deployment shape doesn't (e.g., index staleness too painful, schema mismatch obvious, sidecar adds operational drag). Specify what to absorb (e.g., just the impact-analysis concept built into our own graph) and write a focused spec for that.
+
+---
+
+## What this trial deliberately does NOT do
+
+- Merge GitNexus's node types into our Neo4j graph — premature.
+- Build the "blast radius for function X → which idea/spec/contributor stake" join — only worth it if `adopt`.
+- Replace any existing tool. GitNexus is purely additive.
+- Multi-repo `group_*` features. Single-repo for now.

--- a/scripts/measure_gitnexus_value.py
+++ b/scripts/measure_gitnexus_value.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Measure GitNexus integration value across paired task windows.
+
+Per specs/gitnexus-integration-experiment.md R3: run the same task batch
+twice (with / without GitNexus tools available) and compare four metrics:
+
+  - composted_failures
+  - heal_cycles
+  - time_to_merge_minutes_median
+  - downstream_caller_misses (manually flagged in review)
+
+The script is intentionally simple — it queries the existing pipeline
+APIs that already record task lifecycle events, then renders a side-by-
+side comparison. Markings of which window is "with-gitnexus" vs
+"baseline" come from the operator: this script does not start or stop
+the GitNexus sidecar; it only reads the consequences.
+
+Usage
+-----
+  # Collect both windows from live API
+  python3 scripts/measure_gitnexus_value.py \\
+      --baseline-start 2026-04-20 --baseline-end 2026-04-26 \\
+      --gitnexus-start 2026-04-27 --gitnexus-end 2026-05-03
+
+  # Re-render the comparison from cached collection
+  python3 scripts/measure_gitnexus_value.py --report-only
+
+  # Smoke test (used by the spec's `test:` field)
+  python3 scripts/measure_gitnexus_value.py --report-only
+
+Cached collections live at scripts/.gitnexus-trial-cache.json. The cache
+is content-addressed by window range so re-running on the same window
+hits the cache and surfaces no new HTTP traffic.
+
+Pinned GitNexus revision
+------------------------
+The trial uses GitNexus pinned at the SHA in scripts/.gitnexus-pin. If
+that file does not exist when the trial starts, the operator must
+record the pinned SHA there before the first measurement window opens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Pinned at trial start; operator records the SHA here before opening
+# the first measurement window. See docs/integration/gitnexus-integration-experiment.md
+GITNEXUS_PIN_FILE = Path(__file__).parent / ".gitnexus-pin"
+
+CACHE_FILE = Path(__file__).parent / ".gitnexus-trial-cache.json"
+
+DEFAULT_API = os.environ.get("COHERENCE_API_URL", "https://api.coherencycoin.com")
+API_KEY = os.environ.get("COHERENCE_API_KEY", "dev-key")
+
+
+@dataclass
+class WindowMetrics:
+    """Aggregated metrics for one measurement window."""
+
+    label: str
+    start: str
+    end: str
+    task_count: int = 0
+    composted_failures: int = 0
+    heal_cycles: int = 0
+    time_to_merge_minutes: list[float] = field(default_factory=list)
+    downstream_caller_misses: int = 0
+
+    @property
+    def median_ttm(self) -> float | None:
+        return statistics.median(self.time_to_merge_minutes) if self.time_to_merge_minutes else None
+
+
+def http_get_json(path: str, *, api_base: str = DEFAULT_API) -> Any:
+    """Minimal GET against the public API. Raises on non-2xx."""
+    url = f"{api_base.rstrip('/')}{path}"
+    req = urllib.request.Request(url, headers={"X-API-Key": API_KEY})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - public API
+        return json.loads(resp.read())
+
+
+def collect_window(label: str, start: str, end: str, *, api_base: str) -> WindowMetrics:
+    """Collect a single window's metrics from the live pipeline API."""
+    metrics = WindowMetrics(label=label, start=start, end=end)
+    try:
+        params = f"?since={start}T00:00:00Z&until={end}T23:59:59Z&limit=500"
+        tasks = http_get_json(f"/api/agent/tasks{params}", api_base=api_base)
+    except urllib.error.URLError as exc:
+        print(f"[warn] {label} window — could not reach {api_base}: {exc}", file=sys.stderr)
+        return metrics
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] {label} window — unexpected: {exc}", file=sys.stderr)
+        return metrics
+
+    items = tasks.get("tasks") if isinstance(tasks, dict) else tasks
+    if not isinstance(items, list):
+        return metrics
+
+    metrics.task_count = len(items)
+    for task in items:
+        status = (task.get("status") or "").lower()
+        if status.endswith("_composted") or "composted" in status:
+            metrics.composted_failures += 1
+        if (task.get("type") or "").lower() == "heal":
+            metrics.heal_cycles += 1
+
+        seeded_at = task.get("seeded_at") or task.get("created_at")
+        merged_at = (task.get("metadata") or {}).get("merged_at")
+        if seeded_at and merged_at:
+            try:
+                seeded = datetime.fromisoformat(seeded_at.replace("Z", "+00:00"))
+                merged = datetime.fromisoformat(merged_at.replace("Z", "+00:00"))
+                metrics.time_to_merge_minutes.append((merged - seeded).total_seconds() / 60.0)
+            except (TypeError, ValueError):
+                pass
+
+        # downstream_caller_misses: read from review labels if present
+        review_flags = (task.get("metadata") or {}).get("review_flags") or []
+        if isinstance(review_flags, list):
+            for flag in review_flags:
+                if isinstance(flag, str) and "caller" in flag.lower():
+                    metrics.downstream_caller_misses += 1
+
+    return metrics
+
+
+def render_report(baseline: WindowMetrics, gitnexus: WindowMetrics) -> str:
+    """Format the side-by-side comparison."""
+    pin = GITNEXUS_PIN_FILE.read_text().strip() if GITNEXUS_PIN_FILE.exists() else "(not pinned yet)"
+
+    def fmt_delta(b: float | int | None, g: float | int | None) -> str:
+        if b is None or g is None:
+            return "  n/a"
+        delta = (g if isinstance(g, (int, float)) else 0) - (b if isinstance(b, (int, float)) else 0)
+        sign = "+" if delta > 0 else ""
+        return f"{sign}{delta:.2f}" if isinstance(delta, float) else f"{sign}{delta}"
+
+    rows = [
+        ("tasks observed", baseline.task_count, gitnexus.task_count),
+        ("composted_failures", baseline.composted_failures, gitnexus.composted_failures),
+        ("heal_cycles", baseline.heal_cycles, gitnexus.heal_cycles),
+        ("time_to_merge_min (median)", baseline.median_ttm, gitnexus.median_ttm),
+        ("downstream_caller_misses", baseline.downstream_caller_misses, gitnexus.downstream_caller_misses),
+    ]
+
+    lines = [
+        f"GitNexus integration trial — comparison report",
+        f"GitNexus revision pinned: {pin}",
+        f"Baseline window:  {baseline.start} → {baseline.end}  (label={baseline.label})",
+        f"GitNexus window:  {gitnexus.start} → {gitnexus.end}  (label={gitnexus.label})",
+        "",
+        f"{'Metric':<32}{'Baseline':>14}{'GitNexus':>14}{'Delta':>10}",
+        "-" * 70,
+    ]
+    for name, b_val, g_val in rows:
+        b_str = "n/a" if b_val is None else f"{b_val:.2f}" if isinstance(b_val, float) else str(b_val)
+        g_str = "n/a" if g_val is None else f"{g_val:.2f}" if isinstance(g_val, float) else str(g_val)
+        lines.append(f"{name:<32}{b_str:>14}{g_str:>14}{fmt_delta(b_val, g_val):>10}")
+    lines.append("")
+    lines.append("To record a trial decision, fill the ## Outcome section in")
+    lines.append("specs/gitnexus-integration-experiment.md with these numbers + qualitative notes.")
+    return "\n".join(lines)
+
+
+def load_cache() -> dict:
+    if not CACHE_FILE.exists():
+        return {}
+    try:
+        return json.loads(CACHE_FILE.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def save_cache(data: dict) -> None:
+    CACHE_FILE.write_text(json.dumps(data, indent=2, default=str))
+
+
+def metrics_to_dict(m: WindowMetrics) -> dict:
+    return {
+        "label": m.label,
+        "start": m.start,
+        "end": m.end,
+        "task_count": m.task_count,
+        "composted_failures": m.composted_failures,
+        "heal_cycles": m.heal_cycles,
+        "time_to_merge_minutes": m.time_to_merge_minutes,
+        "downstream_caller_misses": m.downstream_caller_misses,
+    }
+
+
+def metrics_from_dict(d: dict) -> WindowMetrics:
+    m = WindowMetrics(
+        label=d.get("label", "?"),
+        start=d.get("start", "?"),
+        end=d.get("end", "?"),
+        task_count=int(d.get("task_count", 0)),
+        composted_failures=int(d.get("composted_failures", 0)),
+        heal_cycles=int(d.get("heal_cycles", 0)),
+        downstream_caller_misses=int(d.get("downstream_caller_misses", 0)),
+    )
+    m.time_to_merge_minutes = list(d.get("time_to_merge_minutes", []))
+    return m
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Measure GitNexus trial value")
+    parser.add_argument("--api-base", default=DEFAULT_API)
+    parser.add_argument("--baseline-start", help="ISO date YYYY-MM-DD")
+    parser.add_argument("--baseline-end", help="ISO date YYYY-MM-DD")
+    parser.add_argument("--gitnexus-start", help="ISO date YYYY-MM-DD")
+    parser.add_argument("--gitnexus-end", help="ISO date YYYY-MM-DD")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Render comparison from cache without HTTP collection",
+    )
+    args = parser.parse_args(argv)
+
+    cache = load_cache()
+
+    if args.report_only:
+        baseline_d = cache.get("baseline")
+        gitnexus_d = cache.get("gitnexus")
+        if not baseline_d or not gitnexus_d:
+            # Smoke-test path: render an empty comparison so the spec
+            # `test:` field passes before the trial begins.
+            print(render_report(
+                WindowMetrics(label="baseline", start="(unset)", end="(unset)"),
+                WindowMetrics(label="gitnexus", start="(unset)", end="(unset)"),
+            ))
+            return 0
+        print(render_report(metrics_from_dict(baseline_d), metrics_from_dict(gitnexus_d)))
+        return 0
+
+    if not all([args.baseline_start, args.baseline_end, args.gitnexus_start, args.gitnexus_end]):
+        parser.error("collection mode requires all four window dates (or use --report-only)")
+
+    baseline = collect_window("baseline", args.baseline_start, args.baseline_end, api_base=args.api_base)
+    gitnexus = collect_window("gitnexus", args.gitnexus_start, args.gitnexus_end, api_base=args.api_base)
+    cache["baseline"] = metrics_to_dict(baseline)
+    cache["gitnexus"] = metrics_to_dict(gitnexus)
+    cache["collected_at"] = datetime.now(timezone.utc).isoformat()
+    save_cache(cache)
+    print(render_report(baseline, gitnexus))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/gitnexus-integration-experiment.md
+++ b/specs/gitnexus-integration-experiment.md
@@ -2,6 +2,10 @@
 idea_id: knowledge-and-resonance
 status: draft
 source:
+  - file: docs/integration/gitnexus-integration-experiment.md
+    symbols: [setup steps, agent contract, decision criteria]
+  - file: scripts/measure_gitnexus_value.py
+    symbols: [collect_window(), render_report(), WindowMetrics]
   - file: mcp-server/coherence_mcp_server/server.py
     symbols: [MCP server entrypoint — sidecar registration target]
   - file: specs/source-artifact-sensing-graph-integration.md


### PR DESCRIPTION
Per `specs/gitnexus-integration-experiment.md` (#1256), the trial needs two artifacts before any operator can begin a measurement window. This PR lands both.

## R2 — Agent contract documented

`docs/integration/gitnexus-integration-experiment.md`

- **Practical setup**: pin SHA in `scripts/.gitnexus-pin`, install on runner host, register with Claude Code / Cursor / runner agents, reindex on commit.
- **Decision table**: structure-layer questions (callers, blast radius, inheritance) → GitNexus tools; meaning-layer questions (idea ownership, spec coverage, CC stake) → our existing 60. The two layers stay independent during the trial.
- **Concrete examples**: before editing `compute_score`, before renaming `Idea.coherence_score` — both layers consulted independently, no pre-built joiners.
- **Decision criteria**: `adopt` / `drop` / `pivot` at trial close.

## R3 — Paired measurement runner

`scripts/measure_gitnexus_value.py`

- Reads task lifecycle from the existing `/api/agent/tasks` endpoint (no new API, no schema change) and computes the four metrics: `composted_failures`, `heal_cycles`, `time_to_merge_minutes_median`, `downstream_caller_misses`.
- Two modes:
  - `--report-only` renders comparison from `.gitnexus-trial-cache.json` (smoke-test path used by the spec's `test:` field).
  - Collection mode requires both window date ranges, writes the cache.
- `--report-only` without cache emits an empty comparison so the spec's smoke test passes before the trial begins.

## Smoke test

```bash
$ python3 scripts/measure_gitnexus_value.py --report-only
GitNexus integration trial — comparison report
GitNexus revision pinned: (not pinned yet)
...
```

Exits 0; renders empty comparison cleanly. `python3 scripts/validate_spec_quality.py --file specs/gitnexus-integration-experiment.md` passes. `make wellness` shows no new drift (existing flags on `close-awareness-gaps` and `self-custody-wallet-integration` are parallel-agent specs, separate breath).

## What this PR does NOT do

- Install GitNexus on any runner host (operational; in the doc).
- Start the sidecar or pin the SHA — the trial begins when the operator records `scripts/.gitnexus-pin` and runs the first window.
- Register GitNexus with any agent's MCP config (per-agent setup, in the doc).

When the trial begins, the operator follows the integration doc to install + pin + register, runs paired windows of work, then fills the spec's `## Outcome` section with the measurement output.

Updated `specs/gitnexus-integration-experiment.md` source map to point at the now-existing files.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_