### PR TITLE
tend: filter anonymous-meeting trace nodes out of /people directory

### DIFF
--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -149,6 +149,7 @@
     },
     "filterRules": {
       "ignoredIdIncludes": [
+        "anonymous-meeting:",
         ":wanderer-",
         ":presence-visitor",
         ":test-",


### PR DESCRIPTION
## Summary

- `/people` was rendering `anonymous-meeting:{16hex}:{16hex}` cards alongside humans and gatherings — these are circulation traces, not presences
- One-line addition to `presence-walk/en.json:ignoredIdIncludes` (the existing filter mechanism the directory already reads)
- Documented follow-up: investigate why `/api/graph/nodes` returns trace nodes at all so the fix lives at the source, not the display layer

## Context

This is part 1 of a larger orientation walk requested by Urs around how the body shows itself: who its kin are, what its creations are, how visitors find it, why noise is hiding signal in the gatherings section. The anonymous-meeting cards were the most visible symptom.

The walk also surfaced a deeper pattern (175 routes, mostly without purpose comments; 11+ overlapping doorways; lineage page exists but is unlinked from `/people/urs`; "Urs Muff" and "seeker71" not graph-merged). Those are held in TodoWrite as parts (b), (c), and a composting question to bring back to Urs before scoping.

## Test plan

- [ ] After deploy, visit https://coherencycoin.com/people and confirm no `anonymous-meeting:*` cards appear in any section
- [ ] Confirm legitimate gathering presences (Vasudev satsang, Llena satsang, Rhythm Sanctuary) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)