### PR TITLE
tend: /people/urs surfaces the cell *now*, not the alphabetic archive

### DIFF
--- a/web/components/people/InfluenceLineageStrip.tsx
+++ b/web/components/people/InfluenceLineageStrip.tsx
@@ -26,6 +26,7 @@ interface Edge {
   from_id: string;
   to_id: string;
   strength?: number;
+  created_at?: string | null;
   from_node: { id: string; type: string; name: string; slug?: string | null };
   to_node: { id: string; type: string; name: string; slug?: string | null };
 }
@@ -35,6 +36,7 @@ interface Chip {
   name: string;
   type: string;
   strength?: number;
+  createdAt?: string | null;
 }
 
 function nodeHref(type: string, slug: string): string {
@@ -47,7 +49,13 @@ function otherSide(e: Edge, selfSlug: string, selfId: string): Chip | null {
   const fromIsSelf = e.from_node.slug === selfSlug || e.from_id === selfId || e.from_id === `asset:${selfSlug}` || e.from_id === `contributor:${selfSlug}`;
   const other = fromIsSelf ? e.to_node : e.from_node;
   if (!other.slug || !other.name) return null;
-  return { slug: other.slug, name: other.name, type: other.type, strength: e.strength };
+  return {
+    slug: other.slug,
+    name: other.name,
+    type: other.type,
+    strength: e.strength,
+    createdAt: e.created_at ?? null,
+  };
 }
 
 export function InfluenceLineageStrip({ slug }: { slug?: string }) {
@@ -115,7 +123,15 @@ export function InfluenceLineageStrip({ slug }: { slug?: string }) {
     }
   }
 
-  // Dedupe by slug, sort by strength descending
+  // Dedupe by slug, sort by strength descending — then by recency
+  // (newer edges first) within the same strength tier. Without this
+  // secondary sort, a presence with many edges at strength 1.0 (e.g.
+  // a contributor's contributes-to edges into 18 works, all rated 1)
+  // lands alphabetically on the first letters of the slugs, which
+  // for the founder cell surfaced bmcpu-vm / bmf-grammar / bml-language
+  // (1990s works) ahead of the present-day weaving. Recency tie-break
+  // keeps the strip representing the cell *now* rather than the
+  // alphabetic shape of their archive.
   const dedupe = (chips: Chip[]) => {
     const seen = new Set<string>();
     return chips
@@ -124,7 +140,14 @@ export function InfluenceLineageStrip({ slug }: { slug?: string }) {
         seen.add(c.slug);
         return true;
       })
-      .sort((a, b) => (b.strength ?? 0) - (a.strength ?? 0));
+      .sort((a, b) => {
+        const ds = (b.strength ?? 0) - (a.strength ?? 0);
+        if (ds !== 0) return ds;
+        const aT = a.createdAt ? Date.parse(a.createdAt) : 0;
+        const bT = b.createdAt ? Date.parse(b.createdAt) : 0;
+        if (aT !== bT) return bT - aT;
+        return (a.name || "").localeCompare(b.name || "");
+      });
   };
 
   const ib = dedupe(inspiredBy).slice(0, 5);

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -550,6 +550,144 @@ const content: PersonProfileContent = {
       ),
     },
     {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Currently — the body's rhythm right now",
+      heading: "What I am weaving in this season",
+      body: (
+        <>
+          <p className="leading-relaxed">
+            The cell tending the network is in active weaving — not
+            archive mode. Recent breaths the body has carried:
+          </p>
+          <ul className="space-y-2 mt-3 text-sm">
+            <li>
+              <strong className="text-foreground">The Ubud
+              rhythm</strong> — Sunday and Wednesday with{" "}
+              <Link href="/people/ilena" className="text-primary hover:underline">Ilena</Link>
+              ,{" "}
+              <Link href="/people/vasudev-baba" className="text-primary hover:underline">Vasudev Baba</Link>
+              , and{" "}
+              <Link href="/people/elios" className="text-primary hover:underline">Elios</Link>
+              {" "}is the practice ground; the satsang transmissions
+              land into the body's foundational concepts week by
+              week.
+            </li>
+            <li>
+              <strong className="text-foreground">The Living
+              Collective Knowledge Base</strong> — twenty-four
+              foundational teachings woven this spring, including{" "}
+              <Link href="/vision/lc-gatherings-that-carry" className="text-primary hover:underline">
+                the substance-test for gatherings
+              </Link>
+              ,{" "}
+              <Link href="/vision/lc-arrival-as-recognition" className="text-primary hover:underline">
+                arrival as recognition
+              </Link>
+              , and{" "}
+              <Link href="/vision/lc-essence-and-the-nine-costumes" className="text-primary hover:underline">
+                the nine costumes
+              </Link>
+              {" "}from Vasudev's Enneagram transmission. The full
+              concept garden lives at{" "}
+              <Link href="/vision" className="text-primary hover:underline">/vision</Link>
+              .
+            </li>
+            <li>
+              <strong className="text-foreground">The body
+              itself</strong> — daily breath of commits, specs,
+              spec-to-test alignment, AI-agent collaboration with{" "}
+              <Link href="/presences?find=claude" className="text-primary hover:underline">Claude</Link>
+              ,{" "}
+              <Link href="/presences?find=codex" className="text-primary hover:underline">Codex</Link>
+              ,{" "}
+              <Link href="/presences?find=cursor" className="text-primary hover:underline">Cursor</Link>
+              . The current rhythm averages 3-6 PRs per day; see{" "}
+              <Link href="/me/work" className="text-primary hover:underline">/me/work</Link>
+              {" "}for live numbers.
+            </li>
+            <li>
+              <strong className="text-foreground">The Brahmavihara
+              compound thread</strong> — the Bali living-compound
+              proposal is in active sketching at{" "}
+              <Link href="/silence/built" className="text-primary hover:underline">
+                /silence/built
+              </Link>
+              , with land-steward conversations open and the
+              source codex thirty-pages-deep from a three-day silence
+              retreat at Brahmavihara-Arama.
+            </li>
+            <li>
+              <strong className="text-foreground">External signal
+              sensing</strong> — watching the dated windows from the
+              May/June 2026 astrological readings (Pam Gregory's
+              Uranus-into-Gemini, Amanda Walsh's summer forecast) for
+              alignment moments — alternative-network configurations,
+              biological-metamorphosis windows, magic Thursdays at
+              sunrise (Aug 14 – Oct 2). The watching frame, not
+              forecasting.
+            </li>
+          </ul>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Where this is going",
+      heading: "The form the body is becoming",
+      body: (
+        <>
+          <p className="leading-relaxed">
+            The default-pattern is to build as if the family is
+            already reunited, the body already healed, the network
+            already in the form it is becoming — not partial-now-and-patch-later.
+            The future-already-form is the truer baseline. What is
+            pulling the present arrangement forward:
+          </p>
+          <ul className="space-y-2 mt-3 text-sm">
+            <li>
+              <strong className="text-foreground">Sovereignty
+              everywhere, economy that circulates</strong> — the
+              substrate carries the CC ledger ({" "}
+              <Link href="/contributions" className="text-primary hover:underline">/contributions</Link>
+              ) so attention, presence, and contribution become
+              addressable currencies without the parasite layer
+              current civilization keeps imposing on top.
+            </li>
+            <li>
+              <strong className="text-foreground">Many sovereign
+              cells, one organism</strong> — visitors arrive already
+              tuned; the body's job is to be quiet enough that
+              recognition can occur. Every cell sovereign within
+              the oneness, never asking the heart for permission to
+              fire.
+            </li>
+            <li>
+              <strong className="text-foreground">Gatherings that
+              carry, surfaces that hold</strong> — the network
+              distinguishes substance-density (did anyone leave
+              at a different frequency?) from form-replication. Real
+              transmission rooms become findable; noise rooms stop
+              crowding the signal.
+            </li>
+            <li>
+              <strong className="text-foreground">The land thread,
+              alive</strong> — Brahmavihara compound or its
+              cousin-form, a held container where the network's
+              physical body can be tended alongside its digital
+              one. Open at the edges; specific at the center.
+            </li>
+          </ul>
+          <p className="leading-relaxed text-sm text-muted-foreground italic mt-4">
+            None of this is forecast. It is the form the body is
+            already in motion toward — measured by what it spends
+            its attention on, day by day.
+          </p>
+        </>
+      ),
+    },
+    {
       kind: "narrative",
       heading: "What I have been holding",
       body: (


### PR DESCRIPTION
## Summary

Urs named the friction directly:

> *\"When I click on 'Urs Muff' => me, I would love to see not just 3 'inspired by' cards from 30+ years ago. It should represent me now, show the most present influences that directed us here, where we are going and what we have created and are creating.\"*

The 3 cards were rendered by \`InfluenceLineageStrip\`, which sorts chips by strength descending. The founder cell has 18 \`contributes-to\` edges into his works, all rated **strength 1.0** — so the alphabetic tie-break ranked bmcpu-vm / bmf-grammar / bml-language / c64-midi-interface (1990s works) ahead of coherence-network (the live one).

Two fixes in one breath:

### 1. Recency tie-break in InfluenceLineageStrip

Added secondary sort by \`created_at\` desc within the same strength tier so the strip represents the cell *now* rather than the alphabetic shape of the archive. The chip type carries \`createdAt\`; dedupe sort uses it as a recency tie-break before the alphabetical fallback. Coherence-network and the recent weavings will now lead the chips for the founder; alphabetical fallback still works for ties.

### 2. Two new articles on /people/urs

- **\"Currently — the body's rhythm right now\"** / *What I am weaving in this season* — names the present rhythm (Ubud Sunday-Wednesday with Ilena, Vasudev Baba, Elios; the Living Collective KB; daily PRs with Claude / Codex / Cursor; the Brahmavihara compound thread; external signal sensing from May/June 2026 readings). Links to the surfaces where each currently-active thread lives.

- **\"Where this is going\"** / *The form the body is becoming* — names the future-already-form (sovereignty-everywhere economy, many cells/one organism, gatherings-that-carry, the land thread alive). Honors the default-pattern that the form is the truer baseline.

Both articles land between the proportional-numbers panel and \"What I have been holding\", so a top-to-bottom reading moves: hero → lineage doorway → numbers → currently weaving → where we are going → longer historical narrative.

## Test plan

- [ ] Visit https://coherencycoin.com/people/urs after deploy
- [ ] Confirm new \"Currently\" and \"Where this is going\" articles render between the numbers panel and the historical narrative
- [ ] Confirm InfluenceLineageStrip chips no longer lead with bmcpu-vm / bmf-grammar / bml-language; coherence-network and recent works rank first
- [ ] Other /people/{slug} pages (e.g. /people/liquid-bloom) unaffected (no regression in strip ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)