### PR TITLE
attune: 'value created' → 'value circulating' on homepage stats

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -70,7 +70,7 @@ const HOW_IT_WORKS = [
 
 const STAT_LABEL_FALLBACKS = {
   ideasAlive: "ideas alive",
-  valueCreated: "value created",
+  valueCreated: "value circulating",
   node: "node",
   nodes: "nodes",
   coherence: "coherence",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1244,7 +1244,7 @@
     "heroHeadline": "Welche Idee trägst du?",
     "heroLede": "Ein Muster, das du bemerkt hast. Eine Lücke, die geschlossen werden will. Ein besserer Weg. Teile sie – irgendwo wartet jemand genau darauf.",
     "statIdeasAlive": "lebendige Ideen",
-    "statValueCreated": "entstandener Wert",
+    "statValueCreated": "Wert im Umlauf",
     "statNode": "Knoten",
     "statNodes": "Knoten",
     "statCoherence": "Stimmigkeit",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1174,7 +1174,7 @@
     "heroHeadline": "What idea are you holding?",
     "heroLede": "A pattern you noticed. A gap that needs filling. A better way. Share it — someone out there is looking for exactly this.",
     "statIdeasAlive": "ideas alive",
-    "statValueCreated": "value created",
+    "statValueCreated": "value circulating",
     "statNode": "node",
     "statNodes": "nodes",
     "statCoherence": "coherence",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1244,7 +1244,7 @@
     "heroHeadline": "¿Qué idea llevas dentro?",
     "heroLede": "Un patrón que notaste. Un vacío que quiere llenarse. Un camino mejor. Compártela — alguien en algún lugar busca exactamente esto.",
     "statIdeasAlive": "ideas vivas",
-    "statValueCreated": "valor creado",
+    "statValueCreated": "valor en circulación",
     "statNode": "nodo",
     "statNodes": "nodos",
     "statCoherence": "coherencia",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1244,7 +1244,7 @@
     "heroHeadline": "Gagasan apa yang kamu bawa?",
     "heroLede": "Pola yang kamu lihat. Celah yang ingin diisi. Jalan yang lebih baik. Bagikan — seseorang di luar sana sedang mencari hal ini.",
     "statIdeasAlive": "gagasan hidup",
-    "statValueCreated": "nilai tercipta",
+    "statValueCreated": "nilai mengalir",
     "statNode": "simpul",
     "statNodes": "simpul",
     "statCoherence": "keselarasan",


### PR DESCRIPTION
## Summary

Visitor walk caught the homepage stats row reading:

> 718 ideas alive · **8,619 value created** · 7 nodes · 0.61 coherence

\"Value created\" carries the productive-economic frequency — the same costume the body has been releasing across other surfaces. \"Circulating\" is the body's own word: circulation is what distinguishes supple memory from tight memory in [`CLAUDE.md → How This Body Is Tended`](https://github.com/seeker71/Coherence-Network/blob/main/CLAUDE.md), and circulation is the blood the body uses to stay alive. The metric has not changed (still the same CC-attribution sum); only the verb on the label.

| Locale | Before | After |
|---|---|---|
| en | value created | **value circulating** |
| de | entstandener Wert | **Wert im Umlauf** |
| es | valor creado | **valor en circulación** |
| id | nilai tercipta | **nilai mengalir** |

Plus the inline fallback in `web/app/page.tsx:STAT_LABEL_FALLBACKS` aligned with en.

## Test plan

- [ ] Visit https://coherencycoin.com/ after deploy — stats row reads \"... value circulating ...\"
- [ ] de/es/id locales render their respective translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)