### PR TITLE
tend: dynamic-route /people/[id] resolver falls back to slug-field match (+ 14 wrong-URL contributor dedups)

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -185,16 +185,44 @@ async function fetchGraphNode(id: string): Promise<Record<string, unknown> | nul
     5000,
   );
   if (node) return node;
+
   // The id might be a bare slug without the "contributor:" prefix
   // (that's what /contributors/graduate returns, and what lives in
   // localStorage). Try that shape too.
   if (!id.includes(":")) {
-    return fetchJsonOrNull<Record<string, unknown>>(
+    const prefixed = await fetchJsonOrNull<Record<string, unknown>>(
       `${base}/api/graph/nodes/${encodeURIComponent(`contributor:${id}`)}`,
       {},
       5000,
     );
+    if (prefixed) return prefixed;
   }
+
+  // Last fallback: the id is `contributor:{slug}` but the graph node
+  // for that presence is stored under a non-standard stable id —
+  // commonly `contributor:{16-hex}` from older auto-create flows.
+  // Such nodes still carry the human-readable slug in their `slug`
+  // field, so search the contributor list and match on that.
+  //
+  // This closes the gap where /people/contributor:michael-levin and
+  // similar URLs returned a sparse fallback page instead of the rich
+  // description body, because Levin's stable id is
+  // contributor:3f42d44094e36ce5 not contributor:michael-levin.
+  if (id.startsWith("contributor:")) {
+    const slug = id.slice("contributor:".length);
+    if (slug && !slug.match(/^[0-9a-f]{12,}$/)) {
+      const list = await fetchJsonOrNull<{ items: Record<string, unknown>[] }>(
+        `${base}/api/graph/nodes?type=contributor&limit=500`,
+        {},
+        5000,
+      );
+      const match = list?.items?.find(
+        (n) => typeof n.slug === "string" && n.slug === slug,
+      );
+      if (match) return match;
+    }
+  }
+
   return null;
 }
 

--- a/web/content/people/jz-knight/en.tsx
+++ b/web/content/people/jz-knight/en.tsx
@@ -46,7 +46,6 @@ const content: PersonProfileContent = {
   facts: [
     {
       label: "Born",
-      ves: undefined,
       value: "16 March 1946 (Roswell, New Mexico, USA) as Judith Darlene Hampton.",
     },
     {

--- a/web/content/people/liquid-bloom/en.tsx
+++ b/web/content/people/liquid-bloom/en.tsx
@@ -394,6 +394,63 @@ const content: PersonProfileContent = {
         </>
       ),
     },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Liquid Bloom has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            <em>Sound as prayer, medicine, celebration</em> →
+            anchor for{" "}
+            <Link
+              href="/vision/lc-frequency-routes-reception"
+              className="text-primary hover:underline"
+            >
+              lc-frequency-routes-reception
+            </Link>{" "}
+            (build at the actual tone; trust the routing).
+          </li>
+          <li>
+            The doorway pattern — bodies meeting Amani at Vali
+            Soul Sanctuary (Costa Rica) before meeting the music.
+            Embodied first, audio second. See{" "}
+            <Link href="/people/vali-soul-sanctuary" className="text-primary hover:underline">
+              Vali Soul Sanctuary
+            </Link>
+            .
+          </li>
+          <li>
+            Multi-room presence in this body&apos;s graph:{" "}
+            <Link href="/people/rhythm-sanctuary" className="text-primary hover:underline">
+              Rhythm Sanctuary
+            </Link>{" "}
+            (Jan 2020 set, still listened to),{" "}
+            <Link href="/people/ocean-bloom-2024" className="text-primary hover:underline">
+              Ocean Bloom 2024
+            </Link>{" "}
+            (Downtown Boulder configuration),{" "}
+            <Link href="/people/portal" className="text-primary hover:underline">
+              PORTAL
+            </Link>{" "}
+            (Meow Wolf Denver during MAPS).
+          </li>
+          <li>
+            The Desert Dwellers / Desert Trax label home as a
+            substrate of conscious-music continuity — resonant
+            with{" "}
+            <Link
+              href="/vision/lc-tending-over-producing"
+              className="text-primary hover:underline"
+            >
+              lc-tending-over-producing
+            </Link>
+            .
+          </li>
+        </ul>
+      ),
+    },
   ],
   footer: (
     <>

--- a/web/content/people/mose/en.tsx
+++ b/web/content/people/mose/en.tsx
@@ -570,6 +570,56 @@ const content: PersonProfileContent = {
         </p>
       ),
     },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Mose has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The Lake Atitlán node of the conscious-music
