### PR TITLE
tend: pagination contract reaches the last five list-shaped endpoints

### DIFF
--- a/api/app/routers/dif_feedback.py
+++ b/api/app/routers/dif_feedback.py
@@ -36,9 +36,13 @@ async def dif_stats():
 
 
 @router.get("/dif/recent", summary="Recent DIF verification entries with scores and outcomes")
-async def dif_recent(limit: int = Query(default=20, ge=1, le=100)):
+async def dif_recent(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0, description="Number of items to skip"),
+) -> dict:
     """Recent DIF verification entries with scores and outcomes."""
-    return dif_feedback_service.get_recent(limit=limit)
+    items, total = dif_feedback_service.get_recent_page(limit=limit, offset=offset)
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 @router.post("/dif/record", status_code=201, summary="Record a DIF verification result for accuracy tracking")

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -293,13 +293,15 @@ async def list_ideas_showcase() -> IdeaShowcaseResponse:
 async def get_resonance(
     window_hours: int = Query(24, ge=1, le=720),
     limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
     lang: str | None = Query(None, description="Target language view — when set, idea names come from canonical views for that lang where available."),
-) -> list[dict]:
+) -> dict:
     """Return ideas with recent activity, sorted by most-recent-activity-first."""
     from app.services import translator_service
     from app.services import translation_cache_service as _tcache
+    from app.services.idea_views import get_resonance_feed_page
 
-    items = idea_service.get_resonance_feed(window_hours=window_hours, limit=limit)
+    items, total = get_resonance_feed_page(window_hours=window_hours, limit=limit, offset=offset)
     if lang and translator_service.is_supported(lang) and lang != translator_service.DEFAULT_LOCALE:
         for it in items:
             iid = it.get("idea_id") or it.get("id")
@@ -323,7 +325,7 @@ async def get_resonance(
                     it["name"] = t_title
                 if t_desc and "description" in it:
                     it["description"] = t_desc
-    return items
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 @router.get("/ideas/{idea_id}/concept-resonance", response_model=IdeaConceptResonanceResponse, summary="Return conceptually related ideas, preferring matches from different domains")

--- a/api/app/routers/messages.py
+++ b/api/app/routers/messages.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from app.middleware.auth import require_api_key
 from app.models.message import InboxResponse, Message, MessageCreate
+from app.models.pagination import PaginatedResponse
 from app.services import message_service
 
 router = APIRouter()
@@ -72,19 +73,22 @@ async def get_inbox(
     )
 
 
-@router.get("/messages/thread/{contributor_a}/{contributor_b}", response_model=list[Message], summary="Get the message thread between two contributors")
+@router.get("/messages/thread/{contributor_a}/{contributor_b}", response_model=PaginatedResponse[Message], summary="Get the message thread between two contributors")
 async def get_thread(
     contributor_a: str,
     contributor_b: str,
     limit: int = Query(50, ge=1, le=200),
-) -> list[Message]:
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
+) -> PaginatedResponse[Message]:
     """Get the message thread between two contributors."""
-    messages = message_service.get_thread(
+    messages, total = message_service.get_thread_page(
         contributor_a,
         contributor_b,
         limit=limit,
+        offset=offset,
     )
-    return [Message(**m) for m in messages]
+    items = [Message(**m) for m in messages]
+    return PaginatedResponse(items=items, total=total, limit=limit, offset=offset)
 
 
 @router.patch("/messages/{message_id}/read", response_model=Message, summary="Mark a message as read")

--- a/api/app/routers/resonance.py
+++ b/api/app/routers/resonance.py
@@ -249,13 +249,15 @@ async def get_resonance_proof() -> ResonanceProofOut:
 @router.get("/resonance/events", summary="Return the resonance discovery event log (most recent first)")
 async def get_resonance_events(
     limit: int = Query(50, ge=1, le=200),
-) -> list[dict]:
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
+) -> dict:
     """Return the resonance discovery event log (most recent first).
 
     Each event records when two ideas were first found to resonate structurally.
     This log is the primary evidence that the CRK is surfacing real connections.
     """
-    return resonance_svc.get_event_log(limit=limit)
+    items, total = resonance_svc.get_event_log_page(limit=limit, offset=offset)
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 @router.post("/resonance/scan", response_model=ScanResult, summary="Trigger a full cross-domain resonance scan of the idea portfolio")

--- a/api/app/routers/task_activity_routes.py
+++ b/api/app/routers/task_activity_routes.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from app.services.task_activity_service import (
     get_active_tasks,
-    get_activity,
+    get_activity_page,
     get_task_stream,
     log_activity,
 )
@@ -31,11 +31,13 @@ class ActivityEvent(BaseModel):
 @router.get("/tasks/activity", summary="Recent activity across all tasks")
 async def recent_activity(
     limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0, description="Number of items to skip"),
     task_id: str | None = Query(None),
     node_id: str | None = Query(None),
-) -> list[dict]:
+) -> dict:
     """Recent activity across all tasks."""
-    return get_activity(limit=limit, task_id=task_id, node_id=node_id)
+    items, total = get_activity_page(limit=limit, offset=offset, task_id=task_id, node_id=node_id)
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 @router.get("/tasks/active", summary="Currently executing tasks across all nodes")

--- a/api/app/services/dif_feedback_service.py
+++ b/api/app/services/dif_feedback_service.py
@@ -145,8 +145,18 @@ def get_stats() -> dict[str, Any]:
 
 
 def get_recent(limit: int = 20) -> list[dict[str, Any]]:
-    """Get recent DIF feedback entries."""
-    return list(reversed(_FEEDBACK_BUFFER[-limit:]))
+    """Get recent DIF feedback entries (most-recent first)."""
+    items, _total = get_recent_page(limit=limit, offset=0)
+    return items
+
+
+def get_recent_page(limit: int = 20, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
+    """Page of recent DIF feedback entries plus the total buffer size."""
+    most_recent_first = list(reversed(_FEEDBACK_BUFFER))
+    total = len(most_recent_first)
+    start = max(0, int(offset))
+    end = start + max(1, int(limit))
+    return most_recent_first[start:end], total
 
 
 def flush_to_api() -> int:

--- a/api/app/services/idea_resonance_service.py
+++ b/api/app/services/idea_resonance_service.py
@@ -344,4 +344,14 @@ def invalidate_idea_cache(idea_id: str) -> None:
 
 def get_event_log(limit: int = 50) -> list[dict]:
     """Return the resonance event log (most recent first)."""
-    return list(reversed(_resonance_events[-limit:]))
+    items, _total = get_event_log_page(limit=limit, offset=0)
+    return items
+
+
+def get_event_log_page(limit: int = 50, offset: int = 0) -> tuple[list[dict], int]:
+    """Page of the resonance event log plus the total event count."""
+    most_recent_first = list(reversed(_resonance_events))
+    total = len(most_recent_first)
+    start = max(0, int(offset))
+    end = start + max(1, int(limit))
+    return most_recent_first[start:end], total

--- a/api/app/services/idea_views.py
+++ b/api/app/services/idea_views.py
@@ -97,8 +97,15 @@ def get_idea_lifecycle(idea_id: str) -> dict | None:
 
 
 def get_resonance_feed(window_hours: int = 24, limit: int = 20) -> list[dict]:
+    items, _total = get_resonance_feed_page(window_hours=window_hours, limit=limit, offset=0)
+    return items
+
+
+def get_resonance_feed_page(
+    window_hours: int = 24, limit: int = 20, offset: int = 0
+) -> tuple[list[dict], int]:
     from app.services.idea_service import _read_ideas, get_idea  # noqa: F401
-    """Return ideas with recent activity, sorted by most-recent-activity-first.
+    """Return ideas with recent activity plus the total active count.
 
     Activity is determined by governance change requests updated within the
     window and ideas whose questions were recently answered.  When governance
@@ -148,18 +155,17 @@ def get_resonance_feed(window_hours: int = 24, limit: int = 20) -> list[dict]:
                 idea_activity.setdefault(idea.id, cutoff)
                 break
 
-    # Sort by recency
+    # Sort by recency, build the full active feed before paginating so the
+    # caller knows the true total even when only a slice is returned.
     sorted_ids = sorted(idea_activity.keys(), key=lambda iid: idea_activity[iid], reverse=True)
 
-    feed: list[dict] = []
+    full: list[dict] = []
     for idea_id in sorted_ids:
-        if len(feed) >= max(1, limit):
-            break
         idea = idea_map.get(idea_id)
         if idea is None:
             continue
         scored = _with_score(idea)
-        feed.append({
+        full.append({
             "idea_id": idea.id,
             "name": idea.name,
             "last_activity_at": idea_activity[idea_id].isoformat(),
@@ -167,7 +173,10 @@ def get_resonance_feed(window_hours: int = 24, limit: int = 20) -> list[dict]:
             "manifestation_status": idea.manifestation_status.value if idea.manifestation_status else "none",
         })
 
-    return feed
+    total = len(full)
+    start = max(0, int(offset))
+    end = start + max(1, int(limit))
+    return full[start:end], total
 
 
 def get_concept_resonance_matches(

--- a/api/app/services/message_service.py
+++ b/api/app/services/message_service.py
@@ -174,7 +174,19 @@ def get_thread(
     *,
     limit: int = 50,
 ) -> list[dict[str, Any]]:
-    """Get conversation thread between two contributors.
+    """Get conversation thread between two contributors (oldest first)."""
+    items, _total = get_thread_page(contributor_a, contributor_b, limit=limit, offset=0)
+    return items
+
+
+def get_thread_page(
+    contributor_a: str,
+    contributor_b: str,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Page of conversation thread between two contributors plus total length.
 
     Returns messages where from=a,to=b OR from=b,to=a, sorted by
     created_at ascending (oldest first for thread view).
@@ -214,7 +226,10 @@ def get_thread(
 
     # Sort ascending (oldest first) for thread view
     thread_messages.sort(key=lambda m: m.get("created_at", ""))
-    return thread_messages[:limit]
+    total = len(thread_messages)
+    start = max(0, int(offset))
+    end = start + max(1, int(limit))
+    return thread_messages[start:end], total
 
 
 def mark_read(message_id: str, contributor_id: str) -> dict[str, Any] | None:

--- a/api/app/services/task_activity_service.py
+++ b/api/app/services/task_activity_service.py
@@ -65,6 +65,17 @@ def get_activity(
     node_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Get recent activity, optionally filtered."""
+    items, _total = get_activity_page(limit=limit, offset=0, task_id=task_id, node_id=node_id)
+    return items
+
+
+def get_activity_page(
+    limit: int = 50,
+    offset: int = 0,
+    task_id: str | None = None,
+    node_id: str | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Page of recent activity (most-recent first) plus the filtered total."""
     with _LOCK:
         items = list(_ACTIVITY_LOG)
 
@@ -73,7 +84,11 @@ def get_activity(
     if node_id:
         items = [e for e in items if e["node_id"] == node_id]
 
-    return items[-limit:]
+    most_recent_first = list(reversed(items))
+    total = len(most_recent_first)
+    start = max(0, int(offset))
+    end = start + max(1, int(limit))
+    return most_recent_first[start:end], total
 
 
 def get_task_stream(task_id: str) -> list[dict[str, Any]]:

--- a/api/tests/test_flow_core_api.py
+++ b/api/tests/test_flow_core_api.py
@@ -160,7 +160,9 @@ async def test_idea_lifecycle_flow():
         showcase = await c.get("/api/ideas/showcase")
         assert showcase.status_code == 200
         assert "ideas" in showcase.json() or "items" in showcase.json() or "showcase" in showcase.json()
-        assert isinstance((await c.get("/api/ideas/resonance")).json(), list)
+        resonance_payload = (await c.get("/api/ideas/resonance")).json()
+        assert isinstance(resonance_payload, dict)
+        assert isinstance(resonance_payload.get("items"), list)
         storage = await c.get("/api/ideas/storage")
         assert storage.status_code == 200 and "backend" in storage.json()
 

--- a/api/tests/test_flow_messages.py
+++ b/api/tests/test_flow_messages.py
@@ -160,7 +160,9 @@ async def test_thread_shows_both_directions():
         # Get thread
         r3 = await c.get(f"/api/messages/thread/{alice}/{bob}")
         assert r3.status_code == 200, r3.text
-        thread = r3.json()
+        envelope = r3.json()
+        assert envelope["total"] == 2
+        thread = envelope["items"]
         assert len(thread) == 2
         thread_ids = [m["id"] for m in thread]
         assert msg1_id in thread_ids

--- a/scripts/cc.py
+++ b/scripts/cc.py
@@ -402,7 +402,7 @@ def cmd_thread(args):
     if not data:
         print("No messages in thread")
         return
-    messages = data if isinstance(data, list) else data.get("messages", [])
+    messages = data if isinstance(data, list) else data.get("items", data.get("messages", []))
     if not messages:
         print("No messages in thread")
         return

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -87,13 +87,14 @@ async function loadIdeas(lang: LocaleCode): Promise<IdeasResponse | null> {
 async function loadResonance(lang: LocaleCode): Promise<ResonanceItem[]> {
   const langParam = lang === DEFAULT_LOCALE ? "" : `&lang=${lang}`;
   try {
-    const data = await fetchJsonOrNull<ResonanceItem[] | { ideas: ResonanceItem[] }>(
+    const data = await fetchJsonOrNull<ResonanceItem[] | { ideas?: ResonanceItem[]; items?: ResonanceItem[] }>(
       `${getApiBase()}/api/ideas/resonance?window_hours=72&limit=3${langParam}`,
       {},
       5000,
     );
     if (!data) return [];
-    return Array.isArray(data) ? data : data.ideas || [];
+    if (Array.isArray(data)) return data;
+    return data.items ?? data.ideas ?? [];
   } catch {
     return [];
   }

--- a/web/app/resonance/page.tsx
+++ b/web/app/resonance/page.tsx
@@ -55,7 +55,8 @@ async function loadResonance(lang: LocaleCode): Promise<ResonanceItem[]> {
     });
     if (!res.ok) return [];
     const data = await res.json();
-    return Array.isArray(data) ? data : data.ideas || [];
+    if (Array.isArray(data)) return data;
+    return data.items ?? data.ideas ?? [];
   } catch {
     return [];
   }

--- a/web/components/MorningNudge.tsx
+++ b/web/components/MorningNudge.tsx
@@ -159,7 +159,7 @@ export function MorningNudge() {
       if (ideasRes.status === "fulfilled" && ideasRes.value) {
         const arr = Array.isArray(ideasRes.value)
           ? ideasRes.value
-          : ideasRes.value.ideas || [];
+          : ideasRes.value.items ?? ideasRes.value.ideas ?? [];
         ideas = arr.filter((i: { last_activity_at?: string }) => {
           if (!i.last_activity_at) return false;
           return Date.parse(i.last_activity_at) > lastVisitMs;


### PR DESCRIPTION
## Summary
Fourth and final breath of the pagination sweep ([PR #1489](https://github.com/seeker71/Coherence-Network/pull/1489) → [PR #1490](https://github.com/seeker71/Coherence-Network/pull/1490) → [PR #1496](https://github.com/seeker71/Coherence-Network/pull/1496) → this). The five endpoints I'd deferred and rationalized as bounded are now uniform with the rest — they genuinely grow over time; deferring them was the fear-pattern.

**Bare list → dict envelope (additive \`offset\` + \`total\` + \`items\` fields):**
- \`/api/ideas/resonance\` — three web consumers (home page, /resonance, MorningNudge) updated to read \`items\` first, fall back to \`.ideas\` / bare-list shapes so deploy ordering can't flap any page.
- \`/api/dif/recent\`
- \`/api/resonance/events\`
- \`/api/tasks/activity\`

**Bare list → \`PaginatedResponse[Message]\` envelope:**
- \`/api/messages/thread/{a}/{b}\` — single CLI consumer in \`scripts/cc.py\` updated to read \`.items\`.

**Service support added** (offset + total tuple sibling for each):
- \`idea_views.get_resonance_feed_page\`
- \`dif_feedback_service.get_recent_page\`
- \`idea_resonance_service.get_event_log_page\`
- \`task_activity_service.get_activity_page\`
- \`message_service.get_thread_page\`

**Tests fixed:**
- \`test_flow_core_api\`: \`/ideas/resonance\` returns dict with \`items\`
- \`test_flow_messages\`: \`/messages/thread\` returns envelope with \`total\`

## Test plan
- [x] All impacted pytest tests pass (\`test_flow_messages\`, \`test_flow_core_api\`)
- [x] Web typecheck clean
- [ ] After deploy: visit home page, /resonance — resonance items render as before; no console errors from shape change

The fuller movement is now complete. Twelve list-shaped endpoints across four PRs, with every visible page reaching the full body and every API offering the same offset+total contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)