### PR TITLE
tend(spec): re-sync portfolio-governance-health (6 drifts → 0)

### DIFF
--- a/specs/portfolio-governance-health.md
+++ b/specs/portfolio-governance-health.md
@@ -3,19 +3,21 @@ idea_id: portfolio-governance
 status: done
 source:
   - file: api/app/services/governance_service.py
-    symbols: [create_change_request, vote_on_change_request, apply_approved]
+    symbols: [create_change_request, cast_vote, get_change_request, list_change_requests]
   - file: api/app/services/grounded_idea_metrics_service.py
-    symbols: [compute_idea_metrics, compute_portfolio_health]
+    symbols: [compute_idea_metrics, compute_all_idea_metrics, collect_all_data]
+  - file: api/app/services/idea_governance_views.py
+    symbols: [compute_governance_health, list_showcase_ideas]
   - file: api/app/services/coherence_service.py
-    symbols: [compute_coherence_score]
+    symbols: [compute_coherence]
   - file: api/app/services/right_sizing_service.py
     symbols: [build_report, compute_granularity_signal, apply_suggestion]
   - file: api/app/services/vitality_service.py
     symbols: [compute_vitality]
   - file: api/app/services/cc_economics_service.py
-    symbols: [get_supply, stake, unstake]
+    symbols: [supply, exchange_rate, stake, unstake, coherence_score]
   - file: api/app/services/distribution_engine.py
-    symbols: [compute_distribution]
+    symbols: [DistributionEngine, distribute]
 requirements:
   - Governance change requests with voting and auto-apply
   - Grounded idea metrics (actual_value vs potential_value)


### PR DESCRIPTION
## Summary

Third spec resync in the rhythm. Six drifted symbols, all renames or moves — the governance/metrics/economics/distribution surface is alive and load-bearing, just renamed during refactors.

| File | Was | Now |
|---|---|---|
| governance_service | vote_on_change_request | **cast_vote** |
| governance_service | apply_approved | _apply_approved_change_request (private; surface is cast_vote) |
| grounded_idea_metrics_service | compute_portfolio_health | **moved → idea_governance_views.compute_governance_health** |
| coherence_service | compute_coherence_score | **compute_coherence** |
| cc_economics_service | get_supply | **supply** |
| distribution_engine | compute_distribution | **DistributionEngine.distribute** (class wrap) |

Also added the actual public companions the spec wasn't naming (get_change_request, list_change_requests, compute_all_idea_metrics, exchange_rate, coherence_score). The spec's *behavior* — change-request governance, metrics, coherence scoring, right-sizing, vitality, CC economics, distribution — all still describes the body's live work.

After merge: wellness drift drops **74 → 68** across **33 → 32** specs.

Three top-tier resyncs done (knowledge-resonance, external-presence, portfolio-governance). Three remain at 4-5 drifts (federation-network-layer, external-repo-milestone, idea-lifecycle-management); the rest are 2-3 drift specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)