### PR TITLE
deploy(gitnexus): allow runner Claude agents to call GitNexus MCP tools

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -349,7 +349,7 @@ def _detect_providers() -> dict[str, dict]:
         # --dangerously-skip-permissions: bypass all permission checks
         # --output-format text: plain text output (no JSON wrapping)
         # NOTE: --print disables tools — never use it for impl/test tasks
-        "claude": {"cmd": ["claude", "-p", "--dangerously-skip-permissions", "--allowedTools", "Bash,Read,Edit,Write,Glob,Grep,WebFetch", "--output-format", "text"], "append_prompt": True, "check": _check_claude_auth},
+        "claude": {"cmd": ["claude", "-p", "--dangerously-skip-permissions", "--allowedTools", "Bash,Read,Edit,Write,Glob,Grep,WebFetch,mcp__gitnexus__query,mcp__gitnexus__context,mcp__gitnexus__impact,mcp__gitnexus__cypher,mcp__gitnexus__detect_changes,mcp__gitnexus__rename,mcp__gitnexus__list_repos,mcp__gitnexus__group_list,mcp__gitnexus__group_sync,mcp__gitnexus__group_contracts,mcp__gitnexus__group_query,mcp__gitnexus__group_status", "--output-format", "text"], "append_prompt": True, "check": _check_claude_auth},
         # codex exec --full-auto: non-interactive sandboxed execution
         "codex": {"cmd": ["codex", "exec", "--full-auto"], "append_prompt": True},
         # gemini -y -p <prompt>: yolo mode (auto-approve tools) + headless


### PR DESCRIPTION
PR #1264 shipped `.mcp.json` registering `gitnexus@1.6.3` at the repo root, plus VPS auto-install. Interactive Claude Code picks the server up automatically. But the runner spawns claude in headless mode with explicit `--allowedTools`:

```
Bash,Read,Edit,Write,Glob,Grep,WebFetch
```

MCP tools follow `mcp__<server>__<tool>`. Without adding them to `--allowedTools`, the runner agent can't call GitNexus even when `.mcp.json` registers the server. The sidecar would run on port 8765 with no caller. That's the scaffolding-without-integration trap.

## What moves

The 12 GitNexus tools the trial cares about land in `--allowedTools`:

- `query`, `context`, `impact`, `cypher` — the meat: call graph, blast radius, hybrid search, raw graph queries.
- `detect_changes`, `rename` — action-oriented.
- `list_repos`, `group_*` — multi-repo; out of scope for this trial but cheap to allow so agents see consistent surface.

Explicit names rather than `mcp__gitnexus__*` because claude CLI's `--allowedTools` glob support varies by version. Verbose but unambiguous.

## What this PR deliberately does NOT open

`coherence-mcp-server` stays out of `--allowedTools`. The trial measures the *effect of GitNexus*, not the effect of suddenly turning on every MCP surface the runner could reach. Opening coherence-mcp-server to the runner is a separate breath if/when the trial outcome justifies it.

## After this lands

Runner agents in worktree CWDs (which inherit the repo's `.mcp.json`) can call:

```
mcp__gitnexus__impact("_coherence_score")           # before editing
mcp__gitnexus__context("compute_score")             # to see callers
mcp__gitnexus__cypher("MATCH (c:Class)<-[:EXTENDS]-...")  # arbitrary structural q
```

`scripts/measure_gitnexus_value.py` then captures whether outcomes (composted failures, heal cycles, downstream-caller misses) shift.

Verified: `python3 -m py_compile api/scripts/local_runner.py` passes.

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_