### PR TITLE
tend: deploy verifier honors required=0 on web SHA mismatch (rollout race)

### DIFF
--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -733,8 +733,18 @@ check_web_runtime_sha() {
   fi
 
   if [[ "$observed_sha" != "$expected_sha" ]]; then
-    echo "FAIL: web deployed SHA does not match expected main-head SHA"
-    return 1
+    # Two cases produce a mismatch: (a) the deploy is stale (live SHA is
+    # behind expected), or (b) main moved forward during this verification
+    # window (live SHA is ahead of expected — rollout race, not a failure).
+    # When this check is non-required, log it and pass; when required, fail.
+    # The api-side parity check (check_api_runtime_sha) honors `required`
+    # the same way; this brings the web side into symmetry.
+    if [[ "$required" == "1" ]]; then
+      echo "FAIL: web deployed SHA does not match expected main-head SHA"
+      return 1
+    fi
+    echo "WARN: web deployed SHA does not match expected main-head SHA (non-blocking; possibly rollout race)"
+    return 0
   fi
 
   echo "PASS"


### PR DESCRIPTION
## Summary

Wellness has been naming *Hostinger Auto Deploy 24% failed over 7d*. The most recent deploy of [PR #1505](https://github.com/seeker71/Coherence-Network/pull/1505) hit the failure shape in real time:

```
expected_sha: e5c86d33… (older)
observed_sha: f770caec… (newer — my merge; main moved forward during verify)
FAIL: web deployed SHA does not match expected main-head SHA
```

Despite `required=0` (default for `VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA`), `check_web_runtime_sha` returned 1 and bumped `fail=1` for the whole verifier — while the deploy was actually healthy and serving newer code than the verifier expected.

## What changed

`check_api_runtime_sha` at line 639 already honors `required` (WARN when 0, FAIL when 1). `check_web_runtime_sha` at line 735 didn't — it always returned 1 on mismatch. This PR brings the web side into symmetry and adds an inline comment naming the two real-world causes of mismatch (stale deploy vs rollout race), so the next reader doesn't relearn the pattern.

## Why this matches CLAUDE.md

CLAUDE.md → *Fast deploy sensing* already names rollout-lag as informational, not a fresh failure:
> If `verify_web_api_deploy.sh` shows main-head ahead of the live API SHA while Hostinger Auto Deploy is still running, treat that as rollout lag, not a fresh code failure.

The verifier now matches that posture for both api-side and web-side checks.

## Test plan

- [ ] Next merge to main — deploy verifier should PASS even when main moves during verification
- [ ] Hostinger Auto Deploy failure rate (currently 24%) trends down over the next week
- [ ] When `VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA=1` is set explicitly, mismatch still FAILs as before (strict parity preserved when asked)