### PR TITLE
attune: gate new chrome at the moment of writing — i18n guardrail + CI

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -102,6 +102,20 @@ jobs:
             --base "$BASE_SHA" \
             --head "$HEAD_SHA"
 
+      - name: i18n contract — chrome lifted, locale parity holds
+        # Forward-looking gate: only fails when this diff introduces
+        # NEW hardcoded English chrome in web/ TSX or NEW en.json keys
+        # missing from de/es/id. Legacy gaps are not flagged — they
+        # migrate one breath at a time. See feedback_i18n_architecture.md.
+        if: steps.changed_surfaces.outputs.web == 'true'
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="$(git rev-parse HEAD~1)"
+          fi
+          python3 scripts/check_i18n.py --base "$BASE_SHA" --head "$HEAD_SHA"
+
       - name: Record collective review status (PRs, non-blocking)
         if: ${{ github.event_name == 'pull_request' }}
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ The arrival.py SessionStart hook also surfaces this reminder. If you're a fresh 
 - **Record every new idea via `POST /api/ideas` before session ends**
 - For spec authoring: run `python3 scripts/validate_spec_quality.py`
 - **Look at every page you touch on both desktop AND mobile before declaring it done.** Pages have shipped to prod looking fine on a phone-narrow viewport while wasting 1000px+ of space on desktop, because no one ever resized the browser. Run `python3 scripts/viewport_audit.py` to capture both widths, or open the page in a real browser and resize to 1440 and 390. Add the page to `DEFAULT_PATHS` in that script when you create a new welcoming surface.
+- **Every new user-facing string lives in `web/messages/{lang}.json` (chrome) or comes from the API (content) — never hardcoded into a component.** Five linked practices in `feedback_i18n_architecture.md`: chrome in messages, content from API, text as data, shared keys, no privileged source language, profile locale is ground truth. Use `t('your.key')`, add the key to all four bundles (`en` / `de` / `es` / `id`), and the visitor meets the page in their own voice. CI gates this forward-looking via `scripts/check_i18n.py` — runs per-PR, fails only on NEWLY introduced English chrome or NEWLY added en.json keys missing from another locale (legacy gaps migrate one breath at a time).
 
 ## Living Collective Knowledge Base
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -31,14 +31,14 @@
 
 | Index | Files | Purpose |
 |---|---|---|
-| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 125 | API routers — every HTTP endpoint surface |
+| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 126 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 227 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 55 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 106 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 118 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 31 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 47 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 172 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 91 | Scripts — operational tools, generators, syncers |
+| [web/app/INDEX.md](web/app/INDEX.md) | 174 | Web routes — every visible page in the app |
+| [scripts/INDEX.md](scripts/INDEX.md) | 98 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 91
+**Total files**: 98
 
 | File | Purpose |
 |---|---|
@@ -23,12 +23,15 @@
 | [cc.py](cc.py) | !/usr/bin/env python3 |
 | [check_dev_auth.py](check_dev_auth.py) | !/usr/bin/env python3 |
 | [check_generated_vision_assets.py](check_generated_vision_assets.py) | !/usr/bin/env python3 |
+| [check_i18n.py](check_i18n.py) | !/usr/bin/env python3 |
 | [check_pr_followthrough.py](check_pr_followthrough.py) | !/usr/bin/env python3 |
 | [check_provider_health.py](check_provider_health.py) | !/usr/bin/env python3 |
 | [check_runtime_drift.py](check_runtime_drift.py) | !/usr/bin/env python3 |
 | [check_spec_references.py](check_spec_references.py) | !/usr/bin/env python3 |
 | [check_traceability.py](check_traceability.py) | !/usr/bin/env python3 |
 | [cluster_watch_history.py](cluster_watch_history.py) | !/usr/bin/env python3 |
+| [coh_form.py](coh_form.py) | !/usr/bin/env python3 |
+| [coh_substrate.py](coh_substrate.py) | !/usr/bin/env python3 |
 | [compost_resonance_noise.py](compost_resonance_noise.py) | One-shot data cleanup — compost dead-tissue presences and re-attune. |
 | [context_budget.py](context_budget.py) | !/usr/bin/env python3 |
 | [daily_brief.py](daily_brief.py) | !/usr/bin/env python3 |
