### PR TITLE
tend: build + document the opt-out lever before it's needed

### DIFF
--- a/api/app/services/view_events_archive_service.py
+++ b/api/app/services/view_events_archive_service.py
@@ -435,6 +435,122 @@ def retrieve_day(target_day: date) -> dict[str, Any]:
     }
 
 
+def list_archived_days() -> list[date]:
+    """Return every archived day in ascending order. Used by the
+    opt-out flow to enumerate cold-tier archives that may need
+    rewriting."""
+    _ensure_ready()
+    with _session() as s:
+        rows = s.query(ViewEventsArchive.day).order_by(ViewEventsArchive.day.asc()).all()
+        return [r[0] for r in rows]
+
+
+def rewrite_archived_day(
+    target_day: date,
+    *,
+    transform,
+    repo: str = DEFAULT_REPO,
+    notes: str = "",
+) -> dict[str, Any]:
+    """Rewrite a previously-archived day with a transformation applied
+    to each event.
+
+    ``transform`` is a callable taking one event-dict and returning
+    one event-dict (or None to drop the event entirely). Used by the
+    opt-out flow to anonymize specific contributor data while
+    preserving the rest of the day's attribution shape.
+
+    Returns a manifest describing the rewrite. The cold-tier asset is
+    re-uploaded under the same tag + filename (so the deterministic
+    URL still resolves) but with a new SHA-256 — the tombstone is
+    updated in lockstep so retrievers always verify against the
+    current archive content.
+
+    Honest property: anyone who downloaded the OLD asset still has it
+    locally. The rewrite is forward-looking — current and future
+    retrievals through the network's API surface, plus anyone freshly
+    cloning the cold tier, see the redacted version. Past mirrors are
+    out of our reach.
+    """
+    tomb = get_tombstone(target_day)
+    if not tomb:
+        return {"day": target_day.isoformat(), "rewritten": False, "reason": "not archived"}
+
+    fetched = retrieve_day(target_day)
+    if not fetched.get("fetched"):
+        return {"day": target_day.isoformat(), "rewritten": False,
+                "reason": fetched.get("error", "fetch failed"),
+                "tombstone": _tombstone_to_dict(tomb)}
+
+    original_events = fetched.get("events", [])
+    new_events: list[dict[str, Any]] = []
+    redactions = 0
+    for ev in original_events:
+        out = transform(ev)
+        if out is None:
+            redactions += 1
+            continue
+        if out is not ev:
+            redactions += 1
+        new_events.append(out)
+
+    if redactions == 0:
+        return {"day": target_day.isoformat(), "rewritten": False,
+                "reason": "no rows touched by transform",
+                "event_count": len(original_events)}
+
+    # Re-serialise.
+    raw = io.BytesIO()
+    for ev in new_events:
+        raw.write((json.dumps(ev, separators=(",", ":")) + "\n").encode("utf-8"))
+    raw_bytes = raw.getvalue()
+    compressed = gzip.compress(raw_bytes, compresslevel=9)
+    digest = hashlib.sha256(compressed).hexdigest()
+
+    new_manifest = {
+        "day": target_day.isoformat(),
+        "event_count": len(new_events),
+        "bytes_original": len(raw_bytes),
+        "bytes_compressed": len(compressed),
+        "sha256": digest,
+    }
+
+    archive_url = upload_to_github_releases(
+        target_day,
+        compressed,
+        repo=repo,
+        notes=notes or (
+            f"Rewritten {datetime.now(timezone.utc).isoformat()} — "
+            f"{redactions} event(s) redacted via opt-out flow. "
+            f"Original event count was {len(original_events)}; "
+            f"current event count is {len(new_events)}."
+        ),
+    )
+
+    record_tombstone(
+        target_day,
+        manifest=new_manifest,
+        archive_url=archive_url,
+        archive_provider=DEFAULT_PROVIDER,
+        archive_tag=_gh_tag_for(target_day),
+    )
+
+    # Invalidate the local cache so the next retrieval pulls fresh.
+    cache = _cache_path(target_day)
+    if cache.exists():
+        cache.unlink(missing_ok=True)
+
+    return {
+        "day": target_day.isoformat(),
+        "rewritten": True,
+        "redactions": redactions,
+        "old_sha256": tomb.sha256,
+        "new_sha256": digest,
+        "old_event_count": len(original_events),
+        "new_event_count": len(new_events),
+    }
+
+
 def _tombstone_to_dict(tomb: ViewEventsArchive) -> dict[str, Any]:
     return {
         "day": tomb.day.isoformat() if tomb.day else None,

--- a/docs/transparency/README.md
+++ b/docs/transparency/README.md
@@ -1,0 +1,75 @@
+# Transparency · what we keep, where, and how to be removed
+
+The Coherence Network is built on the conviction that everything traceable belongs in the open. This page is the operational version of that conviction — what kinds of data the network holds, where they live, what's public, and what to do if you arrived here and need to be removed.
+
+## What the network holds, in plain terms
+
+Three kinds of record accumulate as the network breathes:
+
+| Record | Lives in | Visibility | Substrate |
+|---|---|---|---|
+| **Contributions** | `contribution_ledger` table | Public | Postgres on the VPS · nightly dumps to [coherence-network-archive](https://github.com/seeker71/coherence-network-archive) |
+| **View events** | `asset_view_events` (last ~7 days) | Public | Postgres + cold-tier per-day archives at [Coherence-Network releases](https://github.com/seeker71/Coherence-Network/releases) tagged `archive-view-events-*` |
+| **Graph state** | Neo4j (contributors, assets, concepts, edges) | Public | Same nightly postgres dump captures the relational mirror |
+
+There is no separate private version. The dumps shipped to the public archive each night are byte-perfect mirrors of the live database. Anyone can verify their own contribution is preserved exactly as recorded, audit attribution chains across days, or stand up a fresh instance of the network from any past dump.
+
+## What you implicitly agree to by participating
+
+When you contribute (a commit, a presence, a refinement, a view event), the following becomes part of the public body of evidence:
+
+1. **The action itself** — what changed, what was contributed, what frequency was emitted.
+2. **Attribution** — your `contributor_id`, the timestamp, the asset/concept/edge that was touched, and the coherence-weighted attention reward (if any).
+3. **Behavioural shape** — the daily rollup of which surfaces you visited (asset views, concept reads). Per-event detail (referrer, session fingerprint, page route) lives in the per-day cold-tier archive for as long as the archive is preserved, which is intended to be indefinitely.
+4. **Lineage edges** — anyone you've referred, anyone you've credited as inspiration, anyone whose contribution your work cites.
+
+Two things the network deliberately doesn't keep:
+
+- **No tracking cookies, no third-party fingerprints, no cross-site tracking.** The session fingerprint is a per-tab UUID generated locally; it never leaves the network's first-party context.
+- **No location, no device specifics, no IP-based geolocation.** The view events carry only the page route, not the visitor's environment.
+
+## How to be removed (the opt-out path)
+
+Public-by-default doesn't mean public-forever-no-matter-what. If your situation has changed since you started contributing — a privacy concern, a dispute, a right-to-be-forgotten request, anything we couldn't anticipate at arrival — the network honours the redaction request through this procedure:
+
+### 1. Open a private channel
+
+Email `umuff71@gmail.com` (network maintainer) with subject "opt-out request" and your `contributor_id`. We confirm the request before acting; nobody else gets to opt out on your behalf.
+
+### 2. The redaction is run
+
+[`scripts/opt_out_contributor.py`](../../scripts/opt_out_contributor.py) is the lever. It performs four passes:
+
+- **Hot tier** — `UPDATE asset_view_events SET contributor_id=NULL, session_fingerprint=NULL, source_page=NULL, referrer_contributor_id=NULL` for every row tied to the contributor. The events stay (the network preserves the *shape* of attention) but the *who* is removed.
+- **Contribution ledger** — `UPDATE contribution_ledger SET contributor_id='contributor:redacted'` for every row tied to the contributor. The ledger keeps WHAT happened; WHO is anonymised.
+- **Cold-tier per-day archives** — for every archived day that contains the contributor, the gzipped JSONL is downloaded, the same anonymisation is applied to each event in-place, the file is re-gzipped, the SHA-256 is recomputed, and the asset is re-uploaded under the same tag + filename (the deterministic URL stays valid; only the SHA changes). The tombstone in the live DB is updated in lockstep so retrievers always verify against the current archive content.
+- **Audit log** — a JSONL record of what was done is written to `/var/lib/coherence-network/opt-outs.log` for compliance review (kept private; never shipped to the public archive).
+
+The same script supports `--dry-run` so you can see exactly what would change before any commit.
+
+### 3. The honest scope
+
+These are the limits of what an opt-out can guarantee, named directly:
+
+- **Past third-party mirrors are out of reach.** Anyone who downloaded a cold-tier archive before the rewrite has the old SHA-256 on their disk. The network's surfaces (live DB, current cold-tier archives, future dumps) reflect the redaction; mirrors elsewhere don't.
+- **Past postgres dumps in the public archive aren't rewritten.** Each nightly dump is a monolithic snapshot; rewriting them retroactively would invalidate every prior cryptographic verification. From the moment of opt-out, every new nightly dump reflects the redacted DB; older dumps in the archive are immutable.
+- **Aggregate counts persist.** The sentinel `contributor:redacted` keeps the ledger's aggregate-counter behaviour intact (the network can still see "N contributions came from redacted cells") without exposing who. If you need stronger removal, say so in your request; we'll discuss what's possible at the substrate level.
+
+The opt-out is **forward-looking and current-state effective**. It honours the request without pretending the substrate has powers it doesn't have.
+
+## Verification
+
+If you ever want to verify what the network holds about you:
+
+- **Live state**: `GET /api/contributions?contributor_id=contributor:...` returns your contribution ledger.
+- **View trail**: `GET /api/views/trail/contributor:...` returns the concepts and assets you've touched.
+- **Cold-tier**: `GET /api/views/archive` lists every archived day with SHA-256; `GET /api/views/archive/{day}` retrieves and verifies a specific day.
+- **Postgres dump**: any release on [coherence-network-archive](https://github.com/seeker71/coherence-network-archive) is downloadable and contains the full DB state at that snapshot time.
+
+Each of these can be cross-referenced against the others. If any single substrate's view of you contradicts another, that's a signal worth raising — the network's posture is that all four should agree.
+
+## Why this document exists
+
+The first time someone asks for an opt-out, the network's response should be a well-rehearsed clean operation, not a credibility crisis. This page exists so the procedure is visible *before* it's needed, and so the conviction that backs it ("public-by-default with explicit, narrow opt-out paths") is on the record from the start rather than retrofitted later.
+
+The opt-out lever has been built and exercised on a synthetic test contributor; the procedure is documented; the audit log path is set up. When the first real request lands, the body responds at the speed of the request, not at the speed of building.

--- a/scripts/opt_out_contributor.py
+++ b/scripts/opt_out_contributor.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Honour a contributor's opt-out across the network's body of evidence.
+
+The Coherence Network's posture is public-by-default — contributions,
+attribution, view events, postgres dumps live in the open as the
+substrate for sovereign-transparent attribution. Most contributors
+arrive knowing this and want their participation visible.
+
+This script is the lever for the case where a contributor genuinely
+needs their data redacted from the body of evidence — a privacy
+concern that emerged after joining, a dispute, a right-to-be-
+forgotten request, anything we couldn't anticipate at arrival.
+
+What it touches, in order:
+
+  1. **Hot tier (asset_view_events)** — UPDATE rows tied to the
+     contributor: contributor_id → NULL, session_fingerprint → NULL,
+     source_page → NULL, referrer_contributor_id → NULL. The events
+     stay (the network preserves the *shape* of attention) but the
+     *who* is removed.
+
+  2. **Contribution ledger (contribution_ledger)** — UPDATE rows
+     tied to the contributor: contributor_id → "contributor:redacted".
+     The ledger keeps WHAT happened; WHO is anonymised. (NULL isn't
+     valid for the ledger's contributor_id column; the sentinel
+     preserves shape without pretending no one was there.)
+
+  3. **Cold tier (per-day archives)** — for each archived day that
+     contains the contributor, download the gzipped JSONL, apply the
+     same anonymisation transform to each event, re-gzip, recompute
+     SHA-256, re-upload (same tag + filename so the deterministic URL
+     stays valid), and update the tombstone in lockstep.
+
+  4. **Audit log** — append a JSONL record to
+     /var/lib/coherence-network/opt-outs.log capturing what was done,
+     when, and what content the redacted contributor data had at the
+     moment of redaction (kept for compliance review only — never
+     shipped to the public archive).
+
+Honest properties of this opt-out:
+
+  · **Past third-party mirrors** can't be unwound. Anyone who
+    downloaded a cold-tier archive before the rewrite has the old
+    SHA on their disk. The opt-out is forward-looking from here.
+  · **Past postgres dumps** in the public archive aren't rewritten
+    by this script — those are monolithic snapshots and rewriting
+    them retroactively would invalidate every prior verification.
+    Going forward, every new nightly dump reflects the redacted DB.
+  · **Sentinel contributor:redacted** preserves the ledger's
+    aggregate-counter behaviour (the network can still see "N
+    contributions came from redacted cells") without exposing who.
+
+Usage:
+
+    # Dry-run — see what would change without touching anything
+    python3 scripts/opt_out_contributor.py \\
+        --contributor-id contributor:abc123 --dry-run
+
+    # Apply — perform the redaction across hot + cold + ledger + audit
+    python3 scripts/opt_out_contributor.py \\
+        --contributor-id contributor:abc123 --apply
+
+    # On VPS, inside the api container (which has gh + auth):
+    docker compose exec -T api python3 /tmp/opt_out_contributor.py \\
+        --contributor-id contributor:abc123 --apply
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+API_ROOT = os.path.join(REPO_ROOT, "api")
+if API_ROOT not in sys.path:
+    sys.path.insert(0, API_ROOT)
+
+from sqlalchemy import or_  # noqa: E402
+
+log = logging.getLogger("opt_out_contributor")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+REDACTED_SENTINEL = "contributor:redacted"
+AUDIT_LOG_PATH = Path(
+    os.environ.get(
+        "COHERENCE_OPTOUT_AUDIT_LOG",
+        "/var/lib/coherence-network/opt-outs.log",
+    )
+)
+
+
+def _human(n: int) -> str:
+    if n < 1_000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n / 1_000:.1f}k"
+    return f"{n / 1_000_000:.2f}M"
+
+
+# ---------------------------------------------------------------------------
+# Hot tier — asset_view_events
+# ---------------------------------------------------------------------------
+
+def count_hot_events(contributor_id: str) -> dict:
+    from app.services.unified_db import session, ensure_schema
+    from app.services.read_tracking_service import AssetViewEvent
+    ensure_schema()
+    with session() as s:
+        as_contributor = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.contributor_id == contributor_id)
+            .count()
+        )
+        as_referrer = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.referrer_contributor_id == contributor_id)
+            .count()
+        )
+    return {"as_contributor": as_contributor, "as_referrer": as_referrer}
+
+
+def anonymize_hot_events(contributor_id: str, *, apply: bool) -> int:
+    from app.services.unified_db import session, ensure_schema
+    from app.services.read_tracking_service import AssetViewEvent
+    ensure_schema()
+    if not apply:
+        return 0
+    with session() as s:
+        n_c = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.contributor_id == contributor_id)
+            .update(
+                {
+                    AssetViewEvent.contributor_id: None,
+                    AssetViewEvent.session_fingerprint: None,
+                    AssetViewEvent.source_page: None,
+                },
+                synchronize_session=False,
+            )
+        )
+        n_r = (
+            s.query(AssetViewEvent)
+            .filter(AssetViewEvent.referrer_contributor_id == contributor_id)
+            .update(
+                {AssetViewEvent.referrer_contributor_id: None},
+                synchronize_session=False,
+            )
+        )
+        s.commit()
+    return (n_c or 0) + (n_r or 0)
+
+
+# ---------------------------------------------------------------------------
+# Ledger — contribution_ledger (sentinel-redact, NULL not allowed)
+# ---------------------------------------------------------------------------
+
+def count_ledger_rows(contributor_id: str) -> int:
+    from app.services.unified_db import session, ensure_schema
+    from app.services.contribution_ledger_service import ContributionLedgerRecord
+    ensure_schema()
+    with session() as s:
+        return (
+            s.query(ContributionLedgerRecord)
+            .filter(ContributionLedgerRecord.contributor_id == contributor_id)
+            .count()
+        )
+
+
+def redact_ledger_rows(contributor_id: str, *, apply: bool) -> int:
+    from app.services.unified_db import session, ensure_schema
+    from app.services.contribution_ledger_service import ContributionLedgerRecord
+    ensure_schema()
+    if not apply:
+        return 0
+    with session() as s:
+        n = (
+            s.query(ContributionLedgerRecord)
+            .filter(ContributionLedgerRecord.contributor_id == contributor_id)
+            .update(
+                {ContributionLedgerRecord.contributor_id: REDACTED_SENTINEL},
+                synchronize_session=False,
+            )
+        )
+        s.commit()
+    return n or 0
+
+
+# ---------------------------------------------------------------------------
+# Cold tier — rewrite per-day archives
+# ---------------------------------------------------------------------------
+
+def _make_event_transform(contributor_id: str):
+    """Return a closure that anonymises events tied to the contributor.
+    Returns the redacted event (not None) so the row count stays
+    stable — the network preserves that *something* happened that
+    day, just not who."""
+    def transform(ev: dict) -> dict:
+        touched = False
+        if ev.get("contributor_id") == contributor_id:
+            ev = {**ev,
+                  "contributor_id": None,
+                  "session_fingerprint": None,
+                  "source_page": None}
+            touched = True
+        if ev.get("referrer_contributor_id") == contributor_id:
+            ev = {**ev, "referrer_contributor_id": None}
+            touched = True
+        return ev if not touched else ev  # event is rewritten in place above
+    return transform
+
+
+def find_archived_days_with_contributor(contributor_id: str) -> list:
+    """Walk every tombstone, fetch its archive, return the days that
+    contain the contributor. Cached locally so re-walks are cheap."""
+    from app.services import view_events_archive_service as vea
+    days = vea.list_archived_days()
+    affected = []
+    for d in days:
+        result = vea.retrieve_day(d)
+        if not result.get("fetched"):
+            log.warning("  could not inspect archive for %s: %s", d, result.get("error"))
+            continue
+        events = result.get("events", [])
+        hit = any(
+            ev.get("contributor_id") == contributor_id
+            or ev.get("referrer_contributor_id") == contributor_id
+            for ev in events
+        )
+        if hit:
+            affected.append(d)
+    return affected
+
+
+def rewrite_cold_tier(contributor_id: str, *, apply: bool, repo: str) -> list:
+    from app.services import view_events_archive_service as vea
+    affected = find_archived_days_with_contributor(contributor_id)
+    log.info("  cold-tier days touched: %s", len(affected))
+    if not apply:
+        for d in affected:
+            log.info("    (dry-run) would rewrite %s", d)
+        return [{"day": str(d), "rewritten": False, "reason": "dry-run"} for d in affected]
+
+    transform = _make_event_transform(contributor_id)
+    summaries = []
+    for d in affected:
+        summary = vea.rewrite_archived_day(
+            d,
+            transform=transform,
+            repo=repo,
+            notes=(
+                f"Opt-out redaction at {datetime.now(timezone.utc).isoformat()} — "
+                f"events tied to a contributor were anonymised. The day's row "
+                f"count is preserved; identifying fields are NULL on those rows."
+            ),
+        )
+        log.info("    rewrote %s: %s", d, summary)
+        summaries.append(summary)
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+def record_audit(contributor_id: str, summary: dict) -> None:
+    try:
+        AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        rec = {
+            "at": datetime.now(timezone.utc).isoformat(),
+            "contributor_id": contributor_id,
+            "summary": summary,
+        }
+        with AUDIT_LOG_PATH.open("a") as f:
+            f.write(json.dumps(rec, default=str) + "\n")
+        log.info("  audit logged → %s", AUDIT_LOG_PATH)
+    except OSError as e:
+        log.warning("  audit log write failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def run(contributor_id: str, *, apply: bool, repo: str) -> dict:
+    log.info("=== opt-out · contributor=%s · mode=%s ===",
+             contributor_id, "APPLY" if apply else "DRY-RUN")
+
+    log.info("\n[1/3] hot tier · asset_view_events")
+    counts = count_hot_events(contributor_id)
+    log.info("  rows where contributor_id matches:        %s", counts["as_contributor"])
+    log.info("  rows where referrer_contributor_id match: %s", counts["as_referrer"])
+    hot_anonymized = anonymize_hot_events(contributor_id, apply=apply)
+    if apply:
+        log.info("  ✓ %s rows anonymised in hot tier", hot_anonymized)
+
+    log.info("\n[2/3] contribution_ledger")
+    ledger_count = count_ledger_rows(contributor_id)
+    log.info("  ledger rows tied to contributor: %s", ledger_count)
+    ledger_redacted = redact_ledger_rows(contributor_id, apply=apply)
+    if apply:
+        log.info("  ✓ %s ledger rows redacted (contributor_id → %s)",
+                 ledger_redacted, REDACTED_SENTINEL)
+
+    log.info("\n[3/3] cold-tier archives")
+    cold_summaries = rewrite_cold_tier(contributor_id, apply=apply, repo=repo)
+
+    summary = {
+        "contributor_id": contributor_id,
+        "applied": apply,
+        "hot_tier": counts,
+        "hot_tier_anonymized": hot_anonymized,
+        "ledger_count": ledger_count,
+        "ledger_redacted": ledger_redacted,
+        "cold_tier": cold_summaries,
+    }
+
+    if apply:
+        record_audit(contributor_id, summary)
+
+    log.info("\n=== summary ===")
+    log.info("  hot-tier rows touched:    %s",
+             counts["as_contributor"] + counts["as_referrer"])
+    log.info("  ledger rows touched:      %s", ledger_count)
+    log.info("  cold-tier days affected:  %s", len(cold_summaries))
+    if not apply:
+        log.info("\n(dry-run) re-run with --apply to commit. body waits.")
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--contributor-id", required=True,
+                   help="The contributor id to opt out (e.g. contributor:abc123).")
+    p.add_argument("--apply", action="store_true",
+                   help="Commit redactions. Without this, run is read-only.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report only — explicit alias for the default behaviour.")
+    p.add_argument("--repo", default=os.environ.get(
+        "COHERENCE_ARCHIVE_REPO", "seeker71/Coherence-Network"),
+                   help="GitHub repo where cold-tier archives live.")
+    args = p.parse_args(argv)
+
+    apply = args.apply and not args.dry_run
+
+    if apply and not args.contributor_id.startswith("contributor:"):
+        log.error("Refusing to apply: contributor-id must start with 'contributor:'")
+        return 2
+
+    run(args.contributor_id, apply=apply, repo=args.repo)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/app/begin/page.tsx
+++ b/web/app/begin/page.tsx
@@ -279,6 +279,53 @@ export default function BeginPage() {
           </div>
         ) : null}
 
