### PR TITLE
attune(creations): sampling discipline — honesty about what the body sees

### DIFF
--- a/api/app/services/creations_importer.py
+++ b/api/app/services/creations_importer.py
@@ -43,6 +43,58 @@ log = logging.getLogger(__name__)
 # etc.) don't carry creations and would only generate noise.
 _PRESENCE_TYPES = ("contributor", "community", "scene", "network-org")
 
+# Sampling discipline. The body of public work a presence has emitted
+# is much larger than any single feed surfaces. Recency-biased feeds
+# return latest-N; without discipline a presence's "spectrum" becomes
+# whatever they happened to publish last week, not what they have
+# emitted across their career.
+#
+# The discipline:
+# - Per-source cap (`_PER_SOURCE_TARGET`) keeps any one platform from
+#   dominating the presence's emitted spectrum.
+# - When a source returns more than the cap, we stratify across the
+#   returned ordering — oldest, newest, plus an evenly-spaced middle
+#   sample — rather than truncating to first-N.
+# - Coverage gaps are recorded on the contributor node so the body
+#   knows where its sampling is thin and where the spectrum we're
+#   drawing is partial.
+_PER_SOURCE_TARGET = 30
+
+
+def _stratify(items: list[Any], target: int) -> list[Any]:
+    """Stratified sample across an ordered list.
+
+    When ``items`` has at most ``target`` entries the whole list is
+    returned. Otherwise the sample includes the oldest entries (tail
+    of the list, since most feeds list newest-first), the newest
+    entries (head), and an evenly-spaced middle slice — together
+    spanning the breadth of what the source returned rather than
+    concentrating on first-N.
+
+    Returns items in source order so dedupe keys stay stable.
+    """
+    n = len(items)
+    if n <= target or target <= 0:
+        return list(items)
+    # Reserve thirds: newest, evenly-spaced middle, oldest.
+    third = max(1, target // 3)
+    newest = list(range(0, third))
+    oldest = list(range(n - third, n))
+    middle_count = target - len(newest) - len(oldest)
+    if middle_count > 0:
+        # Evenly spaced indexes across the middle band.
+        lo = third
+        hi = n - third - 1
+        if hi <= lo:
+            middle = []
+        else:
+            step = (hi - lo) / (middle_count + 1)
+            middle = [int(lo + step * (i + 1)) for i in range(middle_count)]
+    else:
+        middle = []
+    chosen = sorted(set(newest + middle + oldest))
+    return [items[i] for i in chosen]
+
 
 def _gather_source_urls(presence: dict[str, Any]) -> list[str]:
     """Read every URL on the presence node that a creation source
@@ -244,6 +296,7 @@ def import_for_presence(
     invalid_kind_count = 0
     errors: list[dict[str, Any]] = []
 
+    coverage: dict[str, dict[str, Any]] = {}
     for url in source_urls:
         sources = _matching_sources(url, only=only_source)
         if not sources:
@@ -255,6 +308,19 @@ def import_for_presence(
                 log.warning("creation source %s failed on %s: %s", source.name, url, exc)
                 errors.append({"url": url, "source": source.name, "reason": "fetch_error"})
                 continue
+            # Sampling discipline — stratify across the full returned
+            # ordering when the source surfaced more than the per-source
+            # target. Records what we saw vs what we kept so the body
+            # can sense its own coverage gaps later.
+            returned_total = len(creations)
+            creations = _stratify(creations, _PER_SOURCE_TARGET)
+            entry = coverage.setdefault(
+                source.name,
+                {"returned": 0, "sampled": 0, "urls": []},
+            )
+            entry["returned"] += returned_total
+            entry["sampled"] += len(creations)
+            entry["urls"].append(url)
             for creation in creations:
                 # Normalize kind at the import boundary. `is_valid_kind`
                 # accepts case-insensitive input, but downstream the
@@ -299,12 +365,35 @@ def import_for_presence(
                     else:
                         imported.append(result)
 
+    # Record the coverage map on the presence so the next run, the
+    # rendering layer, and any humans looking at the data can sense
+    # what's been sampled vs what each source returned. Keeps gaps
+    # visible rather than silent.
+    if not dry_run and coverage:
+        from datetime import datetime, timezone
+        try:
+            graph_service.update_node(
+                node_id,
+                properties={
+                    "creations_coverage": {
+                        "by_source": coverage,
+                        "total_returned": sum(c["returned"] for c in coverage.values()),
+                        "total_sampled": sum(c["sampled"] for c in coverage.values()),
+                        "per_source_target": _PER_SOURCE_TARGET,
+                        "sampled_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                },
+            )
+        except Exception:  # noqa: BLE001 — coverage record isn't load-bearing
+            log.debug("coverage record write non-fatal", exc_info=True)
+
     return {
         "node_id": node_id,
         "source_urls": source_urls,
         "creations_imported": len(imported),
         "creations_skipped_dedupe": dedupe_count,
         "creations_skipped_invalid_kind": invalid_kind_count,
+        "creations_coverage": coverage,
         "errors": errors,
         "imported": imported,
         "dry_run": dry_run,

--- a/api/app/services/creations_importer.py
+++ b/api/app/services/creations_importer.py
@@ -161,6 +161,21 @@ def _ensure_creation(
         created_by="creations_importer",
     )
     edge_existed = edge_result.get("error") == "edge_exists"
+
+    # A presence's emitted frequency lives in its creations. Each
+    # asset carries its own keyword spectrum (title, description),
+    # so attune the new asset against vision concepts the moment it
+    # enters the graph. The contributor's concept resonance then
+    # composes from the union of their works rather than from the
+    # contributor node's text alone — which for external presences
+    # is often a shallow scaffold.
+    if node_created:
+        try:
+            from app.services import resonance_service
+            resonance_service.attune(node_id)
+        except Exception:  # noqa: BLE001 — attune failure doesn't block import
+            log.debug("auto-attune on creation import non-fatal", exc_info=True)
+
     return {
         "node": node,
         "node_created": node_created,

--- a/api/tests/test_flow_presence.py
+++ b/api/tests/test_flow_presence.py
@@ -1261,3 +1261,33 @@ async def test_get_node_resolves_by_slug_when_id_misses():
             assert r.status_code == 404
     finally:
         _gs.delete_node(node_id)
+
+
+# ── Sampling discipline (creations stratification) ────────────────────
+
+
+def test_stratify_returns_breadth_when_source_returns_more_than_cap():
+    """Sampling discipline: when a source returns more than the
+    per-source target, the importer takes a stratified slice across
+    the full ordering — newest, evenly-spaced middle, oldest — rather
+    than truncating to first-N.
+
+    Without this discipline, a presence's "spectrum" becomes whatever
+    they happened to publish last week, not what they have emitted
+    across their career.
+    """
+    from app.services.creations_importer import _stratify
+
+    # 100 items, cap 30 — should pull a spread, including the very
+    # last item (oldest) and items from the middle band.
+    items = list(range(100))
+    out = _stratify(items, target=30)
+    assert len(out) == 30
+    assert 0 in out, "newest end must be sampled"
+    assert 99 in out, "oldest end must be sampled"
+    middle_hits = [i for i in out if 30 < i < 70]
+    assert middle_hits, "middle band must be represented"
+
+    # Below the cap: pass through unchanged.
+    small = list(range(10))
+    assert _stratify(small, target=30) == small

--- a/specs/external-influences-ingest.md
+++ b/specs/external-influences-ingest.md
@@ -361,6 +361,28 @@ curl -s -X POST "http://localhost:8000/api/influences" -H 'content-type: applica
 - **Cross-contributor encounter aggregation** (e.g. "every contributor who encountered this book on the same day"). The data model supports this via the inspired-by edges; the read API and rendering are left to a follow-up spec.
 - **Authentication-scoped editing rules** beyond the `private` flag's encountered-by check. A broader edit-auth spec governs the graph; this spec only carves out the privacy-flag behaviour the ingest path needs.
 
+## Sampling discipline (the body's emitted spectrum)
+
+A presence's emitted frequency lives in their **public creations** — the works they have shipped into the field. For external presences whose interior we cannot read into, those creations are the only signal we have, and they are the right signal: a body of work is the practitioner's own statement of what they emit.
+
+Sampling these works without discipline introduces several biases that distort the spectrum we render:
+
+- **Recency bias** — most platform feeds (RSS, YouTube uploads pages, podcast feeds) return the latest N items. A presence with a 20-year career and a 4-year-old TEDx talk that defines them gets sampled as "what they posted last month." The TEDx is invisible.
+- **Volume bias** — whichever platform offers the cleanest feed dominates the chip count. A podcaster with a Bandcamp-style discography page may yield 200 entries; a polymath with a personal RSS may yield 10. The visitor reads "this one is more present in the field" when the truth is "this one had the better feed."
+- **Platform bias** — sources we have plugins for (Bandcamp, YouTube, Substack, Goodreads, RSS) catch some emissions; sources we don't (Spotify, Apple Podcasts, Vimeo, Patreon, Instagram, university repositories, Wikipedia bibliographies) catch nothing. Presences who broadcast primarily on uncovered platforms emit zero chips even when their public body is enormous.
+- **Format bias** — a 30-second Instagram reel and a 90-minute TEDx talk become equivalent asset nodes. The reel emits the same chip-weight as the talk; density is unweighted.
+- **Within-source bias** — even from one platform, what surfaces in one crawl is determined by what the page renders in that crawl. No stratification across the source's full catalog.
+
+The discipline this spec commits to:
+
+1. **Per-source target with stratified sampling.** When a source returns more than the per-source target (`_PER_SOURCE_TARGET`, default 30), the importer takes a stratified slice across the full returned ordering — newest, evenly-spaced middle, oldest — rather than truncating to first-N. The cap prevents one platform from dominating; the stratification prevents recency from dominating within that cap.
+2. **Coverage record on the presence.** Every import writes a `creations_coverage` property on the contributor node: per-source returned/sampled counts, the URLs walked, the timestamp. Gaps stay visible. The body knows where its sampling is thin.
+3. **Encyclopedic baseline source (planned).** A Wikipedia source plugin reads "Notable works" / "Bibliography" / "Filmography" sections and creates assets from there. Wikipedia's curation is human-balanced across a presence's career, providing a temporally-spread baseline that platform feeds cannot. Out of scope for the first iteration; tracked in `Out of Scope` below.
+4. **Density weighting (planned).** Each `creation_kind` (book, talk, episode, video, song, post) carries a relative density weight when aggregated into a presence's effective resonance. A book contributes more to the rolled-up frequency than a tweet. Out of scope for the first iteration; tracked.
+5. **Source-coverage gap log.** Presences whose `presences[]` URLs match no source plugin ingest 0 creations; the coverage record makes this visible so future plugin development can prioritize the platforms with the largest gaps.
+
+The discipline is not a guarantee of representativeness. It is a guarantee of **honesty**: the body knows what it has sampled, what it has not, and where its rendered spectrum is partial.
+
 ## Risks and Assumptions
 
 - **Risk**: The privacy filter is necessarily conservative — it may hold back legitimate public influences whose subject happens to match an intimate pattern. Mitigation: blocked records appear in `IngestSummary.blocked` with the matched reason; the contributor can review and either refine the rule (data-driven) or override per-record. The filter errs on the side of holding back; presence over surfacing.

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -352,11 +352,14 @@ export default async function VisionConceptPage({
 
             {/* Every related thread the field has woven through this
                 concept — concepts it bridges, presences carrying it,
-                external influences honoring it through shared
+                and the specific creations (talks, books, songs,
+                podcast episodes) honoring it through shared
                 vibrational resonance — painted in the spectrum color
-                of each relationship's family. */}
+                of each relationship's family. Each creation is a
+                primary frequency emitter; this is what an external
+                presence broadcasts into the field. */}
             <div className="max-w-3xl">
-              <InfluenceWeb presenceId={conceptId} />
+              <InfluenceWeb presenceId={conceptId} showAssets />
             </div>
 
             {/* Live signals from the world resonating with this concept */}

--- a/web/components/presence/InfluenceWeb.tsx
+++ b/web/components/presence/InfluenceWeb.tsx
@@ -54,6 +54,13 @@ type Props = {
   presenceId: string;
   /** External presence links (presences[] on the graph node). */
   externalPresences?: ExternalPresence[];
+  /** When true, asset nodes (creations) appear as chips in the
+   *  influence web. Default false — on a presence page the creations
+   *  render in their own dedicated section, so showing them again
+   *  here would double the surface. On a concept page the creations
+   *  ARE the primary frequency a presence emits, so they belong
+   *  alongside the contributors who made them. */
+  showAssets?: boolean;
 };
 
 type GroupedRelative = {
@@ -64,7 +71,7 @@ type GroupedRelative = {
   strength?: number | null;
 };
 
-export function InfluenceWeb({ presenceId, externalPresences = [] }: Props) {
+export function InfluenceWeb({ presenceId, externalPresences = [], showAssets = false }: Props) {
   const [edges, setEdges] = useState<EdgeRow[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -97,8 +104,8 @@ export function InfluenceWeb({ presenceId, externalPresences = [] }: Props) {
   // Y" and "Y resonates with X" both surface the OTHER node from
   // this presence's point of view.
   const grouped = useMemo(
-    () => groupByFamily(edges, presenceId),
-    [edges, presenceId],
+    () => groupByFamily(edges, presenceId, { showAssets }),
+    [edges, presenceId, showAssets],
   );
 
   const totalRelatives = Object.values(grouped).reduce(
@@ -310,6 +317,7 @@ function isSystemNode(id: string | undefined | null): boolean {
 function groupByFamily(
   edges: EdgeRow[],
   selfId: string,
+  opts: { showAssets?: boolean } = {},
 ): Partial<Record<EdgeFamilySlug, GroupedRelative[]>> {
   const acc: Partial<Record<EdgeFamilySlug, GroupedRelative[]>> = {};
   for (const e of edges) {
@@ -317,11 +325,13 @@ function groupByFamily(
     const isOutgoing = e.from_id === selfId;
     const other = isOutgoing ? e.to_node : e.from_node;
     if (!other) continue;
-    // Hide self-loops, assets, and system tissue (visitors, runners,
-    // test fixtures). Assets render as creations elsewhere on the
-    // page, not as relationship chips.
+    // Hide self-loops and system tissue (visitors, runners, test
+    // fixtures). Assets are hidden by default — they render as
+    // creations elsewhere on a presence page — but are surfaced when
+    // `showAssets` is true (concept pages, where each creation is a
+    // primary frequency emitter the concept met through).
     if (other.id === selfId) continue;
-    if (other.type === "asset") continue;
+    if (other.type === "asset" && !opts.showAssets) continue;
     if (isSystemNode(other.id)) continue;
     const slug = (other as { slug?: string | null }).slug;
     const href = slug


### PR DESCRIPTION
## Summary
A presence's emitted spectrum was being shaped by whichever platform happened to surface latest-N. Robert's TEDx invisible; Lex's last 24 episodes (#473–#496) representing his entire 496+ podcast career; presences without supported platforms emitting zero chips even when their public body is enormous.

This commit lands the **sampling discipline**:

- **Per-source target with stratified sampling.** When a source returns more than the target (default 30), the importer takes a stratified slice across the full ordering — newest, evenly-spaced middle, oldest — rather than truncating to first-N.
- **Coverage record on the presence.** `creations_coverage` property carries per-source returned/sampled counts, URLs walked, timestamp. Gaps stay visible.
- **Spec discipline section** in `specs/external-influences-ingest.md` naming the five biases (recency, volume, platform, format, within-source) and the principles for addressing each.

The discipline isn't a guarantee of representativeness. It's a guarantee of **honesty** — the body knows what it has sampled, what it has not, and where the spectrum is partial.

Wikipedia source plugin (encyclopedic baseline) and density weighting are flagged as next-breath work.

## Test plan
- [x] `tests/test_flow_presence.py` — 33 passed (including the new `test_stratify_returns_breadth_when_source_returns_more_than_cap`)
- [ ] post-merge: re-import Lex's creations, confirm coverage record shows `returned > sampled` and the stratified slice spans early to recent episodes (not just #473–#496)

🤖 Generated with [Claude Code](https://claude.com/claude-code)