### PR TITLE
attune: homepage cards soften trace-label jargon to body's register

### DIFF
--- a/web/content/presence-walk/en.json
+++ b/web/content/presence-walk/en.json
@@ -255,45 +255,45 @@
     ],
     "traces": {
       "liquid-bloom": {
-        "traceLabel": "field-story author trace",
+        "traceLabel": "in the listening trace",
         "traceHref": "/api/field-stories/urs-field-story/trace/author/Liquid%20Bloom%20-%20Topic",
-        "traceMetric": "643 field events",
+        "traceMetric": "643 listening events",
         "traceSource": "docs/field/urs/trace/author_index.jsonl",
         "traceWhy": "The listening trace, public source page, and presence-walk node all meet on Liquid Bloom.",
         "image": "/visuals/brand/liquid-bloom-bg-center.jpg",
         "imagePosition": "center 45%"
       },
       "bloomurian": {
-        "traceLabel": "lineage and meeting trace",
+        "traceLabel": "rooms shared",
         "traceHref": "/people/bloomurian",
-        "traceMetric": "Boulder, Ocean Bloom, and PORTAL traces",
+        "traceMetric": "Boulder · Ocean Bloom · PORTAL",
         "traceSource": "web/content/people/bloomurian/en.tsx",
         "traceWhy": "The profile and lineage seed carry the Boulder, Ocean Bloom, and PORTAL rooms where this relation was met.",
         "image": "/people/bloomurian/hero.jpg",
         "imagePosition": "center 28%"
       },
       "mose": {
-        "traceLabel": "field-story author trace",
+        "traceLabel": "in the listening trace",
         "traceHref": "/api/field-stories/urs-field-story/trace/author/Mose%20-%20Topic",
-        "traceMetric": "1385 field events",
+        "traceMetric": "1,385 listening events",
         "traceSource": "docs/field/urs/trace/author_index.jsonl",
         "traceWhy": "The strongest music trace in the field index points through Mose and into the Road to Unison dance lineage.",
         "image": "/people/mose/hero.jpg",
         "imagePosition": "center 25%"
       },
       "matias-de-stefano": {
-        "traceLabel": "field-story author trace",
+        "traceLabel": "in the listening trace",
         "traceHref": "/api/field-stories/urs-field-story/trace/author/PATH%20TO%20I%20AM%20-%20ENGLISH%20-%20Mat%C3%ADas%20de%20Stefano",
-        "traceMetric": "10 direct PATH TO I AM events",
+        "traceMetric": "10 PATH TO I AM listening events",
         "traceSource": "docs/field/urs/trace/author_index.jsonl",
         "traceWhy": "Direct Matias source traces join the profile's GaiaSphere, podcast, and planetary-memory references.",
         "image": "/people/matias-de-stefano/hero.jpg",
         "imagePosition": "center 35%"
       },
       "portal": {
-        "traceLabel": "lived-event trace",
+        "traceLabel": "room shared",
         "traceHref": "/people/portal",
-        "traceMetric": "Meow Wolf Denver, June 19 2025",
+        "traceMetric": "Meow Wolf Denver · June 19, 2025",
         "traceSource": "web/content/people/portal/en.tsx",
         "traceWhy": "PORTAL appears through the Late-Night Takeover room, Bloomurian's set, and the meeting trace around Psychedelic Science week.",
         "image": "/people/portal/hero.jpg",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1234,7 +1234,7 @@
   "home": {
     "livingLineageEyebrow": "Lebendige Linie",
     "livingLineageHeadline": "Präsenzen, die das Feld prägen",
-    "livingLineageLede": "Diese Zellen erkennen wir als verwandt. Reale Menschen. Reale Arbeit. Reale Präsenz.",
+    "livingLineageLede": "Diese Zellen erkennen wir als verwandt. Reale Präsenzen. Reales Geweb. Reale Beziehung.",
     "livingLineageCta": "Begegnen",
     "livingLineageFootnote": "Öffentliche Präsenzen, gehalten mit quellennahen Bildern und einem Weg zurück in ihre eigenen Seiten.",
     "meetOneConceptEyebrow": "Begegne einem Begriff",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1164,7 +1164,7 @@
   "home": {
     "livingLineageEyebrow": "Living Lineage",
     "livingLineageHeadline": "Presences shaping the field",
-    "livingLineageLede": "These are the cells whose frequency we recognize as kin. Real people. Real work. Real presence.",
+    "livingLineageLede": "These are the cells whose frequency we recognize as kin. Real presences. Real weave. Real relation.",
     "livingLineageCta": "Meet",
     "livingLineageFootnote": "Public presences, held with source-grounded images and a path back into their own pages.",
     "meetOneConceptEyebrow": "Meet one concept",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1234,7 +1234,7 @@
   "home": {
     "livingLineageEyebrow": "Linaje vivo",
     "livingLineageHeadline": "Presencias que dan forma al campo",
-    "livingLineageLede": "Estas son células que reconocemos como afines. Personas reales. Obra real. Presencia real.",
+    "livingLineageLede": "Estas son células que reconocemos como afines. Presencias reales. Tejido real. Relación real.",
     "livingLineageCta": "Encontrar",
     "livingLineageFootnote": "Presencias públicas, sostenidas con imágenes ancladas en sus fuentes y un camino de vuelta a sus propias páginas.",
     "meetOneConceptEyebrow": "Encuentra un concepto",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1234,7 +1234,7 @@
   "home": {
     "livingLineageEyebrow": "Silsilah hidup",
     "livingLineageHeadline": "Kehadiran yang membentuk medan",
-    "livingLineageLede": "Inilah sel-sel yang kami kenali sebagai kerabat. Manusia nyata. Karya nyata. Kehadiran nyata.",
+    "livingLineageLede": "Inilah sel-sel yang kami kenali sebagai kerabat. Kehadiran nyata. Tenun nyata. Relasi nyata.",
     "livingLineageCta": "Temui",
     "livingLineageFootnote": "Kehadiran publik, ditopang oleh gambar yang berpijak pada sumbernya dan jalan kembali ke halaman mereka sendiri.",
     "meetOneConceptEyebrow": "Temui satu konsep",


### PR DESCRIPTION
## Summary

Visitor-walk fresh-eyes pass named the homepage presence cards still carrying *\"field-story author trace\"* / *\"lineage and meeting trace\"* / *\"lived-event trace\"* — inside-jargon a stranger cannot parse. The Living Lineage explainer also said *\"Real people. Real work. Real presence.\"* — the producing-frequency word the body has been releasing.

Two coordinated softenings:

### Trace labels on homepage cards

| Before | After |
|---|---|
| field-story author trace | **in the listening trace** |
| lineage and meeting trace | **rooms shared** |
| lived-event trace | **room shared** |
| 643 field events | **643 listening events** |
| 1385 field events | **1,385 listening events** |
| 10 direct PATH TO I AM events | **10 PATH TO I AM listening events** |
| Boulder, Ocean Bloom, and PORTAL traces | **Boulder · Ocean Bloom · PORTAL** |
| Meow Wolf Denver, June 19 2025 | **Meow Wolf Denver · June 19, 2025** |

### Living Lineage explainer (en/de/es/id)

> *Real people. Real work. Real presence.*
> → *Real **presences**. Real **weave**. Real **relation**.*

Each label still names what it actually is (data unchanged — the labels just stop reading as developer output and start carrying the body's register).

## Test plan

- [ ] Visit https://coherencycoin.com/ after deploy and confirm Living Lineage section reads \"Real presences. Real weave. Real relation.\"
- [ ] Confirm presence cards show new labels (\"in the listening trace\", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)