### PR TITLE
attune(field): move source body inventory into registry

### DIFF
--- a/api/tests/test_field_story_trace_index.py
+++ b/api/tests/test_field_story_trace_index.py
@@ -144,6 +144,7 @@ def test_influence_breath_cycle_registers_youtube_discovery_loop():
     assert "trace-encounter-next-breath" in artifact_ids
     assert "digital-influence-inventory" in artifact_ids
     assert "trace-digital-influence-inventory" in artifact_ids
+    assert "source-body-registry" in artifact_ids
 
     report_response = client.get("/api/field-stories/urs-field-story/artifacts/influence-breath-cycle")
     assert report_response.status_code == 200, report_response.text
@@ -197,6 +198,7 @@ def test_digital_influence_inventory_registers_full_history_attention():
     assert trace_response.status_code == 200, trace_response.text
     trace = json.loads(trace_response.json()["content"])
     assert trace["schema_version"] == "digital-influence-inventory/v1"
+    assert trace["source_body_registry"]["schema_version"] == "field-source-body-registry/v1"
     assert trace["youtube"]["history_only_takeout"]["events"] > 60000
     assert trace["youtube"]["published_gap"]["missing_2023_events"] > 10000
     assert trace["youtube"]["published_gap"]["missing_before_2024_05_07_events"] > 30000
@@ -221,6 +223,7 @@ def test_source_crypto_trace_registers_hash_roots_for_dynamic_access():
     trace = json.loads(response.json()["content"])
     assert trace["schema_version"] == "field-source-crypto-trace/v1"
     assert trace["hash_algorithm"] == "sha256"
+    assert trace["source_body_registry"]["schema_version"] == "field-source-body-registry/v1"
     assert trace["normalized_event_trace"]["line_count"] == 69082
     assert trace["normalized_event_trace"]["event_merkle_root"]
     assert trace["roots"]["combined_trace_root"]

