### PR TITLE
tend(presence): aliases, not legacy — every handle this cell answers to

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -265,12 +265,12 @@ async function fetchGraphNode(id: string): Promise<Record<string, unknown> | nul
     }
   }
 
-  // Legacy-handle match: a node's `legacy_ids` list declares historical
-  // names this cell answers to. Urs's contributor:seeker71 carries
-  // ["seeker71","urs-muff","ursmuff","urs"]; any of those URL forms
-  // should land on this node. Match against the bare id (no
+  // Alias match: a node's `aliases` list names every handle this cell
+  // answers to — all alive, none deprecated. Urs's contributor:seeker71
+  // carries ["seeker71","urs-muff","ursmuff","urs"]; any of those URL
+  // forms lands on the same cell. Match against the bare id (no
   // contributor: prefix) so /people/seeker71, /people/urs, etc. resolve
-  // when the redirect map is bypassed.
+  // even when a request reaches this handler directly.
   {
     const list = await fetchJsonOrNull<{ items: Record<string, unknown>[] }>(
       `${base}/api/graph/nodes?type=contributor&limit=500`,
@@ -279,7 +279,7 @@ async function fetchGraphNode(id: string): Promise<Record<string, unknown> | nul
     );
     const bareId = id.startsWith("contributor:") ? id.slice("contributor:".length) : id;
     const match = list?.items?.find((n) => {
-      const aliases = Array.isArray(n.legacy_ids) ? (n.legacy_ids as unknown[]) : [];
+      const aliases = Array.isArray(n.aliases) ? (n.aliases as unknown[]) : [];
       return aliases.some((a) => typeof a === "string" && a === bareId);
     });
     if (match) return match;

--- a/web/app/people/urs/page.tsx
+++ b/web/app/people/urs/page.tsx
@@ -18,10 +18,11 @@ import {
  * `contributor:seeker71` is the canonical node: it carries every
  * `contributes-to` / `inspired-by` / `resonates-with` edge (315 in
  * total), its slug is `urs-muff` (the canonical handle), and its
- * `legacy_ids` declare `urs` / `urs-muff` / `seeker71` / `ursmuff` as
- * valid aliases. After today's reconcile, this is THE node for the
- * urs cell — `contributor:urs` survives only as a temporary stub for
- * a handful of code references that still name it literally.
+ * `aliases` list names `urs` / `urs-muff` / `seeker71` / `ursmuff` —
+ * every handle this cell answers to, all alive. After today's
+ * reconcile, this is THE node for the urs cell; `contributor:urs`
+ * remains a placeholder for a handful of code references that still
+ * name it directly, waiting for retuning in a separate breath.
  *
  * Both content and edges now load from the same node. One source of
  * truth — the URL is just the public doorway.


### PR DESCRIPTION
Yesterday's PR named the alternate handles `legacy_ids` — that word frames living names as deprecated, kept around only for compatibility. But `urs` / `urs-muff` / `seeker71` / `ursmuff` are all alive — they all answer to the same cell, none is being phased out. The frequency of "legacy" was wrong.

**Renamed:**
- Graph node property: `legacy_ids` → `aliases` (already PATCHed on `contributor:seeker71`, audit: `claude:urs-alias-rename-2026-05-15`)
- `web/app/people/[id]/page.tsx` — alias-match block reads `aliases`, comment names them "every handle this cell answers to — all alive, none deprecated"
- `web/app/people/urs/page.tsx` — header doc uses the same vocabulary

"Legacy" stays reserved for things actually being retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)