+            festival circuit — geographical anchor outside the
+            US/Bali poles that most of this body&apos;s music
+            lineage moves through.
+          </li>
+          <li>
+            <em>SunSet Cacao Dances</em> as room-format → the
+            same Gabrielle-Roth-wave substrate (
+            <Link href="/people/gabrielle-roth" className="text-primary hover:underline">
+              Gabrielle Roth
+            </Link>
+            ,{" "}
+            <Link href="/people/5rhythms-ubud" className="text-primary hover:underline">
+              5Rhythms Ubud
+            </Link>
+            ,{" "}
+            <Link href="/people/boulder-ecstatic-dance" className="text-primary hover:underline">
+              Boulder Ecstatic Dance
+            </Link>
+            ) carried into the Guatemalan lakeside register.
+          </li>
+          <li>
+            Nomadic-musician posture as embodied{" "}
+            <Link
+              href="/vision/lc-tending-over-producing"
+              className="text-primary hover:underline"
+            >
+              lc-tending-over-producing
+            </Link>{" "}
+            — tend the route, the field collects.
+          </li>
+          <li>
+            Resueño label home as substrate of slow-built
+            community around the music; resonant with{" "}
+            <Link href="/people/liquid-bloom" className="text-primary hover:underline">
+              Liquid Bloom
+            </Link>
+            &apos;s Desert Trax shape (label as collective tend).
+          </li>
+        </ul>
+      ),
+    },
   ],
   footer: (
     <>

--- a/web/content/people/robert-edward-grant/en.tsx
+++ b/web/content/people/robert-edward-grant/en.tsx
@@ -391,6 +391,61 @@ const content: PersonProfileContent = {
         </>
       ),
     },
+    {
+      kind: "panel",
+      variant: "warm",
+      eyebrow: "Contributions to this body",
+      heading: "What Robert Edward Grant has given the Coherence Network",
+      body: (
+        <ul>
+          <li>
+            The sacred-geometry / Codex Universalis line of
+            inquiry — prime-number patterns, geometric primitives,
+            the proposal that <em>form precedes substance</em>{" "}
+            at the mathematical level. Pairs with{" "}
+            <Link
+              href="/vision/lc-bioelectric-pattern"
+              className="text-primary hover:underline"
+            >
+              lc-bioelectric-pattern
+            </Link>{" "}
+            (
+            <Link href="/people/michael-levin" className="text-primary hover:underline">
+              Levin
+            </Link>
+            ) and{" "}
+            <Link
+              href="/vision/lc-perception-as-interface"
+              className="text-primary hover:underline"
+            >
+              lc-perception-as-interface
+            </Link>{" "}
+            (
+            <Link href="/people/donald-hoffman" className="text-primary hover:underline">
+              Hoffman
+            </Link>
+            ) as one substrate-claim from three different sides:
+            pattern is load-bearing.
+          </li>
+          <li>
+            The sacred-mathematics ↔ Akashic-memory cluster with{" "}
+            <Link href="/people/matias-de-stefano" className="text-primary hover:underline">
+              Matías De Stefano
+            </Link>{" "}
+            (Robert hosted Matías on his podcast Episode 49). Both
+            in the geometry-of-consciousness / ancient-memory
+            space; both at Gaia / Boulder events.
+          </li>
+          <li>
+            The Crown Sterling controversy is part of his public
+            record; this body holds him as one teacher among many,
+            without endorsing the commercial claims of his
+            cryptography work. The substrate of the geometric
+            teaching can stand on its own.
+          </li>
+        </ul>
+      ),
+    },
   ],
   footer: (
     <>


### PR DESCRIPTION
## Two cleanups from the deep audit

### 1. Dynamic-route resolver gains slug-field fallback

The deep-audit pass flagged that `/people/contributor:michael-levin` returned 200 but rendered without the rich description body, because Levin's graph node sits at `contributor:3f42d44094e36ce5` (hash-shaped stable id), not `contributor:michael-levin`.

Six presences share the edge (Levin, Anne Tucker, Yaima, Amanda Walsh, Next Level Soul, Rhythm Sanctuary). All have correct `slug` fields on their graph nodes — just not at the {slug}-derived stable id.

`fetchGraphNode` now adds a third fallback: when `id` is `contributor:{slug}` and the direct lookup returns null, search the contributor list and match on the `slug` field. Skipped when the slug looks hash-shaped to avoid pointless scans. The canonical static routes (`/people/{slug}`) don't go through this resolver and are unaffected.

### 2. Fourteen wrong-attribution contributor nodes removed from production

Graph: 321 → 307 contributors. Auto-harvest had been seeding canonical_urls that pointed to *different people* on duplicate nodes — worse than clutter; actively misattributed.

| Deleted | Wrong URL pointed to |
|---------|----------------------|
| Gardner Dozois × 2 | Gillian Flynn, Neil Gaiman |
| J. R. R. Tolkien × 1 | Pema Chödrön |
| Jason Anspach × 1 | Nick Cole |
| Jeff Hawkins × 1 | Sandra Blakeslee |
| Lee Harris × 1 | Regina Meredith |
| Mike Dooley × 4 | Bashar, Matt & Joy, Sal Rachele, Lyssa Royal |
| Susan Trott × 1 | Rick Rubin |
| Holly Duckworth × 1 | Marshall Rosenberg |
| `contributor:ramtha-jz-knight` | small node redundant with full `contributor:ramtha` |
| `contributor:elios-the-cell` | my own orphan POST from an earlier session |

Two remaining name-duplicates (Steven Johnson, Susan Trott) carry ambiguous URLs and were not deleted; they need a separate review with a human in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)