### PR TITLE
attune(nav): the lineage walks both ways — era jump-nav, work stitching, sectioned /people

### DIFF
--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -102,6 +102,13 @@ function initialFor(name: string, fallback: string): string {
   return c ? c.toUpperCase() : fallback;
 }
 
+// When a section has dozens of items (the Works section in particular
+// is dominated by 170+ audiobook nodes), the alphabetic flood drowns
+// the rest of the directory. Cap the default render so each section
+// stays scannable; the section header already links to ?kind={key}
+// for the full list, and that filtered view shows everything.
+const PREVIEW_PER_SECTION = 16;
+
 export default async function PeopleIndexPage({
   searchParams,
 }: {
@@ -170,6 +177,14 @@ export default async function PeopleIndexPage({
         const linkHref = isCurrentlyFiltered
           ? "/people"
           : `/people?kind=${encodeURIComponent(section.key)}`;
+        // Default view caps each section at PREVIEW_PER_SECTION so a
+        // long catalog (Works has 170+ audiobook nodes) doesn't bury
+        // the smaller sections. When a kind-filter is active, the
+        // visitor asked for the full list — show everything.
+        const visibleItems = isCurrentlyFiltered
+          ? items
+          : items.slice(0, PREVIEW_PER_SECTION);
+        const hiddenCount = items.length - visibleItems.length;
         return (
           <section key={section.key} className="space-y-4">
             <div>
@@ -194,7 +209,7 @@ export default async function PeopleIndexPage({
               </p>
             </div>
             <ul className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-              {items.map((n) => (
+              {visibleItems.map((n) => (
                 <li key={n.id}>
                   <Link
                     href={presenceHref(n)}
@@ -226,6 +241,14 @@ export default async function PeopleIndexPage({
                 </li>
               ))}
             </ul>
+            {hiddenCount > 0 && (
+              <Link
+                href={linkHref}
+                className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Show all {items.length} {section.title.toLowerCase()} →
+              </Link>
+            )}
           </section>
         );
       })}

--- a/web/app/people/urs/lineage/page.tsx
+++ b/web/app/people/urs/lineage/page.tsx
@@ -7,23 +7,20 @@ export const metadata: Metadata = {
     "The full chronological story — every load-bearing work in the body of evidence from age 13 (Commodore 64 MIDI, ~1984) to the current iteration of the Coherence Network, woven together with the measured streams of attention (audiobooks, listening, reading, named lineage figures) that ran alongside the work at each era.",
 };
 
-const W = (slug: string, name: string, year: string, color: string) => ({ slug, name, year, color });
-
-const WORKS = [
-  W("c64-midi-interface", "C64 MIDI · age 13", "~1984", "hsl(220 60% 65%)"),
-  W("schindler-hc11-protocol", "Schindler HC11 · 7-layer", "~1989", "hsl(0 65% 60%)"),
-  W("backtracking-model-languages", "BML thesis · CU Boulder", "2000", "hsl(38 80% 60%)"),
-  W("quark-virtual-dom", "Quark · Virtual DOM", "2000-05", "hsl(195 60% 55%)"),
-  W("quark-multi-undo-redo", "Quark · Multi-Undo/Redo", "2000-05", "hsl(195 60% 55%)"),
-  W("quark-mono-corba", "Quark · Mono/CORBA", "2000-05", "hsl(195 60% 55%)"),
-  W("mindtouch-wiki-in-a-box", "MindTouch · Wiki-in-a-box", "2005-07", "hsl(140 55% 55%)"),
-  W("trimble-glue-layer", "Trimble · Glue layer", "2007-09", "hsl(80 55% 55%)"),
-  W("qualcomm-test-automation", "Qualcomm · Test Automation", "2009-22", "hsl(40 70% 55%)"),
-  W("qualcomm-hdmi-hdcp", "Qualcomm · HDMI/HDCP kernel", "2009-22", "hsl(40 70% 55%)"),
-  W("living-resonance-codex", "Living-Resonance-Codex", "2023", "hsl(140 60% 55%)"),
-  W("living-codex-csharp", "Living-Codex-CSharp", "2024", "hsl(195 60% 55%)"),
-  W("coherence-network", "Coherence-Network", "2024-now", "hsl(280 60% 65%)"),
-];
+// Era anchors — id, label, year-range, hue. The same record shapes
+// the at-a-glance grid (rendered inline below), the jump-nav strip,
+// and the article id attributes. Order is chronological so a visitor
+// reading top-to-bottom moves with the body's actual time.
+const ERAS = [
+  { id: "keystone", label: "keystone", range: "~1984 – ~1990", hue: "hsl(220 60% 65%)" },
+  { id: "foundation", label: "foundation", range: "1991 – 2000", hue: "hsl(38 80% 60%)" },
+  { id: "quark", label: "Quark Denver", range: "May 2000 – Mar 2005", hue: "hsl(195 60% 55%)" },
+  { id: "mindtouch", label: "MindTouch", range: "Mar 2005 – Jan 2007", hue: "hsl(140 55% 55%)" },
+  { id: "trimble", label: "Trimble Boulder", range: "Jan 2007 – Oct 2009", hue: "hsl(80 55% 55%)" },
+  { id: "qualcomm", label: "Qualcomm Boulder · 12y", range: "Oct 2009 – Jan 2022", hue: "hsl(40 70% 55%)" },
+  { id: "bridge", label: "bridge", range: "Jan 2022 – 2024", hue: "hsl(140 60% 55%)" },
+  { id: "coherence-network", label: "Coherence Network", range: "2024 – present", hue: "hsl(280 70% 65%)" },
+] as const;
 
 export default function UrsLineagePage() {
   return (
@@ -146,7 +143,7 @@ export default function UrsLineagePage() {
                   ],
                 },
                 {
-                  era: "2023 – 2024",
+                  era: "Jan 2022 – 2024",
                   label: "bridge",
                   hue: "hsl(140 60% 55%)",
                   works: [
@@ -216,8 +213,51 @@ export default function UrsLineagePage() {
           </figure>
         </section>
 
+        {/* Era jump-nav — sticky strip so a visitor can leap directly
+           to any era without scrolling through eight long articles.
+           Each chip carries its era's hue so the visual continuity
+           with the at-a-glance grid is preserved. */}
+        <nav
+          className="sticky top-14 z-30 -mx-6 px-6 py-3 bg-background/85 backdrop-blur-md border-y border-border/30"
+          aria-label="Jump to era"
+        >
+          <div className="flex flex-wrap items-center gap-1.5 text-xs">
+            <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground/70 mr-1">
+              Jump to
+            </span>
+            {ERAS.map((e) => (
+              <a
+                key={e.id}
+                href={`#era-${e.id}`}
+                className="rounded-full border px-2.5 py-1 text-[11px] text-foreground/85 hover:text-foreground transition-colors"
+                style={{
+                  borderColor: `${e.hue.replace(")", " / 0.45)")}`,
+                  backgroundColor: `${e.hue.replace(")", " / 0.06)")}`,
+                }}
+              >
+                <span style={{ color: e.hue }}>{e.label}</span>
+                <span className="text-muted-foreground/70 ml-1.5 font-mono">
+                  {e.range.split(" – ")[0].replace("~", "")}
+                </span>
+              </a>
+            ))}
+            <a
+              href="#streams"
+              className="rounded-full border border-border/40 bg-card/40 px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+            >
+              streams of attention
+            </a>
+            <a
+              href="#open-thread"
+              className="rounded-full border border-border/40 bg-card/40 px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+            >
+              open thread
+            </a>
+          </div>
+        </nav>
+
         {/* Era 1 */}
-        <article>
+        <article id="era-keystone" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             The keystone · ~1984 – ~1990 · age 13 to 18
           </h2>
@@ -272,7 +312,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 2 */}
-        <article>
+        <article id="era-foundation" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Foundation · 1991 – 2000 · HTL → Goetheanum → Boulder → BML thesis
           </h2>
@@ -315,7 +355,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 3 */}
-        <article>
+        <article id="era-quark" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Quark Denver · May 2000 – March 2005 · 4 years 11 months
           </h2>
@@ -369,7 +409,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 4 */}
-        <article>
+        <article id="era-mindtouch" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             MindTouch · March 2005 – January 2007 · 1 year 11 months
           </h2>
@@ -405,7 +445,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 5 */}
-        <article>
+        <article id="era-trimble" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Trimble Boulder · January 2007 – October 2009 · 2 years 10 months
           </h2>
@@ -436,7 +476,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 6 */}
-        <article>
+        <article id="era-qualcomm" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Qualcomm Boulder · October 2009 – January 2022 · 12 years 4 months
           </h2>
@@ -506,7 +546,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 7 */}
-        <article>
+        <article id="era-bridge" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Bridge years · January 2022 – 2024 · Merly.ai + the post-thesis arc opens
           </h2>
@@ -559,7 +599,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Era 8 */}
-        <article>
+        <article id="era-coherence-network" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             Coherence Network era · 2024 – present
           </h2>
@@ -597,7 +637,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Influences index */}
-        <article>
+        <article id="streams" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             The streams of attention that ran alongside
           </h2>
@@ -673,7 +713,7 @@ export default function UrsLineagePage() {
         </article>
 
         {/* Closing */}
-        <article>
+        <article id="open-thread" className="scroll-mt-32">
           <h2 className="text-2xl font-light text-foreground mb-4">
             The open thread
           </h2>

--- a/web/components/people/LineageStrip.tsx
+++ b/web/components/people/LineageStrip.tsx
@@ -1,0 +1,67 @@
+// LineageStrip — when the current /people/{slug} page is one of the
+// 13 chronological works in Urs Muff's lineage, surface a small
+// stitching strip: previous work · era anchor · next work · back to
+// lineage. Without this strip, every work page is a dead-end leaf.
+// With it, the visitor walks the body's own time.
+
+import Link from "next/link";
+
+import { findLineageWork } from "@/lib/lineage-works";
+
+export function LineageStrip({ slug }: { slug?: string }) {
+  const found = findLineageWork(slug);
+  if (!found) return null;
+  const { index, work, prev, next } = found;
+
+  return (
+    <nav
+      aria-label="Lineage navigation"
+      className="mb-8 flex flex-wrap items-center gap-2 rounded-xl border border-border/40 bg-card/30 px-3 py-2 text-xs"
+    >
+      <Link
+        href={`/people/urs/lineage#era-${work.eraId}`}
+        className="rounded-full px-2 py-1 text-foreground/85 hover:text-foreground transition-colors"
+        style={{
+          backgroundColor: work.hue.replace(")", " / 0.08)"),
+          border: `1px solid ${work.hue.replace(")", " / 0.45)")}`,
+        }}
+      >
+        <span style={{ color: work.hue }}>{work.eraLabel}</span>
+        <span className="text-muted-foreground/80 ml-1.5 font-mono">{work.year}</span>
+      </Link>
+      <span className="text-muted-foreground/60 font-mono">
+        work {index + 1} of 13
+      </span>
+      <span className="ml-auto flex items-center gap-2">
+        {prev ? (
+          <Link
+            href={`/people/${prev.slug}`}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            title={`Previous: ${prev.short}`}
+          >
+            ← {prev.short}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground/40">—</span>
+        )}
+        <Link
+          href="/people/urs/lineage"
+          className="rounded-full border border-border/40 px-2 py-1 text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+        >
+          ↑ Lineage
+        </Link>
+        {next ? (
+          <Link
+            href={`/people/${next.slug}`}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            title={`Next: ${next.short}`}
+          >
+            {next.short} →
+          </Link>
+        ) : (
+          <span className="text-muted-foreground/40">—</span>
+        )}
+      </span>
+    </nav>
+  );
+}

--- a/web/components/people/PersonProfileTemplate.tsx
+++ b/web/components/people/PersonProfileTemplate.tsx
@@ -19,6 +19,7 @@ import { Panel } from "@/components/Panel";
 import { createTranslator } from "@/lib/i18n";
 import type { LocaleCode } from "@/lib/locales";
 import { TemplateInfluenceWeb } from "./TemplateInfluenceWeb";
+import { LineageStrip } from "./LineageStrip";
 
 export type PersonProfileFact = {
   label: ReactNode;
@@ -163,6 +164,12 @@ export function PersonProfileTemplate({
       </section>
 
       <div className="max-w-3xl mx-auto px-6 py-12">
+        {/* Lineage strip — renders only when the current slug is one
+            of the 13 chronological works. Stitches each work page
+            into the lineage so the visitor walks the body's own time
+            instead of arriving at a dead-end leaf. */}
+        <LineageStrip slug={graphSlug} />
+
         {/* Source-language disclosure — when the visitor's locale is
             not English but the content module bound to this page is
             English (no de.tsx / es.tsx / id.tsx sibling for this slug

--- a/web/lib/lineage-works.ts
+++ b/web/lib/lineage-works.ts
@@ -1,0 +1,51 @@
+// lineage-works — chronological order of the load-bearing works in
+// Urs Muff's 42-year arc. Single source of truth so the lineage
+// page's at-a-glance grid, the per-work prev/next strip, and any
+// future works-strip rendering all read the same list.
+//
+// Order matches /people/urs/lineage page top-to-bottom. Each entry
+// carries enough context for a stitching strip (era id + label,
+// short title, year). Era ids match the article anchors on the
+// lineage page (#era-{eraId}).
+
+export type LineageWork = {
+  slug: string;
+  short: string;
+  year: string;
+  eraId: string;
+  eraLabel: string;
+  hue: string;
+};
+
+export const LINEAGE_WORKS: LineageWork[] = [
+  { slug: "c64-midi-interface", short: "C64 MIDI · age 13", year: "~1984", eraId: "keystone", eraLabel: "keystone", hue: "hsl(220 60% 65%)" },
+  { slug: "schindler-hc11-protocol", short: "Schindler HC11 · 7-layer", year: "~1989", eraId: "keystone", eraLabel: "keystone", hue: "hsl(220 60% 65%)" },
+  { slug: "backtracking-model-languages", short: "BML thesis · CU Boulder", year: "2000", eraId: "foundation", eraLabel: "foundation", hue: "hsl(38 80% 60%)" },
+  { slug: "quark-virtual-dom", short: "Quark · Virtual DOM", year: "2000–05", eraId: "quark", eraLabel: "Quark Denver", hue: "hsl(195 60% 55%)" },
+  { slug: "quark-multi-undo-redo", short: "Quark · Multi-Undo/Redo", year: "2000–05", eraId: "quark", eraLabel: "Quark Denver", hue: "hsl(195 60% 55%)" },
+  { slug: "quark-mono-corba", short: "Quark · Mono/CORBA", year: "2000–05", eraId: "quark", eraLabel: "Quark Denver", hue: "hsl(195 60% 55%)" },
+  { slug: "mindtouch-wiki-in-a-box", short: "MindTouch · Wiki-in-a-box", year: "2005–07", eraId: "mindtouch", eraLabel: "MindTouch", hue: "hsl(140 55% 55%)" },
+  { slug: "trimble-glue-layer", short: "Trimble · Glue layer", year: "2007–09", eraId: "trimble", eraLabel: "Trimble Boulder", hue: "hsl(80 55% 55%)" },
+  { slug: "qualcomm-test-automation", short: "Qualcomm · Test Automation", year: "2009–22", eraId: "qualcomm", eraLabel: "Qualcomm Boulder", hue: "hsl(40 70% 55%)" },
+  { slug: "qualcomm-hdmi-hdcp", short: "Qualcomm · HDMI/HDCP kernel", year: "2009–22", eraId: "qualcomm", eraLabel: "Qualcomm Boulder", hue: "hsl(40 70% 55%)" },
+  { slug: "living-resonance-codex", short: "Living-Resonance-Codex · Python", year: "2023", eraId: "bridge", eraLabel: "bridge", hue: "hsl(140 60% 55%)" },
+  { slug: "living-codex-csharp", short: "Living-Codex-CSharp · U-CORE", year: "2024", eraId: "bridge", eraLabel: "bridge", hue: "hsl(140 60% 55%)" },
+  { slug: "coherence-network", short: "Coherence-Network · live", year: "2024–now", eraId: "coherence-network", eraLabel: "Coherence Network", hue: "hsl(280 70% 65%)" },
+];
+
+export function findLineageWork(slug: string | undefined): {
+  index: number;
+  work: LineageWork;
+  prev: LineageWork | null;
+  next: LineageWork | null;
+} | null {
+  if (!slug) return null;
+  const i = LINEAGE_WORKS.findIndex((w) => w.slug === slug);
+  if (i < 0) return null;
+  return {
+    index: i,
+    work: LINEAGE_WORKS[i],
+    prev: i > 0 ? LINEAGE_WORKS[i - 1] : null,
+    next: i < LINEAGE_WORKS.length - 1 ? LINEAGE_WORKS[i + 1] : null,
+  };
+}


### PR DESCRIPTION
## What this attunes

The new-visitor walk surfaced three structural absences. Closing each one in this single breath.

### 1. Lineage page becomes navigable

Before: 700 lines, 8 long era articles, no anchors, dead WORKS array, Bridge card said "2023 – 2024" hiding a year (Qualcomm ends Jan 2022, Bridge starts Jan 2022).

After:
- Sticky era jump-nav strip below the at-a-glance grid (8 era chips in their own hues + streams + open-thread)
- Each `<article>` carries an id (`era-keystone` … `era-coherence-network`) + `scroll-mt-32` so anchored jumps clear the sticky nav
- Dead `WORKS` array composts into a proper `ERAS` const, single source of truth
- Bridge card now reads "Jan 2022 – 2024" matching the article body

### 2. Each work page stitches into the lineage

Before: every `/people/{work-slug}` page was a 21,000-word leaf with no thread back to the lineage or to sibling works.

After:
- New `web/lib/lineage-works.ts` — 13 chronological works as a single source of truth (slug, year, era id + label, hue)
- New `LineageStrip` component renders on every work page:
  - era badge · "work N of 13" · ← prev work · ↑ Lineage · next work →
- Wired through `PersonProfileTemplate` so all 13 pages get it without per-page edits

### 3. /people stops drowning in audiobooks

Before: 374 entries × alphabetic × 171 `audible-*` nodes meant the directory opened with "audible-21-lessons-..." flooding the front.

After:
- Each section caps at 16 items by default with a "Show all N {section} →" link
- When the visitor is already filtered to a section (`?kind={key}`), the cap drops and they see everything

## What opens for a new visitor

- **Specific work in 2 clicks**: "Quark" chip on lineage → era-quark anchor → click the work card → LineageStrip shows where you are and where to go.
- **Chronology at a glance** without committing to 700 lines of prose.
- **Scannable /people** — the named lineage figures and smaller sections breathe again instead of being buried.

## Still open from the same walk

- Witness-trace surfacing (we record 3,000+ visits/day but no page returns "this is where attention has been")
- Vision ↔ creation ↔ influence cross-layer stitching (graph queries we don't render yet)

These live in the next breath — they need data wiring we don't have today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)