### PR TITLE
tend: pagination contract reaches every list-shaped API endpoint

### DIFF
--- a/api/app/routers/friction.py
+++ b/api/app/routers/friction.py
@@ -12,20 +12,24 @@ from app.models.friction import (
     FrictionEvent,
     FrictionReport,
 )
+from app.models.pagination import PaginatedResponse
 from app.services import friction_service
 
 router = APIRouter()
 
 
-@router.get("/friction/events", response_model=list[FrictionEvent], summary="List Events")
+@router.get("/friction/events", response_model=PaginatedResponse[FrictionEvent], summary="List Events")
 async def list_events(
     limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
     status: Optional[str] = Query(None),
-) -> list[FrictionEvent]:
+) -> PaginatedResponse[FrictionEvent]:
     events, _ignored = friction_service.load_events()
     if status:
         events = [e for e in events if e.status == status]
-    return events[:limit]
+    total = len(events)
+    page = events[offset : offset + limit]
+    return PaginatedResponse(items=page, total=total, limit=limit, offset=offset)
 
 
 @router.post("/friction/events", response_model=FrictionEvent, status_code=201, summary="Create Event")

--- a/api/app/routers/governance.py
+++ b/api/app/routers/governance.py
@@ -7,14 +7,19 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from app.middleware.auth import require_api_key
 
 from app.models.governance import ChangeRequest, ChangeRequestCreate, ChangeRequestVoteCreate
+from app.models.pagination import PaginatedResponse
 from app.services import governance_service
 
 router = APIRouter()
 
 
-@router.get("/governance/change-requests", response_model=list[ChangeRequest], summary="List Change Requests")
-async def list_change_requests(limit: int = Query(200, ge=1, le=1000)) -> list[ChangeRequest]:
-    return governance_service.list_change_requests(limit=limit)
+@router.get("/governance/change-requests", response_model=PaginatedResponse[ChangeRequest], summary="List Change Requests")
+async def list_change_requests(
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
+) -> PaginatedResponse[ChangeRequest]:
+    items, total = governance_service.list_change_requests_page(limit=limit, offset=offset)
+    return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
 @router.get("/governance/change-requests/{change_request_id}", response_model=ChangeRequest, summary="Get Change Request")

