### PR TITLE
attune: lift the i18n hedge so Mom reads the body of evidence

### DIFF
--- a/api/app/routers/contributors.py
+++ b/api/app/routers/contributors.py
@@ -5,13 +5,19 @@ import hashlib
 import re
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.models.contributor import Contributor, ContributorCreate
 from app.models.error import ErrorDetail
 from app.models.pagination import PaginatedResponse
 from app.services import graph_service, contributor_service
+from app.services.locale_projection import (
+    DEFAULT_LOCALE,
+    SUPPORTED_LOCALES,
+    project,
+    resolve_caller_lang,
+)
 
 router = APIRouter()
 
@@ -569,8 +575,19 @@ def create_contributor(contributor: ContributorCreate) -> Contributor:
     summary="Get contributor by ID",
     responses={404: {"model": ErrorDetail, "description": "Contributor not found"}},
 )
-def get_contributor(contributor_id: str) -> Contributor:
-    """Retrieve a single contributor by name or UUID."""
+def get_contributor(
+    contributor_id: str,
+    request: Request,
+    lang: str | None = Query(None),
+) -> Contributor:
+    """Retrieve a single contributor by name or UUID.
+
+    Locale-projected when the caller's lang resolves to a non-default
+    SUPPORTED_LOCALES member. The contributor's name + description (their
+    bio) translate via the same entity_views + libretranslate path graph
+    nodes use, with attune-on-miss writing the EN anchor + translated view
+    on first read.
+    """
     # Try by name first, then by UUID
     node = graph_service.get_node(f"contributor:{contributor_id}")
     if not node:
@@ -582,7 +599,43 @@ def get_contributor(contributor_id: str) -> Contributor:
                 break
     if not node:
         raise HTTPException(status_code=404, detail="Contributor not found")
+    target_lang = resolve_caller_lang(request, lang)
+    if target_lang and target_lang != DEFAULT_LOCALE and target_lang in SUPPORTED_LOCALES:
+        _project_contributor_node(node, target_lang)
     return _node_to_contributor(node)
