### PR TITLE
feat: compound recipes — 3-step patterns in mfb-html

### DIFF
--- a/experiments/memory-as-framebuffer-v0/src/bin/mfb-html.rs
+++ b/experiments/memory-as-framebuffer-v0/src/bin/mfb-html.rs
@@ -173,6 +173,15 @@ fn main() -> io::Result<()> {
         std::collections::HashMap::new();
     let mut prev_changed_cells: Vec<usize> = Vec::new();
 
+    // Compound-recipe accumulators: 3-frame patterns A → B → C. Surfaces
+    // recurring multi-step co-work patterns (e.g. Edit → Bash → Bash for
+    // edit-then-build-then-test) beyond what pair flows alone can name.
+    // Allows A == C (loops like Bash → Read → Bash) but disallows degenerate
+    // self-steps within a chain (A == B or B == C).
+    let mut compound: std::collections::HashMap<(usize, usize, usize), u64> =
+        std::collections::HashMap::new();
+    let mut prev_prev_changed: Vec<usize> = Vec::new();
+
     while let Some(frame) = reader.next() {
         let frame = frame?;
         let live = live_cells(&frame);
@@ -232,7 +241,32 @@ fn main() -> io::Result<()> {
                 }
             }
         }
-        prev_changed_cells = sets.iter().map(|(idx, _, _, _)| *idx).collect();
+
+        // Compound recipe: every (a in prev_prev) → (b in prev) → (c in this)
+        // chain is one compound event. Allows A == C (e.g. Bash → Read → Bash
+        // ping-pong) but disallows A == B or B == C (degenerate self-steps).
+        if !prev_prev_changed.is_empty()
+            && !prev_changed_cells.is_empty()
+            && !sets.is_empty()
+        {
+            for &a in &prev_prev_changed {
+                for &b in &prev_changed_cells {
+                    if a == b {
+                        continue;
+                    }
+                    for (c_idx, _, _, _) in &sets {
+                        let c = *c_idx;
+                        if b != c {
+                            *compound.entry((a, b, c)).or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        let new_prev: Vec<usize> = sets.iter().map(|(idx, _, _, _)| *idx).collect();
+        prev_prev_changed = std::mem::take(&mut prev_changed_cells);
+        prev_changed_cells = new_prev;
 
         if frame_count > 0 {
             frames_json.push(',');
@@ -333,6 +367,32 @@ fn main() -> io::Result<()> {
         s
     };
 
+    // Top-N compound recipes: sort by count desc, take 30. Each entry is
+    // [a, b, c, pa, pb, pc, count]. The leaderboard surfaces 3-step
+    // patterns; longer k-grams (4+) tend to be too sparse to be useful
+    // in typical session sizes, so v0 stops at 3.
+    const COMPOUND_LIMIT: usize = 30;
+    let mut compound_vec: Vec<((usize, usize, usize), u64)> = compound.into_iter().collect();
+    compound_vec.sort_by(|a, b| b.1.cmp(&a.1));
+    compound_vec.truncate(COMPOUND_LIMIT);
+    let compound_count = compound_vec.len();
+    let compound_json = {
+        let mut s = String::from("[");
+        let mut first = true;
+        for ((a, b, c), n) in &compound_vec {
+            if !first {
+                s.push(',');
+            }
+            first = false;
+            let pa = cell_latest_prov.get(a).copied().unwrap_or(0);
+            let pb = cell_latest_prov.get(b).copied().unwrap_or(0);
+            let pc = cell_latest_prov.get(c).copied().unwrap_or(0);
+            s.push_str(&format!("[{},{},{},{},{},{},{}]", a, b, c, pa, pb, pc, n));
+        }
+        s.push(']');
+        s
+    };
+
     let html = build_html(
         input,
         frame_count,
@@ -346,13 +406,14 @@ fn main() -> io::Result<()> {
         &prov_writes_json,
         &provmap_json,
         &flows_json,
+        &compound_json,
     );
 
     let mut out_file = fs::File::create(output)?;
     out_file.write_all(html.as_bytes())?;
 
     eprintln!(
-        "wrote {} ({} frames, bbox {}x{} at ({},{}), {} unique cells, {} unique recipes, {} top flows, {} bytes)",
+        "wrote {} ({} frames, bbox {}x{} at ({},{}), {} unique cells, {} unique recipes, {} top flows, {} top compounds, {} bytes)",
         output,
         frame_count,
         bbox_w,
@@ -362,6 +423,7 @@ fn main() -> io::Result<()> {
         cell_writes.len(),
         prov_writes.len(),
         flow_count,
+        compound_count,
         std::fs::metadata(output)?.len()
     );
     Ok(())
@@ -380,6 +442,7 @@ fn build_html(
     prov_writes_json: &str,
     provmap_json: &str,
     flows_json: &str,
+    compound_json: &str,
 ) -> String {
     // The viewer JS reconstructs full state from deltas. The PALETTE matches
     // the v0 mp4 renderer's tag colors so a viewer who's seen the mp4 has
@@ -554,6 +617,16 @@ fn build_html(
         across adjacent frames. Top 50 by frequency.
       </p>
       <ol id="flows-list"></ol>
+      <hr style="border-color: #222; margin: 16px 0;">
+      <h3 style="margin-top: 0;">Compound recipes</h3>
+      <p style="color: var(--muted); font-size: 12px; margin: 0 0 12px 0;">
+        3-step patterns A → B → C — recurring multi-step co-work shapes
+        (e.g. <code>Edit → Bash → Bash</code> for edit-then-build-then-test,
+        or <code>Bash → Read → Bash</code> for the run-read-run loop).
+        Compounds name the shape of how something happens, not just what
+        happens. Top 30 by frequency.
+      </p>
+      <ol id="compounds-list"></ol>
       <hr style="border-color: #222; margin: 12px 0;">
       <p style="color: var(--muted); font-size: 12px;">
         In Vitality mode, cells are colored by write rate (cool→hot).
@@ -579,6 +652,10 @@ const PROVMAP = {provmap_json};
 // frames. Each row: [src_cell_idx, dst_cell_idx, src_latest_prov,
 // dst_latest_prov, count]. Sorted desc by count, capped at 50.
 const FLOWS = {flows_json};
+// Top compound recipes: 3-step patterns A → B → C derived from triple
+// co-occurrence across consecutive frames. Each row:
+// [a, b, c, pa, pb, pc, count]. Sorted desc, capped at 30.
+const COMPOUNDS = {compound_json};
 
 const PALETTE = {{
   free: "#000000",
@@ -628,6 +705,7 @@ const inspectorPanel = document.getElementById("inspector");
 const recipesPanel = document.getElementById("recipes");
 const recipesList = document.getElementById("recipes-list");
 const flowsList = document.getElementById("flows-list");
+const compoundsList = document.getElementById("compounds-list");
 const modeIdentityBtn = document.getElementById("mode-identity");
 const modeVitalityBtn = document.getElementById("mode-vitality");
 const info = {{
@@ -866,10 +944,66 @@ function highlightFlow(srcIdx, dstIdx) {{
   }}
 }}
 
+// Compound-recipe leaderboard: rank by triple co-occurrence across three
+// consecutive frames. Each row shows label_a → label_b → label_c with
+// the count and a bar. Hovering highlights all three cells in the heap
+// (red src, yellow middle, green dst).
+function buildCompoundsList() {{
+  compoundsList.innerHTML = "";
+  if (!Array.isArray(COMPOUNDS) || COMPOUNDS.length === 0) {{
+    const li = document.createElement("li");
+    li.style.color = "var(--muted)";
+    li.style.fontSize = "12px";
+    li.textContent = "No compounds captured (need ≥3 adjacent frames with changed cells).";
+    compoundsList.appendChild(li);
+    return;
+  }}
+  const top = COMPOUNDS[0][6] || 1;
+  for (const [a, b, c, pa, pb, pc, n] of COMPOUNDS) {{
+    const li = document.createElement("li");
+    li.dataset.aCell = a;
+    li.dataset.bCell = b;
+    li.dataset.cCell = c;
+    const labelA = provSourceLabel(pa) || `cell ${{a}}`;
+    const labelB = provSourceLabel(pb) || `cell ${{b}}`;
+    const labelC = provSourceLabel(pc) || `cell ${{c}}`;
+    const pct = ((n / top) * 100).toFixed(1);
+    li.innerHTML =
+      `<span class="src">${{escapeHtml(labelA)}} → ${{escapeHtml(labelB)}} → ${{escapeHtml(labelC)}}</span>` +
+      `<span class="count">${{n.toLocaleString()}}</span>` +
+      `<div class="bar" style="--bar-pct: ${{pct}}%"></div>`;
+    li.style.cursor = "pointer";
+    li.addEventListener("mouseenter", () => highlightCompound(a, b, c));
+    li.addEventListener("mouseleave", () => highlightCompound(null, null, null));
+    compoundsList.appendChild(li);
+  }}
+}}
+
+function highlightCompound(aIdx, bIdx, cIdx) {{
+  for (const [idx, _] of liveState.entries()) {{
+    const el = cellEls.get(idx);
+    if (!el) continue;
+    if (idx === aIdx) {{
+      el.style.outline = "2px solid #ff7050";
+      el.style.zIndex = "3";
+    }} else if (idx === bIdx) {{
+      el.style.outline = "2px solid #ffd050";
+      el.style.zIndex = "3";
+    }} else if (idx === cIdx) {{
+      el.style.outline = "2px solid #50ffa0";
+      el.style.zIndex = "3";
+    }} else if (highlightedProv === null) {{
+      el.style.outline = "";
+      el.style.zIndex = "";
+    }}
+  }}
+}}
+
 modeIdentityBtn.addEventListener("click", () => setMode("identity"));
 modeVitalityBtn.addEventListener("click", () => setMode("vitality"));
 buildRecipesList();
 buildFlowsList();
+buildCompoundsList();
 
 scrub.addEventListener("input", () => {{
   applyFrameDelta(parseInt(scrub.value, 10));
@@ -929,6 +1063,7 @@ applyFrameDelta(0);
         prov_writes_json = prov_writes_json,
         provmap_json = provmap_json,
         flows_json = flows_json,
+        compound_json = compound_json,
         GRID = GRID,
     )
 }


### PR DESCRIPTION
## Summary

Extends nutrient flow from pair flows (A→B) to triple co-occurrence (A→B→C). Surfaces recurring multi-step co-work patterns that pair flows alone cannot name — *the shape of how something happens*, not just what.

## What you see

The Vitality side panel now has three ranked sections:

1. **Most-alive recipes** — total writes per provenance
2. **Nutrient flows** — pair co-occurrence (A→B)
3. **Compound recipes (new)** — triples ranked by frequency, all three labels resolved via PROVMAP

Hovering a compound row outlines all three cells in the heap: red source, yellow middle, green destination.

## Verified on a real session

Top compound patterns from a real session JSONL — readable real shapes:

| Compound | Count | Pattern named |
|---|---|---|
| `Edit → Read → Edit` | 10 | the verify-revise loop |
| `Bash → Read → Bash` | 8 | the shell loop |
| `Edit → Write → Edit MEMORY.md` | 6 | edit, create, edit memory |
| `Read → Edit → Write` | 6 | read, modify, create-new |
| `Edit → Write → Edit` | 6 | modify-create-modify |
| `Read → Bash → Write` | 6 | read, run, create file |
| `Bash → Edit → Read` | 5 | run, edit, verify |

The body's actual working shapes recovered from substrate observation.

## Algorithm

Maintains rolling 2-frame buffer (prev_prev, prev). For each new frame, every (a∈prev_prev × b∈prev × c∈current) chain where a≠b and b≠c (allowing a==c for ping-pong loops) contributes one count. Top 30 by count embedded as `COMPOUNDS` const. v0 stops at 3-grams since 4+ tend to be too sparse in typical session sizes.

## Test plan

- [x] Build clean
- [x] Render real session, COMPOUNDS populated with 30 entries
- [x] Browser preview shows the new section, labels resolve, three-color hover highlight (red/yellow/green) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)