### PR TITLE
compost(presence): release four curated stubs; aly + mose + bloomurian + elon render from the graph

### DIFF
--- a/web/app/people/[id]/page.tsx
+++ b/web/app/people/[id]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { cookies, headers } from "next/headers";
@@ -9,8 +8,6 @@ import { createTranslator } from "@/lib/i18n";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
 import { Panel, VoiceQuote } from "@/components/Panel";
 import { PersonInspiredBy } from "@/components/PersonInspiredBy";
-import { Button } from "@/components/ui/button";
-import { AttributedExternalLink } from "@/components/content/AttributedExternalLink";
 import {
   PresencePage,
   type Creation,
@@ -45,104 +42,6 @@ import {
  */
 
 export const dynamic = "force-dynamic";
-
-type CuratedPresence = {
-  name: string;
-  slug: string;
-  tagline: string;
-  heroImage: string;
-  bio: string;
-  resonance: { axis: string; score: number; note: string }[];
-  links: { label: string; href: string }[];
-  type: string;
-  location: string;
-};
-
-const CURATED_PRESENCES: Record<string, CuratedPresence> = {
-  "elon-musk": {
-    name: "Elon Musk",
-    slug: "elon-musk",
-    tagline: "Multiplanetary • xAI • Tesla • SpaceX",
-    heroImage: "/presences/elon-musk-hero.jpg",
-    bio: "Founder of Tesla, SpaceX, xAI, and X. A presence driving humanity toward multiplanetary life and accelerating the understanding of the universe through first-principles thinking and bold execution.",
-    resonance: [
-      { axis: "Vitality", score: 0.92, note: "Relentless drive toward life-expanding frontiers" },
-      { axis: "Organic Intelligence", score: 0.87, note: "First-principles reasoning as living intelligence" },
-      { axis: "Expression", score: 0.95, note: "Radical transparency and direct communication" },
-    ],
-    links: [
-      { label: "X / Twitter", href: "https://x.com/elonmusk" },
-      { label: "Tesla", href: "https://tesla.com" },
-      { label: "SpaceX", href: "https://spacex.com" },
-      { label: "xAI", href: "https://x.ai" },
-    ],
-    type: "human",
-    location: "Earth (multiplanetary intent)",
-  },
-  // `liquid-bloom` was once a thin curated entry here; it has been
-  // composted in favor of the full PersonProfileTemplate page at
-  // web/app/people/liquid-bloom/page.tsx with content under
-  // web/content/people/liquid-bloom/{locale}.tsx — same shape as Mose
-  // and Bloomurian. The static `/people/liquid-bloom` route takes
-  // precedence over this dynamic [id] route, so the curated block
-  // would have been unreachable anyway, but keeping it here would
-  // calcify a duplicate source of truth. Released.
-  bloomurian: {
-    name: "Bloomurian",
-    slug: "bloomurian",
-    tagline: "Folktronica • World Bass • Heart-Opening Frequencies",
-    heroImage: "/presences/bloomurian-hero.jpg",
-    bio: "Electronic music & DJ project of Robin Liepman (Bloom). Blends folktronica, world bass, psychedelic bass, and organic house into multidimensional frequencies that cultivate blossoming heart, mind, body, and soul.",
-    resonance: [
-      { axis: "Vitality", score: 0.93, note: "Heart-opening bass that moves the body" },
-      { axis: "Expression", score: 0.89, note: "Live instrumentation + electronic alchemy" },
-      { axis: "Harmony", score: 0.9, note: "Polyphonic frequencies for collective resonance" },
-    ],
-    links: [
-      { label: "Website", href: "https://www.bloomurian.com/" },
-      { label: "Instagram", href: "https://www.instagram.com/bloomurianmusic/" },
-      { label: "Bandcamp", href: "https://bloomurian.bandcamp.com" },
-    ],
-    type: "human",
-    location: "Boulder, Colorado",
-  },
-  mose: {
-    name: "Mose",
-    slug: "mose",
-    tagline: "Shamanic Downtempo • ReGen Remixes • Organic Intelligence",
-    heroImage: "/presences/mose-hero.jpg",
-    bio: "Shamanic electronic musician known for deep, organic, regenerative sound. Creator of the ReGen remix series with Liquid Bloom and collaborator in the conscious music field - frequency work that regenerates the listener.",
-    resonance: [
-      { axis: "Organic Intelligence", score: 0.95, note: "Regenerative, earth-connected sound design" },
-      { axis: "Vitality", score: 0.88, note: "Downtempo that restores nervous system coherence" },
-      { axis: "Harmony", score: 0.86, note: "Folktronica roots meeting modern bass" },
-    ],
-    links: [
-      { label: "Spotify", href: "https://open.spotify.com/artist/mose" },
-      { label: "Bandcamp", href: "https://mose.bandcamp.com" },
-    ],
-    type: "human",
-    location: "Global (shamanic electronic lineage)",
-  },
-  "aly-constantine": {
-    name: "Aly Constantine",
-    slug: "aly-constantine",
-    tagline: "Healing Arts • Conscious Sound • Presence",
-    heroImage: "/presences/aly-constantine-hero.jpg",
-    bio: "Presence in the healing arts and conscious sound field. Works at the intersection of sound, presence, and embodied transformation - helping the field remember itself through voice, vibration, and deep listening.",
-    resonance: [
-      { axis: "Vitality", score: 0.91, note: "Sound as direct transmission of life force" },
-      { axis: "Harmony", score: 0.94, note: "Conscious sound that aligns the field" },
-      { axis: "Expression", score: 0.87, note: "Voice and presence as living art" },
-    ],
-    links: [
-      { label: "Instagram", href: "#" },
-      { label: "Website", href: "#" },
-    ],
-    type: "human",
-    location: "Global (healing arts)",
-  },
-};
 
 type ContributorNode = {
   id?: string;
@@ -480,16 +379,6 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id: rawId } = await params;
   const id = decodeRouteParam(rawId);
-  const curated = CURATED_PRESENCES[id];
-  if (curated) {
-    return {
-      title: `${curated.name} — Coherence Network`,
-      description: curated.bio,
-      openGraph: {
-        images: [{ url: curated.heroImage }],
-      },
-    };
-  }
   // Declare the canonical URL when the graph node carries a slug.
   // One presence, one doorway: shared link previews and search
   // engines converge on `/people/{slug}` even when an inbound link
@@ -511,90 +400,6 @@ function decodeRouteParam(rawId: string): string {
   } catch {
     return rawId;
   }
-}
-
-function renderCuratedPresence(presence: CuratedPresence) {
-  return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-12 space-y-12">
-      <div className="relative h-[60vh] min-h-[420px] w-full overflow-hidden rounded-3xl">
-        <Image
-          src={presence.heroImage}
-          alt={presence.name}
-          fill
-          className="object-cover"
-          priority
-          unoptimized
-        />
-        <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/80" />
-        <div className="absolute bottom-0 left-0 right-0 p-8 md:p-12">
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-white/70 mb-3">
-              {presence.type} · {presence.location}
-            </div>
-            <h1 className="text-6xl md:text-7xl font-light tracking-tight text-white mb-4">
-              {presence.name}
-            </h1>
-            <p className="text-2xl text-white/90 max-w-2xl">{presence.tagline}</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="prose prose-lg max-w-none text-foreground/90">
-        <p>{presence.bio}</p>
-      </div>
-
-      <section>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))]">
-            Resonance with the Living Collective
-          </div>
-          <div className="flex-1 h-px bg-border" />
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-3">
-          {presence.resonance.map((r) => (
-            <div key={r.axis} className="rounded-2xl border border-border/50 bg-card p-6">
-              <div className="flex items-baseline justify-between mb-3">
-                <div className="font-medium text-lg">{r.axis}</div>
-                <div className="text-sm tabular-nums text-[hsl(var(--primary))] font-mono">
-                  {Math.round(r.score * 100)}%
-                </div>
-              </div>
-              <p className="text-sm text-foreground/80 leading-relaxed">{r.note}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section>
-        <div className="text-xs uppercase tracking-[0.18em] font-semibold text-[hsl(var(--primary))] mb-4">
-          Public presence
-        </div>
-        <div className="flex flex-wrap gap-3">
-          {presence.links.map((link) => (
-            <AttributedExternalLink
-              key={link.href}
-              href={link.href}
-              entityId={`presence-link:${presence.slug}:${link.label
-                .toLowerCase()
-                .replace(/[^a-z0-9]+/g, "-")
-                .replace(/^-|-$/g, "")}`}
-              className="inline-flex items-center gap-2 rounded-full border border-border px-5 py-2 text-sm hover:bg-accent transition-colors"
-            >
-              {link.label} →
-            </AttributedExternalLink>
-          ))}
-        </div>
-      </section>
-
-      <div className="pt-8 border-t border-border/50 text-center">
-        <p className="text-sm text-muted-foreground mb-4">This presence is part of the Living Collective.</p>
-        <Button asChild size="lg" className="rounded-full px-10">
-          <Link href="/begin">Weave into the field</Link>
-        </Button>
-      </div>
-    </main>
-  );
 }
 
 function initialFromName(name: string): string {
@@ -641,8 +446,6 @@ export default async function PersonPage({
   // The graph-id → human-slug redirect lives in middleware.ts;
   // requests reaching this handler use either the slug directly
   // (resolved here) or a graph id with no slug registered.
-  const curatedPresence = CURATED_PRESENCES[id];
-  if (curatedPresence) return renderCuratedPresence(curatedPresence);
 
   const cookieLang = (await cookies()).get("NEXT_LOCALE")?.value;
   const headerLang = (await headers())


### PR DESCRIPTION
## What happened

Aly Constantine's `/people/aly-constantine` page was rendering "Healing Arts • Conscious Sound • Presence" — a thin tagline-and-resonance stub — while the graph node already held the full body-authored content: hero welcome, Boulder Ecstatic Dance / Conscious Roots Presents / Courtyard Constellations writing, the *Held with* constellation (Rocco, Danny, Robin, Brigitte, Tay, Andy, Lara), the houseguest months, and the closing of the Boulder arc on Rocco's 36th birthday.

The dynamic `/people/[id]` handler still carried a `CURATED_PRESENCES` dict with four entries — `elon-musk`, `bloomurian`, `mose`, `aly-constantine` — and the early-return for those slugs fired *before* the graph fetch. So even though composting moved the static directories to graph-stored `presence_content` (PR #1646), this older dict was shadowing the result for these four cells.

Verified against the prod API that all four nodes carry `presence_content` in the same shape Aly's JSON does.

## Changes

- Removed `type CuratedPresence` + `CURATED_PRESENCES` record (4 entries)
- Removed `renderCuratedPresence` function
- Removed the curated branch in `generateMetadata`
- Removed the curated early-return in `PersonPage` that shadowed graph render
- Removed unused imports: `next/image`, `Button`, `AttributedExternalLink`

All four cells now flow through `pickPresenceContent` → `PersonProfileTemplate`, the same path Aly's static directory followed before it composted to the graph.

## Test plan

- [x] `tsc --noEmit` clean for the touched file
- [x] Local preview against prod API: `/people/aly-constantine` renders full hero + facts + articles
- [x] `/people/elon-musk`, `/people/bloomurian`, `/people/mose` — no curated stub markers in rendered HTML, breadcrumb present
- [x] No console errors
- [ ] After deploy: re-verify on https://coherencycoin.com/people/aly-constantine

🤖 Generated with [Claude Code](https://claude.com/claude-code)