### PR TITLE
tend(spec): re-sync external-presence-bots-and-news symbols (7 drifts → 0)

### DIFF
--- a/specs/external-presence-bots-and-news.md
+++ b/specs/external-presence-bots-and-news.md
@@ -5,17 +5,17 @@ source:
   - file: api/app/routers/news.py
     symbols: [get_news_feed, get_news_resonance, add_news_source]
   - file: api/app/services/news_ingestion_service.py
-    symbols: [ingest_feeds, get_cached_items]
+    symbols: [fetch_feeds, get_cached_items, extract_trending_keywords]
   - file: api/app/services/news_resonance_service.py
-    symbols: [compute_resonance, match_news_to_ideas]
+    symbols: [compute_resonance, extract_keywords, ResonanceMatch, IdeaResonanceResult]
   - file: api/app/routers/discord_votes.py
-    symbols: [cast_discord_vote]
+    symbols: [vote_on_question]
   - file: api/app/services/telegram_adapter.py
-    symbols: [send_message, handle_update]
+    symbols: [send_alert, send_reply, is_configured, parse_command]
   - file: api/app/services/translate_service.py
-    symbols: [translate_text]
+    symbols: [translate_idea, translate_concept, TranslateLens]
   - file: api/app/routers/geolocation.py
-    symbols: [set_location, get_nearby]
+    symbols: [set_location, get_location, nearby]
 requirements:
   - News ingestion with RSS feed support and resonance matching to ideas
   - Configurable news sources via API


### PR DESCRIPTION
## Summary

Walking the next heaviest drift spec after knowledge-resonance-engine + the lens fix. Seven claimed symbols, all gone — but the underlying services are alive and the spec's described features still work in production.

### What was found

| File | Was | Now |
|---|---|---|
| news_ingestion_service | ingest_feeds | **fetch_feeds** |
| news_resonance_service | match_news_to_ideas | (composted; absorbed into compute_resonance) |
| discord_votes | cast_discord_vote | **vote_on_question** (REST-aligned) |
| telegram_adapter | send_message | split into **send_alert** + **send_reply** |
| telegram_adapter | handle_update | (composted; inbound webhook simplified) |
| translate_service | translate_text | **translate_idea** + **translate_concept** (lens-based redesign via TranslateLens enum) |
| geolocation | get_nearby | **nearby** |

The spec's *behavior* still describes the body's real surface — RSS news ingestion, resonance matching, Discord voting, Telegram alerts/replies, lens-based translation, geolocation. \`status: done\` stays honest. Only the frontmatter anchors needed updating.

### Wellness impact

After this lands, drift drops **81 → 74** across **34 → 33** specs. Two top-tier resyncs done (knowledge-resonance #1605, external-presence here). Four remain in the top tier: portfolio-governance-health (6), federation-network-layer (5), external-repo-milestone (4), idea-lifecycle-management (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)