### PR TITLE
tend(presence): urs / urs-muff / seeker71 converge on one canonical node

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -265,6 +265,26 @@ async function fetchGraphNode(id: string): Promise<Record<string, unknown> | nul
     }
   }
 
+  // Legacy-handle match: a node's `legacy_ids` list declares historical
+  // names this cell answers to. Urs's contributor:seeker71 carries
+  // ["seeker71","urs-muff","ursmuff","urs"]; any of those URL forms
+  // should land on this node. Match against the bare id (no
+  // contributor: prefix) so /people/seeker71, /people/urs, etc. resolve
+  // when the redirect map is bypassed.
+  {
+    const list = await fetchJsonOrNull<{ items: Record<string, unknown>[] }>(
+      `${base}/api/graph/nodes?type=contributor&limit=500`,
+      {},
+      5000,
+    );
+    const bareId = id.startsWith("contributor:") ? id.slice("contributor:".length) : id;
+    const match = list?.items?.find((n) => {
+      const aliases = Array.isArray(n.legacy_ids) ? (n.legacy_ids as unknown[]) : [];
+      return aliases.some((a) => typeof a === "string" && a === bareId);
+    });
+    if (match) return match;
+  }
+
   return null;
 }
 

--- a/web/app/people/urs/page.tsx
+++ b/web/app/people/urs/page.tsx
@@ -13,32 +13,30 @@ import {
 } from "@/lib/presence-content";
 
 /**
- * /people/urs — the central cell, rendered from the graph.
+ * /people/urs — the central cell, rendered from one canonical graph node.
  *
- * Content lives in the graph node `contributor:urs` as `presence_content`
- * (synced 2026-05-15 from the previously-static en.tsx). The route file
- * is the binding layer that pins the URL to this graph node and tells
- * the template to walk `contributor:seeker71`'s edges (works, lineage,
- * inspired-by) — the two-node bifurcation lives in the substrate, and
- * naming both ids here is honest about it.
+ * `contributor:seeker71` is the canonical node: it carries every
+ * `contributes-to` / `inspired-by` / `resonates-with` edge (315 in
+ * total), its slug is `urs-muff` (the canonical handle), and its
+ * `legacy_ids` declare `urs` / `urs-muff` / `seeker71` / `ursmuff` as
+ * valid aliases. After today's reconcile, this is THE node for the
+ * urs cell — `contributor:urs` survives only as a temporary stub for
+ * a handful of code references that still name it literally.
  *
- * The dynamic `/people/[id]` route would also resolve /people/urs to
- * the same node, but this static route file lets us specify the edge-
- * walking node explicitly without baking a special-case into the
- * generic dispatcher.
+ * Both content and edges now load from the same node. One source of
+ * truth — the URL is just the public doorway.
  */
 
 export const dynamic = "force-dynamic";
 
-const STORY_NODE_ID = "contributor:urs";
-const EDGES_NODE_ID = "contributor:seeker71";
+const CANONICAL_NODE_ID = "contributor:seeker71";
 
 async function fetchPresenceContent(
   lang: string,
 ): Promise<PresenceContent | null> {
   const base = getApiBase();
   const node = await fetchJsonOrNull<Record<string, unknown>>(
-    `${base}/api/graph/nodes/${encodeURIComponent(STORY_NODE_ID)}`,
+    `${base}/api/graph/nodes/${encodeURIComponent(CANONICAL_NODE_ID)}`,
     {},
     5000,
   );
@@ -85,7 +83,7 @@ export default async function UrsProfilePage() {
     <PersonProfileTemplate
       content={toPersonProfileContent(presence)}
       lang={lang}
-      graphSlug={EDGES_NODE_ID}
+      graphSlug={CANONICAL_NODE_ID}
     />
   );
 }


### PR DESCRIPTION
## Summary

After yesterday's reconcile the urs cell had **two graph nodes** carrying the same story: `contributor:urs` (presence_content, 0 edges) and `contributor:seeker71` (presence_content + 315 edges, slug=`urs-muff`). The static page read content from one node and edges from the other — two sources for one cell.

This PR collapses to **one canonical node** (`contributor:seeker71`, slug=`urs-muff`) for both content and edges, and records every alias on it.

**Changes:**
- `web/app/people/urs/page.tsx` — single `CANONICAL_NODE_ID = "contributor:seeker71"` for both `presence_content` fetch and `graphSlug` (edges)
- `web/app/people/[id]/page.tsx` — dynamic resolver learns to match `legacy_ids`, so any URL form bypassing the next.config redirects (federation, archived links, direct API lookup) still lands on the canonical node
- Graph PATCH applied (audit: `claude:urs-alias-2026-05-15`): `contributor:seeker71.legacy_ids` is now `["seeker71", "urs-muff", "ursmuff", "urs"]` — every alias attested on the node itself

**After this PR:**
- All edges (315) live on the node whose slug is `urs-muff`
- `/people/urs`, `/people/urs-muff`, `/people/seeker71` all resolve to the same canonical node (via redirects + legacy_id match)
- One source of truth in the DB: edit through `/api/graph/nodes/contributor:seeker71` PATCH

**Test plan:**
- [x] Typecheck clean
- [x] Local preview: all three URLs return 200 with full content (Theban Legion, Walk the 42-year, Bloomurian links)
- [ ] After deploy: prod verification of all three aliases

**Still owed (separate PR):** the runtime code references to `"contributor:urs"` string literal in `organism_influence_cc_service.py` and `field_view_attribution_service.py` need retuning before `contributor:urs` can be deleted from the graph entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)