### PR TITLE
tend(spec): re-sync knowledge-resonance-engine symbols (12 drifts → 0)

### DIFF
--- a/specs/knowledge-resonance-engine.md
+++ b/specs/knowledge-resonance-engine.md
@@ -5,19 +5,19 @@ source:
   - file: api/app/services/concept_service.py
     symbols: [list_concepts, get_concept, search_concepts]
   - file: api/app/services/concept_resonance_kernel.py
-    symbols: [compute_crk, text_to_symbol, ot_phi_distance]
+    symbols: [compute_crk, text_to_symbol, HarmonicComponent, ConceptSymbol, ResonanceResult]
   - file: api/app/services/belief_service.py
-    symbols: [get_belief_profile, compute_resonance, find_resonant_peers]
+    symbols: [get_belief_profile, patch_belief_profile, compute_resonance]
   - file: api/app/services/idea_resonance_service.py
-    symbols: [get_cross_domain_pairs, get_resonance_for_idea]
+    symbols: [get_cross_domain_pairs, find_resonant_ideas, compute_pair_resonance, get_resonance_proof]
   - file: api/app/services/accessible_ontology_service.py
-    symbols: [suggest_concept, approve_suggestion, endorse_concept]
+    symbols: [create_concept, list_concepts, get_concept, patch_concept]
   - file: api/app/services/discovery_service.py
     symbols: [build_discovery_feed]
   - file: api/app/routers/resonance.py
-    symbols: [cross_domain, idea_resonance, resonance_proof]
+    symbols: [get_cross_domain_resonances, get_resonance_for_idea, get_resonance_proof]
   - file: api/app/routers/beliefs.py
-    symbols: [get_profile, update_profile, compute_resonance]
+    symbols: [get_beliefs, patch_beliefs, get_resonance]
 requirements:
   - 184 universal concepts with 46 typed relationships and 53 axes
   - Concept Resonance Kernel (CRK) -- harmonic spectral matching


### PR DESCRIPTION
## Summary

Heaviest single-spec drift surfaced by the new symbol-resolution lens (#1589): \`knowledge-resonance-engine\` claimed 18 symbols, **12 of them no longer resolved**. Walked each one — the pattern: **9 renames, 3 composts**.

### Renames mapped

| File | Was | Now |
|---|---|---|
| idea_resonance_service | get_resonance_for_idea | find_resonant_ideas |
| accessible_ontology_service | suggest_concept | create_concept |
| accessible_ontology_service | approve_suggestion | patch_concept |
| routers/resonance | cross_domain | get_cross_domain_resonances |
| routers/resonance | idea_resonance | get_resonance_for_idea |
| routers/resonance | resonance_proof | get_resonance_proof |
| routers/beliefs | get_profile | get_beliefs |
| routers/beliefs | update_profile | patch_beliefs |
| routers/beliefs | compute_resonance | get_resonance |

### Genuinely composted (no replacement)

- \`ot_phi_distance\` — logic absorbed into \`compute_crk\` + \`_build_ground_cost\`
- \`find_resonant_peers\` — gone, not replaced (function dissolved)
- \`endorse_concept\` — gone, not replaced

The spec's *behavior* is unchanged — the resonance engine still does what the requirements list says. The frontmatter now names current symbols rather than historical ones.

### Wellness impact

After merge: symbol-resolution drift drops **123 → 111** (12 fewer) across **45 → 44** specs.

### Pattern this establishes for future spec re-syncs

1. Run wellness check; find spec with drift
2. For each drifted symbol, grep for it elsewhere in the body
3. Found in same file under new name → rename in frontmatter
4. Found in different file → move the \`source: file:\` claim
5. Not found anywhere → mark composted (optionally add note)
6. Verify wellness count decreases by the expected number

Five other top-tier drift specs remain (home-content-contribution-attribution 12, external-presence-bots-and-news 7, portfolio-governance-health 6, self-custody-wallet-integration 6, federation-network-layer 5). Each its own breath, at the body's rhythm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)