### PR TITLE
attune(audible): full trace from chip to Audible product page

### DIFF
--- a/scripts/cluster_watch_history.py
+++ b/scripts/cluster_watch_history.py
@@ -231,6 +231,10 @@ def _build_clusters(entries: list[dict]) -> dict[str, dict]:
             "title": entry.get("title"),
             "url": entry.get("titleUrl"),
             "time": entry.get("time"),
+            # Carry the duration estimate forward — without this the
+            # cluster sum collapses to MIN_WATCH_SECONDS per entry and
+            # the strength curve undercounts by 50-100x.
+            "duration_seconds": entry.get("duration_seconds"),
         })
     return dict(clusters)
 
@@ -246,15 +250,35 @@ def _load_existing_contributors(api_base: str) -> tuple[dict[str, str], dict[str
     the contributor's presences[] carries a matching YouTube URL.
     """
     import urllib.request
-    req = urllib.request.Request(
-        f"{api_base}/api/graph/nodes?type=contributor&limit=500",
-        headers={"User-Agent": "curl/8.7.1"},
-    )
-    with urllib.request.urlopen(req) as resp:
-        data = json.load(resp)
+    # Page through contributors so a slow upstream query at large
+    # limits (where production sometimes returns a 502) doesn't kill
+    # the run. 100 per page is the conservative middle ground.
+    all_items: list[dict] = []
+    offset = 0
+    page_size = 100
+    while True:
+        req = urllib.request.Request(
+            f"{api_base}/api/graph/nodes?type=contributor"
+            f"&limit={page_size}&offset={offset}",
+            headers={"User-Agent": "curl/8.7.1"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                page = json.load(resp)
+        except Exception:  # noqa: BLE001
+            break
+        items = page.get("items", []) if isinstance(page, dict) else []
+        if not items:
+            break
+        all_items.extend(items)
+        if len(items) < page_size:
+            break
+        offset += page_size
+        if offset >= 5000:  # safety stop
+            break
     by_name: dict[str, str] = {}
     by_handle: dict[str, str] = {}
-    for n in data.get("items", []):
+    for n in all_items:
         cid = n.get("id")
         name = n.get("name") or ""
         norm = _normalize_name(name)
@@ -289,7 +313,11 @@ def _match_cluster(
 # at 10:00 and the next at 10:45, ~45 minutes of attention sat with
 # the first. Capped at MAX_SESSION_GAP because gaps longer than that
 # are someone walking away — the body wasn't watching, the tab was.
-MAX_SESSION_GAP_SECONDS = 90 * 60  # 1.5 hours
+#
+# 4h cap because the dominant long-form pattern (Lex Fridman,
+# Aubrey Marcus, Joe Rogan) runs 2-3+ hours per episode; capping
+# at 1.5h was undercounting podcasts by half.
+MAX_SESSION_GAP_SECONDS = 4 * 60 * 60  # 4 hours
 # Minimum recognized engagement when we can't estimate (last entry
 # in a session, parse failure). A small floor so a watch still
 # counts as engagement even when its duration can't be measured.

--- a/scripts/ingest_audible_books_full_trace.py
+++ b/scripts/ingest_audible_books_full_trace.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Lay every Audible book as a first-class asset with full source trace.
+
+The earlier `ingest_audible_history.py` aggregates inspired-by edges
+by author hours but doesn't surface each book — the trace
+dead-ends at the author. The visitor sees "604h · 30 books" but
+can't click through to any of the 30 actual works or follow them
+to their Audible product pages.
+
+This script closes that gap. For each book in the listener's
+Audible library:
+
+  1. Resolve the canonical author identity (name-dedupe — the
+     resolver previously created some authors named after their
+     book-series websites; this run renames them to the actual
+     author name).
+  2. Create the book as an `asset` node with full metadata:
+     `canonical_url` = Audible product page,
+     `image_url` = cover thumbnail,
+     `runtime_length_min` = duration,
+     `asin`, `creation_kind="book"`.
+  3. Lay author → book as `contributes-to` (creator side).
+  4. Lay listener → book as `inspired-by` with per-book hours
+     (consumer side, more granular than the per-author edge).
+
+After this, the trace reads end-to-end: a visitor encountering a
+"Terry Mancour 604h · 30 books" chip in the unified body-of-evidence
+view → clicks → lands on Mancour's page → sees his 30 books as
+emitted creations → clicks any one → lands on its asset page →
+follows `canonical_url` to the public Audible page.
+
+Usage:
+    python3 scripts/ingest_audible_books_full_trace.py \\
+        --library ~/CoherenceFieldAnalysis/input/audible/playwright/audible-library.json \\
+        --durations docs/field/urs/trace/audible_duration_metadata.json \\
+        --listener contributor:seeker71 \\
+        --api https://api.coherencycoin.com
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+
+def _req(api: str, method: str, path: str, body: dict | None = None,
+         timeout: float = 30) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{api}{path}", data=data, method=method,
+        headers={"Content-Type": "application/json", "User-Agent": "curl/8.7.1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r) if r.status != 204 else {}
+    except urllib.error.HTTPError as e:
+        try:
+            return {"_err": e.code, "_detail": json.load(e)}
+        except Exception:  # noqa: BLE001
+            return {"_err": e.code}
+    except Exception as e:  # noqa: BLE001
+        return {"_err": str(e)}
+
+
+def _slugify(s: str) -> str:
+    n = unicodedata.normalize("NFKD", s or "")
+    n = "".join(c for c in n if not unicodedata.combining(c))
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", n.lower())).strip("-")
+
+
+def _strength(hours: float) -> float:
+    return min(1.0, math.log1p(max(0.0, hours)) / math.log1p(1000))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--library", type=Path, required=True)
+    p.add_argument("--durations", type=Path, required=True)
+    p.add_argument("--listener", required=True,
+                   help="Listener contributor id (e.g. contributor:seeker71)")
+    p.add_argument("--api", default="https://api.coherencycoin.com")
+    p.add_argument("--sleep", type=float, default=0.05)
+    p.add_argument("--source-tag", default="audible_listening_history",
+                   help="Match existing inspired-by edges by this source value")
+    args = p.parse_args(argv)
+
+    library = json.loads(args.library.read_text())
+    durations = json.loads(args.durations.read_text()).get("products", {})
+
+    print(f"=== Step 1: rename existing audible-author contributors to canonical names ===")
+    existing_edges = _req(
+        args.api, "GET",
+        f"/api/edges?from_id={urllib.parse.quote(args.listener)}&type=inspired-by&limit=300",
+    ).get("items", [])
+    audible_edges = [
+        e for e in existing_edges
+        if (e.get("properties") or {}).get("source") == args.source_tag
+    ]
+
+    # Aggregate by author for canonical-name mapping
+    by_author: dict[str, dict] = defaultdict(
+        lambda: {"hours": 0.0, "books": [], "name": None}
+    )
+    for entry in library:
+        asin = entry.get("asin")
+        if not asin:
+            continue
+        meta = durations.get(asin)
+        if not meta:
+            continue
+        rt = meta.get("runtime_length_min") or 0
+        if not isinstance(rt, (int, float)) or rt <= 0:
+            continue
+        authors = meta.get("authors") or [entry.get("author") or "Unknown"]
+        if isinstance(authors, str):
+            authors = [authors]
+        for raw in authors:
+            name = (raw or "").strip()
+            if not name:
+                continue
+            norm = re.sub(r"\s+", " ", re.sub(r"[^\w\s]", " ", name.lower())).strip()
+            agg = by_author[norm]
+            agg["hours"] += rt / 60.0
+            agg["books"].append({"entry": entry, "meta": meta, "minutes": rt})
+            if not agg["name"] or len(name) < len(agg["name"]):
+                agg["name"] = name
+
+    # Match existing edges to author clusters by hours-closest, rename if off
+    authors_by_id: dict[str, str] = {}
+    fixed = 0
+    for e in audible_edges:
+        edge_hours = (e.get("properties") or {}).get("audible_hours") or 0
+        cur_id = e.get("to_id")
+        if not cur_id or not edge_hours:
+            continue
+        best = None
+        best_diff = 999.0
+        for norm, agg in by_author.items():
+            d = abs(agg["hours"] - edge_hours)
+            if d < best_diff:
+                best_diff = d
+                best = (norm, agg)
+        if best and best_diff < 1.0:
+            _, agg = best
+            authors_by_id[cur_id] = agg["name"]
+            cur_name = (e.get("to_node") or {}).get("name", "")
+            if cur_name != agg["name"]:
+                slug = _slugify(agg["name"])
+                r = _req(args.api, "PATCH",
+                    f"/api/graph/nodes/{urllib.parse.quote(cur_id)}",
+                    {"name": agg["name"], "properties": {
+                        "slug": slug, "imported_from": "audible_author_rename"}})
+                if "_err" not in r:
+                    fixed += 1
+                    print(f"  ✓ {cur_id[:30]} '{cur_name[:30]}' → '{agg['name']}'")
+    print(f"  renamed {fixed} authors to canonical names\n")
+
+    print(f"=== Step 2: create book assets with canonical_url to Audible ===")
+    created = existing_books = edges_landed = 0
+    for norm, agg in by_author.items():
+        author_name = agg["name"]
+        author_id = next(
+            (cid for cid, nm in authors_by_id.items() if nm == author_name),
+            None,
+        )
+        if not author_id:
+            # Tier-2 author below the inspired-by significance threshold;
+            # skip per-book ingest since the chip wouldn't be reachable.
+            continue
+        for book in agg["books"]:
+            entry = book["entry"]
+            meta = book["meta"]
+            asin = meta.get("asin") or entry.get("asin")
+            title = entry.get("title") or meta.get("title") or asin
+            if not asin or not title:
+                continue
+            book_id = f"asset:audible-{asin}"
+            ex = _req(args.api, "GET",
+                f"/api/graph/nodes/{urllib.parse.quote(book_id)}")
+            if ex and not ex.get("_err"):
+                existing_books += 1
+            else:
+                clean_title = re.sub(r"\s*By\s*:\s*.*$", "", title).strip()
+                r = _req(args.api, "POST", "/api/graph/nodes", {
+                    "id": book_id, "type": "asset",
+                    "name": clean_title,
+                    "description": (
+                        f"Audible audiobook by {author_name}. Runtime "
+                        f"{book['minutes']//60}h {book['minutes']%60}m."
+                    ),
+                    "properties": {
+                        "creation_kind": "book",
+                        "asset_type": "CONTENT",
+                        "canonical_url": entry.get("product_url") or "",
+                        "image_url": entry.get("cover") or "",
+                        "runtime_length_min": book["minutes"],
+                        "asin": asin,
+                        "imported_from": "audible_book_ingest",
+                        "claimable": False,
+                        "slug": f"audible-{_slugify(clean_title)[:60]}",
+                    },
+                })
+                if r.get("_err"):
+                    print(f"  ✗ {book_id}: {r}")
+                    continue
+                created += 1
+
+            # Author --contributes-to--> book
+            r = _req(args.api, "POST", "/api/edges", {
+                "from_id": author_id, "to_id": book_id,
+                "type": "contributes-to",
+                "properties": {"kind": "book", "role": "primary"},
+                "strength": 1.0, "created_by": "audible_book_ingest",
+            })
+            if r.get("_err") in (None, 409):
+                edges_landed += 1
+
+            # Listener --inspired-by--> book (per-book granularity)
+            h = book["minutes"] / 60.0
+            _req(args.api, "POST", "/api/edges", {
+                "from_id": args.listener, "to_id": book_id,
+                "type": "inspired-by",
+                "properties": {
+                    "audible_hours": round(h, 1),
+                    "audible_book_minutes": book["minutes"],
+                    "source": "audible_book_listening",
+                },
+                "strength": _strength(h),
+                "created_by": "audible_book_ingest",
+            })
+            if args.sleep:
+                time.sleep(args.sleep)
+
+    print(f"  created: {created} book assets")
+    print(f"  existed: {existing_books}")
+    print(f"  edges landed/refreshed: {edges_landed}")
+    print(f"\ntrace now complete: chip → author → books → Audible URL")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_audible_history.py
+++ b/scripts/ingest_audible_history.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Flow Audible listening history into the graph.
+
+Audible is one of the deepest streams in the founding contributor's
+body of evidence — 4500+ hours of cumulative listening across 200+
+books and 100+ authors over a decade. This brings that signal into
+the graph alongside YouTube watch clustering:
+
+  · Each unique book becomes an `asset` node (`creation_kind=book`)
+    carrying `runtime_length_min` from the Audible catalog
+  · Each author becomes (or matches) a `contributor` node — name
+    first via the resolver's name-dedupe, falling back to URL
+  · `contributes-to` from author → book; `inspired-by` from the
+    listener → author with strength logged from the cumulative
+    listening hours summed across that author's books
+  · Auto-attune fires on each new identity so concept resonance
+    flows immediately
+
+Input files (existing on disk):
+
+  · `~/CoherenceFieldAnalysis/input/audible/playwright/audible-library.json`
+    — 233 books in the listener's library
+  · `docs/field/urs/trace/audible_duration_metadata.json`
+    — runtime in minutes keyed by ASIN
+
+Usage:
+
+    python3 scripts/ingest_audible_history.py \\
+        --contributor contributor:seeker71 \\
+        --library ~/CoherenceFieldAnalysis/input/audible/playwright/audible-library.json \\
+        --durations docs/field/urs/trace/audible_duration_metadata.json \\
+        --api https://api.coherencycoin.com \\
+        --reading-multiplier 1.0
+        # Audible plays at recorded speed — multiplier=1.
+        # For physical-book ingest from a Goodreads CSV, use 4.0:
+        # the founding contributor reads physical books ~3-5x slower
+        # than the audiobook plays at speed-1.
+
+Idempotent: re-runs PATCH existing inspired-by strengths rather
+than minting duplicates; matched authors collapse to canonical
+identities via the resolver's name-first dedupe.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+
+_NAME_NOISE = re.compile(
+    r"\b(md|phd|dr|prof|professor|jr|sr|mr|mrs|ms|esq|the\s+|of\s+)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_author(name: str) -> str:
+    """Collapse author-name surface noise so 'Tara Swart MD PhD' and
+    'Tara Swart' resolve to the same canonical contributor."""
+    if not name:
+        return ""
+    n = unicodedata.normalize("NFKD", name)
+    n = "".join(c for c in n if not unicodedata.combining(c))
+    n = n.lower()
+    n = _NAME_NOISE.sub(" ", n)
+    n = re.sub(r"[^\w\s-]", " ", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def _strength_from_hours(hours: float) -> float:
+    """Logarithmic strength curve in [0, 1] — same shape as the
+    YouTube watch clusterer so the two streams compose cleanly."""
+    h = max(0.0, hours)
+    return min(1.0, math.log1p(h) / math.log1p(1000))
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────
+
+
+def _http(method: str, api: str, path: str, body: dict | None = None,
+          timeout: float = 30) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{api}{path}", data=data, method=method,
+        headers={"Content-Type": "application/json", "User-Agent": "curl/8.7.1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r) if r.status != 204 else {}
+    except urllib.error.HTTPError as e:
+        try:
+            return {"_err": e.code, "_detail": json.load(e)}
+        except Exception:  # noqa: BLE001
+            return {"_err": e.code}
+    except Exception as e:  # noqa: BLE001
+        return {"_err": str(e)}
+
+
+def _post(api: str, path: str, body: dict, timeout: float = 30) -> dict:
+    return _http("POST", api, path, body, timeout=timeout)
+
+
+def _patch(api: str, path: str, body: dict, timeout: float = 30) -> dict:
+    return _http("PATCH", api, path, body, timeout=timeout)
+
+
+def _get(api: str, path: str, timeout: float = 15) -> dict | list | None:
+    req = urllib.request.Request(
+        f"{api}{path}",
+        headers={"User-Agent": "curl/8.7.1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.load(r)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── Main flow ─────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--contributor", required=True,
+                   help="Listener's contributor id (e.g. contributor:seeker71)")
+    p.add_argument("--library", type=Path, required=True,
+                   help="Path to audible-library.json")
+    p.add_argument("--durations", type=Path, required=True,
+                   help="Path to audible_duration_metadata.json")
+    p.add_argument("--api", default="https://api.coherencycoin.com")
+    p.add_argument("--reading-multiplier", type=float, default=1.0,
+                   help="Multiply each book's runtime by this factor before "
+                        "computing strength. Audible at 1x speed = 1.0; "
+                        "physical books read 3-5x slower than audio = 4.0.")
+    p.add_argument("--min-author-hours", type=float, default=2.0,
+                   help="Don't lay an inspired-by edge for authors with less "
+                        "than this many cumulative hours (default 2.0)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--top", type=int, default=30)
+    p.add_argument("--sleep", type=float, default=0.4,
+                   help="Seconds to sleep between API writes")
+    args = p.parse_args(argv)
+
+    if not args.library.exists():
+        print(f"library not found: {args.library}", file=sys.stderr)
+        return 2
+    if not args.durations.exists():
+        print(f"duration metadata not found: {args.durations}", file=sys.stderr)
+        return 2
+
+    library = json.loads(args.library.read_text())
+    duration_doc = json.loads(args.durations.read_text())
+    durations_by_asin = duration_doc.get("products") or {}
+
+    print(f"reading {len(library)} library entries from {args.library.name}")
+    print(f"  joined against {len(durations_by_asin)} duration records")
+
+    # Aggregate author hours from joined library + durations
+    by_author: dict[str, dict] = defaultdict(
+        lambda: {"hours": 0.0, "books": 0, "asins": set(), "name": None}
+    )
+    for entry in library:
+        asin = entry.get("asin")
+        if not asin:
+            continue
+        meta = durations_by_asin.get(asin)
+        if not meta:
+            continue
+        runtime = meta.get("runtime_length_min") or 0
+        if not isinstance(runtime, (int, float)) or runtime <= 0:
+            continue
+        hours = (runtime / 60.0) * args.reading_multiplier
+        # Use authors from metadata first (cleaner), fall back to library
+        authors = meta.get("authors") or [entry.get("author") or "Unknown"]
+        if isinstance(authors, str):
+            authors = [authors]
+        for raw_name in authors:
+            name = (raw_name or "").strip()
+            if not name:
+                continue
+            agg = by_author[_normalize_author(name)]
+            agg["hours"] += hours
+            agg["books"] += 1
+            agg["asins"].add(asin)
+            if not agg["name"] or len(name) < len(agg["name"]):
+                # Prefer the shortest variant as canonical display name
+                # ("Tara Swart" over "Tara Swart MD PhD")
+                agg["name"] = name
+
+    significant = [
+        (norm, agg) for norm, agg in by_author.items()
+        if agg["hours"] >= args.min_author_hours
+    ]
+    significant.sort(key=lambda x: -x[1]["hours"])
+    total_hours = sum(a["hours"] for _, a in significant)
+
+    print(f"  {len(significant)} authors at >= {args.min_author_hours}h "
+          f"(~{total_hours:.0f} cumulative hours)")
+    print()
+    print(f"top {min(args.top, len(significant))} authors by cumulative hours:")
+    for norm, agg in significant[: args.top]:
+        s = _strength_from_hours(agg["hours"])
+        print(f"  {agg['hours']:7.1f}h  ({agg['books']:3d} books)  s={s:.2f}  "
+              f"{agg['name'][:40]}")
+
+    if args.dry_run:
+        print("\n(dry-run — no graph mutations performed)")
+        return 0
+
+    print("\napplying to graph…")
+    landed = refreshed = 0
+    for norm, agg in significant:
+        name = agg["name"]
+        hours = agg["hours"]
+        strength = _strength_from_hours(hours)
+
+        # Resolve author through the inspired-by service. The resolver's
+        # name-first dedupe (shipped earlier) collapses surface variants
+        # to the canonical identity if one exists; otherwise mints a
+        # new contributor stub. Auto-attune to vision concepts fires
+        # automatically on creation.
+        res = _post(args.api, "/api/inspired-by", {
+            "name": name,
+            "source_contributor_id": args.contributor,
+        }, timeout=60)
+        if "_err" in res:
+            print(f"  ✗ {name[:40]:40s}  resolver error: {res.get('_err')}")
+            time.sleep(args.sleep)
+            continue
+
+        identity_id = (res.get("identity") or {}).get("id")
+        if not identity_id:
+            time.sleep(args.sleep)
+            continue
+
+        edge = res.get("edge") or {}
+        edge_existed = bool(res.get("edge_existed"))
+        edge_props = {
+            "audible_hours": round(hours, 1),
+            "audible_books": agg["books"],
+            "source": "audible_listening_history",
+        }
+
+        if edge_existed:
+            # Refresh the existing edge's strength + properties so this
+            # ingest pass propagates the cumulative-hours signal onto
+            # whatever the resolver landed previously.
+            existing_url = (
+                f"/api/edges?from_id={urllib.parse.quote(args.contributor)}"
+                f"&to_id={urllib.parse.quote(identity_id)}&type=inspired-by"
+            )
+            edges_resp = _get(args.api, existing_url) or {}
+            for e in edges_resp.get("items", []) if isinstance(edges_resp, dict) else []:
+                _patch(args.api, f"/api/edges/{urllib.parse.quote(e['id'])}", {
+                    "strength": strength,
+                    "properties": edge_props,
+                })
+                refreshed += 1
+                break
+        else:
+            # The resolver's POST already created the edge with default
+            # strength; refresh it to the duration-weighted value.
+            edge_id = edge.get("id")
+            if edge_id:
+                _patch(args.api, f"/api/edges/{urllib.parse.quote(edge_id)}", {
+                    "strength": strength,
+                    "properties": edge_props,
+                })
+            landed += 1
+
+        time.sleep(args.sleep)
+
+    print()
+    print(f"  landed:    {landed} new inspired-by edges to authors")
+    print(f"  refreshed: {refreshed} existing edges with audible-hour strength")
+    print(f"  cumulative: {total_hours:.0f} hours of attention now visible")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -14,9 +14,12 @@ without having to stumble over it.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -184,6 +187,80 @@ def sense_spec_sources() -> list[str]:
     return lines
 
 
+def sense_contracts() -> list[str]:
+    """How are the CI contracts breathing the last 7 days?
+
+    Replaces the inbox channel — the GitHub Actions email firehose was
+    surfacing every flake as urgent. Here friction lives in a place the
+    body senses on arrival, not in interruption. We name patterns
+    (workflow X failed N times this week), not individual flakes.
+
+    Silent when contracts are breathing. Speaks when there's a shape
+    worth naming: 3+ failures of the same workflow, or any workflow
+    with a >40% failure rate over the window.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "run", "list", "--limit", "200",
+             "--json", "conclusion,workflowName,createdAt,event,headBranch"],
+            cwd=ROOT, capture_output=True, text=True, check=False, timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ["  (gh CLI unavailable — skipping contracts sense)"]
+    if r.returncode != 0:
+        return ["  (gh run list failed — skipping; may need `gh auth login`)"]
+
+    try:
+        runs = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return ["  (could not parse gh run list output)"]
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    recent = []
+    for run in runs:
+        try:
+            ts = datetime.fromisoformat(run["createdAt"].replace("Z", "+00:00"))
+        except (KeyError, ValueError):
+            continue
+        if ts >= cutoff:
+            recent.append(run)
+
+    if not recent:
+        return ["  (no runs in the last 7 days — body resting or gh window short)"]
+
+    by_wf: dict[str, dict[str, int]] = {}
+    for run in recent:
+        wf = run.get("workflowName", "?")
+        outcome = run.get("conclusion") or "in_progress"
+        by_wf.setdefault(wf, Counter())[outcome] += 1
+
+    findings = []
+    flagged = False
+    for wf in sorted(by_wf):
+        outcomes = by_wf[wf]
+        total = sum(outcomes.values())
+        failures = outcomes.get("failure", 0) + outcomes.get("startup_failure", 0)
+        if total == 0:
+            continue
+        rate = failures / total
+        if failures >= 3 or rate >= 0.4:
+            flagged = True
+            findings.append(
+                f"  {wf} — {failures}/{total} failed ({int(rate*100)}%) over 7d"
+            )
+
+    if not flagged:
+        green = sum(1 for run in recent if run.get("conclusion") == "success")
+        return [f"  contracts breathing — {green}/{len(recent)} runs green over 7d"]
+
+    findings.insert(0, f"  {len(recent)} runs over 7d; patterns worth naming:")
+    findings.append("")
+    findings.append("  (Friction here is signal, not pain to silence. If a")
+    findings.append("   pattern persists across days, the contract itself may")
+    findings.append("   want re-shaping — not the email channel.)")
+    return findings
+
+
 def main() -> int:
     print("# Wellness check\n")
     print("A gentle sensing. Not an audit. Drift is the signal,")
@@ -206,6 +283,11 @@ def main() -> int:
 
     print("## Source maps — do specs point at files that exist?\n")
     for line in sense_spec_sources():
+        print(line)
+    print()
+
+    print("## Contracts — are the CI gates breathing? (last 7d)\n")
+    for line in sense_contracts():
         print(line)
     print()
 

--- a/web/components/people/TemplateInfluenceWeb.tsx
+++ b/web/components/people/TemplateInfluenceWeb.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useState } from "react";
 import { getApiBase } from "@/lib/api";
