### PR TITLE
attune(spec): honor 'proof: operational' as legitimate proof shape

### DIFF
--- a/docs/spec-proof-shapes.md
+++ b/docs/spec-proof-shapes.md
@@ -1,0 +1,110 @@
+# Spec Proof Shapes — `test:` and `proof: operational`
+
+Every spec frontmatter declares how the spec proves itself. The body
+honors two legitimate shapes — both count as proof; the wellness
+check's chain-reach treats them equally.
+
+## `test:` — automated proof
+
+The spec is proven by a runnable test command.
+
+```yaml
+---
+idea_id: …
+status: done
+source:
+  - file: api/app/services/governance_health.py
+    symbols: [compute_governance_health]
+test: "python3 -m pytest api/tests/test_governance_health.py -x -v"
+---
+```
+
+When to use:
+
+- The spec describes pure logic, a service function, a routing
+  decision, a data transformation — anything where an automated
+  test exercises the behavior cleanly.
+- The test runs in seconds, doesn't require external services
+  beyond what the test fixture sets up, and catches the kind of
+  regression that would actually harm the body if it slipped.
+
+When the `test:` path doesn't exist on disk, wellness names the
+spec as having a phantom test claim. The spec's claim is ahead of
+its proof.
+
+## `proof: operational` — production-exercised proof
+
+The spec is proven by being live in production. The body uses it;
+visitors / operators / agents exercise it. A unit test would be
+theater — either trivially passing while missing real regressions,
+or requiring so much mocking that the test surface doesn't reflect
+the behavior surface.
+
+```yaml
+---
+idea_id: …
+status: done
+source:
+  - file: api/app/services/release_gate_service.py
+    symbols: [evaluate_pr_to_public_report]
+proof: operational
+proof_note: "Exercised every PR merge; regressions surface as
+  Hostinger Auto Deploy or Public Deploy Contract failures."
+---
+```
+
+`proof_note:` is optional but recommended — names how the
+operational proof is observed (which CI gate, which user-visible
+surface, which deploy step) so a reader doesn't have to guess what
+"operational" means for this specific spec.
+
+When to use:
+
+- **GitHub-API or third-party integrations.** The release gates
+  live or die in real GitHub interactions; a mocked test passes
+  while real GitHub API drift breaks production. The proof IS the
+  deploy pipeline.
+- **Deploy paths and contract gates.** The contract is the
+  observable health of the body — pulse, gate, witness silences.
+  Each deploy is a proof event.
+- **CC ledger flows and economic contracts.** Real CC attribution
+  is proven by transactions, not by unit tests of pure functions
+  inside the engine.
+- **Live data ingestion / migration scripts.** The migration's
+  proof is "the database now holds the data correctly"; the
+  observable state is the proof.
+
+When NOT to use:
+
+- The spec describes pure logic that can be cleanly unit-tested.
+  Reaching for `proof: operational` to avoid writing a test isn't
+  honest — the body knows the difference.
+- The spec is genuinely under-tested but could be tested.
+  `proof: operational` then is a hiding shape, not a truthful one.
+
+## How wellness reads them
+
+`make wellness` chain-reach counts a spec as reaching its proof
+when:
+
+1. it has an `idea_id`
+2. every `source: file:` path exists
+3. EITHER (a) its `test:` command names test paths that all exist
+   on disk, OR (b) `proof: operational` is declared
+
+Specs with `proof: operational` are surfaced separately in the
+chain output so the body can sense at a glance how much of its
+proof rests in production observation versus unit tests.
+
+## Sibling teaching
+
+- The [Thread Gates pattern walk](field/urs/thread-gates-pattern-walk.md)
+  names how `proof: operational` could clear the friction for the
+  47 legacy specs whose proof is honestly operational rather than
+  unit-tested.
+- The [Maintainability audit pattern walk](field/urs/maintainability-audit-pattern-walk.md)
+  carries similar shape — contract that wants reshaping to honor
+  the body's actual proof modes.
+
+— *Both shapes are legitimate. The body knows when each fits. The
+discipline is being honest about which one the spec is using.*

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -407,8 +407,20 @@ def sense_chain() -> list[str]:
     tests/test_foo.py` and the spec proudly lives, but the test file
     never landed. The body acts as if it's tested when it isn't.
 
-    Drafts skipped (forward projections). Specs without a test:
-    declaration are noted softly as a separate count.
+    Two legitimate proof shapes are honored:
+
+      · ``test:`` — a runnable test command (the path it names must exist
+        on disk for the proof to count)
+      · ``proof: operational`` — the body proves this spec in production
+        usage, not via unit tests. Used for specs whose substance is
+        operationally exercised (GitHub-API integrations, deploy paths,
+        live ledger flows) where a unit test would be theater. The
+        spec's frontmatter may also carry ``proof_note: "..."`` to
+        describe how the operational proof is observed.
+
+    Drafts skipped (forward projections). Specs with neither a working
+    ``test:`` nor a ``proof: operational`` declaration are noted softly
+    as a separate count — *no proof claimed*.
     """
     specs_dir = ROOT / "specs"
     if not specs_dir.is_dir():
@@ -424,6 +436,7 @@ def sense_chain() -> list[str]:
     missing_tests: dict[str, list[str]] = {}
     no_test_declared: list[str] = []
     orphan_specs: list[str] = []
+    operational_proof: list[str] = []  # specs honoring "proof: operational"
 
     for spec in sorted(specs_dir.glob("*.md")):
         if spec.name in ("INDEX.md", "TEMPLATE.md", "MANIFEST.md"):
@@ -450,6 +463,14 @@ def sense_chain() -> list[str]:
         src_ok = bool(src_paths) and all((ROOT / p).exists() for p in src_paths)
         src_declared = bool(src_paths)
 
+        # ``proof: operational`` is the second legitimate proof shape:
+        # the spec is exercised in production rather than unit-tested.
+        # When present, the spec's chain-reach counts as proven even if
+        # no test: command is declared.
+        proof_m = re.search(r"^\s*proof\s*:\s*(\S+)", fm, re.MULTILINE)
+        proof_value = (proof_m.group(1).strip().strip('"').strip("'").lower() if proof_m else "")
+        is_operational = proof_value == "operational"
+
         # test: declaration (string or list) — extract test paths via the same regex coh_substrate uses
         test_section_m = re.search(r"^test\s*:(.*?)(?:\n[a-z_]+\s*:|---|$)", fm, re.MULTILINE | re.DOTALL)
         test_text = (test_section_m.group(1) if test_section_m else "")
@@ -462,7 +483,7 @@ def sense_chain() -> list[str]:
 
         test_paths = sorted(set(_resolve_test_path(p) for p in test_path_re.findall(test_text)))
         test_declared = bool(test_text.strip())
-        if not test_declared:
+        if not test_declared and not is_operational:
             no_test_declared.append(spec.stem)
             continue
         miss = [t for t in test_paths if not (ROOT / t).exists()]
@@ -471,9 +492,13 @@ def sense_chain() -> list[str]:
             continue
 
         # Chain healthy if: idea_id present, source declared and present,
-        # tests declared and present.
-        if idea_m and src_ok and test_paths and not miss:
+        # AND (tests declared and present) OR (proof: operational).
+        if idea_m and src_ok and (
+            (test_paths and not miss) or (is_operational and not test_declared)
+        ):
             healthy += 1
+            if is_operational:
+                operational_proof.append(spec.stem)
 
     lines = [
         f"  chain healthy: {healthy}/{counted} non-draft specs reach idea→spec→code→test ({(healthy/counted*100) if counted else 0:.0f}%)"
@@ -485,8 +510,12 @@ def sense_chain() -> list[str]:
             lines.append(f"    · {slug} — {miss}")
         if len(missing_tests) > 3:
             lines.append(f"    · (+{len(missing_tests) - 3} more)")
+    if operational_proof:
+        lines.append(
+            f"  {len(operational_proof)} spec(s) honor `proof: operational` — proven in production, not unit-tested"
+        )
     if no_test_declared:
-        lines.append(f"  {len(no_test_declared)} specs have no test: frontmatter (no proof claimed)")
+        lines.append(f"  {len(no_test_declared)} specs have no test: or proof: frontmatter (no proof claimed)")
     if orphan_specs:
         lines.append(f"  {len(orphan_specs)} orphan specs (no idea_id): {', '.join(orphan_specs)}")
     if not missing_tests and not no_test_declared and not orphan_specs:


### PR DESCRIPTION
## Summary

Every spec frontmatter declares how the spec proves itself. Until now the body recognized only one shape: a runnable test command at \`test:\`. Specs without \`test:\` got counted as *\"no proof claimed\"* — even when honestly proven by production observation (release gates exercised every PR merge, deploy contracts observed in real time, CC ledger flows proven in real transactions).

This forced one of two costumes onto specs whose proof is operational: either grow a theater test (mocked GitHub passes while real GitHub API drift breaks production), or sit in the silence-count.

## What changes

Adds the second legitimate proof shape:

\`\`\`yaml
proof: operational
proof_note: \"Exercised every PR merge; regressions surface as Hostinger Auto Deploy failures.\"
\`\`\`

Wellness chain-reach now counts a spec as reaching its proof when:
- it has \`idea_id\`
- every \`source: file:\` path exists
- **EITHER** tests at \`test:\` all exist, **OR** \`proof: operational\` is declared

Specs honoring \`proof: operational\` get surfaced separately so the body can sense how much proof rests in production observation versus unit tests.

Adds \`docs/spec-proof-shapes.md\` naming when each shape fits — and importantly, when NOT to use \`proof: operational\` (when the spec describes pure logic that could be cleanly unit-tested; reaching for operational to avoid writing a real test is a hiding shape, not a truthful one).

## Pairs naturally with

- [\`thread-gates-pattern-walk.md\`](docs/field/urs/thread-gates-pattern-walk.md) — many of the 47 spec-quality failures are honestly operational
- [\`maintainability-audit-pattern-walk.md\`](docs/field/urs/maintainability-audit-pattern-walk.md) — same shape of teaching

Nothing applied to existing specs in this PR. Field is available, adoption is per-spec stewardship.

## Test plan

- [x] \`python3 scripts/wellness_check.py\` runs cleanly with the new branch logic
- [ ] CI passes
- [ ] When a future spec adopts \`proof: operational\`, wellness will surface the count in the Chain section

🤖 Generated with [Claude Code](https://claude.com/claude-code)