--- a/docs/field/urs/input/source_body_registry.json
+++ b/docs/field/urs/input/source_body_registry.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "field-source-body-registry/v1",
+  "publication_boundary": "This registry names local source-body locations, matching patterns, custody classes, and ingestion policies. It does not publish raw source contents. Builder scripts read this registry to produce compact traces and reports.",
+  "root_keys": {
+    "analysis_root": {
+      "default_path": "/Users/ursmuff/CoherenceFieldAnalysis",
+      "description": "Local analysis workspace for extracted source bodies."
+    },
+    "downloads_dir": {
+      "default_path": "/Users/ursmuff/Downloads",
+      "description": "Local Downloads folder holding bulky export archives and source PDFs."
+    }
+  },
+  "source_groups": [
+    {
+      "label": "youtube-takeout",
+      "root_key": "analysis_root",
+      "relative_path": "input/youtube",
+      "patterns": ["*.zip", "*.html", "*.json", "*.jsonl"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "compact_trace_allowed",
+      "publication_boundary": "Raw YouTube Takeout files remain local; derived watch/search events and aggregate traces may be published."
+    },
+    {
+      "label": "audible-export",
+      "root_key": "analysis_root",
+      "relative_path": "input/audible",
+      "patterns": ["*.json", "*.jsonl", "*.csv", "*.html"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "compact_trace_allowed",
+      "publication_boundary": "Raw Audible exports remain local; derived counts, titles, authors, dates, and spectrum summaries may be published."
+    },
+    {
+      "label": "browser-trace",
+      "root_key": "analysis_root",
+      "relative_path": "input/browser",
+      "patterns": ["*.json", "*.jsonl", "*.sqlite", "*.db"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "compact_trace_allowed",
+      "publication_boundary": "Raw browser databases and sessions remain local; compact event traces and domain/title summaries may be published."
+    },
+    {
+      "label": "downloaded-takeout",
+      "root_key": "downloads_dir",
+      "patterns": ["takeout-*.zip"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published."
+    },
+    {
+      "label": "channeled-message-pdf",
+      "root_key": "downloads_dir",
+      "patterns": ["Friday Live Channeled Message *.pdf"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "metadata_hashes_and_summary_only",
+      "publication_boundary": "Raw PDFs and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention until a summary/extracted-concept breath is chosen."
+    },
+    {
+      "label": "photo-archive",
+      "root_key": "downloads_dir",
+      "patterns": ["Photos-*.zip"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "metadata_only",
+      "publication_boundary": "Image pixels remain local; filenames, counts, archive hashes, and date hints may be published."
+    },
+    {
+      "label": "project-archive",
+      "root_key": "downloads_dir",
+      "patterns": ["Water Project.zip", "Angelic-*.zip"],
+      "path_class": "local_source_body",
+      "ingestion_policy": "metadata_and_selected_lineage_allowed",
+      "publication_boundary": "Project archives remain local unless a specific lineage artifact is promoted; compact file counts, extensions, hashes, and sample paths may be published."
+    }
+  ],
+  "digital_inventory": {
+    "youtube": {
+      "history_only_takeout": {"root_key": "downloads_dir", "path": "takeout-20260506T165642Z-3-001.zip"},
+      "full_takeout_part_012": {"root_key": "downloads_dir", "path": "takeout-20260506T023119Z-3-012.zip"},
+      "uploads_and_library_parts": {"root_key": "downloads_dir", "pattern": "takeout-20260506T023119Z-3-*.zip"}
+    },
+    "photos": {
+      "archives": [
+        {
+          "root_key": "downloads_dir",
+          "path": "Photos-3-001.zip",
+          "publication_boundary": "Filenames and counts only in this compact inventory; image pixels can be handled in a later image-specific breath."
+        }
+      ]
+    },
+    "project_archives": {
+      "archives": [
+        {"root_key": "downloads_dir", "path": "Angelic-20260507T052334Z-3-001.zip"},
+        {"root_key": "downloads_dir", "path": "Water Project.zip"}
+      ]
+    },
+    "local_source_pdfs": {
+      "labels": ["channeled-message-pdf"]
+    }
+  }
+}

--- a/docs/field/urs/manifest.json
+++ b/docs/field/urs/manifest.json
@@ -48,6 +48,7 @@
     {"artifact_id": "influence-anchors", "path": "anchors/influence_anchors.json", "kind": "anchor", "content_type": "application/json"},
     {"artifact_id": "manual-reading-anchors", "path": "anchors/manual_reading_anchors.json", "kind": "anchor", "content_type": "application/json"},
     {"artifact_id": "project-lineage-anchors", "path": "anchors/project_lineage_anchors.json", "kind": "anchor", "content_type": "application/json"},
+    {"artifact_id": "source-body-registry", "path": "input/source_body_registry.json", "kind": "source-registry", "content_type": "application/json"},
     {"artifact_id": "resource-timeline", "path": "anchors/resource_timeline.json", "kind": "anchor", "content_type": "application/json"},
     {"artifact_id": "frequency-evolution-summary", "path": "output/frequency_evolution_summary.json", "kind": "summary", "content_type": "application/json"},
     {"artifact_id": "frequency-summary", "path": "output/frequency_summary.json", "kind": "summary", "content_type": "application/json"},

--- a/docs/field/urs/output/digital_influence_inventory.md
+++ b/docs/field/urs/output/digital_influence_inventory.md
@@ -2,7 +2,7 @@
 
 This inventory maps the local digital-history sources available for the Urs field story without committing bulky raw archives.
 
-Generated: `2026-05-13T11:22:31.222991+00:00`
+Generated: `2026-05-13T11:38:52.578915+00:00`
 
 ## Publication Boundary
 

--- a/docs/field/urs/tools/digital_influence_inventory.py
+++ b/docs/field/urs/tools/digital_influence_inventory.py
@@ -18,7 +18,6 @@ from typing import Any
 
 GENERIC_AUTHORS = {"here", "unknown", "empty artist - topic"}
 TAKEOUT_DATE_RE = re.compile(r"([A-Z][a-z]+ \d{1,2}, \d{4}, \d{1,2}:\d{2}:\d{2}\s*[AP]M)\s*([A-Z]+)?")
-LOCAL_SOURCE_PDF_PATTERNS = ("Friday Live Channeled Message *.pdf",)
 PUBLISHED_TRACE_START = datetime(2024, 5, 7)
 
 
@@ -47,6 +46,30 @@ def read_json(path: Path) -> Any:
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def load_source_body_registry(field_dir: Path) -> dict[str, Any]:
+    return read_json(field_dir / "input" / "source_body_registry.json")
+
+
+def registry_roots(
+    registry: dict[str, Any],
+    *,
+    analysis_root: Path,
+    downloads_dir: Path,
+) -> dict[str, Path]:
+    return {
+        "analysis_root": analysis_root,
+        "downloads_dir": downloads_dir,
+    }
+
+
+def registry_path(item: dict[str, Any], roots: dict[str, Path]) -> Path:
+    return roots[item["root_key"]] / item["path"]
+
+
+def source_groups_by_label(registry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {group["label"]: group for group in registry.get("source_groups", [])}
 
 
 def sha256_file(path: Path) -> str:
@@ -150,12 +173,12 @@ def summarize_youtube_full(events: list[dict[str, Any]], story_text: str) -> dic
     return out
 
 
-def summarize_youtube_upload_parts(downloads_dir: Path) -> dict[str, Any]:
+def summarize_youtube_upload_parts(source: dict[str, Any], roots: dict[str, Path]) -> dict[str, Any]:
     audio_exts = {".mp3", ".m4a", ".flac", ".wav", ".aac"}
     video_exts = {".mp4", ".mov", ".m4v"}
     audio: Counter[str] = Counter()
     video: Counter[str] = Counter()
-    zips = sorted(downloads_dir.glob("takeout-20260506T023119Z-3-*.zip"))
+    zips = sorted(roots[source["root_key"]].glob(source["pattern"]))
     for zip_path in zips:
         with zipfile.ZipFile(zip_path) as archive:
             for name in archive.namelist():
@@ -237,9 +260,10 @@ def summarize_browser(analysis_root: Path) -> dict[str, Any]:
     }
 
 
-def summarize_photos(downloads_dir: Path) -> dict[str, Any]:
+def summarize_photos(sources: list[dict[str, Any]], roots: dict[str, Path]) -> dict[str, Any]:
     out: dict[str, Any] = {}
-    for zip_path in [downloads_dir / "Photos-3-001.zip"]:
+    for source in sources:
+        zip_path = registry_path(source, roots)
         if not zip_path.exists():
             continue
         dates = []
@@ -256,21 +280,24 @@ def summarize_photos(downloads_dir: Path) -> dict[str, Any]:
             "first_date_from_filename": min(dates) if dates else None,
             "last_date_from_filename": max(dates) if dates else None,
             "extensions": dict(exts.most_common()),
-        "publication_boundary": "filenames and counts only in this compact inventory; image pixels can be handled in a later image-specific breath",
+            "publication_boundary": source.get(
+                "publication_boundary",
+                "filenames and counts only in this compact inventory; image pixels can be handled in a later image-specific breath",
+            ),
         }
     return out
 
 
-def summarize_project_archives(downloads_dir: Path) -> dict[str, Any]:
+def summarize_project_archives(sources: list[dict[str, Any]], roots: dict[str, Path]) -> dict[str, Any]:
     archives = {}
-    for name in ["Angelic-20260507T052334Z-3-001.zip", "Water Project.zip"]:
-        path = downloads_dir / name
+    for source in sources:
+        path = registry_path(source, roots)
         if not path.exists():
             continue
         with zipfile.ZipFile(path) as archive:
             names = [entry for entry in archive.namelist() if not entry.endswith("/")]
             suffixes = Counter(Path(entry).suffix.lower() or "no-extension" for entry in names)
-        archives[name] = {
+        archives[path.name] = {
             "files": len(names),
             "extensions": dict(suffixes.most_common(15)),
             "sample_paths": names[:20],
@@ -310,11 +337,31 @@ def _date_hint_from_filename(path: Path) -> str | None:
     return f"{year}-{int(month):02d}-{int(day):02d}"
 
 
-def summarize_local_source_pdfs(downloads_dir: Path) -> dict[str, Any]:
+def source_group_paths(group: dict[str, Any], roots: dict[str, Path]) -> list[Path]:
+    root = roots[group["root_key"]]
+    relative = group.get("relative_path")
+    source_root = root / relative if relative else root
+    paths: list[Path] = []
+    for pattern in group.get("patterns", []):
+        paths.extend(sorted(source_root.glob(pattern)))
+    return paths
+
+
+def summarize_local_source_pdfs(
+    registry: dict[str, Any],
+    roots: dict[str, Path],
+) -> dict[str, Any]:
+    labels = registry.get("digital_inventory", {}).get("local_source_pdfs", {}).get("labels", [])
+    groups = source_groups_by_label(registry)
     items: list[dict[str, Any]] = []
     seen: set[Path] = set()
-    for pattern in LOCAL_SOURCE_PDF_PATTERNS:
-        for path in sorted(downloads_dir.glob(pattern)):
+    patterns: list[str] = []
+    for label in labels:
+        group = groups.get(label)
+        if not group:
+            continue
+        patterns.extend(group.get("patterns", []))
+        for path in source_group_paths(group, roots):
             if not path.is_file() or path in seen:
                 continue
             seen.add(path)
@@ -324,7 +371,7 @@ def summarize_local_source_pdfs(downloads_dir: Path) -> dict[str, Any]:
                 {
                     "file_name": path.name,
                     "path": str(path),
-                    "label": "channeled-message-pdf",
+                    "label": label,
                     "title_hint": path.stem,
                     "date_hint": _date_hint_from_filename(path),
                     "size_bytes": stat.st_size,
@@ -334,13 +381,13 @@ def summarize_local_source_pdfs(downloads_dir: Path) -> dict[str, Any]:
                     "pages": int(metadata["pages"]) if metadata.get("pages", "").isdigit() else None,
                     "author": metadata.get("author"),
                     "creator": metadata.get("creator"),
-                    "ingestion_policy": "metadata_hashes_and_summary_only",
-                    "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+                    "ingestion_policy": group.get("ingestion_policy"),
+                    "publication_boundary": group.get("publication_boundary"),
                 }
             )
     return {
         "count": len(items),
-        "patterns": list(LOCAL_SOURCE_PDF_PATTERNS),
+        "patterns": patterns,
         "items": items,
         "publication_boundary": "PDF source bodies are represented by metadata and hashes only until a specific summary/extracted-concept breath is chosen.",
     }
@@ -373,9 +420,12 @@ def summarize_published_trace(field_dir: Path) -> dict[str, Any]:
 
 
 def build(field_dir: Path, analysis_root: Path, downloads_dir: Path) -> dict[str, Any]:
+    registry = load_source_body_registry(field_dir)
+    roots = registry_roots(registry, analysis_root=analysis_root, downloads_dir=downloads_dir)
+    inventory_sources = registry["digital_inventory"]
     story_text = (field_dir / "output" / "chronological_story_with_frequency.md").read_text(encoding="utf-8")
-    full_history = parse_youtube_watch_history(downloads_dir / "takeout-20260506T165642Z-3-001.zip")
-    part_history = parse_youtube_watch_history(downloads_dir / "takeout-20260506T023119Z-3-012.zip")
+    full_history = parse_youtube_watch_history(registry_path(inventory_sources["youtube"]["history_only_takeout"], roots))
+    part_history = parse_youtube_watch_history(registry_path(inventory_sources["youtube"]["full_takeout_part_012"], roots))
     youtube_full = summarize_youtube_full(full_history, story_text)
     youtube_part = summarize_youtube_full(part_history, story_text)
     missing_period = youtube_full["periods"]["before_published_trace"]
@@ -388,11 +438,20 @@ def build(field_dir: Path, analysis_root: Path, downloads_dir: Path) -> dict[str
             "analysis_root": str(analysis_root),
             "downloads_dir": str(downloads_dir),
         },
+        "source_body_registry": {
+            "path": str(field_dir / "input" / "source_body_registry.json"),
+            "schema_version": registry.get("schema_version"),
+            "publication_boundary": registry.get("publication_boundary"),
+            "root_keys": registry.get("root_keys"),
+        },
         "published_trace": summarize_published_trace(field_dir),
         "youtube": {
             "history_only_takeout": youtube_full,
             "full_takeout_part_012": youtube_part,
-            "uploads_and_library_parts": summarize_youtube_upload_parts(downloads_dir),
+            "uploads_and_library_parts": summarize_youtube_upload_parts(
+                inventory_sources["youtube"]["uploads_and_library_parts"],
+                roots,
+            ),
             "published_gap": {
                 "integrated_before_2024_05_07_events": missing_period["events"],
                 "integrated_2023_events": youtube_full["periods"]["year_2023"]["events"],
@@ -406,9 +465,9 @@ def build(field_dir: Path, analysis_root: Path, downloads_dir: Path) -> dict[str
         },
         "audible": summarize_audible(analysis_root),
         "browser": summarize_browser(analysis_root),
-        "photos": summarize_photos(downloads_dir),
-        "project_archives": summarize_project_archives(downloads_dir),
-        "local_source_pdfs": summarize_local_source_pdfs(downloads_dir),
+        "photos": summarize_photos(inventory_sources["photos"]["archives"], roots),
+        "project_archives": summarize_project_archives(inventory_sources["project_archives"]["archives"], roots),
+        "local_source_pdfs": summarize_local_source_pdfs(registry, roots),
         "agent_history": summarize_agent_history(),
     }
 

--- a/docs/field/urs/tools/source_crypto_trace.py
+++ b/docs/field/urs/tools/source_crypto_trace.py
@@ -18,18 +18,8 @@ ANALYSIS_ROOT = Path("/Users/ursmuff/CoherenceFieldAnalysis")
 DOWNLOADS_DIR = Path("/Users/ursmuff/Downloads")
 HASH_ALGORITHM = "sha256"
 
-
-SOURCE_PATTERNS = [
-    ("youtube-takeout", ANALYSIS_ROOT / "input" / "youtube", ["*.zip", "*.html", "*.json", "*.jsonl"]),
-    ("audible-export", ANALYSIS_ROOT / "input" / "audible", ["*.json", "*.jsonl", "*.csv", "*.html"]),
-    ("browser-trace", ANALYSIS_ROOT / "input" / "browser", ["*.json", "*.jsonl", "*.sqlite", "*.db"]),
-    ("downloaded-takeout", DOWNLOADS_DIR, ["takeout-*.zip"]),
-    ("channeled-message-pdf", DOWNLOADS_DIR, ["Friday Live Channeled Message *.pdf"]),
-    ("photo-archive", DOWNLOADS_DIR, ["Photos-*.zip"]),
-    ("project-archive", DOWNLOADS_DIR, ["Water Project.zip", "Angelic-*.zip"]),
-]
-
 REPO_ARTIFACTS = [
+    "input/source_body_registry.json",
     "output/ten_year_events.jsonl",
     "trace/manifest.json",
     "trace/monthly_spectrum.json",
@@ -41,6 +31,28 @@ REPO_ARTIFACTS = [
     "trace/digital_influence_inventory.json",
     "output/chronological_story_with_frequency.md",
 ]
+
+
+def load_source_body_registry(field_dir: Path) -> dict[str, Any]:
+    return json.loads((field_dir / "input" / "source_body_registry.json").read_text(encoding="utf-8"))
+
+
+def registry_roots(
+    registry: dict[str, Any],
+    *,
+    analysis_root: Path = ANALYSIS_ROOT,
+    downloads_dir: Path = DOWNLOADS_DIR,
+) -> dict[str, Path]:
+    return {
+        "analysis_root": analysis_root,
+        "downloads_dir": downloads_dir,
+    }
+
+
+def source_group_root(group: dict[str, Any], roots: dict[str, Path]) -> Path:
+    root = roots[group["root_key"]]
+    relative = group.get("relative_path")
+    return root / relative if relative else root
 
 
 def sha256_bytes(data: bytes) -> str:
@@ -91,10 +103,20 @@ def summarize_zip(path: Path) -> dict[str, Any]:
         return {}
 
 
-def collect_source_bodies() -> list[dict[str, Any]]:
+def collect_source_bodies(
+    field_dir: Path,
+    *,
+    analysis_root: Path = ANALYSIS_ROOT,
+    downloads_dir: Path = DOWNLOADS_DIR,
+) -> list[dict[str, Any]]:
+    registry = load_source_body_registry(field_dir)
+    roots = registry_roots(registry, analysis_root=analysis_root, downloads_dir=downloads_dir)
     rows: list[dict[str, Any]] = []
     seen: set[Path] = set()
-    for label, root, patterns in SOURCE_PATTERNS:
+    for group in registry.get("source_groups", []):
+        label = group["label"]
+        root = source_group_root(group, roots)
+        patterns = group.get("patterns", [])
         if not root.exists():
             continue
         for pattern in patterns:
@@ -107,8 +129,10 @@ def collect_source_bodies() -> list[dict[str, Any]]:
                 row = {
                     "id": source_id(label, path, digest),
                     "label": label,
+                    "ingestion_policy": group.get("ingestion_policy"),
                     "path": str(path),
-                    "path_class": "local_source_body",
+                    "path_class": group.get("path_class", "local_source_body"),
+                    "publication_boundary": group.get("publication_boundary"),
                     "size_bytes": stat.st_size,
                     "modified_at": datetime.fromtimestamp(stat.st_mtime, UTC).isoformat(),
                     "sha256": digest,
@@ -174,8 +198,14 @@ def repo_artifact_trace(field_dir: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def build(field_dir: Path) -> dict[str, Any]:
-    sources = collect_source_bodies()
+def build(
+    field_dir: Path,
+    *,
+    analysis_root: Path = ANALYSIS_ROOT,
+    downloads_dir: Path = DOWNLOADS_DIR,
+) -> dict[str, Any]:
+    registry = load_source_body_registry(field_dir)
+    sources = collect_source_bodies(field_dir, analysis_root=analysis_root, downloads_dir=downloads_dir)
     events = normalized_event_trace(field_dir)
     artifacts = repo_artifact_trace(field_dir)
     source_root = merkle_root([stable_json_hash(row) for row in sources])
@@ -192,6 +222,12 @@ def build(field_dir: Path) -> dict[str, Any]:
         "generated_at": datetime.now(UTC).isoformat(),
         "hash_algorithm": HASH_ALGORITHM,
         "publication_boundary": "This is a compact cryptographic trace. It publishes hashes, sizes, source classes, and Merkle roots; bulky raw source bodies remain outside the repo unless deliberately promoted.",
+        "source_body_registry": {
+            "path": str(field_dir / "input" / "source_body_registry.json"),
+            "schema_version": registry.get("schema_version"),
+            "publication_boundary": registry.get("publication_boundary"),
+            "root_keys": registry.get("root_keys"),
+        },
         "roots": {
             "source_body_merkle_root": source_root,
             "normalized_event_merkle_root": events["event_merkle_root"],
@@ -222,8 +258,10 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Build field source crypto trace manifest.")
     parser.add_argument("--field-dir", type=Path, default=FIELD_DIR)
+    parser.add_argument("--analysis-root", type=Path, default=ANALYSIS_ROOT)
+    parser.add_argument("--downloads-dir", type=Path, default=DOWNLOADS_DIR)
     args = parser.parse_args()
-    payload = build(args.field_dir)
+    payload = build(args.field_dir, analysis_root=args.analysis_root, downloads_dir=args.downloads_dir)
     out = args.field_dir / "trace" / "source_crypto_trace.json"
     write_json(out, payload)
     print(f"source_bodies={len(payload['source_bodies'])}")

--- a/docs/field/urs/trace/digital_influence_inventory.json
+++ b/docs/field/urs/trace/digital_influence_inventory.json
@@ -822,7 +822,7 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T11:22:31.222991+00:00",
+  "generated_at": "2026-05-13T11:38:52.578915+00:00",
   "local_source_pdfs": {
     "count": 2,
     "items": [
@@ -837,7 +837,7 @@
         "modified_at": "2026-01-17T08:47:19.104015+00:00",
         "pages": 5,
         "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 1.16.26.pdf",
-        "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+        "publication_boundary": "Raw PDFs and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention until a summary/extracted-concept breath is chosen.",
         "sha256": "5c8a30ebb8d2eeda1abba2813970359c207583abf2391ab1378230d41692f186",
         "size_bytes": 233747,
         "title_hint": "Friday Live Channeled Message 1.16.26"
@@ -853,7 +853,7 @@
         "modified_at": "2026-05-12T01:23:17.257392+00:00",
         "pages": 4,
         "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 5.8.26.pdf",
-        "publication_boundary": "The raw PDF and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention.",
+        "publication_boundary": "Raw PDFs and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention until a summary/extracted-concept breath is chosen.",
         "sha256": "80a4736c3763be8bc76e15c3242b947b8a7f84bbb0247cbdee90d2ea0355999b",
         "size_bytes": 135871,
         "title_hint": "Friday Live Channeled Message 5.8.26"
@@ -873,7 +873,7 @@
       "files": 74,
       "first_date_from_filename": "20260504",
       "last_date_from_filename": "20260504",
-      "publication_boundary": "filenames and counts only in this compact inventory; image pixels can be handled in a later image-specific breath"
+      "publication_boundary": "Filenames and counts only in this compact inventory; image pixels can be handled in a later image-specific breath."
     }
   },
   "project_archives": {
@@ -956,6 +956,21 @@
     }
   },
   "schema_version": "digital-influence-inventory/v1",
+  "source_body_registry": {
+    "path": "docs/field/urs/input/source_body_registry.json",
+    "publication_boundary": "This registry names local source-body locations, matching patterns, custody classes, and ingestion policies. It does not publish raw source contents. Builder scripts read this registry to produce compact traces and reports.",
+    "root_keys": {
+      "analysis_root": {
+        "default_path": "/Users/ursmuff/CoherenceFieldAnalysis",
+        "description": "Local analysis workspace for extracted source bodies."
+      },
+      "downloads_dir": {
+        "default_path": "/Users/ursmuff/Downloads",
+        "description": "Local Downloads folder holding bulky export archives and source PDFs."
+      }
+    },
+    "schema_version": "field-source-body-registry/v1"
+  },
   "source_roots": {
     "analysis_root": "/Users/ursmuff/CoherenceFieldAnalysis",
     "downloads_dir": "/Users/ursmuff/Downloads",

--- a/docs/field/urs/trace/source_crypto_trace.json
+++ b/docs/field/urs/trace/source_crypto_trace.json
@@ -6,7 +6,7 @@
     "month_trace_api": "/api/field-stories/urs-field-story/trace/month/{YYYY-MM}",
     "work_trace_api": "/api/field-stories/urs-field-story/trace/work/{work_id}"
   },
-  "generated_at": "2026-05-13T11:22:43.188094+00:00",
+  "generated_at": "2026-05-13T11:39:04.764829+00:00",
   "hash_algorithm": "sha256",
   "normalized_event_trace": {
     "event_leaf_hash_algorithm": "sha256('event:' + canonical_json(row))",
@@ -41,6 +41,13 @@
   },
   "publication_boundary": "This is a compact cryptographic trace. It publishes hashes, sizes, source classes, and Merkle roots; bulky raw source bodies remain outside the repo unless deliberately promoted.",
   "repo_artifacts": [
+    {
+      "artifact_relpath": "input/source_body_registry.json",
+      "content_type": "application/json",
+      "path": "docs/field/urs/input/source_body_registry.json",
+      "sha256": "b9643fe74d90b0716ae9cfb4d795b6dbd01f76126aa75d5d9f85990bb5a08b2b",
+      "size_bytes": 4543
+    },
     {
       "artifact_relpath": "output/ten_year_events.jsonl",
       "content_type": "application/octet-stream",
@@ -101,8 +108,8 @@
       "artifact_relpath": "trace/digital_influence_inventory.json",
       "content_type": "application/json",
       "path": "docs/field/urs/trace/digital_influence_inventory.json",
-      "sha256": "a3185f1df9456874687d9bfef0ab296c477a050bfd2cfe78b81380725b177b6b",
-      "size_bytes": 106006
+      "sha256": "462b84346a5c321527b9d38e56f8e367439ef6ba78ad45806cf0994d1fb4bbf0",
+      "size_bytes": 106891
     },
     {
       "artifact_relpath": "output/chronological_story_with_frequency.md",
@@ -113,20 +120,22 @@
     }
   ],
   "roots": {
-    "combined_trace_root": "3dbc40b02749a1fb8d792477c3e52401a0e8b2c5a2bc83ca6344fd8c0ff714fe",
+    "combined_trace_root": "f48e47790cfb41503c482e06fd8c1e948bc254687ac3e308aeed088c16dd2247",
     "normalized_event_merkle_root": "d623a7b9940f55b6430015ad87ee009fe8ed728b6b5ed8b2d07c2c8e53955444",
-    "repo_artifact_merkle_root": "dba1a0430f37bc4ca9b0fcea2cb28560c96cf10a30ae8d950db10ca3a1f7488d",
-    "source_body_merkle_root": "c8f0c8b91859a8f3ee23c8687b42e54ef312d287b89bc33029b39120cc2890f9"
+    "repo_artifact_merkle_root": "91b18a7051b31f4870530758525200b4f0630182a7f6d88f49cc7cdeb96a8fc5",
+    "source_body_merkle_root": "455948a757f0d11843b8895042df880d8c9ce66a74af4622fe2fcdfadd610dad"
   },
   "schema_version": "field-source-crypto-trace/v1",
   "source_bodies": [
     {
       "content_type": "application/zip",
       "id": "source:youtube-takeout:takeout-20260506t165642z-3-001.zip:6dbd39e21bba",
+      "ingestion_policy": "compact_trace_allowed",
       "label": "youtube-takeout",
       "modified_at": "2026-05-06T17:48:31.874941+00:00",
       "path": "/Users/ursmuff/CoherenceFieldAnalysis/input/youtube/takeout-20260506T165642Z-3-001.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw YouTube Takeout files remain local; derived watch/search events and aggregate traces may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/history/search-history.html",
         "Takeout/YouTube and YouTube Music/history/watch-history.html"
@@ -138,40 +147,48 @@
     {
       "content_type": "application/json",
       "id": "source:youtube-takeout:myactivity-playwright-raw.json:386abad259da",
+      "ingestion_policy": "compact_trace_allowed",
       "label": "youtube-takeout",
       "modified_at": "2026-05-06T02:28:11.828689+00:00",
       "path": "/Users/ursmuff/CoherenceFieldAnalysis/input/youtube/myactivity-playwright-raw.json",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw YouTube Takeout files remain local; derived watch/search events and aggregate traces may be published.",
       "sha256": "386abad259da1698a41c58524fc07ee51b67d00e06d36345e2e6b3dd1366f1b4",
       "size_bytes": 230776
     },
     {
       "content_type": "application/json",
       "id": "source:youtube-takeout:youtube-all-myactivity-raw.json:9fd50ede11b4",
+      "ingestion_policy": "compact_trace_allowed",
       "label": "youtube-takeout",
       "modified_at": "2026-05-08T03:12:21.785095+00:00",
       "path": "/Users/ursmuff/CoherenceFieldAnalysis/input/youtube/youtube-all-myactivity-raw.json",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw YouTube Takeout files remain local; derived watch/search events and aggregate traces may be published.",
       "sha256": "9fd50ede11b4faa450dc5814da89673cf6225db85a3f977c6327da4516058b57",
       "size_bytes": 22290450
     },
     {
       "content_type": "application/octet-stream",
       "id": "source:browser-trace:local_browser_events.jsonl:90ec076f4853",
+      "ingestion_policy": "compact_trace_allowed",
       "label": "browser-trace",
       "modified_at": "2026-05-06T02:21:23.685980+00:00",
       "path": "/Users/ursmuff/CoherenceFieldAnalysis/input/browser/local_browser_events.jsonl",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw browser databases and sessions remain local; compact event traces and domain/title summaries may be published.",
       "sha256": "90ec076f4853fbbcc6aad5c6a139d2323ffcafaf1a3761e3a991177ee68d1ab6",
       "size_bytes": 97209
     },
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-001.zip:1a564cbf1495",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-06T18:19:20.579533+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-001.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/live chats/live chats.csv",
         "Takeout/YouTube and YouTube Music/video metadata/video recordings.csv",
@@ -189,10 +206,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-002.zip:1a26a76407f7",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:20.458544+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-002.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Follow Me Home.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/I Don_t Wanna Live Without Your Love.mp3",
@@ -210,10 +229,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-003.zip:9c93a1839f91",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-06T18:13:09.609358+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-003.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Caught With Your Pants Down.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Its My Life.mp3",
@@ -231,10 +252,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-004.zip:4fed99442401",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-06T18:13:12.766740+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-004.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Sheila.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Hello(1).mp3",
@@ -252,10 +275,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-005.zip:18616602c64c",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:31.989212+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-005.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Last Dance.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/I Know.mp3",
@@ -273,10 +298,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-006.zip:0bb3ab581cd0",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:09:24.258587+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-006.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/(They Long To Be) Close To You.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Fast Car.mp3",
@@ -294,10 +321,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-007.zip:bae800618331",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:46.884798+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-007.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/videos/Melvin Harold - Horse with no name.mp4",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Doggy Dogg World.mp3",
@@ -315,10 +344,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-008.zip:d97843986dd1",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:53.665862+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-008.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/videos/Melvin Harold - Apologize.mp4",
         "Takeout/YouTube and YouTube Music/videos/Melvin Harold - Have You Ever Seen The Rain_.mp4",
@@ -336,10 +367,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-009.zip:ab1cdcb9164e",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:55.786683+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-009.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Baby I love you.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Messages.mp3",
@@ -357,10 +390,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-010.zip:6401cdfe9c12",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T01:24:57.159213+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-010.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Concerto For Group & Orchestra, 3rd Movement.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Boys.mp3",
@@ -378,10 +413,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-011.zip:03259919884c",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T06:51:25.599239+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-011.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Forever.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Silent Running.mp3",
@@ -399,10 +436,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-012.zip:4d27abff4026",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T06:42:04.771032+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-012.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/If I Was Your Girlfriend.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Forget Myself.mp3",
@@ -420,10 +459,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t023119z-3-013.zip:c211c6429bdc",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-07T06:41:45.268306+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T023119Z-3-013.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Steamroller.mp3",
         "Takeout/YouTube and YouTube Music/music (library and uploads)/Highwayman  with Johnny Cash, Waylon Jennings, .mp3",
@@ -441,10 +482,12 @@
     {
       "content_type": "application/zip",
       "id": "source:downloaded-takeout:takeout-20260506t165642z-3-001.zip:6dbd39e21bba",
+      "ingestion_policy": "metadata_and_compact_trace_allowed",
       "label": "downloaded-takeout",
       "modified_at": "2026-05-06T17:48:31.874941+00:00",
       "path": "/Users/ursmuff/Downloads/takeout-20260506T165642Z-3-001.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Bulky downloaded Takeout archives remain local; archive names, sizes, hashes, entry samples, and derived counts may be published.",
       "sample_entries": [
         "Takeout/YouTube and YouTube Music/history/search-history.html",
         "Takeout/YouTube and YouTube Music/history/watch-history.html"
@@ -456,30 +499,36 @@
     {
       "content_type": "application/pdf",
       "id": "source:channeled-message-pdf:friday-live-channeled-message-1.16.26.pdf:5c8a30ebb8d2",
+      "ingestion_policy": "metadata_hashes_and_summary_only",
       "label": "channeled-message-pdf",
       "modified_at": "2026-01-17T08:47:19.104015+00:00",
       "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 1.16.26.pdf",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw PDFs and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention until a summary/extracted-concept breath is chosen.",
       "sha256": "5c8a30ebb8d2eeda1abba2813970359c207583abf2391ab1378230d41692f186",
       "size_bytes": 233747
     },
     {
       "content_type": "application/pdf",
       "id": "source:channeled-message-pdf:friday-live-channeled-message-5.8.26.pdf:80a4736c3763",
+      "ingestion_policy": "metadata_hashes_and_summary_only",
       "label": "channeled-message-pdf",
       "modified_at": "2026-05-12T01:23:17.257392+00:00",
       "path": "/Users/ursmuff/Downloads/Friday Live Channeled Message 5.8.26.pdf",
       "path_class": "local_source_body",
+      "publication_boundary": "Raw PDFs and extracted transcript text remain local source bodies; the repo stores only metadata, hashes, and compact source-body attention until a summary/extracted-concept breath is chosen.",
       "sha256": "80a4736c3763be8bc76e15c3242b947b8a7f84bbb0247cbdee90d2ea0355999b",
       "size_bytes": 135871
     },
     {
       "content_type": "application/zip",
       "id": "source:photo-archive:photos-3-001.zip:538ba3330fce",
+      "ingestion_policy": "metadata_only",
       "label": "photo-archive",
       "modified_at": "2026-05-05T01:08:48.897974+00:00",
       "path": "/Users/ursmuff/Downloads/Photos-3-001.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Image pixels remain local; filenames, counts, archive hashes, and date hints may be published.",
       "sample_entries": [
         "20260504_093947.mp4",
         "20260504_095510.mp4",
@@ -497,10 +546,12 @@
     {
       "content_type": "application/zip",
       "id": "source:project-archive:water-project.zip:08de36bd792a",
+      "ingestion_policy": "metadata_and_selected_lineage_allowed",
       "label": "project-archive",
       "modified_at": "2026-05-07T03:38:31.494867+00:00",
       "path": "/Users/ursmuff/Downloads/Water Project.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Project archives remain local unless a specific lineage artifact is promoted; compact file counts, extensions, hashes, and sample paths may be published.",
       "sample_entries": [
         "Water Project/",
         "Water Project/Backtracking Model Languages.doc",
@@ -518,10 +569,12 @@
     {
       "content_type": "application/zip",
       "id": "source:project-archive:angelic-20260507t052334z-3-001.zip:2e5b76c9684f",
+      "ingestion_policy": "metadata_and_selected_lineage_allowed",
       "label": "project-archive",
       "modified_at": "2026-05-07T05:34:49.750274+00:00",
       "path": "/Users/ursmuff/Downloads/Angelic-20260507T052334Z-3-001.zip",
       "path_class": "local_source_body",
+      "publication_boundary": "Project archives remain local unless a specific lineage artifact is promoted; compact file counts, extensions, hashes, and sample paths may be published.",
       "sample_entries": [
         "Angelic/Old/obsolite/",
         "Angelic/Icons/Step Back Over.ico",
@@ -537,6 +590,21 @@
       "zip_entries": 2779
     }
   ],
+  "source_body_registry": {
+    "path": "docs/field/urs/input/source_body_registry.json",
+    "publication_boundary": "This registry names local source-body locations, matching patterns, custody classes, and ingestion policies. It does not publish raw source contents. Builder scripts read this registry to produce compact traces and reports.",
+    "root_keys": {
+      "analysis_root": {
+        "default_path": "/Users/ursmuff/CoherenceFieldAnalysis",
+        "description": "Local analysis workspace for extracted source bodies."
+      },
+      "downloads_dir": {
+        "default_path": "/Users/ursmuff/Downloads",
+        "description": "Local Downloads folder holding bulky export archives and source PDFs."
+      }
+    },
+    "schema_version": "field-source-body-registry/v1"
+  },
   "truth_boundary": {
     "exact_now": "Source bodies, normalized event file, and repo-served trace artifacts have SHA-256 hashes and Merkle roots.",
     "next_precision": "For exact row-to-source-body proofs in every API slice, normalized rows should gain source_body_id and event_hash fields during ingestion."

--- a/docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json
+++ b/docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json
@@ -1,0 +1,118 @@
+{
+  "date": "2026-05-13",
+  "thread_branch": "codex/source-body-registry-20260513",
+  "commit_scope": "Move field source-body inventory policy out of Python builders into a data registry consumed by digital inventory and source crypto traces.",
+  "files_owned": [
+    "api/tests/test_field_story_trace_index.py",
+    "docs/field/urs/input/source_body_registry.json",
+    "docs/field/urs/manifest.json",
+    "docs/field/urs/output/digital_influence_inventory.md",
+    "docs/field/urs/tools/digital_influence_inventory.py",
+    "docs/field/urs/tools/source_crypto_trace.py",
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json",
+    "specs/digital-influence-inventory.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "git worktree add /Users/ursmuff/.claude-worktrees/Coherence-Network/source-body-registry-20260513 -b codex/source-body-registry-20260513 origin/main",
+      "make prompt-guide",
+      "make wellness",
+      "python3 -m py_compile docs/field/urs/tools/digital_influence_inventory.py docs/field/urs/tools/source_crypto_trace.py",
+      "python3 docs/field/urs/tools/digital_influence_inventory.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads",
+      "python3 docs/field/urs/tools/source_crypto_trace.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_field_story_trace_index.py",
+      "git diff --check",
+      "python3 -m json.tool docs/field/urs/input/source_body_registry.json >/dev/null",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json",
+      "git fetch origin main && git rebase origin/main",
+      "git stash push -u -m pre-rebase-source-body-registry && git rebase origin/main && git stash pop",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "summary": "Prompt gate and wellness passed. Source-body groups, exact inventory paths, patterns, custody classes, and ingestion policies now live in docs/field/urs/input/source_body_registry.json. The digital inventory and source crypto builders read that registry and regenerated compact artifacts. Focused field story trace tests pass: 14 tests, 5 warnings. Stale PR follow-through reports zero stale Codex PRs. Local PR guard passes with ready_for_push=True."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy attempted yet in this breath."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Field source-body inventory policy is embodied as a registry artifact served by the field story API and consumed by trace builders instead of being hard-coded in Python.",
+    "public_endpoints": [
+      "/api/field-stories/urs-field-story/artifacts/source-body-registry",
+      "/api/field-stories/urs-field-story/artifacts/trace-digital-influence-inventory",
+      "/api/field-stories/urs-field-story/artifacts/trace-source-crypto"
+    ],
+    "test_flows": [
+      "Field story manifest exposes source-body-registry.",
+      "Digital inventory trace reports field-source-body-registry/v1.",
+      "Source crypto trace reports field-source-body-registry/v1 and includes registry as a repo artifact."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused proof, stale PR follow-through, and local PR guard are complete; PR CI and deploy validation remain pending."
+  },
+  "idea_ids": [
+    "field-sensing",
+    "presence-traces"
+  ],
+  "spec_ids": [
+    "specs/digital-influence-inventory.md",
+    "specs/field-listening-trace-index.md"
+  ],
+  "task_ids": [
+    "next-breath:source-body-registry"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture_correction"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "trace_rebuild",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/field/urs/input/source_body_registry.json",
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "api/tests/test_field_story_trace_index.py",
+    "docs/system_audit/pr_check_failures/pr_check_guard_20260513T114029Z_codex-source-body-registry-20260513.json"
+  ],
+  "change_files": [
+    "api/tests/test_field_story_trace_index.py",
+    "docs/field/urs/input/source_body_registry.json",
+    "docs/field/urs/manifest.json",
+    "docs/field/urs/output/digital_influence_inventory.md",
+    "docs/field/urs/tools/digital_influence_inventory.py",
+    "docs/field/urs/tools/source_crypto_trace.py",
+    "docs/field/urs/trace/digital_influence_inventory.json",
+    "docs/field/urs/trace/source_crypto_trace.json",
+    "docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json",
+    "specs/digital-influence-inventory.md"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/specs/digital-influence-inventory.md
+++ b/specs/digital-influence-inventory.md
@@ -4,6 +4,7 @@ status: implemented
 owners: [urs, agent:codex]
 files:
   - file: docs/field/urs/tools/digital_influence_inventory.py
+  - file: docs/field/urs/input/source_body_registry.json
   - file: docs/field/urs/output/digital_influence_inventory.md
   - file: docs/field/urs/trace/digital_influence_inventory.json
   - file: docs/field/urs/manifest.json
@@ -30,6 +31,7 @@ The contributor has explicitly allowed watch and listen history to be public. Th
 ## Requirements
 
 - [x] Inventory local digital-history source files already present under `~/Downloads` and `~/CoherenceFieldAnalysis`.
+- [x] Keep source-body locations, glob patterns, custody classes, and ingestion policies in `docs/field/urs/input/source_body_registry.json` rather than hard-coding inventory policy in the builder.
 - [x] Publish compact source counts, date spans, and top influence candidates.
 - [x] Identify the missing YouTube history before `2024-05-07`.
 - [x] Name high-signal 2023 and early-2024 influence waves that are not yet represented in the published breath-cycle.
@@ -39,6 +41,7 @@ The contributor has explicitly allowed watch and listen history to be public. Th
 ## Files To Modify
 
 - `docs/field/urs/tools/digital_influence_inventory.py` builds the inventory.
+- `docs/field/urs/input/source_body_registry.json` names local source-body groups, exact source paths, patterns, and ingestion policies.
 - `docs/field/urs/output/digital_influence_inventory.md` is the human-readable report.
 - `docs/field/urs/trace/digital_influence_inventory.json` is the machine-readable trace.
 - `docs/field/urs/manifest.json` publishes the artifacts and builder.
@@ -47,6 +50,7 @@ The contributor has explicitly allowed watch and listen history to be public. Th
 ## Acceptance Criteria
 
 - The builder emits Markdown and JSON from local digital-history source bodies.
+- Source-body inventory policy lives in `docs/field/urs/input/source_body_registry.json`; the builder reads it.
 - The manifest exposes `digital-influence-inventory`, `trace-digital-influence-inventory`, and `digital-influence-inventory-builder`.
 - The API test proves the history-only YouTube Takeout has more than 60,000 events and that more than 10,000 2023 YouTube events are not yet represented in the current published trace.
 - `api/tests/test_field_story_trace_index.py::test_digital_influence_inventory_registers_full_history_attention` passes.


### PR DESCRIPTION
## Summary
- moves source-body groups, exact source paths, glob patterns, custody classes, and ingestion policies into docs/field/urs/input/source_body_registry.json
- updates digital inventory and source crypto builders to read the registry instead of owning inventory policy
- publishes the registry through the field story manifest and validates traces report the registry schema

## Proof
- make prompt-guide
- make wellness
- python3 -m py_compile docs/field/urs/tools/digital_influence_inventory.py docs/field/urs/tools/source_crypto_trace.py
- python3 docs/field/urs/tools/digital_influence_inventory.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads
- python3 docs/field/urs/tools/source_crypto_trace.py --field-dir docs/field/urs --analysis-root /Users/ursmuff/CoherenceFieldAnalysis --downloads-dir /Users/ursmuff/Downloads
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_field_story_trace_index.py
- git diff --check
- python3 -m json.tool docs/field/urs/input/source_body_registry.json >/dev/null
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-13_source_body_registry.json
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main