### PR TITLE
tend(spec): re-sync federation-network-layer (5 drifts → 0)

### DIFF
--- a/specs/federation-network-layer.md
+++ b/specs/federation-network-layer.md
@@ -3,13 +3,13 @@ idea_id: federation-and-nodes
 status: done
 source:
   - file: api/app/routers/federation.py
-    symbols: [register_node, heartbeat_node, list_nodes, push_measurements, list_strategies, send_message, broadcast]
+    symbols: [register_node, heartbeat_node, list_nodes, post_measurement_summaries, get_strategies, send_message, broadcast_message]
   - file: api/app/services/federation_service.py
     symbols: [register_or_update_node, heartbeat_node, store_measurement_summaries, compute_and_store_strategies, record_strategy_effectiveness]
   - file: api/app/services/node_identity_service.py
-    symbols: [derive_node_id]
+    symbols: [get_or_create_node_id, get_node_metadata]
   - file: api/app/routers/openclaw_node_bridge.py
-    symbols: [bridge_sync]
+    symbols: [openclaw_node_bridge, pump_out]
 requirements:
   - Node registration with capabilities declaration
   - Heartbeat keep-alive with system metrics


### PR DESCRIPTION
## Summary

Fourth spec resync in the rhythm. Five drifted symbols, all renames toward more REST-aligned or semantically-truer names.

| File | Was | Now |
|---|---|---|
| routers/federation | push_measurements | **post_measurement_summaries** |
| routers/federation | list_strategies | **get_strategies** |
| routers/federation | broadcast | **broadcast_message** |
| services/node_identity_service | derive_node_id | **get_or_create_node_id** (semantic shift: it persists and reuses across restarts, not just derives from env) |
| routers/openclaw_node_bridge | bridge_sync | **openclaw_node_bridge** + **pump_out** |

The spec's \`federation_service.py\` symbol claims all still resolve — no drift in the service layer, just at the router edges where REST naming got tightened.

The federation layer (multi-node registration, heartbeats, measurement push, strategy propagation, inter-node messaging, OpenClaw bridge) is alive in production. \`status: done\` stays honest.

After merge: wellness drift drops **68 → 63** across **32 → 31** specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)