### PR TITLE
tend(me): surfaces grid links to each contributor's presence page

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 49 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 232 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 101 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 102 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 101
+**Total files**: 102
 
 | File | Purpose |
 |---|---|
@@ -94,6 +94,7 @@
 | [substrate_read_hook.py](substrate_read_hook.py) | !/usr/bin/env python3 |
 | [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | !/usr/bin/env python3 |
 | [sync_kb_to_db.py](sync_kb_to_db.py) | !/usr/bin/env python3 |
+| [sync_presence_slugs.py](sync_presence_slugs.py) | !/usr/bin/env python3 |
 | [sync_presences_to_db.py](sync_presences_to_db.py) | !/usr/bin/env python3 |
 | [trim_view_events.py](trim_view_events.py) | !/usr/bin/env python3 |
 | [upgrade_specs.py](upgrade_specs.py) | !/usr/bin/env python3 |

--- a/scripts/sync_presence_slugs.py
+++ b/scripts/sync_presence_slugs.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Sync `/people/{slug}` presence pages back onto contributor nodes.
+
+Each presence page at `web/app/people/{slug}/page.tsx` declares a
+`graphSlug="..."` that resolves to a graph node. This script walks
+every presence page, resolves the node, and — when the node is a
+contributor — writes `presence_slug = {slug}` onto the contributor
+node so MePage can render a "Your presence page" tile.
+
+Why this lives in a script: the mapping is currently encoded only in
+the per-page TSX files. Pulling it onto the contributor node is the
+edge-completion move — the body knows the link from both sides, so
+no consumer has to recompute it at request time.
+
+Idempotent. Safe to re-run after adding new presence pages.
+
+Usage:
+    python3 scripts/sync_presence_slugs.py                # against prod
+    python3 scripts/sync_presence_slugs.py --dry-run      # show plan
+    python3 scripts/sync_presence_slugs.py --api-url http://localhost:8000
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+import urllib.error
+import urllib.request
+import json
+
+
+DEFAULT_API = "https://api.coherencycoin.com"
+PEOPLE_DIR = Path(__file__).resolve().parent.parent / "web" / "app" / "people"
+
+
+def discover_presence_pages() -> list[tuple[str, str]]:
+    """Walk `web/app/people/*/page.tsx`, return (slug, graphSlug) pairs.
+
+    Skips dynamic [id] and edit-your-profile entries. A page with no
+    `graphSlug=` is silently skipped — those are pages that don't claim
+    a graph anchor and so can't be reverse-linked.
+    """
+    pairs: list[tuple[str, str]] = []
+    if not PEOPLE_DIR.is_dir():
+        return pairs
+    for entry in sorted(PEOPLE_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("[") or entry.name == "edit-your-profile":
+            continue
+        page_file = entry / "page.tsx"
+        if not page_file.is_file():
+            continue
+        text = page_file.read_text(encoding="utf-8")
+        m = re.search(r'graphSlug\s*=\s*[\"\']([^\"\']+)[\"\']', text)
+        if not m:
+            continue
+        pairs.append((entry.name, m.group(1)))
+    return pairs
+
+
+def fetch_node(api_url: str, node_id: str) -> Optional[dict]:
+    """GET /api/graph/nodes/{id}. Returns the node dict or None on 404."""
+    url = f"{api_url.rstrip('/')}/api/graph/nodes/{urllib_quote(node_id)}"
+    req = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "coherence-sync/1.0"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+    except urllib.error.URLError:
+        return None
+
+
+def patch_node(api_url: str, node_id: str, presence_slug: str) -> bool:
+    """PATCH the node's properties with presence_slug. True on success."""
+    url = f"{api_url.rstrip('/')}/api/graph/nodes/{urllib_quote(node_id)}"
+    body = json.dumps({"properties": {"presence_slug": presence_slug}}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="PATCH",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "coherence-sync/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as e:
+        sys.stderr.write(f"PATCH {node_id} failed: {e.code} {e.reason}\n")
+        return False
+    except urllib.error.URLError as e:
+        sys.stderr.write(f"PATCH {node_id} unreachable: {e}\n")
+        return False
+
+
+def urllib_quote(s: str) -> str:
+    import urllib.parse
+    return urllib.parse.quote(s, safe="")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", default=DEFAULT_API)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would change without writing.")
+    args = parser.parse_args()
+
+    pairs = discover_presence_pages()
+    if not pairs:
+        print("No presence pages with graphSlug found.")
+        return 0
+
+    print(f"Walked {len(pairs)} presence pages with graphSlug.")
+    updated = 0
+    skipped_non_contributor = 0
+    skipped_already = 0
+    skipped_aliased = 0
+    missing = 0
+    # Track contributor ids we've already written this run so that when
+    # two presence pages alias to the same contributor (e.g. /people/ilena
+    # and /people/ilena-young both → contributor:ilena), the first match
+    # wins. Alphabetical order makes the choice deterministic; tend the
+    # alias by hand if a different slug should be canonical.
+    written_node_ids: set[str] = set()
+
+    for slug, graph_slug in pairs:
+        node = fetch_node(args.api_url, graph_slug)
+        if node is None:
+            print(f"  · {slug} → {graph_slug} (node not found)")
+            missing += 1
+            continue
+        if node.get("type") != "contributor":
+            skipped_non_contributor += 1
+            continue
+        node_id = node.get("id") or graph_slug
+        if node_id in written_node_ids:
+            print(f"  · skip alias: /people/{slug} also maps to {node_id}")
+            skipped_aliased += 1
+            continue
+        current = (node.get("presence_slug") or "").strip()
+        if current == slug:
+            skipped_already += 1
+            written_node_ids.add(node_id)
+            continue
+        if args.dry_run:
+            print(f"  · would set presence_slug={slug!r} on {node_id} (was {current!r})")
+            updated += 1
+            written_node_ids.add(node_id)
+            continue
+        if patch_node(args.api_url, node_id, slug):
+            print(f"  · set presence_slug={slug!r} on {node_id}")
+            updated += 1
+            written_node_ids.add(node_id)
+
+    print(
+        f"Summary: updated={updated}, "
+        f"already_set={skipped_already}, "
+        f"non_contributor={skipped_non_contributor}, "
+        f"aliased={skipped_aliased}, "
+        f"missing_nodes={missing}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/components/MePage.tsx
+++ b/web/components/MePage.tsx
@@ -145,6 +145,7 @@ export function MePage() {
   const [footprint, setFootprint] = useState<Footprint>(emptyFootprint());
   const [trail, setTrail] = useState<Trail | null>(null);
   const [meetings, setMeetings] = useState<Meeting[]>([]);
+  const [presenceSlug, setPresenceSlug] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   // Cross-device sign-in state — a visitor landing here from a new
@@ -162,7 +163,10 @@ export function MePage() {
           return;
         }
         const base = getApiBase();
-        const [feedRes, trailRes, meetingsRes] = await Promise.all([
+        const nodeId = ident.contributorId.startsWith("contributor:")
+          ? ident.contributorId
+          : `contributor:${ident.contributorId}`;
+        const [feedRes, trailRes, meetingsRes, nodeRes] = await Promise.all([
           fetch(
             `${base}/api/feed/personal?contributor_id=${encodeURIComponent(
               ident.contributorId,
@@ -173,6 +177,9 @@ export function MePage() {
           ).catch(() => null),
           fetch(
             `${base}/api/contributors/${encodeURIComponent(ident.contributorId)}/met-at`,
+          ).catch(() => null),
+          fetch(
+            `${base}/api/graph/nodes/${encodeURIComponent(nodeId)}`,
           ).catch(() => null),
         ]);
         if (!feedRes.ok) {
@@ -196,6 +203,13 @@ export function MePage() {
           setMeetings(
             Array.isArray(meetingsData.meetings) ? meetingsData.meetings : [],
           );
+        }
+        if (nodeRes && nodeRes.ok) {
+          const nodeData = await nodeRes.json();
+          const slug = typeof nodeData?.presence_slug === "string"
+            ? nodeData.presence_slug.trim()
+            : "";
+          if (slug) setPresenceSlug(slug);
         }
         setLoading(false);
       } catch (e) {
@@ -300,6 +314,14 @@ export function MePage() {
                 className="rounded-lg border border-border/40 px-3 py-2 text-sm text-foreground hover:bg-accent/40 hover:border-border transition-colors"
               >
                 {t("me.surfaceProfile")}
+              </a>
+            )}
+            {presenceSlug && (
+              <a
+                href={`/people/${encodeURIComponent(presenceSlug)}`}
+                className="rounded-lg border border-border/40 px-3 py-2 text-sm text-foreground hover:bg-accent/40 hover:border-border transition-colors"
+              >
+                {t("me.surfacePresence")}
               </a>
             )}
             {hasContributor && identity?.contributorId && (

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -273,6 +273,7 @@
     "surfacesEyebrow": "Your surfaces",
     "surfaceFeed": "Your feed",
     "surfaceProfile": "Your public profile",
+    "surfacePresence": "Your presence page",
     "surfacePortfolio": "Your portfolio",
     "surfaceInspiredBy": "Who inspires you",
     "surfaceWork": "Your weaving",


### PR DESCRIPTION
## Summary

- /me hub now renders a "Your presence page" tile linking to /people/{slug} for every contributor whose body has a curated presence page
- New field `presence_slug` on contributor graph nodes carries the edge from contributor → presence page (the reverse of the `graphSlug` each /people/{slug}/page.tsx already declares)
- One-shot sync script populates the field by walking web/app/people/*/page.tsx — already ran once against prod (62 contributors updated, 1 alias dedup, 17 non-contributor pages skipped, 6 missing nodes)

The edge was already half-laid — every /people/{slug}/page.tsx declares its `graphSlug="contributor:..."`. This closes the loop so the body knows the link from both sides and no consumer has to recompute it at request time.

## Test plan

- [ ] After deploy: sign in as a contributor with a presence page (e.g. Urs), visit /me, confirm the new "Your presence page" tile appears in the surfaces grid alongside feed/profile/portfolio/inspired-by/weaving
- [ ] Click the tile, confirm it navigates to /people/{slug} and the page loads
- [ ] Sign in as a contributor without a presence page, confirm the tile is absent (the conditional render is the test)
- [ ] Re-run `python3 scripts/sync_presence_slugs.py --dry-run` after deploy and confirm Summary shows `updated=0, already_set=62` — proves idempotence

🤖 Generated with [Claude Code](https://claude.com/claude-code)