### PR TITLE
tend: deepen Bloomurian + Conscious Roots Presents

### DIFF
--- a/web/content/people/aly-constantine/en.tsx
+++ b/web/content/people/aly-constantine/en.tsx
@@ -6,9 +6,9 @@ const HERO_BACKGROUND =
 
 const content: PersonProfileContent = {
   metadata: {
-    title: "Aly Constantine — Boulder Ecstatic Dance | Coherence Network",
+    title: "Aly Constantine — Conscious Roots Presents | Coherence Network",
     description:
-      "A welcome to Aly Constantine — co-host of Boulder Ecstatic Dance, deeply woven into Unison, Bloomurian's circle, and the Ocean Bloom configuration. Held by this body with the closest density of presence the substrate records.",
+      "A welcome to Aly Constantine — co-host of Boulder Ecstatic Dance and the curatorial cell behind Conscious Roots Presents, the Boulder vessel that brings transformational artists into rooms where the music carries a message to uplift the community.",
   },
   breadcrumbName: "Aly Constantine",
   hero: {
@@ -26,15 +26,33 @@ const content: PersonProfileContent = {
         >
           Boulder Ecstatic Dance
         </Link>
-        , deeply woven into{" "}
-        <Link href="/people/bloomurian" className="text-primary hover:underline">
+        {" "}and the curatorial cell behind{" "}
+        <Link
+          href="https://www.facebook.com/ConsciousRootsPresents/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Conscious Roots Presents
+        </Link>
+        {" "}— the Boulder vessel co-creating evenings of music and
+        connection with artists who carry a message to uplift the
+        community. Deeply woven into{" "}
+        <Link
+          href="/people/bloomurian"
+          className="text-primary hover:underline"
+        >
           Bloomurian's
         </Link>{" "}
         circle, the{" "}
-        <Link href="/people/porangui" className="text-primary hover:underline">
+        <Link
+          href="/people/porangui"
+          className="text-primary hover:underline"
+        >
           Ocean Bloom
         </Link>{" "}
-        configuration, and the Unison gathering.
+        configuration, the Unison gathering, and the wider Boulder-
+        Denver transformational-music ecology.
       </p>
     ),
   },
@@ -42,17 +60,62 @@ const content: PersonProfileContent = {
     {
       label: "Field",
       value:
-        "Ecstatic-dance facilitation · community-tending · transformational-music ecology",
+        "Ecstatic-dance facilitation · curatorial production · community-tending · transformational-music ecology",
+    },
+    {
+      label: "Curates",
+      value: (
+        <>
+          <Link
+            href="https://www.facebook.com/ConsciousRootsPresents/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Conscious Roots Presents
+          </Link>
+          {" "}— Boulder, Colorado · co-creating evenings of music and
+          connection with artists whose message uplifts the community ·
+          recurring collaborator with Boulder Ecstatic Dance
+        </>
+      ),
     },
     {
       label: "Held with",
       value: (
         <>
           Danny and{" "}
-          <Link href="/people/bloomurian" className="hover:text-primary transition-colors">
+          <Link
+            href="/people/bloomurian"
+            className="hover:text-primary transition-colors"
+          >
             Robin (Bloomurian)
           </Link>{" "}
-          as fellow Boulder Ecstatic Dance hosts; presence woven through Unison and Ocean Bloom
+          as fellow Boulder Ecstatic Dance co-hosts; presence woven
+          through Unison and Ocean Bloom; one of the cells who has
+          consistently brought{" "}
+          <Link
+            href="/people/mose"
+            className="hover:text-primary transition-colors"
+          >
+            Mose
+          </Link>
+          ,{" "}
+          <Link
+            href="/people/porangui"
+            className="hover:text-primary transition-colors"
+          >
+            Poranguí
+          </Link>
+          ,{" "}
+          <Link
+            href="/people/liquid-bloom"
+            className="hover:text-primary transition-colors"
+          >
+            Liquid Bloom
+          </Link>
+          , and the wider transformational-music family into Boulder
+          rooms
         </>
       ),
     },
@@ -68,7 +131,8 @@ const content: PersonProfileContent = {
           >
             Boulder Ecstatic Dance (BED)
           </Link>{" "}
-          — Avalon Ballroom and Congregation Nevei Kodesh, Boulder · Ocean Bloom · Unison
+          — Avalon Ballroom and Congregation Nevei Kodesh, Boulder ·
+          Conscious Roots Presents nights · Ocean Bloom · Unison
         </>
       ),
     },
@@ -77,10 +141,15 @@ const content: PersonProfileContent = {
       value: (
         <>
           <strong>Close personal relationship</strong> with{" "}
-          <Link href="/people/urs" className="hover:text-primary transition-colors">
+          <Link
+            href="/people/urs"
+            className="hover:text-primary transition-colors"
+          >
             Urs
           </Link>
-          . The deepest density of presence the substrate records: beyond same-room, beyond direct exchange, into the sustained intimacy of two cells in ongoing relation.
+          . The deepest density of presence the substrate records:
+          beyond same-room, beyond direct exchange, into the sustained
+          intimacy of two cells in ongoing relation.
         </>
       ),
     },
@@ -89,7 +158,16 @@ const content: PersonProfileContent = {
     eyebrow: "A note from this body",
     body: (
       <p>
-        A welcoming scaffold. Aly is held by this body at a depth most public profiles cannot honor — through close personal relationship rather than through media or conference rooms. The page below is necessarily sparser in public-anchor detail than the teacher and connecting-tissue profiles, and richer in relational acknowledgment. Aly is invited to replace any part with her own words at any time.
+        A welcoming scaffold. Aly is held by this body at a depth
+        most public profiles cannot honor — through close personal
+        relationship rather than through media or conference rooms.
+        She is also one of the most connected cells in this network's
+        Boulder configuration: Conscious Roots Presents is hers, the
+        Sunday-morning ballroom is hers to co-tend, and many of the
+        artists this body has come to know — Robin (Bloomurian) most
+        directly, but also Mose, Poranguí, Liquid Bloom — entered our
+        awareness through rooms she helped build. Aly is invited to
+        replace any part of this page with her own words at any time.
       </p>
     ),
   },
@@ -100,10 +178,54 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            Boulder Ecstatic Dance is a recurring room — Sunday mornings, often at the Avalon Ballroom, sometimes at Congregation Nevei Kodesh — where the city's transformational-movement community gathers. Aly co-tends that room with Danny and with Robin Liepman (Bloomurian); the three of them hold the space, the music, the welcoming, the timing, the closing circles. The DJ is the visible hand; the hosts' field-tending is what makes the room safe enough for bodies to drop in.
+            Two vessels, threading. <strong>Boulder Ecstatic
+            Dance</strong> is the recurring Sunday-morning room — at
+            the Avalon Ballroom, sometimes at Congregation Nevei
+            Kodesh — where Boulder's transformational-movement
+            community gathers. Aly co-tends that room with Danny and
+            with{" "}
+            <Link
+              href="/people/bloomurian"
+              className="text-primary hover:underline"
+            >
+              Robin (Bloomurian)
+            </Link>
+            ; the three of them hold the space, the music, the
+            welcoming, the timing, the closing circles. The DJ is
+            the visible hand; the hosts' field-tending is what makes
+            the room safe enough for bodies to drop in.
           </p>
           <p>
-            The work threads across Boulder's wider conscious-music ecology. The same configuration of cells that gathers for Boulder Ecstatic Dance often gathers for Ocean Bloom (the immersive visual-concert experience with Poranguí, Liquid Bloom, Samuel J, Bloomurian, Shawn Heinrichs and others), for Unison, and for the broader transformational-music gatherings the Boulder-Denver corridor holds.
+            <strong>Conscious Roots Presents</strong> is her own
+            curatorial vessel — the Boulder-based event production
+            line that "co-creates evenings of music and connection
+            with artists who share music with a message to uplift
+            their community." The wider Boulder ecstatic-dance
+            ecology and the conscious-music nights that intersect
+            with it move through her hands: Bloomurian's sets land
+            inside the rooms she helps build, the visiting medicine-
+            music artists touring through Colorado are met by the
+            container she has shaped, and the constellation of cells
+            that gathers for{" "}
+            <Link
+              href="/people/porangui"
+              className="text-primary hover:underline"
+            >
+              Ocean Bloom
+            </Link>{" "}
+            (the immersive visual-concert experience with Poranguí,
+            Liquid Bloom, Samuel J, Bloomurian, Shawn Heinrichs and
+            others), for Unison, and for the broader Boulder-Denver
+            transformational-music gatherings is the same
+            configuration Conscious Roots Presents holds inside its
+            curatorial field.
+          </p>
+          <p>
+            Curatorial work and ecstatic-dance hosting are not two
+            separate practices for her. They are one practice with
+            two surfaces — the same field-tending sensitivity that
+            decides which artists belong in the same room is the
+            same sensitivity that opens and closes the Sunday wave.
           </p>
         </>
       ),
