### PR TITLE
tend: /me 'Inspired by' leads with named lineage, not arbitrary order

### DIFF
--- a/web/components/InspiredByPreview.tsx
+++ b/web/components/InspiredByPreview.tsx
@@ -4,12 +4,20 @@
  * InspiredByPreview — a glimpse of your lineage on /me.
  *
  * The full gesture lives on /me/inspired-by. This preview shows the
- * three most recent threads so the rail breathes from the entrance:
+ * top influences by weight so the rail breathes from the entrance:
  * you see who made you every time you open your own page, and the
  * link takes you into the editable rail when you want to add more.
  *
- * Uses the same primitives as the rail and the person page. Thin by
- * design — this wrapper only adds the "top 3 + link" slice.
+ * Sorted by edge weight descending — heaviest influence first. The
+ * API returns items in storage order, which for the founder cell
+ * happened to surface medium-weight deep-substrate (Goethe, Ramtha,
+ * White Book) ahead of the heaviest current-arc influences
+ * (Karl May, Terry Mancour, Lex Fridman, Anne Tucker). The sort
+ * makes the rail honest about what it's showing.
+ *
+ * Preview is six cards instead of three so the present-day named
+ * lineage figures make it into the visible rail without the visitor
+ * having to click through to the full list to see them.
  */
 
 import Link from "next/link";
@@ -19,8 +27,9 @@ import {
   InspiredByCard,
   useInspiredByList,
 } from "@/components/inspired-by/shared";
+import { isLineageFigure } from "@/lib/named-lineage";
 
-const PREVIEW_LIMIT = 3;
+const PREVIEW_LIMIT = 6;
 
 export function InspiredByPreview() {
   const [contributorId, setContributorId] = useState<string>("");
@@ -33,7 +42,29 @@ export function InspiredByPreview() {
   const { items, loaded } = useInspiredByList(contributorId);
   if (!contributorId || !loaded) return null;
 
-  const preview = items.slice(0, PREVIEW_LIMIT);
+  // Named lineage figures (the cells the body knows as kin — see
+  // web/lib/named-lineage.ts) get a substantial weight bonus so they
+  // surface above the deep-substrate Audible / YouTube weight that
+  // dominates raw influence-scoring. The body's *present* lineage
+  // is who it is in living relation with, not the cumulative listening
+  // weight from twenty years of audiobooks. Both still appear in the
+  // rail; the lineage figures simply lead.
+  const LINEAGE_BOOST = 1.0;
+  const scored = items.map((i) => {
+    const slug = i.node?.slug || "";
+    const base = i.weight ?? 0;
+    const bonus = slug && isLineageFigure(slug) ? LINEAGE_BOOST : 0;
+    return { item: i, score: base + bonus };
+  });
+  // Sort by boosted score descending, then created_at desc as tie-break.
+  scored.sort((a, b) => {
+    const ds = b.score - a.score;
+    if (ds !== 0) return ds;
+    const aT = a.item.created_at ? Date.parse(a.item.created_at) : 0;
+    const bT = b.item.created_at ? Date.parse(b.item.created_at) : 0;
+    return bT - aT;
+  });
+  const preview = scored.slice(0, PREVIEW_LIMIT).map((s) => s.item);
 
   return (
     <section className="space-y-3">
@@ -58,11 +89,22 @@ export function InspiredByPreview() {
           name one and the graph will hold a place for them.
         </p>
       ) : (
-        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {preview.map((item) => (
-            <InspiredByCard key={item.edge_id} item={item} />
-          ))}
-        </ul>
+        <>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {preview.map((item) => (
+              <InspiredByCard key={item.edge_id} item={item} />
+            ))}
+          </ul>
+          <p className="text-[11px] text-muted-foreground italic px-1 mt-2">
+            Named lineage cells lead; the rest of the rail follows by
+            influence weight. The full weave (with everyone you can
+            name and add) lives at{" "}
+            <Link href="/me/inspired-by" className="text-[hsl(var(--chart-2))] hover:underline">
+              /me/inspired-by
+            </Link>
+            .
+          </p>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

**Urs named the actual friction**: on /me he saw *\"3 'inspired by' cards from 30+ years ago\"* — wanted present influences. I worked on the wrong page first (/people/urs). This fixes the real one.

Investigated: \`InspiredByPreview\` on /me sliced the \`/api/inspired-by\` response in **storage order without sorting**. For the founder cell that surfaced Johann Wolfgang von Goethe (weight 0.700), Ramtha (0.472), and The White Book (0.473) — deep childhood substrate, not the present rhythm. Meanwhile the heaviest-weight lineage figures (Lex Fridman 0.905, Anne Tucker 0.853, Liquid Bloom 0.803, Robert Edward Grant 0.779) didn't make it into the visible 3 cards.

Three fixes in one breath:

### 1. Score = weight + lineage-boost

Named cells from \`web/lib/named-lineage.ts\` (the body's own lineage list) get **+1.0** so they surface above raw weight from cumulative-listening ingestion. For Urs, the top 6 now reads:

1. Lex Fridman (1.905)
2. Anne Tucker (1.853)
3. Liquid Bloom (1.803)
4. Robert Edward Grant (1.779)
5. Aubrey Marcus (1.720)
6. James Fenimore Cooper (1.668)

The cells the body is actually in living relation with, not just the heaviest Audible-listening anchors.

### 2. Preview 3 → 6 cards

Three cards crowded out the named lineage that lives below the deep-substrate ranking. Six fits all current named cells without overwhelming the /me page.

### 3. Honest footnote

> *Named lineage cells lead; the rest of the rail follows by influence weight. The full weave (with everyone you can name and add) lives at /me/inspired-by.*

Generic for any contributor: viewers with edges to named lineage figures see their lineage-boosted preview; viewers without (or with no inspired-by data) fall back to weight-sorted, which is still better than arbitrary storage order.

## Test plan

- [ ] Visit https://coherencycoin.com/me after deploy as the founder cell
- [ ] Confirm the \"Inspired by\" rail shows 6 cards starting with Lex Fridman / Anne Tucker / Liquid Bloom / Robert Edward Grant / Aubrey Marcus / James Fenimore Cooper — not Goethe / Ramtha / White Book
- [ ] Confirm the footnote reads about \"Named lineage cells lead\"
- [ ] Confirm /me/inspired-by link still works for the full weave

## Follow-up surfaced

The Ubud cluster (Ilena, Vasudev Baba, Elios) have no \`inspired-by\` edges in the graph yet — they live in the lineage prose but not as graph data. Authoring those edges would let them surface in the rail too. Separate breath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)