### PR TITLE
Expose field docs in public API runtime

### DIFF
--- a/api/app/services/field_story_service.py
+++ b/api/app/services/field_story_service.py
@@ -15,6 +15,12 @@ from uuid import uuid4
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIELD_ROOT = REPO_ROOT / "docs" / "field"
+FIELD_ROOT_CANDIDATES = (
+    FIELD_ROOT,
+    REPO_ROOT.parent / "docs" / "field",
+    Path("/app/docs/field"),
+    Path("/app/api/docs/field"),
+)
 CONTRIBUTION_LOG = REPO_ROOT / "api" / "data" / "field_story_contributions.jsonl"
 
 
@@ -23,10 +29,13 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def _story_dir_for_slug(slug: str) -> Path:
-    for manifest_path in FIELD_ROOT.glob("*/manifest.json"):
-        manifest = _load_json(manifest_path)
-        if manifest.get("slug") == slug:
-            return manifest_path.parent
+    for root in FIELD_ROOT_CANDIDATES:
+        if not root.exists():
+            continue
+        for manifest_path in root.glob("*/manifest.json"):
+            manifest = _load_json(manifest_path)
+            if manifest.get("slug") == slug:
+                return manifest_path.parent
     raise KeyError(f"Unknown field story: {slug}")
 
 
@@ -48,20 +57,27 @@ def _safe_artifact_path(story_dir: Path, relative_path: str) -> Path:
 
 def list_field_stories() -> list[dict[str, Any]]:
     stories: list[dict[str, Any]] = []
-    for manifest_path in sorted(FIELD_ROOT.glob("*/manifest.json")):
-        manifest = _load_manifest(manifest_path.parent)
-        stories.append(
-            {
-                "slug": manifest["slug"],
-                "title": manifest.get("title", ""),
-                "contributor_id": manifest.get("contributor_id"),
-                "status": manifest.get("status", "published"),
-                "summary": manifest.get("summary", ""),
-                "artifact_count": manifest.get("artifact_count", 0),
-                "web": manifest.get("agent_use", {}).get("web"),
-                "read_api": manifest.get("agent_use", {}).get("read_api"),
-            }
-        )
+    seen: set[str] = set()
+    for root in FIELD_ROOT_CANDIDATES:
+        if not root.exists():
+            continue
+        for manifest_path in sorted(root.glob("*/manifest.json")):
+            manifest = _load_manifest(manifest_path.parent)
+            if manifest["slug"] in seen:
+                continue
+            seen.add(manifest["slug"])
+            stories.append(
+                {
+                    "slug": manifest["slug"],
+                    "title": manifest.get("title", ""),
+                    "contributor_id": manifest.get("contributor_id"),
+                    "status": manifest.get("status", "published"),
+                    "summary": manifest.get("summary", ""),
+                    "artifact_count": manifest.get("artifact_count", 0),
+                    "web": manifest.get("agent_use", {}).get("web"),
+                    "read_api": manifest.get("agent_use", {}).get("read_api"),
+                }
+            )
     return stories
 
 

