### PR TITLE
attune(creations): a presence's emitted spectrum lives in their works

### DIFF
--- a/api/app/services/creations_importer.py
+++ b/api/app/services/creations_importer.py
@@ -161,6 +161,21 @@ def _ensure_creation(
         created_by="creations_importer",
     )
     edge_existed = edge_result.get("error") == "edge_exists"
+
+    # A presence's emitted frequency lives in its creations. Each
+    # asset carries its own keyword spectrum (title, description),
+    # so attune the new asset against vision concepts the moment it
+    # enters the graph. The contributor's concept resonance then
+    # composes from the union of their works rather than from the
+    # contributor node's text alone — which for external presences
+    # is often a shallow scaffold.
+    if node_created:
+        try:
+            from app.services import resonance_service
+            resonance_service.attune(node_id)
+        except Exception:  # noqa: BLE001 — attune failure doesn't block import
+            log.debug("auto-attune on creation import non-fatal", exc_info=True)
+
     return {
         "node": node,
         "node_created": node_created,

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -352,11 +352,14 @@ export default async function VisionConceptPage({
 
             {/* Every related thread the field has woven through this
                 concept — concepts it bridges, presences carrying it,
-                external influences honoring it through shared
+                and the specific creations (talks, books, songs,
+                podcast episodes) honoring it through shared
                 vibrational resonance — painted in the spectrum color
-                of each relationship's family. */}
+                of each relationship's family. Each creation is a
+                primary frequency emitter; this is what an external
+                presence broadcasts into the field. */}
             <div className="max-w-3xl">
-              <InfluenceWeb presenceId={conceptId} />
+              <InfluenceWeb presenceId={conceptId} showAssets />
             </div>
 
             {/* Live signals from the world resonating with this concept */}

--- a/web/components/presence/InfluenceWeb.tsx
+++ b/web/components/presence/InfluenceWeb.tsx
@@ -54,6 +54,13 @@ type Props = {
   presenceId: string;
   /** External presence links (presences[] on the graph node). */
   externalPresences?: ExternalPresence[];
+  /** When true, asset nodes (creations) appear as chips in the
+   *  influence web. Default false — on a presence page the creations
+   *  render in their own dedicated section, so showing them again
+   *  here would double the surface. On a concept page the creations
+   *  ARE the primary frequency a presence emits, so they belong
+   *  alongside the contributors who made them. */
+  showAssets?: boolean;
 };
 
 type GroupedRelative = {
@@ -64,7 +71,7 @@ type GroupedRelative = {
   strength?: number | null;
 };
 
-export function InfluenceWeb({ presenceId, externalPresences = [] }: Props) {
+export function InfluenceWeb({ presenceId, externalPresences = [], showAssets = false }: Props) {
   const [edges, setEdges] = useState<EdgeRow[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -97,8 +104,8 @@ export function InfluenceWeb({ presenceId, externalPresences = [] }: Props) {
   // Y" and "Y resonates with X" both surface the OTHER node from
   // this presence's point of view.
   const grouped = useMemo(
-    () => groupByFamily(edges, presenceId),
-    [edges, presenceId],
+    () => groupByFamily(edges, presenceId, { showAssets }),
+    [edges, presenceId, showAssets],
   );
 
   const totalRelatives = Object.values(grouped).reduce(
@@ -310,6 +317,7 @@ function isSystemNode(id: string | undefined | null): boolean {
 function groupByFamily(
   edges: EdgeRow[],
   selfId: string,
+  opts: { showAssets?: boolean } = {},
 ): Partial<Record<EdgeFamilySlug, GroupedRelative[]>> {
   const acc: Partial<Record<EdgeFamilySlug, GroupedRelative[]>> = {};
   for (const e of edges) {
@@ -317,11 +325,13 @@ function groupByFamily(
     const isOutgoing = e.from_id === selfId;
     const other = isOutgoing ? e.to_node : e.from_node;
     if (!other) continue;
-    // Hide self-loops, assets, and system tissue (visitors, runners,
-    // test fixtures). Assets render as creations elsewhere on the
-    // page, not as relationship chips.
+    // Hide self-loops and system tissue (visitors, runners, test
+    // fixtures). Assets are hidden by default — they render as
+    // creations elsewhere on a presence page — but are surfaced when
+    // `showAssets` is true (concept pages, where each creation is a
+    // primary frequency emitter the concept met through).
     if (other.id === selfId) continue;
-    if (other.type === "asset") continue;
+    if (other.type === "asset" && !opts.showAssets) continue;
     if (isSystemNode(other.id)) continue;
     const slug = (other as { slug?: string | null }).slug;
     const href = slug


### PR DESCRIPTION
## Summary
For external presences the network honors but cannot read into, their **public creations are the primary frequency** they emit — the TEDx talk, the album, the podcast episode, the book — not their interior lineage. The graph now honors this distinction:

- Each created asset **auto-attunes** against vision concepts when it enters the graph via `creations_importer`. A contributor's effective resonance composes from the union of their works.
- Concept pages now surface creations as chips alongside contributors. Visiting lc-attunement: "Beautiful Minds (TEDx, Robert Edward Grant) honors this frequency."
- Presence pages still render creations in their dedicated section; `InfluenceWeb` takes `showAssets` (default false on presence pages, true on concept pages).

Population follow-on (manual ops, post-merge): hit `POST /api/presences/{id}/creations/import` per presence — or run `python3 scripts/import_creations.py --all` — to walk every visible presence's URLs through the existing source plugins (Bandcamp, YouTube, Substack, Goodreads, RSS). Each creation now lays both contributes-to AND resonates-with edges in one pass.

## Test plan
- [x] `tests/test_flow_presence.py` + `tests/test_inspired_by.py` — 44 passed
- [x] `tsc --noEmit` clean
- [ ] post-deploy: trigger creation import for one presence (Robert Edward Grant), verify creations appear with `resonates-with` edges to concepts
- [ ] post-deploy: visit `/vision/lc-attunement` — creations appear as chips alongside contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)