### PR TITLE
attune(nav): named lineage figures rise; the Concept Garden has a clear door

### DIFF
--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -9,6 +9,7 @@ import {
   getPeoplePageCopy,
 } from "../presence-walk/data";
 import { PeopleSearch } from "./_components/PeopleSearch";
+import { lineageFigureRank } from "@/lib/named-lineage";
 
 /**
  * /people — the directory of every presence the network holds.
@@ -134,9 +135,22 @@ export default async function PeopleIndexPage({
       const items = await fetchType(t);
       combined.push(...items);
     }
-    groups[section.key] = filterScannable(combined, filterRules).sort((a, b) =>
-      (a.name || "").localeCompare(b.name || ""),
-    );
+    // Within-section ordering — named lineage figures (the humans who
+    // actually shaped this work) rank first in their lineage order,
+    // then everyone else alphabetically by display name. Without this
+    // ranking, the alphabetic sort buries Anne Tucker / Liquid Bloom /
+    // Steve G. Bjorg under hundreds of auto-resolved book authors and
+    // YouTube-channel-id rows that share the same section.
+    groups[section.key] = filterScannable(combined, filterRules).sort((a, b) => {
+      const aSlug = a.slug || a.id;
+      const bSlug = b.slug || b.id;
+      const aRank = lineageFigureRank(aSlug);
+      const bRank = lineageFigureRank(bSlug);
+      if (aRank !== null && bRank !== null) return aRank - bRank;
+      if (aRank !== null) return -1;
+      if (bRank !== null) return 1;
+      return (a.name || "").localeCompare(b.name || "");
+    });
   }
 
   const total = Object.values(groups).reduce((sum, g) => sum + g.length, 0);

--- a/web/app/vision/page.tsx
+++ b/web/app/vision/page.tsx
@@ -527,6 +527,29 @@ export default async function VisionPage({
         className="mx-auto max-w-3xl px-6 pb-12 space-y-4 text-base text-stone-400 leading-relaxed"
       />
 
+      {/* Discoverability strip — a clear door to the searchable concept
+         garden, lifted up from the depth of the page so a visitor
+         arriving with a specific concept in mind can find it without
+         scrolling through the curated narrative first. */}
+      <section className="max-w-3xl mx-auto px-6 pb-12">
+        <Link
+          href={localizedHref("/concepts/garden?domain=living-collective", lang)}
+          className="group flex items-center justify-between gap-3 rounded-2xl border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 hover:border-amber-500/30 px-5 py-4 transition-all"
+        >
+          <div className="space-y-0.5">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-amber-300/70 font-medium">
+              {t("visionIndex.gardenStripEyebrow")}
+            </p>
+            <p className="text-base text-stone-200 group-hover:text-amber-100 transition-colors">
+              {t("visionIndex.gardenStripBody")}
+            </p>
+          </div>
+          <span className="text-amber-400/70 group-hover:text-amber-300 text-2xl transition-colors shrink-0">
+            →
+          </span>
+        </Link>
+      </section>
+
       {/* How It Knows */}
       <section className="max-w-3xl mx-auto px-6 py-24 text-center space-y-8">
         <div className="flex justify-center">

--- a/web/lib/named-lineage.ts
+++ b/web/lib/named-lineage.ts
@@ -1,0 +1,54 @@
+// named-lineage — slugs of the load-bearing humans in the lineage,
+// in roughly the chronological order they entered the body's arc.
+// Single source of truth so /people can surface them above the
+// alphabetic flood of book authors and auto-resolved channels, and
+// any future surface that wants "the figures who actually shaped
+// this work" reads from one list.
+//
+// Order matches /people/urs/lineage prose: childhood transmissions →
+// foundation collaborator → bridge listening → current era streams →
+// Ubud cluster → present connections. A figure earns inclusion here
+// only when /people/{slug} renders a curated h1 (not a thin
+// auto-resolved stub) — verified live before authoring.
+
+export const LINEAGE_FIGURE_SLUGS: readonly string[] = [
+  // Era 1 — the keystone (~1984 – ~1990)
+  "michael-ende",
+  "james-fenimore-cooper",
+  // Era 2 — foundation (1991 – 2000)
+  "steve-bjorg",
+  // Era 6 — Qualcomm listening (2009 – 2022)
+  "lex-fridman",
+  // Era 7 — bridge years (Jan 2022 – 2024) and current devotional substrate
+  "anne-tucker",
+  "mose",
+  "liquid-bloom",
+  // Streams that ran alongside
+  "michael-levin",
+  "robert-edward-grant",
+  // Era 8 — Coherence Network present
+  "aubrey-marcus",
+  "bloomurian",
+  // Ubud cluster — transmission node (Sunday-Wednesday rhythm)
+  "ilena",
+  "vasudev-baba",
+  "elios",
+  // Current connections
+  "aly-constantine",
+];
+
+const RANK = new Map(
+  LINEAGE_FIGURE_SLUGS.map((slug, i) => [slug, i] as const),
+);
+
+// Returns 0..N-1 for lineage figures (lower = earlier in the arc),
+// or null when the slug is not a named lineage figure.
+export function lineageFigureRank(slug: string | undefined | null): number | null {
+  if (!slug) return null;
+  const r = RANK.get(slug);
+  return r === undefined ? null : r;
+}
+
+export function isLineageFigure(slug: string | undefined | null): boolean {
+  return lineageFigureRank(slug) !== null;
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1142,6 +1142,8 @@
     "blueprintsLede": "Real open-source plans, live flows, materials, costs, and methods for each aspect of the community. Some pages hold a pure concept. Some hold a living transformation story. They are all part of the same organism.",
     "blueprintsResourcesTag": "{n} resources",
     "blueprintsBrowseAll": "Browse all concepts",
+    "gardenStripEyebrow": "Looking for a specific concept?",
+    "gardenStripBody": "Search the full Concept Garden — every concept, filterable by keyword and domain.",
     "emergingHeading": "Emerging Visions",
     "emergingLede": "The anchors are strong enough to begin envisioning form. Each domain is where flows converge into inhabitable, livable expression.",
     "orientationImmerse": "Surround yourself with it",


### PR DESCRIPTION
## What this attunes

Two more drifts from the same new-visitor walk, closed.

### 1. /people People section — lineage figures rise

Before: pure alphabetic sort meant the curated lineage figures (Anne Tucker, Liquid Bloom, Mose, Steve G. Bjorg, Michael Ende, James Fenimore Cooper, Lex Fridman, Robert Edward Grant, Michael Levin, Aubrey Marcus, Bloomurian, Ilena, Vasudev Baba, Elios, Aly Constantine) were buried under hundreds of auto-resolved book authors. Visitor who wanted "the person who shaped this" had to scroll through the audible-* alphabet.

After: lineage figures rise to the top in lineage order (childhood transmissions → foundation collaborator → bridge listening → current devotional substrate → streams → Ubud cluster → present connections). Everyone else keeps alphabetic sort below.

`web/lib/named-lineage.ts` — single source of truth, 15 verified slugs (each verified live to render a curated h1).

### 2. /vision — Concept Garden gets a top doorway

Before: "Browse all concepts" was buried near the bottom, past Hero → How the Field Knows → sections → galleries → blueprints. Visitor arriving with a specific concept in mind had to scroll past the curated narrative to find the searchable Garden.

After: prominent amber doorway strip right after the hero — *"Looking for a specific concept? Search the full Concept Garden — every concept, filterable by keyword and domain →"*

## Still open from the same walk

- Witness-trace surfacing (3,240 visits/day recorded, no page returns "this is where attention has been")
- Cross-layer stitching (vision ↔ creation ↔ named influence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)