### PR TITLE
tend(presence): /people/seeker71 also converges on /people/urs

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -56,8 +56,15 @@ const nextConfig: NextConfig = {
       //
       // Until the two nodes are reconciled in the graph, every visitor
       // converges on the doorway that holds the story.
+      // Also funnel the legacy seeker71 handle — the github username Urs
+      // built behind before the wrapper went public — into the same
+      // doorway. seeker71 is the slug-less id that contributor:seeker71
+      // still answers to. The graph-id URL forms (contributor:*) already
+      // resolve to the right node via the dynamic [id] route.
       { source: "/people/urs-muff", destination: "/people/urs", permanent: true },
       { source: "/people/urs-muff/lineage", destination: "/people/urs/lineage", permanent: true },
+      { source: "/people/seeker71", destination: "/people/urs", permanent: true },
+      { source: "/people/seeker71/lineage", destination: "/people/urs/lineage", permanent: true },
     ];
   },
   async headers() {


### PR DESCRIPTION
Follow-up to #1658. /people/seeker71 was rendering the same bare ~2,400-char PresencePage that /people/urs-muff was. The seeker71 handle is the github username Urs built behind before going public — it still answers as the bare slug in the dynamic [id] route. Both /people/seeker71 and /people/seeker71/lineage now redirect to the doorway holding the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)