### PR TITLE
attune: /presences as the better word for the directory

### DIFF
--- a/web/app/people/page.tsx
+++ b/web/app/people/page.tsx
@@ -256,8 +256,10 @@ export default async function PeopleIndexPage({
         </Link>
       </header>
 
-      {/* Lenses — sibling perspectives on the same body. */}
-      <LensesNav current="people" />
+      {/* Lenses — sibling perspectives on the same body.
+          Both /people and /presences route to this index, and both
+          highlight the same Presences lens. */}
+      <LensesNav current="presences" />
 
       {/* Structural axes — sort, filter chips, substring search.
           State lives in the URL so any view is shareable. */}

--- a/web/app/presences/page.tsx
+++ b/web/app/presences/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import PeopleIndexPage, { generateMetadata as peopleGenerateMetadata } from "../people/page";
+
+/**
+ * /presences — the directory of every presence the network holds.
+ *
+ * The same body the /people directory renders, addressed by the more
+ * accurate word: presences. Per Urs's directive — *"/people does not
+ * sound right for all the things it has underneath, we need a better
+ * word"* — the directory holds humans, communities, places,
+ * gatherings, practices, and works. "People" is too narrow for that
+ * span; "presences" carries each of them honestly.
+ *
+ * Implementation: thin async wrapper that delegates to PeopleIndexPage
+ * so both URLs render the same body without code duplication. /people
+ * stays canonical for slug routes (/people/urs etc.); /presences is
+ * the preferred URL for the directory itself going forward.
+ */
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return peopleGenerateMetadata();
+}
+
+export default async function PresencesIndexPage(props: {
+  searchParams: Promise<{
+    kind?: string;
+    sort?: string;
+    with?: string;
+    find?: string;
+  }>;
+}) {
+  return PeopleIndexPage(props);
+}

--- a/web/components/LensesNav.tsx
+++ b/web/components/LensesNav.tsx
@@ -20,6 +20,9 @@ import Link from "next/link";
  */
 
 export type LensKey =
+  | "presences"
+  // Legacy alias kept for surfaces still using "people" as the lens
+  // identifier — they still highlight the directory lens correctly.
   | "people"
   | "contributors"
   | "creators"
@@ -33,10 +36,10 @@ const LENSES: Array<{
   desc: string;
 }> = [
   {
-    key: "people",
-    href: "/people",
-    label: "Directory",
-    desc: "Every presence by kind",
+    key: "presences",
+    href: "/presences",
+    label: "Presences",
+    desc: "Every cell, place, gathering, practice, and work the body holds",
   },
   {
     key: "contributors",


### PR DESCRIPTION
## Summary

Per Urs's directive: *\"/people does not sound right for all the things it has underneath, we need a better word.\"* The directory holds humans, communities, places, gatherings, practices, and works — \"people\" is too narrow for that span. \"Presences\" carries each of them honestly.

Adds \`/presences\` as a thin async wrapper that delegates to \`PeopleIndexPage\` so both URLs render the same body without code duplication. \`/people\` stays canonical for slug routes (\`/people/urs\` etc.); \`/presences\` becomes the preferred URL for the directory going forward.

LensesNav updated: Directory lens is now keyed \`presences\`, points at \`/presences\`, with the description *\"Every cell, place, gathering, practice, and work the body holds.\"*

## Test plan

- [ ] Visit https://coherencycoin.com/presences — confirm directory renders identically to /people
- [ ] Visit https://coherencycoin.com/people — confirm still works (no breakage)
- [ ] LensesNav on either page shows \"Presences\" lens highlighted; clicking other lenses navigates correctly
- [ ] /people/{slug} entries (e.g. /people/urs) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)