### PR TITLE
fix: default libretranslate to the internal docker container

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -366,7 +366,7 @@ def _default_config() -> dict[str, Any]:
         },
         "translator": {
             "backend": "libretranslate",
-            "libretranslate_url": "https://libretranslate.com",
+            "libretranslate_url": "http://libretranslate:5000",
             "libretranslate_key": None,
             "anthropic_api_key": None,
             "anthropic_api_url": "https://api.anthropic.com/v1/messages",

--- a/api/app/services/translator_backends.py
+++ b/api/app/services/translator_backends.py
@@ -48,7 +48,7 @@ DEFAULT_TIMEOUT_SECONDS = 120
 # LibreTranslate (default, free, no key)
 # ---------------------------------------------------------------------------
 
-DEFAULT_LIBRETRANSLATE_URL = "https://libretranslate.com"
+DEFAULT_LIBRETRANSLATE_URL = "http://libretranslate:5000"
 
 
 _logger = logging.getLogger("coherence.translator")


### PR DESCRIPTION
Translator backend was defaulting to public libretranslate.com (429-rate-limited). Caught while verifying Mom's DE reads: api logs flooded with 429s while the internal libretranslate container sat healthy. Two-line default change. Production was hot-patched; this just makes the source match the deployed config so clean deploys inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)