### PR TITLE
tend: reduce the fever — bring external tools registry current

### DIFF
--- a/docs/system_audit/external_tools_registry.json
+++ b/docs/system_audit/external_tools_registry.json
@@ -1,23 +1,27 @@
 {
   "policy": {
     "minimum_checks_per_week": 2,
-    "notes": "Track external tool additions and version drift; review and update this registry when intentionally adding new tools."
+    "notes": "Track external tool additions and version drift; review and update this registry when intentionally bumping action versions or adding new tools. POSIX baseline utilities and standard SSH tooling are tracked here because the audit discovers them in workflow run blocks; they are built into runner images and add no new dependency surface."
   },
   "github_actions": [
     "actions/checkout@v4",
+    "actions/checkout@v5",
     "actions/github-script@v7",
     "actions/github-script@v8",
     "actions/setup-node@v4",
     "actions/setup-node@v6",
     "actions/setup-python@v5",
+    "actions/setup-python@v6",
     "actions/upload-artifact@v4",
-    "actions/upload-artifact@v6"
+    "actions/upload-artifact@v6",
+    "actions/upload-artifact@v7"
   ],
   "workflow_cli_tools": [
     ":",
     "bc",
     "cat",
     "cd",
+    "chmod",
     "claude",
     "cp",
     "curl",
@@ -25,13 +29,18 @@
     "gh",
     "git",
     "jq",
+    "mkdir",
     "npm",
     "pip",
+    "printf",
     "python",
     "python3",
-    "printf",
     "railway",
+    "scp",
     "sleep",
+    "ssh",
+    "ssh-keyscan",
+    "test",
     "timeout",
     "which"
   ],


### PR DESCRIPTION
## Summary

The External Tools Audit workflow has been failing 100% on every scheduled run for 5+ consecutive runs (2026-04-24 onward). Wellness has been naming this as persistent strain in its contracts sense. This PR brings the registry current with what the audit actually discovers.

## Two kinds of drift the audit was correctly catching

**1. GH action versions that bumped during routine updates.** Workflows now use:
- `actions/checkout@v5` (was v4)
- `actions/setup-python@v6` (was v5)
- `actions/upload-artifact@v7` (was v4 and v6)

Both old and new versions stay tracked since some workflows still reference older versions. The audit continues to catch *new* version bumps as before.

**2. POSIX baseline + standard SSH tooling.** The audit's run-block scanner discovers these in workflow YAML, but the registry didn't track them:
- `chmod`, `mkdir`, `test` — POSIX baseline (built into every Ubuntu runner)
- `ssh`, `scp`, `ssh-keyscan` — SSH tooling (used in deploy paths to the VPS)

These appear in run blocks but add no new dependency surface — they're in the runner image. Tracking them lets the discovery loop run clean while the audit's actual job (catching intentional new tool additions and version bumps) stays intact.

## Policy clarified

The `policy.notes` field now names explicitly that POSIX baseline + SSH tooling are tracked for the discovery loop's benefit, not because they bring external dependency. The intent — surface intentional version bumps + new tool additions as a moment to verify — stays exactly as before.

## Test plan

- [x] `python3 scripts/audit_external_tools.py --json --fail-on-untracked` returns exit 0
- [x] Report shows `ok: true` with empty untracked lists
- [ ] Next scheduled run (Tue/Fri 09:00 UTC) of External Tools Audit comes back green
- [ ] Future intentional action version bumps will surface as a fresh audit failure, prompting an explicit registry update — the gate stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)