### PR TITLE
attune(encounter): a doorway from the body of evidence into the graph

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -31,14 +31,14 @@
 
 | Index | Files | Purpose |
 |---|---|---|
-| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 121 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 212 | API services — business logic and graph operations |
+| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 125 | API routers — every HTTP endpoint surface |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 220 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 55 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 96 | API tests — flow-centric |
-| [web/lib/INDEX.md](web/lib/INDEX.md) | 28 | Web library — shared client/server helpers |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 105 | API tests — flow-centric |
+| [web/lib/INDEX.md](web/lib/INDEX.md) | 29 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 46 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 148 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 78 | Scripts — operational tools, generators, syncers |
+| [web/app/INDEX.md](web/app/INDEX.md) | 153 | Web routes — every visible page in the app |
+| [scripts/INDEX.md](scripts/INDEX.md) | 84 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/routers/INDEX.md
+++ b/api/app/routers/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 121
+**Total files**: 125
 
 | File | Purpose |
 |---|---|
@@ -14,6 +14,7 @@
 | [agent_auto_heal_routes.py](agent_auto_heal_routes.py) | Agent auto-heal stats route. |
 | [agent_diagnostics_routes.py](agent_diagnostics_routes.py) | Agent diagnostics routes. |
 | [agent_execute_routes.py](agent_execute_routes.py) | Agent task execute and pickup-and-execute routes. |
+| [agent_external_encounters.py](agent_external_encounters.py) | External agent encounter records. |
 | [agent_grounded_metrics_routes.py](agent_grounded_metrics_routes.py) | Routes for grounded idea portfolio metrics (spec 116). |
 | [agent_helpers.py](agent_helpers.py) | Shared helpers for agent router and sub-routers. No routes. |
 | [agent_issues_routes.py](agent_issues_routes.py) | Agent fatal issues, monitor issues, metrics, effectiveness, collective-health routes. |
@@ -61,6 +62,7 @@
 | [explore.py](explore.py) | Explore queue — serendipitous meetings, one after another. |
 | [fallbacks.py](fallbacks.py) | Fallback visibility — read the witness of silent degradation paths. |
 | [federation.py](federation.py) | Federation API routes for cross-instance data exchange. |
+| [field_stories.py](field_stories.py) | Field story router — source-backed narrative and frequency artifacts. |
 | [flow_renderer.py](flow_renderer.py) | Flow renderer data — real energy flows for visualization. |
 | [flow_simulator.py](flow_simulator.py) | Flow simulator — visualize how CC moves through the community. |
 | [friction.py](friction.py) | Friction ledger API routes. |
@@ -80,6 +82,7 @@
 | [lenses.py](lenses.py) | Worldview lens registry — spec-181. |
 | [locales.py](locales.py) | Locales router — list supported languages and their coverage. |
 | [marketplace.py](marketplace.py) | Marketplace router: OpenClaw Idea Marketplace endpoints (spec 121). |
+| [mcp_remote.py](mcp_remote.py) | No-auth remote MCP endpoint for connector clients. |
 | [me_portfolio.py](me_portfolio.py) | Authenticated portfolio routes — same payloads as /api/contributors/{id}/… via X-API-Key. |
 | [meetings.py](meetings.py) | Meeting endpoint — the felt state of a viewer meeting an entity. |
 | [memberships.py](memberships.py) | Workspace membership routes — team edges between contributors and workspaces. |
@@ -96,6 +99,7 @@
 | [personal_feed.py](personal_feed.py) | Personal feed — your corner of the organism. |
 | [pipeline.py](pipeline.py) | Pipeline status routes for the agent pipeline loop. |
 | [pipeline_policies.py](pipeline_policies.py) | Pipeline policy CRUD endpoints. |
+| [places.py](places.py) | Places router — where presences are rooted. |
 | [practice.py](practice.py) | The organism's daily practice, served as a first-class endpoint. |
 | [presence.py](presence.py) | Presence — soft heartbeat + read endpoints. |
 | [presence_resonance.py](presence_resonance.py) | Presence ↔ vision-concept resonance threads. |

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 212
+**Total files**: 220
 
 | File | Purpose |
 |---|---|
@@ -38,6 +38,7 @@
 | [agent_task_continuation_service.py](agent_task_continuation_service.py) | Post-execution task continuation helpers. |
 | [agent_task_store_service.py](agent_task_store_service.py) | Persistent store for agent tasks with shared DB support. |
 | [app_mode.py](app_mode.py) | Application runtime mode helpers backed by config, not environment. |
+| [attunement_scheduler.py](attunement_scheduler.py) | Attunement scheduler — re-attune every presence so newly added concepts |
 | [audit_ledger_service.py](audit_ledger_service.py) | Transparent Audit Ledger service -- spec 123. |
 | [auto_heal_service.py](auto_heal_service.py) | Auto-heal from diagnostics: maps error categories to heal strategies. Spec 114. |
 | [automation_usage_service.py](automation_usage_service.py) | Provider usage adapters, normalized snapshots, and alert evaluation. |
@@ -76,6 +77,7 @@
 | [contributor_profile_service.py](contributor_profile_service.py) | Contributor Profile Service — what the system knows about a contributor. |
 | [contributor_recognition_service.py](contributor_recognition_service.py) | _no top-of-file purpose_ |
 | [contributor_service.py](contributor_service.py) | Contributor service — thin helpers used by auth_keys and other non-router code. |
+| [creations_importer.py](creations_importer.py) | Auto-import creations from a presence's known URLs. |
 | [creator_economy_service.py](creator_economy_service.py) | Creator economy service — computes public stats, proof cards, |
 | [data_retention_service.py](data_retention_service.py) | Data retention service -- tiered telemetry trimming, summarization, off-DB backup. |
 | [dif_feedback_service.py](dif_feedback_service.py) | DIF feedback instrumentation — tracks verification results for accuracy analysis. |
@@ -92,12 +94,15 @@
 | [fallback_witness_service.py](fallback_witness_service.py) | Fallback witness — honest record of when the body runs on reserve. |
 | [federation_push_service.py](federation_push_service.py) | Client-side push logic for federation measurement summaries (Spec 131). |
 | [federation_service.py](federation_service.py) | Federation service: receive, validate, and integrate remote instance data. |
+| [field_story_mcp_tools.py](field_story_mcp_tools.py) | MCP registry entries for published field stories. |
+| [field_story_service.py](field_story_service.py) | Published field-story artifacts and contribution hooks. |
 | [frequency_editor.py](frequency_editor.py) | Frequency editor — finds and rewrites institutional-frequency phrases. |
 | [frequency_field.py](frequency_field.py) | Frequency field analysis — token and phrase level dissonance detection. |
 | [frequency_profile_service.py](frequency_profile_service.py) | Frequency profile service — dynamic, multi-view, multi-hop. |
 | [frequency_scoring.py](frequency_scoring.py) | Frequency scoring engine — measures how "alive" vs "institutional" text reads. |
 | [friction_entry_points_service.py](friction_entry_points_service.py) | Friction entry-point and category rollups. |
 | [friction_service.py](friction_service.py) | Friction ledger service for API and scripts. |
+| [gatherings_importer.py](gatherings_importer.py) | Gatherings importer — scan presences for event listings, plant the missing ones. |
 | [geocoding_service.py](geocoding_service.py) | Forward geocoding: OpenCage → Nominatim → static fallback (Living Codex–style chain). |
 | [geolocation_service.py](geolocation_service.py) | Geolocation service — city-level contributor location storage and proximity search. |
 | [github_client.py](github_client.py) | GitHub API client — spec 029. |
@@ -161,7 +166,10 @@
 | [pipeline_policy_service.py](pipeline_policy_service.py) | Pipeline policy service — data-driven pipeline configuration. |
 | [pipeline_pulse_service.py](pipeline_pulse_service.py) | Pipeline pulse — self-awareness digest for the idea→spec→impl→verify pipeline. |
 | [pipeline_service.py](pipeline_service.py) | Shared state and helpers for the agent pipeline loop (spec 139). |
+| [place_service.py](place_service.py) | Place service — where presences are rooted. |
 | [portfolio_service.py](portfolio_service.py) | Portfolio service — aggregates contributor personal view data (spec 174). |
