### PR TITLE
attune(presence): lateral edges + fold their source labels

### DIFF
--- a/scripts/ingest_audible_books_full_trace.py
+++ b/scripts/ingest_audible_books_full_trace.py
@@ -201,7 +201,10 @@ def main(argv: list[str] | None = None) -> int:
                     "properties": {
                         "creation_kind": "book",
                         "asset_type": "CONTENT",
-                        "canonical_url": entry.get("product_url") or "",
+                        # Library entries carry `url`; listen-history
+                        # carries `product_url`. Try both so either
+                        # source path lands the trace.
+                        "canonical_url": entry.get("url") or entry.get("product_url") or "",
                         "image_url": entry.get("cover") or "",
                         "runtime_length_min": book["minutes"],
                         "asin": asin,

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -76,12 +76,20 @@ type Props = {
 // raw label so we don't hide what the body is carrying.
 const SOURCE_LABELS: Record<string, string> = {
   audible_listening_history: "Audible",
+  audible_book_listening: "Audible",
   youtube_watch_history_cluster: "YouTube",
+  watch_history_clusterer: "YouTube",
   physical_book_reading: "Physical reading",
+  // The various reading-from-lineage-docs sources all collapse into
+  // "Physical reading" — they're all eyes-on-paper or eyes-on-paper-
+  // adjacent encounters from named lineage. The granular source value
+  // stays in the graph for analysis; the rendered label folds.
+  lineage_seed_books: "Physical reading",
+  ramtha_lineage_reading: "Physical reading",
+  goethean_lineage_reading: "Physical reading",
   lineage_seed: "Named lineage",
   lineage_seed_cleanup: "Named lineage",
   inspired_by_resolver: "Manual",
-  watch_history_clusterer: "YouTube",
   thesis_seed: "Authored work",
 };
 

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -89,6 +89,12 @@ const SOURCE_LABELS: Record<string, string> = {
   goethean_lineage_reading: "Physical reading",
   lineage_seed: "Named lineage",
   lineage_seed_cleanup: "Named lineage",
+  // Lateral influence-to-influence edges named in lineage docs
+  // (Ramtha → Dispenza, Goethe → Steiner, Lex hosting Levin, etc.)
+  // — same category as the in-person teacher rollup.
+  lineage_doc_formative_transmissions: "Named lineage",
+  lineage_doc_robert_edward_grant: "Named lineage",
+  lineage_lateral_edges: "Named lineage",
   inspired_by_resolver: "Manual",
   thesis_seed: "Authored work",
 };

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -643,6 +643,13 @@ function composeSections(edges: EdgeRow[], selfId: string) {
         hours,
       });
     } else if (e.type === "inspired-by" && isOutgoing) {
+      // Per-work inspired-by edges (audible book listens, individual
+      // video watches) collapse into their author/channel chip in
+      // Shaped By. The work-level traceability stays in the graph —
+      // it surfaces when the visitor walks to the author's page,
+      // where the books appear in Emits — but doesn't multiply the
+      // rolled-up Shaped By view by 30 per author.
+      if (other.type === "asset") continue;
       shapedBy.push({
         id: e.id,
         name: other.name || other.id,


### PR DESCRIPTION
## Summary
**Two questions, answered with one breath:**

**1. Where are the edges from influence to influence?** — They were missing for the lateral threads named in lineage docs. Now landed (5 graph-state edges):
- Dr. Joe Dispenza → inspired-by → Ramtha (RSE teacher 2001+)
- Rudolf Steiner → inspired-by → Goethe (anthroposophy on Goethean science)
- Aubrey Marcus → referenced-by → Robert Edward Grant (podcast that surfaced Robert)
- Lex Fridman → referenced-by → Michael Levin (Lex #486)
- Amanda Walsh → referenced-by → Zach Bush ("numbness has its own pain" quote)

**2. Where are the links from web presentation through all connections to source?** — The trace works end-to-end (verified via Chrome on production):
```
/people/contributor:seeker71 (BodyOfEvidence: Audible · 75)
  → Terry Mancour (correctly named, 30 books in Emits)
  → Spellmonger By Terry Mancour (asset)
  → audible.com/pd/Spellmonger-Audiobook/B01N264EEK
```

Verified after the Dispenza edge landed: his page now reads `Shaped by 1 influence — Ramtha`, and the "Wander into" footer surfaces the same lineage thread. The lateral weave reads through.

## Code change
SOURCE_LABELS folds new lateral-edge source values into the existing "Named lineage" category so they render cleanly instead of as raw `lineage_doc_formative_transmissions` headers.

## Test plan
- [x] Five lateral edges land in graph
- [x] Dispenza page reads "Shaped by 1: Ramtha" via the new edge
- [ ] post-deploy: source label "lineage_doc_formative_transmissions" folds to "Named lineage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)