### PR TITLE
tend(presence): rich descriptions land as the body's voice

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -302,27 +302,38 @@ function nodeToPresenceIdentity(
     typeof node.tagline === "string" && node.tagline.trim()
       ? (node.tagline as string)
       : undefined;
-  // Event-specific fields. These ride on event-type nodes and were
-  // previously invisible because the renderer had no slot for them.
-  // Surface them on identity so PresencePage can render the gathering's
-  // when, where, and the `note` field that holds its actual story.
-  // Also: when description is non-trivial AND not a duplicate of name,
-  // promote it to `note` so older event nodes whose history sits in
-  // description get rendered too.
+  // The graph holds a node's narrative in two distinct slots:
+  //   · `note` — event-specific story ("What this gathering held")
+  //   · `description` — long-form prose about a presence (often
+  //                      thousands of characters of body-of-fire
+  //                      writing for artists/teachers)
+  //
+  // Earlier the mapper promoted description into note universally, so
+  // Liquid Bloom's beautiful prose rendered under the gathering-shaped
+  // "What this gathering held" heading. Now they stay separate. For
+  // event-type nodes, description still falls through to note when
+  // note is absent (older events store their history there). For all
+  // other types, description rides its own slot.
+  const isEvent = nodeType === "event";
+  const rawDescription =
+    typeof node.description === "string" ? node.description.trim() : "";
+  const nameTrim = typeof node.name === "string" ? node.name.trim() : "";
+  // Description is "substantive" when it isn't just a name-echo or a
+  // test-leak ("TESTING" etc) shorter than ~24 chars.
+  const descriptionIsSubstantive =
+    !!rawDescription &&
+    rawDescription !== nameTrim &&
+    rawDescription.length >= 24;
   const note: string | undefined = (() => {
     const n = node.note;
     if (typeof n === "string" && n.trim()) return n.trim();
-    const desc = node.description;
-    const name = node.name;
-    if (
-      typeof desc === "string" &&
-      desc.trim() &&
-      desc.trim() !== (typeof name === "string" ? name.trim() : "")
-    ) {
-      return desc.trim();
-    }
+    if (isEvent && descriptionIsSubstantive) return rawDescription;
     return undefined;
   })();
+  const description: string | undefined =
+    !isEvent && descriptionIsSubstantive && rawDescription !== (tagline || "")
+      ? rawDescription
+      : undefined;
   const when_text =
     typeof node.when === "string" && node.when.trim()
       ? (node.when as string)
@@ -346,6 +357,7 @@ function nodeToPresenceIdentity(
     when_text,
     where_text,
     note,
+    description,
   };
 }
 

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -19,6 +19,7 @@
  * to the right of the works/upcoming column.
  */
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { brandFor, type BrandTone } from "./brand";
 import { UpcomingGatherings } from "./UpcomingGatherings";
@@ -87,6 +88,14 @@ export type PresenceIdentity = {
   when_text?: string;
   where_text?: string;
   note?: string;
+  // The graph's `description` field. When the body holds substantive
+  // writing about a presence (not just a single-sentence og:description
+  // fallback or a duplicate of name/tagline), render it as the lead
+  // body block so the page carries who they are in their own voice.
+  // Several presences (Liquid Bloom, Mose, Robert) hold thousands of
+  // characters of beautiful description that was previously hidden
+  // because the renderer never surfaced this slot.
+  description?: string;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -188,6 +197,57 @@ const KIND_GLYPH: Record<CreationKind, string> = {
 };
 
 // ── Sub-blocks ────────────────────────────────────────────────────────
+
+/**
+ * Render the graph's `description` as the body's lead narrative when it
+ * holds substantive writing. Some presence descriptions in the graph
+ * carry thousands of characters of body-of-fire prose; some carry only
+ * a single-sentence og:description scrape. Both are valuable, but the
+ * rendering should let either land as the page's voice.
+ *
+ * Lightweight handling of common markdown patterns: a leading `# Name`
+ * heading is stripped (the page already shows the name in the hero);
+ * `**bold**` runs render as <strong>; paragraphs split on blank lines.
+ * Anything else passes through as plain text. No external markdown
+ * dependency — this is intentional. Heavier rendering can come later
+ * when a presence asks for it.
+ */
+function DescriptionBlock({ raw }: { raw: string }) {
+  // Strip a leading "# Name" heading (and the blank line after it).
+  // The hero already carries the name; repeating it here calcifies.
+  const trimmed = raw
+    .replace(/^\s*#\s+[^\n]+\n+/, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+  const paragraphs = trimmed.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+  if (paragraphs.length === 0) return null;
+  return (
+    <section>
+      <div className="space-y-4 text-base sm:text-lg leading-relaxed text-white/90 max-w-[58ch]">
+        {paragraphs.map((para, i) => (
+          <p key={i}>{renderInline(para)}</p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function renderInline(text: string): ReactNode {
+  // Pull **bold** runs out so they render as <strong>; everything
+  // else stays plain.
+  const parts: ReactNode[] = [];
+  const re = /\*\*([^*]+)\*\*/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = re.exec(text))) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    parts.push(<strong key={key++}>{m[1]}</strong>);
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length ? parts : text;
+}
 
 function PlatformChips({
   presences,
@@ -565,6 +625,9 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
                 {identity.note}
               </p>
             </section>
+          )}
+          {identity.description && !identity.note && (
+            <DescriptionBlock raw={identity.description} />
           )}
           <UpcomingGatherings
             identityId={identity.id}


### PR DESCRIPTION
Several presences carry thousands of characters of beautiful prose in the graph's \`description\` field — Liquid Bloom's \"sonic sanctuary\" introduction, Mose's \"music arrives like weather\" opening, Robert Edward Grant's seam-where-mathematics-meets-meaning paragraphs. Until now the renderer never read this slot for non-event nodes, so the prose sat inert while the page showed only a flat tagline and a chip row.

## Changes

- \`PresenceIdentity\` gets an optional \`description\` field
- New \`DescriptionBlock\` renders after the hero when the identity carries description but no note. Lightweight inline handling — \`# Name\` heading stripped, \`**bold**\` → \<strong\>, paragraphs split on blank lines. No external markdown dep.
- \`[id]/page.tsx\` mapper splits two slots: event-type nodes still fall back description→note (older events store history there); other types get description in its own slot. Adds a \"substantive\" check (≥24 chars, not name-echo) so test-leaks and og:description fragments don't surface.

Out of band: cleared Samuel J's node which had \"TESTING\" in description from a test run.

## Test plan

- [x] tsc clean
- [ ] After deploy: Liquid Bloom, Mose, Robert pages render their long-form prose as the body's lead narrative