### PR TITLE
tend(parity): DB revision history + graph→repo export + entity-decode

### DIFF
--- a/api/app/models/graph.py
+++ b/api/app/models/graph.py
@@ -29,8 +29,10 @@ from sqlalchemy import (
     DateTime,
     Float,
     Index,
+    Integer,
     String,
     Text,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy import JSON as _JSON
@@ -303,3 +305,61 @@ class Edge(Base):
         if self.properties:
             d.update({"properties": self.properties})
         return d
+
+
+class NodeRevision(Base):
+    """Per-edit history of every graph node — the DB-layer audit log.
+
+    Every time `update_node` or `create_node` writes to the graph, one
+    row lands here capturing the full state of the node at that moment
+    (the snapshot), the names of fields that changed (so callers can
+    diff cheaply), the source that produced the edit (`api`, `sync`,
+    `web`, `seed`), and the actor when known.
+
+    Why a snapshot rather than just a diff: a snapshot makes rollback
+    trivial (just re-apply revision N) and lets the export-to-git job
+    serialize "the node as it was at time T" without replaying history.
+    Storage cost is fine for node-shaped content (a few KB per revision
+    × tens of thousands of revisions = single-digit GB at worst).
+
+    The revision_number is per-node, monotonically increasing, used by
+    the API to refer to a specific historical state without exposing
+    UUIDs to callers.
+    """
+    __tablename__ = "graph_node_revisions"
+
+    id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    node_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    revision_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False, default="api")
+    author: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    fields_changed: Mapped[list] = mapped_column(
+        _PortableJSON, nullable=False, default=list,
+    )
+    snapshot: Mapped[dict] = mapped_column(
+        _PortableJSON, nullable=False, default=dict,
+    )
+
+    __table_args__ = (
+        Index("ix_node_revisions_node", "node_id"),
+        Index("ix_node_revisions_node_rev", "node_id", "revision_number"),
+        Index("ix_node_revisions_captured", "captured_at"),
+        UniqueConstraint("node_id", "revision_number", name="uq_node_revisions_node_rev"),
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "node_id": self.node_id,
+            "revision_number": self.revision_number,
+            "captured_at": self.captured_at.isoformat() if self.captured_at else None,
+            "source": self.source,
+            "author": self.author or None,
+            "fields_changed": list(self.fields_changed or []),
+            "snapshot": dict(self.snapshot or {}),
+        }

