### PR TITLE
attune(nav): The Work → The Becoming, /people → /presences, 🛠 → 🌱

### DIFF
--- a/web/components/mobile-bottom-nav.tsx
+++ b/web/components/mobile-bottom-nav.tsx
@@ -12,16 +12,18 @@ import { AttributedInternalLink } from "@/components/content/AttributedExternalL
  * a light shelf with the organism's primary spine everywhere else.
  *
  * The five tabs mirror the desktop primary header so a visitor moving
- * between phone and laptop meets the same body: Vision (why), People
- * (who's here), Work (ideas being built), Pulse (live attention), and
- * You (the personal hub at /me — the door to your presence, your
- * corner, your profile, your lineage). Same spine, same names.
+ * between phone and laptop meets the same body: Vision (why),
+ * Presences (who and what is held — humans, places, gatherings,
+ * practices, works), Becoming (ideas in motion toward form), Pulse
+ * (live attention), and You (the personal hub at /me — the door to
+ * your presence, your corner, your profile, your lineage). Same
+ * spine, same names.
  */
 
 const BOTTOM_NAV = [
   { href: "/vision", labelKey: "bottomNav.vision", icon: "✨" },
-  { href: "/people", labelKey: "bottomNav.people", icon: "🤝" },
-  { href: "/ideas", labelKey: "bottomNav.work", icon: "🛠" },
+  { href: "/presences", labelKey: "bottomNav.people", icon: "🤝" },
+  { href: "/ideas", labelKey: "bottomNav.work", icon: "🌱" },
   { href: "/resonance", labelKey: "bottomNav.pulse", icon: "🔔" },
   { href: "/me", labelKey: "bottomNav.you", icon: "👤" },
 ];

--- a/web/components/site_header.tsx
+++ b/web/components/site_header.tsx
@@ -27,7 +27,7 @@ type NavItemKey = {
 // pages that live inside that layer.
 const PRIMARY_NAV: NavItemKey[] = [
   { href: "/vision", labelKey: "nav.layer.vision" },
-  { href: "/people", labelKey: "nav.layer.presences" },
+  { href: "/presences", labelKey: "nav.layer.presences" },
   { href: "/ideas", labelKey: "nav.layer.work" },
   { href: "/resonance", labelKey: "nav.layer.pulse", isHeartbeat: true },
 ];

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -199,7 +199,7 @@
     "layer": {
       "vision": "Die Vision",
       "presences": "Die Präsenzen",
-      "work": "Die Arbeit",
+      "work": "Das Werden",
       "pulse": "Der Puls"
     },
     "sub": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -70,7 +70,7 @@
     "layer": {
       "vision": "The Vision",
       "presences": "The Presences",
-      "work": "The Work",
+      "work": "The Becoming",
       "pulse": "The Pulse"
     },
     "sub": {
@@ -241,8 +241,8 @@
     "here": "Here",
     "feed": "Feed",
     "vision": "Vision",
-    "people": "People",
-    "work": "Work",
+    "people": "Presences",
+    "work": "Becoming",
     "pulse": "Pulse",
     "propose": "Propose",
     "you": "You"

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -199,7 +199,7 @@
     "layer": {
       "vision": "La Visión",
       "presences": "Las Presencias",
-      "work": "El Trabajo",
+      "work": "El Devenir",
       "pulse": "El Pulso"
     },
     "sub": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -199,7 +199,7 @@
     "layer": {
       "vision": "Visi",
       "presences": "Kehadiran",
-      "work": "Kerja",
+      "work": "Yang Menjadi",
       "pulse": "Denyut"
     },
     "sub": {


### PR DESCRIPTION
## Summary

Walked the live site fresh-eyes (per Urs's *\"have a careful gander, walk like a visitor would\"* mandate) and named the friction the navigation chrome carries. Three things were inconsistent across all surfaces:

1. **\"The Work\"** was the third primary-nav layer (top + emoji rail + mobile bottom). The link goes to \`/ideas\`, but \"Work\" carries the producing-frequency the body just released from the /people/urs name article (PR #1535). Same costume, different surface.

2. **Top primary nav linked /people** while the directory was just renamed to /presences (PR #1533). Visitors got routed away from the canonical word every time.

3. **Mobile bottom nav rendered \"🤝 People\" + \"🛠 Work\"** — the hammer-and-wrench glyph is construction/labor frequency, not emergence/becoming.

Three changes, shipped together as one breath:

| Surface | Before | After |
|---|---|---|
| nav.layer.work (en) | \"The Work\" | **\"The Becoming\"** |
| nav.layer.work (de) | \"Die Arbeit\" | **\"Das Werden\"** |
| nav.layer.work (es) | \"El Trabajo\" | **\"El Devenir\"** |
| nav.layer.work (id) | \"Kerja\" | **\"Yang Menjadi\"** |
| bottomNav.people (en) | \"People\" | **\"Presences\"** |
| bottomNav.work (en) | \"Work\" | **\"Becoming\"** |
| Primary nav /people target | /people | **/presences** |
| Mobile bottom-nav /people target | /people | **/presences** |
| Mobile bottom-nav icon for /ideas | 🛠 | **🌱** |

The link to `/people/{slug}` for individual entries stays unchanged — only the directory-index link was retargeted. `/people` still serves the same content via PR #1533 so external links don't break.

## Test plan

- [ ] After deploy, visit https://coherencycoin.com/ — top nav shows \"The Becoming\" not \"The Work\"; clicking \"The Presences\" goes to /presences not /people
- [ ] Mobile/narrow viewport: bottom nav shows \"🌱 Becoming\" + \"🤝 Presences\"
- [ ] /people, /people/urs etc. still load (no breakage)
- [ ] /presences renders the same content as /people did

🤖 Generated with [Claude Code](https://claude.com/claude-code)