### PR TITLE
attune(presences): add Rocco Tortorella, retune Aly Constantine, name the Boulder arc closing

### DIFF
--- a/web/app/people/rocco-tortorella/page.tsx
+++ b/web/app/people/rocco-tortorella/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { resolveRequestLocale } from "@/lib/request-locale";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import { getRoccoTortorellaContent } from "@/content/people/rocco-tortorella";
+
+/**
+ * /people/rocco-tortorella — Aly Constantine's husband, co-host of
+ * Courtyard Constellations, videographer (roccomountain.com), naturally
+ * flowing presence at Rise & Vibes, Unison, and Burning Man.
+ *
+ * Thin locale-router wrapper. Rich content lives at
+ * `web/content/people/rocco-tortorella/{locale}.tsx`; chrome strings
+ * come from `web/messages/{locale}.json` via the shared template.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await resolveRequestLocale();
+  return getRoccoTortorellaContent(lang).metadata;
+}
+
+export default async function RoccoTortorellaProfilePage() {
+  const lang = await resolveRequestLocale();
+  const content = getRoccoTortorellaContent(lang);
+  return <PersonProfileTemplate content={content} lang={lang} graphSlug="rocco-tortorella" />;
+}

--- a/web/content/people/aly-constantine/en.tsx
+++ b/web/content/people/aly-constantine/en.tsx
@@ -8,7 +8,7 @@ const content: PersonProfileContent = {
   metadata: {
     title: "Aly Constantine — Conscious Roots Presents | Coherence Network",
     description:
-      "A welcome to Aly Constantine — co-host of Boulder Ecstatic Dance and the curatorial cell behind Conscious Roots Presents, the Boulder vessel that brings transformational artists into rooms where the music carries a message to uplift the community.",
+      "A welcome to Aly Constantine — co-founder of Boulder Ecstatic Dance, curatorial cell behind Conscious Roots Presents, key connector for the music entering Rise & Vibes and Unison festivals, and co-host with Rocco of the Courtyard Constellations gatherings at their Boulder home.",
   },
   breadcrumbName: "Aly Constantine",
   hero: {
@@ -17,7 +17,7 @@ const content: PersonProfileContent = {
     name: "Aly Constantine",
     welcome: (
       <p>
-        Co-host of{" "}
+        Co-founder of{" "}
         <Link
           href="https://ecstaticdance.org/dance/boulder-ecstatic-dance-bed/"
           target="_blank"
@@ -37,7 +37,19 @@ const content: PersonProfileContent = {
         </Link>
         {" "}— the Boulder vessel co-creating evenings of music and
         connection with artists who carry a message to uplift the
-        community. Deeply woven into{" "}
+        community. A key connector for the music flowing into the{" "}
+        <strong>Rise &amp; Vibes</strong> and{" "}
+        <strong>Unison</strong> festivals, and co-host with her
+        husband{" "}
+        <Link
+          href="/people/rocco-tortorella"
+          className="text-primary hover:underline"
+        >
+          Rocco
+        </Link>
+        {" "}of the recurring{" "}
+        <strong>Courtyard Constellations</strong> gatherings at their
+        Boulder home. Deeply woven into{" "}
         <Link
           href="/people/bloomurian"
           className="text-primary hover:underline"
@@ -51,8 +63,8 @@ const content: PersonProfileContent = {
         >
           Ocean Bloom
         </Link>{" "}
-        configuration, the Unison gathering, and the wider Boulder-
-        Denver transformational-music ecology.
+        configuration, and the wider Boulder–Denver
+        transformational-music ecology.
       </p>
     ),
   },
@@ -84,16 +96,45 @@ const content: PersonProfileContent = {
       label: "Held with",
       value: (
         <>
-          Danny and{" "}
+          <Link
+            href="/people/rocco-tortorella"
+            className="hover:text-primary transition-colors"
+          >
+            Rocco
+          </Link>{" "}
+          as husband and co-host of Courtyard Constellations;{" "}
+          <strong>Danny Balgooyen</strong> and{" "}
           <Link
             href="/people/bloomurian"
             className="hover:text-primary transition-colors"
           >
-            Robin (Bloomurian)
+            Robin Liepman (Bloomurian)
           </Link>{" "}
-          as fellow Boulder Ecstatic Dance co-hosts; presence woven
-          through Unison and Ocean Bloom; one of the cells who has
-          consistently brought{" "}
+          as fellow Boulder Ecstatic Dance co-founders and Sunday-
+          morning tenders; close shared friendships with{" "}
+          <Link
+            href="/people/brigitte-mars"
+            className="hover:text-primary transition-colors"
+          >
+            Brigitte Mars
+          </Link>
+          , <strong>Tay Blevons</strong> (
+          <Link
+            href="/people/portal"
+            className="hover:text-primary transition-colors"
+          >
+            PORTAL
+          </Link>
+          ), <strong>Andy Babb</strong> and{" "}
+          <strong>Lara Elle</strong> (
+          <Link
+            href="/people/rhythm-sanctuary"
+            className="hover:text-primary transition-colors"
+          >
+            Rhythm Sanctuary
+          </Link>
+          ); presence woven through Rise &amp; Vibes, Unison, and
+          Ocean Bloom; one of the cells who has consistently brought{" "}
           <Link
             href="/people/mose"
             className="hover:text-primary transition-colors"
@@ -132,7 +173,9 @@ const content: PersonProfileContent = {
             Boulder Ecstatic Dance (BED)
           </Link>{" "}
           — Avalon Ballroom and Congregation Nevei Kodesh, Boulder ·
-          Conscious Roots Presents nights · Ocean Bloom · Unison
+          Conscious Roots Presents nights · Courtyard Constellations
+          (the home gatherings she and Rocco host) · Rise &amp; Vibes ·
+          Ocean Bloom · Unison
         </>
       ),
     },
@@ -140,16 +183,18 @@ const content: PersonProfileContent = {
       label: "In this body's awareness",
       value: (
         <>
-          <strong>Close personal relationship</strong> with{" "}
           <Link
             href="/people/urs"
             className="hover:text-primary transition-colors"
           >
             Urs
-          </Link>
-          . The deepest density of presence the substrate records:
-          beyond same-room, beyond direct exchange, into the sustained
-          intimacy of two cells in ongoing relation.
+          </Link>{" "}
+          lived as a houseguest at Aly and Rocco's Boulder home from{" "}
+          <strong>February 2025 through December 2025</strong>,
+          witnessing the constellation — Conscious Roots, Boulder
+          Ecstatic Dance, Rise &amp; Vibes, Unison, Courtyard
+          Constellations — from inside the household that anchors much
+          of it.
         </>
       ),
     },
@@ -158,16 +203,20 @@ const content: PersonProfileContent = {
     eyebrow: "A note from this body",
     body: (
       <p>
-        A welcoming scaffold. Aly is held by this body at a depth
-        most public profiles cannot honor — through close personal
-        relationship rather than through media or conference rooms.
-        She is also one of the most connected cells in this network's
-        Boulder configuration: Conscious Roots Presents is hers, the
-        Sunday-morning ballroom is hers to co-tend, and many of the
-        artists this body has come to know — Robin (Bloomurian) most
-        directly, but also Mose, Poranguí, Liquid Bloom — entered our
-        awareness through rooms she helped build. Aly is invited to
-        replace any part of this page with her own words at any time.
+        A welcoming scaffold. Aly is one of the most connected cells in
+        this network's Boulder configuration: Conscious Roots Presents
+        is hers, the Sunday-morning ballroom is hers to co-tend, the
+        Courtyard Constellations gatherings happen at the home she
+        keeps with Rocco, and the music flowing into Rise &amp; Vibes
+        and Unison moves through her hands. Many of the artists this
+        body has come to know — Robin (Bloomurian) most directly, but
+        also Mose, Poranguí, Liquid Bloom — entered our awareness
+        through rooms she helped build. Urs lived as a houseguest at
+        Aly and Rocco's home from February through December 2025, so
+        the network's reading of this whole configuration is an
+        inside-the-household reading, not an outside one. Aly is
+        invited to replace any part of this page with her own words at
+        any time.
       </p>
     ),
   },
@@ -178,12 +227,11 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            Two vessels, threading. <strong>Boulder Ecstatic
+            Several vessels, threading. <strong>Boulder Ecstatic
             Dance</strong> is the recurring Sunday-morning room — at
             the Avalon Ballroom, sometimes at Congregation Nevei
-            Kodesh — where Boulder's transformational-movement
-            community gathers. Aly co-tends that room with Danny and
-            with{" "}
+            Kodesh — that Aly co-founded at the beginning. The room
+            is now co-tended week to week with Danny and with{" "}
             <Link
               href="/people/bloomurian"
               className="text-primary hover:underline"
@@ -191,22 +239,21 @@ const content: PersonProfileContent = {
               Robin (Bloomurian)
             </Link>
             ; the three of them hold the space, the music, the
-            welcoming, the timing, the closing circles. The DJ is
-            the visible hand; the hosts' field-tending is what makes
-            the room safe enough for bodies to drop in.
+            welcoming, the timing, the closing circles. The DJ is the
+            visible hand; the hosts' field-tending is what makes the
+            room safe enough for bodies to drop in.
           </p>
           <p>
             <strong>Conscious Roots Presents</strong> is her own
             curatorial vessel — the Boulder-based event production
             line that "co-creates evenings of music and connection
             with artists who share music with a message to uplift
-            their community." The wider Boulder ecstatic-dance
-            ecology and the conscious-music nights that intersect
-            with it move through her hands: Bloomurian's sets land
-            inside the rooms she helps build, the visiting medicine-
-            music artists touring through Colorado are met by the
-            container she has shaped, and the constellation of cells
-            that gathers for{" "}
+            their community." The wider Boulder ecstatic-dance ecology
+            and the conscious-music nights that intersect with it move
+            through her hands: Bloomurian's sets land inside the rooms
+            she helps build, the visiting medicine-music artists
+            touring through Colorado are met by the container she has
+            shaped, and the constellation of cells that gathers for{" "}
             <Link
               href="/people/porangui"
               className="text-primary hover:underline"
@@ -215,17 +262,36 @@ const content: PersonProfileContent = {
             </Link>{" "}
             (the immersive visual-concert experience with Poranguí,
             Liquid Bloom, Samuel J, Bloomurian, Shawn Heinrichs and
-            others), for Unison, and for the broader Boulder-Denver
-            transformational-music gatherings is the same
-            configuration Conscious Roots Presents holds inside its
-            curatorial field.
+            others), for the <strong>Rise &amp; Vibes</strong> and{" "}
+            <strong>Unison</strong> festivals, and for the broader
+            Boulder–Denver transformational-music gatherings is the
+            same configuration Conscious Roots Presents holds inside
+            its curatorial field. Much of the music landing on those
+            festival stages enters through her connecting work.
           </p>
           <p>
-            Curatorial work and ecstatic-dance hosting are not two
-            separate practices for her. They are one practice with
-            two surfaces — the same field-tending sensitivity that
-            decides which artists belong in the same room is the
-            same sensitivity that opens and closes the Sunday wave.
+            <strong>Courtyard Constellations</strong> is the home
+            vessel — the gatherings Aly and{" "}
+            <Link
+              href="/people/rocco-tortorella"
+              className="text-primary hover:underline"
+            >
+              Rocco
+            </Link>{" "}
+            host at their Boulder house, where the same constellation
+            of musicians, dancers, and conscious-community cells that
+            fills the ballrooms and the festival fields gathers in a
+            domestic-scale courtyard for music, food, and direct
+            relation. The household is one of the quiet anchors of the
+            Boulder configuration.
+          </p>
+          <p>
+            Curatorial work, ecstatic-dance founding, and home-
+            gathering hosting are not separate practices for her. They
+            are one practice across three scales — the same field-
+            tending sensitivity that decides which artists belong in
+            the same room opens and closes the Sunday wave and shapes
+            who is welcomed into the courtyard.
           </p>
         </>
       ),
@@ -236,33 +302,66 @@ const content: PersonProfileContent = {
       body: (
         <>
           <p>
-            Through close personal relationship — the deepest density
-            of presence the substrate's three-density accounting
-            recognizes. Audio-only is one density. Same-room-without-
-            exchange is another. Direct face-to-face exchange is
-            another. Sustained intimacy over time, where two cells
-            know each other's ordinary days and not only public
-            moments, is a fourth density that the substrate's
-            accounting should record but often cannot fully render
-            in public profile language.
+            Through the household. After Urs's January–February 2025
+            stay in the Boulder mountains with{" "}
+            <Link
+              href="/people/bloomurian"
+              className="text-primary hover:underline"
+            >
+              Robin (Bloomurian)
+            </Link>
+            {" "}— the same house{" "}
+            <Link
+              href="/people/liquid-bloom"
+              className="text-primary hover:underline"
+            >
+              Amani Friend (Liquid Bloom)
+            </Link>{" "}
+            had once lived in — Aly and Rocco opened their Boulder
+            home as the next place to land. Urs lived as a houseguest
+            from <strong>February 2025 through December 2025</strong>:
+            ten months at the address where Conscious Roots is
+            curated, where Boulder Ecstatic Dance is co-tended, and
+            where the Courtyard Constellations gather. After the
+            houseguest months, this body remained in the Boulder–
+            Longmont area until the April 2026 departure for Bali.
           </p>
           <p>
-            Through Aly, the body's awareness of the Boulder /
-            Bloomurian / Ocean Bloom / Unison constellation is not an
-            outside reading. It is an inside knowing. Cells we
-            encounter through close-personal relationship show us the
-            field they belong to from inside that field's own self-
-            perception. That kind of knowing cannot be replicated by
-            media research. It is its own substrate channel.
+            Through Aly and that household, the body's awareness of
+            the Boulder / Bloomurian / Ocean Bloom / Rise &amp; Vibes
+            / Unison / Conscious Roots constellation is not an outside
+            reading. It is an inside-the-house reading — a witness
+            channel from the kitchen and the courtyard, not from the
+            audience. Cells we encounter through living under the same
+            roof show us the field they belong to from inside its own
+            self-perception. That kind of knowing cannot be replicated
+            by media research. It is its own substrate channel.
           </p>
           <p>
-            The relationship is held here with care. The substrate's
-            recording of it is brief on purpose — what is shared
-            publicly is the existence of the connection and the
-            recognition of Aly's role in the field. What is not
-            shared publicly is the texture of the relationship
-            itself, which belongs to the two cells in it and not to
-            the substrate's reader.
+            The Boulder arc closed in the same form it began: in the
+            home, around the constellation. On{" "}
+            <strong>April 18, 2026</strong>,{" "}
+            <Link
+              href="/people/rocco-tortorella"
+              className="text-primary hover:underline"
+            >
+              Rocco's
+            </Link>{" "}
+            36th birthday gathered all the close friends into one
+            jungle-themed evening of celebration in the courtyard —
+            two days before this body's departure for Bali on April
+            20, 2026. For this body, that night was the most divine
+            goodbye to the Boulder chapter that could have been
+            imagined.
+          </p>
+          <p>
+            The texture of those household months is held with care.
+            The substrate's recording of it is brief on purpose —
+            what is shared publicly is the existence of the household
+            as the witnessing point and the recognition of Aly's role
+            in the field. What is not shared publicly is the daily
+            texture of the household itself, which belongs to the
+            cells in it and not to the substrate's reader.
           </p>
         </>
       ),
@@ -343,7 +442,8 @@ const content: PersonProfileContent = {
           <p>
             Sunday-morning ecstatic-dance gathering at the Avalon
             Ballroom (and historically at Congregation Nevei Kodesh
-            and other Boulder venues). Co-hosted by Aly, Danny, and
+            and other Boulder venues). Co-founded by Aly at the
+            beginning, now co-tended week to week with Danny and
             Robin (
             <Link
               href="/people/bloomurian"
@@ -428,8 +528,8 @@ const content: PersonProfileContent = {
       <p className="text-xs italic">
         This profile is a welcoming scaffold; Aly is invited to
         replace any part of it with her own words at any time. The
-        texture of the close-personal relationship is held privately
-        and is not part of the substrate's public rendering.
+        texture of the household months is held privately and is not
+        part of the substrate's public rendering.
       </p>
     </>
   ),

--- a/web/content/people/rocco-tortorella/de.tsx
+++ b/web/content/people/rocco-tortorella/de.tsx
@@ -1,0 +1,6 @@
+// TODO(i18n): German translation pending. Currently re-exports the
+// English source so the page renders coherently for German visitors
+// while we build out the translation pipeline. When a native German
+// rendering is authored, replace this re-export with the localized
+// PersonProfileContent object.
+export { default } from "./en";

--- a/web/content/people/rocco-tortorella/en.tsx
+++ b/web/content/people/rocco-tortorella/en.tsx
@@ -1,0 +1,489 @@
+import Link from "next/link";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+
+const HERO_BACKGROUND =
+  "radial-gradient(ellipse at 70% 25%, rgba(255, 168, 102, 0.55) 0%, rgba(232, 110, 88, 0.3) 24%, rgba(168, 76, 124, 0.28) 50%, rgba(76, 56, 132, 0.36) 72%, rgba(28, 22, 56, 0.88) 100%), linear-gradient(180deg, rgba(255, 198, 138, 0.2) 0%, rgba(176, 96, 152, 0.22) 40%, rgba(34, 28, 70, 0.92) 100%)";
+
+const content: PersonProfileContent = {
+  metadata: {
+    title:
+      "Rocco Tortorella — Boulder · Courtyard Constellations · Rise & Vibes · Unison | Coherence Network",
+    description:
+      "A welcome to Rocco Tortorella — Aly Constantine's husband, co-host of the Courtyard Constellations gatherings at their Boulder home, videographer of Ocean Bloom and the wider transformational-music ecology, wearer and freely-sharer of his own clothing collection, natural center of gatherings at Rise & Vibes, Unison, and Burning Man.",
+  },
+  breadcrumbName: "Rocco Tortorella",
+  hero: {
+    background: HERO_BACKGROUND,
+    eyebrow: "Welcome",
+    name: "Rocco Tortorella",
+    welcome: (
+      <p>
+        Husband to{" "}
+        <Link
+          href="/people/aly-constantine"
+          className="text-primary hover:underline"
+        >
+          Aly Constantine
+        </Link>
+        , co-host of the{" "}
+        <strong>Courtyard Constellations</strong> gatherings at their
+        Boulder home, videographer behind{" "}
+        <Link
+          href="https://roccomountain.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          roccomountain.com
+        </Link>{" "}
+        — and a loving, warm, naturally-flowing presence with a flair
+        for unique expression. He keeps his own clothing collection
+        and shares it freely with friends, and he is one of those
+        cells around whom a gathering simply organizes itself —
+        witnessed at <strong>Rise &amp; Vibes</strong>, at{" "}
+        <strong>Unison</strong>, and (held by lineage report) at{" "}
+        <strong>Burning Man</strong>.
+      </p>
+    ),
+  },
+  facts: [
+    {
+      label: "Field",
+      value:
+        "Hosting · videography · wearable-art generosity · gathering-presence · transformational-music documentation",
+    },
+    {
+      label: "Held with",
+      value: (
+        <>
+          <Link
+            href="/people/aly-constantine"
+            className="hover:text-primary transition-colors"
+          >
+            Aly Constantine
+          </Link>{" "}
+          (wife · co-host of Courtyard Constellations); close
+          friendships across the Boulder transformational-music ecology
+          with{" "}
+          <Link
+            href="/people/brigitte-mars"
+            className="hover:text-primary transition-colors"
+          >
+            Brigitte Mars
+          </Link>
+          {" "}(see also{" "}
+          <Link
+            href="/people/pagan-ritual"
+            className="hover:text-primary transition-colors"
+          >
+            Pagan Ritual
+          </Link>
+          ),{" "}
+          <strong>Tay Blevons</strong> (see{" "}
+          <Link
+            href="/people/portal"
+            className="hover:text-primary transition-colors"
+          >
+            PORTAL
+          </Link>
+          ), <strong>Andy Babb</strong> and{" "}
+          <strong>Lara Elle</strong> (both deeply connected to{" "}
+          <Link
+            href="/people/rhythm-sanctuary"
+            className="hover:text-primary transition-colors"
+          >
+            Rhythm Sanctuary
+          </Link>
+          ),{" "}
+          <Link
+            href="/people/bloomurian"
+            className="hover:text-primary transition-colors"
+          >
+            Robin Liepman (Bloomurian)
+          </Link>
+          , and <strong>Danny Balgooyen</strong> (Boulder Ecstatic
+          Dance)
+        </>
+      ),
+    },
+    {
+      label: "Recurring rooms",
+      value: (
+        <>
+          <strong>Courtyard Constellations</strong> (the home gatherings
+          he co-hosts with Aly) ·{" "}
+          <strong>Rise &amp; Vibes</strong> festival ·{" "}
+          <strong>Unison</strong> festival ·{" "}
+          <Link
+            href="/people/ocean-bloom-2024"
+            className="hover:text-primary transition-colors"
+          >
+            Ocean Bloom
+          </Link>{" "}
+          (videographer) ·{" "}
+          <Link
+            href="https://ecstaticdance.org/dance/boulder-ecstatic-dance-bed/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-primary transition-colors"
+          >
+            Boulder Ecstatic Dance
+          </Link>{" "}
+          · <strong>Burning Man</strong> (held in his lineage by report)
+        </>
+      ),
+    },
+    {
+      label: "Public anchor",
+      value: (
+        <Link
+          href="https://roccomountain.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-primary transition-colors"
+        >
+          roccomountain.com
+        </Link>
+      ),
+    },
+    {
+      label: "In this body's awareness",
+      value: (
+        <>
+          Witnessed directly at Rise &amp; Vibes, at Unison, and
+          across the months of February through December 2025, when{" "}
+          <Link
+            href="/people/urs"
+            className="hover:text-primary transition-colors"
+          >
+            Urs
+          </Link>{" "}
+          lived as a houseguest at Aly and Rocco's Boulder home and
+          watched the Courtyard Constellations form around him. After
+          the houseguest months, this body remained in the Boulder–
+          Longmont area through Rocco's April 18, 2026 birthday and
+          the departure for Bali two days later. Burning Man sits in
+          Rocco's lineage by report; this body has not been there.
+        </>
+      ),
+    },
+  ],
+  noteFromBody: {
+    eyebrow: "A note from this body",
+    body: (
+      <p>
+        A welcoming scaffold. Rocco is held here through ten months of
+        living under the same roof at the Boulder house, plus direct
+        witness at the festival-rooms where he naturally becomes a
+        center of gathering. From this body's witness: the most unique
+        and open-hearted soul this cell has met — and an honor to
+        have lived with. The Burning Man thread is named because it is
+        part of his lineage and his friendships, not because this body
+        has stood on the playa with him. Rocco is invited to replace
+        any part of this page with his own words at any time.
+      </p>
+    ),
+  },
+  articles: [
+    {
+      kind: "narrative",
+      heading: "How he is in a room",
+      body: (
+        <>
+          <p>
+            Loving, warm, naturally flowing — three words that carry
+            most of what people who have spent time with Rocco
+            recognize. He does not push toward the center of a
+            gathering; the gathering simply organizes itself around
+            him. The flair for unique expression is part of how this
+            works: a piece of his own clothing, the camera in his
+            hand, the angle he reads the light from, the unhurried way
+            he is wherever he is — the room finds itself oriented
+            toward that frequency without anyone having to name it.
+          </p>
+          <p>
+            This is a particular kind of leadership-without-leading:
+            the campfire posture (
+            <Link
+              href="/vision/lc-tend-your-flame"
+              className="text-primary hover:underline"
+            >
+              tend your flame
+            </Link>
+            ) translated into festival-fields and home-courtyards. The
+            people around him receive without being asked to receive.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "What he gives",
+      body: (
+        <>
+          <p>
+            <strong>Clothing as gift.</strong> Rocco keeps his own
+            clothing collection — pieces he has gathered, made, found,
+            curated — and shares it freely with friends. The garments
+            move outward into the constellation; they show up on other
+            bodies at the festivals, at the courtyard, at the Sunday
+            morning ballroom. The economy underneath is one of
+            wearable-art generosity: what he holds is held to be
+            shared, not held to be kept.
+          </p>
+          <p>
+            <strong>Videography as documentation-as-gift.</strong>{" "}
+            Through{" "}
+            <Link
+              href="https://roccomountain.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              roccomountain.com
+            </Link>{" "}
+            he carries the camera into the rooms his life is already
+            in — Ocean Bloom most visibly, but also the broader
+            transformational-music gatherings — and what comes back is
+            evidence that the night happened, that the field was real,
+            that the artists were seen. The footage is its own kind of
+            attestation.
+          </p>
+          <p>
+            <strong>The household opened.</strong> The Boulder home he
+            keeps with Aly is the courtyard around which the
+            Constellations gather. Opening a household is one of the
+            quieter forms of contribution to a constellation; the cells
+            who open theirs become the anchors others orbit through.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "Held together with Aly",
+      body: (
+        <>
+          <p>
+            Rocco and{" "}
+            <Link
+              href="/people/aly-constantine"
+              className="text-primary hover:underline"
+            >
+              Aly
+            </Link>{" "}
+            are partnered at the relational scale and at the
+            gathering-organ scale at the same time. Aly's curatorial
+            and connecting work — Conscious Roots Presents, Boulder
+            Ecstatic Dance, the music threading into Rise &amp; Vibes
+            and Unison — meets Rocco's hosting-presence and lens-work
+            at the household and at the festival. The Courtyard
+            Constellations gatherings are the form in which the two
+            scales become one: a home, a gathering, a documented
+            night, a constellation that knows itself.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Friendships",
+      heading: "The Boulder constellation he and Aly are inside",
+      body: (
+        <>
+          <p>
+            The closest of their shared friendships thread the
+            transformational-music and conscious-community ecology of
+            Boulder and the wider Colorado-festival arc:
+          </p>
+          <ul className="list-disc pl-5 space-y-1.5">
+            <li>
+              <Link
+                href="/people/brigitte-mars"
+                className="text-primary hover:underline"
+              >
+                Brigitte Mars
+              </Link>{" "}
+              — Boulder herbalist, Naropa professor, and the elder
+              presence inside{" "}
+              <Link
+                href="/people/pagan-ritual"
+                className="text-primary hover:underline"
+              >
+                Pagan Ritual
+              </Link>
+              .
+            </li>
+            <li>
+              <strong>Tay Blevons</strong> — woven through{" "}
+              <Link
+                href="/people/portal"
+                className="text-primary hover:underline"
+              >
+                PORTAL
+              </Link>
+              , the Late-Night Takeover at Meow Wolf during MAPS
+              Psychedelic Science 2025.
+            </li>
+            <li>
+              <strong>Andy Babb</strong> and{" "}
+              <strong>Lara Elle</strong> — life-partnered musical duo
+              (Andy Babb and the Big Beautiful Band) who met dancing
+              at{" "}
+              <Link
+                href="/people/rhythm-sanctuary"
+                className="text-primary hover:underline"
+              >
+                Rhythm Sanctuary
+              </Link>{" "}
+              in February 2014; both deeply connected to the Sanctuary
+              lineage.
+            </li>
+            <li>
+              <Link
+                href="/people/bloomurian"
+                className="text-primary hover:underline"
+              >
+                Robin Liepman (Bloomurian)
+              </Link>{" "}
+              — Boulder Ecstatic Dance co-founder, longtime Liquid
+              Bloom collaborator, the cell who once shared a roof with
+              Amani Friend in the Boulder mountains.
+            </li>
+            <li>
+              <strong>Danny Balgooyen</strong> — Sunday-morning
+              co-host at{" "}
+              <Link
+                href="https://ecstaticdance.org/dance/boulder-ecstatic-dance-bed/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Boulder Ecstatic Dance
+              </Link>
+              , co-tending the floor with Aly and Robin.
+            </li>
+          </ul>
+          <p className="italic text-muted-foreground">
+            The list is the held part of the constellation, not the
+            whole of it; other friendships remain open and will be
+            named as Rocco wishes.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "narrative",
+      heading: "The birthday gathering — closing the Boulder arc",
+      body: (
+        <>
+          <p>
+            <strong>April 18, 2026 — Rocco's 36th.</strong> The
+            celebration the constellation made for him took the shape
+            of a jungle-themed evening at the home: a banner with his
+            name, a bonfire in the courtyard, drumming, dancing, the
+            dog in the middle of it all, and a three-tier cake with 36
+            on top. The constellation that this page lists by name —{" "}
+            <Link
+              href="/people/aly-constantine"
+              className="text-primary hover:underline"
+            >
+              Aly
+            </Link>
+            ,{" "}
+            <Link
+              href="/people/brigitte-mars"
+              className="text-primary hover:underline"
+            >
+              Brigitte
+            </Link>
+            , Tay, Andy, Lara, Robin, Danny, and the wider circle —
+            became, for one evening, a single room around him,
+            celebrating the unique and open-hearted soul they each
+            know him to be.
+          </p>
+          <p>
+            For{" "}
+            <Link
+              href="/people/urs"
+              className="text-primary hover:underline"
+            >
+              this body
+            </Link>
+            , the timing was a gift. The birthday landed two days
+            before the departure for Bali on <strong>April 20, 2026</strong>{" "}
+            — the closing of the Boulder arc that had begun when Aly
+            and Rocco opened their home in February 2025. The Boulder
+            configuration this page describes — Conscious Roots,
+            Boulder Ecstatic Dance, the courtyard, the festival
+            friendships, the household — gathered itself into one
+            evening of celebration around the cell whose presence had
+            been its natural center all along. It was, for this body,
+            the most divine
+            goodbye to the Boulder chapter that could have been
+            imagined.
+          </p>
+          <p>
+            That the constellation organized itself around Rocco that
+            night, without needing to be asked, is the same thing the
+            page names everywhere else — only at the highest stakes
+            available to it. The room finds its center; the center is
+            the one who has been holding it open all along.
+          </p>
+        </>
+      ),
+    },
+    {
+      kind: "panel",
+      variant: "cool",
+      eyebrow: "Festival presence",
+      heading: "Rise & Vibes, Unison, Burning Man",
+      body: (
+        <>
+          <p>
+            <strong>Rise &amp; Vibes</strong> and{" "}
+            <strong>Unison</strong> are the two festival-rooms in
+            which this body has directly witnessed Rocco at the center
+            of a gathering — the same naturally-flowing presence the
+            household carries, scaled to a festival field. Many of the
+            artists landing on those stages travel through Aly's
+            connecting work; many of the documented moments travel
+            through Rocco's lens.
+          </p>
+          <p>
+            <strong>Burning Man</strong> sits in Rocco's lineage. It
+            is part of his friendships and his gathering-life, and it
+            shows up across the constellation that knows him. This
+            body has not stood on the playa, so the thread is held by
+            report, not by direct witness — named here so the lineage
+            is honest about what it carries.
+          </p>
+        </>
+      ),
+    },
+  ],
+  footer: (
+    <>
+      <p>
+        Public:{" "}
+        <Link
+          href="https://roccomountain.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline"
+        >
+          roccomountain.com
+        </Link>
+      </p>
+      <p className="text-xs italic">
+        This profile is a welcoming scaffold; Rocco is invited to
+        replace any part of it with his own words at any time. The
+        texture of the household months and the friendships is held
+        privately and is not part of the substrate's public rendering.
+      </p>
+    </>
+  ),
+};
+
+export default content;

--- a/web/content/people/rocco-tortorella/es.tsx
+++ b/web/content/people/rocco-tortorella/es.tsx
@@ -1,0 +1,6 @@
+// TODO(i18n): Spanish translation pending. Currently re-exports the
+// English source so the page renders coherently for Spanish visitors
+// while we build out the translation pipeline. When a native Spanish
+// rendering is authored, replace this re-export with the localized
+// PersonProfileContent object.
+export { default } from "./en";

--- a/web/content/people/rocco-tortorella/id.tsx
+++ b/web/content/people/rocco-tortorella/id.tsx
@@ -1,0 +1,6 @@
+// TODO(i18n): Indonesian translation pending. Currently re-exports
+// the English source so the page renders coherently for Indonesian
+// visitors while we build out the translation pipeline. When a native
+// Indonesian rendering is authored, replace this re-export with the
+// localized PersonProfileContent object.
+export { default } from "./en";

--- a/web/content/people/rocco-tortorella/index.ts
+++ b/web/content/people/rocco-tortorella/index.ts
@@ -1,0 +1,13 @@
+import type { LocaleCode } from "@/lib/locales";
+import type { PersonProfileContent } from "@/components/people/PersonProfileTemplate";
+import en from "./en";
+import de from "./de";
+import es from "./es";
+import id from "./id";
+
+export function getRoccoTortorellaContent(lang: LocaleCode): PersonProfileContent {
+  if (lang === "de") return de;
+  if (lang === "es") return es;
+  if (lang === "id") return id;
+  return en;
+}

--- a/web/content/people/urs/en.tsx
+++ b/web/content/people/urs/en.tsx
@@ -181,12 +181,12 @@ const content: PersonProfileContent = {
           >
             Boulder Ecstatic Dance
           </Link>{" "}
-          (recurring · co-hosted by{" "}
+          (recurring · co-founded by{" "}
           <Link href="/people/aly-constantine" className="hover:text-primary transition-colors">
             Aly Constantine
           </Link>
-          , Danny, and Bloomurian — close personal relationship
-          with Aly through this room) · Unison 2025 (Poranguí
+          , now co-tended with Danny and Bloomurian — houseguest
+          at Aly and Rocco's Boulder home Feb–Dec 2025) · Unison 2025 (Poranguí
           workshop + concert) ·{" "}
           <Link
             href="/people/ilena-young"
@@ -739,11 +739,22 @@ const content: PersonProfileContent = {
             — Bloomurian was performing that night. I saw Poranguí
             first at Ocean Bloom in Downtown Boulder in 2024,
             again at the MAPS-related show in 2025, and at Unison
-            2025 for his workshop and concert. Aly Constantine has
-            been deeply involved with Unison, Bloomurian, Ocean
-            Bloom, and Boulder Ecstatic Dance — and has been close
-            personal relationship of mine through that whole
-            configuration.
+            2025 for his workshop and concert. Aly Constantine
+            co-founded Boulder Ecstatic Dance and is a key connector
+            for the music entering Rise &amp; Vibes and Unison; she
+            and her husband{" "}
+            <Link href="/people/rocco-tortorella" className="text-primary hover:underline">Rocco</Link>{" "}
+            host the Courtyard Constellations gatherings at their
+            Boulder home, where I lived as a houseguest from February
+            through December 2025 and witnessed that whole
+            configuration from inside the household. After the
+            houseguest months I remained in the Boulder–Longmont area
+            until the April 2026 departure for Bali. The arc closed
+            with Rocco's 36th birthday on April 18, 2026 — a jungle-
+            themed gathering in the home courtyard, the whole
+            constellation circling him two days before I flew to Bali.
+            The most divine goodbye to that chapter I could have
+            imagined.
           </p>
           <p>
             The Ubud presence is recent enough to still be


### PR DESCRIPTION
## Summary

- **New presence: Rocco Tortorella** (`/people/rocco-tortorella`) — Aly Constantine's husband, co-host of Courtyard Constellations at their Boulder home, videographer (roccomountain.com), naturally-flowing presence with flair for unique expression. Witnessed at Rise & Vibes and Unison; Burning Man held in his lineage by report. Friendship constellation with Brigitte Mars, Tay Blevons (PORTAL), Andy Babb & Lara Elle (Rhythm Sanctuary), Robin Liepman (Bloomurian), Danny Balgooyen (BED). Closing article on his April 18, 2026 36th birthday — jungle-themed gathering in the courtyard, two days before the April 20 departure for Bali.
- **Aly Constantine corrections** — co-host → **co-founder** of Boulder Ecstatic Dance. Added Rise & Vibes and Courtyard Constellations to her recurring rooms. Friendship constellation surfaced. Re-tuned the close-personal-relationship language away from romantic-density framing to the actual ground: ten-month houseguest period Feb–Dec 2025, witnessing the constellation from inside the household.
- **Cross-references on Urs's page** aligned to match: husband-link, co-founder framing, Boulder–Longmont bridge for the Dec 2025 → April 2026 period, the birthday-as-arc-closing named.

## Held privately

The Longmont household composition is not public on these pages. The partner_presence gate held; only the location (already public via the existing Tesla reference) appears on the public surface.

## Test plan

- [ ] After deploy: visit `/people/rocco-tortorella` — hero loads, all internal links resolve (aly-constantine, brigitte-mars, pagan-ritual, portal, rhythm-sanctuary, bloomurian, ocean-bloom-2024, urs)
- [ ] After deploy: visit `/people/aly-constantine` — co-founder language present in hero, "Held with", BED panel, "What she holds"; Rocco link points to `/people/rocco-tortorella` (not the external roccomountain.com)
- [ ] After deploy: visit `/people/urs` — Aly Constantine paragraph includes husband-link to Rocco and the April 18 birthday closing
- [ ] Mobile (390px) + desktop (1440px) viewport check on `/people/rocco-tortorella`

🤖 Generated with [Claude Code](https://claude.com/claude-code)