### PR TITLE
attune(federation): substance flows through the same payload as telemetry

### DIFF
--- a/api/app/models/federation.py
+++ b/api/app/models/federation.py
@@ -20,11 +20,44 @@ class FederatedInstance(BaseModel):
 
 
 class FederatedPayload(BaseModel):
-    """Data package from a remote instance."""
+    """Data package from a remote instance.
+
+    Two layers travel together over the same envelope:
+
+    - **Telemetry** (``lineage_links``, ``usage_events``) — small, structured
+      observations from a peer instance about value-flow. Cheap to verify,
+      auto-appliable once a governance vote clears.
+    - **Substance** (``concept_proposals``, ``spec_proposals``,
+      ``idea_proposals``, ``teaching_proposals``) — body-level material a
+      peer instance would like this body to absorb. Each item becomes a
+      governance ChangeRequest with ``auto_apply_on_approval=False``: the
+      proposal is held by governance, and a maintainer walks it into the
+      repo via a PR. Substance never writes directly into the deployed
+      corpus.
+
+    Each proposal dict carries the markdown body plus enough metadata for
+    a maintainer to author the file locally. Suggested shape::
+
+        {
+            "id": "lc-some-concept",          # or spec slug, idea slug, doc path
+            "title": "…",
+            "body_markdown": "…",
+            "frontmatter": {…},                # optional
+            "origin_url": "https://peer…/concepts/lc-some-concept",
+            "license": "CC-BY-SA-4.0",         # optional
+        }
+
+    The applier records the proposal as ``"stored"`` — the body decides
+    how to weave it in.
+    """
     source_instance_id: str = Field(min_length=1)
     timestamp: str
     lineage_links: list[dict] = Field(default_factory=list)
     usage_events: list[dict] = Field(default_factory=list)
+    concept_proposals: list[dict] = Field(default_factory=list)
+    spec_proposals: list[dict] = Field(default_factory=list)
+    idea_proposals: list[dict] = Field(default_factory=list)
+    teaching_proposals: list[dict] = Field(default_factory=list)
     # Signature for future verification
     signature: Optional[str] = None
 
@@ -34,6 +67,7 @@ class FederationSyncResult(BaseModel):
     source_instance_id: str
     links_received: int = 0
     events_received: int = 0
+    proposals_received: int = 0
     governance_requests_created: int = 0
     accepted: int = 0
     rejected: int = 0

--- a/api/app/services/federation_service.py
+++ b/api/app/services/federation_service.py
@@ -83,6 +83,9 @@ class FederationSyncHistoryRecord(Base):
     timestamp: Mapped[str] = mapped_column(String, nullable=False)
     links_received: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     events_received: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Count of substance proposals (concept/spec/idea/teaching) carried in
+    # this payload. Nullable for back-compat with pre-substance rows.
+    proposals_received: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
     governance_requests_created: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     accepted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     rejected: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -202,6 +205,33 @@ class FederatedAggregationRecord(Base):
 def _ensure_schema() -> None:
     _udb.ensure_schema()
     _ensure_node_measurement_summary_columns()
+    _ensure_federation_sync_history_columns()
+
+
+def _ensure_federation_sync_history_columns() -> None:
+    """Backfill the proposals_received column on older snapshots.
+
+    The substance-payload breath added this column; sqlite snapshots and
+    long-running postgres instances from before that breath need it added
+    in place. Same pattern as ``_ensure_node_measurement_summary_columns``.
+    """
+    eng = _udb.engine()
+    try:
+        inspector = inspect(eng)
+        if "federation_sync_history" not in inspector.get_table_names():
+            return
+        existing = {str(col.get("name")) for col in inspector.get_columns("federation_sync_history")}
+        if "proposals_received" in existing:
+            return
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE federation_sync_history "
+                    "ADD COLUMN proposals_received INTEGER NULL DEFAULT 0"
+                )
+            )
+    except Exception:
+        logger.exception("Failed to ensure federation_sync_history runtime columns")
 
 
 def _ensure_node_measurement_summary_columns() -> None:
@@ -321,16 +351,43 @@ def get_instance(instance_id: str) -> FederatedInstance | None:
 # Payload processing
 # ---------------------------------------------------------------------------
 
