### PR TITLE
tend: surface the Quark-era works (Virtual DOM + Multi-Undo/Redo)

### DIFF
--- a/web/app/people/quark-multi-undo-redo/page.tsx
+++ b/web/app/people/quark-multi-undo-redo/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getQuarkMultiUndoRedoContent } from "@/content/people/quark-multi-undo-redo";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getQuarkMultiUndoRedoContent(lang).metadata;
+}
+
+export default async function QuarkMultiUndoRedoProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getQuarkMultiUndoRedoContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="quark-multi-undo-redo"
+    />
+  );
+}

--- a/web/app/people/quark-virtual-dom/page.tsx
+++ b/web/app/people/quark-virtual-dom/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getQuarkVirtualDomContent } from "@/content/people/quark-virtual-dom";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getQuarkVirtualDomContent(lang).metadata;
+}
+
+export default async function QuarkVirtualDomProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getQuarkVirtualDomContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="quark-virtual-dom"
+    />
+  );
+}

--- a/web/content/people/quark-multi-undo-redo/en.tsx
+++ b/web/content/people/quark-multi-undo-redo/en.tsx
@@ -1,0 +1,366 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Quark Multi-Document Undo/Redo Engine",
+    description:
+      "An undo/redo engine for QuarkXPress that worked across documents and across application surfaces. Any user action — per-document edits, application-wide preference changes that cascaded into every open document — could be unwound and re-played without leaving sediment. The architecturally hard part: actions whose blast radius spanned multiple documents had to interleave correctly into every per-document timeline.",
+  },
+  breadcrumbName: "Quark Multi-Undo/Redo",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(20 35% 14%) 50%, hsl(40 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · Quark Software Inc. · Denver · early 2000s",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Quark Multi-Document Undo/Redo Engine",
+    welcome: (
+      <p>
+        An undo/redo engine that worked across <em>every</em> open
+        document and <em>every</em> application surface in
+        QuarkXPress. Any user action could be unwound and re-played —
+        per-document edits in the obvious way, but also app-wide
+        preference changes that cascaded into multiple open documents
+        at once. The architecturally hard part: actions whose blast
+        radius spanned multiple documents had to interleave correctly
+        into each document's per-document timeline so undoing in any
+        document carried the right slice of the global change.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "Quark Software Inc. · Denver office · early-to-mid 2000s · post-MS thesis. Exact tenure dates from LinkedIn — refine below." },
+    { label: "Substrate", value: "C++ · QuarkXPress runtime · Mac OS Classic / Mac OS X / Windows · cross-platform action-record model" },
+    { label: "Application", value: (<>QuarkXPress — desktop publishing across multiple simultaneous documents per session. <Link href="https://www.quark.com" target="_blank" rel="noopener noreferrer" className="hover:text-primary">quark.com</Link></>) },
+    {
+      label: "Lineage back",
+      value: (
+        <>
+          Backtracking-as-unwinding-without-sediment from the{" "}
+          <Link href="/people/bml-language" className="hover:text-primary">2000 BML thesis</Link>
+          , now applied at the application level: a user's keystroke
+          had a <code className="text-foreground/80">DO</code> and an{" "}
+          <code className="text-foreground/80">UNDO</code>, the same
+          way every BMA instruction did in the{" "}
+          <Link href="/people/bmcpu-vm" className="hover:text-primary">BMCPU virtual machine</Link>
+          .
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The same <em>tend / attune / compost / release</em> commit
+          posture that powers{" "}
+          <Link href="/people/coherence-network" className="hover:text-primary">Coherence-Network</Link>
+          {" "}today is the same conviction this engine encoded at the
+          desktop-app scale: the system never accumulates dead
+          sediment, because every change has a clean reverse.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "What was actually hard",
+    body: (
+      <p>
+        Single-document undo is a textbook problem. Multi-document
+        undo with shared application state is{" "}
+        <em>not</em>. A "set hyphenation rules" change is not local
+        to a document — it modifies an app-wide setting that every
+        currently-open document immediately re-paginates against.
+        Undoing that change has to either roll back the global state
+        AND re-paginate every affected document, or it has to{" "}
+        <em>partially</em> roll back if some documents have since
+        moved on. The engine had to know, for every action, who its
+        affected parties were, and how to compose its reverse with
+        the actions that landed after it.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "Two realms of state, one timeline per scope",
+      body: (
+        <>
+          <p>
+            QuarkXPress lived in two state realms at once. The{" "}
+            <strong>document realm</strong> held everything specific
+            to a single open document — pages, text, boxes, style
+            sheets local to that document. The{" "}
+            <strong>application realm</strong> held everything shared
+            — preferences, hyphenation rules, color profiles, font
+            substitution policies, plug-in registry — settings that,
+            when changed, took effect immediately in every currently-
+            open document.
+          </p>
+          <p>
+            The engine modeled each realm with its own action stack.
+            Each open document carried a per-document undo stack;
+            the application carried a global app-state stack. The
+            challenge was that some actions belonged to{" "}
+            <em>both</em> realms — an app-wide preference change is
+            one global action that produces a consequence in every
+            document. The engine had to record one global action
+            with N document-side consequences and route undo
+            requests so the right slice of the change came back at
+            the right moment.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 340" className="w-full h-auto" role="img" aria-labelledby="undo-arch-title">
+              <title id="undo-arch-title">Multi-document undo/redo timeline interleaving</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="11">
+                {/* Application realm timeline */}
+                <text x="40" y="40" fill="hsl(40 80% 75%)" fontSize="12">App realm</text>
+                <line x1="40" y1="60" x2="680" y2="60" stroke="hsl(40 60% 50%)" strokeWidth="1.5" />
+                {/* Three global actions */}
+                <g>
+                  <rect x="120" y="48" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" />
+                  <text x="150" y="64" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">prefs A</text>
+                </g>
+                <g>
+                  <rect x="320" y="48" width="80" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" />
+                  <text x="360" y="64" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">hyphenation</text>
+                </g>
+                <g>
+                  <rect x="540" y="48" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" />
+                  <text x="570" y="64" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">color</text>
+                </g>
+
+                {/* Doc 1 timeline */}
+                <text x="40" y="120" fill="hsl(195 80% 75%)" fontSize="12">Doc 1</text>
+                <line x1="40" y1="140" x2="680" y2="140" stroke="hsl(195 60% 50%)" strokeWidth="1.5" />
+                <g>
+                  <rect x="80" y="128" width="40" height="24" rx="4" fill="hsl(195 60% 28%)" stroke="hsl(195 70% 60%)" />
+                  <text x="100" y="144" textAnchor="middle" fill="hsl(195 90% 85%)" fontSize="10">edit</text>
+                </g>
+                <g>
+                  <rect x="120" y="128" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="150" y="144" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">prefs ↓</text>
+                </g>
+                <g>
+                  <rect x="220" y="128" width="40" height="24" rx="4" fill="hsl(195 60% 28%)" stroke="hsl(195 70% 60%)" />
+                  <text x="240" y="144" textAnchor="middle" fill="hsl(195 90% 85%)" fontSize="10">box</text>
+                </g>
+                <g>
+                  <rect x="320" y="128" width="80" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="360" y="144" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">hyphen ↓</text>
+                </g>
+                <g>
+                  <rect x="440" y="128" width="40" height="24" rx="4" fill="hsl(195 60% 28%)" stroke="hsl(195 70% 60%)" />
+                  <text x="460" y="144" textAnchor="middle" fill="hsl(195 90% 85%)" fontSize="10">page</text>
+                </g>
+
+                {/* Doc 2 timeline */}
+                <text x="40" y="200" fill="hsl(280 70% 80%)" fontSize="12">Doc 2</text>
+                <line x1="40" y1="220" x2="680" y2="220" stroke="hsl(280 60% 60%)" strokeWidth="1.5" />
+                <g>
+                  <rect x="120" y="208" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="150" y="224" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">prefs ↓</text>
+                </g>
+                <g>
+                  <rect x="200" y="208" width="50" height="24" rx="4" fill="hsl(280 60% 30%)" stroke="hsl(280 70% 65%)" />
+                  <text x="225" y="224" textAnchor="middle" fill="hsl(280 90% 88%)" fontSize="10">color</text>
+                </g>
+                <g>
+                  <rect x="320" y="208" width="80" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="360" y="224" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">hyphen ↓</text>
+                </g>
+                <g>
+                  <rect x="540" y="208" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="570" y="224" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">color ↓</text>
+                </g>
+
+                {/* Doc 3 closed-then-reopened */}
+                <text x="40" y="278" fill="hsl(140 70% 75%)" fontSize="12">Doc 3</text>
+                <line x1="40" y1="298" x2="290" y2="298" stroke="hsl(140 60% 50%)" strokeWidth="1.5" />
+                <line x1="450" y1="298" x2="680" y2="298" stroke="hsl(140 60% 50%)" strokeWidth="1.5" strokeDasharray="3,3" />
+                <text x="370" y="302" textAnchor="middle" fill="hsl(140 50% 70%)" fontSize="10">closed</text>
+                <g>
+                  <rect x="120" y="286" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="150" y="302" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">prefs ↓</text>
+                </g>
+                <g>
+                  <rect x="540" y="286" width="60" height="24" rx="4" fill="hsl(40 70% 28%)" stroke="hsl(40 80% 60%)" strokeDasharray="3,2" />
+                  <text x="570" y="302" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="10">color ↓</text>
+                </g>
+
+                <text x="360" y="335" fill="hsl(220 30% 70%)" textAnchor="middle" fontSize="11" fontStyle="italic">
+                  global actions cast shadows (dashed) onto every affected document timeline
+                </text>
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              Solid blocks are document-local actions. Dashed blocks are
+              the per-document <em>shadow</em> of a global action — the
+              same shared event recorded onto each affected document's
+              undo stack so unwinding the global state can also unwind
+              its document-level consequences correctly.
+            </figcaption>
+          </figure>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "The hard case made concrete",
+      heading: "Hyphenation, three documents, one undo",
+      body: (
+        <>
+          <p>
+            User opens documents <em>A</em>, <em>B</em>, <em>C</em>.
+            Edits boxes in each. Then changes the application-wide
+            hyphenation rules. All three documents instantly
+            re-paginate. User does more work in <em>A</em> and{" "}
+            <em>B</em>, then closes <em>C</em> entirely. Now: user
+            presses ⌘Z in <em>A</em>. What should happen?
+          </p>
+          <p>
+            The naïve answer is "undo the most recent action in A's
+            stack" — which would unwind one of A's box edits. The
+            naïve answer is wrong if the user's mental model is "undo
+            the last thing I changed," because the most recent shared
+            change was the hyphenation. The engine had to surface the
+            hyphenation as an undoable action visible from{" "}
+            <em>any</em> currently-open document — not just where it
+            originated. Undoing the hyphenation change has to roll
+            back the global state, then re-paginate every still-open
+            document at its current state. Document <em>C</em>, having
+            closed, does not get re-paginated; the engine drops its
+            shadow when the document unmounts. If the user later
+            re-opens <em>C</em> from disk, its on-disk version reflects
+            its state at close-time — independent of the timeline.
+            <em> The engine must know what it can and cannot reach</em>.
+          </p>
+          <p>
+            And then there's <em>redo</em>. The user now hits ⌘⇧Z. The
+            hyphenation change has to come back, and every still-open
+            document has to re-receive its shadow. The two action
+            stacks (global, per-document) had to stay in sync without
+            either being authoritative — every undoable was tagged
+            with its scope, and the engine composed reverses across
+            scopes when it had to.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "The architectural shape that emerged",
+      body: (
+        <>
+          <p>
+            Three primitives carried the weight:
+          </p>
+          <ul className="space-y-2 list-disc list-inside marker:text-muted-foreground">
+            <li>
+              <strong>Action records.</strong> Every user-visible
+              change emitted a record carrying its forward
+              effect, its reverse effect, and the set of document
+              + application surfaces it touched. Records were
+              immutable and value-typed; reversing produced a new
+              record that the redo stack could re-apply.
+            </li>
+            <li>
+              <strong>Scope-tagged stacks.</strong> Each open
+              document held its own undo and redo stack. The
+              application held a global undo and redo stack. A
+              record could appear in more than one stack — once on
+              the global timeline as the canonical event, plus a
+              shadow on each document timeline that sees it. All
+              shadows pointed at the same underlying record.
+            </li>
+            <li>
+              <strong>Reachability awareness.</strong> When a
+              document closed, its shadow links dropped from the
+              global record's affected-set. When the user pressed
+              undo, the engine asked: "is this record still
+              consistent given the current set of open documents?"
+              and either applied it normally or applied its
+              partially-effective reverse. No silent corruption.
+            </li>
+          </ul>
+          <p>
+            Two readings the engine carried that the rest of the
+            industry didn't yet have widely. First,{" "}
+            <strong>undo as a tree, not a line</strong> — branches
+            from divergent edits were addressable, not collapsed
+            into a single linear stream. Second,{" "}
+            <strong>scope as a first-class property of an action</strong>
+            {" "}— the question "what does this change affect?" was
+            answered at the moment the action was recorded, not
+            inferred at undo time. Both convictions show up later in
+            the network's design — the graph as the substrate where
+            scope is reachable through edges, and the contribution
+            attribution arc as a tree of related actions, not a
+            ledger of disconnected events.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Same conviction · different substrate",
+      heading: "The lineage stays unbroken",
+      body: (
+        <p>
+          The 2000 thesis (
+          <Link href="/people/backtracking-model-languages" className="text-primary hover:underline">
+            Backtracking Model Languages
+          </Link>
+          ) made backtracking the architecture of execution: every
+          BMA instruction had a forward and a reverse semantics.
+          The Quark engine made the same conviction the architecture
+          of <em>user experience</em>: every user-action had a forward
+          and a reverse, with the reverse aware of its full
+          cross-document blast radius. The Coherence Network now
+          carries the same posture into{" "}
+          <em>commit verbs</em> —{" "}
+          <code className="text-foreground/80">tend</code> /{" "}
+          <code className="text-foreground/80">attune</code> /{" "}
+          <code className="text-foreground/80">compost</code> /{" "}
+          <code className="text-foreground/80">release</code> — where
+          unwinding without sediment is named directly, and git's tree
+          of commits is the timeline that the QuarkXPress engine
+          carried per-document, scaled out across cells.
+        </p>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Application context:{" "}
+      <Link
+        href="https://www.quark.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        quark.com
+      </Link>
+      {" · "}
+      <Link
+        href="https://en.wikipedia.org/wiki/QuarkXPress"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        QuarkXPress on Wikipedia
+      </Link>
+      . The implementation is internal to Quark and not public — what
+      lives here is the architectural shape, the design rationale,
+      and the lived memory of building and shipping it. Urs is
+      invited to refine exact tenure dates, the canonical action-
+      record vocabulary, and any technical detail through the Refine
+      doorway below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/quark-multi-undo-redo/index.ts
+++ b/web/content/people/quark-multi-undo-redo/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getQuarkMultiUndoRedoContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}

--- a/web/content/people/quark-virtual-dom/en.tsx
+++ b/web/content/people/quark-virtual-dom/en.tsx
@@ -1,0 +1,326 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Quark Virtual DOM — application API as a live DOM tree",
+    description:
+      "While at Quark in Denver, Urs designed and shipped a virtual DOM that exposed the entire QuarkXPress API as a live document tree. Every setting, every document, every box, every attribute became a DOM node addressable by a standard DOM client — read or write any part of the running application without a custom binding layer.",
+  },
+  breadcrumbName: "Quark Virtual DOM",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(195 35% 14%) 50%, hsl(280 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · Quark Software Inc. · Denver · early 2000s",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Quark Virtual DOM",
+    welcome: (
+      <p>
+        A virtual DOM exposing the entire QuarkXPress API. Every
+        application setting, every open document, every page, every
+        text box, every measurement — addressable as a node in a
+        standard DOM tree. A scripting client could read or write
+        any part of the running application without a custom
+        per-feature binding. Years before the browser-side virtual-
+        DOM idea entered the public conversation, the same shape was
+        running production at Quark — applied to a desktop publisher
+        instead of a web view.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "Quark Software Inc. · Denver office · early-to-mid 2000s · post-MS thesis. Exact tenure dates from LinkedIn — refine below." },
+    { label: "Substrate", value: "C++ · QuarkXPress runtime · Mac OS Classic / Mac OS X · Windows · COM bindings on the Windows side" },
+    { label: "Application", value: (<>QuarkXPress — the desktop publishing application that defined a generation of print and layout work. <Link href="https://www.quark.com" target="_blank" rel="noopener noreferrer" className="hover:text-primary">quark.com</Link></>) },
+    {
+      label: "Lineage back",
+      value: (
+        <>
+          Carries forward the self-describing posture from the{" "}
+          <Link href="/people/bml-language" className="hover:text-primary">2000 BML thesis</Link>
+          {" "}— a system that describes its own structure to itself.
+          BML's grammar parsed itself; the Quark Virtual DOM made
+          QuarkXPress query and mutate itself.
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The everything-is-a-node primitive that became U-CORE in{" "}
+          <Link href="/people/living-codex-csharp" className="hover:text-primary">Living-Codex-CSharp</Link>
+          {" "}and the live-graph data layer in{" "}
+          <Link href="/people/coherence-network" className="hover:text-primary">Coherence-Network</Link>
+          {" "}is the same conviction at network scale — the Quark
+          Virtual DOM was the desktop-app form of the same idea.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "Why this is here",
+    body: (
+      <p>
+        Two design choices the Quark years committed to ride forward
+        through every later iteration:{" "}
+        <strong>self-description as architecture</strong> — the system
+        is its own API surface — and <strong>universal addressing</strong>{" "}
+        — every part of state has a path. They show up in BML (2000)
+        as the grammar-in-grammar, in this Quark Virtual DOM as the
+        application-in-DOM, in U-CORE as Everything-is-a-Node, and in
+        Coherence-Network as the graph-of-presences. One conviction;
+        four substrates.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "The shape of the API",
+      body: (
+        <>
+          <p>
+            The conventional way to expose a desktop application's API
+            in 2000-era C++ was binding-per-feature: one C function or
+            COM method for each thing the API needed to surface, hand-
+            written, hand-versioned, exposed through a SDK. AppleScript
+            on the Mac side, COM Automation on the Windows side. Every
+            new feature meant a new pair of bindings. The surface area
+            grew faster than the team's capacity to keep it consistent.
+          </p>
+          <p>
+            The Quark Virtual DOM took the opposite turn. Instead of
+            exposing N APIs, it exposed{" "}
+            <em>one</em> API — the standard DOM interface — and made
+            every application object reachable as a DOM node. The
+            running application became a live tree. Settings,
+            documents, pages, text boxes, picture boxes, style sheets,
+            colors, hyphenation rules — each appeared as a node with
+            attributes, children, and the standard DOM operations
+            (<code className="text-foreground/80">getElementById</code>,{" "}
+            <code className="text-foreground/80">setAttribute</code>,{" "}
+            <code className="text-foreground/80">appendChild</code>) acting on
+            real application state.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 320" className="w-full h-auto" role="img" aria-labelledby="qdom-arch-title">
+              <title id="qdom-arch-title">Quark Virtual DOM architecture</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {/* Top: Clients */}
+                <rect x="60" y="20" width="600" height="44" rx="10" fill="hsl(220 25% 18%)" stroke="hsl(195 60% 60%)" />
+                <text x="80" y="42" fill="hsl(195 80% 80%)" fontSize="13">Standard DOM clients</text>
+                <text x="80" y="58" fill="hsl(195 50% 70%)" fontSize="10">automation scripts · plug-ins · third-party tools · QA harnesses · headless test runners</text>
+
+                <line x1="360" y1="64" x2="360" y2="80" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+
+                {/* Middle: Virtual DOM layer */}
+                <rect x="60" y="80" width="600" height="100" rx="10" fill="hsl(195 35% 16%)" stroke="hsl(195 70% 60%)" strokeWidth="2" />
+                <text x="80" y="106" fill="hsl(195 90% 85%)" fontSize="14" fontWeight="500">Virtual DOM Layer</text>
+                <text x="80" y="124" fill="hsl(195 60% 75%)" fontSize="11">node ↔ application-object resolver · attribute getter/setter dispatch</text>
+                <text x="80" y="140" fill="hsl(195 60% 75%)" fontSize="11">dynamic node creation on traversal · lazy materialization · change notification</text>
+                <text x="80" y="156" fill="hsl(195 60% 75%)" fontSize="11">document-context aware · type-tagged · path-addressable</text>
+                <text x="80" y="172" fill="hsl(195 50% 70%)" fontSize="10">/quarkxpress/preferences/measurements/units = "points"  →  app-wide setting write</text>
+
+                <line x1="240" y1="180" x2="240" y2="200" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+                <line x1="480" y1="180" x2="480" y2="200" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+
+                {/* Bottom: real app state */}
+                <rect x="60" y="200" width="280" height="80" rx="10" fill="hsl(220 25% 16%)" stroke="hsl(40 70% 55%)" />
+                <text x="80" y="226" fill="hsl(40 90% 80%)" fontSize="13">Application state · global</text>
+                <text x="80" y="244" fill="hsl(40 50% 70%)" fontSize="10">preferences · hyphenation · color-management · plug-in registry</text>
+                <text x="80" y="260" fill="hsl(40 50% 70%)" fontSize="10">window manager · undo manager · clipboard</text>
+
+                <rect x="380" y="200" width="280" height="80" rx="10" fill="hsl(220 25% 16%)" stroke="hsl(280 50% 60%)" />
+                <text x="400" y="226" fill="hsl(280 80% 80%)" fontSize="13">Document state · per-document</text>
+                <text x="400" y="244" fill="hsl(280 50% 70%)" fontSize="10">pages · spreads · master pages · style sheets</text>
+                <text x="400" y="260" fill="hsl(280 50% 70%)" fontSize="10">text boxes · picture boxes · groups · layers · runs</text>
+
+                <text x="360" y="305" fill="hsl(220 30% 65%)" textAnchor="middle" fontSize="11" fontStyle="italic">
+                  one DOM tree · two state realms · live read and write
+                </text>
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              Standard DOM clients on top, the virtual-DOM resolver in
+              the middle, real C++ application state at the bottom —
+              with the tree spanning both the global app realm and the
+              per-document realm.
+            </figcaption>
+          </figure>
+          <p>
+            From a script's perspective there was nothing virtual about
+            it. It was a real DOM. From the runtime's perspective, the
+            tree didn't exist — it was materialized lazily on traversal,
+            so a script that asked for{" "}
+            <code className="text-foreground/80">documents[0].pages[3].boxes[7].font</code>
+            {" "}only paid for the path it walked. The full application
+            state was never serialized into nodes; the nodes were
+            <em>views</em> on the state.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Sample · what a script saw",
+      heading: "QuarkXPress as a tree",
+      body: (
+        <>
+          <p>
+            A script using nothing more than the standard DOM
+            interface — the same shape any web developer was already
+            fluent in — could now drive a desktop publisher:
+          </p>
+          <pre className="text-[11px] leading-5 bg-background/60 border border-border/40 rounded-lg p-4 overflow-x-auto font-mono">
+{`// Read an application-wide preference
+const units = xpressDom
+  .getElementById('preferences')
+  .getAttribute('measurements/units');
+
+// Walk the document tree
+const docs = xpressDom.documentElement.children;          // open documents
+const firstDoc = docs[0];
+const page3 = firstDoc.querySelector('page[index="3"]');
+const titleBox = page3.querySelector('text-box[role="title"]');
+
+// Mutate live state — change is reflected immediately
+titleBox.setAttribute('font-family', 'Adobe Caslon Pro');
+titleBox.setAttribute('font-size', '24pt');
+titleBox.firstChild.textContent = 'New headline';
+
+// Listen for changes anyone makes (script, user, plug-in)
+firstDoc.addEventListener('attribute-changed', (e) => {
+   console.log(e.target.path, e.detail.attr, e.detail.from, e.detail.to);
+});`}
+          </pre>
+          <p>
+            Standard idioms — <code className="text-foreground/80">getElementById</code>,{" "}
+            <code className="text-foreground/80">querySelector</code>,{" "}
+            <code className="text-foreground/80">setAttribute</code>,{" "}
+            <code className="text-foreground/80">addEventListener</code> —
+            performing real desktop-app operations. A QA harness could
+            drive QuarkXPress through arbitrary keystrokes by setting
+            attributes. A plug-in could register for change events on
+            any path. An external automation tool could open a document,
+            edit ten boxes, save, and exit — without a single
+            QuarkXPress-specific API call.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "Why this was hard",
+      body: (
+        <>
+          <p>
+            The shape is elegant; the implementation was load-bearing.
+            Three things had to be true at once:
+          </p>
+          <ul className="space-y-2 list-disc list-inside marker:text-muted-foreground">
+            <li>
+              <strong>Lazy materialization.</strong> A QuarkXPress
+              document with hundreds of pages and thousands of objects
+              cannot have all those nodes pre-allocated. Nodes had to
+              materialize on traversal — a child request walked into the
+              underlying C++ object graph and minted the node on demand.
+              GC of unreferenced nodes had to happen invisibly.
+            </li>
+            <li>
+              <strong>Bi-directional change propagation.</strong> A
+              script's <code className="text-foreground/80">setAttribute</code>{" "}
+              had to land in the real C++ state and trigger every
+              redraw, undo-record, and document-changed notification a
+              user-driven equivalent action would. Symmetrically, a
+              user dragging a box had to make the corresponding DOM
+              attributes update so any listening script saw the change.
+            </li>
+            <li>
+              <strong>Type-tagged dynamic schema.</strong> Every node
+              kind had its own attribute set; the resolver had to know
+              what attributes were valid on{" "}
+              <code className="text-foreground/80">text-box</code> versus{" "}
+              <code className="text-foreground/80">picture-box</code>,
+              what type each attribute carried (point, color, font
+              identifier, percentage), how to coerce string values
+              the DOM API enforced. Dynamic creation of nodes and
+              attributes meant the schema had to be queryable from the
+              API too — the DOM described its own shape.
+            </li>
+          </ul>
+          <p>
+            That last point is the deep one. The tree wasn't a fixed
+            DTD. New plug-ins added new node kinds. New document
+            features grew the attribute vocabulary. The Virtual DOM
+            had to stay self-describing — clients could ask the tree
+            what it could do, and the tree would answer. That's the
+            same posture the{" "}
+            <Link href="/people/bml-language" className="text-primary hover:underline">
+              2000 BML thesis
+            </Link>
+            {" "}committed to with grammar-in-grammar — and the same
+            posture that, twenty-some years later,{" "}
+            <Link href="/people/coherence-network" className="text-primary hover:underline">
+              Coherence-Network
+            </Link>
+            {" "}now lives at the network scale.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "The historical reading",
+      heading: "Years before the browser conversation",
+      body: (
+        <p>
+          The phrase <em>virtual DOM</em> entered the public
+          vocabulary mostly through React, around 2013. By that point
+          the same architectural pattern — a virtual tree fronting a
+          mutable state graph, with bidirectional change propagation —
+          had been running in QuarkXPress production for nearly a
+          decade. Different problem (desktop publishing rather than
+          UI rendering), different substrate (C++ on Mac/Windows
+          rather than JavaScript in a browser), but the same
+          architectural turn. This page exists in part to write the
+          desktop-application form of the pattern back into the public
+          record where it was first lived.
+        </p>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Application context:{" "}
+      <Link
+        href="https://www.quark.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        quark.com
+      </Link>
+      {" · "}
+      <Link
+        href="https://en.wikipedia.org/wiki/QuarkXPress"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary hover:underline"
+      >
+        QuarkXPress on Wikipedia
+      </Link>
+      . Source code is internal to Quark and not public; the substance
+      above is the architectural shape, the design rationale, and the
+      lived memory of building it. Urs is invited to refine exact
+      tenure dates and any technical detail through the Refine doorway
+      below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/quark-virtual-dom/index.ts
+++ b/web/content/people/quark-virtual-dom/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getQuarkVirtualDomContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}


### PR DESCRIPTION
## Summary

Two curated /people pages for the Quark Software / QuarkXPress era that's been missing from the body of evidence:

- **/people/quark-virtual-dom** — virtual DOM exposing the entire QuarkXPress API as a live tree. Standard DOM clients could read/write any app or document state without per-feature bindings. Architecture diagram + worked code sample.
- **/people/quark-multi-undo-redo** — multi-document undo/redo engine. Per-document edits + app-wide changes that cascaded into every open document, with correct timeline interleaving. Diagram showing global actions casting shadows onto each document's stack.

Graph: created `asset:quark-virtual-dom` + `asset:quark-multi-undo-redo`, wired `contributor:seeker71 --contributes-to-->` both, plus inspired-by edges back to the 2000 thesis (BML self-describing → quark-virtual-dom; BMCPU DO/UNDO → quark-multi-undo-redo) and forward into Living-Resonance-Codex.

The lineage now reads BML thesis (2000) → Quark works (early-to-mid 2000s, app-level) → Living-Resonance-Codex (2023) → CSharp (2024) → Coherence-Network.

Tenure dates labeled "early-to-mid 2000s · post-MS" with Refine invitation since LinkedIn auth-walls the exact range.

## Test plan
- [ ] /people/quark-virtual-dom renders hero, architecture SVG, code sample, and influence web
- [ ] /people/quark-multi-undo-redo renders hero, timeline-interleaving SVG, hyphenation case panel, and influence web
- [ ] Both pages show "Recognized by" / "Emits" surfacing from BML and BMCPU pages
- [ ] Urs's profile shows the two new works in Emits

🤖 Generated with [Claude Code](https://claude.com/claude-code)