-import { InfluenceWeb } from "@/components/presence/InfluenceWeb";
+import { BodyOfEvidence } from "@/components/presence/BodyOfEvidence";
 import { RefineDoorway } from "@/components/presence/RefineDoorway";
 import type { PresenceIdentity } from "@/components/presence/PresencePage";
 
@@ -66,7 +66,7 @@ export function TemplateInfluenceWeb({ graphSlug }: { graphSlug: string }) {
 
   return (
     <div className="space-y-10">
-      <InfluenceWeb
+      <BodyOfEvidence
         presenceId={node.id}
         externalPresences={node.presences || []}
       />

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -1,0 +1,721 @@
+"use client";
+
+/**
+ * BodyOfEvidence — the unified surface of every contribution and
+ * influence flowing through a presence, from any source.
+ *
+ * Three sections, all reading from the same edge fetch:
+ *
+ *   1. Emits into the field — outgoing `contributes-to` edges, the
+ *      works this presence has put into the world. Each weighted
+ *      by its own creation_hours / view_count when available.
+ *
+ *   2. Shaped by — outgoing `inspired-by` edges, the influences that
+ *      shaped this presence. Grouped by source (Audible, YouTube,
+ *      physical reading, named lineage, manual) so the visitor can
+ *      read which stream of attention each tie comes from. Within
+ *      each source, sorted by strength.
+ *
+ *   3. Field connections — every other relational edge (resonates-with,
+ *      at-place, analogous-to, etc.) grouped by the seven canonical
+ *      edge-type families. The spectrum-colored view from the earlier
+ *      InfluenceWeb is preserved here as the third lens.
+ *
+ *   4. Inbound recognition — incoming `inspired-by` edges, the
+ *      contributors who claim this presence as one of theirs.
+ *
+ * Sections collapse independently. Each chip carries the spectrum
+ * color of its relationship family; the strength bar carries the
+ * weight (cumulative hours, watch count, view count, depending on
+ * source).
+ */
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { getApiBase } from "@/lib/api";
+import { brandFor } from "./brand";
+import { SpectrumLink } from "./SpectrumLink";
+import {
+  EDGE_FAMILIES,
+  edgeTypeLabel,
+  EDGE_TYPE_TO_FAMILY,
+  familyForEdgeType,
+  hsl,
+  type EdgeFamily,
+  type EdgeFamilySlug,
+} from "@/lib/edge-spectrum";
+
+type EdgeRow = {
+  id: string;
+  from_id: string;
+  to_id: string;
+  type: string;
+  strength?: number | null;
+  properties?: Record<string, unknown> | null;
+  from_node?: NodeStub;
+  to_node?: NodeStub;
+};
+
+type NodeStub = {
+  id: string;
+  name: string;
+  type: string;
+  image_url?: string | null;
+  slug?: string | null;
+};
+
+type ExternalPresence = { provider: string; url: string };
+
+type Props = {
+  presenceId: string;
+  externalPresences?: ExternalPresence[];
+};
+
+// Source labels — readable names for the edge-property `source` values
+// the various ingest paths write. Unknown sources fall through to the
+// raw label so we don't hide what the body is carrying.
+const SOURCE_LABELS: Record<string, string> = {
+  audible_listening_history: "Audible",
+  youtube_watch_history_cluster: "YouTube",
+  physical_book_reading: "Physical reading",
+  lineage_seed: "Named lineage",
+  lineage_seed_cleanup: "Named lineage",
+  inspired_by_resolver: "Manual",
+  watch_history_clusterer: "YouTube",
+  thesis_seed: "Authored work",
+};
+
+const SOURCE_ORDER = [
+  "Authored work",
+  "Audible",
+  "YouTube",
+  "Physical reading",
+  "Named lineage",
+  "Manual",
+];
+
+function sourceLabelFor(props: Record<string, unknown> | null | undefined): string {
+  const raw = props?.source;
+  if (typeof raw !== "string" || !raw) return "Other";
+  return SOURCE_LABELS[raw] ?? raw;
+}
+
+// ── System tissue (visitors, runners, fixtures) — never render ───────
+
+const SYSTEM_PATTERNS = [
+  ":wanderer-", ":presence-visitor", ":test-", ":smoke-", "-smoke-", "-bot",
+  ":external-proof", "decomposition-verify", ":friend-", "-placeholder",
+  ":claude-opus-mac-node", ":coherence-runner", ":e-m-t-", ":email-",
+  ":qa-", ":ci-",
+];
+const SYSTEM_EXACT = new Set([
+  "contributor:claude", "contributor:codex", "contributor:codex-agent",
+  "contributor:cursor-agent", "contributor:grok", "contributor:gemini",
+  "person:codex-smoke-human", "contributor:presence-visitor",
+  "person:presence-visitor",
+]);
+
+function isSystem(id: string): boolean {
+  if (SYSTEM_EXACT.has(id)) return true;
+  return SYSTEM_PATTERNS.some((p) => id.includes(p));
+}
+
+// ── Component ─────────────────────────────────────────────────────────
+
+export function BodyOfEvidence({ presenceId, externalPresences = [] }: Props) {
+  const [edges, setEdges] = useState<EdgeRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!presenceId) return;
+    (async () => {
+      try {
+        const r = await fetch(
+          `${getApiBase()}/api/graph/nodes/${encodeURIComponent(
+            presenceId,
+          )}/edges?direction=both`,
+        );
+        if (r.ok) {
+          const body = await r.json();
+          setEdges(Array.isArray(body) ? body : body?.items ?? []);
+        }
+      } catch {
+        // empty body — the rest of the page still renders
+      } finally {
+        setLoaded(true);
+      }
+    })();
+  }, [presenceId]);
+
+  const sections = useMemo(() => composeSections(edges, presenceId), [edges, presenceId]);
+
+  if (!loaded) {
+    return (
+      <section className="space-y-3">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-muted-foreground">
+          Body of evidence
+        </h2>
+        <div className="h-12 animate-pulse rounded-lg bg-muted/40" />
+      </section>
+    );
+  }
+
+  const totalEdges =
+    sections.emissions.length +
+    sections.shapedBy.length +
+    sections.fieldConnections.length +
+    sections.recognition.length;
+
+  if (totalEdges === 0 && externalPresences.length === 0) {
+    return (
+      <section className="space-y-3">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-muted-foreground">
+          Body of evidence
+        </h2>
+        <p className="text-sm text-muted-foreground/80 italic">
+          The web around this presence is just beginning to weave. Add
+          relationships, public presences, or works to surface the threads.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-1">
+        <h2 className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
+          Body of evidence
+        </h2>
+        <p className="text-xs text-muted-foreground/80">
+          {totalEdges} threads woven through this presence
+          {externalPresences.length > 0 && ` · ${externalPresences.length} doorways beyond the network`}
+        </p>
+      </header>
+
+      {sections.emissions.length > 0 && (
+        <Emissions items={sections.emissions} />
+      )}
+
+      {sections.shapedBy.length > 0 && (
+        <ShapedBy items={sections.shapedBy} />
+      )}
+
+      {sections.fieldConnections.length > 0 && (
+        <FieldConnections items={sections.fieldConnections} />
+      )}
+
+      {sections.recognition.length > 0 && (
+        <Recognition items={sections.recognition} />
+      )}
+
+      {externalPresences.length > 0 && (
+        <BeyondTheNetwork presences={externalPresences} />
+      )}
+    </section>
+  );
+}
+
+// ── Section 1: Emissions ──────────────────────────────────────────────
+
+type EmissionRow = {
+  id: string;
+  name: string;
+  href: string;
+  imageUrl?: string | null;
+  strength: number;
+  kind: string;
+  hours: number | null;
+};
+
+function Emissions({ items }: { items: EmissionRow[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? items : items.slice(0, 8);
+  return (
+    <SectionShell
+      title="Emits into the field"
+      hint={`${items.length} ${items.length === 1 ? "creation" : "creations"} this presence has put into the world`}
+      familyHue={40} // attribution-gold
+    >
+      <ul className="space-y-1.5">
+        {visible.map((it) => (
+          <RowChip
+            key={it.id}
+            href={it.href}
+            name={it.name}
+            imageUrl={it.imageUrl}
+            strength={it.strength}
+            tag={it.kind}
+            metric={it.hours ? `${it.hours.toFixed(0)}h created` : null}
+            hue={40}
+          />
+        ))}
+      </ul>
+      {items.length > 8 && (
+        <ShowAllToggle
+          showAll={showAll}
+          total={items.length}
+          onClick={() => setShowAll((v) => !v)}
+        />
+      )}
+    </SectionShell>
+  );
+}
+
+// ── Section 2: Shaped By (influences) ─────────────────────────────────
+
+type ShapedRow = {
+  id: string;
+  name: string;
+  href: string;
+  imageUrl?: string | null;
+  strength: number;
+  source: string;
+  metric: string | null;
+};
+
+function ShapedBy({ items }: { items: ShapedRow[] }) {
+  // Group by source, sort each group by strength desc
+  const grouped = useMemo(() => {
+    const map: Record<string, ShapedRow[]> = {};
+    for (const it of items) {
+      (map[it.source] ||= []).push(it);
+    }
+    for (const src of Object.keys(map)) {
+      map[src].sort((a, b) => b.strength - a.strength);
+    }
+    return map;
+  }, [items]);
+
+  const orderedSources = [
+    ...SOURCE_ORDER.filter((s) => grouped[s]?.length),
+    ...Object.keys(grouped).filter((s) => !SOURCE_ORDER.includes(s)),
+  ];
+
+  return (
+    <SectionShell
+      title="Shaped by"
+      hint={`${items.length} influences across ${orderedSources.length} ${orderedSources.length === 1 ? "stream" : "streams"} of attention`}
+      familyHue={270} // ontological violet
+    >
+      <div className="space-y-5">
+        {orderedSources.map((src) => (
+          <SourceGroup key={src} source={src} rows={grouped[src]} />
+        ))}
+      </div>
+    </SectionShell>
+  );
+}
+
+function SourceGroup({ source, rows }: { source: string; rows: ShapedRow[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? rows : rows.slice(0, 8);
+  const totalHours = rows.reduce((sum, r) => {
+    const m = r.metric?.match(/^([\d.]+)h/);
+    return m ? sum + parseFloat(m[1]) : sum;
+  }, 0);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <h4 className="text-[10px] uppercase tracking-[0.15em] font-semibold text-muted-foreground">
+          {source}
+        </h4>
+        <span className="text-[10px] text-muted-foreground/60">
+          · {rows.length}
+          {totalHours > 0 ? ` · ${Math.round(totalHours)}h` : ""}
+        </span>
+      </div>
+      <ul className="space-y-1.5">
+        {visible.map((it) => (
+          <RowChip
+            key={it.id}
+            href={it.href}
+            name={it.name}
+            imageUrl={it.imageUrl}
+            strength={it.strength}
+            metric={it.metric}
+            hue={270}
+          />
+        ))}
+      </ul>
+      {rows.length > 8 && (
+        <ShowAllToggle
+          showAll={showAll}
+          total={rows.length}
+          onClick={() => setShowAll((v) => !v)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Section 3: Field Connections ──────────────────────────────────────
+
+type FieldRow = {
+  id: string;
+  name: string;
+  href: string;
+  imageUrl?: string | null;
+  strength: number;
+  edgeType: string;
+  family: EdgeFamilySlug;
+};
+
+function FieldConnections({ items }: { items: FieldRow[] }) {
+  const grouped = useMemo(() => {
+    const map: Partial<Record<EdgeFamilySlug, FieldRow[]>> = {};
+    for (const it of items) {
+      (map[it.family] ||= []).push(it);
+    }
+    return map;
+  }, [items]);
+
+  return (
+    <SectionShell
+      title="Field connections"
+      hint="Concepts, places, kindred presences — the relational threads"
+      familyHue={158}
+    >
+      <div className="space-y-4">
+        {EDGE_FAMILIES.map((fam) => {
+          const list = grouped[fam.slug];
+          if (!list?.length) return null;
+          return <FamilyBand key={fam.slug} family={fam} items={list} />;
+        })}
+      </div>
+    </SectionShell>
+  );
+}
+
+function FamilyBand({ family, items }: { family: EdgeFamily; items: FieldRow[] }) {
+  const tone = useFamilyTone(family);
+  const fg = hsl(tone, "fg");
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2" title={family.feeling}>
+        <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ background: fg }} />
+        <h4 className="text-[10px] uppercase tracking-[0.15em] font-semibold" style={{ color: fg }}>
+          {family.name}
+        </h4>
+        <span className="text-[10px] text-muted-foreground/60">· {items.length}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {items.slice(0, 30).map((it, i) => (
+          <SpectrumLink
+            key={`${it.id}-${i}`}
+            edgeType={it.edgeType}
+            href={it.href}
+            name={it.name}
+            imageUrl={it.imageUrl}
+            strength={it.strength}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Section 4: Inbound Recognition ────────────────────────────────────
+
+type RecRow = { id: string; name: string; href: string; imageUrl?: string | null; strength: number };
+
+function Recognition({ items }: { items: RecRow[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? items : items.slice(0, 8);
+  return (
+    <SectionShell
+      title="Recognized by"
+      hint={`${items.length} ${items.length === 1 ? "presence claims" : "presences claim"} this one as part of their lineage`}
+      familyHue={340}
+    >
+      <ul className="space-y-1.5">
+        {visible.map((it) => (
+          <RowChip
+            key={it.id}
+            href={it.href}
+            name={it.name}
+            imageUrl={it.imageUrl}
+            strength={it.strength}
+            hue={340}
+          />
+        ))}
+      </ul>
+      {items.length > 8 && (
+        <ShowAllToggle
+          showAll={showAll}
+          total={items.length}
+          onClick={() => setShowAll((v) => !v)}
+        />
+      )}
+    </SectionShell>
+  );
+}
+
+// ── Beyond the network ────────────────────────────────────────────────
+
+function BeyondTheNetwork({ presences }: { presences: ExternalPresence[] }) {
+  return (
+    <SectionShell
+      title="Beyond the network"
+      hint="Public URLs the world reaches them through"
+      familyHue={215}
+    >
+      <div className="flex flex-wrap gap-2">
+        {presences.map((p, i) => {
+          const tone = brandFor(p.provider);
+          return (
+            <a
+              key={`${p.provider}-${i}`}
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition-all hover:scale-[1.02]"
+              style={{
+                background: tone.gradient || tone.bg,
+                color: tone.fg,
+                borderColor: `color-mix(in oklch, ${tone.fg} 30%, transparent)`,
+              }}
+              title={`${tone.label} · ${p.url}`}
+            >
+              <span className="font-medium">{tone.label}</span>
+              <span className="opacity-60">↗</span>
+            </a>
+          );
+        })}
+      </div>
+    </SectionShell>
+  );
+}
+
+// ── Reusable shells ───────────────────────────────────────────────────
+
+function SectionShell({
+  title,
+  hint,
+  familyHue,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  familyHue: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <header className="space-y-0.5">
+        <div className="flex items-baseline gap-2">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: `hsl(${familyHue} 70% 60%)` }}
+          />
+          <h3 className="text-[11px] uppercase tracking-[0.15em] font-semibold text-foreground/80">
+            {title}
+          </h3>
+        </div>
+        {hint && <p className="text-[11px] text-muted-foreground/70 ml-4">{hint}</p>}
+      </header>
+      <div className="ml-4">{children}</div>
+    </section>
+  );
+}
+
+function RowChip({
+  href,
+  name,
+  imageUrl,
+  strength,
+  tag,
+  metric,
+  hue,
+}: {
+  href: string;
+  name: string;
+  imageUrl?: string | null;
+  strength: number;
+  tag?: string | null;
+  metric?: string | null;
+  hue: number;
+}) {
+  const pct = Math.round(Math.max(0.02, Math.min(1, strength)) * 100);
+  return (
+    <li>
+      <Link
+        href={href}
+        className="group flex items-center gap-3 rounded-md py-1.5 px-2 hover:bg-card/60 transition-colors"
+      >
+        {imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={imageUrl}
+            alt=""
+            className="w-8 h-8 rounded-full object-cover shrink-0 border border-border/40"
+          />
+        ) : (
+          <span
+            className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium shrink-0 border"
+            style={{
+              background: `hsl(${hue} 60% 92% / 0.15)`,
+              color: `hsl(${hue} 70% 70%)`,
+              borderColor: `hsl(${hue} 50% 40% / 0.4)`,
+            }}
+          >
+            {(name || "·").charAt(0).toUpperCase()}
+          </span>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2">
+            <span className="text-sm text-foreground/90 group-hover:text-foreground truncate">
+              {name}
+            </span>
+            {tag && (
+              <span className="text-[10px] uppercase tracking-[0.1em] text-muted-foreground/70 shrink-0">
+                {tag}
+              </span>
+            )}
+            {metric && (
+              <span className="text-[10px] text-muted-foreground/70 ml-auto shrink-0 tabular-nums">
+                {metric}
+              </span>
+            )}
+          </div>
+          <div
+            className="mt-1 h-[3px] rounded-full overflow-hidden"
+            style={{ background: `hsl(${hue} 60% 50% / 0.12)` }}
+          >
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${pct}%`,
+                background: `hsl(${hue} 70% 60%)`,
+              }}
+            />
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+function ShowAllToggle({
+  showAll,
+  total,
+  onClick,
+}: {
+  showAll: boolean;
+  total: number;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-[11px] text-[hsl(var(--primary))] hover:opacity-80 mt-1 ml-2"
+    >
+      {showAll ? "← show fewer" : `show all ${total} →`}
+    </button>
+  );
+}
+
+// ── Composition ───────────────────────────────────────────────────────
+
+function composeSections(edges: EdgeRow[], selfId: string) {
+  const emissions: EmissionRow[] = [];
+  const shapedBy: ShapedRow[] = [];
+  const fieldConnections: FieldRow[] = [];
+  const recognition: RecRow[] = [];
+
+  for (const e of edges) {
+    const isOutgoing = e.from_id === selfId;
+    const other = isOutgoing ? e.to_node : e.from_node;
+    if (!other || other.id === selfId) continue;
+    if (isSystem(other.id)) continue;
+    const strength = e.strength ?? 0;
+    const props = e.properties || {};
+
+    if (e.type === "contributes-to" && isOutgoing) {
+      const hours = numberFrom(props.creation_hours) ?? null;
+      emissions.push({
+        id: e.id,
+        name: other.name || other.id,
+        href: hrefFor(other),
+        imageUrl: other.image_url,
+        strength,
+        kind: ((props.kind as string) || "work").toLowerCase(),
+        hours,
+      });
+    } else if (e.type === "inspired-by" && isOutgoing) {
+      shapedBy.push({
+        id: e.id,
+        name: other.name || other.id,
+        href: hrefFor(other),
+        imageUrl: other.image_url,
+        strength,
+        source: sourceLabelFor(props),
+        metric: metricFor(props),
+      });
+    } else if (e.type === "inspired-by" && !isOutgoing) {
+      recognition.push({
+        id: e.id,
+        name: other.name || other.id,
+        href: hrefFor(other),
+        imageUrl: other.image_url,
+        strength,
+      });
+    } else {
+      fieldConnections.push({
+        id: e.id,
+        name: other.name || other.id,
+        href: hrefFor(other),
+        imageUrl: other.image_url,
+        strength,
+        edgeType: e.type,
+        family: (EDGE_TYPE_TO_FAMILY[e.type] ?? "attribution") as EdgeFamilySlug,
+      });
+    }
+  }
+
+  emissions.sort((a, b) => b.strength - a.strength);
+  shapedBy.sort((a, b) => b.strength - a.strength);
+  fieldConnections.sort((a, b) => b.strength - a.strength);
+  recognition.sort((a, b) => b.strength - a.strength);
+
+  return { emissions, shapedBy, fieldConnections, recognition };
+}
+
+function metricFor(props: Record<string, unknown>): string | null {
+  const ah = numberFrom(props.audible_hours);
+  const ab = numberFrom(props.audible_books);
+  if (ah != null) return ab ? `${ah.toFixed(0)}h · ${ab} books` : `${ah.toFixed(0)}h`;
+  const wh = numberFrom(props.watch_hours);
+  const wc = numberFrom(props.watch_count);
+  if (wh != null) return wc ? `${wh.toFixed(0)}h · ${wc} watches` : `${wh.toFixed(0)}h`;
+  const ph = numberFrom(props.physical_read_hours);
+  if (ph != null) return `${ph.toFixed(0)}h read`;
+  return null;
+}
+
+function numberFrom(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function hrefFor(other: NodeStub): string {
+  if (other.type === "concept") return `/vision/${encodeURIComponent(other.id)}`;
+  if (other.slug) return `/people/${other.slug}`;
+  return `/people/${encodeURIComponent(other.id)}`;
+}
+
+function useFamilyTone(family: EdgeFamily) {
+  const [isLight, setIsLight] = useState(false);
+  useEffect(() => {
+    const update = () => setIsLight(document.documentElement.classList.contains("light"));
+    update();
+    const mo = new MutationObserver(update);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => mo.disconnect();
+  }, []);
+  return isLight ? family.light : family.dark;
+}

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -25,7 +25,7 @@ import { brandFor, type BrandTone } from "./brand";
 import { UpcomingGatherings } from "./UpcomingGatherings";
 import { ResonatesWith } from "./ResonatesWith";
 import { KindredPresences } from "./KindredPresences";
-import { InfluenceWeb } from "./InfluenceWeb";
+import { BodyOfEvidence } from "./BodyOfEvidence";
 import { RefineDoorway } from "./RefineDoorway";
 import { LocationChip } from "./LocationChip";
 import { CoLocated } from "./CoLocated";
@@ -653,12 +653,13 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
             the platforms appear immediately after on mobile. */}
         <aside className="space-y-10 lg:space-y-8 min-w-0">
           <PresenceOverview identity={identity} inspiredCount={inspired.length} />
-          {/* Every related influence the body holds, inside and
-              outside the network, painted in the spectrum color of
-              its relationship family. The visitor reads the shape
-              of the presence by the spread of color and density
-              of chips. */}
-          <InfluenceWeb
+          {/* Every contribution and influence flowing through this
+              presence, from any source — the unified body-of-evidence
+              view. Emissions (works), Shaped-by (influences grouped
+              by source: Audible, YouTube, Physical, Lineage), Field
+              connections (concept resonances + relational threads
+              colored by family), and Inbound recognition. */}
+          <BodyOfEvidence
             presenceId={identity.id}
             externalPresences={identity.presences}
           />


### PR DESCRIPTION
## Summary
You named the actual gap: Audible chips dead-ended at wrongly-named author nodes (resolver minted "The Spellmonger Series" instead of Terry Mancour, "The Frontiers Saga Official We..." instead of Ryk Brown), and none of the 75 authors had their books visible as creations.

[`scripts/ingest_audible_books_full_trace.py`](scripts/ingest_audible_books_full_trace.py) closes both gaps in one pass:

- **Step 1**: matches each existing audible inspired-by edge to a canonical author cluster by hours-closest, PATCH-renames the wrongly-named contributor to the actual author name (Spellmonger Series → Terry Mancour, Frontiers Saga → Ryk Brown, etc.)
- **Step 2**: for each book in the library, mints an `asset` node with full metadata — `canonical_url` = Audible product URL, `image_url` = cover, `runtime_length_min` = duration, `asin`, `creation_kind="book"`. Lays author → book (`contributes-to`) and listener → book (`inspired-by` with per-book hours).

## End-to-end trace after this lands

```
chip in BodyOfEvidence
  "Terry Mancour 604h · 30 books"
        ↓
  /people/{mancour-id}
        ↓
  Emits into the field — 30 book chips
        ↓
  click any book
        ↓
  /people/asset:audible-{asin}
        ↓
  canonical_url footer → public Audible page
```

Stays consistent with the master's-thesis pattern: every meaningful work has a graph node, every node carries a URL to its public source material.

## Test plan
- [x] Audit existing edges shows 75 audible inspired-by, several misnamed
- [ ] post-merge: ingest run completes — count of renames + book assets created
- [ ] post-merge: visit a renamed author's page (e.g. Terry Mancour) → should now see 30 book chips → click any → asset page → canonical_url footer reaches Audible

🤖 Generated with [Claude Code](https://claude.com/claude-code)