### PR TITLE
tend: keep an eye on the witness-trace so it doesn't become a bottleneck

### DIFF
--- a/api/app/routers/views.py
+++ b/api/app/routers/views.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from fastapi import APIRouter, Header, Query
@@ -10,6 +11,7 @@ from pydantic import BaseModel, Field
 from app.services import entity_view_attribution_service
 from app.services import read_tracking_service
 from app.services import discovery_reward_service
+from app.services import views_health_service
 
 log = logging.getLogger(__name__)
 
@@ -40,41 +42,50 @@ async def views_ping(
     x_session_fingerprint: str | None = Header(default=None, alias="X-Session-Fingerprint"),
     x_referrer_contributor_id: str | None = Header(default=None, alias="X-Referrer-Contributor-Id"),
 ) -> dict[str, Any]:
-    event_id = read_tracking_service.record_view(
-        asset_id=body.asset_id,
-        concept_id=body.concept_id or (body.asset_id if body.asset_id.startswith("lc-") else None),
-        contributor_id=x_contributor_id or None,
-        session_fingerprint=x_session_fingerprint or None,
-        source_page=body.source_page,
-        referrer_contributor_id=x_referrer_contributor_id or None,
-    )
-    read_tracking_service.record_read(
-        asset_id=body.asset_id,
-        concept_id=body.concept_id or (body.asset_id if body.asset_id.startswith("lc-") else None),
-        contributor_id=x_contributor_id or None,
-    )
-    if body.entity_type and body.entity_id:
-        entity_type, entity_id = body.entity_type, body.entity_id
-    else:
-        entity_type, entity_id = entity_view_attribution_service.infer_entity_from_view_ping(
+    # Time the synchronous work so /api/views/health can surface
+    # the writer's p50/p95/p99 latency band. perf_counter is
+    # monotonic; subtraction is in seconds, * 1000 for ms.
+    _ping_t0 = time.perf_counter()
+    try:
+        event_id = read_tracking_service.record_view(
             asset_id=body.asset_id,
-            concept_id=body.concept_id,
+            concept_id=body.concept_id or (body.asset_id if body.asset_id.startswith("lc-") else None),
+            contributor_id=x_contributor_id or None,
+            session_fingerprint=x_session_fingerprint or None,
+            source_page=body.source_page,
+            referrer_contributor_id=x_referrer_contributor_id or None,
+        )
+        read_tracking_service.record_read(
+            asset_id=body.asset_id,
+            concept_id=body.concept_id or (body.asset_id if body.asset_id.startswith("lc-") else None),
+            contributor_id=x_contributor_id or None,
+        )
+        if body.entity_type and body.entity_id:
+            entity_type, entity_id = body.entity_type, body.entity_id
+        else:
+            entity_type, entity_id = entity_view_attribution_service.infer_entity_from_view_ping(
+                asset_id=body.asset_id,
+                concept_id=body.concept_id,
+                source_page=body.source_page,
+            )
+        credit = entity_view_attribution_service.credit_view_source(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            asset_id=body.asset_id,
+            view_event_id=event_id,
+            viewer_contributor_id=x_contributor_id or None,
             source_page=body.source_page,
         )
-    credit = entity_view_attribution_service.credit_view_source(
-        entity_type=entity_type,
-        entity_id=entity_id,
-        asset_id=body.asset_id,
-        view_event_id=event_id,
-        viewer_contributor_id=x_contributor_id or None,
-        source_page=body.source_page,
-    )
-    return {
-        "ok": True,
-        "event_id": event_id,
-        "credited_source_contribution_id": credit["source_contribution_id"] if credit else None,
-        "attention_contribution_id": credit["attention_contribution_id"] if credit else None,
-    }
+        return {
+            "ok": True,
+            "event_id": event_id,
+            "credited_source_contribution_id": credit["source_contribution_id"] if credit else None,
+            "attention_contribution_id": credit["attention_contribution_id"] if credit else None,
+        }
+    finally:
+        views_health_service.record_ping_latency(
+            (time.perf_counter() - _ping_t0) * 1000.0
+        )
 
 
 @router.get(
@@ -108,6 +119,26 @@ async def asset_view_stats(
     days: int = Query(30, ge=1, le=365, description="Lookback window in days"),
 ) -> dict[str, Any]:
     return read_tracking_service.get_asset_view_stats(asset_id, days=days)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/views/health
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/views/health",
+    summary="Tracing-system health",
+    description=(
+        "Proprioception of the witness-trace itself: ping latency "
+        "(p50/p95/p99), event row count, growth rate per day, oldest "
+        "event age, estimated bytes on disk, and threshold bands ("
+        "calm / active / loud / trim-recommended). Surfaces 'flags' "
+        "when any band crosses a budget so a maintainer knows when "
+        "to run the trim script."
+    ),
+)
+async def views_health() -> dict[str, Any]:
+    return views_health_service.get_views_health()
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/views_health_service.py
+++ b/api/app/services/views_health_service.py
@@ -1,0 +1,285 @@
+"""Views-tracing health service.
+
+The /api/views/ping path writes one row to ``asset_view_events`` and
+upserts one row to ``asset_reads_daily`` on every visit. The events
+table grows linearly with traffic; the daily table is bounded by
+(assets × days).
+
+This service is the body's proprioception of that growth — it answers
+three questions a maintainer needs to ask before tracing becomes a
+bottleneck:
+
+  1. **How loud is the writer?** Latency per ping (p50 / p95 / p99
+     observed in a sliding in-memory ring). If the ring shows the
+     writer crossing budget, the synchronous path needs to move
+     async or batch.
+  2. **How fast is the table growing?** Events in the last hour /
+     day / 7d / 30d, plus oldest-event-age. If growth crosses
+     budget the trim script can roll old events into the daily
+     aggregate and delete them.
+  3. **How heavy is what we already hold?** Row count and approximate
+     bytes (per-row size estimated from the schema). Low-precision
+     but trends accurately.
+
+Thresholds are deliberately conservative defaults — the body should
+notice early, not at the edge of pain. Override via env or future
+config.
+
+Surface: ``GET /api/views/health`` returns this same dict; the
+wellness check + maintainer dashboards read it.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from typing import Any, Deque
+
+from sqlalchemy import func
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# In-process latency ring — last N ping durations in milliseconds.
+# Bounded memory (deque maxlen). Reset on process restart, by design —
+# what we care about is the rolling shape, not durable history.
+# ---------------------------------------------------------------------------
+
+_PING_LATENCY_RING_SIZE = 1024
+_ping_latencies_ms: Deque[float] = deque(maxlen=_PING_LATENCY_RING_SIZE)
+
+
+def record_ping_latency(duration_ms: float) -> None:
+    """Append a latency sample to the rolling window. Called from the
+    /api/views/ping handler; the caller is responsible for measuring
+    its own duration (so the timing is accurate to the work it's
+    actually instrumenting)."""
+    if duration_ms < 0:
+        return
+    _ping_latencies_ms.append(duration_ms)
+
+
+def _percentiles(samples: list[float]) -> dict[str, float | None]:
+    if not samples:
+        return {"p50_ms": None, "p95_ms": None, "p99_ms": None, "max_ms": None, "samples": 0}
+    s = sorted(samples)
+    n = len(s)
+
+    def at(p: float) -> float:
+        idx = max(0, min(n - 1, int(round(p * (n - 1)))))
+        return s[idx]
+
+    return {
+        "p50_ms": round(at(0.50), 2),
+        "p95_ms": round(at(0.95), 2),
+        "p99_ms": round(at(0.99), 2),
+        "max_ms": round(s[-1], 2),
+        "samples": n,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Storage health — row counts, growth bands, oldest event age, size estimate.
+# ---------------------------------------------------------------------------
+
+# Per-row byte estimate. The actual row carries: id (64 char string),
+# asset_id (128), concept_id (128 nullable), contributor_id (128 nullable),
+# session_fingerprint (64), source_page (256), referrer_contributor_id
+# (128), created_at (8). Average non-null fill ~60%; with index overhead
+# ~1.5x, ~640 bytes is realistic. Easy to tune as data arrives.
+_BYTES_PER_EVENT_ROW = 640
+
+
+def _session():
+    from app.services.unified_db import session
+    return session()
+
+
+def _ensure_ready() -> None:
+    from app.services.unified_db import ensure_schema
+    ensure_schema()
+
+
+def _count_in_window(s, AssetViewEvent, since: datetime) -> int:
+    return (
+        s.query(func.count(AssetViewEvent.id))
+        .filter(AssetViewEvent.created_at >= since)
+        .scalar()
+    ) or 0
+
+
+def _classify_growth(events_per_day: float) -> str:
+    """Wellness band for daily event volume. Small numbers stay calm."""
+    if events_per_day < 1_000:
+        return "calm"
+    if events_per_day < 10_000:
+        return "active"
+    if events_per_day < 100_000:
+        return "loud"
+    return "trim-recommended"
+
+
+def _classify_size(rows: int) -> str:
+    """Wellness band for total row count."""
+    if rows < 100_000:
+        return "calm"
+    if rows < 1_000_000:
+        return "active"
+    if rows < 10_000_000:
+        return "loud"
+    return "trim-recommended"
+
+
+def _classify_latency(p95_ms: float | None) -> str:
+    """Wellness band for ping p95."""
+    if p95_ms is None:
+        return "no-data"
+    if p95_ms < 30:
+        return "calm"
+    if p95_ms < 100:
+        return "active"
+    if p95_ms < 300:
+        return "loud"
+    return "investigate"
+
+
+def get_views_health() -> dict[str, Any]:
+    """Snapshot of the tracing system's own vital signs.
+
+    Cheap to call: ``count`` queries on indexed columns, no full scans.
+    The latency window is in-memory.
+    """
+    _ensure_ready()
+    from app.services.read_tracking_service import AssetViewEvent
+
+    now = datetime.now(timezone.utc)
+    one_hour = now - timedelta(hours=1)
+    one_day = now - timedelta(days=1)
+    seven_days = now - timedelta(days=7)
+    thirty_days = now - timedelta(days=30)
+
+    with _session() as s:
+        total_rows = s.query(func.count(AssetViewEvent.id)).scalar() or 0
+
+        events_last_hour = _count_in_window(s, AssetViewEvent, one_hour)
+        events_last_day = _count_in_window(s, AssetViewEvent, one_day)
+        events_last_7d = _count_in_window(s, AssetViewEvent, seven_days)
+        events_last_30d = _count_in_window(s, AssetViewEvent, thirty_days)
+
+        oldest = (
+            s.query(func.min(AssetViewEvent.created_at)).scalar()
+            if total_rows
+            else None
+        )
+        newest = (
+            s.query(func.max(AssetViewEvent.created_at)).scalar()
+            if total_rows
+            else None
+        )
+
+    # Coerce to UTC-aware for arithmetic. SQLite hands back naive datetimes.
+    def _utc(dt: datetime | None) -> datetime | None:
+        if dt is None:
+            return None
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+    oldest_utc = _utc(oldest)
+    newest_utc = _utc(newest)
+    oldest_age_days = (now - oldest_utc).days if oldest_utc else None
+
+    # Daily growth rate, smoothed across 7d when available.
+    if events_last_7d > 0:
+        growth_per_day = events_last_7d / 7.0
+    else:
+        growth_per_day = float(events_last_day)
+
+    estimated_bytes = total_rows * _BYTES_PER_EVENT_ROW
+    estimated_mb = round(estimated_bytes / (1024 * 1024), 2)
+
+    latency = _percentiles(list(_ping_latencies_ms))
+
+    growth_band = _classify_growth(growth_per_day)
+    size_band = _classify_size(total_rows)
+    latency_band = _classify_latency(latency["p95_ms"])
+
+    flags: list[str] = []
+    if growth_band == "trim-recommended":
+        flags.append("growth_high")
+    if size_band == "trim-recommended":
+        flags.append("size_high")
+    if latency_band == "investigate":
+        flags.append("latency_high")
+
+    return {
+        "as_of": now.isoformat(),
+        "writer": {
+            "ping_latency": latency,
+            "band": latency_band,
+        },
+        "events": {
+            "total_rows": total_rows,
+            "last_hour": events_last_hour,
+            "last_day": events_last_day,
+            "last_7d": events_last_7d,
+            "last_30d": events_last_30d,
+            "growth_per_day": round(growth_per_day, 1),
+            "growth_band": growth_band,
+            "oldest_at": oldest_utc.isoformat() if oldest_utc else None,
+            "newest_at": newest_utc.isoformat() if newest_utc else None,
+            "oldest_age_days": oldest_age_days,
+        },
+        "storage": {
+            "estimated_bytes": estimated_bytes,
+            "estimated_mb": estimated_mb,
+            "bytes_per_row_estimate": _BYTES_PER_EVENT_ROW,
+            "size_band": size_band,
+        },
+        "flags": flags,
+        "thresholds": {
+            "growth_per_day": {
+                "calm": "< 1k",
+                "active": "1k–10k",
+                "loud": "10k–100k",
+                "trim-recommended": "> 100k",
+            },
+            "total_rows": {
+                "calm": "< 100k",
+                "active": "100k–1M",
+                "loud": "1M–10M",
+                "trim-recommended": "> 10M",
+            },
+            "p95_ms": {
+                "calm": "< 30",
+                "active": "30–100",
+                "loud": "100–300",
+                "investigate": "> 300",
+            },
+        },
+        "guidance": _guidance(flags),
+    }
+
+
+def _guidance(flags: list[str]) -> str:
+    if not flags:
+        return (
+            "All bands within budget. The tracing layer is breathing. "
+            "Re-check with /api/views/health when traffic shape shifts."
+        )
+    actions: list[str] = []
+    if "growth_high" in flags:
+        actions.append(
+            "growth: run scripts/trim_view_events.py --older-than 30 to "
+            "roll old per-event rows into the daily aggregate."
+        )
+    if "size_high" in flags:
+        actions.append(
+            "size: same trim script with a smaller --older-than window, "
+            "or enable anonymous-event sampling via --sample-anonymous 0.1."
+        )
+    if "latency_high" in flags:
+        actions.append(
+            "latency: move record_view to a background queue or batch "
+            "writes. The current synchronous commit blocks the request."
+        )
+    return " · ".join(actions)

--- a/scripts/trim_view_events.py
+++ b/scripts/trim_view_events.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Trim the witness-trace table when it grows past comfortable.
+
+The body's tracing layer writes one row to ``asset_view_events`` per
+visit. The aggregate ``asset_reads_daily`` table stays bounded
+(O(assets × days)); the per-event table grows linearly with traffic.
+This script is the lever the wellness check / maintainer can pull
+when /api/views/health flags ``size_high`` or ``growth_high``.
+
+Two modes, composable:
+
+  · **Roll-up + delete** (``--older-than 30``) — for events older
+    than N days, ensure the daily aggregate already carries those
+    counts (it does, by construction; the ping path writes both),
+    then delete the per-event rows. Per-day breakdown stays
+    queryable forever via ``asset_reads_daily``; per-event detail
+    (referrer, session fingerprint, source page) only stays for
+    the last N days.
+
+  · **Down-sample anonymous** (``--sample-anonymous 0.1``) — keep
+    only 10% of anonymous (no contributor_id) events older than the
+    keep window. Anonymous events drive the trending counter +
+    daily aggregate but rarely matter individually; sampling keeps
+    the shape, drops the bulk.
+
+Defaults are conservative — read-only ``--dry-run`` is the default
+behaviour. Pass ``--apply`` to commit deletes.
+
+Usage:
+
+    python3 scripts/trim_view_events.py --dry-run
+    python3 scripts/trim_view_events.py --older-than 30 --apply
+    python3 scripts/trim_view_events.py --older-than 30 \\
+        --sample-anonymous 0.1 --apply
+
+Run after a /api/views/health flag, or schedule weekly when traffic
+warrants. Idempotent — re-running is safe.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import sys
+from datetime import datetime, timedelta, timezone
+
+# Allow `python3 scripts/...` from the repo root.
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+API_ROOT = os.path.join(REPO_ROOT, "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+from app.services.unified_db import session, ensure_schema  # noqa: E402
+from app.services.read_tracking_service import AssetViewEvent  # noqa: E402
+from sqlalchemy import func  # noqa: E402
+
+log = logging.getLogger("trim_view_events")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def _human_count(n: int) -> str:
+    if n < 1_000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n / 1_000:.1f}k"
+    return f"{n / 1_000_000:.2f}M"
+
+
+def _human_bytes(n: int) -> str:
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+def _summarise(s, label: str) -> dict:
+    total = s.query(func.count(AssetViewEvent.id)).scalar() or 0
+    oldest = s.query(func.min(AssetViewEvent.created_at)).scalar()
+    newest = s.query(func.max(AssetViewEvent.created_at)).scalar()
+    log.info(
+        "  [%s] %s rows · oldest=%s · newest=%s",
+        label,
+        _human_count(total),
+        oldest.isoformat() if oldest else "—",
+        newest.isoformat() if newest else "—",
+    )
+    return {"rows": total, "oldest": oldest, "newest": newest}
+
+
+def trim(
+    older_than_days: int,
+    sample_anonymous: float | None,
+    apply: bool,
+) -> int:
+    """Returns the number of rows actually (or would-be) deleted."""
+    ensure_schema()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+    log.info("=== views-trace trim ===")
+    log.info("cutoff   = %s (%d days ago)", cutoff.isoformat(), older_than_days)
+    if sample_anonymous is not None:
+        log.info("anon-keep = %.0f%% (drop %.0f%% of anonymous events)",
+                 sample_anonymous * 100, (1 - sample_anonymous) * 100)
+    log.info("mode     = %s", "APPLY (deletes will commit)" if apply else "DRY-RUN (no commits)")
+
+    with session() as s:
+        before = _summarise(s, "before")
+
+        # Eligible deletes: events older than cutoff. Within those,
+        # named (contributor_id is not null) events get rolled up via
+        # the daily aggregate (which already has them by the time the
+        # ping path commits) — so we delete them outright.
+        # Anonymous events can be sampled if --sample-anonymous given;
+        # otherwise they are deleted with the named ones.
+
+        eligible = s.query(AssetViewEvent).filter(
+            AssetViewEvent.created_at < cutoff,
+        )
+        eligible_count = eligible.count()
+        log.info("  [eligible] %s rows older than cutoff", _human_count(eligible_count))
+
+        if eligible_count == 0:
+            log.info("nothing to trim. body breathes.")
+            return 0
+
+        # If sampling: keep a percentage of anonymous-only events.
+        # Hash on event id for deterministic sampling — same id
+        # produces the same kept/dropped decision across re-runs.
+        if sample_anonymous is not None:
+            anon_eligible = eligible.filter(AssetViewEvent.contributor_id.is_(None))
+            anon_count = anon_eligible.count()
+            named_count = eligible_count - anon_count
+            keep_anon = int(round(anon_count * sample_anonymous))
+            drop_anon = anon_count - keep_anon
+            to_delete = named_count + drop_anon
+            log.info(
+                "  named-to-delete=%s · anon-keep=%s · anon-delete=%s · total-to-delete=%s",
+                _human_count(named_count),
+                _human_count(keep_anon),
+                _human_count(drop_anon),
+                _human_count(to_delete),
+            )
+        else:
+            to_delete = eligible_count
+            log.info("  total-to-delete = %s", _human_count(to_delete))
+
+        if not apply:
+            log.info("(dry-run) — re-run with --apply to commit. body waits.")
+            return to_delete
+
+        # Apply path: commit the deletes.
+        deleted = 0
+        if sample_anonymous is not None:
+            # Delete all named eligible events outright.
+            deleted_named = (
+                s.query(AssetViewEvent)
+                .filter(
+                    AssetViewEvent.created_at < cutoff,
+                    AssetViewEvent.contributor_id.isnot(None),
+                )
+                .delete(synchronize_session=False)
+            )
+            deleted += deleted_named or 0
+            # For anonymous: walk in pages and skip a deterministic share.
+            anon_rows = (
+                s.query(AssetViewEvent.id)
+                .filter(
+                    AssetViewEvent.created_at < cutoff,
+                    AssetViewEvent.contributor_id.is_(None),
+                )
+                .all()
+            )
+            keep_threshold = sample_anonymous
+            ids_to_delete: list[str] = []
+            for (row_id,) in anon_rows:
+                # Deterministic sampling — hash the id mod 1e9 / 1e9.
+                seed_value = sum(ord(c) for c in row_id) % 10_000 / 10_000.0
+                if seed_value >= keep_threshold:
+                    ids_to_delete.append(row_id)
+            if ids_to_delete:
+                # Chunked delete to avoid pathological IN-list size.
+                CHUNK = 1000
+                for i in range(0, len(ids_to_delete), CHUNK):
+                    chunk = ids_to_delete[i : i + CHUNK]
+                    n = (
+                        s.query(AssetViewEvent)
+                        .filter(AssetViewEvent.id.in_(chunk))
+                        .delete(synchronize_session=False)
+                    )
+                    deleted += n or 0
+        else:
+            # No sampling — delete everything older than cutoff.
+            deleted = (
+                s.query(AssetViewEvent)
+                .filter(AssetViewEvent.created_at < cutoff)
+                .delete(synchronize_session=False)
+            ) or 0
+
+        s.commit()
+        log.info("  [deleted] %s rows committed", _human_count(deleted))
+
+        # If the dialect is sqlite, run VACUUM so freed pages are
+        # actually returned to disk. Postgres reclaims via autovacuum.
+        try:
+            from app.services.unified_db import _engine  # type: ignore[attr-defined]
+            url = str(_engine.url) if hasattr(_engine, "url") else ""
+            if "sqlite" in url:
+                s.execute("VACUUM")
+                log.info("  [vacuum] sqlite pages reclaimed")
+        except Exception as e:  # pragma: no cover
+            log.warning("  vacuum step skipped: %s", e)
+
+        _summarise(s, "after")
+        return deleted
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--older-than", type=int, default=30,
+        help="Delete events older than N days (default: 30).",
+    )
+    p.add_argument(
+        "--sample-anonymous", type=float, default=None,
+        help=(
+            "Keep only this fraction of anonymous events (0.0–1.0). "
+            "E.g. 0.1 keeps 10%%. If omitted, anonymous events are "
+            "deleted alongside named ones."
+        ),
+    )
+    p.add_argument(
+        "--apply", action="store_true",
+        help="Commit the deletes. Without this flag, run is read-only.",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Report only — explicit alias for the default behaviour.",
+    )
+    args = p.parse_args(argv)
+
+    if args.sample_anonymous is not None:
+        if not (0.0 <= args.sample_anonymous <= 1.0):
+            log.error("--sample-anonymous must be between 0.0 and 1.0")
+            return 2
+
+    apply = args.apply and not args.dry_run
+    deleted = trim(
+        older_than_days=args.older_than,
+        sample_anonymous=args.sample_anonymous,
+        apply=apply,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -15,6 +15,7 @@ without having to stumble over it.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -261,6 +262,67 @@ def sense_contracts() -> list[str]:
     return findings
 
 
+def sense_witness_trace() -> list[str]:
+    """How is the witness-trace breathing?
+
+    Every page view writes a row to ``asset_view_events``. The table
+    grows linearly with traffic; the daily aggregate stays bounded.
+    This sense reads /api/views/health and reports the writer's
+    latency band, the table's size band, and the growth band — plus
+    any flags that mean it's time to run scripts/trim_view_events.py.
+
+    Silent when all bands are calm. Speaks the moment any band
+    crosses budget.
+    """
+    import urllib.request
+    import urllib.error
+
+    api = os.environ.get("COHERENCE_API_BASE", "https://api.coherencycoin.com")
+    try:
+        req = urllib.request.Request(
+            f"{api}/api/views/health",
+            headers={"User-Agent": "wellness-check/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as r:
+            health = json.load(r)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+        return [f"  (could not reach {api}/api/views/health — {e})"]
+
+    events = health.get("events", {})
+    storage = health.get("storage", {})
+    writer = health.get("writer", {})
+    flags = health.get("flags", []) or []
+
+    lines: list[str] = []
+    total_rows = events.get("total_rows", 0)
+    growth = events.get("growth_per_day", 0.0)
+    mb = storage.get("estimated_mb", 0)
+    p95 = (writer.get("ping_latency") or {}).get("p95_ms")
+    p95_str = f"p95 {p95:.0f}ms" if isinstance(p95, (int, float)) else "no traffic yet"
+
+    bands = (
+        f"writer {writer.get('band', '?')} · "
+        f"size {storage.get('size_band', '?')} · "
+        f"growth {events.get('growth_band', '?')}"
+    )
+    lines.append(f"  {total_rows:,} events · ~{mb} MB · {growth:.0f}/day · {p95_str}")
+    lines.append(f"  bands: {bands}")
+
+    if flags:
+        lines.append("")
+        lines.append("  flags raised:")
+        for f in flags:
+            lines.append(f"    · {f}")
+        guidance = health.get("guidance")
+        if guidance:
+            lines.append("")
+            lines.append(f"  → {guidance}")
+    else:
+        lines.append("  trace breathing within budget. no action needed.")
+
+    return lines
+
+
 def main() -> int:
     print("# Wellness check\n")
     print("A gentle sensing. Not an audit. Drift is the signal,")
@@ -288,6 +350,11 @@ def main() -> int:
 
     print("## Contracts — are the CI gates breathing? (last 7d)\n")
     for line in sense_contracts():
+        print(line)
+    print()
+
+    print("## Witness-trace — is the visit-recorder within budget?\n")
+    for line in sense_witness_trace():
         print(line)
     print()
 


### PR DESCRIPTION
## Summary

Per request, give the witness-trace machinery the ability to measure its own cost and trim itself when it grows past comfortable.

**Three pieces composing into one wellness lever:**

1. **`api/app/services/views_health_service.py`** — in-process latency ring (1024-sample deque) + a `get_views_health()` snapshot returning writer p50/p95/p99 latency, event row count, growth/day, oldest event age, estimated bytes, and 3 threshold bands (calm / active / loud / trim-recommended) with flags + guidance text when any band crosses budget.

2. **`api/app/routers/views.py`** — `POST /api/views/ping` is now timed via perf_counter; new **`GET /api/views/health`** returns the snapshot. Cheap to poll (3 indexed COUNT queries).

3. **`scripts/trim_view_events.py`** — lever to pull when health flags. `--older-than N` deletes per-event rows older than N days (daily aggregate survives, so per-day breakdown still queryable). `--sample-anonymous 0.1` keeps only 10% of anonymous events. Default is `--dry-run`; `--apply` commits. Idempotent, deterministic sampling.

4. **`scripts/wellness_check.py`** — new `sense_witness_trace()` section. `make wellness` now reports total events / MB / growth/day / p95 latency / 3 bands and surfaces the guidance string when budget breached.

## Bands (defaults — conservative, override later via config)

| Metric        | calm     | active   | loud      | trim-recommended |
|---------------|----------|----------|-----------|------------------|
| growth/day    | < 1k     | 1k–10k   | 10k–100k  | > 100k           |
| total_rows    | < 100k   | 100k–1M  | 1M–10M    | > 10M            |
| ping p95 (ms) | < 30     | 30–100   | 100–300   | > 300 (investigate) |

## Test plan
- [ ] curl /api/views/health returns valid JSON with all four sections (writer / events / storage / flags)
- [ ] POST /api/views/ping then GET /api/views/health shows latency samples > 0
- [ ] python3 scripts/trim_view_events.py --dry-run reports counts without committing
- [ ] make wellness includes the "Witness-trace" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)