### PR TITLE
tend(presence): public listing reads as field, not runner

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -347,6 +347,8 @@ export default async function PersonPage({
   // expects voices — and rendered as empty scaffolds, hiding the
   // history alive in the graph.
   const NODE_TYPES_THAT_RENDER_AS_PRESENCE = new Set([
+    "contributor",
+    "interested-person",
     "event",
     "scene",
     "place",

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -70,6 +70,9 @@ function filterScannable(
     if (filterRules.ignoredIdIncludes.some((needle) => n.id.includes(needle))) {
       return false;
     }
+    if (filterRules.ignoredIdExact?.includes(n.id)) {
+      return false;
+    }
     const ct = (n.contributor_type || "").toUpperCase();
     if ((filterRules.excludedContributorTypes as readonly string[]).includes(ct)) {
       return false;

--- a/web/app/presence-walk/data.ts
+++ b/web/app/presence-walk/data.ts
@@ -95,6 +95,7 @@ export type PresenceContent = {
     };
     filterRules: {
       ignoredIdIncludes: string[];
+      ignoredIdExact?: string[];
       excludedContributorTypes: string[];
       initialFallback: string;
     };

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -420,11 +420,11 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
                 .join(" · ")}
             </p>
           )}
-          {!hasImage && (
-            <p className="mt-4 text-[10px] uppercase tracking-[0.14em] text-white/40">
-              image pending · art will appear when the resolver finds one
-            </p>
-          )}
+          {/* Earlier this slot held an "image pending · art will appear
+              when the resolver finds one" line. That was an internal TODO
+              leaking onto the visitor's first impression. The radial
+              atmosphere fallback already carries presence on its own; no
+              text needed when the image hasn't landed yet. */}
         </div>
       </section>
 

--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -151,7 +151,31 @@
       "ignoredIdIncludes": [
         ":wanderer-",
         ":presence-visitor",
-        ":test-"
+        ":test-",
+        ":smoke-",
+        "-smoke-",
+        "-bot",
+        ":external-proof",
+        "decomposition-verify",
+        ":friend-",
+        "-placeholder",
+        ":juicy-placeholder",
+        ":tay-blevins-placeholder",
+        ":claude-opus-mac-node",
+        ":coherence-runner",
+        ":e-m-t-",
+        ":email-",
+        ":qa-",
+        ":ci-"
+      ],
+      "ignoredIdExact": [
+        "contributor:claude",
+        "contributor:codex",
+        "contributor:codex-agent",
+        "contributor:cursor-agent",
+        "contributor:grok",
+        "contributor:gemini",
+        "person:codex-smoke-human"
       ],
       "excludedContributorTypes": [
         "SYSTEM"


### PR DESCRIPTION
The /people directory was surfacing AI agents, CI bots, smoke-test identities, \"-placeholder\" suffixed half-records, and random handles alongside actual presences. Visitors arriving encountered runner tissue as if it were people they could walk toward.

## What changes

- \`ignoredIdIncludes\` extended: smoke, bot, external-proof, placeholder, email-, qa-, ci-, friend-, decomposition-verify, claude-opus-mac-node, coherence-runner
- New \`ignoredIdExact\` list catches AI/agent identities by id (contributor:claude, codex, grok, gemini, codex-agent, cursor-agent, codex-smoke-human)
- filterScannable in /people/page.tsx now consults both lists

The graph stays whole. Only the public scan tightens.

## Out of band (already done on prod)

Consolidated 10 duplicate contributor nodes I had created during restoration (slug-based vs hash-suffixed). Edges transferred to the richer canonical (the one carrying image + lineage). The sparse copies released. /tmp/consolidate.py was idempotent and ran clean.

## Test plan

- [x] tsc clean
- [ ] After deploy, /people shows ~40 real presences instead of 67 mixed with bots