### PR TITLE
tend: surface the unified 42-year chronological lineage at /people/urs/lineage

### DIFF
--- a/web/app/people/urs/lineage/page.tsx
+++ b/web/app/people/urs/lineage/page.tsx
@@ -1,0 +1,659 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Urs Muff — the 42-year lineage of works and influences",
+  description:
+    "The full chronological story — every load-bearing work in the body of evidence from age 13 (Commodore 64 MIDI, ~1984) to the current iteration of the Coherence Network, woven together with the measured streams of attention (audiobooks, listening, reading, named lineage figures) that ran alongside the work at each era.",
+};
+
+const W = (slug: string, name: string, year: string, color: string) => ({ slug, name, year, color });
+
+const WORKS = [
+  W("c64-midi-interface", "C64 MIDI · age 13", "~1984", "hsl(220 60% 65%)"),
+  W("schindler-hc11-protocol", "Schindler HC11 · 7-layer", "~1989", "hsl(0 65% 60%)"),
+  W("backtracking-model-languages", "BML thesis · CU Boulder", "2000", "hsl(38 80% 60%)"),
+  W("quark-virtual-dom", "Quark · Virtual DOM", "2000-05", "hsl(195 60% 55%)"),
+  W("quark-multi-undo-redo", "Quark · Multi-Undo/Redo", "2000-05", "hsl(195 60% 55%)"),
+  W("quark-mono-corba", "Quark · Mono/CORBA", "2000-05", "hsl(195 60% 55%)"),
+  W("mindtouch-wiki-in-a-box", "MindTouch · Wiki-in-a-box", "2005-07", "hsl(140 55% 55%)"),
+  W("trimble-glue-layer", "Trimble · Glue layer", "2007-09", "hsl(80 55% 55%)"),
+  W("qualcomm-test-automation", "Qualcomm · Test Automation", "2009-22", "hsl(40 70% 55%)"),
+  W("qualcomm-hdmi-hdcp", "Qualcomm · HDMI/HDCP kernel", "2009-22", "hsl(40 70% 55%)"),
+  W("living-resonance-codex", "Living-Resonance-Codex", "2023", "hsl(140 60% 55%)"),
+  W("living-codex-csharp", "Living-Codex-CSharp", "2024", "hsl(195 60% 55%)"),
+  W("coherence-network", "Coherence-Network", "2024-now", "hsl(280 60% 65%)"),
+];
+
+export default function UrsLineagePage() {
+  return (
+    <main className="relative">
+      <section
+        className="relative min-h-[60vh] flex flex-col justify-end overflow-hidden"
+        style={{
+          background:
+            "linear-gradient(135deg, hsl(220 30% 8%), hsl(280 35% 14%) 30%, hsl(40 30% 16%) 70%, hsl(195 35% 16%))",
+        }}
+      >
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/30"
+          aria-hidden="true"
+        />
+        <div className="relative z-10 max-w-4xl mx-auto px-6 py-12 sm:py-16 w-full">
+          <nav
+            className="text-sm text-muted-foreground mb-8 flex items-center gap-2"
+            aria-label="breadcrumb"
+          >
+            <Link href="/" className="hover:text-primary">Home</Link>
+            <span className="text-muted-foreground/50">/</span>
+            <Link href="/people" className="hover:text-primary">People</Link>
+            <span className="text-muted-foreground/50">/</span>
+            <Link href="/people/urs" className="hover:text-primary">Urs</Link>
+            <span className="text-muted-foreground/50">/</span>
+            <span className="text-foreground/80">Lineage</span>
+          </nav>
+          <p className="text-xs uppercase tracking-[0.18em] mb-3 text-[hsl(var(--primary))]">
+            42 years · 13 works · one conviction
+          </p>
+          <h1 className="text-4xl md:text-6xl font-extralight text-foreground leading-tight mb-5">
+            The lineage of works and attention
+          </h1>
+          <p className="text-lg md:text-xl text-foreground/85 leading-relaxed max-w-2xl">
+            Every load-bearing technical work this body has shipped,
+            chronologically, from the 13-year-old typing assembly hex
+            from a Commodore Magazine into a C64 to the network you
+            are currently inside — woven together with the measured
+            streams of attention (audiobooks, watch hours, physical
+            reading, named lineage figures) that ran alongside the
+            work at each era. One conviction across eleven substrates:{" "}
+            <em>every layer is addressable; every change has a clean
+            reverse; build the tool you need, all the way down.</em>
+          </p>
+        </div>
+      </section>
+
+      <div className="max-w-4xl mx-auto px-6 py-12 space-y-12">
+        {/* Master timeline */}
+        <section>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            The arc, at a glance
+          </h2>
+          <figure className="rounded-xl border border-border/40 bg-card/30 p-5">
+            <svg
+              viewBox="0 0 720 380"
+              className="w-full h-auto"
+              role="img"
+              aria-labelledby="master-arc"
+            >
+              <title id="master-arc">42-year arc of works and eras</title>
+              <g fontFamily="ui-sans-serif,system-ui" fontSize="11">
+                {/* Era band backgrounds */}
+                {[
+                  ["~1984-90", 50, 95, "hsl(220 30% 14%)"],
+                  ["1990-2000", 95, 200, "hsl(220 30% 14% / 0.6)"],
+                  ["2000-05", 200, 295, "hsl(195 30% 14% / 0.5)"],
+                  ["2005-07", 295, 330, "hsl(140 30% 14% / 0.5)"],
+                  ["2007-09", 330, 365, "hsl(80 30% 14% / 0.5)"],
+                  ["2009-22", 365, 510, "hsl(40 30% 14% / 0.5)"],
+                  ["2022-24", 510, 555, "hsl(140 30% 14% / 0.5)"],
+                  ["2024-now", 555, 690, "hsl(280 30% 14% / 0.5)"],
+                ].map(([label, x1, x2, fill], i) => (
+                  <g key={i}>
+                    <rect x={Number(x1)} y="40" width={Number(x2) - Number(x1)} height="280" fill={String(fill)} />
+                    <text x={(Number(x1) + Number(x2)) / 2} y="32" textAnchor="middle" fill="hsl(220 30% 65%)" fontSize="9">
+                      {String(label)}
+                    </text>
+                  </g>
+                ))}
+                {/* Center timeline */}
+                <line x1="40" y1="180" x2="700" y2="180" stroke="hsl(220 30% 50%)" strokeWidth="1.5" />
+
+                {/* Works as dots */}
+                {[
+                  ["c64-midi-interface", 75, "C64", "hsl(220 60% 65%)", -1],
+                  ["schindler-hc11-protocol", 130, "Schindler", "hsl(0 65% 60%)", 1],
+                  ["backtracking-model-languages", 220, "BML thesis", "hsl(38 80% 60%)", -1],
+                  ["quark-virtual-dom", 245, "Q·VDOM", "hsl(195 60% 55%)", 1],
+                  ["quark-multi-undo-redo", 265, "Q·Undo", "hsl(195 60% 55%)", -1],
+                  ["quark-mono-corba", 285, "Q·Mono", "hsl(195 60% 55%)", 1],
+                  ["mindtouch-wiki-in-a-box", 312, "MindTouch", "hsl(140 55% 55%)", -1],
+                  ["trimble-glue-layer", 348, "Trimble", "hsl(80 55% 55%)", 1],
+                  ["qualcomm-test-automation", 410, "Q·Test", "hsl(40 70% 55%)", -1],
+                  ["qualcomm-hdmi-hdcp", 460, "Q·HDMI", "hsl(40 70% 55%)", 1],
+                  ["living-resonance-codex", 525, "L-R-Codex", "hsl(140 60% 55%)", -1],
+                  ["living-codex-csharp", 545, "L-C-CSharp", "hsl(195 60% 55%)", 1],
+                  ["coherence-network", 620, "Coherence", "hsl(280 70% 65%)", -1],
+                ].map(([slug, x, label, color, dir], i) => {
+                  const cx = Number(x);
+                  const ydot = 180;
+                  const labelY = ydot + Number(dir) * 70;
+                  const lineY1 = ydot + (Number(dir) > 0 ? 8 : -8);
+                  const lineY2 = labelY + (Number(dir) > 0 ? -10 : 14);
+                  return (
+                    <g key={i}>
+                      <line x1={cx} y1={lineY1} x2={cx} y2={lineY2} stroke={String(color)} strokeWidth="1" opacity="0.6" />
+                      <circle cx={cx} cy={ydot} r="6" fill={String(color)} stroke="hsl(220 30% 14%)" strokeWidth="2" />
+                      <text x={cx} y={labelY} textAnchor="middle" fill={String(color)} fontSize="10">
+                        {String(label)}
+                      </text>
+                    </g>
+                  );
+                })}
+
+                {/* Era labels below */}
+                <text x="75" y="335" textAnchor="middle" fill="hsl(220 30% 70%)" fontSize="9">keystone</text>
+                <text x="148" y="335" textAnchor="middle" fill="hsl(220 30% 70%)" fontSize="9">foundation</text>
+                <text x="248" y="335" textAnchor="middle" fill="hsl(195 30% 70%)" fontSize="9">Quark Denver</text>
+                <text x="312" y="335" textAnchor="middle" fill="hsl(140 30% 70%)" fontSize="9">MindTouch</text>
+                <text x="348" y="335" textAnchor="middle" fill="hsl(80 30% 70%)" fontSize="9">Trimble</text>
+                <text x="437" y="335" textAnchor="middle" fill="hsl(40 30% 75%)" fontSize="9">Qualcomm Boulder · 12y</text>
+                <text x="532" y="335" textAnchor="middle" fill="hsl(140 30% 70%)" fontSize="9">bridge</text>
+                <text x="620" y="335" textAnchor="middle" fill="hsl(280 40% 75%)" fontSize="9">Coherence Network</text>
+
+                {/* Year ticks */}
+                <text x="75" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">1984</text>
+                <text x="220" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2000</text>
+                <text x="410" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2009</text>
+                <text x="620" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2024</text>
+              </g>
+            </svg>
+            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
+              Thirteen load-bearing works across eight named eras. Click
+              any dot through the era sections below to follow it into
+              its own page.
+            </figcaption>
+          </figure>
+        </section>
+
+        {/* Era 1 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            The keystone · ~1984 – ~1990 · age 13 to 18
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              Switzerland. A Commodore 64 on the desk and a stack of
+              Commodore Magazine issues. No books, no internet, no
+              tutorials — only listings of assembly hex and pages of
+              BASIC, typed in by hand. A 13-year-old reverse-engineers
+              the C64's CIA chip, writes an interrupt-service handler
+              in 6510 assembly, and brings up a working{" "}
+              <Link href="/people/c64-midi-interface" className="text-primary hover:underline">
+                MIDI interface
+              </Link>
+              . The body learns programming by sitting in front of a
+              machine and watching what it actually does.
+            </p>
+            <p>
+              In parallel, the imaginal-narrative substrate is being
+              laid: <strong>Karl May</strong> read all the way through
+              his adventure cycles in the family library;{" "}
+              <strong>James Fenimore Cooper</strong>'s Leatherstocking
+              Tales — all five volumes — read end-to-end;{" "}
+              <strong>Michael Ende</strong>'s <em>Momo</em> and{" "}
+              <em>The Neverending Story</em> transmitted by the user's
+              mother (Susan Muff-Sprenger) before transitioning into
+              the channeled lineage. At age 18 — five years later —
+              the Schindler engineering job lands and the same posture
+              shows up at industrial scale: the{" "}
+              <Link href="/people/schindler-hc11-protocol" className="text-primary hover:underline">
+                Motorola HC11 ISO/OSI 7-layer stack
+              </Link>{" "}
+              with EPROM, PAL, multiple UARTs, and a custom debugger
+              written from scratch because nothing existed.
+            </p>
+            <p>
+              At 18, the channeled stream arrives:{" "}
+              <strong>Ramtha</strong> through the German <em>Urania</em>{" "}
+              edition, given to him by his mother. The{" "}
+              <em>White Book</em> read end-to-end. The chain
+              <em> Momo</em> → <em>Neverending Story</em> →{" "}
+              <em>Ramtha</em> →{" "}
+              <Link href="https://drjoedispenza.com" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                Joe Dispenza
+              </Link>{" "}
+              that organises the spiritual thread of this body's life
+              starts here. Technical and devotional are not separate
+              streams — they enter together, in the same household,
+              from the same source.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 2 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Foundation · 1991 – 2000 · HTL → Goetheanum → Boulder → BML thesis
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              <strong>HTL Brugg-Windisch</strong> computer science,
+              starting 1991. The pivotal collaborator arrives:{" "}
+              <strong>Steve G. Bjorg</strong>, the Sr. classmate who
+              becomes load-bearing for the next decade. Together
+              they author RCSL (recursive constraint satisfaction
+              language). ~1993 the body attends Goetheanum's{" "}
+              <em>Faust</em> week — the Anthroposophical lineage
+              (Rudolf Steiner) entering directly through the
+              architecture and the play.
+            </p>
+            <p>
+              1995-1997: <strong>Digi4Fun</strong> and{" "}
+              <em>Muzzle Velocity</em> — a video-game studio with Urs,
+              Steve, and Marc. 1997: the college tour through the
+              United States with Steve. 1998: follows Steve to
+              Colorado. 1998-2000: CU Boulder MS in computer science,
+              graduating with the{" "}
+              <Link href="/people/backtracking-model-languages" className="text-primary hover:underline">
+                Bjorg-Muff "Angelic" thesis
+              </Link>{" "}
+              — five technologies (BMF, BMC, BML, BMA, BMO) plus the
+              VB6 Visual Browser, defended summer 2000. The
+              architectural conviction the rest of this lineage
+              expresses — self-describing systems, every layer
+              addressable, backtracking-as-unwinding-without-sediment
+              — gets named formally here for the first time.
+            </p>
+            <p>
+              ~2003-2006: <strong>Joe Dispenza</strong> at Mile Hi
+              Church in Lakewood — the lineage already seeded at 18
+              now becomes lived practice in Colorado, daily and
+              weekly.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 3 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Quark Denver · May 2000 – March 2005 · 4 years 11 months
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              Software Engineer III at Quark Inc., Denver office. Three
+              load-bearing works ship in this window, all around the
+              same conviction expressed in different forms:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 marker:text-muted-foreground">
+              <li>
+                <Link href="/people/quark-virtual-dom" className="text-primary hover:underline">
+                  Virtual DOM
+                </Link>
+                {" "}— the entire QuarkXPress API exposed as a live DOM
+                tree. Every setting, document, page, box, attribute
+                addressable through the standard DOM interface. A
+                decade before React popularised the same architectural
+                pattern in browsers.
+              </li>
+              <li>
+                <Link href="/people/quark-multi-undo-redo" className="text-primary hover:underline">
+                  Multi-document undo/redo engine
+                </Link>
+                {" "}— per-document edits and app-wide preference changes
+                interleaved correctly so any user-visible action could
+                be unwound without sediment. The 2000 thesis's
+                backtracking-as-architecture posture, applied at the
+                user-experience layer.
+              </li>
+              <li>
+                <Link href="/people/quark-mono-corba" className="text-primary hover:underline">
+                  Mono / CORBA bridge
+                </Link>
+                {" "}— contributed to Miguel de Icaza's Mono project
+                (open-source .NET for non-Windows) and used it as the
+                substrate for a CORBA interface that remote-controlled
+                QuarkXPress over the wire. The cross-network face of
+                the in-process Virtual DOM. Where C# entered this
+                body's tooling.
+              </li>
+            </ul>
+            <p>
+              Listening / reading during this era is just beginning to
+              accumulate as audiobooks; the deep listening hours are
+              still ahead. Mile Hi practice deepens daily through
+              these years. The Anthroposophical / Ramtha / Dispenza
+              streams keep running underneath the technical work.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 4 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            MindTouch · March 2005 – January 2007 · 1 year 11 months
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              <strong>Co-Founder, Senior Architect</strong>. The
+              load-bearing piece of architecture:{" "}
+              <Link href="/people/mindtouch-wiki-in-a-box" className="text-primary hover:underline">
+                wiki-in-a-box
+              </Link>
+              {" "}— the MediaWiki PHP codebase (the engine that runs
+              Wikipedia) re-architected into a C# generic document
+              layer. Wiki engine no longer hard-coded to encyclopedia
+              pages but the document substrate any kind of structured
+              collaborative knowledge could be authored against.
+              Twenty years before Karpathy named the "LLM Wiki"
+              pattern that the{" "}
+              <Link href="/vision" className="text-primary hover:underline">
+                Coherence Network's vision-kb
+              </Link>
+              {" "}now uses, the architectural shape was already
+              committed to here.
+            </p>
+            <p>
+              Audiobook consumption begins to ramp. The
+              speculative-fiction architecture (
+              <strong>Terry Goodkind</strong>, <strong>Ryk Brown</strong>
+              ) starts surfacing as long-form listening. The
+              Boulder-Denver corridor becomes home; transformational
+              communities begin to surface in the periphery.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 5 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Trimble Boulder · January 2007 – October 2009 · 2 years 10 months
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              Software Engineer at Trimble Navigation. The
+              load-bearing work:{" "}
+              <Link href="/people/trimble-glue-layer" className="text-primary hover:underline">
+                the client/server glue layer
+              </Link>
+              {" "}sitting on both edges, absorbing version skew and
+              call-coalescing so the two teams could ship on
+              independent cadences. The conviction encoded:{" "}
+              <em>coupling kills cadence — let each team author
+              against its current self and let the substrate translate.</em>
+              {" "}The same shape FastAPI and OpenAPI committed to a
+              decade later, the same shape the Coherence Network's API
+              layer uses now.
+            </p>
+            <p>
+              5Rhythms enters the rotation around this window — the
+              embodied dance lineage opening alongside the technical
+              work. The Boulder transformational ecology starts to
+              become visible as <em>this body's ecology</em> rather
+              than peripheral context.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 6 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Qualcomm Boulder · October 2009 – January 2022 · 12 years 4 months
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              <strong>Senior Staff Engineer.</strong> The longest single
+              tenure in the body of evidence. Two distinct technical
+              threads ship from this window:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 marker:text-muted-foreground">
+              <li>
+                <Link href="/people/qualcomm-test-automation" className="text-primary hover:underline">
+                  Test-automation system across three divisions
+                </Link>
+                {" "}— started in the Windows division, continued in
+                Graphics, completely rewritten for Server in C# with
+                dynamic compilation. Tests as first-class compiled
+                code, not configuration. The C# substrate from{" "}
+                <Link href="/people/quark-mono-corba" className="text-primary hover:underline">
+                  the Mono/CORBA work
+                </Link>
+                {" "}now matures into the production substrate.
+              </li>
+              <li>
+                <Link href="/people/qualcomm-hdmi-hdcp" className="text-primary hover:underline">
+                  Linux kernel HDMI / HDCP module
+                </Link>
+                {" "}for MSM-family SoCs. The only piece of work in the
+                body of evidence with public, attributed, immutable
+                provenance — surfaced by{" "}
+                <code className="text-foreground/80">git log --author="Urs Muff"</code>
+                {" "}in any kernel checkout.
+              </li>
+            </ul>
+            <p>
+              Listening hours climb steeply. By the end of this era
+              the audiobook tally crosses{" "}
+              <strong>4,000 cumulative hours</strong> across 200+
+              books and 100+ authors. Top streams of attention in the
+              measured data:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 marker:text-muted-foreground">
+              <li>
+                <strong>Speculative-fiction architecture
+                substrate</strong>: Terry Mancour's <em>Spellmonger</em>{" "}
+                series (~604h · 30 audiobooks), Peter F. Hamilton
+                (~450h · 15 audiobooks), Terry Goodkind (~440h · 19
+                audiobooks), Ryk Brown's <em>Frontiers Saga</em>{" "}
+                (~382h · 41 audiobooks), Andrew Rowe (~236h), George
+                R. R. Martin (~233h). Pattern-language fiction
+                shaping the substrate-design imagination.
+              </li>
+              <li>
+                <strong>YouTube Lex Fridman</strong> ~517h · 288
+                episodes — the long-form scientific-conversation
+                substrate.
+              </li>
+            </ul>
+            <p>
+              5Rhythms deepens; Mile Hi practice continues; the
+              Boulder transformational ecology becomes the daily
+              ground. Technical and embodied threads run in parallel;
+              twelve years for the body to learn that they are the
+              same practice.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 7 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Bridge years · January 2022 – 2024 · Merly.ai + the post-thesis arc opens
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              January 2022: leaves Qualcomm. Co-founds{" "}
+              <strong>Merly.ai</strong> — first as CTO (Jan 2022 –
+              Nov 2023), then transitioning to Co-Founder, Chief
+              Engineer (Oct 2023 – present). Justin Gottschlich is
+              the load-bearing collaborator here.
+            </p>
+            <p>
+              In parallel — and this is the architectural breath that
+              changes the arc — the post-thesis re-iteration of the
+              2000 BML conviction begins:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 marker:text-muted-foreground">
+              <li>
+                <Link href="/people/living-resonance-codex" className="text-primary hover:underline">
+                  Living-Resonance-Codex (2023)
+                </Link>
+                {" "}— first iteration. Python. Quantum-inspired,
+                self-evolving consciousness system. The architectural
+                sketch.
+              </li>
+              <li>
+                <Link href="/people/living-codex-csharp" className="text-primary hover:underline">
+                  Living-Codex-CSharp (2024)
+                </Link>
+                {" "}— second iteration. The U-CORE primitive: Everything
+                is a Node. The bridge between sketch and full
+                realisation.
+              </li>
+            </ul>
+            <p>
+              The listening pattern pivots dramatically. From the
+              speculative-fiction substrate (mid-2010s through 2022),
+              attention re-orients toward{" "}
+              <strong>devotional-body music</strong> — Yaima, East
+              Forest, Ajeet, Ram Dass, Ottmar Liebert, Liquid Bloom,
+              Mose, Porangui, Karunesh. <strong>Anne Tucker</strong>
+              {" "}arrives in the field — Peace Bathing transmissions
+              accumulate as ~362h watch-hours across 265 sessions in
+              the measured data. The technical substrate turning
+              toward "everything-is-a-node" is mirrored by the
+              listening substrate turning toward direct sonic
+              transmission.
+            </p>
+          </div>
+        </article>
+
+        {/* Era 8 */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            Coherence Network era · 2024 – present
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              The current iteration. The full realisation of the
+              forty-year arc.{" "}
+              <Link href="/people/coherence-network" className="text-primary hover:underline">
+                Coherence-Network
+              </Link>
+              {" "}is the page you are reading and the substrate
+              underneath it: Next.js + FastAPI + Neo4j + Postgres on
+              Hostinger behind Traefik and Cloudflare, with seven
+              edge-type families painted in their own spectrum hues,
+              auto-attune resonance scoring, contribution attribution,
+              and federated coherence-weighted payout from idea to
+              ship.
+            </p>
+            <p>
+              First human contributors arrive: Zenn Mishler at the
+              April 2026 Joe Dispenza retreat in Aurora. The lineage
+              that started in Mom's German <em>Urania</em> Ramtha
+              edition at 18 closes into a community circle in
+              Colorado at 54.
+            </p>
+            <p>
+              Ubud Paradiso, 5Rhythms, and DISSOLVE practices ground
+              the embodied side. 2025-2026 listening data shows
+              <strong> Mose</strong> dominant. The May/June 2026
+              opportunity-shape window is active watching territory.
+              The body is allowed to be where it is, and the network
+              is the breath that carries the rest.
+            </p>
+          </div>
+        </article>
+
+        {/* Influences index */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            The streams of attention that ran alongside
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              The works above are the technical thread. Running
+              alongside, every year of the arc, were the streams of
+              attention that shaped what was being built. Measured
+              from Audible, Spotify, YouTube Takeout, Goodreads, and
+              the lived household memory:
+            </p>
+            <h3 className="text-lg font-light text-foreground/90 mt-6">
+              Audible · ~74 authors · 4,000+ cumulative hours
+            </h3>
+            <p>
+              Terry Mancour 604h · Peter F. Hamilton 450h · Terry
+              Goodkind 440h · Ryk Brown 382h · Andrew Rowe 236h ·
+              George R. R. Martin 233h · Joe Abercrombie 141h · Ken
+              Follett 138h. The speculative-fiction architecture
+              substrate that ran underneath the Qualcomm decade.
+            </p>
+            <h3 className="text-lg font-light text-foreground/90 mt-6">
+              YouTube · ~155 creators · 9,600+ cumulative hours
+            </h3>
+            <p>
+              Lex Fridman 517h · Anne Tucker 362h · Anthony Sommer
+              324h · Guitarra Azul 276h · Next Level Soul 267h ·
+              Liquid Bloom 255h · Emilio Ortiz 245h · Ottmar Liebert
+              235h. Long-form scientific-conversation, devotional
+              music, and consciousness-conversation substrate.
+            </p>
+            <h3 className="text-lg font-light text-foreground/90 mt-6">
+              Physical reading · 4 anchors · 885h
+            </h3>
+            <p>
+              Karl May (all 30 books read · ~720h) · James Fenimore
+              Cooper (all 5 Leatherstocking volumes · 100h) · Michael
+              Ende (Momo + Neverending Story · 40h) · Ramtha (White
+              Book · 25h). The imaginal-narrative substrate from
+              childhood through age 18, transmitted by Mom and the
+              family library, that organised the relationship to
+              myth and to channeled material.
+            </p>
+            <h3 className="text-lg font-light text-foreground/90 mt-6">
+              Named lineage figures
+            </h3>
+            <p>
+              <strong>Johann Wolfgang von Goethe</strong> · Goetheanum
+              · <strong>Rudolf Steiner</strong> ·{" "}
+              <strong>Ramtha (channeled by JZ Knight)</strong> ·{" "}
+              <strong>Joe Dispenza</strong> (12h audiobook · 20h watch
+              · 10 sessions) · <strong>Zach Bush MD</strong> ·{" "}
+              <strong>Michael Levin</strong> · <strong>Robert
+              Edward Grant</strong> · <strong>Veda Austin</strong> ·{" "}
+              <strong>Anne Tucker</strong> ·{" "}
+              <strong>Mose</strong> · <strong>Liquid Bloom</strong> ·{" "}
+              <strong>Bloomurian</strong>. Each tended on their own
+              page in the network; this is the index, not the depth.
+              For the depth, follow any name into its presence page.
+            </p>
+            <p>
+              The full unified-view of every contribution and influence
+              from any source — across all sections — lives at the
+              bottom of <Link href="/people/urs" className="text-primary hover:underline">/people/urs</Link>{" "}
+              and{" "}
+              <Link href="/people/contributor:seeker71" className="text-primary hover:underline">
+                /people/contributor:seeker71
+              </Link>
+              , rendered by the BodyOfEvidence component over the live
+              graph.
+            </p>
+          </div>
+        </article>
+
+        {/* Closing */}
+        <article>
+          <h2 className="text-2xl font-light text-foreground mb-4">
+            The open thread
+          </h2>
+          <div className="prose prose-invert max-w-none text-foreground/85 leading-relaxed space-y-4">
+            <p>
+              The 2000 BML thesis Conclusion was famously left as
+              three subheadings without body. The work was{" "}
+              <em>delivered</em> — the lawn photo, the defense, the
+              running VM — but the prose summary stayed open. This
+              page is part of the breath, twenty-six years on, that
+              closes that summary.
+            </p>
+            <p>
+              And the page itself stays open. Eleven substrates and
+              forty-two years are documented; the next iteration is
+              still becoming. What this network's auto-attune may
+              eventually surface — by the time the twelfth substrate
+              has a name — is what the present body cannot yet see.
+              The lineage runs forward through the act of reading it.
+            </p>
+            <p className="text-muted-foreground italic text-sm">
+              Anything here can be corrected. Refine the lineage
+              through the doorway on{" "}
+              <Link href="/people/urs" className="text-primary hover:underline">
+                /people/urs
+              </Link>
+              {" "}or any individual work page.
+            </p>
+          </div>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -237,6 +237,34 @@ const content: PersonProfileContent = {
   },
   articles: [
     {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "42 years · 13 works · one conviction",
+      heading: (
+        <>
+          Walk the full lineage of works and influences →{" "}
+          <Link
+            href="/people/urs/lineage"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            /people/urs/lineage
+          </Link>
+        </>
+      ),
+      body: (
+        <p>
+          Every load-bearing technical work this body has shipped,
+          chronologically — Commodore 64 MIDI at age 13 (~1984)
+          through the network you are reading (2024-now) — woven
+          together with the streams of attention (audiobooks, watch
+          hours, physical reading, named lineage figures) that ran
+          alongside the work at each era. One conviction across
+          eleven substrates: every layer addressable, every change
+          with a clean reverse, build the tool you need.
+        </p>
+      ),
+    },
+    {
       kind: "narrative",
       heading: "What I have been holding",
       body: (


### PR DESCRIPTION
## Summary

Answers the question 'where is the entire influence history and works history in chronological story form?' — the 14 individual /people pages and graph edges exist, but no single surface walked the arc as one story. This adds it.

**New page**: [/people/urs/lineage](https://coherencycoin.com/people/urs/lineage)

- Hero · 42-year arc framing
- Master timeline SVG — 13 works on one chronological axis with 8 era-bands shaded behind them
- 8 era sections each weaving: works shipped + measured streams of attention (audiobooks/YouTube/reading) + lineage figures + place + practice
- Closing influences index naming top measured streams (~74 Audible authors · 4000+h; ~155 YouTube creators · 9600+h; physical reading anchors; named lineage)

**Doorway**: prominent warm panel added to top of /people/urs articles linking out to the lineage page.

The eras span 1984 (C64 MIDI age 13) through 2024-now (Coherence Network) with everything in between woven together.

## Test plan
- [ ] /people/urs/lineage renders hero, master timeline SVG with 13 dots, 8 era sections
- [ ] /people/urs shows the new "Walk the full lineage" panel at the top of articles linking to /people/urs/lineage
- [ ] Each era section's links to individual work pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)