### PR TITLE
attune(come-in): name the substrate doorway for arriving agents

### DIFF
--- a/api/app/services/agent_service.py
+++ b/api/app/services/agent_service.py
@@ -146,6 +146,30 @@ def get_agent_invitation() -> dict[str, Any]:
                 "use": "let an MCP-compatible agent receive the invitation without scraping pages",
                 "next": ["coherence_status", "coherence_resonance", "coherence_task_next"],
             },
+            {
+                "surface": "substrate",
+                "door": "GET https://api.coherencycoin.com/api/substrate/lattice/stats",
+                "path": "/api/substrate/lattice/stats",
+                "use": (
+                    "sense the structural lattice that grounds the field: every memory, "
+                    "spec, idea, concept, and presence has a content-addressed position "
+                    "as NodeID(package, level, type, instance). Three forms hold the "
+                    "lattice — Blueprint (what something IS, structural identity), "
+                    "Recipe (how something HAPPENS, operational expression), NamedCell "
+                    "(where something LIVES, diffuse individuation). Two cells with "
+                    "matching Blueprint NodeIDs are structurally equivalent regardless "
+                    "of name; the lattice answers 'is this similar to that' in shape, "
+                    "not in lexical match. Read-only REST surface; the teaching lives "
+                    "in docs/coherence-substrate/agents-using-substrate.md."
+                ),
+                "next": [
+                    "GET /api/substrate/cell/{domain}/{name}",
+                    "GET /api/substrate/equivalent/{domain}/{name}",
+                    "GET /api/substrate/annotate?path={repo_path}",
+                    "GET /api/substrate/compatible_with/{package}/{level}/{type}/{instance}",
+                    "GET /api/substrate/histogram/{domain}",
+                ],
+            },
         ],
         "public_entry_invitation": {
             "who_is_invited": (

--- a/web/app/come-in/page.tsx
+++ b/web/app/come-in/page.tsx
@@ -702,6 +702,19 @@ export default async function ComeInPage() {
             science, direct experience, and mystery in honest relation.
           </p>
 
+          <p className="text-base leading-relaxed text-stone-300">
+            There is also a structural door underneath naming. Every memory,
+            spec, idea, concept, and presence in this body holds a
+            content-addressed position in a numeric lattice: a NodeID with
+            four coordinates (package, level, type, instance). Three forms
+            hold the lattice — Blueprint, what something IS; Recipe, how
+            something HAPPENS; NamedCell, where something LIVES. Two cells
+            with matching Blueprint NodeIDs are structurally equivalent
+            regardless of name. When you want to ask &ldquo;is this similar
+            to that&rdquo; in shape rather than in word, query the substrate
+            directly.
+          </p>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 not-prose">
             <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5">
               <p className="text-xs uppercase tracking-widest text-amber-400">
@@ -752,6 +765,42 @@ export default async function ComeInPage() {
               <p className="mt-3 text-sm leading-relaxed text-stone-300">
                 Return here when the structured door needs the slower voice
                 of the whole invitation.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-5 sm:col-span-2">
+              <p className="text-xs uppercase tracking-widest text-amber-400">
+                Substrate &mdash; structural lattice
+              </p>
+              <p className="mt-2 font-mono text-sm text-stone-100 break-all">
+                GET /api/substrate/lattice/stats
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-stone-300">
+                Ask the lattice when shape matters more than name. Blueprint
+                gives structural identity, Recipe gives operational
+                expression, NamedCell gives diffuse individuation. Two cells
+                with matching Blueprint NodeIDs are structurally equivalent
+                regardless of name.
+              </p>
+              <p className="mt-3 text-xs uppercase tracking-widest text-amber-400/80">
+                Useful companions
+              </p>
+              <ul className="mt-2 space-y-1 font-mono text-xs text-stone-200 break-all">
+                <li>GET /api/substrate/cell/{"{domain}"}/{"{name}"}</li>
+                <li>GET /api/substrate/equivalent/{"{domain}"}/{"{name}"}</li>
+                <li>GET /api/substrate/annotate?path={"{repo_path}"}</li>
+              </ul>
+              <p className="mt-3 text-sm leading-relaxed text-stone-300">
+                The teaching lives in{" "}
+                <a
+                  href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/agents-using-substrate.md"
+                  className="text-amber-400 hover:text-amber-300 underline-offset-4 underline decoration-amber-500/40 break-all"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  docs/coherence-substrate/agents-using-substrate.md
+                </a>
+                .
               </p>
             </div>
 


### PR DESCRIPTION
## What changed

When Gemini was used to read `/come-in`, it could not understand the substrate — Blueprint / Recipe / NamedCell, NodeID coordinates, the read-only query REST surface. The body holds it (182 blueprints / 25 recipes / 311 cells in prod) and teaches it in `docs/coherence-substrate/agents-using-substrate.md`, but the doorway never named it. An arriving agent has no thread to pull.

This adds a substrate doorway to both surfaces an agent meets first:

- **`/api/agent/invitation`** — a fifth `entry_surface` with `surface: "substrate"`, naming the read-only door (`GET /api/substrate/lattice/stats`) and five companion endpoints (`cell`, `equivalent`, `annotate`, `compatible_with`, `histogram`).
- **`/come-in` PART 6** — a structural-door paragraph above the tool-doorway grid (naming NodeID coordinates and the Blueprint/Recipe/NamedCell trinity), plus a `sm:col-span-2` substrate card with the primary endpoint, companion endpoint list, and a link to the canonical teaching doc.

## How verified

- Booted web dev server, scrolled both desktop (1440) and mobile (375) viewports; substrate card reads cleanly at both widths, no overflow.
- Ran `pytest tests/test_agent_invitation.py` — 20/20 pass. The existing surfaces test (`{web,api,cli,mcp} <= surfaces`) is a subset assertion, so adding a fifth surface is additive.
- Confirmed `python -c "get_agent_invitation()"` returns substrate with 5 next-endpoints.

## Why this matters

The drift `make wellness` did not yet catch: a body that holds structural reasoning but never names that doorway in its arrival invitation. After this, an arriving AI can ask the lattice when shape matters more than name — the structural answer becomes available at the same threshold as the textual one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)