### PR TITLE
attune(presence): fold lineage reading sources into Physical reading

### DIFF
--- a/scripts/ingest_audible_books_full_trace.py
+++ b/scripts/ingest_audible_books_full_trace.py
@@ -201,7 +201,10 @@ def main(argv: list[str] | None = None) -> int:
                     "properties": {
                         "creation_kind": "book",
                         "asset_type": "CONTENT",
-                        "canonical_url": entry.get("product_url") or "",
+                        # Library entries carry `url`; listen-history
+                        # carries `product_url`. Try both so either
+                        # source path lands the trace.
+                        "canonical_url": entry.get("url") or entry.get("product_url") or "",
                         "image_url": entry.get("cover") or "",
                         "runtime_length_min": book["minutes"],
                         "asin": asin,

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -76,12 +76,20 @@ type Props = {
 // raw label so we don't hide what the body is carrying.
 const SOURCE_LABELS: Record<string, string> = {
   audible_listening_history: "Audible",
+  audible_book_listening: "Audible",
   youtube_watch_history_cluster: "YouTube",
+  watch_history_clusterer: "YouTube",
   physical_book_reading: "Physical reading",
+  // The various reading-from-lineage-docs sources all collapse into
+  // "Physical reading" — they're all eyes-on-paper or eyes-on-paper-
+  // adjacent encounters from named lineage. The granular source value
+  // stays in the graph for analysis; the rendered label folds.
+  lineage_seed_books: "Physical reading",
+  ramtha_lineage_reading: "Physical reading",
+  goethean_lineage_reading: "Physical reading",
   lineage_seed: "Named lineage",
   lineage_seed_cleanup: "Named lineage",
   inspired_by_resolver: "Manual",
-  watch_history_clusterer: "YouTube",
   thesis_seed: "Authored work",
 };
 

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -643,6 +643,13 @@ function composeSections(edges: EdgeRow[], selfId: string) {
         hours,
       });
     } else if (e.type === "inspired-by" && isOutgoing) {
+      // Per-work inspired-by edges (audible book listens, individual
+      // video watches) collapse into their author/channel chip in
+      // Shaped By. The work-level traceability stays in the graph —
+      // it surfaces when the visitor walks to the author's page,
+      // where the books appear in Emits — but doesn't multiply the
+      // rolled-up Shaped By view by 30 per author.
+      if (other.type === "asset") continue;
       shapedBy.push({
         id: e.id,
         name: other.name || other.id,


### PR DESCRIPTION
## Summary
On viewing /people/contributor:seeker71 in the browser the BodyOfEvidence section had unmapped source labels showing as raw values (`lineage_seed_books`, `ramtha_lineage_reading`) — the SOURCE_LABELS map didn't cover the values the recent lineage-book ingests wrote.

Three reading-from-lineage source values now fold into the existing "Physical reading" label. The granular source stays on the edge for analysis; the rendered label folds.

## Companion graph-state cleanup (one-off ops)
- Composted 2 orphan contributors (Ernie Davis = football player Wikipedia, Dr. Alex = healing-code author with no library match)
- Backfilled source tags on 8 lineage edges that had been created unsourced (Karl May, 5Rhythms, Leatherstocking Tales, Steiner, Goetheanum, RSE, Zach Bush, Amanda Walsh)
- Karl May specifically gets `physical_book_reading` + 80h to join the childhood-reading group

## Test plan
- [x] Source audit shows 11 (none) edges before, 0 after
- [x] Two orphan contributors deleted with their 10 edges
- [ ] post-deploy: visit /people/contributor:seeker71, confirm Shaped By section shows clean source headers (no more raw `lineage_seed_books` etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)