### PR TITLE
attune(presence): URL canonicalization lives as graph data

### DIFF
--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -112,8 +112,18 @@ async def graph_stats():
 
 @router.get("/graph/nodes/{node_id}", summary="Get a single node")
 async def get_node(node_id: str):
-    """Get a single node."""
+    """Get a single node by id, falling back to slug lookup.
+
+    The path argument is treated as a graph id first. When that misses
+    and the value contains no namespace prefix (no colon), the lookup
+    retries against the `slug` property — the same human-readable
+    doorway used in `/people/{slug}` URLs. This lets every URL form
+    converge to one identity through one endpoint, with the mapping
+    living in the graph instead of a hand-curated table.
+    """
     node = graph_service.get_node(node_id)
+    if not node and ":" not in node_id:
+        node = graph_service.get_node_by_slug(node_id)
     if not node:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
     return node

--- a/api/app/services/graph_service.py
+++ b/api/app/services/graph_service.py
@@ -179,6 +179,29 @@ def get_node(node_id: str) -> dict[str, Any] | None:
         return node.to_dict() if node else None
 
 
+def get_node_by_slug(slug: str) -> dict[str, Any] | None:
+    """Resolve a node by the `slug` property a presence carries.
+
+    The slug is the human-readable doorway URL (`/people/{slug}`).
+    Storing it as a node property keeps the URL→identity mapping in
+    the graph itself, so it stays editable through the same flow that
+    edits everything else; nothing about the public surface lives in
+    a hand-curated table in code.
+    """
+    if not slug:
+        return None
+    with session() as s:
+        # Postgres + SQLite both store properties as JSON; the SQLAlchemy
+        # JSON column adapter exposes ``Node.properties["slug"]`` as a
+        # comparable expression on either backend.
+        node = (
+            s.query(Node)
+            .filter(Node.properties["slug"].as_string() == slug)
+            .first()
+        )
+        return node.to_dict() if node else None
+
+
 # Types a PATCH may move a node between — the presence bucket. This
 # guards against a visitor rewriting their own contributor node as a
 # concept, idea, spec, or system identity via a rogue PATCH.

--- a/api/tests/test_flow_presence.py
+++ b/api/tests/test_flow_presence.py
@@ -1218,3 +1218,46 @@ async def test_place_endpoints_round_trip():
     finally:
         _graph_service.delete_node(presence_id)
         _graph_service.delete_node(place_id)
+
+
+# ── Slug-resolved lookup (data-driven canonical URL) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_node_resolves_by_slug_when_id_misses():
+    """`GET /graph/nodes/{slug}` resolves to the node carrying that
+    slug property when no node has the literal id.
+
+    Lets `/people/{slug}` URLs converge to the canonical graph node
+    without a hand-curated slug→id mapping in code. The mapping lives
+    in the graph itself, editable through the same flow that edits
+    everything else.
+    """
+    from app.services import graph_service as _gs
+
+    node_id = "contributor:slug-lookup-test-fixture"
+    slug = "slug-lookup-test"
+    _gs.create_node(
+        id=node_id, type="contributor",
+        name="Slug Lookup Fixture",
+        properties={"slug": slug, "contributor_type": "TEST"},
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+            # Direct id still works.
+            r = await c.get(f"/api/graph/nodes/{node_id}")
+            assert r.status_code == 200
+            assert r.json()["id"] == node_id
+
+            # Slug resolves to the same node.
+            r = await c.get(f"/api/graph/nodes/{slug}")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["id"] == node_id
+            assert body["slug"] == slug
+
+            # Unknown slug → 404.
+            r = await c.get("/api/graph/nodes/no-such-slug-anywhere")
+            assert r.status_code == 404
+    finally:
+        _gs.delete_node(node_id)

--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -387,12 +387,18 @@ export async function generateMetadata({
       },
     };
   }
