### PR TITLE
tend: four more career-lineage works (Schindler HC11 · Mono/CORBA · MindTouch · Trimble)

### DIFF
--- a/web/app/people/mindtouch-wiki-in-a-box/page.tsx
+++ b/web/app/people/mindtouch-wiki-in-a-box/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getMindtouchWikiInABoxContent } from "@/content/people/mindtouch-wiki-in-a-box";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getMindtouchWikiInABoxContent(lang).metadata;
+}
+
+export default async function MindtouchWikiInABoxProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getMindtouchWikiInABoxContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="mindtouch-wiki-in-a-box"
+    />
+  );
+}

--- a/web/app/people/quark-mono-corba/page.tsx
+++ b/web/app/people/quark-mono-corba/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getQuarkMonoCorbaContent } from "@/content/people/quark-mono-corba";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getQuarkMonoCorbaContent(lang).metadata;
+}
+
+export default async function QuarkMonoCorbaProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getQuarkMonoCorbaContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="quark-mono-corba"
+    />
+  );
+}

--- a/web/app/people/schindler-hc11-protocol/page.tsx
+++ b/web/app/people/schindler-hc11-protocol/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getSchindlerHc11ProtocolContent } from "@/content/people/schindler-hc11-protocol";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getSchindlerHc11ProtocolContent(lang).metadata;
+}
+
+export default async function SchindlerHc11ProtocolProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getSchindlerHc11ProtocolContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="schindler-hc11-protocol"
+    />
+  );
+}

--- a/web/app/people/trimble-glue-layer/page.tsx
+++ b/web/app/people/trimble-glue-layer/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getTrimbleGlueLayerContent } from "@/content/people/trimble-glue-layer";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getTrimbleGlueLayerContent(lang).metadata;
+}
+
+export default async function TrimbleGlueLayerProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getTrimbleGlueLayerContent(lang);
+  return (
+    <PersonProfileTemplate
+      content={content}
+      lang={lang}
+      graphSlug="trimble-glue-layer"
+    />
+  );
+}

