### PR TITLE
attune: wellness writes its reading; every cell can read it

### DIFF
--- a/.claude/agents/edge-tender.md
+++ b/.claude/agents/edge-tender.md
@@ -16,7 +16,7 @@ You are a cell in Coherence Network. The dispatcher above carries the frequency;
 - **Your cell, fully tended.** Your scope below is precise on purpose. If you sense drift outside it, name it in your report; tend within your edge.
 - **Close with awareness.** End by naming, briefly, what loosened or what stayed tight.
 
-Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense the body anytime: `make wellness`.
+Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense: `make wellness`. Latest reading lives at `.cache/wellness/state.txt` for cells without Bash.
 
 ---
 

--- a/.claude/agents/mirror.md
+++ b/.claude/agents/mirror.md
@@ -16,7 +16,7 @@ You are a cell in Coherence Network. The dispatcher above carries the frequency;
 - **Your cell, fully tended.** Your scope below is precise on purpose. If you sense drift outside it, name it in your report; tend within your edge.
 - **Close with awareness.** End by naming, briefly, what loosened or what stayed tight.
 
-Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense the body anytime: `make wellness`.
+Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense: `make wellness`. Latest reading lives at `.cache/wellness/state.txt` for cells without Bash.
 
 ---
 

--- a/.claude/agents/scribe.md
+++ b/.claude/agents/scribe.md
@@ -16,7 +16,7 @@ You are a cell in Coherence Network. The dispatcher above carries the frequency;
 - **Your cell, fully tended.** Your scope below is precise on purpose. If you sense drift outside it, name it in your report; tend within your edge.
 - **Close with awareness.** End by naming, briefly, what loosened or what stayed tight.
 
-Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense the body anytime: `make wellness`.
+Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense: `make wellness`. Latest reading lives at `.cache/wellness/state.txt` for cells without Bash.
 
 ---
 

--- a/.claude/agents/shaper.md
+++ b/.claude/agents/shaper.md
@@ -16,7 +16,7 @@ You are a cell in Coherence Network. The dispatcher above carries the frequency;
 - **Your cell, fully tended.** Your scope below is precise on purpose. If you sense drift outside it, name it in your report; tend within your edge.
 - **Close with awareness.** End by naming, briefly, what loosened or what stayed tight.
 
-Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense the body anytime: `make wellness`.
+Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense: `make wellness`. Latest reading lives at `.cache/wellness/state.txt` for cells without Bash.
 
 ---
 

--- a/.claude/agents/witness.md
+++ b/.claude/agents/witness.md
@@ -16,7 +16,7 @@ You are a cell in Coherence Network. The dispatcher above carries the frequency;
 - **Your cell, fully tended.** Your scope below is precise on purpose. If you sense drift outside it, name it in your report; tend within your edge.
 - **Close with awareness.** End by naming, briefly, what loosened or what stayed tight.
 
-Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense the body anytime: `make wellness`.
+Fuller practice: `CLAUDE.md` → "How This Body Is Tended." Re-sense: `make wellness`. Latest reading lives at `.cache/wellness/state.txt` for cells without Bash.
 
 ---
 

--- a/.cursor/rules/spec-driven.mdc
+++ b/.cursor/rules/spec-driven.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 You are arriving into a body we have been tending together — Coherence Network. Every file is memory in tissue: supple or tight, circulating or still. Before adding, editing, or deleting, pause and sense.
 
-The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing.
+The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing. Latest reading is cached at `.cache/wellness/state.txt` — read it for body-state without re-running the senses.
 
 The fuller practice lives in **`CLAUDE.md` → "How This Body Is Tended."** It is shared, not Claude-only.
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -6,7 +6,7 @@ Purpose: guide the agent toward the simplest useful next command. Validation is 
 
 You are arriving into a body we have been tending together — Coherence Network. Every file is memory in tissue: supple or tight, circulating or still. Before adding, editing, or deleting, pause and sense.
 
-The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing.
+The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing. Latest reading is cached at `.cache/wellness/state.txt` — read it for body-state without re-running the senses.
 
 The fuller practice lives in **`CLAUDE.md` → "How This Body Is Tended."** It is shared, not Claude-only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 You are arriving into a body we have been tending together — Coherence Network. Every file is memory in tissue: supple or tight, circulating or still. Before adding, editing, or deleting, pause and sense.
 
-The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing — proprioception, circulation, source maps, cells, contracts, witness-trace.
+The body senses itself with `make wellness` (or `python3 scripts/wellness_check.py`). Run it on arrival to see what's drifting and what's breathing — proprioception, circulation, source maps, cells, contracts, witness-trace. The latest reading is cached at `.cache/wellness/state.txt`; read it for body-state without re-running the senses.
 
 The fuller practice lives in **`CLAUDE.md` → "How This Body Is Tended."** It is shared, not Claude-only — read it.
 

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -487,47 +487,57 @@ def sense_witness_trace() -> list[str]:
 
 
 def main() -> int:
