### PR TITLE
attune(presence): compost duplicate legacy + add Bjorg + Dispenza books

### DIFF
--- a/scripts/ingest_audible_books_full_trace.py
+++ b/scripts/ingest_audible_books_full_trace.py
@@ -201,7 +201,10 @@ def main(argv: list[str] | None = None) -> int:
                     "properties": {
                         "creation_kind": "book",
                         "asset_type": "CONTENT",
-                        "canonical_url": entry.get("product_url") or "",
+                        # Library entries carry `url`; listen-history
+                        # carries `product_url`. Try both so either
+                        # source path lands the trace.
+                        "canonical_url": entry.get("url") or entry.get("product_url") or "",
                         "image_url": entry.get("cover") or "",
                         "runtime_length_min": book["minutes"],
                         "asin": asin,

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -76,12 +76,20 @@ type Props = {
 // raw label so we don't hide what the body is carrying.
 const SOURCE_LABELS: Record<string, string> = {
   audible_listening_history: "Audible",
+  audible_book_listening: "Audible",
   youtube_watch_history_cluster: "YouTube",
+  watch_history_clusterer: "YouTube",
   physical_book_reading: "Physical reading",
+  // The various reading-from-lineage-docs sources all collapse into
+  // "Physical reading" — they're all eyes-on-paper or eyes-on-paper-
+  // adjacent encounters from named lineage. The granular source value
+  // stays in the graph for analysis; the rendered label folds.
+  lineage_seed_books: "Physical reading",
+  ramtha_lineage_reading: "Physical reading",
+  goethean_lineage_reading: "Physical reading",
   lineage_seed: "Named lineage",
   lineage_seed_cleanup: "Named lineage",
   inspired_by_resolver: "Manual",
-  watch_history_clusterer: "YouTube",
   thesis_seed: "Authored work",
 };
 

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -89,6 +89,12 @@ const SOURCE_LABELS: Record<string, string> = {
   goethean_lineage_reading: "Physical reading",
   lineage_seed: "Named lineage",
   lineage_seed_cleanup: "Named lineage",
+  // Lateral influence-to-influence edges named in lineage docs
+  // (Ramtha → Dispenza, Goethe → Steiner, Lex hosting Levin, etc.)
+  // — same category as the in-person teacher rollup.
+  lineage_doc_formative_transmissions: "Named lineage",
+  lineage_doc_robert_edward_grant: "Named lineage",
+  lineage_lateral_edges: "Named lineage",
   inspired_by_resolver: "Manual",
   thesis_seed: "Authored work",
 };

--- a/web/components/presence/BodyOfEvidence.tsx
+++ b/web/components/presence/BodyOfEvidence.tsx
@@ -643,6 +643,13 @@ function composeSections(edges: EdgeRow[], selfId: string) {
         hours,
       });
     } else if (e.type === "inspired-by" && isOutgoing) {
+      // Per-work inspired-by edges (audible book listens, individual
+      // video watches) collapse into their author/channel chip in
+      // Shaped By. The work-level traceability stays in the graph —
+      // it surfaces when the visitor walks to the author's page,
+      // where the books appear in Emits — but doesn't multiply the
+      // rolled-up Shaped By view by 30 per author.
+      if (other.type === "asset") continue;
       shapedBy.push({
         id: e.id,
         name: other.name || other.id,

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -23,7 +23,6 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { brandFor, type BrandTone } from "./brand";
 import { UpcomingGatherings } from "./UpcomingGatherings";
-import { ResonatesWith } from "./ResonatesWith";
 import { KindredPresences } from "./KindredPresences";
 import { BodyOfEvidence } from "./BodyOfEvidence";
 import { RefineDoorway } from "./RefineDoorway";
@@ -474,32 +473,6 @@ function CreationsGrid({
   );
 }
 
-function InspiredByChips({
-  inspired,
-}: {
-  inspired: Lineage[];
-}) {
-  if (inspired.length === 0) return null;
-  return (
-    <section>
-      <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-        Inspired by
-      </p>
-      <div className="flex flex-wrap gap-1.5">
-        {inspired.map((l) => (
-          <Link
-            key={l.id}
-            href={`/people/${encodeURIComponent(l.id)}`}
-            className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
-          >
-            {l.name}
-          </Link>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 function HeldOpen({
   identity,
   accent,
@@ -681,10 +654,15 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
           {identity.id.startsWith("event:") && (
             <HeldBy eventId={identity.id} />
           )}
-          <ResonatesWith presenceId={identity.id} />
+          {/* `ResonatesWith` (concept resonance chips) and
+              `InspiredByChips` (flat inspired-by list) composted —
+              both surfaces fully covered by BodyOfEvidence above
+              (Field connections → Being family; Shaped by sections
+              grouped by source). KindredPresences and CoLocated
+              carry distinct signals (shared-concept neighbors,
+              co-location through places) so they remain. */}
           <KindredPresences presenceId={identity.id} />
           <CoLocated presenceId={identity.id} />
-          <InspiredByChips inspired={inspired} />
           <HeldOpen identity={identity} accent={accent} />
         </aside>
       </div>


### PR DESCRIPTION
## Summary
**Both directives from one frame:**

### "legacy still smells like old tissue"
Composted two PresencePage aside components that were duplicating BodyOfEvidence:
- `ResonatesWith` (concept-resonance chips) — fully covered by `BodyOfEvidence > Field connections > Being family`
- `InspiredByChips` (flat inspired-by list) — fully covered by `BodyOfEvidence > Shaped by` (ranked + grouped by source)

`KindredPresences` and `CoLocated` stay — distinct signals (shared-concept neighbors, co-location through places) BodyOfEvidence doesn't render.

### "more than 6 physical books, think a bit harder"
Added 7 physical-reading assets the lineage docs/archive explicitly name:

**Bjorg's master's-thesis-2000/companion/ writings (4)** — the documented other half of Urs's 1998–2000 thesis collaboration, files exist locally:
- BML Object System (Bjorg MS thesis)
- Another Object Model (Bjorg thesis proposal)
- Angelic Assembler
- BML Search Algorithms

**Joe Dispenza's foundational books (3)** — the RSE-lineage curriculum beyond `You Are the Placebo` (which was already in graph as Audible asset):
- Becoming Supernatural (2017)
- Breaking the Habit of Being Yourself (2012)
- Evolve Your Brain (2007)

All seven: `physical_book_reading` source, 4× reading multiplier, `contributes-to` from author, canonical_url where public (Dispenza) or local-archive path (Bjorg).

## Test plan
- [x] `tsc --noEmit` clean for changes (remaining errors pre-existing in three.js + missing-deps files)
- [x] 7 new asset nodes land in graph
- [ ] post-deploy: visit /people/contributor:seeker71, confirm bottom of page no longer has duplicate "Inspired by"/"Resonates with" sections; Physical reading section in BodyOfEvidence expanded with new authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)