### PR TITLE
attune(creations): loudness-aware sampling + watch-history ingest

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 29 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 46 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 153 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 84 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 85 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/services/creation_sources/base.py
+++ b/api/app/services/creation_sources/base.py
@@ -56,6 +56,13 @@ class ImportedCreation:
     because it's how dedupe keys against existing graph nodes.
     `image_url`, `description`, and `when` are best-effort
     enrichment that the renderer uses when present.
+
+    `view_count` (when a source can read it — YouTube's renderer
+    surfaces it, others typically don't) carries the loudness of
+    this creation's broadcast into the field. The aggregation layer
+    weights a presence's emitted spectrum by view counts so a
+    high-viewed TEDx talk emits more strongly than a low-viewed
+    behind-the-scenes clip.
     """
     name: str
     kind: str
@@ -63,6 +70,7 @@ class ImportedCreation:
     image_url: str | None = None
     description: str | None = None
     when: str | None = None  # release date if known (free-text ISO or label)
+    view_count: int | None = None  # public reach signal when available
 
 
 class CreationSource(Protocol):

--- a/api/app/services/creation_sources/youtube_source.py
+++ b/api/app/services/creation_sources/youtube_source.py
@@ -2,13 +2,20 @@
 
 YouTube channel pages embed an enormous JSON blob in
 ``var ytInitialData = …`` that holds every recent upload's
-title, video id, and thumbnail. We extract video items from that
-blob — no API key, no rate-limited official endpoint, just the
-public page the same as any browser would.
+title, video id, thumbnail, view count, and published time text.
+We extract video items from that blob — no API key, no
+rate-limited official endpoint, just the public page the same as
+any browser would.
 
 Each match becomes an ``ImportedCreation`` with ``kind="video"``.
-Capped at 24 most recent (a presence page renders a band of recent
-videos, not a 600-video catalog).
+View counts ride along as a property so the rendering layer can
+weight a presence's emitted spectrum by which works actually
+broadcast loudest into the field.
+
+The cap is set generously so the importer's stratified-sampling
+discipline has material to spread across rather than just truncating
+to first-N. The body of work a YouTuber emits is never truly the
+last 24 uploads.
 """
 from __future__ import annotations
 
@@ -21,7 +28,7 @@ from .base import ImportedCreation
 from ._http import safe_get
 
 
-YOUTUBE_VIDEO_CAP = 24
+YOUTUBE_VIDEO_CAP = 60
 
 # Match `var ytInitialData = {…};` — content stops at the closing
 # `};` on its own line. Greedy match between the assignment and
@@ -104,6 +111,7 @@ def _extract_videos(html: str) -> list[ImportedCreation]:
             t = pt.get("simpleText")
             if isinstance(t, str):
                 published_text = t.strip()
+        view_count = _parse_view_count(node)
         seen_ids.add(vid)
         found.append(ImportedCreation(
             name=unescape(title)[:200],
@@ -111,10 +119,51 @@ def _extract_videos(html: str) -> list[ImportedCreation]:
             url=f"https://www.youtube.com/watch?v={vid}",
             image_url=image,
             when=published_text,
+            view_count=view_count,
         ))
         if len(found) >= YOUTUBE_VIDEO_CAP:
             break
     return found
+
+
+_VIEW_COUNT_NUM = re.compile(r"([0-9][0-9.,]*)\s*([KMB]?)\s*views?", re.IGNORECASE)
+
+
+def _parse_view_count(node: dict) -> int | None:
+    """Extract the integer view count from a YouTube videoRenderer.
+
+    The renderer carries view counts in two places — `viewCountText`
+    (visible label, e.g. "1.2M views") and `shortViewCountText`
+    (compact label). We try the visible one first and parse the
+    "K/M/B" suffix when present. Returns None when no count is
+    readable; that's normal for newly-published videos and shorts.
+    """
+    for key in ("viewCountText", "shortViewCountText"):
+        slot = node.get(key)
+        if not isinstance(slot, dict):
+            continue
+        text: str | None = None
+        if isinstance(slot.get("simpleText"), str):
+            text = slot["simpleText"]
+        else:
+            runs = slot.get("runs")
+            if isinstance(runs, list) and runs:
+                first = runs[0]
+                if isinstance(first, dict) and isinstance(first.get("text"), str):
+                    text = first["text"]
+        if not text:
+            continue
+        m = _VIEW_COUNT_NUM.search(text)
+        if not m:
+            continue
+        raw, suffix = m.group(1), (m.group(2) or "").upper()
+        try:
+            value = float(raw.replace(",", ""))
+        except ValueError:
+            continue
+        multiplier = {"K": 1_000, "M": 1_000_000, "B": 1_000_000_000}.get(suffix, 1)
+        return int(value * multiplier)
+    return None
 
 
 class YouTubeSource:

--- a/api/app/services/creations_importer.py
+++ b/api/app/services/creations_importer.py
@@ -65,34 +65,64 @@ def _stratify(items: list[Any], target: int) -> list[Any]:
     """Stratified sample across an ordered list.
 
     When ``items`` has at most ``target`` entries the whole list is
-    returned. Otherwise the sample includes the oldest entries (tail
-    of the list, since most feeds list newest-first), the newest
-    entries (head), and an evenly-spaced middle slice — together
-    spanning the breadth of what the source returned rather than
-    concentrating on first-N.
+    returned. Otherwise the sample weaves four bands together:
+
+    - Newest (head of the list, since most feeds are newest-first)
+    - Oldest (tail of the list)
+    - Evenly-spaced middle (career-spanning coverage)
+    - Highest-loudness — top items by ``view_count`` when present
+
+    The view-count band makes "general signal" — what a presence
+    actually broadcast loudest into the field — visible in the
+    sample even when those works fall outside the temporal bands.
+    Items without a view count are skipped from that band only;
+    they still participate in the temporal bands.
 
     Returns items in source order so dedupe keys stay stable.
     """
     n = len(items)
     if n <= target or target <= 0:
         return list(items)
-    # Reserve thirds: newest, evenly-spaced middle, oldest.
-    third = max(1, target // 3)
-    newest = list(range(0, third))
-    oldest = list(range(n - third, n))
-    middle_count = target - len(newest) - len(oldest)
+    # Quarter-reserves so each band has weight without crowding out
+    # the others. With target=30: 8 newest + 8 oldest + 8 by-views +
+    # 6 evenly-spaced middle = 30.
+    quarter = max(1, target // 4)
+    newest = set(range(0, quarter))
+    oldest = set(range(n - quarter, n))
+
+    # Loudness band — sort indexes by view_count desc, take the top
+    # `quarter` that aren't already in newest/oldest. When no view
+    # counts are present this band collapses gracefully.
+    def _vc(idx: int) -> int:
+        item = items[idx]
+        v = getattr(item, "view_count", None) if hasattr(item, "view_count") else (
+            (item.get("view_count") if isinstance(item, dict) else None)
+        )
+        return v if isinstance(v, (int, float)) else -1
+    by_loudness_sorted = sorted(range(n), key=lambda i: -_vc(i))
+    loudest: set[int] = set()
+    for idx in by_loudness_sorted:
+        if _vc(idx) <= 0:
+            break
+        if idx in newest or idx in oldest:
+            continue
+        loudest.add(idx)
+        if len(loudest) >= quarter:
+            break
+
+    middle_count = target - len(newest) - len(oldest) - len(loudest)
+    middle: set[int] = set()
     if middle_count > 0:
-        # Evenly spaced indexes across the middle band.
-        lo = third
-        hi = n - third - 1
-        if hi <= lo:
-            middle = []
-        else:
+        lo = quarter
+        hi = n - quarter - 1
+        if hi > lo:
             step = (hi - lo) / (middle_count + 1)
-            middle = [int(lo + step * (i + 1)) for i in range(middle_count)]
-    else:
-        middle = []
-    chosen = sorted(set(newest + middle + oldest))
+            for i in range(middle_count):
+                idx = int(lo + step * (i + 1))
+                if idx not in newest and idx not in oldest and idx not in loudest:
+                    middle.add(idx)
+
+    chosen = sorted(newest | oldest | loudest | middle)
     return [items[i] for i in chosen]
 
 
@@ -186,21 +216,29 @@ def _ensure_creation(
         node = existing
         node_created = False
     else:
+        properties: dict[str, Any] = {
+            "asset_type": "CONTENT",
+            "creation_kind": creation.kind,
+            "canonical_url": creation.url,
+            "image_url": creation.image_url,
+            "when": creation.when,
+            "imported_from": source_name,
+            "total_cost": "0",
+            "claimable": True,
+        }
+        # View count carries the loudness this work broadcasts into
+        # the field — used downstream to weight a presence's emitted
+        # spectrum so a high-viewed TEDx talk emits more strongly
+        # than a low-viewed behind-the-scenes clip. None when the
+        # source can't read it (early-life videos, no-API platforms).
+        if getattr(creation, "view_count", None) is not None:
+            properties["view_count"] = creation.view_count
         node = graph_service.create_node(
             id=node_id,
             type="asset",
             name=creation.name,
             description=creation.description or creation.name,
-            properties={
-                "asset_type": "CONTENT",
-                "creation_kind": creation.kind,
-                "canonical_url": creation.url,
-                "image_url": creation.image_url,
-                "when": creation.when,
-                "imported_from": source_name,
-                "total_cost": "0",
-                "claimable": True,
-            },
+            properties=properties,
             phase="ice",
         )
         node_created = True

--- a/api/tests/test_flow_presence.py
+++ b/api/tests/test_flow_presence.py
@@ -1291,3 +1291,34 @@ def test_stratify_returns_breadth_when_source_returns_more_than_cap():
     # Below the cap: pass through unchanged.
     small = list(range(10))
     assert _stratify(small, target=30) == small
+
+
+def test_stratify_lifts_high_view_items_into_the_sample():
+    """Sampling discipline: when items carry view counts, the
+    high-loudness ones rise into the sample even when they fall in
+    the temporally-spread middle band that would otherwise be
+    skipped. The presence's "general signal" — what they actually
+    broadcast loudest into the field — stays visible.
+    """
+    from dataclasses import dataclass
+    from app.services.creations_importer import _stratify
+
+    @dataclass
+    class Item:
+        idx: int
+        view_count: int | None = None
+
+    items = [Item(idx=i, view_count=10) for i in range(100)]
+    # Plant a clear loudness signal mid-list: items 40..43 have very
+    # high view counts. They sit outside the newest/oldest bands.
+    for i in (40, 41, 42, 43):
+        items[i] = Item(idx=i, view_count=1_000_000)
+
+    out = _stratify(items, target=30)
+    out_idx = [it.idx for it in out]
+    assert any(i in out_idx for i in (40, 41, 42, 43)), (
+        f"loud items missing from sample: out_idx={out_idx}"
+    )
+    # Newest + oldest bands still represented.
+    assert 0 in out_idx
+    assert 99 in out_idx

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 84
+**Total files**: 85
 
 | File | Purpose |
 |---|---|
@@ -48,6 +48,7 @@
 | [import_creations.py](import_creations.py) | !/usr/bin/env python3 |
 | [import_gatherings.py](import_gatherings.py) | !/usr/bin/env python3 |
 | [import_lineage.py](import_lineage.py) | !/usr/bin/env python3 |
+| [ingest_youtube_watch_history.py](ingest_youtube_watch_history.py) | !/usr/bin/env python3 |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
 | [local_runner.py](local_runner.py) | !/usr/bin/env python3 |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | !/usr/bin/env python3 |

--- a/scripts/ingest_youtube_watch_history.py
+++ b/scripts/ingest_youtube_watch_history.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Ingest a YouTube watch-history file from Google Takeout.
+
+Google Takeout exports YouTube watch history as
+``Takeout/YouTube and YouTube Music/history/watch-history.json`` —
+a JSON array of every video the user watched, with title, URL,
+channel, and timestamp. Each entry becomes:
+
+  · An ``asset`` node for the video (deduped by canonical URL)
+  · A low-confidence ``contributor`` node for the channel (when not
+    yet in the graph) so the video has a creator
+  · A ``contributes-to`` edge from channel → video
+  · An ``inspired-by`` edge from the watcher → video, carrying the
+    watch timestamp on the edge as ``encountered_at``
+  · Auto-resonance edges from the video to vision concepts the
+    title or channel name shares frequency with
+
+Usage:
+
+    python3 scripts/ingest_youtube_watch_history.py \\
+        --contributor contributor:seeker71 \\
+        --file ~/Takeout/YouTube\\ and\\ YouTube\\ Music/history/watch-history.json
+
+By default the script ingests every entry in the file. Use ``--limit``
+when iterating; the script is idempotent so a re-run with a higher
+limit just adds the next slice.
+
+Watch history can be tens of thousands of entries for long-time
+users. The script reports progress every 50 entries and skips
+ad-impression / removed / restricted videos that have no real URL.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def _ensure_app_path() -> None:
+    here = Path(__file__).resolve().parent
+    api_dir = here.parent / "api"
+    if api_dir.exists():
+        p = str(api_dir)
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+
+def _is_real_video_url(url: str | None) -> bool:
+    """A real watch-history entry points at a watch URL with a real
+    video id. Ad impressions and removed videos either lack
+    ``titleUrl`` or point at ``youtube.com`` without a video id."""
+    if not url:
+        return False
+    try:
+        p = urlparse(url)
+    except ValueError:
+        return False
+    host = (p.netloc or "").lower()
+    if not (host.endswith("youtube.com") or host == "youtu.be"):
+        return False
+    if host.endswith("youtube.com"):
+        # Real watches have ``?v=...`` on the watch URL.
+        return "v=" in (p.query or "")
+    # youtu.be/<id>
+    return bool((p.path or "").lstrip("/"))
+
+
+def _ingest_one(entry: dict, contributor_id: str) -> dict:
+    """Resolve one watch-history entry into the graph."""
+    from app.services import inspired_by_service as service
+    from app.services import graph_service
+
+    url = entry.get("titleUrl")
+    if not _is_real_video_url(url):
+        return {"skipped": True, "reason": "no_real_url"}
+
+    resolved = service.resolve(url)
+    if resolved is None:
+        return {"skipped": True, "reason": "resolver_miss", "url": url}
+
+    result = service.import_inspired_by(contributor_id, resolved)
+
+    # Tag the inspired-by edge with the watch timestamp.
+    when = entry.get("time")
+    if when and result.get("edge"):
+        edge_id = result["edge"].get("id")
+        if edge_id:
+            try:
+                graph_service.update_edge(
+                    edge_id, properties={"encountered_at": when, "source": "youtube_watch_history"},
+                )
+            except Exception:  # noqa: BLE001 — encounter metadata isn't load-bearing
+                pass
+    return {
+        "ok": True,
+        "name": result["resolved"]["name"],
+        "node_id": result["identity"]["id"],
+        "edge_existed": result.get("edge_existed", False),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--contributor", required=True,
+                   help="Contributor id of the watcher (e.g. contributor:seeker71)")
+    p.add_argument("--file", type=Path, required=True,
+                   help="Path to watch-history.json from Google Takeout")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Stop after N entries (0 = no limit). Idempotent — re-runs continue.")
+    p.add_argument("--start", type=int, default=0,
+                   help="Skip the first N entries (resume from offset)")
+    args = p.parse_args(argv)
+
+    if not args.file.exists():
+        print(f"file not found: {args.file}", file=sys.stderr)
+        return 2
+
+    _ensure_app_path()
+
+    raw = args.file.read_text(encoding="utf-8")
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"could not parse {args.file} as JSON: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(entries, list):
+        print(f"expected a JSON array, got {type(entries).__name__}", file=sys.stderr)
+        return 2
+
+    if args.start:
+        entries = entries[args.start:]
+    if args.limit > 0:
+        entries = entries[: args.limit]
+
+    print(f"ingesting {len(entries)} watch-history entries → {args.contributor}")
+    landed = skipped = errored = duped = 0
+    for i, entry in enumerate(entries, 1):
+        try:
+            r = _ingest_one(entry, args.contributor)
+        except Exception as exc:  # noqa: BLE001
+            errored += 1
+            print(f"  [{i:5d}] ✗ {exc}")
+            continue
+        if r.get("skipped"):
+            skipped += 1
+            continue
+        if r.get("edge_existed"):
+            duped += 1
+        else:
+            landed += 1
+        if i % 50 == 0:
+            print(f"  [{i:5d}] landed={landed} duped={duped} skipped={skipped} errored={errored}")
+
+    print()
+    print(f"  landed:  {landed}")
+    print(f"  duped:   {duped}  (already in graph)")
+    print(f"  skipped: {skipped}  (ads / removed / no real URL)")
+    print(f"  errored: {errored}")
+    return 0 if (landed + duped) > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Two paths Urs named, woven together:

- **Public channel + view counts → loudness band.** YouTube source extracts `view_count` per video (K/M/B suffix aware) and stores it on the asset. `_stratify` now weaves four bands: newest, oldest, evenly-spaced middle, and **top-by-views loudness**. A presence's strongest broadcasts stay visible in the sample even when they fall outside the temporal bands. Cap raised 24→60 so stratification has material to spread across.
- **Watch history → encountered-by edges.** New CLI [`scripts/ingest_youtube_watch_history.py`](scripts/ingest_youtube_watch_history.py) reads Google Takeout `watch-history.json` and resolves every real watch URL through `inspired_by_service`. Each video becomes an asset; each channel a low-confidence contributor; each watch lays `inspired-by` from watcher → video with `encountered_at` on the edge. Auto-resonance fires per video so the watcher's body of evidence enters carrying concept-resonance.

The two paths reinforce: a video Urs watched that came from a public channel in the network amplifies that presence's emitted spectrum from both directions.

## Test plan
- [x] `tests/test_flow_presence.py` — 34 passed (3 new sampling tests)
- [x] `_parse_view_count` handles K/M/B/comma/no-views inputs correctly
- [ ] post-merge: re-import a presence with high-view videos (e.g. Lex Fridman), confirm `view_count` lands on assets and the stratified slice includes loud items not just recent ones
- [ ] post-merge: drop a small `watch-history.json` slice through the new CLI, confirm assets + inspired-by edges + concept resonance all flow

## Usage
```bash
# Watch history from a Takeout export
python3 scripts/ingest_youtube_watch_history.py \
    --contributor contributor:seeker71 \
    --file ~/Takeout/YouTube\ and\ YouTube\ Music/history/watch-history.json \
    --limit 100  # iterate up; idempotent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)