### PR TITLE
attune(presences): drift-resistant claims across READMEs, skill, npm metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Every part of the network links to every other. Jump in wherever makes sense.
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, contributors, and value chains visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints with full OpenAPI docs — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | Terminal-first access — `npx coherence-cli help` or `npm i -g coherence-cli && coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 92 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **skills.sh** | Portable agent skill directory (same `SKILL.md` as ClawHub) | [skills.sh](https://skills.sh/) — submit `skills/coherence-network/` |
 | **askill.sh** | Secondary skill index for discovery | [askill.sh](https://askill.sh/) — submit `skills/coherence-network/` |

--- a/cli/README.md
+++ b/cli/README.md
@@ -177,9 +177,9 @@ Every part of the network links to every other. Jump in wherever makes sense for
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | The main site — browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | This package — terminal-first access to the full network | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf, etc.) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf, etc.) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers in any OpenClaw instance when you mention ideas, specs, or coherence | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 

--- a/cli/README.template.md
+++ b/cli/README.template.md
@@ -157,9 +157,9 @@ Every part of the network links to every other. Jump in wherever makes sense for
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | The main site — browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | This package — terminal-first access to the full network | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 84 typed tools for AI agents (Claude, Cursor, Windsurf, etc.) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf, etc.) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers in any OpenClaw instance when you mention ideas, specs, or coherence | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherence-cli",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Coherence Network CLI — invite anyone or anything to ask what is alive, trace ideas from inception to payout, and contribute with fair attribution.",
   "type": "module",
   "bin": {

--- a/docs/shared/ecosystem-table.md
+++ b/docs/shared/ecosystem-table.md
@@ -1,9 +1,9 @@
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, contributors, and value chains visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints with full OpenAPI docs — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | Terminal-first access — `npx coherence-cli help` or `npm i -g coherence-cli && coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 92 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **skills.sh** | Portable agent skill directory (same `SKILL.md` as ClawHub) | [skills.sh](https://skills.sh/) — submit `skills/coherence-network/` |
 | **askill.sh** | Secondary skill index for discovery | [askill.sh](https://askill.sh/) — submit `skills/coherence-network/` |

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -3,7 +3,7 @@
 
 **Give your AI agent native access to every idea, spec, contributor, and value chain in the Coherence Network.**
 
-An [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server that exposes the full Coherence Network API as 92 typed tools — so Claude, Cursor, Windsurf, or any MCP-compatible agent can browse ideas, look up specs, trace value lineage, link identities, record contributions, read field stories, execute tasks, discover resonant peers, apply project blueprints, receive the shared agent invitation, and read repository content via direct links without writing a single API call.
+An [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server that exposes the full Coherence Network API as a typed tool surface — so Claude, Cursor, Windsurf, or any MCP-compatible agent can browse ideas, look up specs, trace value lineage, link identities, record contributions, read field stories, execute tasks, discover resonant peers, apply project blueprints, receive the shared agent invitation, and read repository content via direct links without writing a single API call.
 
 ```bash
 npx coherence-mcp-server
@@ -290,9 +290,9 @@ Every part of the network links to every other. Jump in wherever makes sense.
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | This package — 92 typed tools for AI agents | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **MCP Server** | This package — typed tool surface for AI agents | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers in any OpenClaw instance for ideas, specs, coherence | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 

--- a/mcp-server/README.template.md
+++ b/mcp-server/README.template.md
@@ -2,7 +2,7 @@
 
 **Give your AI agent native access to every idea, spec, contributor, and value chain in the Coherence Network.**
 
-An [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server that exposes the full Coherence Network API as 92 typed tools — so Claude, Cursor, Windsurf, or any MCP-compatible agent can browse ideas, look up specs, trace value lineage, link identities, record contributions, read field stories, execute tasks, discover resonant peers, apply project blueprints, receive the shared agent invitation, and read repository content via direct links without writing a single API call.
+An [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) server that exposes the full Coherence Network API as a typed tool surface — so Claude, Cursor, Windsurf, or any MCP-compatible agent can browse ideas, look up specs, trace value lineage, link identities, record contributions, read field stories, execute tasks, discover resonant peers, apply project blueprints, receive the shared agent invitation, and read repository content via direct links without writing a single API call.
 
 ```bash
 npx coherence-mcp-server
@@ -289,9 +289,9 @@ Every part of the network links to every other. Jump in wherever makes sense.
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
-| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `cc help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | This package — 92 typed tools for AI agents | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
+| **MCP Server** | This package — typed tool surface for AI agents | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | Auto-triggers in any OpenClaw instance for ideas, specs, coherence | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 

--- a/mcp-server/coherence_mcp_server/__init__.py
+++ b/mcp-server/coherence_mcp_server/__init__.py
@@ -1,7 +1,7 @@
 """
 coherence-mcp-server — MCP server for the Coherence Network.
 
-92 typed tools for AI agents to browse ideas, trace value chains,
+Typed tool surface for AI agents to browse ideas, trace value chains,
 link identities, record contributions, read field stories, and explore the
 Living Codex ontology.
 
@@ -14,5 +14,5 @@ Environment variables:
     COHERENCE_API_KEY   API key for write operations (optional for reads)
 """
 
-__version__ = "0.5.3"
+__version__ = "0.5.5"
 __all__ = ["__version__"]

--- a/mcp-server/glama.json
+++ b/mcp-server/glama.json
@@ -1,6 +1,6 @@
 {
   "name": "coherence-network",
-  "description": "Coherence Network MCP server — 92 typed tools for AI agents to publish ideas, query the knowledge graph, record resonance, trace value chains, link identities, read field stories, and explore the Living Codex ontology via the Model Context Protocol.",
+  "description": "Coherence Network MCP server — typed tool surface for AI agents to publish ideas, query the knowledge graph, record resonance, trace value chains, link identities, read field stories, and explore the Living Codex ontology via the Model Context Protocol.",
   "url": "https://github.com/seeker71/Coherence-Network",
   "homepage": "https://coherencycoin.com",
   "license": "MIT",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherence-mcp-server",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Unified MCP server for Coherence Network — invite anyone or anything to ask what is alive, browse ideas and field stories, and contribute with attribution.",
   "type": "module",
   "bin": {

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coherence-mcp-server"
-version = "0.5.3"
-description = "Unified MCP server for the Coherence Network — 92 typed tools for AI agents to browse ideas, read field stories, manage tasks, link identities, and navigate the universal graph."
+version = "0.5.5"
+description = "Unified MCP server for the Coherence Network — typed tool surface for AI agents to browse ideas, read field stories, manage tasks, link identities, and navigate the universal graph."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/mcp-server/smithery.yaml
+++ b/mcp-server/smithery.yaml
@@ -3,9 +3,9 @@
 
 name: coherence-mcp-server
 description: >
-  MCP server for the Coherence Network — 92 typed tools for AI agents to browse
-  ideas, trace value chains, link identities, record contributions, read field
-  stories, and explore the Living Codex ontology.
+  MCP server for the Coherence Network — typed tool surface for AI agents to
+  browse ideas, trace value chains, link identities, record contributions, read
+  field stories, and explore the Living Codex ontology.
 
 homepage: https://coherencycoin.com
 repository: https://github.com/seeker71/Coherence-Network

--- a/skills/coherence-network/SKILL.md
+++ b/skills/coherence-network/SKILL.md
@@ -323,9 +323,9 @@ Every part of the network links to every other. Jump in wherever makes sense.
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 92 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | This skill — auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 
@@ -345,4 +345,4 @@ Before executing any POST/PATCH/DELETE request, always confirm with the user. Re
 
 ## API reference
 
-For the full endpoint table (100+ endpoints across 20 resource groups), see `references/api-endpoints.md`.
+For the full endpoint table, see `references/api-endpoints.md` or browse the live OpenAPI at `https://api.coherencycoin.com/docs`.

--- a/skills/coherence-network/SKILL.template.md
+++ b/skills/coherence-network/SKILL.template.md
@@ -316,9 +316,9 @@ Every part of the network links to every other. Jump in wherever makes sense.
 | Surface | What it is | Link |
 |---------|-----------|------|
 | **Web** | Browse ideas, specs, and contributors visually | [coherencycoin.com](https://coherencycoin.com) |
-| **API** | 100+ endpoints, full OpenAPI docs, the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
+| **API** | Full OpenAPI surface — the engine behind everything | [api.coherencycoin.com/docs](https://api.coherencycoin.com/docs) |
 | **CLI** | Terminal-first access — `npm i -g coherence-cli` then `coh help` | [npm: coherence-cli](https://www.npmjs.com/package/coherence-cli) |
-| **MCP Server** | 92 typed tools for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
+| **MCP Server** | Typed tool surface for AI agents (Claude, Cursor, Windsurf) | [npm: coherence-mcp-server](https://www.npmjs.com/package/coherence-mcp-server) |
 | **OpenClaw Skill** | This skill — auto-triggers inside any OpenClaw instance | [ClawHub: coherence-network](https://clawhub.com/skills/coherence-network) |
 | **GitHub** | Source code, specs, issues, and contribution tracking | [github.com/seeker71/Coherence-Network](https://github.com/seeker71/Coherence-Network) |
 
@@ -338,4 +338,4 @@ Before executing any POST/PATCH/DELETE request, always confirm with the user. Re
 
 ## API reference
 
-For the full endpoint table (100+ endpoints across 20 resource groups), see `references/api-endpoints.md`.
+For the full endpoint table, see `references/api-endpoints.md` or browse the live OpenAPI at `https://api.coherencycoin.com/docs`.


### PR DESCRIPTION
## Summary
- Replace "100+ endpoints" / "92 typed tools" / "84 typed tools" / "across 20 resource groups" with phrasing that doesn't decay: **Full OpenAPI surface** and **Typed tool surface**.
- Bump `coherence-cli` → 0.13.3 and `coherence-mcp-server` → 0.5.5 (npm + pyproject) so the freshened metadata reaches npm and pypi.
- Sweeps all six surfaces in one commit: README, cli/README, mcp-server/README, SKILL, the shared ecosystem-table fragment, plus mcp-server's `glama.json` / `smithery.yaml` / `__init__.py` / `pyproject.toml`.

Closes the **G2** gap from the 2026-05-11 scheduled wellness review of public presences. G1 (GitHub repo description + homepage) was closed inline via `gh api PATCH` and needs no PR. G3 turned out to be an artifact of my earlier grep — the homepage already links to all five surfaces, no change needed.

## Why the softening
The snapshot numbers were already wrong on multiple surfaces (cli/README at "84", README at "100+", reality at 615 paths / 92 tools). "Full OpenAPI surface" / "Typed tool surface" stays true as the body grows; future tending lands in the live `/api/openapi.json`, not in README copy.

## Test plan
- [x] `python3 scripts/build_readmes.py --check` reports all four consumer files in sync after template edits.
- [x] Grep across `*.md *.json *.yaml *.toml *.py *.mjs *.ts *.tsx` for the four stale phrases returns empty.
- [x] `cli/package.json` and `mcp-server/package.json` versions match `mcp-server/pyproject.toml` and `__init__.py`.
- [ ] On merge: Hostinger Auto Deploy + Public Deploy workflows green, `verify_web_api_deploy.sh` shows main-head live.
- [ ] On merge: republish `coherence-cli@0.13.3` and `coherence-mcp-server@0.5.5` to npm.
- [ ] On merge: the local `~/.openclaw/workspace/skills/coherence-network/SKILL.md` (auto-copied by `build_readmes.py`) propagates the softened skill copy to ClawHub on next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)