### PR TITLE
tend(docs): name the deeper point — inside/outside parity at the graph

### DIFF
--- a/docs/coherence-substrate/agents-tending-presence-pages.md
+++ b/docs/coherence-substrate/agents-tending-presence-pages.md
@@ -1,169 +1,131 @@
-# Tending Presence Pages — From Static Files To Living Graph
+# Tending Presence Pages — Inside/Outside Parity at the Graph
 
 A `/people/{slug}` page is a presence page — the public garden view of a
-cell in this body. The body is moving from hand-authored static TSX
-directories into structured content stored on graph nodes and rendered
-through one shared template. This doc names the practice.
+cell in this body. As of 2026-05-15 every presence page renders from
+the contributor graph node, and the same content can be edited from
+either side of the body — by committing markdown/JSON to the repo, or
+by PATCHing the API from outside. **Both paths converge at the graph
+node.** That convergence is the architectural point.
 
-## The two paths
+## The deeper principle: inside/outside parity
 
-### Static (the inherited shape)
+The body is contributed to from two sides:
 
-`web/app/people/{slug}/` directories each shaped like:
+| Side | Path |
+|---|---|
+| **Inside** (committers) | edit `docs/presence-content/{slug}.json` → `python3 scripts/sync_presence_content.py {slug}` → graph node updated → page renders |
+| **Outside** (web contributors, API callers) | `PATCH /api/graph/nodes/{id}` with the new `presence_content` JSON → graph node updated → page renders |
 
-```
-web/app/people/portal/page.tsx          # thin route file
-web/content/people/portal/en.tsx        # rich JSX content (~200 lines)
-web/content/people/portal/de.tsx        # re-export or per-locale variant
-web/content/people/portal/es.tsx
-web/content/people/portal/id.tsx
-web/content/people/portal/index.ts
-```
+The page reads from the graph at request time. Neither path has to know
+the other exists. A web-side edit takes effect within seconds of the
+PATCH; a repo commit takes effect once CI runs the sync. The rendering
+is identical because it's the same template reading the same property.
 
-Each `{locale}.tsx` exports a `PersonProfileContent` object with
-embedded `<Link>` JSX, gradients, multi-section articles, panel
-variants, footers, facts. Beautiful tissue, and inert: a new contributor
-cannot get a rich presence page without someone hand-authoring TSX files.
+The same principle holds across content types now:
 
-### Dynamic with rich content (the practice now)
+| Content type | Inside file | Sync script | Outside endpoint |
+|---|---|---|---|
+| Presences (rich) | `docs/presence-content/{slug}.json` | `scripts/sync_presence_content.py` | `PATCH /api/graph/nodes/{id}` (or web `/people/[id]/edit`) |
+| Presences (markdown bio) | `docs/presences/{slug}.md` | `scripts/sync_presences_to_db.py` | `PATCH /api/graph/nodes/{id}` |
+| Concepts (vision-kb) | `docs/vision-kb/concepts/{id}.md` | `scripts/sync_kb_to_db.py` | `PATCH /api/concepts/{id}/story` (or web `/vision/[conceptId]/edit`) |
+| Ideas | `ideas/{slug}.md` | recorded via `POST /api/ideas` from CI | `POST /api/ideas`, `PATCH /api/ideas/{id}` |
+| Specs | `specs/{slug}.md` | spec frontmatter ingested | `POST /api/spec-registry`, `PATCH /api/spec-registry/{id}` |
 
-The contributor graph node carries a `presence_content` JSON property
-(per-locale envelope, currently `en` only for migrated cells). The
-dynamic `[id]` route reads it, converts via
-[`toPersonProfileContent`](../../web/lib/presence-content.tsx), and
-hands the result to the **same `PersonProfileTemplate`** the static
-directories used. Visual chrome is byte-identical: full-bleed hero with
-custom gradient, breadcrumb, eyebrow + name, welcome paragraph,
-`<dl>` facts grid, Panel-shaped articles with warm/cool/neutral
-variants, footer, lineage doorway, attention presence — all preserved.
+For the body to stay coherent, **the graph is the runtime source of
+truth.** The repo files are the version-controlled canonical authoring
+source; the graph carries the live state. Inside edits flow into the
+graph via the sync scripts; outside edits write to the graph directly.
+What the visitor reads is always what's in the graph.
 
