### PR TITLE
attune: spec test claims point at actual proof — pass 2

### DIFF
--- a/specs/contributor-onboarding-and-governed-change-flow.md
+++ b/specs/contributor-onboarding-and-governed-change-flow.md
@@ -16,7 +16,7 @@ done_when:
   - "Change request stores proposer attribution and vote attribution."
   - "Human or machine reviewer can cast yes/no vote via API and web."
   - "Approved request auto-applies by default and records apply result."
-test: "- `pytest -q tests/test_ideas.py tests/test_spec_registry_api.py tests/test_governance_api.py tests/test_inventory_api.py`"
+test: "cd api && pytest -q tests/test_contributor_journey.py"
 constraints:
   - "changes scoped to listed files only"
   - "no schema migrations without explicit approval"

--- a/specs/project-manager-pipeline.md
+++ b/specs/project-manager-pipeline.md
@@ -25,7 +25,7 @@ done_when:
   - "After review, validates: pytest passes and review output indicates pass"
   - "If validation fails: loops back to impl (fix), then test, then review until all pass or max iterations"
   - "If validation passes: advances to next task, starts with spec phase"
-test: "cd api && python -m pytest api/tests/test_project_manager_pipeline.py -q"
+test: "cd api && python -m pytest tests/test_flow_pipeline.py tests/test_agent_monitor_helpers.py tests/test_task_dedup_service.py -q -k 'pipeline or project_manager or split'"
 constraints:
   - "changes scoped to listed files only"
   - "no schema migrations without explicit approval"


### PR DESCRIPTION
## Summary

Continuing the test-claim reconciliation arc started in [PR #1512](https://github.com/seeker71/Coherence-Network/pull/1512). Two more confident fixes; phantom-test count drops 18 → 16.

## What lands

**`specs/contributor-onboarding-and-governed-change-flow.md`** (status: done)
- Was claiming **4 phantom tests** (`test_ideas.py` + `test_spec_registry_api.py` + `test_governance_api.py` + `test_inventory_api.py`, none exist)
- Actual coverage: **`test_contributor_journey.py`**, whose docstring explicitly enumerates `POST /api/onboarding/register`, `GET /api/onboarding/contributors`, `POST /api/governance/change-requests`, vote recording, and `/api/messages/inbox` — exactly the spec's surface

**`specs/project-manager-pipeline.md`** (status: done)
- Was claiming `test_project_manager_pipeline.py` (doesn't exist)
- Actual coverage: `test_flow_pipeline.py` + `test_agent_monitor_helpers.py` + `test_task_dedup_service.py` (cover `project_manager`, `pipeline_advance_service`, `split_item`, `_extract_partial_work`)

## Remaining 16

The remaining phantom-test specs split into two shapes:
- Specs whose feature has no per-feature test by design (the work shipped through flow tests; no rename target exists)
- Specs whose actual coverage hides under symbol names too generic for fast grep to surface confidently

Both want individual breath attention; this PR carries only the cases where confidence is high.

## Test plan

- [ ] `make wellness` shows 16 phantom-test specs after merge
- [ ] `pytest tests/test_contributor_journey.py` passes
- [ ] `pytest tests/test_flow_pipeline.py tests/test_agent_monitor_helpers.py tests/test_task_dedup_service.py -k 'pipeline or project_manager or split'` passes