### PR TITLE
tend(render): h3 + heading parity for /people/urs (and every cell)

### DIFF
--- a/web/lib/presence-content.tsx
+++ b/web/lib/presence-content.tsx
@@ -229,7 +229,7 @@ export function renderBlockMarkdown(text: string): ReactNode {
         }
         if (block.startsWith("### ")) {
           return (
-            <h3 key={i} className="text-base font-semibold mt-4 mb-2">
+            <h3 key={i} className="text-base font-medium text-foreground/90 mt-6">
               {renderInlineMarkdown(block.slice(4))}
             </h3>
           );
@@ -317,18 +317,22 @@ export function toPersonProfileContent(
 
   const articles: PersonProfileArticle[] = (content.articles ?? []).map((a) => {
     const body = renderBlockMarkdown(a.body_md);
+    // Headings carry inline markdown so a panel/narrative heading can hold
+    // a Link or em/strong without the migration losing JSX richness.
+    // Example: "Walk the full lineage of works and influences → [/people/urs/lineage](/people/urs/lineage)".
+    const heading = a.heading ? renderInlineMarkdown(a.heading) : undefined;
     if (a.kind === "panel") {
       return {
         kind: "panel",
         variant: a.variant,
         eyebrow: a.eyebrow ?? undefined,
-        heading: a.heading ?? undefined,
+        heading,
         body,
       };
     }
     return {
       kind: "narrative",
-      heading: a.heading,
+      heading,
       body,
     };
   });


### PR DESCRIPTION
Two render divergences surfaced after [PR #1661](https://github.com/seeker71/Coherence-Network/pull/1661) made /people/urs graph-backed:

1. **h3 subsections** inside narrative articles ("The Western root...", "The Sufi root...", "The meeting place") rendered heavier than the original. Static JSX used `text-base font-medium text-foreground/90 mt-6`; the markdown renderer used `text-base font-semibold mt-4 mb-2`. Aligning the renderer matches the original.

2. **Panel/narrative headings** rendered as plain strings, losing any inline Links the original JSX held. The first panel's heading ("Walk the full lineage of works and influences → /people/urs/lineage") carried a Link in the original. Headings now run through `renderInlineMarkdown` so they can carry Link / em / strong / code — same expressiveness as the body.

The graph nodes `contributor:urs` and `contributor:seeker71` already have the heading restored via authenticated PATCH (audit log: `claude:urs-restore-heading-2026-05-15`).

## Test plan

- [x] Typecheck clean (the one pre-existing test error is unrelated)
- [ ] After deploy: /people/urs h3 sections match the original elegance — lighter weight, more top breathing room
- [ ] First panel shows "Walk the full lineage of works and influences → /people/urs/lineage" with the path as a clickable Link

🤖 Generated with [Claude Code](https://claude.com/claude-code)