### PR TITLE
attune(presence): the spectrum web — every influence, every doorway

### DIFF
--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -116,14 +116,18 @@ async def get_node(node_id: str):
 
     The path argument is treated as a graph id first. When that misses
     and the value contains no namespace prefix (no colon), the lookup
-    retries against the `slug` property — the same human-readable
-    doorway used in `/people/{slug}` URLs. This lets every URL form
-    converge to one identity through one endpoint, with the mapping
-    living in the graph instead of a hand-curated table.
+    retries against the `slug` property and finally against the
+    `contributor:{path}` form — the same human-readable doorway used
+    in `/people/{slug}` URLs, plus the legacy bare-name shape used by
+    older routes. This lets every URL form converge to one identity
+    through one endpoint, with the mapping living in the graph
+    instead of a hand-curated table.
     """
     node = graph_service.get_node(node_id)
     if not node and ":" not in node_id:
         node = graph_service.get_node_by_slug(node_id)
+    if not node and ":" not in node_id:
+        node = graph_service.get_node(f"contributor:{node_id}")
     if not node:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
     return node
@@ -185,8 +189,22 @@ async def get_edges(
     direction: str = Query(default="both", pattern="^(both|outgoing|incoming)$"),
     type: str | None = None,
 ):
-    """Get edges for a node."""
-    return graph_service.get_edges(node_id, direction=direction, edge_type=type)
+    """Get edges for a node, accepting either the graph id or a slug.
+
+    The path argument resolves through the same slug-or-id lookup as
+    `GET /graph/nodes/{node_id}` so callers using the human-readable
+    URL get the right edges without a second round-trip.
+    """
+    resolved = graph_service.get_node(node_id)
+    if not resolved and ":" not in node_id:
+        resolved = graph_service.get_node_by_slug(node_id)
+    if not resolved and ":" not in node_id:
+        resolved = graph_service.get_node(f"contributor:{node_id}")
+    if not resolved:
+        return []
+    return graph_service.get_edges(
+        resolved["id"], direction=direction, edge_type=type,
+    )
 
 
 @router.post("/graph/edges", summary="Create an edge between two nodes. Validates edge_type and prevents self-loops (Spec 169)")

--- a/api/app/services/graph_service.py
+++ b/api/app/services/graph_service.py
@@ -367,9 +367,14 @@ def get_edges(
     direction: str = "both",
     edge_type: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Get edges for a node.
+    """Get edges for a node, enriched with node stubs on both ends.
 
     direction: 'outgoing', 'incoming', or 'both'
