### PR TITLE
attune: /silence/soulution describes what the notebook actually shows

### DIFF
--- a/web/app/silence/_data.tsx
+++ b/web/app/silence/_data.tsx
@@ -91,24 +91,28 @@ export const NOTEBOOK_PAGES: NotebookPageData[] = [
     n: 3,
     slug: "soulution",
     image: "/silence/2026-05-04-brahmavihara/3-soulution.jpg",
-    alt: "Notebook page with the playful word 'soulution' rendered in large hand-drawn letters with spirals, almost a calligraphic doodle.",
-    title: "Soulution",
-    shortTitle: "Soulution — the play",
-    blurb: "A pun, drawn large. Soul-ution. Spirals. Held space for play.",
+    alt: "Notebook page with the phrase 'silent wittn e ss' drawn large — the letters of 'witness' deliberately broken open with spaces, spiral S's holding the shape, the word slowed down across the page so each part has its own room.",
+    title: "silent wittn e ss",
+    shortTitle: "silent wittn e ss — the play",
+    blurb:
+      "Witness slowed down on the page — the letters spread apart so each one has space, spiral S's, the word breathing.",
     body: () => (
       <>
         <p>
-          A pun, drawn large. {E("Soul-ution")}. Spirals. The play in the
-          middle of the work.
+          {E("silent wittn e ss")}. The letters of {E("witness")} pulled
+          apart on the page until each one has its own room — spiral S's
+          holding the edges, the word slowed down so the act of witnessing
+          becomes visible as its parts.
         </p>
         <p>
           On its own page. Not a footnote, not a flourish — given the same
-          held space as the decision body and the codex.
+          held space as the decision body and the codex. The play in the
+          middle of the work.
         </p>
       </>
     ),
     held:
-      "The body that takes itself fully seriously without ever taking itself only seriously. The breath that makes the rest of the architecture possible.",
+      "The body that takes itself fully seriously without ever taking itself only seriously. Witness held in spaces wide enough that silence has somewhere to live between the letters.",
   },
   {
     n: 4,


### PR DESCRIPTION
## Summary

The page at [/silence/soulution](https://coherencycoin.com/silence/soulution) was titled \"Soulution\" with copy framing the page as a pun on soul + solution. The notebook image on the page actually shows something else: **silent wittn e ss** — the letters of \"witness\" pulled apart on the page so each part has its own room, spiral S's holding the shape. The play is the slowing-down of the word, not a soul/solution pun.

This PR updates the page text to describe what the visitor actually sees:
- title: \"Soulution\" → \"silent wittn e ss\"
- shortTitle: \"Soulution — the play\" → \"silent wittn e ss — the play\"
- alt, blurb, body, held: rewritten to describe the actual hand-drawn letters and what they hold

Slug stays \`soulution\` so existing URLs keep resolving. Image filename also unchanged.

## Test plan

- [x] Local Next.js dev server: \`<title>\`, h1, body, held all render \"silent wittn e ss\" — verified
- [x] /silence index: shortTitle on the card now reads \"silent wittn e ss — the play\"
- [x] /silence/soulution still routes (slug unchanged) — verified
- [x] Image still loads (filename unchanged) — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)