### PR TITLE
attune(field): register Friday message PDFs as source bodies

### DIFF
--- a/api/tests/test_field_story_trace_index.py
+++ b/api/tests/test_field_story_trace_index.py
@@ -200,6 +200,12 @@ def test_digital_influence_inventory_registers_full_history_attention():
     assert trace["youtube"]["history_only_takeout"]["events"] > 60000
     assert trace["youtube"]["published_gap"]["missing_2023_events"] > 10000
     assert trace["youtube"]["published_gap"]["missing_before_2024_05_07_events"] > 30000
+    pdf_items = trace["local_source_pdfs"]["items"]
+    assert any(item["file_name"] == "Friday Live Channeled Message 5.8.26.pdf" for item in pdf_items)
+    friday_pdf = next(item for item in pdf_items if item["file_name"] == "Friday Live Channeled Message 5.8.26.pdf")
+    assert friday_pdf["label"] == "channeled-message-pdf"
+    assert friday_pdf["ingestion_policy"] == "metadata_hashes_and_summary_only"
+    assert friday_pdf["content_type"] == "application/pdf"
     assert trace["publication_boundary"].startswith("This compact artifact publishes")
 
 
@@ -219,6 +225,12 @@ def test_source_crypto_trace_registers_hash_roots_for_dynamic_access():
     assert trace["normalized_event_trace"]["event_merkle_root"]
     assert trace["roots"]["combined_trace_root"]
     assert len(trace["source_bodies"]) >= 10
+    assert any(
+        row["label"] == "channeled-message-pdf"
+        and row["path"].endswith("Friday Live Channeled Message 5.8.26.pdf")
+        and row["content_type"] == "application/pdf"
+        for row in trace["source_bodies"]
+    )
     assert trace["dynamic_access"]["mcp_tool"] == "get_field_story_trace"
     assert trace["truth_boundary"]["next_precision"].startswith("For exact row-to-source-body proofs")
 

--- a/docs/field/urs/output/digital_influence_inventory.md
+++ b/docs/field/urs/output/digital_influence_inventory.md
@@ -2,7 +2,7 @@
 
 This inventory maps the local digital-history sources available for the Urs field story without committing bulky raw archives.
 
-Generated: `2026-05-13T00:02:31.724515+00:00`
+Generated: `2026-05-13T11:22:31.222991+00:00`
 
 ## Publication Boundary
 
@@ -16,6 +16,7 @@ This compact artifact publishes source counts, date spans, filenames, and aggreg
 - YouTube uploads/library archives: 4743 audio files and 5 video files across 13 archives.
 - Audible library/listen/purchase captures: 233 library, 50 listen-history, 198 purchase-history rows.
 - Local browser trace: 167 events, `2026-02-05T05:59:11.980937+00:00` to `2026-05-06T02:16:11.728236+00:00`.
+- Local source PDFs: 2 metadata-only bodies.
 
 ## Expanded Trace Before The Former Window
 
@@ -119,9 +120,17 @@ This compact artifact publishes source counts, date spans, filenames, and aggreg
 - `Angelic-20260507T052334Z-3-001.zip`: 2774 files
 - `Water Project.zip`: 8 files
 
+## Local Source PDFs
+
+PDF source bodies are represented by metadata and hashes only until a specific summary/extracted-concept breath is chosen.
+
+- `Friday Live Channeled Message 1.16.26.pdf`: `channeled-message-pdf`, 233747 bytes, 5 pages, author `Anne Tucker`, date hint `2026-01-16`; policy `metadata_hashes_and_summary_only`.
+- `Friday Live Channeled Message 5.8.26.pdf`: `channeled-message-pdf`, 135871 bytes, 4 pages, author `Anne Tucker`, date hint `2026-05-08`; policy `metadata_hashes_and_summary_only`.
+
 ## Next Breath
 
 - Use `trace/monthly_spectrum.json`, `trace/author_index.jsonl`, and `trace/work_index.jsonl` as the compact query layer for the expanded YouTube trace.
 - Add a 2023/early-2024 transition room for the flamenco/Spanish-guitar body wave and its bridge into devotional-body music.
 - Add a separate unresolved-author cleanup for `here` YouTube rows before treating them as real influence presences.
+- Decide whether `Friday Live Channeled Message 5.8.26.pdf` wants a separate summary/extracted-concept artifact; the raw PDF remains a local source body.
 - Keep Photos and Gmail at metadata/header level in this compact pass; deeper source-specific analysis can happen when that breath is useful.

