### PR TITLE
tend(spec): re-sync external-repo-milestone (4 drifts → 0)

### DIFF
--- a/specs/external-repo-milestone.md
+++ b/specs/external-repo-milestone.md
@@ -3,17 +3,17 @@ idea_id: developer-experience
 status: done
 source:
   - file: scripts/external_proof_demo.py
-    symbols: [_idea_create_payload, run_idea_lifecycle, record_contribution, check_coherence_score]
+    symbols: [ProofRunner, create_idea, advance_stage, record_contribution, check_coherence_score, archive_idea, run]
   - file: api/tests/test_external_proof_demo.py
     symbols: [test_external_proof_idea_payload_matches_public_contract]
   - file: api/app/routers/ideas.py
-    symbols: [create_idea, get_idea, update_idea_stage, list_ideas]
+    symbols: [create_idea, get_idea, advance_idea_stage, set_idea_stage, list_ideas]
   - file: api/app/routers/contributions.py
-    symbols: [record_contribution, list_contributions]
+    symbols: [create_contribution, record_open_contribution, list_contributions, get_contribution]
   - file: api/app/routers/coherence.py
-    symbols: [get_coherence_score]
+    symbols: [get_coherence_score, CoherenceScoreResponse]
   - file: api/app/routers/health.py
-    symbols: [health_check]
+    symbols: [health, ready, ping, HealthResponse]
   - file: docs/EXTERNAL_ENABLEMENT_TRACKING.md
     symbols: []
 requirements:


### PR DESCRIPTION
## Summary

Fifth spec resync in the rhythm. Four drifted symbols — one script-level refactor, three router-edge REST tightenings.

| File | Was | Now |
|---|---|---|
| scripts/external_proof_demo | run_idea_lifecycle | **ProofRunner class with .run()** (procedural → class-based) |
| routers/ideas | update_idea_stage | **advance_idea_stage** (POST /advance) + **set_idea_stage** (PUT /stage) — split |
| routers/contributions | record_contribution | **create_contribution** (auth path) + **record_open_contribution** (public, used by external-proof) — split |
| routers/health | health_check | **health** (mounted at /health) |

The spec's behavior — external proof of the body's contract, run from outside the repo — is alive. \`status: done\` stays honest.

After merge: wellness drift drops **63 → 59** across **31 → 30** specs.

**Pattern continuation**: the body's metabolism prefers REST-aligned naming + small focused functions over verbose monoliths. Five resyncs now consistent on this character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)