### PR TITLE
feat: mfb vitality lens — busy heatmap + recipe ranking

### DIFF
--- a/experiments/memory-as-framebuffer-v0/.gitignore
+++ b/experiments/memory-as-framebuffer-v0/.gitignore
@@ -3,3 +3,4 @@
 *.mfb
 *.png
 *.html
+*.provmap

--- a/experiments/memory-as-framebuffer-v0/README.md
+++ b/experiments/memory-as-framebuffer-v0/README.md
@@ -222,3 +222,28 @@ The viewer reconstructs full state from the .mfb's delta-encoded frames —
 stepping forward applies deltas, stepping backward replays from the start.
 For 6-second captures (~390 frames) the HTML lands ~250–700 KB; opens
 instantly. Easily shareable as a single artifact.
+
+### Vitality mode + recipe leaderboard
+
+A header toggle switches the viewer between **Identity** mode (the
+default — cells colored by type tag, side panel shows the cell inspector)
+and **Vitality** mode (cells colored by total write count, side panel
+shows ranked recipes by total cell-writes).
+
+For the recipe leaderboard to label entries with `examples/fizzbuzz.rs:42`
+instead of raw hex hashes, the runtime writes a `{capture}.provmap` JSON
+sidecar at `shutdown_framebuffer()` that maps every observed provenance
+hash back to its `(file, line)`. The mfb-html bin auto-loads it next
+to the `.mfb` if present.
+
+Vitality mode is what surfaces *busy areas of the heap* and *which recipe
+is most alive in this run*. For fizzbuzz: the shift loop at
+`examples/fizzbuzz.rs:42` dominates with ~24,000 writes (visiting each
+of 99 history cells per snapshot frame), with the four fizz/buzz/fizzbuzz
+branch sites visible at realistic ratios (plain > fizz > buzz > fizzbuzz).
+Click any recipe in the list to highlight every cell that recipe writes
+to in the current frame.
+
+The cell inspector also shows the resolved source location (`Source:
+examples/fizzbuzz.rs:34`) and the cell's lifetime write count, both
+read from the same provmap + write-count tables embedded in the HTML.

--- a/experiments/memory-as-framebuffer-v0/src/bin/mfb-html.rs
+++ b/experiments/memory-as-framebuffer-v0/src/bin/mfb-html.rs
@@ -105,6 +105,35 @@ fn live_cells(frame: &FrameSnapshot) -> Vec<(usize, u16, String, u32)> {
     out
 }
 
