### PR TITLE
i18n: lift PresencePage chrome into the messages bundle

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -580,7 +580,7 @@ export default async function PersonPage({
       fetchIdentityInspiredBy(nodeId),
     ]);
     return (
-      <PresencePage identity={nodeToPresenceIdentity(graphNode, creations, inspiredBy)} />
+      <PresencePage identity={nodeToPresenceIdentity(graphNode, creations, inspiredBy)} lang={lang} />
     );
   }
 
@@ -634,7 +634,7 @@ export default async function PersonPage({
       fetchIdentityInspiredBy(nodeId),
     ]);
     return (
-      <PresencePage identity={nodeToPresenceIdentity(graphNode, creations, inspiredBy)} />
+      <PresencePage identity={nodeToPresenceIdentity(graphNode, creations, inspiredBy)} lang={lang} />
     );
   }
 

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -31,6 +31,8 @@ import { CoLocated } from "./CoLocated";
 import { RootedHere } from "./RootedHere";
 import { HeldBy } from "./HeldBy";
 import { WanderInto } from "./WanderInto";
+import { createTranslator, type Translator } from "@/lib/i18n";
+import { DEFAULT_LOCALE, type LocaleCode } from "@/lib/locales";
 
 export type Presence = {
   provider: string;
@@ -296,15 +298,17 @@ function renderInline(text: string): ReactNode {
 function PlatformChips({
   presences,
   identityName,
+  t,
 }: {
   presences: Presence[];
   identityName: string;
+  t: Translator;
 }) {
   if (presences.length === 0) return null;
   return (
     <section>
       <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-        Find them
+        {t("presence.findThem")}
       </p>
       <div className="flex flex-wrap gap-2.5">
         {presences.map((p) => {
@@ -349,9 +353,11 @@ function PlatformChips({
 function PresenceOverview({
   identity,
   inspiredCount,
+  t,
 }: {
   identity: PresenceIdentity;
   inspiredCount: number;
+  t: Translator;
 }) {
   const canonicalDisplay = compactUrl(identity.canonical_url);
   const graphHref = `/nodes/${encodeURIComponent(identity.id)}`;
@@ -370,19 +376,19 @@ function PresenceOverview({
   return (
     <section className="rounded-2xl border border-white/10 bg-white/[0.035] p-5">
       <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-4">
-        At a glance
+        {t("presence.atAGlance")}
       </p>
       <dl className="space-y-3 text-sm">
         <div>
           <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-            Category
+            {t("presence.category")}
           </dt>
           <dd className="mt-1 text-white/90">{identity.category}</dd>
         </div>
         {canonicalDisplay && (
           <div>
             <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-              Home
+              {t("presence.home")}
             </dt>
             <dd className="mt-1 break-words text-white/90">{canonicalDisplay}</dd>
           </div>
@@ -390,13 +396,13 @@ function PresenceOverview({
         <div className="grid grid-cols-2 gap-3">
           <div>
             <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-              Works
+              {t("presence.works")}
             </dt>
             <dd className="mt-1 text-white/90">{identity.creations.length}</dd>
           </div>
           <div>
             <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-              Lineage
+              {t("presence.lineage")}
             </dt>
             <dd className="mt-1 text-white/90">{inspiredCount}</dd>
           </div>
@@ -406,7 +412,7 @@ function PresenceOverview({
       {dedupedSurfaces.length > 0 && (
         <div className="mt-6">
           <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-            Presence map
+            {t("presence.presenceMap")}
           </p>
           <div className="space-y-2">
             {dedupedSurfaces.map((surface) => {
@@ -434,7 +440,7 @@ function PresenceOverview({
 
       <div className="mt-6">
         <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-          Entry points
+          {t("presence.entryPoints")}
         </p>
         <div className="space-y-2">
           {identity.canonical_url && (
@@ -444,14 +450,14 @@ function PresenceOverview({
               rel="noopener noreferrer"
               className="block rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/80 hover:bg-white/[0.07]"
             >
-              Official source
+              {t("presence.officialSource")}
             </a>
           )}
           <Link
             href={graphHref}
             className="block rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/80 hover:bg-white/[0.07]"
           >
-            Graph node
+            {t("presence.graphNode")}
           </Link>
         </div>
       </div>
@@ -459,24 +465,32 @@ function PresenceOverview({
   );
 }
 
-// Compact era marker for the tile corner. Strips wordy prefixes
-// ("approximately ", "~") so the year-shape lands clean. Falls back
-// to the raw string if no year is parseable. Empty string → no marker.
+// Compact era marker for the tile corner. Strips wordy prefixes so
+// the year-shape lands clean. The English "approximately/circa/~"
+// list is paralleled by the German "ungefähr/zirka", Spanish
+// "aproximadamente/hacia", and Indonesian "sekitar/kira-kira" — kept
+// inline so the parser stays locale-aware while the era field itself
+// remains content (not chrome) and comes from the asset's own voice.
+// Falls back to the raw string if nothing matches; empty era yields
+// no marker.
+const ERA_PREFIX_RE =
+  /^\s*(approximately|approx\.?|circa|ca\.?|~|ungef(ä|ae)hr|zirka|ca\b|aproximadamente|hacia|aprox\.?|sekitar|kira-?kira)\s*/i;
+const ERA_AGE_SUFFIX_RE =
+  /\s+·\s+(age|alter|edad|usia)\s+\d+\s*$/i;
+
 function eraMarker(era: string | null | undefined): string {
   if (!era) return "";
-  const compact = era
-    .replace(/^\s*(approximately|approx\.?|circa|ca\.?|~)\s*/i, "")
-    .replace(/\s+·\s+age\s+\d+\s*$/i, "")
-    .trim();
-  return compact;
+  return era.replace(ERA_PREFIX_RE, "").replace(ERA_AGE_SUFFIX_RE, "").trim();
 }
 
 function CreationsGrid({
   creations,
   accent,
+  t,
 }: {
   creations: Creation[];
   accent: BrandTone;
+  t: Translator;
 }) {
   const visible = creations.filter((c) => c.kind !== "event");
   if (visible.length === 0) return null;
@@ -496,7 +510,7 @@ function CreationsGrid({
   return (
     <section>
       <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-        Works
+        {t("presence.works")}
       </p>
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4">
         {ordered.map((c) => {
@@ -533,7 +547,7 @@ function CreationsGrid({
                 {c.name}
               </p>
               <p className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-                {c.kind}
+                {localizeKind(c.kind, t)}
               </p>
             </Tag>
           );
@@ -543,31 +557,44 @@ function CreationsGrid({
   );
 }
 
+// Render a creation_kind label in the active locale. Kind values like
+// "software-system" or "kernel-driver" are stable English identifiers
+// in the graph; the rendered label is chrome and lives in the messages
+// bundle keyed by `presence.creationKind.{kind}`. When the bundle has
+// no entry for an unfamiliar kind, fall back to the kind itself with
+// hyphens turned to spaces so the tile still reads.
+function localizeKind(kind: string, t: Translator): string {
+  const key = `presence.creationKind.${kind}`;
+  const translated = t(key);
+  if (translated === key) return kind.replace(/-/g, " ");
+  return translated;
+}
+
 function HeldOpen({
   identity,
   accent,
+  t,
 }: {
   identity: PresenceIdentity;
   accent: BrandTone;
+  t: Translator;
 }) {
   if (identity.claimed !== false) return null;
   return (
     <section>
       <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
         <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-1.5">
-          Held open
+          {t("presence.heldOpen")}
         </p>
         <p className="text-sm text-white/80 leading-relaxed">
-          This page is a door held open for {identity.name}. Nothing is
-          asked; if this is you, you can take the page as-is or send any
-          edits and they&apos;ll be applied same day.
+          {t("presence.heldOpenBody", { name: identity.name })}
         </p>
         <Link
           href={`/claim/${encodeURIComponent(identity.id)}`}
           className="mt-3 inline-flex items-center gap-1 text-sm font-medium"
           style={{ color: accent.bg }}
         >
-          this is me →
+          {t("presence.thisIsMe")} →
         </Link>
       </div>
     </section>
@@ -616,7 +643,19 @@ function pickAccentProvider(identity: PresenceIdentity): string {
   return identity.provider;
 }
 
-export function PresencePage({ identity }: { identity: PresenceIdentity }) {
+export function PresencePage({
+  identity,
+  lang = DEFAULT_LOCALE,
+}: {
+  identity: PresenceIdentity;
+  /** Active locale for the chrome — passed in by the server-rendered
+   *  page that resolved cookie/profile/Accept-Language. Defaults to
+   *  the bundle default for any older callers that haven't been
+   *  threaded through yet; the chrome falls back to English in that
+   *  case rather than missing-key warnings. */
+  lang?: LocaleCode;
+}) {
+  const t: Translator = createTranslator(lang);
   const accent = brandFor(pickAccentProvider(identity));
   const hasImage = Boolean(identity.image_url);
   const inspired = identity.inspired_by || [];
@@ -670,7 +709,7 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
           {identity.note && (
             <section>
               <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
-                What this gathering held
+                {t("presence.gatheringHeld")}
               </p>
               <p className="text-base sm:text-lg leading-relaxed text-white/90 max-w-[58ch]">
                 {identity.note}
@@ -685,7 +724,7 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
             identityName={identity.name}
             accent={accent}
           />
-          <CreationsGrid creations={identity.creations} accent={accent} />
+          <CreationsGrid creations={identity.creations} accent={accent} t={t} />
         </div>
 
         {/* Sidebar — collapses to full-width above the main column on
@@ -695,7 +734,7 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
             works, the hero already shows the name+category+tagline and
             the platforms appear immediately after on mobile. */}
         <aside className="space-y-10 lg:space-y-8 min-w-0">
-          <PresenceOverview identity={identity} inspiredCount={inspired.length} />
+          <PresenceOverview identity={identity} inspiredCount={inspired.length} t={t} />
           {/* Every contribution and influence flowing through this
               presence, from any source — the unified body-of-evidence
               view. Emissions (works), Shaped-by (influences grouped
@@ -710,6 +749,7 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
           <PlatformChips
             presences={identity.presences}
             identityName={identity.name}
+            t={t}
           />
           <LocationChip presenceId={identity.id} />
           {/* When the page IS a place, show every presence rooted in
@@ -733,7 +773,7 @@ export function PresencePage({ identity }: { identity: PresenceIdentity }) {
               co-location through places) so they remain. */}
           <KindredPresences presenceId={identity.id} />
           <CoLocated presenceId={identity.id} />
-          <HeldOpen identity={identity} accent={accent} />
+          <HeldOpen identity={identity} accent={accent} t={t} />
         </aside>
       </div>
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1999,6 +1999,41 @@
         "frequent": "häufig",
         "founded": "gegründet"
       }
+    },
+    "findThem": "Finde sie",
+    "atAGlance": "Auf einen Blick",
+    "category": "Art",
+    "home": "Zuhause",
+    "works": "Werke",
+    "lineage": "Linie",
+    "presenceMap": "Präsenz-Karte",
+    "entryPoints": "Eingänge",
+    "officialSource": "Offizielle Quelle",
+    "graphNode": "Graph-Knoten",
+    "heldOpen": "Offen gehalten",
+    "heldOpenBody": "Diese Seite ist eine Tür, die für {name} offen gehalten wird. Es wird nichts verlangt; wenn du das bist, kannst du die Seite so übernehmen oder Änderungen schicken — sie werden noch am selben Tag eingearbeitet.",
+    "thisIsMe": "das bin ich",
+    "gatheringHeld": "Was diese Zusammenkunft hielt",
+    "creationKind": {
+      "album": "Album",
+      "track": "Track",
+      "video": "Video",
+      "film": "Film",
+      "event": "Veranstaltung",
+      "book": "Buch",
+      "teaching": "Lehre",
+      "podcast": "Podcast",
+      "episode": "Episode",
+      "essay": "Essay",
+      "article": "Artikel",
+      "course": "Kurs",
+      "workshop": "Workshop",
+      "work": "Werk",
+      "software-system": "Software-System",
+      "kernel-driver": "Kernel-Treiber",
+      "hardware-firmware-software": "Hardware · Firmware · Software",
+      "hardware-firmware-system": "Hardware · Firmware · System",
+      "thesis": "Diplomarbeit"
     }
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2138,6 +2138,41 @@
         "frequent": "frequent",
         "founded": "founded"
       }
+    },
+    "findThem": "Find them",
+    "atAGlance": "At a glance",
+    "category": "Category",
+    "home": "Home",
+    "works": "Works",
+    "lineage": "Lineage",
+    "presenceMap": "Presence map",
+    "entryPoints": "Entry points",
+    "officialSource": "Official source",
+    "graphNode": "Graph node",
+    "heldOpen": "Held open",
+    "heldOpenBody": "This page is a door held open for {name}. Nothing is asked; if this is you, you can take the page as-is or send any edits and they'll be applied same day.",
+    "thisIsMe": "this is me",
+    "gatheringHeld": "What this gathering held",
+    "creationKind": {
+      "album": "album",
+      "track": "track",
+      "video": "video",
+      "film": "film",
+      "event": "event",
+      "book": "book",
+      "teaching": "teaching",
+      "podcast": "podcast",
+      "episode": "episode",
+      "essay": "essay",
+      "article": "article",
+      "course": "course",
+      "workshop": "workshop",
+      "work": "work",
+      "software-system": "software system",
+      "kernel-driver": "kernel driver",
+      "hardware-firmware-software": "hardware · firmware · software",
+      "hardware-firmware-system": "hardware · firmware · system",
+      "thesis": "thesis"
     }
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1999,6 +1999,41 @@
         "frequent": "frecuente",
         "founded": "fundado"
       }
+    },
+    "findThem": "Encuéntralos",
+    "atAGlance": "De un vistazo",
+    "category": "Categoría",
+    "home": "Hogar",
+    "works": "Obras",
+    "lineage": "Linaje",
+    "presenceMap": "Mapa de presencia",
+    "entryPoints": "Puntos de entrada",
+    "officialSource": "Fuente oficial",
+    "graphNode": "Nodo del grafo",
+    "heldOpen": "Mantenida abierta",
+    "heldOpenBody": "Esta página es una puerta mantenida abierta para {name}. No se pide nada; si eres tú, puedes tomar la página tal cual o enviar cambios — se aplicarán el mismo día.",
+    "thisIsMe": "esta soy yo",
+    "gatheringHeld": "Lo que sostuvo este encuentro",
+    "creationKind": {
+      "album": "álbum",
+      "track": "pista",
+      "video": "video",
+      "film": "película",
+      "event": "evento",
+      "book": "libro",
+      "teaching": "enseñanza",
+      "podcast": "podcast",
+      "episode": "episodio",
+      "essay": "ensayo",
+      "article": "artículo",
+      "course": "curso",
+      "workshop": "taller",
+      "work": "obra",
+      "software-system": "sistema de software",
+      "kernel-driver": "driver de kernel",
+      "hardware-firmware-software": "hardware · firmware · software",
+      "hardware-firmware-system": "hardware · firmware · sistema",
+      "thesis": "tesis"
     }
   }
 }

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1999,6 +1999,41 @@
         "frequent": "sering",
         "founded": "didirikan"
       }
+    },
+    "findThem": "Temukan mereka",
+    "atAGlance": "Sekilas",
+    "category": "Kategori",
+    "home": "Rumah",
+    "works": "Karya",
+    "lineage": "Garis silsilah",
+    "presenceMap": "Peta kehadiran",
+    "entryPoints": "Pintu masuk",
+    "officialSource": "Sumber resmi",
+    "graphNode": "Simpul graf",
+    "heldOpen": "Tetap terbuka",
+    "heldOpenBody": "Halaman ini adalah pintu yang dibiarkan terbuka untuk {name}. Tidak ada yang diminta; jika ini kamu, kamu bisa menerima halaman ini apa adanya atau mengirim perubahan — akan diterapkan pada hari yang sama.",
+    "thisIsMe": "ini saya",
+    "gatheringHeld": "Apa yang dipegang oleh pertemuan ini",
+    "creationKind": {
+      "album": "album",
+      "track": "trek",
+      "video": "video",
+      "film": "film",
+      "event": "acara",
+      "book": "buku",
+      "teaching": "ajaran",
+      "podcast": "podcast",
+      "episode": "episode",
+      "essay": "esai",
+      "article": "artikel",
+      "course": "kursus",
+      "workshop": "lokakarya",
+      "work": "karya",
+      "software-system": "sistem perangkat lunak",
+      "kernel-driver": "driver kernel",
+      "hardware-firmware-software": "perangkat keras · firmware · perangkat lunak",
+      "hardware-firmware-system": "perangkat keras · firmware · sistem",
+      "thesis": "tesis"
     }
   }
 }


### PR DESCRIPTION
## Summary

The polished presence page had thirteen English chrome strings hardcoded into the component — section headings ("Find them", "At a glance", "Held open", ...), overview labels ("Category", "Home", "Works", "Lineage", ...), entry-point links, the held-open body, and the raw `c.kind` label rendered directly to the user. None of it reached the German / Spanish / Indonesian visitor in their voice.

## How

- Threads `lang` from the page (`/people/[id]/page.tsx` already resolved cookie + Accept-Language + profile locale) into `PresencePage`, which builds a translator and passes it down to `PlatformChips`, `PresenceOverview`, `CreationsGrid`, and `HeldOpen`.
- Replaces every hardcoded chrome string with `t('presence.…')`.
- Adds a `localizeKind()` helper that resolves `presence.creationKind.{kind}` for the tile's kind label, falling back gracefully (`hardware-firmware-software` → `hardware firmware software`) for kinds that haven't been translated yet.
- Loosens `eraMarker()`'s prefix-stripping regex to recognise `"ungefähr / zirka / aproximadamente / hacia / sekitar / kira-kira"` (and `"Alter / edad / usia"`) alongside English. The era field itself is content (still comes from the asset's own voice) — when asset endpoints learn `?lang=`, the prefixes will already be recognised.
- Adds 15 new keys to each of `en.json`, `de.json`, `es.json`, `id.json` under `presence.*`, including a `creationKind.*` sub-tree covering the eight kinds currently in the graph plus the full `Creation` type vocabulary.

## What stays content (separate breath)

The era marker text and the `c.name` heading remain API content. When asset endpoints learn `?lang=`, those land in the visitor's voice without further code changes.

## Files

- `web/components/presence/PresencePage.tsx` — translator threaded, 13 chrome strings + kind label lifted.
- `web/app/people/[id]/page.tsx` — passes `lang` to `PresencePage` (already resolved upstream).
- `web/messages/{en,de,es,id}.json` — 15 new `presence.*` keys each.

## Test plan
- [ ] Verify on prod: https://coherencycoin.com/people/contributor:seeker71 — chrome reads in English.
- [ ] `https://coherencycoin.com/people/contributor:seeker71?lang=de` — chrome reads in German ("Werke", "Auf einen Blick", "Linie", ...).
- [ ] `?lang=es` and `?lang=id` — chrome reads in Spanish and Indonesian.
- [ ] Tile kind labels render translated ("Software-System" / "sistema de software" / "sistem perangkat lunak") and unfamiliar kinds still render as humanised slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)