+
+
+def _project_contributor_node(node: dict, lang: str) -> None:
+    """Project a contributor's name + description into the caller's locale.
+
+    Anchor-write on first miss, attune via libretranslate, write
+    translated view, re-project. Failures fail-warm: returns source
+    text rather than blocking the read."""
+    node_id = node.get("id")
+    if not node_id:
+        return
+    project(node, "node", node_id, lang, title_field="name", body_field="description")
+    try:
+        from app.services import translation_cache_service as _tcache
+        from app.services import translator_service as _ts
+        if _tcache.canonical_view("node", node_id, lang) is None and _ts.has_backend():
+            anchors = _tcache.all_canonical_views("node", node_id)
+            if not _tcache.find_anchor(anchors):
+                _tcache.write_view(
+                    entity_type="node",
+                    entity_id=node_id,
+                    lang=DEFAULT_LOCALE,
+                    content_title=node.get("name", "") or "",
+                    content_description=node.get("description", "") or "",
+                    content_markdown="",
+                    author_type=_tcache.AUTHOR_TYPE_ORIGINAL_HUMAN,
+                )
+            _ts.attune_from_anchor(
+                entity_type="node", entity_id=node_id, target_lang=lang,
+            )
+            project(node, "node", node_id, lang, title_field="name", body_field="description")
+    except Exception:
+        pass  # translation must never block reads
 
 
 @router.get(

--- a/web/components/people/PersonProfileTemplate.tsx
+++ b/web/components/people/PersonProfileTemplate.tsx
@@ -163,6 +163,19 @@ export function PersonProfileTemplate({
       </section>
 
       <div className="max-w-3xl mx-auto px-6 py-12">
+        {/* Source-language disclosure — when the visitor's locale is
+            not English but the content module bound to this page is
+            English (no de.tsx / es.tsx / id.tsx sibling for this slug
+            yet), surface that honestly so the reader knows what they're
+            looking at. They can use their browser's built-in
+            translate-this-page until an author-curated translation
+            arrives. The chrome (breadcrumbs, headings) is already in
+            their language; this banner addresses the prose. */}
+        {lang !== "en" && (content.metadata as { authoredLang?: string })?.authoredLang !== lang && (
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3 text-xs text-stone-300 leading-relaxed mb-8">
+            {t("personProfile.sourceLanguageDisclosure")}
+          </div>
+        )}
         {content.noteFromBody && (
           <Panel variant="warm" eyebrow={content.noteFromBody.eyebrow ?? t("personProfile.noteEyebrow")}>
             <div className="text-sm text-foreground/85 leading-relaxed">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -2250,7 +2250,8 @@
       "people": "Menschen"
     },
     "noteEyebrow": "Eine Notiz aus diesem Körper",
-    "editProfileCta": "Wie du dieses Profil beanspruchst, bearbeitest oder entfernst →"
+    "editProfileCta": "Wie du dieses Profil beanspruchst, bearbeitest oder entfernst →",
+    "sourceLanguageDisclosure": "Hinweis: Der kuratierte Inhalt dieser Seite ist derzeit auf Englisch. Die Seitennavigation und Überschriften und der Datenbereich darunter (Werktitel, Beschreibungen, Evidenzkörper) werden automatisch in deine Sprache übersetzt; eine vom Autor kuratierte Übersetzung der längeren Prosa auf dieser Seite folgt. In der Zwischenzeit zeigt dir die eingebaute Funktion deines Browsers „Diese Seite übersetzen“ den Rest in deiner Sprache."
   },
   "presence": {
     "location": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2169,7 +2169,8 @@
       "people": "People"
     },
     "noteEyebrow": "A note from this body",
-    "editProfileCta": "How to claim, edit, or remove this profile →"
+    "editProfileCta": "How to claim, edit, or remove this profile →",
+    "sourceLanguageDisclosure": "Note: this page's curated content is currently in English. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature will render the rest in your language too."
   },
   "presence": {
     "location": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -2250,7 +2250,8 @@
       "people": "Personas"
     },
     "noteEyebrow": "Una nota desde este cuerpo",
-    "editProfileCta": "Cómo reclamar, editar o eliminar este perfil →"
+    "editProfileCta": "Cómo reclamar, editar o eliminar este perfil →",
+    "sourceLanguageDisclosure": "Nota: el contenido curado de esta página está actualmente en inglés. La navegación, los encabezados y la capa de datos a continuación (títulos de obras, descripciones, cuerpo de evidencia) se traducen automáticamente a tu idioma; una traducción curada por el autor de la prosa más larga en esta página vendrá después. Mientras tanto, la función incorporada de tu navegador „traducir esta página“ mostrará el resto en tu idioma."
   },
   "presence": {
     "location": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -2250,7 +2250,8 @@
       "people": "Orang"
     },
     "noteEyebrow": "Catatan dari tubuh ini",
-    "editProfileCta": "Cara mengklaim, mengedit, atau menghapus profil ini →"
+    "editProfileCta": "Cara mengklaim, mengedit, atau menghapus profil ini →",
+    "sourceLanguageDisclosure": "Catatan: konten kuratorial halaman ini saat ini dalam bahasa Inggris. Navigasi situs (judul, label) dan lapisan data di bawah (judul karya, deskripsi, kumpulan bukti) diterjemahkan secara otomatis ke dalam bahasa Anda; terjemahan kuratorial penulis dari prosa yang lebih panjang di halaman ini akan menyusul. Sementara itu, fitur „terjemahkan halaman ini“ bawaan browser Anda akan menampilkan sisanya dalam bahasa Anda."
   },
   "presence": {
     "location": {


### PR DESCRIPTION
Mom asked 'how come we don't allow her to read it all?' Honest answer was that I'd hedged on machine-translation quality of curated content modules; the conviction is to lift that hedge.

Ships:
- `/api/contributors` now locale-projects name + description via entity_views + libretranslate (same pattern as /api/graph/nodes shipped previously)
- PersonProfileTemplate renders a 'source language disclosure' banner in visitor's locale when curated content module is EN-only (most curated /people/{slug} works) — chrome + data-layer translate; longer authored prose explained honestly while author-curated DE awaits

Deferred to next breath: machine-translated de.tsx siblings (JSX-body translation needs placeholder-tag preservation pass; libretranslate format=html mangles <Link> tags), /api/concepts wire, author-curated DE translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)