### PR TITLE
tend: contributors page retries on transient 502

### DIFF
--- a/web/app/contributors/page.tsx
+++ b/web/app/contributors/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { getApiBase } from "@/lib/api";
+import { fetchJsonOrNull } from "@/lib/fetch";
 import { useLiveRefresh } from "@/lib/live_refresh";
 import { useT, useLocale } from "@/components/MessagesProvider";
 import { LedgerNav } from "@/app/_components/LedgerNav";
@@ -120,29 +121,31 @@ function ContributorsPageContent() {
   const loadRows = useCallback(async () => {
     setStatus((prev) => (prev === "ok" ? "ok" : "loading"));
     setError(null);
-    try {
-      const [contributorsRes, flowRes] = await Promise.all([
-        fetch(`${API_URL}/api/contributors`, { cache: "no-store" }),
-        fetch(`${API_URL}/api/inventory/flow?runtime_window_seconds=86400`, { cache: "no-store" }),
-      ]);
-      if (!contributorsRes.ok) {
-        const body = await contributorsRes.text();
-        throw new Error(`contributors HTTP ${contributorsRes.status}: ${body.slice(0, 200)}`);
-      }
-      if (!flowRes.ok) {
-        const body = await flowRes.text();
-        throw new Error(`flow HTTP ${flowRes.status}: ${body.slice(0, 200)}`);
-      }
-      const contributorsJson = await contributorsRes.json();
-      const flowJson = (await flowRes.json()) as FlowResponse;
-      const contributorData = contributorsJson?.items ?? (Array.isArray(contributorsJson) ? contributorsJson : []);
-      setRows(contributorData);
-      setFlowRows(Array.isArray(flowJson?.items) ? flowJson.items : []);
-      setStatus("ok");
-    } catch (e) {
+    const [contributorsJson, flowJson] = await Promise.all([
+      fetchJsonOrNull<{ items?: Contributor[] } | Contributor[]>(
+        `${API_URL}/api/contributors`,
+        { cache: "no-store" },
+        8000,
+        3,
+      ),
+      fetchJsonOrNull<FlowResponse>(
+        `${API_URL}/api/inventory/flow?runtime_window_seconds=86400`,
+        { cache: "no-store" },
+        20000,
+        3,
+      ),
+    ]);
+    if (contributorsJson === null && flowJson === null) {
       setStatus("error");
-      setError(String(e));
+      setError("api unreachable");
+      return;
     }
+    const contributorData = Array.isArray(contributorsJson)
+      ? contributorsJson
+      : contributorsJson?.items ?? [];
+    setRows(contributorData);
+    setFlowRows(Array.isArray(flowJson?.items) ? flowJson.items : []);
+    setStatus("ok");
   }, []);
 
   useLiveRefresh(loadRows);


### PR DESCRIPTION
## Summary
- Routes the contributors page's two upstream fetches through `fetchJsonOrNull` — the existing helper already used by ~10 other pages — which retries 3× on 502/503/504/408/429 plus network-level TypeErrors (CORS preflight failures land there).
- Widens timeouts to match the data: 8s for `/api/contributors`, 20s for `/api/inventory/flow` (typically 3–12s in prod).
- Surfaces a visible error only if both calls return null after retries; otherwise renders whatever data did arrive.

The user reported a 502 on `/contributors`; the burst lined up with the api container restart during PR #1475's deploy at 07:11–07:15 UTC. The retry budget now covers that ~30s window.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Page renders normally against live api in dev (100 cells)
- [x] Observed retry-on-502 in flight: a CORS-preflight 502 (`net::ERR_FAILED`) on the first attempt was caught as TypeError and the second attempt succeeded
- [ ] Watch one prod deploy: contributors page should ride through the api restart without showing the red error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)