### PR TITLE
tend: link works tiles to their own asset profile pages

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -238,10 +238,14 @@ async function fetchCreations(nodeId: string): Promise<Creation[]> {
     const kind = (edge.properties?.kind as Creation["kind"]) ||
       (fullAsset?.creation_kind as Creation["kind"]) ||
       "work";
+    const slug = (fullAsset?.slug as string) || null;
+    const internalUrl = slug ? `/people/${slug}` : null;
+    const canonical = (fullAsset?.canonical_url as string) || null;
     creations.push({
       kind,
       name: (fullAsset?.name as string) || edge.to_node?.name || "Untitled",
-      url: (fullAsset?.canonical_url as string) || null,
+      url: internalUrl ?? canonical,
+      internal: Boolean(internalUrl),
       image_url: (fullAsset?.image_url as string) || null,
     });
   }

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -63,6 +63,8 @@ export type Creation = {
   name: string;
   url?: string | null;
   image_url?: string | null;
+  /** When true, `url` is an internal Network route (same-tab nav); otherwise external (new tab). */
+  internal?: boolean;
 };
 
 export type Lineage = {
@@ -440,7 +442,9 @@ function CreationsGrid({
         {visible.map((c) => {
           const Tag = (c.url ? "a" : "div") as "a" | "div";
           const extra = c.url
-            ? { href: c.url, target: "_blank", rel: "noopener noreferrer" }
+            ? c.internal
+              ? { href: c.url }
+              : { href: c.url, target: "_blank", rel: "noopener noreferrer" }
             : {};
           return (
             <Tag


### PR DESCRIPTION
## Summary
- The eight career-lineage works on `/people/contributor:seeker71` were rendering as gradient squares with no images and no links — most asset nodes have neither `image_url` nor `canonical_url`, but they all have rich detail pages at `/people/{slug}`.
- Route every works tile to `/people/{slug}` (its own asset profile) as the primary destination. The detail page already surfaces source/lineage where they exist, so canonical URLs (kernel.org, trimble.com, ...) become facets inside the work rather than the tile's only door.
- Internal links open in the same tab; external (no slug) keeps the new-tab + `noopener` behavior.

## Files
- `web/app/people/[id]/page.tsx` — fetchCreations builds `/people/{slug}` from `fullAsset.slug`, falls back to `canonical_url`, marks `internal: true` when slug-based.
- `web/components/presence/PresencePage.tsx` — `Creation.internal?: boolean`; `CreationsGrid` chooses same-tab vs new-tab based on the flag.

## Test plan
- [ ] Verify on prod after deploy: https://coherencycoin.com/people/contributor:seeker71 — works tiles are clickable, route to their `/people/{slug}` detail pages.
- [ ] Spot-check assets with `canonical_url` (qualcomm-hdmi-hdcp, trimble-glue-layer) — internal route still wins; canonical visible inside the detail page.
- [ ] Image-fallback gradient still renders cleanly when `image_url` is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)