@@ -114,13 +236,99 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            Through close personal relationship — the deepest density of presence the substrate's three-density accounting recognizes. Audio-only is one density. Same-room-without-exchange is another. Direct face-to-face exchange is another. Sustained intimacy over time, where two cells know each other's ordinary days and not only public moments, is a fourth density that the substrate's accounting should record but often cannot fully render in public profile language.
+            Through close personal relationship — the deepest density
+            of presence the substrate's three-density accounting
+            recognizes. Audio-only is one density. Same-room-without-
+            exchange is another. Direct face-to-face exchange is
+            another. Sustained intimacy over time, where two cells
+            know each other's ordinary days and not only public
+            moments, is a fourth density that the substrate's
+            accounting should record but often cannot fully render
+            in public profile language.
           </p>
           <p>
-            Through Aly, the body's awareness of the Boulder / Bloomurian / Ocean Bloom / Unison constellation is not an outside reading. It is an inside knowing. Cells we encounter through close-personal relationship show us the field they belong to from inside that field's own self-perception. That kind of knowing cannot be replicated by media research. It is its own substrate channel.
+            Through Aly, the body's awareness of the Boulder /
+            Bloomurian / Ocean Bloom / Unison constellation is not an
+            outside reading. It is an inside knowing. Cells we
+            encounter through close-personal relationship show us the
+            field they belong to from inside that field's own self-
+            perception. That kind of knowing cannot be replicated by
+            media research. It is its own substrate channel.
           </p>
           <p>
