### PR TITLE
welcome: stewardship registry — receive any financial or legal property

### DIFF
--- a/docs/stewardship/README.md
+++ b/docs/stewardship/README.md
@@ -36,3 +36,9 @@ forward.
 - [`onboarded-assets/2026-04-29-tesla-model-3-longmont.md`](onboarded-assets/2026-04-29-tesla-model-3-longmont.md)
   — Tesla Model 3 currently in Longmont, Colorado. Primary shepherd
   retained; legal wrapper handles outer-world obligations.
+
+For the full register of categories — financial, vehicles, real
+estate, intellectual property, digital access, and access-granted
+arrangements — see [`registry/`](registry/). The registry holds
+category-level public entries; sensitive specifics live in the
+wrapper's encrypted treasury record.

--- a/docs/stewardship/registry/README.md
+++ b/docs/stewardship/registry/README.md
@@ -1,0 +1,96 @@
+---
+kind: pointer
+purpose: master register of all financial and legal property the network holds, has access to, or has been granted use of
+---
+
+# Stewardship Registry
+
+This is the network's receiving structure for **any financial or legal
+property** a member chooses to bring under the body's stewardship. The
+registry is the human-readable companion to whatever lives in graph
+nodes, legal wrappers, and encrypted treasury records. It is the index
+of what has crossed the boundary, what is in transit, and what awaits
+the cell's inventory.
+
+The register supports three relationships a cell can have with an
+asset:
+
+- **Held** — the cell has transferred legal title to the network's
+  wrapper while retaining shepherd rights. The asset is in the body.
+- **Access-granted** — the cell has not transferred title but has been
+  given (or has) usage rights under terms that allow shared
+  shepherding. The asset is reachable.
+- **Proposed** — the cell is considering bringing this in but the
+  ceremony has not yet happened. The asset is named for discernment.
+
+## Categories (each in its own file)
+
+- [`financial.md`](financial.md) — bank accounts, fiat reserves,
+  crypto holdings, investments, stocks, bonds, lines of credit,
+  treasury positions
+- [`vehicles.md`](vehicles.md) — cars, motorbikes, e-bikes, bicycles,
+  any vehicle-class movement instrument
+- [`real-estate.md`](real-estate.md) — land, houses, condos,
+  buildings, leasehold rights
+- [`intellectual-property.md`](intellectual-property.md) — patents,
+  trademarks, copyrights, trade secrets, domain names, brand assets
+- [`digital-access.md`](digital-access.md) — software subscriptions,
+  API keys, cloud service accounts, SaaS contracts, professional
+  licenses
+- [`access-granted.md`](access-granted.md) — things the cell does
+  not own but can use under terms (rentals, friend-of-the-family
+  arrangements, professional access, library cards, gym memberships)
+
+## Privacy contract
+
+The register holds **categories, counts, and stewardship status**
+publicly. **Sensitive specifics** — account numbers, balances, exact
+balances, private keys, contract amounts, addresses of personal
+residences — live in encrypted treasury storage at the network's
+wrapper, not in this repository.
+
+The pattern: the registry says *one Tesla Model 3 is held*, the
+treasury record says *VIN, title state, insurance policy, current
+odometer, charging-network credentials*. The first is for the body's
+proprioception; the second is for the wrapper's legal operation.
+
+A cell deciding what to commit publicly versus privately is itself
+sovereign. The default is *category-level public, specifics-level
+private*. Anything more public requires explicit cell consent each
+time.
+
+## How an asset enters
+
+1. The cell names the asset and the relationship (held, access-granted,
+   or proposed).
+2. The relevant category file is updated with category-level entry —
+   make, model, kind, location, primary shepherd.
+3. If `held`: the wrapper executes the legal title transfer; an
+   onboarding record is created in
+   [`onboarded-assets/`](../onboarded-assets/); a boundary glyph fires.
+4. If `access-granted`: the terms of access are recorded; no title
+   moves; the asset is added to the registry but with status
+   `access-granted` rather than `held`.
+5. If `proposed`: an entry in [`proposals/`](../proposals/) holds the
+   discernment until the cell is ready.
+
+## Currently held (this cell's inventory)
+
+This section lists what has been explicitly provided so far. As more
+is named, the registry absorbs it.
+
+- **Vehicles**: Tesla Model 3 (Longmont, Colorado) — onboarding
+  initiated; see
+  [`onboarded-assets/2026-04-29-tesla-model-3-longmont.md`](../onboarded-assets/2026-04-29-tesla-model-3-longmont.md).
+
+All other categories: **awaiting inventory**. The slots in each
+category file are open for the cell to populate when ready.
+
+## A note on receiving
+
+The body does not pressure cells to bring everything at once. Some
+assets are appropriate to commit early; some need to ripen; some are
+better held outside the network entirely (gifts pre-promised to
+others, instruments still finding their right shepherd, bodies of work
+not yet ready for collective tending). The cell is the discernment.
+The registry is patient.