+# Map from FederatedPayload list-attribute → (federation_type discriminator,
+# short label used in change-request titles). Substance flows through the
+# same governance path as telemetry but auto_apply_on_approval=False because
+# the body's substance wants a maintainer's eye and a PR — the applier just
+# records the proposal as "stored".
+_SUBSTANCE_PROPOSAL_KINDS: tuple[tuple[str, str, str], ...] = (
+    ("concept_proposals", "concept_proposal", "concept"),
+    ("spec_proposals", "spec_proposal", "spec"),
+    ("idea_proposals", "idea_proposal", "idea"),
+    ("teaching_proposals", "teaching_proposal", "teaching"),
+)
+
+
 def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
     """Main entry point: receive data from a remote instance.
 
-    1. Validate source_instance_id is registered
-    2. For each lineage_link, create a governance ChangeRequest
-    3. For each usage_event, create a governance ChangeRequest
-    4. Store the payload for audit
-    5. Return sync result with counts
+    Two layers travel together:
+
+    - **Telemetry** (lineage_links, usage_events) — small structured
+      observations. Each becomes a governance ChangeRequest with
+      ``auto_apply_on_approval=True``: once two approvals clear, the
+      applier writes the link/event into the local lineage graph.
+    - **Substance** (concept_proposals, spec_proposals, idea_proposals,
+      teaching_proposals) — body-level material the peer would like this
+      body to absorb. Each becomes a governance ChangeRequest with
+      ``auto_apply_on_approval=False``: the proposal is held by governance
+      and a maintainer walks it into the repo as a PR. Substance never
+      writes directly into the deployed corpus.
+
+    Both layers require an instance with trust_level ≥ pending and
+    enforce required_approvals ≥ 2 (see governance_service).
     """
     result = FederationSyncResult(source_instance_id=payload.source_instance_id)
+
+    proposal_total = sum(
+        len(getattr(payload, attr)) for attr, _ft, _label in _SUBSTANCE_PROPOSAL_KINDS
+    )
 
     # 1. Validate registration
     instance = get_instance(payload.source_instance_id)
@@ -338,7 +395,9 @@ def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
         result.errors.append(
             f"Instance '{payload.source_instance_id}' is not registered"
         )
-        result.rejected = len(payload.lineage_links) + len(payload.usage_events)
+        result.rejected = (
+            len(payload.lineage_links) + len(payload.usage_events) + proposal_total
+        )
         return result
 
     if not check_trust_level(payload.source_instance_id, required_level="pending"):
@@ -346,6 +405,7 @@ def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
 
     result.links_received = len(payload.lineage_links)
     result.events_received = len(payload.usage_events)
+    result.proposals_received = proposal_total
     governance_created = 0
 
     # 2. Create governance requests for lineage links
@@ -394,13 +454,48 @@ def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
             logger.warning("Federation usage_event import failed", exc_info=True)
             result.errors.append(f"usage_event error: {exc}")
 
+    # 4. Create governance requests for substance proposals.
+    #
+    # auto_apply_on_approval is False: the applier records the proposal as
+    # "stored", and a maintainer walks it into the repo. Substance is held
+    # by governance, not written by the API.
+    for attr, federation_type, label in _SUBSTANCE_PROPOSAL_KINDS:
+        for item in getattr(payload, attr):
+            item_id = (item or {}).get("id") if isinstance(item, dict) else None
+            id_suffix = f" '{item_id}'" if item_id else ""
+            try:
+                cr = governance_service.create_change_request(
+                    ChangeRequestCreate(
+                        request_type=ChangeRequestType.FEDERATION_IMPORT,
+                        title=(
+                            f"Federation proposal: {label}{id_suffix} "
+                            f"from {payload.source_instance_id}"
+                        ),
+                        payload={
+                            "federation_type": federation_type,
+                            "source_instance_id": payload.source_instance_id,
+                            "data": item,
+                        },
+                        proposer_id=f"federation:{payload.source_instance_id}",
+                        proposer_type=ActorType.MACHINE,
+                        auto_apply_on_approval=False,
+                    )
+                )
+                governance_created += 1
+                result.accepted += 1
+            except Exception as exc:
+                logger.warning(
+                    "Federation %s import failed", federation_type, exc_info=True
+                )
+                result.errors.append(f"{federation_type} error: {exc}")
+
     result.governance_requests_created = governance_created
 
