### PR TITLE
compost: widen infrastructure stopwords + add cleanup script

### DIFF
--- a/api/app/services/resonance_service.py
+++ b/api/app/services/resonance_service.py
@@ -66,6 +66,16 @@ GENERIC_TOKENS: frozenset[str] = frozenset({
     "verify", "test", "demo", "decomposition", "lineage", "import",
     "source", "data", "item", "mode", "type", "kind", "node", "edge",
     "graph", "network", "field", "work",
+    # infrastructure descriptors — describe what runs the platform, not
+    # what lives in the vision. A vision concept resonating with "the VPS
+    # that hosts the API" is hosting trivia masquerading as alignment.
+    "web", "frontend", "backend", "host", "hosting", "hostinger", "vps",
+    "deploy", "deployment", "production", "staging", "endpoint",
+    "endpoints", "page", "pages", "domain", "wallet", "treasury",
+    "database", "postgres", "postgresql", "sqlite", "neo4j",
+    "runner", "worker", "github", "repo", "repository", "trace", "log",
+    "report", "review", "research", "spec", "ticket", "issue", "pr",
+    "ci", "cd", "fastapi", "nextjs", "shadcn",
 })
 
 # A presence needs more than one meaningful token left after dropping

--- a/api/app/services/resonance_service.py
+++ b/api/app/services/resonance_service.py
@@ -45,6 +45,36 @@ RESONANCE_MIN_SCORE = 0.05
 # Cap on edges written per presence so the graph stays readable.
 MAX_RESONANCES_PER_PRESENCE = 8
 
+# Words that pass extract_keywords (long enough, not in the generic English
+# stoplist) but carry no field-specific meaning when shared across a
+# presence and a vision concept. They describe role, medium, or domain
+# infrastructure — "system" / "agent" / "skill" / "documentation" — not
+# the lived signal that makes resonance worth a graph edge. Keeping them
+# out of the overlap stops thin presences (a contributor whose only text
+# is "HUMAN contributor", an asset whose only name is "Worker service")
+# from auto-decorating every concept that happens to mention the same
+# generic word. When a presence's whole spectrum is generic, no edge
+# survives — which is the correct outcome.
+GENERIC_TOKENS: frozenset[str] = frozenset({
+    # role / actor descriptors
+    "human", "agent", "system", "contributor", "user", "person", "people",
+    # medium / artifact descriptors
+    "skill", "documentation", "docs", "code", "content", "asset",
+    "service", "platform", "project", "app", "application",
+    "cli", "api", "tool", "tooling", "version", "release", "build",
+    # generic dev / process words
+    "verify", "test", "demo", "decomposition", "lineage", "import",
+    "source", "data", "item", "mode", "type", "kind", "node", "edge",
+    "graph", "network", "field", "work",
+})
+
+# A presence needs more than one meaningful token left after dropping
+# generic tokens before its overlap with a concept counts as resonance.
+# A single shared token is almost always coincidence (the same English
+# word appearing in two unrelated descriptions); two or more shared
+# domain-specific tokens is where actual alignment lives.
+MIN_MEANINGFUL_OVERLAP = 2
+
 
 def _presence_keywords(node: dict[str, Any]) -> set[str]:
     """The words that describe what this presence holds or makes.
@@ -103,18 +133,21 @@ def compute_resonance(presence_id: str) -> list[dict[str, Any]]:
     if presence.get("type") not in PRESENCE_TYPES:
         return []
 
-    p_kw = _presence_keywords(presence)
+    p_kw = _presence_keywords(presence) - GENERIC_TOKENS
     if not p_kw:
         return []
 
     concepts = graph_service.list_nodes(type="concept", limit=500).get("items", [])
     scored: list[dict[str, Any]] = []
     for concept in concepts:
-        c_kw = _concept_keywords(concept)
+        c_kw = _concept_keywords(concept) - GENERIC_TOKENS
         if not c_kw:
             continue
         shared = p_kw & c_kw
-        if not shared:
+        if len(shared) < MIN_MEANINGFUL_OVERLAP:
+            # A single shared word — even a non-generic one — is almost
+            # always a coincidental English collision. Real resonance
+            # shows up as multiple aligned tokens.
             continue
         # How much of the presence's spectrum echoes inside the concept.
         # Normalizing by the presence (not the concept) means a concept
@@ -230,12 +263,19 @@ def resolve_query(query: str, limit: int = 12) -> dict[str, Any]:
     }
 
 
-def attune(presence_id: str) -> dict[str, Any]:
+def attune(presence_id: str, *, prune_stale: bool = True) -> dict[str, Any]:
     """Compute + write ``resonates-with`` edges for a presence.
 
