### PR TITLE
tend(discovery): every page becomes a doorway

### DIFF
--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -150,12 +150,34 @@ export default async function PeopleIndexPage({
       {directorySections.map((section) => {
         const items = groups[section.key] || [];
         if (items.length === 0) return null;
+        // Each section header doubles as a filter link — clicking
+        // it narrows the listing to just that section. Same view
+        // as visiting /people?kind={key} directly. When already
+        // filtered to that section, the link goes back to the full
+        // directory.
+        const isCurrentlyFiltered = kindFilter === section.key;
+        const linkHref = isCurrentlyFiltered
+          ? "/people"
+          : `/people?kind=${encodeURIComponent(section.key)}`;
         return (
           <section key={section.key} className="space-y-4">
             <div>
-              <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
-                {section.title} · {items.length}
-              </h2>
+              <Link
+                href={linkHref}
+                className="group inline-flex items-baseline gap-2 hover:opacity-80 transition-opacity"
+                aria-label={
+                  isCurrentlyFiltered
+                    ? `Show all sections`
+                    : `Show only ${section.title}`
+                }
+              >
+                <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
+                  {section.title} · {items.length}
+                </h2>
+                <span className="text-[10px] text-muted-foreground/60 group-hover:text-foreground/80 transition-colors">
+                  {isCurrentlyFiltered ? "← all" : "→ filter"}
+                </span>
+              </Link>
               <p className="text-xs text-muted-foreground/80 italic mt-1">
                 {section.lede}
               </p>

--- a/web/components/presence/HeldBy.tsx
+++ b/web/components/presence/HeldBy.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * HeldBy — when the page IS an event, surface every presence that
+ * hosted, performed, or co-led it.
+ *
+ * The graph stores contributes-to edges from each host into the event,
+ * so reading them as incoming edges into the event yields the hosts.
+ * Each host link is a doorway off the event page back into the
+ * lineage that brought the gathering into being.
+ *
+ * Visual style mirrors KindredPresences/RootedHere so the sidebar
+ * reads as one continuous body. Empty events (no hosts in the graph
+ * yet) render nothing — quiet honesty over scaffolded placeholders.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+
+type Host = {
+  id: string;
+  name: string;
+  role?: string;
+};
+
+type EdgeRow = {
+  from_id: string;
+  type: string;
+  from_node?: { id: string; name: string; type: string };
+  properties?: { kind?: string; role?: string } & Record<string, unknown>;
+};
+
+export function HeldBy({ eventId }: { eventId: string }) {
+  const [items, setItems] = useState<Host[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const apiBase = getApiBase();
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(
+          `${apiBase}/api/edges?to_id=${encodeURIComponent(eventId)}&type=contributes-to&limit=50`,
+          { cache: "no-store" },
+        );
+        if (!r.ok) {
+          if (!cancelled) setLoaded(true);
+          return;
+        }
+        const body: { items: EdgeRow[] } = await r.json();
+        const seen = new Set<string>();
+        const hosts: Host[] = [];
+        for (const e of body.items || []) {
+          const id = e.from_id;
+          // The host edge lives between a presence (contributor /
+          // community / scene / network-org) and the event. Filter to
+          // those types — concepts and assets sometimes carry the same
+          // edge type but aren't hosts.
+          const fromType = e.from_node?.type || "";
+          if (
+            !["contributor", "community", "scene", "network-org"].includes(
+              fromType,
+            )
+          ) {
+            continue;
+          }
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+          hosts.push({
+            id,
+            name: e.from_node?.name || id,
+            role:
+              (e.properties?.role as string) ||
+              undefined,
+          });
+        }
+        if (!cancelled) {
+          setItems(hosts);
+          setLoaded(true);
+        }
+      } catch {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId]);
+
+  if (!loaded || items.length === 0) return null;
+
+  return (
+    <section>
+      <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
+        Held by
+      </p>
+      <ul className="space-y-1.5">
+        {items.map((h) => (
+          <li key={h.id}>
+            <Link
+              href={`/people/${encodeURIComponent(h.id)}`}
+              className="flex items-baseline justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 hover:bg-white/[0.06] transition-colors"
+            >
+              <span className="text-sm text-white/85 truncate">{h.name}</span>
+              {h.role && h.role !== "primary" && (
+                <span className="text-[10px] uppercase tracking-[0.14em] text-white/45 shrink-0">
+                  {h.role}
+                </span>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -28,6 +28,8 @@ import { KindredPresences } from "./KindredPresences";
 import { LocationChip } from "./LocationChip";
 import { CoLocated } from "./CoLocated";
 import { RootedHere } from "./RootedHere";
+import { HeldBy } from "./HeldBy";
+import { WanderInto } from "./WanderInto";
 
 export type Presence = {
   provider: string;
@@ -658,12 +660,22 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
           {identity.id.startsWith("place:") && (
             <RootedHere placeId={identity.id} />
           )}
+          {/* When the page IS an event, surface the hosts as living
+              doorways back into the lineage that held it. */}
+          {identity.id.startsWith("event:") && (
+            <HeldBy eventId={identity.id} />
+          )}
           <ResonatesWith presenceId={identity.id} />
           <KindredPresences presenceId={identity.id} />
           <CoLocated presenceId={identity.id} />
           <InspiredByChips inspired={inspired} />
           <HeldOpen identity={identity} accent={accent} />
         </aside>
+      </div>
+
+      {/* ── Wander into — closing doorways into the body ─────────── */}
+      <div className="mx-auto w-full max-w-6xl px-6 sm:px-8 lg:px-12 pb-12">
+        <WanderInto presenceId={identity.id} />
       </div>
 
       {/* ── Canonical link ────────────────────────────────────────── */}
@@ -679,6 +691,72 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
           </a>
         </footer>
       )}
+
+      {/* ── Schema.org structured data — for machine readers ──────── */}
+      {/* Helps search engines and LLM crawlers see the shape of each
+          presence: their type, name, image, related URLs, and
+          (where relevant) location. Inline JSON-LD keeps it
+          server-rendered and crawlable on first paint. */}
+      <SchemaOrgScript identity={identity} />
     </main>
+  );
+}
+
+/**
+ * Inline JSON-LD using schema.org vocabulary so machine readers
+ * (Google, Bing, LLM crawlers) understand each presence's shape.
+ *
+ * Mapping graph node types → schema.org types:
+ *   contributor / interested-person → Person
+ *   community / network-org          → Organization
+ *   event                             → Event
+ *   place / scene                     → Place
+ *   asset                             → CreativeWork
+ *   practice                          → Course (closest schema type)
+ *
+ * Only fields the body actually carries are emitted. This is a
+ * server-renderable component (no client effects, no state) so the
+ * JSON-LD ships with the first HTML payload.
+ */
+function SchemaOrgScript({ identity }: { identity: PresenceIdentity }) {
+  const id = identity.id;
+  let schemaType: string;
+  if (id.startsWith("event:")) schemaType = "Event";
+  else if (id.startsWith("place:") || id.startsWith("scene:"))
+    schemaType = "Place";
+  else if (
+    id.startsWith("community:") ||
+    id.startsWith("community-") ||
+    id.startsWith("network-")
+  )
+    schemaType = "Organization";
+  else if (id.startsWith("asset:")) schemaType = "CreativeWork";
+  else if (id.startsWith("practice:")) schemaType = "Course";
+  else schemaType = "Person";
+
+  const json: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": schemaType,
+    name: identity.name,
+    url: `https://coherencycoin.com/people/${encodeURIComponent(id)}`,
+  };
+  if (identity.image_url) json.image = identity.image_url;
+  if (identity.tagline || identity.note || identity.description) {
+    json.description = (identity.tagline ||
+      identity.note ||
+      identity.description ||
+      "")
+      .substring(0, 500);
+  }
+  if (identity.canonical_url) json.sameAs = [identity.canonical_url];
+  if (schemaType === "Event") {
+    if (identity.when_text) json.startDate = identity.when_text;
+    if (identity.where_text) json.location = { "@type": "Place", name: identity.where_text };
+  }
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(json) }}
+    />
   );
 }

--- a/web/components/presence/WanderInto.tsx
+++ b/web/components/presence/WanderInto.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * WanderInto — closing doorway block on every presence page.
+ *
+ * Reaching the bottom of a presence page should always offer somewhere
+ * to wander next, not a dead-end. Pulls a small mix of nearby presences
+ * from the body's actual edges:
+ *
+ *   · 1 place (where they're rooted)
+ *   · 1-2 events (gatherings they hosted or kindred to)
+ *   · 1-2 kindred presences (concept overlap)
+ *   · 1 inspired-by (lineage)
+ *
+ * Each link reads as an invitation, not a CTA. The visual register is
+ * quieter than the sidebar — small chip-row at the bottom, no heavy
+ * heading.
+ *
+ * Renders nothing if no edges surface — empty presences stay quiet.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+
+type WanderItem = {
+  id: string;
+  name: string;
+  kind: "place" | "gathering" | "kindred" | "lineage";
+};
+
+type EdgeRow = {
+  from_id?: string;
+  to_id?: string;
+  type: string;
+  to_node?: { id: string; name: string; type: string };
+  from_node?: { id: string; name: string; type: string };
+  properties?: { kind?: string } & Record<string, unknown>;
+};
+
+export function WanderInto({ presenceId }: { presenceId: string }) {
+  const [items, setItems] = useState<WanderItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const apiBase = getApiBase();
+    let cancelled = false;
+    (async () => {
+      try {
+        // Pull outgoing edges in one shot — we'll filter by type below.
+        const r = await fetch(
+          `${apiBase}/api/edges?from_id=${encodeURIComponent(presenceId)}&limit=80`,
+          { cache: "no-store" },
+        );
+        if (!r.ok) {
+          if (!cancelled) setLoaded(true);
+          return;
+        }
+        const body: { items: EdgeRow[] } = await r.json();
+        const edges = body.items || [];
+
+        const out: WanderItem[] = [];
+        const seen = new Set<string>();
+        const add = (item: WanderItem) => {
+          if (seen.has(item.id) || item.id === presenceId) return;
+          seen.add(item.id);
+          out.push(item);
+        };
+
+        // 1 place
+        const place = edges.find(
+          (e) => e.type === "at-place" && e.to_node?.type === "place",
+        );
+        if (place && place.to_node) {
+          add({
+            id: place.to_node.id,
+            name: place.to_node.name,
+            kind: "place",
+          });
+        }
+
+        // up to 2 events (contributes-to → event)
+        const events = edges
+          .filter(
+            (e) => e.type === "contributes-to" && e.to_node?.type === "event",
+          )
+          .slice(0, 2);
+        for (const e of events) {
+          if (e.to_node) {
+            add({ id: e.to_node.id, name: e.to_node.name, kind: "gathering" });
+          }
+        }
+
+        // 1 inspired-by
+        const lineage = edges.find(
+          (e) => e.type === "inspired-by" && e.to_node?.id,
+        );
+        if (lineage && lineage.to_node) {
+          add({
+            id: lineage.to_node.id,
+            name: lineage.to_node.name,
+            kind: "lineage",
+          });
+        }
+
+        // Up to 2 kindred — fall back to /api/presences/{id}/resonances
+        // pivot to other presences. Light fetch only when above didn't
+        // fill 4+ items.
+        if (out.length < 4) {
+          const kindredR = await fetch(
+            `${apiBase}/api/presences/${encodeURIComponent(presenceId)}/resonances?limit=4`,
+            { cache: "no-store" },
+          ).catch(() => null);
+          if (kindredR && kindredR.ok) {
+            const kbody: { items: { concept_id: string; concept_name: string }[] } =
+              await kindredR.json();
+            // Take up to 2 concepts and link the visitor toward the
+            // concept page itself — wandering laterally through ideas.
+            for (const c of (kbody.items || []).slice(0, 2)) {
+              add({
+                id: c.concept_id,
+                name: c.concept_name,
+                kind: "kindred",
+              });
+              if (out.length >= 5) break;
+            }
+          }
+        }
+
+        if (!cancelled) {
+          setItems(out.slice(0, 5));
+          setLoaded(true);
+        }
+      } catch {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [presenceId]);
+
+  if (!loaded || items.length === 0) return null;
+
+  return (
+    <section className="border-t border-white/10 pt-8 mt-12">
+      <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-4">
+        Wander into
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => {
+          const href =
+            item.kind === "kindred"
+              ? `/vision/${encodeURIComponent(item.id)}`
+              : `/people/${encodeURIComponent(item.id)}`;
+          const eyebrow = labelForKind(item.kind);
+          return (
+            <Link
+              key={item.id}
+              href={href}
+              className="group inline-flex items-baseline gap-2 rounded-full border border-white/15 bg-white/[0.03] px-3 py-1.5 text-sm text-white/80 hover:bg-white/[0.08] hover:border-white/30 transition-colors"
+            >
+              <span className="text-[9px] uppercase tracking-[0.14em] text-white/40 group-hover:text-white/60">
+                {eyebrow}
+              </span>
+              <span>{item.name}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function labelForKind(kind: WanderItem["kind"]): string {
+  switch (kind) {
+    case "place":
+      return "place";
+    case "gathering":
+      return "gathering";
+    case "kindred":
+      return "concept";
+    case "lineage":
+      return "lineage";
+  }
+}


### PR DESCRIPTION
Reaching the bottom of a page should never be a dead end. Each presence carries living edges into the rest of the body — places it's rooted in, gatherings it held, contributors who held it, kindred and co-located neighbors — and those edges deserve to be doorways visitors and machines can walk through.

## What ships

- **HeldBy** sidebar block on event pages — surfaces hosts as links back into the lineage
- **WanderInto** closing block on every presence — 3-5 chip links drawn from real edges (place, gatherings, lineage, concepts)
- **Filter-link section headers** on /people — click PEOPLE · 45 to narrow to humans, click again to return
- **Schema.org JSON-LD** server-rendered on every presence — Person/Event/Place/Organization mapping helps machines see the shape

Every component returns null on empty data. Doorways only land where the edges actually live.

## Test plan

- [x] tsc clean
- [ ] After deploy: Anne Tucker retreat page shows 'Held by → Anne Tucker' linking back to her; Boulder Theater event lights up its 5 hosts; Liquid Bloom page closes with 'Wander into' chip row