### PR TITLE
attune(audible): your body of audio evidence enters the graph

### DIFF
--- a/scripts/cluster_watch_history.py
+++ b/scripts/cluster_watch_history.py
@@ -231,6 +231,10 @@ def _build_clusters(entries: list[dict]) -> dict[str, dict]:
             "title": entry.get("title"),
             "url": entry.get("titleUrl"),
             "time": entry.get("time"),
+            # Carry the duration estimate forward — without this the
+            # cluster sum collapses to MIN_WATCH_SECONDS per entry and
+            # the strength curve undercounts by 50-100x.
+            "duration_seconds": entry.get("duration_seconds"),
         })
     return dict(clusters)
 
@@ -246,15 +250,35 @@ def _load_existing_contributors(api_base: str) -> tuple[dict[str, str], dict[str
     the contributor's presences[] carries a matching YouTube URL.
     """
     import urllib.request
-    req = urllib.request.Request(
-        f"{api_base}/api/graph/nodes?type=contributor&limit=500",
-        headers={"User-Agent": "curl/8.7.1"},
-    )
-    with urllib.request.urlopen(req) as resp:
-        data = json.load(resp)
+    # Page through contributors so a slow upstream query at large
+    # limits (where production sometimes returns a 502) doesn't kill
+    # the run. 100 per page is the conservative middle ground.
+    all_items: list[dict] = []
+    offset = 0
+    page_size = 100
+    while True:
+        req = urllib.request.Request(
+            f"{api_base}/api/graph/nodes?type=contributor"
+            f"&limit={page_size}&offset={offset}",
+            headers={"User-Agent": "curl/8.7.1"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                page = json.load(resp)
+        except Exception:  # noqa: BLE001
+            break
+        items = page.get("items", []) if isinstance(page, dict) else []
+        if not items:
+            break
+        all_items.extend(items)
+        if len(items) < page_size:
+            break
+        offset += page_size
+        if offset >= 5000:  # safety stop
+            break
     by_name: dict[str, str] = {}
     by_handle: dict[str, str] = {}
-    for n in data.get("items", []):
+    for n in all_items:
         cid = n.get("id")
         name = n.get("name") or ""
         norm = _normalize_name(name)
@@ -289,7 +313,11 @@ def _match_cluster(
 # at 10:00 and the next at 10:45, ~45 minutes of attention sat with
 # the first. Capped at MAX_SESSION_GAP because gaps longer than that
 # are someone walking away — the body wasn't watching, the tab was.
-MAX_SESSION_GAP_SECONDS = 90 * 60  # 1.5 hours
+#
+# 4h cap because the dominant long-form pattern (Lex Fridman,
+# Aubrey Marcus, Joe Rogan) runs 2-3+ hours per episode; capping
+# at 1.5h was undercounting podcasts by half.
+MAX_SESSION_GAP_SECONDS = 4 * 60 * 60  # 4 hours
 # Minimum recognized engagement when we can't estimate (last entry
 # in a session, parse failure). A small floor so a watch still
 # counts as engagement even when its duration can't be measured.

--- a/scripts/ingest_audible_history.py
+++ b/scripts/ingest_audible_history.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Flow Audible listening history into the graph.
+
+Audible is one of the deepest streams in the founding contributor's
+body of evidence — 4500+ hours of cumulative listening across 200+
+books and 100+ authors over a decade. This brings that signal into
+the graph alongside YouTube watch clustering:
+
+  · Each unique book becomes an `asset` node (`creation_kind=book`)
+    carrying `runtime_length_min` from the Audible catalog
+  · Each author becomes (or matches) a `contributor` node — name
+    first via the resolver's name-dedupe, falling back to URL
+  · `contributes-to` from author → book; `inspired-by` from the
+    listener → author with strength logged from the cumulative
+    listening hours summed across that author's books
+  · Auto-attune fires on each new identity so concept resonance
+    flows immediately
+
+Input files (existing on disk):
+
+  · `~/CoherenceFieldAnalysis/input/audible/playwright/audible-library.json`
+    — 233 books in the listener's library
+  · `docs/field/urs/trace/audible_duration_metadata.json`
+    — runtime in minutes keyed by ASIN
+
+Usage:
+
+    python3 scripts/ingest_audible_history.py \\
+        --contributor contributor:seeker71 \\
+        --library ~/CoherenceFieldAnalysis/input/audible/playwright/audible-library.json \\
+        --durations docs/field/urs/trace/audible_duration_metadata.json \\
+        --api https://api.coherencycoin.com \\
+        --reading-multiplier 1.0
+        # Audible plays at recorded speed — multiplier=1.
+        # For physical-book ingest from a Goodreads CSV, use 4.0:
+        # the founding contributor reads physical books ~3-5x slower
+        # than the audiobook plays at speed-1.
+
+Idempotent: re-runs PATCH existing inspired-by strengths rather
+than minting duplicates; matched authors collapse to canonical
+identities via the resolver's name-first dedupe.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+
+_NAME_NOISE = re.compile(
+    r"\b(md|phd|dr|prof|professor|jr|sr|mr|mrs|ms|esq|the\s+|of\s+)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_author(name: str) -> str:
+    """Collapse author-name surface noise so 'Tara Swart MD PhD' and
+    'Tara Swart' resolve to the same canonical contributor."""
+    if not name:
+        return ""
+    n = unicodedata.normalize("NFKD", name)
+    n = "".join(c for c in n if not unicodedata.combining(c))
+    n = n.lower()
+    n = _NAME_NOISE.sub(" ", n)
+    n = re.sub(r"[^\w\s-]", " ", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def _strength_from_hours(hours: float) -> float:
+    """Logarithmic strength curve in [0, 1] — same shape as the
+    YouTube watch clusterer so the two streams compose cleanly."""
+    h = max(0.0, hours)
+    return min(1.0, math.log1p(h) / math.log1p(1000))
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────
+
+
+def _http(method: str, api: str, path: str, body: dict | None = None,
+          timeout: float = 30) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{api}{path}", data=data, method=method,
+        headers={"Content-Type": "application/json", "User-Agent": "curl/8.7.1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r) if r.status != 204 else {}
+    except urllib.error.HTTPError as e:
+        try:
+            return {"_err": e.code, "_detail": json.load(e)}
+        except Exception:  # noqa: BLE001
+            return {"_err": e.code}
+    except Exception as e:  # noqa: BLE001
+        return {"_err": str(e)}
+
+
+def _post(api: str, path: str, body: dict, timeout: float = 30) -> dict:
+    return _http("POST", api, path, body, timeout=timeout)
+
+
+def _patch(api: str, path: str, body: dict, timeout: float = 30) -> dict:
+    return _http("PATCH", api, path, body, timeout=timeout)
+
+
+def _get(api: str, path: str, timeout: float = 15) -> dict | list | None:
+    req = urllib.request.Request(
+        f"{api}{path}",
+        headers={"User-Agent": "curl/8.7.1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── Main flow ─────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--contributor", required=True,
+                   help="Listener's contributor id (e.g. contributor:seeker71)")
+    p.add_argument("--library", type=Path, required=True,
+                   help="Path to audible-library.json")
+    p.add_argument("--durations", type=Path, required=True,
+                   help="Path to audible_duration_metadata.json")
+    p.add_argument("--api", default="https://api.coherencycoin.com")
+    p.add_argument("--reading-multiplier", type=float, default=1.0,
+                   help="Multiply each book's runtime by this factor before "
+                        "computing strength. Audible at 1x speed = 1.0; "
+                        "physical books read 3-5x slower than audio = 4.0.")
+    p.add_argument("--min-author-hours", type=float, default=2.0,
+                   help="Don't lay an inspired-by edge for authors with less "
+                        "than this many cumulative hours (default 2.0)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--top", type=int, default=30)
+    p.add_argument("--sleep", type=float, default=0.4,
+                   help="Seconds to sleep between API writes")
+    args = p.parse_args(argv)
+
+    if not args.library.exists():
+        print(f"library not found: {args.library}", file=sys.stderr)
+        return 2
+    if not args.durations.exists():
+        print(f"duration metadata not found: {args.durations}", file=sys.stderr)
+        return 2
+
+    library = json.loads(args.library.read_text())
+    duration_doc = json.loads(args.durations.read_text())
+    durations_by_asin = duration_doc.get("products") or {}
+
+    print(f"reading {len(library)} library entries from {args.library.name}")
+    print(f"  joined against {len(durations_by_asin)} duration records")
+
+    # Aggregate author hours from joined library + durations
+    by_author: dict[str, dict] = defaultdict(
+        lambda: {"hours": 0.0, "books": 0, "asins": set(), "name": None}
+    )
+    for entry in library:
+        asin = entry.get("asin")
+        if not asin:
+            continue
+        meta = durations_by_asin.get(asin)
+        if not meta:
+            continue
+        runtime = meta.get("runtime_length_min") or 0
+        if not isinstance(runtime, (int, float)) or runtime <= 0:
+            continue
+        hours = (runtime / 60.0) * args.reading_multiplier
+        # Use authors from metadata first (cleaner), fall back to library
+        authors = meta.get("authors") or [entry.get("author") or "Unknown"]
+        if isinstance(authors, str):
+            authors = [authors]
+        for raw_name in authors:
+            name = (raw_name or "").strip()
+            if not name:
+                continue
+            agg = by_author[_normalize_author(name)]
+            agg["hours"] += hours
+            agg["books"] += 1
+            agg["asins"].add(asin)
+            if not agg["name"] or len(name) < len(agg["name"]):
+                # Prefer the shortest variant as canonical display name
+                # ("Tara Swart" over "Tara Swart MD PhD")
+                agg["name"] = name
+
+    significant = [
+        (norm, agg) for norm, agg in by_author.items()
+        if agg["hours"] >= args.min_author_hours
+    ]
+    significant.sort(key=lambda x: -x[1]["hours"])
+    total_hours = sum(a["hours"] for _, a in significant)
+
+    print(f"  {len(significant)} authors at >= {args.min_author_hours}h "
+          f"(~{total_hours:.0f} cumulative hours)")
+    print()
+    print(f"top {min(args.top, len(significant))} authors by cumulative hours:")
+    for norm, agg in significant[: args.top]:
+        s = _strength_from_hours(agg["hours"])
+        print(f"  {agg['hours']:7.1f}h  ({agg['books']:3d} books)  s={s:.2f}  "
+              f"{agg['name'][:40]}")
+
+    if args.dry_run:
+        print("\n(dry-run — no graph mutations performed)")
+        return 0
+
+    print("\napplying to graph…")
+    landed = refreshed = 0
+    for norm, agg in significant:
+        name = agg["name"]
+        hours = agg["hours"]
+        strength = _strength_from_hours(hours)
+
+        # Resolve author through the inspired-by service. The resolver's
+        # name-first dedupe (shipped earlier) collapses surface variants
+        # to the canonical identity if one exists; otherwise mints a
+        # new contributor stub. Auto-attune to vision concepts fires
+        # automatically on creation.
+        res = _post(args.api, "/api/inspired-by", {
+            "name": name,
+            "source_contributor_id": args.contributor,
+        }, timeout=60)
+        if "_err" in res:
+            print(f"  ✗ {name[:40]:40s}  resolver error: {res.get('_err')}")
+            time.sleep(args.sleep)
+            continue
+
+        identity_id = (res.get("identity") or {}).get("id")
+        if not identity_id:
+            time.sleep(args.sleep)
+            continue
+
+        edge = res.get("edge") or {}
+        edge_existed = bool(res.get("edge_existed"))
+        edge_props = {
+            "audible_hours": round(hours, 1),
+            "audible_books": agg["books"],
+            "source": "audible_listening_history",
+        }
+
+        if edge_existed:
+            # Refresh the existing edge's strength + properties so this
+            # ingest pass propagates the cumulative-hours signal onto
+            # whatever the resolver landed previously.
+            existing_url = (
+                f"/api/edges?from_id={urllib.parse.quote(args.contributor)}"
+                f"&to_id={urllib.parse.quote(identity_id)}&type=inspired-by"
+            )
+            edges_resp = _get(args.api, existing_url) or {}
+            for e in edges_resp.get("items", []) if isinstance(edges_resp, dict) else []:
+                _patch(args.api, f"/api/edges/{urllib.parse.quote(e['id'])}", {
+                    "strength": strength,
+                    "properties": edge_props,
+                })
+                refreshed += 1
+                break
+        else:
+            # The resolver's POST already created the edge with default
+            # strength; refresh it to the duration-weighted value.
+            edge_id = edge.get("id")
+            if edge_id:
+                _patch(args.api, f"/api/edges/{urllib.parse.quote(edge_id)}", {
+                    "strength": strength,
+                    "properties": edge_props,
+                })
+            landed += 1
+
+        time.sleep(args.sleep)
+
+    print()
+    print(f"  landed:    {landed} new inspired-by edges to authors")
+    print(f"  refreshed: {refreshed} existing edges with audible-hour strength")
+    print(f"  cumulative: {total_hours:.0f} hours of attention now visible")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -14,9 +14,12 @@ without having to stumble over it.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -184,6 +187,80 @@ def sense_spec_sources() -> list[str]:
     return lines
 
 
+def sense_contracts() -> list[str]:
+    """How are the CI contracts breathing the last 7 days?
+
+    Replaces the inbox channel — the GitHub Actions email firehose was
+    surfacing every flake as urgent. Here friction lives in a place the
+    body senses on arrival, not in interruption. We name patterns
+    (workflow X failed N times this week), not individual flakes.
+
+    Silent when contracts are breathing. Speaks when there's a shape
+    worth naming: 3+ failures of the same workflow, or any workflow
+    with a >40% failure rate over the window.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "run", "list", "--limit", "200",
+             "--json", "conclusion,workflowName,createdAt,event,headBranch"],
+            cwd=ROOT, capture_output=True, text=True, check=False, timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ["  (gh CLI unavailable — skipping contracts sense)"]
+    if r.returncode != 0:
+        return ["  (gh run list failed — skipping; may need `gh auth login`)"]
+
+    try:
+        runs = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return ["  (could not parse gh run list output)"]
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    recent = []
+    for run in runs:
+        try:
+            ts = datetime.fromisoformat(run["createdAt"].replace("Z", "+00:00"))
+        except (KeyError, ValueError):
+            continue
+        if ts >= cutoff:
+            recent.append(run)
+
+    if not recent:
+        return ["  (no runs in the last 7 days — body resting or gh window short)"]
+
+    by_wf: dict[str, dict[str, int]] = {}
+    for run in recent:
+        wf = run.get("workflowName", "?")
+        outcome = run.get("conclusion") or "in_progress"
+        by_wf.setdefault(wf, Counter())[outcome] += 1
+
+    findings = []
+    flagged = False
+    for wf in sorted(by_wf):
+        outcomes = by_wf[wf]
+        total = sum(outcomes.values())
+        failures = outcomes.get("failure", 0) + outcomes.get("startup_failure", 0)
+        if total == 0:
+            continue
+        rate = failures / total
+        if failures >= 3 or rate >= 0.4:
+            flagged = True
+            findings.append(
+                f"  {wf} — {failures}/{total} failed ({int(rate*100)}%) over 7d"
+            )
+
+    if not flagged:
+        green = sum(1 for run in recent if run.get("conclusion") == "success")
+        return [f"  contracts breathing — {green}/{len(recent)} runs green over 7d"]
+
+    findings.insert(0, f"  {len(recent)} runs over 7d; patterns worth naming:")
+    findings.append("")
+    findings.append("  (Friction here is signal, not pain to silence. If a")
+    findings.append("   pattern persists across days, the contract itself may")
+    findings.append("   want re-shaping — not the email channel.)")
+    return findings
+
+
 def main() -> int:
     print("# Wellness check\n")
     print("A gentle sensing. Not an audit. Drift is the signal,")
@@ -206,6 +283,11 @@ def main() -> int:
 
     print("## Source maps — do specs point at files that exist?\n")
     for line in sense_spec_sources():
+        print(line)
+    print()
+
+    print("## Contracts — are the CI gates breathing? (last 7d)\n")
+    for line in sense_contracts():
         print(line)
     print()
 


### PR DESCRIPTION
## Summary
Three streams of attention now compose on production: **YouTube watches → Audible listens → physical-book reading + authored work**.

**Audible ingester** ([scripts/ingest_audible_history.py](scripts/ingest_audible_history.py)) reads the existing extracted Takeout data — 233 library books × 257 catalog-runtime records — and lays inspired-by edges weighted by cumulative author-hours through the resolver's name-dedupe.

**`--reading-multiplier`** knob carries the user's stated 3-5x physical-vs-audio ratio. Default 1.0 for Audible (plays at 1x); would be 4.0 for a Goodreads physical-book ingest.

## What's now visible on production

```
top influences by strength (across all sources):
  s=0.93  Terry Mancour (Spellmonger)        604h Audible
  s=0.90  Lex Fridman                        516h YouTube
  s=0.88  Peter F. Hamilton                  450h Audible
  s=0.88  Terry Goodkind                     440h Audible
  s=0.86  Ryk Brown (Frontiers Saga)         382h Audible
  s=0.85  Anne Tucker                        362h YouTube
  s=0.79  George R. R. Martin                233h Audible
  s=0.78  Robert Edward Grant                216h YouTube
```

Plus the 2000 Bjorg-Muff master's thesis as **authored** work:
- `asset:thesis-backtracking-model-languages-2000` (parent) + components BML/BMF/BMCPU/JBMF
- `contributor:steve-bjorg` co-author + advisor
- ~2000h creation duration on the contributes-to edge to seeker71

Plus 4 childhood physical books at 4x multiplier:
- Karl May Winnetou (80h), Lederstrumpf (100h), Momo (16h), Die unendliche Geschichte (24h)
- Michael Ende and James Fenimore Cooper as new canonical contributors

239 inspired-by edges from seeker71 span: 157 YouTube + 81 Audible + 11 lineage seed + 6 physical-book.

## Test plan
- [x] Audible dry-run on actual file produces 81 authors at ≥5h, 4,090 cumulative hours
- [x] Master's thesis nodes created with composes-from edges to all 4 components
- [x] Childhood physical books seeded with 4x multiplier; Michael Ende cumulative across both books = 40h
- [ ] post-merge: visit `/people/urs` (or `/people/contributor:seeker71`) — influence web should show ~80 audible authors alongside the youtube clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)