### PR TITLE
tend: gate create-plan toward /welcome for anonymous visitors

### DIFF
--- a/web/app/ideas/[idea_id]/page.tsx
+++ b/web/app/ideas/[idea_id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 
 import { getApiBase } from "@/lib/api";
@@ -368,6 +369,8 @@ export default async function IdeaDetailPage({ params }: { params: Promise<{ ide
   }
 
   const idea = ideaResult.idea;
+  const cookieStore = await cookies();
+  const contributorName = cookieStore.get("coh_contributor_name")?.value || null;
   const [flowResult, stakes, activity, registrySpecs, childIdeas] = await Promise.all([
     loadFlowForIdea(ideaId),
     loadIdeaStakes(ideaId),
@@ -463,6 +466,7 @@ export default async function IdeaDetailPage({ params }: { params: Promise<{ ide
           estimatedCost={idea.estimated_cost}
           openQuestions={idea.open_questions.filter((q) => !q.answer).map((q) => q.question)}
           existingSpecIds={flow?.spec.spec_ids ?? []}
+          contributorName={contributorName}
         />
 
         <div className="border-t border-amber-200/40 dark:border-amber-800/20 pt-4">

--- a/web/components/ideas/IdeaDsssSpecBuilder.tsx
+++ b/web/components/ideas/IdeaDsssSpecBuilder.tsx
@@ -13,6 +13,11 @@ type IdeaDsssSpecBuilderProps = {
   estimatedCost: number;
   openQuestions: string[];
   existingSpecIds: string[];
+  // The name the visitor was welcomed under (read server-side from the
+  // coh_contributor_name cookie). null when no welcome has happened yet —
+  // the action area then guides toward /welcome instead of offering buttons
+  // that would 401 without an attached identity.
+  contributorName: string | null;
 };
 
 type DsssMode = "single" | "set";
@@ -164,7 +169,9 @@ export default function IdeaDsssSpecBuilder({
   estimatedCost,
   openQuestions,
   existingSpecIds,
+  contributorName,
 }: IdeaDsssSpecBuilderProps) {
+  const isWelcomed = Boolean(contributorName);
   const [mode, setMode] = useState<DsssMode>(existingSpecIds.length === 0 ? "set" : "single");
   const [createState, setCreateState] = useState<CreateState>("idle");
   const [busyKey, setBusyKey] = useState("");
@@ -377,15 +384,30 @@ export default function IdeaDsssSpecBuilder({
         <Button type="button" variant={mode === "set" ? "default" : "outline"} onClick={() => applyMode("set")}>
           Split into smaller plans
         </Button>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => void createAllSpecs()}
-          disabled={createState === "saving" || allSuggestedKnown}
-        >
-          {createState === "saving" && busyKey === "all" ? "Creating plans..." : "Create all plans"}
-        </Button>
+        {isWelcomed ? (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void createAllSpecs()}
+            disabled={createState === "saving" || allSuggestedKnown}
+          >
+            {createState === "saving" && busyKey === "all" ? "Creating plans..." : "Create all plans"}
+          </Button>
+        ) : null}
       </div>
+
+      {isWelcomed ? null : (
+        <div className="rounded border border-amber-300/50 bg-amber-50/40 p-4 text-sm dark:border-amber-700/30 dark:bg-amber-950/10">
+          <p className="font-medium">Plans you place here carry the name you choose.</p>
+          <p className="mt-1 text-muted-foreground">
+            You can shape the preview below now. To place a plan, first be welcomed:{" "}
+            <Link href="/welcome" className="underline hover:text-foreground">
+              choose a name
+            </Link>
+            . You will return here, and the plans will carry your name.
+          </p>
+        </div>
+      )}
 
       <div className="space-y-3">
         {suggestedSpecs.map((draft) => {
@@ -404,16 +426,22 @@ export default function IdeaDsssSpecBuilder({
                     <Link href={`/specs/${encodeURIComponent(draft.specId)}`} className="underline hover:text-foreground">
                       Open plan
                     </Link>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => void startWorkFromPlan(draft)}
-                      disabled={startState === "saving"}
-                    >
-                      {startState === "saving" && startBusyKey === draft.specId ? "Creating work card..." : "Start first work step"}
-                    </Button>
+                    {isWelcomed ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => void startWorkFromPlan(draft)}
+                        disabled={startState === "saving"}
+                      >
+                        {startState === "saving" && startBusyKey === draft.specId ? "Creating work card..." : "Start first work step"}
+                      </Button>
+                    ) : (
+                      <Link href="/welcome" className="underline hover:text-foreground">
+                        Be welcomed to start work from this plan
+                      </Link>
+                    )}
                   </>
-                ) : (
+                ) : isWelcomed ? (
                   <Button
                     type="button"
                     variant="outline"
@@ -422,6 +450,10 @@ export default function IdeaDsssSpecBuilder({
                   >
                     {createState === "saving" && busyKey === draft.specId ? "Creating..." : "Create plan"}
                   </Button>
+                ) : (
+                  <Link href="/welcome" className="underline hover:text-foreground">
+                    Be welcomed to place this plan
+                  </Link>
                 )}
                 <span className="text-muted-foreground">
                   Expected impact {draft.potentialValue.toFixed(1)} | Work size {draft.estimatedCost.toFixed(1)}


### PR DESCRIPTION
## Summary
- Idea page server-reads `coh_contributor_name` cookie and passes it into `IdeaDsssSpecBuilder`
- Anonymous visitors see a warm notice ("Plans you place here carry the name you choose") and "Be welcomed to place this plan" links to `/welcome` instead of buttons that silently 401
- Welcomed visitors see the full Create plan / Create all plans / Start first work step buttons, attributed to their name
- DSSS framing + mode toggle stay visible for everyone — the preview shape is sense-able before being welcomed

Pairs with the previous tend ([#1475](https://github.com/seeker71/Coherence-Network/pull/1475) — contributor cookie → upstream attribution).

## Test plan
- [x] Anonymous: GET `/ideas/{id}` → notice block + 2 `/welcome` links + 0 Create plan buttons
- [x] Welcomed (cookie set): GET `/ideas/{id}` → no notice + Create plan / Create all plans buttons present
- [x] Registered create-plan flow validated against prod: 201 with `x-attributed-to: urs`, `x-attribution-source: verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)