--- a/docs/field/urs/tools/digital_influence_inventory.py
+++ b/docs/field/urs/tools/digital_influence_inventory.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import html
 import json
+import mimetypes
 import re
+import subprocess
 import zipfile
 from collections import Counter
 from datetime import UTC, datetime
@@ -15,6 +18,7 @@ from typing import Any
 
 GENERIC_AUTHORS = {"here", "unknown", "empty artist - topic"}
 TAKEOUT_DATE_RE = re.compile(r"([A-Z][a-z]+ \d{1,2}, \d{4}, \d{1,2}:\d{2}:\d{2}\s*[AP]M)\s*([A-Z]+)?")
+LOCAL_SOURCE_PDF_PATTERNS = ("Friday Live Channeled Message *.pdf",)
 PUBLISHED_TRACE_START = datetime(2024, 5, 7)
 
 
@@ -43,6 +47,14 @@ def read_json(path: Path) -> Any:
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def top(counter: Counter[Any], limit: int = 20) -> list[dict[str, Any]]:
@@ -266,6 +278,74 @@ def summarize_project_archives(downloads_dir: Path) -> dict[str, Any]:
     return archives
 
 
+def _pdfinfo(path: Path) -> dict[str, str]:
+    try:
+        result = subprocess.run(
+            ["pdfinfo", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    rows: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        rows[key.strip().lower().replace(" ", "_")] = clean(value)
+    return rows
+
+
+def _date_hint_from_filename(path: Path) -> str | None:
+    match = re.search(r"\b(\d{1,2})\.(\d{1,2})\.(\d{2,4})\b", path.stem)
+    if not match:
+        return None
+    month, day, year = match.groups()
+    if len(year) == 2:
+        year = f"20{year}"
+    return f"{year}-{int(month):02d}-{int(day):02d}"
+
+
+def summarize_local_source_pdfs(downloads_dir: Path) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    seen: set[Path] = set()
+    for pattern in LOCAL_SOURCE_PDF_PATTERNS:
+        for path in sorted(downloads_dir.glob(pattern)):
+            if not path.is_file() or path in seen:
+                continue
+            seen.add(path)
+            stat = path.stat()
+            metadata = _pdfinfo(path)
+            items.append(
+                {
+                    "file_name": path.name,
+                    "path": str(path),
+                    "label": "channeled-message-pdf",
+                    "title_hint": path.stem,
+                    "date_hint": _date_hint_from_filename(path),
+                    "size_bytes": stat.st_size,
+                    "modified_at": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
+                    "sha256": sha256_file(path),
+                    "content_type": mimetypes.guess_type(path.name)[0] or "application/pdf",
+                    "pages": int(metadata["pages"]) if metadata.get("pages", "").isdigit() else None,
+                    "author": metadata.get("author"),
+                    "creator": metadata.get("creator"),
+                    "ingestion_policy": "metadata_hashes_and_summary_only",
+                    "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+                }
+            )
+    return {
+        "count": len(items),
+        "patterns": list(LOCAL_SOURCE_PDF_PATTERNS),
+        "items": items,
+        "publication_boundary": "PDF source bodies are represented by metadata and hashes only until a specific summary/extracted-concept breath is chosen.",
+    }
+
+
 def summarize_agent_history() -> dict[str, Any]:
     root = Path.home() / ".gemini" / "history"
     if not root.exists():
@@ -328,6 +408,7 @@ def build(field_dir: Path, analysis_root: Path, downloads_dir: Path) -> dict[str
         "browser": summarize_browser(analysis_root),
         "photos": summarize_photos(downloads_dir),
         "project_archives": summarize_project_archives(downloads_dir),
+        "local_source_pdfs": summarize_local_source_pdfs(downloads_dir),
         "agent_history": summarize_agent_history(),
     }
 
@@ -358,6 +439,7 @@ def write_markdown(path: Path, payload: dict[str, Any]) -> None:
         f"- YouTube uploads/library archives: {payload['youtube']['uploads_and_library_parts']['audio_upload_files']} audio files and {payload['youtube']['uploads_and_library_parts']['video_upload_files']} video files across {payload['youtube']['uploads_and_library_parts']['archives']} archives.",
         f"- Audible library/listen/purchase captures: {payload['audible']['library']['events']} library, {payload['audible']['listen_history']['events']} listen-history, {payload['audible']['purchase_history']['events']} purchase-history rows.",
         f"- Local browser trace: {payload['browser']['events']} events, `{payload['browser']['first']}` to `{payload['browser']['last']}`.",
+        f"- Local source PDFs: {payload['local_source_pdfs']['count']} metadata-only bodies.",
         "",
         "## Expanded Trace Before The Former Window",
         "",
@@ -389,10 +471,22 @@ def write_markdown(path: Path, payload: dict[str, Any]) -> None:
         lines.append(f"- `{name}`: {row['files']} files, filename dates `{row['first_date_from_filename']}` to `{row['last_date_from_filename']}`")
     for name, row in payload["project_archives"].items():
         lines.append(f"- `{name}`: {row['files']} files")
+    lines.extend(["", "## Local Source PDFs", ""])
+    lines.append(payload["local_source_pdfs"]["publication_boundary"])
+    lines.append("")
+    for row in payload["local_source_pdfs"]["items"]:
+        page_note = f", {row['pages']} pages" if row.get("pages") else ""
+        author_note = f", author `{row['author']}`" if row.get("author") else ""
+        date_note = f", date hint `{row['date_hint']}`" if row.get("date_hint") else ""
+        lines.append(
+            f"- `{row['file_name']}`: `{row['label']}`, {row['size_bytes']} bytes{page_note}{author_note}{date_note}; "
+            f"policy `{row['ingestion_policy']}`."
+        )
     lines.extend(["", "## Next Breath", ""])
     lines.append("- Use `trace/monthly_spectrum.json`, `trace/author_index.jsonl`, and `trace/work_index.jsonl` as the compact query layer for the expanded YouTube trace.")
     lines.append("- Add a 2023/early-2024 transition room for the flamenco/Spanish-guitar body wave and its bridge into devotional-body music.")
     lines.append("- Add a separate unresolved-author cleanup for `here` YouTube rows before treating them as real influence presences.")
+    lines.append("- Decide whether `Friday Live Channeled Message 5.8.26.pdf` wants a separate summary/extracted-concept artifact; the raw PDF remains a local source body.")
     lines.append("- Keep Photos and Gmail at metadata/header level in this compact pass; deeper source-specific analysis can happen when that breath is useful.")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/docs/field/urs/tools/source_crypto_trace.py
+++ b/docs/field/urs/tools/source_crypto_trace.py
@@ -24,6 +24,7 @@ SOURCE_PATTERNS = [
     ("audible-export", ANALYSIS_ROOT / "input" / "audible", ["*.json", "*.jsonl", "*.csv", "*.html"]),
     ("browser-trace", ANALYSIS_ROOT / "input" / "browser", ["*.json", "*.jsonl", "*.sqlite", "*.db"]),
     ("downloaded-takeout", DOWNLOADS_DIR, ["takeout-*.zip"]),
+    ("channeled-message-pdf", DOWNLOADS_DIR, ["Friday Live Channeled Message *.pdf"]),
     ("photo-archive", DOWNLOADS_DIR, ["Photos-*.zip"]),
     ("project-archive", DOWNLOADS_DIR, ["Water Project.zip", "Angelic-*.zip"]),
 ]

--- a/docs/field/urs/trace/digital_influence_inventory.json
+++ b/docs/field/urs/trace/digital_influence_inventory.json
@@ -822,7 +822,48 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T00:02:31.724515+00:00",
+  "generated_at": "2026-05-13T11:22:31.222991+00:00",
+  "local_source_pdfs": {
+    "count": 2,
+    "items": [
+      {
+        "author": "Anne Tucker",
+        "content_type": "application/pdf",
+        "creator": "Microsoft Word",
+        "date_hint": "2026-01-16",
+        "file_name": "Friday Live Channeled Message 1.16.26.pdf",
+        "ingestion_policy": "metadata_hashes_and_summary_only",
+        "label": "channeled-message-pdf",
+        "modified_at": "2026-01-17T08:47:19.104015+00:00",
+        "pages": 5,
+        "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 1.16.26.pdf",
+        "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+        "sha256": "5c8a30ebb8d2eeda1abba2813970359c207583abf2391ab1378230d41692f186",
+        "size_bytes": 233747,
+        "title_hint": "Friday Live Channeled Message 1.16.26"
+      },
+      {
+        "author": "Anne Tucker",
+        "content_type": "application/pdf",
+        "creator": "Microsoft Word",
+        "date_hint": "2026-05-08",
+        "file_name": "Friday Live Channeled Message 5.8.26.pdf",
+        "ingestion_policy": "metadata_hashes_and_summary_only",
+        "label": "channeled-message-pdf",
+        "modified_at": "2026-05-12T01:23:17.257392+00:00",
+        "pages": 4,
+        "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 5.8.26.pdf",
+        "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+        "sha256": "80a4736c3763be8bc76e15c3242b947b8a7f84bbb0247cbdee90d2ea0355999b",
+        "size_bytes": 135871,
+        "title_hint": "Friday Live Channeled Message 5.8.26"
+      }
+    ],
+    "patterns": [
+      "Friday Live Channeled Message *.pdf"
+    ],
+    "publication_boundary": "PDF source bodies are represented by metadata and hashes only until a specific summary/extracted-concept breath is chosen."
+  },
   "photos": {
     "Photos-3-001.zip": {
       "extensions": {

--- a/docs/field/urs/trace/source_crypto_trace.json
+++ b/docs/field/urs/trace/source_crypto_trace.json
@@ -6,7 +6,7 @@
     "month_trace_api": "/api/field-stories/urs-field-story/trace/month/{YYYY-MM}",
     "work_trace_api": "/api/field-stories/urs-field-story/trace/work/{work_id}"
   },
-  "generated_at": "2026-05-13T00:02:48.625458+00:00",
+  "generated_at": "2026-05-13T11:22:43.188094+00:00",
   "hash_algorithm": "sha256",
   "normalized_event_trace": {
     "event_leaf_hash_algorithm": "sha256('event:' + canonical_json(row))",
@@ -101,8 +101,8 @@
       "artifact_relpath": "trace/digital_influence_inventory.json",
       "content_type": "application/json",
       "path": "docs/field/urs/trace/digital_influence_inventory.json",
-      "sha256": "e8447bf5b62db7642303f93ef4d604bf27c57e9b81b73b31d6033efad536d96b",
-      "size_bytes": 104002
+      "sha256": "a3185f1df9456874687d9bfef0ab296c477a050bfd2cfe78b81380725b177b6b",
+      "size_bytes": 106006
     },
     {
       "artifact_relpath": "output/chronological_story_with_frequency.md",
@@ -113,10 +113,10 @@
     }
   ],
   "roots": {
-    "combined_trace_root": "21a16d4b5e5283f820a32f238e736db1e020539a53190b2d7753edfacfcd224c",
+    "combined_trace_root": "3dbc40b02749a1fb8d792477c3e52401a0e8b2c5a2bc83ca6344fd8c0ff714fe",
     "normalized_event_merkle_root": "d623a7b9940f55b6430015ad87ee009fe8ed728b6b5ed8b2d07c2c8e53955444",
-    "repo_artifact_merkle_root": "e8582e36ae46e1ac948de16629f7b7f42377ff4af863c4cbc9ee798238a69a7e",
-    "source_body_merkle_root": "f913a1e53db49ad868bb49def9e78108a1146a2e5d23368b9c3ce6addcafbe3e"
+    "repo_artifact_merkle_root": "dba1a0430f37bc4ca9b0fcea2cb28560c96cf10a30ae8d950db10ca3a1f7488d",
+    "source_body_merkle_root": "c8f0c8b91859a8f3ee23c8687b42e54ef312d287b89bc33029b39120cc2890f9"
   },
   "schema_version": "field-source-crypto-trace/v1",
   "source_bodies": [
@@ -452,6 +452,26 @@
       "sha256": "6dbd39e21bbac1a0e9dd6ac5b464edf93b638761391c894c151876c9561a5f5c",
       "size_bytes": 4081111,
       "zip_entries": 2
+    },
+    {
+      "content_type": "application/pdf",
+      "id": "source:channeled-message-pdf:friday-live-channeled-message-1.16.26.pdf:5c8a30ebb8d2",
+      "label": "channeled-message-pdf",
+      "modified_at": "2026-01-17T08:47:19.104015+00:00",
+      "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 1.16.26.pdf",
+      "path_class": "local_source_body",
+      "sha256": "5c8a30ebb8d2eeda1abba2813970359c207583abf2391ab1378230d41692f186",
+      "size_bytes": 233747
+    },
+    {
+      "content_type": "application/pdf",
+      "id": "source:channeled-message-pdf:friday-live-channeled-message-5.8.26.pdf:80a4736c3763",
+      "label": "channeled-message-pdf",
+      "modified_at": "2026-05-12T01:23:17.257392+00:00",
+      "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 5.8.26.pdf",
+      "path_class": "local_source_body",
+      "sha256": "80a4736c3763be8bc76e15c3242b947b8a7f84bbb0247cbdee90d2ea0355999b",
+      "size_bytes": 135871
     },
     {
       "content_type": "application/zip",

--- a/docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json
+++ b/docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json
@@ -1,0 +1,113 @@
+{
+  "date": "2026-05-13",
+  "thread_branch": "codex/field-trace-pdf-source-20260513",
+  "commit_scope": "Represent Friday Live Channeled Message PDFs as metadata-only local field source bodies in the digital inventory and source crypto trace.",
+  "files_owned": [
+    "api/tests/test_field_story_trace_index.py",
+    "docs/field/urs/output/digital_influence_inventory.md",
+    "docs/field/urs/tools/digital_influence_inventory.py",
+    "docs/field/urs/tools/source_crypto_trace.py",
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "git worktree add /Users/ursmuff/.claude-worktrees/Coherence-Network/field-trace-pdf-source-20260513 -b codex/field-trace-pdf-source-20260513 origin/main",
+      "make prompt-guide",
+      "make wellness",
+      "pdfinfo /Users/ursmuff/Downloads/'Friday Live Channeled Message 5.8.26.pdf'",
+      "pdftotext /Users/ursmuff/Downloads/'Friday Live Channeled Message 5.8.26.pdf' -",
+      "python3 docs/field/urs/tools/digital_influence_inventory.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads",
+      "python3 docs/field/urs/tools/source_crypto_trace.py --field-dir docs/field/urs",
+      "python3 -m py_compile docs/field/urs/tools/digital_influence_inventory.py docs/field/urs/tools/source_crypto_trace.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_field_story_trace_index.py",
+      "git diff --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json",
+      "git fetch origin main && git rebase origin/main",
+      "git stash push -u -m pre-rebase-field-trace-pdf-source && git rebase origin/main && git stash pop",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "summary": "Prompt gate and wellness passed in the dedicated worktree. The 2026-05-08 Friday Live Channeled Message PDF was confirmed as a 4-page local PDF source body. The compact builders now register Friday message PDFs as metadata/hash-only source bodies without storing PDF text or raw files in the repo. Focused field story trace tests pass: 14 tests, 7 warnings. Stale PR follow-through reports zero stale Codex PRs. Local PR guard passes with ready_for_push=True."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy attempted yet in this breath."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The digital influence inventory exposes local source PDFs as metadata-only bodies, and source crypto includes their SHA-256-backed source-body rows in the Merkle root.",
+    "public_endpoints": [
+      "/api/field-stories/urs-field-story/artifacts/digital-influence-inventory",
+      "/api/field-stories/urs-field-story/artifacts/trace-digital-influence-inventory",
+      "/api/field-stories/urs-field-story/artifacts/trace-source-crypto"
+    ],
+    "test_flows": [
+      "Digital influence inventory artifact includes Friday Live Channeled Message 5.8.26.pdf with metadata_hashes_and_summary_only policy.",
+      "Source crypto trace includes channeled-message-pdf source bodies with application/pdf content type."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused proof, stale PR follow-through, and local PR guard are complete; PR CI and deploy validation remain pending."
+  },
+  "idea_ids": [
+    "field-sensing",
+    "presence-traces"
+  ],
+  "spec_ids": [
+    "specs/digital-influence-inventory.md",
+    "specs/field-listening-trace-index.md"
+  ],
+  "task_ids": [
+    "automation:field-trace-living-ingest",
+    "next-breath:field-trace-pdf-source"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "source_body_custody"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "source_body_inventory",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "docs/field/urs/output/digital_influence_inventory.md",
+    "api/tests/test_field_story_trace_index.py",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260513T112433Z_codex-field-trace-pdf-source-20260513.json"
+  ],
+  "change_files": [
+    "api/tests/test_field_story_trace_index.py",
+    "docs/field/urs/output/digital_influence_inventory.md",
+    "docs/field/urs/tools/digital_influence_inventory.py",
+    "docs/field/urs/tools/source_crypto_trace.py",
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json"
+  ],
+  "change_intent": "runtime_fix"
+}


### PR DESCRIPTION
## Summary
- registers Friday Live Channeled Message PDFs as metadata/hash-only local source bodies
- updates digital influence inventory and source crypto trace artifacts
- keeps raw PDF files and extracted transcript text outside the repo

## Proof
- make prompt-guide
- make wellness
- python3 docs/field/urs/tools/digital_influence_inventory.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads
- python3 docs/field/urs/tools/source_crypto_trace.py --field-dir docs/field/urs
- python3 -m py_compile docs/field/urs/tools/digital_influence_inventory.py docs/field/urs/tools/source_crypto_trace.py
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_field_story_trace_index.py
- git diff --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-13_field_trace_pdf_source.json
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main