### PR TITLE
fix: make memory-as-framebuffer cells visibly bright

### DIFF
--- a/experiments/memory-as-framebuffer-v0/README.md
+++ b/experiments/memory-as-framebuffer-v0/README.md
@@ -24,18 +24,30 @@ This produces `fizzbuzz.mp4` in the crate directory (~30 seconds, 1024×1024,
 
 ## What you'll see
 
+The fizzbuzz example only allocates 100 cells out of the 65,536-cell heap.
+With deterministic next-free-slot allocation, those 100 cells live at
+indices 0..99 — which on the 256×256 grid is **the very top row** at
+y ∈ [0, 4) px. So you're looking at a thin **400×4 px lit strip** along
+the top edge of the 1024×1024 frame, with the rest correctly black
+(free cells render as black). LOD-zoom — the v1-3d sibling spec — is the
+proper UX answer for "show me where the activity actually is"; v0
+renders the heap honestly at fixed 1:1 scale.
+
+What's happening in that strip:
+
 - **Cell 0** (top-left, single 4×4 px block): the current `i` (1..=10000).
-  Its inner color is the `u32` palette entry; brightness pulses with the
-  payload's nonzero-byte count.
-- **Cells 1..99** (the rest of the top row): the rolling fizz/buzz history.
-  As the loop runs, tag values shift down the strip: `1=plain`, `2=fizz`,
-  `3=buzz`, `4=fizzbuzz`. Inner color is the same palette entry (all `u32`),
-  but brightness varies with the value.
-- **Halos** (outer ring of every 4×4 block): the provenance hash. The four
-  branches of the fizzbuzz `match` (`write_plain`, `write_fizz`, `write_buzz`,
-  `write_fizzbuzz`) each live at a distinct `file:line`, so each branch's
-  halo color is distinct. You should see the strip's halos shimmer between
-  four colors as the loop progresses.
+  Inner color is the `u32` palette entry, modulated within a 0.7..1.0
+  brightness range so it stays clearly visible at any value; a CRC-driven
+  channel offset gives value-change flicker.
+- **Cells 1..99** (the rest of the top strip): the rolling fizz/buzz
+  history. As the loop runs, tag values shift down the strip: `1=plain`,
+  `2=fizz`, `3=buzz`, `4=fizzbuzz`. Inner color is the same palette entry
+  (all `u32`); the CRC-driven flicker per-value gives a perceptible drift.
+- **Halos** (outer ring of every 4×4 block): the provenance hash. The
+  four branches of the fizzbuzz `match` (`write_plain`, `write_fizz`,
+  `write_buzz`, `write_fizzbuzz`) each live at a distinct `file:line`, so
+  each branch's halo color is distinct. You should see the strip's halos
+  shimmer between four colors as the loop progresses.
 
 ## Tests
 

--- a/experiments/memory-as-framebuffer-v0/src/render.rs
+++ b/experiments/memory-as-framebuffer-v0/src/render.rs
@@ -121,15 +121,31 @@ fn pointer_halo_pair(kind: PointerKind, prov: u32) -> ([u8; 3], [u8; 3]) {
     }
 }
 
