### PR TITLE
attune(concepts): every vision concept meets its influences in spectrum

### DIFF
--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -1278,6 +1278,19 @@ def import_inspired_by(
     )
     edge_existed = edge_result.get("error") == "edge_exists"
 
+    # Auto-attune the new identity against vision concepts so the
+    # influence ↔ concept resonance edges flow without a separate call.
+    # Each external influence (book, talk, song, gathering) the
+    # network honors enters carrying its own keyword spectrum; the
+    # concepts it shares frequency with become visible immediately on
+    # both the concept side and the influence side.
+    if identity_created:
+        try:
+            from app.services import resonance_service
+            resonance_service.attune(identity_id)
+        except Exception:  # noqa: BLE001 — attune failure doesn't block the encounter
+            log.debug("auto-attune on inspired-by import non-fatal error", exc_info=True)
+
     return {
         "identity": identity_node,
         "identity_created": identity_created,

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -28,6 +28,7 @@ import { ResonantAssets } from "./_components/ResonantAssets";
 import { CarriedBy } from "./_components/CarriedBy";
 import { ConceptVoices } from "./_components/ConceptVoices";
 import { ReactionBar } from "@/components/ReactionBar";
+import { InfluenceWeb } from "@/components/presence/InfluenceWeb";
 
 export const dynamic = "force-dynamic";
 
@@ -347,6 +348,15 @@ export default async function VisionConceptPage({
             {/* Multiple visual expressions — most resonant rises */}
             <div className="max-w-3xl">
               <ResonantAssets conceptId={conceptId} />
+            </div>
+
+            {/* Every related thread the field has woven through this
+                concept — concepts it bridges, presences carrying it,
+                external influences honoring it through shared
+                vibrational resonance — painted in the spectrum color
+                of each relationship's family. */}
+            <div className="max-w-3xl">
+              <InfluenceWeb presenceId={conceptId} />
             </div>
 
             {/* Live signals from the world resonating with this concept */}

--- a/web/components/presence/InfluenceWeb.tsx
+++ b/web/components/presence/InfluenceWeb.tsx
@@ -262,6 +262,51 @@ function ExternalPresenceRow({ presences }: { presences: ExternalPresence[] }) {
   );
 }
 
+/**
+ * Patterns in graph node ids that mark system tissue — runners, test
+ * fixtures, visitors, agent identities. These never render as
+ * relationship chips on a public presence page.
+ *
+ * Mirrors the filter rules used by the /people directory in
+ * `web/content/presence-walk/en.json`. The list lives in two places
+ * for now; consolidating into a shared lib is future-breath work.
+ */
+const SYSTEM_ID_PATTERNS = [
+  ":wanderer-",
+  ":presence-visitor",
+  ":test-",
+  ":smoke-",
+  "-smoke-",
+  "-bot",
+  ":external-proof",
+  "decomposition-verify",
+  ":friend-",
+  "-placeholder",
+  ":claude-opus-mac-node",
+  ":coherence-runner",
+  ":e-m-t-",
+  ":email-",
+  ":qa-",
+  ":ci-",
+];
+const SYSTEM_EXACT_IDS = new Set([
+  "contributor:claude",
+  "contributor:codex",
+  "contributor:codex-agent",
+  "contributor:cursor-agent",
+  "contributor:grok",
+  "contributor:gemini",
+  "person:codex-smoke-human",
+  "contributor:presence-visitor",
+  "person:presence-visitor",
+]);
+
+function isSystemNode(id: string | undefined | null): boolean {
+  if (!id) return false;
+  if (SYSTEM_EXACT_IDS.has(id)) return true;
+  return SYSTEM_ID_PATTERNS.some((p) => id.includes(p));
+}
+
 function groupByFamily(
   edges: EdgeRow[],
   selfId: string,
@@ -272,10 +317,12 @@ function groupByFamily(
     const isOutgoing = e.from_id === selfId;
     const other = isOutgoing ? e.to_node : e.from_node;
     if (!other) continue;
-    // Hide self-loops and assets (assets render as creations elsewhere
-    // on the page, not as relationship chips).
+    // Hide self-loops, assets, and system tissue (visitors, runners,
+    // test fixtures). Assets render as creations elsewhere on the
+    // page, not as relationship chips.
     if (other.id === selfId) continue;
     if (other.type === "asset") continue;
+    if (isSystemNode(other.id)) continue;
     const slug = (other as { slug?: string | null }).slug;
     const href = slug
       ? `/people/${slug}`


### PR DESCRIPTION
## Summary
- The concept page (`/vision/{conceptId}`) now surfaces its full spectrum web — concepts it bridges, presences carrying it, and external influences honoring it — painted in the family color of each relationship.
- `import_inspired_by` triggers `resonance_service.attune()` on every newly-resolved external influence, so concept ↔ influence edges flow automatically the moment an encounter enters the graph.
- The architecture spec for the larger ingest body (Audible, YouTube, YT Music, Calendar, Photos, Gmail) is in flight as a parallel agent and will land at `specs/external-influences-ingest.md`.

## Test plan
- [x] `tests/test_flow_presence.py` + `tests/test_inspired_by.py` — 44 passed
- [x] `tsc --noEmit` clean
- [ ] post-deploy: visit `/vision/lc-attunement` — spectrum web visible with all related nodes
- [ ] post-deploy: pulse witness clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)