### PR TITLE
tend: POST /api/inspired-by/manual — link cells the resolver cannot find

### DIFF
--- a/api/app/routers/inspired_by.py
+++ b/api/app/routers/inspired_by.py
@@ -24,6 +24,31 @@ class InspiredByCreateRequest(BaseModel):
     source_contributor_id: str = Field(..., min_length=1, max_length=255)
 
 
+class InspiredByManualRequest(BaseModel):
+    """Direct link to an existing graph node — no web resolution.
+
+    Used for private/local cells the open-web resolver cannot find
+    (people whose practice is offline, communities that aren't on the
+    public web, sanctuaries that hold a frequency but not a domain).
+    The body's lineage prose may name them; this endpoint lets the
+    graph hold the relation too.
+    """
+
+    source_contributor_id: str = Field(..., min_length=1, max_length=255)
+    target_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Existing graph node id, e.g. 'contributor:ilena' or 'scene:vali-soul-sanctuary'",
+    )
+    weight: float = Field(
+        default=0.8,
+        ge=0.0,
+        le=1.0,
+        description="Strength of the inspired-by relation; 0..1",
+    )
+
+
 @router.post(
     "/inspired-by",
     status_code=201,
@@ -44,6 +69,37 @@ async def create_inspired_by(body: InspiredByCreateRequest) -> dict[str, Any]:
             ),
         )
     return service.import_inspired_by(body.source_contributor_id, resolved)
