### PR TITLE
tend: fix the lineage timelines so they're actually legible

### DIFF
--- a/web/app/people/[id]/lineage/page.tsx
+++ b/web/app/people/[id]/lineage/page.tsx
@@ -182,20 +182,21 @@ export default async function ContributorLineagePage({
     ([, a], [, b]) => b.length - a.length,
   );
 
-  // For the master timeline SVG, position each work along an x axis by year.
-  const minYear = works.length ? yearFromEra(works[0].era) : 1980;
-  const maxYear = works.length
-    ? Math.max(yearFromEra(works[works.length - 1].era), 2026)
-    : 2026;
-  const span = Math.max(maxYear - minYear, 1);
-  const dotsForSvg = works.map((w, i) => {
+  // Group works by year for the swimlane visualisation. Multiple
+  // works in the same year stack vertically rather than colliding.
+  const knownYearWorks = works.filter((w) => yearFromEra(w.era) !== 9999);
+  const unknownYearWorks = works.filter((w) => yearFromEra(w.era) === 9999);
+  const yearBuckets = new Map<number, GraphNode[]>();
+  for (const w of knownYearWorks) {
     const y = yearFromEra(w.era);
-    const x = 50 + ((y - minYear) / span) * 620;
-    const dir = i % 2 === 0 ? -1 : 1;
-    return { w, x, y, dir };
-  });
-
-  const eras = ["era", "decade-band"]; // placeholder for future grouping
+    if (!yearBuckets.has(y)) yearBuckets.set(y, []);
+    yearBuckets.get(y)!.push(w);
+  }
+  const sortedYears = [...yearBuckets.keys()].sort((a, b) => a - b);
+  const minYear = sortedYears.length ? sortedYears[0] : 1980;
+  const maxYear = sortedYears.length
+    ? Math.max(sortedYears[sortedYears.length - 1], 2026)
+    : 2026;
 
   return (
     <main className="relative">
@@ -259,68 +260,71 @@ export default async function ContributorLineagePage({
               <h2 className="text-xl font-light text-foreground mb-4">
                 The arc, at a glance
               </h2>
-              <figure className="rounded-xl border border-border/40 bg-card/30 p-5">
-                <svg
-                  viewBox="0 0 720 220"
-                  className="w-full h-auto"
-                  role="img"
-                  aria-labelledby="contributor-arc"
-                >
-                  <title id="contributor-arc">Chronological arc of works</title>
-                  <g fontFamily="ui-sans-serif,system-ui" fontSize="11">
-                    <line x1="40" y1="110" x2="700" y2="110" stroke="hsl(220 30% 50%)" strokeWidth="1.5" />
-                    <text x="50" y="195" fill="hsl(220 30% 55%)" fontSize="10">{minYear}</text>
-                    <text x="670" y="195" textAnchor="end" fill="hsl(220 30% 55%)" fontSize="10">{maxYear}</text>
-                    {dotsForSvg.map(({ w, x, dir }, i) => {
-                      const labelY = 110 + dir * 50;
-                      const lineY1 = 110 + (dir > 0 ? 8 : -8);
-                      const lineY2 = labelY + (dir > 0 ? -10 : 14);
-                      const display = (w.name || w.id).slice(0, 26);
-                      return (
-                        <g key={i}>
-                          <line
-                            x1={x}
-                            y1={lineY1}
-                            x2={x}
-                            y2={lineY2}
-                            stroke="hsl(195 60% 60%)"
-                            strokeWidth="1"
-                            opacity="0.5"
-                          />
-                          <circle
-                            cx={x}
-                            cy={110}
-                            r="5"
-                            fill="hsl(195 60% 60%)"
-                            stroke="hsl(220 30% 14%)"
-                            strokeWidth="2"
-                          />
-                          <text
-                            x={x}
-                            y={labelY}
-                            textAnchor="middle"
-                            fill="hsl(195 60% 80%)"
-                            fontSize="9"
-                          >
-                            {display}
-                          </text>
-                          <text
-                            x={x}
-                            y={labelY + (dir > 0 ? 12 : -12)}
-                            textAnchor="middle"
-                            fill="hsl(220 30% 65%)"
-                            fontSize="8"
-                          >
-                            {yearFromEra(w.era) === 9999 ? "" : yearFromEra(w.era)}
-                          </text>
-                        </g>
-                      );
-                    })}
-                  </g>
-                </svg>
-                <figcaption className="text-xs text-muted-foreground mt-3 text-center">
-                  Each work positioned by extracted year from its era
-                  field. Works without a year cluster at the right.
+              <figure className="rounded-xl border border-border/40 bg-card/30 p-5 overflow-hidden">
+                <ol className="relative border-l border-border/50 pl-6 space-y-3">
+                  {sortedYears.map((year) => {
+                    const bucket = yearBuckets.get(year)!;
+                    return (
+                      <li key={year} className="relative">
+                        <span
+                          className="absolute -left-[33px] top-0.5 inline-flex items-center justify-center w-12 h-5 rounded-md bg-card border border-border/50 text-[10px] text-[hsl(var(--primary))] font-mono"
+                          aria-hidden="true"
+                        >
+                          {year}
+                        </span>
+                        <ul className="ml-2 space-y-1">
+                          {bucket.map((w) => (
+                            <li key={w.id} className="flex items-baseline gap-2">
+                              <span
+                                className="inline-block w-2 h-2 rounded-full bg-[hsl(195_60%_60%)] shrink-0 translate-y-[1px]"
+                                aria-hidden="true"
+                              />
+                              <Link
+                                href={slugDoor(w)}
+                                className="text-sm text-foreground/90 hover:text-[hsl(var(--primary))] leading-tight"
+                              >
+                                {w.name || w.id}
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      </li>
+                    );
+                  })}
+                  {unknownYearWorks.length > 0 ? (
+                    <li className="relative pt-2 border-t border-border/30">
+                      <span className="absolute -left-[33px] top-2.5 inline-flex items-center justify-center w-12 h-5 rounded-md bg-card border border-border/50 text-[10px] text-muted-foreground font-mono">
+                        —
+                      </span>
+                      <p className="text-xs text-muted-foreground italic mb-1.5 ml-2">
+                        Year not yet recorded
+                      </p>
+                      <ul className="ml-2 space-y-1">
+                        {unknownYearWorks.map((w) => (
+                          <li key={w.id} className="flex items-baseline gap-2">
+                            <span
+                              className="inline-block w-2 h-2 rounded-full bg-muted-foreground/50 shrink-0 translate-y-[1px]"
+                              aria-hidden="true"
+                            />
+                            <Link
+                              href={slugDoor(w)}
+                              className="text-sm text-foreground/85 hover:text-[hsl(var(--primary))] leading-tight"
+                            >
+                              {w.name || w.id}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  ) : null}
+                </ol>
+                <figcaption className="text-xs text-muted-foreground mt-4 pt-3 border-t border-border/30">
+                  {sortedYears.length > 0
+                    ? `${knownYearWorks.length} work${knownYearWorks.length === 1 ? "" : "s"} from ${minYear} to ${maxYear === 2026 || maxYear === new Date().getFullYear() ? "now" : maxYear}`
+                    : ""}
+                  {unknownYearWorks.length > 0
+                    ? ` · ${unknownYearWorks.length} without a recorded year`
+                    : ""}
                 </figcaption>
               </figure>
             </section>

--- a/web/app/people/urs/lineage/page.tsx
+++ b/web/app/people/urs/lineage/page.tsx
@@ -73,94 +73,145 @@ export default function UrsLineagePage() {
       </section>
 
       <div className="max-w-4xl mx-auto px-6 py-12 space-y-12">
-        {/* Master timeline */}
+        {/* Master timeline — era swimlanes */}
         <section>
           <h2 className="text-2xl font-light text-foreground mb-4">
             The arc, at a glance
           </h2>
           <figure className="rounded-xl border border-border/40 bg-card/30 p-5">
-            <svg
-              viewBox="0 0 720 380"
-              className="w-full h-auto"
-              role="img"
-              aria-labelledby="master-arc"
-            >
-              <title id="master-arc">42-year arc of works and eras</title>
-              <g fontFamily="ui-sans-serif,system-ui" fontSize="11">
-                {/* Era band backgrounds */}
-                {[
-                  ["~1984-90", 50, 95, "hsl(220 30% 14%)"],
-                  ["1990-2000", 95, 200, "hsl(220 30% 14% / 0.6)"],
-                  ["2000-05", 200, 295, "hsl(195 30% 14% / 0.5)"],
-                  ["2005-07", 295, 330, "hsl(140 30% 14% / 0.5)"],
-                  ["2007-09", 330, 365, "hsl(80 30% 14% / 0.5)"],
-                  ["2009-22", 365, 510, "hsl(40 30% 14% / 0.5)"],
-                  ["2022-24", 510, 555, "hsl(140 30% 14% / 0.5)"],
-                  ["2024-now", 555, 690, "hsl(280 30% 14% / 0.5)"],
-                ].map(([label, x1, x2, fill], i) => (
-                  <g key={i}>
-                    <rect x={Number(x1)} y="40" width={Number(x2) - Number(x1)} height="280" fill={String(fill)} />
-                    <text x={(Number(x1) + Number(x2)) / 2} y="32" textAnchor="middle" fill="hsl(220 30% 65%)" fontSize="9">
-                      {String(label)}
-                    </text>
-                  </g>
-                ))}
-                {/* Center timeline */}
-                <line x1="40" y1="180" x2="700" y2="180" stroke="hsl(220 30% 50%)" strokeWidth="1.5" />
-
-                {/* Works as dots */}
-                {[
-                  ["c64-midi-interface", 75, "C64", "hsl(220 60% 65%)", -1],
-                  ["schindler-hc11-protocol", 130, "Schindler", "hsl(0 65% 60%)", 1],
-                  ["backtracking-model-languages", 220, "BML thesis", "hsl(38 80% 60%)", -1],
-                  ["quark-virtual-dom", 245, "Q·VDOM", "hsl(195 60% 55%)", 1],
-                  ["quark-multi-undo-redo", 265, "Q·Undo", "hsl(195 60% 55%)", -1],
-                  ["quark-mono-corba", 285, "Q·Mono", "hsl(195 60% 55%)", 1],
-                  ["mindtouch-wiki-in-a-box", 312, "MindTouch", "hsl(140 55% 55%)", -1],
-                  ["trimble-glue-layer", 348, "Trimble", "hsl(80 55% 55%)", 1],
-                  ["qualcomm-test-automation", 410, "Q·Test", "hsl(40 70% 55%)", -1],
-                  ["qualcomm-hdmi-hdcp", 460, "Q·HDMI", "hsl(40 70% 55%)", 1],
-                  ["living-resonance-codex", 525, "L-R-Codex", "hsl(140 60% 55%)", -1],
-                  ["living-codex-csharp", 545, "L-C-CSharp", "hsl(195 60% 55%)", 1],
-                  ["coherence-network", 620, "Coherence", "hsl(280 70% 65%)", -1],
-                ].map(([slug, x, label, color, dir], i) => {
-                  const cx = Number(x);
-                  const ydot = 180;
-                  const labelY = ydot + Number(dir) * 70;
-                  const lineY1 = ydot + (Number(dir) > 0 ? 8 : -8);
-                  const lineY2 = labelY + (Number(dir) > 0 ? -10 : 14);
-                  return (
-                    <g key={i}>
-                      <line x1={cx} y1={lineY1} x2={cx} y2={lineY2} stroke={String(color)} strokeWidth="1" opacity="0.6" />
-                      <circle cx={cx} cy={ydot} r="6" fill={String(color)} stroke="hsl(220 30% 14%)" strokeWidth="2" />
-                      <text x={cx} y={labelY} textAnchor="middle" fill={String(color)} fontSize="10">
-                        {String(label)}
-                      </text>
-                    </g>
-                  );
-                })}
-
-                {/* Era labels below */}
-                <text x="75" y="335" textAnchor="middle" fill="hsl(220 30% 70%)" fontSize="9">keystone</text>
-                <text x="148" y="335" textAnchor="middle" fill="hsl(220 30% 70%)" fontSize="9">foundation</text>
-                <text x="248" y="335" textAnchor="middle" fill="hsl(195 30% 70%)" fontSize="9">Quark Denver</text>
-                <text x="312" y="335" textAnchor="middle" fill="hsl(140 30% 70%)" fontSize="9">MindTouch</text>
-                <text x="348" y="335" textAnchor="middle" fill="hsl(80 30% 70%)" fontSize="9">Trimble</text>
-                <text x="437" y="335" textAnchor="middle" fill="hsl(40 30% 75%)" fontSize="9">Qualcomm Boulder · 12y</text>
-                <text x="532" y="335" textAnchor="middle" fill="hsl(140 30% 70%)" fontSize="9">bridge</text>
-                <text x="620" y="335" textAnchor="middle" fill="hsl(280 40% 75%)" fontSize="9">Coherence Network</text>
-
-                {/* Year ticks */}
-                <text x="75" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">1984</text>
-                <text x="220" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2000</text>
-                <text x="410" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2009</text>
-                <text x="620" y="360" textAnchor="middle" fill="hsl(220 30% 55%)" fontSize="9">2024</text>
-              </g>
-            </svg>
-            <figcaption className="text-xs text-muted-foreground mt-3 text-center">
-              Thirteen load-bearing works across eight named eras. Click
-              any dot through the era sections below to follow it into
-              its own page.
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {[
+                {
+                  era: "~1984 – ~1990",
+                  label: "keystone",
+                  hue: "hsl(220 60% 65%)",
+                  works: [
+                    { slug: "c64-midi-interface", short: "C64 MIDI · age 13" },
+                    { slug: "schindler-hc11-protocol", short: "Schindler HC11 · age 18" },
+                  ],
+                },
+                {
+                  era: "1991 – 2000",
+                  label: "foundation",
+                  hue: "hsl(38 80% 60%)",
+                  works: [
+                    {
+                      slug: "backtracking-model-languages",
+                      short: "BML thesis · CU Boulder",
+                    },
+                  ],
+                },
+                {
+                  era: "May 2000 – Mar 2005",
+                  label: "Quark Denver",
+                  hue: "hsl(195 60% 55%)",
+                  works: [
+                    { slug: "quark-virtual-dom", short: "Virtual DOM" },
+                    { slug: "quark-multi-undo-redo", short: "Multi-Undo / Redo" },
+                    { slug: "quark-mono-corba", short: "Mono / CORBA" },
+                  ],
+                },
+                {
+                  era: "Mar 2005 – Jan 2007",
+                  label: "MindTouch",
+                  hue: "hsl(140 55% 55%)",
+                  works: [
+                    {
+                      slug: "mindtouch-wiki-in-a-box",
+                      short: "Wiki-in-a-Box",
+                    },
+                  ],
+                },
+                {
+                  era: "Jan 2007 – Oct 2009",
+                  label: "Trimble Boulder",
+                  hue: "hsl(80 55% 55%)",
+                  works: [
+                    { slug: "trimble-glue-layer", short: "Client/Server Glue" },
+                  ],
+                },
+                {
+                  era: "Oct 2009 – Jan 2022",
+                  label: "Qualcomm Boulder · 12y",
+                  hue: "hsl(40 70% 55%)",
+                  works: [
+                    {
+                      slug: "qualcomm-test-automation",
+                      short: "Test Automation · 3 divisions",
+                    },
+                    {
+                      slug: "qualcomm-hdmi-hdcp",
+                      short: "Linux HDMI / HDCP kernel",
+                    },
+                  ],
+                },
+                {
+                  era: "2023 – 2024",
+                  label: "bridge",
+                  hue: "hsl(140 60% 55%)",
+                  works: [
+                    {
+                      slug: "living-resonance-codex",
+                      short: "Living-Resonance-Codex · Python",
+                    },
+                    {
+                      slug: "living-codex-csharp",
+                      short: "Living-Codex-CSharp · U-CORE",
+                    },
+                  ],
+                },
+                {
+                  era: "2024 – present",
+                  label: "Coherence Network",
+                  hue: "hsl(280 70% 65%)",
+                  works: [
+                    {
+                      slug: "coherence-network",
+                      short: "Coherence-Network · live",
+                    },
+                  ],
+                },
+              ].map((era, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border border-border/40 bg-card/40 p-3 flex flex-col gap-2 min-h-[8rem]"
+                  style={{ borderLeft: `3px solid ${era.hue}` }}
+                >
+                  <div>
+                    <p
+                      className="text-[11px] uppercase tracking-[0.16em]"
+                      style={{ color: era.hue }}
+                    >
+                      {era.label}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground font-mono mt-0.5">
+                      {era.era}
+                    </p>
+                  </div>
+                  <ul className="space-y-1 mt-1">
+                    {era.works.map((w) => (
+                      <li key={w.slug} className="flex items-baseline gap-2">
+                        <span
+                          className="inline-block w-1.5 h-1.5 rounded-full shrink-0 translate-y-[1px]"
+                          style={{ background: era.hue }}
+                          aria-hidden="true"
+                        />
+                        <Link
+                          href={`/people/${w.slug}`}
+                          className="text-xs text-foreground/85 hover:text-[hsl(var(--primary))] leading-snug"
+                        >
+                          {w.short}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+            <figcaption className="text-xs text-muted-foreground mt-4 text-center">
+              Thirteen load-bearing works across eight named eras.
+              Each card is an era; the works inside it link to their
+              individual pages.
             </figcaption>
           </figure>
         </section>


### PR DESCRIPTION
## Summary

A screenshot review of /people/urs/lineage and /people/{id}/lineage revealed both pages were rendering timelines that were **not** something we'd be proud of.

**Problems:**
- Curated /people/urs/lineage: labels colliding in the 2000-2005 cluster (BML thesis · Q·VDOM · Q·Undo · Q·Mono in ~65px), era band labels overlapping
- Dynamic /people/{id}/lineage: 8 of 17 works lacked `era` properties so the year-extraction fell back to 9999 — only 2 dots visible at 1984 and 9999 with illegible label stacks

**Fixes:**

1. **Curated** — replaced the cramped horizontal SVG with a 2-up / 4-up responsive grid of era cards. Each card carries its own hue-coloured left border, era label, date range, and bullet-list of works with hyperlinks. Mobile-friendly. No collisions possible.

2. **Dynamic** — replaced the SVG with a vertical-track timeline (semantic `<ol>`) where each year is a row with a year badge on the left and works stacked inside. Works without recorded year go in a clearly separated bucket at the bottom rather than corrupting the year axis.

3. Backfilled `era` properties via API PATCH on 8 older asset nodes that were missing them so year extraction resolves cleanly for every work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)