### PR TITLE
tend: visual weight differentiation on /people cards

### DIFF
--- a/web/app/people/_components/PeopleFilters.tsx
+++ b/web/app/people/_components/PeopleFilters.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * PeopleFilters — structural sort/filter axes for /people.
+ *
+ * The directory previously offered only one knob (`?kind=`) plus a
+ * resonance search. A visitor wanting to see "the most recent
+ * presences" or "only entries with real descriptions" or "any name
+ * containing 'mose'" had no surface for it. This component renders
+ * a thin row of structural axes: sort dropdown, two filter toggles,
+ * and a substring search. All state lives in the URL so any view
+ * is shareable.
+ *
+ * Server-side filtering happens in /people/page.tsx — this component
+ * just writes URL params; the page reads them and shapes the rendered
+ * directory.
+ */
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useState, useTransition, useEffect } from "react";
+
+export type PeopleSort = "lineage" | "recent" | "alpha";
+
+const SORT_LABELS: Record<PeopleSort, string> = {
+  lineage: "Lineage rank",
+  recent: "Most recent first",
+  alpha: "Alphabetical",
+};
+
+export function PeopleFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const sort = (searchParams.get("sort") || "lineage") as PeopleSort;
+  const withDesc = searchParams.get("with") === "description";
+  const withImage = searchParams.get("with") === "image";
+  const initialFind = searchParams.get("find") || "";
+  const [find, setFind] = useState(initialFind);
+
+  // Keep input in sync if URL changes from elsewhere (e.g. back/forward).
+  useEffect(() => {
+    setFind(searchParams.get("find") || "");
+  }, [searchParams]);
+
+  function update(next: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(next)) {
+      if (v === null || v === "") params.delete(k);
+      else params.set(k, v);
+    }
+    const qs = params.toString();
+    startTransition(() => {
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    });
+  }
+
+  function submitFind(e: React.FormEvent) {
+    e.preventDefault();
+    update({ find: find.trim() || null });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      {/* Sort dropdown */}
+      <label className="flex items-center gap-1.5 rounded-full border border-border/40 bg-card/40 px-3 py-1.5 hover:border-border transition-colors">
+        <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Sort
+        </span>
+        <select
+          value={sort}
+          onChange={(e) => update({ sort: e.target.value === "lineage" ? null : e.target.value })}
+          className="bg-transparent text-foreground text-xs cursor-pointer focus:outline-none"
+        >
+          {(Object.keys(SORT_LABELS) as PeopleSort[]).map((s) => (
+            <option key={s} value={s} className="bg-background">
+              {SORT_LABELS[s]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {/* Filter chips */}
+      <button
+        type="button"
+        onClick={() => update({ with: withDesc ? null : "description" })}
+        className={`rounded-full border px-3 py-1.5 transition-colors ${
+          withDesc
+            ? "border-[hsl(var(--primary))]/60 bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))]"
+            : "border-border/40 bg-card/40 text-muted-foreground hover:text-foreground hover:border-border"
+        }`}
+        aria-pressed={withDesc}
+      >
+        With description
+      </button>
+
+      <button
+        type="button"
+        onClick={() => update({ with: withImage ? null : "image" })}
+        className={`rounded-full border px-3 py-1.5 transition-colors ${
+          withImage
+            ? "border-[hsl(var(--primary))]/60 bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))]"
+            : "border-border/40 bg-card/40 text-muted-foreground hover:text-foreground hover:border-border"
+        }`}
+        aria-pressed={withImage}
+      >
+        With image
+      </button>
+
+      {/* Substring search */}
+      <form onSubmit={submitFind} className="flex items-center gap-1.5 rounded-full border border-border/40 bg-card/40 hover:border-border transition-colors px-3 py-1.5 ml-auto">
+        <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground" aria-hidden="true">
+          Find
+        </span>
+        <input
+          type="text"
+          value={find}
+          onChange={(e) => setFind(e.target.value)}
+          placeholder="name contains…"
+          className="bg-transparent text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none w-32 sm:w-44"
+          aria-label="Filter by substring in name"
+        />
+        {find && (
+          <button
+            type="button"
+            onClick={() => {
+              setFind("");
+              update({ find: null });
+            }}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Clear filter"
+          >
+            ×
+          </button>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -135,6 +135,63 @@ function initialFor(name: string, fallback: string): string {
   return c ? c.toUpperCase() : fallback;
 }
 
+/**
+ * Visual weight of a presence in the directory — coarse, four-tier
+ * signal so the eye can see proportion at a glance instead of every
+ * entry rendering at the same size.
+ *
+ *   lineage — named in LINEAGE_FIGURE_SLUGS (the humans who actually
+ *             shaped this body's work). Strongest visual.
+ *   curated — has slug + real description + image (a real authored
+ *             entry, not just an auto-resolved stub).
+ *   named   — has at least one of {real description, image} so the
+ *             card carries some signal beyond name + initial.
+ *   bare    — name only. Renders compactly to leave room for the
+ *             cards that carry signal.
+ */
+type PresenceWeight = "lineage" | "curated" | "named" | "bare";
+
+function isPlaceholderDescription(d: string | undefined): boolean {
+  const t = (d || "").trim();
+  if (!t) return true;
+  return /^[A-Z_]+\s+(contributor|asset|presence)$/.test(t);
+}
+
+function presenceWeight(n: PresenceNode): PresenceWeight {
+  const slug = n.slug || n.id;
+  if (lineageFigureRank(slug) !== null) return "lineage";
+  const hasDesc = !isPlaceholderDescription(n.description);
+  const hasImage = !!n.image_url;
+  const hasSlug = !!n.slug;
+  if (hasSlug && hasDesc && hasImage) return "curated";
+  if (hasDesc || hasImage) return "named";
+  return "bare";
+}
+
+const WEIGHT_CARD_CLASSES: Record<PresenceWeight, string> = {
+  lineage:
+    "border-[hsl(var(--primary))]/45 bg-[hsl(var(--primary))]/[0.04] hover:bg-[hsl(var(--primary))]/[0.08] hover:border-[hsl(var(--primary))]/70",
+  curated:
+    "border-border/50 bg-card/55 hover:bg-card/80 hover:border-border",
+  named: "border-border/30 bg-card/40 hover:bg-card/65 hover:border-border",
+  bare: "border-border/20 bg-card/20 hover:bg-card/45 hover:border-border/50",
+};
+
+const WEIGHT_AVATAR_CLASSES: Record<PresenceWeight, string> = {
+  lineage:
+    "w-12 h-12 ring-2 ring-[hsl(var(--primary))]/40 ring-offset-1 ring-offset-background",
+  curated: "w-10 h-10",
+  named: "w-9 h-9",
+  bare: "w-8 h-8",
+};
+
+const WEIGHT_NAME_CLASSES: Record<PresenceWeight, string> = {
+  lineage: "text-sm md:text-base font-medium text-foreground",
+  curated: "text-sm text-foreground/95",
+  named: "text-sm text-foreground/90",
+  bare: "text-xs text-foreground/80",
+};
+
 // When a section has dozens of items (the Works section in particular
 // is dominated by 170+ audiobook nodes), the alphabetic flood drowns
 // the rest of the directory. Cap the default render so each section
@@ -307,48 +364,60 @@ export default async function PeopleIndexPage({
               </p>
             </div>
             <ul className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-              {visibleItems.map((n) => (
-                <li key={n.id}>
-                  <Link
-                    href={presenceHref(n)}
-                    className="group flex items-center gap-3 rounded-xl border border-border/30 bg-card/40 hover:bg-card/70 hover:border-border p-3 transition-colors"
-                  >
-                    {n.image_url ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={n.image_url}
-                        alt=""
-                        className="w-10 h-10 rounded-full object-cover border border-border/40 shrink-0"
-                      />
-                    ) : (
-                      <span className="w-10 h-10 rounded-full bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))] flex items-center justify-center text-sm font-medium shrink-0">
-                        {initialFor(n.name, filterRules.initialFallback)}
-                      </span>
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm text-foreground/90 truncate group-hover:text-foreground">
-                        {n.name}
-                      </p>
-                      {(() => {
-                        const excerpt = presenceExcerpt(n.description);
-                        return excerpt ? (
-                          <p className="text-[11px] text-muted-foreground/90 line-clamp-2 leading-snug mt-0.5">
-                            {excerpt}
-                          </p>
-                        ) : null;
-                      })()}
-                      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1 text-[10px] text-muted-foreground/80">
-                        {n.provider && <span className="truncate">{n.provider}</span>}
-                        {n.lifecycle_state && n.lifecycle_state !== n.provider && (
-                          <span className="rounded-full border border-border/30 px-1.5 py-px">
-                            {n.lifecycle_state}
-                          </span>
-                        )}
+              {visibleItems.map((n) => {
+                const weight = presenceWeight(n);
+                return (
+                  <li key={n.id}>
+                    <Link
+                      href={presenceHref(n)}
+                      className={`group flex items-center gap-3 rounded-xl border p-3 transition-colors ${WEIGHT_CARD_CLASSES[weight]}`}
+                    >
+                      {n.image_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={n.image_url}
+                          alt=""
+                          className={`rounded-full object-cover border border-border/40 shrink-0 ${WEIGHT_AVATAR_CLASSES[weight]}`}
+                        />
+                      ) : (
+                        <span
+                          className={`rounded-full bg-[hsl(var(--primary)/0.12)] text-[hsl(var(--primary))] flex items-center justify-center text-sm font-medium shrink-0 ${WEIGHT_AVATAR_CLASSES[weight]}`}
+                        >
+                          {initialFor(n.name, filterRules.initialFallback)}
+                        </span>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className={`truncate group-hover:text-foreground ${WEIGHT_NAME_CLASSES[weight]}`}
+                        >
+                          {n.name}
+                        </p>
+                        {(() => {
+                          const excerpt = presenceExcerpt(n.description);
+                          return excerpt ? (
+                            <p className="text-[11px] text-muted-foreground/90 line-clamp-2 leading-snug mt-0.5">
+                              {excerpt}
+                            </p>
+                          ) : null;
+                        })()}
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1 text-[10px] text-muted-foreground/80">
+                          {weight === "lineage" && (
+                            <span className="rounded-full bg-[hsl(var(--primary))]/15 text-[hsl(var(--primary))] border border-[hsl(var(--primary))]/30 px-1.5 py-px font-medium">
+                              lineage
+                            </span>
+                          )}
+                          {n.provider && <span className="truncate">{n.provider}</span>}
+                          {n.lifecycle_state && n.lifecycle_state !== n.provider && (
+                            <span className="rounded-full border border-border/30 px-1.5 py-px">
+                              {n.lifecycle_state}
+                            </span>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  </Link>
-                </li>
-              ))}
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
             {hiddenCount > 0 && (
               <Link

--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -9,6 +9,7 @@ import {
   getPeoplePageCopy,
 } from "../presence-walk/data";
 import { PeopleSearch } from "./_components/PeopleSearch";
+import { PeopleFilters, type PeopleSort } from "./_components/PeopleFilters";
 import { lineageFigureRank } from "@/lib/named-lineage";
 
 /**
@@ -45,6 +46,8 @@ type PresenceNode = {
   slug?: string | null;
   lifecycle_state?: string;
   phase?: string;
+  created_at?: string | null;
+  updated_at?: string | null;
 };
 
 function presenceExcerpt(text: string | undefined, max = 110): string | null {
@@ -142,7 +145,12 @@ const PREVIEW_PER_SECTION = 16;
 export default async function PeopleIndexPage({
   searchParams,
 }: {
-  searchParams: Promise<{ kind?: string }>;
+  searchParams: Promise<{
+    kind?: string;
+    sort?: string;
+    with?: string;
+    find?: string;
+  }>;
 }) {
   const sp = await searchParams;
   const lang = await resolveRequestLocale();
@@ -153,6 +161,16 @@ export default async function PeopleIndexPage({
   // works) filters the page to just that section. No filter → all
   // sections render, the visitor wanders.
   const kindFilter = sp?.kind;
+  // Structural axes that compose with the section filter:
+  //   sort=lineage (default) | recent | alpha
+  //   with=description | image — require a real entry of that kind
+  //   find=<substring> — case-insensitive name contains
+  const sort: PeopleSort = (sp?.sort === "recent" || sp?.sort === "alpha")
+    ? sp.sort
+    : "lineage";
+  const requireDescription = sp?.with === "description";
+  const requireImage = sp?.with === "image";
+  const findQuery = (sp?.find || "").trim().toLowerCase();
 
   // Load every presence-type node. The page groups them below; the
   // search bar overlays a resonance-based filter on top.
@@ -164,22 +182,55 @@ export default async function PeopleIndexPage({
       const items = await fetchType(t);
       combined.push(...items);
     }
-    // Within-section ordering — named lineage figures (the humans who
-    // actually shaped this work) rank first in their lineage order,
-    // then everyone else alphabetically by display name. Without this
-    // ranking, the alphabetic sort buries Anne Tucker / Liquid Bloom /
-    // Steve G. Bjorg under hundreds of auto-resolved book authors and
-    // YouTube-channel-id rows that share the same section.
-    groups[section.key] = filterScannable(combined, filterRules).sort((a, b) => {
-      const aSlug = a.slug || a.id;
-      const bSlug = b.slug || b.id;
-      const aRank = lineageFigureRank(aSlug);
-      const bRank = lineageFigureRank(bSlug);
-      if (aRank !== null && bRank !== null) return aRank - bRank;
-      if (aRank !== null) return -1;
-      if (bRank !== null) return 1;
-      return (a.name || "").localeCompare(b.name || "");
-    });
+    // Apply structural filters before sorting so the count and the
+    // visible list stay aligned.
+    let scoped = filterScannable(combined, filterRules);
+    if (requireDescription) {
+      scoped = scoped.filter((n) => {
+        const d = (n.description || "").trim();
+        // Same heuristic as presenceExcerpt — placeholder auto-descriptions
+        // ("HUMAN contributor") don't count as real descriptions.
+        if (!d) return false;
+        if (/^[A-Z_]+\s+(contributor|asset|presence)$/.test(d)) return false;
+        return true;
+      });
+    }
+    if (requireImage) {
+      scoped = scoped.filter((n) => Boolean(n.image_url));
+    }
+    if (findQuery) {
+      scoped = scoped.filter((n) =>
+        (n.name || "").toLowerCase().includes(findQuery),
+      );
+    }
+
+    // Within-section ordering. The default `lineage` sort puts
+    // named-lineage figures (the humans who actually shaped this work)
+    // first in their lineage order, then everyone else alphabetically.
+    // Other sorts override entirely — `recent` orders by created_at
+    // newest-first; `alpha` is pure case-insensitive alphabetical.
+    if (sort === "recent") {
+      scoped.sort((a, b) => {
+        const aT = a.created_at ? Date.parse(a.created_at) : 0;
+        const bT = b.created_at ? Date.parse(b.created_at) : 0;
+        if (aT !== bT) return bT - aT;
+        return (a.name || "").localeCompare(b.name || "");
+      });
+    } else if (sort === "alpha") {
+      scoped.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    } else {
+      scoped.sort((a, b) => {
+        const aSlug = a.slug || a.id;
+        const bSlug = b.slug || b.id;
+        const aRank = lineageFigureRank(aSlug);
+        const bRank = lineageFigureRank(bSlug);
+        if (aRank !== null && bRank !== null) return aRank - bRank;
+        if (aRank !== null) return -1;
+        if (bRank !== null) return 1;
+        return (a.name || "").localeCompare(b.name || "");
+      });
+    }
+    groups[section.key] = scoped;
   }
 
   const total = Object.values(groups).reduce((sum, g) => sum + g.length, 0);
@@ -203,6 +254,10 @@ export default async function PeopleIndexPage({
           {pageCopy.presenceWalkCta}
         </Link>
       </header>
+
+      {/* Structural axes — sort, filter chips, substring search.
+          State lives in the URL so any view is shareable. */}
+      <PeopleFilters />
 
       {/* Resonance-based search surfaces the weave for any query */}
       <PeopleSearch />

--- a/web/app/people/urs/lineage/page.tsx
+++ b/web/app/people/urs/lineage/page.tsx
@@ -649,6 +649,109 @@ export default function UrsLineagePage() {
               from Audible, Spotify, YouTube Takeout, Goodreads, and
               the lived household memory:
             </p>
+
+            {/* Frequency evolution — proportional shape over time.
+                Source: docs/field/urs/output/frequency_evolution_report.md
+                (generated 2026-05-07 from 27,443 dated trace events).
+                The bar widths are proportional to event counts so a
+                visitor sees the size and shape of the listening arc. */}
+            <h3 className="text-lg font-light text-foreground/90 mt-6 not-prose">
+              Frequency evolution · six phases · 27,443 dated events
+            </h3>
+            <figure className="not-prose rounded-xl border border-border/40 bg-card/30 p-5 my-4">
+              <ul className="space-y-3 text-sm">
+                {[
+                  {
+                    label: "early systems & speculative architecture",
+                    period: "2016 – 2021",
+                    events: 112,
+                    coh: 39.1,
+                    top: "Ryk Brown · Terry Mancour · Terry Goodkind · Peter F. Hamilton",
+                    hue: "hsl(220 50% 60%)",
+                  },
+                  {
+                    label: "fictional systems intensification",
+                    period: "2022-01 – 2023-09",
+                    events: 46,
+                    coh: 33.2,
+                    top: "Kel Kade · Ryk Brown · Terry Mancour · Andrew Rowe",
+                    hue: "hsl(195 55% 60%)",
+                  },
+                  {
+                    label: "transition into practice & presence",
+                    period: "2023-10 – 2024-05",
+                    events: 998,
+                    coh: 46.6,
+                    top: "Yaima · East Forest · Parijat · Ajeet · Ram Dass",
+                    hue: "hsl(140 50% 55%)",
+                  },
+                  {
+                    label: "embodied devotional field expansion",
+                    period: "2024-06 – 2024-12",
+                    events: 9044,
+                    coh: 48.3,
+                    top: "Yaima · Liquid Bloom · Mose · Ajeet · Karunesh · Poranguí",
+                    hue: "hsl(38 75% 60%)",
+                  },
+                  {
+                    label: "coherence consolidation",
+                    period: "2025",
+                    events: 13354,
+                    coh: 48.1,
+                    top: "Yaima · Mose · Poranguí · Liquid Bloom · Malte Marten · Ajeet",
+                    hue: "hsl(280 65% 65%)",
+                  },
+                  {
+                    label: "current integration",
+                    period: "2026-01 – 2026-05",
+                    events: 3889,
+                    coh: 47.6,
+                    top: "Mose · Yaima · Poranguí · Maneesh De Moor · Malte Marten",
+                    hue: "hsl(310 60% 65%)",
+                  },
+                ].map((p, i) => {
+                  const max = 13354;
+                  const pct = Math.max(2, Math.round((p.events / max) * 100));
+                  return (
+                    <li key={i} className="flex flex-col gap-1">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <span
+                          className="text-[11px] uppercase tracking-[0.16em]"
+                          style={{ color: p.hue }}
+                        >
+                          {p.label}
+                        </span>
+                        <span className="text-[10px] font-mono text-muted-foreground shrink-0">
+                          {p.period} · {p.events.toLocaleString()} events · coh {p.coh}
+                        </span>
+                      </div>
+                      <div
+                        className="h-2 rounded-full"
+                        style={{
+                          background: `linear-gradient(90deg, ${p.hue} 0%, ${p.hue.replace(")", " / 0.4)")} 100%)`,
+                          width: `${pct}%`,
+                        }}
+                        aria-hidden="true"
+                      />
+                      <p className="text-xs text-foreground/75 leading-snug">
+                        {p.top}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+              <figcaption className="text-[10px] text-muted-foreground/80 mt-4 italic">
+                Generated 2026-05-07 from{" "}
+                <code className="not-italic">docs/field/urs/output/frequency_evolution_report.md</code>.
+                Coherence is a 0-100 score for how concentrated the
+                phase's attention was on its dominant frequencies; bar
+                widths are proportional to event counts. The arc shows
+                the move from speculative-architecture listening toward
+                the devotional / consciousness substrate that runs
+                alongside the present network.
+              </figcaption>
+            </figure>
+
             <h3 className="text-lg font-light text-foreground/90 mt-6">
               Audible · ~74 authors · 4,000+ cumulative hours
             </h3>

--- a/web/components/people/PersonProfileTemplate.tsx
+++ b/web/components/people/PersonProfileTemplate.tsx
@@ -42,6 +42,16 @@ export type PersonProfileArticle =
       body: ReactNode;
     };
 
+export type PersonProfileLineageDoorway = {
+  /** Path to the lineage walk for this person (e.g. /people/urs/lineage). */
+  href: string;
+  /** Short, action-shaped label — e.g. "Walk the 42-year lineage". */
+  label: ReactNode;
+  /** One-line proportional summary — e.g. "13 works · 11 substrates · 1984–now".
+   *  Lets the visitor sense the size before clicking through. */
+  summary?: ReactNode;
+};
+
 export type PersonProfileContent = {
   // Full Next.js Metadata so each page can supply openGraph, twitter,
   // and any other metadata fields. The root layout's title.template
@@ -70,6 +80,14 @@ export type PersonProfileContent = {
     eyebrowClass?: string;
     name: ReactNode;
     welcome: ReactNode;
+    /**
+     * Prominent doorway shown high in the hero — directly under the
+     * welcome paragraph, above facts. Use for the lineage walk so a
+     * visitor sees the shape and size of what's there before scrolling
+     * past several other rendering elements to find it. The whole
+     * affordance is a Link to `lineageDoorway.href`.
+     */
+    lineageDoorway?: PersonProfileLineageDoorway;
   };
   facts?: PersonProfileFact[];
   noteFromBody?: {
@@ -155,6 +173,29 @@ export function PersonProfileTemplate({
           <div className="text-lg md:text-xl text-foreground/85 leading-relaxed max-w-2xl">
             {hero.welcome}
           </div>
+          {hero.lineageDoorway && (
+            <Link
+              href={hero.lineageDoorway.href}
+              className="group mt-6 inline-flex items-center gap-3 rounded-lg border border-[hsl(var(--primary))]/40 bg-[hsl(var(--primary))]/5 hover:bg-[hsl(var(--primary))]/10 hover:border-[hsl(var(--primary))]/70 px-4 py-3 transition-colors max-w-2xl w-full sm:w-auto"
+            >
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm md:text-base text-[hsl(var(--primary))] font-medium group-hover:underline">
+                  {hero.lineageDoorway.label}
+                </span>
+                {hero.lineageDoorway.summary && (
+                  <span className="block text-xs text-foreground/70 mt-0.5">
+                    {hero.lineageDoorway.summary}
+                  </span>
+                )}
+              </span>
+              <span
+                aria-hidden="true"
+                className="text-[hsl(var(--primary))] text-lg group-hover:translate-x-0.5 transition-transform shrink-0"
+              >
+                →
+              </span>
+            </Link>
+          )}
           {content.facts && content.facts.length > 0 && (
             <dl className="mt-7 text-sm text-foreground/85 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 max-w-2xl">
               {content.facts.map((fact, i) => (

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -20,6 +20,11 @@ const content: PersonProfileContent = {
       "absolute inset-0 bg-gradient-to-t from-background via-background/85 to-background/20",
     eyebrow: "The body's primary shepherd",
     name: "Urs Muff",
+    lineageDoorway: {
+      href: "/people/urs/lineage",
+      label: "Walk the 42-year lineage of works and influences",
+      summary: "13 load-bearing works · 8 eras · 1984 → now · the streams of attention woven alongside",
+    },
     welcome: (
       <p>
         Founder of Coherence Network. Swiss-American by lineage,

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -270,6 +270,56 @@ const content: PersonProfileContent = {
       ),
     },
     {
+      kind: "panel",
+      variant: "neutral",
+      eyebrow: "Body of work — proportional shape",
+      heading: "What I have built, in numbers",
+      body: (
+        <>
+          <p className="leading-relaxed">
+            Past, external — across forty-two years and eleven
+            substrates: <strong>13 load-bearing technical works</strong>{" "}
+            shipped from C64 MIDI (age 13, ~1984) through the bridge
+            substrates that preceded this network. Each work has its
+            own page in /people. Walk them via{" "}
+            <Link href="/people/urs/lineage" className="text-primary hover:underline">
+              the lineage
+            </Link>
+            .
+          </p>
+          <p className="leading-relaxed mt-3">
+            Present, in this body — measured 2026-05-05, verifiable
+            on GitHub:
+          </p>
+          <ul className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 mt-3 text-sm">
+            <li><strong className="text-foreground">1,372</strong> <span className="text-muted-foreground">commits</span></li>
+            <li><strong className="text-foreground">200</strong> <span className="text-muted-foreground">PRs merged</span></li>
+            <li><strong className="text-foreground">90</strong> <span className="text-muted-foreground">specs authored</span></li>
+            <li><strong className="text-foreground">61</strong> <span className="text-muted-foreground">concepts written</span></li>
+            <li><strong className="text-foreground">16</strong> <span className="text-muted-foreground">ideas captured</span></li>
+            <li><strong className="text-foreground">3,163</strong> <span className="text-muted-foreground">co-authorships with Claude</span></li>
+          </ul>
+          <p className="leading-relaxed mt-4 text-sm">
+            The current body of work view lives at{" "}
+            <Link href="/me/work" className="text-primary hover:underline">
+              /me/work
+            </Link>
+            {" "}— recent PRs, AI co-authorship counts, and the live
+            link to{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/commits?author=seeker71"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              GitHub commits
+            </Link>
+            .
+          </p>
+        </>
+      ),
+    },
+    {
       kind: "narrative",
       heading: "What I have been holding",
       body: (

--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -176,6 +176,7 @@
         "contributor:cursor-agent",
         "contributor:grok",
         "contributor:gemini",
+        "contributor:urs",
         "person:codex-smoke-human"
       ],
       "excludedContributorTypes": [

--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -149,6 +149,7 @@
     },
     "filterRules": {
       "ignoredIdIncludes": [
+        "anonymous-meeting:",
         ":wanderer-",
         ":presence-visitor",
         ":test-",

--- a/web/lib/named-lineage.ts
+++ b/web/lib/named-lineage.ts
@@ -12,6 +12,11 @@
 // auto-resolved stub) — verified live before authoring.
 
 export const LINEAGE_FIGURE_SLUGS: readonly string[] = [
+  // The body's primary cell — ranks first in any contributors section
+  // so a visitor to /people sees the founder card before scrolling
+  // through the alphabetic flood. The slug matches what the
+  // contributor:seeker71 graph node carries.
+  "urs-muff",
   // Era 1 — the keystone (~1984 – ~1990)
   "michael-ende",
   "james-fenimore-cooper",


### PR DESCRIPTION
## Summary

Every entry on \`/people\` previously rendered at the same visual weight. Anne Tucker (in \`LINEAGE_FIGURE_SLUGS\`, twelve months of measured listening, named in the body's lineage prose) and an auto-resolved audiobook author rendered identically. The eye couldn't see proportion.

Adds a coarse four-tier visual weight:

- **lineage** — named in \`LINEAGE_FIGURE_SLUGS\`. Gold-toned border, ring around avatar, larger and bolder name, small \"lineage\" tag in meta row.
- **curated** — has slug + real description + image. Standard card.
- **named** — has any of {real description, image}. Slightly quieter card.
- **bare** — name only. Most compact card.

The directory still feels like a directory — same grid, same flow — but figures who actually shaped the body now read as load-bearing at a glance, and trace cards step back.

## Direct answer to Urs's question

> \"it is not clear what the influence was in shape and size\"

## Test plan

- [ ] Visit https://coherencycoin.com/people after deploy
- [ ] Confirm Anne Tucker, Vasudev Baba, Ilena, Liquid Bloom, Mose render with gold-toned border and \"lineage\" chip
- [ ] Confirm Urs Muff (founder) card renders with the lineage treatment at the top of contributors
- [ ] Confirm bare-name auto-resolved entries render visibly smaller
- [ ] Combine with sort=recent / find=mose / etc. and confirm weight styling persists across sorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)