### PR TITLE
attune: regenerate repo indexes after memory-as-framebuffer merges

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -32,13 +32,13 @@
 | Index | Files | Purpose |
 |---|---|---|
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 125 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 221 | API services — business logic and graph operations |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 227 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 55 | API models — Pydantic + ORM shapes |
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 106 | API tests — flow-centric |
-| [web/lib/INDEX.md](web/lib/INDEX.md) | 29 | Web library — shared client/server helpers |
+| [web/lib/INDEX.md](web/lib/INDEX.md) | 31 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 47 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 153 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 85 | Scripts — operational tools, generators, syncers |
+| [web/app/INDEX.md](web/app/INDEX.md) | 172 | Web routes — every visible page in the app |
+| [scripts/INDEX.md](scripts/INDEX.md) | 91 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 220
+**Total files**: 227
 
 | File | Purpose |
 |---|---|
@@ -37,6 +37,7 @@
 | [agent_service_usage_visibility.py](agent_service_usage_visibility.py) | Agent usage, visibility, and orchestration guidance summaries. |
 | [agent_task_continuation_service.py](agent_task_continuation_service.py) | Post-execution task continuation helpers. |
 | [agent_task_store_service.py](agent_task_store_service.py) | Persistent store for agent tasks with shared DB support. |
+| [anonymous_meeting_trace_service.py](anonymous_meeting_trace_service.py) | Anonymous meeting traces. |
 | [app_mode.py](app_mode.py) | Application runtime mode helpers backed by config, not environment. |
 | [attunement_scheduler.py](attunement_scheduler.py) | Attunement scheduler — re-attune every presence so newly added concepts |
 | [audit_ledger_service.py](audit_ledger_service.py) | Transparent Audit Ledger service -- spec 123. |
@@ -96,6 +97,8 @@
 | [federation_service.py](federation_service.py) | Federation service: receive, validate, and integrate remote instance data. |
 | [field_story_mcp_tools.py](field_story_mcp_tools.py) | MCP registry entries for published field stories. |
 | [field_story_service.py](field_story_service.py) | Published field-story artifacts and contribution hooks. |
+| [field_view_attribution_adjustment_service.py](field_view_attribution_adjustment_service.py) | Living append-only adjustments for field-story view attribution flow. |
+| [field_view_attribution_service.py](field_view_attribution_service.py) | Field story view attribution receipts and CC circulation rows. |
 | [frequency_editor.py](frequency_editor.py) | Frequency editor — finds and rewrites institutional-frequency phrases. |
 | [frequency_field.py](frequency_field.py) | Frequency field analysis — token and phrase level dissonance detection. |
 | [frequency_profile_service.py](frequency_profile_service.py) | Frequency profile service — dynamic, multi-view, multi-hop. |
@@ -132,6 +135,7 @@
 | [idea_views.py](idea_views.py) | Read-only idea views — lifecycle, activity feed, concept resonance matches. |
 | [idea_write_ops.py](idea_write_ops.py) | Idea CRUD writes — create, update, batch update, slug update, tags, questions. |
 | [identity_providers.py](identity_providers.py) | Identity provider registry — single source of truth for all supported providers. |
+| [influence_teaching_translator_service.py](influence_teaching_translator_service.py) | Influence teaching translator for field story traces. |
 | [inspired_by_service.py](inspired_by_service.py) | Inspired-by resolver — turn a name (or URL) into a small subgraph. |
 | [interest_service.py](interest_service.py) | Interest registration service — privacy-first community gathering. |
 | [inventory_service.py](inventory_service.py) | Unified inventory service for ideas, questions, specs, implementations, and usage. |
@@ -157,6 +161,7 @@
 | [openclaw_node_bridge_service.py](openclaw_node_bridge_service.py) | OpenClaw node bridge: WebSocket delivery for federation messages (Spec 156 Phase 3). |
 | [openrouter_client.py](openrouter_client.py) | Minimal OpenRouter client for server-side task execution. |
 | [orchestrator_policy_service.py](orchestrator_policy_service.py) | Data-driven orchestrator policy configuration. |
