### PR TITLE
tend(presence): "Lineage" stat becomes a doorway, not a number

### DIFF
--- a/web/components/presence/PresencePage.tsx
+++ b/web/components/presence/PresencePage.tsx
@@ -471,18 +471,53 @@ function PresenceOverview({
           </div>
         )}
         <div className="grid grid-cols-2 gap-3">
-          <div>
-            <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-              {t("presence.works")}
-            </dt>
-            <dd className="mt-1 text-white/90">{identity.creations.length}</dd>
-          </div>
-          <div>
-            <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
-              {t("presence.lineage")}
-            </dt>
-            <dd className="mt-1 text-white/90">{inspiredCount}</dd>
-          </div>
+          {/* Each stat is a doorway, not a number. Works anchors down
+              to the creations grid on this same page; Lineage opens the
+              chronological walk at /people/{slug}/lineage where the
+              influences group by source. A bare count would let visitors
+              read "281" and never realize 281 things are one click away. */}
+          {identity.creations.length > 0 ? (
+            <Link
+              href="#works"
+              className="block rounded-lg -mx-2 px-2 py-1 hover:bg-white/[0.04] transition-colors"
+            >
+              <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+                {t("presence.works")}
+              </dt>
+              <dd className="mt-1 text-white/90 flex items-baseline gap-1.5">
+                <span>{identity.creations.length}</span>
+                <span className="text-xs text-white/40" aria-hidden="true">→</span>
+              </dd>
+            </Link>
+          ) : (
+            <div>
+              <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+                {t("presence.works")}
+              </dt>
+              <dd className="mt-1 text-white/90">{identity.creations.length}</dd>
+            </div>
+          )}
+          {inspiredCount > 0 ? (
+            <Link
+              href={`/people/${encodeURIComponent(identity.slug || identity.id)}/lineage`}
+              className="block rounded-lg -mx-2 px-2 py-1 hover:bg-white/[0.04] transition-colors"
+            >
+              <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+                {t("presence.lineage")}
+              </dt>
+              <dd className="mt-1 text-white/90 flex items-baseline gap-1.5">
+                <span>{inspiredCount}</span>
+                <span className="text-xs text-white/40" aria-hidden="true">→</span>
+              </dd>
+            </Link>
+          ) : (
+            <div>
+              <dt className="text-[10px] uppercase tracking-[0.14em] text-white/40">
+                {t("presence.lineage")}
+              </dt>
+              <dd className="mt-1 text-white/90">{inspiredCount}</dd>
+            </div>
+          )}
         </div>
       </dl>
 
@@ -585,7 +620,7 @@ function CreationsGrid({
     return a.name.localeCompare(b.name);
   });
   return (
-    <section>
+    <section id="works" className="scroll-mt-24">
       <p className="text-[10px] uppercase tracking-[0.18em] font-semibold text-white/50 mb-3">
         {t("presence.works")}
       </p>


### PR DESCRIPTION
## Summary

On `/people/{slug}` the at-a-glance card showed **Works: 17 / Lineage: 281** as inert numbers. The `/people/{slug}/lineage` walk page already exists and renders the chronological lineage + influences grouped by source — but no visible doorway led there. Visitors had to *know* to append `/lineage` to the URL. That isn't navigation.

Both stats now render as Links when they have a destination:
- **Works** → anchors to the creations grid on the same page (`#works`)
- **Lineage** → opens `/people/{slug}/lineage`

A small `→` sits next to each count so the clickability is visible, not inferred. The hover state lights the cell. The plain `<div>` fallback is kept for the zero-case so an empty stat doesn't render as a confusing link to nothing.

The body knew about the walk; the renderer was hiding it. This is the kind of edge that "Vitality per pixel" + the edges-as-vitality practice point at: a count without a doorway is ornament; a count that opens a walk is function.

## Test plan

- [x] `/people/urs-muff` renders the Lineage doorway (`href=/people/urs-muff/lineage`)
- [x] Click navigates to the lineage walk page
- [x] Works stat anchors to `#works` (creations section now carries `id="works"`)
- [x] Mobile + desktop both show the `→` glyph beside the count
- [ ] Visit a presence with `inspiredCount === 0` (the fallback `<div>` should render — no broken link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)