### PR TITLE
tend: lift filesystem paths off homepage cards + soften autoRefresh body

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -601,13 +601,14 @@ export default async function Home() {
                 <p className="mt-2 min-h-12 text-xs leading-relaxed text-foreground/75 line-clamp-3">
                   {presence.traceWhy}
                 </p>
-                <div className="mt-4 flex items-center justify-between gap-3">
-                  <span
-                    className="min-w-0 truncate text-[10px] text-muted-foreground"
-                    title={presence.traceSource}
-                  >
-                    {presence.traceSource}
-                  </span>
+                <div className="mt-4 flex items-center justify-end gap-3">
+                  {/* The filesystem-source path lives in the i18n record
+                      (`traceSource`) for verifiability and is reachable
+                      via the trace link below; rendering the path itself
+                      on the homepage made the cards feel like developer
+                      output to a fresh visitor. The link still goes to
+                      the same evidence — you just no longer have to
+                      walk past the path to reach the door. */}
                   <AttributedInternalLink
                     href={presence.traceHref}
                     entityId={`trace:${presence.slug}`}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -105,7 +105,7 @@
     "statusOn": "On",
     "statusAvailable": "Available",
     "statusOff": "Off",
-    "body": "Keep this page up to date while you work, then pause when you want a quieter view.",
+    "body": "Keeps this page in sync as the body changes. Pause it any time for a quieter view.",
     "pathLabel": "Path",
     "lastRefresh": "Last refresh",
     "never": "never",


### PR DESCRIPTION
## Summary

Two micro-cleanups from the fresh-eyes visitor walk:

### 1. Filesystem paths leaked into homepage presence cards

The Liquid Bloom / Bloomurian / Mose / Matías / PORTAL cards on the homepage rendered \`presence.traceSource\` — literal filesystem paths like \`docs/field/urs/trace/author_index.jsonl\` and \`web/content/people/bloomurian/en.tsx\` — under each card. Verifiable evidence for a developer; *developer output* for a fresh visitor.

The path stays in the i18n record (other surfaces may use it for verifiability), and the trace link below still points at the same evidence — visitors just no longer have to walk past the path to reach the door.

### 2. Auto-refresh widget body text carried wrong frequency

\`autoRefresh.body\` said *\"Keep this page up to date while you work, then pause when you want a quieter view.\"* — the same producing-frequency word the body has been releasing.

Now: *\"Keeps this page in sync as the body changes. Pause it any time for a quieter view.\"*

The widget itself is hidden on mobile and collapsed-by-default on desktop, so the visible footprint stays the same; the body text now matches the register the rest of the body carries.

## Test plan

- [ ] Visit https://coherencycoin.com/ after deploy — confirm presence cards in \"Living Lineage\" no longer show filesystem paths
- [ ] Open the autoRefresh pill (desktop, bottom-right) — confirm the body text reads the new line
- [ ] Confirm \"Meet →\" links on each presence card still go to the correct trace destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)