### PR TITLE
tend(place): place pages surface every presence rooted there

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -302,27 +302,38 @@ function nodeToPresenceIdentity(
     typeof node.tagline === "string" && node.tagline.trim()
       ? (node.tagline as string)
       : undefined;
-  // Event-specific fields. These ride on event-type nodes and were
-  // previously invisible because the renderer had no slot for them.
-  // Surface them on identity so PresencePage can render the gathering's
-  // when, where, and the `note` field that holds its actual story.
-  // Also: when description is non-trivial AND not a duplicate of name,
-  // promote it to `note` so older event nodes whose history sits in
-  // description get rendered too.
+  // The graph holds a node's narrative in two distinct slots:
+  //   · `note` — event-specific story ("What this gathering held")
+  //   · `description` — long-form prose about a presence (often
+  //                      thousands of characters of body-of-fire
+  //                      writing for artists/teachers)
+  //
+  // Earlier the mapper promoted description into note universally, so
+  // Liquid Bloom's beautiful prose rendered under the gathering-shaped
+  // "What this gathering held" heading. Now they stay separate. For
+  // event-type nodes, description still falls through to note when
+  // note is absent (older events store their history there). For all
+  // other types, description rides its own slot.
+  const isEvent = nodeType === "event";
+  const rawDescription =
+    typeof node.description === "string" ? node.description.trim() : "";
+  const nameTrim = typeof node.name === "string" ? node.name.trim() : "";
+  // Description is "substantive" when it isn't just a name-echo or a
+  // test-leak ("TESTING" etc) shorter than ~24 chars.
+  const descriptionIsSubstantive =
+    !!rawDescription &&
+    rawDescription !== nameTrim &&
+    rawDescription.length >= 24;
   const note: string | undefined = (() => {
     const n = node.note;
     if (typeof n === "string" && n.trim()) return n.trim();
-    const desc = node.description;
-    const name = node.name;
-    if (
-      typeof desc === "string" &&
-      desc.trim() &&
-      desc.trim() !== (typeof name === "string" ? name.trim() : "")
-    ) {
-      return desc.trim();
-    }
+    if (isEvent && descriptionIsSubstantive) return rawDescription;
     return undefined;
   })();
+  const description: string | undefined =
+    !isEvent && descriptionIsSubstantive && rawDescription !== (tagline || "")
+      ? rawDescription
+      : undefined;
   const when_text =
     typeof node.when === "string" && node.when.trim()
       ? (node.when as string)
@@ -346,6 +357,7 @@ function nodeToPresenceIdentity(
     when_text,
     where_text,
     note,
+    description,
   };
 }
 

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -27,6 +27,7 @@ import { ResonatesWith } from "./ResonatesWith";
 import { KindredPresences } from "./KindredPresences";
 import { LocationChip } from "./LocationChip";
 import { CoLocated } from "./CoLocated";
