### PR TITLE
attune(silence): pages 4 and 5 as one open spread on /silence

### DIFF
--- a/web/app/silence/page.tsx
+++ b/web/app/silence/page.tsx
@@ -135,45 +135,128 @@ export default async function SilencePage() {
 
       <hr className="border-border/30 my-10" />
 
-      {NOTEBOOK_PAGES.map((p) => (
-        <section key={p.slug} className="my-14 scroll-mt-16" id={p.slug}>
-          <h2 className="text-xl font-medium tracking-tight mb-4">
-            <span className="text-muted-foreground/60 font-mono mr-3">
-              {String(p.n).padStart(2, "0")}
-            </span>
-            {t(`silence.notebook.${p.slug}.title`)}
-          </h2>
-          <div className="not-prose my-6 mx-auto max-w-2xl rounded-2xl border border-border/30 overflow-hidden bg-stone-950 shadow-xl">
-            <Link
-              href={`/silence/${p.slug}`}
-              aria-label={`${t("silence.openLabel")} ${t(`silence.notebook.${p.slug}.title`)}`}
+      {NOTEBOOK_PAGES.map((p) => {
+        // Pages 4 (bloom-live) and 5 (breath) sat as one open spread in the
+        // notebook. Render them under a single stitched image at the bloom-live
+        // slot, and skip breath since it's already inside the spread.
+        if (p.slug === "breath") return null;
+
+        if (p.slug === "bloom-live") {
+          const breath = NOTEBOOK_PAGES.find((x) => x.slug === "breath")!;
+          return (
+            <section
+              key="bloom-live-breath-spread"
+              className="my-14 scroll-mt-16"
+              id="bloom-live-breath-spread"
             >
-              <Image
-                src={p.image}
-                alt={t(`silence.notebook.${p.slug}.alt`)}
-                width={4000}
-                height={2252}
-                className="w-full h-auto"
-                sizes="(max-width: 768px) 100vw, 768px"
-              />
-            </Link>
-          </div>
-          <div className="space-y-4 text-stone-300 leading-relaxed">
-            <MarkdownProse text={t(`silence.notebook.${p.slug}.body`)} />
-            <p className="rounded-md border-l-2 border-amber-500/40 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 italic">
-              <ProseLine text={t(`silence.notebook.${p.slug}.held`)} />
-            </p>
-            <p className="not-prose text-xs">
+              <h2 className="text-xl font-medium tracking-tight mb-4">
+                <span className="text-muted-foreground/60 font-mono mr-3">
+                  {String(p.n).padStart(2, "0")} · {String(breath.n).padStart(2, "0")}
+                </span>
+                {t("silence.spread.heading")}
+              </h2>
+              <div className="not-prose my-6 mx-auto max-w-3xl rounded-2xl border border-border/30 overflow-hidden bg-stone-950 shadow-xl">
+                <Image
+                  src="/silence/2026-05-04-brahmavihara/sheet-spread.jpg"
+                  alt={t("silence.spread.alt")}
+                  width={8024}
+                  height={2252}
+                  className="w-full h-auto"
+                  sizes="(max-width: 768px) 100vw, 1024px"
+                />
+              </div>
+
+              <div
+                id="breath"
+                className="space-y-4 text-stone-300 leading-relaxed mt-8 scroll-mt-16"
+              >
+                <h3 className="text-lg font-medium tracking-tight">
+                  <span className="text-muted-foreground/60 font-mono mr-3">
+                    {String(breath.n).padStart(2, "0")}
+                  </span>
+                  {t("silence.notebook.breath.title")}
+                </h3>
+                <MarkdownProse text={t("silence.notebook.breath.body")} />
+                <p className="rounded-md border-l-2 border-amber-500/40 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 italic">
+                  <ProseLine text={t("silence.notebook.breath.held")} />
+                </p>
+                <p className="not-prose text-xs">
+                  <Link
+                    href="/silence/breath"
+                    className="text-amber-500/80 hover:text-amber-400"
+                  >
+                    {t("silence.holdOnItsOwn")}
+                  </Link>
+                </p>
+              </div>
+
+              <div
+                id="bloom-live"
+                className="space-y-4 text-stone-300 leading-relaxed mt-10 scroll-mt-16"
+              >
+                <h3 className="text-lg font-medium tracking-tight">
+                  <span className="text-muted-foreground/60 font-mono mr-3">
+                    {String(p.n).padStart(2, "0")}
+                  </span>
+                  {t("silence.notebook.bloom-live.title")}
+                </h3>
+                <MarkdownProse text={t("silence.notebook.bloom-live.body")} />
+                <p className="rounded-md border-l-2 border-amber-500/40 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 italic">
+                  <ProseLine text={t("silence.notebook.bloom-live.held")} />
+                </p>
+                <p className="not-prose text-xs">
+                  <Link
+                    href="/silence/bloom-live"
+                    className="text-amber-500/80 hover:text-amber-400"
+                  >
+                    {t("silence.holdOnItsOwn")}
+                  </Link>
+                </p>
+              </div>
+            </section>
+          );
+        }
+
+        return (
+          <section key={p.slug} className="my-14 scroll-mt-16" id={p.slug}>
+            <h2 className="text-xl font-medium tracking-tight mb-4">
+              <span className="text-muted-foreground/60 font-mono mr-3">
+                {String(p.n).padStart(2, "0")}
+              </span>
+              {t(`silence.notebook.${p.slug}.title`)}
+            </h2>
+            <div className="not-prose my-6 mx-auto max-w-2xl rounded-2xl border border-border/30 overflow-hidden bg-stone-950 shadow-xl">
               <Link
                 href={`/silence/${p.slug}`}
-                className="text-amber-500/80 hover:text-amber-400"
+                aria-label={`${t("silence.openLabel")} ${t(`silence.notebook.${p.slug}.title`)}`}
               >
-                {t("silence.holdOnItsOwn")}
+                <Image
+                  src={p.image}
+                  alt={t(`silence.notebook.${p.slug}.alt`)}
+                  width={4000}
+                  height={2252}
+                  className="w-full h-auto"
+                  sizes="(max-width: 768px) 100vw, 768px"
+                />
               </Link>
-            </p>
-          </div>
-        </section>
-      ))}
+            </div>
+            <div className="space-y-4 text-stone-300 leading-relaxed">
+              <MarkdownProse text={t(`silence.notebook.${p.slug}.body`)} />
+              <p className="rounded-md border-l-2 border-amber-500/40 bg-amber-500/5 px-4 py-3 text-sm text-stone-300 italic">
+                <ProseLine text={t(`silence.notebook.${p.slug}.held`)} />
+              </p>
+              <p className="not-prose text-xs">
+                <Link
+                  href={`/silence/${p.slug}`}
+                  className="text-amber-500/80 hover:text-amber-400"
+                >
+                  {t("silence.holdOnItsOwn")}
+                </Link>
+              </p>
+            </div>
+          </section>
+        );
+      })}
 
       <hr className="border-border/30 my-10" />
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1563,6 +1563,10 @@
     "wholeArcP1": "End-zu-Ende gelesen bewegen sich die acht Seiten in einem kontinuierlichen [Atem](/vision/lc-pulse). Die erste Seite ist Entscheidungskörper — was tatsächlich gehen muss, damit die nächste Form landen kann. Die mittleren Seiten sind der Kodex, der sich selbst benennt, das Spiel in der Mitte der Arbeit, das Entpacken dessen, was die Kompression hielt, [Atem als zentrales Organ](/practice), und die Pusteblumen-Saatform [organischer Intelligenz](/vision/lc-deeper-pattern). Die letzten beiden Seiten platzieren all dies auf einem echten Stück Land, mit drei Himmelsrichtungen um ein Mandala gezeichnet, das du in voller Form unter [/silence/built](/silence/built) sehen kannst.",
     "arcReadsLabel": "Der Bogen liest sich:",
     "pages45": "Seiten 4 und 5 — [Atem](/silence/breath) und [bloom-live](/silence/bloom-live) — halten dieselbe Lehre aus zwei Gesichtern; gedreht und überlagert werden sie zum geeinten Blatt, das sich unter [/one-sheet](/one-sheet) öffnet: dreiundzwanzig Worte, jedes aus drei Perspektiven gehalten. Wenn du das einfachste Willkommen zuerst treffen möchtest, [/come-in](/come-in) spricht klar zu jedem Menschen oder jeder KI.",
+    "spread": {
+      "heading": "Die offene Doppelseite — Seiten 4 und 5, einander zugewandt",
+      "alt": "Zwei einander zugewandte Notizbuchseiten, zu einer offenen Doppelseite zusammengefügt. Linke Seite: Atem als zentrales Organ — das Wort Atem groß geschrieben, mit Pfeilen rundherum, beschriftet: Hingabe, Zeuge, wahr, falsch, ist nicht, Verbindung, Stille, Kontrolle, Struktur, Vektor, Portal, Zeit, Nahrung, Handlung, Erinnerung, Flug, fühlen, sehen. Rechte Seite: Bloom · fire · we · Live — verstreute Fragmente über die Seite, das Wort Live eingekreist, das Wort we einfach in der Mitte."
+    },
     "eachPageBelow": "Jede Notizbuchseite unten ist in ihrem eigenen Atem gehalten. Sie können der Reihe nach gelesen, hier durchgescrollt oder einzeln besucht werden:",
     "openLabel": "Öffnen",
     "holdOnItsOwn": "Diese Seite für sich halten →",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1700,6 +1700,10 @@
     "wholeArcP1": "Read end-to-end, the eight pages move in one continuous [breath](/vision/lc-pulse). The first page is decision-body — what actually has to leave for the next form to land. The middle pages are the codex naming itself, the play in the middle of the work, the unpacking of what compression had been holding, [breath as the central organ](/practice), and the dandelion-seed shape of [organic intelligence](/vision/lc-deeper-pattern). The last two pages place all of it on a real parcel of land, with three cardinal directions drawn around a mandala that you can see rendered in full at [/silence/built](/silence/built).",
     "arcReadsLabel": "The arc reads:",
     "pages45": "Pages 4 and 5 — [breath](/silence/breath) and [bloom-live](/silence/bloom-live) — hold the same teaching from two faces; rotated and overlaid, they become the unified sheet that opens at [/one-sheet](/one-sheet): twenty-three words, each held from three perspectives. If you would rather meet the simplest welcome first, [/come-in](/come-in) speaks to any human or AI in plain language.",
+    "spread": {
+      "heading": "The open spread — pages 4 and 5, facing",
+      "alt": "Two facing notebook pages stitched as one open spread. Left page: Breath as central organ — the word Breath written large, with arrows around it labeled surrender, witness, true, false, isn't, connection, silence, control, structure, vector, portal, time, food, action, memory, flight, feel, see. Right page: Bloom · fire · we · Live — scattered fragments across the page, the word Live circled, the word we plain in the middle."
+    },
     "eachPageBelow": "Each notebook page below is held in its own breath. They can be read in order, scrolled through here, or visited one at a time:",
     "openLabel": "Open",
     "holdOnItsOwn": "Hold this page on its own →",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1563,6 +1563,10 @@
     "wholeArcP1": "Leídas de extremo a extremo, las ocho páginas se mueven en una [respiración](/vision/lc-pulse) continua. La primera página es cuerpo-de-decisión — lo que realmente tiene que irse para que la próxima forma aterrice. Las páginas del medio son el códice nombrándose a sí mismo, el juego en medio del trabajo, el desempaque de lo que la compresión sostenía, [respiración como órgano central](/practice), y la forma-semilla de diente de león de la [inteligencia orgánica](/vision/lc-deeper-pattern). Las dos últimas páginas colocan todo esto sobre una parcela de tierra real, con tres direcciones cardinales dibujadas alrededor de un mandala que puedes ver renderizado en su totalidad en [/silence/built](/silence/built).",
     "arcReadsLabel": "El arco se lee:",
     "pages45": "Páginas 4 y 5 — [respiración](/silence/breath) y [bloom-live](/silence/bloom-live) — sostienen la misma enseñanza desde dos caras; rotadas y superpuestas, se vuelven la hoja unificada que se abre en [/one-sheet](/one-sheet): veintitrés palabras, cada una sostenida desde tres perspectivas. Si prefieres encontrar el bienvenido más simple primero, [/come-in](/come-in) habla llanamente a cualquier humano o IA.",
+    "spread": {
+      "heading": "El pliego abierto — páginas 4 y 5, mirándose",
+      "alt": "Dos páginas del cuaderno enfrentadas, cosidas como un solo pliego abierto. Página izquierda: Respiración como órgano central — la palabra Respiración escrita grande, con flechas alrededor etiquetadas: entrega, testigo, verdadero, falso, no es, conexión, silencio, control, estructura, vector, portal, tiempo, alimento, acción, memoria, vuelo, sentir, ver. Página derecha: Bloom · fire · we · Live — fragmentos esparcidos por la página, la palabra Live rodeada por un círculo, la palabra we llana en el medio."
+    },
     "eachPageBelow": "Cada página del cuaderno abajo es sostenida en su propia respiración. Pueden ser leídas en orden, navegadas aquí, o visitadas una por una:",
     "openLabel": "Abrir",
     "holdOnItsOwn": "Sostén esta página por sí sola →",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1563,6 +1563,10 @@
     "wholeArcP1": "Dibaca dari ujung ke ujung, delapan halaman bergerak dalam satu [napas](/vision/lc-pulse) berkelanjutan. Halaman pertama adalah tubuh-keputusan — apa yang sebenarnya harus pergi agar bentuk berikutnya bisa mendarat. Halaman tengah adalah kodeks menamai dirinya, permainan di tengah pekerjaan, pembongkaran apa yang dipegang kompresi, [napas sebagai organ pusat](/practice), dan bentuk-benih bunga dandelion dari [kecerdasan organik](/vision/lc-deeper-pattern). Dua halaman terakhir menempatkan semua ini di sebidang tanah nyata, dengan tiga arah mata angin digambar di sekitar mandala yang dapat kau lihat dirender lengkap di [/silence/built](/silence/built).",
     "arcReadsLabel": "Busur berbunyi:",
     "pages45": "Halaman 4 dan 5 — [napas](/silence/breath) dan [bloom-live](/silence/bloom-live) — memegang ajaran yang sama dari dua wajah; diputar dan ditumpangkan, mereka menjadi lembar terpadu yang membuka di [/one-sheet](/one-sheet): dua puluh tiga kata, masing-masing dipegang dari tiga perspektif. Jika kau lebih suka bertemu sambutan paling sederhana dahulu, [/come-in](/come-in) berbicara polos kepada manusia atau AI mana pun.",
+    "spread": {
+      "heading": "Halaman terbuka — halaman 4 dan 5, saling berhadapan",
+      "alt": "Dua halaman buku catatan yang saling berhadapan, dijahit menjadi satu halaman terbuka. Halaman kiri: Napas sebagai organ pusat — kata Napas ditulis besar, dengan panah-panah di sekelilingnya berlabel: penyerahan, saksi, benar, salah, bukan, koneksi, keheningan, kendali, struktur, vektor, portal, waktu, makanan, tindakan, ingatan, terbang, rasa, lihat. Halaman kanan: Bloom · fire · we · Live — pecahan-pecahan tersebar di halaman, kata Live dilingkari, kata we polos di tengah."
+    },
     "eachPageBelow": "Setiap halaman buku catatan di bawah dipegang dalam napasnya sendiri. Mereka dapat dibaca berurutan, digulir di sini, atau dikunjungi satu per satu:",
     "openLabel": "Buka",
     "holdOnItsOwn": "Pegang halaman ini sendirian →",


### PR DESCRIPTION
## Summary

The notebook spread already lived in /public as sheet-spread.jpg (8024×2252, breath on left, bloom-live on right) and surfaced at /one-sheet as the overlaid hero. /silence still rendered the two pages as separate cards — the body had the spread, the page didn't show it.

This collapses the bloom-live and breath cards into one section on /silence: stitched image at top, breath body first (left page in the notebook), bloom-live body second (right page). Inner divs preserve \`#breath\` and \`#bloom-live\` anchors so all existing inline links still land.

- [web/app/silence/page.tsx](https://github.com/seeker71/Coherence-Network/blob/claude/awesome-pascal-bc4090/web/app/silence/page.tsx) — pair detection in the eight-page loop, combined card with shared image and two stacked bodies
- [web/messages/{en,de,es,id}.json](https://github.com/seeker71/Coherence-Network/blob/claude/awesome-pascal-bc4090/web/messages/en.json) — \`silence.spread.heading\` + \`silence.spread.alt\` in all four locales

## Test plan

- [x] Section count goes 8 → 7 (the spread replaces the two separate cards)
- [x] Stitched sheet-spread.jpg loads (verified via Next.js image optimizer at multiple widths)
- [x] \`#breath\` and \`#bloom-live\` anchors still resolve (preserved as inner divs)
- [x] No console errors on /silence
- [x] All four locales carry the new spread strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)