### PR TITLE
tend(substrate): self-ingesting body — auto-populate substrate on deploy

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -153,6 +153,43 @@ sync_field_docs() {
 
 sync_field_docs
 
+# Substrate auto-ingest. The coherence-substrate (content-addressed
+# numeric lattice) lives in the api's database. Each deploy syncs the
+# source-of-truth content (specs, ideas, vision-kb concepts, presences)
+# into the container and re-runs the ingester. Re-ingestion is
+# idempotent — content-addressed Blueprint NodeIDs hash-match existing
+# cells. Memory cells live outside the repo (in ~/.claude/) and are
+# skipped automatically. Non-blocking: any failure logs and the deploy
+# still succeeds; the substrate's empty state is visible via the API.
+# Runs AFTER wait_for_running api so the DB connection is stable.
+sync_substrate_content() {
+  log "substrate: syncing content + scripts into api container"
+  docker compose exec -T api sh -lc 'rm -rf /app/specs /app/ideas /app/scripts /app/docs/vision-kb /app/docs/presences' \
+    2>&1 | tee -a "$LOG_FILE" || true
+  docker compose cp "$REPO_DIR/scripts" api:/app/scripts 2>&1 | tee -a "$LOG_FILE"
+  docker compose cp "$REPO_DIR/specs" api:/app/specs 2>&1 | tee -a "$LOG_FILE"
+  docker compose cp "$REPO_DIR/ideas" api:/app/ideas 2>&1 | tee -a "$LOG_FILE"
+  if [[ -d "$REPO_DIR/docs/vision-kb" ]]; then
+    docker compose cp "$REPO_DIR/docs/vision-kb" api:/app/docs/vision-kb 2>&1 | tee -a "$LOG_FILE"
+  fi
+  if [[ -d "$REPO_DIR/docs/presences" ]]; then
+    docker compose cp "$REPO_DIR/docs/presences" api:/app/docs/presences 2>&1 | tee -a "$LOG_FILE"
+  fi
+}
+
+run_substrate_ingest() {
+  log "substrate: running coh_substrate.py ingest --all"
+  set +e
+  docker compose exec -T api sh -lc 'cd /app && python3 scripts/coh_substrate.py ingest --all' \
+    2>&1 | tee -a "$LOG_FILE"
+  local rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    log "substrate: ingest returned $rc — non-blocking, deploy continues"
+  fi
+  return 0
+}
+
 # Wait for both containers to reach the "running" state in docker compose.
 # The deeper health check is left to the workflow's Verify Public Deployment
 # step, which curls the real public domain through the full request path
@@ -188,6 +225,9 @@ else
   log "FAIL: web container did not reach running state within 180s"
   exit 1
 fi
+
+sync_substrate_content
+run_substrate_ingest
 
 log "Deploy complete (${TARGET_SHA:0:12}) — public health check runs next in CI"
 

--- a/scripts/coh_substrate.py
+++ b/scripts/coh_substrate.py
@@ -101,8 +101,11 @@ def _ingest_domain(domain: str) -> int:
         return 1
     base, ingester, filter_fn = _INGESTERS[domain]
     if not base.exists():
-        print(f"{domain} dir not found: {base}", file=sys.stderr)
-        return 1
+        # Some domains live outside the repo (memory) and are absent in
+        # production / CI / fresh checkouts. Skipping is the right shape:
+        # `--all` should populate what it can find, not refuse the run.
+        print(f"{domain}: dir not found ({base}) — skipped", file=sys.stderr)
+        return 0
     md_files = sorted([p for p in base.glob("*.md") if filter_fn(p)])
     print(f"Ingesting {len(md_files)} {domain} files from {base}")
     success = fail = 0


### PR DESCRIPTION
## Summary

The coherence-substrate that merged in #1421 deployed live but stayed empty in production — kernel + tables were there, no cells. This wires the auto-ingest into the deploy pipeline so the lattice fills itself on every deploy, and stays in step with main.

## What changes

**`deploy/hostinger/auto-deploy.sh`** — after both api + web containers reach 'running', sync the source-of-truth content (`scripts/` + `specs/` + `ideas/` + `docs/vision-kb/` + `docs/presences/`) into the api container, then run `python3 scripts/coh_substrate.py ingest --all`. Non-blocking — failures log and the deploy still succeeds.

**`scripts/coh_substrate.py`** — `ingest --all` no longer hard-fails when a domain dir is missing. Memory cells live outside the repo (`~/.claude/`) and are absent in production / CI / fresh checkouts. Skip-with-warning is the right shape.

## Why this is safe

- Re-ingestion is idempotent: Blueprint NodeIDs are content-addressed, so re-runs add zero new cells when content hasn't changed.
- Each deploy syncs fresh content — substrate stays in step with main automatically.
- Performance: ~280 cells, mostly hash-lookups, runs in seconds.

## Test plan

- [x] `ingest --all` runs end-to-end locally: 40 memories + 123 specs + 16 ideas + 89 concepts + 11 presences
- [x] `HOME=/tmp/nope ingest --memories` exits 0 with "dir not found — skipped"
- [ ] After this PR merges + Hostinger deploys, `curl https://api.coherencycoin.com/api/substrate/lattice/stats` shows non-zero counts
- [ ] `https://coherencycoin.com/substrate` shows lattice stats and per-domain histograms

🤖 Generated with [Claude Code](https://claude.com/claude-code)