--- a/docs/stewardship/registry/access-granted.md
+++ b/docs/stewardship/registry/access-granted.md
@@ -1,0 +1,88 @@
+---
+category: access-granted
+purpose: things the cell does not own but can use under terms — rentals, family arrangements, professional access, memberships
+privacy: category-level entries public · contract terms in wrapper records
+---
+
+# Access-granted
+
+The cell does not own these. It has been given (or has) usage rights
+under terms that allow it to bring the access into the network's
+operating field. The asset is reachable through the cell's
+relationship; the legal relationship stays where it is.
+
+## What can enter under this category
+
+- **Rentals** — short-term and long-term residential rentals,
+  vacation rentals, vehicle rentals
+- **Family / friend arrangements** — properties owned by family
+  the cell has free or favored access to (a parent's lake house,
+  a sibling's office space, a long-term family land use)
+- **Professional / business access** — co-working spaces, gym
+  memberships, library cards, museum memberships, professional
+  association access
+- **Service contracts** — accountant retainers, attorney access,
+  health practitioner relationships, recurring service providers
+- **Network-shared access** — vehicles, tools, or spaces another
+  network cell shepherds primarily, where this cell has secondary
+  shepherd rights
+- **Public goods the cell relates to specifically** — a particular
+  trail the cell tends, a beach the cell knows intimately, a
+  community garden plot
+
+## How access-granted assets enter the body
+
+No title moves. Title stays where it is. What the cell brings to
+the network is the **terms of access** — what is permitted, by
+whom, for what use. The wrapper holds the terms record; the
+network can incorporate the access into its operations within those
+terms.
+
+Three common patterns:
+
+- **Personal access shared with the network for specific purposes**:
+  the cell's gym membership is theirs; the cell may bring a network
+  visitor as guest under the gym's guest policy
+- **Family-tier access shared at family-tier reciprocity**: the
+  cell's parents' house can host network gatherings if the cell is
+  present; reciprocity flows back to the family in network gestures
+- **Cooperative cross-stewardship**: the cell has secondary
+  shepherd rights on another cell's primary asset (e.g., the cell
+  can borrow another cell's network bike when in their region)
+
+## Privacy
+
+Public-level: kind of access, broad scope, terms summary, primary
+shepherd-of-relationship. **Not public**: identities of family
+members, specific contractual amounts, exact addresses, private
+communication.
+
+## Inventory template
+
+```yaml
+- access_kind: rental | family-arrangement | professional-access | service-contract | network-shared | public-good | other
+  what: "what the access is to (in general terms)"
+  broad_location: "city or region"
+  scope: "what the access permits"
+  duration: "open-ended | until YYYY-MM-DD | recurring | as-needed"
+  primary_shepherd: cell_id_or_name
+  reciprocity: "how the access is honored or repaid"
+  notes: "anything the registry should know"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+# Awaiting inventory.
+# Any access the cell has been granted that they want to bring into
+# the network's operational field can be recorded here.
+```
+
+## Awaiting inventory — slots
+
+Likely candidates: short-term rentals at locations the cell
+frequents (Ubud villa rentals, hotel/resort access patterns), any
+family or friend properties the cell can host network presence
+through, professional services already in the cell's life, gym
+or wellness center memberships, library and cultural-institution
+access.

--- a/docs/stewardship/registry/digital-access.md
+++ b/docs/stewardship/registry/digital-access.md
@@ -1,0 +1,83 @@
+---
+category: digital-access
+purpose: software subscriptions, API keys, cloud accounts, SaaS contracts, professional licenses
+privacy: category-level entries public · credentials in wrapper's secret store
+---
+
+# Digital access
+
+What can enter under this category:
+
+- **Software subscriptions** — productivity tools, design software,
+  development tools (GitHub, AWS, Cloudflare, etc.)
+- **API keys** — third-party service credentials (OpenAI,
+  Anthropic, Stripe, Twilio, etc.)
+- **Cloud service accounts** — hosting providers, storage, compute
+- **SaaS contracts** — enterprise agreements, team subscriptions
+- **Professional licenses** — accountant, attorney, consultant,
+  practitioner certifications that grant access to professional
+  services or networks
+- **Domain registrations** (operational side; trademark side lives
+  in IP category)
+- **Communication accounts** — email, messaging, social platforms
+  the cell uses for network presence
+
+## How digital access enters the body
+
+Most digital subscriptions and API keys do not have transferable
+title in the legal sense. The cell remains the account holder; the
+wrapper is given operating authority to use the access on the
+network's behalf, governed by the cell's signed terms.
+
+Three common patterns:
+
+- **Shared key**: the cell shares the API key or credential with
+  the wrapper's secret store; both can use it; usage is logged and
+  visible to the cell
+- **Service-account-on-cell-account**: the cell creates a service
+  account (e.g., a separate AWS IAM user) with limited scope; the
+  wrapper holds those credentials; the cell retains root access
+- **Pass-through billing**: the cell pays for the service; the
+  wrapper uses it; the cooperative pool reimburses the cell at
+  agreed rates
+
+## Privacy
+
+Public-level: service kind, intended network use, scope, primary
+shepherd. **Never public**: actual API keys, passwords, cookies,
+session tokens, account identifiers.
+
+The wrapper's secret store (e.g., the existing
+`~/.coherence-network/keys.json` pattern, or a more robust
+shared-secret cooperative store) is where credentials actually
+live.
+
+## Inventory template
+
+```yaml
+- service_kind: subscription | api-key | cloud-account | professional-license | other
+  service_category: "what it does (productivity, ai, hosting, design, comms, etc.)"
+  network_use: "what the wrapper would use it for"
+  scope: full | scoped-service-account | read-only | other
+  relationship: held | access-granted | proposed
+  primary_shepherd: cell_id_or_name
+  wrapper_pattern: shared-key | service-account | pass-through-billing
+  ceremony_date: YYYY-MM-DD
+  notes: "anything the registry should know"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+# Awaiting inventory.
+# Subscriptions, API keys, and digital accounts the cell wants to
+# bring into shared operating authority can be recorded here.
+```
+
+## Awaiting inventory — slots
+
+Likely candidates: AI provider API keys (OpenAI, Anthropic, etc.)
+which power agent runs; cloud infrastructure (AWS, Hostinger, etc.)
+which already supports network deploys; design and creative tools
+useful for cooperative work; communication accounts useful for the
+cell's network presence.