--- a/api/app/routers/news.py
+++ b/api/app/routers/news.py
@@ -110,6 +110,7 @@ def _ideas_as_dicts(ideas) -> list[dict]:
 async def get_news_feed(
     request: Request,
     limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
     source: Optional[str] = Query(None, description="Filter by source name"),
     refresh: bool = Query(False, description="Force refresh feeds"),
     lang: Optional[str] = Query(None, description="Target language. When set, item titles and descriptions are rendered in this locale on-demand."),
@@ -137,7 +138,8 @@ async def get_news_feed(
             scored.append((sc, it))
         scored.sort(key=lambda x: x[0], reverse=True)
         out_items = [it for sc, it in scored if sc >= pov_min_score]
-    out_items = out_items[:limit]
+    total = len(out_items)
+    out_items = out_items[offset : offset + limit]
     item_dicts = [i.to_dict() for i in out_items]
     if target_lang and target_lang != "en":
         for d in item_dicts:
@@ -152,6 +154,9 @@ async def get_news_feed(
     payload = {
         "count": len(item_dicts),
         "items": item_dicts,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
         "lang": target_lang,
     }
     if pov:

--- a/api/app/routers/runtime.py
+++ b/api/app/routers/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Body, Query, Request
 from pydantic import BaseModel
 
+from app.models.pagination import PaginatedResponse
 from app.models.runtime import (
     EndpointAttentionReport,
     RuntimeEvent,
@@ -29,13 +30,20 @@ async def create_runtime_event(payload: RuntimeEventCreate) -> RuntimeEvent:
     return runtime_service.record_event(payload)
 
 
-@router.get("/runtime/events", response_model=list[RuntimeEvent], summary="List Runtime Events")
+@router.get("/runtime/events", response_model=PaginatedResponse[RuntimeEvent], summary="List Runtime Events")
 async def list_runtime_events(
     limit: int = Query(100, ge=1, le=2000),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
     source: str | None = Query(default=None, max_length=64),
     force_refresh: bool = Query(False),
-) -> list[RuntimeEvent]:
-    return runtime_service.cached_runtime_events(limit=limit, source=source, force_refresh=force_refresh)
+) -> PaginatedResponse[RuntimeEvent]:
+    # Telemetry stream is high-volume and time-cursor would be cleaner long-term;
+    # for now, fetch a window large enough to cover offset+limit and slice. The
+    # underlying service caches the full window so subsequent pages reuse it.
+    window = max(limit + offset, limit)
+    full = runtime_service.cached_runtime_events(limit=window, source=source, force_refresh=force_refresh)
+    page = full[offset : offset + limit]
+    return PaginatedResponse(items=page, total=len(full), limit=limit, offset=offset)
 
 
 @router.get("/runtime/change-token", summary="Runtime Change Token")

--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -186,16 +186,18 @@ def get_equivalent(domain: str, name: str) -> EquivalentResponse:
 def list_cells(
     domain: str | None = Query(None, description="Filter by domain"),
     limit: int = Query(50, ge=1, le=500),
-) -> list[CellOut]:
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
+) -> dict[str, Any]:
     """List cells (optionally filtered by domain)."""
     with session_scope() as session:
-        q = session.query(SubstrateNamedCellORM)
+        base = session.query(SubstrateNamedCellORM)
         if domain is not None:
-            q = q.filter_by(domain=domain)
-        q = q.limit(limit)
-        rows = q.all()
+            base = base.filter_by(domain=domain)
+        total = base.count()
+        rows = base.offset(offset).limit(limit).all()
         from app.services.substrate.kernel import _orm_to_cell  # internal helper
-        return [CellOut.from_cell(_orm_to_cell(session, r)) for r in rows]
+        items = [CellOut.from_cell(_orm_to_cell(session, r)) for r in rows]
+        return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 class PathAnnotationOut(BaseModel):

--- a/api/app/services/governance_service.py
+++ b/api/app/services/governance_service.py
@@ -264,12 +264,22 @@ def _apply_change_request(change_request: ChangeRequest) -> dict[str, Any]:
 
 
 def list_change_requests(limit: int = 200) -> list[ChangeRequest]:
+    items, _total = list_change_requests_page(limit=limit, offset=0)
+    return items
+
+
+def list_change_requests_page(
+    limit: int = 200, offset: int = 0
+) -> tuple[list[ChangeRequest], int]:
     ensure_schema()
     with _session() as session:
+        base = session.query(ChangeRequestRecord).order_by(
+            ChangeRequestRecord.updated_at.desc(), ChangeRequestRecord.created_at.desc()
+        )
+        total = base.count()
         rows = (
-            session.query(ChangeRequestRecord)
-            .order_by(ChangeRequestRecord.updated_at.desc(), ChangeRequestRecord.created_at.desc())
-            .limit(max(1, min(limit, 1000)))
+            base.offset(max(0, int(offset)))
+            .limit(max(1, min(int(limit), 1000)))
             .all()
         )
         out: list[ChangeRequest] = []
@@ -280,7 +290,7 @@ def list_change_requests(limit: int = 200) -> list[ChangeRequest]:
                 .all()
             )
             out.append(_to_model(row, votes))
-        return out
+        return out, total
 
 
 def get_change_request(change_request_id: str) -> ChangeRequest | None:

--- a/api/tests/test_governance_change_flow.py
+++ b/api/tests/test_governance_change_flow.py
@@ -282,7 +282,8 @@ async def test_approval_lifecycle_and_queries_flow():
 
         # List surfaces all change requests (at minimum ours).
         listing = (await c.get("/api/governance/change-requests")).json()
-        assert len(listing) >= 1
+        assert listing["total"] >= 1
+        assert len(listing["items"]) >= 1
 
         # Get-by-id round-trips; unknown id → 404.
         fetched = (await c.get(f"/api/governance/change-requests/{idea_cr_id}")).json()

--- a/web/app/contribute/page.tsx
+++ b/web/app/contribute/page.tsx
@@ -148,7 +148,7 @@ export default function ContributePage() {
         open_questions: Array.isArray(item.open_questions) ? item.open_questions : [],
       }));
       const specRows = (Array.isArray(specsJson) ? specsJson : []) as SpecEntry[];
-      const requestRows = (Array.isArray(crJson) ? crJson : []) as ChangeRequest[];
+      const requestRows = (Array.isArray(crJson) ? crJson : (crJson?.items ?? [])) as ChangeRequest[];
 
       setContributors(contributorRows);
       setIdeas(ideaRows);

--- a/web/app/friction/page.tsx
+++ b/web/app/friction/page.tsx
@@ -84,10 +84,11 @@ export default function FrictionPage() {
         throw new Error(`HTTP ${reportRes.status}/${eventsRes.status}/${entryRes.status}`);
       }
       const reportJson = (await reportRes.json()) as FrictionReport;
-      const eventsJson = (await eventsRes.json()) as FrictionEvent[];
+      const eventsJson = (await eventsRes.json()) as { items?: FrictionEvent[] } | FrictionEvent[];
+      const eventsList = Array.isArray(eventsJson) ? eventsJson : eventsJson?.items ?? [];
       const entryJson = (await entryRes.json()) as FrictionEntryPointReport;
       setReport(reportJson);
