### PR TITLE
attune(resolver): name-dedupe so the same identity collapses to one node

### DIFF
--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -26,6 +26,7 @@ import json
 import logging
 import re
 import socket
+import unicodedata
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import Any
@@ -1033,6 +1034,58 @@ def find_existing_identity(canonical_url: str) -> dict[str, Any] | None:
     return None
 
 
+# Channel/show suffixes that don't change identity. "Lex Fridman" and
+# "Lex Fridman Podcast - Official" are the same person.
+_NAME_SUFFIX_NOISE = re.compile(
+    r"\b(official|vevo|topic|channel|youtube|music|podcast|show|tv|live)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_identity_name(name: str) -> str:
+    """Same shape as the watch-history clusterer — collapse common
+    platform-noise tokens so two surface variants of the same human
+    resolve to one identity. Used by name-based dedupe below."""
+    if not name:
+        return ""
+    n = unicodedata.normalize("NFKD", name)
+    n = "".join(c for c in n if not unicodedata.combining(c))
+    n = n.lower()
+    n = _NAME_SUFFIX_NOISE.sub(" ", n)
+    n = re.sub(r"[^\w\s-]", " ", n)
+    n = re.sub(r"-+", " ", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def find_existing_identity_by_name(name: str, slug: str | None = None) -> dict[str, Any] | None:
+    """Look up an already-imported identity by name or slug.
+
+    The canonical-URL dedupe in :func:`find_existing_identity` misses
+    when the same person resolves to a different URL than the existing
+    node carries — bare-name input, multiple personal URLs, Wikipedia
+    vs personal site. This name-fallback closes that gap.
+
+    Match strategy:
+    1. Slug exact match (the human-readable doorway property — unique
+       per the URL canonicalization PR), then
+    2. Normalized name match — "Lex Fridman", "Lex Fridman Podcast",
+       "Lex Fridman - Official" all collapse to "lex fridman".
+
+    The first canonical match wins. Skipped for empty input.
+    """
+    target_name = _normalize_identity_name(name)
+    if not target_name and not slug:
+        return None
+    for node_type in CROSS_REF_NODE_TYPES:
+        result = graph_service.list_nodes(type=node_type, limit=500)
+        for node in result.get("items", []):
+            if slug and node.get("slug") == slug:
+                return node
+            if target_name and _normalize_identity_name(node.get("name") or "") == target_name:
+                return node
+    return None
+
+
 def _creation_node_id(creation: Creation, identity_id: str) -> str:
     """Deterministic id for an asset node — URL-derived when we have
     one, name+owner-derived as a fallback.
@@ -1205,6 +1258,12 @@ def ensure_identity(resolved: ResolvedIdentity) -> tuple[dict[str, Any], bool, l
     Returns ``(identity_node, created, creations_out)``.
     """
     existing = find_existing_identity(resolved.canonical_url)
+    if not existing:
+        # Name-fallback: the same person can resolve to a different
+        # canonical URL (Wikipedia vs personal site, or a fresh
+        # bare-name resolve picking a different anchor). Match against
+        # the existing node's name + slug before minting a duplicate.
+        existing = find_existing_identity_by_name(resolved.name)
     if existing:
         identity_node = existing
         identity_id = existing["id"]

--- a/api/tests/test_inspired_by.py
+++ b/api/tests/test_inspired_by.py
@@ -737,3 +737,67 @@ async def test_list_and_delete_leaves_identity_and_creations_intact():
         assert graph_service.get_node(creation_id) is not None
         identity_edges = graph_service.list_edges(from_id=identity_id, edge_type="contributes-to")
         assert any(e["to_id"] == creation_id for e in identity_edges.get("items", []))
+
+
+def test_ensure_identity_name_dedupe_collapses_canonical_variants():
+    """Same person, two canonical URLs (personal site vs Wikipedia
+    vs YouTube channel) — the second resolve must find the first
+    node by name, not mint a duplicate.
+
+    Why this matters: bare-name inputs to the resolver pick whatever
+    URL the search finds; that URL almost never matches what the
+    canonical node was created with, so URL-only dedupe misses every
+    time. Name-fallback closes the gap.
+    """
+    from app.services import inspired_by_service as service
+    from app.services import graph_service
+
+    # Seed a canonical Lex node with the personal-site URL
+    canonical_id = "contributor:lex-fridman-test-fixture"
+    graph_service.create_node(
+        id=canonical_id, type="contributor",
+        name="Lex Fridman",
+        properties={"canonical_url": "https://lexfridman.com/", "slug": "lex-fridman-test"},
+    )
+    try:
+        # A fresh resolve that produces a different canonical URL
+        # (e.g. Wikipedia) must collapse to the existing node.
+        from app.services.inspired_by_service import ResolvedIdentity, ensure_identity
+        resolved = ResolvedIdentity(
+            input="Lex Fridman",
+            name="Lex Fridman",  # same display name
+            canonical_url="https://en.wikipedia.org/wiki/Lex_Fridman",  # different URL
+            description="podcaster",
+            provider="wikipedia",
+            provider_id="lex-fridman-wp",
+            node_type="contributor",
+            image_url=None,
+            presences=[],
+            creations=[],
+        )
+        node, created, _ = ensure_identity(resolved)
+        assert node["id"] == canonical_id, (
+            f"name-dedupe should have returned the canonical; got {node['id']}"
+        )
+        assert created is False
+
+        # Surface variant ("Lex Fridman Podcast - Official") collapses too
+        variant = ResolvedIdentity(
+            input="Lex Fridman Podcast",
+            name="Lex Fridman Podcast - Official",
+            canonical_url="https://example.com/some-other-url",
+            description="",
+            provider="other",
+            provider_id="x",
+            node_type="contributor",
+            image_url=None,
+            presences=[],
+            creations=[],
+        )
+        node2, created2, _ = ensure_identity(variant)
+        assert node2["id"] == canonical_id, (
+            f"surface-variant name should still collapse; got {node2['id']}"
+        )
+        assert created2 is False
+    finally:
+        graph_service.delete_node(canonical_id)


### PR DESCRIPTION
## Summary
**Why duplicates were forming:** the resolver dedupes only on `canonical_url`. Bare-name input ("Lex Fridman") resolves to whatever URL the search finds (Wikipedia, personal site, YouTube channel) — which almost never matches the URL the canonical node carries. URL-only dedupe missed every time, minting `contributor:f2b79c15...` alongside the canonical `contributor:lex-fridman`.

**The fix:** name-fallback inside `ensure_identity`. After URL lookup misses, normalize the resolved name (collapsing "- Topic", "Podcast", "Official" surface noise) and search existing contributors for a slug or normalized-name match. First canonical match wins.

Three surface variants now collapse to the same node:
- "Lex Fridman" (bare name → Wikipedia URL)
- "Lex Fridman Podcast - Official" (channel listing)
- "Lex Fridman" with personal-site URL

The data-cleanup pass that manually fixed the duplicate Lex node last session is now structurally prevented at the resolver layer.

## Test plan
- [x] `tests/test_inspired_by.py::test_ensure_identity_name_dedupe_collapses_canonical_variants` passes
- [x] full `test_inspired_by.py` + `test_flow_presence.py` — 18 passed
- [ ] post-merge: re-run the lineage seed; bare-name inputs that previously created duplicates now collapse to existing canonicals

🤖 Generated with [Claude Code](https://claude.com/claude-code)