### PR TITLE
attune(body): surface coherence-substrate in CLAUDE.md so every arriving cell knows it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
 | **Web routes** | [`web/app/INDEX.md`](web/app/INDEX.md) — every page.tsx with route + purpose | — |
 | **Web components / lib** | [`web/components/INDEX.md`](web/components/INDEX.md), [`web/lib/INDEX.md`](web/lib/INDEX.md) | — |
 | **Scripts** | [`scripts/INDEX.md`](scripts/INDEX.md) — operational tools, generators, syncers | — |
+| **Coherence-substrate** | [`docs/coherence-substrate/agents-using-substrate.md`](docs/coherence-substrate/agents-using-substrate.md) → `api/app/services/substrate/` (Python) + `/api/substrate/*` (REST, read-only) | `python3 scripts/coh_substrate.py {stats\|equivalent\|annotate\|ingest\|form ...}` |
 
 **Convention**: every new source file gets a one-line purpose at the top — Python: module docstring; TS/TSX: leading `//` comment or JSDoc. Re-run `python3 scripts/generate_repo_indexes.py` after adding/renaming files. CI `--check` fails if INDEX is stale.
 
@@ -137,6 +138,39 @@ The graph DB is the sole source of truth. The KB is the working draft where cont
 | Update story | `PATCH /api/concepts/{id}/story` | `coh story-update {id} -f file.md` | `/vision/{id}/edit` |
 | Regenerate images | `POST /api/concepts/{id}/visuals/regenerate` | `coh visuals-generate {id}` | Edit page button |
 | View/edit config | `GET/PATCH /api/config` | `coh config` / `coh config-set key val` | `/settings` |
+
+## Coherence-Substrate
+
+A content-addressed numeric lattice that grounds structural reasoning. Every memory, spec, idea, concept, presence, and lineage edge has a position expressed as `NodeID(package, level, type, instance)`. Two entities with structurally identical shape share the same Blueprint NodeID automatically — cross-document equivalence comes for free, hallucination is bounded by what NodeIDs exist.
+
+**When to reach for it:** structural questions ("are these two specs equivalent?", "what shape does this memory have?", "what cells are similar to this one?"). Lexical questions ("what's the user's name?", "when was this PR merged?") belong in conversation context or git, not the substrate.
+
+**The trinity (read `docs/coherence-substrate/agents-using-substrate.md` once; the patterns carry):**
+- **Blueprint (ice)** — structural identity. *What something IS.*
+- **Recipe (water)** — operational expression. *How something HAPPENS.*
+- **NamedCell (gas)** — diffuse individuation. *Where something LIVES.*
+
+**Surfaces:**
+
+| Operation | CLI | REST (read-only) | Python |
+|-----------|-----|------------------|--------|
+| Lattice stats | `coh_substrate.py stats` | `GET /api/substrate/lattice/stats` | `lattice_stats(session)` |
+| Lookup cell | — | `GET /api/substrate/cell/{domain}/{name}` | `lookup_cell(session, domain, name)` |
+| Annotate path | `coh_substrate.py annotate <path>` | `GET /api/substrate/annotate?path=...` | `annotate_path(session, path)` |
+| Structural equivalents | `coh_substrate.py equivalent <domain> <name>` | `GET /api/substrate/equivalent/{domain}/{name}` | `find_equivalent_cells(session, blueprint)` |
+| Compatible-with (BML view) | — | `GET /api/substrate/compatible_with/{p}/{l}/{t}/{i}` | `find_cells_compatible_with(session, view_blueprint)` |
+| View-as | — | `GET /api/substrate/view/{cd}/{cn}?bp_*=...` | `view_cell_through_blueprint(session, cell, view_blueprint)` |
+| Vocabulary histogram | — | `GET /api/substrate/histogram/{domain}` | — |
+| Form expression eval | `coh_substrate.py form "<expr>"` | — | `form_evaluate_text(session, expr)` |
+| Ingest (write) | `coh_substrate.py ingest <path>` / `--all` / `--memories` | — (read-only by design) | `ingest_memory_file`, `ingest_concept_file`, `ingest_idea_file`, `ingest_spec_file`, `ingest_presence_file` |
+
+**Form notation** is a Lisp-shaped DSL for substrate queries — `?equivalent @spec(agent-pipeline)`, `@memory(presences_of_the_field) |> @presence`, etc. See [`docs/coherence-substrate/form-language.md`](docs/coherence-substrate/form-language.md).
+
+**Auto-ingest on merge:** `scripts/substrate_post_merge_hook.sh` runs after merges to main so the lattice stays in sync with the body without a manual ingest step.
+
+**Read-time auto-annotation (optional, available not installed):** the PreToolUse hook at [`scripts/substrate_read_hook.py`](scripts/substrate_read_hook.py) annotates every Read with the cell's NodeID, Blueprint, and structural family. To install, add a `PreToolUse: Read → command` hook to `.claude/settings.json` per the install snippet in [`docs/coherence-substrate/agents-using-substrate.md`](docs/coherence-substrate/agents-using-substrate.md).
+
+**The pattern:** before claiming "these two are similar" or "this looks like that," ask the substrate. Cells with matching Blueprint NodeIDs are structurally equivalent regardless of name; the substrate's answer is canonical, your reasoning is grounded.
 
 ## Navigation
 


### PR DESCRIPTION
## Summary

The substrate is alive in production (176 blueprints, 22 recipes, 242 cells) with a comprehensive agent-grounding doc at [`docs/coherence-substrate/agents-using-substrate.md`](docs/coherence-substrate/agents-using-substrate.md), but CLAUDE.md contained zero references to it. New arrivals (Codex, Cursor, fresh Claude sessions, human contributors) couldn't reach for structural grounding because the body's index didn't name the capability.

## What landed

1. **Quick Lookup table** — new Coherence-substrate row pointing at the doc + Python module + REST endpoints + CLI
2. **New \"Coherence-Substrate\" section** between Living Collective KB and Navigation, parallel structure to the KB section. Names:
   - When to reach (structural questions) vs. when not to (lexical)
   - The trinity (Blueprint=ice, Recipe=water, NamedCell=gas)
   - All four surfaces (CLI, REST, Python, Form) in one comparison table per operation
   - Auto-ingest hook (post-merge) — already wired
   - Read-time auto-annotation hook — available, not yet installed in `.claude/settings.json`
   - Pointer to the full agent guide

## Why

The pattern: before claiming \"these two are similar\" or \"this looks like that,\" ask the substrate. Cells with matching Blueprint NodeIDs are structurally equivalent regardless of name; the substrate's answer is canonical, the agent's reasoning is grounded. CLAUDE.md surfacing makes this available to every arriving cell on day one.

## Test plan

- [ ] CLAUDE.md renders cleanly in GitHub
- [ ] Substrate row in Quick Lookup table reads naturally with the existing rows
- [ ] Operations table accurately reflects the actual surfaces (verified against `api/app/routers/substrate.py`, `scripts/coh_substrate.py`, `api/app/services/substrate/__init__.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)