--- a/api/app/routers/graph.py
+++ b/api/app/routers/graph.py
@@ -231,16 +231,26 @@ async def get_node(node_id: str, request: Request, lang: str | None = Query(None
 
 
 @router.patch("/graph/nodes/{node_id}", summary="Update a node")
-async def update_node(node_id: str, body: NodeUpdate):
+async def update_node(node_id: str, body: NodeUpdate, request: Request):
     """Update a node.
 
     When a presence-type node's name or description changes, the
     resonance service automatically re-runs so the concept edges
     stay aligned with the current text. The graph keeps itself
     attuned without anyone having to trigger a manual refresh.
+
+    Every successful update appends a NodeRevision row capturing the
+    new node state, the fields that changed, and where the edit came
+    from. Callers can pass `X-Edit-Source` (`api` / `sync` / `web` /
+    `seed`) and `X-Edit-Author` (an opaque identifier) headers to
+    attribute the revision; both default to `api` / empty when absent.
     """
     updates = body.model_dump(exclude_none=True)
-    result = graph_service.update_node(node_id, **updates)
+    source = request.headers.get("x-edit-source") or "api"
+    author = request.headers.get("x-edit-author") or ""
+    result = graph_service.update_node(
+        node_id, _source=source, _author=author, **updates,
+    )
     if not result:
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
 
@@ -267,6 +277,29 @@ async def update_node(node_id: str, body: NodeUpdate):
             )
 
     return result
+
+
+@router.get(
+    "/graph/nodes/{node_id}/revisions",
+    summary="List the audit-log revisions for a node — most recent first",
+)
+async def get_node_revisions(
+    node_id: str,
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """Return the per-node audit log produced by every successful PATCH
+    and create. Each row carries the full node snapshot at that
+    revision, the fields that changed, the source (`api`/`sync`/`web`),
+    and the author when known. Combined with the snapshot, this is the
+    rollback substrate: re-PATCH a node's properties with any past
+    revision's snapshot to restore that state."""
+    # Existence check so 404 is honest for a node that was never created
+    # (vs 200 with an empty list, which conflates "no edits yet" with
+    # "no such node"). Cheap — single primary-key lookup.
+    if not graph_service.get_node(node_id):
+        raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
+    return graph_service.list_node_revisions(node_id, limit=limit, offset=offset)
 
 
 @router.delete("/graph/nodes/{node_id}", summary="Delete a node and all its edges")

--- a/api/app/services/graph_service.py
+++ b/api/app/services/graph_service.py
@@ -15,6 +15,9 @@ from typing import Any
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
+from app.models.graph import (  # noqa: F401 — NodeRevision imported for table creation
+    NodeRevision,
+)
 from app.models.graph import (
     Edge, Node,
     CANONICAL_EDGE_TYPE_SET, CANONICAL_NODE_TYPE_SET, NODE_TYPE_SET,
@@ -118,6 +121,42 @@ def get_lifecycle_default(node_type: str) -> str:
 # ── Node CRUD ────────────────────────────────────────────────────────
 
 
+def _record_revision(
+    s,
+    node: Node,
+    *,
+    source: str,
+    author: str,
+    fields_changed: list[str],
+) -> None:
+    """Append a NodeRevision row for the current node state.
+
+    Best-effort: a failure here logs and continues — losing an audit
+    row is preferable to refusing the write. The revision_number is
+    the next per-node sequence value computed inside the same session
+    as the write, so commits stay atomic.
+    """
+    try:
+        last_rev = (
+            s.query(func.max(NodeRevision.revision_number))
+            .filter(NodeRevision.node_id == node.id)
+            .scalar()
+        )
+        next_rev = (last_rev or 0) + 1
+        revision = NodeRevision(
+            id=str(uuid.uuid4()),
+            node_id=node.id,
+            revision_number=next_rev,
+            source=source or "api",
+            author=author or "",
+            fields_changed=list(fields_changed or []),
+            snapshot=node.to_dict(),
+        )
+        s.add(revision)
+    except Exception:
+        log.exception("Failed to record NodeRevision for %s", node.id)
+
+
 def create_node(
     *,
     id: str | None = None,
@@ -127,6 +166,8 @@ def create_node(
     properties: dict[str, Any] | None = None,
     phase: str | None = None,
     strict: bool = False,
+    source: str = "api",
+    author: str = "",
 ) -> dict[str, Any]:
     """Create a node. Returns the node dict.
 
@@ -162,6 +203,14 @@ def create_node(
         )
         s.add(node)
         try:
+            s.flush()  # populate id/timestamps so the revision snapshot is real
+            _record_revision(
+                s,
+                node,
+                source=source,
+                author=author,
+                fields_changed=["__create__"],
+            )
             s.commit()
             s.refresh(node)
             return node.to_dict()
@@ -211,7 +260,13 @@ _RETYPEABLE_TYPES = frozenset({
 })
 
 
-def update_node(node_id: str, **updates: Any) -> dict[str, Any] | None:
+def update_node(
+    node_id: str,
+    *,
+    _source: str = "api",
+    _author: str = "",
+    **updates: Any,
+) -> dict[str, Any] | None:
     """Update a node. Supports name, description, phase, properties,
     and — within the presence bucket — type.
 
@@ -219,14 +274,24 @@ def update_node(node_id: str, **updates: Any) -> dict[str, Any] | None:
     from the default contributor bucket (where the resolver first
     dropped it) into `scene` where it belongs. Cross-bucket moves
     (contributor → concept, or scene → system) are refused so a
-    rogue PATCH can't reshape an identity."""
+    rogue PATCH can't reshape an identity.
+
+    `_source` and `_author` flow into the NodeRevision row that's
+    appended after the write — `api` for direct PATCH, `sync` for the
+    sync scripts that import repo files, `web` for the edit UI when
+    we know it, `seed` for one-time data loads. Both are optional;
+    when omitted, defaults attribute the edit to anonymous API."""
     with session() as s:
         node = s.get(Node, node_id)
         if not node:
             return None
 
+        fields_changed: list[str] = []
+
         for key in ("name", "description", "phase"):
             if key in updates and updates[key] is not None:
+                if getattr(node, key) != updates[key]:
+                    fields_changed.append(key)
                 setattr(node, key, updates[key])
 
         # Type change — only within the presence bucket, and only if
@@ -236,18 +301,62 @@ def update_node(node_id: str, **updates: Any) -> dict[str, Any] | None:
         new_type = updates.get("type")
         if new_type is not None and new_type != node.type:
             if node.type in _RETYPEABLE_TYPES and new_type in _RETYPEABLE_TYPES:
+                fields_changed.append("type")
                 node.type = new_type
 
         if "properties" in updates and isinstance(updates["properties"], dict):
-            # Merge properties (don't replace — merge new keys into existing)
+            # Merge properties (don't replace — merge new keys into existing).
+            # Record which property keys actually changed (not just every key
+            # the PATCH carried) so the revision row stays meaningful.
+            current = dict(node.properties or {})
+            for k, v in updates["properties"].items():
+                if current.get(k) != v:
+                    fields_changed.append(f"properties.{k}")
             merged = dict(node.properties or {})
             merged.update(updates["properties"])
             node.properties = merged
 
         node.updated_at = datetime.now(timezone.utc)
+        if fields_changed:
+            _record_revision(
+                s,
+                node,
+                source=_source,
+                author=_author,
+                fields_changed=fields_changed,
+            )
         s.commit()
         s.refresh(node)
         return node.to_dict()
+
+
+def list_node_revisions(
+    node_id: str,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Return the audit log for one node — most-recent revision first.
+
+    Each row is the NodeRevision dict (revision_number, captured_at,
+    source, author, fields_changed, snapshot). The snapshot is the
+    full node state at that revision, which makes rollback a matter
+    of re-PATCHing the historical values.
+    """
+    with session() as s:
+        q = (
+            s.query(NodeRevision)
+            .filter(NodeRevision.node_id == node_id)
+            .order_by(NodeRevision.revision_number.desc())
+        )
+        total = q.count()
+        rows = q.offset(offset).limit(limit).all()
+        return {
+            "items": [r.to_dict() for r in rows],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
 
 
 def delete_node(node_id: str) -> bool:

--- a/scripts/export_graph_to_repo.py
+++ b/scripts/export_graph_to_repo.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Export graph-stored content back into the repo as files.
+
+The graph is the runtime source of truth — every page renders from it.
+This script closes the loop by walking each content-bearing node and
+projecting its current state back into the repo's canonical files
+(`docs/presence-content/{slug}.json`, etc.). Run periodically (or
+on-demand after a wave of web edits) to keep the repo as a readable
+mirror of what's live.
+
+Outside edits flow into the graph immediately. This job is how those
+edits flow back into git history so the repo remains the body's
+autobiography rather than its sole input.
+
+Content types currently exported:
+
+  presence_content  → docs/presence-content/{slug}.json
+                      walked from any node whose properties carry a
+                      `presence_content` JSON envelope (mostly
+                      contributors and a few assets/places).
+
+Future content types (concept stories, idea bodies, spec frontmatter)
+follow the same pattern — add a walker per type.
+
+Usage:
+    python3 scripts/export_graph_to_repo.py                 # dry-run, prints diffs
+    python3 scripts/export_graph_to_repo.py --write         # write files (no commit)
+    python3 scripts/export_graph_to_repo.py --commit        # write + git commit + push
+    python3 scripts/export_graph_to_repo.py --api-url …     # alternate API root
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib import request as urlrequest
+from urllib.error import HTTPError, URLError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRESENCE_CONTENT_DIR = REPO_ROOT / "docs" / "presence-content"
+DEFAULT_API = "https://api.coherencycoin.com"
+
+
+def _fetch_json(url: str, timeout: int = 30) -> dict | None:
+    req = urlrequest.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "coherence-export/1.0",
+        },
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError) as e:
+        sys.stderr.write(f"fetch {url} failed: {e}\n")
+        return None
+
+
+def list_nodes_with_presence_content(api_url: str) -> list[dict]:
+    """Walk every node carrying a `presence_content` property.
+
+    The list endpoint already returns full node.to_dict() including
+    properties, so a single page-walk per type is enough — no need to
+    re-fetch each node. Types covered are the ones the composting move
+    populated (contributor, asset, scene, place, community, event,
+    network-org, practice); adding a new type later is one entry in
+    this tuple.
+    """
+    items: list[dict] = []
+    seen_ids: set[str] = set()
+    for node_type in (
+        "contributor",
+        "asset",
+        "scene",
+        "place",
+        "community",
+        "event",
+        "network-org",
+        "practice",
+        "workspace",
+        "interested-person",
+    ):
+        offset = 0
+        page_size = 500
+        while True:
+            url = (
+                f"{api_url.rstrip('/')}/api/graph/nodes"
+                f"?type={node_type}&limit={page_size}&offset={offset}"
+            )
+            page = _fetch_json(url, timeout=60)
+            if not page or not page.get("items"):
+                break
+            for n in page["items"]:
+                if n.get("id") in seen_ids:
+                    continue
+                seen_ids.add(n["id"])
+                if n.get("presence_content"):
+                    items.append(n)
+            if len(page["items"]) < page_size:
+                break
+            offset += page_size
+    return items
+
+
+def _quote(s: str) -> str:
+    import urllib.parse
+    return urllib.parse.quote(s, safe="")
+
+
+def slug_for_node(node: dict) -> str | None:
+    """Resolve the repo filename slug for a node.
+
+    Prefers the node's `presence_slug` override (when the static
+    directory used a non-slug URL like /people/urs ↔ slug=urs-muff),
+    then the `slug` property, then the id-suffix.
+    """
+    slug = node.get("presence_slug") or node.get("slug")
+    if slug:
+        return str(slug)
+    node_id = node.get("id", "")
+    if ":" in node_id:
+        return node_id.split(":", 1)[1]
+    return node_id or None
+
+
+def export_presence_content(
+    nodes: list[dict],
+    *,
+    write: bool,
+) -> tuple[list[Path], list[Path]]:
+    """Project each node's `presence_content` to its JSON file on disk.
+
+    Returns (written_files, removed_files).
+    """
+    PRESENCE_CONTENT_DIR.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    removed: list[Path] = []
+    expected_files: set[Path] = set()
+
+    for node in nodes:
+        slug = slug_for_node(node)
+        if not slug:
+            sys.stderr.write(f"skipping node {node.get('id')!r} — no slug\n")
+            continue
+        content = node.get("presence_content")
+        if not isinstance(content, dict):
+            continue
+        dest = PRESENCE_CONTENT_DIR / f"{slug}.json"
+        expected_files.add(dest)
+
+        new_text = json.dumps(content, indent=2, ensure_ascii=False) + "\n"
+
+        # Semantic diff: parse both files as JSON and compare as dicts.
+        # The graph stores property dicts whose key-order is not
+        # guaranteed, and human-authored files may have different
+        # whitespace. Treat structurally-equal content as no-change.
+        existing_content: dict | None = None
+        if dest.exists():
+            try:
+                existing_content = json.loads(dest.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                existing_content = None
+        if existing_content == content:
+            continue  # no semantic change
+
+        if write:
+            dest.write_text(new_text, encoding="utf-8")
+        written.append(dest)
+        print(f"  {'wrote' if write else 'would write'} {dest.relative_to(REPO_ROOT)}")
+
+    # Files in the repo that don't correspond to any live node — these
+    # are orphans (node deleted but file remained). Don't auto-remove
+    # them in the dry-run print; let the writer make the call.
+    for existing in PRESENCE_CONTENT_DIR.glob("*.json"):
+        if existing not in expected_files:
+            removed.append(existing)
+            print(f"  {'removed' if write else 'would remove'} {existing.relative_to(REPO_ROOT)} (orphan)")
+            if write:
+                existing.unlink()
+
+    return written, removed
+
+
+def git_commit_and_push(written: list[Path], removed: list[Path]) -> bool:
+    """Stage the writes/removals, commit if there's a diff, push.
+
+    Returns True if a commit was made. False if there was nothing to
+    commit. Raises if git itself errors.
+    """
+    if not written and not removed:
+        return False
+
+    # Stage everything in docs/presence-content/
+    subprocess.check_call(
+        ["git", "add", str(PRESENCE_CONTENT_DIR.relative_to(REPO_ROOT))],
+        cwd=REPO_ROOT,
+    )
+
+    # Bail if the index is clean (e.g. files were re-written with
+    # identical content after JSON formatting normalised them)
+    diff = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=REPO_ROOT,
+    )
+    if diff.returncode == 0:
+        print("  no staged changes after `git add` — index clean")
+        return False
+
+    summary = f"{len(written)} written, {len(removed)} removed"
+    message = (
+        "tend(content): scheduled export of graph content to repo\n"
+        "\n"
+        "Mirror of the graph's authored content into the repo. Outside\n"
+        "edits land in the graph immediately; this commit brings the\n"
+        f"repo's projection into alignment. {summary}.\n"
+        "\n"
+        "Generated by scripts/export_graph_to_repo.py.\n"
+    )
+    subprocess.check_call(
+        ["git", "commit", "-m", message],
+        cwd=REPO_ROOT,
+    )
+    print(f"  committed: {summary}")
+
+    # Push if a remote is configured and we're on a branch that tracks it
+    try:
+        subprocess.check_call(["git", "push"], cwd=REPO_ROOT)
+        print("  pushed to remote")
+    except subprocess.CalledProcessError:
+        sys.stderr.write("  push failed — leaving commit local\n")
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", default=DEFAULT_API)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write changed files to disk (default: dry-run)",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Write + git commit + push the diff (implies --write)",
+    )
+    args = parser.parse_args()
+
+    if args.commit:
+        args.write = True
+
+    if not shutil.which("git") and args.commit:
+        sys.stderr.write("git not on PATH; cannot --commit\n")
+        return 2
+
+    print(f"Walking graph at {args.api_url}…")
+    nodes = list_nodes_with_presence_content(args.api_url)
+    print(f"Found {len(nodes)} nodes carrying presence_content")
+
+    written, removed = export_presence_content(nodes, write=args.write)
+    if not written and not removed:
+        print("repo already matches graph — nothing to export")
+        return 0
+
+    if args.commit:
+        git_commit_and_push(written, removed)
+    elif args.write:
+        print(f"wrote {len(written)}, removed {len(removed)} — repo updated, no commit (--commit to push)")
+    else:
+        print(f"would write {len(written)}, remove {len(removed)} (re-run with --write)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/lib/presence-content.tsx
+++ b/web/lib/presence-content.tsx
@@ -80,7 +80,29 @@ export type PresenceContentByLocale = {
  * Internal links (starting with `/`) become Next.js `<Link>`; external
  * links open in a new tab with rel=noopener.
  */
-export function renderInlineMarkdown(text: string): ReactNode {
+/**
+ * HTML-decode the common named entities and numeric references. Web-side
+ * edit forms (and some linters) round-trip strings through innerHTML or
+ * a JSON-pretty step that encodes `'` → `&apos;`, `"` → `&quot;`,
+ * `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`. React renders strings
+ * verbatim, so without this decode the literal entity would surface on
+ * the page. Keep the decode narrow — only the entities web editors
+ * actually produce — so the function stays predictable.
+ */
+function decodeEntities(text: string): string {
+  if (!text || text.indexOf("&") === -1) return text;
+  return text
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&amp;/g, "&");
+}
+
+export function renderInlineMarkdown(rawText: string): ReactNode {
+  const text = decodeEntities(rawText);
   if (!text) return null;
   const parts: ReactNode[] = [];
   const re =


### PR DESCRIPTION
## Summary

The two halves of inside/outside parity that were named but not built:

- **(E) DB revision history** — every PATCH and create on a graph node now appends a row to a new \`graph_node_revisions\` table (per-node monotonic revision_number, full snapshot at that revision, fields_changed, source attribution, author).
- **(A) Graph→repo export** — \`scripts/export_graph_to_repo.py\` walks every node carrying \`presence_content\` and projects the current state back into \`docs/presence-content/{slug}.json\`, optionally committing the diff. Idempotent (semantic diff).
- **Heal on the way through** — \`renderInlineMarkdown\` now HTML-decodes \`&apos;\`, \`&quot;\`, \`&lt;\`, \`&gt;\`, \`&amp;\`, numeric entities — so content round-tripped through any web edit form renders as the intended characters, not literal entity text.

## End-to-end verification

Locally:
- \`create_node\` + 2 \`update_node\` calls produced 3 revisions with correct source/author/fields_changed/ordering ✓
- 21 graph layer/boundary tests + 4 concept-story tests pass ✓
- Web typecheck clean ✓

Against prod (dry-run):
- \`export_graph_to_repo.py\` walked 87 nodes carrying \`presence_content\` across contributor/asset/scene/place/community/event/network-org/practice/workspace/interested-person types. Repo currently matches graph — idempotent ✓

## What's wired

| Surface | Behavior |
|---|---|
| \`PATCH /api/graph/nodes/{id}\` | Captures revision; respects \`X-Edit-Source\` and \`X-Edit-Author\` headers |
| \`GET /api/graph/nodes/{id}/revisions\` | Lists audit log, most-recent first, with full snapshots for rollback |
| \`scripts/export_graph_to_repo.py\` | \`--write\` writes diff, \`--commit\` writes + commits + pushes |

## Next breath

Schedule the export via GitHub Actions cron (nightly + workflow_dispatch). ~30 lines of YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)