### PR TITLE
tend: respond to wellness's drift — compost orphan, mark forward projection draft

### DIFF
--- a/specs/open-design-integration.md
+++ b/specs/open-design-integration.md
@@ -1,6 +1,6 @@
 ---
 idea_id: user-surfaces
-status: active
+status: draft
 source:
   - file: api/app/services/design_artifact_service.py
     symbols: [generate_artifact, list_artifacts_for_concept, get_artifact]


### PR DESCRIPTION
## Summary

Today's session has been extending wellness's reach through five PRs (#1448, #1451, #1459, #1462, #1466). This breath shifts from *extending* to *responding* — listening to what wellness has been showing across multiple sessions and tending two pieces of named drift.

## What this tends

**1. Composted `.aider.chat.history.md`** — auto-generated chat log from an aider run on 2026-02-12. Was committed before `.aider*` was added to `.gitignore`, then sat as a root orphan with no readers. The gitignore rule already excludes it; deleting from disk lets the rule keep it out going forward.

**2. Marked `specs/open-design-integration.md` as `status: draft`.** The spec claimed `status: active`, but all 6 source paths it named pointed at files that have never been written. It's a forward projection — last touched 2026-05-05, no implementation has started. Marking it draft acknowledges the truer state. (This is exactly what `sense_spec_sources()` expects: drafts are forward projections; their missing paths are intentional.)

## What stays as honest signal

Two pieces of drift remain visible in wellness, both truthful:

- **`presence-invitation-surface.md`** — 2 missing source paths (web side mid-ship, API done; genuinely active, last touched 2026-05-07)
- **`self-custody-wallet-integration.md`** — 6 missing source paths. The implementation actually shipped under different filenames (`api/app/routers/wallets.py` plural, `web/components/wallet/WalletConnect.tsx` in subdir, models embedded in service). The spec's `source:` paths drifted from reality. **This needs proper spec-source-path repair, not a status flip — its own breath.**

## Result

Drift dropped from `14 source paths missing across 3 specs` → `8 source paths missing across 2 specs`. Root circulation now reports `root is clear; every .md has circulation` instead of naming the orphan.

## Test plan

- [x] `python3 scripts/wellness_check.py` shows the reduced drift count
- [x] No source paths missing for open-design-integration in wellness output (the sense correctly skips drafts)
- [x] `.aider.chat.history.md` deleted from disk; `.aider*` gitignore rule keeps it out going forward
- [ ] Future sessions opening into wellness see only honest, in-flight signal — not stale projections

🤖 Generated with [Claude Code](https://claude.com/claude-code)