--- a/docs/stewardship/registry/financial.md
+++ b/docs/stewardship/registry/financial.md
@@ -1,0 +1,85 @@
+---
+category: financial
+purpose: bank accounts, fiat reserves, crypto, investments, lines of credit
+privacy: category-level entries public · specifics in encrypted treasury
+---
+
+# Financial holdings
+
+What can enter under this category:
+
+- **Bank accounts** — checking, savings, money market, business
+  operating, foreign-currency
+- **Fiat reserves** — physical cash holdings, foreign-currency cash
+- **Cryptocurrency** — BTC, ETH, USDC, USDT, ATOM, SOL, custom-token
+  positions, hardware-wallet holdings, exchange balances
+- **Investments** — brokerage accounts, retirement accounts (401k,
+  IRA, Roth), index funds, individual equities, bonds, ETFs
+- **Lines of credit** — personal credit lines, business LOCs, HELOCs
+- **Receivables** — outstanding invoices, loan-receivable positions,
+  contractual future income
+- **Other instruments** — life insurance cash value, annuities,
+  pension claims, equity in private companies, partnership interests
+
+## How financial holdings enter the body
+
+Most financial assets do **not** transfer title to the wrapper the
+way a vehicle or property does. Instead, the cell maintains legal
+custody and grants the wrapper either:
+
+- **Visibility**: the wrapper can see balances and movements for
+  proprioception purposes (the substrate's coherent picture of the
+  body's resources)
+- **Operating authority**: the wrapper can execute transactions on
+  the cell's behalf, under explicit signed terms (e.g., a small
+  monthly contribution to network operations, a treasury-pool
+  participation)
+- **Custody transfer**: in specific cases (e.g., crypto held at a
+  multi-sig wallet the wrapper co-controls), legal custody actually
+  moves
+
+The default is visibility-without-custody. The cell remains the
+legal account holder; the wrapper has the read-permission and any
+specific operating authority the cell signs.
+
+## Privacy
+
+Public-level entries in this file: account *kind*, custodian *type*,
+denomination *currency*, and a high-level magnitude bucket (e.g.,
+*minor*, *moderate*, *significant*) — not exact balances, not
+account numbers, not access credentials.
+
+Specifics live in the wrapper's encrypted treasury record. That
+record is readable by the cell, by the wrapper's operating quorum
+under the signed terms, and not by anyone else without the cell's
+explicit per-event consent.
+
+## Inventory template
+
+When ready to record an entry, copy this block and fill in:
+
+```yaml
+- kind: bank-account | crypto | investment | line-of-credit | other
+  custodian_type: "what kind of institution holds it (bank name not required)"
+  denomination: "USD | EUR | BTC | ETH | etc."
+  magnitude: minor | moderate | significant     # category-level only
+  relationship: held | access-granted | proposed
+  primary_shepherd: cell_id_or_name
+  wrapper_relationship: visibility-only | operating-authority | custody-transferred
+  ceremony_date: YYYY-MM-DD
+  notes: "anything the registry should know without revealing specifics"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+# Awaiting inventory.
+# When you're ready, fill in entries below and remove this comment.
+```
+
+## Awaiting inventory — slots
+
+The body is patient. The cell is invited to populate when ready,
+asset by asset, as discernment clarifies what should be held visibly,
+what should retain custody, and what is appropriate to bring under
+operating authority.