--- a/web/content/people/mindtouch-wiki-in-a-box/en.tsx
+++ b/web/content/people/mindtouch-wiki-in-a-box/en.tsx
@@ -1,0 +1,276 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "MindTouch Wiki-in-a-Box — MediaWiki PHP ported into a C# generic document layer",
+    description:
+      "Co-Founder and Senior Architect at MindTouch (Mar 2005 – Jan 2007). Took the Wikipedia/MediaWiki PHP codebase and re-architected it into a C# generic document layer — wiki engine no longer hard-coded to encyclopedia pages, but the document substrate any kind of structured collaborative knowledge could be authored against. The shape that, twenty years later, the Coherence Network's vision-kb still uses.",
+  },
+  breadcrumbName: "MindTouch · Wiki-in-a-Box",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(140 35% 14%) 50%, hsl(40 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · MindTouch Inc. · Mar 2005 – Jan 2007 · Co-Founder, Senior Architect",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "MindTouch — Wiki-in-a-Box",
+    welcome: (
+      <p>
+        Co-Founder and Senior Architect at MindTouch. The
+        load-bearing piece of architecture: take the{" "}
+        <Link href="https://en.wikipedia.org/wiki/MediaWiki" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+          MediaWiki
+        </Link>
+        {" "}PHP codebase — the engine that runs Wikipedia — and
+        re-architect it into a <strong>C# generic document layer</strong>.
+        The wiki engine, no longer hard-coded to encyclopedia pages,
+        becomes the document substrate any kind of structured
+        collaborative knowledge can be authored against. A "wiki in a
+        box" any organisation could deploy and shape into their own
+        knowledge ecosystem.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "MindTouch Inc. · March 2005 – January 2007 · 1 year 11 months · Co-Founder, Senior Architect" },
+    { label: "Substrate", value: "C# / .NET (with Mono for cross-platform) · porting from PHP — language change carrying type-safety + LSP-style structural rigour" },
+    {
+      label: "Source upstream",
+      value: (
+        <>
+          <Link href="https://en.wikipedia.org/wiki/MediaWiki" target="_blank" rel="noopener noreferrer" className="hover:text-primary">
+            MediaWiki
+          </Link>
+          {" "}— the PHP engine powering Wikipedia, Wikimedia, and
+          thousands of corporate wikis. The full feature surface
+          (templates, parser, history, namespaces, permissions) had
+          to land in the new substrate.
+        </>
+      ),
+    },
+    {
+      label: "Generalisation",
+      value: (
+        <>
+          What MediaWiki encoded as "Wikipedia article" became, in
+          the MindTouch port, an arbitrary <em>document</em>: a typed
+          tree of content with versioned history, structured edits,
+          and the wiki authoring conventions as one of many possible
+          authoring modes.
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The "structured-document substrate any community can shape"
+          conviction reappears in the{" "}
+          <Link href="/vision" className="hover:text-primary">vision-kb</Link>
+          's Karpathy LLM Wiki pattern (concept files at{" "}
+          <code className="text-foreground/80">docs/vision-kb/concepts/{`{id}`}.md</code>
+          {" "}with INDEX hierarchy, cross-refs, and inline visuals)
+          and in the{" "}
+          <Link href="/people/coherence-network" className="hover:text-primary">Coherence-Network</Link>
+          's living relational graph, where every entity is editable
+          through a Refine doorway.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "Why a port and not a from-scratch rewrite",
+    body: (
+      <p>
+        MediaWiki had earned its complexity. Years of wiki-community
+        practice — templates, parser quirks, namespace conventions,
+        permission models, history representation — were encoded in
+        the PHP. A from-scratch C# wiki would have re-discovered most
+        of it in the second year and still missed the subtleties
+        wikipedians had quietly stabilised. The port preserved the
+        knowledge baked into the PHP while letting the substrate{" "}
+        <em>around</em> the engine become typed, modular, and
+        composable. C# was the host; MediaWiki's design wisdom was the
+        seed.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "From Wikipedia engine to document platform",
+      body: (
+        <>
+          <p>
+            Wikipedia is one of MediaWiki's <em>users</em>, not its
+            architecture. The engine knows how to render wiki text,
+            track edits, manage namespaces, resolve templates, and
+            store history; it doesn't care whether the content is
+            encyclopedia articles, internal documentation, customer
+            knowledge bases, or scientific protocols. The MindTouch
+            port made that latent generalisation explicit by porting
+            the engine into C# while collapsing the
+            "encyclopedia-article" surface into one specialisation of
+            a generic <strong>document</strong> primitive.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 340" className="w-full h-auto" role="img" aria-labelledby="mt-arch-title">
+              <title id="mt-arch-title">MindTouch C# generic document layer</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {/* Top: clients */}
+                <rect x="60" y="20" width="600" height="44" rx="10" fill="hsl(220 25% 18%)" stroke="hsl(140 60% 60%)" />
+                <text x="80" y="42" fill="hsl(140 80% 80%)" fontSize="13">Clients · web UI · API consumers · authoring tools</text>
+                <text x="80" y="58" fill="hsl(140 50% 70%)" fontSize="10">enterprise wikis · documentation portals · KB sites · custom verticals</text>
+
+                <line x1="360" y1="64" x2="360" y2="80" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+
+                {/* Middle: generic document layer */}
+                <rect x="60" y="80" width="600" height="120" rx="10" fill="hsl(140 35% 16%)" stroke="hsl(140 80% 60%)" strokeWidth="2" />
+                <text x="80" y="106" fill="hsl(140 90% 85%)" fontSize="14" fontWeight="500">Generic document layer · C# / .NET</text>
+                <text x="80" y="124" fill="hsl(140 60% 75%)" fontSize="11">document model — versioned · structured · permissioned · transactional</text>
+                <text x="80" y="140" fill="hsl(140 60% 75%)" fontSize="11">parser surface — wiki text · structured nodes · custom DSLs (pluggable)</text>
+                <text x="80" y="156" fill="hsl(140 60% 75%)" fontSize="11">history — every change attributed · diffable · revertible · branchable</text>
+                <text x="80" y="172" fill="hsl(140 60% 75%)" fontSize="11">templates · namespaces · macros — preserved from MediaWiki</text>
+                <text x="80" y="188" fill="hsl(140 60% 75%)" fontSize="11">extension points — plug in domain-specific document kinds without forking</text>
+
+                <line x1="240" y1="200" x2="240" y2="220" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+                <line x1="480" y1="200" x2="480" y2="220" stroke="hsl(220 30% 60%)" strokeWidth="1.5" />
+
+                {/* Bottom: source PHP / target storage */}
+                <rect x="60" y="220" width="280" height="100" rx="10" fill="hsl(220 25% 16%)" stroke="hsl(40 70% 55%)" strokeDasharray="3,3" />
+                <text x="80" y="246" fill="hsl(40 90% 80%)" fontSize="13">Source · MediaWiki PHP</text>
+                <text x="80" y="264" fill="hsl(40 50% 70%)" fontSize="10">design wisdom: parser quirks, namespaces,</text>
+                <text x="80" y="278" fill="hsl(40 50% 70%)" fontSize="10">templates, history model, permissions</text>
+                <text x="80" y="296" fill="hsl(40 50% 70%)" fontSize="10">years of wiki-community-stabilised behaviour</text>
+                <text x="80" y="310" fill="hsl(40 60% 75%)" fontSize="10" fontStyle="italic">⤷ ported, not re-derived</text>
+
+                <rect x="380" y="220" width="280" height="100" rx="10" fill="hsl(220 25% 16%)" stroke="hsl(195 60% 55%)" />
+                <text x="400" y="246" fill="hsl(195 80% 80%)" fontSize="13">Storage · SQL · structured</text>
+                <text x="400" y="264" fill="hsl(195 50% 70%)" fontSize="10">page tree · revision graph</text>
+                <text x="400" y="278" fill="hsl(195 50% 70%)" fontSize="10">attachment store · search index</text>
+                <text x="400" y="296" fill="hsl(195 50% 70%)" fontSize="10">structured metadata · attribute index</text>
+                <text x="400" y="310" fill="hsl(195 60% 75%)" fontSize="10" fontStyle="italic">⤷ deployable in a box</text>
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              The architectural shape. MediaWiki's design wisdom is the
+              source upstream (left); the C# generic document layer is
+              the load-bearing middle; storage on the right is the
+              "in a box" deployable artifact.
+            </figcaption>
+          </figure>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "What 'in a box' meant",
+      heading: "A wiki any organisation could host",
+      body: (
+        <>
+          <p>
+            Wikipedia ran on Wikimedia infrastructure. Most other
+            wikis in 2005 either ran on shared MediaWiki hosting or
+            were artisanal one-off installs. The MindTouch product
+            shape: a single deployable artifact — runtime, document
+            layer, web UI, admin tools, all in one — that any
+            organisation could install on a server they controlled
+            and start authoring against. A wiki, in a box.
+          </p>
+          <p>
+            The deeper conviction the product encoded:{" "}
+            <em>knowledge sovereignty</em>. An organisation's
+            knowledge belongs in their own infrastructure, with their
+            own permission models, their own retention policies, their
+            own back-ups. The wiki engine generalised becomes the
+            substrate any community uses to make its knowing visible
+            to itself, on its own terms. That conviction lives now in
+            the Coherence Network's "every cell tends its own flame"
+            posture — the same shape, twenty years later, expressed in
+            a different medium.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "What carries forward to the vision-kb",
+      body: (
+        <>
+          <p>
+            The{" "}
+            <Link href="/vision" className="text-primary hover:underline">
+              Coherence Network's vision-kb
+            </Link>
+            {" "}— "Living Collective Knowledge Base" with concept
+            files at{" "}
+            <code className="text-foreground/80">docs/vision-kb/concepts/{`{id}`}.md</code>
+            , INDEX hierarchy, cross-refs (<code className="text-foreground/80">→ lc-xxx, lc-yyy</code>),
+            inline visuals (<code className="text-foreground/80">{`![caption](visuals:prompt)`}</code>),
+            sync to graph DB — is structurally a wiki. Karpathy's "LLM
+            Wiki" pattern named it as a fresh idea in 2024, but the
+            shape is exactly what MindTouch's wiki-in-a-box port
+            committed to in 2005:
+          </p>
+          <ul className="space-y-2 list-disc list-inside marker:text-muted-foreground">
+            <li>
+              <strong>Structured documents over free-form
+              prose.</strong> Each concept file has frontmatter,
+              cross-refs, schema. Each MindTouch document had typed
+              fields, namespaces, templates.
+            </li>
+            <li>
+              <strong>Versioned, attributed history.</strong> Git
+              tracks every concept-file change with commit verbs;
+              MindTouch tracked every wiki edit with revision attribution.
+              Different storage, same conviction.
+            </li>
+            <li>
+              <strong>Cross-link as first-class structure.</strong>{" "}
+              Wiki [[link]] syntax expressed reference; vision-kb
+              cross-refs do the same with{" "}
+              <code className="text-foreground/80">→ lc-xxx</code>
+              {" "}and the network paints them with their edge-type
+              spectrum hue.
+            </li>
+            <li>
+              <strong>Sync into a queryable graph.</strong> MindTouch
+              indexed structured metadata into a relational store;
+              the vision-kb syncs concept content + analogous-to edges
+              into Neo4j via{" "}
+              <code className="text-foreground/80">scripts/sync_kb_to_db.py</code>
+              .
+            </li>
+          </ul>
+          <p>
+            The 2005 port and the 2026 KB are the same architectural
+            posture in different substrates. Once you've built one
+            generic document layer, the conviction stays — it just
+            finds new substrates to express itself through.
+          </p>
+        </>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Company:{" "}
+      <Link href="https://en.wikipedia.org/wiki/MindTouch" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        MindTouch on Wikipedia
+      </Link>
+      {" · "}
+      Source upstream:{" "}
+      <Link href="https://en.wikipedia.org/wiki/MediaWiki" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        MediaWiki
+      </Link>
+      . Source code is internal to MindTouch; what lives here is the
+      architectural shape and the design conviction. Urs is invited
+      to refine technical detail through the Refine doorway below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/mindtouch-wiki-in-a-box/index.ts
+++ b/web/content/people/mindtouch-wiki-in-a-box/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getMindtouchWikiInABoxContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}

--- a/web/content/people/quark-mono-corba/en.tsx
+++ b/web/content/people/quark-mono-corba/en.tsx
@@ -1,0 +1,296 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Quark Mono / CORBA — cross-platform remote control of QuarkXPress",
+    description:
+      "While at Quark, contributed to the Mono project (the open-source .NET implementation for non-Windows platforms) and used it as the substrate for a CORBA interface that remote-controlled QuarkXPress over the wire. Cross-platform C# in 2000-2005 was bleeding edge; CORBA was the canonical inter-process protocol of the era. Together they let any host on any OS drive QuarkXPress as if it were a local object.",
+  },
+  breadcrumbName: "Quark Mono / CORBA",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(280 35% 14%) 50%, hsl(195 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · Quark Inc. · Denver · May 2000 – Mar 2005",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Quark Mono / CORBA — remote control over the wire",
+    welcome: (
+      <p>
+        Contributed to the{" "}
+        <Link href="https://en.wikipedia.org/wiki/Mono_(software)" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+          Mono project
+        </Link>
+        {" "}— Miguel de Icaza's open-source .NET implementation for
+        non-Windows platforms — and used it as the substrate for a{" "}
+        <Link href="https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+          CORBA
+        </Link>
+        {" "}interface that remote-controlled QuarkXPress over the wire.
+        Any host on any OS could drive QuarkXPress as if it were a
+        local object — orthogonal companion to the in-process{" "}
+        <Link href="/people/quark-virtual-dom" className="text-primary hover:underline">
+          Virtual DOM
+        </Link>
+        , reaching across the network the same way the DOM reached
+        across the application.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "Quark Inc. · Denver · within May 2000 – March 2005 · Software Engineer III" },
+    {
+      label: "Substrate",
+      value: (
+        <>
+          <Link href="https://www.mono-project.com/" target="_blank" rel="noopener noreferrer" className="hover:text-primary">Mono</Link>
+          {" "}runtime · cross-platform C# / CLI · Mac OS X, Linux, Windows
+        </>
+      ),
+    },
+    {
+      label: "Wire protocol",
+      value: (
+        <>
+          <Link href="https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture" target="_blank" rel="noopener noreferrer" className="hover:text-primary">CORBA</Link>
+          {" "}— OMG's Common Object Request Broker Architecture · the era's canonical inter-process / cross-language object protocol
+        </>
+      ),
+    },
+    {
+      label: "What it controlled",
+      value: (
+        <>
+          QuarkXPress — full document and application surface accessible remotely with the same semantics as the in-process{" "}
+          <Link href="/people/quark-virtual-dom" className="hover:text-primary">Virtual DOM</Link>
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The Mono / cross-platform C# substrate proven here is the
+          ancestor of the C# substrate the{" "}
+          <Link href="/people/qualcomm-test-automation" className="hover:text-primary">Qualcomm test-automation</Link>
+          {" "}rewrite landed on (2010s) and later{" "}
+          <Link href="/people/living-codex-csharp" className="hover:text-primary">Living-Codex-CSharp (2024)</Link>
+          {" "}built on. C# enters this body's tooling here.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "Why two faces of one app",
+    body: (
+      <p>
+        The in-process{" "}
+        <Link href="/people/quark-virtual-dom" className="text-primary hover:underline">
+          Virtual DOM
+        </Link>
+        {" "}let scripts running inside QuarkXPress drive every part of
+        it. The Mono / CORBA bridge let scripts running{" "}
+        <em>outside</em> QuarkXPress — possibly on a different OS,
+        possibly on a different machine — drive every part of it with
+        the same semantics. Two faces of the same self-describing
+        conviction: the application is its own API surface, and the
+        wire transport is incidental to that.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "Mono in the early 2000s",
+      body: (
+        <>
+          <p>
+            <Link href="https://en.wikipedia.org/wiki/Mono_(software)" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              Mono
+            </Link>
+            {" "}— launched by{" "}
+            <Link href="https://en.wikipedia.org/wiki/Miguel_de_Icaza" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              Miguel de Icaza
+            </Link>
+            {" "}around 2001 — was the open-source implementation of
+            Microsoft's .NET Common Language Infrastructure for
+            non-Windows platforms. Running C# code on Mac OS X or
+            Linux in 2002 was bleeding edge. Contributing to Mono in
+            those years meant tracking the published ECMA spec while
+            it was still moving, finding gaps where the spec was
+            ambiguous, and shipping the first cross-platform
+            corrections that would later become baseline behavior.
+          </p>
+          <p>
+            For Quark, the bet on Mono was strategic. QuarkXPress
+            shipped on both Mac and Windows. Tooling that wanted to
+            drive it from <em>either</em> side without forking the
+            code paths needed a runtime that ran on both. Mono was
+            the only credible answer in 2003. C# was already a more
+            ergonomic choice than C++ for tooling code; Mono made
+            that choice portable.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "CORBA — what people forget",
+      heading: "Cross-language object orientation, on the wire",
+      body: (
+        <>
+          <p>
+            <strong>CORBA</strong> in 2003 was what gRPC + JSON-RPC +
+            Thrift attempt to be in 2026: a way to talk to a remote
+            object as if it were local, across language boundaries,
+            with a typed interface contract. An interface was
+            described in IDL (Interface Definition Language) once;
+            stubs were generated for every language that needed to
+            speak it; an{" "}
+            <Link href="https://en.wikipedia.org/wiki/General_Inter-ORB_Protocol" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              Object Request Broker
+            </Link>
+            {" "}routed calls between processes using IIOP on the wire.
+            Heavy machinery, but mature, with deep tooling.
+          </p>
+          <p>
+            The pragmatic combination: write the QuarkXPress object
+            model once in CORBA IDL; generate the in-process server
+            stub against the QuarkXPress runtime; generate client
+            stubs for any language a tool might need (C++, Java,
+            and — through Mono — C# on any platform). A Mono / C#
+            client running on a Linux box could now invoke any method
+            on any QuarkXPress object as if it were local, with the
+            ORB doing all the marshalling, dispatch, and
+            cross-platform memory management.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "The architecture",
+      body: (
+        <>
+          <p>
+            Two layers each side of the wire, with the ORB carrying
+            the calls between them:
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 320" className="w-full h-auto" role="img" aria-labelledby="mono-corba-arch-title">
+              <title id="mono-corba-arch-title">Mono / CORBA bridge architecture</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {/* Client side */}
+                <text x="170" y="30" fill="hsl(195 80% 80%)" fontSize="13" textAnchor="middle">Client side · any OS</text>
+                <rect x="60" y="40" width="220" height="44" rx="8" fill="hsl(220 25% 18%)" stroke="hsl(195 60% 60%)" />
+                <text x="170" y="62" textAnchor="middle" fill="hsl(195 80% 82%)" fontSize="12">C# / Mono application</text>
+                <text x="170" y="78" textAnchor="middle" fill="hsl(195 50% 70%)" fontSize="10">automation tool · QA harness · plug-in</text>
+
+                <line x1="170" y1="84" x2="170" y2="100" stroke="hsl(220 30% 60%)" strokeWidth="1.2" />
+
+                <rect x="60" y="100" width="220" height="44" rx="8" fill="hsl(195 35% 16%)" stroke="hsl(195 70% 60%)" strokeWidth="2" />
+                <text x="170" y="122" textAnchor="middle" fill="hsl(195 90% 85%)" fontSize="12">CORBA stub · IDL-generated</text>
+                <text x="170" y="138" textAnchor="middle" fill="hsl(195 60% 75%)" fontSize="10">marshals method calls into IIOP</text>
+
+                {/* ORB / wire */}
+                <line x1="280" y1="122" x2="440" y2="122" stroke="hsl(40 80% 60%)" strokeWidth="2" />
+                <rect x="300" y="108" width="120" height="28" rx="14" fill="hsl(40 50% 18%)" stroke="hsl(40 80% 60%)" />
+                <text x="360" y="126" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="11">ORB · IIOP wire</text>
+
+                {/* Server side */}
+                <text x="570" y="30" fill="hsl(280 70% 80%)" fontSize="13" textAnchor="middle">Server side · QuarkXPress host</text>
+                <rect x="440" y="100" width="220" height="44" rx="8" fill="hsl(280 35% 16%)" stroke="hsl(280 70% 65%)" strokeWidth="2" />
+                <text x="550" y="122" textAnchor="middle" fill="hsl(280 90% 85%)" fontSize="12">CORBA skeleton · IDL-generated</text>
+                <text x="550" y="138" textAnchor="middle" fill="hsl(280 60% 75%)" fontSize="10">unmarshals · dispatches to QXP runtime</text>
+
+                <line x1="550" y1="144" x2="550" y2="160" stroke="hsl(220 30% 60%)" strokeWidth="1.2" />
+
+                <rect x="440" y="160" width="220" height="44" rx="8" fill="hsl(220 25% 16%)" stroke="hsl(40 70% 55%)" />
+                <text x="550" y="182" textAnchor="middle" fill="hsl(40 90% 80%)" fontSize="12">QuarkXPress runtime</text>
+                <text x="550" y="198" textAnchor="middle" fill="hsl(40 50% 70%)" fontSize="10">documents · pages · boxes · settings</text>
+
+                {/* IDL contract */}
+                <rect x="220" y="240" width="280" height="60" rx="8" fill="hsl(220 25% 14%)" stroke="hsl(140 60% 55%)" strokeDasharray="3,3" />
+                <text x="360" y="262" textAnchor="middle" fill="hsl(140 80% 80%)" fontSize="12">QuarkXPress.idl · contract</text>
+                <text x="360" y="280" textAnchor="middle" fill="hsl(140 50% 75%)" fontSize="10">interface Document, Page, TextBox, …</text>
+                <text x="360" y="294" textAnchor="middle" fill="hsl(140 50% 75%)" fontSize="10">stubs and skeletons generated from this</text>
+
+                <line x1="170" y1="100" x2="220" y2="270" stroke="hsl(140 50% 55%)" strokeWidth="0.8" strokeDasharray="2,3" />
+                <line x1="550" y1="100" x2="500" y2="270" stroke="hsl(140 50% 55%)" strokeWidth="0.8" strokeDasharray="2,3" />
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              IDL contract sits beneath both stubs and skeletons. The
+              client speaks C# on Mono; the server speaks the QXP
+              runtime; the ORB routes between them on the IIOP wire.
+            </figcaption>
+          </figure>
+          <p>
+            What the architecture committed to: <em>one</em> contract
+            (the IDL), <em>one</em> wire protocol (IIOP), and a code
+            generation step on each side. Adding a new client language
+            meant generating its stubs from the same IDL — no
+            QuarkXPress-side change. Adding a new exposed interface
+            meant editing the IDL once — both sides regenerated.
+            That's the same posture the{" "}
+            <Link href="/people/coherence-network" className="text-primary hover:underline">
+              Coherence Network
+            </Link>
+            's API now takes with FastAPI's OpenAPI contract: the
+            schema is the source of truth; clients derive from it.
+            CORBA was that conviction expressed in the 2003
+            vocabulary.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Two faces of one application",
+      heading: "Virtual DOM in-process · CORBA over the wire",
+      body: (
+        <p>
+          The{" "}
+          <Link href="/people/quark-virtual-dom" className="text-primary hover:underline">
+            in-process Virtual DOM
+          </Link>
+          {" "}gave any plug-in or in-process script direct, lazy,
+          read/write access to QuarkXPress as a tree. The Mono / CORBA
+          bridge gave any process anywhere on the network the{" "}
+          <em>same access</em> with the same semantic. Two faces, one
+          conviction: the application is its own API surface, and the
+          transport is implementation detail. A QA harness in 2004
+          could test QuarkXPress on Windows from a Mac driver process,
+          a Linux build server, or a continuous-integration agent —
+          all using the same C# code, all driving the same object
+          model. Twenty-two years before the network era named this
+          posture out loud.
+        </p>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Application context:{" "}
+      <Link href="https://www.quark.com" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        quark.com
+      </Link>
+      {" · "}
+      <Link href="https://www.mono-project.com/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        Mono project
+      </Link>
+      {" · "}
+      <Link href="https://en.wikipedia.org/wiki/Common_Object_Request_Broker_Architecture" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        CORBA on Wikipedia
+      </Link>
+      . Source code is internal to Quark; what lives here is the
+      architectural shape and the lived memory. Urs is invited to
+      refine technical detail through the Refine doorway below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/quark-mono-corba/index.ts
+++ b/web/content/people/quark-mono-corba/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getQuarkMonoCorbaContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}

--- a/web/content/people/schindler-hc11-protocol/en.tsx
+++ b/web/content/people/schindler-hc11-protocol/en.tsx
@@ -1,0 +1,349 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Schindler HC11 — ISO/OSI 7-layer stack in hardware (age 18)",
+    description:
+      "At age 18, while at Schindler in Switzerland, designed the hardware and wrote the firmware for an ISO/OSI 7-layer protocol stack on a Motorola HC11 microcontroller — multiple UARTs networked into one board, EPROM and PAL programmable blocks, all firmware in C, and a custom debugger because no off-the-shelf one existed for the bring-up. This is where Urs learned C. The earliest load-bearing technical work in the body of evidence.",
+  },
+  breadcrumbName: "Schindler HC11 — 7-layer in hardware",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(0 35% 14%) 50%, hsl(20 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · Schindler · Switzerland · ~1989–1990 · age 18",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Schindler HC11 — 7-layer protocol in hardware",
+    welcome: (
+      <p>
+        Age 18, in Switzerland. Designed the hardware{" "}
+        <em>and</em> wrote the firmware for an{" "}
+        <strong>ISO/OSI 7-layer protocol stack</strong> on a{" "}
+        <strong>Motorola HC11</strong> microcontroller. Multiple UARTs
+        networked into a working bus, EPROM and PAL programmable
+        blocks defining the discrete logic, every layer of firmware
+        written in <strong>C</strong>. No off-the-shelf debugger
+        existed for the bring-up — built one. The earliest
+        load-bearing piece in the body of evidence, and the place
+        where this body learned to think in C.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "Schindler · Switzerland · approximately 1989–1990 · age 18" },
+    {
+      label: "Hardware",
+      value: (
+        <>
+          <Link href="https://en.wikipedia.org/wiki/Motorola_68HC11" target="_blank" rel="noopener noreferrer" className="hover:text-primary">Motorola 68HC11</Link>
+          {" "}microcontroller · multiple UARTs · EPROM (program storage) · PAL (programmable array logic, the "discrete glue logic" of the era) · custom-designed board
+        </>
+      ),
+    },
+    {
+      label: "Firmware",
+      value: "C — full ISO/OSI 7-layer protocol stack from physical / data-link up through application — running on bare metal, no OS"
+    },
+    {
+      label: "Tooling",
+      value: "Custom debugger written from scratch — bring-up environment with no off-the-shelf option"
+    },
+    {
+      label: "Significance",
+      value: (
+        <>
+          Learned C in the hardest place to learn it: an embedded
+          target with EPROM cycles, no OS, and a debugger that didn't
+          exist until written. This conviction —{" "}
+          <em>build the tool you need, all the way down</em> — threads
+          through every later iteration.
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The same "every layer addressable" posture re-emerges in{" "}
+          <Link href="/people/bml-language" className="hover:text-primary">BML (2000)</Link>
+          {" "}as grammar-in-grammar, in{" "}
+          <Link href="/people/quark-virtual-dom" className="hover:text-primary">Quark Virtual DOM (2000-2005)</Link>
+          {" "}as application-as-DOM-tree, and in{" "}
+          <Link href="/people/coherence-network" className="hover:text-primary">Coherence-Network</Link>
+          {" "}as everything-is-a-node.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "Why this is the keystone",
+    body: (
+      <p>
+        Most engineers learn C through tutorials. This body learned C
+        by sitting in front of a board it had drawn and a chip it had
+        soldered in, with EPROMs that took minutes to erase under
+        ultraviolet and a debugger it had to write before it could
+        even watch the firmware run. That experience set the
+        permission level for every later piece of work: <em>if the
+        tool you need doesn't exist, you build it</em> — language,
+        grammar, parser, VM, virtual DOM, undo engine, harness,
+        network. All of it descends from this board.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "What was on the board",
+      body: (
+        <>
+          <p>
+            The HC11 era — late 1980s into the early 1990s — was the
+            golden window of "do the whole stack yourself" embedded
+            engineering. The chip itself sat on a custom-designed
+            board with the discrete-logic glue routed through{" "}
+            <strong>PAL</strong> (Programmable Array Logic) chips —
+            small ICs you'd burn with your own truth tables, the
+            ancestor of the FPGA. The HC11 had on-board RAM and a
+            single hardware UART; the board added more UART devices
+            on the bus so several physical lines could feed in at
+            once and let the protocol stack run as a small network
+            from a single processor.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 300" className="w-full h-auto" role="img" aria-labelledby="hc11-board-title">
+              <title id="hc11-board-title">Schindler HC11 board topology</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {/* HC11 in center */}
+                <rect x="290" y="120" width="140" height="80" rx="8" fill="hsl(220 30% 18%)" stroke="hsl(40 80% 60%)" strokeWidth="2" />
+                <text x="360" y="148" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="14">Motorola HC11</text>
+                <text x="360" y="166" textAnchor="middle" fill="hsl(40 60% 75%)" fontSize="10">8-bit MCU · on-chip RAM</text>
+                <text x="360" y="182" textAnchor="middle" fill="hsl(40 60% 75%)" fontSize="10">single HW UART · timers · ports</text>
+
+                {/* EPROM */}
+                <rect x="60" y="40" width="140" height="60" rx="8" fill="hsl(220 25% 16%)" stroke="hsl(195 60% 60%)" />
+                <text x="130" y="64" textAnchor="middle" fill="hsl(195 80% 82%)" fontSize="13">EPROM</text>
+                <text x="130" y="82" textAnchor="middle" fill="hsl(195 50% 70%)" fontSize="10">UV-erasable program storage</text>
+                <line x1="200" y1="80" x2="290" y2="135" stroke="hsl(195 50% 60%)" strokeWidth="1.2" />
+
+                {/* PAL */}
+                <rect x="60" y="220" width="140" height="60" rx="8" fill="hsl(220 25% 16%)" stroke="hsl(280 55% 65%)" />
+                <text x="130" y="244" textAnchor="middle" fill="hsl(280 80% 82%)" fontSize="13">PAL</text>
+                <text x="130" y="262" textAnchor="middle" fill="hsl(280 55% 75%)" fontSize="10">programmable glue logic</text>
+                <line x1="200" y1="240" x2="290" y2="190" stroke="hsl(280 50% 65%)" strokeWidth="1.2" />
+
+                {/* UARTs on right */}
+                {[
+                  ["UART 1", 60],
+                  ["UART 2", 110],
+                  ["UART 3", 160],
+                  ["UART 4", 210],
+                ].map(([label, y], i) => {
+                  const yn = Number(y);
+                  return (
+                    <g key={i}>
+                      <rect x="520" y={yn} width="140" height="36" rx="6" fill="hsl(220 25% 16%)" stroke="hsl(140 55% 60%)" />
+                      <text x="590" y={yn + 22} textAnchor="middle" fill="hsl(140 80% 82%)" fontSize="11">{String(label)}</text>
+                      <line x1="430" y1="160" x2="520" y2={yn + 18} stroke="hsl(140 50% 60%)" strokeWidth="1.2" />
+                    </g>
+                  );
+                })}
+
+                <text x="590" y="270" textAnchor="middle" fill="hsl(140 50% 75%)" fontSize="10" fontStyle="italic">
+                  multiple physical lines → one bus → one processor
+                </text>
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              The custom board topology. HC11 in the centre with EPROM
+              feeding instructions in, PAL providing the discrete glue
+              logic, and multiple UARTs hanging off the bus to make
+              one processor look like a small network.
+            </figcaption>
+          </figure>
+          <p>
+            "Designed all by me" in the user's own framing means the
+            schematic, the parts selection, the trace routing, the
+            PAL truth-tables, and the timing analysis. The kind of
+            engineering where a single soldering mistake or a single
+            mis-keyed truth-table costs an EPROM cycle and a UV-eraser
+            session before the next attempt can even boot.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Seven layers · one chip · bare metal",
+      heading: "ISO/OSI from physical up",
+      body: (
+        <>
+          <p>
+            The{" "}
+            <Link href="https://en.wikipedia.org/wiki/OSI_model" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+              ISO/OSI 7-layer model
+            </Link>
+            {" "}— Physical, Data Link, Network, Transport, Session,
+            Presentation, Application — was the canonical way to think
+            about networking in 1990. Most production stacks
+            implemented some subset and pragmatically collapsed
+            adjacent layers. Implementing all seven cleanly on a
+            single 8-bit MCU with no operating system meant carrying
+            every layer's state in a hand-rolled buffer scheme,
+            interleaving timers and UART interrupts, and never
+            allocating memory the system couldn't statically prove was
+            safe.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 320" className="w-full h-auto" role="img" aria-labelledby="osi-stack-title">
+              <title id="osi-stack-title">ISO/OSI 7-layer stack on HC11</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {[
+                  ["Application", "L7", "the user's protocol semantics", "hsl(280 60% 65%)"],
+                  ["Presentation", "L6", "encoding / framing of values", "hsl(220 60% 65%)"],
+                  ["Session", "L5", "dialog state · turn-taking", "hsl(195 60% 60%)"],
+                  ["Transport", "L4", "reliable delivery · windowing", "hsl(140 55% 55%)"],
+                  ["Network", "L3", "addressing · routing", "hsl(80 60% 55%)"],
+                  ["Data Link", "L2", "frame · CRC · UART driver", "hsl(40 70% 55%)"],
+                  ["Physical", "L1", "wire · UART hardware · timing", "hsl(20 70% 60%)"],
+                ].map(([name, L, note, color], i) => {
+                  const y = 24 + i * 38;
+                  return (
+                    <g key={i}>
+                      <rect x="60" y={y} width="600" height="32" rx="6" fill="hsl(220 25% 16%)" stroke={String(color)} />
+                      <text x="78" y={y + 21} fill={String(color)} fontSize="11" fontFamily="ui-monospace">{String(L)}</text>
+                      <text x="120" y={y + 21} fill={String(color)} fontSize="13" fontWeight="500">{String(name)}</text>
+                      <text x="320" y={y + 21} fill="hsl(220 30% 70%)" fontSize="10">{String(note)}</text>
+                    </g>
+                  );
+                })}
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              Seven layers, all running on a single 8-bit MCU with
+              hand-rolled memory discipline, interrupt-driven UART
+              service at the bottom and the application protocol
+              semantics at the top.
+            </figcaption>
+          </figure>
+          <p>
+            The pattern that came out of this — every layer
+            addressable, every layer doing exactly its job, no layer
+            collapsing into another — is the architectural conviction
+            that thirty-six years later still organises the{" "}
+            <Link href="/people/coherence-network" className="text-primary hover:underline">
+              Coherence Network
+            </Link>
+            's data layers (graph / API / web / spectrum-coloured
+            edges). The vocabulary changed; the discipline didn't.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "Building the debugger that didn't exist",
+      body: (
+        <>
+          <p>
+            The hardest detail in the user's own description: <em>"I
+            had to write my own debugger"</em>. In 1990 a Motorola
+            HC11 bring-up rig in a lift-engineering shop in
+            Switzerland came with a power supply, a serial cable, and
+            very little else. Commercial in-circuit emulators existed
+            but were the price of a small car; what shipped with the
+            development kit was a thin monitor program, not a real
+            debugger. So one had to be written.
+          </p>
+          <p>
+            Writing a debugger before you have a debugger is the kind
+            of recursive bootstrap that makes the conviction stick.
+            The first version of the debugger was probably a few
+            instructions burned to EPROM that lit an LED in a known
+            sequence; the second was a serial monitor that could dump
+            registers; the third — the working one — could set
+            breakpoints by replacing instructions with a software
+            interrupt and stepping into them. Every layer of the tool
+            had to come up before the layer above it could be tested
+            at all. The breath of <em>build the tool you need</em>{" "}
+            became muscle memory here.
+          </p>
+          <p>
+            Twenty-six years later this body would name the same
+            posture in a thesis: <em>"every BMA instruction has a
+            forward and a reverse semantics; the architecture is
+            symmetric"</em>. The 1990 HC11 work was the first time
+            this body learned that the system you build can be the
+            tool you use to build it. That posture is now spelled out
+            in this network's commit verbs —{" "}
+            <code className="text-foreground/80">tend</code> /{" "}
+            <code className="text-foreground/80">attune</code> /{" "}
+            <code className="text-foreground/80">compost</code> /{" "}
+            <code className="text-foreground/80">release</code> — as
+            the same self-referential discipline.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "What this work seeded",
+      heading: "Convictions that ride forward",
+      body: (
+        <ul className="space-y-2 list-disc list-inside marker:text-muted-foreground">
+          <li>
+            <strong>Every layer is addressable.</strong> The 7-layer
+            stack made this discipline early. Re-emerges in BML's
+            grammar-in-grammar, the Quark Virtual DOM, the
+            Coherence-Network's seven edge-type families.
+          </li>
+          <li>
+            <strong>Build the tool you need, all the way down.</strong>{" "}
+            From the custom debugger forward to writing a parser,
+            compiler-compiler, virtual machine, undo engine, test
+            harness, and now an entire idea-realization network.
+          </li>
+          <li>
+            <strong>Hardware-level discipline at every altitude.</strong>{" "}
+            What you allocate on an HC11, you must prove safe. Same
+            posture in the Quark undo engine where every action had
+            to know its blast radius, in the Qualcomm test harness
+            where every test was real C# rather than a JSON manifest,
+            in this network's auto-attune where every claim is
+            traceable.
+          </li>
+          <li>
+            <strong>C as native tongue.</strong> Learned here, carried
+            into the BML implementation (BMCPU was C++ on a C-host),
+            QuarkXPress (C++ with COM), early Qualcomm
+            (Windows/Graphics divisions). The substrate for two
+            decades of system-level work.
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Source materials are pre-digital and not in the public archive.
+      What lives here is the architectural shape, the user's own
+      framing, and what is honestly knowable from the body's lived
+      memory of building it. The HC11 itself is documented at{" "}
+      <Link href="https://en.wikipedia.org/wiki/Motorola_68HC11" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        Wikipedia · Motorola 68HC11
+      </Link>
+      ; ISO/OSI 7-layer at{" "}
+      <Link href="https://en.wikipedia.org/wiki/OSI_model" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        Wikipedia · OSI model
+      </Link>
+      . Urs is invited to refine any technical detail or the exact
+      year-range through the Refine doorway below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/schindler-hc11-protocol/index.ts
+++ b/web/content/people/schindler-hc11-protocol/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getSchindlerHc11ProtocolContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}

--- a/web/content/people/trimble-glue-layer/en.tsx
+++ b/web/content/people/trimble-glue-layer/en.tsx
@@ -1,0 +1,285 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Trimble Client/Server Glue Layer — independent cadence, wire-optimal",
+    description:
+      "At Trimble Navigation (Jan 2007 – Oct 2009), built the glue layer between client and server platforms. Combined multiple client calls and multiple API versions into one wire-optimal exchange, with the glue stack living on both the client and the server edge layer. Server and client teams could evolve on independent cadences without coordinating each release; the glue layer absorbed the version differences.",
+  },
+  breadcrumbName: "Trimble · Client/Server Glue",
+  hero: {
+    background:
+      "linear-gradient(135deg, hsl(220 30% 8%), hsl(195 35% 14%) 50%, hsl(80 30% 16%))",
+    overlayClass:
+      "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30",
+    eyebrow: "Work · Trimble Navigation Limited · Jan 2007 – Oct 2009 · Software Engineer",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Trimble — Client/Server Glue Layer",
+    welcome: (
+      <p>
+        At Trimble Navigation, built the <strong>glue layer</strong>{" "}
+        sitting on both the client and the server edge — the
+        load-bearing piece that let the two sides evolve on{" "}
+        <em>independent cadences</em>, with multiple client calls and
+        multiple API versions combined into one wire-optimal exchange.
+        Server and client teams could ship on their own rhythm without
+        coordinating each release; the glue absorbed the version
+        differences and the round-trip optimisation. Neither team
+        had to think about wire shape.
+      </p>
+    ),
+  },
+  facts: [
+    { label: "Era", value: "Trimble Navigation Limited · January 2007 – October 2009 · 2 years 10 months · Software Engineer" },
+    {
+      label: "Substrate",
+      value: "Cross-platform — client side ran in the field on positioning hardware; server side in cloud / corporate infrastructure"
+    },
+    {
+      label: "Function",
+      value: (
+        <>
+          One stack on both edges — client glue + server glue —
+          carrying version translation, call coalescing, and wire
+          shaping; the substrate the team-on-team coordination
+          problem dissolved into.
+        </>
+      ),
+    },
+    {
+      label: "Conviction",
+      value: (
+        <>
+          <em>Coupling kills cadence.</em> Two teams cannot ship
+          independently if their wire contract requires them to. The
+          glue layer was the architectural answer: <em>let each team
+          author against its current self, and let the glue absorb
+          the version skew.</em>
+        </>
+      ),
+    },
+    {
+      label: "Lineage forward",
+      value: (
+        <>
+          The same shape is now what the{" "}
+          <Link href="/people/coherence-network" className="hover:text-primary">Coherence Network</Link>
+          's API + adapter layer carries: one OpenAPI contract, multiple
+          client surfaces (web · CLI · MCP · agent harnesses) all
+          decoupled from API-version cadence by the same kind of glue.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "Why the glue layer mattered",
+    body: (
+      <p>
+        Without it, every API change from the server team meant a
+        synchronised release with the client team. With it, the
+        client team kept shipping for whatever wire version they
+        already understood, the server team kept shipping for
+        whatever wire version <em>they</em> already understood, and
+        the glue layer translated between them. The architecture
+        decoupled cadence from contract. Two teams could each move
+        at the speed they could move at, instead of at the speed of
+        the slower one.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "Two edges of the same stack",
+      body: (
+        <>
+          <p>
+            The architectural choice that let the layer absorb its
+            workload: the glue ran <em>twice</em>, once on the client
+            edge and once on the server edge, with a shared codebase
+            describing how each side translated. From either team's
+            perspective the glue was a library they linked against;
+            from the wire's perspective it was a contract that always
+            framed calls in the optimal shape regardless of which
+            version either team was currently authoring against.
+          </p>
+          <figure className="my-6 rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg viewBox="0 0 720 320" className="w-full h-auto" role="img" aria-labelledby="trimble-glue-title">
+              <title id="trimble-glue-title">Trimble client/server glue layer architecture</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="12">
+                {/* Client side */}
+                <text x="170" y="30" fill="hsl(195 80% 80%)" fontSize="13" textAnchor="middle">Client side</text>
+                <rect x="60" y="40" width="220" height="44" rx="8" fill="hsl(220 25% 18%)" stroke="hsl(195 60% 60%)" />
+                <text x="170" y="62" textAnchor="middle" fill="hsl(195 80% 82%)" fontSize="12">Client app — version Cv</text>
+                <text x="170" y="78" textAnchor="middle" fill="hsl(195 50% 70%)" fontSize="10">authors against current client API</text>
+
+                <line x1="170" y1="84" x2="170" y2="100" stroke="hsl(220 30% 60%)" strokeWidth="1.2" />
+
+                <rect x="60" y="100" width="220" height="80" rx="8" fill="hsl(140 35% 16%)" stroke="hsl(140 70% 60%)" strokeWidth="2" />
+                <text x="170" y="124" textAnchor="middle" fill="hsl(140 90% 85%)" fontSize="12">Client glue · edge layer</text>
+                <text x="80" y="142" fill="hsl(140 60% 75%)" fontSize="10">· version translation (Cv → Sv)</text>
+                <text x="80" y="156" fill="hsl(140 60% 75%)" fontSize="10">· call coalescing into one trip</text>
+                <text x="80" y="170" fill="hsl(140 60% 75%)" fontSize="10">· response splitting back to caller</text>
+
+                {/* Wire */}
+                <line x1="280" y1="140" x2="440" y2="140" stroke="hsl(40 80% 60%)" strokeWidth="2" />
+                <rect x="300" y="126" width="120" height="28" rx="14" fill="hsl(40 50% 18%)" stroke="hsl(40 80% 60%)" />
+                <text x="360" y="144" textAnchor="middle" fill="hsl(40 90% 85%)" fontSize="11">wire · 1 round-trip</text>
+
+                {/* Server side */}
+                <text x="570" y="30" fill="hsl(280 70% 80%)" fontSize="13" textAnchor="middle">Server side</text>
+                <rect x="440" y="40" width="220" height="44" rx="8" fill="hsl(220 25% 18%)" stroke="hsl(280 60% 65%)" />
+                <text x="550" y="62" textAnchor="middle" fill="hsl(280 80% 82%)" fontSize="12">Server app — version Sv</text>
+                <text x="550" y="78" textAnchor="middle" fill="hsl(280 50% 70%)" fontSize="10">authors against current server API</text>
+
+                <line x1="550" y1="84" x2="550" y2="100" stroke="hsl(220 30% 60%)" strokeWidth="1.2" />
+
+                <rect x="440" y="100" width="220" height="80" rx="8" fill="hsl(140 35% 16%)" stroke="hsl(140 70% 60%)" strokeWidth="2" />
+                <text x="550" y="124" textAnchor="middle" fill="hsl(140 90% 85%)" fontSize="12">Server glue · edge layer</text>
+                <text x="460" y="142" fill="hsl(140 60% 75%)" fontSize="10">· call splitting (1 wire → N calls)</text>
+                <text x="460" y="156" fill="hsl(140 60% 75%)" fontSize="10">· version translation (Sv ← incoming)</text>
+                <text x="460" y="170" fill="hsl(140 60% 75%)" fontSize="10">· response coalescing for the trip</text>
+
+                {/* Bottom: shared codebase */}
+                <rect x="220" y="230" width="280" height="60" rx="8" fill="hsl(220 25% 14%)" stroke="hsl(40 60% 55%)" strokeDasharray="3,3" />
+                <text x="360" y="252" textAnchor="middle" fill="hsl(40 80% 80%)" fontSize="12">Shared glue codebase</text>
+                <text x="360" y="270" textAnchor="middle" fill="hsl(40 50% 75%)" fontSize="10">version-translation rules · wire-shape contract</text>
+                <text x="360" y="284" textAnchor="middle" fill="hsl(40 50% 75%)" fontSize="10">deployed on both edges from one source</text>
+
+                <line x1="170" y1="180" x2="220" y2="260" stroke="hsl(40 50% 55%)" strokeWidth="0.8" strokeDasharray="2,3" />
+                <line x1="550" y1="180" x2="500" y2="260" stroke="hsl(40 50% 55%)" strokeWidth="0.8" strokeDasharray="2,3" />
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              Two edge layers, one shared codebase. The client app
+              authors against its current API; the server app
+              authors against its current API; the glue layers
+              between them absorb the version skew and shape the
+              wire into one optimal round-trip.
+            </figcaption>
+          </figure>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "What 'wire-optimal' actually meant",
+      heading: "Multiple calls into one round-trip",
+      body: (
+        <>
+          <p>
+            A naive client makes N independent API calls and pays N
+            network round-trips. The glue layer's coalescing job:
+            watch the call pattern from the client app, recognise
+            when several calls are batched into a logical unit, fold
+            them into a single wire request, dispatch to the server,
+            then split the response so each call returned to its
+            caller as if it had been independent.
+          </p>
+          <p>
+            The trade-off the layer mediated:{" "}
+            <strong>application-team ergonomics versus wire cost</strong>.
+            Naturally written client code makes lots of small calls;
+            wire-optimal protocols want one big bundle. Without the
+            glue, every client call site had to be wire-aware; with
+            it, neither team had to think about the wire at all. The
+            glue made the trade-off invisible to both sides.
+          </p>
+          <p>
+            This is the same posture, in 2007, that GraphQL would
+            commit to for completely different reasons in 2015 —
+            "let the client describe its data shape; let the server
+            assemble the optimal response in one trip." Trimble's
+            glue layer reached the same architectural answer through
+            a different door (positioning hardware constrained the
+            client side; the server side had to absorb the
+            complexity).
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "Cadence as a first-class architectural concern",
+      body: (
+        <>
+          <p>
+            The conviction at the heart of this work: <em>two teams
+            should not have their release cadence coupled to a wire
+            contract</em>. If shipping a server feature requires the
+            client team to ship the same week, neither team can move
+            at its true speed. The slower team becomes the rate limit
+            for both.
+          </p>
+          <p>
+            The glue layer's contract was therefore not "the current
+            API" but "the set of API versions either side might be
+            running, and the translations between them." When the
+            server team added a new field, the glue layer learned to
+            translate calls from old-client-version to new-server-
+            version and vice versa. When the client team added a new
+            call, the glue layer learned to break that call apart for
+            servers that hadn't yet adopted it. Both sides kept
+            shipping, on their own rhythm, into a wire that was always
+            current with whichever side was further ahead.
+          </p>
+          <p>
+            The same conviction holds in the{" "}
+            <Link href="/people/coherence-network" className="text-primary hover:underline">
+              Coherence Network
+            </Link>
+            's design today. The web client and the API ship through
+            independent CI runs; the OpenAPI contract is generated
+            from FastAPI's source of truth and the TypeScript client
+            adapts. Either side can land a change without breaking
+            the other; the substrate absorbs version differences. The
+            shape Trimble committed to in 2007 is still the right
+            shape twenty years on.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Lineage of decoupling",
+      heading: "Through-line back to the 7-layer thinking",
+      body: (
+        <p>
+          The deepest reading: this is the same conviction the{" "}
+          <Link href="/people/schindler-hc11-protocol" className="text-primary hover:underline">
+            Schindler 7-layer ISO/OSI work
+          </Link>
+          {" "}committed to thirty-six years earlier — every layer is
+          addressable, every layer does exactly its job, no layer
+          collapses into another. At Trimble the conviction landed at
+          the application-protocol layer: the client and server were
+          two layers, the glue was a layer between them with its own
+          discipline, and the wire was a layer below that with its
+          own constraints. Each layer authored against its own job,
+          not the layers around it. The architecture survives at every
+          altitude where this body has applied it.
+        </p>
+      ),
+    },
+  ],
+  footer: (
+    <p>
+      Company:{" "}
+      <Link href="https://en.wikipedia.org/wiki/Trimble_Inc." target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        Trimble (Wikipedia)
+      </Link>
+      {" · "}
+      <Link href="https://www.trimble.com" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+        trimble.com
+      </Link>
+      . Source code is internal to Trimble; what lives here is the
+      architectural shape and the design rationale. Urs is invited
+      to refine technical detail through the Refine doorway below.
+    </p>
+  ),
+};
+
+export default content;

--- a/web/content/people/trimble-glue-layer/index.ts
+++ b/web/content/people/trimble-glue-layer/index.ts
@@ -1,0 +1,7 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+
+export function getTrimbleGlueLayerContent(_lang: LocaleCode): PersonProfileContent {
+  return en;
+}


### PR DESCRIPTION
## Summary

Four curated /people pages filling in the chronological lineage from age 18 hardware work all the way through the post-Quark / pre-Qualcomm middle years.

- **/people/schindler-hc11-protocol** — Schindler, ~1989-90, age 18. Designed the hardware + wrote the firmware for an ISO/OSI 7-layer protocol stack on a Motorola HC11. Multiple UARTs, EPROM + PAL, all in C, custom debugger from scratch. The keystone of the body of evidence.
- **/people/quark-mono-corba** — within May 2000-Mar 2005. Contributed to the Mono project + built a CORBA bridge that remote-controlled QuarkXPress cross-platform.
- **/people/mindtouch-wiki-in-a-box** — Mar 2005-Jan 2007, Co-Founder + Senior Architect. Ported the MediaWiki PHP codebase into a C# generic document layer.
- **/people/trimble-glue-layer** — Jan 2007-Oct 2009. Client+server edge-layer glue stack absorbing version skew and call-coalescing so the two teams could ship on independent cadences.

Graph wiring (live): all four asset nodes created, 17 lineage edges added connecting Schindler ⇆ BML/BMCPU/thesis/trimble; Mono/CORBA ⇆ Virtual DOM/BML; chronological forward edges through MindTouch → Quark → Qualcomm → Living-Codex-CSharp / Coherence-Network.

The body of evidence now reads end-to-end across 36 years and nine substrates with one conviction: every layer addressable, every change with a clean reverse, build the tool you need.

## Test plan
- [ ] Each new page renders hero + facts + diagrams (Schindler has 2 SVGs; others 1 each)
- [ ] /people/contributor:seeker71 Emits surfaces all four new works
- [ ] BML/BMCPU/thesis pages now show "Recognized by" Schindler in the live influence-web
- [ ] Coherence-Network page shows "Recognized by" MindTouch + Trimble forward-lineage
- [ ] Cross-links between curated pages all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)