--- a/api/tests/test_field_story_runtime_docs.py
+++ b/api/tests/test_field_story_runtime_docs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+from app.services import field_story_service
+
+
+def test_field_story_service_uses_container_field_doc_fallback(tmp_path, monkeypatch):
+    field_root = tmp_path / "docs" / "field"
+    story_dir = field_root / "probe"
+    story_dir.mkdir(parents=True)
+    (story_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "slug": "runtime-field-doc-probe",
+                "title": "Runtime Field Doc Probe",
+                "artifacts": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(field_story_service, "FIELD_ROOT_CANDIDATES", (tmp_path / "missing", field_root))
+
+    stories = field_story_service.list_field_stories()
+
+    assert stories == [
+        {
+            "slug": "runtime-field-doc-probe",
+            "title": "Runtime Field Doc Probe",
+            "contributor_id": None,
+            "status": "published",
+            "summary": "",
+            "artifact_count": 0,
+            "web": None,
+            "read_api": None,
+        }
+    ]

--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -136,6 +136,23 @@ docker compose build api web pulse 2>&1 | tee -a "$LOG_FILE"
 log "docker compose up -d api web pulse"
 docker compose up -d api web pulse 2>&1 | tee -a "$LOG_FILE"
 
+sync_field_docs() {
+  if [[ ! -d "$REPO_DIR/docs/field" ]]; then
+    log "field docs: no docs/field directory found (skipped)"
+    return 0
+  fi
+
+  for target_parent in /app/docs /app/api/docs; do
+    log "field docs: syncing docs/field to api:${target_parent}/field"
+    docker compose exec -T api sh -lc "mkdir -p '${target_parent}' && rm -rf '${target_parent}/field'" \
+      2>&1 | tee -a "$LOG_FILE"
+    docker compose cp "$REPO_DIR/docs/field" "api:${target_parent}/field" \
+      2>&1 | tee -a "$LOG_FILE"
+  done
+}
+
+sync_field_docs
+
 # Wait for both containers to reach the "running" state in docker compose.
 # The deeper health check is left to the workflow's Verify Public Deployment
 # step, which curls the real public domain through the full request path

--- a/docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json
+++ b/docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-05-07",
+  "thread_branch": "codex/field-docs-public-runtime-20260507",
+  "commit_scope": "Make published field-story docs available to the public API runtime after Hostinger deploy.",
+  "files_owned": [
+    "api/app/services/field_story_service.py",
+    "api/tests/test_field_story_runtime_docs.py",
+    "deploy/hostinger/auto-deploy.sh",
+    "specs/field-story-public-runtime-docs.md",
+    "docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-gate",
+      "cd api && .venv/bin/pytest -q tests/test_field_story_runtime_docs.py tests/test_field_story_trace_index.py",
+      "api/.venv/bin/ruff check api/app/services/field_story_service.py api/tests/test_field_story_runtime_docs.py",
+      "bash -n deploy/hostinger/auto-deploy.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json"
+    ],
+    "notes": [
+      "Public API at ef414172 exposed the trace route but returned Unknown field story because deployed API runtime listed zero field stories.",
+      "Hostinger deploy now syncs docs/field into API container doc paths and the service resolves both repo-root and container layouts."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending GitHub PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending Hostinger deploy and public endpoint verification after merge."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof passes; CI, deploy, and public endpoint validation are still pending."
+  },
+  "idea_ids": [
+    "field-story-public-runtime-docs",
+    "profile-contribution-derived-data"
+  ],
+  "spec_ids": [
+    "field-story-public-runtime-docs"
+  ],
+  "task_ids": [
+    "field-docs-public-runtime-20260507"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "requirements"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "public API before fix: /api/field-stories returned {\"items\":[]}",
+    "public API before fix: /api/field-stories/urs-field-story/trace/month/2026-04 returned Unknown field story",
+    "pytest: 4 passed, 5 warnings",
+    "bash -n deploy/hostinger/auto-deploy.sh: pass"
+  ],
+  "change_files": [
+    "api/app/services/field_story_service.py",
+    "api/tests/test_field_story_runtime_docs.py",
+    "deploy/hostinger/auto-deploy.sh",
+    "specs/field-story-public-runtime-docs.md",
+    "docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+        "status": "pending",
+    "expected_behavior_delta": "Public API runtime can read repo-published field-story docs and serve trace slices.",
+    "public_endpoints": [
+      "/api/field-stories",
+      "/api/field-stories/urs-field-story/trace/month/2026-04"
+    ],
+    "test_flows": [
+      "Field story runtime-doc fallback unit test",
+      "Hostinger deploy workflow",
+      "Public trace endpoint curl"
+    ]
+  }
+}

--- a/specs/field-story-public-runtime-docs.md
+++ b/specs/field-story-public-runtime-docs.md
@@ -1,0 +1,45 @@
+# Field Story Public Runtime Docs
+
+## Purpose
+
+Ensure the public API runtime can read published field-story docs after deployment, including trace artifacts that live outside the API source tree.
+
+## Requirements
+
+- [x] Resolve field-story manifests from repo-root and API-container field-doc locations.
+- [x] Sync `docs/field` into the Hostinger API container during deploy.
+- [x] Preserve local repository behavior and avoid environment-variable configuration fallbacks.
+
+## Files To Modify
+
+- `api/app/services/field_story_service.py`
+- `api/tests/test_field_story_runtime_docs.py`
+- `deploy/hostinger/auto-deploy.sh`
+- `specs/field-story-public-runtime-docs.md`
+- `docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json`
+
+## Acceptance Criteria
+
+- `api/tests/test_field_story_runtime_docs.py` verifies fallback field-doc roots.
+- Public deploy copies `docs/field` into API container locations used by the service.
+- `/api/field-stories` can return published stories after Hostinger deploy.
+
+## Verification
+
+```bash
+cd api && .venv/bin/pytest -q tests/test_field_story_runtime_docs.py tests/test_field_story_trace_index.py
+python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-07_field_story_public_runtime_docs.json
+```
+
+## Out Of Scope
+
+- This does not change field-story content or trace classification.
+- This does not introduce runtime environment-variable configuration for field docs.
+
+## Risks
+
+- Copying all field docs increases deploy artifact transfer size, but keeps the API runtime aligned with repo-published story artifacts.
+
+## Known Gaps
+
+- None for this runtime unblock; future task can bake `docs/field` directly into an API image if the compose build context is moved to repo root.


### PR DESCRIPTION
## Summary
- let field story service resolve docs from repo-root and API container doc layouts
- sync docs/field into the Hostinger API container during deploy
- add runtime fallback test, spec, and evidence

## Validation
- cd api && .venv/bin/pytest -q tests/test_field_story_runtime_docs.py tests/test_field_story_trace_index.py
- api/.venv/bin/ruff check api/app/services/field_story_service.py api/tests/test_field_story_runtime_docs.py
- bash -n deploy/hostinger/auto-deploy.sh
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict