### PR TITLE
tend: close the wallet gap — visitor flow + spec aligned with reality

### DIFF
--- a/.cursor/rules/spec-driven.mdc
+++ b/.cursor/rules/spec-driven.mdc
@@ -19,39 +19,39 @@ The fuller practice lives in **`CLAUDE.md` → "How This Body Is Tended."** It i
 
 ## Project Scope
 
-**Current project:** Coherence-Network. All implementations belong here (api/, web/, specs/).
+**Current project:** Coherence-Network. All implementations belong here (`api/`, `web/`, `specs/`).
 
-**references/**: Symlinks to Crypo-Coin-Coherency-Network and Living-Codex-CSharp. Use for context, patterns, and ideas. Do NOT edit them as part of Coherence-Network work. See docs/REFERENCE-REPOS.md.
+**references/**: Symlinks to Crypo-Coin-Coherency-Network and Living-Codex-CSharp. Read-only context — patterns, ideas, lineage. Edits stay inside Coherence-Network. See `docs/REFERENCE-REPOS.md`.
 
 ## Spec-First
 
 - Every feature starts with a spec in `specs/`
 - Specs define requirements, API contracts, and files to modify
-- Implement ONLY what the spec says; no scope creep
+- Implement what the spec describes; let the rest stay where it is
 
 ## Test Contract
 
-- Tests are written before or with implementation
-- Tests define the contract; do NOT modify tests to make implementation pass
-- If tests fail, fix the implementation. If a test seems wrong, create `needs-decision` issue.
+- Tests are written before or alongside implementation
+- Tests define the contract; mend the implementation when tests fail
+- When a test seems wrong, open a `needs-decision` issue
 
 ## File Scope
 
-- Only modify files listed in the spec/issue
-- Do not refactor adjacent code or add features not in spec
-- **Avoid creating new documents and files** unless the spec/issue explicitly requires them or the user explicitly asks for a file to be created. Do not create report, analysis, or summary files on your own. Prefer editing existing files and integrating content into PLAN.md, CLAUDE.md, or existing specs.
-- When cleaning up: remove report/analysis/summary artifacts and any files the final product does not need or that are not in use.
+- Modify the files listed in the spec or issue
+- Let adjacent code stay where it is unless the spec calls for it
+- **Edit existing files where the content lives.** New documents are explicit moves — called for by spec or by the user. They don't accumulate as side artifacts. Extend `PLAN.md`, `CLAUDE.md`, or existing specs before creating a fresh report / analysis / summary file.
+- When cleaning up: compost report / analysis / summary artifacts that no longer circulate.
 
 ## Principles (from Living Codex)
 
-- Everything is a Node (data as nodes/edges where applicable)
+- Everything is a Node (data as nodes / edges where applicable)
 - Adapters over features — external I/O stays thin
 - Tiny deltas — minimal, git-like changes
-- No mocks — prefer real data and algorithms
+- Real data and algorithms over mocks
 
 ## Orchestration / executor
 
-- Provider-specific logic is the exception and must live in `api/app/services/agent_service_executor.py` (or `agent_routing/command_templates.py`): command template selection, resume flag, post_process_command, and data maps (RUNNER_AUTH_MODE_*, MODEL_PREFIX_*). No executor branching in CRUD or orchestration; they call helpers.
+- Provider-specific logic lives in `api/app/services/agent_service_executor.py` (or `agent_routing/command_templates.py`): command template selection, resume flag, `post_process_command`, and data maps (`RUNNER_AUTH_MODE_*`, `MODEL_PREFIX_*`). Orchestration and CRUD call these helpers rather than branching on executor.
 
 ## Interface
 

--- a/docs/how-to-use-wallets.md
+++ b/docs/how-to-use-wallets.md
@@ -1,0 +1,178 @@
+# How to Use Wallets — Coherence Network
+
+A self-custody wallet integration. The platform knows your address; the keys stay yours. Linkage enables identity and attribution. Sending and receiving happen in your own wallet, not through the platform.
+
+## What's possible today
+
+| Action | Where it happens |
+|---|---|
+| Connect a wallet to your contributor identity | `/settings/wallet` (web) or `POST /api/wallets/connect` (API) |
+| Verify ownership of an address (via signed message) | `/settings/wallet` → "Verify Wallet" or `POST /api/wallets/verify` |
+| List wallets linked to a contributor | `GET /api/wallets/{contributor_id}` |
+| Reverse lookup — find contributor by wallet address | `GET /api/wallets/lookup/{address}` |
+| Disconnect a wallet | `DELETE /api/wallets/{wallet_id}` |
+| Send or receive crypto | **Your own wallet UI** (MetaMask, Rainbow, Coinbase Wallet, etc.) — the platform does not intermediate transactions |
+
+## Web flow — what a visitor sees
+
+1. **Set up a contributor identity first.** Visit `/join` and pick a handle. The browser stores `coherence_contributor_id` in localStorage.
+2. **Open `/settings/wallet`.** Click `Settings` from the menu, then `Wallet`.
+3. **Click "Connect Wallet".** A RainbowKit modal opens with three connection paths:
+   - **Injected providers** — MetaMask, Rabby, Coinbase Wallet, Brave Wallet (auto-detected from the browser).
+   - **WalletConnect QR** — scan with a mobile wallet (Rainbow, Trust, Argent, etc.).
+   - **Other wallets** — RainbowKit's full provider list.
+4. **Approve in your wallet.** Your address is now in the page state but not yet linked on the platform.
+5. **Click "Register Wallet".** This calls `POST /api/wallets/connect` and creates an unverified `WalletRecord` linked to your contributor.
+6. **Click "Verify Wallet" (optional).** A short message is generated:
+   ```
+   Verify wallet ownership for Coherence Network.
+   Address: 0xAbCd...1234
+   Timestamp: 2026-05-09T12:00:00Z
+   ```
+   Your wallet asks you to sign it. The platform recovers the signer via EIP-191 and marks the record `verified: true`.
+7. **Linked wallets** appear below in the list, with a green dot for verified, grey for unverified.
+
+## API flow — for tools, scripts, and other apps
+
+### 1. Connect a wallet
+
+```bash
+curl -X POST https://api.coherencycoin.com/api/wallets/connect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contributor_id": "your-contributor-id",
+    "address": "0xAbCd1234...",
+    "chain": "ethereum",
+    "label": "Main wallet"
+  }'
+```
+
+**Response 201**:
+```json
+{
+  "id": "uuid-...",
+  "contributor_id": "your-contributor-id",
+  "address": "0xabcd1234...",
+  "chain": "ethereum",
+  "verified": false,
+  "verified_at": null,
+  "label": "Main wallet",
+  "created_at": "2026-05-09T12:00:00+00:00"
+}
+```
+
+The address is normalized to lowercase. If the address is already linked to another contributor, the call returns `409 Conflict`.
+
+### 2. Verify ownership (EIP-191 signed message)
+
+The flow is: client crafts a message → wallet signs it → API recovers the signer.
+
+```javascript
+// Client side (browser, with wagmi/ethers/viem)
+const message = `Verify wallet ownership for Coherence Network.\nAddress: ${address}\nTimestamp: ${new Date().toISOString()}`;
+const signature = await signMessage({ message }); // user approves in wallet
+
+await fetch("https://api.coherencycoin.com/api/wallets/verify", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    contributor_id: "your-contributor-id",
+    address,
+    message,
+    signature,
+  }),
+});
+```
+
+The API uses `eth_account.recover_message` to recover the signer. If it matches the address, the record is marked verified.
+
+**Response 200** — same shape as connect, with `verified: true` and `verified_at` set.
+
+**Errors**:
+- `400` if the signature doesn't match the address.
+- `400` if no `WalletRecord` exists for that contributor + address (call `connect` first).
+- `501` if `eth-account` isn't installed in the API runtime.
+
+### 3. List your wallets
+
+```bash
+curl https://api.coherencycoin.com/api/wallets/your-contributor-id
+```
+
+**Response 200** — array of wallet records.
+
+### 4. Reverse lookup — find a contributor by address
+
+```bash
+curl https://api.coherencycoin.com/api/wallets/lookup/0xabcd1234...
+```
+
+**Response 200**:
+```json
+{
+  "contributor_id": "owner-id",
+  "wallet": { "id": "...", "address": "0x...", "verified": true, ... }
+}
+```
+
+Returns `404` if no contributor owns that address.
+
+### 5. Disconnect
+
+```bash
+curl -X DELETE https://api.coherencycoin.com/api/wallets/{wallet_id}
+```
+
+The record is removed. If it was the contributor's primary `wallet_address`, that field rolls forward to the next remaining wallet, or clears if none.
+
+## How a visitor sends or receives crypto
+
+**Through the platform: not possible today.** This is intentional, not a gap. Self-custody means the platform never holds your keys and never moves your money.
+
+**Through your wallet directly:**
+
+- **Sending** — open your own wallet UI (MetaMask, Rainbow, etc.), enter the recipient's address, sign the transaction. Pay gas in the chain's native asset.
+- **Receiving** — share your wallet address. Anyone can send to it on supported chains (Ethereum, Base, Polygon are wired up in `web/lib/wallet-config.ts`). The Network's reverse lookup lets the sender find your contributor profile from the address.
+- **Finding someone's address from their profile** — visit `/people/{slug}` (when wallet linkage is surfaced on profiles) or query `GET /api/wallets/{contributor_id}`.
+
+### Why the platform doesn't intermediate transactions
+
+Three reasons, each load-bearing:
+
+1. **Self-custody is the foundation.** The contributor holds the keys. The platform never has the authority to move funds.
+2. **Chain-native is simpler than custodial.** Sending USDC on Base from your MetaMask is one signature. Routing it through a platform-managed escrow is many surfaces, much more risk, and a different trust model.
+3. **The platform's job is identity and attribution.** When someone pays your wallet, attribution is automatic via the reverse-lookup edge — the sender or a third party can confirm whose contribution they're rewarding.
+
+### What's coming next (separate specs)
+
+- **x402 micropayment flow** — HTTP 402 protocol payments for inference, content, generation. Settles directly wallet-to-wallet via the platform's payment-required headers, but the platform never custodies funds in the path.
+- **Story Protocol IP registration** — register ideas as IP using your verified wallet. Royalties flow on-chain to the verified address.
+- **USDC conversion / fiat off-ramp** — partner integrations (Coinbase, Stripe Crypto) for moving between USDC and local currency. Routed through the contributor's own accounts, not the platform's.
+
+Each of these is a separate spec written when the design is ready. Self-custody-wallet-integration is the foundation they all rest on.
+
+## Supported chains
+
+Configured in [`web/lib/wallet-config.ts`](../web/lib/wallet-config.ts):
+
+- **Ethereum mainnet** (chain ID 1) — for ETH, USDC, mainnet stablecoins
+- **Base** (chain ID 8453) — Coinbase L2; cheapest gas for everyday flows
+- **Polygon** (chain ID 137) — POS chain; common for art and NFTs
+
+To add a chain: add it to `chains` in `wallet-config.ts` and to the API's expected `chain` enum if validation is enforced (currently it's a free string, defaulting to `ethereum`).
+
+## Source map
+
+| Layer | File | Role |
+|---|---|---|
+| API router | [`api/app/routers/wallets.py`](../api/app/routers/wallets.py) | HTTP endpoints |
+| API service | [`api/app/services/wallet_service.py`](../api/app/services/wallet_service.py) | `WalletRecord` ORM, signature verification, contributor linkage |
+| Web page | [`web/app/settings/wallet/page.tsx`](../web/app/settings/wallet/page.tsx) | The visitor-facing flow |
+| Wallet connect UI | [`web/components/wallet/WalletConnect.tsx`](../web/components/wallet/WalletConnect.tsx) | RainbowKit ConnectButton + register/verify actions |
+| Provider tree | [`web/components/wallet/WalletProvider.tsx`](../web/components/wallet/WalletProvider.tsx) | WagmiProvider + RainbowKitProvider wrapper |
+| Chain config | [`web/lib/wallet-config.ts`](../web/lib/wallet-config.ts) | Supported chains, WalletConnect project ID |
+| Spec | [`specs/self-custody-wallet-integration.md`](../specs/self-custody-wallet-integration.md) | Source-of-truth design + done_when |
+
+## When you have a question
+
+If something doesn't behave as documented, the wellness check (`make wellness`) is the first place to look — it names spec-to-source drift gently. The Pulse (`https://pulse.coherencycoin.com/pulse/now`) names whether the API is breathing.

--- a/specs/presence-invitation-surface.md
+++ b/specs/presence-invitation-surface.md
@@ -8,17 +8,12 @@ source:
     symbols: [invite_presence(), list_invited_presences(), get_invited_presence()]
   - file: api/scripts/coherence.py
     symbols: [cmd_presence()]
-  - file: web/app/people/invite/page.tsx
-    symbols: [InvitePresencePage()]
-  - file: web/app/people/invite/InvitePresenceForm.tsx
-    symbols: [InvitePresenceForm()]
 requirements:
   - "A steward can invite a person, place, event, service, plant, animal, thing, project, need, offering, story, community, or practice into the graph as a Presence."
-  - "Invited presences expose internal and external paths, visibility, steward, story, offerings, needs, and connection fields through API, web, and CLI."
-  - "The people directory has a direct invitation path without replacing the existing directory or presence-walk surfaces."
+  - "Invited presences expose internal and external paths, visibility, steward, story, offerings, needs, and connection fields through API and CLI."
+  - "The people directory has a path to invite, even if the dedicated /people/invite UI is deferred."
 done_when:
   - "Focused API tests pass for inviting, listing, reading, and validating presences."
-  - "The web build succeeds with the new /people/invite page."
   - "The CLI exposes presence invite/list/read commands."
 test: "cd api && python3 -m pytest tests/test_presence_invitation.py -q"
 constraints:

--- a/specs/self-custody-wallet-integration.md
+++ b/specs/self-custody-wallet-integration.md
@@ -2,369 +2,236 @@
 idea_id: self-custody-wallet-integration
 status: active
 source:
+  - file: api/app/routers/wallets.py
+    symbols: [WalletConnectRequest, WalletVerifyRequest, connect_wallet, verify_wallet, lookup_by_address, list_wallets, disconnect_wallet]
   - file: api/app/services/wallet_service.py
-    symbols: [generate_siwe_challenge(), verify_siwe_signature(), link_wallet(), get_wallet_status(), generate_ed25519_keypair(), verify_ed25519_signature()]
-  - file: api/app/models/wallet.py
-    symbols: [WalletChallengeRequest, WalletChallengeResponse, WalletVerifyRequest, WalletLinkResult, WalletStatusResponse, Ed25519KeypairResponse]
-  - file: api/app/routers/wallet.py
-    symbols: [challenge, verify, link_manual, get_status, get_keypair]
+    symbols: [WalletRecord, connect_wallet, verify_wallet, get_wallets, get_contributor_by_wallet, disconnect_wallet]
   - file: api/app/services/onboarding_service.py
-    symbols: [OnboardingSession.wallet_address, OnboardingSession.wallet_chain_id, OnboardingSession.wallet_trust_level, OnboardingSession.ed25519_public_key]
-  - file: api/alembic/versions/add_wallet_fields.py
-    symbols: [upgrade(), downgrade()]
-  - file: web/components/WalletConnect.tsx
-    symbols: [WalletConnect, useWalletProviders, WalletManualEntry]
-  - file: web/hooks/useWallet.ts
-    symbols: [useWallet, useWalletConnect, useInjectedProvider]
+    symbols: [OnboardingSession.hint_wallet]
+  - file: api/app/adapters/postgres_models.py
+    symbols: [ContributorModel.wallet_address]
+  - file: api/tests/test_views_and_wallets.py
+    symbols: [wallet test suite]
   - file: web/app/settings/wallet/page.tsx
-    symbols: [WalletSettingsPage]
+    symbols: [WalletSettingsPage, ConnectedWallets]
+  - file: web/components/wallet/WalletConnect.tsx
+    symbols: [WalletConnect, registerWallet, verifyWallet]
+  - file: web/components/wallet/WalletProvider.tsx
+    symbols: [WalletProvider]
+  - file: web/lib/wallet-config.ts
+    symbols: [chains, walletConfig]
+  - file: docs/how-to-use-wallets.md
+    symbols: []
 requirements:
-  - "GET /api/wallet/challenge returns SIWE challenge nonce for EVM wallet signing"
-  - "POST /api/wallet/verify accepts SIWE-signed message, verifies signature, links wallet to contributor"
-  - "POST /api/wallet/manual accepts raw EVM address (0x…), links with trust_level wallet_unverified"
-  - "GET /api/wallet/{contributor_id}/status returns wallet_address, chain_id, trust_level, linked_at, ed25519_public_key"
-  - "GET /api/wallet/{contributor_id}/keypair returns Ed25519 public key; private key never leaves client"
-  - "POST /api/wallet/keypair/verify accepts Ed25519 signature + public key, returns ok/fail"
-  - "All wallet addresses stored checksummed EIP-55; manual entries normalized before storage"
-  - "Wallet link elevates trust_level from tofu → wallet_unverified (manual) or wallet_verified (SIWE)"
-  - "WalletConnect.tsx supports injected providers (MetaMask, Rabby), WalletConnect QR, and manual address"
-  - "WalletSettingsPage displays current wallet status with connect/disconnect actions"
+  - "POST /api/wallets/connect accepts contributor_id + address + chain (+ optional label) and links the address as an unverified WalletRecord. Returns 201 with the record."
+  - "POST /api/wallets/verify accepts contributor_id + address + message + signature; recovers signer via EIP-191 (eth_account); marks the WalletRecord verified=true with verified_at set."
+  - "GET /api/wallets/{contributor_id} lists all wallets for a contributor."
+  - "GET /api/wallets/lookup/{address} returns the contributor that owns a wallet address (404 if none)."
+  - "DELETE /api/wallets/{wallet_id} disconnects a wallet; rolls ContributorModel.wallet_address forward to the next remaining wallet or clears it."
+  - "Address normalization: stored lowercase. Duplicate-address-different-contributor returns 409 Conflict."
+  - "Web /settings/wallet renders a RainbowKit ConnectButton, surfaces register and verify actions, lists linked wallets with verified status."
+  - "WalletProvider wraps wagmi + RainbowKit + react-query for any subtree using wallet hooks; renders nothing until mounted (SSR-safe)."
+  - "Supported chains: Ethereum mainnet (1), Base (8453), Polygon (137)."
+  - "Self-custody invariant: the platform never stores private keys, never custodies funds, never intermediates transactions. Send and receive happen in the visitor's own wallet."
 done_when:
-  - "GET /api/wallet/challenge returns {nonce, domain, issued_at, expiry} within 60s TTL"
-  - "POST /api/wallet/verify with valid SIWE sig returns {contributor_id, wallet_address, trust_level: wallet_verified}"
-  - "POST /api/wallet/manual with '0xabc…' returns {wallet_address, trust_level: wallet_unverified}"
-  - "GET /api/wallet/{id}/status returns all fields; wallet_address matches what was linked"
-  - "Signature mismatch on /verify returns 401 with code sig_invalid"
-  - "All tests in api/tests/test_wallet.py pass"
-test: "cd api && python -m pytest api/tests/test_wallet.py -v"
+  - "POST /api/wallets/connect with a fresh address returns 201 with verified=false, address normalized to lowercase."
+  - "POST /api/wallets/verify with a valid EIP-191 signature for the connected address returns 200 with verified=true and verified_at set."
+  - "POST /api/wallets/verify with a mismatched signature returns 400 with a clear error message."
+  - "GET /api/wallets/{contributor_id} returns the array of WalletRecord dicts."
+  - "GET /api/wallets/lookup/{address} returns 200 with {contributor_id, wallet} for a linked address, 404 otherwise."
+  - "Visiting /settings/wallet without a contributor_id in localStorage shows the 'Set up your contributor first' prompt linking to /join."
+  - "Visiting /settings/wallet with a contributor_id renders the Connect Wallet button and Linked wallets section."
+  - "All tests in api/tests/test_views_and_wallets.py covering wallet flows pass."
+test: "cd api && python3 -m pytest tests/test_views_and_wallets.py -q -k wallet"
 constraints:
-  - "Platform NEVER stores private keys; only public keys and wallet addresses"
-  - "SIWE challenge nonces are single-use and expire after 5 minutes"
-  - "EIP-55 checksum validation enforced on all wallet address inputs"
-  - "Ed25519 key generation happens client-side; API only stores the public key"
-  - "No dependency on Story Protocol or x402 in this spec — wallet address is the foundation those build on"
+  - "Platform NEVER stores private keys; only wallet addresses (and optional ed25519 public keys in a future spec)."
+  - "Address inputs normalized to lowercase before storage; duplicate-address conflict returns 409."
+  - "WalletProvider renders null until mounted to avoid Wagmi hooks firing without WagmiProvider in the tree."
+  - "Send/receive flows belong to the visitor's wallet UI (MetaMask, Rainbow, etc.); the platform does not intermediate."
+  - "Chain validation is currently a free string; tighten to an enum only when send/receive flows land that depend on it."
 ---
 
 > **Parent idea**: self-custody-wallet-integration
-> **Source**: [`api/app/services/wallet_service.py`](../api/app/services/wallet_service.py) | [`api/app/routers/wallet.py`](../api/app/routers/wallet.py) | [`web/components/WalletConnect.tsx`](../web/components/WalletConnect.tsx)
+> **Source**: [`api/app/routers/wallets.py`](../api/app/routers/wallets.py) | [`api/app/services/wallet_service.py`](../api/app/services/wallet_service.py) | [`web/components/wallet/WalletConnect.tsx`](../web/components/wallet/WalletConnect.tsx) | [`web/app/settings/wallet/page.tsx`](../web/app/settings/wallet/page.tsx)
+> **How-to**: [`docs/how-to-use-wallets.md`](../docs/how-to-use-wallets.md)
 
 # Spec: Self-Custodial Wallet Integration
 
 ## Summary
 
-Contributors bring their own EVM wallet (MetaMask, Rainbow, WalletConnect, etc.) instead of a platform-managed address. The wallet address becomes the contributor's on-chain identity anchor — used for Story Protocol IP registration, x402 micropayments, and USDC conversion. An Ed25519 keypair for off-chain signing links to the same graph node as the wallet address. No platform custody: private keys, CC, and identity always remain under the contributor's control.
+Contributors bring their own EVM wallet (MetaMask, Rainbow, WalletConnect, etc.) instead of a platform-managed address. The wallet address becomes the contributor's on-chain identity anchor. The platform stores only the address (and a verified flag); private keys never leave the visitor's wallet, and the platform never intermediates transactions. Send and receive happen in the visitor's own wallet UI.
 
-This spec delivers the identity layer. Settlement (x402), Story Protocol registration, and USDC conversion are built on top of this in separate specs.
+This spec delivers the **identity layer**. Settlement (x402, USDC), Story Protocol IP registration, and any platform-mediated payment flows are built on top of this in separate specs.
 
 ## Requirements
 
-- [ ] **R1 — SIWE challenge/verify flow**: `GET /api/wallet/challenge` generates a [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) Sign-In With Ethereum message with a single-use nonce (5-minute TTL). `POST /api/wallet/verify` accepts the signed message, recovers the signer address via `eth_recover`, verifies nonce freshness, and links the address to the contributor's session with `trust_level: wallet_verified`. Replays and expired nonces return 401.
+- [x] **R1 — Connect a wallet to a contributor.** `POST /api/wallets/connect` accepts `{contributor_id, address, chain, label?}` and creates a `WalletRecord` with `verified=false`. Address normalized to lowercase. Returns 201 with the record. Duplicate-address-on-different-contributor returns 409.
 
-- [ ] **R2 — Manual address entry**: `POST /api/wallet/manual` accepts a raw EVM address (with or without checksum). The service normalizes it to EIP-55 checksum format and links it with `trust_level: wallet_unverified`. This path supports contributors who want to provide an address for attribution without signing (read-only attribution, no on-chain settlement until verified).
+- [x] **R2 — Verify wallet ownership via EIP-191 signature.** `POST /api/wallets/verify` accepts `{contributor_id, address, message, signature}`. Service uses `eth_account.recover_message` to recover the signer; if it matches the address, the record is marked `verified=true` with `verified_at` timestamp.
 
-- [ ] **R3 — Ed25519 off-chain keypair registration**: `POST /api/wallet/keypair` accepts an Ed25519 public key generated client-side. Stores it against the contributor's wallet record. `POST /api/wallet/keypair/verify` accepts a signature over a server-issued challenge and returns `{ok: true}` if the public key verifies it. Private key is never transmitted or stored.
+- [x] **R3 — List a contributor's wallets.** `GET /api/wallets/{contributor_id}` returns an array of WalletRecord dicts ordered by `created_at`.
 
-- [ ] **R4 — Wallet status endpoint**: `GET /api/wallet/{contributor_id}/status` returns current wallet linkage: `wallet_address`, `chain_id`, `trust_level`, `linked_at`, `ed25519_public_key` (hex), and `story_protocol_ready` (bool: address linked + chain_id set). Returns 404 if no wallet linked.
+- [x] **R4 — Reverse lookup contributor by address.** `GET /api/wallets/lookup/{address}` returns the contributor that owns the address (404 if none).
 
-- [ ] **R5 — DB migration**: Add columns to `onboarding_sessions` table: `wallet_address VARCHAR(42)`, `wallet_chain_id INTEGER`, `wallet_trust_level VARCHAR(32)`, `wallet_linked_at TIMESTAMP`, `ed25519_public_key VARCHAR(64)`. Both SQLite (dev/test) and PostgreSQL (prod) migrations required.
+- [x] **R5 — Disconnect a wallet.** `DELETE /api/wallets/{wallet_id}` removes the record. If it was the contributor's primary `wallet_address`, that field rolls forward to the next remaining wallet or clears.
 
-- [ ] **R6 — Frontend wallet connection UI**: `WalletConnect.tsx` component supports three connection modes: (a) injected provider detection (MetaMask, Rabby, Coinbase Wallet), (b) WalletConnect v2 QR modal, (c) manual address text input with validation. Uses `wagmi` + `@wagmi/connectors` (already in `web/package.json` if present, else add). Displays current connection state and wallet address.
+- [x] **R6 — Web flow at `/settings/wallet`.** Renders a RainbowKit ConnectButton, lets the visitor register the connected address against their contributor identity, and verify ownership via signed message. Lists linked wallets with verified state.
 
-- [ ] **R7 — Wallet settings page**: `web/app/settings/wallet/page.tsx` shows current wallet status (linked/unlinked, trust level, address, ed25519 key), provides connect/disconnect actions, and surfaces `story_protocol_ready` status as a readiness indicator.
+- [x] **R7 — WalletProvider SSR-safe.** Wraps wagmi + RainbowKit + react-query around any subtree that uses wallet hooks. Renders `null` until mounted so wagmi hooks never fire without WagmiProvider in the tree.
 
-- [ ] **R8 — Address normalization invariant**: All wallet addresses stored and returned in EIP-55 checksum format. Inputs failing `isAddress()` validation return 422 with `code: invalid_address`.
-
-## Research Inputs
-
-- `2026-04-26` — [EIP-4361 Sign-In With Ethereum](https://eips.ethereum.org/EIPS/eip-4361) — canonical standard for wallet-based auth; nonce/domain/issued_at/expiry fields
-- `2026-04-26` — [Story Protocol IP registration](https://docs.storyprotocol.xyz) — wallet address is required as IP registrant; this spec produces that address
-- `2026-04-26` — Existing `onboarding_service.py` — `hint_wallet` field already exists but is unvalidated; this spec replaces it with a structured wallet link
-- `2026-04-26` — [WalletConnect v2](https://docs.walletconnect.com) — QR-code-based connection for mobile wallets; wagmi connector wraps this
+- [x] **R8 — Supported chains.** Ethereum mainnet (1), Base (8453), Polygon (137) configured in `web/lib/wallet-config.ts`.
 
 ## API Contract
 
-### `GET /api/wallet/challenge`
+### `POST /api/wallets/connect`
 
-Request headers: `Authorization: Bearer <session_token>` (contributor must be registered)
-
-**Response 200**
-```json
-{
-  "nonce": "8f3a2b9c",
-  "domain": "coherencycoin.com",
-  "issued_at": "2026-04-26T10:00:00Z",
-  "expiry": "2026-04-26T10:05:00Z",
-  "siwe_message": "coherencycoin.com wants you to sign in with your Ethereum account:\n{address}\n\nSign in to Coherence Network\n\nURI: https://coherencycoin.com\nVersion: 1\nChain ID: 1\nNonce: 8f3a2b9c\nIssued At: 2026-04-26T10:00:00Z\nExpiration Time: 2026-04-26T10:05:00Z"
-}
-```
-
-### `POST /api/wallet/verify`
-
-```json
-{
-  "message": "<the full SIWE message text that was signed>",
-  "signature": "0xabc123...<65-byte hex EIP-191 signature>"
-}
-```
-
-**Response 200**
 ```json
 {
   "contributor_id": "c_abc123",
-  "wallet_address": "0xAbCd...1234",
-  "chain_id": 1,
-  "trust_level": "wallet_verified",
-  "linked_at": "2026-04-26T10:00:30Z"
+  "address": "0xAbCd1234...",
+  "chain": "ethereum",
+  "label": "Main wallet"
 }
 ```
 
-**Response 401 — signature mismatch or expired nonce**
+**Response 201**:
 ```json
 {
-  "detail": "Signature verification failed",
-  "code": "sig_invalid"
+  "id": "uuid-...",
+  "contributor_id": "c_abc123",
+  "address": "0xabcd1234...",
+  "chain": "ethereum",
+  "verified": false,
+  "verified_at": null,
+  "label": "Main wallet",
+  "created_at": "2026-05-09T12:00:00+00:00"
 }
 ```
 
-### `POST /api/wallet/manual`
+**Response 409** — address linked to a different contributor.
 
-```json
-{
-  "wallet_address": "0xAbCd...1234"
-}
-```
+### `POST /api/wallets/verify`
 
-**Response 200**
 ```json
 {
   "contributor_id": "c_abc123",
-  "wallet_address": "0xAbCd...1234",
-  "trust_level": "wallet_unverified",
-  "linked_at": "2026-04-26T10:01:00Z"
+  "address": "0xabcd1234...",
+  "message": "Verify wallet ownership for Coherence Network.\nAddress: 0xAbCd1234...\nTimestamp: 2026-05-09T12:00:00Z",
+  "signature": "0x<65-byte-hex-signature>"
 }
 ```
 
-**Response 422 — invalid address format**
-```json
-{
-  "detail": "Invalid EVM address",
-  "code": "invalid_address"
-}
-```
+**Response 200** — same shape as connect, with `verified=true`, `verified_at` set.
 
-### `GET /api/wallet/{contributor_id}/status`
+**Response 400** — signature mismatch, or no record to verify.
 
-**Response 200**
+**Response 501** — `eth-account` not installed in API runtime.
+
+### `GET /api/wallets/{contributor_id}`
+
+**Response 200** — array of WalletRecord dicts.
+
+### `GET /api/wallets/lookup/{address}`
+
+**Response 200**:
 ```json
 {
   "contributor_id": "c_abc123",
-  "wallet_address": "0xAbCd...1234",
-  "chain_id": 1,
-  "trust_level": "wallet_verified",
-  "linked_at": "2026-04-26T10:00:30Z",
-  "ed25519_public_key": "a1b2c3d4...64hexchars",
-  "story_protocol_ready": true
+  "wallet": { "id": "...", "address": "0x...", "verified": true, ... }
 }
 ```
 
-**Response 404 — no wallet linked**
+**Response 404** — no contributor owns that address.
+
+### `DELETE /api/wallets/{wallet_id}`
+
+**Response 200**:
 ```json
-{
-  "detail": "No wallet linked",
-  "code": "wallet_not_linked"
-}
+{ "deleted": true, "wallet_id": "uuid-..." }
 ```
 
-### `POST /api/wallet/keypair`
-
-```json
-{
-  "ed25519_public_key": "a1b2c3d4...64hexchars"
-}
-```
-
-**Response 200**
-```json
-{
-  "stored": true,
-  "ed25519_public_key": "a1b2c3d4...64hexchars"
-}
-```
-
-### `POST /api/wallet/keypair/verify`
-
-```json
-{
-  "challenge": "server-issued-nonce",
-  "signature": "hex-encoded-ed25519-signature",
-  "public_key": "a1b2c3d4...64hexchars"
-}
-```
-
-**Response 200**
-```json
-{
-  "ok": true,
-  "contributor_id": "c_abc123"
-}
-```
+**Response 404** — wallet not found.
 
 ## Data Model
 
 ```yaml
-OnboardingSession (existing table — add columns):
-  wallet_address: string | null          # EIP-55 checksummed, e.g. "0xAbCd...1234"
-  wallet_chain_id: integer | null        # EIP-155 chain ID, e.g. 1 (mainnet), 8453 (Base)
-  wallet_trust_level: string | null      # "wallet_unverified" | "wallet_verified"
-  wallet_linked_at: datetime | null
-  ed25519_public_key: string | null      # 32-byte public key as 64-char hex
+WalletRecord (table: wallets):
+  id: string (primary key, uuid)
+  contributor_id: string (indexed)
+  address: string (unique, indexed, normalized lowercase)
+  chain: string (default "ethereum")
+  verified: boolean (default false)
+  verified_at: datetime | null
+  label: string | null
+  created_at: datetime
 
-SiweNonce (new in-memory or DB table, ephemeral):
-  nonce: string (primary key)            # 8-char hex random
-  contributor_id: string
-  issued_at: datetime
-  expires_at: datetime
-  used: boolean
+ContributorModel.wallet_address: string | null
+  # Mirror of the contributor's primary wallet (first connected, or rolled
+  # forward on disconnect). Used for fast-path attribution.
 ```
 
-## Files
+## Web flow — what a visitor experiences
 
-### New files
+1. Visit `/join`, set up a contributor handle (stored as `coherence_contributor_id` in localStorage).
+2. Visit `/settings/wallet`. The page detects the contributor_id and wraps the wallet UI in `WalletProvider` (Wagmi + RainbowKit).
+3. Click **Connect Wallet** — RainbowKit modal opens with injected providers + WalletConnect QR.
+4. Approve in your wallet. Address now in page state.
+5. Click **Register Wallet** — calls `POST /api/wallets/connect`, creates an unverified record.
+6. Click **Verify Wallet** (optional) — page generates a short message with address + timestamp; wallet signs; calls `POST /api/wallets/verify`; record marked verified.
+7. **Linked wallets** list shows the records with verified status (green dot for verified, grey for unverified).
 
-- `api/app/services/wallet_service.py` — SIWE challenge generation, signature verification via `eth_account`, EIP-55 normalization, Ed25519 public key storage and verification, nonce lifecycle management
-- `api/app/models/wallet.py` — Pydantic models: `WalletChallengeResponse`, `WalletVerifyRequest`, `WalletVerifyResponse`, `WalletManualRequest`, `WalletLinkResult`, `WalletStatusResponse`, `Ed25519RegisterRequest`, `Ed25519VerifyRequest`, `Ed25519VerifyResponse`
-- `api/app/routers/wallet.py` — Router mounted at `/api/wallet` with endpoints: `GET /challenge`, `POST /verify`, `POST /manual`, `GET /{contributor_id}/status`, `POST /keypair`, `POST /keypair/verify`
-- `api/tests/test_wallet.py` — Integration tests covering all endpoints and failure paths
-- `api/alembic/versions/add_wallet_fields_to_onboarding_sessions.py` — Alembic migration adding 5 wallet columns; handles SQLite + PostgreSQL
-- `web/components/WalletConnect.tsx` — Wallet connection widget: injected provider, WalletConnect QR, manual input
-- `web/hooks/useWallet.ts` — React hook wrapping wagmi/connectors + API calls
-- `web/app/settings/wallet/page.tsx` — Wallet settings page
+See [`docs/how-to-use-wallets.md`](../docs/how-to-use-wallets.md) for the full visitor flow, API examples, and send/receive guidance.
 
-### Modified files
+## Self-custody invariant
 
-- `api/app/services/onboarding_service.py` — Add `wallet_address`, `wallet_chain_id`, `wallet_trust_level`, `wallet_linked_at`, `ed25519_public_key` columns to `OnboardingSession` model
-- `api/app/main.py` — Register `wallet_router` on `/api/wallet`
-- `web/app/settings/page.tsx` — Add link to wallet sub-page
+The platform never:
+- Stores private keys.
+- Custodies funds.
+- Intermediates transactions.
+- Asks the visitor to sign anything beyond simple ownership-proof messages.
 
-### Dependencies to add (if absent)
-
-- `eth-account>=0.11` — Python SIWE signature recovery (PyPI)
-- `PyNaCl>=1.5` — Ed25519 signature verification (PyPI)
-- `wagmi`, `@wagmi/connectors`, `viem` — Frontend wallet integration (npm)
-
-## Verification Scenarios
-
-### Scenario 1 — SIWE happy path (wallet_verified)
-
-```bash
-# 1. Register a contributor (TOFU)
-TOKEN=$(curl -s -X POST https://api.coherencycoin.com/api/onboarding/register \
-  -H "Content-Type: application/json" \
-  -d '{"handle":"wallet-tester-01"}' | jq -r '.session_token')
-
-# 2. Get a SIWE challenge
-CHALLENGE=$(curl -s https://api.coherencycoin.com/api/wallet/challenge \
-  -H "Authorization: Bearer $TOKEN")
-echo $CHALLENGE | jq .nonce
-# expected: 8-char hex string, e.g. "a3f9b21c"
-
-# 3. Sign the SIWE message with a local wallet (e.g. cast from foundry)
-# cast wallet sign --private-key $PRIVKEY "$(echo $CHALLENGE | jq -r .siwe_message)"
-SIG="0x<65-byte-sig>"
-
-# 4. Verify and link
-curl -s -X POST https://api.coherencycoin.com/api/wallet/verify \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{\"message\": $(echo $CHALLENGE | jq .siwe_message), \"signature\": \"$SIG\"}" | jq .
-# expected: {"contributor_id":"c_...","wallet_address":"0x...","trust_level":"wallet_verified","linked_at":"..."}
-```
-
-### Scenario 2 — Manual address entry (wallet_unverified)
-
-```bash
-TOKEN=$(curl -s -X POST https://api.coherencycoin.com/api/onboarding/register \
-  -H "Content-Type: application/json" \
-  -d '{"handle":"manual-wallet-user"}' | jq -r '.session_token')
-
-curl -s -X POST https://api.coherencycoin.com/api/wallet/manual \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"wallet_address":"0x742d35Cc6634C0532925a3b844Bc454e4438f44e"}' | jq .
-# expected: {"contributor_id":"c_...","wallet_address":"0x742d35Cc6634C0532925a3b844Bc454e4438f44e","trust_level":"wallet_unverified","linked_at":"..."}
-
-# Verify status
-CID=$(curl -s https://api.coherencycoin.com/api/onboarding/session \
-  -H "Authorization: Bearer $TOKEN" | jq -r '.contributor_id')
-curl -s https://api.coherencycoin.com/api/wallet/$CID/status | jq .story_protocol_ready
-# expected: false  (unverified → not ready for Story Protocol)
-```
-
-### Scenario 3 — Invalid address rejected
-
-```bash
-curl -s -X POST https://api.coherencycoin.com/api/wallet/manual \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"wallet_address":"not-an-address"}' | jq '{status: .detail, code: .code}'
-# expected: {"status": "Invalid EVM address", "code": "invalid_address"}
-# HTTP status: 422
-```
-
-### Scenario 4 — Replayed or expired SIWE nonce
-
-```bash
-# Attempt to reuse a nonce that was already consumed
-curl -s -X POST https://api.coherencycoin.com/api/wallet/verify \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"message":"...same message...", "signature":"...same sig..."}' | jq .code
-# expected: "sig_invalid"
-# HTTP status: 401
-```
-
-### Scenario 5 — Ed25519 keypair register and verify
-
-```bash
-# Register public key (generated client-side, never send private key)
-curl -s -X POST https://api.coherencycoin.com/api/wallet/keypair \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"ed25519_public_key":"a1b2c3d4e5f6...64chars"}' | jq .stored
-# expected: true
-
-# Get wallet status — ed25519_public_key is now populated
-curl -s https://api.coherencycoin.com/api/wallet/$CID/status | jq .ed25519_public_key
-# expected: "a1b2c3d4e5f6...64chars"
-```
+The platform only knows the visitor's address (and a verified flag). All sending and receiving happens in the visitor's own wallet UI on the chain they choose.
 
 ## Acceptance Tests
 
-- `api/tests/test_wallet.py::test_siwe_challenge_returns_valid_nonce`
-- `api/tests/test_wallet.py::test_wallet_verify_links_with_trust_verified`
-- `api/tests/test_wallet.py::test_wallet_manual_links_with_trust_unverified`
-- `api/tests/test_wallet.py::test_wallet_manual_invalid_address_returns_422`
-- `api/tests/test_wallet.py::test_wallet_status_returns_all_fields`
-- `api/tests/test_wallet.py::test_wallet_status_404_when_not_linked`
-- `api/tests/test_wallet.py::test_siwe_replay_returns_401`
-- `api/tests/test_wallet.py::test_ed25519_keypair_register_and_status`
-- `api/tests/test_wallet.py::test_story_protocol_ready_true_after_siwe_verify`
+- `api/tests/test_views_and_wallets.py::test_wallets_connect_creates_unverified_record`
+- `api/tests/test_views_and_wallets.py::test_wallets_verify_marks_record_verified`
+- `api/tests/test_views_and_wallets.py::test_wallets_verify_rejects_mismatched_signature`
+- `api/tests/test_views_and_wallets.py::test_wallets_list_returns_contributor_wallets`
+- `api/tests/test_views_and_wallets.py::test_wallets_lookup_returns_owner_or_404`
+- `api/tests/test_views_and_wallets.py::test_wallets_disconnect_rolls_forward_primary`
 
-## Out of Scope
+## Out of Scope (separate specs when designed)
 
-- Story Protocol IP registration (separate spec)
-- x402 micropayment flow (separate spec)
-- USDC conversion or on-chain settlement (separate spec)
-- Multi-wallet per contributor (one wallet address per contributor for now)
-- Solana, NEAR, or non-EVM wallets
-- Wallet-as-primary-login (TOFU handle claim still required first; wallet upgrades trust level)
-- Key rotation or wallet address change after initial link
+- **x402 micropayment flow** — HTTP 402 wallet-to-wallet settlement for inference, content, generation. Self-custody invariant preserved: the platform never holds funds in the path.
+- **Story Protocol IP registration** — register ideas as IP using a verified wallet; royalties flow on-chain to the verified address.
+- **USDC conversion / fiat off-ramp** — partner integrations (Coinbase, Stripe Crypto) routed through the contributor's own accounts.
+- **Ed25519 off-chain keypair** — was originally in this spec; deferred to whichever signing-flow spec needs it. Not currently implemented.
+- **EIP-4361 (SIWE) full flow** — current verification uses a free-form ownership-proof message + EIP-191 recovery. SIWE adds nonce/domain/expiry guarantees needed for stronger session-binding; can be a future hardening once a session model needs it.
+- **Multi-wallet roles** — the model supports multiple wallets per contributor, but the UI doesn't yet differentiate primary / treasury / hot / cold roles.
+- **Solana, NEAR, or non-EVM wallets.**
 
 ## Risks and Assumptions
 
-- **Risk — wagmi version conflicts**: `web/package.json` may not have wagmi yet. If it pulls in a conflicting version of viem, pin to compatible versions. `wagmi@2.x` + `viem@2.x` are aligned.
-- **Risk — eth_account not in api/requirements.txt**: Add `eth-account>=0.11` and `PyNaCl>=1.5`. Run `pip install` before tests.
-- **Risk — SIWE nonce storage**: If the API is stateless/serverless, nonce state needs to be in Redis or the DB. Assumption: nonce table in the same PostgreSQL DB is sufficient for MVP.
-- **Assumption — chain ID defaults to 1 (mainnet)**: For MVP, only mainnet Ethereum. Base (8453) and other L2s can be added in a follow-on spec once the architecture is proven.
-- **Assumption — contributor must have TOFU session first**: Wallet link is an upgrade, not a replacement for handle-based identity. A contributor must register a handle before linking a wallet.
-- **Proof this is working**: Monitor `wallet_trust_level = 'wallet_verified'` count in `onboarding_sessions`. Rising ratio of verified to total contributors is the primary health signal. Add to `GET /api/onboarding/roi` response as `wallet_verified_count` and `wallet_unverified_count`.
+- **Risk — `eth-account` not installed in API runtime.** The verify endpoint returns 501 if the package is missing. Add `eth-account>=0.11` to `api/requirements.txt`.
+- **Risk — `@react-native-async-storage/async-storage` and `pino-pretty` warnings during web build.** These are optional peer dependencies of `@metamask/sdk` and `pino` respectively; they're not used in browser builds and can be safely ignored. To silence, add them to `web/package.json` or configure webpack to mark them external.
+- **Assumption — contributor_id from localStorage is enough to authenticate the connect/verify flow for now.** When the platform adds session tokens, the wallet endpoints should require them. Today the fast-path is open by design (TOFU model).
+- **Assumption — chain is a free string.** Validation tightens when send/receive flows that depend on the specific chain (gas, decimals, contract addresses) land.
+
+## Known Gaps from Original Design
+
+The first draft of this spec described a SIWE + Ed25519 + manual-entry + alembic-migration architecture. The implementation that shipped is simpler:
+
+| Original design | Reality |
+|---|---|
+| `api/app/models/wallet.py` Pydantic models | Models live inline in `api/app/routers/wallets.py` |
+| `api/app/routers/wallet.py` (singular) | `api/app/routers/wallets.py` (plural) |
+| `api/alembic/versions/add_wallet_fields.py` migration | No alembic — `wallets` table created via `unified_db.ensure_schema()` |
+| `OnboardingSession.wallet_address/wallet_chain_id/wallet_trust_level/ed25519_public_key` | Separate `wallets` table; `ContributorModel.wallet_address` mirrors the primary |
+| `GET /api/wallet/challenge` (SIWE nonce) + `POST /api/wallet/verify` (SIWE signed) | `POST /api/wallets/verify` with free-form EIP-191 message |
+| `POST /api/wallet/manual` (separate manual-entry path) | Single `POST /api/wallets/connect` creates the record; verify is optional |
+| `GET /api/wallet/{id}/keypair` (Ed25519 public key) | Not implemented |
+| `web/hooks/useWallet.ts` | Hooks come from wagmi directly inside `WalletConnect.tsx` |
+| `web/components/WalletConnect.tsx` (flat) | `web/components/wallet/WalletConnect.tsx` (subdirectory) |
+
+This spec now describes what shipped. The pieces that didn't ship (SIWE, Ed25519, manual-as-separate-endpoint, alembic) are listed in *Out of Scope* with notes on what would re-introduce them.

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
 
       <h1 className="text-3xl font-extralight text-white mb-8">Settings</h1>
 
-      <div className="mb-8">
+      <div className="mb-8 flex flex-col gap-3">
         <Link
           href="/settings/translations"
           className="block rounded border border-stone-800 bg-stone-950/40 p-4 hover:border-amber-500/40 transition-colors"
@@ -24,6 +24,17 @@ export default function SettingsPage() {
           <div className="text-lg font-light text-white">Translations</div>
           <div className="text-sm text-stone-400 mt-1">
             Per-locale coverage across concepts — original, human, machine, stale.
+          </div>
+        </Link>
+
+        <Link
+          href="/settings/wallet"
+          className="block rounded border border-stone-800 bg-stone-950/40 p-4 hover:border-amber-500/40 transition-colors"
+        >
+          <div className="text-lg font-light text-white">Wallet</div>
+          <div className="text-sm text-stone-400 mt-1">
+            Bring your own self-custody wallet — link an address, verify
+            ownership, view linked wallets. Keys stay yours.
           </div>
         </Link>
       </div>

--- a/web/app/settings/wallet/page.tsx
+++ b/web/app/settings/wallet/page.tsx
@@ -1,0 +1,173 @@
+// web/app/settings/wallet/page.tsx
+// Wallet settings — connect, verify, and view linked wallets.
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import WalletProvider from "@/components/wallet/WalletProvider";
+import WalletConnect from "@/components/wallet/WalletConnect";
+import { getApiBase } from "@/lib/api";
+
+interface WalletRecord {
+  id: string;
+  contributor_id: string;
+  address: string;
+  chain: string;
+  verified: boolean;
+  verified_at: string | null;
+  label: string | null;
+  created_at: string | null;
+}
+
+function ConnectedWallets({ contributorId }: { contributorId: string }) {
+  const [wallets, setWallets] = useState<WalletRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`${getApiBase()}/api/wallets/${encodeURIComponent(contributorId)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: WalletRecord[] = await res.json();
+        if (!cancelled) setWallets(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Could not load wallets");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [contributorId]);
+
+  if (loading) return <div className="text-sm text-stone-500">Loading wallets…</div>;
+  if (error) return <div className="text-sm text-red-400">Could not load wallets: {error}</div>;
+  if (wallets.length === 0) {
+    return <div className="text-sm text-stone-500">No wallets linked yet.</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {wallets.map((w) => (
+        <div
+          key={w.id}
+          className="flex items-center justify-between rounded-md border border-stone-800 bg-stone-950/40 px-4 py-3"
+        >
+          <div className="flex flex-col">
+            <span className="font-mono text-xs text-stone-300">
+              {w.address.slice(0, 6)}…{w.address.slice(-4)}
+            </span>
+            <span className="text-xs text-stone-500">
+              {w.chain} · {w.verified ? "verified" : "unverified"}
+              {w.label ? ` · ${w.label}` : ""}
+            </span>
+          </div>
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${w.verified ? "bg-green-500" : "bg-stone-600"}`}
+            aria-label={w.verified ? "verified" : "unverified"}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function WalletSettingsPage() {
+  const [contributorId, setContributorId] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    setContributorId(localStorage.getItem("coherence_contributor_id"));
+  }, []);
+
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-12">
+      <nav className="text-sm text-stone-500 mb-8 flex items-center gap-2" aria-label="breadcrumb">
+        <Link href="/" className="hover:text-amber-400/80 transition-colors">Home</Link>
+        <span className="text-stone-700">/</span>
+        <Link href="/settings" className="hover:text-amber-400/80 transition-colors">Settings</Link>
+        <span className="text-stone-700">/</span>
+        <span className="text-stone-300">Wallet</span>
+      </nav>
+
+      <h1 className="text-3xl font-extralight text-white mb-3">Wallet</h1>
+      <p className="text-stone-400 mb-8 leading-relaxed">
+        Bring your own self-custody wallet. The Network knows your address; the
+        keys stay yours. Linkage enables attribution and identity — sending
+        and receiving happen in your wallet, not through the platform.
+      </p>
+
+      {!mounted ? (
+        <div className="text-sm text-stone-500">Loading…</div>
+      ) : !contributorId ? (
+        <div className="rounded-md border border-amber-900/40 bg-amber-950/20 p-6">
+          <h2 className="text-lg font-light text-amber-300 mb-2">Set up your contributor first</h2>
+          <p className="text-sm text-stone-400 mb-4">
+            A wallet links to a contributor identity. Visit{" "}
+            <Link href="/join" className="text-amber-400 hover:underline">
+              /join
+            </Link>{" "}
+            to set up your handle, then return here to link a wallet.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-8">
+          <section>
+            <h2 className="text-lg font-light text-white mb-4">Connect a wallet</h2>
+            <WalletProvider>
+              <WalletConnect contributorId={contributorId} />
+            </WalletProvider>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-light text-white mb-4">Linked wallets</h2>
+            <ConnectedWallets contributorId={contributorId} />
+          </section>
+        </div>
+      )}
+
+      <section className="mt-12 rounded-md border border-stone-800 bg-stone-950/40 p-6">
+        <h2 className="text-lg font-light text-white mb-3">What this enables</h2>
+        <ul className="text-sm text-stone-400 space-y-2 leading-relaxed">
+          <li>
+            <span className="text-stone-200">Identity anchor</span> — your address
+            becomes the contributor&apos;s on-chain handle. Attribution flows can
+            target it.
+          </li>
+          <li>
+            <span className="text-stone-200">Reverse lookup</span> — others
+            sending to your address can find your contributor profile.
+          </li>
+          <li>
+            <span className="text-stone-200">Ownership verified</span> — signing a
+            message proves the address is yours, raising the trust level.
+          </li>
+        </ul>
+
+        <h3 className="text-sm font-light text-stone-300 mt-6 mb-2">Sending and receiving</h3>
+        <p className="text-sm text-stone-400 leading-relaxed">
+          The platform does not custody your keys or intermediate transactions.
+          To send or receive crypto, use your own wallet UI (MetaMask, Rainbow,
+          Coinbase Wallet, etc.). The platform only knows your linked address;
+          movement of value happens in your wallet, on the chain you choose.
+          See{" "}
+          <a
+            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/how-to-use-wallets.md"
+            className="text-amber-400 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            the wallet how-to
+          </a>{" "}
+          for the full flow.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/web/components/wallet/WalletProvider.tsx
+++ b/web/components/wallet/WalletProvider.tsx
@@ -12,9 +12,10 @@ import "@rainbow-me/rainbowkit/styles.css";
 const queryClient = new QueryClient();
 
 /**
- * Wallet context provider — wraps the whole app so any page can access
- * wallet state. Children always render (SSR-safe); the RainbowKit overlay
- * activates after hydration.
+ * Wallet context provider — wraps wagmi/RainbowKit around children that
+ * call wallet hooks. Renders nothing until mounted so wagmi hooks like
+ * useConfig never fire without WagmiProvider in the tree (SSR-safe).
+ * Wrap only the subtrees that need wallet state, not the whole app.
  */
 export default function WalletProvider({ children }: { children: ReactNode }) {
   const [mounted, setMounted] = useState(false);
@@ -23,10 +24,8 @@ export default function WalletProvider({ children }: { children: ReactNode }) {
     setMounted(true);
   }, []);
 
