### PR TITLE
tend: paginate /assets, /contributions, /people directory

### DIFF
--- a/web/app/assets/page.tsx
+++ b/web/app/assets/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { getApiBase } from "@/lib/api";
-import { useLiveRefresh } from "@/lib/live_refresh";
+import { usePagedList } from "@/lib/use-paged-list";
 import { useT, useLocale } from "@/components/MessagesProvider";
 import { LedgerNav } from "@/app/_components/LedgerNav";
 import { AssetGlyph, assetTypeTone } from "@/app/_components/AssetGlyph";
@@ -13,6 +13,7 @@ import { assetTypeLabel } from "@/lib/asset-types";
 import { decodeEntities } from "@/lib/html-entities";
 
 const API_URL = getApiBase();
+const PAGE_SIZE = 100;
 
 function formatDate(iso: string, locale: string): string {
   try {
@@ -44,33 +45,43 @@ function AssetsPageContent() {
   const t = useT();
   const locale = useLocale();
   const searchParams = useSearchParams();
-  const [rows, setRows] = useState<Asset[]>([]);
-  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
-  const [error, setError] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<string>("ALL");
 
   const selectedAssetId = useMemo(() => (searchParams.get("asset_id") || "").trim(), [searchParams]);
 
-  const loadRows = useCallback(async () => {
-    setStatus((prev) => (prev === "ok" ? "ok" : "loading"));
-    setError(null);
-    try {
-      const res = await fetch(`${API_URL}/api/assets?limit=500`, { cache: "no-store" });
-      if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`HTTP ${res.status}: ${body.slice(0, 200)}`);
-      }
-      const json = await res.json();
-      const data = json?.items ?? (Array.isArray(json) ? json : []);
-      setRows(data);
-      setStatus("ok");
-    } catch (e) {
-      setStatus("error");
-      setError(String(e));
-    }
-  }, []);
+  const buildAssetsUrl = useCallback(
+    (offset: number, limit: number) => `${API_URL}/api/assets?offset=${offset}&limit=${limit}`,
+    [],
+  );
 
-  useLiveRefresh(loadRows);
+  const assets = usePagedList<Asset>({
+    buildUrl: buildAssetsUrl,
+    pageSize: PAGE_SIZE,
+    timeoutMs: 10000,
+    retries: 3,
+  });
+  const rows = assets.items;
+  const totalKnown = assets.total;
+
+  // Sentinel: when the bottom marker enters the viewport, ask for more.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            assets.loadMore();
+          }
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, [assets.loadMore]);
 
   const typeCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -96,6 +107,10 @@ function AssetsPageContent() {
     () => filteredRows.reduce((sum, row) => sum + (Number(row.total_cost) || 0), 0),
     [filteredRows],
   );
+
+  const isFirstLoad = assets.loading && rows.length === 0;
+  const initialError = assets.error && rows.length === 0 ? assets.error : null;
+  const visibleTotal = totalKnown !== null && totalKnown > rows.length ? totalKnown : rows.length;
 
   return (
     <main className="bg-stone-950 min-h-screen">
@@ -145,7 +160,7 @@ function AssetsPageContent() {
         <section className="grid gap-3 grid-cols-2 lg:grid-cols-4">
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4">
             <p className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("assets.statVisible")}</p>
-            <p className="mt-2 text-3xl font-light text-stone-100">{filteredRows.length.toLocaleString(locale)}</p>
+            <p className="mt-2 text-3xl font-light text-stone-100">{visibleTotal.toLocaleString(locale)}</p>
             <p className="mt-1 text-xs text-stone-400">{t("assets.statVisibleHint")}</p>
           </div>
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-amber-500/10 to-amber-500/5 p-4">
@@ -215,17 +230,17 @@ function AssetsPageContent() {
           </div>
         )}
 