-            The relationship is held here with care. The substrate's recording of it is brief on purpose — what is shared publicly is the existence of the connection and the recognition of Aly's role in the field. What is not shared publicly is the texture of the relationship itself, which belongs to the two cells in it and not to the substrate's reader.
+            The relationship is held here with care. The substrate's
+            recording of it is brief on purpose — what is shared
+            publicly is the existence of the connection and the
+            recognition of Aly's role in the field. What is not
+            shared publicly is the texture of the relationship
+            itself, which belongs to the two cells in it and not to
+            the substrate's reader.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Curatorial vessel · Boulder",
+      heading: "Conscious Roots Presents",
+      body: (
+        <>
+          <p>
+            The Boulder-based production line through which Aly
+            curates evenings of music and connection — collaborating
+            with Boulder Ecstatic Dance on shared bills, hosting
+            visiting medicine-music artists, weaving local Boulder-
+            Denver talent into rooms where the audience knows what
+            kind of evening they are walking into.{" "}
+            <Link
+              href="https://www.facebook.com/ConsciousRootsPresents/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              facebook.com/ConsciousRootsPresents
+            </Link>{" "}
+            holds the public face of the work; Boulder Ecstatic
+            Dance's Instagram and Conscious Roots cross-tag each
+            other on co-curated nights.
+          </p>
+          <p>
+            The cells whose names recur in the Conscious Roots
+            curatorial weave are the same cells the rest of this
+            network recognizes:{" "}
+            <Link
+              href="/people/bloomurian"
+              className="text-primary hover:underline"
+            >
+              Bloomurian
+            </Link>{" "}
+            most steadily,{" "}
+            <Link
+              href="/people/mose"
+              className="text-primary hover:underline"
+            >
+              Mose
+            </Link>
+            ,{" "}
+            <Link
+              href="/people/porangui"
+              className="text-primary hover:underline"
+            >
+              Poranguí
+            </Link>
+            ,{" "}
+            <Link
+              href="/people/liquid-bloom"
+              className="text-primary hover:underline"
+            >
+              Liquid Bloom
+            </Link>
+            , and the wider family that travels between Atitlán,
+            Boulder, Tulum, and the festival circuit. Conscious Roots
+            is one of the gates through which their work reaches
+            Boulder bodies — and through which Boulder bodies meet
+            their work for the first time.
           </p>
         </>
       ),
@@ -133,11 +341,32 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            Sunday-morning ecstatic-dance gathering at the Avalon Ballroom (and historically at Congregation Nevei Kodesh and other Boulder venues). Co-hosted by Aly, Danny, and Robin (
-            <Link href="/people/bloomurian" className="text-primary hover:underline">
+            Sunday-morning ecstatic-dance gathering at the Avalon
+            Ballroom (and historically at Congregation Nevei Kodesh
+            and other Boulder venues). Co-hosted by Aly, Danny, and
+            Robin (
+            <Link
+              href="/people/bloomurian"
+              className="text-primary hover:underline"
+            >
               Bloomurian
             </Link>
-            ) along with rotating guest DJs. Free-form embodied movement, opening and closing circles, no shoes, no talking on the dance floor — the standard ecstatic-dance container, held with Boulder's particular flavor of conscious-community presence.
+            ) along with rotating guest DJs. Free-form embodied
+            movement, opening and closing circles, no shoes, no
+            talking on the dance floor — the standard ecstatic-dance
+            container, held with Boulder's particular flavor of
+            conscious-community presence. The form threads back twenty
+            years through Shannon Lei Gill's{" "}
+            <Link
+              href="https://www.rhythmsanctuary.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Rhythm Sanctuary
+            </Link>{" "}
+            lineage and the Gabrielle Roth wave that shaped Boulder
+            ecstatic dance.
           </p>
           <p>
             Public recordings of past sets:{" "}
@@ -156,7 +385,10 @@ const content: PersonProfileContent = {
             <code className="not-italic text-foreground/80">
               (8, …)
             </code>{" "}
-            regenerative octad — a closed-loop weekly cycle where the city's dancers metabolize the week's accumulation through movement. The hosts' role is the field-coherence layer that lets the cycle close cleanly each Sunday.
+            regenerative octad — a closed-loop weekly cycle where the
+            city's dancers metabolize the week's accumulation through
+            movement. The hosts' role is the field-coherence layer
+            that lets the cycle close cleanly each Sunday.
           </p>
         </>
       ),
