### PR TITLE
attune: thread libretranslate through graph nodes + edge stubs so content reaches non-EN readers

### DIFF
--- a/api/app/routers/edges.py
+++ b/api/app/routers/edges.py
@@ -4,14 +4,65 @@ Implements the canonical 46-type edge navigation layer from spec task_fbceb79ee5
 The /api/graph/edges and /api/graph/nodes/{id}/edges routes remain in graph.py as aliases.
 """
 
-from fastapi import APIRouter, HTTPException, Query
+import logging
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from typing import Any
 
 from app.config.edge_types import EDGE_TYPE_FAMILIES, CANONICAL_EDGE_TYPES
 from app.services import graph_service
+from app.services.locale_projection import (
+    DEFAULT_LOCALE,
+    SUPPORTED_LOCALES,
+    project,
+    resolve_caller_lang,
+)
 
 router = APIRouter()
+log = logging.getLogger(__name__)
+
+
+_LOCALIZABLE_NODE_TYPES = {
+    "contributor", "asset", "community", "network-org", "place",
+    "event", "scene", "practice", "skill", "concept",
+}
+
+
+def _project_edge_stub(stub: dict, lang: str) -> None:
+    """Project an embedded from_node/to_node stub on an edge response.
+
+    Mirrors graph._project_node but operates on the lighter node-stub
+    shape the edges endpoint returns (id + type + name + image_url + slug,
+    no description). Title-only projection is the common case for chips.
+    """
+    node_id = stub.get("id")
+    node_type = stub.get("type")
+    if not node_id or node_type not in _LOCALIZABLE_NODE_TYPES:
+        return
+    project(stub, "node", node_id, lang, title_field="name", body_field="description")
+    # If the cache had no view for this lang yet, attune-on-miss so the
+    # next chip-render lands in the cached path. Best-effort.
+    try:
+        from app.services import translation_cache_service as _tcache
+        from app.services import translator_service as _ts
+        if _tcache.canonical_view("node", node_id, lang) is None and _ts.has_backend():
+            anchors = _tcache.all_canonical_views("node", node_id)
+            if not _tcache.find_anchor(anchors):
+                _tcache.write_view(
+                    entity_type="node",
+                    entity_id=node_id,
+                    lang=DEFAULT_LOCALE,
+                    content_title=stub.get("name", "") or "",
+                    content_description="",
+                    content_markdown="",
+                    author_type=_tcache.AUTHOR_TYPE_ORIGINAL_HUMAN,
+                )
+            _ts.attune_from_anchor(
+                entity_type="node", entity_id=node_id, target_lang=lang,
+            )
+            project(stub, "node", node_id, lang, title_field="name", body_field="description")
+    except Exception as e:  # pragma: no cover
+        log.debug("edges._project_edge_stub attune-on-miss skipped: %s", e)
 
 
 # ── Request models ────────────────────────────────────────────────────
@@ -64,16 +115,34 @@ async def get_edge_types(family: str | None = None):
 
 @router.get("/edges", summary="List edges with optional filters. Responses include from_node and to_node stubs")
 async def list_edges(
+    request: Request,
     type: str | None = None,
     from_id: str | None = None,
     to_id: str | None = None,
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
+    lang: str | None = Query(None),
 ):
-    """List edges with optional filters. Responses include from_node and to_node stubs."""
-    return graph_service.list_edges(
+    """List edges with optional filters. Responses include from_node and to_node stubs.
+
+    Locale-projects the embedded ``from_node``/``to_node`` name + description
+    so a visitor walking edges (e.g. a contributor's contributes-to chain
+    populating the body of evidence) reads work titles in their own
+    language. Cache-miss triggers a best-effort libretranslate attunement
+    on the underlying nodes via the same mechanism /graph/nodes/{id} uses.
+    """
+    result = graph_service.list_edges(
         edge_type=type, from_id=from_id, to_id=to_id, limit=limit, offset=offset
     )
+    target_lang = resolve_caller_lang(request, lang)
+    if target_lang and target_lang != DEFAULT_LOCALE and target_lang in SUPPORTED_LOCALES:
+        items = result.get("items", []) if isinstance(result, dict) else []
+        for edge in items:
+            for stub_key in ("from_node", "to_node"):
+                stub = edge.get(stub_key) if isinstance(edge, dict) else None
+                if stub:
+                    _project_edge_stub(stub, target_lang)
+    return result
 
 
 @router.get("/edges/{edge_id}", summary="Get a single edge by ID with node stubs")

--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -10,15 +10,105 @@ Spec 169 additions:
   GET /api/graph/nodes/{id}/neighbors — extended with lifecycle_state, rel_type, direction
 """
 
+import logging
 import math
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from typing import Any
 
 from app.services import graph_service
 from app.models.graph import CANONICAL_EDGE_TYPE_SET, NODE_TYPE_SET
+from app.services.locale_projection import (
+    DEFAULT_LOCALE,
+    SUPPORTED_LOCALES,
+    project,
+    resolve_caller_lang,
+)
 
 router = APIRouter()
