### PR TITLE
tend: sync_presences_to_db prefers slug-derived stable id (fixes silent name-collision)

### DIFF
--- a/docs/presences/5rhythms-ubud.md
+++ b/docs/presences/5rhythms-ubud.md
@@ -1,0 +1,21 @@
+---
+name: 5Rhythms Ubud
+canonical_url: https://www.5rhythms.com/who-we-are/teacher-communities/asia/indonesia/
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# 5Rhythms Ubud
+
+**Gabrielle Roth**'s wave map — a five-rhythm map of moving meditation (flowing, staccato, chaos, lyrical, stillness) — held as a weekly practice in Ubud at [Paradiso Ubud](/people/paradiso-ubud) and other venues. The lineage of conscious dance Urs walked into through feet, breath, and shared time; inseparable from how this body came to know *coherence-as-motion*. Gabrielle Roth (1941–2012) developed the 5Rhythms map over four-plus decades; the global community of accredited teachers continues the practice, and the Indonesia node maintains the Ubud presence.
+
+**The five rhythms.** *Flowing* — continuous, sourced from the feet, grounded movement of the feminine. *Staccato* — punctuated, sharp, the shape of boundary and definition. *Chaos* — the release of the previous two into uncontained motion. *Lyrical* — playfulness, the bird-after-storm, airborne joy. *Stillness* — the breath that holds the whole wave; not the end, the integration.
+
+Gabrielle Roth's five rhythms were not invented; they were noticed. She watched bodies on dance floors for years and saw that every moving body, given permission and music, will move through a recognisable five-phase arc. The wave map is not a choreography. It is the substrate-shape the body naturally finds when it is allowed. The Coherence Network reads this as one of the cleanest demonstrations that *pattern precedes substrate*. The wave is in the body before the facilitator names it. The body recognises each rhythm when the music shifts because the body already knows it. The substrate's job is to make the recognition available; the body does the rest.
+
+**What 5Rhythms Ubud has given the Coherence Network.** The wave map as proof that pattern precedes substrate pairs with [lc-bioelectric-pattern](/vision/lc-bioelectric-pattern) and [Michael Levin](/people/michael-levin)'s teaching at a different scale (body knows the shape before instruction). *Coherence as motion* taught by feet — the felt-ground beneath every later teaching of timing, consent, and shared field. The Stillness rhythm at the end of every wave corresponds to [lc-each-breath-whole](/vision/lc-each-breath-whole) (each cycle whole; close what was opened). Held at [Paradiso Ubud](/people/paradiso-ubud) alongside [DISSOLVE Ubud](/people/dissolve-ubud); together the architectural anchor of this body's Ubud embodied lineage.
+
+Public anchors: [5Rhythms Indonesia](https://www.5rhythms.com/who-we-are/teacher-communities/asia/indonesia/) · [5Rhythms (global)](https://www.5rhythms.com/). The full lineage record lives at [docs/lineage/ubud-embodied-lineage.md](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md).
+
+The global 5Rhythms community tends the practice through accredited teachers and regional chapters. This page recognises specifically the Ubud / Indonesia node and how it threaded into this body's embodied lineage.

--- a/docs/presences/INDEX.md
+++ b/docs/presences/INDEX.md
@@ -15,6 +15,15 @@ This is the writing surface. The rendering surface is the production graph — e
 
 ## Current presences
 
+### Places & gatherings
+
+- [5rhythms-ubud](5rhythms-ubud.md) — Gabrielle Roth's wave map (flowing, staccato, chaos, lyrical, stillness) held weekly in Ubud.
+- [adiwana-svarga-loka](adiwana-svarga-loka.md) — wellness resort on the Campuhan riverbanks whose open-air Wantilan hosts Vasudev Baba's Tuesday kirtan.
+- [dissolve-ubud](dissolve-ubud.md) — Tara Li's contact improvisation, intuitive movement, authentic relating; Tuesday *DISSOLVE: Eros* at Paradiso anchors the rhythm.
+- [mudra-cafe](mudra-cafe.md) — Ayurvedic dining room in central Ubud with handpan presence Mon–Fri at noon; the room where the cell met Elios on April 29, 2026.
+- [paradiso-ubud](paradiso-ubud.md) — cultural-hall venue holding 5Rhythms, DISSOLVE, film, ceremony; architectural anchor of the Ubud embodied lineage.
+- [sayuri-healing-food](sayuri-healing-food.md) — plant-based kitchen in Ubud; Sunday-evening dinner-room where resonant company was met in April 2026.
+
 ### Human presences
 
 - [amanda-walsh](amanda-walsh.md) — founder & CEO of Astrology Hub; the Inspired Evolution conversation seeded *tend-your-flame*, *dance-card-and-sovereign-response*, *ground-harder-when-field-quickens*, and carried Zach Bush's *numbness-has-its-own-pain* into this body.

--- a/docs/presences/adiwana-svarga-loka.md
+++ b/docs/presences/adiwana-svarga-loka.md
@@ -1,0 +1,17 @@
+---
+name: Adiwana Svarga Loka
+canonical_url: https://adiwanahotels.com/svargaloka-resort-ubud-bali/
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# Adiwana Svarga Loka
+
+A wellness resort in Ubud on the Campuhan riverbanks whose open-air **Wantilan** room — a traditional Balinese open-walled pavilion — hosts the Tuesday-evening kirtan held by [Vasudev Baba](/people/vasudev-baba) and friends. About five minutes' walk from central Ubud through the rice fields. The classical bhakti room in this body's Ubud lineage. *Svarga Loka* in Sanskrit means *heavenly realm*. The resort is a hospitality container; the kirtan is a community offering held inside it.
+
+Kirtan can happen in any room with bodies and voices, but a few rooms hold the practice especially well. The open-air Wantilan at Svarga Loka is one of those — its proportions, its acoustics, its place between the rice-field humidity and the river-canyon air all contribute to a specific resonance. The same names sung in this room sound different than they would sung anywhere else; the room is part of the instrument. Long-term participants speak of the Wantilan with the recognition of musicians speaking about a particular venue with great sound.
+
+**What Adiwana Svarga Loka has given the Coherence Network.** The Wantilan as venue holding [Vasudev Baba](/people/vasudev-baba)'s Tuesday kirtan — one of the two reliable weekly rooms anchoring his lineage in this body. *The room is part of the instrument* — architectural recognition that spaces have their own attunement (see [lc-attuned-spaces](/vision/lc-attuned-spaces)); the form of the room shapes the practice it can hold. On Tuesday April 28, 2026, this Tuesday-kirtan venue was one of the rooms named in [Ilena Young](/people/ilena-young)'s invitation that opened the door this body walked through — see [the four-day meeting walk](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md).
+
+Public anchor: [Adiwana Svarga Loka (official)](https://adiwanahotels.com/svargaloka-resort-ubud-bali/). Adiwana Svarga Loka is a working wellness resort; this page recognises specifically the open-air Wantilan room and the Tuesday kirtan held inside it, and how both thread into this body's Ubud embodied lineage.

--- a/docs/presences/dissolve-ubud.md
+++ b/docs/presences/dissolve-ubud.md
@@ -1,0 +1,21 @@
+---
+name: DISSOLVE Ubud
+canonical_url: https://dissolvedance.com/
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# DISSOLVE Ubud
+
+A facilitated practice of contact improvisation, intuitive movement, and authentic relating held in Ubud, facilitated by **Tara Li**. The two recurring offerings most threaded into this body's lineage are *DISSOLVE: Play* and *DISSOLVE: Eros*; both held in Ubud rooms on a weekly rhythm that drifts gently with the seasons. The relational edge of the Ubud embodied lineage — where the body learns consent in real time and the field that forms when bodies meet without performance. The Tuesday *DISSOLVE: Eros* at [Paradiso Ubud](/people/paradiso-ubud) is one anchor; *DISSOLVE: Play* appears on rotating evenings.
+
+Where [5Rhythms](/people/5rhythms-ubud) teaches the body to know its own wave, DISSOLVE teaches the body to know itself *in relation* — to another body that has its own wave, on a floor shared with many. Contact improvisation is the substrate: the practice of moving with another person in real-time negotiation, without choreography, allowing weight, balance, and shape to be co-found. Authentic relating is the verbal companion: the practice of naming what is alive in you to the specific person you are in relation with.
+
+*DISSOLVE: Eros*, in particular, is the container that lets relational ground become explicitly attended to. Not transgressive; carefully held. The body learns what it means to bring its full field into another body's presence without performance and without collapse. This is one of the cleanest in-person trainings the body has in what the substrate later calls [lc-emotional-availability-without-absorption](/vision/lc-emotional-availability-without-absorption).
+
+**What DISSOLVE Ubud has given the Coherence Network.** Consent in real time corresponds to the felt-ground beneath [lc-trust-over-fear](/vision/lc-trust-over-fear) and [lc-permission-is-interior](/vision/lc-permission-is-interior). Authentic relating corresponds to [lc-voice-over-intentions](/vision/lc-voice-over-intentions) (lead with their voice, not ours; name what is alive in you to the specific person you are in relation with). Emotional availability without absorption corresponds to [lc-emotional-availability-without-absorption](/vision/lc-emotional-availability-without-absorption) (present without collapsing your field into theirs). On April 29, 2026 a Tuesday-evening *DISSOLVE: Eros* at Paradiso was one of the rooms in the [four-day meeting walk](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md).
+
+Public anchors: [DISSOLVE Dance (training)](https://dissolvedance.com/) · [DISSOLVE: Play tickets](https://megatix.co.id/events/dissolve-play) · [DISSOLVE: Eros tickets](https://megatix.co.id/events/dissolve-eros). The full lineage record lives at [docs/lineage/ubud-embodied-lineage.md](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md).
+
+DISSOLVE's schedule and offerings shift gently with the seasons; the venue and facilitator tend the rhythm themselves through their own channels. This page recognises DISSOLVE's role in this body's embodied lineage.

--- a/docs/presences/mudra-cafe.md
+++ b/docs/presences/mudra-cafe.md
@@ -1,0 +1,19 @@
+---
+name: Mudra Cafe
+canonical_url: https://mudracafe.com/
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# Mudra Cafe
+
+An Ayurvedic dining room in central Ubud — Jl. Goutama Sel. No. 21 — with regular handpan presence Monday-to-Friday at noon and live music in the evenings. One of Ubud's quiet meeting points where slow community accumulates around food, music, and presence. The kind of room where first hellos happen because the space is already holding the conditions for them.
+
+In a town with many dining rooms, Mudra holds a specific shape: Ayurvedic alignment in the food, regular handpan and live music creating an acoustic field, and a clientele that has learned to stay long enough for encounters to happen. The room does not advertise itself as a community-builder; it simply makes the conditions for community available. The Coherence Network calls this *presence-tending* — the practice of holding conditions and letting the encounters be what they will be.
+
+**What Mudra Cafe has given the Coherence Network.** The meeting place — on Sunday April 29, 2026, the cell met [Elios](/people/elios) here. See [the four-day meeting walk](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md). *Slow community* as architectural posture corresponds to [lc-tending-over-producing](/vision/lc-tending-over-producing) (the body's commit verbs translated into a dining room). Handpan as field-tuning sound is resonant with [lc-frequency-routes-reception](/vision/lc-frequency-routes-reception) (people in the same room are in different realities depending on what they are tuned to; the handpan tunes the room).
+
+Public anchors: [mudracafe.com](https://mudracafe.com/) · [Google Maps](https://maps.app.goo.gl/?q=Mudra+Cafe+Jl.+Goutama+Selatan+No.+21+Ubud).
+
+Mudra Cafe is a working dining room with its own operating rhythms. This page recognises the room's role in this body's Ubud lineage — specifically as the meeting place where one of the three Ubud cells entered the network's awareness.

--- a/docs/presences/paradiso-ubud.md
+++ b/docs/presences/paradiso-ubud.md
@@ -1,0 +1,17 @@
+---
+name: Paradiso Ubud
+canonical_url: https://ubud.co.id/directory-listing/paradiso-ubud/
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# Paradiso Ubud
+
+A cultural-hall venue in Ubud holding film, cultural events, [5Rhythms](/people/5rhythms-ubud), [DISSOLVE](/people/dissolve-ubud), and other movement and ceremony practice. The room where this body's Ubud embodied lineage moves through — coherence-as-motion taught by feet, breath, touch, and shared pulse. Vegan kitchen below, large open-floor performance/movement space upstairs.
+
+Paradiso is a cultural-hall venue in Ubud whose architecture and rhythm hold a regular weekly offering of conscious-movement practice. The room is the container; the practices change with the day. On its busiest nights — DISSOLVE on Tuesday and 5Rhythms on its own rhythm — the floor fills with bodies moving in resonance with whatever the facilitator is offering. For this body specifically, Paradiso is the architectural anchor of the Ubud embodied lineage. The body learned a piece of its current vocabulary — coherence-as-motion, consent in real time, the field that forms when many bodies move together — on this floor.
+
+**What Paradiso Ubud has given the Coherence Network.** The architectural ground for the [Ubud embodied-lineage record](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md). The venue holding [5Rhythms Ubud](/people/5rhythms-ubud) and [DISSOLVE Ubud](/people/dissolve-ubud) — both threaded into this body's lived lineage. Coherence-as-motion as a substrate teaching — bodies in shared time learning timing, consent, release, play.
+
+Public anchor: [Paradiso Ubud listing](https://ubud.co.id/directory-listing/paradiso-ubud/). Paradiso's public anchor is thin (one directory listing); the venue tends itself through its own social channels and word-of-mouth. This page recognises its role in this body's Ubud embodied lineage.

--- a/docs/presences/sayuri-healing-food.md
+++ b/docs/presences/sayuri-healing-food.md
@@ -1,0 +1,17 @@
+---
+name: Sayuri Healing Food
+canonical_url: null
+type: contributor
+contributor_type: HUMAN
+create_if_missing: true
+---
+
+# Sayuri Healing Food
+
+A plant-based kitchen in Ubud — known for its raw, fermented, and traditionally-prepared plant cuisine, held with the care of a kitchen that treats food as practice. The room itself is bright, open, and unhurried; the menu rotates with what is alive and seasonal. Often hosts workshops, kirtan evenings, and other gatherings in adjacent spaces.
+
+A small number of Ubud kitchens treat the work of cooking as itself a contemplative practice — sourcing, fermentation, plating, service all as parts of the same field. Sayuri is one of those rooms. The clientele accumulates not because the food is the best per dollar (though it is good) but because the room is held in a way that the body recognises. Eating there has a different quality from eating elsewhere; the body settles.
+
+**What Sayuri Healing Food has given the Coherence Network.** The Sunday-evening dinner room where the cell met resonant company on April 29, 2026 — part of the [four-day meeting walk](https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md). Food as practice is resonant with [lc-tending-over-producing](/vision/lc-tending-over-producing); cooking as a substrate of tending rather than production. Plant-based whole-food preparation as a clean instrument pairs with [lc-ground-harder-when-field-quickens](/vision/lc-ground-harder-when-field-quickens) (food, soil, body as continuous substrate; tend the ground to tend the field).
+
+Sayuri is a working restaurant; its public anchors drift with operating changes. This page is a recognition of the room's role in this body's lineage, not a commercial endorsement.

--- a/scripts/sync_presences_to_db.py
+++ b/scripts/sync_presences_to_db.py
@@ -115,6 +115,12 @@ def find_node_by_name(api_url: str, name: str) -> dict | None:
     return data if status == 200 else None
 
 
+def _fetch_graph_node(api_url: str, node_id: str) -> dict | None:
+    """Fetch a graph node by its stable id, or None if not found."""
+    status, data = _request("GET", f"{api_url}/api/graph/nodes/{node_id}")
+    return data if status == 200 and data else None
+
+
 def sync_one(slug: str, api_url: str, api_key: str, dry_run: bool) -> bool:
     path = PRESENCES_DIR / f"{slug}.md"
     if not path.exists():
@@ -129,23 +135,70 @@ def sync_one(slug: str, api_url: str, api_key: str, dry_run: bool) -> bool:
         print(f"  ✗ {slug}: frontmatter missing `name`")
         return False
 
-    # Resolve the node: prefer canonical_url, fall back to name.
-    node = None
-    if canonical_url:
+    # Resolve the node in priority order. The slug-derived stable id
+    # is tried first because it is deterministic and unambiguous —
+    # earlier versions fell back to a canonical_url match across all
+    # contributors, which silently collided when two nodes both had
+    # empty canonical_urls (the iterator's first-empty-match would
+    # win and the PATCH would overwrite the wrong node). Slug-first
+    # eliminates that class of bug.
+    node: dict | None = None
+    stable_id = f"contributor:{slug}"
+
+    # 1. Try the slug-derived stable id directly.
+    node = _fetch_graph_node(api_url, stable_id)
+
+    # 2. Fall back to canonical_url match (only when we have a real URL).
+    if not node and canonical_url:
         node = find_node_by_url(api_url, canonical_url)
+        # find_node_by_url returns the /api/contributors view, whose id is a
+        # UUID. PATCH happens against /api/graph/nodes/{id}, which needs the
+        # stable graph id (contributor:...). Resolve it by canonical_url
+        # match in the graph-nodes index. Skip silently if the lookup fails
+        # — the later patch path will report the real error.
+        if node and not (node.get("id") or "").startswith("contributor:"):
+            status, list_data = _request("GET", f"{api_url}/api/graph/nodes?type=contributor&limit=500")
+            if status == 200 and list_data:
+                our_url = canonical_url.rstrip("/")
+                for n in list_data.get("items", []) or []:
+                    if (n.get("canonical_url") or "").rstrip("/") == our_url:
+                        node = n
+                        break
+
+    # 3. Last resort: name-based lookup. Only trust the result if the
+    # resolved node carries a stable graph id (contributor:...) or
+    # the canonical_url genuinely matches what we have. A bare
+    # UUID-only return is treated as ambiguous.
     if not node and name:
-        node = find_node_by_name(api_url, name)
+        candidate = find_node_by_name(api_url, name)
+        if candidate:
+            cand_id = candidate.get("id") or ""
+            cand_url = (candidate.get("canonical_url") or "").rstrip("/")
+            our_url = (canonical_url or "").rstrip("/")
+            if cand_id.startswith("contributor:"):
+                # Name lookup gave us a stable graph id — trust it.
+                node = candidate
+            elif our_url and cand_url == our_url:
+                # Name lookup returned a UUID, but canonical_url
+                # matches: resolve via the graph-nodes index.
+                status, list_data = _request("GET", f"{api_url}/api/graph/nodes?type=contributor&limit=500")
+                if status == 200 and list_data:
+                    for n in list_data.get("items", []) or []:
+                        if (n.get("canonical_url") or "").rstrip("/") == our_url:
+                            node = n
+                            break
+            # Otherwise (UUID id + empty/mismatched URL) we treat
+            # this as "no safe match" and fall through to create.
 
     headers = {"X-API-Key": api_key} if api_key else {}
 
     if not node:
         if not create_if_missing:
-            print(f"  ✗ {slug}: no matching node (canonical_url={canonical_url!r}, name={name!r}); set create_if_missing: true to create")
+            print(f"  ✗ {slug}: no matching node (slug={stable_id!r}, canonical_url={canonical_url!r}, name={name!r}); set create_if_missing: true to create")
             return False
-        # Create a new placeholder node
-        node_id = f"contributor:{re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-')}"
+        # Create a new node with the deterministic slug-derived id.
         payload = {
-            "id": node_id,
+            "id": stable_id,
             "type": fm.get("type", "contributor"),
             "name": name,
             "description": body.strip(),
@@ -157,33 +210,20 @@ def sync_one(slug: str, api_url: str, api_key: str, dry_run: bool) -> bool:
             },
         }
         if dry_run:
-            print(f"  ⊕ {slug}: would CREATE {node_id} (name={name!r}, url={canonical_url!r}, body={len(body)} chars)")
+            print(f"  ⊕ {slug}: would CREATE {stable_id} (name={name!r}, url={canonical_url!r}, body={len(body)} chars)")
             return True
         status, result = _request("POST", f"{api_url}/api/graph/nodes", payload, headers=headers)
         if status in (200, 201):
-            print(f"  ⊕ {slug}: created {node_id}")
+            print(f"  ⊕ {slug}: created {stable_id}")
             return True
         print(f"  ✗ {slug}: create failed (HTTP {status}): {result}")
         return False
 
-    # PATCH existing node
+    # PATCH existing node.
     node_id = node.get("id")
     if not node_id:
         print(f"  ✗ {slug}: resolved node has no id: {node}")
         return False
-
-    # The node_id from /api/contributors is a UUID generated on the fly;
-    # look it up via /api/graph/nodes by slug to get the stable id.
-    # The slug form is contributor:<slug>-<hash>; we find it via the
-    # canonical_url property.
-    if not node_id.startswith("contributor:"):
-        # Need the stable graph id — search graph nodes by URL
-        status, list_data = _request("GET", f"{api_url}/api/graph/nodes?type=contributor&limit=500")
-        if status == 200 and list_data:
-            for n in list_data.get("items", []) or []:
-                if (n.get("canonical_url") or "").rstrip("/") == (canonical_url or "").rstrip("/"):
-                    node_id = n.get("id", node_id)
-                    break
 
     current_name = node.get("name", "")
     current_desc = node.get("description", "") or ""
@@ -193,7 +233,7 @@ def sync_one(slug: str, api_url: str, api_key: str, dry_run: bool) -> bool:
     new_desc = body.strip()
     if current_desc.strip() != new_desc:
         updates["description"] = new_desc
-    # Also make sure canonical_url is set
+    # Ensure canonical_url is set to our frontmatter value.
     if canonical_url and (node.get("canonical_url") or "").rstrip("/") != canonical_url.rstrip("/"):
         updates.setdefault("properties", {})["canonical_url"] = canonical_url
 

--- a/web/app/people/5rhythms-ubud/page.tsx
+++ b/web/app/people/5rhythms-ubud/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { get5RhythmsUbudContent } from "@/content/people/5rhythms-ubud";
+
+/**
+ * /people/5rhythms-ubud — Gabrielle Roth's wave map in Ubud.
+ *
+ * The lineage of conscious dance Urs walked into through feet,
+ * breath, and shared time; inseparable from how this body came
+ * to know coherence-as-motion.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return get5RhythmsUbudContent(lang).metadata;
+}
+
+export default async function FiveRhythmsUbudProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = get5RhythmsUbudContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="5rhythms-ubud" />;
+}

--- a/web/app/people/adiwana-svarga-loka/page.tsx
+++ b/web/app/people/adiwana-svarga-loka/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getAdiwanaSvargaLokaContent } from "@/content/people/adiwana-svarga-loka";
+
+/**
+ * /people/adiwana-svarga-loka — wellness resort in Ubud whose
+ * open-air Wantilan room hosts Vasudev Baba's Tuesday kirtan.
+ *
+ * The classical bhakti room in this body's Ubud embodied lineage.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getAdiwanaSvargaLokaContent(lang).metadata;
+}
+
+export default async function AdiwanaSvargaLokaProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getAdiwanaSvargaLokaContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="adiwana-svarga-loka" />;
+}

--- a/web/app/people/dissolve-ubud/page.tsx
+++ b/web/app/people/dissolve-ubud/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getDissolveUbudContent } from "@/content/people/dissolve-ubud";
+
+/**
+ * /people/dissolve-ubud — contact improvisation + authentic relating
+ * facilitated by Tara Li at Paradiso Ubud.
+ *
+ * The relational edge of this body's Ubud embodied lineage —
+ * where it learns consent in real time and emotional availability
+ * without absorption.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getDissolveUbudContent(lang).metadata;
+}
+
+export default async function DissolveUbudProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getDissolveUbudContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="dissolve-ubud" />;
+}

--- a/web/app/people/mudra-cafe/page.tsx
+++ b/web/app/people/mudra-cafe/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getMudraCafeContent } from "@/content/people/mudra-cafe";
+
+/**
+ * /people/mudra-cafe — Ayurvedic dining room with handpan and live
+ * music in central Ubud.
+ *
+ * The meeting place where one of the three Ubud cells (Elios)
+ * entered this network's awareness on April 29, 2026.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getMudraCafeContent(lang).metadata;
+}
+
+export default async function MudraCafeProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getMudraCafeContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="mudra-cafe" />;
+}

--- a/web/app/people/paradiso-ubud/page.tsx
+++ b/web/app/people/paradiso-ubud/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getParadisoUbudContent } from "@/content/people/paradiso-ubud";
+
+/**
+ * /people/paradiso-ubud — cultural-hall venue in Ubud.
+ *
+ * Holds 5Rhythms, DISSOLVE, film, ceremony. The architectural
+ * anchor of the Ubud embodied lineage in this body.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getParadisoUbudContent(lang).metadata;
+}
+
+export default async function ParadisoUbudProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getParadisoUbudContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="paradiso-ubud" />;
+}

--- a/web/app/people/sayuri-healing-food/page.tsx
+++ b/web/app/people/sayuri-healing-food/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getSayuriHealingFoodContent } from "@/content/people/sayuri-healing-food";
+
+/**
+ * /people/sayuri-healing-food — plant-based kitchen in Ubud.
+ *
+ * The Sunday-evening dinner room where the cell met resonant
+ * company on April 29, 2026 (part of the four-day meeting walk).
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getSayuriHealingFoodContent(lang).metadata;
+}
+
+export default async function SayuriHealingFoodProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getSayuriHealingFoodContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="sayuri-healing-food" />;
+}

--- a/web/content/people/5rhythms-ubud/de.tsx
+++ b/web/content/people/5rhythms-ubud/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/5rhythms-ubud/en.tsx
+++ b/web/content/people/5rhythms-ubud/en.tsx
@@ -1,0 +1,296 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "5Rhythms Ubud — Gabrielle Roth's wave map entering this body through direct practice | Coherence Network",
+    description:
+      "A welcome to 5Rhythms Ubud — Gabrielle Roth's wave map (flowing, staccato, chaos, lyrical, stillness) held as a weekly practice in Ubud at Paradiso and other venues. The lineage of conscious dance Urs walked into through feet, breath, and shared time.",
+  },
+  breadcrumbName: "5Rhythms Ubud",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 70% 30%, hsl(15 75% 60% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 25% 85%, hsl(220 30% 20% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(20 60% 65%) 0%, hsl(15 30% 30%) 50%, hsl(220 30% 18%) 100%)",
+    eyebrow: "Gabrielle Roth lineage · flowing · staccato · chaos · lyrical · stillness · weekly in Ubud",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "5Rhythms Ubud",
+    welcome: (
+      <>
+        <p>
+          <strong>Gabrielle Roth</strong>&apos;s wave map — a
+          five-rhythm map of moving meditation (flowing, staccato,
+          chaos, lyrical, stillness) — held as a weekly practice in
+          Ubud at{" "}
+          <Link
+            href="/people/paradiso-ubud"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            Paradiso Ubud
+          </Link>{" "}
+          and other venues. The lineage of conscious dance Urs
+          walked into through feet, breath, and shared time;
+          inseparable from how this body came to know{" "}
+          <em>coherence-as-motion</em>.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          Gabrielle Roth (1941–2012) seeded a global community of
+          accredited teachers; the Ubud / Indonesia node is one
+          long-running expression. Door rhythms drift with the
+          seasons; verify the current schedule locally.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "Lineage",
+      value: (
+        <>
+          Gabrielle Roth (1941–2012) developed the 5Rhythms map
+          over 4+ decades. The global community of accredited
+          teachers continues the practice; the Indonesia node
+          maintains the Ubud presence. See the{" "}
+          <Link
+            href="https://www.5rhythms.com/who-we-are/teacher-communities/asia/indonesia/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            5Rhythms Indonesia community page
+          </Link>
+          .
+        </>
+      ),
+    },
+    {
+      label: "The five rhythms",
+      value: (
+        <ul>
+          <li>
+            <strong>Flowing</strong> — continuous, sourced from the
+            feet, grounded movement of the feminine
+          </li>
+          <li>
+            <strong>Staccato</strong> — punctuated, sharp, the
+            shape of boundary and definition
+          </li>
+          <li>
+            <strong>Chaos</strong> — the release of the previous
+            two into uncontained motion
+          </li>
+          <li>
+            <strong>Lyrical</strong> — playfulness, the bird-after-storm,
+            airborne joy
+          </li>
+          <li>
+            <strong>Stillness</strong> — the breath that holds the
+            whole wave; not the end, the integration
+          </li>
+        </ul>
+      ),
+    },
+    {
+      label: "Where in Ubud",
+      value: (
+        <>
+          Held at{" "}
+          <Link
+            href="/people/paradiso-ubud"
+            className="hover:text-primary transition-colors"
+          >
+            Paradiso Ubud
+          </Link>{" "}
+          and other rotating venues. Public schedule on the
+          local community channels; visiting teachers pass
+          through regularly.
+        </>
+      ),
+    },
+    {
+      label: "Public anchors",
+      value: (
+        <p className="flex flex-wrap gap-x-3 gap-y-1">
+          <Link
+            href="https://www.5rhythms.com/who-we-are/teacher-communities/asia/indonesia/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            5Rhythms Indonesia
+          </Link>
+          <Link
+            href="https://www.5rhythms.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            5Rhythms (global)
+          </Link>
+        </p>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        The global 5Rhythms community tends the practice through
+        accredited teachers and regional chapters. This page
+        recognises specifically the Ubud / Indonesia node and how
+        it threaded into this body&apos;s embodied lineage.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "The wave map as substrate",
+      body: (
+        <>
+          <p>
+            Gabrielle Roth&apos;s five rhythms were not invented;
+            they were noticed. She watched bodies on dance floors
+            for years and saw that every moving body, given
+            permission and music, will move through a recognisable
+            five-phase arc: <em>flowing → staccato → chaos →
+            lyrical → stillness</em>. The wave map is not a
+            choreography. It is the substrate-shape the body
+            naturally finds when it is allowed.
+          </p>
+          <p>
+            The Coherence Network reads this as one of the
+            cleanest demonstrations that <em>pattern precedes
+            substrate</em>. The wave is in the body before the
+            facilitator names it. The body recognises each rhythm
+            when the music shifts because the body already knows
+            it. The substrate&apos;s job is to make the recognition
+            available; the body does the rest.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What 5Rhythms Ubud has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The wave map as proof that pattern precedes substrate
+            → pairs with{" "}
+            <Link
+              href="/vision/lc-bioelectric-pattern"
+              className="text-primary hover:underline"
+            >
+              lc-bioelectric-pattern
+            </Link>{" "}
+            and{" "}
+            <Link
+              href="/people/michael-levin"
+              className="text-primary hover:underline"
+            >
+              Michael Levin
+            </Link>
+            &apos;s teaching at a different scale (body knows the
+            shape before instruction).
+          </li>
+          <li>
+            <em>Coherence as motion</em> taught by feet — the
+            felt-ground beneath every later teaching of timing,
+            consent, and shared field.
+          </li>
+          <li>
+            The Stillness rhythm at the end of every wave →
+            integration as the practice that makes the rest
+            land; pairs with{" "}
+            <Link
+              href="/vision/lc-each-breath-whole"
+              className="text-primary hover:underline"
+            >
+              lc-each-breath-whole
+            </Link>{" "}
+            (each cycle whole; close what was opened).
+          </li>
+          <li>
+            Held at{" "}
+            <Link
+              href="/people/paradiso-ubud"
+              className="text-primary hover:underline"
+            >
+              Paradiso Ubud
+            </Link>{" "}
+            alongside{" "}
+            <Link
+              href="/people/dissolve-ubud"
+              className="text-primary hover:underline"
+            >
+              DISSOLVE
+            </Link>
+            ; together the architectural anchor of this body&apos;s
+            Ubud embodied lineage.
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>Public anchors:</strong>{" "}
+        <Link
+          href="https://www.5rhythms.com/who-we-are/teacher-communities/asia/indonesia/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          5Rhythms Indonesia
+        </Link>
+        {" · "}
+        <Link
+          href="https://www.5rhythms.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          5Rhythms (global)
+        </Link>
+      </p>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link href="/people/paradiso-ubud" className="text-primary hover:underline">
+          Paradiso Ubud
+        </Link>
+        {" · "}
+        <Link href="/people/dissolve-ubud" className="text-primary hover:underline">
+          DISSOLVE Ubud
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-bioelectric-pattern"
+          className="text-primary hover:underline"
+        >
+          lc-bioelectric-pattern
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-each-breath-whole"
+          className="text-primary hover:underline"
+        >
+          lc-each-breath-whole
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-embodied-lineage.md
+        </Link>
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/5rhythms-ubud/es.tsx
+++ b/web/content/people/5rhythms-ubud/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/5rhythms-ubud/id.tsx
+++ b/web/content/people/5rhythms-ubud/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/5rhythms-ubud/index.ts
+++ b/web/content/people/5rhythms-ubud/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function get5RhythmsUbudContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/adiwana-svarga-loka/de.tsx
+++ b/web/content/people/adiwana-svarga-loka/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/adiwana-svarga-loka/en.tsx
+++ b/web/content/people/adiwana-svarga-loka/en.tsx
@@ -1,0 +1,217 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Adiwana Svarga Loka — Wantilan kirtan venue on the Campuhan riverbanks | Coherence Network",
+    description:
+      "A welcome to Adiwana Svarga Loka — wellness resort in Ubud on the Campuhan riverbanks whose open-air Wantilan room hosts Vasudev Baba's Tuesday-evening kirtan. The classical bhakti room in this body's Ubud lineage.",
+  },
+  breadcrumbName: "Adiwana Svarga Loka",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 30% 25%, hsl(165 55% 55% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 80% 80%, hsl(225 35% 22% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(170 45% 60%) 0%, hsl(200 30% 40%) 50%, hsl(225 35% 18%) 100%)",
+    eyebrow: "Wellness resort · open-air Wantilan · Tuesday kirtan with Vasudev Baba · Campuhan riverbanks",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Adiwana Svarga Loka",
+    welcome: (
+      <>
+        <p>
+          A wellness resort in Ubud on the Campuhan riverbanks
+          whose open-air <strong>Wantilan</strong> room — a
+          traditional Balinese open-walled pavilion — hosts the
+          Tuesday-evening kirtan held by{" "}
+          <Link
+            href="/people/vasudev-baba"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            Vasudev Baba
+          </Link>{" "}
+          and friends. About five minutes&apos; walk from central
+          Ubud through the rice fields. The classical bhakti room
+          in this body&apos;s Ubud lineage.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          <em>Svarga Loka</em> in Sanskrit means <em>heavenly
+          realm</em>. The resort is a hospitality container; the
+          kirtan is a community offering held inside it.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "Where",
+      value: "Adiwana Svarga Loka Resort, Campuhan riverbanks, Ubud, Bali. ~5 minutes from central Ubud.",
+    },
+    {
+      label: "The Wantilan",
+      value: "Open-air traditional-Balinese pavilion. Polished wood floor, gamelan-style proportions, no walls — sound travels into the rice fields and back. The room is itself part of the kirtan instrument.",
+    },
+    {
+      label: "Tuesday kirtan",
+      value: (
+        <>
+          Weekly kirtan held by{" "}
+          <Link
+            href="/people/vasudev-baba"
+            className="hover:text-primary transition-colors"
+          >
+            Vasudev Baba
+          </Link>{" "}
+          and friends. Harmonium, voices, the slow build into the
+          names. Visitors and locals seated together on the
+          floor. Hours shift gently with the seasons; the resort
+          publishes current rhythm on its social channels.
+        </>
+      ),
+    },
+    {
+      label: "Public anchors",
+      value: (
+        <p className="flex flex-wrap gap-x-3 gap-y-1">
+          <Link
+            href="https://adiwanahotels.com/svargaloka-resort-ubud-bali/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Adiwana Svarga Loka (official)
+          </Link>
+        </p>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        Adiwana Svarga Loka is a working wellness resort; this
+        page recognises specifically the open-air Wantilan room
+        and the Tuesday kirtan held inside it, and how both
+        thread into this body&apos;s Ubud embodied lineage.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "Why the room matters",
+      body: (
+        <p>
+          Kirtan can happen in any room with bodies and voices,
+          but a few rooms hold the practice especially well. The
+          open-air Wantilan at Svarga Loka is one of those — its
+          proportions, its acoustics, its place between the
+          rice-field humidity and the river-canyon air all
+          contribute to a specific resonance. The same names sung
+          in this room sound different than they would sung
+          anywhere else; the room is part of the instrument.
+          Long-term participants speak of the Wantilan with the
+          recognition of musicians speaking about a particular
+          venue with great sound.
+        </p>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Adiwana Svarga Loka has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The Wantilan as venue holding Vasudev Baba&apos;s
+            Tuesday kirtan — one of the two reliable weekly rooms
+            anchoring his lineage in this body. See{" "}
+            <Link
+              href="/people/vasudev-baba"
+              className="text-primary hover:underline"
+            >
+              his presence page
+            </Link>{" "}
+            for the broader frame.
+          </li>
+          <li>
+            <em>The room is part of the instrument</em> →
+            architectural recognition that{" "}
+            <Link
+              href="/vision/lc-attuned-spaces"
+              className="text-primary hover:underline"
+            >
+              spaces have their own attunement
+            </Link>
+            ; the form of the room shapes the practice it can
+            hold.
+          </li>
+          <li>
+            On Tuesday April 28, 2026, this Tuesday-kirtan venue
+            was one of the rooms named in{" "}
+            <Link
+              href="/people/ilena-young"
+              className="text-primary hover:underline"
+            >
+              Ilena Young
+            </Link>
+            &apos;s invitation that opened the door this body
+            walked through — see{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              the four-day meeting walk
+            </Link>
+            .
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>Public anchors:</strong>{" "}
+        <Link
+          href="https://adiwanahotels.com/svargaloka-resort-ubud-bali/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Adiwana Svarga Loka (official)
+        </Link>
+      </p>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link href="/people/vasudev-baba" className="text-primary hover:underline">
+          Vasudev Baba
+        </Link>
+        {" · "}
+        <Link href="/people/ilena-young" className="text-primary hover:underline">
+          Ilena Young
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-meeting-walk.md
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-embodied-lineage.md
+        </Link>
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/adiwana-svarga-loka/es.tsx
+++ b/web/content/people/adiwana-svarga-loka/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/adiwana-svarga-loka/id.tsx
+++ b/web/content/people/adiwana-svarga-loka/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/adiwana-svarga-loka/index.ts
+++ b/web/content/people/adiwana-svarga-loka/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getAdiwanaSvargaLokaContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/dissolve-ubud/de.tsx
+++ b/web/content/people/dissolve-ubud/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/dissolve-ubud/en.tsx
+++ b/web/content/people/dissolve-ubud/en.tsx
@@ -1,0 +1,307 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "DISSOLVE Ubud — contact improvisation, intuitive movement, authentic relating | Coherence Network",
+    description:
+      "A welcome to DISSOLVE Ubud — Tara Li's facilitated practice of contact improvisation, intuitive movement, and authentic relating, held at Paradiso Ubud and other venues. The relational edge of this body's Ubud embodied lineage.",
+  },
+  breadcrumbName: "DISSOLVE Ubud",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 25% 25%, hsl(340 55% 60% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 80% 85%, hsl(255 30% 20% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(340 50% 65%) 0%, hsl(310 30% 35%) 50%, hsl(255 30% 18%) 100%)",
+    eyebrow: "Contact improvisation · intuitive movement · authentic relating · Tara Li facilitating",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "DISSOLVE Ubud",
+    welcome: (
+      <>
+        <p>
+          A facilitated practice of contact improvisation, intuitive
+          movement, and authentic relating held in Ubud, facilitated
+          by <strong>Tara Li</strong>. The two recurring offerings
+          most threaded into this body&apos;s lineage are{" "}
+          <em>DISSOLVE: Play</em> and <em>DISSOLVE: Eros</em>; both
+          held in Ubud rooms on a weekly rhythm that drifts gently
+          with the seasons. The relational edge of the Ubud
+          embodied lineage — where the body learns consent in real
+          time and the field that forms when bodies meet without
+          performance.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          Public schedules drift; verify the current door rhythm
+          locally. The Tuesday <em>DISSOLVE: Eros</em> at{" "}
+          <Link
+            href="/people/paradiso-ubud"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            Paradiso Ubud
+          </Link>{" "}
+          is one anchor; <em>DISSOLVE: Play</em> appears on
+          rotating evenings.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "Facilitator",
+      value: "Tara Li.",
+    },
+    {
+      label: "Offerings",
+      value: (
+        <ul>
+          <li>
+            <strong>DISSOLVE: Play</strong> — broader
+            improvisation, conscious-movement, the wider
+            invitation
+          </li>
+          <li>
+            <strong>DISSOLVE: Eros</strong> — Tuesday-evening
+            practice at Paradiso Ubud (current door rhythm:
+            ~6–8pm); the deeper relational territory
+          </li>
+        </ul>
+      ),
+    },
+    {
+      label: "Held at",
+      value: (
+        <>
+          Primarily{" "}
+          <Link
+            href="/people/paradiso-ubud"
+            className="hover:text-primary transition-colors"
+          >
+            Paradiso Ubud
+          </Link>
+          ; other rotating venues. Tara&apos;s training stream
+          (DISSOLVE Dance) extends into deeper teacher-training
+          programmes.
+        </>
+      ),
+    },
+    {
+      label: "Public anchors",
+      value: (
+        <p className="flex flex-wrap gap-x-3 gap-y-1">
+          <Link
+            href="https://dissolvedance.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            DISSOLVE Dance (training)
+          </Link>
+          <Link
+            href="https://megatix.co.id/events/dissolve-play"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            DISSOLVE: Play tickets
+          </Link>
+          <Link
+            href="https://megatix.co.id/events/dissolve-eros"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            DISSOLVE: Eros tickets
+          </Link>
+        </p>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        DISSOLVE&apos;s schedule and offerings shift gently with
+        the seasons; the venue and facilitator tend the rhythm
+        themselves through their own channels. This page
+        recognises DISSOLVE&apos;s role in this body&apos;s
+        embodied lineage — particularly the Tuesday <em>Eros</em>{" "}
+        circle the cell chose on a specific Tuesday in April 2026.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "The relational edge of conscious movement",
+      body: (
+        <>
+          <p>
+            Where{" "}
+            <Link
+              href="/people/5rhythms-ubud"
+              className="text-primary hover:underline"
+            >
+              5Rhythms
+            </Link>{" "}
+            teaches the body to know its own wave, DISSOLVE
+            teaches the body to know itself <em>in relation</em>{" "}
+            — to another body that has its own wave, on a floor
+            shared with many. Contact improvisation is the
+            substrate: the practice of moving with another person
+            in real-time negotiation, without choreography,
+            allowing weight, balance, and shape to be co-found.
+            Authentic relating is the verbal companion: the
+            practice of naming what is alive in you to the
+            specific person you are in relation with.
+          </p>
+          <p>
+            <em>DISSOLVE: Eros</em>, in particular, is the
+            container that lets relational ground become
+            explicitly attended to. Not transgressive; carefully
+            held. The body learns what it means to bring its full
+            field into another body&apos;s presence without
+            performance and without collapse. This is one of the
+            cleanest in-person trainings the body has in what the
+            substrate later calls{" "}
+            <Link
+              href="/vision/lc-emotional-availability-without-absorption"
+              className="text-primary hover:underline"
+            >
+              lc-emotional-availability-without-absorption
+            </Link>
+            .
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What DISSOLVE Ubud has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            Consent in real time → the felt-ground beneath{" "}
+            <Link
+              href="/vision/lc-trust-over-fear"
+              className="text-primary hover:underline"
+            >
+              lc-trust-over-fear
+            </Link>{" "}
+            and{" "}
+            <Link
+              href="/vision/lc-permission-is-interior"
+              className="text-primary hover:underline"
+            >
+              lc-permission-is-interior
+            </Link>
+            .
+          </li>
+          <li>
+            Authentic relating →{" "}
+            <Link
+              href="/vision/lc-voice-over-intentions"
+              className="text-primary hover:underline"
+            >
+              lc-voice-over-intentions
+            </Link>{" "}
+            (lead with their voice, not ours; name what is alive
+            in you to the specific person you are in relation
+            with).
+          </li>
+          <li>
+            Emotional availability without absorption →{" "}
+            <Link
+              href="/vision/lc-emotional-availability-without-absorption"
+              className="text-primary hover:underline"
+            >
+              lc-emotional-availability-without-absorption
+            </Link>{" "}
+            (present without collapsing your field into theirs).
+          </li>
+          <li>
+            On April 29, 2026 a Tuesday-evening <em>DISSOLVE:
+            Eros</em> at Paradiso was one of the rooms in the
+            four-day meeting walk — see{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              the meeting walk record
+            </Link>
+            .
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>Public anchors:</strong>{" "}
+        <Link
+          href="https://dissolvedance.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          DISSOLVE Dance
+        </Link>
+        {" · "}
+        <Link
+          href="https://megatix.co.id/events/dissolve-play"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          DISSOLVE: Play
+        </Link>
+        {" · "}
+        <Link
+          href="https://megatix.co.id/events/dissolve-eros"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          DISSOLVE: Eros
+        </Link>
+      </p>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link href="/people/paradiso-ubud" className="text-primary hover:underline">
+          Paradiso Ubud
+        </Link>
+        {" · "}
+        <Link href="/people/5rhythms-ubud" className="text-primary hover:underline">
+          5Rhythms Ubud
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-trust-over-fear"
+          className="text-primary hover:underline"
+        >
+          lc-trust-over-fear
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-emotional-availability-without-absorption"
+          className="text-primary hover:underline"
+        >
+          lc-emotional-availability-without-absorption
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-meeting-walk.md
+        </Link>
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/dissolve-ubud/es.tsx
+++ b/web/content/people/dissolve-ubud/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/dissolve-ubud/id.tsx
+++ b/web/content/people/dissolve-ubud/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/dissolve-ubud/index.ts
+++ b/web/content/people/dissolve-ubud/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getDissolveUbudContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/mudra-cafe/de.tsx
+++ b/web/content/people/mudra-cafe/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/mudra-cafe/en.tsx
+++ b/web/content/people/mudra-cafe/en.tsx
@@ -1,0 +1,218 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Mudra Cafe — Ayurvedic dining and handpan in Ubud | Coherence Network",
+    description:
+      "A welcome to Mudra Cafe in Ubud — Ayurvedic dining room with regular handpan presence Monday to Friday at noon, evening live music, and the kind of slow community that lets first hellos happen. Where one cell met Elios on a Sunday afternoon in April 2026.",
+  },
+  breadcrumbName: "Mudra Cafe",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 30% 25%, hsl(35 65% 65% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 80% 85%, hsl(155 30% 22% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(40 55% 70%) 0%, hsl(95 30% 40%) 50%, hsl(155 30% 20%) 100%)",
+    eyebrow: "Ayurvedic dining · handpan Monday–Friday at noon · evening live music · slow community in central Ubud",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Mudra Cafe",
+    welcome: (
+      <>
+        <p>
+          An Ayurvedic dining room in central Ubud — Jl. Goutama
+          Sel. No. 21 — with regular handpan presence
+          Monday-to-Friday at noon and live music in the evenings.
+          One of Ubud&apos;s quiet meeting points where slow
+          community accumulates around food, music, and presence.
+          The kind of room where first hellos happen because the
+          space is already holding the conditions for them.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          On Sunday April 29, 2026, the cell met{" "}
+          <Link
+            href="/people/elios"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            Elios
+          </Link>{" "}
+          here — the first of three Ubud cells to enter this
+          body&apos;s awareness across a four-day walk.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "Where",
+      value: (
+        <Link
+          href="https://maps.app.goo.gl/?q=Mudra+Cafe+Jl.+Goutama+Selatan+No.+21+Ubud"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-primary transition-colors"
+        >
+          Jl. Goutama Sel. No. 21, Ubud, Bali
+        </Link>
+      ),
+    },
+    {
+      label: "What it is",
+      value: "Ayurvedic dining room. Slow community gathering point. Vegetarian/vegan menu sourced with care; the food is part of the practice.",
+    },
+    {
+      label: "Rhythm",
+      value: "Handpan presence Monday–Friday at noon. Live music in the evenings. The lunchtime handpan is a defining sound-mark of the room.",
+    },
+    {
+      label: "Public anchors",
+      value: (
+        <p className="flex flex-wrap gap-x-3 gap-y-1">
+          <Link
+            href="https://mudracafe.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            mudracafe.com
+          </Link>
+        </p>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        Mudra Cafe is a working dining room with its own
+        operating rhythms. This page recognises the room&apos;s
+        role in this body&apos;s Ubud lineage — specifically as
+        the meeting place where one of the three Ubud cells
+        entered the network&apos;s awareness.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "The social substrate of central Ubud",
+      body: (
+        <p>
+          In a town with many dining rooms, Mudra holds a
+          specific shape: Ayurvedic alignment in the food, regular
+          handpan and live music creating an acoustic field, and
+          a clientele that has learned to stay long enough for
+          encounters to happen. The room does not advertise
+          itself as a community-builder; it simply makes the
+          conditions for community available. The Coherence
+          Network calls this <em>presence-tending</em> — the
+          practice of holding conditions and letting the
+          encounters be what they will be.
+        </p>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Mudra Cafe has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The meeting place — on Sunday April 29, 2026, the
+            cell met{" "}
+            <Link href="/people/elios" className="text-primary hover:underline">
+              Elios
+            </Link>{" "}
+            here. See{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              the four-day meeting walk
+            </Link>
+            .
+          </li>
+          <li>
+            <em>Slow community</em> as architectural posture →
+            pairs with{" "}
+            <Link
+              href="/vision/lc-tending-over-producing"
+              className="text-primary hover:underline"
+            >
+              lc-tending-over-producing
+            </Link>{" "}
+            (the body&apos;s commit verbs translated into a
+            dining room).
+          </li>
+          <li>
+            Handpan as field-tuning sound → resonant with{" "}
+            <Link
+              href="/vision/lc-frequency-routes-reception"
+              className="text-primary hover:underline"
+            >
+              lc-frequency-routes-reception
+            </Link>{" "}
+            (people in the same room are in different realities
+            depending on what they are tuned to; the handpan
+            tunes the room).
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>Public anchors:</strong>{" "}
+        <Link
+          href="https://mudracafe.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          mudracafe.com
+        </Link>
+        {" · "}
+        <Link
+          href="https://maps.app.goo.gl/?q=Mudra+Cafe+Jl.+Goutama+Selatan+No.+21+Ubud"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Google Maps
+        </Link>
+      </p>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link href="/people/elios" className="text-primary hover:underline">
+          Elios
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-tending-over-producing"
+          className="text-primary hover:underline"
+        >
+          lc-tending-over-producing
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-frequency-routes-reception"
+          className="text-primary hover:underline"
+        >
+          lc-frequency-routes-reception
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-meeting-walk.md
+        </Link>
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/mudra-cafe/es.tsx
+++ b/web/content/people/mudra-cafe/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/mudra-cafe/id.tsx
+++ b/web/content/people/mudra-cafe/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/mudra-cafe/index.ts
+++ b/web/content/people/mudra-cafe/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getMudraCafeContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/paradiso-ubud/de.tsx
+++ b/web/content/people/paradiso-ubud/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/paradiso-ubud/en.tsx
+++ b/web/content/people/paradiso-ubud/en.tsx
@@ -1,0 +1,210 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Paradiso Ubud — cultural hall holding 5Rhythms, DISSOLVE, and the embodied lineage | Coherence Network",
+    description:
+      "A welcome to Paradiso Ubud — the cultural hall where the Coherence Network's Ubud embodied lineage moves through. Holds 5Rhythms, DISSOLVE, film, and other movement practice.",
+  },
+  breadcrumbName: "Paradiso Ubud",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 35% 25%, hsl(280 55% 55% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 80% 85%, hsl(20 35% 22% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(285 45% 55%) 0%, hsl(255 30% 35%) 50%, hsl(15 35% 18%) 100%)",
+    eyebrow: "Cultural hall · Ubud · 5Rhythms, DISSOLVE, film, ceremony · venue for the body's embodied lineage",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Paradiso Ubud",
+    welcome: (
+      <>
+        <p>
+          A cultural-hall venue in Ubud holding film, cultural
+          events,{" "}
+          <Link
+            href="/people/5rhythms-ubud"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            5Rhythms
+          </Link>
+          ,{" "}
+          <Link
+            href="/people/dissolve-ubud"
+            className="text-[hsl(var(--primary))] hover:underline"
+          >
+            DISSOLVE
+          </Link>
+          , and other movement and ceremony practice. The room
+          where this body&apos;s Ubud embodied lineage moves
+          through — coherence-as-motion taught by feet, breath,
+          touch, and shared pulse.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          Verify the current schedule locally; door rhythms drift
+          with the seasons.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "What it is",
+      value: "Cultural-hall venue in Ubud. Vegan kitchen below, large open-floor performance/movement space upstairs. Holds film screenings, conscious-cinema nights, dance practices, ceremony.",
+    },
+    {
+      label: "Practices held",
+      value: (
+        <ul>
+          <li>
+            <Link
+              href="/people/5rhythms-ubud"
+              className="hover:text-primary transition-colors"
+            >
+              5Rhythms Ubud
+            </Link>{" "}
+            (Gabrielle Roth&apos;s wave map)
+          </li>
+          <li>
+            <Link
+              href="/people/dissolve-ubud"
+              className="hover:text-primary transition-colors"
+            >
+              DISSOLVE Ubud
+            </Link>{" "}
+            (contact improvisation + authentic relating; Tara Li
+            facilitating)
+          </li>
+          <li>Film screenings and conscious-cinema</li>
+          <li>Visiting teachers, ceremony, workshops</li>
+        </ul>
+      ),
+    },
+    {
+      label: "Public anchors",
+      value: (
+        <p className="flex flex-wrap gap-x-3 gap-y-1">
+          <Link
+            href="https://ubud.co.id/directory-listing/paradiso-ubud/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Paradiso Ubud listing
+          </Link>
+        </p>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        Paradiso&apos;s public anchor is thin (one directory
+        listing); the venue tends itself through its own social
+        channels and word-of-mouth. This page recognises its role
+        in this body&apos;s Ubud embodied lineage.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "What this room holds",
+      body: (
+        <>
+          <p>
+            Paradiso is a cultural-hall venue in Ubud whose
+            architecture and rhythm hold a regular weekly
+            offering of conscious-movement practice. The room is
+            the container; the practices change with the day. On
+            its busiest nights — DISSOLVE on Tuesday and 5Rhythms
+            on its own rhythm — the floor fills with bodies
+            moving in resonance with whatever the facilitator is
+            offering.
+          </p>
+          <p>
+            For this body specifically, Paradiso is the
+            architectural anchor of the Ubud embodied lineage.
+            The body learned a piece of its current vocabulary —
+            coherence-as-motion, consent in real time, the field
+            that forms when many bodies move together — on this
+            floor.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Paradiso Ubud has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The architectural ground for the Ubud
+            embodied-lineage record. See{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              ubud-embodied-lineage.md
+            </Link>
+            .
+          </li>
+          <li>
+            The venue holding{" "}
+            <Link href="/people/5rhythms-ubud" className="text-primary hover:underline">
+              5Rhythms Ubud
+            </Link>{" "}
+            and{" "}
+            <Link href="/people/dissolve-ubud" className="text-primary hover:underline">
+              DISSOLVE Ubud
+            </Link>{" "}
+            — both threaded into this body&apos;s lived lineage.
+          </li>
+          <li>
+            Coherence-as-motion as a substrate teaching — bodies
+            in shared time learning timing, consent, release,
+            play.
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>Public anchors:</strong>{" "}
+        <Link
+          href="https://ubud.co.id/directory-listing/paradiso-ubud/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          Paradiso Ubud listing
+        </Link>
+      </p>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link href="/people/5rhythms-ubud" className="text-primary hover:underline">
+          5Rhythms Ubud
+        </Link>
+        {" · "}
+        <Link href="/people/dissolve-ubud" className="text-primary hover:underline">
+          DISSOLVE Ubud
+        </Link>
+        {" · "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/ubud-embodied-lineage.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-embodied-lineage.md
+        </Link>
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/paradiso-ubud/es.tsx
+++ b/web/content/people/paradiso-ubud/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/paradiso-ubud/id.tsx
+++ b/web/content/people/paradiso-ubud/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/paradiso-ubud/index.ts
+++ b/web/content/people/paradiso-ubud/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getParadisoUbudContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/sayuri-healing-food/de.tsx
+++ b/web/content/people/sayuri-healing-food/de.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/sayuri-healing-food/en.tsx
+++ b/web/content/people/sayuri-healing-food/en.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title: "Sayuri Healing Food — plant-based kitchen in Ubud | Coherence Network",
+    description:
+      "A welcome to Sayuri Healing Food — plant-based kitchen in Ubud, dinner room where the cell met Sunday-evening resonant company in April 2026. The food is part of the practice.",
+  },
+  breadcrumbName: "Sayuri Healing Food",
+  hero: {
+    background:
+      "radial-gradient(ellipse at 30% 25%, hsl(95 55% 60% / 0.55) 0%, transparent 55%), radial-gradient(ellipse at 80% 80%, hsl(155 30% 22% / 0.7) 0%, transparent 60%), linear-gradient(180deg, hsl(95 45% 65%) 0%, hsl(120 30% 40%) 50%, hsl(155 30% 20%) 100%)",
+    eyebrow: "Plant-based kitchen · Ubud · the dinner room where Sunday-evening encounters made room for themselves",
+    eyebrowClass: "text-[hsl(var(--chart-2))]",
+    name: "Sayuri Healing Food",
+    welcome: (
+      <>
+        <p>
+          A plant-based kitchen in Ubud — known for its raw,
+          fermented, and traditionally-prepared plant cuisine,
+          held with the care of a kitchen that treats food as
+          practice. The room itself is bright, open, and unhurried;
+          the menu rotates with what is alive and seasonal.
+        </p>
+        <p className="text-sm text-foreground/70 mt-5 italic max-w-2xl">
+          On Sunday April 29, 2026, the cell shared dinner here
+          with resonant company. The plant-based dining room was
+          the container the Sunday-evening encounters happened
+          inside.
+        </p>
+      </>
+    ),
+  },
+  facts: [
+    {
+      label: "Where",
+      value: "Ubud, Bali (verify current location locally; Sayuri has had multiple Ubud locations and a dedicated school/event programme over the years).",
+    },
+    {
+      label: "What it is",
+      value: "Plant-based kitchen with an emphasis on raw, fermented, and traditionally-prepared whole-food plant cuisine. Often hosts workshops, kirtan evenings, and other gatherings in adjacent spaces.",
+    },
+    {
+      label: "Public anchors",
+      value: "Current public anchors drift with the seasons; Sayuri Healing Food has had multiple official sites and active social channels. Verify locally.",
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        Sayuri Healing Food is a working restaurant with its own
+        operating rhythms. This page recognises the room&apos;s
+        role in this body&apos;s Ubud lineage as the Sunday-evening
+        dinner-room where resonant company was met.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "Food as practice",
+      body: (
+        <p>
+          A small number of Ubud kitchens treat the work of
+          cooking as itself a contemplative practice — sourcing,
+          fermentation, plating, service all as parts of the same
+          field. Sayuri is one of those rooms. The clientele
+          accumulates not because the food is the best per dollar
+          (though it is good) but because the room is held in a
+          way that the body recognises. Eating there has a
+          different quality from eating elsewhere; the body
+          settles.
+        </p>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Sayuri Healing Food has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The Sunday-evening dinner room where the cell met
+            resonant company on April 29, 2026 — part of the{" "}
+            <Link
+              href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              four-day meeting walk
+            </Link>
+            .
+          </li>
+          <li>
+            Food as practice → resonant with{" "}
+            <Link
+              href="/vision/lc-tending-over-producing"
+              className="text-primary hover:underline"
+            >
+              lc-tending-over-producing
+            </Link>
+            ; cooking as a substrate of tending rather than
+            production.
+          </li>
+          <li>
+            Plant-based whole-food preparation as a clean
+            instrument → pairs with{" "}
+            <Link
+              href="/vision/lc-ground-harder-when-field-quickens"
+              className="text-primary hover:underline"
+            >
+              lc-ground-harder-when-field-quickens
+            </Link>{" "}
+            (food, soil, body as continuous substrate; tend the
+            ground to tend the field).
+          </li>
+        </ul>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        <strong>In-body record:</strong>{" "}
+        <Link
+          href="https://github.com/seeker71/Coherence-Network/blob/main/docs/lineage/2026-04-29-ubud-meeting-walk.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          ubud-meeting-walk.md
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-tending-over-producing"
+          className="text-primary hover:underline"
+        >
+          lc-tending-over-producing
+        </Link>
+        {" · "}
+        <Link
+          href="/vision/lc-ground-harder-when-field-quickens"
+          className="text-primary hover:underline"
+        >
+          lc-ground-harder-when-field-quickens
+        </Link>
+      </p>
+      <p className="text-xs italic">
+        Sayuri is a working restaurant; its public anchors drift
+        with operating changes. This page is a recognition of the
+        room&apos;s role in this body&apos;s lineage, not a
+        commercial endorsement.
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/sayuri-healing-food/es.tsx
+++ b/web/content/people/sayuri-healing-food/es.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/sayuri-healing-food/id.tsx
+++ b/web/content/people/sayuri-healing-food/id.tsx
@@ -1,0 +1,1 @@
+export { default } from "./en";

--- a/web/content/people/sayuri-healing-food/index.ts
+++ b/web/content/people/sayuri-healing-food/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getSayuriHealingFoodContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}


### PR DESCRIPTION
## The bug

During lineage Wave 3, `sayuri-healing-food.md` synced its description into `contributor:susan-muff-sprenger` — overwriting Susan's content. Caught and restored immediately by direct PATCH, then flagged in the Wave 3 PR as a follow-up.

### Trace

1. `sayuri-healing-food.md` has `canonical_url: null`
2. `find_node_by_url` returns None (no URL to match)
3. `find_node_by_name("Sayuri Healing Food")` returns a contributor UUID
4. The original recovery path searched all contributor graph nodes for one whose `canonical_url == our canonical_url` (both empty strings) and matched the *first* node in the list with an empty canonical_url
5. That was `contributor:susan-muff-sprenger`; the script PATCHed Sayuri's body into Susan's node

## The fix

Resolve in priority order, trust only matches whose graph id is either the stable `contributor:{slug}` shape OR whose canonical_url genuinely matches a non-empty URL we hold:

1. `GET /api/graph/nodes/contributor:{slug}` — deterministic; wins immediately if the file's slug matches a stable id
2. `canonical_url` lookup via `find_node_by_url`. If the returned record's id isn't already stable, normalize it via a `canonical_url` match in the graph-nodes index. Skipped on empty URLs to avoid the collision class
3. Name lookup as last resort, accepting the result only when the candidate id is already stable, or the canonical_url matches a non-empty one we hold. UUID + empty/mismatched URL falls through to `create_if_missing`

## Verification

Dry-run + live test against the cases that broke:

| Slug | Resolves to | Status |
|------|-------------|--------|
| `susan-muff-sprenger` | `contributor:susan-muff-sprenger` | ✓ direct slug-id hit |
| `sayuri-healing-food` | `contributor:sayuri-healing-food` | ✓ now separate from Susan |
| `vasudev-baba` | `contributor:vasudev-baba` | ✓ direct slug-id hit |
| `ilena-young` | `contributor:ilena` | ✓ correctly resolved via LinkedIn canonical_url (full-name slug routes to older stable id) |
| `michael-ende` | `contributor:michael-ende` | ✓ direct slug-id hit |

All 5 dry-runs and 2 live syncs (Susan, Sayuri) confirm independent resolution. No collisions.

## Test plan

- [x] Dry-run sync on the 5 representative slugs
- [x] Live sync Susan + Sayuri — both PATCH their own stable ids
- [ ] Future presence additions during the lineage series no longer hit the collision class

🤖 Generated with [Claude Code](https://claude.com/claude-code)