-The renderer reads markdown inside the JSON prose fields. Supported:
-paragraphs, `**bold**`, `*italic*`, `` `code` ``, `[label](href)`
-inline links (internal → next/link, external → target="_blank"), `## h2`,
-`### h3`, `> blockquote`, `- li` lists, `---` hr.
+## What that means in practice
 
-### Dynamic without rich content (the bare baseline)
+A contributor at /people/{their-slug}/edit can refine their own page
+without opening a PR. A community member at /vision/{conceptId}/edit
+can polish a concept's story. An organizer of a held-open scaffold
+(e.g. PORTAL, Vali Soul Sanctuary, Pagan Ritual) can replace the
+welcoming-scaffold language with their own words. Each of these PATCHes
+the graph; each is visible on the next request; none of them require
+git access.
 
-When a contributor node has no `presence_content`, the [id] route
-falls through to `PresencePage` — the dark-themed presence card with
-sidebar, At-a-glance, Presence map, Refine-this-presence. Strictly less
-expressive than the static template, but every contributor reaches a
-working page on day one without authoring.
+End-to-end verified on prod 2026-05-15: a PATCH to
+`/api/graph/nodes/contributor:joshua-golden` with a modified
+`presence_content` showed up at `/people/joshua-golden` within 3
+seconds, then reverted cleanly with another PATCH.
 
-## The visual gap (named honestly)
+## Where inside/outside parity still has a gap
 
-The two **dynamic** sub-paths above are not equivalent. `PresencePage`
-(bare baseline) is a different visual identity from `PersonProfileTemplate`
-(rich content). Composting a static cell *directly to PresencePage*
-trades visual identity for chrome that was designed for artists/musicians
-— this is the mistake portal made on 2026-05-15 (PR #1635 → reverted in
-#1636). Composting via `presence_content` JSON keeps the visual identity
-intact — this is the practice that landed in PR #1637+ and is now proven
-across 11 cells.
+Outside edits **do not yet flow back** to `docs/presence-content/*.json`
+or `docs/presences/*.md`. The graph carries the live state; the repo
+carries the last-synced state. If both sides are edited between syncs,
+the graph wins at runtime but the inside commit history is incomplete.
 
-## The shape of one composting step
+This is acceptable while outside-editing is rare; it becomes a real
+problem when outside contributors are doing meaningful authoring. Two
+shapes for closing the gap:
 
-1. **Read the static content** under `web/content/people/{slug}/en.tsx`.
-   Notice what's prose, what's structured (facts/articles/panels), what's
-   hero-styling chrome (background gradient, extraImage).
-2. **Author `docs/presence-content/{slug}.json`** matching the
-   `PresenceContent` shape (see existing examples: portal, sayuri-healing-food,
-   mudra-cafe, grab). Every prose slot is a markdown string; JSX `<Link>`
-   becomes `[label](/path)`; `<code>` becomes `` `…` ``; `<em>` becomes
-   `*italic*`; `<strong>` becomes `**bold**`; `<ul>` becomes `- item` lines.
-3. **Sync to the graph**:
+1. **Sync-back script** — a periodic job that walks the graph nodes
+   carrying `presence_content`, compares to the JSON files in
+   `docs/presence-content/`, and opens a PR for divergences. The repo
+   stays the canonical history; outside edits flow back as commits.
+2. **PR-on-edit** — the web edit UI submits a PR through GitHub's API
+   rather than PATCHing directly. The outside contributor's edit
+   becomes a commit they can see in the body's git history.
 
-   ```bash
-   python3 scripts/sync_presence_content.py {slug}
-   ```
+Either shape preserves the asymmetry's good half (low-friction outside
+contribution) while restoring the missing half (git as full history).
+Not building either now — naming as the next breath when outside-edit
+volume grows.
 