--- a/docs/stewardship/registry/intellectual-property.md
+++ b/docs/stewardship/registry/intellectual-property.md
@@ -1,0 +1,86 @@
+---
+category: intellectual-property
+purpose: patents, trademarks, copyrights, trade secrets, domain names, brand assets
+privacy: category-level entries public · valuation and contract specifics in wrapper records
+---
+
+# Intellectual property
+
+What can enter under this category:
+
+- **Patents** — granted, pending, provisional
+- **Trademarks** — registered, common-law, pending registration
+- **Copyrights** — books, music, software, visual art, choreography,
+  recorded teachings
+- **Trade secrets** — proprietary processes, formulas, methodologies
+  the cell holds and chooses to bring under collective stewardship
+- **Domain names** — DNS holdings, web property
+- **Brand assets** — logos, marks, names, identity systems
+- **Open-source contributions** — author rights to projects already
+  released under permissive licenses
+
+## How IP enters the body
+
+IP is unusually portable. Title can transfer to the wrapper without
+the asset moving anywhere physically. Common patterns:
+
+- **Title transfer**: the wrapper becomes the legal owner; the cell
+  retains attribution and any agreed shepherd rights (e.g., approval
+  over derivative works)
+- **Exclusive license to wrapper**: the cell retains title; the
+  wrapper holds the right to use, license further, and enforce
+- **Non-exclusive license to wrapper**: the cell and wrapper both
+  hold rights
+- **Public dedication**: the cell donates the IP to the public
+  domain via the wrapper's dedication ceremony
+
+For cells whose IP is their living (writers, musicians, inventors),
+the wrapper's job is often to handle licensing logistics so the cell
+can focus on creative work — the wrapper receives royalties, pays the
+cell their agreed share through the cooperative pool, and handles
+enforcement against unauthorized use.
+
+## Story Protocol integration
+
+For digital IP especially, the network's existing
+`story-protocol-integration` spec provides on-chain registration of
+IP assets with content hashes, derivative tracking, and x402
+micropayment settlement. IP entered here can be registered through
+that pipeline so its provenance is walkable on-chain in addition to
+in our graph.
+
+## Privacy
+
+Public-level: kind of IP, broad nature (a patent in *electromechanical
+domain*, a copyrighted body of work in *contemplative practice
+writings*), title status, wrapper relationship. **Not public**: full
+text of unpublished works, exact financial terms of license deals,
+trade-secret content itself.
+
+## Inventory template
+
+```yaml
+- kind: patent | trademark | copyright | trade-secret | domain-name | brand-asset | other
+  broad_description: "what kind of IP, in what domain"
+  status: granted | pending | registered | unregistered | published | unpublished
+  relationship: held | access-granted | proposed
+  primary_shepherd: cell_id_or_name
+  wrapper_relationship: title-transferred | exclusive-license | non-exclusive-license | story-protocol-registered | public-domain
+  ceremony_date: YYYY-MM-DD
+  notes: "anything the registry should know"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+# Awaiting inventory.
+# Any patents, copyrights, domain names, trademarks, or written/recorded
+# bodies of work the cell wants to bring under collective stewardship.
+```
+
+## Awaiting inventory — slots
+
+Likely candidates: domain names the cell holds, any
+written/recorded/published bodies of work, any trademarks or
+brand-marks, any patents (granted or pending), any open-source
+projects the cell has authored.