+| [organism_influence_cc_service.py](organism_influence_cc_service.py) | Computed CC sensing for organism-scale influences. |
 | [page_lineage_service.py](page_lineage_service.py) | Public mapping of human web pages to idea ids (for ontology traversal). |
 | [peer_resonance_service.py](peer_resonance_service.py) | Peer resonance scoring shared by discovery and peer routes. |
 | [permanent_storage_service.py](permanent_storage_service.py) | Permanent storage service — Arweave + IPFS bundler integration (pending). |
@@ -220,6 +225,8 @@
 | [unified_models.py](unified_models.py) | All ORM models registered on the unified Base. |
 | [value_lineage_service.py](value_lineage_service.py) | Service for persistent value lineage and payout attribution previews. |
 | [verification_service.py](verification_service.py) | Verification service — Merkle hash chains + Ed25519 signed snapshots. |
+| [view_events_archive_service.py](view_events_archive_service.py) | Cold-tier archival for ``asset_view_events``. |
+| [views_health_service.py](views_health_service.py) | Views-tracing health service. |
 | [vision_content_service.py](vision_content_service.py) | Graph-backed page content for Living Collective vision surfaces. |
 | [vitality_service.py](vitality_service.py) | Vitality service — living-system health metrics for a workspace. |
 | [wallet_service.py](wallet_service.py) | Wallet service — links contributor identities to on-chain addresses. |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 105
+**Total files**: 106
 
 | File | Purpose |
 |---|---|
@@ -15,6 +15,7 @@
 | [test_agent_monitor_helpers.py](test_agent_monitor_helpers.py) | _no top-of-file purpose_ |
 | [test_agent_runner_tool_failure_telemetry.py](test_agent_runner_tool_failure_telemetry.py) | Tests for tool-failure-awareness spec: runtime telemetry + friction events. |
 | [test_agent_task_claims.py](test_agent_task_claims.py) | Task claim tracking and ROI auto-pick deduplication. |
+| [test_anonymous_meeting_traces.py](test_anonymous_meeting_traces.py) | Anonymous meeting trace tests. |
 | [test_asset_registration.py](test_asset_registration.py) | Tests for POST /api/assets/register and GET /api/assets/{id}/registration. |
 | [test_asset_renderer.py](test_asset_renderer.py) | Tests for the asset-renderer-plugin spec pure-logic pieces. |
 | [test_attribution_middleware.py](test_attribution_middleware.py) | Tests for the attribution middleware. |

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 85
+**Total files**: 91
 
 | File | Purpose |
 |---|---|
@@ -12,6 +12,7 @@
 | [add_crosslinks.py](add_crosslinks.py) | !/usr/bin/env python3 |
 | [add_task_cards_to_specs.py](add_task_cards_to_specs.py) | !/usr/bin/env python3 |
 | [agent_status.py](agent_status.py) | !/usr/bin/env python3 |
+| [archive_view_events.py](archive_view_events.py) | !/usr/bin/env python3 |
 | [arrival.py](arrival.py) | !/usr/bin/env python3 |
 | [audit_external_tools.py](audit_external_tools.py) | !/usr/bin/env python3 |
 | [audit_vision_image_candidates.py](audit_vision_image_candidates.py) | !/usr/bin/env python3 |
@@ -49,12 +50,16 @@
 | [import_creations.py](import_creations.py) | !/usr/bin/env python3 |
 | [import_gatherings.py](import_gatherings.py) | !/usr/bin/env python3 |
 | [import_lineage.py](import_lineage.py) | !/usr/bin/env python3 |