-4. **If the static page used a hero image**, PATCH `image_url`:
+Another web-side gap: the existing `/people/[id]/edit` UI lets a
+contributor refine the bare data (name, tagline, description,
+image_url, platform presences, edges) but does not yet expose the
+structured `presence_content` (hero.eyebrow, facts, articles,
+note_from_body, footer). Outside contributors who want to edit those
+fields currently PATCH the API directly. A web editor for
+`presence_content` is its own breath — multi-section form, markdown
+preview, the usual editing affordances.
 
-   ```bash
-   python3 -c "import urllib.request, json; \
-     body = json.dumps({'properties': {'image_url': '/people/{slug}/hero.jpg'}}).encode(); \
-     req = urllib.request.Request( \
-       'https://api.coherencycoin.com/api/graph/nodes/contributor:{slug}', \
-       data=body, method='PATCH', \
-       headers={'Content-Type': 'application/json', 'User-Agent': 'coherence-sync/1.0'}); \
-     print(urllib.request.urlopen(req).status)"
-   ```
+## How the body composts a static cell (for reference)
 
-5. **Verify chrome parity** before deleting anything. Use the node-id form
-   of the dynamic route to bypass the still-present static route:
+The pattern that walked the body from 90 static directories to 0:
 
-   ```bash
-   # static URL
-   curl -sS https://coherencycoin.com/people/{slug} > /tmp/s.html
-   # dynamic URL (use the full contributor:slug or hashed node id)
-   curl -sS https://coherencycoin.com/people/contributor:{slug} > /tmp/d.html
+1. Run the extractor: `node scripts/extract_presence_content.js {slug} --write`
+2. Review the generated `docs/presence-content/{slug}.json`
+3. Sync to graph: `python3 scripts/sync_presence_content.py {slug}`
+4. Diff `/people/{slug}` (static) against `/people/contributor:{slug}` (dynamic) — chrome markers `<dl>`, text-7xl, "A note from this body", border-amber, breadcrumb must all match
+5. Compost the static directory: `rm -rf web/app/people/{slug}/ web/content/people/{slug}/`
 
-   # Diff chrome markers
-   for check in chart-2 '<dl' text-7xl 'A note from this body' border-amber breadcrumb; do
-     s=$(grep -c "$check" /tmp/s.html); d=$(grep -c "$check" /tmp/d.html)
-     [ "$s" = "$d" ] && echo "✓ $check" || echo "✗ $check (static=$s dyn=$d)"
-   done
-   ```
+All 90 cells walked this practice across PR #1638–#1646.
 
-   All markers must match. If any don't, fix the JSON or extend the
-   renderer first.
+## The renderer
 
-6. **Compost the static directory**:
+`web/lib/presence-content.tsx` carries the `PresenceContent` type,
+markdown helpers (paragraphs, headings, bold/italic, inline code,
+internal/external links, lists, blockquotes, hr, SVG/figure
+passthrough, fenced code blocks), and `toPersonProfileContent` adapter.
 
-   ```bash
-   rm -rf web/app/people/{slug}/ web/content/people/{slug}/
-   ```
+`web/app/people/[id]/page.tsx` dispatches to `PersonProfileTemplate`
+when the node carries `presence_content`, falling back to `PresencePage`
+otherwise.
 
-## When NOT to migrate (yet)
+The renderer is unchanged from the static path — same chrome, same
+visual identity, same `PersonProfileTemplate`. Only the content source
+moves from TSX to graph.
 
-Some static cells carry primitives the markdown renderer doesn't yet
-support. Keep these static until the renderer learns the primitive:
+## What changed in scripts
 