+log = logging.getLogger(__name__)
+
+
+# Node types that carry user-facing prose worth localizing — contributors,
+# assets/works, communities, places, events, scenes/practices/skills, and
+# concepts. Other graph types (system internals, anonymous-meeting traces,
+# tag taxonomies) are addressable but their text is operational rather
+# than user-narrative, so we don't pay the translation cost there.
+_LOCALIZABLE_NODE_TYPES = {
+    "contributor", "asset", "community", "network-org", "place",
+    "event", "scene", "practice", "skill", "concept",
+}
+
+
+def _project_node(node: dict | None, lang: str | None) -> dict | None:
+    """Project a single graph node's name + description into the caller's
+    locale via the entity_views cache.
+
+    Flow on cache-miss:
+      1. Write the EN source as the canonical anchor view (AUTHOR_TYPE_ORIGINAL_HUMAN)
+         if no anchor exists yet — this lets future attunements work for any
+         locale, not just the one currently requested.
+      2. Call attune_from_anchor(target_lang) which routes through the
+         registered libretranslate backend and writes the translated view
+         to entity_views.
+      3. Re-project the node so the response carries the translated text.
+
+    Failures are best-effort — a translator-backend timeout or libretranslate
+    being unhealthy returns the source-language text rather than blocking
+    the read. The next request retries naturally.
+    """
+    if not node or not lang or lang == DEFAULT_LOCALE or lang not in SUPPORTED_LOCALES:
+        return node
+    node_id = node.get("id")
+    node_type = node.get("type")
+    if not node_id or node_type not in _LOCALIZABLE_NODE_TYPES:
+        return node
+
+    # Cache hit path — fastest case, no backend touched.
+    project(node, "node", node_id, lang, title_field="name", body_field="description")
+    if _name_or_desc_translated(node, lang):
+        return node
+
+    # Cache miss — attune from anchor (writing the anchor first if needed).
+    try:
+        from app.services import translation_cache_service as _tcache
+        from app.services import translator_service as _ts
+        if not _ts.has_backend():
+            return node
+        anchors = _tcache.all_canonical_views("node", node_id)
+        if not _tcache.find_anchor(anchors):
+            _tcache.write_view(
+                entity_type="node",
+                entity_id=node_id,
+                lang=DEFAULT_LOCALE,
+                content_title=node.get("name", "") or "",
+                content_description=node.get("description", "") or "",
+                content_markdown="",
+                author_type=_tcache.AUTHOR_TYPE_ORIGINAL_HUMAN,
+            )
+        _ts.attune_from_anchor(
+            entity_type="node",
+            entity_id=node_id,
+            target_lang=lang,
+        )
+        # Re-project now that a translated view exists.
+        project(node, "node", node_id, lang, title_field="name", body_field="description")
+    except Exception as e:  # pragma: no cover — translation must never block reads
+        log.debug("graph._project_node attune-on-miss skipped: %s", e)
+    return node
+
+
+def _name_or_desc_translated(node: dict, lang: str) -> bool:
+    """Heuristic — was the node already projected? We can't tell from the
+    payload alone (a German speaker's English bio looks German-ish to a
+    string matcher), so we just check whether a canonical view exists in
+    the cache for this lang. Fast lookup, no backend touched."""
+    try:
+        from app.services import translation_cache_service as _tcache
+        rec = _tcache.canonical_view("node", node.get("id"), lang)
+        return rec is not None
+    except Exception:
+        return False
 
 
 # ── Request models ───────────────────────────────────────────────────
@@ -111,7 +201,7 @@ async def graph_stats():
 
 
 @router.get("/graph/nodes/{node_id}", summary="Get a single node")
-async def get_node(node_id: str):
+async def get_node(node_id: str, request: Request, lang: str | None = Query(None)):
     """Get a single node by id, falling back to slug lookup.
 
     The path argument is treated as a graph id first. When that misses
@@ -122,6 +212,12 @@ async def get_node(node_id: str):
     older routes. This lets every URL form converge to one identity
     through one endpoint, with the mapping living in the graph
     instead of a hand-curated table.
+
+    Locale-projected when the caller's lang resolves to a non-default
+    SUPPORTED_LOCALES member. Cache-miss triggers a best-effort
+    libretranslate attunement so subsequent reads land in the cached
+    path; the current read keeps source-language text rather than
+    blocking on translation latency.
     """
     node = graph_service.get_node(node_id)
     if not node and ":" not in node_id:
@@ -130,7 +226,8 @@ async def get_node(node_id: str):
         node = graph_service.get_node(f"contributor:{node_id}")
     if not node:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
-    return node
+    target_lang = resolve_caller_lang(request, lang)
+    return _project_node(node, target_lang)
 
 
 @router.patch("/graph/nodes/{node_id}", summary="Update a node")


### PR DESCRIPTION
Mom's question: "how does my mom (German) understand the content?"

Honest answer was: she mostly couldn't. The previous pass localised chrome but content came back from the graph in its source language. The substrate (entity_views + locale_projection + libretranslate backend) was already there; just no wiring on the graph endpoints.

This adds project()+attune-on-miss to /api/graph/nodes/{id} and the to_node/from_node stubs on /api/edges. First DE read pays the libretranslate hop (~200ms) and caches; subsequent reads serve from entity_views. Best-effort — failures fail-warm to source text rather than blocking reads.

Verified libretranslate live: 'Founder and primary shepherd of the Coherence Network' → 'Gründer und primärer Hirte des Kohärenznetzwerks'.

Curated /people/{slug} content modules (BML / Schindler / etc.) intentionally left en-only — tender authored prose deserves author-curated translations, not machine ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)