-/// Modulate a base RGB by payload entropy. More nonzero bytes = brighter,
-/// all zeros = dim (15% of base).
+/// Modulate a base RGB by payload content. Cells must be visibly bright at
+/// any nonzero value (the heap is meant to be *seen*); within that floor,
+/// payload content drives a hue/value flicker so the eye perceives change.
+///
+/// Brightness floor is 0.7 of the base palette so even a single-byte value
+/// (e.g. `u32 = 1` with payload [1,0,0,...]) renders as a clearly-lit cell
+/// rather than a near-black smudge. A small CRC-driven channel offset
+/// (±25 per channel, anti-correlated across R/B) makes adjacent values
+/// distinguishable as they change.
 pub fn modulate_brightness(base: [u8; 3], payload: &[u8; 14]) -> [u8; 3] {
     let nonzero = payload.iter().filter(|b| **b != 0).count() as f32;
-    let factor = 0.15 + (nonzero / 14.0) * 0.85;
+    let factor = 0.7 + (nonzero / 14.0) * 0.3;
+
+    // Payload-driven channel offset for value-change flicker.
+    let h = crc32fast::hash(payload);
+    let offset = ((h % 51) as i16) - 25; // -25..=25
+
+    let r = (base[0] as f32 * factor) as i16 + offset;
+    let g = (base[1] as f32 * factor) as i16;
+    let b = (base[2] as f32 * factor) as i16 - offset;
+
     [
-        ((base[0] as f32) * factor) as u8,
-        ((base[1] as f32) * factor) as u8,
-        ((base[2] as f32) * factor) as u8,
+        r.clamp(0, 255) as u8,
+        g.clamp(0, 255) as u8,
+        b.clamp(0, 255) as u8,
     ]
 }
 
@@ -271,5 +287,56 @@ mod tests {
         let i = (1 * RENDER_W + 1) * 4;
         let r = frame[i];
         assert!(r > 100, "expected bright red channel, got {}", r);
+    }
+
+    #[test]
+    fn small_value_cell_is_still_visibly_bright() {
+        // A u32 with value 1 (payload = [1, 0, 0, 0, 0...]) is the dimmest realistic
+        // fizzbuzz value — only one byte nonzero. It MUST render visibly bright,
+        // otherwise the demo looks like an all-black frame to the eye.
+        let mut data = vec![0u8; NUM_CELLS * CELL_BYTES];
+        // Cell 0: tag = TAG_U32 (0x0003), payload = [1, 0, 0, ..., 0]
+        data[0] = 0x03;
+        data[1] = 0x00;
+        data[2] = 0x01;
+        // bytes 3..15 stay 0
+        let prov = vec![0u32; NUM_CELLS];
+        let frame = render_frame(&data, &prov);
+        // Inner pixel of cell 0 = (1,1).
+        let i = (1 * RENDER_W + 1) * 4;
+        let max_channel = frame[i].max(frame[i + 1]).max(frame[i + 2]);
+        assert!(
+            max_channel > 100,
+            "u32(1) inner pixel must be visibly bright; got max channel {} (RGB={:?})",
+            max_channel,
+            (frame[i], frame[i + 1], frame[i + 2])
+        );
+    }
+
+    #[test]
+    fn distinct_payloads_render_distinguishable_colors() {
+        // Two u32 cells with values 1 vs 2 should produce visibly different colors
+        // (CRC-driven flicker), so changing values are perceptible across frames.
+        let mut data = vec![0u8; NUM_CELLS * CELL_BYTES];
+        // Cell 0: u32 = 1
+        data[0] = 0x03;
+        data[2] = 0x01;
+        // Cell 1: u32 = 2
+        data[CELL_BYTES] = 0x03;
+        data[CELL_BYTES + 2] = 0x02;
+        let prov = vec![0u32; NUM_CELLS];
+        let frame = render_frame(&data, &prov);
+        // Inner pixels of cells 0 and 1 (cells 0 at x=1,y=1; cell 1 at x=5,y=1)
+        let i0 = (1 * RENDER_W + 1) * 4;
+        let i1 = (1 * RENDER_W + 5) * 4;
+        let dr = (frame[i0] as i16 - frame[i1] as i16).abs();
+        let db = (frame[i0 + 2] as i16 - frame[i1 + 2] as i16).abs();
+        assert!(
+            dr + db > 5,
+            "u32(1) and u32(2) must render distinguishable colors; \
+             got cell0 RGB=({},{},{}) cell1 RGB=({},{},{})",
+            frame[i0], frame[i0 + 1], frame[i0 + 2],
+            frame[i1], frame[i1 + 1], frame[i1 + 2]
+        );
     }
 }

