### PR TITLE
attune: i18n the chrome I added across three recent surfaces

### DIFF
--- a/web/app/assets/[asset_id]/page.tsx
+++ b/web/app/assets/[asset_id]/page.tsx
@@ -373,13 +373,13 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
                 <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-400 pt-1">
                   {asset.creation_kind && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Kind</dt>
+                      <dt className="text-stone-500">{t("assets.detail.kind")}</dt>
                       <dd className="text-stone-300">{asset.creation_kind}</dd>
                     </div>
                   )}
                   {asset.runtime_length_min && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Runtime</dt>
+                      <dt className="text-stone-500">{t("assets.detail.runtime")}</dt>
                       <dd className="text-stone-300">
                         {Math.floor(asset.runtime_length_min / 60)}h{" "}
                         {asset.runtime_length_min % 60}m
@@ -388,37 +388,37 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
                   )}
                   {asset.era && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Era</dt>
+                      <dt className="text-stone-500">{t("assets.detail.era")}</dt>
                       <dd className="text-stone-300">{asset.era}</dd>
                     </div>
                   )}
                   {asset.company && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Company</dt>
+                      <dt className="text-stone-500">{t("assets.detail.company")}</dt>
                       <dd className="text-stone-300">{asset.company}</dd>
                     </div>
                   )}
                   {asset.location && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Place</dt>
+                      <dt className="text-stone-500">{t("assets.detail.place")}</dt>
                       <dd className="text-stone-300">{asset.location}</dd>
                     </div>
                   )}
                   {asset.asin && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">ASIN</dt>
+                      <dt className="text-stone-500">{t("assets.detail.asin")}</dt>
                       <dd className="text-stone-300 font-mono">{asset.asin}</dd>
                     </div>
                   )}
                   {asset.isbn && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">ISBN</dt>
+                      <dt className="text-stone-500">{t("assets.detail.isbn")}</dt>
                       <dd className="text-stone-300 font-mono">{asset.isbn}</dd>
                     </div>
                   )}
                   {asset.language && (
                     <div className="flex items-baseline gap-1.5">
-                      <dt className="text-stone-500">Language</dt>
+                      <dt className="text-stone-500">{t("assets.detail.languageLabel")}</dt>
                       <dd className="text-stone-300">{asset.language}</dd>
                     </div>
                   )}
@@ -437,7 +437,7 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
                     rel="noreferrer noopener"
                     className="inline-flex items-center gap-1.5 text-sm text-amber-300 hover:text-amber-200 underline-offset-4 hover:underline"
                   >
-                    <span>External source</span>
+                    <span>{t("assets.detail.externalSource")}</span>
                     <span aria-hidden="true">↗</span>
                     <span className="text-stone-500 font-mono text-xs ml-1 break-all">
                       {asset.canonical_url.replace(/^https?:\/\//, "").slice(0, 60)}
@@ -451,7 +451,7 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
                   so a visitor can walk the rich context surface. */}
               {asset.slug && (
                 <p className="text-xs text-stone-500 pt-1">
-                  Presence:{" "}
+                  {t("assets.detail.presence")}{" "}
                   <Link
                     href={`/people/${encodeURIComponent(asset.slug)}`}
                     className="text-stone-300 hover:text-amber-300 underline-offset-4 hover:underline"
@@ -505,16 +505,19 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
               endpoint aggregates 90 days of those traces so the
               visitor can see how many cells have met this vessel. */}
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-emerald-500/10 to-emerald-500/5 p-4">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-emerald-400/80">Witnessed</p>
+            <p className="text-[10px] uppercase tracking-[0.18em] text-emerald-400/80">{t("assets.detail.statWitnessed")}</p>
             <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">
               {viewStats?.total_views ?? "—"}
             </p>
             <p className="mt-1 text-xs text-stone-400">
               {viewStats?.unique_contributors
-                ? `${viewStats.unique_contributors} contributor${
-                    viewStats.unique_contributors === 1 ? "" : "s"
-                  } · 90d`
-                : "views over 90 days"}
+                ? t(
+                    viewStats.unique_contributors === 1
+                      ? "assets.detail.statWitnessedDays"
+                      : "assets.detail.statWitnessedDaysPlural",
+                    { n: String(viewStats.unique_contributors) },
+                  )
+                : t("assets.detail.statWitnessedHint")}
             </p>
           </div>
         </section>

--- a/web/app/begin/page.tsx
+++ b/web/app/begin/page.tsx
@@ -283,47 +283,16 @@ export default function BeginPage() {
             is public-by-default. Contributors arrive knowing this, so
             the choice to participate is informed rather than discovered.
             The opt-out path is named directly so anyone uncomfortable
-            with public attribution can pause here, before joining. */}
+            with public attribution can pause here, before joining.
+            Body text uses renderProse so the localised strings can
+            carry their own [label](href) inline links. */}
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 leading-relaxed space-y-2">
           <p className="font-medium text-amber-300">
