### PR TITLE
tend(presence): graph-stored content renders through the same template as static pages

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -17,6 +17,13 @@ import {
   type Presence,
   type PresenceIdentity,
 } from "@/components/presence/PresencePage";
+import { PersonProfileTemplate } from "@/components/people/PersonProfileTemplate";
+import {
+  pickLocaleContent,
+  toPersonProfileContent,
+  type PresenceContent,
+  type PresenceContentByLocale,
+} from "@/lib/presence-content";
 
 /**
  * /people/[id] — a warm public garden view of a contributor.
@@ -161,6 +168,41 @@ type FeedResponse = {
   count: number;
   locale: string;
 };
+
+/**
+ * Pull the `presence_content` property off the graph node and return
+ * the locale-appropriate slice, if any. Returns null when:
+ *   · the node has no `presence_content` property
+ *   · the property isn't a JSON object
+ *   · no locale (including `en`) has authored content
+ *
+ * Accepts either a per-locale envelope (`{en: {...}, de: {...}}`) or
+ * a single PresenceContent (which is treated as the `en` variant).
+ */
+function pickPresenceContent(
+  node: Record<string, unknown> | null,
+  lang: string,
+): PresenceContent | null {
+  if (!node) return null;
+  const raw = (node as Record<string, unknown>).presence_content;
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  // Envelope shape: presence of any known locale key signals the
+  // per-locale layout. A bare PresenceContent has `hero` at the top
+  // level instead.
+  const looksLikeEnvelope =
+    typeof obj.en === "object" ||
+    typeof obj.de === "object" ||
+    typeof obj.es === "object" ||
+    typeof obj.id === "object";
+  if (looksLikeEnvelope) {
+    return pickLocaleContent(obj as PresenceContentByLocale, lang);
+  }
+  if (typeof obj.hero === "object" && obj.hero) {
+    return obj as unknown as PresenceContent;
+  }
+  return null;
+}
 
 async function fetchContributor(id: string): Promise<ContributorNode | null> {
   const base = getApiBase();
@@ -594,11 +636,32 @@ export default async function PersonPage({
     : DEFAULT_LOCALE;
   const t = createTranslator(lang);
 
+  const graphNode = await fetchGraphNode(id);
+
+  // First dispatch: the graph node carries a structured `presence_content`
+  // JSON — the body's authored content for this cell, in the same shape
+  // a static `web/content/people/{slug}/{locale}.tsx` would carry. Render
+  // it through the same template the static directories use, so the
+  // visual identity is identical regardless of whether content lives on
+  // disk or in the graph. This is the path a composted static cell
+  // moves onto.
+  const presenceContent = pickPresenceContent(graphNode, lang);
+  if (graphNode && presenceContent) {
+    const nodeId = (graphNode.id as string) || id;
+    const slug = typeof graphNode.slug === "string" ? graphNode.slug : null;
+    return (
+      <PersonProfileTemplate
+        content={toPersonProfileContent(presenceContent)}
+        lang={lang}
+        graphSlug={slug || nodeId}
+      />
+    );
+  }
+
   // When the graph node carries a canonical_url, this identity has an
   // outward-facing presence. Render the polished presence page —
   // hero, platforms, creations, lineage — before calling contributor
   // endpoints that only apply to local human profiles.
-  const graphNode = await fetchGraphNode(id);
   if (graphNode && typeof graphNode.canonical_url === "string" && graphNode.canonical_url) {
     const nodeId = (graphNode.id as string) || id;
     const [creations, inspiredBy] = await Promise.all([

--- a/web/lib/presence-content.tsx
+++ b/web/lib/presence-content.tsx
@@ -1,0 +1,296 @@
+/**
+ * PresenceContent — the shape `web/content/people/{slug}/{locale}.tsx`
+ * is moving toward. Same visual richness as `PersonProfileContent`,
+ * but every prose field is a markdown string so the body can be stored
+ * as JSON on the graph node rather than as TSX in 4 locale files.
+ *
+ * The `toPersonProfileContent` converter takes one of these JSON
+ * payloads and produces a `PersonProfileContent` ready to feed to
+ * `PersonProfileTemplate`. That means the dynamic [id] route and the
+ * static directories share *one* renderer; only the content source
+ * differs. Visual parity is the test.
+ */
+import { Fragment, type ReactNode } from "react";
+import Link from "next/link";
+import type { Metadata } from "next";
+import type {
+  PersonProfileContent,
+  PersonProfileFact,
+  PersonProfileArticle,
+  PersonProfileLineageDoorway,
+} from "@/components/people/PersonProfileTemplate";
+
+export type PresenceContent = {
+  metadata?: Metadata;
+  breadcrumb_name?: string;
+  hero: {
+    image_url?: string | null;
+    background?: string | null;
+    extra_image?: {
+      url: string;
+      opacity_class?: string | null;
+      mix_blend_class?: string | null;
+    } | null;
+    overlay_class?: string | null;
+    eyebrow?: string | null;
+    eyebrow_class?: string | null;
+    name: string;
+    welcome_md: string;
+    lineage_doorway?: {
+      href: string;
+      label: string;
+      summary?: string | null;
+    } | null;
+  };
+  facts?: { label: string; value_md: string }[];
+  note_from_body?: { eyebrow?: string | null; body_md: string } | null;
+  articles?: (
+    | { kind: "narrative"; heading: string; body_md: string }
+    | {
+        kind: "panel";
+        variant?: "warm" | "cool" | "neutral" | "empty";
+        eyebrow?: string | null;
+        heading?: string | null;
+        body_md: string;
+      }
+  )[];
+  footer_md?: string | null;
+};
+
+/**
+ * Per-locale envelope. Stored as the graph node property
+ * `presence_content`. The renderer picks the caller's locale and
+ * falls back to `en` when a specific locale view isn't authored yet.
+ */
+export type PresenceContentByLocale = {
+  en?: PresenceContent;
+  de?: PresenceContent;
+  es?: PresenceContent;
+  id?: PresenceContent;
+  [locale: string]: PresenceContent | undefined;
+};
+
+/* ── Markdown helpers ────────────────────────────────────────────── */
+
+/**
+ * Inline markdown — for one-line fields (facts values, eyebrows,
+ * lineage doorway label, etc.). Handles `**bold**`, `*italic*`, and
+ * `[label](href)`. Anything else passes through as text.
+ *
+ * Internal links (starting with `/`) become Next.js `<Link>`; external
+ * links open in a new tab with rel=noopener.
+ */
+export function renderInlineMarkdown(text: string): ReactNode {
+  if (!text) return null;
+  const parts: ReactNode[] = [];
+  const re =
+    /\*\*([^*\n]+)\*\*|\*([^*\n]+)\*|\[([^\]\n]+)\]\(([^)\s]+)\)/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    if (m[1] !== undefined) {
+      parts.push(<strong key={key++}>{m[1]}</strong>);
+    } else if (m[2] !== undefined) {
+      parts.push(<em key={key++}>{m[2]}</em>);
+    } else if (m[3] !== undefined && m[4] !== undefined) {
+      const label = m[3];
+      const href = m[4];
+      if (href.startsWith("/") || href.startsWith("#")) {
+        parts.push(
+          <Link key={key++} href={href} className="text-primary hover:underline">
+            {label}
+          </Link>,
+        );
+      } else {
+        parts.push(
+          <a
+            key={key++}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            {label}
+          </a>,
+        );
+      }
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length === 1 ? parts[0] : <>{parts}</>;
+}
+
+/**
+ * Block markdown — for multi-paragraph fields (welcome, article body,
+ * note body, footer). Splits on blank lines, recognizes:
+ *
+ *   - blank-line-separated paragraphs       → <p>
+ *   - lines starting with `## `             → <h2>     (rare inside article body)
+ *   - lines starting with `### `            → <h3>
+ *   - lines starting with `> `              → <blockquote>
+ *   - blocks of `- item` lines              → <ul><li>
+ *   - `---` on its own line                 → <hr>
+ *
+ * Inline formatting (bold/italic/links) is applied within each block.
+ */
+export function renderBlockMarkdown(text: string): ReactNode {
+  if (!text) return null;
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const blocks = normalized.split(/\n{2,}/).map((b) => b.trim()).filter(Boolean);
+  return (
+    <>
+      {blocks.map((block, i) => {
+        if (/^-{3,}$/.test(block)) {
+          return <hr key={i} className="border-border/40 my-4" aria-hidden="true" />;
+        }
+        if (block.startsWith("### ")) {
+          return (
+            <h3 key={i} className="text-base font-semibold mt-4 mb-2">
+              {renderInlineMarkdown(block.slice(4))}
+            </h3>
+          );
+        }
+        if (block.startsWith("## ")) {
+          return (
+            <h2 key={i} className="text-xl font-light mt-6 mb-3">
+              {renderInlineMarkdown(block.slice(3))}
+            </h2>
+          );
+        }
+        if (block.startsWith("> ")) {
+          const inner = block
+            .split("\n")
+            .map((l) => (l.startsWith("> ") ? l.slice(2) : l))
+            .join(" ");
+          return (
+            <blockquote
+              key={i}
+              className="border-l-2 border-primary/40 pl-4 italic text-foreground/80"
+            >
+              {renderInlineMarkdown(inner)}
+            </blockquote>
+          );
+        }
+        if (block.startsWith("- ")) {
+          const items = block
+            .split("\n")
+            .filter((l) => l.startsWith("- "))
+            .map((l) => l.slice(2).trim());
+          return (
+            <ul key={i} className="list-disc pl-5 space-y-1">
+              {items.map((it, j) => (
+                <li key={j}>{renderInlineMarkdown(it)}</li>
+              ))}
+            </ul>
+          );
+        }
+        // Default: paragraph. Single-newline becomes <br/> so multi-line
+        // prose authored in one block stays on its own visual lines.
+        const lines = block.split("\n");
+        return (
+          <p key={i}>
+            {lines.map((line, j) => (
+              <Fragment key={j}>
+                {j > 0 && <br />}
+                {renderInlineMarkdown(line)}
+              </Fragment>
+            ))}
+          </p>
+        );
+      })}
+    </>
+  );
+}
+
+/* ── PresenceContent → PersonProfileContent converter ────────────── */
+
+/**
+ * Pick the locale-appropriate slice of a per-locale envelope, falling
+ * back to `en` if the requested locale isn't authored, then to any
+ * locale if `en` isn't authored either. Returns null when nothing is
+ * authored yet — the caller renders the existing PresencePage instead.
+ */
+export function pickLocaleContent(
+  envelope: PresenceContentByLocale | null | undefined,
+  locale: string,
+): PresenceContent | null {
+  if (!envelope) return null;
+  if (envelope[locale]) return envelope[locale]!;
+  if (envelope.en) return envelope.en;
+  for (const k of Object.keys(envelope)) {
+    if (envelope[k]) return envelope[k]!;
+  }
+  return null;
+}
+
+export function toPersonProfileContent(
+  content: PresenceContent,
+): PersonProfileContent {
+  const facts: PersonProfileFact[] | undefined = content.facts?.map((f) => ({
+    label: f.label,
+    value: renderInlineMarkdown(f.value_md),
+  }));
+
+  const articles: PersonProfileArticle[] = (content.articles ?? []).map((a) => {
+    const body = renderBlockMarkdown(a.body_md);
+    if (a.kind === "panel") {
+      return {
+        kind: "panel",
+        variant: a.variant,
+        eyebrow: a.eyebrow ?? undefined,
+        heading: a.heading ?? undefined,
+        body,
+      };
+    }
+    return {
+      kind: "narrative",
+      heading: a.heading,
+      body,
+    };
+  });
+
+  const lineageDoorway: PersonProfileLineageDoorway | undefined =
+    content.hero.lineage_doorway
+      ? {
+          href: content.hero.lineage_doorway.href,
+          label: content.hero.lineage_doorway.label,
+          summary: content.hero.lineage_doorway.summary ?? undefined,
+        }
+      : undefined;
+
+  return {
+    metadata: content.metadata ?? {},
+    breadcrumbName: content.breadcrumb_name ?? content.hero.name,
+    hero: {
+      image: content.hero.image_url
+        ? { src: content.hero.image_url }
+        : undefined,
+      background: content.hero.background ?? undefined,
+      extraImage: content.hero.extra_image
+        ? {
+            src: content.hero.extra_image.url,
+            opacityClass: content.hero.extra_image.opacity_class ?? undefined,
+            mixBlendClass: content.hero.extra_image.mix_blend_class ?? undefined,
+          }
+        : undefined,
+      overlayClass: content.hero.overlay_class ?? undefined,
+      eyebrow: content.hero.eyebrow ?? "",
+      eyebrowClass: content.hero.eyebrow_class ?? undefined,
+      name: content.hero.name,
+      welcome: renderBlockMarkdown(content.hero.welcome_md),
+      lineageDoorway,
+    },
+    facts,
+    noteFromBody: content.note_from_body
+      ? {
+          eyebrow: content.note_from_body.eyebrow ?? undefined,
+          body: renderBlockMarkdown(content.note_from_body.body_md),
+        }
+      : undefined,
+    articles,
+    footer: content.footer_md ? renderBlockMarkdown(content.footer_md) : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

PR 1 of the composting move. Foundation only — no cell migrates, no static directory is touched.

Closes the visual gap exposed by the portal experiment (#1635 → reverted in #1636). The same `PersonProfileTemplate` that produces the body's visual identity for static `/people/{slug}` pages can now also render content that lives on the graph node, via a new \`presence_content\` JSON property.

## What changed

- **\`web/lib/presence-content.tsx\`** — \`PresenceContent\` type (mirrors \`PersonProfileContent\` field-for-field with markdown strings instead of JSX), markdown converters (inline + block), \`toPersonProfileContent\` adapter, \`pickLocaleContent\` for per-locale envelopes.
- **\`web/app/people/[id]/page.tsx\`** — dispatches to \`PersonProfileTemplate\` first when the contributor node carries \`presence_content\`. Static directories continue to win by Next.js route priority; this branch only activates for composted cells.

## Test plan

- [ ] No visible behavior change yet — no contributor node has \`presence_content\` set
- [ ] Typecheck passes (the pre-existing test-file error stays)
- [ ] Next PR (portal migration) will verify visual parity end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)