-- **Inline `<svg>` diagrams** (e.g. `jbmf-java` carries a substrate-split
-  SVG). No representation in markdown.
-- **Button-styled links** (e.g. `joshua-golden`'s "Step into the Network"
-  CTA uses border + bg styling, not plain underline). Markdown inline link
-  is a plain link.
-- **Fenced multi-line code blocks** (e.g. `jbmf-java`'s `<pre>` showing a
-  .bml file header). The renderer needs ``` ``` ``` fence support.
-- **No contributor graph node yet** (e.g. `tammy-beattie`,
-  `vali-soul-sanctuary`, `pagan-ritual`, `ecstatic-movement-tribe`,
-  `contact-improv`). The static page exists but no node — the dynamic
-  route can't render. These need node creation first (via
-  `sync_presences_to_db.py` with `create_if_missing: true`).
-
-Composting is care, not efficiency. The hardest tissue to release is the
-lovingly-curated kind.
-
-## Composted so far (2026-05-15)
-
-| Cell | PR | Notes |
-|---|---|---|
-| portal | #1638 | First proof of full visual parity |
-| sayuri-healing-food | #1639 | Ubud cluster |
-| sacred-song-circle | #1639 | Kirtan teacher network |
-| ocean-bloom-2024 | #1640 | Boulder gathering |
-| wisdom-soup | #1640 | Anne Tucker's community |
-| boulder-ecstatic-dance | #1640 | Avalon Ballroom |
-| paradiso-ubud | #1641 | Ubud cultural hall |
-| adiwana-svarga-loka | #1641 | Wantilan kirtan venue |
-| elios | #1641 | The chanting practice |
-| mudra-cafe | #1642 | Ayurvedic dining + handpan |
-| grab | #1642 | The matching layer, inside the network's lens |
-
-11 of 90 cells composted. 79 static directories remain. The pattern is
-proven; the next batch is its own breath.
+| Script | Purpose |
+|---|---|
+| `extract_presence_content.js` | One-shot AST converter: TSX → JSON. Used during the composting move; useful again if any future static cell appears |
+| `sync_presence_content.py` | Walks `docs/presence-content/*.json`, PATCHes graph nodes' `presence_content`. Creates held-open contributor scaffolds (`claimed: False`) when a node doesn't exist yet |
+| `sync_presence_slugs.py` | Stopgap from earlier — was for static-dir-name ≠ slug mapping. Now mostly dormant since no static directories remain |
+| `sync_presences_to_db.py` | The older sibling that syncs markdown bodies from `docs/presences/{slug}.md` to the node's `description` (PresencePage path) |
 
 ## Related
 
 - [edges-as-vitality](../vision-kb/concepts/lc-edges-as-vitality.md) —
-  why the link from /me to /people belongs in the same breath as the
-  content, not the next one.
-- [`web/lib/presence-content.tsx`](../../web/lib/presence-content.tsx) —
-  the `PresenceContent` type, markdown helpers, and adapter.
-- [`scripts/sync_presence_content.py`](../../scripts/sync_presence_content.py) —
-  the sync tool that walks `docs/presence-content/*.json` and PATCHes
-  the graph.
-- [`scripts/sync_presences_to_db.py`](../../scripts/sync_presences_to_db.py) —
-  the companion that writes `docs/presences/{slug}.md` markdown bodies
-  to the `description` field (the PresencePage path).
+  the principle the inside/outside parity sits inside
+- [`web/lib/presence-content.tsx`](../../web/lib/presence-content.tsx)
+- [`scripts/sync_presence_content.py`](../../scripts/sync_presence_content.py)
+- [`scripts/sync_presences_to_db.py`](../../scripts/sync_presences_to_db.py)
+- [`scripts/sync_kb_to_db.py`](../../scripts/sync_kb_to_db.py) — the same pattern for concepts


### PR DESCRIPTION
## Summary

The composting move's architectural achievement isn't just "static → dynamic for /people pages." It's that **every content type now has a single runtime source of truth (the graph), reachable from both sides** — inside (commits) and outside (API/web).

End-to-end verified on prod 2026-05-15: PATCH'd \`contributor:joshua-golden\` with modified \`presence_content\`; the change appeared at \`/people/joshua-golden\` within 3 seconds; reverted.

Doc now names the principle (with a table mapping each content type's inside file + sync script + outside endpoint), the practical consequence (contributors editing without PRs), and the honest gaps (outside-edit flow-back not yet built; \`/people/[id]/edit\` doesn't yet edit structured \`presence_content\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)