+| [influence_teaching_translator.py](influence_teaching_translator.py) | !/usr/bin/env python3 |
+| [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | !/usr/bin/env python3 |
+| [ingest_audible_history.py](ingest_audible_history.py) | !/usr/bin/env python3 |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
 | [local_runner.py](local_runner.py) | !/usr/bin/env python3 |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | !/usr/bin/env python3 |
 | [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | !/usr/bin/env python3 |
 | [migrate_spec_slugs.py](migrate_spec_slugs.py) | !/usr/bin/env python3 |
 | [morning_coherence_brief.py](morning_coherence_brief.py) | !/usr/bin/env python3 |
+| [organism_influence_cc.py](organism_influence_cc.py) | !/usr/bin/env python3 |
 | [plan_vision_image_regeneration.py](plan_vision_image_regeneration.py) | !/usr/bin/env python3 |
 | [poll_task_progress.py](poll_task_progress.py) | !/usr/bin/env python3 |
 | [pr_check_failure_triage.py](pr_check_failure_triage.py) | !/usr/bin/env python3 |
@@ -80,6 +85,7 @@
 | [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | !/usr/bin/env python3 |
 | [sync_kb_to_db.py](sync_kb_to_db.py) | !/usr/bin/env python3 |
 | [sync_presences_to_db.py](sync_presences_to_db.py) | !/usr/bin/env python3 |
+| [trim_view_events.py](trim_view_events.py) | !/usr/bin/env python3 |
 | [upgrade_specs.py](upgrade_specs.py) | !/usr/bin/env python3 |
 | [validate_commit_evidence.py](validate_commit_evidence.py) | !/usr/bin/env python3 |
 | [validate_local_api_matrix.py](validate_local_api_matrix.py) | !/usr/bin/env python3 |

--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 153
+**Total files**: 172
 
 | Route | File | Purpose |
 |---|---|---|
@@ -91,23 +91,42 @@
 | `/` | [page.tsx](page.tsx) | _no top-of-file purpose_ |
 | `/peers` | [page.tsx](peers/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]/edit` | [page.tsx](people/[id]/edit/page.tsx) | _no top-of-file purpose_ |
+| `/people/[id]/lineage` | [page.tsx](people/[id]/lineage/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]` | [page.tsx](people/[id]/page.tsx) | _no top-of-file purpose_ |
 | `/people/aly-constantine` | [page.tsx](people/aly-constantine/page.tsx) | _no top-of-file purpose_ |
 | `/people/aubrey-marcus` | [page.tsx](people/aubrey-marcus/page.tsx) | _no top-of-file purpose_ |
+| `/people/backtracking-model-languages` | [page.tsx](people/backtracking-model-languages/page.tsx) | _no top-of-file purpose_ |
 | `/people/bloomurian` | [page.tsx](people/bloomurian/page.tsx) | _no top-of-file purpose_ |
+| `/people/bmcpu-vm` | [page.tsx](people/bmcpu-vm/page.tsx) | _no top-of-file purpose_ |
+| `/people/bmf-grammar` | [page.tsx](people/bmf-grammar/page.tsx) | _no top-of-file purpose_ |
+| `/people/bml-language` | [page.tsx](people/bml-language/page.tsx) | _no top-of-file purpose_ |
+| `/people/c64-midi-interface` | [page.tsx](people/c64-midi-interface/page.tsx) | _no top-of-file purpose_ |
+| `/people/coherence-network` | [page.tsx](people/coherence-network/page.tsx) | _no top-of-file purpose_ |
 | `/people/edit-your-profile` | [page.tsx](people/edit-your-profile/page.tsx) | _no top-of-file purpose_ |
 | `/people/elios` | [page.tsx](people/elios/page.tsx) | _no top-of-file purpose_ |
 | `/people/elon-musk` | [page.tsx](people/elon-musk/page.tsx) | _no top-of-file purpose_ |
 | `/people/grab` | [page.tsx](people/grab/page.tsx) | _no top-of-file purpose_ |
 | `/people/ilena` | [page.tsx](people/ilena/page.tsx) | _no top-of-file purpose_ |
+| `/people/jbmf-java` | [page.tsx](people/jbmf-java/page.tsx) | _no top-of-file purpose_ |
 | `/people/joshua-golden` | [page.tsx](people/joshua-golden/page.tsx) | _no top-of-file purpose_ |
 | `/people/lex-fridman` | [page.tsx](people/lex-fridman/page.tsx) | _no top-of-file purpose_ |
+| `/people/living-codex-csharp` | [page.tsx](people/living-codex-csharp/page.tsx) | _no top-of-file purpose_ |
+| `/people/living-resonance-codex` | [page.tsx](people/living-resonance-codex/page.tsx) | _no top-of-file purpose_ |
 | `/people/matias-de-stefano` | [page.tsx](people/matias-de-stefano/page.tsx) | _no top-of-file purpose_ |
+| `/people/mindtouch-wiki-in-a-box` | [page.tsx](people/mindtouch-wiki-in-a-box/page.tsx) | _no top-of-file purpose_ |
 | `/people/mose` | [page.tsx](people/mose/page.tsx) | _no top-of-file purpose_ |
 | `/people` | [page.tsx](people/page.tsx) | _no top-of-file purpose_ |
 | `/people/porangui` | [page.tsx](people/porangui/page.tsx) | _no top-of-file purpose_ |
 | `/people/portal` | [page.tsx](people/portal/page.tsx) | _no top-of-file purpose_ |
+| `/people/qualcomm-hdmi-hdcp` | [page.tsx](people/qualcomm-hdmi-hdcp/page.tsx) | _no top-of-file purpose_ |
+| `/people/qualcomm-test-automation` | [page.tsx](people/qualcomm-test-automation/page.tsx) | _no top-of-file purpose_ |
+| `/people/quark-mono-corba` | [page.tsx](people/quark-mono-corba/page.tsx) | _no top-of-file purpose_ |
+| `/people/quark-multi-undo-redo` | [page.tsx](people/quark-multi-undo-redo/page.tsx) | _no top-of-file purpose_ |
+| `/people/quark-virtual-dom` | [page.tsx](people/quark-virtual-dom/page.tsx) | _no top-of-file purpose_ |
 | `/people/robert-edward-grant` | [page.tsx](people/robert-edward-grant/page.tsx) | _no top-of-file purpose_ |
+| `/people/schindler-hc11-protocol` | [page.tsx](people/schindler-hc11-protocol/page.tsx) | _no top-of-file purpose_ |
+| `/people/trimble-glue-layer` | [page.tsx](people/trimble-glue-layer/page.tsx) | _no top-of-file purpose_ |
+| `/people/urs/lineage` | [page.tsx](people/urs/lineage/page.tsx) | _no top-of-file purpose_ |
 | `/people/urs` | [page.tsx](people/urs/page.tsx) | _no top-of-file purpose_ |
 | `/people/vasudev-baba` | [page.tsx](people/vasudev-baba/page.tsx) | _no top-of-file purpose_ |
 | `/pipeline` | [page.tsx](pipeline/page.tsx) | _no top-of-file purpose_ |

--- a/web/components/INDEX.md
+++ b/web/components/INDEX.md
@@ -4,10 +4,11 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 46
+**Total files**: 47
 
 | File | Purpose |
 |---|---|
+| [AnonymousMeetingTrace.tsx](AnonymousMeetingTrace.tsx) | _no top-of-file purpose_ |
 | [AssetRenderer.tsx](AssetRenderer.tsx) | _no top-of-file purpose_ |
 | [EnablePush.tsx](EnablePush.tsx) | _no top-of-file purpose_ |
 | [ExplorePager.tsx](ExplorePager.tsx) | _no top-of-file purpose_ |

--- a/web/lib/INDEX.md
+++ b/web/lib/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 29
+**Total files**: 31
 
 | File | Purpose |
 |---|---|
@@ -16,7 +16,9 @@
 | [automation-page-data.ts](automation-page-data.ts) | _no top-of-file purpose_ |
 | [edge-spectrum.ts](edge-spectrum.ts) | Spectrum colors for the seven canonical edge-type families. |
 | [egress.ts](egress.ts) | _no top-of-file purpose_ |
+| [entry-paths.ts](entry-paths.ts) | _no top-of-file purpose_ |
 | [fetch.ts](fetch.ts) | _no top-of-file purpose_ |
+| [home-presence-traces.ts](home-presence-traces.ts) | _no top-of-file purpose_ |
 | [html-entities.ts](html-entities.ts) | Many imported asset descriptions arrive carrying WordPress HTML |
 | [humanize.ts](humanize.ts) | _no top-of-file purpose_ |
 | [i18n.ts](i18n.ts) | Locale-text-as-data helpers. |


### PR DESCRIPTION
## Summary

Auto-regenerated by \`python3 scripts/generate_repo_indexes.py\` after the v0 spec (#1434) and crate (#1436) landed. Pure tooling output — no semantic changes.

The MANIFEST + 6 INDEX files had drifted relative to current tree state; this clears the CI staleness flag.

## Test plan

- [ ] \`python3 scripts/generate_repo_indexes.py --check\` returns clean after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)