### PR TITLE
tend(web): inspired-by cards render markdown and platform icons

### DIFF
--- a/web/components/inspired-by/shared.tsx
+++ b/web/components/inspired-by/shared.tsx
@@ -13,6 +13,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { getApiBase } from "@/lib/api";
+import { PROVIDER_BRAND, brandFor } from "@/components/presence/brand";
+import { MarkdownProse } from "@/components/markdown-prose";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -101,23 +103,80 @@ export function Avatar({ item }: { item: InspiredByItem }) {
   );
 }
 
-export function PresencesRow({ presences, limit = 6 }: { presences: Presence[]; limit?: number }) {
+export function PresencesRow({ presences, limit = 8 }: { presences: Presence[]; limit?: number }) {
   if (!presences || presences.length === 0) return null;
   return (
-    <div className="flex flex-wrap gap-1.5 mt-2">
-      {presences.slice(0, limit).map((p) => (
-        <a
-          key={p.url}
-          href={p.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-[10px] uppercase tracking-[0.12em] rounded-full border border-border/40 px-2 py-0.5 text-muted-foreground hover:text-foreground hover:border-border"
-        >
-          {p.provider}
-        </a>
-      ))}
+    <div className="flex flex-wrap items-center gap-1.5 mt-2">
+      {presences.slice(0, limit).map((p) => {
+        const tone = brandFor(p.provider);
+        const hasIcon = !!PROVIDER_BRAND[p.provider]?.iconPath;
+        if (hasIcon && tone.iconPath) {
+          return (
+            <a
+              key={p.url}
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={`${tone.label} · ${p.url}`}
+              aria-label={tone.label}
+              className="inline-flex items-center justify-center w-7 h-7 rounded-full transition-transform hover:scale-110"
+              style={{
+                background: tone.gradient || tone.bg,
+                color: tone.fg,
+              }}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="14"
+                height="14"
+                aria-hidden="true"
+                fill="currentColor"
+              >
+                <path d={tone.iconPath} />
+              </svg>
+            </a>
+          );
+        }
+        return (
+          <a
+            key={p.url}
+            href={p.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={p.url}
+            className="text-[10px] uppercase tracking-[0.12em] rounded-full border border-border/40 px-2 py-0.5 text-muted-foreground hover:text-foreground hover:border-border"
+          >
+            {tone.label}
+          </a>
+        );
+      })}
     </div>
   );
+}
+
+/**
+ * Drop a leading `# Name` heading from a description when it just
+ * duplicates the card's title. The card already shows the name above
+ * the description; rendering it a second time as an `<h1>` adds noise.
+ * Anything else (subheadings, italics, links, lists) is left intact for
+ * MarkdownProse to render.
+ */
+export function dropRedundantTitle(raw: string, name?: string): string {
+  let text = raw.replace(/\r\n?/g, "\n").trim();
+  if (!name) return text;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Leading `# Name\n` or `## Name\n` etc. — drop the whole line.
+  text = text.replace(
+    new RegExp(`^#{1,6}\\s*${escaped}\\s*\\n+`, "i"),
+    "",
+  );
+  // Same heading without a trailing newline (the whole description is
+  // the heading plus a blob — odd but seen in the wild).
+  text = text.replace(
+    new RegExp(`^#{1,6}\\s*${escaped}\\s+`, "i"),
+    "",
+  );
+  return text.trim();
 }
 
 // ── Card ──────────────────────────────────────────────────────────────
@@ -133,7 +192,8 @@ export type CardProps = {
 export function InspiredByCard({ item, onRemove, highlightShared }: CardProps) {
   const shared = highlightShared && !!item.shared_with_viewer;
   const presences = Array.isArray(item.node.presences) ? item.node.presences : [];
-  const description = item.node.tagline || item.node.description || "";
+  const rawDescription = item.node.tagline || item.node.description || "";
+  const description = dropRedundantTitle(rawDescription, item.node.name);
   const baseClass = shared
     ? "border-[hsl(var(--chart-2)/0.45)] bg-[linear-gradient(135deg,hsl(var(--card))_0%,hsl(var(--card))_55%,hsl(var(--chart-2)/0.10)_100%)]"
     : "border-border/30 bg-card/50 hover:bg-card/70 hover:border-border/60";
@@ -173,12 +233,14 @@ export function InspiredByCard({ item, onRemove, highlightShared }: CardProps) {
             {item.node.name}
           </p>
           {description ? (
-            // Description gets four lines of breathing room (was two).
             // The graph holds 300-450 chars of context for figures like
-            // Goethe and Ramtha; a 2-line clamp turned that into noise.
-            <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed line-clamp-4">
-              {description}
-            </p>
+            // Goethe and Ramtha — sometimes with markdown (headings,
+            // italics, links). MarkdownProse renders the small set we
+            // support; the wrapper bounds height so the card stays
+            // compact, with a soft fade hinting more on click-through.
+            <div className="text-sm text-muted-foreground mt-1.5 leading-relaxed max-h-[6.5rem] overflow-hidden [mask-image:linear-gradient(to_bottom,black_70%,transparent_100%)] [&_p]:m-0 [&_p+p]:mt-1.5 [&_em]:italic [&_strong]:font-semibold [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-foreground [&_h1]:mb-1 [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-foreground [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-foreground [&_h3]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:space-y-0.5 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:text-[0.85em]">
+              <MarkdownProse text={description} />
+            </div>
           ) : null}
           <PresencesRow presences={presences} />
           <div className="flex items-center gap-3 mt-2.5 flex-wrap">

--- a/web/components/markdown-prose.tsx
+++ b/web/components/markdown-prose.tsx
@@ -4,11 +4,14 @@
 // lives in messages/{lang}.json as a single string. The string carries
 // a small set of inline markup:
 //   - blank line separates paragraphs
+//   - a paragraph whose lines all begin with "# / ## / ### " becomes a heading
 //   - a paragraph whose lines all begin with "- " becomes a bullet list
 //   - inline *text* renders as <em>
+//   - inline **text** renders as <strong>
+//   - inline `text` renders as <code>
 //   - inline [label](href) renders as a Link via the L() helper
 //
-// Anything richer (tables, headings, code) belongs in its own component.
+// Anything richer (tables, code blocks) belongs in its own component.
 
 import type { ReactNode } from "react";
 import { L } from "@/components/inline-link";
@@ -17,20 +20,31 @@ let rendererKey = 0;
 
 function renderInline(text: string, keyBase: string): ReactNode[] {
   const out: ReactNode[] = [];
-  // First split on links, then handle *em* within each non-link chunk.
+  // First split on links, then handle **strong** / *em* / `code` within
+  // each non-link chunk. Strong is matched before em so `**foo**` doesn't
+  // get half-consumed as a stray asterisk pair.
   const linkRe = /\[([^\]]+)\]\(([^)]+)\)/g;
   let lastIdx = 0;
   let m: RegExpExecArray | null;
   let i = 0;
   const pushPlain = (chunk: string) => {
     if (!chunk) return;
-    const emRe = /\*([^*\n]+)\*/g;
+    // Tokenize on **strong**, *em*, and `code` in one pass so we don't
+    // double-consume nested markers. Strong must come before em so its
+    // outer ** isn't read as two adjacent * pairs.
+    const tokenRe = /(\*\*([^*\n]+)\*\*|\*([^*\n]+)\*|`([^`\n]+)`)/g;
     let li = 0;
-    let em: RegExpExecArray | null;
-    while ((em = emRe.exec(chunk)) !== null) {
-      if (em.index > li) out.push(chunk.slice(li, em.index));
-      out.push(<em key={`${keyBase}-e${i++}`}>{em[1]}</em>);
-      li = em.index + em[0].length;
+    let tok: RegExpExecArray | null;
+    while ((tok = tokenRe.exec(chunk)) !== null) {
+      if (tok.index > li) out.push(chunk.slice(li, tok.index));
+      if (tok[2] !== undefined) {
+        out.push(<strong key={`${keyBase}-s${i++}`}>{tok[2]}</strong>);
+      } else if (tok[3] !== undefined) {
+        out.push(<em key={`${keyBase}-e${i++}`}>{tok[3]}</em>);
+      } else if (tok[4] !== undefined) {
+        out.push(<code key={`${keyBase}-c${i++}`}>{tok[4]}</code>);
+      }
+      li = tok.index + tok[0].length;
     }
     if (li < chunk.length) out.push(chunk.slice(li));
   };
@@ -48,6 +62,38 @@ function renderInline(text: string, keyBase: string): ReactNode[] {
   return out;
 }
 
+const HEADING_CLASS: Record<number, string> = {
+  1: "text-base font-semibold leading-snug mt-0 mb-1",
+  2: "text-sm font-semibold leading-snug mt-0 mb-1",
+  3: "text-sm font-medium leading-snug mt-0 mb-1",
+  4: "text-xs font-medium leading-snug mt-0 mb-1 uppercase tracking-[0.08em]",
+  5: "text-xs font-medium leading-snug mt-0 mb-1 uppercase tracking-[0.08em]",
+  6: "text-xs font-medium leading-snug mt-0 mb-1 uppercase tracking-[0.08em]",
+};
+
+function renderHeading(
+  level: number,
+  inner: ReactNode[],
+  key: string,
+): ReactNode {
+  const className = HEADING_CLASS[level] || HEADING_CLASS[6];
+  const props = { key, className, children: inner };
+  switch (level) {
+    case 1:
+      return <h1 {...props} />;
+    case 2:
+      return <h2 {...props} />;
+    case 3:
+      return <h3 {...props} />;
+    case 4:
+      return <h4 {...props} />;
+    case 5:
+      return <h5 {...props} />;
+    default:
+      return <h6 {...props} />;
+  }
+}
+
 export function MarkdownProse({ text }: { text: string }) {
   rendererKey++;
   const baseKey = `mp${rendererKey}`;
@@ -56,6 +102,16 @@ export function MarkdownProse({ text }: { text: string }) {
     <>
       {blocks.map((block, idx) => {
         const lines = block.split("\n").map((l) => l.trim());
+        const headingMatch =
+          lines.length === 1 ? /^(#{1,6})\s+(.+)$/.exec(lines[0]) : null;
+        if (headingMatch) {
+          const level = headingMatch[1].length;
+          return renderHeading(
+            level,
+            renderInline(headingMatch[2], `${baseKey}-${idx}`),
+            `${baseKey}-${idx}`,
+          );
+        }
         const isList = lines.every((l) => l.startsWith("- "));
         if (isList) {
           return (


### PR DESCRIPTION
## Summary

- The card description in inspired-by cards (on `/me` and `/people/[id]`) now renders through `MarkdownProse` instead of plain text, so headings, italics, bold, links, and lists in graph descriptions come through alive instead of leaking raw `#` and `*` markers. A leading `# {Name}` heading that duplicates the card's title is dropped so the name doesn't appear twice.
- `MarkdownProse` grew a small vocabulary: `#`–`######` headings, `**strong**`, and inline `` `code` `` (italics, links, paragraphs, list bullets were already in place).
- The provider row uses the existing `brandFor()` icon set — known platforms (Bandcamp, Spotify, YouTube, SoundCloud, Apple Music, Substack, Patreon, Instagram, TikTok, X, Facebook, Linktree, Wikipedia, LinkedIn, Vimeo, IMDb) render as colored brand circles. Unknown providers fall back to a soft text pill.

Reported case `Liquid Bloom` on `/me`: the card title shows `Liquid Bloom`, the description shows the paragraph with `sonic sanctuary` italicized — no raw markdown.

## Test plan

- [ ] Visit `/me` while logged in as a contributor with inspired-by entries — cards render descriptions with markdown headings/italics/links honored; no raw `#` or `*` visible.
- [ ] Visit `/people/{slug}` for someone with inspired-by entries — same rendering, plus the shared-thread highlighting still works.
- [ ] Provider chips show as colored brand icons for known platforms; unknown providers still render as text pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)