-  // Best-effort: show a human-ish title. We don't fetch here to keep
-  // the metadata path cheap.
-  const display = id.replace(/-[a-z0-9]{6,}$/, "").replace(/-/g, " ");
+  // Declare the canonical URL when the graph node carries a slug.
+  // One presence, one doorway: shared link previews and search
+  // engines converge on `/people/{slug}` even when an inbound link
+  // arrives at the graph-id form. The mapping lives in the graph.
+  const node = await fetchGraphNode(id);
+  const slug = node && typeof node.slug === "string" ? node.slug : null;
+  const name = node && typeof node.name === "string" ? node.name : null;
+  const display = name || id.replace(/-[a-z0-9]{6,}$/, "").replace(/-/g, " ");
   return {
     title: `${display} — Coherence Network`,
     description: `A corner of the organism held by ${display}.`,
+    alternates: slug ? { canonical: `/people/${slug}` } : undefined,
   };
 }
 
@@ -529,6 +535,9 @@ export default async function PersonPage({
   // literal `%3A` still in place. Decode once so downstream fetches
   // don't re-encode into `%253A` and miss the node.
   const id = decodeRouteParam(rawId);
+  // The graph-id → human-slug redirect lives in middleware.ts;
+  // requests reaching this handler use either the slug directly
+  // (resolved here) or a graph id with no slug registered.
   const curatedPresence = CURATED_PRESENCES[id];
   if (curatedPresence) return renderCuratedPresence(curatedPresence);
 

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -41,7 +41,18 @@ type PresenceNode = {
   provider?: string;
   contributor_type?: string;
   asset_type?: string;
+  slug?: string | null;
 };
+
+/**
+ * Canonical href for a presence — slug when the graph node carries
+ * one, falling back to the graph id encoded in the path. The mapping
+ * lives in the graph as data, never in this codebase.
+ */
+function presenceHref(n: PresenceNode): string {
+  if (n.slug && typeof n.slug === "string") return `/people/${n.slug}`;
+  return `/people/${encodeURIComponent(n.id)}`;
+}
 
 async function fetchType(type: string, limit = 200): Promise<PresenceNode[]> {
   try {
@@ -186,7 +197,7 @@ export default async function PeopleIndexPage({
               {items.map((n) => (
                 <li key={n.id}>
                   <Link
-                    href={`/people/${encodeURIComponent(n.id)}`}
+                    href={presenceHref(n)}
                     className="group flex items-center gap-3 rounded-xl border border-border/30 bg-card/40 hover:bg-card/70 hover:border-border p-3 transition-colors"
                   >
                     {n.image_url ? (


### PR DESCRIPTION
## Summary
- Each presence carries a `slug` property on its graph node — the human-readable doorway URL. Directory reads it for hrefs; `[id]` page declares it as `<link rel="canonical">` so shared previews and search engines converge on `/people/{slug}` even when an inbound link arrives at the graph-id form.
- `GET /graph/nodes/{node_id}` resolves slugs alongside ids: when the literal id misses and the path has no namespace prefix, the lookup retries against the `slug` property.
- 44 visible presences received auto-derived slugs from their canonical names. The slug→identity mapping lives in the graph itself, editable through the same flow that edits everything else; the briefly-attempted hardcoded mapping table composts.

This is the URL layer becoming data-driven. The next breath (separate PR) is the rendering + content layer becoming data-driven: the harmonization algorithm that computes tagline/facts/bio/lineage from primary graph data, with hand-built TSX welcome pages composting as their content flows back into the graph.

## Test plan
- [x] `tests/test_flow_presence.py::test_get_node_resolves_by_slug_when_id_misses` passes
- [x] `tests/test_flow_presence.py` + `tests/test_flow_constellation.py` — 35 passed, 0 failed
- [x] `tsc --noEmit` clean
- [x] dev: `/people` directory link for Robert is `/people/robert-edward-grant` (read from graph slug)
- [x] dev: `/people/contributor:robert-edward-grant-f7e43ccfb4b0` declares `<link rel="canonical" href="https://coherencycoin.com/people/robert-edward-grant"/>`
- [x] dev: contributors without a slug still render with no canonical declared
- [ ] post-deploy: `curl https://api.coherencycoin.com/api/graph/nodes/robert-edward-grant` returns the node
- [ ] post-deploy: pulse witness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)