-      setEvents(eventsJson);
+      setEvents(eventsList);
       setEntryPoints(entryJson);
       setStatus("ok");
       setError(null);

--- a/web/app/usage/data.ts
+++ b/web/app/usage/data.ts
@@ -132,12 +132,17 @@ export async function loadRuntimeSlice(
     warnings.push(`runtime summary (${seconds}s)`);
   }
 
-  const fallbackEvents = await fetchJsonOrNull<RuntimeEvent[]>(
+  const fallbackEvents = await fetchJsonOrNull<RuntimeEvent[] | { items?: RuntimeEvent[] }>(
     `${apiBase}/api/runtime/events?limit=${Math.max(150, pageSize * 6)}`,
     RUNTIME_EVENTS_FALLBACK_TIMEOUT_MS,
   );
-  if (fallbackEvents && Array.isArray(fallbackEvents)) {
-    const fallback = summarizeRuntimeEvents(fallbackEvents, pageSize, offset);
+  const fallbackList = Array.isArray(fallbackEvents)
+    ? fallbackEvents
+    : Array.isArray(fallbackEvents?.items)
+      ? fallbackEvents.items
+      : null;
+  if (fallbackList) {
+    const fallback = summarizeRuntimeEvents(fallbackList, pageSize, offset);
     warnings.push("runtime summary fallback to recent runtime events");
     return { runtime: fallback.runtime, hasMore: fallback.hasMore, warnings };
   }

--- a/web/components/today/TodayTopIdeaQuickLaunch.tsx
+++ b/web/components/today/TodayTopIdeaQuickLaunch.tsx
@@ -340,9 +340,14 @@ export default function TodayTopIdeaQuickLaunch({
     try {
       const eventsResponse = await fetch(`/api/runtime/events?limit=80`, { cache: "no-store" });
       if (eventsResponse.ok) {
-        const eventsPayload = (await eventsResponse.json()) as RuntimeEvent[];
-        if (Array.isArray(eventsPayload)) {
-          timeline = eventsPayload
+        const eventsPayload = (await eventsResponse.json()) as RuntimeEvent[] | { items?: RuntimeEvent[] };
+        const eventsList = Array.isArray(eventsPayload)
+          ? eventsPayload
+          : Array.isArray(eventsPayload?.items)
+            ? eventsPayload.items
+            : [];
+        if (eventsList.length) {
+          timeline = eventsList
             .filter((event) => {
               const metadata = asRecord(event.metadata);
               return String(metadata.task_id || "").trim() === taskId;


### PR DESCRIPTION
## Summary
Third breath of the pagination sweep ([PR #1489](https://github.com/seeker71/Coherence-Network/pull/1489) → [PR #1490](https://github.com/seeker71/Coherence-Network/pull/1490) → this). Endpoints that returned bare lists or count+items dicts now offer \`offset\` + \`total\` so any client can walk the full body, not just the first cap-sized slice.

**Bare list → \`PaginatedResponse[T]\` envelope (response shape changes, all known web consumers updated in same commit):**
- \`GET /api/friction/events\`
- \`GET /api/governance/change-requests\`
- \`GET /api/runtime/events\`

**Dict response → additive \`offset\` + \`total\` fields (non-breaking):**
- \`GET /api/news/feed\` (already had \`count\` + \`items\`)
- \`GET /api/substrate/cells\` (was bare list; switched to dict envelope)

**Service support:**
- \`governance_service.list_change_requests_page()\` — \`base.count()\` + offset/limit
- runtime/events: route-layer slicing over the cached window (telemetry is high-volume; time-cursor would be the longer-term shape)

**Web consumers updated** to read the envelope with \`Array.isArray\` fallback so deploy ordering can't flap any page:
- /friction page
- /contribute page
- /usage data
- TodayTopIdeaQuickLaunch component

**Test fixed:** \`test_governance_change_flow\` now asserts on \`listing["items"]\` / \`["total"]\`.

**Skipped intentionally** (no current consumer pressure, or bounded by nature — recent-window snapshots or top-N ranks where offset isn't the right cursor): \`/ideas/resonance\`, \`/news/resonance\`, \`/dif/recent\`, \`/resonance/events\`, \`/tasks/activity\`, \`/messages/thread\`, \`/concepts/search\`. Each can adopt offset or time-cursor when its consumer actually grows past the cap.

## Test plan
- [x] \`tsc --noEmit\` clean for web
- [x] \`pytest test_governance_change_flow.py\` and \`pytest -k news\` pass
- [x] No remaining bare-list assertions in tests against changed endpoints
- [ ] After deploy: visit /friction, /contribute, /tasks pages — list data renders normally; no console errors from shape changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)