+
+
+@router.post(
+    "/inspired-by/manual",
+    status_code=201,
+    summary="Link two existing nodes with an inspired-by edge (no resolver)",
+)
+async def create_inspired_by_manual(body: InspiredByManualRequest) -> dict[str, Any]:
+    """Create (or refresh) an inspired-by edge between two existing
+    graph nodes. The resolver-based POST /inspired-by handles open-web
+    cells; this endpoint handles cells the body already knows
+    locally — Ubud sanctuary teachers, private circles, communities
+    whose substance the web has no page for.
+
+    The source contributor and target node must both exist; this is a
+    relation step, not a creation step. Returns the edge as stored.
+    """
+    edge = service.import_inspired_by_manual(
+        source_contributor_id=body.source_contributor_id,
+        target_id=body.target_id,
+        weight=body.weight,
+    )
+    if edge is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Source contributor or target node not found in the graph. "
+                "Use POST /api/inspired-by for cells that don't exist yet."
+            ),
+        )
+    return edge
 
 
 @router.get(

--- a/api/app/services/inspired_by_service.py
+++ b/api/app/services/inspired_by_service.py
@@ -1425,3 +1425,40 @@ def remove_inspired_by_edge(edge_id: str) -> bool:
     """Drop the inspired-by edge. The identity node stays — it's still
     claimable and still linked to its creations."""
     return graph_service.delete_edge(edge_id)
+
+
+def import_inspired_by_manual(
+    *,
+    source_contributor_id: str,
+    target_id: str,
+    weight: float = 0.8,
+) -> dict[str, Any] | None:
+    """Create an inspired-by edge between two existing graph nodes.
+
+    Mirrors ``import_inspired_by`` but skips the open-web resolution
+    step. Both nodes must already exist; this is a relation gesture,
+    not a creation gesture. Idempotent — calling twice with the same
+    pair refreshes the weight rather than creating a duplicate edge
+    (the underlying ``graph_service.create_edge`` upserts on the
+    (from, to, type) unique constraint).
+
+    Returns the edge as stored, or None when either node is missing.
+    """
+    source_id = _normalize_contributor_id(source_contributor_id)
+    source_node = graph_service.get_node(source_id)
+    if not source_node:
+        return None
+    target_node = graph_service.get_node(target_id)
+    if not target_node:
+        return None
+    # Clamp weight to [0, 1] as a defensive measure even though the
+    # router already validates.
+    w = max(0.0, min(1.0, float(weight)))
+    return graph_service.create_edge(
+        from_id=source_id,
+        to_id=target_node["id"],
+        type="inspired-by",
+        properties={"manual": True},
+        strength=w,
+        created_by="manual:inspired-by",
+    )

--- a/scripts/connect_ubud_cluster_inspired_by.py
+++ b/scripts/connect_ubud_cluster_inspired_by.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Connect Urs's contributor node to the Ubud cluster via inspired-by edges.
+
+The body's named lineage (web/lib/named-lineage.ts) holds Ilena,
+Vasudev Baba, Elios, Aly Constantine, and Steve Bjorg as cells in
+active or foundational relation with the founder. Each has a
+contributor graph node, but no inspired-by edge from `contributor:urs`
+or `contributor:seeker71`. The /me 'Inspired by' rail therefore
+ranks them silently — they never surface.
+
+This script creates the missing edges idempotently. Runs against the
+live API; re-running refreshes the weight rather than duplicating.
+
+Weights reflect the body's felt-ground, not algorithmic ranking:
+the Sunday-Wednesday Ubud rhythm is load-bearing for the present
+cell, so those cells sit at 0.80-0.85 — equal to the heaviest
+Audible/YouTube cells (Karl May 0.953, Terry Mancour 0.927).
+
+Usage:
+    python3 scripts/connect_ubud_cluster_inspired_by.py
+    python3 scripts/connect_ubud_cluster_inspired_by.py --api https://api.coherencycoin.com
+    python3 scripts/connect_ubud_cluster_inspired_by.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+DEFAULT_API = "https://api.coherencycoin.com"
+SOURCE_CONTRIBUTOR = "contributor:seeker71"
+
+# Cell, target_id in graph, weight
+# Weights chosen to match the felt-ground of the present rhythm:
+#   Ubud cluster (current sustained presence)  → 0.85
+#   Aly Constantine (close Boulder relation)   → 0.80
+#   Steve Bjorg (foundation collaborator)      → 0.75
+CONNECTIONS: list[tuple[str, str, float]] = [
+    ("Ilena (Ranakami host, Sunday rhythm)", "contributor:ilena", 0.85),
+    ("Vasudev Baba (Wednesday Satsang)", "contributor:vasudev-baba", 0.85),
+    ("Elios (Sunday chanting)", "contributor:elios", 0.80),
+    ("Aly Constantine (Boulder ecstatic dance)", "contributor:aly-constantine", 0.80),
+    ("Steve G. Bjorg (foundation collaborator, BML era)", "contributor:steve-bjorg", 0.75),
+]
+
+
+def post_inspired_by_manual(
+    api: str, source: str, target: str, weight: float
+) -> tuple[bool, str]:
+    payload = json.dumps(
+        {"source_contributor_id": source, "target_id": target, "weight": weight}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{api}/api/inspired-by/manual",
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            body = r.read().decode("utf-8")
+            return True, body
+    except urllib.error.HTTPError as e:
+        try:
+            detail = e.read().decode("utf-8")
+        except Exception:
+            detail = ""
+        return False, f"HTTP {e.code}: {detail}"
+    except Exception as e:
+        return False, str(e)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--api", default=DEFAULT_API, help="API base URL")
+    ap.add_argument(
+        "--source",
+        default=SOURCE_CONTRIBUTOR,
+        help="Source contributor id (default contributor:seeker71)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be posted; do not actually create edges",
+    )
+    args = ap.parse_args()
+
+    print(f"Source: {args.source}")
+    print(f"API: {args.api}")
+    print()
+
+    ok = 0
+    failed = 0
+    for label, target, weight in CONNECTIONS:
+        prefix = "[DRY] " if args.dry_run else ""
+        print(f"{prefix}{label}")
+        print(f"  → {target}  weight={weight}")
+        if args.dry_run:
+            ok += 1
+            continue
+        success, msg = post_inspired_by_manual(args.api, args.source, target, weight)
+        if success:
+            print("  ✓ edge created/refreshed")
+            ok += 1
+        else:
+            print(f"  ✗ FAILED: {msg}")
+            failed += 1
+        print()
+
+    print(f"Done. {ok} ok, {failed} failed.")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The web-resolver path (`POST /api/inspired-by`) handles cells with public web presence. It can't help with cells whose substance is private/local: the Ubud sanctuary teachers (Ilena, Vasudev Baba, Elios), Boulder ecstatic dance hosts (Aly Constantine), foundation-era collaborators with no public profile (Steve G. Bjorg). The body's lineage prose names them; the graph holds them as contributor nodes; but no inspired-by edges connect the founder cell to them, so they never surfaced in the /me \"Inspired by\" rail even after PR #1547's lineage-boost sort.

### Adds POST /api/inspired-by/manual

- `source_contributor_id` + `target_id` + `weight` (0..1)
- Both nodes must already exist (this is a relation gesture, not a creation gesture)
- Idempotent — re-running refreshes weight via the unique (from, to, type) constraint
- Bypasses the open-web resolver; calls `graph_service.create_edge` directly with `type=\"inspired-by\"`

### Adds scripts/connect_ubud_cluster_inspired_by.py

One-shot operational script that uses the new endpoint to create the five missing inspired-by edges from `contributor:seeker71`:

| Cell | Weight | Context |
|---|---|---|
| Ilena | 0.85 | Sunday rhythm at Ranakami |
| Vasudev Baba | 0.85 | Wednesday Satsang |
| Elios | 0.80 | Sunday chanting |
| Aly Constantine | 0.80 | Boulder ecstatic dance |
| Steve G. Bjorg | 0.75 | foundation collaborator |

Weights chosen to match the felt-ground of the present rhythm. After lineage-boost in /me, these all sit above the heaviest cumulative-listening anchors (Karl May 0.953, Terry Mancour 0.927) once their +1.0 bonus kicks in.

### Run after deploy

```
python3 scripts/connect_ubud_cluster_inspired_by.py
```

## Test plan

- [ ] After deploy, run the script and confirm 5/5 ok
- [ ] Visit https://coherencycoin.com/me as the founder cell and confirm Ilena / Vasudev Baba / Elios cards appear in the \"Inspired by\" rail
- [ ] Re-run the script and confirm idempotent (no duplicate edges, weights refresh cleanly)
- [ ] Visit https://api.coherencycoin.com/api/inspired-by?contributor_id=contributor:seeker71 and verify the five new edges are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)