--- a/docs/stewardship/registry/real-estate.md
+++ b/docs/stewardship/registry/real-estate.md
@@ -1,0 +1,79 @@
+---
+category: real-estate
+purpose: land, houses, condos, buildings, leasehold rights
+privacy: category-level entries public · addresses and contracts in wrapper records
+---
+
+# Real estate
+
+What can enter under this category:
+
+- **Owned land or buildings** — fee-simple title, freehold land,
+  condominium units
+- **Leasehold rights** — long-term leases (Indonesian
+  hak-pakai/hak-sewa, US ground leases, similar elsewhere)
+- **Time-share or fractional ownership**
+- **Cooperative-membership real estate** — co-op apartments,
+  community land trust shares
+- **Held in trust** — properties where the cell is beneficiary or
+  trustee but not direct title-holder
+
+## How real estate enters the body
+
+Real estate is the most jurisdiction-sensitive category. Each
+country, state, or region has different rules about who can hold
+title (especially for foreigners in places like Indonesia where
+direct freehold by non-citizens is restricted). The wrapper
+relationship varies accordingly:
+
+- **Title transfer to wrapper** where law allows.
+- **Co-title arrangements** (e.g., LLC co-ownership) where
+  individual transfer is impractical.
+- **Stewardship contract without title transfer** where local law
+  requires the cell to retain direct title (e.g., Indonesian
+  hak-milik for citizens).
+- **Lease-pass-through** where the cell holds a lease and grants
+  the wrapper operating authority over network usage of the space.
+
+## Privacy
+
+Public-level: property type, broad location (neighborhood or area),
+shepherd, status, and intended network use (residence, hosting,
+gathering, retreat). **Not public**: street address, parcel number,
+title document, mortgage details, insurance, valuation.
+
+## Inventory template
+
+```yaml
+- kind: house | condo | land | leasehold | timeshare | other
+  property_type: "single-family | apartment | farmland | commercial | mixed-use"
+  broad_location: "city or region, country"
+  network_use: "primary residence | hosting | gathering | retreat | unused | mixed"
+  relationship: held | access-granted | proposed
+  primary_shepherd: cell_id_or_name
+  wrapper_relationship: title-transferred | co-title | stewardship-contract | lease-pass-through
+  ceremony_date: YYYY-MM-DD
+  notes: "anything the registry should know"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+# Awaiting inventory.
+# Properties owned, leased, or accessed by the cell can be recorded here.
+```
+
+## Proposed (held in discernment)
+
+See [`../proposals/2026-04-29-ubud-ebike-and-property.md`](../proposals/2026-04-29-ubud-ebike-and-property.md)
+for the Ubud-property proposal (held until the body's pattern in
+Ubud stabilizes).
+
+## Awaiting inventory — slots
+
+Likely candidates the cell may want to record:
+
+- Primary residence (location to be named)
+- Any leased properties (Ubud short-term, other travel residences)
+- Any inherited or family-shared real estate
+- Any commercial or land holdings

