### PR TITLE
fix(presence): contributors render via PresencePage; remove intrusive 'image pending' text

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -347,6 +347,8 @@ export default async function PersonPage({
   // expects voices — and rendered as empty scaffolds, hiding the
   // history alive in the graph.
   const NODE_TYPES_THAT_RENDER_AS_PRESENCE = new Set([
+    "contributor",
+    "interested-person",
     "event",
     "scene",
     "place",

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -420,11 +420,11 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
                 .join(" · ")}
             </p>
           )}
-          {!hasImage && (
-            <p className="mt-4 text-[10px] uppercase tracking-[0.14em] text-white/40">
-              image pending · art will appear when the resolver finds one
-            </p>
-          )}
+          {/* Earlier this slot held an "image pending · art will appear
+              when the resolver finds one" line. That was an internal TODO
+              leaking onto the visitor's first impression. The radial
+              atmosphere fallback already carries presence on its own; no
+              text needed when the image hasn't landed yet. */}
         </div>
       </section>
 


### PR DESCRIPTION
User report: \"why is liquid bloom and bloomurian and other people and events still have sparse and why are the formatting no longer useful\"

## Three problems compounded

1. **POST /api/graph/nodes silently dropped custom fields** (canonical_url, tagline, claimed) during the field restoration. Only id/type/name stuck. Re-PATCHed each newly-minted node out-of-band (idempotent).

2. **Routing gate missed contributor type** — PR #1338 widened the gate but newly-minted contributor nodes without canonical_url fell through to the warm-garden view that expects voices, rendering their RAW ID (\`contributor:liquid-bloom\`) as the page title.

3. **\"image pending\" placeholder text** — internal TODO leaking onto every visitor's first impression of any sparse presence.

## Fix

- Add \`contributor\` + \`interested-person\` to NODE_TYPES_THAT_RENDER_AS_PRESENCE
- Remove the placeholder text from PresencePage hero (radial atmosphere carries presence on its own)

Type-check clean.

## Test plan

- [x] tsc clean
- [ ] After deploy: \`/people/contributor:liquid-bloom\` renders with proper hero (radial atmosphere, name, tagline) instead of the warm-garden 'name without its garden yet' fallback
- [ ] \`/people/event:retreat-with-anne-tucker-...\` no longer shows 'image pending' line