+| [presence_invitation_service.py](presence_invitation_service.py) | Graph-backed invitation surface for living presences. |
+| [presence_resolver.py](presence_resolver.py) | Presence resolver — backfill image_url + tagline on existing graph nodes. |
 | [presence_service.py](presence_service.py) | Presence — felt-witness that others are here too. |
 | [prompt_ab_roi_service.py](prompt_ab_roi_service.py) | Backward-compatible wrapper around SlotSelector for prompt variant selection. |
 | [proposal_service.py](proposal_service.py) | Proposals — short suggestions the collective can vote on by meeting. |

--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -1278,6 +1278,19 @@ def import_inspired_by(
     )
     edge_existed = edge_result.get("error") == "edge_exists"
 
+    # Auto-attune the new identity against vision concepts so the
+    # influence ↔ concept resonance edges flow without a separate call.
+    # Each external influence (book, talk, song, gathering) the
+    # network honors enters carrying its own keyword spectrum; the
+    # concepts it shares frequency with become visible immediately on
+    # both the concept side and the influence side.
+    if identity_created:
+        try:
+            from app.services import resonance_service
+            resonance_service.attune(identity_id)
+        except Exception:  # noqa: BLE001 — attune failure doesn't block the encounter
+            log.debug("auto-attune on inspired-by import non-fatal error", exc_info=True)
+
     return {
         "identity": identity_node,
         "identity_created": identity_created,

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 96
+**Total files**: 105
 
 | File | Purpose |
 |---|---|
@@ -38,11 +38,15 @@
 | [test_edge_cases_regression.py](test_edge_cases_regression.py) | Edge-case and regression tests that catch tricky bugs flow tests miss. |
 | [test_entity_view_attribution.py](test_entity_view_attribution.py) | Entity-view attribution and attention credit tests. |
 | [test_evidence_flow.py](test_evidence_flow.py) | Flow tests for /api/evidence — story-protocol-integration R9. |
+| [test_external_agent_encounters.py](test_external_agent_encounters.py) | External agent encounter record tests. |
 | [test_external_presence.py](test_external_presence.py) | Acceptance tests for spec: external-presence-bots-and-news (idea: external-presence). |
 | [test_external_proof_demo.py](test_external_proof_demo.py) | _no top-of-file purpose_ |
 | [test_failure_taxonomy_service.py](test_failure_taxonomy_service.py) | _no top-of-file purpose_ |
 | [test_federation_layer.py](test_federation_layer.py) | Acceptance tests for spec: federation-network-layer (idea: federation-and-nodes). |
 | [test_federation_message_readback.py](test_federation_message_readback.py) | _no top-of-file purpose_ |
+| [test_field_story_agent_surface.py](test_field_story_agent_surface.py) | _no top-of-file purpose_ |
+| [test_field_story_runtime_docs.py](test_field_story_runtime_docs.py) | _no top-of-file purpose_ |
+| [test_field_story_trace_index.py](test_field_story_trace_index.py) | _no top-of-file purpose_ |
 | [test_financial_integration.py](test_financial_integration.py) | Pure-logic tests for the financial-integration spec. |
 | [test_flow_activity.py](test_flow_activity.py) | Flow-centric tests for workspace activity feeds. |
 | [test_flow_agent_lifecycle.py](test_flow_agent_lifecycle.py) | Flow-centric tests for agent task lifecycle. |
@@ -63,16 +67,20 @@
 | [test_flow_reactions.py](test_flow_reactions.py) | Flow tests for reactions — emoji + comment across any entity. |
 | [test_flow_vitality.py](test_flow_vitality.py) | Flow-centric tests for the Workspace Vitality + related sensing |
 | [test_flow_workspaces.py](test_flow_workspaces.py) | Flow-centric tests for the Workspace tenant primitive. |
+| [test_frequency_profile_contributor_alias.py](test_frequency_profile_contributor_alias.py) | Contributor profile aliases resolve through the generic graph profile path. |
 | [test_generate_visuals_manifest.py](test_generate_visuals_manifest.py) | _no top-of-file purpose_ |
 | [test_governance_change_flow.py](test_governance_change_flow.py) | Contributor onboarding + governed change flow (spec: |
 | [test_graph_model_boundaries.py](test_graph_model_boundaries.py) | _no top-of-file purpose_ |
 | [test_homepage_contrast.py](test_homepage_contrast.py) | WCAG AA contrast tests for homepage CSS palette (ux-homepage-readability). |
 | [test_idea_lifecycle_closure.py](test_idea_lifecycle_closure.py) | Tests for idea lifecycle closure (spec: idea-lifecycle-closure). |
+| [test_import_lineage_edges.py](test_import_lineage_edges.py) | Lineage importer replays explicit graph edges from manifests. |
 | [test_inspired_by.py](test_inspired_by.py) | Flow-centric tests for the inspired-by resolver and /api/inspired-by. |
 | [test_interest_registration.py](test_interest_registration.py) | Flow-centric tests for interest registration — privacy-first community gathering. |
 | [test_knowledge_resonance.py](test_knowledge_resonance.py) | Acceptance tests for spec: knowledge-resonance-engine (idea: knowledge-and-resonance). |
 | [test_lens_translation_boundaries.py](test_lens_translation_boundaries.py) | _no top-of-file purpose_ |
 | [test_libretranslate_backend.py](test_libretranslate_backend.py) | LibreTranslate backend — verifies translation + glossary post-substitution. |
+| [test_mcp_remote_no_oauth.py](test_mcp_remote_no_oauth.py) | _no top-of-file purpose_ |
+| [test_meeting_resonance_capture.py](test_meeting_resonance_capture.py) | Meeting resonance capture flow tests. |
 | [test_monitor_resolution.py](test_monitor_resolution.py) | Tests for heal-completion-issue-resolution spec (047). |
 | [test_morning_coherence_brief.py](test_morning_coherence_brief.py) | _no top-of-file purpose_ |
 | [test_mvp_acceptance.py](test_mvp_acceptance.py) | MVP acceptance summary and judge endpoint tests. |
@@ -80,6 +88,7 @@
 | [test_peer_resonance_service.py](test_peer_resonance_service.py) | _no top-of-file purpose_ |
 | [test_persistence_contract_config.py](test_persistence_contract_config.py) | _no top-of-file purpose_ |
 | [test_portfolio_governance.py](test_portfolio_governance.py) | Acceptance tests for spec: portfolio-governance-health (idea: portfolio-governance). |
+| [test_presence_invitation.py](test_presence_invitation.py) | Acceptance tests for the graph-backed Presence invitation surface. |
 | [test_proprioception.py](test_proprioception.py) | Flow-centric integration tests for the Proprioception (auto-sensing) feature. |
 | [test_pytest_suite_budget.py](test_pytest_suite_budget.py) | _no top-of-file purpose_ |
 | [test_render_events_router.py](test_render_events_router.py) | Tests for POST /api/render-events — the economic loop closure. |

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 78
+**Total files**: 84
 
 | File | Purpose |
 |---|---|
@@ -31,6 +31,7 @@
 | [context_budget.py](context_budget.py) | !/usr/bin/env python3 |
 | [daily_brief.py](daily_brief.py) | !/usr/bin/env python3 |
 | [demo_dual_identity.py](demo_dual_identity.py) | !/usr/bin/env python3 |
+| [encounter.py](encounter.py) | !/usr/bin/env python3 |
 | [ensure_worktree_start_clean.py](ensure_worktree_start_clean.py) | !/usr/bin/env python3 |
 | [executor_handoff.py](executor_handoff.py) | !/usr/bin/env python3 |
 | [export_lineage.py](export_lineage.py) | !/usr/bin/env python3 |
@@ -44,6 +45,8 @@
 | [generate_silence_design_log_v2.py](generate_silence_design_log_v2.py) | !/usr/bin/env python3 |
 | [generate_visuals.py](generate_visuals.py) | !/usr/bin/env python3 |
 | [idea_to_task_bridge.py](idea_to_task_bridge.py) | !/usr/bin/env python3 |
+| [import_creations.py](import_creations.py) | !/usr/bin/env python3 |
+| [import_gatherings.py](import_gatherings.py) | !/usr/bin/env python3 |
 | [import_lineage.py](import_lineage.py) | !/usr/bin/env python3 |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
 | [local_runner.py](local_runner.py) | !/usr/bin/env python3 |
@@ -57,10 +60,12 @@
 | [publish_snapshot.py](publish_snapshot.py) | !/usr/bin/env python3 |
 | [reclassify_presence_types.py](reclassify_presence_types.py) | !/usr/bin/env python3 |
 | [register_providers.py](register_providers.py) | !/usr/bin/env python3 |
+| [resolve_presences.py](resolve_presences.py) | !/usr/bin/env python3 |
 | [restructure_spec_frontmatter.py](restructure_spec_frontmatter.py) | Restructure spec frontmatter: absorb requirements, done_when, test command. |
 | [run_claude_impl_with_report.py](run_claude_impl_with_report.py) | !/usr/bin/env python3 |
 | [run_pinned_idea_acceptance.py](run_pinned_idea_acceptance.py) | !/usr/bin/env python3 |
 | [scan_code_spec_references.py](scan_code_spec_references.py) | !/usr/bin/env python3 |
+| [schedule_attunement.py](schedule_attunement.py) | !/usr/bin/env python3 |
 | [seed_commit_evidence.py](seed_commit_evidence.py) | !/usr/bin/env python3 |
 | [seed_db.py](seed_db.py) | !/usr/bin/env python3 |
 | [seed_grant_ideas.py](seed_grant_ideas.py) | !/usr/bin/env python3 |
@@ -82,6 +87,7 @@
 | [validate_spec_quality.py](validate_spec_quality.py) | !/usr/bin/env python3 |
 | [validate_workflow_references.py](validate_workflow_references.py) | !/usr/bin/env python3 |
 | [verify_hashes.py](verify_hashes.py) | !/usr/bin/env python3 |
+| [viewport_audit.py](viewport_audit.py) | !/usr/bin/env python3 |
 | [wander.py](wander.py) | !/usr/bin/env python3 |
 | [wellness_check.py](wellness_check.py) | !/usr/bin/env python3 |
 | [worktree_continuity_guard.py](worktree_continuity_guard.py) | !/usr/bin/env python3 |

--- a/scripts/encounter.py
+++ b/scripts/encounter.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Encounter — flow external influences into the graph.
+
+A contributor brings the body of evidence they carry — books read,
+talks watched, songs listened to, gatherings attended — into the
+graph by naming each one. Each becomes an asset or contributor
+node; an `inspired-by` edge from the encountering contributor
+holds the weave; auto-resonance computes which vision concepts
+share frequency with the influence.
+
+Two paths:
+
+    # Single encounter from the command line
+    python3 scripts/encounter.py \\
+        --contributor contributor:seeker71 \\
+        --url https://example.com/book-page
+
+    # Bulk encounter from a file (one URL or name per line)
+    python3 scripts/encounter.py \\
+        --contributor contributor:seeker71 \\
+        --file ~/encounters.txt
+
+Each line in the file is treated as input to the resolver — a URL,
+a name, or a paste. Empty lines and lines starting with ``#`` are
+ignored so the file can be human-edited.
+
+Lines beginning with a `>` are treated as encounter notes attached
+to the *next* URL/name line — letting you record what was happening
+in your field when you encountered it. The note lands as edge
+metadata on the inspired-by edge.
+
+Output prints one line per encounter: status + identity + concept
+resonances landed. Idempotent — re-running on the same input doesn't
+duplicate edges.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _ensure_app_path() -> None:
+    here = Path(__file__).resolve().parent
+    api_dir = here.parent / "api"
+    if api_dir.exists():
+        sys_path = str(api_dir)
+        if sys_path not in sys.path:
+            sys.path.insert(0, sys_path)
+
+
+def _encounter_one(input_text: str, contributor_id: str, *, note: str | None = None) -> dict:
+    from app.services import inspired_by_service as service
+    from app.services import graph_service
+
+    resolved = service.resolve(input_text)
+    if resolved is None:
+        return {"input": input_text, "ok": False, "reason": "resolver couldn't make sense of input"}
+
+    result = service.import_inspired_by(contributor_id, resolved)
+
+    # Surface concept resonance the auto-attune produced for this
+    # newly-resolved identity. Reading the edges back lets the caller
+    # see what frequencies the influence met.
+    identity_id = result["identity"]["id"]
+    try:
+        concept_edges = graph_service.list_edges(
+            from_id=identity_id, edge_type="resonates-with", limit=20,
+        ).get("items", [])
+        concepts = sorted(
+            (e for e in concept_edges if (e.get("to_id") or "").startswith("lc-")),
+            key=lambda e: -(e.get("strength") or 0),
+        )
+    except Exception:  # noqa: BLE001
+        concepts = []
+
+    # Tag the edge with the encounter note when one was supplied.
+    if note and result.get("edge"):
+        edge_id = result["edge"].get("id")
+        if edge_id:
+            try:
+                graph_service.update_edge(
+                    edge_id, properties={"encounter_note": note},
+                )
+            except Exception:  # noqa: BLE001 — fall back gracefully
+                pass
+
+    return {
+        "input": input_text,
+        "ok": True,
+        "identity_id": identity_id,
+        "name": result["resolved"]["name"],
+        "node_type": result["resolved"]["node_type"],
+        "edge_existed": result.get("edge_existed", False),
+        "weight": result.get("weight"),
+        "concepts": [
+            {"id": e["to_id"], "score": e.get("strength")} for e in concepts[:5]
+        ],
+    }
+
+
+def _encounters_from_file(path: Path) -> list[tuple[str, str | None]]:
+    """Read encounters from a text file.
+
+    Returns a list of (input, note) tuples. A line starting with `>`
+    is held as the next encounter's note.
+    """
+    pending_note: str | None = None
+    out: list[tuple[str, str | None]] = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(">"):
+            pending_note = line[1:].strip() or None
+            continue
+        out.append((line, pending_note))
+        pending_note = None
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--contributor", required=True, help="Contributor id of the encountering presence (e.g. contributor:seeker71)")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--url", help="A single URL or name to encounter")
+    src.add_argument("--file", type=Path, help="Path to a file with one URL or name per line")
+    p.add_argument("--note", help="Optional encounter note (only with --url)")
+    p.add_argument("--limit", type=int, default=0, help="Stop after N encounters (0 = no limit)")
+    args = p.parse_args()
+
+    _ensure_app_path()
+
+    encounters: list[tuple[str, str | None]]
+    if args.url:
+        encounters = [(args.url, args.note)]
+    else:
+        if not args.file.exists():
+            print(f"file not found: {args.file}", file=sys.stderr)
+            return 2
+        encounters = _encounters_from_file(args.file)
+
+    if args.limit > 0:
+        encounters = encounters[: args.limit]
+
+    landed = 0
+    for i, (text, note) in enumerate(encounters, 1):
+        result = _encounter_one(text, args.contributor, note=note)
+        if not result["ok"]:
+            print(f"  [{i:3d}] ✗ {text[:60]:60s}  {result['reason']}")
+            continue
+        concepts = ", ".join(
+            f"{c['id'].replace('lc-', '')}({c['score']:.2f})" if c.get("score") else c["id"]
+            for c in result["concepts"]
+        )
+        marker = "↺" if result["edge_existed"] else "✓"
+        print(
+            f"  [{i:3d}] {marker} {result['name'][:38]:38s}  → {concepts or '(no concept resonance)'}"
+        )
+        landed += 1
+    print()
+    print(f"landed: {landed}/{len(encounters)} encounters")
+    return 0 if landed > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/external-influences-ingest.md
+++ b/specs/external-influences-ingest.md
@@ -1,0 +1,371 @@
+---
+id: external-influences-ingest
+idea_id: external-presence
+status: draft
+source:
+  - file: api/app/services/influence_ingest.py
+    symbols: [ingest_one, ingest_bulk, IngestResult, EncounterMetadata, build_asset_node, write_inspired_by_edge, attune_after_write]
+  - file: api/app/services/influence_ingest/privacy_filter.py
+    symbols: [filter_candidate, PrivacyRule, load_rules, partner_pattern, intimate_pattern, scan_for_intimate, FilterDecision]
+  - file: api/app/services/influence_ingest/sources/audible.py
+    symbols: [parse_goodreads_csv, parse_audible_library, row_to_asset, infer_canonical_url]
+  - file: api/app/services/influence_ingest/sources/youtube_takeout.py
+    symbols: [parse_watch_history_json, entry_to_asset, infer_kind]
+  - file: api/app/services/influence_ingest/sources/yt_music_takeout.py
+    symbols: [parse_listening_history_json, entry_to_asset]
+  - file: api/app/services/influence_ingest/sources/google_calendar_ics.py
+    symbols: [parse_ics, event_to_gathering_asset]
+  - file: api/app/services/influence_ingest/sources/google_photos_takeout.py
+    symbols: [parse_photo_metadata_json, photo_to_place_encounter, NEVER_INGEST_PIXELS]
+  - file: api/app/services/influence_ingest/sources/gmail_takeout.py
+    symbols: [parse_mbox_headers, header_to_correspondence_asset, subject_filter]
+  - file: api/app/services/influence_ingest/sources/manual_paste.py
+    symbols: [paste_to_asset]
+  - file: api/app/routers/influences.py
+    symbols: [create_influence_from_url, get_influence, list_influences_for_contributor, list_resonating_concepts, patch_influence_privacy]
+  - file: api/app/routers/inspired_by.py
+    symbols: [create_inspired_by, InspiredByCreateRequest]
+  - file: api/app/services/inspired_by_service.py
+    symbols: [resolve, ensure_identity, import_inspired_by, _scan_cross_references, canonicalize_url, canonical_url_hash]
+  - file: api/app/services/resonance_service.py
+    symbols: [attune, compute_resonance, PRESENCE_TYPES]
+  - file: api/app/models/influence.py
+    symbols: [ExternalInfluence, EncounterMetadata, InfluenceCategory, InfluenceSource, IngestSummary]
+  - file: api/db/migrations/NNNN_external_influences.sql
+    symbols: [external_influences view, encounter_metadata edge property index, privacy_rules table]
+  - file: scripts/ingest_audible_csv.py
+    symbols: [main, run, fixture]
+  - file: scripts/ingest_youtube_takeout.py
+    symbols: [main, run]
+  - file: scripts/ingest_yt_music_takeout.py
+    symbols: [main, run]
+  - file: scripts/ingest_google_calendar_ics.py
+    symbols: [main, run]
+  - file: scripts/ingest_google_photos_takeout.py
+    symbols: [main, run]
+  - file: scripts/ingest_gmail_takeout.py
+    symbols: [main, run]
+  - file: config/privacy_rules.json
+    symbols: [intimate_patterns, source_defaults, contributor_overrides]
+  - file: web/components/concept/CarriedExternalPresences.tsx
+    symbols: [CarriedExternalPresences, InfluenceChip, family_color_for_kind]
+  - file: web/components/influence/InfluencePage.tsx
+    symbols: [InfluencePage, ResonatingConcepts, EncounteredBy]
+  - file: web/app/influences/[slug]/page.tsx
+    symbols: [InfluenceRoute, fetchInfluence]
+  - file: api/tests/test_influence_ingest.py
+    symbols: [test_manual_paste_creates_asset_and_inspired_by_edge, test_audible_csv_idempotent_on_canonical_url, test_youtube_takeout_bulk, test_calendar_ics_becomes_gathering, test_photos_metadata_no_pixels_only_place_and_date, test_gmail_subject_filter_holds_intimate, test_privacy_filter_blocks_partner_pattern_before_write, test_attune_runs_after_ingest, test_encounter_metadata_on_edge, test_private_flag_hides_from_public_query]
+requirements:
+  - "ingest_one(url, contributor_id, source, encounter) and ingest_bulk(records, contributor_id, source) are the two entry points; both return IngestSummary with created/updated/skipped/blocked-by-privacy counts"
+  - "External influences land as nodes of type=asset with creation_kind in {book,video,song,podcast,gathering,article,photo-encounter,correspondence}; no new node type is introduced"
+  - "Every ingest path resolves through inspired_by_service.ensure_identity() so canonical_url canonicalization, deterministic ids, and the existing mention-scan stay the single source of truth — no duplicate URL-keying or id-minting logic"
+  - "Each ingest writes an inspired-by edge contributor -> influence carrying EncounterMetadata in edge properties: when_encountered (ISO date), where_encountered (place node id, when known), surrounding_concepts (concept ids active in the field at encounter time, when known), source (audible|youtube|yt-music|calendar|photos|gmail|manual|takeout-import)"
+  - "Each ingest writes a created-by edge influence -> contributor when the influence's author/artist resolves to an existing graph node via canonical URL (skipped silently otherwise — no speculative author nodes)"
+  - "After every successful asset write, resonance_service.attune(asset_id) runs once so resonates-with edges to vision concepts flow without manual call; bulk ingest batches attune calls and reports total resonance edges written in IngestSummary"
+  - "Privacy filter (privacy_filter.filter_candidate) runs before any graph write, draws rules from config/privacy_rules.json (data-driven, never hardcoded names), and returns FilterDecision in {allow, block, mark-private}; blocked candidates are recorded in IngestSummary.blocked with reason for auditability"
+  - "Per-influence private:true flag persists on the asset node; queries hide private influences from anonymous viewers and from contributors other than encountered_by; the contributor's own edit view shows them"
+  - "Bulk imports are idempotent on canonicalize_url(canonical_url) — re-running an Audible CSV or a YouTube Takeout twice produces zero net change beyond updated encountered_at on the inspired-by edge"
+  - "POST /api/influences accepts a URL + contributor_id + optional encounter metadata, runs through manual_paste source, and returns the created/found influence with its resonance edges; extends rather than replaces POST /api/inspired-by"
+  - "GET /api/influences/{slug} returns the influence node, the contributors who encountered it (filtered by privacy), and the concepts it resonates with sorted by score"
+  - "GET /api/concepts/{id}/external-presences returns the spectrum of influences whose resonates-with score is above threshold, grouped by creation_kind, painted with the family color of their relationship — feeds CarriedExternalPresences on each concept page"
+  - "Bulk import scripts (ingest_audible_csv.py, ingest_youtube_takeout.py, ingest_yt_music_takeout.py, ingest_google_calendar_ics.py, ingest_google_photos_takeout.py, ingest_gmail_takeout.py) accept --file, --contributor-id, --dry-run; print IngestSummary; never write graph nodes when --dry-run is set"
+  - "Google Photos ingest reads metadata JSON only — never image pixels, never face/people detection — and produces at-place + when-encountered metadata that flows onto the inspired-by edge of whatever influence (gathering, place) is associated with the same date+location"
+  - "Gmail ingest reads sender + subject + date headers only, never message bodies, and the subject_filter holds back intimate-domain subjects (partner/family/health/scheduling) per the privacy rules; an allowed correspondence becomes an asset of creation_kind=correspondence keyed on a synthetic canonical_url derived from sender+subject+date"
+done_when:
+  - "POST /api/influences with a book URL creates an asset node, writes an inspired-by edge with encounter metadata, runs attune, and returns the resonance list in one round trip"
+  - "scripts/ingest_audible_csv.py --file goodreads.csv --contributor-id contributor:urs creates one asset per row, idempotent across two runs (second run reports 0 created, N updated)"
+  - "scripts/ingest_youtube_takeout.py --file watch-history.json --contributor-id contributor:urs creates one asset per watched video, attune produces resonates-with edges to vision concepts, IngestSummary reports the totals"
+  - "scripts/ingest_google_calendar_ics.py --file calendar.ics --contributor-id contributor:urs creates gathering-kind assets with at-place + when_encountered metadata"
+  - "scripts/ingest_google_photos_takeout.py --file photos-metadata.json --contributor-id contributor:urs writes only place + date encounter metadata onto existing or new gathering/place assets — never reads pixels, never writes a 'photo' asset that carries the image"
+  - "scripts/ingest_gmail_takeout.py --file mbox --contributor-id contributor:urs writes correspondence-kind assets only for subjects passing the privacy filter; held subjects appear in IngestSummary.blocked with reason='intimate_subject'"
+  - "Privacy filter test: a synthetic record matching the partner_pattern is blocked before any graph write; never appears in any node, edge, or query result; appears in IngestSummary.blocked with reason='privacy:partner'"
+  - "Per-influence private:true flag: an anonymous GET /api/contributors/{id}/influences hides private items; the same contributor's authenticated GET shows them; the public concept page omits them"
+  - "GET /api/concepts/lc-attunement/external-presences returns a non-empty spectrum after ingesting at least one resonant book or video, grouped by creation_kind"
+  - "Encounter metadata on the inspired-by edge survives a second ingest of the same canonical_url — when_encountered updates to the most recent encounter, surrounding_concepts merge rather than overwrite"
+  - "/influences/{slug} page renders an ingested book with its title, image, encounter date, the concepts it resonates with, and (where present) the contributors who also encountered it"
+  - "all api tests pass"
+test: "cd api && python -m pytest tests/test_influence_ingest.py tests/test_flow_influences.py -q && python3 scripts/ingest_audible_csv.py --file api/tests/fixtures/goodreads_sample.csv --contributor-id contributor:urs --dry-run"
+constraints:
+  - "No OAuth in this iteration — manual paste plus bulk file import only; Audible/YouTube/Calendar/Photos/Gmail flows all consume Google Takeout exports or CSV exports the contributor downloads themselves"
+  - "Never surface intimate content (partner, family, son, health, intimate-detail) in any visible artifact — privacy filter runs before graph writes, rules are data-driven via config/privacy_rules.json and never hardcoded names"
+  - "Reuse existing inspired_by_service and resonance_service — never duplicate canonicalize_url, ensure_identity, or keyword-overlap logic; this spec composes them, it does not reimplement them"
+  - "All new edges flow through canonical edge types already in the graph: inspired-by, resonates-with, created-by, referenced-by, at-place — no new edge types are invented"
+  - "Encounter metadata stays on the inspired-by edge as JSON properties; no separate Encounter node is introduced (keeps the graph clean)"
+  - "Bulk imports are idempotent on canonicalize_url(canonical_url); re-running an export updates encountered_at and merges surrounding_concepts but never duplicates assets or edges"
+  - "Google Photos ingest never reads pixels, never runs face/people detection, never stores image content; metadata only (date + location)"
+  - "Gmail ingest never reads message bodies — sender + subject + date headers only, and subjects pass through the privacy filter before becoming nodes"
+  - "Live OAuth sync (Google OAuth 2.0, Audible scrape) is explicitly out of scope for this spec; a future spec layers it on top of the same ingest path"
+---
+
+> **Parent idea**: [external-presence](../ideas/external-presence.md)
+
+# Spec: External Influences Ingest
+
+## Purpose
+
+Each contributor — starting with Urs as the founding contributor, eventually any contributor who connects their accounts — carries a body of evidence. Books read on Audible. Videos watched on YouTube. Songs listened to on YouTube Music. Gatherings attended via Google Calendar. Places sat in via Google Photos. Correspondences held via Gmail. These are the encounters where vibrational resonance left a mark on a life.
+
+The graph today holds presences (people, communities, places) and concepts (the vision's living vocabulary), but not the influences a person has actually encountered. Without those influences, a concept page knows the people in its lineage but not the books and videos and songs that shaped the field around it; a contributor page shows who they're inspired by but not what they're inside of.
+
+This spec defines how external influences enter the graph through manual paste plus bulk file import, how each influence resolves into an asset node honoring the canonical URL discipline already established, how the encounter metadata stays alive on the edge rather than collapsing to a flat link, and how every newly-resolved influence runs through resonance attunement so that vision concepts (lc-attunement, lc-ceremony, lc-circulation, and the rest) and external influences meet through shared vibrational resonance — each carrying the honor of recognising the other through the experiences they share.
+
+## Requirements
+
+- [ ] **R1** — Two entry points: `ingest_one(url, contributor_id, source, encounter)` for a single influence and `ingest_bulk(records, contributor_id, source)` for an export file. Both return `IngestSummary` with created / updated / skipped / blocked-by-privacy counts plus the list of resonance edges written by the post-ingest attune pass.
+
+- [ ] **R2** — External influences land as `asset` nodes (no new node type). The `creation_kind` property carries the sub-type: `book`, `video`, `song`, `podcast`, `gathering`, `article`, `photo-encounter`, `correspondence`. The renderer paints each kind in its own family color; the asset node itself is the canonical kind already in the graph.
+
+- [ ] **R3** — Every ingest path flows through `inspired_by_service.ensure_identity()` so canonical-URL canonicalization, deterministic ids (`asset:{canonical_url_hash}`), and the existing mention-scan run once at the boundary. No path mints its own ids or canonicalizes its own URLs — that logic lives in one place.
+
+- [ ] **R4** — Each ingest writes an `inspired-by` edge from `contributor:{id}` to the influence. Edge properties carry `EncounterMetadata`:
+  - `when_encountered` — ISO date of when the contributor met this influence
+  - `where_encountered` — graph id of the place node, when known (a gathering's venue, a photo's location)
+  - `surrounding_concepts` — list of concept ids active in the field at encounter time, when known (the field shape around the encounter, not just the influence in isolation)
+  - `source` — one of `audible | youtube | yt-music | calendar | photos | gmail | manual | takeout-import`
+
+  The metadata stays on the edge as JSON; no separate `Encounter` node is introduced. Re-ingesting the same influence updates `when_encountered` to the most recent and merges `surrounding_concepts` rather than overwriting.
+
+- [ ] **R5** — When the influence has a known author/artist that resolves to an existing graph node by canonical URL, the ingest writes a `created-by` edge from the influence to the contributor/community node. When no existing node matches, the edge is skipped silently — never speculate authors into existence; never bind a stranger to the influence on a fuzzy name match.
+
+- [ ] **R6** — After every successful asset write, `resonance_service.attune(asset_id)` runs once so `resonates-with` edges to vision concepts flow without a manual call. Bulk ingest batches the attune calls (one per newly-written asset, skipped for assets where only the inspired-by edge was updated) and reports the total resonance edges written in `IngestSummary`.
+
+- [ ] **R7** — Privacy filter runs **before** any graph write. `privacy_filter.filter_candidate(record, source, contributor_id)` returns one of:
+  - `FilterDecision.allow` — write to graph, render publicly
+  - `FilterDecision.mark_private` — write to graph with `private: true`, render only to `encountered_by`
+  - `FilterDecision.block` — never write; record in `IngestSummary.blocked` with reason for auditability
+
+  The filter draws its rules from `config/privacy_rules.json` (data-driven, never hardcoded names). Rules carry: intimate-content patterns (partner / family / son / health / scheduling), per-source defaults (Gmail subjects default to `block`, Photos default to `mark-private`, etc.), and per-contributor overrides (a contributor can mark a source as `allow` for themselves). The mental model draws from `partner_presence.md`: tender content held privately by default; the filter holds back rather than surfaces.
+
+- [ ] **R8** — Per-influence `private: true` flag persists on the asset node. Public queries (anonymous viewers, contributors other than `encountered_by`) hide private influences from list responses. The encountering contributor's own authenticated edit view shows them with a private badge so they can promote one to public when they choose. Concept pages that aggregate "external presences resonating here" omit private influences entirely from the public spectrum.
+
+- [ ] **R9** — Bulk imports are idempotent on `canonicalize_url(canonical_url)`. Re-running the same Audible CSV, YouTube Takeout JSON, or Calendar ICS produces zero net asset creations on the second run; the only writes are `encountered_at` updates on the inspired-by edge and `surrounding_concepts` merges. The `IngestSummary` distinguishes `created` from `updated` from `skipped` so the contributor sees what changed.
+
+- [ ] **R10** — `POST /api/influences` accepts `{url, contributor_id, encounter?}`, runs through the `manual_paste` source, returns the resolved influence + its newly-written resonance edges. Extends rather than replaces `POST /api/inspired-by` — the inspired-by router is the existing happy path for contributors and stays as is; this new route exists to carry encounter metadata that the older route doesn't take.
+
+- [ ] **R11** — `GET /api/influences/{slug}` returns the influence node, the contributors who encountered it (filtered by privacy — anonymous viewers see only contributors whose edge is non-private), and the concepts it resonates with sorted by score.
+
+- [ ] **R12** — `GET /api/concepts/{id}/external-presences` returns the spectrum of influences whose `resonates-with` score is above the threshold, grouped by `creation_kind`, painted with the family color of their relationship. Powers `CarriedExternalPresences` on each concept page — the visible row of books, videos, songs, gatherings honoring the concept through resonance.
+
+- [ ] **R13** — Six bulk import scripts (`ingest_audible_csv.py`, `ingest_youtube_takeout.py`, `ingest_yt_music_takeout.py`, `ingest_google_calendar_ics.py`, `ingest_google_photos_takeout.py`, `ingest_gmail_takeout.py`). Each accepts `--file`, `--contributor-id`, `--dry-run`. All print `IngestSummary` on completion. None writes to the graph when `--dry-run` is set.
+
+- [ ] **R14** — Google Photos ingest reads metadata JSON only — date taken, geographic location, album name. Never reads pixels, never runs face or people detection, never writes a `photo` asset that carries image content. The output is `at-place` + `when_encountered` metadata that lands on the inspired-by edge of whatever gathering or place asset shares the same date and location (or creates a new place-encounter asset when no host is found).
+
+- [ ] **R15** — Gmail ingest reads `From`, `Subject`, `Date` headers only — never message bodies. Subjects pass through `subject_filter` (privacy filter scoped to email subjects) before becoming nodes; intimate-domain subjects (per the rules) are held back. An allowed correspondence becomes an asset of `creation_kind=correspondence` keyed on a synthetic canonical URL derived from `mailto:{sender}#{subject_slug}#{date}`.
+
+## Research Inputs
+
+- `2026-05-07` — User naming the shape: contributor body of evidence (Audible, YouTube, YT Music, Calendar, Photos, Gmail) flowing into the graph so vision concepts and external influences honor each other through shared vibrational resonance.
+- `api/app/services/inspired_by_service.py` — already does most of what manual paste needs (resolve, ensure_identity, canonicalize_url, mention scan). The new ingest paths compose this service rather than reimplement it.
+- `api/app/services/resonance_service.py` — keyword-overlap engine that auto-computes concept resonance via `attune(presence_id)`. The new ingest hooks call this after every asset write.
+- `api/app/services/creation_sources/` — existing source adapters for Bandcamp, Goodreads (Audible-adjacent), YouTube, RSS, Substack. Bulk Audible/YouTube ingest reuses the JSON-LD and HTML parsing already there; the new `influence_ingest/sources/` plugins focus on the export-file shapes (CSV / Takeout JSON / ICS / mbox) those existing sources don't cover.
+- `partner_presence.md` (held tenderly, not surfaced) — mental model for the privacy filter. Partner, family, son, intimate-detail are private-by-default in every visible artifact, even when the source export contains them. The filter holds back rather than surfaces.
+- `specs/presence-harmonization.md` — companion spec; same idea_id (`external-presence`); same privacy stance; same data-driven, never-hardcoded approach. Where presence-harmonization composes the presented shape of an existing presence, this spec brings new presences (external influences) into the graph in the first place.
+
+## API Contract
+
+### `POST /api/influences`
+
+Resolve a URL into an external-influence asset, write the inspired-by edge with encounter metadata, attune for concept resonance.
+
+**Request**
+```json
+{
+  "url": "https://www.audible.com/pd/Becoming-Supernatural-Audiobook/B0791WT8K6",
+  "contributor_id": "contributor:urs",
+  "source": "audible",
+  "encounter": {
+    "when_encountered": "2024-09-12",
+    "where_encountered": null,
+    "surrounding_concepts": ["lc-attunement", "lc-coherence"]
+  }
+}
+```
+
+**Response 201**
+```json
+{
+  "influence": {
+    "id": "asset:9f2a...",
+    "name": "Becoming Supernatural",
+    "creation_kind": "book",
+    "canonical_url": "https://audible.com/pd/becoming-supernatural-audiobook/b0791wt8k6",
+    "image_url": "https://...",
+    "private": false
+  },
+  "inspired_by_edge": {
+    "id": "edge:...",
+    "from_id": "contributor:urs",
+    "to_id": "asset:9f2a...",
+    "type": "inspired-by",
+    "properties": {
+      "when_encountered": "2024-09-12",
+      "source": "audible",
+      "surrounding_concepts": ["lc-attunement", "lc-coherence"]
+    }
+  },
+  "resonance": [
+    {"concept_id": "lc-attunement", "score": 0.42, "shared_tokens": ["frequency", "field", "coherence"]},
+    {"concept_id": "lc-ceremony", "score": 0.18, "shared_tokens": ["practice", "embodiment"]}
+  ],
+  "summary": {"created": 1, "updated": 0, "skipped": 0, "blocked": 0, "resonance_edges_written": 2}
+}
+```
+
+### `GET /api/influences/{slug}`
+
+Return the influence + the contributors who encountered it (filtered by privacy) + concepts it resonates with.
+
+```json
+{
+  "influence": { "id": "asset:9f2a...", "name": "Becoming Supernatural", "creation_kind": "book" },
+  "encountered_by": [
+    {"contributor_id": "contributor:urs", "when_encountered": "2024-09-12", "where_encountered": null}
+  ],
+  "resonates_with": [
+    {"concept_id": "lc-attunement", "score": 0.42},
+    {"concept_id": "lc-ceremony", "score": 0.18}
+  ],
+  "created_by": {"contributor_id": "contributor:joe-dispenza-...", "name": "Joe Dispenza"}
+}
+```
+
+### `GET /api/concepts/{concept_id}/external-presences`
+
+Return the spectrum of influences resonating with this concept, grouped by `creation_kind`. Feeds `CarriedExternalPresences` on `/vision/{id}`.
+
+```json
+{
+  "concept_id": "lc-attunement",
+  "groups": [
+    {"creation_kind": "book", "family_color": "#8b6f47", "items": [
+      {"id": "asset:9f2a...", "name": "Becoming Supernatural", "score": 0.42, "image_url": "..."}
+    ]},
+    {"creation_kind": "video", "family_color": "#3b6dac", "items": [...]},
+    {"creation_kind": "gathering", "family_color": "#7a5fb8", "items": [...]}
+  ]
+}
+```
+
+### `PATCH /api/influences/{slug}/privacy`
+
+Flip an influence between public and private (only the `encountered_by` contributor can call).
+
+```json
+{ "private": true }
+```
+
+## Data Model
+
+```yaml
+ExternalInfluence:                  # rendered as asset node, type=asset
+  id: string                        # asset:{canonical_url_hash}
+  type: "asset"
+  name: string
+  description: string | null
+  canonical_url: string
+  image_url: string | null
+  creation_kind: "book" | "video" | "song" | "podcast" | "gathering" | "article" | "photo-encounter" | "correspondence"
+  private: boolean                  # default false
+  source: "audible" | "youtube" | "yt-music" | "calendar" | "photos" | "gmail" | "manual" | "takeout-import"
+  ingested_at: timestamp
+
+EncounterMetadata:                  # JSON properties on the inspired-by edge
+  when_encountered: string          # ISO date
+  where_encountered: string | null  # place node id
+  surrounding_concepts: string[]    # concept ids
+  source: string
+
+InfluenceCategory:
+  enum: ["book", "video", "song", "podcast", "gathering", "article", "photo-encounter", "correspondence"]
+
+InfluenceSource:
+  enum: ["audible", "youtube", "yt-music", "calendar", "photos", "gmail", "manual", "takeout-import"]
+
+IngestSummary:
+  created: int
+  updated: int
+  skipped: int
+  blocked:                          # privacy filter rejections, with reasons
+    - record_id: string
+      reason: "privacy:partner" | "privacy:family" | "privacy:son" | "privacy:intimate_subject" | ...
+  resonance_edges_written: int
+  errors: { record_id, message }[]
+
+PrivacyRule:                        # config/privacy_rules.json
+  pattern: string                   # regex, case-insensitive
+  domains: ["partner", "family", "son", "health", "scheduling", ...]
+  default_decision: "block" | "mark-private" | "allow"
+  applies_to_sources: string[]      # which ingest sources the rule binds to
+
+FilterDecision:
+  enum: ["allow", "mark-private", "block"]
+```
+
+## Files to Create / Modify
+
+- `api/app/services/influence_ingest.py` — `ingest_one`, `ingest_bulk`, `IngestSummary`, post-ingest attune wiring.
+- `api/app/services/influence_ingest/privacy_filter.py` — `filter_candidate`, rule loader, `FilterDecision`.
+- `api/app/services/influence_ingest/sources/audible.py` — Goodreads CSV / Audible library export parser.
+- `api/app/services/influence_ingest/sources/youtube_takeout.py` — Google Takeout `watch-history.json` parser.
+- `api/app/services/influence_ingest/sources/yt_music_takeout.py` — Google Takeout YT Music history parser.
+- `api/app/services/influence_ingest/sources/google_calendar_ics.py` — ICS feed parser → gathering assets.
+- `api/app/services/influence_ingest/sources/google_photos_takeout.py` — Photos metadata JSON parser (place + date only).
+- `api/app/services/influence_ingest/sources/gmail_takeout.py` — mbox header parser (sender + subject + date only).
+- `api/app/services/influence_ingest/sources/manual_paste.py` — single-URL passthrough wrapping `inspired_by_service.resolve`.
+- `api/app/routers/influences.py` — `POST /api/influences`, `GET /api/influences/{slug}`, `PATCH /api/influences/{slug}/privacy`, `GET /api/contributors/{id}/influences`, `GET /api/concepts/{id}/external-presences`.
+- `api/app/models/influence.py` — Pydantic shapes.
+- `api/db/migrations/NNNN_external_influences.sql` — index on `(creation_kind, private)`, `privacy_rules` table mirror.
+- `config/privacy_rules.json` — data-driven rule set; never hardcoded names.
+- `scripts/ingest_audible_csv.py`, `scripts/ingest_youtube_takeout.py`, `scripts/ingest_yt_music_takeout.py`, `scripts/ingest_google_calendar_ics.py`, `scripts/ingest_google_photos_takeout.py`, `scripts/ingest_gmail_takeout.py` — CLI wrappers.
+- `web/components/concept/CarriedExternalPresences.tsx` — spectrum-row component on each concept page.
+- `web/components/influence/InfluencePage.tsx` — influence detail page (resonating concepts + encountered-by list).
+- `web/app/influences/[slug]/page.tsx` — `/influences/{slug}` route.
+- `web/components/concept/StoryContent.tsx` (touch only) — slot the `CarriedExternalPresences` row into the existing concept page render.
+- `api/tests/test_influence_ingest.py` — unit tests (one per source, privacy filter, idempotency, attune wiring, encounter metadata, private flag).
+- `api/tests/test_flow_influences.py` — flow test for the new routes + concept aggregation.
+- `api/tests/fixtures/goodreads_sample.csv`, `youtube_watch_history_sample.json`, `calendar_sample.ics`, `photos_metadata_sample.json`, `gmail_sample.mbox` — small fixtures.
+
+## Acceptance Tests
+
+- `api/tests/test_influence_ingest.py::test_manual_paste_creates_asset_and_inspired_by_edge` — single URL ingest writes one asset + one inspired-by edge with encounter metadata; attune runs.
+- `api/tests/test_influence_ingest.py::test_audible_csv_idempotent_on_canonical_url` — two runs of the same CSV → second produces 0 created, N updated.
+- `api/tests/test_influence_ingest.py::test_youtube_takeout_bulk` — sample watch-history.json → one asset per video, attune produces resonates-with edges, IngestSummary totals match.
+- `api/tests/test_influence_ingest.py::test_calendar_ics_becomes_gathering` — one event → one asset of `creation_kind=gathering` with `at-place` + `when_encountered`.
+- `api/tests/test_influence_ingest.py::test_photos_metadata_no_pixels_only_place_and_date` — Photos ingest never reads pixels; output is encounter metadata on existing or new place-encounter assets.
+- `api/tests/test_influence_ingest.py::test_gmail_subject_filter_holds_intimate` — sample mbox containing a subject matching the partner/family pattern → the subject is blocked; `IngestSummary.blocked` records it with reason; no asset is written.
+- `api/tests/test_influence_ingest.py::test_privacy_filter_blocks_partner_pattern_before_write` — synthetic record matching the partner pattern is blocked before any graph write; never appears in any node, edge, or query.
+- `api/tests/test_influence_ingest.py::test_attune_runs_after_ingest` — newly-written asset has `resonates-with` edges to vision concepts after `ingest_one`.
+- `api/tests/test_influence_ingest.py::test_encounter_metadata_on_edge` — edge properties carry `when_encountered`, `where_encountered`, `surrounding_concepts`, `source`; second ingest merges rather than overwrites `surrounding_concepts`.
+- `api/tests/test_influence_ingest.py::test_private_flag_hides_from_public_query` — `private: true` asset is hidden from anonymous `GET /api/contributors/{id}/influences` and from `GET /api/concepts/{id}/external-presences`; the encountering contributor's authenticated view shows it.
+- `api/tests/test_flow_influences.py::test_post_get_round_trip` — POST creates, GET returns the same shape with resonance.
+- `api/tests/test_flow_influences.py::test_concept_external_presences_grouped_by_kind` — after ingesting a book + a video + a gathering, `GET /api/concepts/{id}/external-presences` returns three groups.
+
+## Verification
+
+```bash
+cd api && python -m pytest tests/test_influence_ingest.py tests/test_flow_influences.py -q
+python3 scripts/ingest_audible_csv.py --file api/tests/fixtures/goodreads_sample.csv --contributor-id contributor:urs --dry-run
+python3 scripts/ingest_youtube_takeout.py --file api/tests/fixtures/youtube_watch_history_sample.json --contributor-id contributor:urs --dry-run
+curl -s "http://localhost:8000/api/concepts/lc-attunement/external-presences" | jq '.groups[].creation_kind'
+curl -s -X POST "http://localhost:8000/api/influences" -H 'content-type: application/json' \
+  -d '{"url":"https://www.audible.com/pd/Becoming-Supernatural-Audiobook/B0791WT8K6","contributor_id":"contributor:urs","source":"audible","encounter":{"when_encountered":"2024-09-12"}}' | jq .resonance
+```
+
+## Out of Scope
+
+- **Live OAuth sync.** Google OAuth 2.0 + Audible scrape (ongoing live mirror) are explicitly out of this iteration. A future spec layers OAuth-driven ingest on top of the same `ingest_one` / `ingest_bulk` entry points; the source plugins this spec creates already carry the per-source parsing logic.
+- **Pixel-level image analysis from Google Photos.** Photos ingest reads metadata only. A future spec can add an opt-in image-tagging path; this one stays at place + date.
+- **Gmail body content.** Headers only. A future spec governs whether body content can ever be ingested; this one says no.
+- **New edge types.** All connectivity flows through `inspired-by`, `resonates-with`, `created-by`, `referenced-by`, `at-place`. If a future ingest pattern needs richer connectivity, that's a separate spec.
+- **Encounter as its own node.** Encounter metadata stays on the inspired-by edge. A future spec could promote it to a node if encounters become first-class for analytics, but the graph stays clean for now.
+- **Cross-contributor encounter aggregation** (e.g. "every contributor who encountered this book on the same day"). The data model supports this via the inspired-by edges; the read API and rendering are left to a follow-up spec.
+- **Authentication-scoped editing rules** beyond the `private` flag's encountered-by check. A broader edit-auth spec governs the graph; this spec only carves out the privacy-flag behaviour the ingest path needs.
+
+## Risks and Assumptions
+
+- **Risk**: The privacy filter is necessarily conservative — it may hold back legitimate public influences whose subject happens to match an intimate pattern. Mitigation: blocked records appear in `IngestSummary.blocked` with the matched reason; the contributor can review and either refine the rule (data-driven) or override per-record. The filter errs on the side of holding back; presence over surfacing.
+- **Risk**: Goodreads CSV is an Audible adjacency, not the canonical Audible export — some books in an Audible library don't appear in Goodreads. Mitigation: this spec ships the Goodreads path as the first buildable Audible-adjacent flow; a richer Audible parser is a future enhancement once OAuth sync is in scope.
+- **Risk**: YouTube Takeout exports are large (tens of thousands of entries for long-time users); naive ingest could overwhelm the resonance attune step. Mitigation: bulk ingest batches attune calls and reports total resonance edges written; if performance becomes a concern, attune can be deferred to an off-line sweep without changing the API contract.
+- **Risk**: Google Photos location data carries privacy weight even without pixels (a home address pattern across many photos exposes residence). Mitigation: the privacy filter applies to Photos metadata too; residence-pattern detection (multiple encounters at the same private location) can flow `mark-private` rather than `allow`.
+- **Assumption**: `inspired_by_service.ensure_identity()` handles the `asset` node type as well as the contributor types it was originally written for. If the asset path needs additional defaults (e.g. `claimable: true` already in `_ensure_creation_nodes`), this spec extends `ensure_identity` rather than forking.
+- **Assumption**: The vision concepts already in the graph carry enough story_content for `resonance_service.attune` to produce meaningful overlap with influence keywords. Verified for the existing lc-* concepts; sparse concepts will produce sparse resonance, which is the right behaviour.

--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 148
+**Total files**: 153
 
 | Route | File | Purpose |
 |---|---|---|
@@ -56,6 +56,7 @@
 | `/federation` | [page.tsx](federation/page.tsx) | _no top-of-file purpose_ |
 | `/feed` | [page.tsx](feed/page.tsx) | _no top-of-file purpose_ |
 | `/feed/you` | [page.tsx](feed/you/page.tsx) | _no top-of-file purpose_ |
+| `/field/urs` | [page.tsx](field/urs/page.tsx) | _no top-of-file purpose_ |
 | `/flow` | [page.tsx](flow/page.tsx) | _no top-of-file purpose_ |
 | `/friction` | [page.tsx](friction/page.tsx) | _no top-of-file purpose_ |
 | `/gates` | [page.tsx](gates/page.tsx) | _no top-of-file purpose_ |
@@ -89,14 +90,17 @@
 | `/ontology` | [page.tsx](ontology/page.tsx) | _no top-of-file purpose_ |
 | `/` | [page.tsx](page.tsx) | _no top-of-file purpose_ |
 | `/peers` | [page.tsx](peers/page.tsx) | _no top-of-file purpose_ |
+| `/people/[id]/edit` | [page.tsx](people/[id]/edit/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]` | [page.tsx](people/[id]/page.tsx) | _no top-of-file purpose_ |
 | `/people/aly-constantine` | [page.tsx](people/aly-constantine/page.tsx) | _no top-of-file purpose_ |
 | `/people/aubrey-marcus` | [page.tsx](people/aubrey-marcus/page.tsx) | _no top-of-file purpose_ |
 | `/people/bloomurian` | [page.tsx](people/bloomurian/page.tsx) | _no top-of-file purpose_ |
 | `/people/edit-your-profile` | [page.tsx](people/edit-your-profile/page.tsx) | _no top-of-file purpose_ |
 | `/people/elios` | [page.tsx](people/elios/page.tsx) | _no top-of-file purpose_ |
+| `/people/elon-musk` | [page.tsx](people/elon-musk/page.tsx) | _no top-of-file purpose_ |
 | `/people/grab` | [page.tsx](people/grab/page.tsx) | _no top-of-file purpose_ |
 | `/people/ilena` | [page.tsx](people/ilena/page.tsx) | _no top-of-file purpose_ |
+| `/people/joshua-golden` | [page.tsx](people/joshua-golden/page.tsx) | _no top-of-file purpose_ |
 | `/people/lex-fridman` | [page.tsx](people/lex-fridman/page.tsx) | _no top-of-file purpose_ |
 | `/people/matias-de-stefano` | [page.tsx](people/matias-de-stefano/page.tsx) | _no top-of-file purpose_ |
 | `/people/mose` | [page.tsx](people/mose/page.tsx) | _no top-of-file purpose_ |
@@ -129,6 +133,7 @@
 | `/share` | [page.tsx](share/page.tsx) | _no top-of-file purpose_ |
 | `/signals` | [page.tsx](signals/page.tsx) | _no top-of-file purpose_ |
 | `/silence/[slug]` | [page.tsx](silence/[slug]/page.tsx) | _no top-of-file purpose_ |
+| `/silence/built/design-log` | [page.tsx](silence/built/design-log/page.tsx) | _no top-of-file purpose_ |
 | `/silence/built` | [page.tsx](silence/built/page.tsx) | _no top-of-file purpose_ |
 | `/silence` | [page.tsx](silence/page.tsx) | _no top-of-file purpose_ |
 | `/specs/[spec_id]` | [page.tsx](specs/[spec_id]/page.tsx) | _no top-of-file purpose_ |

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -28,6 +28,7 @@ import { ResonantAssets } from "./_components/ResonantAssets";
 import { CarriedBy } from "./_components/CarriedBy";
 import { ConceptVoices } from "./_components/ConceptVoices";
 import { ReactionBar } from "@/components/ReactionBar";
+import { InfluenceWeb } from "@/components/presence/InfluenceWeb";
 
 export const dynamic = "force-dynamic";
 
@@ -347,6 +348,15 @@ export default async function VisionConceptPage({
             {/* Multiple visual expressions — most resonant rises */}
             <div className="max-w-3xl">
               <ResonantAssets conceptId={conceptId} />
+            </div>
+
+            {/* Every related thread the field has woven through this
+                concept — concepts it bridges, presences carrying it,
+                external influences honoring it through shared
+                vibrational resonance — painted in the spectrum color
+                of each relationship's family. */}
+            <div className="max-w-3xl">
+              <InfluenceWeb presenceId={conceptId} />
             </div>
 
             {/* Live signals from the world resonating with this concept */}

--- a/web/components/presence/InfluenceWeb.tsx
+++ b/web/components/presence/InfluenceWeb.tsx
@@ -262,6 +262,51 @@ function ExternalPresenceRow({ presences }: { presences: ExternalPresence[] }) {
   );
 }
 
+/**
+ * Patterns in graph node ids that mark system tissue — runners, test
+ * fixtures, visitors, agent identities. These never render as
+ * relationship chips on a public presence page.
+ *
+ * Mirrors the filter rules used by the /people directory in
+ * `web/content/presence-walk/en.json`. The list lives in two places
+ * for now; consolidating into a shared lib is future-breath work.
+ */
+const SYSTEM_ID_PATTERNS = [
+  ":wanderer-",
+  ":presence-visitor",
+  ":test-",
+  ":smoke-",
+  "-smoke-",
+  "-bot",
+  ":external-proof",
+  "decomposition-verify",
+  ":friend-",
+  "-placeholder",
+  ":claude-opus-mac-node",
+  ":coherence-runner",
+  ":e-m-t-",
+  ":email-",
+  ":qa-",
+  ":ci-",
+];
+const SYSTEM_EXACT_IDS = new Set([
+  "contributor:claude",
+  "contributor:codex",
+  "contributor:codex-agent",
+  "contributor:cursor-agent",
+  "contributor:grok",
+  "contributor:gemini",
+  "person:codex-smoke-human",
+  "contributor:presence-visitor",
+  "person:presence-visitor",
+]);
+
+function isSystemNode(id: string | undefined | null): boolean {
+  if (!id) return false;
+  if (SYSTEM_EXACT_IDS.has(id)) return true;
+  return SYSTEM_ID_PATTERNS.some((p) => id.includes(p));
+}
+
 function groupByFamily(
   edges: EdgeRow[],
   selfId: string,
@@ -272,10 +317,12 @@ function groupByFamily(
     const isOutgoing = e.from_id === selfId;
     const other = isOutgoing ? e.to_node : e.from_node;
     if (!other) continue;
-    // Hide self-loops and assets (assets render as creations elsewhere
-    // on the page, not as relationship chips).
+    // Hide self-loops, assets, and system tissue (visitors, runners,
+    // test fixtures). Assets render as creations elsewhere on the
+    // page, not as relationship chips.
     if (other.id === selfId) continue;
     if (other.type === "asset") continue;
+    if (isSystemNode(other.id)) continue;
     const slug = (other as { slug?: string | null }).slug;
     const href = slug
       ? `/people/${slug}`

--- a/web/lib/INDEX.md
+++ b/web/lib/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 28
+**Total files**: 29
 
 | File | Purpose |
 |---|---|
@@ -14,6 +14,7 @@
 | [attribution-ping-dedupe.ts](attribution-ping-dedupe.ts) | _no top-of-file purpose_ |
 | [attribution-target.ts](attribution-target.ts) | _no top-of-file purpose_ |
 | [automation-page-data.ts](automation-page-data.ts) | _no top-of-file purpose_ |
+| [edge-spectrum.ts](edge-spectrum.ts) | Spectrum colors for the seven canonical edge-type families. |
 | [egress.ts](egress.ts) | _no top-of-file purpose_ |
 | [fetch.ts](fetch.ts) | _no top-of-file purpose_ |
 | [html-entities.ts](html-entities.ts) | Many imported asset descriptions arrive carrying WordPress HTML |


### PR DESCRIPTION
## Summary
- New CLI [`scripts/encounter.py`](scripts/encounter.py) flows external influences into the graph from a contributor's body of evidence — books, talks, songs, gatherings.
- Single-input or bulk-from-file. Lines starting with \`>\` become encounter notes recording what was happening in the field when the influence met the body. Notes land as edge metadata on the inspired-by edge.
- Reuses `inspired_by_service.resolve` + `import_inspired_by` (now auto-attuning against vision concepts), so each encounter automatically lays both the inspired-by edge and the resonates-with edges to concepts sharing frequency.
- The first practical path on [`specs/external-influences-ingest.md`](specs/external-influences-ingest.md). Goodreads-CSV and YouTube-Takeout adapters follow as their own breaths.

## Test plan
- [x] `python3 scripts/encounter.py --help` renders the docstring
- [ ] post-merge: run with one real URL (Robert's TEDx, an Audible book page, a YouTube talk) and verify graph node + concept resonance edges appear
- [ ] bulk run from a small text file works idempotently (re-runs don't duplicate edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)