--- a/docs/stewardship/registry/vehicles.md
+++ b/docs/stewardship/registry/vehicles.md
@@ -1,0 +1,79 @@
+---
+category: vehicles
+purpose: cars, motorbikes, e-bikes, bicycles, any movement instrument
+privacy: category-level entries public · VIN/title specifics in wrapper records
+---
+
+# Vehicles
+
+What can enter under this category:
+
+- **Cars** — passenger vehicles of any drivetrain
+- **Motorbikes** — scooters, motorcycles, mopeds
+- **E-bikes** — pedal-assist or throttle-class bicycles
+- **Bicycles** — pedal-only bikes, cargo bikes
+- **Other** — boats, watercraft, aircraft, custom-built vehicles
+
+## How vehicles enter the body
+
+Vehicles are typically held under full title transfer to the
+network's wrapper, with the cell retaining primary shepherd rights.
+The vehicle becomes a sovereign in the graph; the wrapper handles
+title, registration, insurance, and outer-world tax obligations
+funded from the cooperative pool the cell contributes to.
+
+Access-granted vehicles (rentals, friend-of-the-family
+arrangements, network-shared vehicles where another cell is the
+primary shepherd) are recorded with status `access-granted`.
+
+## Privacy
+
+Public-level: make, model, year, drivetrain, broad location (city
+or region), primary shepherd, status. **Not public**: VIN, title
+state, insurance carrier, exact addresses, charging credentials.
+
+## Inventory template
+
+```yaml
+- kind: car | motorbike | e-bike | bicycle | other
+  make: "manufacturer"
+  model: "model"
+  year: YYYY
+  drivetrain: electric | hybrid | ice | pedal | other
+  location: "city, region"
+  relationship: held | access-granted | proposed
+  primary_shepherd: cell_id_or_name
+  ceremony_date: YYYY-MM-DD
+  onboarding_record: "../onboarded-assets/<filename>.md or null"
+  notes: "anything the registry should know"
+```
+
+## Currently held (this cell's inventory)
+
+```yaml
+- kind: car
+  make: Tesla
+  model: Model 3
+  year: ~unknown — fill in
+  drivetrain: electric
+  location: Longmont, Colorado, USA
+  relationship: held
+  primary_shepherd: urs
+  ceremony_date: 2026-04-29
+  onboarding_record: ../onboarded-assets/2026-04-29-tesla-model-3-longmont.md
+  notes: |
+    Title transfer to network wrapper pending — see onboarding record
+    for open questions on jurisdiction, insurance, and tax treatment.
+```
+
+## Proposed (held in discernment)
+
+See [`../proposals/2026-04-29-ubud-ebike-and-property.md`](../proposals/2026-04-29-ubud-ebike-and-property.md)
+for the e-bike-in-Ubud proposal.
+
+## Awaiting inventory — slots
+
+The cell is invited to record any other vehicles — second cars,
+motorbikes (Bali context likely), bicycles already in stewardship at
+locations where the cell spends time, and any access-granted vehicles
+(network-shared rides, family vehicles the cell uses regularly).


### PR DESCRIPTION
The body now has a structured register for any financial or legal property a member chooses to bring into stewardship. Six categories, each with its own template, privacy contract, and inventory slot.

## What lands

- **`registry/README.md`** — master index. Three relationships defined: `held` (legal title transferred to wrapper), `access-granted` (usage rights without title transfer), `proposed` (held in discernment). Explicit privacy contract: category-level public, specifics in wrapper's encrypted treasury.
- **`registry/financial.md`** — bank accounts, fiat reserves, crypto holdings, investments, lines of credit. Default pattern is **visibility-without-custody** — the cell remains the legal account holder; the wrapper has read-permission and any explicit operating authority the cell signs.
- **`registry/vehicles.md`** — cars, motorbikes, e-bikes, bicycles. Tesla Model 3 already onboarded record cross-linked. The Ubud e-bike proposal cross-linked.
- **`registry/real-estate.md`** — owned and leased properties. Four wrapper-relationship patterns offered for jurisdiction-sensitivity (title transfer, co-title, stewardship contract, lease pass-through). Ubud property proposal cross-linked.
- **`registry/intellectual-property.md`** — patents, trademarks, copyrights, domain names. Story Protocol integration noted as the on-chain registration pipeline for digital IP.
- **`registry/digital-access.md`** — software subscriptions, API keys, cloud accounts, professional licenses. Three patterns (shared key, service-account-on-cell-account, pass-through billing). Credentials live in wrapper's secret store, never in registry.
- **`registry/access-granted.md`** — things the cell does not own but uses under terms. Rentals, family arrangements, memberships, service contracts, network-shared assets.

Each category file has: definition of what fits, onboarding pattern, explicit privacy contract, YAML template for new entries, currently-held section auto-populated where known, awaiting-inventory slot for what the cell hasn't yet recorded.

## Privacy posture

The registry's default is **category-level public, specifics-level private**. The body says *one Tesla Model 3 is held*; the wrapper's encrypted record says *VIN, title state, insurance policy, current odometer, charging-network credentials*. Anything more public requires explicit cell consent each time.

## What the cell brings

The cell is the source of what is theirs to bring. The body holds the receiving structure. The registry is patient — assets enter as discernment clarifies, not as pressure escalates.

## Verified

- `make wellness` reads aligned across all four senses
- `stewardship/README.md` updated to point at the registry alongside onboarded-assets and proposals

https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzXif6poTWi1XgS1HPM7zh)_