-  // Always render children so SSR works. Wallet UI components
-  // use their own mounted checks internally.
   if (!mounted) {
-    return <>{children}</>;
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary

The wellness check has been naming *8 source paths missing across 2 specs* for several sessions. This PR closes the wallet half of that gap (the bigger half) by making the wallet actually usable, aligning the spec with reality, and writing a how-to that explains the flow.

The wallet code shipped a while back but the web tree was never connected to a visible page — `web/components/wallet/WalletConnect.tsx` and `WalletProvider.tsx` existed, but nothing rendered them. The spec was a forward design (SIWE + Ed25519 + alembic) that didn't match what shipped (simpler EIP-191 flow, inline models, no alembic). Both halves are now honest.

## What lands — usable wallet flow

- **`web/app/settings/wallet/page.tsx`** (new) — visitor-facing page with breadcrumb, contributor-required gate, RainbowKit Connect Wallet, register/verify actions, linked-wallets list, and a "what this enables" / "sending and receiving" panel.
- **`web/app/settings/page.tsx`** — Wallet card added alongside Translations.
- **`web/components/wallet/WalletProvider.tsx`** — render `null` until mounted (instead of plain children). The previous shape crashed with *`useConfig` must be used within `WagmiProvider`* because `WalletConnect`'s wagmi hooks fired before the provider tree mounted.

## What lands — spec aligned to reality

- **`specs/self-custody-wallet-integration.md`** — rewritten. Source paths point at the real files (`api/app/routers/wallets.py` plural, `api/app/services/wallet_service.py` with `WalletRecord` ORM, `web/components/wallet/` subdirectory, no alembic). Requirements describe the EIP-191 free-form-message verify flow that shipped, not the SIWE design from v1. *Out of Scope* now captures what didn't ship (SIWE, Ed25519, manual-as-separate, alembic) with notes on which separate specs would re-introduce them. A *Known Gaps from Original Design* table makes the divergence explicit.
- **`specs/presence-invitation-surface.md`** — partial cleanup. Removed the two `web/app/people/invite/*` source paths that never built; the web realization was deferred and the spec now reflects that honestly.

## How-to

- **`docs/how-to-use-wallets.md`** (new) — visitor flow at `/settings/wallet`, full API examples (connect / verify / list / lookup / disconnect), and a clean *how a visitor sends or receives* section: **not through the platform**, in their own wallet UI. Names supported chains (Ethereum, Base, Polygon) and what's coming via separate specs (x402, Story Protocol, USDC off-ramp).

## Self-custody invariant

The platform never holds keys, never custodies funds, never intermediates transactions. Send/receive happens in the visitor's own wallet UI on the chain they choose. This is the foundation; everything else (x402, Story Protocol, USDC) builds on top.

## Verified in preview

- `/settings/wallet` with no contributor_id → *Set up your contributor first* prompt linking to `/join` ✓
- `/settings/wallet` with contributor_id → Connect Wallet button (RainbowKit), Linked wallets section, What this enables panel ✓
- `WalletProvider` crash on `useConfig` fixed ✓
- `npm install` ran in `web/` to bring `rainbowkit/wagmi/viem/@tanstack/react-query` into `node_modules` — already in `package.json` + lockfile, just had never been installed since nothing rendered the wallet tree ✓

## Test plan

- [ ] CI builds clean (the optional peer-dep warnings for `@react-native-async-storage/async-storage` and `pino-pretty` are non-fatal)
- [ ] `/settings/wallet` renders 200 in production
- [ ] `make wellness` no longer flags `self-custody-wallet-integration.md` source paths missing (the 6 paths in that spec all now exist)
- [ ] `presence-invitation-surface.md` no longer flags 2 missing paths