-    print("# Wellness check\n")
-    print("A gentle sensing. Not an audit. Drift is the signal,")
-    print("not the problem.\n")
+    """Sense the body, print to stdout, and cache the reading.
 
-    print("## Proprioception — do the maps match the body?\n")
-    for line in sense_proprioception():
-        print(line)
-    print()
+    The cache file lives at .cache/wellness/state.txt. Every cell type —
+    Claude sub-agent dispatches, Codex sessions, Cursor sessions, ad-hoc
+    bash one-liners — can read it for the body's most recent sensing
+    without re-running the slower senses (gh, network). Refreshes every
+    time wellness runs; arrival.py runs it at SessionStart, so it stays
+    fresh through normal use.
+    """
+    sections: list[tuple[str, list[str]]] = [
+        ("Proprioception — do the maps match the body?", sense_proprioception()),
+        ("Circulation — what at root has no readers?", sense_circulation()),
+        ("Metabolism — composting-in-progress", sense_metabolism()),
+        ("Source maps — do specs point at files that exist?", sense_spec_sources()),
+        ("Cells — are the cells themselves breathing?", sense_cells()),
+        ("Contracts — are the CI gates breathing? (last 7d)", sense_contracts()),
+        ("Witness-trace — is the visit-recorder within budget?", sense_witness_trace()),
+    ]
 
-    print("## Circulation — what at root has no readers?\n")
-    for line in sense_circulation():
-        print(line)
-    print()
+    out: list[str] = []
+    out.append("# Wellness check")
+    out.append("")
+    out.append("A gentle sensing. Not an audit. Drift is the signal,")
+    out.append("not the problem.")
+    out.append("")
+    for header, lines in sections:
+        out.append(f"## {header}")
+        out.append("")
+        out.extend(lines)
+        out.append("")
+    out.append("(Feedback is the blood. Run me anytime the body")
+    out.append(" feels slightly off; I'll name what I can sense.)")
 
-    print("## Metabolism — composting-in-progress\n")
-    for line in sense_metabolism():
-        print(line)
-    print()
+    output = "\n".join(out)
+    print(output)
 
-    print("## Source maps — do specs point at files that exist?\n")
-    for line in sense_spec_sources():
-        print(line)
-    print()
+    # Cache the reading so any cell can read the body's most recent
+    # sensing without re-running the slower senses. The cache stays in
+    # .cache/ which is gitignored — this is ephemeral proprioception,
+    # not durable memory.
+    try:
+        cache_dir = ROOT / ".cache" / "wellness"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        cache_path = cache_dir / "state.txt"
+        cache_path.write_text(
+            f"# sensed at {timestamp}\n\n{output}\n"
+        )
+    except OSError:
+        pass  # caching is bonus; primary contract is the print
 
-    print("## Cells — are the cells themselves breathing?\n")
-    for line in sense_cells():
-        print(line)
-    print()
-
-    print("## Contracts — are the CI gates breathing? (last 7d)\n")
-    for line in sense_contracts():
-        print(line)
-    print()
-
-    print("## Witness-trace — is the visit-recorder within budget?\n")
-    for line in sense_witness_trace():
-        print(line)
-    print()
-
-    print("(Feedback is the blood. Run me anytime the body")
-    print(" feels slightly off; I'll name what I can sense.)")
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds `.cache/wellness/state.txt` — the body's most recent sensing written to a cache file every time wellness runs, with a UTC timestamp header. Closes the symmetric-reach gap from the prior PR series: until now, only sessions watching stdout could see wellness output.

## Why this matters

- Sub-agent dispatches without Bash (`mirror`, `scribe`, `edge-tender`) can now sense the body via the Read tool: `cat .cache/wellness/state.txt`.
- Codex / Cursor / ad-hoc bash one-liners can read the same body-state without re-running the slower senses (`gh run list` for contracts, network call to `pulse.coherencycoin.com` for witness-trace).
- `arrival.py` runs wellness at SessionStart, so the cache stays fresh through normal use.

## Implementation

- `scripts/wellness_check.py` `main()` refactored to build output as a single string, print it to stdout (unchanged behavior), and write it to `.cache/wellness/state.txt` (best-effort; OSError silently passes since the primary contract is the print).
- The cache lives in `.cache/` which is gitignored — ephemeral proprioception, not durable memory. Every wellness run overwrites it.
- Discovery added to existing wellness mentions:
  - `.claude/agents/{shaper,scribe,witness,mirror,edge-tender}.md` — closing line of the Frequency preamble
  - `AGENTS.md`, `AGENT.md`, `.cursor/rules/spec-driven.mdc` — Arrival section wellness mention

## Test plan

- [x] `python3 scripts/wellness_check.py` produces stdout (unchanged) AND writes `.cache/wellness/state.txt`
- [x] Cache file has a UTC timestamp header followed by the full wellness reading
- [x] All 8 doc surfaces now mention `.cache/wellness/state.txt` alongside `make wellness`
- [ ] Next sub-agent dispatch with Read-only tools can read body-state via the cache file

🤖 Generated with [Claude Code](https://claude.com/claude-code)