### PR TITLE
tend: cold-tier the witness-trace + answer the off-site backup gap

### DIFF
--- a/api/app/routers/views.py
+++ b/api/app/routers/views.py
@@ -12,6 +12,7 @@ from app.services import entity_view_attribution_service
 from app.services import read_tracking_service
 from app.services import discovery_reward_service
 from app.services import views_health_service
+from app.services import view_events_archive_service
 
 log = logging.getLogger(__name__)
 
@@ -134,11 +135,58 @@ async def asset_view_stats(
         "event age, estimated bytes on disk, and threshold bands ("
         "calm / active / loud / trim-recommended). Surfaces 'flags' "
         "when any band crosses a budget so a maintainer knows when "
-        "to run the trim script."
+        "to run the trim or archive script. Includes a `cold_tier` "
+        "section reporting how many days have been archived to the "
+        "cold tier (GitHub releases by default), the compression "
+        "ratio achieved, and the estimated retrieval cost when the "
+        "data needs to come back."
     ),
 )
 async def views_health() -> dict[str, Any]:
-    return views_health_service.get_views_health()
+    health = views_health_service.get_views_health()
+    try:
+        health["cold_tier"] = view_events_archive_service.stats()
+    except Exception as e:  # pragma: no cover — never block the health endpoint
+        log.warning("views_health: cold_tier stats failed: %s", e)
+        health["cold_tier"] = {"error": str(e)}
+    return health
+
+
+# ---------------------------------------------------------------------------
+# GET /api/views/archive/{day}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/views/archive/{day}",
+    summary="Retrieve a day from the cold-tier archive",
+    description=(
+        "Fetches the gzipped JSONL of events for a previously-archived "
+        "UTC day, verifies the SHA-256 against the tombstone, "
+        "decompresses, and returns the events. Local cache makes "
+        "repeat reads instant. The tombstone is included in the "
+        "response so callers can verify integrity themselves."
+    ),
+)
+async def views_archive_retrieve(day: str) -> dict[str, Any]:
+    try:
+        from datetime import date as _date
+        target_day = _date.fromisoformat(day)
+    except ValueError:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=400,
+            detail=f"day must be YYYY-MM-DD (got {day!r})",
+        )
+    return view_events_archive_service.retrieve_day(target_day)
+
+
+@router.get(
+    "/views/archive",
+    summary="List all archived days",
+    description="Tombstone index — every day in cold-tier storage, with URL + sha256 + ETA.",
+)
+async def views_archive_list() -> dict[str, Any]:
+    return view_events_archive_service.stats()
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/view_events_archive_service.py
+++ b/api/app/services/view_events_archive_service.py
@@ -1,0 +1,480 @@
+"""Cold-tier archival for ``asset_view_events``.
+
+The hot tier (Postgres ``asset_view_events``) keeps full per-event
+detail for the last N days. Older events are dumped to a free,
+durable, public substrate (GitHub releases) with byte-perfect
+fidelity, and replaced in the DB by a single tombstone row per day
+that knows where the original lives and how to verify it.
+
+The pattern preserves three invariants:
+
+  1. **Full traceability** — any archived day can be retrieved
+     bit-for-bit. The tombstone carries the SHA-256 of the gzipped
+     JSONL, so we know an answer matches what was archived.
+  2. **Compact in-DB footprint** — one tombstone (~150 bytes) per
+     archived day replaces ~2 MB of per-event rows. The hot table
+     stops growing without bound.
+  3. **Known retrieval cost** — the tombstone records compressed
+     bytes + an estimated retrieval seconds, so a caller knows
+     before they ask whether the trip is cheap or expensive.
+
+Surface:
+  · ``ViewEventsArchive`` — the tombstone ORM model (``view_events_archive``)
+  · ``serialise_day(day)`` — pull a day's events into JSONL bytes
+  · ``upload_to_github_releases(...)`` — push to the cold tier
+  · ``record_tombstone(...)`` — write the DB tombstone
+  · ``retrieve_day(day)`` — fetch from cold tier, verify, decompress
+  · ``stats()`` — totals + provider breakdown for the health endpoint
+
+Re-key on ``day`` (UTC date). Each archive is one calendar day's
+events, ordered by ``created_at`` ascending, one JSON object per line.
+"""
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+import logging
+import os
+import subprocess
+import time
+import urllib.request
+import urllib.error
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from sqlalchemy import Date, DateTime, Float, Integer, String, func
+from sqlalchemy.orm import mapped_column
+
+log = logging.getLogger(__name__)
+
+
+# Estimated network throughput on the VPS for retrieval-cost
+# guesses. Conservative ~10 MB/s sustained; gh.io serves quickly.
+_RETRIEVAL_BYTES_PER_SECOND = 10 * 1024 * 1024
+
+# Local cache for retrieved archives — re-fetching the same day from
+# GitHub is free (no egress fee) but still ~1-2s; caching makes
+# repeated retrievals instant.
+_CACHE_DIR = Path(
+    os.environ.get(
+        "COHERENCE_ARCHIVE_CACHE",
+        "/tmp/coherence-archive-cache",
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# ORM
+# ---------------------------------------------------------------------------
+
+from app.services.unified_db import Base
+
+
+class ViewEventsArchive(Base):
+    """Tombstone — one row per archived day. Replaces O(events) hot
+    rows with O(days) tombstones in the DB while keeping full
+    fidelity in the cold tier.
+    """
+
+    __tablename__ = "view_events_archive"
+
+    day = mapped_column(Date, primary_key=True)
+    event_count = mapped_column(Integer, nullable=False)
+    bytes_compressed = mapped_column(Integer, nullable=False)
+    bytes_original = mapped_column(Integer, nullable=False)
+    sha256 = mapped_column(String(64), nullable=False)
+    archive_url = mapped_column(String(512), nullable=False)
+    archive_provider = mapped_column(String(64), nullable=False)
+    archive_tag = mapped_column(String(128), nullable=True)
+    archived_at = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    estimated_retrieval_seconds = mapped_column(Float, nullable=True)
+
+
+def _session():
+    from app.services.unified_db import session
+    return session()
+
+
+def _ensure_ready() -> None:
+    from app.services.unified_db import ensure_schema
+    ensure_schema()
+
+
+# ---------------------------------------------------------------------------
+# Serialisation — pull a day's events into gzipped JSONL bytes.
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "asset_id": row.asset_id,
+        "concept_id": row.concept_id,
+        "contributor_id": row.contributor_id,
+        "session_fingerprint": row.session_fingerprint,
+        "source_page": row.source_page,
+        "referrer_contributor_id": row.referrer_contributor_id,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+    }
+
+
+def serialise_day(target_day: date) -> tuple[bytes, dict[str, Any]]:
+    """Return (gzipped JSONL, manifest) for a single UTC day's events.
+
+    The JSONL is one event per line, ordered by created_at ascending.
+    The manifest carries totals so the caller can record a tombstone.
+    """
+    _ensure_ready()
+    from app.services.read_tracking_service import AssetViewEvent
+
+    start = datetime.combine(target_day, datetime.min.time(), tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+
+    with _session() as s:
+        rows = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.created_at >= start)
+            .filter(AssetViewEvent.created_at < end)
+            .order_by(AssetViewEvent.created_at.asc(), AssetViewEvent.id.asc())
+            .all()
+        )
+
+    raw = io.BytesIO()
+    count = 0
+    for row in rows:
+        raw.write((json.dumps(_row_to_dict(row), separators=(",", ":")) + "\n").encode("utf-8"))
+        count += 1
+    raw_bytes = raw.getvalue()
+
+    compressed = gzip.compress(raw_bytes, compresslevel=9)
+    digest = hashlib.sha256(compressed).hexdigest()
+
+    return compressed, {
+        "day": target_day.isoformat(),
+        "event_count": count,
+        "bytes_original": len(raw_bytes),
+        "bytes_compressed": len(compressed),
+        "sha256": digest,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cold-tier upload — GitHub releases on the existing repo.
+#
+# We use a deterministic tag pattern `archive/view-events/YYYY-MM-DD`
+# so retrievers can construct the URL without round-tripping the API.
+# Asset filename is `events-YYYY-MM-DD.jsonl.gz`. Both upload and
+# tag-create are idempotent (re-running on a re-archived day will
+# fail or warn loudly — the caller should check tombstone first).
+# ---------------------------------------------------------------------------
+
+DEFAULT_REPO = os.environ.get("COHERENCE_ARCHIVE_REPO", "seeker71/Coherence-Network")
+# Hyphenated, slash-free tag prefix. GitHub release download URLs are
+# path-based and ambiguous when tags contain "/", so we keep the tag
+# flat: e.g. ``archive-view-events-2026-05-08``.
+DEFAULT_TAG_PREFIX = "archive-view-events"
+DEFAULT_PROVIDER = "github-releases"
+
+
+def _gh_tag_for(target_day: date) -> str:
+    return f"{DEFAULT_TAG_PREFIX}-{target_day.isoformat()}"
+
+
+def _gh_asset_name(target_day: date) -> str:
+    return f"events-{target_day.isoformat()}.jsonl.gz"
+
+
+def github_release_url(target_day: date, repo: str = DEFAULT_REPO) -> str:
+    """Deterministic public download URL for a day's archive."""
+    return (
+        f"https://github.com/{repo}/releases/download/"
+        f"{_gh_tag_for(target_day)}/{_gh_asset_name(target_day)}"
+    )
+
+
+def upload_to_github_releases(
+    target_day: date,
+    payload: bytes,
+    *,
+    repo: str = DEFAULT_REPO,
+    notes: str = "",
+) -> str:
+    """Push the gzipped JSONL to a GitHub release. Returns the URL.
+
+    Requires ``gh`` CLI available and authenticated on the host
+    running this. Idempotent on tag creation (uses ``gh release create
+    --notes``; if the tag already exists this falls through to upload
+    using ``--clobber``).
+
+    Raises CalledProcessError on failure so the caller does not
+    record a tombstone for an upload that didn't land.
+    """
+    tag = _gh_tag_for(target_day)
+    asset = _gh_asset_name(target_day)
+
+    # Stage payload to a temp file for `gh release upload`.
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+        f.write(payload)
+        tmp_path = f.name
+
+    try:
+        # Best-effort tag create; if it already exists, that's fine.
+        # `gh release create` returns non-zero when the tag exists,
+        # so swallow that specific failure.
+        try:
+            subprocess.run(
+                ["gh", "release", "create", tag, "--repo", repo,
+                 "--title", f"view-events archive · {target_day.isoformat()}",
+                 "--notes", notes or "Cold-tier archive of one day of view events."],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            if "already exists" in (e.stderr or ""):
+                log.info("archive: tag %s already exists, re-uploading asset", tag)
+            else:
+                raise
+
+        # Upload (or clobber) the asset.
+        subprocess.run(
+            ["gh", "release", "upload", tag, f"{tmp_path}#{asset}",
+             "--repo", repo, "--clobber"],
+            check=True, capture_output=True, text=True,
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    return github_release_url(target_day, repo=repo)
+
+
+# ---------------------------------------------------------------------------
+# Tombstone
+# ---------------------------------------------------------------------------
+
+def record_tombstone(
+    target_day: date,
+    *,
+    manifest: dict[str, Any],
+    archive_url: str,
+    archive_provider: str = DEFAULT_PROVIDER,
+    archive_tag: str | None = None,
+) -> ViewEventsArchive:
+    """Write/upsert the tombstone row. Idempotent on day primary key."""
+    _ensure_ready()
+    eta_seconds = round(manifest["bytes_compressed"] / _RETRIEVAL_BYTES_PER_SECOND, 3)
+
+    with _session() as s:
+        existing = s.query(ViewEventsArchive).filter_by(day=target_day).first()
+        if existing:
+            existing.event_count = manifest["event_count"]
+            existing.bytes_compressed = manifest["bytes_compressed"]
+            existing.bytes_original = manifest["bytes_original"]
+            existing.sha256 = manifest["sha256"]
+            existing.archive_url = archive_url
+            existing.archive_provider = archive_provider
+            existing.archive_tag = archive_tag
+            existing.archived_at = datetime.now(timezone.utc)
+            existing.estimated_retrieval_seconds = eta_seconds
+            row = existing
+        else:
+            row = ViewEventsArchive(
+                day=target_day,
+                event_count=manifest["event_count"],
+                bytes_compressed=manifest["bytes_compressed"],
+                bytes_original=manifest["bytes_original"],
+                sha256=manifest["sha256"],
+                archive_url=archive_url,
+                archive_provider=archive_provider,
+                archive_tag=archive_tag,
+                estimated_retrieval_seconds=eta_seconds,
+            )
+            s.add(row)
+        s.commit()
+        # Refresh primary key fields after commit.
+        s.refresh(row)
+        return row
+
+
+def delete_hot_rows_for_day(target_day: date) -> int:
+    """Delete the per-event rows for a day after the tombstone lands.
+
+    The caller should verify the tombstone exists for ``target_day``
+    before calling this. Returns the number of rows removed.
+    """
+    _ensure_ready()
+    from app.services.read_tracking_service import AssetViewEvent
+
+    start = datetime.combine(target_day, datetime.min.time(), tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    with _session() as s:
+        n = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.created_at >= start)
+            .filter(AssetViewEvent.created_at < end)
+            .delete(synchronize_session=False)
+        )
+        s.commit()
+        return n or 0
+
+
+# ---------------------------------------------------------------------------
+# Retrieval — fetch + verify + decompress.
+# ---------------------------------------------------------------------------
+
+def _cache_path(target_day: date) -> Path:
+    return _CACHE_DIR / f"events-{target_day.isoformat()}.jsonl.gz"
+
+
+def get_tombstone(target_day: date) -> ViewEventsArchive | None:
+    _ensure_ready()
+    with _session() as s:
+        row = s.query(ViewEventsArchive).filter_by(day=target_day).first()
+        if not row:
+            return None
+        # Detach from session so caller can read after session closes.
+        s.expunge(row)
+        return row
+
+
+def retrieve_day(target_day: date) -> dict[str, Any]:
+    """Retrieve a day's archived events. Verifies SHA-256, caches
+    locally for repeat reads. Returns a manifest with the event list.
+    """
+    tomb = get_tombstone(target_day)
+    if not tomb:
+        return {"day": target_day.isoformat(), "events": [], "found": False, "reason": "not archived"}
+
+    cache = _cache_path(target_day)
+    payload: bytes
+    fetched_from_cache = False
+
+    if cache.exists():
+        payload = cache.read_bytes()
+        if hashlib.sha256(payload).hexdigest() == tomb.sha256:
+            fetched_from_cache = True
+        else:
+            log.warning("archive: cached payload sha256 mismatch — re-fetching")
+            cache.unlink(missing_ok=True)
+            payload = b""
+
+    fetch_seconds: float | None = None
+    if not fetched_from_cache:
+        t0 = time.perf_counter()
+        try:
+            req = urllib.request.Request(
+                tomb.archive_url,
+                headers={"User-Agent": "coherence-network-archive/1.0"},
+            )
+            with urllib.request.urlopen(req, timeout=60) as r:
+                payload = r.read()
+        except (urllib.error.URLError, TimeoutError) as e:
+            return {
+                "day": target_day.isoformat(),
+                "events": [],
+                "found": True,
+                "fetched": False,
+                "error": f"fetch failed: {e}",
+                "tombstone": _tombstone_to_dict(tomb),
+            }
+        fetch_seconds = round(time.perf_counter() - t0, 3)
+
+        actual_sha = hashlib.sha256(payload).hexdigest()
+        if actual_sha != tomb.sha256:
+            return {
+                "day": target_day.isoformat(),
+                "events": [],
+                "found": True,
+                "fetched": False,
+                "error": (
+                    f"integrity check failed: tombstone sha256={tomb.sha256} "
+                    f"actual={actual_sha}"
+                ),
+                "tombstone": _tombstone_to_dict(tomb),
+            }
+        # Persist to cache for the next reader.
+        try:
+            _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            cache.write_bytes(payload)
+        except OSError as e:
+            log.warning("archive: could not write cache %s: %s", cache, e)
+
+    # Decompress + parse JSONL.
+    try:
+        raw = gzip.decompress(payload)
+    except gzip.BadGzipFile as e:
+        return {
+            "day": target_day.isoformat(),
+            "events": [],
+            "found": True,
+            "fetched": True,
+            "error": f"gunzip failed: {e}",
+            "tombstone": _tombstone_to_dict(tomb),
+        }
+
+    events = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    return {
+        "day": target_day.isoformat(),
+        "events": events,
+        "found": True,
+        "fetched": True,
+        "verified_sha256": tomb.sha256,
+        "fetched_from_cache": fetched_from_cache,
+        "fetch_seconds": fetch_seconds,
+        "tombstone": _tombstone_to_dict(tomb),
+    }
+
+
+def _tombstone_to_dict(tomb: ViewEventsArchive) -> dict[str, Any]:
+    return {
+        "day": tomb.day.isoformat() if tomb.day else None,
+        "event_count": tomb.event_count,
+        "bytes_compressed": tomb.bytes_compressed,
+        "bytes_original": tomb.bytes_original,
+        "sha256": tomb.sha256,
+        "archive_url": tomb.archive_url,
+        "archive_provider": tomb.archive_provider,
+        "archive_tag": tomb.archive_tag,
+        "archived_at": tomb.archived_at.isoformat() if tomb.archived_at else None,
+        "estimated_retrieval_seconds": tomb.estimated_retrieval_seconds,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Stats — for the health endpoint.
+# ---------------------------------------------------------------------------
+
+def stats() -> dict[str, Any]:
+    """Aggregate stats on archived days. Cheap; one query."""
+    _ensure_ready()
+    with _session() as s:
+        rows = s.query(ViewEventsArchive).all()
+        total_archived_days = len(rows)
+        total_archived_events = sum(r.event_count or 0 for r in rows)
+        total_compressed_bytes = sum(r.bytes_compressed or 0 for r in rows)
+        total_original_bytes = sum(r.bytes_original or 0 for r in rows)
+        oldest = min((r.day for r in rows), default=None)
+        newest = max((r.day for r in rows), default=None)
+        providers: dict[str, int] = {}
+        for r in rows:
+            providers[r.archive_provider] = providers.get(r.archive_provider, 0) + 1
+
+    compression_ratio = (
+        round(total_original_bytes / total_compressed_bytes, 1)
+        if total_compressed_bytes > 0
+        else None
+    )
+    return {
+        "total_archived_days": total_archived_days,
+        "total_archived_events": total_archived_events,
+        "total_compressed_bytes": total_compressed_bytes,
+        "total_original_bytes": total_original_bytes,
+        "compression_ratio": compression_ratio,
+        "oldest_archived_day": oldest.isoformat() if oldest else None,
+        "newest_archived_day": newest.isoformat() if newest else None,
+        "providers": providers,
+    }

--- a/scripts/archive_view_events.py
+++ b/scripts/archive_view_events.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Move days of asset_view_events into cold-tier storage.
+
+Pattern:
+
+  hot tier (Postgres asset_view_events)
+    └─ archive day D:
+       1. SELECT * FROM asset_view_events WHERE created_at on D
+       2. JSONL → gzip → SHA-256
+       3. ``gh release upload archive/view-events/D events-D.jsonl.gz``
+       4. INSERT INTO view_events_archive (tombstone with URL + SHA)
+       5. DELETE hot rows for D
+       6. VACUUM (sqlite only)
+
+The tombstone (~150 bytes) replaces ~2 MB of hot rows per day with
+full retrievability via SHA-256-verified GitHub-release fetch.
+
+Usage:
+
+    # Dry-run — see what would be archived
+    python3 scripts/archive_view_events.py --keep-days 30 --dry-run
+
+    # Archive everything older than 30 days, in chronological order
+    python3 scripts/archive_view_events.py --keep-days 30 --apply
+
+    # Archive a single specific day (re-archive / repair)
+    python3 scripts/archive_view_events.py --day 2026-04-20 --apply
+
+    # Different repo (default: $COHERENCE_ARCHIVE_REPO or seeker71/Coherence-Network)
+    python3 scripts/archive_view_events.py --keep-days 30 --apply \\
+        --repo seeker71/coherence-network-archive
+
+Requires ``gh`` CLI authenticated on the host. Idempotent: re-running
+on an already-archived day verifies the existing tombstone and
+re-uploads only if the SHA changed (e.g. after a hot-tier repair).
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+API_ROOT = os.path.join(REPO_ROOT, "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+from app.services import view_events_archive_service as vea  # noqa: E402
+from app.services.unified_db import session, ensure_schema  # noqa: E402
+from sqlalchemy import func  # noqa: E402
+
+log = logging.getLogger("archive_view_events")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def _human(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+def days_with_hot_events_older_than(keep_days: int) -> list[date]:
+    """Return UTC dates that have at least one row older than the
+    keep window. Sorted ascending so we archive oldest-first."""
+    ensure_schema()
+    from app.services.read_tracking_service import AssetViewEvent
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=keep_days)
+    with session() as s:
+        # Pull distinct days; func.date works on both sqlite and postgres.
+        rows = (
+            s.query(func.date(AssetViewEvent.created_at).label("d"))
+            .filter(AssetViewEvent.created_at < cutoff)
+            .distinct()
+            .all()
+        )
+    days: list[date] = []
+    for (d,) in rows:
+        if isinstance(d, date) and not isinstance(d, datetime):
+            days.append(d)
+        elif isinstance(d, datetime):
+            days.append(d.date())
+        elif isinstance(d, str):
+            days.append(date.fromisoformat(d))
+    return sorted(days)
+
+
+def archive_one_day(target_day: date, *, repo: str, apply: bool) -> dict:
+    """Archive a single day. Returns a summary dict."""
+    log.info("==> day %s", target_day.isoformat())
+
+    payload, manifest = vea.serialise_day(target_day)
+    log.info(
+        "    %s events · original %s · compressed %s · sha256=%s…",
+        manifest["event_count"],
+        _human(manifest["bytes_original"]),
+        _human(manifest["bytes_compressed"]),
+        manifest["sha256"][:12],
+    )
+
+    if manifest["event_count"] == 0:
+        log.info("    no events for this day — skipping (no upload, no tombstone)")
+        return {"day": target_day.isoformat(), "skipped": "no events"}
+
+    # Idempotency: if a tombstone exists with the same sha256, the
+    # archive is already current — skip the upload but ensure hot
+    # rows are gone.
+    existing = vea.get_tombstone(target_day)
+    if existing and existing.sha256 == manifest["sha256"]:
+        log.info("    tombstone already current (sha256 matches)")
+        if apply:
+            removed = vea.delete_hot_rows_for_day(target_day)
+            log.info("    deleted %s hot rows for day", removed)
+            return {"day": target_day.isoformat(), "skipped_upload": True, "deleted": removed}
+        return {"day": target_day.isoformat(), "skipped_upload": True, "deleted": 0}
+
+    if not apply:
+        log.info("    (dry-run) — would upload %s and write tombstone",
+                 vea._gh_asset_name(target_day))
+        return {"day": target_day.isoformat(), "would_upload": True}
+
+    # Upload to cold tier.
+    archive_url = vea.upload_to_github_releases(
+        target_day,
+        payload,
+        repo=repo,
+        notes=(
+            f"Daily cold-tier archive of asset_view_events for "
+            f"{target_day.isoformat()}.\n\n"
+            f"Event count: {manifest['event_count']}\n"
+            f"Original size: {_human(manifest['bytes_original'])}\n"
+            f"Compressed size: {_human(manifest['bytes_compressed'])}\n"
+            f"SHA-256: {manifest['sha256']}\n\n"
+            f"Format: gzipped JSON Lines, one event per line, ordered "
+            f"by created_at ascending. Verify integrity by computing "
+            f"SHA-256 of the gzipped asset and comparing to this note."
+        ),
+    )
+    log.info("    uploaded → %s", archive_url)
+
+    # Tombstone.
+    tomb = vea.record_tombstone(
+        target_day,
+        manifest=manifest,
+        archive_url=archive_url,
+        archive_provider=vea.DEFAULT_PROVIDER,
+        archive_tag=vea._gh_tag_for(target_day),
+    )
+    log.info("    tombstone recorded · ETA retrieval %.2fs", tomb.estimated_retrieval_seconds or 0)
+
+    # Delete hot rows.
+    removed = vea.delete_hot_rows_for_day(target_day)
+    log.info("    deleted %s hot rows for day", removed)
+
+    return {
+        "day": target_day.isoformat(),
+        "event_count": manifest["event_count"],
+        "bytes_compressed": manifest["bytes_compressed"],
+        "bytes_original": manifest["bytes_original"],
+        "sha256": manifest["sha256"],
+        "archive_url": archive_url,
+        "deleted": removed,
+    }
+
+
+def vacuum_if_sqlite() -> None:
+    try:
+        from app.services.unified_db import _engine  # type: ignore
+        if "sqlite" in str(getattr(_engine, "url", "")):
+            with session() as s:
+                s.execute("VACUUM")
+                log.info("(sqlite) VACUUM — pages reclaimed")
+    except Exception as e:  # pragma: no cover
+        log.warning("vacuum step skipped: %s", e)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--keep-days", type=int, default=30,
+        help="Archive days older than N days (default: 30). Ignored if --day given.",
+    )
+    p.add_argument(
+        "--day", type=str, default=None,
+        help="Archive a single specific UTC day (YYYY-MM-DD). Overrides --keep-days.",
+    )
+    p.add_argument(
+        "--repo", type=str,
+        default=os.environ.get("COHERENCE_ARCHIVE_REPO", vea.DEFAULT_REPO),
+        help="GitHub repo for cold-tier releases (default: $COHERENCE_ARCHIVE_REPO).",
+    )
+    p.add_argument(
+        "--apply", action="store_true",
+        help="Commit upload + tombstone + hot-row delete. Without this flag, run is read-only.",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Report only — explicit alias for the default behaviour.",
+    )
+    p.add_argument(
+        "--limit", type=int, default=0,
+        help="Maximum number of days to archive in this run (0 = no limit).",
+    )
+    args = p.parse_args(argv)
+
+    apply = args.apply and not args.dry_run
+
+    if args.day:
+        target = date.fromisoformat(args.day)
+        days = [target]
+    else:
+        days = days_with_hot_events_older_than(args.keep_days)
+        if args.limit > 0:
+            days = days[: args.limit]
+
+    log.info("=== archive_view_events ===")
+    log.info("repo:       %s", args.repo)
+    log.info("mode:       %s", "APPLY (uploads + commits)" if apply else "DRY-RUN")
+    log.info("days_found: %s%s",
+             len(days), f" (limited to first {args.limit})" if args.limit > 0 else "")
+    if not days:
+        log.info("nothing to archive. body breathes.")
+        return 0
+
+    summaries: list[dict] = []
+    for d in days:
+        try:
+            summaries.append(archive_one_day(d, repo=args.repo, apply=apply))
+        except Exception as e:
+            log.error("    FAILED for %s: %s", d.isoformat(), e)
+            summaries.append({"day": d.isoformat(), "error": str(e)})
+
+    if apply:
+        vacuum_if_sqlite()
+
+    log.info("\n=== summary ===")
+    total_events = sum(s.get("event_count", 0) for s in summaries)
+    total_bytes = sum(s.get("bytes_compressed", 0) for s in summaries)
+    total_deleted = sum(s.get("deleted", 0) for s in summaries)
+    log.info("days handled:  %s", len(summaries))
+    log.info("events archived: %s", total_events)
+    log.info("compressed cold-tier bytes: %s", _human(total_bytes))
+    log.info("hot rows deleted: %s", total_deleted)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -52,7 +52,64 @@ fi
 
 echo "[$(date -u +%FT%TZ)] backup ok size=${SIZE} contribution_ledger_rows=${LEDGER_ROWS}" >> "${LOG}"
 
-# Prune old dumps
+# ---------------------------------------------------------------------------
+# Off-site replica — optional, gated on env vars so existing crons keep
+# working. Without this step, dumps live ONLY on the VPS — same disk and
+# zone as the live DB. Off-site upload survives a VPS-loss event.
+#
+# Two paths are supported:
+#
+#   1. COHERENCE_OFFSITE_GH_REPO=owner/private-repo
+#      Upload the gzipped dump to a GitHub release on a PRIVATE repo.
+#      Requires `gh` authenticated on the host. Idempotent on tag.
+#
+#   2. COHERENCE_OFFSITE_GPG_RECIPIENT=key-id-or-email
+#      Encrypt the dump to a GPG public key BEFORE upload — safe even
+#      against a public repo. Requires `gpg --import` of the public
+#      key on the VPS once. Combine with (1) for encrypted-public.
+#
+# When neither is set the script proceeds as before (local-only).
+# ---------------------------------------------------------------------------
+
+OFFSITE_OUT="${OUT}"
+if [[ -n "${COHERENCE_OFFSITE_GPG_RECIPIENT:-}" ]]; then
+  ENC="${OUT}.gpg"
+  if gpg --batch --yes --trust-model always --output "${ENC}" \
+       --encrypt --recipient "${COHERENCE_OFFSITE_GPG_RECIPIENT}" "${OUT}"; then
+    OFFSITE_OUT="${ENC}"
+    echo "[$(date -u +%FT%TZ)] gpg encrypted -> ${ENC}" >> "${LOG}"
+  else
+    echo "[$(date -u +%FT%TZ)] WARNING: gpg encryption failed — skipping offsite upload" >> "${LOG}"
+    OFFSITE_OUT=""
+  fi
+fi
+
+if [[ -n "${COHERENCE_OFFSITE_GH_REPO:-}" && -n "${OFFSITE_OUT}" ]]; then
+  TAG="backup-postgres-${TS}"
+  ASSET="$(basename "${OFFSITE_OUT}")"
+  if gh release create "${TAG}" \
+       --repo "${COHERENCE_OFFSITE_GH_REPO}" \
+       --title "Postgres backup ${TS}" \
+       --notes "Nightly pg_dump · size=${SIZE} · ledger_rows=${LEDGER_ROWS}$( [[ "${OFFSITE_OUT}" == *.gpg ]] && echo " · gpg-encrypted" )" \
+       >> "${LOG}" 2>&1; then
+    if gh release upload "${TAG}" "${OFFSITE_OUT}#${ASSET}" \
+         --repo "${COHERENCE_OFFSITE_GH_REPO}" --clobber \
+         >> "${LOG}" 2>&1; then
+      echo "[$(date -u +%FT%TZ)] offsite ok repo=${COHERENCE_OFFSITE_GH_REPO} tag=${TAG}" >> "${LOG}"
+    else
+      echo "[$(date -u +%FT%TZ)] WARNING: gh release upload failed for ${ASSET}" >> "${LOG}"
+    fi
+  else
+    echo "[$(date -u +%FT%TZ)] WARNING: gh release create failed for ${TAG}" >> "${LOG}"
+  fi
+
+  # If we encrypted before upload, leave the encrypted artifact in
+  # the local backups dir too (cheap, useful for parity), but prune
+  # it under the same retention rules below.
+fi
+
+# Prune old dumps (local + any encrypted siblings)
 find "${BACKUP_DIR}" -maxdepth 1 -name 'coherence-*.sql.gz' -mtime "+${RETENTION_DAYS}" -print -delete >> "${LOG}" 2>&1 || true
+find "${BACKUP_DIR}" -maxdepth 1 -name 'coherence-*.sql.gz.gpg' -mtime "+${RETENTION_DAYS}" -print -delete >> "${LOG}" 2>&1 || true
 
 echo "${OUT}"


### PR DESCRIPTION
## Summary

Two gaps the user surfaced honestly:
1. **Backups die with the VPS** — current pg_dump lives on the same disk as the live DB.
2. **Witness-trace grows linearly** — `asset_view_events` is at 65k rows / 40 MB / 3.1k/day.

This ships the **cold-tier pattern** that answers both with the same machinery: free + durable + public substrate (GitHub releases), compact tombstone in DB that carries URL + SHA-256 + retrieval ETA, and full byte-perfect retrievability.

**Compression**: ~640 B × 3,000 events/day = 2 MB hot per day → ~300 KB on GitHub + 150 B tombstone in DB → **~13,000× compression at the DB layer**, full fidelity preserved.

## What ships

- `api/app/services/view_events_archive_service.py` — `ViewEventsArchive` ORM, `serialise_day`, `upload_to_github_releases`, `record_tombstone`, `retrieve_day` (with SHA-256 verify + local cache), `stats()`.
- `scripts/archive_view_events.py` — CLI: `--keep-days N`, `--day YYYY-MM-DD`, `--apply` (default dry-run), `--limit N`. Idempotent.
- `api/app/routers/views.py` — `GET /api/views/archive` (list), `GET /api/views/archive/{day}` (retrieve), `/api/views/health` extended with `cold_tier` section.
- `scripts/backup_postgres.sh` — optional off-site replica gated on env vars: `COHERENCE_OFFSITE_GH_REPO` (private repo for releases) + optional `COHERENCE_OFFSITE_GPG_RECIPIENT` (encrypt before upload).

## Test plan
- [ ] `python3 scripts/archive_view_events.py --dry-run` reports days with hot events older than 30 days
- [ ] `--day 2026-04-16 --apply` uploads a release + writes tombstone + deletes hot rows + idempotent on re-run
- [ ] `GET /api/views/archive` lists tombstones with stats
- [ ] `GET /api/views/archive/2026-04-16` fetches + verifies SHA-256 + returns events
- [ ] `/api/views/health` `cold_tier` section reports archived day count + compression ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)