--- a/experiments/memory-as-framebuffer-v0/tests/smoke.rs
+++ b/experiments/memory-as-framebuffer-v0/tests/smoke.rs
@@ -60,16 +60,39 @@ fn fizzbuzz_produces_watchable_mp4() {
     // Find at least two pixels with distinct RGB values.
     let mut first: Option<[u8; 3]> = None;
     let mut found_distinct = false;
-    'outer: for px in img.pixels() {
+    let mut max_channel: u8 = 0;
+    let mut bright_pixels: usize = 0;
+    for px in img.pixels() {
         let rgb = [px.0[0], px.0[1], px.0[2]];
         match first {
             None => first = Some(rgb),
             Some(prev) if prev != rgb => {
                 found_distinct = true;
-                break 'outer;
             }
             _ => {}
         }
+        let m = rgb[0].max(rgb[1]).max(rgb[2]);
+        if m > max_channel {
+            max_channel = m;
+        }
+        if m > 80 {
+            bright_pixels += 1;
+        }
     }
     assert!(found_distinct, "first frame is uniform; renderer not producing color variance");
+
+    // Visibility floor: the heap must actually be visible to a human, not just
+    // technically non-uniform. Without these assertions the v0 demo can ship
+    // a frame that passes pixel-distinctness while being indistinguishable
+    // from black to the eye.
+    assert!(
+        max_channel > 100,
+        "first frame's brightest pixel max channel = {}; the heap must be visibly lit",
+        max_channel
+    );
+    assert!(
+        bright_pixels > 50,
+        "only {} pixels with max channel > 80; the heap region is too dim or too small to see",
+        bright_pixels
+    );
 }


### PR DESCRIPTION
## Summary

Black-frames bug: the entropy-based brightness modulation in v0's renderer produced factor 0.21 for typical fizzbuzz values (a `u32` with one nonzero byte), multiplying the palette into near-black colors. Combined with the cells clustering in a thin top strip (100 cells × 4×4 px = 0.15% of the 1024×1024 frame), the rendered videos were visually indistinguishable from black even though pixel data technically varied.

## Diagnosis (empirical)

| | Before | After |
|---|---|---|
| max channel anywhere in frame | 138 | 239 |
| top-strip max RGB | (119, 75, 33) — dim olive | (239, 126, 110) — visible salmon |
| top-strip avg max-channel | 33/255 (13%) | 72/255 (28%) |
| pixels with max channel > 80 | ~30 | 1598 |

The smoke test was too weak — it asserted only \"two pixels have distinct RGB values,\" which passes when one near-black pixel sits next to many true-black pixels.

## Changes

- **`src/render.rs::modulate_brightness`** — brightness floor 0.7 (was 0.15); add CRC-driven ±25 per-channel offset so value-changes are visible as flicker rather than indistinguishable
- **`src/render.rs` tests** — `small_value_cell_is_still_visibly_bright` asserts a `u32(1)` cell has max channel > 100; `distinct_payloads_render_distinguishable_colors` asserts adjacent values render differently
- **`tests/smoke.rs`** — assert max channel > 100 anywhere in the frame and ≥ 50 pixels with max channel > 80, in addition to pixel-distinctness
- **`README.md`** — document the v0 reality: cells appear in a thin top strip because deterministic next-free-slot allocation puts the 100 fizzbuzz cells at indices 0..99 (grid row y=0); the proper UX answer for \"show me where the activity is\" is v1-3d's LOD zoom; v0 renders the heap honestly at 1:1 scale

## Test plan

- [x] \`cargo test --release\` passes — 5 pointer-smoke + 4 lib (incl. 2 new visibility tests) + 1 smoke
- [x] \`cargo run --release --example fizzbuzz\` → fizzbuzz.mp4 with max channel 239, 1598 bright pixels
- [x] \`cargo run --release --example linked_list\` → linked_list.mp4 with max channel 228, 424 bright pixels
- [x] \`cargo run --release --example binary_tree\` → binary_tree.mp4 with max channel 239, 327 bright pixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)