### PR TITLE
tend: fix two dangling concept cross-refs (lc-cell → lc-w-cell, lc-mycorrhizal → lc-w-mycorrhizal)

### DIFF
--- a/docs/vision-kb/concepts/lc-each-breath-whole.md
+++ b/docs/vision-kb/concepts/lc-each-breath-whole.md
@@ -155,7 +155,7 @@ a book. The fractal honors each layer at its own register.
 
 ## Cross-References
 
-→ lc-w-cell, lc-pulse, lc-spec-breath, lc-rhythm, lc-perception-as-interface, lc-future-already-shaping, lc-tend-your-flame, lc-sovereignty-within-oneness, lc-frequency-routes-reception, lc-mycorrhizal, lc-circulation, lc-coherence-over-control
+→ lc-w-cell, lc-pulse, lc-spec-breath, lc-rhythm, lc-perception-as-interface, lc-future-already-shaping, lc-tend-your-flame, lc-sovereignty-within-oneness, lc-frequency-routes-reception, lc-w-mycorrhizal, lc-circulation, lc-coherence-over-control
 
 ## Sources to walk further
 

--- a/docs/vision-kb/concepts/lc-release-what-drifts.md
+++ b/docs/vision-kb/concepts/lc-release-what-drifts.md
@@ -212,7 +212,7 @@ is the careful return of form to ground so new form can grow.
 
 ## Cross-References
 
-→ lc-composting, lc-tending-over-producing, lc-edges-as-vitality, lc-each-breath-whole, lc-tend-your-flame, lc-coherence-over-control, lc-trust-over-fear, lc-cell, lc-wholeness, lc-circulation
+→ lc-composting, lc-tending-over-producing, lc-edges-as-vitality, lc-each-breath-whole, lc-tend-your-flame, lc-coherence-over-control, lc-trust-over-fear, lc-w-cell, lc-wholeness, lc-circulation
 
 ## Sources to walk further
 


### PR DESCRIPTION
## Summary

Two concept files carried cross-references to slug names that don't exist on disk:

- \`lc-release-what-drifts\` → \`lc-cell\` (actual: \`lc-w-cell\`)
- \`lc-each-breath-whole\` → \`lc-mycorrhizal\` (actual: \`lc-w-mycorrhizal\`)

The \"lc-w-\" prefix is the body's deliberate naming for one subset of concepts; the references dropped it. Cross-ref integrity in the vision-kb is mostly whole — these were the only two real danglers once the \`guides/\` directory was correctly recognized as a sibling home for \"lc-X-guide.md\" references.

Tiny tend; the body's cross-ref weave is now whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)