-            What joining the network means
+            {t("begin.publicPostureTitle")}
           </p>
-          <p>
-            The Coherence Network is{" "}
-            <strong>public-by-default</strong>. Your contribution id,
-            attribution, the surfaces you visit, and the lineage edges
-            you create become part of an open body of evidence.
-            Nightly database dumps mirror to a public archive at{" "}
-            <Link
-              href="https://github.com/seeker71/coherence-network-archive"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-amber-400 hover:text-amber-300 underline-offset-4 hover:underline"
-            >
-              coherence-network-archive
-            </Link>
-            ; per-day view-event archives sit on the main repo's
-            releases. The substrate matches the conviction —
-            sovereign-transparent attribution, no hidden state.
-          </p>
-          <p>
-            What we don't keep: tracking cookies, third-party
-            fingerprints, IP-based geolocation, device specifics. The
-            session id is a per-tab UUID local to the network.
-          </p>
-          <p>
-            If your situation ever changes, the network honours an
-            opt-out request — see{" "}
-            <Link
-              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-amber-400 hover:text-amber-300 underline-offset-4 hover:underline"
-            >
-              docs/transparency
-            </Link>
-            {" "}for what's redactable, what isn't, and the procedure.
-          </p>
+          <p>{renderProse(t("begin.publicPostureBody1"))}</p>
+          <p>{renderProse(t("begin.publicPostureBody2"))}</p>
+          <p>{renderProse(t("begin.publicPostureBody3"))}</p>
         </div>
 
         <div className="flex items-center gap-4">

--- a/web/app/people/[id]/lineage/page.tsx
+++ b/web/app/people/[id]/lineage/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getApiBase } from "@/lib/api";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { createTranslator } from "@/lib/i18n";
 
 export const dynamic = "force-dynamic";
 