+/// Parse `{input}.provmap` if present, returning a JSON object string ready
+/// to embed. Empty `{}` if missing or unreadable. The provmap is written by
+/// `shutdown_framebuffer()` when MFB_CAPTURE was set; format is
+/// `{ "<hash_decimal>": {"file": "...", "line": N}, ... }`.
+fn load_provmap_json(input_path: &str) -> String {
+    let provmap_path = format!("{}.provmap", input_path);
+    match std::fs::read_to_string(&provmap_path) {
+        Ok(content) => {
+            // Sanity-check it's a JSON object — pass through verbatim if so.
+            if content.trim_start().starts_with('{') {
+                content
+            } else {
+                eprintln!(
+                    "warning: {} doesn't look like JSON; ignoring",
+                    provmap_path
+                );
+                "{}".into()
+            }
+        }
+        Err(_) => {
+            eprintln!(
+                "note: no provmap sidecar at {} — recipe leaderboard will show raw hashes",
+                provmap_path
+            );
+            "{}".into()
+        }
+    }
+}
+
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
@@ -114,11 +143,12 @@ fn main() -> io::Result<()> {
     let input = &args[1];
     let output = &args[2];
 
+    let provmap_json = load_provmap_json(input);
+
     let mut reader = CaptureReader::open(input)?;
     let fps_hint = reader.fps_hint();
 
     // Parse all frames into delta records (relative to previous frame).
-    // First frame is encoded as `set` containing every live cell.
     let mut prev_state: std::collections::HashMap<usize, (u16, String, u32)> =
         std::collections::HashMap::new();
     let mut frames_json = String::from("[");
@@ -128,16 +158,20 @@ fn main() -> io::Result<()> {
     let mut max_x: usize = 0;
     let mut max_y: usize = 0;
 
+    // Vitality lens accumulators: total writes per cell + per provenance hash.
+    let mut cell_writes: std::collections::HashMap<usize, u64> =
+        std::collections::HashMap::new();
+    let mut prov_writes: std::collections::HashMap<u32, u64> =
+        std::collections::HashMap::new();
+
     while let Some(frame) = reader.next() {
         let frame = frame?;
         let live = live_cells(&frame);
 
-        // Build new_state map.
         let mut new_state: std::collections::HashMap<usize, (u16, String, u32)> =
             std::collections::HashMap::with_capacity(live.len());
         for (idx, tag, val, prov) in &live {
             new_state.insert(*idx, (*tag, val.clone(), *prov));
-            // Track bounding box across all frames for the viewer's grid sizing.
             let x = idx % GRID;
             let y = idx / GRID;
             if x < min_x {
@@ -154,7 +188,6 @@ fn main() -> io::Result<()> {
             }
         }
 
-        // Diff against prev.
         let mut sets: Vec<(usize, u16, String, u32)> = Vec::new();
         let mut unsets: Vec<usize> = Vec::new();
         for (&idx, val) in &new_state {
@@ -164,6 +197,9 @@ fn main() -> io::Result<()> {
             };
             if changed {
                 sets.push((idx, val.0, val.1.clone(), val.2));
+                // Vitality counters: count one "write" per changed cell per frame.
+                *cell_writes.entry(idx).or_insert(0) += 1;
+                *prov_writes.entry(val.2).or_insert(0) += 1;
             }
         }
         for &idx in prev_state.keys() {
@@ -209,7 +245,6 @@ fn main() -> io::Result<()> {
     }
     frames_json.push(']');
 
-    // If no live cells ever appeared, default the bbox to the top-left 12x12.
     if max_x < min_x {
         min_x = 0;
         min_y = 0;
@@ -220,6 +255,34 @@ fn main() -> io::Result<()> {
     let bbox_w = max_x - min_x + 1;
     let bbox_h = max_y - min_y + 1;
 
+    // Serialize vitality data to compact JSON.
+    let cell_writes_json = {
+        let mut s = String::from("{");
+        let mut first = true;
+        for (idx, count) in &cell_writes {
+            if !first {
+                s.push(',');
+            }
+            first = false;
+            s.push_str(&format!("\"{}\":{}", idx, count));
+        }
+        s.push('}');
+        s
+    };
+    let prov_writes_json = {
+        let mut s = String::from("{");
+        let mut first = true;
+        for (hash, count) in &prov_writes {
+            if !first {
+                s.push(',');
+            }
+            first = false;
+            s.push_str(&format!("\"{}\":{}", hash, count));
+        }
+        s.push('}');
+        s
+    };
+
     let html = build_html(
         input,
         frame_count,
@@ -229,19 +292,24 @@ fn main() -> io::Result<()> {
         bbox_w,
         bbox_h,
         &frames_json,
+        &cell_writes_json,
+        &prov_writes_json,
+        &provmap_json,
     );
 
     let mut out_file = fs::File::create(output)?;
     out_file.write_all(html.as_bytes())?;
 
     eprintln!(
-        "wrote {} ({} frames, bbox {}x{} at ({},{}), {} bytes)",
+        "wrote {} ({} frames, bbox {}x{} at ({},{}), {} unique cells, {} unique recipes, {} bytes)",
         output,
         frame_count,
         bbox_w,
         bbox_h,
         min_x,
         min_y,
+        cell_writes.len(),
+        prov_writes.len(),
         std::fs::metadata(output)?.len()
     );
     Ok(())
@@ -256,10 +324,13 @@ fn build_html(
     bbox_w: usize,
     bbox_h: usize,
     frames_json: &str,
+    cell_writes_json: &str,
+    prov_writes_json: &str,
+    provmap_json: &str,
 ) -> String {
     // The viewer JS reconstructs full state from deltas. The PALETTE matches
     // the v0 mp4 renderer's tag colors so a viewer who's seen the mp4 has
-    // continuity of identity.
+    // continuity of identity. Vitality mode uses a heat-scale instead.
     format!(
         r##"<!DOCTYPE html>
 <html lang="en">
@@ -285,7 +356,17 @@ fn build_html(
     display: flex; align-items: baseline; gap: 16px;
   }}
   header h1 {{ margin: 0; font-size: 16px; font-weight: 500; }}
-  header .meta {{ color: var(--muted); font-size: 13px; }}
+  header .meta {{ color: var(--muted); font-size: 13px; flex: 1; }}
+  header .modes {{ display: flex; gap: 0; }}
+  header .modes button {{
+    background: #1f1f1f; color: var(--muted); border: 0;
+    padding: 4px 10px; cursor: pointer; font-size: 12px;
+    border-right: 1px solid #2a2a2a;
+  }}
+  header .modes button:first-child {{ border-radius: 3px 0 0 3px; }}
+  header .modes button:last-child {{ border-radius: 0 3px 3px 0; border-right: 0; }}
+  header .modes button.active {{ background: var(--accent); color: #000; font-weight: 500; }}
+  header .modes button:hover:not(.active) {{ color: var(--fg); }}
   main {{
     display: grid;
     grid-template-columns: 1fr 280px;
@@ -314,19 +395,51 @@ fn build_html(
   }}
   .cell.live {{ background: var(--cell-color, #888); }}
   .cell:hover {{ outline: 2px solid var(--accent); z-index: 1; }}
-  #info {{
+  #side {{
     background: var(--panel);
     border-radius: 4px;
     padding: 16px;
     font-size: 13px;
     line-height: 1.5;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
   }}
-  #info h3 {{ margin: 0 0 12px 0; font-weight: 500; font-size: 14px; }}
-  #info .row {{ display: flex; gap: 8px; margin-bottom: 6px; }}
-  #info .label {{ color: var(--muted); width: 80px; flex-shrink: 0; }}
-  #info .value {{ color: var(--fg); font-family: ui-monospace, "SF Mono", monospace; word-break: break-all; }}
-  #info.empty .value {{ color: var(--muted); }}
+  #side h3 {{ margin: 0 0 12px 0; font-weight: 500; font-size: 14px; }}
+  #side .row {{ display: flex; gap: 8px; margin-bottom: 6px; }}
+  #side .label {{ color: var(--muted); width: 80px; flex-shrink: 0; }}
+  #side .value {{ color: var(--fg); font-family: ui-monospace, "SF Mono", monospace; word-break: break-all; }}
+  #side.empty .value {{ color: var(--muted); }}
+  .panel {{ display: none; }}
+  .panel.active {{ display: block; }}
+  #recipes ol {{ margin: 0; padding: 0; list-style: none; counter-reset: rank; }}
+  #recipes li {{
+    counter-increment: rank;
+    display: grid;
+    grid-template-columns: 24px 1fr auto;
+    gap: 8px;
+    align-items: baseline;
+    padding: 6px 0;
+    border-bottom: 1px solid #222;
+    font-size: 12px;
+  }}
+  #recipes li:before {{
+    content: counter(rank);
+    color: var(--muted);
+    text-align: right;
+    font-family: ui-monospace, monospace;
+  }}
+  #recipes .src {{ color: var(--fg); font-family: ui-monospace, monospace; word-break: break-all; }}
+  #recipes .count {{
+    color: var(--accent);
+    font-family: ui-monospace, monospace;
+    font-variant-numeric: tabular-nums;
+  }}
+  #recipes .bar {{
+    grid-column: 1 / -1;
+    height: 2px;
+    background: linear-gradient(to right, var(--accent) var(--bar-pct, 0%), transparent var(--bar-pct, 0%));
+    margin-top: 4px;
+  }}
   footer {{
     padding: 8px 20px;
     border-top: 1px solid #222;
@@ -347,24 +460,46 @@ fn build_html(
 <header>
   <h1>memory-as-framebuffer / replay</h1>
   <span class="meta">{source_esc} · {frame_count} frames · {fps_hint} fps · viewport {bbox_w}×{bbox_h} from ({min_x},{min_y})</span>
+  <div class="modes">
+    <button id="mode-identity" class="active" title="Color cells by their type tag">Identity</button>
+    <button id="mode-vitality" title="Color cells by total write count (busy heatmap) and rank recipes by activity">Vitality</button>
+  </div>
 </header>
 <main>
   <div id="heap"></div>
-  <div id="info" class="empty">
-    <h3>Cell inspector</h3>
-    <div class="row"><span class="label">Index</span><span class="value" id="cell-id">hover a cell</span></div>
-    <div class="row"><span class="label">Grid (x,y)</span><span class="value" id="cell-xy">—</span></div>
-    <div class="row"><span class="label">Tag</span><span class="value" id="cell-tag">—</span></div>
-    <div class="row"><span class="label">Value</span><span class="value" id="cell-val">—</span></div>
-    <div class="row"><span class="label">Provenance</span><span class="value" id="cell-prov">—</span></div>
-    <hr style="border-color: #222; margin: 12px 0;">
-    <p style="color: var(--muted); font-size: 12px;">
-      Pointers show their target cell index. Provenance is the
-      <code>crc32(file:line)</code> of the call site of the most recent
-      <code>track!</code> on this cell. Pointer cells share inner color with
-      their target — the v0/v1-pointers Superliminal idiom.
-    </p>
-  </div>
+  <aside id="side" class="empty">
+    <div id="inspector" class="panel active">
+      <h3>Cell inspector</h3>
+      <div class="row"><span class="label">Index</span><span class="value" id="cell-id">hover a cell</span></div>
+      <div class="row"><span class="label">Grid (x,y)</span><span class="value" id="cell-xy">—</span></div>
+      <div class="row"><span class="label">Tag</span><span class="value" id="cell-tag">—</span></div>
+      <div class="row"><span class="label">Value</span><span class="value" id="cell-val">—</span></div>
+      <div class="row"><span class="label">Provenance</span><span class="value" id="cell-prov">—</span></div>
+      <div class="row"><span class="label">Source</span><span class="value" id="cell-src">—</span></div>
+      <div class="row"><span class="label">Writes</span><span class="value" id="cell-writes">—</span></div>
+      <hr style="border-color: #222; margin: 12px 0;">
+      <p style="color: var(--muted); font-size: 12px;">
+        Pointers show their target cell index. Provenance is the
+        <code>crc32(file:line)</code> of the call site of the most recent
+        <code>track!</code> on this cell. Pointer cells share inner color
+        with their target — the v0/v1-pointers Superliminal idiom.
+      </p>
+    </div>
+    <div id="recipes" class="panel">
+      <h3>Most-alive recipes</h3>
+      <p style="color: var(--muted); font-size: 12px; margin: 0 0 12px 0;">
+        Recipes ranked by total cell-writes across the run. The bar shows
+        each recipe's share of the busiest one. Click a recipe to highlight
+        all cells it writes to.
+      </p>
+      <ol id="recipes-list"></ol>
+      <hr style="border-color: #222; margin: 12px 0;">
+      <p style="color: var(--muted); font-size: 12px;">
+        In Vitality mode, cells are colored by write rate (cool→hot).
+        Toggle back to Identity to see type-tag coloring + cell inspector.
+      </p>
+    </div>
+  </aside>
 </main>
 <footer>
   <button id="play">▶ Play</button>
@@ -376,6 +511,9 @@ const GRID = {GRID};
 const FPS = {fps_hint};
 const BBOX = {{ minX: {min_x}, minY: {min_y}, w: {bbox_w}, h: {bbox_h} }};
 const FRAMES = {frames_json};
+const CELL_WRITES = {cell_writes_json};
+const PROV_WRITES = {prov_writes_json};
+const PROVMAP = {provmap_json};
 
 const PALETTE = {{
   free: "#000000",
@@ -388,17 +526,52 @@ const PALETTE = {{
   unknown: "#444444"
 }};
 
+// Heat scale for vitality coloring: 0 → invisible, max → bright orange/red.
+// Uses a perceptually-decent gradient cool → green → yellow → orange → red.
+function heatColor(t) {{
+  // t in [0, 1]
+  if (t <= 0) return "transparent";
+  const stops = [
+    [0.0, [10, 20, 60]],     // deep blue
+    [0.15, [30, 80, 180]],   // blue
+    [0.35, [50, 200, 200]],  // teal
+    [0.55, [120, 230, 80]],  // green
+    [0.75, [255, 220, 60]],  // yellow
+    [0.9, [255, 130, 40]],   // orange
+    [1.0, [255, 70, 50]],    // red
+  ];
+  for (let i = 1; i < stops.length; i++) {{
+    if (t <= stops[i][0]) {{
+      const [t0, c0] = stops[i - 1];
+      const [t1, c1] = stops[i];
+      const u = (t - t0) / (t1 - t0);
+      const r = Math.round(c0[0] + (c1[0] - c0[0]) * u);
+      const g = Math.round(c0[1] + (c1[1] - c0[1]) * u);
+      const b = Math.round(c0[2] + (c1[2] - c0[2]) * u);
+      return `rgb(${{r}}, ${{g}}, ${{b}})`;
+    }}
+  }}
+  return `rgb(255, 70, 50)`;
+}}
+
 const heapEl = document.getElementById("heap");
 const scrub = document.getElementById("scrubber");
 const counter = document.getElementById("counter");
 const playBtn = document.getElementById("play");
+const sideEl = document.getElementById("side");
+const inspectorPanel = document.getElementById("inspector");
+const recipesPanel = document.getElementById("recipes");
+const recipesList = document.getElementById("recipes-list");
+const modeIdentityBtn = document.getElementById("mode-identity");
+const modeVitalityBtn = document.getElementById("mode-vitality");
 const info = {{
-  panel: document.getElementById("info"),
   id: document.getElementById("cell-id"),
   xy: document.getElementById("cell-xy"),
   tag: document.getElementById("cell-tag"),
   val: document.getElementById("cell-val"),
   prov: document.getElementById("cell-prov"),
+  src: document.getElementById("cell-src"),
+  writes: document.getElementById("cell-writes"),
 }};
 
 heapEl.style.gridTemplateColumns = `repeat(${{BBOX.w}}, 1fr)`;
@@ -421,14 +594,33 @@ for (let y = BBOX.minY; y < BBOX.minY + BBOX.h; y++) {{
 
 const liveState = new Map();  // idx → {{tag, val, prov}}
 let appliedFrame = -1;
+let mode = "identity"; // or "vitality"
+let highlightedProv = null;
+
+// Pre-compute max write counts for vitality scaling.
+const maxCellWrites = Math.max(1, ...Object.values(CELL_WRITES));
+const maxProvWrites = Math.max(1, ...Object.values(PROV_WRITES));
+
+function colorForCell(idx, tag) {{
+  if (mode === "vitality") {{
+    const writes = CELL_WRITES[idx] || 0;
+    if (writes === 0) return "transparent";
+    // Log-scale so a 100-write cell isn't drowned by a 1000-write cell.
+    const t = Math.log1p(writes) / Math.log1p(maxCellWrites);
+    return heatColor(t);
+  }}
+  return PALETTE[tag] || PALETTE.unknown;
+}}
 
 function setCell(idx, tag, val, prov) {{
   liveState.set(idx, {{ tag, val, prov }});
   const el = cellEls.get(idx);
   if (el) {{
     el.classList.add("live");
-    el.style.setProperty("--cell-color", PALETTE[tag] || PALETTE.unknown);
+    el.style.setProperty("--cell-color", colorForCell(idx, tag));
     el.dataset.tag = tag;
+    el.dataset.prov = prov;
+    applyHighlight(el, prov);
   }}
 }}
 
@@ -439,12 +631,32 @@ function unsetCell(idx) {{
     el.classList.remove("live");
     el.style.removeProperty("--cell-color");
     delete el.dataset.tag;
+    delete el.dataset.prov;
+    el.style.outline = "";
+  }}
+}}
+
+function applyHighlight(el, prov) {{
+  if (highlightedProv !== null && Number(prov) === highlightedProv) {{
+    el.style.outline = "2px solid var(--accent)";
+    el.style.zIndex = "2";
+  }} else {{
+    el.style.outline = "";
+    el.style.zIndex = "";
+  }}
+}}
+
+function recolorAllLive() {{
+  for (const [idx, cell] of liveState.entries()) {{
+    const el = cellEls.get(idx);
+    if (el) {{
+      el.style.setProperty("--cell-color", colorForCell(idx, cell.tag));
+    }}
   }}
 }}
 
 function applyFrameDelta(toIdx) {{
   if (toIdx === appliedFrame) return;
-  // Stepping backward — replay from the start (frame 0 is full state).
   if (toIdx < appliedFrame) {{
     for (const idx of Array.from(liveState.keys())) unsetCell(idx);
     appliedFrame = -1;
@@ -460,24 +672,87 @@ function applyFrameDelta(toIdx) {{
   counter.textContent = `Frame ${{toIdx}} / {max_idx} · t=${{(fr.t / 1000).toFixed(0)}}ms`;
 }}
 
+function provSourceLabel(prov) {{
+  const entry = PROVMAP[String(prov)];
+  if (!entry) return null;
+  return `${{entry.file}}:${{entry.line}}`;
+}}
+
 function showCell(idx) {{
   const cell = liveState.get(idx);
   const x = idx % GRID;
   const y = Math.floor(idx / GRID);
   info.id.textContent = idx;
   info.xy.textContent = `(${{x}}, ${{y}})`;
+  info.writes.textContent = (CELL_WRITES[idx] || 0).toLocaleString();
   if (cell) {{
-    info.panel.classList.remove("empty");
+    sideEl.classList.remove("empty");
     info.tag.textContent = cell.tag;
     info.val.textContent = cell.val;
     info.prov.textContent = "0x" + cell.prov.toString(16).padStart(8, "0");
+    info.src.textContent = provSourceLabel(cell.prov) || "(unmapped)";
   }} else {{
-    info.panel.classList.add("empty");
+    sideEl.classList.add("empty");
     info.tag.textContent = "(free)";
     info.val.textContent = "—";
     info.prov.textContent = "—";
+    info.src.textContent = "—";
   }}
 }}
+
+// Recipes leaderboard: rank by write count, show file:line, click to highlight.
+function buildRecipesList() {{
+  const ranked = Object.entries(PROV_WRITES)
+    .map(([hash, count]) => ({{ hash: Number(hash), count }}))
+    .sort((a, b) => b.count - a.count);
+  const top = maxProvWrites;
+  recipesList.innerHTML = "";
+  for (const {{ hash, count }} of ranked) {{
+    const li = document.createElement("li");
+    li.dataset.prov = hash;
+    const src = provSourceLabel(hash) || `0x${{hash.toString(16).padStart(8, "0")}}`;
+    const pct = ((count / top) * 100).toFixed(1);
+    li.innerHTML =
+      `<span class="src">${{escapeHtml(src)}}</span>` +
+      `<span class="count">${{count.toLocaleString()}}</span>` +
+      `<div class="bar" style="--bar-pct: ${{pct}}%"></div>`;
+    li.style.cursor = "pointer";
+    li.addEventListener("click", () => toggleRecipeHighlight(hash));
+    recipesList.appendChild(li);
+  }}
+}}
+
+function escapeHtml(s) {{
+  return String(s).replace(/[&<>"']/g, c => ({{
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  }})[c]);
+}}
+
+function toggleRecipeHighlight(prov) {{
+  highlightedProv = (highlightedProv === prov) ? null : prov;
+  for (const [idx, cell] of liveState.entries()) {{
+    const el = cellEls.get(idx);
+    if (el) applyHighlight(el, cell.prov);
+  }}
+  // Visual feedback on the recipes list.
+  for (const li of recipesList.children) {{
+    li.style.background = (Number(li.dataset.prov) === highlightedProv) ? "#222" : "";
+  }}
+}}
+
+function setMode(newMode) {{
+  if (newMode === mode) return;
+  mode = newMode;
+  modeIdentityBtn.classList.toggle("active", mode === "identity");
+  modeVitalityBtn.classList.toggle("active", mode === "vitality");
+  inspectorPanel.classList.toggle("active", mode === "identity");
+  recipesPanel.classList.toggle("active", mode === "vitality");
+  recolorAllLive();
+}}
+
+modeIdentityBtn.addEventListener("click", () => setMode("identity"));
+modeVitalityBtn.addEventListener("click", () => setMode("vitality"));
+buildRecipesList();
 
 scrub.addEventListener("input", () => {{
   applyFrameDelta(parseInt(scrub.value, 10));
@@ -533,6 +808,9 @@ applyFrameDelta(0);
         bbox_h = bbox_h,
         max_idx = frame_count.saturating_sub(1),
         frames_json = frames_json,
+        cell_writes_json = cell_writes_json,
+        prov_writes_json = prov_writes_json,
+        provmap_json = provmap_json,
         GRID = GRID,
     )
 }

--- a/experiments/memory-as-framebuffer-v0/src/lib.rs
+++ b/experiments/memory-as-framebuffer-v0/src/lib.rs
@@ -16,6 +16,7 @@ pub mod render;
 pub mod snapshot;
 
 use once_cell::sync::OnceCell;
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 pub use allocator::{CellHandle, SlabFramebuffer, CELL_BYTES, GRID, NUM_CELLS};
@@ -120,6 +121,32 @@ impl Drop for Framebuffer {
 
 static FRAMEBUFFER: OnceCell<Framebuffer> = OnceCell::new();
 
+/// Process-global registry mapping `crc32(file:line)` provenance hashes back
+/// to their `(file, line)` origin. Populated by `compute_and_register_prov()`
+/// every time a `track!` or `Tracked::new[_at]()` runs. Dumped to a
+/// `{MFB_CAPTURE}.provmap` JSON sidecar at `shutdown_framebuffer()` so any
+/// downstream renderer (mfb-html, future 3D, etc.) can resolve hashes back
+/// to source locations and group cells by recipe.
+static PROV_REGISTRY: OnceCell<Mutex<HashMap<u32, (String, u32)>>> = OnceCell::new();
+
+fn prov_registry() -> &'static Mutex<HashMap<u32, (String, u32)>> {
+    PROV_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Compute the provenance hash for a `(file, line)` source location AND
+/// register the mapping in the global registry. All three primitive write
+/// sites (`Tracked::new`, `Tracked::new_at`, `track!` via
+/// `write_with_provenance`) route through this so the registry is complete
+/// at shutdown time.
+fn compute_and_register_prov(file: &str, line: u32) -> u32 {
+    let hash = crc32fast::hash(format!("{}:{}", file, line).as_bytes());
+    if let Ok(mut reg) = prov_registry().lock() {
+        reg.entry(hash)
+            .or_insert_with(|| (file.to_string(), line));
+    }
+    hash
+}
+
 /// Initialize the global framebuffer. Spawns the snapshot thread which spawns ffmpeg
 /// and pipes RGBA frames at MFB_FPS (default 60) to OUTPUT (default "framebuffer.mp4").
 ///
@@ -170,7 +197,11 @@ pub fn framebuffer() -> &'static Framebuffer {
         .expect("framebuffer not initialized; call init_framebuffer() first")
     }
 
-/// Shut down the global framebuffer (closes ffmpeg, finalizes mp4).
+/// Shut down the global framebuffer (closes ffmpeg, finalizes mp4 + .mfb).
+/// Also dumps the provenance registry to a `{MFB_CAPTURE}.provmap` JSON
+/// sidecar so downstream renderers can resolve provenance hashes back to
+/// `(file, line)` source locations.
+///
 /// Idempotent. Should be called at the end of main; otherwise the OnceCell
 /// is leaked at process exit and ffmpeg may not flush cleanly.
 pub fn shutdown_framebuffer() {
@@ -181,6 +212,38 @@ pub fn shutdown_framebuffer() {
             }
         }
     }
+    if let Ok(capture_path) = std::env::var("MFB_CAPTURE") {
+        let provmap_path = format!("{}.provmap", capture_path);
+        if let Err(e) = write_provmap_json(&provmap_path) {
+            eprintln!(
+                "memory-as-framebuffer: failed to write {}: {}",
+                provmap_path, e
+            );
+        }
+    }
+}
+
+/// Serialize the provenance registry to a JSON file at `path`. Manual
+/// serialization avoids pulling serde into the crate just for this.
+fn write_provmap_json(path: &str) -> std::io::Result<()> {
+    let reg = prov_registry()
+        .lock()
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "provmap mutex poisoned"))?;
+    let mut s = String::from("{");
+    let mut first = true;
+    for (hash, (file, line)) in reg.iter() {
+        if !first {
+            s.push(',');
+        }
+        first = false;
+        let escaped = file.replace('\\', "\\\\").replace('"', "\\\"");
+        s.push_str(&format!(
+            "\"{}\":{{\"file\":\"{}\",\"line\":{}}}",
+            hash, escaped, line
+        ));
+    }
+    s.push('}');
+    std::fs::write(path, s)
 }
 
 /// A tracked primitive value. Construction allocates a cell; the tag and
@@ -196,7 +259,7 @@ impl<T: TrackedPrimitive> Tracked<T> {
     #[track_caller]
     pub fn new(value: T) -> Self {
         let caller = std::panic::Location::caller();
-        let prov = crc32fast::hash(format!("{}:{}", caller.file(), caller.line()).as_bytes());
+        let prov = compute_and_register_prov(caller.file(), caller.line());
 
         let fb = framebuffer();
         let handle = {
@@ -224,7 +287,7 @@ impl<T: TrackedPrimitive> Tracked<T> {
     #[track_caller]
     pub fn new_at(idx: usize, value: T) -> Self {
         let caller = std::panic::Location::caller();
-        let prov = crc32fast::hash(format!("{}:{}", caller.file(), caller.line()).as_bytes());
+        let prov = compute_and_register_prov(caller.file(), caller.line());
 
         let fb = framebuffer();
         let handle = {
@@ -260,7 +323,7 @@ impl<T: TrackedPrimitive> Tracked<T> {
     /// Write a new value AND stamp provenance at the given file:line.
     /// Used by the `track!` macro; not normally called directly.
     pub fn write_with_provenance(&mut self, value: T, file: &str, line: u32) {
-        let prov = crc32fast::hash(format!("{}:{}", file, line).as_bytes());
+        let prov = compute_and_register_prov(file, line);
         let fb = framebuffer();
         {
             let mut data = fb.data.lock().unwrap();


### PR DESCRIPTION
## Summary

Three lenses in the HTML viewer to find busy areas of the heap and surface which recipe is most alive:

1. **Provenance resolver** — runtime tracks every \`crc32(file:line)\` → source location, dumps a \`{capture}.provmap\` JSON sidecar at shutdown. Inspector now shows real \`examples/fizzbuzz.rs:34\` instead of opaque \`0xf90de596\`.
2. **Busy heatmap** — Vitality mode colors each cell by total write count using a perceptual heat scale (cool→hot, log-scaled).
3. **Recipe vitality leaderboard** — side panel ranks recipes by total cell-writes with their source location + share-of-busiest bar. Click a recipe to highlight every cell it writes to.

## What this reads from fizzbuzz instantly

| Recipe | Writes | What it is |
|---|---|---|
| \`examples/fizzbuzz.rs:42\` | 24,058 | the shift loop — 99 cells × 390 frames worth of motion |
| \`examples/fizzbuzz.rs:34\` | 388 | \`track!(current, n)\` — once per frame |
| \`examples/fizzbuzz.rs:79\` | 96 | \`write_plain\` — most common branch |
| \`examples/fizzbuzz.rs:84\` | 78 | \`write_fizz\` |
| \`examples/fizzbuzz.rs:89\` | 38 | \`write_buzz\` — n%5 hits less often |
| \`examples/fizzbuzz.rs:94\` | 25 | \`write_fizzbuzz\` — rarest |
| \`examples/fizzbuzz.rs:29\` | 40 | history-allocation closure |
| \`examples/fizzbuzz.rs:27\` | 1 | current-allocation |

Realistic ratios across all eight recipes — exactly what fizzbuzz should produce.

## Architecture validated again

Pure addition over the .mfb substrate. The capture format didn't change; only the runtime's provenance bookkeeping (one new global registry + one shutdown hook) and the renderer (new mode toggle + heat scale + recipes panel). Data layer didn't move.

## Verification (live browser)

- **Identity mode**: 100 yellow u32 cells, inspector shows decoded value (`9002` at frame 350), Source `examples/fizzbuzz.rs:34`, Writes `389` for cell 0.
- **Vitality mode**: cell 0 visibly red (hottest), shift-loop cells orange, recipes panel populated with 8 entries in correct rank order, click-to-highlight working.
- All 17 tests still pass (10 lib + 1 capture e2e + 5 pointer-smoke + 1 fizzbuzz mp4 smoke).

## Test plan

- [x] \`cargo test --release\` — all green
- [x] \`MFB_CAPTURE=fizzbuzz.mfb cargo run --release --example fizzbuzz\` produces .mfb + .mfb.provmap
- [x] \`cargo run --release --bin mfb-html -- fizzbuzz.mfb fizzbuzz.html\` produces HTML with both modes working
- [x] Loaded HTML in real browser: hover, mode toggle, recipes click — all working

🤖 Generated with [Claude Code](https://claude.com/claude-code)