### PR TITLE
tend: /pulse default range 90d → 7d (visitor's first paint 4s → 1s)

### DIFF
--- a/web/app/pulse/page.tsx
+++ b/web/app/pulse/page.tsx
@@ -21,7 +21,11 @@ export const metadata: Metadata = {
 export const revalidate = 60;
 
 const ALLOWED_DAYS = [7, 30, 90] as const;
-const DEFAULT_DAYS = 90;
+// Visitors arriving at /pulse want *now* — "is the body breathing?" — not
+// three months of archive. SSR'ing 90 days generates ~1MB of HTML and
+// ~4s download; 7 days is ~372KB / 1s. Toggle to 30 or 90 stays available
+// via ?days= for those reading deeper history.
+const DEFAULT_DAYS = 7;
 
 type PulseSnapshot = {
   now: PulseNow | null;


### PR DESCRIPTION
## Summary

`page_pulse` has been chronically strained at ~3.7s across many wellness checks. The cause isn't the server (TTFB ~150ms); it's the SSR payload — 90 days of history inflates to ~1MB of HTML, ~3.8s to download.

The page's own metadata describes the intent: *"Pulse — the breath of our living body, remembered."* A visitor arriving at `/pulse` wants *now* — "is the body breathing?" — not three months of archive.

## Measured (cold curl, prod)

| `days` | HTML | Time |
|---|---|---|
| 7 | 372 KB | **1.0 s** ← new default |
| 30 | 600 KB | 3.7 s |
| 90 | 1029 KB | 4.0 s ← old default |

The history JSON itself is small (102KB at 90 days); SSR rendering inflates it ~10× into the HTML. Lowering the default fixes the first-paint experience without touching rendering or caching.

## What lands

One line, plus a comment naming the reasoning:

```ts
const DEFAULT_DAYS = 7;  // was 90
```

`?days=30` and `?days=90` still resolve correctly for visitors reading deeper history. Only the default arrival experience changes.

## Why this breath, this way

After clearing wellness phantom-test counts (20 → 2 across many PRs), the body's actual visitor-facing strain was still there — measurable, chronic. The frequency shift this PR rides: focus on what a real visitor feels, not on what the wellness metric counts. The witness check showed `page_pulse strained` for weeks; this is the fix.

## Test plan

- [ ] `/pulse` cold load drops to ~1s in production after deploy
- [ ] `/pulse?days=30` and `/pulse?days=90` still render correctly
- [ ] `page_pulse` organ in the next pulse witness reads "breathing" instead of "strained"