+import { RootedHere } from "./RootedHere";
 
 export type Presence = {
   provider: string;
@@ -650,6 +651,13 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
             identityName={identity.name}
           />
           <LocationChip presenceId={identity.id} />
+          {/* When the page IS a place, show every presence rooted in
+              it. The component renders nothing for non-place ids, so
+              passing the id unconditionally is safe and keeps the
+              place-vs-presence rendering unified. */}
+          {identity.id.startsWith("place:") && (
+            <RootedHere placeId={identity.id} />
+          )}
           <ResonatesWith presenceId={identity.id} />
           <KindredPresences presenceId={identity.id} />
           <CoLocated presenceId={identity.id} />

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -19,6 +19,7 @@
  * to the right of the works/upcoming column.
  */
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { brandFor, type BrandTone } from "./brand";
 import { UpcomingGatherings } from "./UpcomingGatherings";
@@ -87,6 +88,14 @@ export type PresenceIdentity = {
   when_text?: string;
   where_text?: string;
   note?: string;
+  // The graph's `description` field. When the body holds substantive
+  // writing about a presence (not just a single-sentence og:description
+  // fallback or a duplicate of name/tagline), render it as the lead
+  // body block so the page carries who they are in their own voice.
+  // Several presences (Liquid Bloom, Mose, Robert) hold thousands of
+  // characters of beautiful description that was previously hidden
+  // because the renderer never surfaced this slot.
+  description?: string;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -188,6 +197,57 @@ const KIND_GLYPH: Record<CreationKind, string> = {
 };
 
 // ── Sub-blocks ────────────────────────────────────────────────────────
+
+/**
+ * Render the graph's `description` as the body's lead narrative when it
+ * holds substantive writing. Some presence descriptions in the graph
+ * carry thousands of characters of body-of-fire prose; some carry only
+ * a single-sentence og:description scrape. Both are valuable, but the
+ * rendering should let either land as the page's voice.
+ *
+ * Lightweight handling of common markdown patterns: a leading `# Name`
+ * heading is stripped (the page already shows the name in the hero);
+ * `**bold**` runs render as <strong>; paragraphs split on blank lines.
+ * Anything else passes through as plain text. No external markdown
+ * dependency — this is intentional. Heavier rendering can come later
+ * when a presence asks for it.
+ */
+function DescriptionBlock({ raw }: { raw: string }) {
+  // Strip a leading "# Name" heading (and the blank line after it).
+  // The hero already carries the name; repeating it here calcifies.
+  const trimmed = raw
+    .replace(/^\s*#\s+[^\n]+\n+/, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+  const paragraphs = trimmed.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+  if (paragraphs.length === 0) return null;
+  return (
+    <section>
+      <div className="space-y-4 text-base sm:text-lg leading-relaxed text-white/90 max-w-[58ch]">
+        {paragraphs.map((para, i) => (
+          <p key={i}>{renderInline(para)}</p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function renderInline(text: string): ReactNode {
+  // Pull **bold** runs out so they render as <strong>; everything
+  // else stays plain.
+  const parts: ReactNode[] = [];
+  const re = /\*\*([^*]+)\*\*/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = re.exec(text))) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    parts.push(<strong key={key++}>{m[1]}</strong>);
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length ? parts : text;
+}
 
 function PlatformChips({
   presences,
@@ -565,6 +625,9 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
                 {identity.note}
               </p>
             </section>
+          )}
+          {identity.description && !identity.note && (
+            <DescriptionBlock raw={identity.description} />
           )}
           <UpcomingGatherings
             identityId={identity.id}

--- a/web/components/presence/RootedHere.tsx
+++ b/web/components/presence/RootedHere.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * RootedHere — when the page IS a place, surface every presence rooted
+ * in it.
+ *
+ * The body's place pages (Boulder, Aurora, Seattle, Ubud, Newport
+ * Beach) sit in the graph carrying the connections of every presence
+ * that's at-place there — but until now those edges flowed only one
+ * way (a person's page showed their place; a place's page showed
+ * nothing back). This block reads the inverse: presences rooted here.
+ *
+ * Visually mirrors KindredPresences and CoLocated so the sidebar reads
+ * as one continuous body. Renders nothing when the place has no
+ * presences yet — empty places stay quiet rather than scaffolded.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+
+type PresenceRow = {
+  presence_id: string;
+  presence_name?: string;
+  presence_type?: string | null;
+  role?: string | null;
+};
+
+export function RootedHere({ placeId }: { placeId: string }) {
+  const [items, setItems] = useState<PresenceRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const apiBase = getApiBase();
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(
+          `${apiBase}/api/places/${encodeURIComponent(placeId)}/presences`,
+          { cache: "no-store" },
+        );
+        if (!r.ok) {
+          if (!cancelled) setLoaded(true);
+          return;
+        }
+        const body: { items: PresenceRow[] } = await r.json();
+        const presences = Array.isArray(body.items) ? body.items : [];
+        if (!cancelled) {
+          setItems(presences.slice(0, 24));
+          setLoaded(true);
+        }
+      } catch {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [placeId]);
+
+  if (!loaded || items.length === 0) return null;
+
+  return (
+    <section>
+      <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
+        Rooted here
+      </p>
+      <ul className="space-y-1.5">
+        {items.map((p) => (
+          <li key={p.presence_id}>
+            <Link
+              href={`/people/${encodeURIComponent(p.presence_id)}`}
+              className="flex items-baseline justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 hover:bg-white/[0.06] transition-colors"
+            >
+              <span className="text-sm text-white/85 truncate">
+                {p.presence_name || p.presence_id}
+              </span>
+              {p.role && (
+                <span className="text-[10px] uppercase tracking-[0.14em] text-white/45 shrink-0">
+                  {p.role}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
Boulder, Colorado — the body's first ground — was rendering as a sparse scaffold. The graph already carried every at-place edge but the renderer only flowed them one direction.

Adds a "Rooted here" sidebar block that fires on place-type identities, fetches `/api/places/{id}/presences`, and renders the constellation. Same visual register as KindredPresences and CoLocated — sidebar reads as one continuous body.

Empty places stay quiet (component returns null when zero presences).

## Test plan

- [x] tsc clean
- [ ] After deploy: /people/place:boulder-colorado shows Bloomurian, Liquid Bloom, Boulder Theater etc in 'Rooted here'