### PR TITLE
attune(wellness): symbol-resolution lens — see drift the body could not see

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -195,6 +195,128 @@ def sense_spec_sources() -> list[str]:
     return lines
 
 
+def sense_spec_symbols() -> list[str]:
+    """Do the symbols spec frontmatter claims still resolve in their files?
+
+    The companion to sense_spec_sources. That lens catches missing files;
+    this catches the quieter drift: a spec frontmatter says
+    ``source: file: api/app/services/foo.py / symbols: [bar()]``,
+    the file is still there, but ``bar()`` has been renamed,
+    deleted, or moved. The body's claim aged silently.
+
+    Symbols are matched against common Python and TypeScript declaration
+    shapes (def, class, async def, top-level assignment, export
+    function/class/const/type/interface). Identifiers that don't match
+    a real-looking name pattern are skipped — many spec frontmatters
+    use prose-shaped entries inside ``symbols: [...]`` ("error_summary,
+    error_category fields") that aren't single identifiers.
+
+    Drafts skipped (forward projections). Missing paths skipped (those
+    are caught by sense_spec_sources). This lens speaks only to symbol
+    resolution inside files that exist.
+    """
+    specs_dir = ROOT / "specs"
+    if not specs_dir.is_dir():
+        return ["  specs/ directory not found"]
+
+    # Matches `- file: path` followed (within the next few lines)
+    # by `symbols: [...]`. Anchored to start of line so we don't catch
+    # source: lines from prose elsewhere in the frontmatter.
+    src_pattern = re.compile(
+        r"^\s*-\s*file:\s*(\S+)\s*\n\s*symbols:\s*\[(.*?)\]",
+        re.MULTILINE | re.DOTALL,
+    )
+    # Strict identifier shape — skip prose-y entries like "GovernanceHealth fields"
+    ident_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def _symbol_resolves(text: str, sym: str) -> bool:
+        # A handful of common declaration shapes across Python and TS.
+        patterns = [
+            rf"\bdef\s+{re.escape(sym)}\b",            # python function
+            rf"\bclass\s+{re.escape(sym)}\b",          # python class
+            rf"\basync\s+def\s+{re.escape(sym)}\b",    # async python function
+            rf"\bexport\s+(?:async\s+)?function\s+{re.escape(sym)}\b",
+            rf"\bexport\s+(?:default\s+)?(?:const|let|var)\s+{re.escape(sym)}\b",
+            rf"\bexport\s+(?:default\s+)?class\s+{re.escape(sym)}\b",
+            rf"\bexport\s+(?:type|interface)\s+{re.escape(sym)}\b",
+            rf"^{re.escape(sym)}\s*[:=]",              # top-level assignment / type alias
+            rf"\b{re.escape(sym)}\s*=\s*\(",           # arrow function / lambda binding
+        ]
+        return any(re.search(p, text, re.MULTILINE) for p in patterns)
+
+    drift_by_spec: dict[str, list[tuple[str, str]]] = {}
+    specs_with_symbol_claims = 0
+    symbols_checked = 0
+
+    for spec in sorted(specs_dir.glob("*.md")):
+        if spec.name in ("INDEX.md", "TEMPLATE.md", "MANIFEST.md"):
+            continue
+        text = spec.read_text()
+        head, *rest = text.split("---", 2)
+        if not rest:
+            continue
+        fm = rest[0] if len(rest) == 1 else rest[0]
+        status_m = re.search(r"^\s*status\s*:\s*(\S+)", fm, re.MULTILINE)
+        status = (status_m.group(1).strip().strip('"').strip("'") if status_m else "").lower()
+        if status == "draft":
+            continue
+
+        spec_had_claims = False
+        for m in src_pattern.finditer(fm):
+            path = m.group(1).strip()
+            if path.startswith("..") or "://" in path or path.startswith("specs/"):
+                continue
+            file_path = ROOT / path
+            if not file_path.exists():
+                # sense_spec_sources handles missing-file drift.
+                continue
+            raw_symbols = m.group(2)
+            # Strip () call shape, quotes, surrounding whitespace.
+            candidates = [s.strip().strip("'\"") for s in raw_symbols.split(",")]
+            candidates = [re.sub(r"\(.*", "", s).strip() for s in candidates]
+            # Keep only identifier-shaped entries.
+            candidates = [s for s in candidates if ident_re.match(s)]
+            if not candidates:
+                continue
+            spec_had_claims = True
+            try:
+                file_text = file_path.read_text()
+            except Exception:
+                continue
+            for sym in candidates:
+                symbols_checked += 1
+                if not _symbol_resolves(file_text, sym):
+                    drift_by_spec.setdefault(spec.stem, []).append((path, sym))
+
+        if spec_had_claims:
+            specs_with_symbol_claims += 1
+
+    if not drift_by_spec:
+        return [
+            f"  every claimed symbol resolves in its file ({symbols_checked} symbols "
+            f"across {specs_with_symbol_claims} spec(s) checked)"
+        ]
+
+    total_drifts = sum(len(v) for v in drift_by_spec.values())
+    lines = [
+        f"  {total_drifts} symbol claim(s) do not resolve across {len(drift_by_spec)} spec(s) "
+        f"(of {specs_with_symbol_claims} with symbol claims · {symbols_checked} symbols checked)"
+    ]
+    for spec_name in sorted(drift_by_spec)[:3]:
+        items = drift_by_spec[spec_name]
+        first = items[0]
+        lines.append(f"    · {spec_name} — `{first[1]}` not found in {first[0]}")
+        if len(items) > 1:
+            lines.append(f"      (+{len(items) - 1} more in this spec)")
+    if len(drift_by_spec) > 3:
+        lines.append(f"    · (+{len(drift_by_spec) - 3} more specs with symbol drift)")
+    lines.append(
+        "  (Drift here is signal, not failure. A renamed function is the body "
+        "evolving; the spec's claim wants the same breath.)"
+    )
+    return lines
+
+
 def sense_chain() -> list[str]:
     """Sense the idea→spec→code→test chain at the segment everything
     else doesn't see: tests the spec claims to have but that don't exist.
@@ -597,6 +719,7 @@ def main() -> int:
         ("Circulation — what at root has no readers?", sense_circulation()),
         ("Metabolism — composting-in-progress", sense_metabolism()),
         ("Source maps — do specs point at files that exist?", sense_spec_sources()),
+        ("Symbol resolution — do the named symbols still live in those files?", sense_spec_symbols()),
         ("Chain — does idea→spec→code→test reach end to end?", sense_chain()),
         ("Cells — are the cells themselves breathing?", sense_cells()),
         ("Contracts — are the CI gates breathing? (last 7d)", sense_contracts()),


### PR DESCRIPTION
## Summary

\`make wellness\` already senses spec source-path existence (does \`api/app/services/foo.py\` still live?) but stops there. The quieter drift — a spec frontmatter claims \`symbols: [bar()]\`, the file exists, \`bar()\` was renamed three weeks ago — has been invisible. The body's claim aged silently while the wellness check kept passing.

Adds \`sense_spec_symbols\` as a sibling lens to \`sense_spec_sources\`:

- Walks every non-draft spec's \`source: file: + symbols: [...]\` blocks
- Skips files that don't exist (already covered by \`sense_spec_sources\`)
- Skips prose-shaped entries inside \`symbols:\` brackets (many specs use natural language like *\"error_summary, error_category fields\"* rather than strict identifiers)
- For identifier-shaped symbols, checks for common Python and TS declaration shapes: \`def\`, \`class\`, \`async def\`, \`export function/class/const/type/interface\`, top-level assignment, arrow-function binding
- Surfaces drift in the same shape as other lenses — counts + 3 examples + remainder + a tender frame: *\"A renamed function is the body evolving; the spec's claim wants the same breath.\"*

## First run reveals

> **123 symbol claim(s) do not resolve across 45 spec(s)** (of 82 with symbol claims · 504 symbols checked)

Examples surfaced:
- \`agent-memory-system\` — \`MemoryMoment\` not found in \`api/app/routers/memory.py\`
- \`agent-resonance-onboarding\` — \`Home\` not found in \`web/app/page.tsx\`
- \`agent-self-orientation-contract\` — \`ComeInPage\` not found in \`web/app/come-in/page.tsx\` (recent reorder)

None of these are urgent. Each is now visible to every future wellness pass, so the body can tend them as it chooses without rushing through them.

This is the first of several additions Urs blessed for the body's sensing.

## Test plan

- [x] \`python3 scripts/wellness_check.py\` runs cleanly and surfaces the new lens between Source maps and Chain sections
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)