+        {/* Public-posture disclosure — the network's body of evidence
+            is public-by-default. Contributors arrive knowing this, so
+            the choice to participate is informed rather than discovered.
+            The opt-out path is named directly so anyone uncomfortable
+            with public attribution can pause here, before joining. */}
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 leading-relaxed space-y-2">
+          <p className="font-medium text-amber-300">
+            What joining the network means
+          </p>
+          <p>
+            The Coherence Network is{" "}
+            <strong>public-by-default</strong>. Your contribution id,
+            attribution, the surfaces you visit, and the lineage edges
+            you create become part of an open body of evidence.
+            Nightly database dumps mirror to a public archive at{" "}
+            <Link
+              href="https://github.com/seeker71/coherence-network-archive"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-400 hover:text-amber-300 underline-offset-4 hover:underline"
+            >
+              coherence-network-archive
+            </Link>
+            ; per-day view-event archives sit on the main repo's
+            releases. The substrate matches the conviction —
+            sovereign-transparent attribution, no hidden state.
+          </p>
+          <p>
+            What we don't keep: tracking cookies, third-party
+            fingerprints, IP-based geolocation, device specifics. The
+            session id is a per-tab UUID local to the network.
+          </p>
+          <p>
+            If your situation ever changes, the network honours an
+            opt-out request — see{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-400 hover:text-amber-300 underline-offset-4 hover:underline"
+            >
+              docs/transparency
+            </Link>
+            {" "}for what's redactable, what isn't, and the procedure.
+          </p>
+        </div>
+
         <div className="flex items-center gap-4">
           <button
             type="submit"


### PR DESCRIPTION
Public-by-default with explicit, narrow opt-out paths. Lever + doc + arrival disclosure all in one breath, so the first opt-out request gets a clean operation instead of a scramble.

- `scripts/opt_out_contributor.py` — hot-tier UPDATE + ledger sentinel-redact + cold-tier rewrite (download → anonymize → re-gzip → re-upload → update tombstone) + audit log
- `docs/transparency/README.md` — public-facing doc with what we keep, what's redactable, and the procedure end-to-end
- `web/app/begin/page.tsx` — public-posture disclosure on the arrival flow above the submit button
- `view_events_archive_service.py` — `rewrite_archived_day(transform=...)` for per-event anonymisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)