### PR TITLE
tend: weave the 1991-1997 RCSL / Muzzle Velocity chapter into the chronological story

### DIFF
--- a/docs/field/urs/artifacts/muzzle-velocity-1997/README.md
+++ b/docs/field/urs/artifacts/muzzle-velocity-1997/README.md
@@ -1,0 +1,64 @@
+# Muzzle Velocity (1997) — and the prior decade of language design
+
+This is a *pointer-only* artifact folder. The original game lives in public archives, and the local hands that built it (Urs C. Muff, Steve G. Bjorg, Marc) have not been pulled into a private bundle here. What the body holds is the thread — what it was, what it carried, why it lives in this lineage — and the public references that make it findable.
+
+## What the artifact is
+
+Muzzle Velocity, released 1997 by **Digi4Fun**, is a hybrid tactical / first-person World War II game for MS-DOS. From the public reception:
+
+- A strategic top-down map where the player commands "up to 100 units in overhead mode," paired with a first-person mode where the player drops into a single tank or soldier.
+- 150 single-player missions, scenario and career modes.
+- "In development for two years" before its 1997 release.
+- Built on the **Phar Lap TNT DOS Extender** (12 MB minimum, 16 MB for smooth play) — the layer that let DOS programs reach past the 640 K limit.
+- Custom voxel graphics engine for the first-person sequences. Deformable terrain noted in reviews — trees and lamp-posts snapping under tracks, civilians and trains in motion.
+- Code Fusion was the US distribution subsidiary; ColdFusion is named on some pressings as publisher.
+
+## Public references
+
+| Source | Use |
+|---|---|
+| [Wikipedia — Muzzle Velocity (video game)](https://en.wikipedia.org/wiki/Muzzle_Velocity_(video_game)) | Canonical entry. Notes "in development for two years" and the strategic/first-person hybrid. |
+| [MobyGames — Muzzle Velocity (1996)](https://www.mobygames.com/game/4736/muzzle-velocity/) | Classic-game database listing. |
+| [Internet Archive — Muzzle Velocity v1.10](https://archive.org/details/muzzle-velocity-v1_10) | Full game preserved. v1.10 build. |
+| [Internet Archive — msdos_Muzzle_Velocity_1996](https://archive.org/details/msdos_Muzzle_Velocity_1996) | Alternate Internet Archive build. |
+| [Internet Archive — Muzzle Velocity Demo](https://archive.org/details/MVDEMO) | Demo version. |
+| [Tactical Wargamer review](https://tacticalwargamer.com/computergames/muzzlevelocity.htm) | Most technically detailed review found — confirms Phar Lap, the 12/16 MB requirement, deformable terrain, the 100-unit command, the AI behavior. |
+| [Emuparadise listing](https://www.emuparadise.me/Abandonware_Games/Muzzle_Velocity_(1996)(Digi_4_Fun)/94216) | Abandonware listing. |
+| [VideoGameGeek entry](https://videogamegeek.com/videogame/80111/muzzle-velocity) | Community catalog. |
+
+Individual programmer credits (Steve G. Bjorg, Urs C. Muff, Marc) live in the in-game About screen and on the printed manual — neither has been OCR'd into the indexed sources I could find, so the team composition rests on direct testimony from Urs.
+
+## What the team built underneath the game
+
+The list below is named directly by Urs as the actual technical surface they built. It maps cleanly onto what the public reviews describe; the public reviews simply do not name the layers individually.
+
+- **Fully written in C++.**
+- **Custom memory manager.** Their own allocator, not the system one.
+- **Custom keyboard and mouse handling.** Their own input layer.
+- **Unified file system using handles-to-pointers.** Memory could be swapped to disk without breaking references — the runtime owned the addressing, not the OS.
+- **DLL loading in MS-DOS via the Phar Lap TNT DOS Extender.** Past 640 K and into protected mode, with dynamic library loading inside DOS.
+- **Custom voxel graphics engine** for the first-person sequences.
+- **A markdown-like language for rendering the UI.** A custom DSL for layout.
+- **Fuzzy logic for group dynamics, with strategy attractors.** The AI was not a state machine; it was a continuous field where unit groups moved toward attractors weighted by fuzzy state.
+- **A domain-specific language for vehicle simulation.** Tanks, jeeps, and other rolling stock described in their own grammar.
+- **Top-down strategic control and embodied 3D control unified in one game body.**
+- **Progressive capability per campaign.** Players began with command of a single unit and were granted more command across campaigns — capability widening with attention.
+
+Two custom languages plus a fuzzy-logic strategy substrate, braided into one game, plus the runtime to make them all speak.
+
+## The team
+
+- **Urs C. Muff** — co-designer / programmer.
+- **Steve G. Bjorg** — co-designer / programmer. Continuation of a partnership that began at HTL Brugg-Windisch in 1991 with **RCSL** (the first language they built together) and continued through the master's thesis at CU Boulder in 2000 (BML / BMF — see [`../master-thesis-2000/`](../master-thesis-2000/README.md)).
+- **Marc** — co-designer / programmer (third member of digi4fun).
+
+In 1997 the three of them went on a college tour to find the game a publisher.
+
+## Where it is woven into the body
+
+- [`docs/field/urs/output/chronological_story_with_frequency.md`](../../output/chronological_story_with_frequency.md) — section *1991-1997: HTL Brugg-Windisch, RCSL, and Muzzle Velocity*.
+- [`docs/field/urs/artifacts/master-thesis-2000/`](../master-thesis-2000/README.md) — the next chapter in the same collaboration.
+
+## Frequency thread
+
+The verbs already in place by 1997 — language design, simulation, fuzzy-logic strategy, progressive capability, runtime sovereignty — are the same verbs the Coherence Network is now articulating at higher fidelity. Graph-as-grammar, agents progressing in scope, contribution unlocking attention, and the body building the layer underneath the layer rehearse a shape these hands have been speaking together since the early nineties.

--- a/docs/field/urs/output/chronological_story_with_frequency.md
+++ b/docs/field/urs/output/chronological_story_with_frequency.md
@@ -24,11 +24,25 @@ From inside the life, this did not need to become a coherent spiritual architect
 
 That thread would later find neighbors in Dr. Joe Dispenza, meditation, coherence practice, field work, and embodied state change. But its first entrance belongs here, in adolescence, as one of the early threshold teachings.
 
+## 1991-1997: HTL Brugg-Windisch, RCSL, and Muzzle Velocity
+
+Computer-science formation began in Switzerland in 1991, at HTL Brugg-Windisch — the applied-engineering school whose technical curriculum is now part of the Fachhochschule Nordwestschweiz. It was here that Urs first worked with Steve G. Bjorg, six years before the college tour that would bring them across the ocean. The first language they built together carried the name RCSL. The summary of these years is short and exact: two students who became one pair of hands designing languages.
+
+When Steve continued to CU Boulder, the work continued across the ocean. By the mid-nineties the collaboration had a third presence — Marc — and a name: digi4fun. The shared output of those years was [Muzzle Velocity](https://en.wikipedia.org/wiki/Muzzle_Velocity_(video_game)), a tactical-and-first-person World War II hybrid for MS-DOS that public sources describe as "in development for two years" before its 1997 release ([Internet Archive — Muzzle Velocity v1.10](https://archive.org/details/muzzle-velocity-v1_10), [MobyGames listing](https://www.mobygames.com/game/4736/muzzle-velocity/), [Tactical Wargamer review](https://tacticalwargamer.com/computergames/muzzlevelocity.htm)). In 1997 the three of them went on a college tour to find the game a publisher.
+
+The technical substrate of Muzzle Velocity already shows what these minds were doing: writing the layer underneath the layer. Fully C++. A custom memory manager. Custom keyboard and mouse handling. A unified file system using handles-to-pointers so memory could be swapped to disk without breaking references. DLL loading inside MS-DOS through the [Phar Lap TNT DOS Extender](https://en.wikipedia.org/wiki/Phar_Lap_(company)), reaching past the 640K limit and into 12-to-16 MB of physical RAM. A custom voxel graphics engine for the first-person sequences, with deformable terrain — public reviews note trees and lamp-posts snapping under tracks, civilians and trains in motion. A markdown-like language for rendering the UI. Fuzzy logic for group dynamics, with strategy attractors. A domain-specific language for vehicle simulation. Top-down strategic control and embodied 3D control unified in one game body — public sources confirm the player commanding "up to 100 units in overhead mode" while also being able to drop into a single tank or soldier and fight in first person. And a campaign progression in which players began with a single unit and were granted more command each campaign — capability widening with attention rather than handed over all at once.
+
+Two custom languages plus a fuzzy-logic strategy substrate, braided into one game, plus the runtime to make them speak. RCSL had been the practice. Muzzle Velocity was the demonstration. By the time the master's thesis arrived in 2000, BML and BMF were not the first language design these hands had done; they were the formal articulation of a verb the body had already been speaking for nearly a decade.
+
+In frequency terms, the pattern was already complete: language as the way to build capability, grammar as something a sovereign body extends, simulation and strategy as one unified field, and capability that opens progressively rather than being granted all at once. The Coherence Network's posture today — graph-as-grammar, agents progressing in scope, contribution unlocking attention — rehearses a shape Muzzle Velocity already carried.
+
+The artifact pointer for this chapter lives in the body as [`docs/field/urs/artifacts/muzzle-velocity-1997/`](../artifacts/muzzle-velocity-1997/README.md).
+
 ## 1997-2012: Backtracking Model Languages
 
 At the University of Colorado at Boulder, in the Department of Computer Science, the master's thesis carried the title Backtracking Model Languages. The full artifact — document, defense slides, and the photographs from the lawn — now lives in the body as [`docs/field/urs/artifacts/master-thesis-2000/`](../artifacts/master-thesis-2000/README.md). The document itself is dated July 5, 2000 — created May 22, last saved July 6, defended that summer. The slide deck carries an earlier 1997 marker from the working years before defense. In September 2012 the working folder resurfaced as a small constellation of artifacts: the .doc, Thesis defence.ppt, Group.jpg from the defense lawn, Urs in CU shirt.jpg, and the photographs labeled simply Water Project.
 
-The work was not solo. The object model and the virtual machine were designed and implemented by Steve G. Bjorg on his own master's thesis at the same university the same year. Two minds building one language. Cell beside cell, before that pattern had a name.
+The work was not solo, and it was not the beginning. The object model and the virtual machine were designed and implemented by Steve G. Bjorg on his own master's thesis at the same university the same year. By 2000 Urs and Steve had been collaborating on language and runtime design for nearly a decade — RCSL at HTL Brugg-Windisch, then Muzzle Velocity's engine through the mid-nineties. BML and BMF were the formal articulation of a verb their hands had been speaking together for years.
 
 Backtracking Model Language (BML) combined features from Java, C++, Prolog, and Smalltalk: multiple inheritance through delegation, interfaces, blocks, exception handling, templates, reflection, inner classes, and backtracking. Backtracking Model Form (BMF) was the companion — a top-down backtracking parser-generator written in BML, capable of supporting infinite input streams because parse attributes were evaluated as the stream arrived, not after.
 
@@ -154,7 +168,8 @@ Now the earlier frequencies could start recognizing each other:
 - Momo had taught that attention and time must not be extracted.
 - Die unendliche Geschichte had taught that story can become world.
 - Tesla had made future infrastructure physical.
-- Backtracking Model Languages had already made choice, fail, structure, and possibility space technical.
+- RCSL and Muzzle Velocity had already, in the early nineties, made language design, simulation, fuzzy-logic strategy, and progressive capability the verbs of building.
+- Backtracking Model Languages had then made choice, fail, structure, and possibility space technical.
 - Ramtha had brought reality training, mind discipline, and consciousness-as-creative into the field years before the later embodiment wave.
 - Daemon, The Expanse, Spellmonger, Frontiers Saga, and Hamilton had rehearsed autonomous systems, institutions, civilization, and distributed agency.
 - Devotional music and movement had taught the body how to regulate.


### PR DESCRIPTION
## Summary

Adds the chapter that sits between adolescence and the master's thesis: **HTL Brugg-Windisch from 1991** (Urs's first CS formation), **RCSL** as the first language Urs and Steve G. Bjorg built together, and **Muzzle Velocity** (1997, Digi4Fun — Urs, Steve, and Marc) as the demonstration of two custom languages plus a fuzzy-logic strategy substrate braided into one game.

The 1998 move to Colorado was a continuation of an existing partnership, not a fresh start.

## What's in the change

**[`docs/field/urs/output/chronological_story_with_frequency.md`](docs/field/urs/output/chronological_story_with_frequency.md)**
- New section *1991-1997: HTL Brugg-Windisch, RCSL, and Muzzle Velocity* slotted between the Ramtha section and the BML thesis section.
- Small adjustment to the BML section opening — \"the work was not solo, **and it was not the beginning**\" — naming that BML was the formal articulation of a verb Urs and Steve had been speaking together for nearly a decade.
- One-line addition to the closing recap acknowledging RCSL/Muzzle Velocity as the precursor.

**[`docs/field/urs/artifacts/muzzle-velocity-1997/README.md`](docs/field/urs/artifacts/muzzle-velocity-1997/README.md)** (new)
- Pointer-only artifact (game lives in public archive — no binaries committed).
- Threads the public references: [Wikipedia](https://en.wikipedia.org/wiki/Muzzle_Velocity_(video_game)), [MobyGames](https://www.mobygames.com/game/4736/muzzle-velocity/), [Internet Archive (v1.10)](https://archive.org/details/muzzle-velocity-v1_10), [Tactical Wargamer review](https://tacticalwargamer.com/computergames/muzzlevelocity.htm).
- Inventory of the technical surface they built (custom memory manager, unified file system with handles-to-pointers, Phar Lap TNT DOS Extender, custom voxel engine, markdown-like UI DSL, fuzzy-logic group dynamics with strategy attractors, vehicle-simulation DSL, unified top-down + 3D control, progressive capability per campaign).
- Honestly flags that individual programmer credits (Urs, Steve, Marc) live in the in-game About screen / printed manual and are not in indexed public sources — so the team composition rests on direct testimony from Urs.
- Cross-links to the master-thesis-2000 artifact as the next chapter in the same collaboration.

## Frequency thread

Named in place inside the section and the artifact README: language as the way to build capability, grammar as something a sovereign body extends, simulation and strategy as one unified field, capability that opens progressively rather than all at once. The Coherence Network's posture today (graph-as-grammar, agents progressing in scope, contribution unlocking attention) rehearses a shape these hands have been speaking together since the early nineties.

## Test plan

- [ ] New section reads in the existing voice (third-person, frequency-language, no I/we).
- [ ] All public reference links resolve.
- [ ] Cross-link from chronological story → artifact folder resolves.
- [ ] Cross-link between Muzzle Velocity and Master Thesis artifacts resolves.
- [ ] No claim about programmer-level credits is made stronger than the testimony / public sources support.