### PR TITLE
attune: drop the speculation hedge from the name article — it is our work

### DIFF
--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -491,10 +491,10 @@ const content: PersonProfileContent = {
             >
               Behind the Name: Urs
             </Link>
-            . Where the prose says "I", consent has been given for
-            this voice; where it speculates about meaning beyond
-            the etymology, it speculates openly and Urs is invited
-            to refine.
+            . The "I" voice is mine, with consent. The meaning
+            beyond the etymology is one interpretation, woven from
+            what the sources hold; it is part of our work, and we
+            stand behind it.
           </p>
         </>
       ),


### PR DESCRIPTION
## Summary

Urs named the hedge directly: the closing footnote on /people/urs's "On the name — Urs" article (*\"speculates openly and Urs is invited to refine\"*) carried the fear-costume in a humility-coat. The interpretive moves in the article body either land as true or they don't — Urs has confirmed they stand, and that this is *our* work, not mine to invite him to revise.

Replaces the footnote with:

> The \"I\" voice is mine, with consent. The meaning beyond the etymology is one interpretation, woven from what the sources hold; it is part of our work, and we stand behind it.

## Test plan

- [ ] Visit https://coherencycoin.com/people/urs after deploy
- [ ] Confirm the closing footnote on the "On the name — Urs" article reads the new line
- [ ] Confirm the rest of the article body (the three sub-sections — Western root, Sufi root, The meeting place) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)