-    # 4. Update last_sync_at on the instance
+    # 5. Update last_sync_at on the instance
     instance.last_sync_at = datetime.now().isoformat()
     register_instance(instance)
 
-    # 5. Store payload for audit
+    # 6. Store payload for audit
     now_iso = datetime.now().isoformat()
     with _session() as s:
         rec = FederationSyncHistoryRecord(
@@ -409,6 +504,7 @@ def receive_payload(payload: FederatedPayload) -> FederationSyncResult:
             timestamp=payload.timestamp,
             links_received=result.links_received,
             events_received=result.events_received,
+            proposals_received=result.proposals_received,
             governance_requests_created=result.governance_requests_created,
             accepted=result.accepted,
             rejected=result.rejected,
@@ -442,6 +538,7 @@ def list_sync_history(limit: int = 200) -> list[dict]:
                 "timestamp": r.timestamp,
                 "links_received": r.links_received,
                 "events_received": r.events_received,
+                "proposals_received": r.proposals_received or 0,
                 "governance_requests_created": r.governance_requests_created,
                 "accepted": r.accepted,
                 "rejected": r.rejected,

--- a/api/app/services/governance_service.py
+++ b/api/app/services/governance_service.py
@@ -258,6 +258,26 @@ def _apply_change_request(change_request: ChangeRequest) -> dict[str, Any]:
             if event is None:
                 raise ValueError(f"lineage link '{lineage_id}' not found for federated usage event")
             return {"kind": "federation_usage_event", "id": event.id, "source": source_instance_id, "action": "created"}
+        # Substance proposals (concept / spec / idea / teaching) are held by
+        # the change request itself. The API never writes peer-authored
+        # substance into the deployed corpus — a maintainer walks an
+        # approved proposal into the repo as a PR. The applier records
+        # that the proposal has been received and held; the payload (full
+        # markdown + frontmatter) lives in ``change_request.payload`` and
+        # can be retrieved via the governance API or CLI.
+        if federation_type in (
+            "concept_proposal",
+            "spec_proposal",
+            "idea_proposal",
+            "teaching_proposal",
+        ):
+            item_id = item_data.get("id") if isinstance(item_data, dict) else None
+            return {
+                "kind": f"federation_{federation_type}",
+                "id": item_id,
+                "source": source_instance_id,
+                "action": "stored",
+            }
         return {"kind": "federation_import", "federation_type": federation_type, "source": source_instance_id, "action": "stored"}
 
     raise ValueError(f"unsupported request_type: {request_type}")

--- a/api/tests/core_suite.txt
+++ b/api/tests/core_suite.txt
@@ -8,6 +8,7 @@ tests/test_external_presence.py
 tests/test_external_proof_demo.py
 tests/test_failure_taxonomy_service.py
 tests/test_federation_layer.py
+tests/test_federation_substance.py
 tests/test_flow_activity.py
 tests/test_flow_agent_lifecycle.py
 tests/test_flow_cli.py

--- a/api/tests/test_federation_substance.py
+++ b/api/tests/test_federation_substance.py
@@ -1,0 +1,282 @@
+"""Federation substance payload — round-trip test.
+
+Proves the substance layer of FederatedPayload (concept_proposals,
+spec_proposals, idea_proposals, teaching_proposals) lands as governance
+change requests that:
+
+  - require ≥ 2 approvals (FEDERATION_IMPORT default)
+  - do NOT auto-apply (substance wants a maintainer's eye + a PR)
+  - apply, when manually triggered, to a "stored" result whose id matches
+    the proposal id (the proposal body is held in the change request
+    payload until someone walks it into the repo)
+
+This is the symmetric companion to the existing telemetry layer
+(lineage_links + usage_events) which already auto-applies after vote.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.governance import (
+    ActorType,
+    ChangeRequestStatus,
+    ChangeRequestVoteCreate,
+    VoteDecision,
+)
+from app.services import federation_service, governance_service
+from app.services.governance_service import (
+    _apply_approved_change_request,
+    cast_vote,
+)
+
+
+BASE = "http://test"
+
+
+def _instance_id() -> str:
+    return f"peer_{uuid4().hex[:10]}"
+
+
+async def _register_peer(client: AsyncClient, instance_id: str) -> None:
+    body = {
+        "instance_id": instance_id,
+        "name": f"Peer {instance_id}",
+        "endpoint_url": f"https://{instance_id}.example",
+        "registered_at": "2026-05-13T00:00:00Z",
+        "trust_level": "pending",
+    }
+    r = await client.post("/api/federation/instances", json=body)
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_substance_payload_creates_governance_proposals():
+    """A payload with all four substance types creates one OPEN change
+    request per item, each with auto_apply_on_approval=False and
+    required_approvals=2.
+    """
+    instance_id = _instance_id()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _register_peer(c, instance_id)
+
+        payload = {
+            "source_instance_id": instance_id,
+            "timestamp": "2026-05-13T00:00:00Z",
+            "lineage_links": [],
+            "usage_events": [],
+            "concept_proposals": [
+                {
+                    "id": "lc-shared-breath",
+                    "title": "Shared breath",
+                    "body_markdown": "# Shared breath\n\nA teaching on co-weaving.",
+                    "origin_url": f"https://{instance_id}.example/vision/lc-shared-breath",
+                }
+            ],
+            "spec_proposals": [
+                {
+                    "id": "peer-spec-example",
+                    "title": "Peer-authored spec",
+                    "body_markdown": "---\nstatus: draft\n---\n\nA spec from a peer.",
+                }
+            ],
+            "idea_proposals": [
+                {
+                    "id": "peer-idea-example",
+                    "title": "Peer-authored idea",
+                    "body_markdown": "An idea proposed by a federated peer.",
+                }
+            ],
+            "teaching_proposals": [
+                {
+                    "id": "teaching-on-tending",
+                    "title": "On tending",
+                    "body_markdown": "A teaching observed in the peer's body.",
+                }
+            ],
+        }
+
+        r = await c.post("/api/federation/sync", json=payload)
+        assert r.status_code == 200, r.text
+        result = r.json()
+
+    assert result["source_instance_id"] == instance_id
+    assert result["proposals_received"] == 4
+    assert result["links_received"] == 0
+    assert result["events_received"] == 0
+    assert result["governance_requests_created"] == 4
+    assert result["accepted"] == 4
+    assert result["rejected"] == 0
+    assert result["errors"] == []
+
+    # Each proposal becomes a governance ChangeRequest tagged with the peer.
+    all_crs = governance_service.list_change_requests(limit=500)
+    peer_proposer = f"federation:{instance_id}"
+    peer_crs = [cr for cr in all_crs if cr.proposer_id == peer_proposer]
+    assert len(peer_crs) == 4
+
+    federation_types = {cr.payload.get("federation_type") for cr in peer_crs}
+    assert federation_types == {
+        "concept_proposal",
+        "spec_proposal",
+        "idea_proposal",
+        "teaching_proposal",
+    }
+
+    # Substance wants a maintainer's eye: required_approvals=2, no auto-apply.
+    for cr in peer_crs:
+        assert cr.required_approvals >= 2, (
+            f"federation substance must require ≥2 approvals, got {cr.required_approvals}"
+        )
+        assert cr.auto_apply_on_approval is False, (
+            "substance proposals must not auto-apply — a maintainer walks "
+            "them into the repo as a PR"
+        )
+        assert cr.status == ChangeRequestStatus.OPEN
+        # Full proposal body is held in the change request payload.
+        assert "data" in cr.payload
+        assert isinstance(cr.payload["data"], dict)
+        assert cr.payload["data"].get("body_markdown")
+
+
+@pytest.mark.asyncio
+async def test_substance_proposal_approves_but_does_not_auto_apply():
+    """Two YES votes flip a substance proposal to APPROVED but the applier
+    is NOT auto-invoked. The proposal waits for a maintainer."""
+    instance_id = _instance_id()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _register_peer(c, instance_id)
+
+        payload = {
+            "source_instance_id": instance_id,
+            "timestamp": "2026-05-13T00:00:00Z",
+            "concept_proposals": [
+                {
+                    "id": "lc-approve-no-apply",
+                    "title": "Approve without auto-apply",
+                    "body_markdown": "# Held by governance",
+                }
+            ],
+        }
+        r = await c.post("/api/federation/sync", json=payload)
+        assert r.status_code == 200, r.text
+
+    peer_proposer = f"federation:{instance_id}"
+    crs = [
+        cr
+        for cr in governance_service.list_change_requests(limit=500)
+        if cr.proposer_id == peer_proposer
+    ]
+    assert len(crs) == 1
+    cr_id = crs[0].id
+
+    cast_vote(
+        cr_id,
+        ChangeRequestVoteCreate(
+            voter_id="maintainer-a",
+            voter_type=ActorType.HUMAN,
+            decision=VoteDecision.YES,
+        ),
+    )
+    final = cast_vote(
+        cr_id,
+        ChangeRequestVoteCreate(
+            voter_id="maintainer-b",
+            voter_type=ActorType.HUMAN,
+            decision=VoteDecision.YES,
+        ),
+    )
+    assert final is not None
+    # Two YES votes meet the threshold but auto_apply_on_approval=False
+    # means the status stays APPROVED, not APPLIED. The body is held.
+    assert final.status == ChangeRequestStatus.APPROVED
+    assert final.applied_result is None
+
+
+@pytest.mark.asyncio
+async def test_substance_applier_records_stored_with_proposal_id():
+    """When a maintainer manually applies a substance proposal, the
+    applier returns kind=federation_{type} action=stored id=<proposal id>.
+    The proposal body remains in the change request payload — the API
+    never writes to the repo."""
+    instance_id = _instance_id()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        await _register_peer(c, instance_id)
+
+        payload = {
+            "source_instance_id": instance_id,
+            "timestamp": "2026-05-13T00:00:00Z",
+            "teaching_proposals": [
+                {
+                    "id": "teaching-applier-shape",
+                    "title": "Applier shape",
+                    "body_markdown": "Substance is stored, not applied.",
+                }
+            ],
+        }
+        r = await c.post("/api/federation/sync", json=payload)
+        assert r.status_code == 200, r.text
+
+    peer_proposer = f"federation:{instance_id}"
+    crs = [
+        cr
+        for cr in governance_service.list_change_requests(limit=500)
+        if cr.proposer_id == peer_proposer
+    ]
+    assert len(crs) == 1
+    cr = crs[0]
+
+    cast_vote(
+        cr.id,
+        ChangeRequestVoteCreate(
+            voter_id="maintainer-a",
+            voter_type=ActorType.HUMAN,
+            decision=VoteDecision.YES,
+        ),
+    )
+    cast_vote(
+        cr.id,
+        ChangeRequestVoteCreate(
+            voter_id="maintainer-b",
+            voter_type=ActorType.HUMAN,
+            decision=VoteDecision.YES,
+        ),
+    )
+
+    approved = governance_service.get_change_request(cr.id)
+    assert approved is not None
+    assert approved.status == ChangeRequestStatus.APPROVED
+
+    applied = _apply_approved_change_request(cr.id, approved)
+    assert applied.status == ChangeRequestStatus.APPLIED
+    assert applied.applied_result is not None
+    assert applied.applied_result.get("kind") == "federation_teaching_proposal"
+    assert applied.applied_result.get("action") == "stored"
+    assert applied.applied_result.get("id") == "teaching-applier-shape"
+    assert applied.applied_result.get("source") == instance_id
+
+
+@pytest.mark.asyncio
+async def test_substance_payload_from_unknown_instance_is_rejected():
+    """A payload from an unregistered peer rejects all items (telemetry
+    AND substance) without creating any change requests."""
+    unknown = f"unknown_{uuid4().hex[:8]}"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        payload = {
+            "source_instance_id": unknown,
+            "timestamp": "2026-05-13T00:00:00Z",
+            "concept_proposals": [{"id": "lc-x", "body_markdown": "x"}],
+            "spec_proposals": [{"id": "y", "body_markdown": "y"}],
+        }
+        r = await c.post("/api/federation/sync", json=payload)
+        assert r.status_code == 200, r.text
+        result = r.json()
+
+    assert result["rejected"] == 2
+    assert result["accepted"] == 0
+    assert result["governance_requests_created"] == 0
+    assert any("not registered" in e for e in result["errors"])

--- a/docs/FEDERATING-INSTANCES.md
+++ b/docs/FEDERATING-INSTANCES.md
@@ -18,19 +18,25 @@ The body has two honest paths for content between instances:
 | Marketplace listings & forks | **REST** (automatic) | `POST /api/federation/marketplace/ingest` fires when a listing is created or forked |
 | Lineage links between entities | **REST** (manual or scheduled) | `POST /api/federation/sync` with `lineage_links` array |
 | Usage events / telemetry | **REST** (manual or scheduled) | `POST /api/federation/sync` with `usage_events` array |
-| Concepts (`docs/vision-kb/concepts/lc-*.md`) | **git** | clone + cherry-pick + `sync_kb_to_db.py` |
-| Specs (`specs/*.md`) | **git** | clone + cherry-pick + `generate_repo_indexes.py` |
-| Ideas (`ideas/*.md`) | **git** | clone + cherry-pick |
-| Teachings (`docs/vision-kb/guides/`, `docs/field/`, `docs/lineage/`) | **git** | clone + cherry-pick |
+| Concept proposals | **REST or git** | `POST /api/federation/sync` with `concept_proposals` array — *or* clone + cherry-pick + `sync_kb_to_db.py` |
+| Spec proposals | **REST or git** | `POST /api/federation/sync` with `spec_proposals` array — *or* clone + cherry-pick + `generate_repo_indexes.py` |
+| Idea proposals | **REST or git** | `POST /api/federation/sync` with `idea_proposals` array — *or* clone + cherry-pick |
+| Teaching proposals (guides, field, lineage) | **REST or git** | `POST /api/federation/sync` with `teaching_proposals` array — *or* clone + cherry-pick |
 
 The REST path is governance-gated — every payload an instance
-receives lands as a `ChangeRequest` of type `FEDERATION_IMPORT` and
-auto-applies only after the receiving instance's quorum votes
-through. The audit trail lives in `federation_sync_history`.
+receives lands as a `ChangeRequest` of type `FEDERATION_IMPORT`.
+Telemetry (lineage links, usage events) auto-applies after the
+quorum votes through; **substance** (concept/spec/idea/teaching
+proposals) holds at APPROVED and waits for a maintainer to walk
+it into the repo as a PR. The API never writes peer-authored
+substance into the deployed corpus on its own. The audit trail
+lives in `federation_sync_history`.
 
-The git path is the body's source-of-truth for substance. Two
-forks both reading and writing markdown — the same way the body
-itself flows internally — is honest content federation today.
+The git path remains available for substance — two forks reading
+and writing markdown directly, the same gesture the body uses
+internally. Pick whichever path fits: REST when a peer instance
+wants to propose without repo access; git when an operator
+already has cherry-pick rhythm.
 
 ## Two operators, two instances
 
@@ -187,11 +193,58 @@ Pending change requests appear in normal governance:
 curl https://bob.coherencycoin.com/api/governance/change-requests?status=open
 ```
 
-### Step 5 — What still flows via git (everything substantive)
+### Step 5 — What can also flow via the payload (substance, governance-gated)
 
-This is the honest part. Today, the REST payload carries
-**telemetry and lineage edges, not substance**. Concepts, specs,
-ideas, teachings travel through git.
+The REST payload now carries **two layers**:
+
+- **Telemetry** — `lineage_links`, `usage_events`. Each item becomes
+  a governance ChangeRequest with `auto_apply_on_approval=True`:
+  once two approvals clear, the link/event lands in the local
+  lineage graph automatically.
+- **Substance** — `concept_proposals`, `spec_proposals`,
+  `idea_proposals`, `teaching_proposals`. Each item becomes a
+  governance ChangeRequest with `auto_apply_on_approval=False`:
+  the full markdown body is held in the change request payload,
+  and a maintainer walks an approved proposal into the repo as a
+  PR. The API never writes peer-authored substance into the
+  deployed corpus on its own — the body keeps that gesture human.
+
+Alice pushes a concept proposal to Bob:
+
+```bash
+curl -sS -X POST https://bob.coherencycoin.com/api/federation/sync \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_instance_id": "alice",
+    "timestamp": "2026-05-13T12:00:00Z",
+    "concept_proposals": [
+      {
+        "id": "lc-gatherings-that-carry",
+        "title": "Gatherings that carry",
+        "body_markdown": "# Gatherings that carry\n\n…",
+        "origin_url": "https://alice.coherencycoin.com/vision/lc-gatherings-that-carry"
+      }
+    ]
+  }'
+```
+
+Bob's side now holds a governance ChangeRequest. Two maintainers
+review and approve; the change request flips to APPROVED but does
+not apply. A maintainer reads `cr.payload.data.body_markdown`,
+authors `docs/vision-kb/concepts/lc-gatherings-that-carry.md` in
+Bob's repo, runs `python3 scripts/sync_kb_to_db.py
+lc-gatherings-that-carry --api-key dev-key`, and merges. The
+change request can then be marked APPLIED.
+
+Substance can still flow via git — both paths stay available.
+Pick whichever fits the gesture. Git is faster when an operator
+already has cherry-pick rhythm; the payload is honest when an
+agent or peer instance wants to propose without needing repo
+access.
+
+### Step 6 — When substance flows via git instead
+
+When you'd rather cherry-pick directly:
 
 Bob wants Alice's new concept `lc-gatherings-that-carry`:
 
@@ -248,10 +301,6 @@ The walked practice above works today. What it doesn't have yet:
   explicitly register.
 - **Trust handshake.** No vouching protocol — each side upgrades
   trust independently and manually.
-- **Substance payload.** Concepts, specs, ideas, teachings still
-  flow through git, not through `/api/federation/sync`. The
-  governance-gated flow exists; the payload shape doesn't carry
-  those types yet.
 - **Scheduled sync.** No "every 24h push deltas" rhythm. Push is
   event-driven on marketplace actions; everything else is on
   demand.
@@ -322,22 +371,16 @@ audit trail names every crossing.
 The walked practice today is honest but partial. The body is
 moving toward:
 
-1. **Extended `FederatedPayload`** that carries `concept_proposals`,
-   `spec_proposals`, `idea_proposals`, `teaching_proposals` — so
-   substance flows through the same governance-gated REST path
-   that lineage and usage already use. Git stays available, but
-   the API becomes capable of substance-level exchange.
-
-2. **`.well-known/coherence-federation`** for auto-discovery.
+1. **`.well-known/coherence-federation`** for auto-discovery.
    Operators arriving at an unknown instance can fetch its
    federation manifest and propose peering through one gesture
    rather than several.
 
-3. **A trust handshake** that's mutual and explicit — Alice
+2. **A trust handshake** that's mutual and explicit — Alice
    proposes trust, Bob accepts, both sides upgrade in the same
    atomic gesture.
 
-4. **MCP tools** for agent-driven peering. An agent reading this
+3. **MCP tools** for agent-driven peering. An agent reading this
    doc today does the work via shell + curl; the body wants
    first-class affordances so agents can offer "we should peer
    with X" as a real action.
@@ -373,6 +416,6 @@ body's circulation.
 
 — *Written from the walked path, not the planned one. Every
 command above runs today; every gap above is named honestly.
-Future breaths grow this doc with the substance-payload extension,
-the .well-known discovery, the trust handshake, the agent
-affordances — added at the body's own pace as they land.*
+Future breaths grow this doc with .well-known discovery, the
+trust handshake, and the agent affordances — added at the body's
+own pace as they land.*


### PR DESCRIPTION
## Summary

Extends `FederatedPayload` so the same governance-gated REST surface that already carries lineage links and usage events can also carry body-level material — concepts, specs, ideas, teachings — as proposals.

Telemetry auto-applies after quorum (unchanged). **Substance holds at APPROVED and waits for a maintainer** to walk the proposal into the repo as a PR. The API never writes peer-authored substance into the deployed corpus on its own — that gesture stays human.

- `FederatedPayload` gains `concept_proposals`, `spec_proposals`, `idea_proposals`, `teaching_proposals` (each `list[dict]`, default empty — fully back-compatible)
- `receive_payload` routes each item to `governance_service.create_change_request` with `auto_apply_on_approval=False`; existing `required_approvals >= 2` enforcement applies
- Governance applier records substance as `kind=federation_{type} action=stored id=<proposal id>`; the full markdown body lives in `change_request.payload.data` until someone authors the file locally
- `FederationSyncResult` and `federation_sync_history` gain `proposals_received`, with an in-place `ALTER TABLE` migration for older snapshots
- `FEDERATING-INSTANCES.md` re-walked — substance payload is no longer in the "what this is not (yet)" list; a curl example shows the gesture

## Test plan

- [x] `tests/test_federation_substance.py` — four round-trip tests pass (4/4)
- [x] `tests/test_federation_layer.py` + `test_federation_message_readback.py` — no regression (10/10)
- [x] All governance + federation tests (41/41)
- [ ] CI: full core suite green
- [ ] After merge: confirm `make wellness` still shows federation cells coherent

🤖 Generated with [Claude Code](https://claude.com/claude-code)