### PR TITLE
fix(presence): collapse per-work inspired-by into the author chip

### DIFF
--- a/scripts/ingest_audible_books_full_trace.py
+++ b/scripts/ingest_audible_books_full_trace.py
@@ -201,7 +201,10 @@ def main(argv: list[str] | None = None) -> int:
                     "properties": {
                         "creation_kind": "book",
                         "asset_type": "CONTENT",
-                        "canonical_url": entry.get("product_url") or "",
+                        # Library entries carry `url`; listen-history
+                        # carries `product_url`. Try both so either
+                        # source path lands the trace.
+                        "canonical_url": entry.get("url") or entry.get("product_url") or "",
                         "image_url": entry.get("cover") or "",
                         "runtime_length_min": book["minutes"],
                         "asin": asin,

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -643,6 +643,13 @@ function composeSections(edges: EdgeRow[], selfId: string) {
         hours,
       });
     } else if (e.type === "inspired-by" && isOutgoing) {
+      // Per-work inspired-by edges (audible book listens, individual
+      // video watches) collapse into their author/channel chip in
+      // Shaped By. The work-level traceability stays in the graph —
+      // it surfaces when the visitor walks to the author's page,
+      // where the books appear in Emits — but doesn't multiply the
+      // rolled-up Shaped By view by 30 per author.
+      if (other.type === "asset") continue;
       shapedBy.push({
         id: e.id,
         name: other.name || other.id,


### PR DESCRIPTION
## Summary
After the [audible-books-full-trace ingest](https://github.com/seeker71/Coherence-Network/pull/1408) landed 189 book asset nodes with per-book inspired-by edges from the listener, the BodyOfEvidence "Shaped by" section was rendering **30 separate Mancour-book chips alongside the rolled-up Mancour author chip**. The work-level traceability is real (the books still exist as graph nodes and surface on the author's Emits page), but the rolled-up Shaped By view shouldn't multiply by per-work depth.

`composeSections` now skips inspired-by edges whose target is an asset; only contributor-targeted inspired-by edges enter the Shaped By rollup. The asset-targeted edges keep carrying per-book listening hours; they surface when the visitor walks to the author's page.

Also fixes the script to read the library entry's `url` field in addition to `product_url` so `canonical_url` lands on the asset for either source. Backfilled 189 existing book assets — Spellmonger now traces:

```
chip Terry Mancour 604h · 30 books
  → /people/{mancour-id}
  → 30 book chips in Emits
  → asset:audible-B01N264EEK (Spellmonger)
  → canonical_url https://www.audible.com/pd/Spellmonger-Audiobook/B01N264EEK
```

## Test plan
- [x] `tsc --noEmit` clean for changes (remaining errors pre-existing in unrelated three.js files)
- [x] Spellmonger asset verified: name + canonical_url to Audible product page
- [x] Mancour contributor renamed (was "The Spellmonger Series")
- [x] 30 contributes-to edges from Mancour to his books
- [ ] post-deploy: visit `/people/contributor:seeker71` — Shaped By section shows ~75 author chips (rolled up), not ~265 chips (one per book + author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)