+
+    Each edge in the response carries `from_node` and `to_node` stubs
+    (id, type, name, image_url, slug) so a UI rendering the influence
+    web around this node has everything it needs to draw a labelled,
+    spectrum-colored chip without a follow-up fetch per edge.
     """
     with session() as s:
         if direction == "outgoing":
@@ -384,7 +389,28 @@ def get_edges(
         if edge_type:
             q = q.filter(Edge.type == edge_type)
 
-        return [e.to_dict() for e in q.order_by(Edge.created_at.desc()).all()]
+        edges = q.order_by(Edge.created_at.desc()).all()
+
+        # Batch-load referenced nodes so the response is single-query
+        # in addition to the edge query (no N+1).
+        ref_ids: set[str] = set()
+        for e in edges:
+            ref_ids.add(e.from_id)
+            ref_ids.add(e.to_id)
+        nodes_map: dict[str, Node] = (
+            {n.id: n for n in s.query(Node).filter(Node.id.in_(ref_ids)).all()}
+            if ref_ids
+            else {}
+        )
+
+        out: list[dict[str, Any]] = []
+        for e in edges:
+            d = e.to_dict()
+            d["from_node"] = _node_stub(nodes_map.get(e.from_id))
+            d["to_node"] = _node_stub(nodes_map.get(e.to_id))
+            d["canonical"] = e.type in CANONICAL_EDGE_TYPES
+            out.append(d)
+        return out
 
 
 def delete_edge(edge_id: str) -> bool:
@@ -604,10 +630,22 @@ def get_subgraph(
 
 
 def _node_stub(node: Node | None) -> dict[str, Any] | None:
-    """Return a minimal node stub for edge enrichment."""
+    """Return a node stub for edge enrichment.
+
+    Carries enough surface for a relationship chip to render: identity,
+    display name, image for the avatar, and the slug so the chip's
+    href resolves to `/people/{slug}` without an extra round-trip.
+    """
     if not node:
         return None
-    return {"id": node.id, "type": node.type, "name": node.name}
+    props = node.properties or {}
+    return {
+        "id": node.id,
+        "type": node.type,
+        "name": node.name,
+        "image_url": props.get("image_url"),
+        "slug": props.get("slug"),
+    }
 
 
 def _enrich_edge(edge: Edge, s) -> dict[str, Any]:

--- a/specs/presence-harmonization.md
+++ b/specs/presence-harmonization.md
@@ -1,0 +1,314 @@
+---
+id: presence-harmonization
+idea_id: external-presence
+status: draft
+source:
+  - file: api/app/services/presence_harmonizer.py
+    symbols: [harmonize, gather_candidates, score_candidate, compose_shape, PresenceShape, FieldTrace, CandidateSource]
+  - file: api/app/services/presence_harmonizer/sources.py
+    symbols: [from_self_description, from_canonical_url_metadata, from_graph_edges, from_inspired_by, from_contributes_to, from_at_place, from_co_located]
+  - file: api/app/services/presence_harmonizer/scoring.py
+    symbols: [warmth_score, recency_score, frequency_score, sovereignty_score, privacy_filter, score_candidate]
+  - file: api/app/services/presence_harmonizer/compose.py
+    symbols: [compose_tagline, compose_bio, compose_facts, compose_hero, compose_lineage, compose_broadcasts, compose_resonance]
+  - file: api/app/models/presence_view.py
+    symbols: [PresenceView, PresenceShape, FieldTrace, HarmonizedFact, HarmonizedBroadcast, HarmonizedLineage]
+  - file: api/app/routers/presence_views.py
+    symbols: [get_presence_view, get_presence_view_traces, recompute_presence_view]
+  - file: api/db/migrations/NNNN_presence_views.sql
+    symbols: [presence_views table, presence_view_traces table]
+  - file: scripts/sync_presence_views.py
+    symbols: [sync_one, sync_all, harvest_canonical_url_metadata]
+  - file: scripts/calibrate_presence_robert.py
+    symbols: [calibrate, diff_against_handbuilt, fixture_handbuilt_shape]
+  - file: web/app/people/[id]/page.tsx
+    symbols: [PersonPage, fetchPresenceView, nodeToPresenceIdentity]
+  - file: web/components/presence/PresencePage.tsx
+    symbols: [PresencePage, PresenceIdentity]
+  - file: api/tests/test_presence_harmonizer.py
+    symbols: [test_robert_calibration, test_traces_every_field, test_privacy_filter_drops_intimate, test_per_locale_candidates, test_recompute_on_edge_change]
+requirements:
+  - "Pure function harmonize(graph_node_id, locale) -> PresenceShape composed from primary data — never from hand-curated overrides"
+  - "PresenceShape mirrors what hand-built /people pages render today: tagline, bio (paragraphs), facts list, hero image, lineage, resonance, broadcasts/works, footer links"
+  - "Per-field algorithm runs in three movements: gather candidates -> score -> pick + compose; every picked field carries a FieldTrace pointing at the source candidate(s)"
+  - "Score factors: warmth (self-description > third-party), recency (present-day > stale), frequency (lived voice > institutional/policy), sovereignty (their canonical_url > scraped og:* > inferred)"
+  - "Privacy filter rejects any candidate matching intimate-content patterns (partner, family, residence specifics, health, scheduling) before scoring — even when scraped from a public URL"
+  - "Per-locale harmonization: same algorithm, locale-scoped candidate set; falls back through the locale chain (requested -> en -> source_lang) and records the fallback in the trace"
+  - "Precomputed via scripts/sync_presence_views.py mirroring the sync_kb_to_db.py precedent — writes to presence_views table; rendering reads precomputed shape"
+  - "Editing primary graph data (presences[], image_url, canonical_url, description, edges contributes-to | inspired-by | at-place) marks the corresponding presence_view stale; sync recomputes"
+  - "GET /api/presence-views/{node_id}?lang={locale} returns the harmonized PresenceShape with embedded traces"
+  - "GET /api/presence-views/{node_id}/traces?lang={locale} returns just the field-by-field trace map (answering 'why was this tagline picked?')"
+  - "POST /api/presence-views/{node_id}/recompute forces re-harvest of canonical_url metadata and recomputation; idempotent"
+  - "Calibration target: Robert Edward Grant's harmonized output covers every section the hand-built en.tsx renders (tagline, facts, two-paragraph bio, broadcasts, lineage, footer links) using only the graph node + edges + a periodic harvest of canonical_url"
+  - "Calibration script (scripts/calibrate_presence_robert.py) compares harmonized shape against the hand-built fixture and prints field-by-field equivalence; passing calibration unlocks compost of the hand-built TSX files for that human"
+  - "PresencePage component continues to render the existing PresenceIdentity shape; harmonizer output flows through nodeToPresenceIdentity unchanged so no visual regression for already-rendering presences"
+done_when:
+  - "harmonize('contributor:robert-edward-grant-f7e43ccfb4b0', 'en') returns a PresenceShape with non-empty tagline, bio (>=2 paragraphs), >=3 facts, >=2 broadcasts, >=1 lineage edge"
+  - "Every field on the returned shape carries a FieldTrace naming source candidate(s) and the score that picked it"
+  - "GET /api/presence-views/contributor:robert-edward-grant-f7e43ccfb4b0?lang=en returns harmonized output identical to the live Python call"
+  - "GET /api/presence-views/contributor:robert-edward-grant-f7e43ccfb4b0/traces?lang=en answers 'why was the tagline picked' with the candidate URL/edge and the warmth/recency/frequency/sovereignty subscores"
+  - "calibrate_presence_robert.py reports parity-or-richer for hero, tagline, facts, bio paragraphs, broadcasts, footer links versus the hand-built en.tsx"
+  - "Adding an inspired-by edge via existing graph PATCH endpoint and rerunning sync_presence_views.py surfaces the new lineage in the harmonized shape on next read"
+  - "Privacy filter test: a synthetic candidate matching the partner/family pattern is dropped before scoring, never appears in any field, and is recorded in trace.rejected with reason='privacy'"
+  - "Per-locale test: harmonize(node, 'de') returns German-locale candidates where present, falls through to en otherwise, and records fallback in trace"
+  - "/people/{slug} page renders a presence whose graph node has only canonical_url + description + a few edges (no hand-built TSX) and the page carries the same warmth as the hand-built ones"
+  - "all api tests pass"
+test: "cd api && python -m pytest tests/test_presence_harmonizer.py tests/test_flow_presence_views.py -q && python3 scripts/calibrate_presence_robert.py --check"
+constraints:
+  - "Never read the hand-built web/content/people/{slug}/{locale}.tsx files at runtime — they are calibration fixtures only, composted per-human as harmonization reaches parity"
+  - "Never invent content the primary data does not support — if no candidate scores above the floor for a field, the field is omitted from the shape (presence over scaffolding)"
+  - "Never surface intimate content (partner, family, residence specifics, health, scheduling) even when scraped from a public canonical_url — privacy filter runs before scoring, not after"
+  - "No edits to the bio go directly to the harmonized output — primary-data edits are the only editing surface; harmonizer recomputes from the data"
+  - "Re-harvesting canonical_url metadata happens on a slow cadence (hourly at most for any one URL); never on the request path"
+  - "PresencePage rendering contract is not changed by this spec — the harmonizer feeds richer data through the existing PresenceIdentity shape"
+  - "Authentication-scoped editing rules are out of scope; primary-data PATCH endpoints stay as they are today (currently open) — a future spec governs edit auth"
+---
+
+> **Parent idea**: [external-presence](../ideas/external-presence.md)
+
+# Spec: Presence Harmonization
+
+## Purpose
+
+Today, public presence pages at `/people/{slug}` render through three different shapes living side by side: a hardcoded `CURATED_PRESENCES` record in `web/app/people/[id]/page.tsx` (English-only bios for about five humans), hand-built TSX welcome pages in `web/content/people/{slug}/{en,de,es,id}.tsx` (around fourteen humans times four locales — fifty-six hand-written files; Robert Edward Grant's `en.tsx` alone is 426 lines of JSX-as-data), and a generic graph-driven `PresencePage` component for everyone else. The rich content is locked in code, not editable by anyone, not data-driven, and not multilingual without another hand-written file.
+
+The right shape is the one this body already speaks: compute the presented form from primary data. Primary data lives in the graph — `canonical_url`, `image_url`, `presences[]`, `description`, edges like `contributes-to` / `inspired-by` / `at-place` — refreshed by a periodic harvest of each `canonical_url` for og:* metadata. A harmonizer composes the presented shape (tagline, bio, facts, hero, lineage, broadcasts, resonance) from those signals. Editing primary data is the only editing surface; nobody edits the bio directly. The hand-built files become calibration fixtures and compost human-by-human as harmonization reaches parity.
+
+## Requirements
+
+- [ ] **R1** — `harmonize(graph_node_id, locale) -> PresenceShape`. Pure function. Composes the presented shape from primary graph data plus harvested `canonical_url` metadata. No hand-curated overrides.
+
+- [ ] **R2** — `PresenceShape` carries the same blocks the hand-built pages render today: `hero` (image_url, eyebrow, name), `tagline`, `facts[]` (Based, Public broadcasts, Field), `bio` (paragraphs, ordered), `broadcasts[]` (recurring or one-shot, with cadence), `lineage[]` (inspired-by edges), `resonance[]` (axis + score + note), `footer_links[]` (canonical + presences). Every field is `Optional` — a presence with sparse data renders sparsely, never with invented scaffolding.
+
+- [ ] **R3** — Per-field algorithm runs in three movements:
+  1. **Gather candidates** — every primary-data slot that could feed this field becomes a `Candidate` with `value`, `source` (e.g. `graph.description`, `canonical_url.og_description`, `edge:inspired-by:lex-fridman`), `locale`, `harvested_at`.
+  2. **Score** — each candidate gets warmth, recency, frequency, sovereignty subscores; total = weighted sum.
+  3. **Pick + compose** — top-scoring candidate (or composition of candidates for multi-paragraph fields like bio) becomes the field value; a `FieldTrace` records the picked candidate, the runners-up, and the subscores.
+
+- [ ] **R4** — Score factors:
+  - **Warmth** — the contributor's own self-description (graph `description` they wrote, presences they registered) outranks third-party scrape (og:description from a press page).
+  - **Recency** — present-day candidates outrank stale ones; a 2026 self-description outranks a 2018 wikipedia paragraph.
+  - **Frequency** — lived voice outranks institutional / policy / press-release register. Implemented as a small classifier on the candidate text (heuristic for now: passive voice + corporate vocabulary lowers the score).
+  - **Sovereignty** — their own `canonical_url` outranks scraped third-party content; their registered `presences[]` outrank inferred social handles.
+
+- [ ] **R5** — Privacy filter runs **before** scoring. Drops any candidate matching intimate-content patterns: partner / family / residence specifics / health / scheduling. The filter draws its mental model from `partner_presence.md` — partner, family, intimate-detail are private-by-default and never surface in visible artifacts even when scraped from a publicly accessible URL. Rejected candidates are recorded in `trace.rejected` with `reason: "privacy"` so an auditor can see what was held back.
+
+- [ ] **R6** — Traceability is first-class. Every field on the returned shape carries a `FieldTrace` answering "why was this picked?" — source candidate(s), runners-up, subscores, and any privacy rejections. `GET /api/presence-views/{node_id}/traces` exposes this for any presence.
+
+- [ ] **R7** — Per-locale harmonization. The same algorithm runs per locale; the candidate set is locale-scoped (a German `description` outranks an English one when `locale=de`). Locale fallback chain: requested → `en` → source_lang of the graph node. Fallback is recorded in the trace so a reader can see "this German page is showing English bio because no German candidate exists."
+
+- [ ] **R8** — Compute strategy follows the `sync_kb_to_db.py` precedent: a `scripts/sync_presence_views.py` job runs harmonization across all presences (or one named one) and writes the output to a `presence_views` table keyed by `(node_id, locale)`. Rendering reads precomputed; harmonization never runs on the request path. Re-harvest of `canonical_url` metadata happens on a slow cadence (hourly at most for any single URL).
+
+- [ ] **R9** — Editability flows through primary data. Editing the graph node (adding a presence URL, correcting an `image_url`, adding an `inspired-by` edge, replacing a stale `description`) marks the corresponding `presence_view` rows stale. The next sync run recomputes. Nobody edits the harmonized bio directly. Primary-data PATCH reuses existing graph endpoints (currently open; auth is a future spec's concern).
+
+- [ ] **R10** — `PresencePage.tsx` rendering contract stays as it is today. The harmonizer's output flows through `nodeToPresenceIdentity` so the existing `PresenceIdentity` shape is filled with richer data; no visual regression for presences already rendering through `PresencePage`.
+
+- [ ] **R11** — Calibration step. `scripts/calibrate_presence_robert.py` loads the hand-built `web/content/people/robert-edward-grant/en.tsx` as a fixture, runs the harmonizer on `contributor:robert-edward-grant-f7e43ccfb4b0` for `locale=en`, and prints a field-by-field equivalence report (hero, tagline, facts, bio paragraphs, broadcasts, lineage, footer links). When the report shows parity-or-richer for every section, that human's hand-built TSX files (en, de, es, id) compost in the same commit.
+
+- [ ] **R12** — Composting cadence. The hand-built `web/content/people/{slug}/{locale}.tsx` files are calibration fixtures, not runtime sources. Each human composts only after harmonization proves parity for them. Composting is per-human, not bulk; the spec defines the bar (R11), the rhythm matches the body's tending practice.
+
+## Research Inputs
+
+- `2026-05-07` — User naming the wrong-shape problem: rich content locked in code, fifty-six hand-written files for fourteen humans, not editable by anyone, not data-driven.
+- `web/content/people/robert-edward-grant/en.tsx` — calibration target. Carries the full vocabulary the harmonizer must produce: tagline, three facts, multi-paragraph welcome, two cool-panel broadcasts (ORION Live, Architect on ORION Messenger), inspired-by lineage hint, footer links to canonical_url + ORION Messenger.
+- `web/components/people/PersonProfileTemplate.tsx` — confirms the rendered blocks the harmonizer must produce: hero (image, eyebrow, name, welcome), facts (dl), noteFromBody, articles[] (narrative + panel kinds), footer.
+- `web/components/presence/PresencePage.tsx` — current graph-driven renderer. The harmonizer feeds this through the existing `PresenceIdentity` shape; no contract change.
+- `scripts/sync_kb_to_db.py` — precedent for "expand content in the working layer, sync to DB on demand." The harmonizer mirrors this rhythm: harvest + harmonize + sync.
+- `partner_presence.md` (held tenderly, not for surfacing) — mental model for the privacy filter. Partner, family, intimate-detail are private-by-default in every visible artifact, even when public sources mention them.
+- `CLAUDE.md` "Frequency Sensing" — the harmonizer composes prose; the same flatness-detection that motivates the i18n glossary motivates the **frequency** subscore here.
+
+## API Contract
+
+### `GET /api/presence-views/{node_id}?lang={locale}`
+
+Returns the harmonized `PresenceShape` for the named graph node in the requested locale. Reads from precomputed `presence_views`. If no row exists yet, returns `404 not_yet_harmonized` with a hint to call `recompute`.
+
+```json
+{
+  "node_id": "contributor:robert-edward-grant-f7e43ccfb4b0",
+  "locale": "en",
+  "shape": {
+    "hero": {
+      "image_url": "https://robertedwardgrant.com/wp-content/uploads/2025/03/Robert-SoloFloat2025.png",
+      "eyebrow": "Polymath · Sacred Mathematics",
+      "name": "Robert Edward Grant"
+    },
+    "tagline": "Numbers as living archetypes — geometric forms with their own symmetries.",
+    "facts": [
+      {"label": "Based", "value": "Newport Beach, California — work circulates worldwide"},
+      {"label": "Public broadcasts", "value": "ORION Live (YouTube) · ORION Messenger"},
+      {"label": "Field", "value": "Sacred geometry · cryptography · AI partnership · sovereign comms"}
+    ],
+    "bio": [
+      "Numbers are not labels for quantities. They are living archetypes...",
+      "The Architect, the AI he trained on a decade of his mathematical work, is not a tool he built..."
+    ],
+    "broadcasts": [
+      {"name": "ORION Live", "cadence": "recurring · irregular", "url": "https://www.youtube.com/playlist?list=PLCatuaiI1RhcjJV5MyIYQj5v9zQfnw01o"},
+      {"name": "The Architect on ORION Messenger", "cadence": "continuous", "url": "https://www.crownsterling.io/orion/"}
+    ],
+    "lineage": [
+      {"id": "contributor:aubrey-marcus-...", "name": "Aubrey Marcus", "relation": "first encountered through"}
+    ],
+    "resonance": [
+      {"axis": "Geometric Coherence", "score": 0.95, "note": "Numbers as living archetypes; the substrate this organism rests on"}
+    ],
+    "footer_links": [
+      {"label": "robertedwardgrant.com", "href": "https://robertedwardgrant.com/"},
+      {"label": "ORION Messenger", "href": "https://robertedwardgrant.com/introducing-orion-messenger/"}
+    ]
+  },
+  "harvested_at": "2026-05-07T03:14:22Z",
+  "computed_at": "2026-05-07T03:14:30Z"
+}
+```
+
+### `GET /api/presence-views/{node_id}/traces?lang={locale}`
+
+Returns the field-by-field `FieldTrace` map. Answers "why was this picked?" for any field on the shape.
+
+```json
+{
+  "node_id": "contributor:robert-edward-grant-f7e43ccfb4b0",
+  "locale": "en",
+  "traces": {
+    "tagline": {
+      "picked": {
+        "source": "graph.description.paragraph[0].sentence[0]",
+        "value": "Numbers are not labels for quantities. They are living archetypes...",
+        "subscores": {"warmth": 0.95, "recency": 0.88, "frequency": 0.92, "sovereignty": 1.0},
+        "total": 0.94
+      },
+      "runners_up": [
+        {"source": "canonical_url.og_description", "total": 0.71}
+      ],
+      "rejected": []
+    },
+    "bio": {
+      "picked": [
+        {"source": "graph.description.paragraph[0]", "total": 0.94},
+        {"source": "graph.description.paragraph[2]", "total": 0.91}
+      ],
+      "rejected": [
+        {"source": "canonical_url.scraped.about", "reason": "frequency_floor", "total": 0.31}
+      ]
+    },
+    "lineage": {
+      "picked": [
+        {"source": "edge:inspired-by:aubrey-marcus", "total": 0.88}
+      ]
+    }
+  },
+  "fallback_chain": ["en"]
+}
+```
+
+### `POST /api/presence-views/{node_id}/recompute`
+
+Force re-harvest of `canonical_url` metadata and recomputation for all locales (or just the locale named in `?lang=`). Idempotent. Body is empty. Returns the freshly computed shape so a caller can verify the change before the next sync sweep.
+
+## Data Model
+
+```yaml
+PresenceShape:
+  hero:
+    image_url: string | null
+    eyebrow: string | null
+    name: string
+  tagline: string | null
+  facts: HarmonizedFact[]
+  bio: string[]                    # paragraphs, ordered
+  broadcasts: HarmonizedBroadcast[]
+  lineage: HarmonizedLineage[]
+  resonance: ResonanceItem[]
+  footer_links: FooterLink[]
+
+HarmonizedFact:
+  label: string                    # "Based", "Public broadcasts", "Field"
+  value: string
+
+HarmonizedBroadcast:
+  name: string
+  cadence: string                  # "recurring · irregular", "continuous", "weekly"
+  url: string | null
+
+HarmonizedLineage:
+  id: string                       # graph node id of the inspirer
+  name: string
+  relation: string                 # "inspired by", "first encountered through", "studies"
+
+CandidateSource:
+  source: string                   # "graph.description", "canonical_url.og_description", "edge:inspired-by:..."
+  value: any
+  locale: string
+  harvested_at: timestamp
+
+FieldTrace:
+  picked: CandidateSource | CandidateSource[]
+  runners_up: CandidateSource[]
+  rejected: { source, reason, total }[]   # reason: "privacy" | "frequency_floor" | "stale" | ...
+
+PresenceView:                      # database row
+  node_id: string                  # FK -> graph node
+  locale: string                   # "en" | "de" | "es" | "id"
+  shape: PresenceShape             # JSONB
+  traces: { [field]: FieldTrace }  # JSONB
+  fallback_chain: string[]
+  harvested_at: timestamp          # last canonical_url harvest
+  computed_at: timestamp           # last harmonization run
+  stale: boolean                   # set true on primary-data edit; sync clears
+  PRIMARY KEY (node_id, locale)
+```
+
+## Files to Create / Modify
+
+- `api/app/services/presence_harmonizer.py` — entry point; `harmonize(node_id, locale)`.
+- `api/app/services/presence_harmonizer/sources.py` — candidate gatherers (one per primary-data shape).
+- `api/app/services/presence_harmonizer/scoring.py` — warmth / recency / frequency / sovereignty + privacy filter.
+- `api/app/services/presence_harmonizer/compose.py` — per-field composers (tagline, bio, facts, broadcasts, lineage, resonance).
+- `api/app/models/presence_view.py` — Pydantic models.
+- `api/app/routers/presence_views.py` — three endpoints above.
+- `api/db/migrations/NNNN_presence_views.sql` — `presence_views` table; index on `(node_id, locale)` and `stale`.
+- `scripts/sync_presence_views.py` — sync job mirroring `sync_kb_to_db.py`. Flags: one node id, list of node ids, `--all`, `--stale-only`, `--dry-run`.
+- `scripts/calibrate_presence_robert.py` — calibration script for Robert Edward Grant.
+- `web/app/people/[id]/page.tsx` — call `GET /api/presence-views/{id}?lang={locale}` first; fall through to current `nodeToPresenceIdentity` path only if `404 not_yet_harmonized`. Drop the `CURATED_PRESENCES` record once every name in it has a harmonized view.
+- `api/tests/test_presence_harmonizer.py` — unit tests for gatherers, scoring, privacy filter, locale fallback, traces.
+- `api/tests/test_flow_presence_views.py` — flow test for the three endpoints + recompute round-trip.
+
+## Acceptance Tests
+
+- `api/tests/test_presence_harmonizer.py::test_robert_calibration` — harmonized shape for Robert covers every section of the hand-built fixture.
+- `api/tests/test_presence_harmonizer.py::test_traces_every_field` — every field on the returned shape has a non-empty `FieldTrace`.
+- `api/tests/test_presence_harmonizer.py::test_privacy_filter_drops_intimate` — synthetic partner/family candidate is dropped before scoring; appears in `trace.rejected` with `reason="privacy"`; never appears in any field.
+- `api/tests/test_presence_harmonizer.py::test_per_locale_candidates` — German candidate outranks English when `locale=de`; falls through to `en` when no German candidate; trace records the fallback.
+- `api/tests/test_presence_harmonizer.py::test_recompute_on_edge_change` — adding an `inspired-by` edge marks the row stale; sync recomputes; new lineage appears.
+- `api/tests/test_presence_harmonizer.py::test_omit_when_no_candidate_above_floor` — sparse presence with only an image_url renders shape with `tagline=None`, empty broadcasts, empty lineage; no invented scaffolding.
+- `api/tests/test_flow_presence_views.py::test_get_view_round_trip` — sync writes; GET returns the same shape; traces endpoint exposes the picked subscores.
+- `api/tests/test_flow_presence_views.py::test_recompute_endpoint_idempotent` — POST recompute twice; second run produces identical shape with newer `computed_at`.
+
+## Verification
+
+```bash
+cd api && python -m pytest tests/test_presence_harmonizer.py tests/test_flow_presence_views.py -q
+python3 scripts/sync_presence_views.py contributor:robert-edward-grant-f7e43ccfb4b0
+python3 scripts/calibrate_presence_robert.py --check
+curl -s "http://localhost:8000/api/presence-views/contributor:robert-edward-grant-f7e43ccfb4b0?lang=en" | jq .shape.tagline
+curl -s "http://localhost:8000/api/presence-views/contributor:robert-edward-grant-f7e43ccfb4b0/traces?lang=en" | jq .traces.tagline
+```
+
+## Out of Scope
+
+- **Authentication-scoped editing rules.** Primary-data PATCH endpoints stay as they are today (currently open). A future spec governs edit auth across the graph; this spec only notes that the harmonizer recomputes from whatever the graph holds, regardless of who put it there.
+- **Bulk composting of all hand-built TSX files.** Composting is per-human, only after calibration parity for that human. This spec defines the calibration bar (Robert as the calibration target) and the rhythm; it does not delete files for humans whose harmonization hasn't reached parity yet.
+- **Changes to the `PresencePage` rendering contract.** The component continues to consume `PresenceIdentity`. The harmonizer simply feeds richer data through that shape.
+- **Real-time harmonization on the request path.** Harmonization is precomputed via the sync job. A future spec can add request-path warming for cold presences if needed.
+- **New canonical_url harvesters beyond og:* metadata.** A richer harvester (sitemap walking, structured-data parsing, video transcript extraction) is a future spec; this one uses the og:* metadata already harvested by existing infrastructure plus whatever the graph already holds.
+- **Resonance score computation.** Resonance candidates flow through the harmonizer (warmth/recency/frequency/sovereignty subscores apply), but the underlying axis-score values come from existing CRK coherence scoring; this spec does not redefine how those scores are computed.
+
+## Risks and Assumptions
+
+- **Risk**: The frequency subscore (lived-voice vs institutional register) is hard to get right with heuristics alone. Mitigation: ship with a simple classifier (passive voice + corporate vocabulary lowers the score), expose the subscore in traces, iterate from observed mis-picks. A small LLM-based classifier is a future enhancement once the heuristic shows its ceiling.
+- **Risk**: The privacy filter is necessarily conservative — it may drop legitimate public content that happens to mention family. Mitigation: rejected candidates are recorded in the trace with their reason, so an auditor can see what was held back and tune the patterns. The filter errs on the side of holding back; presence over scaffolding.
+- **Risk**: Calibration parity is subjective for prose-heavy fields like the bio. Mitigation: the calibration script reports field-by-field equivalence and the human (this body, or anyone reading) makes the parity call before composting that human's hand-built file. No automated greenlight.
+- **Assumption**: The graph node already carries enough primary data for the calibration target. Verified for Robert Edward Grant: `contributor:robert-edward-grant-f7e43ccfb4b0` holds a ~1700-word `description`, a `canonical_url`, an `image_url`, and existing `inspired-by` edges. For sparser presences, the harmonized shape will be sparser — that's the right behavior.
+- **Assumption**: The og:* metadata for `canonical_url` is already harvested by existing infrastructure (the news / external-presence pipeline). If not, a small harvester lives in `scripts/sync_presence_views.py::harvest_canonical_url_metadata` as a near-term placeholder.

--- a/web/app/people/[id]/edit/page.tsx
+++ b/web/app/people/[id]/edit/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { PresenceRefineForm } from "@/components/presence/PresenceRefineForm";
+import { getApiBase } from "@/lib/api";
+import { fetchJsonOrNull } from "@/lib/fetch";
+
+/**
+ * /people/[id]/edit — refine any presence's primary data.
+ *
+ * Anyone arriving here can shape the data this presence is composed
+ * from: the core text fields (name, tagline, description, image,
+ * slug), the public presence URLs across platforms, and the
+ * relationship edges that weave this presence into the field. The
+ * page that visitors read at /people/{slug} is rendered from this
+ * primary data, so refining it here is what better-represents the
+ * presence — the bio doesn't get edited, the data the bio harmonizes
+ * from gets edited.
+ *
+ * The id segment accepts both graph-canonical ids and human-readable
+ * slugs (the API resolves either).
+ */
+
+export const dynamic = "force-dynamic";
+
+type GraphNode = {
+  id: string;
+  type: string;
+  name?: string;
+  description?: string;
+  slug?: string | null;
+  tagline?: string | null;
+  image_url?: string | null;
+  presences?: { provider: string; url: string }[];
+};
+
+async function fetchNode(id: string): Promise<GraphNode | null> {
+  return fetchJsonOrNull<GraphNode>(
+    `${getApiBase()}/api/graph/nodes/${encodeURIComponent(id)}`,
+    {},
+    5000,
+  );
+}
+
+function decodeRouteParam(rawId: string): string {
+  try {
+    return decodeURIComponent(rawId);
+  } catch {
+    return rawId;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id: rawId } = await params;
+  const id = decodeRouteParam(rawId);
+  const node = await fetchNode(id);
+  const name = node?.name || id.replace(/-[a-z0-9]{6,}$/, "").replace(/-/g, " ");
+  return {
+    title: `Refine ${name} — Coherence Network`,
+    description: `Refine the primary data this presence is composed from. The page reflects the data; the data reflects the field.`,
+  };
+}
+
+export default async function PresenceEditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: rawId } = await params;
+  const id = decodeRouteParam(rawId);
+  const node = await fetchNode(id);
+  if (!node) notFound();
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 sm:px-6 py-8 space-y-8">
+      <header className="space-y-3">
+        <p className="text-[10px] uppercase tracking-[0.22em] font-semibold text-[hsl(var(--primary))]">
+          Refine
+        </p>
+        <h1 className="text-3xl md:text-4xl font-light tracking-tight">
+          {node.name || node.id}
+        </h1>
+        <p className="text-sm text-muted-foreground max-w-2xl leading-relaxed">
+          Anything below can be corrected. The presence page rebuilds
+          itself from this data, so what you change here is what visitors
+          will see — image, tagline, description, the platforms linked
+          from the page, and the relationships that weave this presence
+          into the field.
+        </p>
+      </header>
+
+      <PresenceRefineForm node={node} />
+    </main>
+  );
+}

--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -344,6 +344,7 @@ function nodeToPresenceIdentity(
       : undefined;
   return {
     id: (node.id as string) || "",
+    slug: typeof node.slug === "string" && node.slug ? (node.slug as string) : null,
     name: (node.name as string) || "",
     category: categoryMap[nodeType] || nodeType,
     tagline,

--- a/web/app/people/aly-constantine/page.tsx
+++ b/web/app/people/aly-constantine/page.tsx
@@ -19,5 +19,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AlyConstantineProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getAlyConstantineContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="aly-constantine" />;
 }

--- a/web/app/people/aubrey-marcus/page.tsx
+++ b/web/app/people/aubrey-marcus/page.tsx
@@ -19,5 +19,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AubreyMarcusProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getAubreyMarcusContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="aubrey-marcus" />;
 }

--- a/web/app/people/bloomurian/page.tsx
+++ b/web/app/people/bloomurian/page.tsx
@@ -21,5 +21,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function BloomurianProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getBloomurianContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="bloomurian" />;
 }

--- a/web/app/people/elios/page.tsx
+++ b/web/app/people/elios/page.tsx
@@ -22,5 +22,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function EliosProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getEliosContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="elios" />;
 }

--- a/web/app/people/grab/page.tsx
+++ b/web/app/people/grab/page.tsx
@@ -30,5 +30,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function GrabProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getGrabContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="grab" />;
 }

--- a/web/app/people/ilena/page.tsx
+++ b/web/app/people/ilena/page.tsx
@@ -21,5 +21,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function IlenaProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getIlenaContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="ilena" />;
 }

--- a/web/app/people/joshua-golden/page.tsx
+++ b/web/app/people/joshua-golden/page.tsx
@@ -21,5 +21,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function JoshuaGoldenProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getJoshuaGoldenContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="joshua-golden" />;
 }

--- a/web/app/people/lex-fridman/page.tsx
+++ b/web/app/people/lex-fridman/page.tsx
@@ -27,5 +27,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function LexFridmanProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getLexFridmanContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="lex-fridman" />;
 }

--- a/web/app/people/matias-de-stefano/page.tsx
+++ b/web/app/people/matias-de-stefano/page.tsx
@@ -26,5 +26,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function MatiasDeStefanoProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getMatiasDeStefanoContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="matias-de-stefano" />;
 }

--- a/web/app/people/mose/page.tsx
+++ b/web/app/people/mose/page.tsx
@@ -21,5 +21,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function MoseProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getMoseContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="mose" />;
 }

--- a/web/app/people/porangui/page.tsx
+++ b/web/app/people/porangui/page.tsx
@@ -21,5 +21,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function PoranguiProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getPoranguiContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="porangui" />;
 }

--- a/web/app/people/robert-edward-grant/page.tsx
+++ b/web/app/people/robert-edward-grant/page.tsx
@@ -22,5 +22,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function RobertEdwardGrantProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getRobertEdwardGrantContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="robert-edward-grant" />;
 }

--- a/web/app/people/urs/page.tsx
+++ b/web/app/people/urs/page.tsx
@@ -23,5 +23,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function UrsProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getUrsContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="contributor:seeker71" />;
 }

--- a/web/app/people/vasudev-baba/page.tsx
+++ b/web/app/people/vasudev-baba/page.tsx
@@ -26,5 +26,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function VasudevBabaProfilePage() {
   const lang = await resolveRequestLocale();
   const content = getVasudevBabaContent(lang);
-  return <PersonProfileTemplate content={content} lang={lang} />;
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="vasudev-baba" />;
 }

--- a/web/components/people/PersonProfileTemplate.tsx
+++ b/web/components/people/PersonProfileTemplate.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { Panel } from "@/components/Panel";
 import { createTranslator } from "@/lib/i18n";
 import type { LocaleCode } from "@/lib/locales";
+import { TemplateInfluenceWeb } from "./TemplateInfluenceWeb";
 
 export type PersonProfileFact = {
   label: ReactNode;
@@ -82,9 +83,15 @@ const DEFAULT_OVERLAY =
 export function PersonProfileTemplate({
   content,
   lang,
+  graphSlug,
 }: {
   content: PersonProfileContent;
   lang: LocaleCode;
+  /** Slug or graph id of the corresponding contributor node, when
+   *  this hand-built page maps to one. Plumbing this lets the page
+   *  surface the live influence web and the refine doorway alongside
+   *  the hand-curated content. Both forms are accepted by the API. */
+  graphSlug?: string;
 }) {
   const t = createTranslator(lang);
   const { hero } = content;
@@ -169,6 +176,12 @@ export function PersonProfileTemplate({
             {content.articles.map((article, i) => (
               <ArticleBlock key={i} article={article} />
             ))}
+          </section>
+        )}
+
+        {graphSlug && (
+          <section className="mt-16 pt-8 border-t border-border/40">
+            <TemplateInfluenceWeb graphSlug={graphSlug} />
           </section>
         )}
 

--- a/web/components/people/TemplateInfluenceWeb.tsx
+++ b/web/components/people/TemplateInfluenceWeb.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * TemplateInfluenceWeb — surface the spectrum web + refine doorway
+ * on hand-built /people/{slug} pages.
+ *
+ * Hand-built pages render rich curated content; this component
+ * carries the live data layer alongside it: every relationship
+ * edge from the graph node, painted with its family's spectrum
+ * color, plus the doorway any visitor uses to refine the data.
+ * Both surfaces stay in sync with the graph automatically — the
+ * curated text updates take a code change; the data here updates
+ * the moment a visitor saves a refinement.
+ */
+
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import { InfluenceWeb } from "@/components/presence/InfluenceWeb";
+import { RefineDoorway } from "@/components/presence/RefineDoorway";
+import type { PresenceIdentity } from "@/components/presence/PresencePage";
+
+type GraphNode = {
+  id: string;
+  type: string;
+  name?: string;
+  slug?: string | null;
+  presences?: { provider: string; url: string }[];
+  claimed?: boolean;
+};
+
+export function TemplateInfluenceWeb({ graphSlug }: { graphSlug: string }) {
+  const [node, setNode] = useState<GraphNode | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(
+          `${getApiBase()}/api/graph/nodes/${encodeURIComponent(graphSlug)}`,
+        );
+        if (r.ok) setNode(await r.json());
+      } catch {
+        // page still renders — the data layer is just absent
+      } finally {
+        setLoaded(true);
+      }
+    })();
+  }, [graphSlug]);
+
+  if (!loaded || !node) return null;
+
+  // Build a minimal PresenceIdentity for RefineDoorway. The fields
+  // it actually reads are id, slug, name, claimed.
+  const identity: PresenceIdentity = {
+    id: node.id,
+    slug: node.slug ?? null,
+    name: node.name || node.id,
+    category: node.type,
+    canonical_url: "",
+    provider: "",
+    image_url: null,
+    claimed: node.claimed,
+    presences: [],
+    creations: [],
+  };
+
+  return (
+    <div className="space-y-10">
+      <InfluenceWeb
+        presenceId={node.id}
+        externalPresences={node.presences || []}
+      />
+      <RefineDoorway identity={identity} />
+    </div>
+  );
+}

--- a/web/components/presence/InfluenceWeb.tsx
+++ b/web/components/presence/InfluenceWeb.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+/**
+ * InfluenceWeb — every related influence around a presence, inside
+ * and outside the network, rendered with the spectrum color of each
+ * connection's family.
+ *
+ * Inside the network: every graph edge from this node, grouped by
+ * the seven canonical edge families (Being, Transformation, Structure,
+ * Scale, Time, Tension, Attribution). Each chip walks to the related
+ * presence, painted in the family's color so the visitor reads the
+ * frequency at a glance.
+ *
+ * Outside the network: every external presence URL the node carries
+ * — YouTube, Instagram, podcasts, the canonical website — colored by
+ * the platform brand. These are doorways out of the network into the
+ * public-facing voice this presence already broadcasts.
+ *
+ * The visitor should be able to feel the shape of a presence by the
+ * spread of color and density of chips alone.
+ */
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import { brandFor } from "./brand";
+import { SpectrumLink } from "./SpectrumLink";
+import {
+  EDGE_FAMILIES,
+  edgeTypeLabel,
+  EDGE_TYPE_TO_FAMILY,
+  hsl,
+  type EdgeFamily,
+  type EdgeFamilySlug,
+} from "@/lib/edge-spectrum";
+
+type EdgeRow = {
+  id: string;
+  from_id: string;
+  to_id: string;
+  type: string;
+  strength?: number | null;
+  from_node?: { id: string; name: string; type: string; image_url?: string | null; slug?: string | null };
+  to_node?: { id: string; name: string; type: string; image_url?: string | null; slug?: string | null };
+};
+
+type ExternalPresence = {
+  provider: string;
+  url: string;
+};
+
+type Props = {
+  /** Graph node id of the presence whose web we're rendering. */
+  presenceId: string;
+  /** External presence links (presences[] on the graph node). */
+  externalPresences?: ExternalPresence[];
+};
+
+type GroupedRelative = {
+  edgeType: string;
+  href: string;
+  name: string;
+  imageUrl?: string | null;
+  strength?: number | null;
+};
+
+export function InfluenceWeb({ presenceId, externalPresences = [] }: Props) {
+  const [edges, setEdges] = useState<EdgeRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!presenceId) return;
+    const apiBase = getApiBase();
+    (async () => {
+      try {
+        const r = await fetch(
+          `${apiBase}/api/graph/nodes/${encodeURIComponent(
+            presenceId,
+          )}/edges?direction=both`,
+        );
+        if (r.ok) {
+          const body = await r.json();
+          const items: EdgeRow[] = Array.isArray(body)
+            ? body
+            : body?.items ?? [];
+          setEdges(items);
+        }
+      } catch {
+        // network failure → empty web; the rest of the page still renders
+      } finally {
+        setLoaded(true);
+      }
+    })();
+  }, [presenceId]);
+
+  // Group edges by family, preserving direction so "X resonates with
+  // Y" and "Y resonates with X" both surface the OTHER node from
+  // this presence's point of view.
+  const grouped = useMemo(
+    () => groupByFamily(edges, presenceId),
+    [edges, presenceId],
+  );
+
+  const totalRelatives = Object.values(grouped).reduce(
+    (sum, list) => sum + list.length,
+    0,
+  );
+
+  // Empty state: a presence newly woven into the field. Surface the
+  // doorway so the visitor knows the web isn't broken — it's young.
+  if (loaded && totalRelatives === 0 && externalPresences.length === 0) {
+    return (
+      <section className="space-y-3">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-muted-foreground">
+          Influences and connections
+        </h2>
+        <p className="text-sm text-muted-foreground/80 italic">
+          The web around this presence is just beginning to weave. Add a
+          relationship or a public presence link to surface the threads.
+        </p>
+      </section>
+    );
+  }
+
+  if (!loaded) {
+    return (
+      <section className="space-y-3">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-muted-foreground">
+          Influences and connections
+        </h2>
+        <div className="h-12 animate-pulse rounded-lg bg-muted/40" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
+          Influences and connections
+        </h2>
+        <p className="text-xs text-muted-foreground/80">
+          {totalRelatives} relationship{totalRelatives === 1 ? "" : "s"}{" "}
+          inside the field
+          {externalPresences.length > 0 && (
+            <>
+              {" · "}
+              {externalPresences.length} presence
+              {externalPresences.length === 1 ? "" : "s"} beyond it
+            </>
+          )}
+        </p>
+      </header>
+
+      {/* Inside the network — grouped by family, colored by spectrum */}
+      {EDGE_FAMILIES.map((family) => {
+        const list = grouped[family.slug] || [];
+        if (list.length === 0) return null;
+        return (
+          <FamilySection key={family.slug} family={family} relatives={list} />
+        );
+      })}
+
+      {/* Outside the network — public presences across platforms */}
+      {externalPresences.length > 0 && (
+        <ExternalPresenceRow presences={externalPresences} />
+      )}
+    </section>
+  );
+}
+
+function FamilySection({
+  family,
+  relatives,
+}: {
+  family: EdgeFamily;
+  relatives: GroupedRelative[];
+}) {
+  const [tone, setTone] = useState(family.dark);
+  useEffect(() => {
+    const update = () =>
+      setTone(
+        document.documentElement.classList.contains("light")
+          ? family.light
+          : family.dark,
+      );
+    update();
+    const mo = new MutationObserver(update);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => mo.disconnect();
+  }, [family]);
+  const fg = hsl(tone, "fg");
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2" title={family.feeling}>
+        <span
+          aria-hidden="true"
+          className="inline-block w-2.5 h-2.5 rounded-full"
+          style={{ background: fg }}
+        />
+        <h3
+          className="text-[11px] uppercase tracking-[0.15em] font-semibold"
+          style={{ color: fg }}
+        >
+          {family.name}
+        </h3>
+        <span className="text-[10px] text-muted-foreground/60">
+          · {relatives.length}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {relatives.map((r, i) => (
+          <SpectrumLink
+            key={`${r.edgeType}-${r.href}-${i}`}
+            edgeType={r.edgeType}
+            href={r.href}
+            name={r.name}
+            imageUrl={r.imageUrl}
+            strength={r.strength}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ExternalPresenceRow({ presences }: { presences: ExternalPresence[] }) {
+  return (
+    <div className="space-y-2 pt-2 border-t border-border/30">
+      <h3 className="text-[11px] uppercase tracking-[0.15em] font-semibold text-muted-foreground">
+        Beyond the network
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {presences.map((p, i) => {
+          const tone = brandFor(p.provider);
+          return (
+            <a
+              key={`${p.provider}-${i}`}
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition-all hover:scale-[1.02]"
+              style={{
+                background: tone.bg,
+                color: tone.fg,
+                borderColor: `color-mix(in oklch, ${tone.fg} 30%, transparent)`,
+                ...(tone.gradient ? { background: tone.gradient } : {}),
+              }}
+              title={`${tone.label} · ${p.url}`}
+            >
+              <span className="font-medium">{tone.label}</span>
+              <span className="opacity-60">↗</span>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function groupByFamily(
+  edges: EdgeRow[],
+  selfId: string,
+): Partial<Record<EdgeFamilySlug, GroupedRelative[]>> {
+  const acc: Partial<Record<EdgeFamilySlug, GroupedRelative[]>> = {};
+  for (const e of edges) {
+    const familySlug = EDGE_TYPE_TO_FAMILY[e.type] ?? "attribution";
+    const isOutgoing = e.from_id === selfId;
+    const other = isOutgoing ? e.to_node : e.from_node;
+    if (!other) continue;
+    // Hide self-loops and assets (assets render as creations elsewhere
+    // on the page, not as relationship chips).
+    if (other.id === selfId) continue;
+    if (other.type === "asset") continue;
+    const slug = (other as { slug?: string | null }).slug;
+    const href = slug
+      ? `/people/${slug}`
+      : nodeHrefFor(other.id, other.type);
+    if (!acc[familySlug]) acc[familySlug] = [];
+    acc[familySlug]!.push({
+      edgeType: e.type,
+      href,
+      name: other.name || other.id,
+      imageUrl: other.image_url ?? null,
+      strength: e.strength ?? null,
+    });
+  }
+  // Sort within each family by strength desc → name asc
+  for (const slug of Object.keys(acc) as EdgeFamilySlug[]) {
+    acc[slug]!.sort((a, b) => {
+      const sa = a.strength ?? 0;
+      const sb = b.strength ?? 0;
+      if (sb !== sa) return sb - sa;
+      return a.name.localeCompare(b.name);
+    });
+  }
+  return acc;
+}
+
+function nodeHrefFor(id: string, type: string): string {
+  // Concepts live in /vision; everything else flows through /people
+  // by id (which the graph resolves slug-or-id alike).
+  if (type === "concept") return `/vision/${encodeURIComponent(id)}`;
+  return `/people/${encodeURIComponent(id)}`;
+}

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -25,6 +25,8 @@ import { brandFor, type BrandTone } from "./brand";
 import { UpcomingGatherings } from "./UpcomingGatherings";
 import { ResonatesWith } from "./ResonatesWith";
 import { KindredPresences } from "./KindredPresences";
+import { InfluenceWeb } from "./InfluenceWeb";
+import { RefineDoorway } from "./RefineDoorway";
 import { LocationChip } from "./LocationChip";
 import { CoLocated } from "./CoLocated";
 import { RootedHere } from "./RootedHere";
@@ -72,6 +74,9 @@ export type Lineage = {
 
 export type PresenceIdentity = {
   id: string;
+  /** Human-readable doorway slug from the graph node, when set.
+   *  Drives `/people/{slug}` URL forms (refine, share, canonical). */
+  slug?: string | null;
   name: string;
   category: string; // "Artist" | "Community" | "Project" | "Gathering" | ...
   tagline?: string;
@@ -648,6 +653,16 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
             the platforms appear immediately after on mobile. */}
         <aside className="space-y-10 lg:space-y-8 min-w-0">
           <PresenceOverview identity={identity} inspiredCount={inspired.length} />
+          {/* Every related influence the body holds, inside and
+              outside the network, painted in the spectrum color of
+              its relationship family. The visitor reads the shape
+              of the presence by the spread of color and density
+              of chips. */}
+          <InfluenceWeb
+            presenceId={identity.id}
+            externalPresences={identity.presences}
+          />
+          <RefineDoorway identity={identity} />
           <PlatformChips
             presences={identity.presences}
             identityName={identity.name}

--- a/web/components/presence/PresenceRefineForm.tsx
+++ b/web/components/presence/PresenceRefineForm.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+/**
+ * PresenceRefineForm — the visitor's hands on the primary data.
+ *
+ * Three sections, each saving independently to the API so a visitor
+ * who only wants to fix a typo doesn't have to confront the rest:
+ *
+ *   1. Identity   — name, tagline, slug, image, description
+ *   2. Presences  — public URLs across platforms (presences[] array)
+ *   3. Influences — graph edges, with a spectrum-colored picker for
+ *                   the edge type
+ *
+ * Mutations write through the existing graph endpoints:
+ *   PATCH  /api/graph/nodes/{id}
+ *   POST   /api/edges
+ *   DELETE /api/edges/{edge_id}
+ *
+ * No auth gate today — the whole network is wiki-shape. Edits land
+ * immediately and are visible to everyone.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import {
+  EDGE_FAMILIES,
+  EDGE_TYPE_TO_FAMILY,
+  edgeTypeLabel,
+  familyForEdgeType,
+  hsl,
+  type EdgeFamilySlug,
+} from "@/lib/edge-spectrum";
+
+type GraphNode = {
+  id: string;
+  type: string;
+  name?: string;
+  description?: string;
+  slug?: string | null;
+  tagline?: string | null;
+  image_url?: string | null;
+  presences?: { provider: string; url: string }[];
+};
+
+type Edge = {
+  id: string;
+  from_id: string;
+  to_id: string;
+  type: string;
+  from_node?: { id: string; name: string; type: string; slug?: string | null };
+  to_node?: { id: string; name: string; type: string; slug?: string | null };
+};
+
+const ALL_EDGE_TYPES: { type: string; family: EdgeFamilySlug }[] = Object.entries(
+  EDGE_TYPE_TO_FAMILY,
+)
+  .map(([type, family]) => ({ type, family: family as EdgeFamilySlug }))
+  .sort((a, b) => a.type.localeCompare(b.type));
+
+export function PresenceRefineForm({ node }: { node: GraphNode }) {
+  return (
+    <div className="space-y-10">
+      <IdentitySection node={node} />
+      <PresencesSection node={node} />
+      <InfluencesSection node={node} />
+      <footer className="pt-6 border-t border-border/30">
+        <Link
+          href={`/people/${encodeURIComponent(node.slug || node.id)}`}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← back to the page
+        </Link>
+      </footer>
+    </div>
+  );
+}
+
+// ── 1. Identity ─────────────────────────────────────────────────────
+
+function IdentitySection({ node }: { node: GraphNode }) {
+  const [name, setName] = useState(node.name || "");
+  const [tagline, setTagline] = useState(node.tagline || "");
+  const [slug, setSlug] = useState(node.slug || "");
+  const [imageUrl, setImageUrl] = useState(node.image_url || "");
+  const [description, setDescription] = useState(node.description || "");
+  const [status, setStatus] = useState<SaveStatus>("idle");
+
+  async function save() {
+    setStatus("saving");
+    const res = await fetch(
+      `${getApiBase()}/api/graph/nodes/${encodeURIComponent(node.id)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          description,
+          properties: {
+            tagline: tagline || null,
+            slug: slug || null,
+            image_url: imageUrl || null,
+          },
+        }),
+      },
+    );
+    setStatus(res.ok ? "saved" : "error");
+    if (res.ok) setTimeout(() => setStatus("idle"), 2400);
+  }
+
+  return (
+    <Section
+      title="Identity"
+      hint="Name, tagline, the doorway slug, the hero image, and the body of writing about this presence."
+    >
+      <Field label="Name">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={inputClass}
+        />
+      </Field>
+      <Field label="Tagline" hint="One short sentence in their voice. ≤200 chars.">
+        <input
+          type="text"
+          value={tagline}
+          maxLength={200}
+          onChange={(e) => setTagline(e.target.value)}
+          className={inputClass}
+        />
+      </Field>
+      <Field
+        label="Slug"
+        hint="The human-readable URL: /people/{slug}. Lowercase, hyphens."
+      >
+        <input
+          type="text"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))}
+          className={inputClass}
+        />
+      </Field>
+      <Field label="Hero image URL" hint="A current, present-day image. HTTPS.">
+        <input
+          type="url"
+          value={imageUrl}
+          onChange={(e) => setImageUrl(e.target.value)}
+          className={inputClass}
+        />
+        {imageUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={imageUrl}
+            alt=""
+            className="mt-2 w-24 h-24 rounded-lg object-cover border border-border/40"
+          />
+        )}
+      </Field>
+      <Field
+        label="Description"
+        hint="Long-form body. Multiple paragraphs welcome. Their voice when possible; never invent words they didn't say."
+      >
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={10}
+          className={`${inputClass} font-mono text-xs leading-relaxed`}
+        />
+      </Field>
+      <SaveBar status={status} onSave={save} label="Save identity" />
+    </Section>
+  );
+}
+
+// ── 2. Public presences ─────────────────────────────────────────────
+
+function PresencesSection({ node }: { node: GraphNode }) {
+  const [items, setItems] = useState<{ provider: string; url: string }[]>(
+    node.presences || [],
+  );
+  const [status, setStatus] = useState<SaveStatus>("idle");
+
+  async function save() {
+    setStatus("saving");
+    const res = await fetch(
+      `${getApiBase()}/api/graph/nodes/${encodeURIComponent(node.id)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ properties: { presences: items } }),
+      },
+    );
+    setStatus(res.ok ? "saved" : "error");
+    if (res.ok) setTimeout(() => setStatus("idle"), 2400);
+  }
+
+  return (
+    <Section
+      title="Beyond the network"
+      hint="Public URLs the world reaches them through. The provider is auto-detected from the URL."
+    >
+      <ul className="space-y-2">
+        {items.map((p, i) => (
+          <li key={i} className="flex flex-wrap items-center gap-2">
+            <input
+              type="text"
+              value={p.provider}
+              onChange={(e) => {
+                const next = items.slice();
+                next[i] = { ...next[i], provider: e.target.value };
+                setItems(next);
+              }}
+              placeholder="provider"
+              className={`${inputClass} max-w-[10rem]`}
+            />
+            <input
+              type="url"
+              value={p.url}
+              onChange={(e) => {
+                const next = items.slice();
+                next[i] = {
+                  ...next[i],
+                  url: e.target.value,
+                  provider: next[i].provider || providerForUrl(e.target.value),
+                };
+                setItems(next);
+              }}
+              placeholder="https://…"
+              className={`${inputClass} flex-1 min-w-[16rem]`}
+            />
+            <button
+              type="button"
+              onClick={() => setItems(items.filter((_, j) => j !== i))}
+              className="text-xs text-muted-foreground hover:text-foreground px-2 py-1.5"
+            >
+              remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={() => setItems([...items, { provider: "", url: "" }])}
+        className="text-sm text-[hsl(var(--primary))] hover:opacity-80"
+      >
+        + add a presence
+      </button>
+      <SaveBar status={status} onSave={save} label="Save presences" />
+    </Section>
+  );
+}
+
+function providerForUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.replace(/^www\./, "").toLowerCase();
+    if (host.includes("youtube.com") || host.includes("youtu.be")) return "youtube";
+    if (host.includes("instagram.com")) return "instagram";
+    if (host.includes("tiktok.com")) return "tiktok";
+    if (host.includes("spotify.com")) return "spotify";
+    if (host.includes("bandcamp.com")) return "bandcamp";
+    if (host.includes("apple.com")) return "apple-music";
+    if (host.includes("soundcloud.com")) return "soundcloud";
+    if (host === "x.com" || host === "twitter.com") return "x";
+    if (host.includes("facebook.com")) return "facebook";
+    if (host.includes("substack.com")) return "substack";
+    if (host.includes("patreon.com")) return "patreon";
+    return host;
+  } catch {
+    return "";
+  }
+}
+
+// ── 3. Influences (graph edges) ─────────────────────────────────────
+
+function InfluencesSection({ node }: { node: GraphNode }) {
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const r = await fetch(
+        `${getApiBase()}/api/graph/nodes/${encodeURIComponent(
+          node.id,
+        )}/edges?direction=both`,
+      );
+      if (r.ok) {
+        const body = await r.json();
+        const items: Edge[] = Array.isArray(body) ? body : body?.items ?? [];
+        setEdges(items);
+      }
+      setLoaded(true);
+    })();
+  }, [node.id]);
+
+  async function removeEdge(edgeId: string) {
+    const res = await fetch(
+      `${getApiBase()}/api/edges/${encodeURIComponent(edgeId)}`,
+      { method: "DELETE" },
+    );
+    if (res.ok) setEdges(edges.filter((e) => e.id !== edgeId));
+  }
+
+  async function addEdge(toId: string, edgeType: string) {
+    const res = await fetch(`${getApiBase()}/api/edges`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from_id: node.id,
+        to_id: toId,
+        type: edgeType,
+      }),
+    });
+    if (res.ok) {
+      const created = await res.json();
+      setEdges([created, ...edges]);
+    }
+  }
+
+  return (
+    <Section
+      title="Influences and connections"
+      hint="Each relationship paints the spectrum of its family. Add or remove the threads that weave this presence into the field."
+    >
+      {!loaded ? (
+        <div className="h-12 animate-pulse rounded-lg bg-muted/40" />
+      ) : (
+        <>
+          <ul className="space-y-1">
+            {edges.length === 0 && (
+              <li className="text-sm text-muted-foreground italic">
+                No relationships yet.
+              </li>
+            )}
+            {edges.map((e) => {
+              const isOutgoing = e.from_id === node.id;
+              const other = isOutgoing ? e.to_node : e.from_node;
+              const family = familyForEdgeType(e.type);
+              const fg = `hsl(${family.dark.hue} ${family.dark.saturation}% ${family.dark.lightness}%)`;
+              return (
+                <li
+                  key={e.id}
+                  className="flex items-center gap-2 py-1 px-2 rounded-md hover:bg-card/40"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="w-2 h-2 rounded-full shrink-0"
+                    style={{ background: fg }}
+                  />
+                  <span
+                    className="text-[10px] uppercase tracking-[0.1em] shrink-0"
+                    style={{ color: fg }}
+                  >
+                    {isOutgoing ? "→" : "←"} {edgeTypeLabel(e.type)}
+                  </span>
+                  <span className="text-sm text-foreground/85 truncate flex-1">
+                    {other?.name || other?.id || "—"}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeEdge(e.id)}
+                    className="text-xs text-muted-foreground hover:text-foreground px-2"
+                  >
+                    remove
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <AddEdgeForm onAdd={addEdge} />
+        </>
+      )}
+    </Section>
+  );
+}
+
+function AddEdgeForm({
+  onAdd,
+}: {
+  onAdd: (toId: string, edgeType: string) => Promise<void> | void;
+}) {
+  const [toId, setToId] = useState("");
+  const [edgeType, setEdgeType] = useState("inspired-by");
+  const [busy, setBusy] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!toId.trim() || !edgeType) return;
+    setBusy(true);
+    await onAdd(toId.trim(), edgeType);
+    setToId("");
+    setBusy(false);
+  }
+
+  const family = familyForEdgeType(edgeType);
+  const fg = `hsl(${family.dark.hue} ${family.dark.saturation}% ${family.dark.lightness}%)`;
+
+  return (
+    <form onSubmit={submit} className="mt-3 flex flex-wrap items-center gap-2">
+      <select
+        value={edgeType}
+        onChange={(e) => setEdgeType(e.target.value)}
+        className={`${inputClass} max-w-[14rem] font-medium`}
+        style={{ color: fg, borderColor: `color-mix(in oklch, ${fg} 30%, transparent)` }}
+      >
+        {EDGE_FAMILIES.map((fam) => (
+          <optgroup key={fam.slug} label={fam.name}>
+            {ALL_EDGE_TYPES.filter((et) => et.family === fam.slug).map((et) => (
+              <option key={et.type} value={et.type}>
+                {edgeTypeLabel(et.type)}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+      <input
+        type="text"
+        value={toId}
+        onChange={(e) => setToId(e.target.value)}
+        placeholder="other presence id (e.g. contributor:aubrey-marcus)"
+        className={`${inputClass} flex-1 min-w-[18rem]`}
+      />
+      <button
+        type="submit"
+        disabled={busy || !toId.trim()}
+        className="rounded-full px-4 py-1.5 text-xs font-medium border disabled:opacity-50"
+        style={{
+          color: fg,
+          borderColor: `color-mix(in oklch, ${fg} 45%, transparent)`,
+          background: `color-mix(in oklch, ${fg} 10%, transparent)`,
+        }}
+      >
+        {busy ? "…" : "add"}
+      </button>
+    </form>
+  );
+}
+
+// ── shared bits ─────────────────────────────────────────────────────
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+function Section({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3 rounded-2xl border border-border/40 bg-card/30 p-5">
+      <header className="space-y-1">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
+          {title}
+        </h2>
+        {hint && <p className="text-xs text-muted-foreground/80">{hint}</p>}
+      </header>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-[11px] uppercase tracking-[0.12em] font-medium text-muted-foreground">
+        {label}
+      </span>
+      {hint && (
+        <span className="block text-[11px] text-muted-foreground/70 italic">
+          {hint}
+        </span>
+      )}
+      {children}
+    </label>
+  );
+}
+
+function SaveBar({
+  status,
+  onSave,
+  label,
+}: {
+  status: SaveStatus;
+  onSave: () => void | Promise<void>;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 pt-2">
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={status === "saving"}
+        className="rounded-full bg-[hsl(var(--primary))] px-5 py-1.5 text-xs font-medium text-[hsl(var(--primary-foreground))] hover:opacity-90 disabled:opacity-50"
+      >
+        {status === "saving" ? "saving…" : label}
+      </button>
+      {status === "saved" && (
+        <span className="text-xs text-[hsl(var(--chart-2))]">✓ saved</span>
+      )}
+      {status === "error" && (
+        <span className="text-xs text-rose-400">couldn&apos;t save — try again</span>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-md border border-border/60 bg-background/60 px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-[hsl(var(--primary)/0.4)] focus:border-[hsl(var(--primary)/0.5)]";

--- a/web/components/presence/RefineDoorway.tsx
+++ b/web/components/presence/RefineDoorway.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * RefineDoorway — visible permission and ability to update what
+ * this presence carries.
+ *
+ * Anyone visiting this page can correct, deepen, or refine what's
+ * here. The doorway is intentionally calm and ambient: not asking
+ * the visitor to "edit" but inviting them to bring this presence
+ * into truer alignment. Two paths converge here:
+ *
+ *   · "this is me"  → claim the page, own the editing
+ *   · "refine"      → suggest a refinement as a visitor
+ *
+ * The data this page renders comes from primary signals on the
+ * graph node — image, description, presence URLs across platforms,
+ * relationship edges. Refining that primary data is what changes
+ * the page; the visitor doesn't edit a frozen bio, they shape the
+ * data the bio is composed from.
+ */
+
+import Link from "next/link";
+import type { PresenceIdentity } from "./PresencePage";
+
+export function RefineDoorway({ identity }: { identity: PresenceIdentity }) {
+  // Slug-based edit URL when the graph node carries a slug; else
+  // the id form (the route resolves both).
+  const idForUrl = encodeURIComponent(identity.id);
+  const editHref = identity.slug
+    ? `/people/${identity.slug}/edit`
+    : `/people/${idForUrl}/edit`;
+  return (
+    <section>
+      <div className="rounded-2xl border border-[hsl(var(--primary)/0.25)] bg-[hsl(var(--primary)/0.04)] p-5">
+        <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-1.5">
+          Refine this presence
+        </p>
+        <p className="text-sm text-foreground/85 leading-relaxed">
+          Anything here can be corrected. If something doesn&apos;t represent{" "}
+          <span className="font-medium">{identity.name}</span> well — image,
+          tagline, the relationships, the platforms linked from here — open
+          the refinement door and shape it.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link
+            href={editHref}
+            className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--primary)/0.45)] bg-[hsl(var(--primary)/0.1)] px-3.5 py-1.5 text-xs font-medium text-[hsl(var(--primary))] hover:bg-[hsl(var(--primary)/0.18)] transition-colors"
+          >
+            Refine
+          </Link>
+          {identity.claimed === false && (
+            <Link
+              href={`/claim/${idForUrl}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border/50 px-3.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+            >
+              this is me →
+            </Link>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/presence/SpectrumLink.tsx
+++ b/web/components/presence/SpectrumLink.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * SpectrumLink — a relationship rendered with the color of its family.
+ *
+ * Every edge between two presences carries a frequency. The chip's
+ * fill, border, and text are sampled from the edge's family color
+ * (see `web/lib/edge-spectrum.ts`). The label above the chip names
+ * the relationship verb ("resonates with", "inspired by"); the chip
+ * itself names the other presence.
+ *
+ * On hover the chip brightens; on tap it walks the visitor to the
+ * other presence. The colored line between two adjacent chips —
+ * when rendered side-by-side in a row — reads as a small spectrum
+ * arc, the band the relationship occupies in the field.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  edgeTypeLabel,
+  familyForEdgeType,
+  hsl,
+  type EdgeFamily,
+} from "@/lib/edge-spectrum";
+
+type Props = {
+  /** The canonical edge type (e.g., "resonates-with", "at-place"). */
+  edgeType: string;
+  /** href the chip walks the visitor to. */
+  href: string;
+  /** Display name of the other presence. */
+  name: string;
+  /** Optional thumbnail (square) for the other presence. */
+  imageUrl?: string | null;
+  /** When the relationship has a strength score [0..1], the chip
+   *  brightens with it. Otherwise the chip uses the family's full
+   *  saturation. */
+  strength?: number | null;
+  /** When true, the verb label is suppressed — useful in a list
+   *  already grouped by edge type. */
+  verbInline?: boolean;
+};
+
+export function SpectrumLink({
+  edgeType,
+  href,
+  name,
+  imageUrl,
+  strength,
+  verbInline = false,
+}: Props) {
+  const family = familyForEdgeType(edgeType);
+  const tone = useFamilyTone(family);
+  const fg = hsl(tone, "fg");
+  const bg = hsl(tone, "bg");
+  // Strength bows the chip's emphasis: low-strength edges sit quieter
+  // so the eye finds the high-strength weave first.
+  const opacity =
+    typeof strength === "number" && Number.isFinite(strength)
+      ? Math.max(0.55, Math.min(1, strength))
+      : 0.95;
+
+  return (
+    <Link
+      href={href}
+      title={`${edgeTypeLabel(edgeType)} · ${name}`}
+      className="group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition-all hover:scale-[1.02] hover:shadow-sm"
+      style={{
+        background: bg,
+        borderColor: `color-mix(in oklch, ${fg} 35%, transparent)`,
+        color: fg,
+        opacity,
+      }}
+    >
+      {imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={imageUrl}
+          alt=""
+          className="w-5 h-5 rounded-full object-cover"
+          style={{ borderColor: fg, borderWidth: 1, borderStyle: "solid" }}
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: fg }}
+        />
+      )}
+      <span className="truncate max-w-[12rem] font-medium">{name}</span>
+      {!verbInline && (
+        <span
+          className="text-[10px] tracking-[0.05em] opacity-70 hidden sm:inline"
+          style={{ color: fg }}
+        >
+          · {edgeTypeLabel(edgeType).toLowerCase()}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+/**
+ * Pick the light or dark tone based on the document's current mode.
+ * Re-evaluates when the `light` class on `<html>` is toggled by the
+ * theme switcher.
+ */
+function useFamilyTone(family: EdgeFamily) {
+  const [isLight, setIsLight] = useState(false);
+  useEffect(() => {
+    const update = () =>
+      setIsLight(document.documentElement.classList.contains("light"));
+    update();
+    const mo = new MutationObserver(update);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => mo.disconnect();
+  }, []);
+  return isLight ? family.light : family.dark;
+}

--- a/web/lib/edge-spectrum.ts
+++ b/web/lib/edge-spectrum.ts
@@ -1,0 +1,202 @@
+/**
+ * Spectrum colors for the seven canonical edge-type families.
+ *
+ * Every relationship in this body carries a frequency. Ontological
+ * edges paint violet (the ground of being); operational edges paint
+ * gold (the warm hand of giving); knowledge edges paint blue (the
+ * crystalline architecture); and so on across the seven families.
+ * The palette is the visible spectrum of the connection.
+ *
+ * Edge type families come from `api/app/config/edge_types.py` —
+ * the single source of truth for relationship types in the network.
+ * Adding a new family means: new entry here + new entry there.
+ *
+ * Each family declares hue/saturation/lightness for both light and
+ * dark themes. The chip and the link inherit the family's color
+ * with reduced saturation for the surface and full saturation for
+ * the text and the connecting line.
+ */
+
+export type EdgeFamilySlug =
+  | "ontological"
+  | "process"
+  | "knowledge"
+  | "scale"
+  | "temporal"
+  | "tension"
+  | "attribution";
+
+export type EdgeFamilyTone = {
+  /** Hue in degrees (0–360). The single number that carries the family. */
+  hue: number;
+  /** Saturation/lightness for the chip text + connecting line. Bright. */
+  saturation: number;
+  lightness: number;
+  /** Slightly dimmer values for the chip background fill. Soft. */
+  bgSaturation: number;
+  bgLightness: number;
+};
+
+export type EdgeFamily = {
+  slug: EdgeFamilySlug;
+  /** Display label for the family heading. */
+  name: string;
+  /** A felt-sense description of what this family of relationships
+   *  carries. Shown as a tooltip on the family heading. */
+  feeling: string;
+  light: EdgeFamilyTone;
+  dark: EdgeFamilyTone;
+};
+
+export const EDGE_FAMILIES: readonly EdgeFamily[] = [
+  {
+    slug: "ontological",
+    name: "Being",
+    feeling:
+      "Resonance and emergence — what this presence is in relation to other forms of being.",
+    light: { hue: 270, saturation: 50, lightness: 55, bgSaturation: 55, bgLightness: 92 },
+    dark: { hue: 270, saturation: 70, lightness: 70, bgSaturation: 50, bgLightness: 22 },
+  },
+  {
+    slug: "process",
+    name: "Transformation",
+    feeling:
+      "Catalysts and changes — what this presence enables, blocks, amplifies, or transforms.",
+    light: { hue: 25, saturation: 75, lightness: 50, bgSaturation: 75, bgLightness: 92 },
+    dark: { hue: 25, saturation: 80, lightness: 65, bgSaturation: 60, bgLightness: 22 },
+  },
+  {
+    slug: "knowledge",
+    name: "Structure",
+    feeling:
+      "Architecture — what this presence implements, extends, refines, or stands in tension with as a structure of thought.",
+    light: { hue: 215, saturation: 60, lightness: 50, bgSaturation: 65, bgLightness: 92 },
+    dark: { hue: 215, saturation: 70, lightness: 70, bgSaturation: 50, bgLightness: 22 },
+  },
+  {
+    slug: "scale",
+    name: "Scale",
+    feeling:
+      "Fractals and aggregates — how this presence composes, decomposes, and repeats across scales.",
+    light: { hue: 145, saturation: 50, lightness: 45, bgSaturation: 55, bgLightness: 92 },
+    dark: { hue: 145, saturation: 60, lightness: 60, bgSaturation: 50, bgLightness: 22 },
+  },
+  {
+    slug: "temporal",
+    name: "Time",
+    feeling:
+      "Sequence and cause — what precedes, follows, triggers, resolves, or co-occurs with this presence.",
+    light: { hue: 240, saturation: 55, lightness: 50, bgSaturation: 60, bgLightness: 92 },
+    dark: { hue: 240, saturation: 65, lightness: 70, bgSaturation: 50, bgLightness: 22 },
+  },
+  {
+    slug: "tension",
+    name: "Tension",
+    feeling:
+      "Productive friction — paradoxes held, polarities bridged, integrations earned.",
+    light: { hue: 340, saturation: 65, lightness: 55, bgSaturation: 70, bgLightness: 92 },
+    dark: { hue: 340, saturation: 75, lightness: 70, bgSaturation: 55, bgLightness: 22 },
+  },
+  {
+    slug: "attribution",
+    name: "Attribution",
+    feeling:
+      "The warm hand — what this presence contributes to, is rooted in, is inspired by, depends on.",
+    light: { hue: 40, saturation: 75, lightness: 48, bgSaturation: 80, bgLightness: 92 },
+    dark: { hue: 40, saturation: 80, lightness: 65, bgSaturation: 60, bgLightness: 22 },
+  },
+] as const;
+
+const FAMILY_BY_SLUG: Record<EdgeFamilySlug, EdgeFamily> = Object.fromEntries(
+  EDGE_FAMILIES.map((f) => [f.slug, f]),
+) as Record<EdgeFamilySlug, EdgeFamily>;
+
+/**
+ * Map of canonical edge type → family slug. Mirrors the families
+ * in `api/app/config/edge_types.py`. Synced manually; if a new
+ * canonical edge type is introduced there it must also land here.
+ */
+export const EDGE_TYPE_TO_FAMILY: Record<string, EdgeFamilySlug> = {
+  // ontological
+  "resonates-with": "ontological",
+  "emerges-from": "ontological",
+  "transcends": "ontological",
+  "instantiates": "ontological",
+  "embodies": "ontological",
+  "reflects": "ontological",
+  // process
+  "transforms-into": "process",
+  "enables": "process",
+  "blocks": "process",
+  "catalyzes": "process",
+  "stabilizes": "process",
+  "amplifies": "process",
+  "dampens": "process",
+  // knowledge
+  "implements": "knowledge",
+  "extends": "knowledge",
+  "refines": "knowledge",
+  "generalises": "knowledge",
+  "contradicts": "knowledge",
+  "complements": "knowledge",
+  "subsumes": "knowledge",
+  // scale
+  "fractal-scaling": "scale",
+  "composes-from": "scale",
+  "decomposes-into": "scale",
+  "aggregates": "scale",
+  "specialises": "scale",
+  // temporal
+  "precedes": "temporal",
+  "follows": "temporal",
+  "co-occurs-with": "temporal",
+  "triggers": "temporal",
+  "resolves": "temporal",
+  "iterates": "temporal",
+  // tension
+  "paradox-resolution": "tension",
+  "polarity-of": "tension",
+  "tension-with": "tension",
+  "bridges": "tension",
+  "integrates": "tension",
+  // attribution
+  "contributes-to": "attribution",
+  "funded-by": "attribution",
+  "inspired-by": "attribution",
+  "referenced-by": "attribution",
+  "challenges": "attribution",
+  "validates": "attribution",
+  "invalidates": "attribution",
+  "analogous-to": "attribution",
+  "depends-on": "attribution",
+  "precondition-of": "attribution",
+  "at-place": "attribution",
+};
+
+/**
+ * Convert a family tone into an `hsl(h s% l%)` CSS string.
+ * Use the bg variant for surface fills, the main variant for text
+ * and connector lines.
+ */
+export function hsl(tone: EdgeFamilyTone, surface: "fg" | "bg" = "fg"): string {
+  const s = surface === "bg" ? tone.bgSaturation : tone.saturation;
+  const l = surface === "bg" ? tone.bgLightness : tone.lightness;
+  return `hsl(${tone.hue} ${s}% ${l}%)`;
+}
+
+export function familyForEdgeType(edgeType: string): EdgeFamily {
+  const slug = EDGE_TYPE_TO_FAMILY[edgeType];
+  // Unknown edge types fall to the attribution family — the warm
+  // default, since most ad-hoc relationships are credit-shaped.
+  return FAMILY_BY_SLUG[slug ?? "attribution"];
+}
+
+/**
+ * Display label for a canonical edge type. Replaces hyphens with
+ * spaces and renders sentence-case. "resonates-with" → "Resonates with".
+ */
+export function edgeTypeLabel(edgeType: string): string {
+  if (!edgeType) return "";
+  const words = edgeType.replace(/-/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}


### PR DESCRIPTION
## Summary
- Every presence page now surfaces **every related influence inside and outside the network**, painted in the spectrum color of its relationship family. Inside: every graph edge grouped by the seven canonical families (Being / Transformation / Structure / Scale / Time / Tension / Attribution). Outside: every public URL across platforms.
- Editability is open. `/people/{slug}/edit` lets any visitor refine the primary data — text fields, hero image, public presences, and graph edges with a spectrum-colored picker. Edits land through existing PATCH/POST/DELETE endpoints.
- API enriches edge stubs (id, type, name, image_url, slug) so influence chips render without per-edge round-trips. Both `/graph/nodes/{path}` and `/graph/nodes/{path}/edges` resolve slugs and the legacy `contributor:{path}` fallback so every URL form converges.
- Hand-built `/people/{slug}` pages plumb their graph slug through `PersonProfileTemplate`; the curated text stays, the live data layer joins it.
- Spec for the next breath at [`specs/presence-harmonization.md`](specs/presence-harmonization.md): algorithmic harmonization of the presented form from primary data.

## Test plan
- [x] `tests/test_flow_presence.py` — 32 passed
- [x] `tsc --noEmit` clean across all 27 changed files
- [x] dev: `/people/robert-edward-grant` 200, hand-built page renders + `TemplateInfluenceWeb` chunk loaded
- [x] dev: `/people/{slug}/edit` 200 for both slug and graph-id forms
- [x] API enriched edges include slug + image_url on stubs
- [ ] post-deploy: visit `/people/robert-edward-grant` — colored chips visible, refine button leads to working form
- [ ] post-deploy: pulse witness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)