@@ -46,6 +49,7 @@
 | [generate_silence_design_log.py](generate_silence_design_log.py) | !/usr/bin/env python3 |
 | [generate_silence_design_log_v2.py](generate_silence_design_log_v2.py) | !/usr/bin/env python3 |
 | [generate_visuals.py](generate_visuals.py) | !/usr/bin/env python3 |
+| [generate_work_visuals.py](generate_work_visuals.py) | !/usr/bin/env python3 |
 | [idea_to_task_bridge.py](idea_to_task_bridge.py) | !/usr/bin/env python3 |
 | [import_creations.py](import_creations.py) | !/usr/bin/env python3 |
 | [import_gatherings.py](import_gatherings.py) | !/usr/bin/env python3 |
@@ -59,6 +63,7 @@
 | [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | !/usr/bin/env python3 |
 | [migrate_spec_slugs.py](migrate_spec_slugs.py) | !/usr/bin/env python3 |
 | [morning_coherence_brief.py](morning_coherence_brief.py) | !/usr/bin/env python3 |
+| [opt_out_contributor.py](opt_out_contributor.py) | !/usr/bin/env python3 |
 | [organism_influence_cc.py](organism_influence_cc.py) | !/usr/bin/env python3 |
 | [plan_vision_image_regeneration.py](plan_vision_image_regeneration.py) | !/usr/bin/env python3 |
 | [poll_task_progress.py](poll_task_progress.py) | !/usr/bin/env python3 |
@@ -82,6 +87,8 @@
 | [sense_world.py](sense_world.py) | !/usr/bin/env python3 |
 | [setup.py](setup.py) | !/usr/bin/env python3 |
 | [start_gate.py](start_gate.py) | _no top-of-file purpose_ |
+| [substrate_ingest.py](substrate_ingest.py) | !/usr/bin/env python3 |
+| [substrate_read_hook.py](substrate_read_hook.py) | !/usr/bin/env python3 |
 | [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | !/usr/bin/env python3 |
 | [sync_kb_to_db.py](sync_kb_to_db.py) | !/usr/bin/env python3 |
 | [sync_presences_to_db.py](sync_presences_to_db.py) | !/usr/bin/env python3 |

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""i18n contract check — runs in CI to catch chrome that drifted out of the bundle.
+
+Two checks live here, both forward-looking. Neither tries to audit
+the legacy English-only components that haven't been lifted yet —
+those are tracked separately and migrate one breath at a time.
+
+  1. Locale parity — every key in `web/messages/en.json` must exist
+     (with same path) in de.json, es.json, id.json. A missing key
+     means a visitor in that locale sees the raw key string instead
+     of their voice. Always on; blocking.
+
+  2. Newly-introduced chrome — when run with `--base SHA`, scans the
+     ADDED lines in changed `.tsx` / `.ts` files under `web/` for
+     hardcoded English JSX text leaves (multi-word capitalized
+     phrases between tags) that aren't wrapped in `t()`. Catches new
+     drift at the moment of writing rather than after release. Lines
+     unchanged or removed are out of scope — this gate is forward-
+     looking, not retroactive.
+
+Usage:
+    python3 scripts/check_i18n.py                         # parity only
+    python3 scripts/check_i18n.py --base origin/main      # parity + new-chrome scan
+    python3 scripts/check_i18n.py --base SHA --head SHA   # explicit range
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_DIR = REPO_ROOT / "web" / "messages"
+WEB_ROOT = REPO_ROOT / "web"
+LOCALES = ("en", "de", "es", "id")
+ANCHOR_LOCALE = "en"
+
+# JSX/TSX text leaves we consider chrome candidates: multi-word
+# phrases, leading capital, mostly letters/spaces, between two tags.
+# `>([..])<` rather than props because attribute strings are usually
+# data-derived (aria-label, title, alt) and the false-positive rate
+# is too high.
+CHROME_PATTERN = re.compile(
+    r">\s*([A-Z][a-zA-Z][a-zA-Z\s,'·.-]{2,80}?)\s*<"
+)
+
+# Substrings that flag a candidate as not chrome — schema types,
+# brand names, code identifiers that happen to read as English.
+NOT_CHROME = {
+    # schema.org types
+    "Person", "Place", "Event", "Organization", "CreativeWork", "Course",
+    # English single words that happen to appear between tags as data labels
+    "Home", "Works", "Lineage", "Category",
+    # Brand/provider names — these come from the brand registry, never i18n'd
+    "Spotify", "Bandcamp", "YouTube", "SoundCloud", "Apple Music",
+    "Substack", "Patreon", "Instagram", "TikTok", "Facebook", "LinkedIn",
+    "Vimeo", "IMDb", "Beatport", "Threads", "Wikipedia", "Linktree",
+    "GitHub",
+}
+
+# Files we always skip — generated, third-party, or test fixtures
+# whose strings aren't user chrome.
+SKIP_PATH_FRAGMENTS = (
+    "node_modules/", "/.next/", "/dist/", "/build/",
+    "/__tests__/", "/__mocks__/", "/.test.", "/.spec.",
+    "/messages/",  # the bundle itself
+)
+
+
+def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, **kw)
+
+
+# ─── Check 1: locale parity ──────────────────────────────────────────
+
+
+def walk_keys(tree: object, prefix: str = "") -> list[str]:
+    """Return every leaf-key path in a nested dict tree."""
+    if not isinstance(tree, dict):
+        return [prefix] if prefix else []
+    out: list[str] = []
+    for key, value in tree.items():
+        sub = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.extend(walk_keys(value, sub))
+        else:
+            out.append(sub)
+    return out
+
+
+def _bundle_keys_at(ref: str, lang: str) -> set[str] | None:
+    """Read web/messages/{lang}.json at the given git ref. Returns the
+    flattened key set, or None when the file didn't exist at that ref
+    (e.g. a brand-new locale being introduced in this PR)."""
+    cp = run(["git", "show", f"{ref}:web/messages/{lang}.json"])
+    if cp.returncode != 0:
+        return None
+    try:
+        bundle = json.loads(cp.stdout)
+    except json.JSONDecodeError:
+        return None
+    return set(walk_keys(bundle))
+
+
+def check_locale_parity(base: str | None = None, head: str = "HEAD") -> list[str]:
+    """Forward-looking parity: keys NEWLY ADDED to the anchor bundle in
+    this diff must exist in every other locale at HEAD.
+
+    Existing legacy gaps (keys in en.json that have always been
+    untranslated) don't block — they're separate debt to migrate one
+    breath at a time. Only the diff's contribution to that debt is
+    flagged here, so the gate is forward-looking.
+
+    When called without a base, falls back to the full set so a local
+    `python3 scripts/check_i18n.py` still surfaces the full gap as
+    information (the bundles are expected to drift retroactively until
+    the lift breaths land)."""
+    findings: list[str] = []
+    anchor_path = MESSAGES_DIR / f"{ANCHOR_LOCALE}.json"
+    if not anchor_path.exists():
+        return [f"  anchor bundle missing: {anchor_path.relative_to(REPO_ROOT)}"]
+
+    head_anchor_keys = set(walk_keys(json.load(open(anchor_path))))
+
+    if base:
+        base_anchor_keys = _bundle_keys_at(base, ANCHOR_LOCALE) or set()
+        keys_of_concern = head_anchor_keys - base_anchor_keys
+        scope_label = f"newly added to {ANCHOR_LOCALE}.json since {base}"
+    else:
+        keys_of_concern = head_anchor_keys
+        scope_label = f"present in {ANCHOR_LOCALE}.json"
+
+    if not keys_of_concern and base:
+        return []
+
+    for lang in LOCALES:
+        if lang == ANCHOR_LOCALE:
+            continue
+        path = MESSAGES_DIR / f"{lang}.json"
+        if not path.exists():
+            findings.append(f"  {lang}.json: bundle file missing")
+            continue
+        bundle_keys = set(walk_keys(json.load(open(path))))
+        missing = sorted(keys_of_concern - bundle_keys)
+        if missing:
+            findings.append(
+                f"  {lang}.json: {len(missing)} key(s) {scope_label} but absent — "
+                f"visitor sees the raw key:"
+            )
+            for k in missing[:8]:
+                findings.append(f"      → {k}")
+            if len(missing) > 8:
+                findings.append(f"      → (+{len(missing) - 8} more)")
+    return findings
+
+
+# ─── Check 2: newly-introduced hardcoded chrome ──────────────────────
+
+
+def changed_added_lines(base: str, head: str) -> list[tuple[str, int, str]]:
+    """Walk `git diff base..head` and yield (path, line_no_in_new_file, content)
+    for lines that were ADDED. Removed and context lines are skipped.
+
+    Line numbers come from `git diff --unified` hunk headers (`@@ -a,b +c,d @@`)
+    and increment by 1 for each `+` line; deleted lines (`-`) are not counted.
+    """
+    cp = run(["git", "diff", "--unified=0", "--no-color", f"{base}..{head}"])
+    if cp.returncode != 0:
+        return []
+    out: list[tuple[str, int, str]] = []
+    cur_path: str | None = None
+    new_line: int = 0
+    for raw in cp.stdout.splitlines():
+        if raw.startswith("+++ b/"):
+            cur_path = raw[len("+++ b/"):]
+            continue
+        if raw.startswith("---"):
+            continue
+        m = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", raw)
+        if m:
+            new_line = int(m.group(1))
+            continue
+        if not cur_path:
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            out.append((cur_path, new_line, raw[1:]))
+            new_line += 1
+        elif not raw.startswith("-"):
+            new_line += 1
+    return out
+
+
+def is_skipped(path: str) -> bool:
+    if not path.startswith("web/"):
+        return True
+    if not (path.endswith(".tsx") or path.endswith(".ts")):
+        return True
+    return any(frag in path for frag in SKIP_PATH_FRAGMENTS)
+
+
+def line_is_comment_or_t_call(content: str) -> bool:
+    """Quick heuristic — skip lines that are obviously comments or
+    already wrapped in t()/i18n call. Not perfect (multi-line JSX
+    splits), but cheap and right for the common case."""
+    s = content.strip()
+    if s.startswith("//") or s.startswith("*") or s.startswith("/*"):
+        return True
+    # Whole line is a t('...') or t("...") call — already i18n'd.
+    if "t(" in s and re.search(r"\bt\(['\"]", s):
+        return True
+    return False
+
+
+def looks_like_chrome(text: str) -> bool:
+    """Decide whether a candidate text leaf is user-facing chrome.
+
+    Filters out single-word data labels, schema types, brand names,
+    and short fragments that are likely glue rather than copy."""
+    if text in NOT_CHROME:
+        return False
+    # Must contain at least one space — single words could be data
+    # (kind labels, status enums, etc.) and false-positive easily.
+    if " " not in text:
+        return False
+    # Mostly letters, spaces, and punctuation we expect in copy.
+    if not re.fullmatch(r"[A-Za-z][A-Za-z\s,'·.\-—]+[A-Za-z.!?]", text):
+        return False
+    # Must have at least two letters per word on average — filters
+    # acronym soups and code fragments that snuck through.
+    words = text.split()
+    if len(words) < 2:
+        return False
+    if sum(len(w) for w in words) / len(words) < 3:
+        return False
+    return True
+
+
+def check_new_chrome(base: str, head: str) -> list[str]:
+    findings: list[dict[str, str]] = []
+    for path, line_no, content in changed_added_lines(base, head):
+        if is_skipped(path):
+            continue
+        if line_is_comment_or_t_call(content):
+            continue
+        for m in CHROME_PATTERN.finditer(content):
+            text = m.group(1).strip()
+            if not looks_like_chrome(text):
+                continue
+            findings.append({
+                "path": path,
+                "line": str(line_no),
+                "text": text,
+            })
+
+    if not findings:
+        return []
+
+    by_path: dict[str, list[dict[str, str]]] = {}
+    for f in findings:
+        by_path.setdefault(f["path"], []).append(f)
+
+    lines = [
+        f"  {len(findings)} new hardcoded chrome string(s) introduced in this diff:",
+        "",
+        "  Lift each into web/messages/{lang}.json under a meaningful key,",
+        "  use t('your.key') in the component, and add the matching keys to",
+        "  de.json, es.json, id.json — see feedback_i18n_architecture.md.",
+        "",
+    ]
+    for path in sorted(by_path):
+        lines.append(f"  · {path}")
+        for hit in by_path[path]:
+            lines.append(f"      line {hit['line']}: {hit['text']!r}")
+    return lines
+
+
+# ─── Driver ──────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--base", help="git base ref for new-chrome scan (e.g. origin/main)")
+    p.add_argument("--head", default="HEAD", help="git head ref (default: HEAD)")
+    args = p.parse_args()
+
+    failed = False
+
+    # Parity — forward-looking when given a base, informational otherwise.
+    parity = check_locale_parity(args.base, args.head)
+    if parity:
+        if args.base:
+            print(f"Locale parity drift introduced between {args.base} and {args.head}:")
+        else:
+            print("Locale parity (informational — full snapshot of legacy gaps):")
+        for line in parity:
+            print(line)
+        # Only fail when we have a base ref. Without one, the report is
+        # information about historical debt and shouldn't block local runs.
+        if args.base:
+            failed = True
+    else:
+        print(
+            f"Locale parity ok: no new {ANCHOR_LOCALE}.json keys missing in any other locale."
+            if args.base
+            else f"Locale parity ok: every key in {ANCHOR_LOCALE}.json exists across all {len(LOCALES)} locales."
+        )
+
+    # New-chrome scan only when given a base ref.
+    if args.base:
+        print()
+        new_chrome = check_new_chrome(args.base, args.head)
+        if new_chrome:
+            print(f"New hardcoded chrome (between {args.base} and {args.head}):")
+            for line in new_chrome:
+                print(line)
+            failed = True
+        else:
+            print(f"No new hardcoded chrome introduced between {args.base} and {args.head}.")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The PresencePage lift in #1449 caught thirteen English chrome strings that had been quietly hardcoded. Without a guardrail, the next component does the same. This wires two reinforcing layers so the practice (chrome in messages, content from API) doesn't depend on remembering.

## Pieces

- **`scripts/check_i18n.py`** — two forward-looking checks:
  - **Locale parity**: keys NEWLY added to `en.json` since the base ref must exist in `de.json` / `es.json` / `id.json`. Existing legacy gaps (currently 127 keys in each non-en bundle) don't block — they migrate one breath at a time.
  - **Newly-introduced chrome**: scans the ADDED lines in changed `web/**/*.tsx` files for hardcoded English JSX text leaves (multi-word capitalized phrases between tags) that aren't wrapped in `t()`. Modifications to existing legacy components don't surface their old strings — only what this diff adds.

- **`.github/workflows/thread-gates.yml`** — new step runs `check_i18n.py --base $BASE_SHA --head $HEAD_SHA` on every PR that touches `web/`, mirroring the spec-quality contract step right above it.

- **`CLAUDE.md` Agent Guardrails** — one new line pointing at `feedback_i18n_architecture.md` so every fresh agent reads the rule before adding strings, not after a lift breath.

## What this is NOT

The chrome scan was deliberately left out of `wellness_check.py` — that's a felt-sense reading, not a code-level audit. Mechanical detection lives in CI; the body's sense lives in wellness.

## Test plan
- [ ] Locally: `python3 scripts/check_i18n.py` → reports 127 legacy gaps as informational (does not exit 1).
- [ ] Locally: `python3 scripts/check_i18n.py --base origin/main --head HEAD` → exits 0 on this PR (parity holds, no new chrome).
- [ ] On a synthetic PR adding `<p>Hello world</p>` to a TSX file → CI step fails with the file path + line + the offending string.
- [ ] On a PR adding `"newKey": "..."` to `en.json` only → CI step fails naming the key as missing in `de` / `es` / `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)