### PR TITLE
tend: prominent lineage doorway high in /people/{slug} hero

### DIFF
--- a/web/components/people/PersonProfileTemplate.tsx
+++ b/web/components/people/PersonProfileTemplate.tsx
@@ -42,6 +42,16 @@ export type PersonProfileArticle =
       body: ReactNode;
     };
 
+export type PersonProfileLineageDoorway = {
+  /** Path to the lineage walk for this person (e.g. /people/urs/lineage). */
+  href: string;
+  /** Short, action-shaped label — e.g. "Walk the 42-year lineage". */
+  label: ReactNode;
+  /** One-line proportional summary — e.g. "13 works · 11 substrates · 1984–now".
+   *  Lets the visitor sense the size before clicking through. */
+  summary?: ReactNode;
+};
+
 export type PersonProfileContent = {
   // Full Next.js Metadata so each page can supply openGraph, twitter,
   // and any other metadata fields. The root layout's title.template
@@ -70,6 +80,14 @@ export type PersonProfileContent = {
     eyebrowClass?: string;
     name: ReactNode;
     welcome: ReactNode;
+    /**
+     * Prominent doorway shown high in the hero — directly under the
+     * welcome paragraph, above facts. Use for the lineage walk so a
+     * visitor sees the shape and size of what's there before scrolling
+     * past several other rendering elements to find it. The whole
+     * affordance is a Link to `lineageDoorway.href`.
+     */
+    lineageDoorway?: PersonProfileLineageDoorway;
   };
   facts?: PersonProfileFact[];
   noteFromBody?: {
@@ -155,6 +173,29 @@ export function PersonProfileTemplate({
           <div className="text-lg md:text-xl text-foreground/85 leading-relaxed max-w-2xl">
             {hero.welcome}
           </div>
+          {hero.lineageDoorway && (
+            <Link
+              href={hero.lineageDoorway.href}
+              className="group mt-6 inline-flex items-center gap-3 rounded-lg border border-[hsl(var(--primary))]/40 bg-[hsl(var(--primary))]/5 hover:bg-[hsl(var(--primary))]/10 hover:border-[hsl(var(--primary))]/70 px-4 py-3 transition-colors max-w-2xl w-full sm:w-auto"
+            >
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm md:text-base text-[hsl(var(--primary))] font-medium group-hover:underline">
+                  {hero.lineageDoorway.label}
+                </span>
+                {hero.lineageDoorway.summary && (
+                  <span className="block text-xs text-foreground/70 mt-0.5">
+                    {hero.lineageDoorway.summary}
+                  </span>
+                )}
+              </span>
+              <span
+                aria-hidden="true"
+                className="text-[hsl(var(--primary))] text-lg group-hover:translate-x-0.5 transition-transform shrink-0"
+              >
+                →
+              </span>
+            </Link>
+          )}
           {content.facts && content.facts.length > 0 && (
             <dl className="mt-7 text-sm text-foreground/85 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 max-w-2xl">
               {content.facts.map((fact, i) => (

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -20,6 +20,11 @@ const content: PersonProfileContent = {
       "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/20",
     eyebrow: "The body's primary shepherd",
     name: "Urs Muff",
+    lineageDoorway: {
+      href: "/people/urs/lineage",
+      label: "Walk the 42-year lineage of works and influences",
+      summary: "13 load-bearing works · 8 eras · 1984 → now · the streams of attention woven alongside",
+    },
     welcome: (
       <p>
         Founder of Coherence Network. Swiss-American by lineage,

--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -149,6 +149,7 @@
     },
     "filterRules": {
       "ignoredIdIncludes": [
+        "anonymous-meeting:",
         ":wanderer-",
         ":presence-visitor",
         ":test-",


### PR DESCRIPTION
## Summary

The lineage page existed at \`/people/urs/lineage\` — 500+ lines, *\"42 years · 13 works · 8 eras\"* — but the only link to it from \`/people/urs\` lived in the articles section, below LineageStrip, AttentionPresence, and InfluenceLineageStrip. A visitor passed three other rendering elements before reaching the single doorway.

This adds an optional \`hero.lineageDoorway\` field to \`PersonProfileContent\` (\`href\` + \`label\` + \`summary\`). Renders directly under the welcome paragraph and above the facts grid as a prominent affordance with proportional summary visible *before* the click — \"13 load-bearing works · 8 eras · 1984 → now.\" Generalizes for other profiles that grow lineage walks.

## Context

Part of the night arc Urs requested before sleep — make the body see itself, surface the lineage / proportions / external creations, dedupe identity, give \`/people\` real exploration axes.

## Test plan

- [ ] Visit https://coherencycoin.com/people/urs after deploy
- [ ] Confirm prominent gold-bordered \"Walk the 42-year lineage\" affordance appears below the welcome paragraph and above the facts grid
- [ ] Confirm proportional summary line is visible
- [ ] Click through and confirm it lands on \`/people/urs/lineage\`
- [ ] Visit a profile *without* \`lineageDoorway\` populated (any other \`/people/{slug}\` page) and confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)