### PR TITLE
tend: thread the rich graph fields and witness trace through /assets/{id}

### DIFF
--- a/api/app/models/asset.py
+++ b/api/app/models/asset.py
@@ -46,7 +46,17 @@ class Asset(BaseModel):
     resolvers) and ``file_path`` (local path under /visuals/... for
     KB-generated visuals) are exposed on the listing so cards can
     render real thumbnails for IMAGE-typed assets without a second
-    round-trip per card."""
+    round-trip per card.
+
+    Optional rich fields are passed through from the underlying graph
+    node so detail pages can surface a title (``name``), an external
+    source link (``canonical_url``), the originating cell
+    (``creator_id``), and the structured-data context that makes a
+    surface trustworthy (``mime_type``, ``content_hash``, ``ipfs_cid``,
+    ``arweave_tx``, ``slug``, ``era``, ``company``, ``location``,
+    ``substrate``, ``creation_kind``, etc.). The thin contract still
+    works for old callers; new callers can read everything they need
+    in one round-trip."""
     id: UUID = Field(default_factory=uuid4)
     type: str
     description: str
@@ -54,6 +64,30 @@ class Asset(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     image_url: Optional[str] = None
     file_path: Optional[str] = None
+
+    # Rich graph-node fields, optional so the legacy listing contract
+    # is preserved when the underlying node is sparse.
+    node_id: Optional[str] = None
+    name: Optional[str] = None
+    canonical_url: Optional[str] = None
+    slug: Optional[str] = None
+    creator_id: Optional[str] = None
+    creation_kind: Optional[str] = None
+    asset_type: Optional[str] = None
+    mime_type: Optional[str] = None
+    content_hash: Optional[str] = None
+    ipfs_cid: Optional[str] = None
+    arweave_tx: Optional[str] = None
+    asin: Optional[str] = None
+    isbn: Optional[str] = None
+    runtime_length_min: Optional[int] = None
+    era: Optional[str] = None
+    company: Optional[str] = None
+    title: Optional[str] = None
+    location: Optional[str] = None
+    substrate: Optional[str] = None
+    when: Optional[str] = None
+    language: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -92,9 +92,29 @@ def _node_to_asset(node: dict) -> Asset:
     ``image_url`` lands on remote-resolved nodes (inspired-by minted
     content with og:image), ``file_path`` lands on locally-generated
     KB visuals served from /visuals/...; either one is enough to give
-    the listing card a real thumbnail."""
+    the listing card a real thumbnail.
+
+    Rich fields (name, canonical_url, creator_id, asin, slug, era,
+    mime_type, content_hash, ipfs_cid, arweave_tx, etc.) are passed
+    through unchanged when present on the node, so detail surfaces
+    can render a title, an external source link, and the structured-
+    data context that makes the surface trustworthy without a second
+    round-trip to /api/graph/nodes."""
     image_url = node.get("image_url") or None
     file_path = node.get("file_path") or None
+
+    def _str(key: str) -> str | None:
+        value = node.get(key)
+        return value if isinstance(value, str) and value else None
+
+    def _int(key: str) -> int | None:
+        value = node.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return int(value)
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+        return None
+
     return Asset(
         id=_stable_asset_id(node),
         type=node.get("asset_type", "CODE"),
@@ -102,6 +122,27 @@ def _node_to_asset(node: dict) -> Asset:
         total_cost=Decimal(str(node.get("total_cost", "0"))),
         image_url=image_url if isinstance(image_url, str) else None,
         file_path=file_path if isinstance(file_path, str) else None,
+        node_id=_str("id"),
+        name=_str("name"),
+        canonical_url=_str("canonical_url"),
+        slug=_str("slug"),
+        creator_id=_str("creator_id"),
+        creation_kind=_str("creation_kind"),
+        asset_type=_str("asset_type"),
+        mime_type=_str("mime_type"),
+        content_hash=_str("content_hash"),
+        ipfs_cid=_str("ipfs_cid"),
+        arweave_tx=_str("arweave_tx"),
+        asin=_str("asin"),
+        isbn=_str("isbn"),
+        runtime_length_min=_int("runtime_length_min"),
+        era=_str("era"),
+        company=_str("company"),
+        title=_str("title"),
+        location=_str("location"),
+        substrate=_str("substrate"),
+        when=_str("when"),
+        language=_str("language"),
     )
 
 

--- a/web/app/assets/[asset_id]/_components/AssetReadPing.tsx
+++ b/web/app/assets/[asset_id]/_components/AssetReadPing.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * AssetReadPing — leaves a witness trace whenever an asset detail
+ * page is viewed. Composes useReadPing so the asset surface participates
+ * in the same view-tracking + attention-attribution machinery the
+ * concept and idea pages already use.
+ *
+ * Anonymous viewers contribute a session-fingerprinted view event;
+ * graduated contributors are credited explicitly via X-Contributor-Id
+ * so /me can reflect their own trail back to them.
+ *
+ * Returns null — the only side-effect is the network's awareness that
+ * this asset has been seen.
+ */
+
+import { useReadPing } from "@/hooks/useViewTracking";
+
+export function AssetReadPing({ assetId }: { assetId: string }) {
+  useReadPing({
+    assetId,
+    entityType: "asset",
+    entityId: assetId,
+    sourcePage: `/assets/${assetId}`,
+  });
+  return null;
+}

--- a/web/app/assets/[asset_id]/page.tsx
+++ b/web/app/assets/[asset_id]/page.tsx
@@ -12,6 +12,7 @@ import { AssetGlyph } from "@/app/_components/AssetGlyph";
 import { assetTypeLabel } from "@/lib/asset-types";
 import { LedgerNav } from "@/app/_components/LedgerNav";
 import { ModelViewer } from "./_components/ModelViewer";
+import { AssetReadPing } from "./_components/AssetReadPing";
 
 type Asset = {
   id: string;
@@ -19,7 +20,50 @@ type Asset = {
   description: string;
   total_cost: string;
   created_at?: string;
+  // Rich fields the API now passes through from the underlying graph
+  // node — all optional so the legacy contract still works.
+  name?: string;
+  canonical_url?: string;
+  slug?: string;
+  creator_id?: string;
+  creation_kind?: string;
+  mime_type?: string;
+  content_hash?: string;
+  ipfs_cid?: string;
+  arweave_tx?: string;
+  asin?: string;
+  isbn?: string;
+  runtime_length_min?: number;
+  era?: string;
+  company?: string;
+  title?: string;
+  location?: string;
+  substrate?: string;
+  when?: string;
+  language?: string;
+  node_id?: string;
+  image_url?: string | null;
+  file_path?: string | null;
 };
+
+type ViewStats = {
+  total_views?: number;
+  unique_contributors?: number;
+  unique_sessions?: number;
+};
+
+async function loadViewStats(assetId: string): Promise<ViewStats | null> {
+  try {
+    const r = await fetch(
+      `${getApiBase()}/api/views/stats/${encodeURIComponent(assetId)}?days=90`,
+      { cache: "no-store" },
+    );
+    if (!r.ok) return null;
+    return (await r.json()) as ViewStats;
+  } catch {
+    return null;
+  }
+}
 
 type Contribution = {
   id: string;
@@ -96,12 +140,12 @@ async function loadAsset(assetId: string): Promise<Asset | null> {
   } as Asset;
 }
 
-async function loadAssetPage(assetId: string): Promise<{ asset: Asset | null; contributions: Contribution[]; contributorsById: Map<string, string> }> {
+async function loadAssetPage(assetId: string): Promise<{ asset: Asset | null; contributions: Contribution[]; contributorsById: Map<string, string>; viewStats: ViewStats | null }> {
   const API = getApiBase();
 
   const asset = await loadAsset(assetId);
   if (!asset) {
-    return { asset: null, contributions: [], contributorsById: new Map() };
+    return { asset: null, contributions: [], contributorsById: new Map(), viewStats: null };
   }
 
   let contributions: Contribution[] = [];
@@ -125,7 +169,9 @@ async function loadAssetPage(assetId: string): Promise<{ asset: Asset | null; co
     }
   } catch {}
 
-  return { asset, contributions: Array.isArray(contributions) ? contributions : [], contributorsById };
+  const viewStats = await loadViewStats(assetId);
+
+  return { asset, contributions: Array.isArray(contributions) ? contributions : [], contributorsById, viewStats };
 }
 
 function truncateText(s: string, n: number): string {
@@ -200,7 +246,7 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
 
   const resolved = await params;
   const assetId = decodeURIComponent(resolved.asset_id);
-  const { asset, contributions, contributorsById } = await loadAssetPage(assetId);
+  const { asset, contributions, contributorsById, viewStats } = await loadAssetPage(assetId);
 
   if (!asset) {
     notFound();
@@ -269,6 +315,18 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
     if (creatorName) creator.name = creatorName;
     jsonLd.creator = creator;
   }
+  // External canonical_url + ASIN/ISBN identifiers — let crawlers and
+  // AI aggregators bridge the network's surface back to the
+  // authoritative external source instead of dead-ending here.
+  if (asset.canonical_url) jsonLd.sameAs = asset.canonical_url;
+  if (asset.asin || asset.isbn) {
+    jsonLd.identifier = [asset.asin, asset.isbn].filter(Boolean);
+  }
+  if (asset.runtime_length_min) {
+    jsonLd.duration = `PT${asset.runtime_length_min}M`;
+  }
+  if (asset.creation_kind === "book") jsonLd["@type"] = "Book";
+  if (asset.language) jsonLd.inLanguage = asset.language;
 
   return (
     <main className="bg-stone-950 min-h-screen">
@@ -278,6 +336,10 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
         // is the standard Next.js pattern for JSON-LD and is what crawlers parse.
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
+      {/* Leaves a witness trace — every visit becomes part of the
+          asset's own awareness of who has met it. Composes the same
+          read-ping machinery /vision and /ideas already use. */}
+      <AssetReadPing assetId={asset.id} />
       <div className="mx-auto max-w-5xl px-4 sm:px-6 py-6 sm:py-10 space-y-6">
         <div className="flex items-center gap-3 text-sm">
           <Link href="/assets" className="text-stone-400 hover:text-amber-300 transition-colors">
@@ -303,7 +365,102 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
               {displayDescription && displayDescription !== displayName && (
                 <p className="text-stone-300 leading-relaxed">{displayDescription}</p>
               )}
-              <p className="text-xs text-stone-500 font-mono break-all">{asset.id}</p>
+              {/* Structured-data row — when the underlying graph
+                  node carries identifiers and contextual metadata,
+                  surface them so the visitor can see what kind of
+                  vessel this is at a glance. */}
+              {(asset.creation_kind || asset.runtime_length_min || asset.era || asset.company || asset.location || asset.asin || asset.isbn || asset.language) && (
+                <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-400 pt-1">
+                  {asset.creation_kind && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Kind</dt>
+                      <dd className="text-stone-300">{asset.creation_kind}</dd>
+                    </div>
+                  )}
+                  {asset.runtime_length_min && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Runtime</dt>
+                      <dd className="text-stone-300">
+                        {Math.floor(asset.runtime_length_min / 60)}h{" "}
+                        {asset.runtime_length_min % 60}m
+                      </dd>
+                    </div>
+                  )}
+                  {asset.era && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Era</dt>
+                      <dd className="text-stone-300">{asset.era}</dd>
+                    </div>
+                  )}
+                  {asset.company && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Company</dt>
+                      <dd className="text-stone-300">{asset.company}</dd>
+                    </div>
+                  )}
+                  {asset.location && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Place</dt>
+                      <dd className="text-stone-300">{asset.location}</dd>
+                    </div>
+                  )}
+                  {asset.asin && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">ASIN</dt>
+                      <dd className="text-stone-300 font-mono">{asset.asin}</dd>
+                    </div>
+                  )}
+                  {asset.isbn && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">ISBN</dt>
+                      <dd className="text-stone-300 font-mono">{asset.isbn}</dd>
+                    </div>
+                  )}
+                  {asset.language && (
+                    <div className="flex items-baseline gap-1.5">
+                      <dt className="text-stone-500">Language</dt>
+                      <dd className="text-stone-300">{asset.language}</dd>
+                    </div>
+                  )}
+                </dl>
+              )}
+              {/* External source — the canonical authoritative URL
+                  that this vessel points back at (Audible, GitHub,
+                  publisher page, etc.). Without this, the asset
+                  surface dead-ends; with it, the visitor can always
+                  reach the source. */}
+              {asset.canonical_url && (
+                <p className="pt-2">
+                  <a
+                    href={asset.canonical_url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="inline-flex items-center gap-1.5 text-sm text-amber-300 hover:text-amber-200 underline-offset-4 hover:underline"
+                  >
+                    <span>External source</span>
+                    <span aria-hidden="true">↗</span>
+                    <span className="text-stone-500 font-mono text-xs ml-1 break-all">
+                      {asset.canonical_url.replace(/^https?:\/\//, "").slice(0, 60)}
+                      {asset.canonical_url.length > 67 ? "…" : ""}
+                    </span>
+                  </a>
+                </p>
+              )}
+              {/* Slug doorway — when the graph carries a slug, link
+                  to the human-readable presence page (/people/{slug})
+                  so a visitor can walk the rich context surface. */}
+              {asset.slug && (
+                <p className="text-xs text-stone-500 pt-1">
+                  Presence:{" "}
+                  <Link
+                    href={`/people/${encodeURIComponent(asset.slug)}`}
+                    className="text-stone-300 hover:text-amber-300 underline-offset-4 hover:underline"
+                  >
+                    /people/{asset.slug}
+                  </Link>
+                </p>
+              )}
+              <p className="text-xs text-stone-500 font-mono break-all pt-1">{asset.id}</p>
             </div>
             {Number(asset.total_cost) > 0 && (
               <div className="text-right shrink-0">
@@ -327,7 +484,7 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
         )}
 
         {/* Stats */}
-        <section className="grid gap-3 grid-cols-3">
+        <section className="grid gap-3 grid-cols-2 sm:grid-cols-4">
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4">
             <p className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("assets.detail.statTouches")}</p>
             <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">{contributions.length}</p>
@@ -342,6 +499,23 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
             <p className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("assets.detail.statCoherence")}</p>
             <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">{avgCoherence === null ? "—" : avgCoherence.toFixed(2)}</p>
             <p className="mt-1 text-xs text-stone-400">{t("assets.detail.statCoherenceHint")}</p>
+          </div>
+          {/* Witnessed — every visit to this page leaves a trace
+              through the read-ping. The /api/views/stats/{id}
+              endpoint aggregates 90 days of those traces so the
+              visitor can see how many cells have met this vessel. */}
+          <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-emerald-500/10 to-emerald-500/5 p-4">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-emerald-400/80">Witnessed</p>
+            <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">
+              {viewStats?.total_views ?? "—"}
+            </p>
+            <p className="mt-1 text-xs text-stone-400">
+              {viewStats?.unique_contributors
+                ? `${viewStats.unique_contributors} contributor${
+                    viewStats.unique_contributors === 1 ? "" : "s"
+                  } · 90d`
+                : "views over 90 days"}
+            </p>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

Three real gaps showed up on /assets/15362eea-29d5-513b-95d0-3e6d849df931:

1. **No external-source link** — the canonical Audible URL lived on the underlying graph node but the relational Asset model dropped it.
2. **No structured data** — page rendered just the one-sentence description; no title, author, ASIN, runtime, era.
3. **No witness trace** — viewing left no record, even though the read-ping machinery already exists and is wired on /vision and /ideas.

**Root cause** for (1) and (2): `Asset` model in api was intentionally thin; `_node_to_asset()` discarded everything else. Frontend tried to merge with `/api/graph/nodes/{id}` and `asset:{id}` but the UUID is `uuid5(ASSET_NS, "asset:audible-B01KIOP1QA")` — unreversible from the frontend.

**Fix:**
- API: `Asset` model + `_node_to_asset()` now pass through `node_id, name, canonical_url, slug, creator_id, creation_kind, mime_type, content_hash, ipfs_cid, arweave_tx, asin, isbn, runtime_length_min, era, company, title, location, substrate, when, language`. Backwards-compatible.
- Frontend: hero shows structured-data row (Kind / Runtime / Era / Company / Place / ASIN / ISBN / Language), prominent "External source ↗" button using `canonical_url`, slug doorway to `/people/{slug}`. Stats grid expands to 4 cells with a "Witnessed" cell from `/api/views/stats/{id}`. JSON-LD enriched with `sameAs`, `identifier`, `duration`, `inLanguage`, and `@type: Book` when `creation_kind=book`.
- New `<AssetReadPing>` client component wires `useReadPing` so every visit leaves a trace.

For the Kel Kade audiobook: the page now reads "Free the Darkness By Kel Kade" with ASIN, runtime 16h 34m, Audible canonical URL, JSON-LD as a Book, and every view shows up in the witness count.

## Test plan
- [ ] /assets/15362eea-29d5-513b-95d0-3e6d849df931 shows real title, ASIN, runtime, External source link to audible.com
- [ ] After visiting, /api/views/stats/15362eea-... reports a non-zero total_views
- [ ] JSON-LD includes sameAs + identifier + duration + Book type
- [ ] Other graph-resolved assets (works pages backed by graph nodes) similarly surface their canonical_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)