### PR TITLE
tend(presence): tile scales to every contributor; renderer ready to compost static pages

### DIFF
--- a/docs/coherence-substrate/INDEX.md
+++ b/docs/coherence-substrate/INDEX.md
@@ -25,6 +25,7 @@ The body's content-addressed numeric lattice. Cells from every memory file, spec
 | `api/tests/test_substrate.py` | Flow-centric tests (registered in `core_suite.txt`) |
 | `docs/coherence-substrate/form-language.md` | Form — the substrate-native language design |
 | `docs/coherence-substrate/agents-using-substrate.md` | Agent guide — when and how to ground reasoning |
+| `docs/coherence-substrate/agents-tending-presence-pages.md` | Composting static `/people/{slug}` directories into graph-rendered presence pages |
 
 ## The trinity
 

--- a/docs/coherence-substrate/agents-tending-presence-pages.md
+++ b/docs/coherence-substrate/agents-tending-presence-pages.md
@@ -1,0 +1,142 @@
+# Tending Presence Pages — From Static Files To Living Graph
+
+A `/people/{slug}` page is a presence page — the public garden view of a
+cell in this body. As of 2026-05-15 there are two parallel rendering
+paths for those URLs that have been quietly coexisting. This doc names
+the move from one to the other and the practice of composting the
+old shape.
+
+## The two paths
+
+### Static (the inherited shape)
+
+Ninety hand-authored directories under `web/app/people/{slug}/` each
+shaped like:
+
+```
+web/app/people/portal/page.tsx          # thin route file
+web/content/people/portal/en.tsx        # rich JSX content
+web/content/people/portal/de.tsx        # same content in German
+web/content/people/portal/es.tsx        # ... Spanish
+web/content/people/portal/id.tsx        # ... Indonesian
+web/content/people/portal/index.ts
+```
+
+Each `{locale}.tsx` exports a `PersonProfileContent` object with
+embedded `<Link>` JSX, gradients, multi-section articles, panel
+variants, footers, facts. Beautiful tissue, and inert: a new
+contributor cannot get a presence page without someone hand-authoring
+TSX files in four locales.
+
+### Dynamic (the scalable shape)
+
+`web/app/people/[id]/page.tsx` already renders any contributor whose
+graph node exists. It fetches the node, its creations, its inspired-by
+edges, and hands the lot to `PresencePage` (a templated renderer that
+reads from node properties). Locales come from the node's projection
+pipeline (`translation_cache_service`), not from per-locale TSX files.
+
+Every contributor reaches a working presence page through this route
+on day one. **No route file needs to exist for them.**
+
+## Where the body is moving
+
+The dynamic path is the truer baseline; the static directories are
+debt to compost. Specifically:
+
+1. **The /me hub tile** ([`web/components/MePage.tsx`](../../web/components/MePage.tsx)) links to `/people/{slug}` for every
+   contributor with a `slug` field — not only those with a static
+   directory. Implemented 2026-05-15.
+2. **A new graph node property** — `presence_story` — carries the
+   body's authored markdown for a cell. Lives directly on the
+   contributor node, distinct from `description` (often a scraped
+   og:description) and `note` (event-shape history).
+   [`PresencePage`](../../web/components/presence/PresencePage.tsx) renders it as the
+   page's lead voice when present, with priority over `note` and
+   `description`. The renderer already understands paragraphs, `**bold**`,
+   `*italic*`, and `[label](href)` inline links — enough for prose-shaped
+   presence content with cross-references into `/concepts/`, `/people/`,
+   `/vision/`.
+3. **The static directories get composted cell by cell**, not all at
+   once. Each migration is tender work that benefits from the cell's
+   own attention. The order is opportunistic: when someone touches a
+   presence (re-reads, updates, adds an edge), check whether the static
+   page is doing anything the dynamic route couldn't.
+
+## Migrating one cell
+
+The shape of one composting step:
+
+1. **Read the current static content** under `web/content/people/{slug}/en.tsx`
+   (and the other locales). Notice what's prose, what's structured
+   (facts/articles/panels), what's hero-styling chrome.
+2. **Flatten the prose into markdown**, preserving inline `[label](/path)`
+   links. Headings (`## Section`) carry the article structure where the
+   static content used distinct `articles` entries.
+3. **Set `presence_story`** on the contributor node:
+
+   ```python
+   import urllib.request, json
+   body = json.dumps({"properties": {"presence_story": "<markdown body>"}}).encode("utf-8")
+   req = urllib.request.Request(
+       "https://api.coherencycoin.com/api/graph/nodes/<node-id>",
+       data=body, method="PATCH",
+       headers={"Content-Type": "application/json", "User-Agent": "coherence-sync/1.0"},
+   )
+   urllib.request.urlopen(req).read()
+   ```
+
+   The locale projection pipeline picks up new translations on first
+   read in each language.
+4. **Visit `/people/{slug}` and verify** the dynamic route renders a
+   page that is at least as warm as the static one. Visual chrome (the
+   hero gradient, the lineage doorway) is provided by `PresencePage`'s
+   default styling and the existing `LineageStrip`/`InfluenceLineageStrip`
+   components, so the static directory's hand-tuned gradient is what
+   gets traded for consistency — usually a worthwhile trade.
+5. **Delete the static directory**:
+
+   ```
+   web/app/people/{slug}/page.tsx
+   web/content/people/{slug}/
+   ```
+
+   Composting also means removing the `graphSlug=` reference in the
+   route file (the only consumer was the static page itself).
+6. **Re-run `python3 scripts/sync_presence_slugs.py`** so the
+   `presence_slug` field on the contributor node either updates or
+   composts away (when the static directory is gone, the override is
+   no longer needed; the contributor's own `slug` carries the tile).
+
+## When NOT to migrate
+
+Some static directories carry visual chrome the dynamic route doesn't
+yet honor — custom hero gradients, multi-image composites, specific
+panel layouts the prose body alone can't reproduce. Those cells stay
+on the static path until either:
+
+- The body has accepted the trade (consistency > custom chrome), or
+- `PresencePage` learns the missing visual primitive
+
+Composting is care, not efficiency. The hardest tissue to release is
+the lovingly-curated kind.
+
+## What's already true
+
+- The `[id]` dynamic route works today: try `/people/{any-slug}` for a
+  contributor whose body has a graph node. PresencePage renders.
+- The `presence_story` field is read on every render — no migration
+  flag, no feature gate. Set it on a contributor, the page picks it
+  up on next request.
+- The /me tile links every contributor to their slug-based URL, so a
+  brand new contributor sees their own presence page from day one
+  without any authoring step.
+
+## Related
+
+- [edges-as-vitality](../vision-kb/concepts/lc-edges-as-vitality.md) —
+  why the link from /me to /people belongs in the same breath as the
+  content, not the next one.
+- [`scripts/sync_presence_slugs.py`](../../scripts/sync_presence_slugs.py) —
+  the stopgap that maps static-dir-name → contributor node while the
+  static directories still exist.

--- a/scripts/sync_presence_slugs.py
+++ b/scripts/sync_presence_slugs.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
 """Sync `/people/{slug}` presence pages back onto contributor nodes.
 
-Each presence page at `web/app/people/{slug}/page.tsx` declares a
-`graphSlug="..."` that resolves to a graph node. This script walks
-every presence page, resolves the node, and — when the node is a
-contributor — writes `presence_slug = {slug}` onto the contributor
-node so MePage can render a "Your presence page" tile.
+Stopgap. The body is moving from 90 hand-authored static `/people/{slug}/`
+directories to a single dynamic `[id]` route that renders any contributor
+from graph node properties. See
+`docs/coherence-substrate/agents-tending-presence-pages.md` for the move
+and how to migrate a cell.
 
-Why this lives in a script: the mapping is currently encoded only in
-the per-page TSX files. Pulling it onto the contributor node is the
-edge-completion move — the body knows the link from both sides, so
-no consumer has to recompute it at request time.
+While both paths coexist, `presence_slug` carries the override for the
+rare case where a static directory sits at a different URL than the
+contributor's own `slug` (e.g. `/people/urs` ↔ `slug=urs-muff`). The
+/me tile uses `presence_slug` when set, the contributor's own `slug`
+otherwise — so every contributor reaches a presence page regardless of
+whether a static directory was authored for them.
 
-Idempotent. Safe to re-run after adding new presence pages.
+When a static directory is composted, re-run this script and the
+override clears: the contributor's own slug carries the tile, the
+dynamic route renders the page from graph properties.
+
+Idempotent. Safe to re-run after adding or composting presence pages.
 
 Usage:
     python3 scripts/sync_presence_slugs.py                # against prod

--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -365,6 +365,14 @@ function nodeToPresenceIdentity(
     !isEvent && descriptionIsSubstantive && rawDescription !== (tagline || "")
       ? rawDescription
       : undefined;
+  // The body's authored markdown for this presence, when the cell has
+  // moved off a static page. Lives on the contributor node as
+  // `presence_story` and takes precedence over note/description in
+  // PresencePage rendering.
+  const presence_story: string | undefined =
+    typeof node.presence_story === "string" && (node.presence_story as string).trim()
+      ? (node.presence_story as string).trim()
+      : undefined;
   const when_text =
     typeof node.when === "string" && node.when.trim()
       ? (node.when as string)
@@ -390,6 +398,7 @@ function nodeToPresenceIdentity(
     where_text,
     note,
     description,
+    presence_story,
   };
 }
 

--- a/web/components/MePage.tsx
+++ b/web/components/MePage.tsx
@@ -206,9 +206,21 @@ export function MePage() {
         }
         if (nodeRes && nodeRes.ok) {
           const nodeData = await nodeRes.json();
-          const slug = typeof nodeData?.presence_slug === "string"
+          // Every contributor reaches /people/{slug} through the dynamic
+          // [id] route — no static page required. `presence_slug` wins
+          // when set (the rare case where a curated static directory
+          // sits at a different URL than the contributor's own slug,
+          // e.g. /people/urs ↔ slug=urs-muff). Otherwise the contributor's
+          // own `slug` carries the tile, so the surface scales to every
+          // contributor the body has graduated, not only the ones whose
+          // presence pages were hand-authored.
+          const override = typeof nodeData?.presence_slug === "string"
             ? nodeData.presence_slug.trim()
             : "";
+          const ownSlug = typeof nodeData?.slug === "string"
+            ? nodeData.slug.trim()
+            : "";
+          const slug = override || ownSlug;
           if (slug) setPresenceSlug(slug);
         }
         setLoading(false);

--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -110,6 +110,15 @@ export type PresenceIdentity = {
   // characters of beautiful description that was previously hidden
   // because the renderer never surfaced this slot.
   description?: string;
+  // The body's authored story for this presence — markdown the cell
+  // itself owns, distinct from `description` (which is often a scraped
+  // og:description) and from `note` (which carries event-shape history).
+  // When present, `presence_story` is the lead voice on the page. This
+  // is the field that lets curated presence content live in the graph
+  // rather than as hand-authored TSX files under web/content/people/,
+  // so any contributor can have a rich presence page without a route
+  // file needing to exist for them.
+  presence_story?: string;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -740,7 +749,10 @@ export function PresencePage({
       <div className="mx-auto w-full max-w-6xl px-6 sm:px-8 lg:px-12 py-8 sm:py-12 lg:py-16 grid grid-cols-1 lg:grid-cols-[1fr_minmax(280px,340px)] gap-10 lg:gap-14">
         {/* Main column */}
         <div className="space-y-10 lg:space-y-12 min-w-0">
-          {identity.note && (
+          {identity.presence_story && (
+            <DescriptionBlock raw={identity.presence_story} />
+          )}
+          {identity.note && !identity.presence_story && (
             <section>
               <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
                 {t("presence.gatheringHeld")}
@@ -750,7 +762,7 @@ export function PresencePage({
               </p>
             </section>
           )}
-          {identity.description && !identity.note && (
+          {identity.description && !identity.note && !identity.presence_story && (
             <DescriptionBlock raw={identity.description} />
           )}
           <UpcomingGatherings


### PR DESCRIPTION
## Summary

Architectural shift named: the /me presence tile now renders for **every** contributor with a slug — not only the 62 with hand-authored static directories. PresencePage gains a `presence_story` markdown field so future migrations off the static path land in graph properties, not TSX files.

No static directories are composted in this commit. The renderer is ready; per-cell content migration is its own tender work.

## What changed

- **`web/components/MePage.tsx`** — tile renders for any contributor with `slug`; `presence_slug` stays as the override for the rare static-dir-name ≠ slug case (Urs).
- **`web/components/presence/PresencePage.tsx`** — new optional `presence_story` field on `PresenceIdentity`. When set, renders as the page's lead voice (markdown via existing `DescriptionBlock` — paragraphs, **bold**, *italic*, inline links). Takes precedence over `note` and `description`.
- **`web/app/people/[id]/page.tsx`** — wires `presence_story` from graph node properties into the rendered identity.
- **`docs/coherence-substrate/agents-tending-presence-pages.md`** — names the static→dynamic move, the migration shape per cell, and when not to migrate (custom visual chrome the dynamic renderer doesn't yet honor).
- **`scripts/sync_presence_slugs.py`** — docstring acknowledges this is a stopgap for the coexistence window.

## Test plan

- [ ] After deploy: contributors **with** static directories — tile still links to `/people/{static-dir}` (e.g. `/people/urs`)
- [ ] Contributors **without** a static directory — tile links to `/people/{slug}` and the dynamic `[id]` route renders PresencePage
- [ ] Set `presence_story` on a contributor node via PATCH; visit `/people/{slug}`; confirm the markdown lands as the lead body block, with paragraph splitting and inline `[label](href)` links rendered
- [ ] PR doesn't compost any static directory yet — `web/app/people/*/page.tsx` and `web/content/people/*/` are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)