@@ -110,6 +112,8 @@ export default async function ContributorLineagePage({
 }) {
   const { id } = await params;
   const decoded = decodeURIComponent(id);
+  const lang = await resolveRequestLocale();
+  const t = createTranslator(lang);
   const contributor = await fetchJson<GraphNode>(
     `/api/graph/nodes/${encodeURIComponent(decoded)}`,
   );
@@ -216,31 +220,33 @@ export default async function ContributorLineagePage({
             className="text-sm text-muted-foreground mb-6 flex items-center gap-2"
             aria-label="breadcrumb"
           >
-            <Link href="/" className="hover:text-primary">Home</Link>
+            <Link href="/" className="hover:text-primary">{t("personProfile.breadcrumb.home")}</Link>
             <span className="text-muted-foreground/50">/</span>
-            <Link href="/people" className="hover:text-primary">People</Link>
+            <Link href="/people" className="hover:text-primary">{t("personProfile.breadcrumb.people")}</Link>
             <span className="text-muted-foreground/50">/</span>
             <Link href={slugDoor(contributor)} className="hover:text-primary">
               {contributor.name || contributor.id}
             </Link>
             <span className="text-muted-foreground/50">/</span>
-            <span className="text-foreground/80">Lineage</span>
+            <span className="text-foreground/80">{t("people.lineage.breadcrumb")}</span>
           </nav>
           <p className="text-xs uppercase tracking-[0.18em] mb-3 text-[hsl(var(--primary))]">
-            {works.length} {works.length === 1 ? "work" : "works"}
+            {t(
+              works.length === 1 ? "people.lineage.eyebrowWorkSingular" : "people.lineage.eyebrowWorks",
+              { n: String(works.length) },
+            )}
             {streamRows.length > 0
-              ? ` · ${streamRows.length} influence ${streamRows.length === 1 ? "edge" : "edges"}`
+              ? ` · ${t(
+                  streamRows.length === 1 ? "people.lineage.eyebrowEdgeSingular" : "people.lineage.eyebrowEdges",
+                  { n: String(streamRows.length) },
+                )}`
               : ""}
           </p>
           <h1 className="text-3xl md:text-5xl font-extralight text-foreground leading-tight mb-4">
-            {contributor.name || contributor.id} — lineage
+            {t("people.lineage.title", { name: contributor.name || contributor.id })}
           </h1>
           <p className="text-base md:text-lg text-foreground/85 leading-relaxed max-w-2xl">
-            Every work this cell has contributed to, in chronological
-            order, with the streams of attention that ran alongside.
-            Composed from the live graph; the data is what the
-            substrate currently knows. Refine through the doorway on
-            the profile page.
+            {t("people.lineage.welcome")}
           </p>
         </div>
       </section>
@@ -249,16 +255,14 @@ export default async function ContributorLineagePage({
         {works.length === 0 ? (
           <section>
             <p className="text-sm text-muted-foreground italic">
-              No works have been attributed to this cell yet. As
-              contributions are recorded, they will appear here in
-              chronological order.
+              {t("people.lineage.empty")}
             </p>
           </section>
         ) : (
           <>
             <section>
               <h2 className="text-xl font-light text-foreground mb-4">
-                The arc, at a glance
+                {t("people.lineage.arcAtAGlance")}
               </h2>
               <figure className="rounded-xl border border-border/40 bg-card/30 p-5 overflow-hidden">
                 <ol className="relative border-l border-border/50 pl-6 space-y-3">
@@ -297,7 +301,7 @@ export default async function ContributorLineagePage({
                         —
                       </span>
                       <p className="text-xs text-muted-foreground italic mb-1.5 ml-2">
-                        Year not yet recorded
+                        {t("people.lineage.yearNotRecorded")}
                       </p>
                       <ul className="ml-2 space-y-1">
                         {unknownYearWorks.map((w) => (
@@ -320,10 +324,19 @@ export default async function ContributorLineagePage({
                 </ol>
                 <figcaption className="text-xs text-muted-foreground mt-4 pt-3 border-t border-border/30">
                   {sortedYears.length > 0
-                    ? `${knownYearWorks.length} work${knownYearWorks.length === 1 ? "" : "s"} from ${minYear} to ${maxYear === 2026 || maxYear === new Date().getFullYear() ? "now" : maxYear}`
+                    ? t(
+                        knownYearWorks.length === 1
+                          ? "people.lineage.figcaptionRangeSingular"
+                          : "people.lineage.figcaptionRange",
+                        {
+                          n: String(knownYearWorks.length),
+                          from: String(minYear),
+                          to: maxYear === new Date().getFullYear() ? t("people.lineage.now") : String(maxYear),
+                        },
+                      )
                     : ""}
                   {unknownYearWorks.length > 0
-                    ? ` · ${unknownYearWorks.length} without a recorded year`
+                    ? " · " + t("people.lineage.figcaptionUnknownYears", { n: String(unknownYearWorks.length) })
                     : ""}
                 </figcaption>
               </figure>
@@ -331,7 +344,7 @@ export default async function ContributorLineagePage({
 
             <section>
               <h2 className="text-xl font-light text-foreground mb-4">
-                Works · chronological
+                {t("people.lineage.worksHeading")}
               </h2>
               <ul className="space-y-3">
                 {works.map((w) => {
@@ -382,12 +395,10 @@ export default async function ContributorLineagePage({
         {streamBucketsSorted.length > 0 && (
           <section>
             <h2 className="text-xl font-light text-foreground mb-4">
-              Streams of attention that ran alongside
+              {t("people.lineage.streamsHeading")}
             </h2>
             <p className="text-sm text-muted-foreground mb-4">
-              Inspired-by edges grouped by source. The full unified
-              influence-web — with measured hours and per-source
-              spectrum colouring — lives at the bottom of{" "}
+              {t("people.lineage.streamsLede")}{" "}
               <Link href={slugDoor(contributor)} className="text-primary hover:underline">
                 {contributor.name || contributor.id}
               </Link>
@@ -429,16 +440,13 @@ export default async function ContributorLineagePage({
 
         <section className="pt-6 border-t border-border/40">
           <p className="text-sm text-muted-foreground">
-            This page is composed live from the graph. Anything here
-            can be corrected — refine through the doorway on{" "}
+            {t("people.lineage.footerLede")}{" "}
             <Link href={slugDoor(contributor)} className="text-primary hover:underline">
-              {contributor.name || contributor.id}'s profile
+              {contributor.name || contributor.id}
             </Link>
-            . Programmatic clients can fetch the same data directly:
-            <code className="ml-1 text-foreground/80">
+            <code className="ml-2 text-foreground/80 text-xs">
               GET /api/edges?from_id={stableId}&type=contributes-to
             </code>
-            .
           </p>
         </section>
       </div>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -367,7 +367,27 @@
     "replied": "hat geantwortet:",
     "emptyHeading": "Ein Name, dessen Garten noch wartet.",
     "emptyLede": "Sie hat eine Mitwirkenden-ID, aber noch nicht gesprochen oder Reaktionen empfangen. Ihre Ecke wartet.",
-    "backToVision": "Die Vision begehen"
+    "backToVision": "Die Vision begehen",
+    "lineage": {
+      "breadcrumb": "Lineage",
+      "eyebrowWorks": "{n} Werke",
+      "eyebrowWorkSingular": "{n} Werk",
+      "eyebrowEdges": "{n} Einflusskanten",
+      "eyebrowEdgeSingular": "{n} Einflusskante",
+      "title": "{name} — Lineage",
+      "welcome": "Jedes Werk, zu dem diese Zelle beigetragen hat, in chronologischer Reihenfolge, mit den Aufmerksamkeitsströmen, die nebenher liefen. Aus dem lebenden Graphen zusammengesetzt; die Daten sind das, was das Substrat derzeit weiß. Verfeinere über den Eingang auf der Profilseite.",
+      "arcAtAGlance": "Der Bogen auf einen Blick",
+      "yearNotRecorded": "Jahr noch nicht erfasst",
+      "worksHeading": "Werke · chronologisch",
+      "streamsHeading": "Aufmerksamkeitsströme, die nebenher liefen",
+      "streamsLede": "Inspired-by-Kanten nach Quelle gruppiert. Das vollständige vereinheitlichte Einflussnetz — mit gemessenen Stunden und Spektrum-Färbung pro Quelle — lebt am unteren Rand der Profilseite.",
+      "empty": "Dieser Zelle wurden noch keine Werke zugeschrieben. Wenn Beiträge erfasst werden, erscheinen sie hier in chronologischer Reihenfolge.",
+      "footerLede": "Diese Seite wird live aus dem Graphen zusammengesetzt. Alles hier kann korrigiert werden — verfeinere über den Eingang auf der Profilseite. Programmgesteuerte Clients können dieselben Daten direkt über den contributes-to-Kanten-Endpunkt abrufen.",
+      "figcaptionRange": "{n} Werke von {from} bis {to}",
+      "figcaptionRangeSingular": "{n} Werk von {from} bis {to}",
+      "now": "jetzt",
+      "figcaptionUnknownYears": "{n} ohne erfasstes Jahr"
+    }
   },
   "morningNudge": {
     "ariaLabel": "Morgen-Rückblick",
@@ -691,7 +711,23 @@
     "assetOne": "{n} Werk",
     "assetMany": "{n} Werke",
     "loadingAssets": "Werke werden geladen …",
-    "thumbnailAlt": "{description}"
+    "thumbnailAlt": "{description}",
+    "detail": {
+      "kind": "Art",
+      "runtime": "Laufzeit",
+      "era": "Zeitraum",
+      "company": "Unternehmen",
+      "place": "Ort",
+      "asin": "ASIN",
+      "isbn": "ISBN",
+      "languageLabel": "Sprache",
+      "externalSource": "Externe Quelle",
+      "presence": "Präsenz:",
+      "statWitnessed": "Bezeugt",
+      "statWitnessedDays": "{n} Mitwirkender · 90 T",
+      "statWitnessedDaysPlural": "{n} Mitwirkende · 90 T",
+      "statWitnessedHint": "Aufrufe über 90 Tage"
+    }
   },
   "search": {
     "title": "Projekte suchen",
@@ -1430,7 +1466,11 @@
       "transport-mechanic": "Transport · Mechaniker",
       "elder-witness": "Ältester · Zeuge",
       "other": "Anders (in deinen eigenen Worten unten)"
-    }
+    },
+    "publicPostureTitle": "Was es heißt, dem Netzwerk beizutreten",
+    "publicPostureBody1": "Das Coherence Network ist standardmäßig öffentlich. Deine Mitwirkenden-ID, Zuschreibung, die Oberflächen, die du besuchst, und die Verbindungslinien, die du erstellst, werden Teil eines offenen Evidenzkörpers. Nächtliche Datenbank-Dumps spiegeln in ein öffentliches Archiv bei [coherence-network-archive](https://github.com/seeker71/coherence-network-archive); tagesweise Ereignis-Archive liegen in den Releases des Hauptrepos. Das Substrat entspricht der Überzeugung — souveräne, transparente Zuschreibung, kein verborgener Zustand.",
+    "publicPostureBody2": "Was wir nicht aufbewahren: Tracking-Cookies, Drittanbieter-Fingerabdrücke, IP-basierte Geolokalisierung, Geräte-Details. Die Sitzungs-ID ist eine UUID pro Tab, lokal im Netzwerk.",
+    "publicPostureBody3": "Sollte sich deine Situation jemals ändern, ehrt das Netzwerk eine Opt-Out-Anfrage — siehe [docs/transparency](https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md) für das, was redigierbar ist, was nicht, und das Verfahren."
   },
   "share": {
     "eyebrow": "Teilen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -367,7 +367,27 @@
     "replied": "replied:",
     "emptyHeading": "A name without its garden yet.",
     "emptyLede": "She has a contributor id but hasn't voiced or been reacted to yet. Her corner is waiting.",
-    "backToVision": "Walk the vision"
+    "backToVision": "Walk the vision",
+    "lineage": {
+      "breadcrumb": "Lineage",
+      "eyebrowWorks": "{n} works",
+      "eyebrowWorkSingular": "{n} work",
+      "eyebrowEdges": "{n} influence edges",
+      "eyebrowEdgeSingular": "{n} influence edge",
+      "title": "{name} — lineage",
+      "welcome": "Every work this cell has contributed to, in chronological order, with the streams of attention that ran alongside. Composed from the live graph; the data is what the substrate currently knows. Refine through the doorway on the profile page.",
+      "arcAtAGlance": "The arc, at a glance",
+      "yearNotRecorded": "Year not yet recorded",
+      "worksHeading": "Works · chronological",
+      "streamsHeading": "Streams of attention that ran alongside",
+      "streamsLede": "Inspired-by edges grouped by source. The full unified influence-web — with measured hours and per-source spectrum colouring — lives at the bottom of the profile page.",
+      "empty": "No works have been attributed to this cell yet. As contributions are recorded, they will appear here in chronological order.",
+      "footerLede": "This page is composed live from the graph. Anything here can be corrected — refine through the doorway on the profile page. Programmatic clients can fetch the same data directly via the contributes-to edges endpoint.",
+      "figcaptionRange": "{n} works from {from} to {to}",
+      "figcaptionRangeSingular": "{n} work from {from} to {to}",
+      "now": "now",
+      "figcaptionUnknownYears": "{n} without a recorded year"
+    }
   },
   "morningNudge": {
     "ariaLabel": "Morning catch-up",
@@ -739,7 +759,21 @@
       "provenanceArweave": "Arweave",
       "provenanceLinkOpen": "↗",
       "conceptsTitle": "Concepts",
-      "conceptsLede": "What this vessel resonates with."
+      "conceptsLede": "What this vessel resonates with.",
+      "kind": "Kind",
+      "runtime": "Runtime",
+      "era": "Era",
+      "company": "Company",
+      "place": "Place",
+      "asin": "ASIN",
+      "isbn": "ISBN",
+      "languageLabel": "Language",
+      "externalSource": "External source",
+      "presence": "Presence:",
+      "statWitnessed": "Witnessed",
+      "statWitnessedDays": "{n} contributor · 90d",
+      "statWitnessedDaysPlural": "{n} contributors · 90d",
+      "statWitnessedHint": "views over 90 days"
     },
     "notFound": {
       "eyebrow": "A vessel not in the body",
@@ -1569,7 +1603,11 @@
       "transport-mechanic": "Transport · mechanic",
       "elder-witness": "Elder · witness",
       "other": "Other (in your own words below)"
-    }
+    },
+    "publicPostureTitle": "What joining the network means",
+    "publicPostureBody1": "The Coherence Network is public-by-default. Your contribution id, attribution, the surfaces you visit, and the lineage edges you create become part of an open body of evidence. Nightly database dumps mirror to a public archive at [coherence-network-archive](https://github.com/seeker71/coherence-network-archive); per-day view-event archives sit on the main repo's releases. The substrate matches the conviction — sovereign-transparent attribution, no hidden state.",
+    "publicPostureBody2": "What we don't keep: tracking cookies, third-party fingerprints, IP-based geolocation, device specifics. The session id is a per-tab UUID local to the network.",
+    "publicPostureBody3": "If your situation ever changes, the network honours an opt-out request — see [docs/transparency](https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md) for what's redactable, what isn't, and the procedure."
   },
   "share": {
     "eyebrow": "Sharing",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -367,7 +367,27 @@
     "replied": "respondió:",
     "emptyHeading": "Un nombre cuyo jardín aún espera.",
     "emptyLede": "Tiene un id de contribuyente pero aún no ha hablado ni ha recibido reacciones. Su rincón espera.",
-    "backToVision": "Caminar la visión"
+    "backToVision": "Caminar la visión",
+    "lineage": {
+      "breadcrumb": "Linaje",
+      "eyebrowWorks": "{n} obras",
+      "eyebrowWorkSingular": "{n} obra",
+      "eyebrowEdges": "{n} aristas de influencia",
+      "eyebrowEdgeSingular": "{n} arista de influencia",
+      "title": "{name} — linaje",
+      "welcome": "Cada obra a la que esta célula ha contribuido, en orden cronológico, con las corrientes de atención que corrieron en paralelo. Compuesto desde el grafo vivo; los datos son lo que el sustrato sabe actualmente. Refina a través de la puerta en la página de perfil.",
+      "arcAtAGlance": "El arco, de un vistazo",
+      "yearNotRecorded": "Año aún no registrado",
+      "worksHeading": "Obras · cronológico",
+      "streamsHeading": "Corrientes de atención que corrieron en paralelo",
+      "streamsLede": "Aristas inspired-by agrupadas por fuente. La red de influencia unificada completa — con horas medidas y color de espectro por fuente — vive al pie de la página de perfil.",
+      "empty": "Aún no se han atribuido obras a esta célula. A medida que se registren las contribuciones, aparecerán aquí en orden cronológico.",
+      "footerLede": "Esta página se compone en vivo a partir del grafo. Todo aquí se puede corregir — refina a través de la puerta en la página de perfil. Los clientes programáticos pueden obtener los mismos datos directamente a través del endpoint de aristas contributes-to.",
+      "figcaptionRange": "{n} obras desde {from} hasta {to}",
+      "figcaptionRangeSingular": "{n} obra desde {from} hasta {to}",
+      "now": "ahora",
+      "figcaptionUnknownYears": "{n} sin año registrado"
+    }
   },
   "morningNudge": {
     "ariaLabel": "Resumen de la mañana",
@@ -691,7 +711,23 @@
     "assetOne": "{n} obra",
     "assetMany": "{n} obras",
     "loadingAssets": "Cargando obras…",
-    "thumbnailAlt": "{description}"
+    "thumbnailAlt": "{description}",
+    "detail": {
+      "kind": "Tipo",
+      "runtime": "Duración",
+      "era": "Era",
+      "company": "Empresa",
+      "place": "Lugar",
+      "asin": "ASIN",
+      "isbn": "ISBN",
+      "languageLabel": "Idioma",
+      "externalSource": "Fuente externa",
+      "presence": "Presencia:",
+      "statWitnessed": "Atestiguado",
+      "statWitnessedDays": "{n} contribuyente · 90d",
+      "statWitnessedDaysPlural": "{n} contribuyentes · 90d",
+      "statWitnessedHint": "vistas durante 90 días"
+    }
   },
   "search": {
     "title": "Buscar proyectos",
@@ -1430,7 +1466,11 @@
       "transport-mechanic": "Transporte · mecánico",
       "elder-witness": "Anciano · testigo",
       "other": "Otro (en tus propias palabras abajo)"
-    }
+    },
+    "publicPostureTitle": "Lo que significa unirse a la red",
+    "publicPostureBody1": "La Coherence Network es pública por defecto. Tu identificador de contribución, atribución, las superficies que visitas y los enlaces de linaje que creas se convierten en parte de un cuerpo de evidencia abierto. Los volcados nocturnos de la base de datos se reflejan en un archivo público en [coherence-network-archive](https://github.com/seeker71/coherence-network-archive); los archivos diarios de eventos viven en los releases del repositorio principal. El sustrato coincide con la convicción — atribución soberana y transparente, sin estado oculto.",
+    "publicPostureBody2": "Lo que no guardamos: cookies de seguimiento, huellas digitales de terceros, geolocalización basada en IP, detalles del dispositivo. El identificador de sesión es un UUID por pestaña, local a la red.",
+    "publicPostureBody3": "Si tu situación cambia alguna vez, la red honra una solicitud de exclusión — consulta [docs/transparency](https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md) para saber qué es redactable, qué no, y el procedimiento."
   },
   "share": {
     "eyebrow": "Compartiendo",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -367,7 +367,27 @@
     "replied": "membalas:",
     "emptyHeading": "Nama yang tamannya masih menunggu.",
     "emptyLede": "Ia memiliki id penyumbang tetapi belum bersuara atau menerima reaksi. Sudutnya menunggu.",
-    "backToVision": "Jelajahi visi"
+    "backToVision": "Jelajahi visi",
+    "lineage": {
+      "breadcrumb": "Garis keturunan",
+      "eyebrowWorks": "{n} karya",
+      "eyebrowWorkSingular": "{n} karya",
+      "eyebrowEdges": "{n} tepi pengaruh",
+      "eyebrowEdgeSingular": "{n} tepi pengaruh",
+      "title": "{name} — garis keturunan",
+      "welcome": "Setiap karya yang telah dikontribusikan oleh sel ini, dalam urutan kronologis, dengan aliran perhatian yang berjalan di sampingnya. Disusun dari graf langsung; data adalah apa yang saat ini diketahui substrat. Sempurnakan melalui pintu di halaman profil.",
+      "arcAtAGlance": "Busur, sekilas",
+      "yearNotRecorded": "Tahun belum dicatat",
+      "worksHeading": "Karya · kronologis",
+      "streamsHeading": "Aliran perhatian yang berjalan di sampingnya",
+      "streamsLede": "Tepi inspired-by yang dikelompokkan menurut sumber. Jaring pengaruh yang dipersatukan secara penuh — dengan jam yang diukur dan pewarnaan spektrum per-sumber — berada di bagian bawah halaman profil.",
+      "empty": "Belum ada karya yang dikaitkan dengan sel ini. Saat kontribusi dicatat, mereka akan muncul di sini dalam urutan kronologis.",
+      "footerLede": "Halaman ini disusun secara langsung dari graf. Apa pun di sini dapat diperbaiki — sempurnakan melalui pintu di halaman profil. Klien programatik dapat mengambil data yang sama langsung melalui endpoint tepi contributes-to.",
+      "figcaptionRange": "{n} karya dari {from} sampai {to}",
+      "figcaptionRangeSingular": "{n} karya dari {from} sampai {to}",
+      "now": "sekarang",
+      "figcaptionUnknownYears": "{n} tanpa tahun yang dicatat"
+    }
   },
   "morningNudge": {
     "ariaLabel": "Rangkuman pagi",
@@ -691,7 +711,23 @@
     "assetOne": "{n} karya",
     "assetMany": "{n} karya",
     "loadingAssets": "Memuat karya…",
-    "thumbnailAlt": "{description}"
+    "thumbnailAlt": "{description}",
+    "detail": {
+      "kind": "Jenis",
+      "runtime": "Durasi",
+      "era": "Era",
+      "company": "Perusahaan",
+      "place": "Tempat",
+      "asin": "ASIN",
+      "isbn": "ISBN",
+      "languageLabel": "Bahasa",
+      "externalSource": "Sumber eksternal",
+      "presence": "Kehadiran:",
+      "statWitnessed": "Disaksikan",
+      "statWitnessedDays": "{n} kontributor · 90h",
+      "statWitnessedDaysPlural": "{n} kontributor · 90h",
+      "statWitnessedHint": "tampilan selama 90 hari"
+    }
   },
   "search": {
     "title": "Cari proyek",
@@ -1430,7 +1466,11 @@
       "transport-mechanic": "Transportasi · mekanik",
       "elder-witness": "Tetua · saksi",
       "other": "Lainnya (dengan kata-katamu sendiri di bawah)"
-    }
+    },
+    "publicPostureTitle": "Apa artinya bergabung dengan jaringan",
+    "publicPostureBody1": "Coherence Network bersifat publik secara default. ID kontribusi, atribusi, permukaan yang Anda kunjungi, dan tepi silsilah yang Anda buat menjadi bagian dari kumpulan bukti terbuka. Dump basis data setiap malam dicerminkan ke arsip publik di [coherence-network-archive](https://github.com/seeker71/coherence-network-archive); arsip peristiwa harian berada di rilis repositori utama. Substrat sesuai dengan keyakinan — atribusi berdaulat dan transparan, tanpa status tersembunyi.",
+    "publicPostureBody2": "Yang tidak kami simpan: cookie pelacak, sidik jari pihak ketiga, geolokasi berbasis IP, detail perangkat. ID sesi adalah UUID per-tab yang lokal di jaringan.",
+    "publicPostureBody3": "Jika situasi Anda berubah, jaringan menghormati permintaan opt-out — lihat [docs/transparency](https://github.com/seeker71/Coherence-Network/blob/main/docs/transparency/README.md) untuk apa yang dapat diredaksi, apa yang tidak, dan prosedurnya."
   },
   "share": {
     "eyebrow": "Membagikan",


### PR DESCRIPTION
Per CLAUDE.md MEMORY feedback_i18n_architecture (chrome lives in web/messages/{locale}.json, accessed via t()/useT, profile locale is ground truth), recently-introduced English-only chrome on three surfaces is now lifted into all four locale files (en / de / es / id) and wired through t().

Surfaces fixed: /people/[id]/lineage page (dynamic chronological view), /assets/[asset_id] page (structured-data row + External source + Presence + Witnessed stat), /begin page (public-posture disclosure block). Curated /people/{slug} content modules left as-is — those are content not chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)