-        {status === "loading" && <p className="text-stone-400 text-sm">{t("common.loading")}</p>}
-        {status === "error" && (
+        {isFirstLoad && <p className="text-stone-400 text-sm">{t("common.loading")}</p>}
+        {initialError && (
           <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-300">
-            {t("assets.errorPrefix")} {error}
+            {t("assets.errorPrefix")} {initialError}
           </div>
         )}
 
-        {status === "ok" && (
+        {!isFirstLoad && !initialError && (
           <section className="space-y-3">
             <ul className="grid gap-3 sm:grid-cols-2">
-              {filteredRows.slice(0, 100).map((a) => {
+              {filteredRows.map((a) => {
                 const name = decodeEntities(a.description || a.type || t("assets.untitled"));
                 const thumbSrc = a.file_path || a.image_url || null;
                 const tone = assetTypeTone(a.type);
@@ -334,6 +349,24 @@ function AssetsPageContent() {
                     {t("assets.emptyCtaLedger")}
                   </Link>
                 </div>
+              </div>
+            )}
+
+            {/* Sentinel + loading-more — only when there's more to fetch */}
+            {!assets.loadedAll && (
+              <div ref={sentinelRef} className="flex items-center justify-center py-6">
+                {assets.loading && (
+                  <p className="text-stone-500 text-sm">{t("common.loading")}</p>
+                )}
+                {!assets.loading && assets.error && (
+                  <button
+                    type="button"
+                    onClick={assets.loadMore}
+                    className="text-stone-400 hover:text-amber-300 text-sm underline-offset-4 hover:underline"
+                  >
+                    {t("common.loading")}
+                  </button>
+                )}
               </div>
             )}
           </section>

--- a/web/app/contributions/page.tsx
+++ b/web/app/contributions/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { getApiBase } from "@/lib/api";
-import { useLiveRefresh } from "@/lib/live_refresh";
+import { fetchJsonOrNull } from "@/lib/fetch";
+import { usePagedList } from "@/lib/use-paged-list";
 import { useT, useLocale } from "@/components/MessagesProvider";
 import { LedgerNav } from "@/app/_components/LedgerNav";
 import { decodeEntities } from "@/lib/html-entities";
 
 const API_URL = getApiBase();
+const PAGE_SIZE = 100;
 
 function formatDate(iso: string, locale: string): string {
   try {
@@ -69,9 +71,6 @@ function ContributionsPageContent() {
   const t = useT();
   const locale = useLocale();
   const searchParams = useSearchParams();
-  const [rows, setRows] = useState<Contribution[]>([]);
-  const [status, setStatus] = useState<"loading" | "ok" | "error">("loading");
-  const [error, setError] = useState<string | null>(null);
   const [liveCoherenceScore, setLiveCoherenceScore] = useState<number | null>(null);
   const [contributorNames, setContributorNames] = useState<NameLookup>(new Map());
   const [assetNames, setAssetNames] = useState<NameLookup>(new Map());
@@ -85,50 +84,92 @@ function ContributionsPageContent() {
     [searchParams]
   );
 
-  const loadRows = useCallback(async () => {
-    setStatus((prev) => (prev === "ok" ? "ok" : "loading"));
-    setError(null);
-    try {
-      const [contribRes, coherenceRes, contributorsRes, assetsRes] = await Promise.all([
-        fetch(`${API_URL}/api/contributions`, { cache: "no-store" }),
-        fetch(`${API_URL}/api/coherence/score`, { cache: "no-store" }),
-        fetch(`${API_URL}/api/contributors`, { cache: "no-store" }).catch(() => null),
-        fetch(`${API_URL}/api/assets`, { cache: "no-store" }).catch(() => null),
+  const buildContributionsUrl = useCallback(
+    (offset: number, limit: number) =>
+      `${API_URL}/api/contributions?offset=${offset}&limit=${limit}`,
+    [],
+  );
+
+  const contributions = usePagedList<Contribution>({
+    buildUrl: buildContributionsUrl,
+    pageSize: PAGE_SIZE,
+    timeoutMs: 10000,
+    retries: 3,
+  });
+  const rows = contributions.items;
+  const totalKnown = contributions.total;
+
+  // Sentinel: when bottom marker enters viewport, ask for the next page.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            contributions.loadMore();
+          }
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, [contributions.loadMore]);
+
+  // Auxiliary fetches: live coherence score (single value) + name lookups
+  // (best-effort; names that miss fall back to truncated id).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [coherenceJson, contributorsJson, assetsJson] = await Promise.all([
+        fetchJsonOrNull<CoherenceScoreResponse>(
+          `${API_URL}/api/coherence/score`,
+          { cache: "no-store" },
+          8000,
+          3,
+        ),
+        fetchJsonOrNull<{ items?: Array<{ id: string; name?: string }> } | Array<{ id: string; name?: string }>>(
+          `${API_URL}/api/contributors?limit=1000`,
+          { cache: "no-store" },
+          10000,
+          3,
+        ),
+        fetchJsonOrNull<{ items?: Array<{ id: string; description?: string; type?: string }> } | Array<{ id: string; description?: string; type?: string }>>(
+          `${API_URL}/api/assets?limit=1000`,
+          { cache: "no-store" },
+          10000,
+          3,
+        ),
       ]);
-      const contribJson = await contribRes.json();
-      if (!contribRes.ok) throw new Error(JSON.stringify(contribJson));
-      const data = contribJson?.items ?? (Array.isArray(contribJson) ? contribJson : []);
-      const coherenceJson = coherenceRes.ok ? ((await coherenceRes.json()) as CoherenceScoreResponse) : null;
+      if (cancelled) return;
+
+      if (coherenceJson && Number.isFinite(coherenceJson.score)) {
+        setLiveCoherenceScore(Number(coherenceJson.score));
+      }
 
       const cNames = new Map<string, string>();
-      const aNames = new Map<string, string>();
-      if (contributorsRes?.ok) {
-        const cJson = await contributorsRes.json();
-        for (const c of cJson?.items ?? (Array.isArray(cJson) ? cJson : [])) {
-          if (c.id && c.name) cNames.set(c.id, c.name);
-        }
-      }
-      if (assetsRes?.ok) {
-        const aJson = await assetsRes.json();
-        for (const a of aJson?.items ?? (Array.isArray(aJson) ? aJson : [])) {
-          if (a.id) aNames.set(a.id, decodeEntities(a.description || a.type || "Untitled asset"));
-        }
+      const cItems = Array.isArray(contributorsJson)
+        ? contributorsJson
+        : contributorsJson?.items ?? [];
+      for (const c of cItems) {
+        if (c.id && c.name) cNames.set(c.id, c.name);
       }
       setContributorNames(cNames);
+
+      const aNames = new Map<string, string>();
+      const aItems = Array.isArray(assetsJson) ? assetsJson : assetsJson?.items ?? [];
+      for (const a of aItems) {
+        if (a.id) aNames.set(a.id, decodeEntities(a.description || a.type || "Untitled asset"));
+      }
       setAssetNames(aNames);
-
-      setRows(data);
-      setLiveCoherenceScore(
-        coherenceJson && Number.isFinite(coherenceJson.score) ? Number(coherenceJson.score) : null,
-      );
-      setStatus("ok");
-    } catch (e) {
-      setStatus("error");
-      setError(String(e));
-    }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
-
-  useLiveRefresh(loadRows);
 
   const filteredRows = useMemo(() => {
     return rows.filter((row) => {
@@ -206,6 +247,13 @@ function ContributionsPageContent() {
     return null;
   })();
 
+  const isFirstLoad = contributions.loading && rows.length === 0;
+  const initialError = contributions.error && rows.length === 0 ? contributions.error : null;
+  const visibleEntriesLabel =
+    totalKnown !== null && rows.length < totalKnown && !contributorFilter && !assetFilter
+      ? `${filteredRows.length.toLocaleString(locale)} / ${totalKnown.toLocaleString(locale)}`
+      : filteredRows.length.toLocaleString(locale);
+
   return (
     <main className="bg-stone-950 min-h-screen">
       {/* Hero — value flowing through the body */}
@@ -270,7 +318,7 @@ function ContributionsPageContent() {
         <section className="grid gap-3 grid-cols-2 lg:grid-cols-4">
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4">
             <p className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("contributions.statEntries")}</p>
-            <p className="mt-2 text-3xl font-light text-stone-100">{filteredRows.length.toLocaleString(locale)}</p>
+            <p className="mt-2 text-3xl font-light text-stone-100">{visibleEntriesLabel}</p>
             <p className="mt-1 text-xs text-stone-400">{t("contributions.statEntriesHint")}</p>
           </div>
           <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-amber-500/10 to-amber-500/5 p-4">
@@ -292,17 +340,17 @@ function ContributionsPageContent() {
           </div>
         </section>
 
-        {status === "loading" && <p className="text-stone-400 text-sm">{t("contributions.loading")}</p>}
-        {status === "error" && (
+        {isFirstLoad && <p className="text-stone-400 text-sm">{t("contributions.loading")}</p>}
+        {initialError && (
           <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-300">
-            {t("contributions.errorPrefix")} {error}
+            {t("contributions.errorPrefix")} {initialError}
           </div>
         )}
 
-        {status === "ok" && (
+        {!isFirstLoad && !initialError && (
           <section className="space-y-3">
             <ul className="space-y-3">
-              {filteredRows.slice(0, 100).map((c, idx) => {
+              {filteredRows.map((c, idx) => {
                 const cost = effectiveCost(c);
                 const commitHash = c.metadata?.commit_hash;
                 const displayCoherence = c.coherence_score > 0 ? c.coherence_score : liveCoherenceScore;
@@ -407,6 +455,24 @@ function ContributionsPageContent() {
                     {t("contributions.emptyCtaContribute")}
                   </Link>
                 </div>
+              </div>
+            )}
+
+            {/* Sentinel + loading-more — only when there's more to fetch */}
+            {!contributions.loadedAll && (
+              <div ref={sentinelRef} className="flex items-center justify-center py-6">
+                {contributions.loading && (
+                  <p className="text-stone-500 text-sm">{t("common.loading")}</p>
+                )}
+                {!contributions.loading && contributions.error && (
+                  <button
+                    type="button"
+                    onClick={contributions.loadMore}
+                    className="text-stone-400 hover:text-amber-300 text-sm underline-offset-4 hover:underline"
+                  >
+                    {t("common.loading")}
+                  </button>
+                )}
               </div>
             )}
           </section>

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -54,18 +54,34 @@ function presenceHref(n: PresenceNode): string {
   return `/people/${encodeURIComponent(n.id)}`;
 }
 
-async function fetchType(type: string, limit = 200): Promise<PresenceNode[]> {
-  try {
-    const res = await fetch(
-      `${getApiBase()}/api/graph/nodes?type=${encodeURIComponent(type)}&limit=${limit}`,
-      { next: { revalidate: 30 } },
-    );
-    if (!res.ok) return [];
-    const data = await res.json();
-    return (data.items || []) as PresenceNode[];
-  } catch {
-    return [];
+// Walk every page of /api/graph/nodes for this type so the directory
+// reflects the body's actual count, not whatever fits in one slice. The
+// graph endpoint caps `limit` at 500; most types have well under that,
+// but `contributor` is already past 200 and growing — without the walk,
+// /people silently truncates lineage.
+async function fetchType(type: string): Promise<PresenceNode[]> {
+  const PAGE = 500;
+  const HARD_CAP_PAGES = 20; // safety valve at 10k items
+  const all: PresenceNode[] = [];
+  for (let page = 0; page < HARD_CAP_PAGES; page++) {
+    try {
+      const offset = page * PAGE;
+      const res = await fetch(
+        `${getApiBase()}/api/graph/nodes?type=${encodeURIComponent(type)}&offset=${offset}&limit=${PAGE}`,
+        { next: { revalidate: 30 } },
+      );
+      if (!res.ok) break;
+      const data = await res.json();
+      const items = (data.items || []) as PresenceNode[];
+      all.push(...items);
+      const total = typeof data.total === "number" ? data.total : null;
+      if (items.length < PAGE) break;
+      if (total !== null && all.length >= total) break;
+    } catch {
+      break;
+    }
   }
+  return all;
 }
 
 function filterScannable(


### PR DESCRIPTION
## Summary
Sibling sweep of [PR #1489](https://github.com/seeker71/Coherence-Network/pull/1489). Three more list surfaces stop silently truncating.

- **/assets** — was \`?limit=500\`. Production has 680 vessels; 180 were invisible. Now walks every page via \`usePagedList\` + \`IntersectionObserver\` sentinel.
- **/contributions** — was default 100. Same hook, same sentinel. The contributor/asset name-lookup auxiliaries lift to \`limit=1000\` so labels resolve across both bodies (currently 295 / 680, well under cap).
- **/people** directory — server component now walks every page of \`/api/graph/nodes\` per type until \`total\` is reached (max 20 × 500 = 10k as safety valve). The 295 contributor cells that drowned curated presences arrive complete instead of capped at 200.

The hook \`usePagedList\` already shipped with the contributors PR — this PR adopts it across the siblings.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] API endpoints confirmed paginated: \`/api/contributors\` total=295, \`/api/assets\` total=680, \`/api/contributions\` total=0, \`/api/graph/nodes?type=contributor\` total=295
- [ ] After deploy: visit /assets and confirm scroll loads past 500. Visit /people and confirm contributor section reaches all 295 (was capped at 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)