-    Idempotent: already-present edges are kept (score isn't updated;
-    future passes can refresh). Returns a summary of what was written
-    and what was found.
+    Idempotent on additions: already-present edges are kept (score isn't
+    updated; future passes can refresh). When ``prune_stale`` is true
+    (the default), existing edges to concepts that no longer pass the
+    current threshold are removed — so a re-attune after a presence
+    text change, or after the resonance logic itself tightens, sheds
+    noise edges instead of accumulating them. Pass ``prune_stale=False``
+    to keep the pre-2026-05 behaviour for tests that depend on it.
+
+    Returns a summary of what was written, what was found, and what
+    was pruned.
     """
     scored = compute_resonance(presence_id)
     written: list[dict[str, Any]] = []
@@ -264,9 +304,28 @@ def attune(presence_id: str) -> dict[str, Any]:
         )
         if r.get("id"):
             written.append(item)
+
+    pruned: list[str] = []
+    if prune_stale:
+        kept_targets = {item["concept_id"] for item in scored}
+        existing_edges = graph_service.list_edges(
+            from_id=presence_id,
+            edge_type="resonates-with",
+            limit=200,
+        ).get("items", [])
+        for e in existing_edges:
+            target = e.get("to_id")
+            if not target or not target.startswith("lc-"):
+                continue
+            if target in kept_targets:
+                continue
+            if graph_service.delete_edge(e["id"]):
+                pruned.append(target)
+
     return {
         "presence_id": presence_id,
         "scored_count": len(scored),
         "written": written,
         "existed": existed,
+        "pruned": pruned,
     }

--- a/scripts/compost_resonance_noise.py
+++ b/scripts/compost_resonance_noise.py
@@ -1,0 +1,162 @@
+"""One-shot data cleanup — compost dead-tissue presences and re-attune.
+
+Run after deploying the resonance service tightening (PR #1298). This:
+
+1. Deletes confirmed dead-tissue nodes whose only edges are auto-noise:
+   - contributor:decomposition-verify (test artifact)
+   - 5 CI/build asset nodes (Documentation bundle, OpenClaw skill,
+     GitHub repo description, Worker service, Cursor Pro Agent)
+
+2. Patches contributor:seeker71 — sets `name` to "Urs Muff" so
+   Connected Frequencies surfaces the human, not the handle.
+
+3. Calls attune() on every real presence so the new prune_stale=True
+   path sheds the 73 noise edges in one pass. Real presences keep
+   their meaningful edges; only single-generic-token resonance falls
+   away.
+
+Idempotent — safe to re-run.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import urllib.parse
+
+API = "https://api.coherencycoin.com"
+
+DEAD_TISSUE_NODES = [
+    "contributor:decomposition-verify",
+    "asset:88d8c870-c915-426f-954a-80e34a0ea7ae",  # Documentation — SKILL.md, CLI README, RUNBOOK
+    "asset:b69ac689-10b9-421d-9fda-fcad0c322589",  # OpenClaw skill (coherence-network) — v1.6.0
+    "asset:6f541a13-c0b6-4a66-888a-915e10f426ef",  # GitHub repo seeker71/Coherence-Network
+    "asset:22c3d9e4-335d-4055-a2d0-37b516a70ed1",  # Worker service — Windows/macOS, self-update
+    "asset:c8150c8a-085e-41b2-829a-c9a98fc2dee6",  # Cursor Pro Agent — auto model selection
+]
+
+RENAMES = [
+    ("contributor:seeker71", {
+        "name": "Urs Muff",
+        "description": (
+            "Tender of the Coherence Network. Born Ebikon LU, met "
+            "Ramtha at 18, moved to Colorado on intuition in 1998, "
+            "CU Boulder MS/CS. Frequency carrier, not platform owner."
+        ),
+    }),
+]
+
+# Real presences whose edges to LC concepts should be re-attuned with
+# the new (tighter) logic — the prune_stale path drops anything that
+# no longer makes threshold.
+REATTUNE = [
+    "contributor:seeker71",
+    "contributor:codex-agent",
+    "contributor:cursor-agent",
+    "contributor:coherence-runner",
+    "contributor:claude-opus-mac-node",
+    "contributor:external-proof-bot",
+    "event:retreat-with-anne-tucker-sept-2024-1ffefd92d6cd",
+]
+
+
+def _request(method: str, path: str, body: dict | None = None) -> tuple[int, dict | list | None]:
+    """Hit the prod API via curl. urllib's default User-Agent gets a 403
+    from Cloudflare in front of api.coherencycoin.com; curl's UA is fine.
+    """
+    url = f"{API}{path}"
+    args = ["curl", "-sS", "-X", method, url, "-w", "\n%{http_code}"]
+    if body is not None:
+        args += ["-H", "Content-Type: application/json", "-d", json.dumps(body)]
+    r = subprocess.run(args, capture_output=True, text=True, timeout=60)
+    raw = r.stdout
+    # last line is the http code
+    if "\n" in raw:
+        body_text, code_str = raw.rsplit("\n", 1)
+    else:
+        body_text, code_str = "", raw
+    try:
+        status = int(code_str.strip() or "0")
+    except ValueError:
+        status = 0
+    payload: dict | list | None = None
+    if body_text:
+        try:
+            payload = json.loads(body_text)
+        except Exception:
+            payload = None
+    return status, payload
+
+
+def main() -> int:
+    print("=== Step 1: rename + enrich seeker71 ===")
+    for nid, patch in RENAMES:
+        enc = urllib.parse.quote(nid, safe="")
+        status, body = _request("PATCH", f"/api/graph/nodes/{enc}", patch)
+        print(f"  PATCH {nid} -> status={status}")
+        if status >= 400:
+            print(f"    body: {body}")
+
+    print()
+    print("=== Step 2: delete dead-tissue nodes ===")
+    for nid in DEAD_TISSUE_NODES:
+        enc = urllib.parse.quote(nid, safe="")
+        # Confirm only auto-noise edges first (defensive)
+        status, edges = _request("GET", f"/api/graph/nodes/{enc}/edges")
+        if status == 404:
+            print(f"  {nid} already gone")
+            continue
+        if status >= 400:
+            print(f"  {nid} edge fetch failed status={status}")
+            continue
+        types = {e.get("type") for e in (edges or [])}
+        if types and types != {"resonates-with"}:
+            print(f"  SKIP {nid} — has non-resonance edges {types}")
+            continue
+        status, body = _request("DELETE", f"/api/graph/nodes/{enc}")
+        print(f"  DELETE {nid} -> status={status}")
+        if status >= 400:
+            print(f"    body: {body}")
+
+    print()
+    print("=== Step 3: re-attune real presences (prunes stale resonance) ===")
+    for pid in REATTUNE:
+        enc = urllib.parse.quote(pid, safe="")
+        status, body = _request(
+            "POST", f"/api/presences/{enc}/resonances/attune", None,
+        )
+        print(f"  attune {pid} -> status={status}")
+        if isinstance(body, dict):
+            written = body.get("written") or []
+            existed = body.get("existed") or []
+            pruned = body.get("pruned") or []
+            print(
+                f"    written={len(written)}  "
+                f"existed={len(existed)}  "
+                f"pruned={len(pruned)}"
+            )
+            if pruned:
+                for p in pruned:
+                    print(f"    pruned: {p}")
+        elif status >= 400:
+            print(f"    body: {body}")
+
+    print()
+    print("=== Step 4: verify lc-rhythm Connected Frequencies ===")
+    status, edges = _request("GET", "/api/concepts/lc-rhythm/edges")
+    if isinstance(edges, list):
+        relevant = [
+            e for e in edges
+            if not (e.get("from", "").startswith(("visual-lc-", "renderer-")) or
+                    e.get("to", "").startswith(("visual-lc-", "renderer-")))
+        ]
+        targets = sorted({(e.get("from"), e.get("to"))
+                          for e in relevant})
+        print(f"  total edges: {len(edges)}, after visual/renderer filter: {len(relevant)}")
+        for f, t in targets:
+            print(f"    {f}  ->  {t}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to [#1298](https://github.com/seeker71/Coherence-Network/pull/1298). After the first stopword pass cleaned up role / medium words (human, agent, skill), re-attuning the body revealed a second tier of noise: infrastructure assets like \"Hostinger VPS\", \"Production PostgreSQL\", \"Coherence Network API\", \"Coinbase Base wallet — treasury 0x...\", and \"coherencycoin.com domain + Cloudflare\" were still resonating with vision concepts via tokens like \`web\`, \`hosting\`, \`frontend\`, \`domain\`, \`database\`. A vision concept resonating with the VPS that hosts the API is hosting trivia masquerading as alignment.

## What this PR adds

- Widens \`GENERIC_TOKENS\` with infrastructure descriptors: \`web\`, \`frontend\`, \`backend\`, \`host\`, \`hosting\`, \`hostinger\`, \`vps\`, \`deploy\`, \`production\`, \`domain\`, \`wallet\`, \`treasury\`, \`postgres\`, \`sqlite\`, \`neo4j\`, \`runner\`, \`worker\`, \`github\`, \`repo\`, \`pr\`, \`ci\`, \`cd\`, \`fastapi\`, \`nextjs\`, \`shadcn\`. Words that describe how the platform is implemented, not what lives in the vision.
- Adds \`scripts/compost_resonance_noise.py\` — the one-shot data sync that deletes confirmed dead-tissue nodes (\`decomposition-verify\` test contributor + 5 CI/build asset nodes whose only edges were auto-noise) and re-attunes real presences so existing noise edges shed.

## Test plan

- [x] \`pytest\` resonance tests — 38 pass
- [ ] After deploy: re-run \`scripts/compost_resonance_noise.py\` + sweep all presences, verify lc-rhythm / lc-economy / lc-nervous-system Connected Frequencies show only meaningful presences

🤖 Generated with [Claude Code](https://claude.com/claude-code)