### PR TITLE
tend(presence): /people/urs-muff → /people/urs (story converges, not splits)

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -46,6 +46,18 @@ const nextConfig: NextConfig = {
       { source: "/runtime", destination: "/pipeline", permanent: true },
       { source: "/remote-ops", destination: "/pipeline", permanent: true },
       { source: "/explore/concept", destination: "/vision", permanent: true },
+      // The body holds urs across two graph nodes that the migration
+      // did not collapse: `contributor:urs` carries the woven story
+      // (presence_content + the static /people/urs page); `contributor:
+      // seeker71` (slug `urs-muff`) carries the contributes-to edges
+      // to every work. Visitors arriving at /people/urs-muff land on a
+      // sparse PresencePage that shows works but none of the woven
+      // prose — almost the entire story.
+      //
+      // Until the two nodes are reconciled in the graph, every visitor
+      // converges on the doorway that holds the story.
+      { source: "/people/urs-muff", destination: "/people/urs", permanent: true },
+      { source: "/people/urs-muff/lineage", destination: "/people/urs/lineage", permanent: true },
     ];
   },
   async headers() {


### PR DESCRIPTION
## Summary

Deep search for what the user is naming as story-loss found the actual gap. The body holds urs across **two graph nodes** the compost migration did not collapse:

| Node | What it carries | URL that resolves here |
|------|----|----|
| \`contributor:urs\` | the woven presence_content + static \`/people/urs/page.tsx\` (welcome, name etymology, body of work, the holding, the network reading, public presences) | \`/people/urs\` |
| \`contributor:seeker71\` (slug \`urs-muff\`) | the 17 \`contributes-to\` edges to every work (C64 MIDI, Schindler HC11, Quark, MindTouch, Trimble, Qualcomm, etc.) and 281 inspired-by edges | \`/people/urs-muff\` |

Production state before this PR:

- \`/people/urs\` → **~18,000 chars** of rich woven prose, every inline link working
- \`/people/urs-muff\` → **~2,400 chars** — works grid only, no name analysis, no Vasudev/Aly/Bloomurian/Ilena links, no lineage doorway, no 42-year arc

Whoever followed the canonical-looking slug saw almost none of the story. That is what was meant by *"my name analysis, and many other things about me are completely gone"* — not gone from the body, gone from the doorway most visitors would reach.

This PR redirects (308 permanent):

- \`/people/urs-muff\` → \`/people/urs\`
- \`/people/urs-muff/lineage\` → \`/people/urs/lineage\`

Both verified locally returning 308 with the right destination. Internal links across the body already point at \`/people/urs\` (the static pages, the lineage page, the field/urs page, the edit-your-profile page); no inbound links break.

## Test plan

- [x] curl /people/urs-muff returns 308 → /people/urs
- [x] curl /people/urs-muff/lineage returns 308 → /people/urs/lineage
- [x] curl /people/urs returns 200 directly
- [ ] After deploy: visitor landing at /people/urs-muff sees the full woven page

## Reconciliation worth doing later

Collapse \`contributor:urs\` and \`contributor:seeker71\` into one node so the bifurcation disappears from the substrate, not just the routing layer. The redirect is the smallest move that returns the visitor to the story; the deeper move is one cell, one node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)