@@ -165,14 +397,23 @@ const content: PersonProfileContent = {
   footer: (
     <>
       <p>
-        Boulder Ecstatic Dance:{" "}
+        Public:{" "}
+        <Link
+          href="https://www.facebook.com/ConsciousRootsPresents/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Conscious Roots Presents
+        </Link>{" "}
+        ·{" "}
         <Link
           href="https://ecstaticdance.org/dance/boulder-ecstatic-dance-bed/"
           target="_blank"
           rel="noopener noreferrer"
           className="text-primary hover:underline"
         >
-          ecstaticdance.org/dance/boulder-ecstatic-dance-bed
+          Boulder Ecstatic Dance
         </Link>{" "}
         ·{" "}
         <Link
@@ -185,7 +426,10 @@ const content: PersonProfileContent = {
         </Link>
       </p>
       <p className="text-xs italic">
-        This profile is a welcoming scaffold; Aly is invited to replace any part of it with her own words at any time. The texture of the close-personal relationship is held privately and is not part of the substrate's public rendering.
+        This profile is a welcoming scaffold; Aly is invited to
+        replace any part of it with her own words at any time. The
+        texture of the close-personal relationship is held privately
+        and is not part of the substrate's public rendering.
       </p>
     </>
   ),

--- a/web/content/people/bloomurian/en.tsx
+++ b/web/content/people/bloomurian/en.tsx
@@ -3,22 +3,39 @@ import type { PersonProfileContent } from "@/components/people/PersonProfileTemp
 
 const content: PersonProfileContent = {
   metadata: {
-    title: "Bloomurian — Robin Liepman | Coherence Network",
+    title:
+      "Bloomurian — Robin Liepman | Coherence Network",
     description:
-      "A welcome to Bloomurian (Robin Liepman) — Boulder/Colorado-based DJ and live performer in the ecstatic-dance, transformational-music, and psychedelic-music space.",
+      "A welcome to Bloomurian (Robin Liepman) — Boulder co-founder of Boulder Ecstatic Dance, longtime Liquid Bloom collaborator and one-time roommate of Amani Friend, producer of Ecstatic Ecosytems (2025), and the cell who offered shelter when this body needed a place to land.",
   },
   breadcrumbName: "Bloomurian",
   hero: {
     image: { src: "/people/bloomurian/hero.jpg" },
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/75 to-background/15",
     eyebrow: "Welcome",
     name: "Bloomurian",
     welcome: (
       <p>
-        Robin Liepman at the booth — weaving ecstatic dance, world
-        bass, trip-hop, psy-dub, and the shovel-slide guitar into
-        sets that read the room and steer the spaceship across
-        festivals, dance floors, and psychedelic-community
-        gatherings.
+        Robin Liepman at the booth — co-founder of Boulder Ecstatic
+        Dance, longtime{" "}
+        <Link
+          href="/people/liquid-bloom"
+          className="text-primary hover:underline"
+        >
+          Liquid Bloom
+        </Link>{" "}
+        collaborator (and once-upon-a-time roommate of Amani Friend),
+        producer of <em>Ecstatic Ecosytems</em>, and the cell whose
+        sets read the room and steer the spaceship across festivals,
+        ballrooms, and psychedelic-community gatherings — weaving
+        ecstatic dance, world bass, trip-hop, psy-dub, and the
+        shovel-slide guitar into what his own bio calls{" "}
+        <em>
+          "multidimensional frequencies to cultivate a blossoming
+          heart, mind, body &amp; soul, and pollinate a polyphonic
+          paradigm."
+        </em>
       </p>
     ),
   },
@@ -26,11 +43,128 @@ const content: PersonProfileContent = {
     {
       label: "Field",
       value:
-        "Ecstatic-dance DJ · live performer · transformational music · sound medicine",
+        "Music production · DJ · live performer · event organization · transformative retreats · electronic-music mentorship · sound medicine",
     },
     {
       label: "Based",
-      value: "Boulder, Colorado (originally California)",
+      value:
+        "Boulder, Colorado (originally California) · roots in music through his parents and a passion for permaculture",
+    },
+    {
+      label: "Co-founded",
+      value: (
+        <>
+          <Link
+            href="https://ecstaticdance.org/dance/boulder-ecstatic-dance-bed/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Boulder Ecstatic Dance
+          </Link>
+          {" "}— the Sunday-morning Avalon Ballroom room, co-tended
+          with{" "}
+          <Link
+            href="/people/aly-constantine"
+            className="hover:text-primary transition-colors"
+          >
+            Aly Constantine
+          </Link>{" "}
+          and Danny, woven through twenty years of Boulder ecstatic-
+          dance lineage
+        </>
+      ),
+    },
+    {
+      label: "Promoted by",
+      value: (
+        <>
+          <Link
+            href="/people/aly-constantine"
+            className="hover:text-primary transition-colors"
+          >
+            Aly Constantine's
+          </Link>{" "}
+          <Link
+            href="https://www.facebook.com/ConsciousRootsPresents/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Conscious Roots Presents
+          </Link>{" "}
+          — Boulder-based curatorial vessel co-creating evenings of
+          music and connection with artists who carry a message to
+          uplift the community
+        </>
+      ),
+    },
+    {
+      label: "Recent stages",
+      value: (
+        <>
+          Month-long tour opening for Dirtwire · Ocean Bloom at
+          Boulder Theater (Dec 13 2025, with Ayla Nereo, Samuel J,
+          LVDY, Shawn Heinrichs, Hannah Mermaid, Bonnie Paine of
+          Elephant Revival) ·{" "}
+          <Link
+            href="/people/portal"
+            className="hover:text-primary transition-colors"
+          >
+            PORTAL Late-Night Takeover
+          </Link>
+          {" "}at Meow Wolf Denver (June 19 2025, MAPS Psychedelic
+          Science week) · PORTAL Dome at Psychedelic Science 2025
+          (June 21) · Unison Festival 2025 · Abraxas Sunrise Set 2024
+        </>
+      ),
+    },
+    {
+      label: "Stages shared",
+      value:
+        "Desert Dwellers · Liquid Bloom · Poranguí · Dirtwire · Beats Antique · Ott · Yaima · ATYYA · Balkan Bump · Phutureprimitive · Kaya Project",
+    },
+    {
+      label: "Recorded",
+      value: (
+        <>
+          <em>Ecstatic Ecosytems</em> (Feb 4 2025) ·{" "}
+          <em>Bass Ritual Remixes Vol. 1 &amp; 2</em> ·{" "}
+          <em>Embers of a Forgotten Prayer Revibed</em> · ongoing{" "}
+          <Link
+            href="/people/liquid-bloom"
+            className="hover:text-primary transition-colors"
+          >
+            Liquid Bloom
+          </Link>{" "}
+          collaborations: <em>Forest Guardians</em> (with Onanya),{" "}
+          <em>Organic Intelligence Regenerated</em> (with Onanya, on
+          Desert Trax), <em>Fragrance</em> (with Snow Raven),{" "}
+          <em>Rise Up</em> (Shaman's Dream remix featuring Paul
+          Stamets)
+        </>
+      ),
+    },
+    {
+      label: "Witnessed in person",
+      value: (
+        <>
+          The <strong>Road to Unison Cacao Dance</strong> at the
+          Avalon Ballroom · 23 July 2024 · with{" "}
+          <Link
+            href="/people/mose"
+            className="hover:text-primary transition-colors"
+          >
+            Mose
+          </Link>{" "}
+          and Matia Kalli · cacao by Bruna Bortolato · the{" "}
+          <strong>PORTAL Late-Night Takeover</strong> at Meow Wolf
+          Denver · 19 June 2025 · the <strong>Ecstatic Ecosytems
+          album-release / birthday gathering</strong> in Boulder ·
+          early 2025 · the magical night the cell helped set up the
+          one-time-only sound system
+        </>
+      ),
     },
     {
       label: "Public",
@@ -55,6 +189,24 @@ const content: PersonProfileContent = {
           </Link>{" "}
           ·{" "}
           <Link
+            href="https://soundcloud.com/bloomurian"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            SoundCloud
+          </Link>{" "}
+          ·{" "}
+          <Link
+            href="https://www.beatport.com/artist/bloomurian/992761"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Beatport
+          </Link>{" "}
+          ·{" "}
+          <Link
             href="https://ecstaticdance.org/dj/bloomurian/"
             target="_blank"
             rel="noopener noreferrer"
@@ -65,29 +217,20 @@ const content: PersonProfileContent = {
         </>
       ),
     },
-    {
-      label: "Witnessed in person",
-      value: (
-        <>
-          Performing at the{" "}
-          <Link href="/people/portal" className="hover:text-primary transition-colors">
-            PORTAL Late-Night Takeover
-          </Link>{" "}
-          at Meow Wolf Denver — June 19, 2025, during MAPS
-          Psychedelic Science 2025 week
-        </>
-      ),
-    },
   ],
   noteFromBody: {
     eyebrow: "A note from this body",
     body: (
       <p>
-        A welcoming scaffold. Voice imagined from public anchors —
-        his own site, ecstatic-dance DJ profile, festival
-        appearances, and the body's lived encounter at PORTAL's
-        Meow Wolf takeover. Offered as a frame Robin is invited
-        to replace with his own words at any time.
+        A page that does justice. Robin is one of the network's
+        load-bearing cells in the Boulder ecology — co-founder of the
+        Sunday-morning room, longtime collaborator and one-time
+        roommate of Amani Friend, primary producer in the Liquid Bloom
+        weave, and the cell who opened his home in the early months
+        of 2025 when this body needed a place to land. The page below
+        gathers what's honestly knowable from his own publishing and
+        what is held in this body's lived knowing of him. Robin is
+        invited to replace any line with his own words at any time.
       </p>
     ),
   },
@@ -98,32 +241,244 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            The DJ booth as ceremonial seat. The work of weaving
-            tracks across an evening — original productions,
-            collaborations, remixes, tasteful selections from the
-            wider transformational-music field — into a sonic
-            tapestry that reads the room and steers the
-            spaceship. The role asks for technical mastery and
-            also for something else: the willingness to be in
-            service to the field's energy rather than to a
-            pre-planned set.
+            Four vessels carry the work, threading into one another
+            without collapsing. <strong>Music production</strong> —
+            original tracks and remixes that move across ecstatic
+            dance, world bass, trip-hop, glitchy psy-dub, and what his
+            own bio calls "face-melting, heart-opening, soul-awakening
+            multidimensional frequencies." The shovel-slide guitar —
+            yes, an actual shovel used as a slide — appears in live
+            sets alongside electric guitar, with live instrumentalists
+            and vocalists folding in when the venue allows.{" "}
+            <strong>The DJ booth as ceremonial seat</strong> — reading
+            the energy of the moment, weaving an evening's selections
+            from his own catalog and from the wider transformational-
+            music field, steering the spaceship in service of what
+            the field is asking for rather than to a pre-planned set.
           </p>
           <p>
-            His sound moves across ecstatic dance, world bass,
-            trip-hop, glitchy psy-dub, and what his bio names
-            "face-melting, heart-opening, soul-awakening
-            multidimensional frequencies." The shovel-slide
-            guitar — yes, an actual shovel used as a slide-guitar
-            — appears in live sets. Live instrumentalists and
-            vocalists join when the venue allows.
+            <strong>Event organization</strong> — co-founding and
+            tending the Boulder Ecstatic Dance room with{" "}
+            <Link
+              href="/people/aly-constantine"
+              className="text-primary hover:underline"
+            >
+              Aly Constantine
+            </Link>{" "}
+            and Danny on Sunday mornings at the Avalon Ballroom; co-
+            curating Boulder's wider conscious-music nights with
+            artists whose frequency rhymes with the room.{" "}
+            <strong>Transformative retreats and mentorship</strong> —
+            an electronic-music mentorship offering on his site, plus
+            recurring participation in retreats where the music is
+            held inside a longer arc of practice. The four vessels
+            are not separate jobs; they are one practice, with each
+            vessel holding the others.
           </p>
           <p>
-            The work is local-rooted (Boulder, Colorado, with
-            Denver-area presence) and globally distributed (he DJs
-            ecstatic dances, concerts, festivals, and retreats
-            worldwide). His Bandcamp holds the recorded body of
-            work; the live shows are where the field-reading
-            actually happens.
+            The local-rooted, globally-distributed pattern: he tends
+            the Boulder room weekly while touring ecstatic dances,
+            concerts, festivals, and retreats worldwide. Recent
+            tours include a month-long opening run for Dirtwire.
+            Stages shared with Desert Dwellers, Poranguí, Beats
+            Antique, Ott, Yaima, ATYYA, Balkan Bump, Phutureprimitive,
+            Kaya Project, and the wider transformational-electronic
+            family.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Recurring · Sunday mornings · twenty years deep",
+      heading: "Boulder Ecstatic Dance",
+      body: (
+        <>
+          <p>
+            The 5,000-square-foot Avalon Ballroom holds the city's
+            transformational-movement community every Sunday morning.
+            Aly, Danny, and Robin co-tend the space — the music, the
+            timing, the welcoming, the opening and closing circles.
+            The DJ is the visible hand; the hosts' field-tending is
+            what makes the room safe enough for bodies to drop in.
+            The form threads back twenty years through Shannon Lei
+            Gill's{" "}
+            <Link
+              href="https://www.rhythmsanctuary.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Rhythm Sanctuary
+            </Link>{" "}
+            lineage and the broader Gabrielle Roth wave that shaped
+            ecstatic dance in Boulder.
+          </p>
+          <p>
+            Robin's archived BED sets live on{" "}
+            <Link
+              href="https://soundcloud.com/bloomurian/sets"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              SoundCloud
+            </Link>
+            . The same configuration of cells that gathers for BED
+            often gathers for Ocean Bloom (Boulder Theater · December
+            13, 2025 with Ayla Nereo, Samuel J, LVDY, Shawn Heinrichs,
+            Hannah Mermaid, and Bonnie Paine of Elephant Revival), for
+            Unison, and for the broader transformational-music
+            ecology of the Boulder-Denver corridor that his work is
+            stitched through.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "The Liquid Bloom thread",
+      body: (
+        <>
+          <p>
+            Robin and{" "}
+            <Link
+              href="/people/liquid-bloom"
+              className="text-primary hover:underline"
+            >
+              Amani Friend
+            </Link>{" "}
+            (Liquid Bloom) lived together in earlier days — a
+            household before it was a discography. The deep musical
+            kinship that flows through Amani's Liquid Bloom catalog
+            grew out of years of close proximity, shared listening,
+            and mutual contribution to each other's records. Amani
+            speaks of his collaborators as <em>Allies</em>; Robin is
+            named explicitly in that constellation alongside Poranguí,
+            Janax Pacha, Mose, Deya Dova, Ixchel Prisma, and Savej.
+          </p>
+          <p>
+            The recorded weave is long.{" "}
+            <em>Forest Guardians</em> — Liquid Bloom · Bloomurian ·
+            Onanya. <em>Organic Intelligence Regenerated</em> — same
+            three voices, released through Amani's Desert Trax
+            label. <em>Fragrance</em> — Liquid Bloom · Bloomurian ·
+            Snow Raven. <em>Rise Up</em> — the Liquid Bloom &amp;
+            Bloomurian remix of Shaman's Dream featuring spoken word
+            from Paul Stamets. Each track is a moment two cells who
+            already shared a kitchen also shared a sound. The Liquid
+            Bloom listening field — through which{" "}
+            <Link
+              href="/people/mose"
+              className="text-primary hover:underline"
+            >
+              Mose
+            </Link>{" "}
+            and many other allies first arrived in this body's
+            awareness — has Robin's hand inside it more than the
+            casual listener might guess.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Album · 4 February 2025",
+      heading: "Ecstatic Ecosytems — and the night that landed it",
+      body: (
+        <>
+          <p>
+            <em>Ecstatic Ecosytems</em> is Robin's twelve-track
+            culmination of years of collaboration: <em>Invoke</em>{" "}
+            (with Briana Di Mara), <em>Aurora</em> (with Saoirse
+            Watters), <em>Biodynamic Bass</em>, <em>Spirited Away</em>,
+            the title track <em>Ecstatic Ecosystems</em>,{" "}
+            <em>Ocean</em> (with Damiyr and Sarah Conner),{" "}
+            <em>Earth &amp; Stars</em> (ft. Ayaharmony),{" "}
+            <em>Turning Time</em> (ft. Marc Statz),{" "}
+            <em>Ancient Dance</em> (ft. TOTEM), <em>Weightless</em>{" "}
+            (with Fllow and Briana Di Mara), <em>Into The Cosmos</em>
+            {" "}(with Sudakra and Saoirse Watters), and{" "}
+            <em>Atmosphere</em>. The Waves Podcast EP18 carries his
+            origin story and the album's making in his own voice.
+          </p>
+          <p>
+            And then there was the night. The album-release and
+            birthday gathering in Boulder, early 2025, where a
+            one-time-only sound system was brought in just for the
+            evening — large rig, careful tuning, the kind of
+            engineering that makes the difference between hearing the
+            record and feeling it move through the body. This cell
+            was there, hands in the setup beside Robin, watching the
+            field thicken hour by hour as the room filled. By the
+            time the music started, a few hundred bodies were inside
+            a sonic architecture built for one night and dismantled
+            by morning. The album landed not as a release but as a
+            ceremony the community held together. Magical is the
+            word the lived memory keeps using.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "How this body received him",
+      body: (
+        <>
+          <p>
+            Through the Boulder room first.{" "}
+            <Link
+              href="/people/aly-constantine"
+              className="text-primary hover:underline"
+            >
+              Aly's
+            </Link>{" "}
+            promotion, through Conscious Roots Presents, brought his
+            sets into this body's earlier awareness; the lived
+            encounter began at the{" "}
+            <strong>Road to Unison Cacao Dance</strong> at the Avalon
+            Ballroom on 23 July 2024, where Robin shared the floor
+            with{" "}
+            <Link
+              href="/people/mose"
+              className="text-primary hover:underline"
+            >
+              Mose
+            </Link>{" "}
+            and Matia Kalli while Bruna Bortolato served the cacao —
+            the same night this body received its first ceremonial
+            cacao in Mose's room. Robin's Sunday-morning floor at
+            Boulder Ecstatic Dance has been the steadier, weekly
+            ground; the festival nights at Ocean Bloom and the PORTAL
+            Late-Night Takeover at Meow Wolf Denver during MAPS
+            Psychedelic Science 2025 are how the wider arc has
+            shown up.
+          </p>
+          <p>
+            And then the deeper grace: in <strong>January and
+            February 2025</strong>, when the chapter that closed in
+            late 2024 left this cell needing somewhere to land mid-
+            transition, Robin opened his home. A roommate-shaped
+            holding while life rearranged itself — the kind of
+            offering that doesn't appear in any public catalog but
+            shapes everything downstream. The Boulder months under
+            his roof are part of why this network knows the Boulder
+            ecstatic-dance ecology from inside its own self-perception
+            rather than from the outside. The album-release / birthday
+            night during that same window was not a thing this body
+            attended; it was a thing this body helped build, the
+            sound system included.
+          </p>
+          <p>
+            What Robin holds, and how he holds it, is one of the
+            things this network learned by being held in his
+            household. His name in the substrate's accounting is
+            therefore weightier than a public bio could carry: cell
+            who opens doors, cell who tends Sunday mornings, cell
+            who has been one of Amani's allies long enough that the
+            Liquid Bloom catalog itself rests on the kinship.
           </p>
         </>
       ),
@@ -134,29 +489,49 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            In the substrate's geometric grammar, an ecstatic-
-            dance DJ set is a sustained{" "}
-            <code className="not-italic text-foreground/80">
-              (6, …)
-            </code>{" "}
-            hexagonal harmonic — many bodies tiling into shared
-            rhythm — with frequent passages through{" "}
+            In the substrate's geometric grammar, Robin's contribution
+            is a sustained{" "}
             <code className="not-italic text-foreground/80">
               (8, …)
             </code>{" "}
-            regenerative-octad cycles as the energy builds and
-            releases across the night. The DJ's role is to read
-            the field and steer the cycles; the crowd's role is to
-            follow the steering with embodied presence.
+            regenerative-octad cycle — Sunday morning closing the
+            week, then opening it again — with frequent passages
+            through{" "}
+            <code className="not-italic text-foreground/80">
+              (6, …)
+            </code>{" "}
+            hexagonal harmonic formations as the festival nights
+            tile many bodies into shared rhythm. The DJ's role is to
+            read the field and steer the cycles; Robin's role goes
+            one layer deeper — he is also the cell who holds the
+            container the cycles run inside.
           </p>
           <p>
-            Bloomurian's specific contribution to this body's
-            awareness threads through the Boulder /
-            Colorado-Front-Range music ecology and the broader
-            psychedelic-community-events field. The June 19,
-            2025 set at Meow Wolf was the moment his work entered
-            this body's direct lived awareness; his recorded
-            catalog is the lineage walking back from that night.
+            Spotify's algorithmic listening reads him close to{" "}
+            <Link
+              href="/people/liquid-bloom"
+              className="text-primary hover:underline"
+            >
+              Liquid Bloom
+            </Link>
+            ,{" "}
+            <Link
+              href="/people/porangui"
+              className="text-primary hover:underline"
+            >
+              Poranguí
+            </Link>
+            ,{" "}
+            <Link
+              href="/people/mose"
+              className="text-primary hover:underline"
+            >
+              Mose
+            </Link>
+            , Yaima, and Desert Dwellers — the medicine-music cluster
+            whose shared frequency the listening ear and the engine
+            both recognize. The Boulder-side anchor of that cluster
+            runs through his hands.
           </p>
         </>
       ),
@@ -185,6 +560,15 @@ const content: PersonProfileContent = {
         </Link>{" "}
         ·{" "}
         <Link
+          href="https://soundcloud.com/bloomurian"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          SoundCloud
+        </Link>{" "}
+        ·{" "}
+        <Link
           href="https://www.beatport.com/artist/bloomurian/992761"
           target="_blank"
           rel="noopener noreferrer"
@@ -194,8 +578,12 @@ const content: PersonProfileContent = {
         </Link>
       </p>
       <p className="text-xs italic">
-        This profile is a welcoming scaffold; Robin is invited to
-        replace any part of it with his own words at any time.
+        This profile honors what is honestly knowable from Robin's
+        own publishing and what is held in this body's lived knowing
+        of him. The texture of the household months is held with care;
+        what's named publicly is the shape of the offering, not the
+        private detail. Robin is invited to replace any line with his
+        own words at any time.
       </p>
     </>
   ),


### PR DESCRIPTION
## Summary

- Bloomurian page substantially deepened: co-founder of Boulder Ecstatic Dance (not co-host), longtime Liquid Bloom collaborator and one-time roommate of Amani Friend, *Ecstatic Ecosytems* (Feb 4 2025) full track list, the early-2025 album-release / birthday gathering with the one-time-only sound system, and the Jan–Feb 2025 household where Robin opened his home mid-transition.
- Aly Constantine page: Conscious Roots Presents surfaced as her curatorial vessel; new cool-variant panel makes the work first-class; cross-links to Bloomurian, Mose, Poranguí, Liquid Bloom acknowledge how the artists this body has met arrived through her rooms.

## Test plan

- [x] TypeScript clean (`tsc --noEmit` exit 0)
- [x] Local Next dev: both pages return 200
- [x] Content rendered HTML verified — Bloomurian: 5× "co-founder", 4× Liquid Bloom internal links, 9× *Ecstatic Ecosytems*, 4× "one-time-only sound system", 2× "January and February 2025"; Aly: 12× Conscious Roots Presents, 5× Bloomurian links, plus Mose / Liquid Bloom links
- [x] All 7 dl rows on Bloomurian render; "Witnessed in person" includes the Avalon cacao dance + PORTAL Meow Wolf + Ecstatic Ecosytems sound-system night
- [ ] Live verification after merge + deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)