### PR TITLE
attune(form): runtime + defn/recursion + tree navigation + structural composition discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,30 @@ A content-addressed numeric lattice that grounds structural reasoning. Every mem
 
 **The pattern:** before claiming "these two are similar" or "this looks like that," ask the substrate. Cells with matching Blueprint NodeIDs are structurally equivalent regardless of name; the substrate's answer is canonical, your reasoning is grounded.
 
+### Structural composition discipline — keep the tree, refuse the slug
+
+The substrate's promise is **fractal/holographic composition**: every entity is a tree where each level is itself composed, all the way down to numeric trivials. Blueprint NodeID `@1.5.4.1` for a Memory cell is a 4-level deep composite of (B_Domain.MEMORY + 4 field-Blueprints + 4 sub-Blueprints + leaves). This is the NUMS-Go origin's load-bearing teaching: **the right primitive isn't a syntax tree, it's a content-addressed numeric lattice composed bottom-up**.
+
+**The discipline.** When ingesting or composing anything that lands in the substrate, *structure-first, never flat-first*. A slug is a query key, not a container for structure; an object literal is a leaf-level convenience, not a place to stuff a sub-tree. Every field that has internal structure (key + value, head + tail, type + token, source + target) should be expressed as a composed Recipe — children visible to `.child(n)`, equivalences discoverable by content-addressing, the tree readable from Form's surface via `.blueprint` / `.ctor` / `.children`.
+
+**The default is to compose.** The exception is to leaf — and the exception requires a *great reason*. What counts:
+
+1. **Genuinely atomic value.** A single integer, a single date, a URL pointing externally, a content-hash. Composing further would invent fake structure.
+2. **Free-form prose body.** Natural-language text that has no a-priori structure to extract (the *access-recipe* of a memory body — separate from the CTOR, which is the frontmatter). Markdown body parsing into a recipe-tree is a future move; until then, the body is a content-hash leaf, not a slug.
+3. **External reference.** A GitHub issue ID, a Linear ticket, a URL — the structure lives outside the substrate and our representation is necessarily a pointer.
+4. **Bootstrap primitives.** A SubstrateString value at the very bottom of the leaf chain — by definition the atomic value the tree resolves to.
+
+Anything else — frontmatter fields, cross-references, type enumerations, edge kinds, statuses, list contents, configuration values — is composition territory. *"It's just a string"* is not a great reason; *"it's just an object"* is not a great reason; *"we'll structure it later"* is not a great reason. The cost of flat-now-structure-later is silent: drift in proprioception, lost cross-domain equivalences, the substrate stops being able to recognize same-shape across documents.
+
+**Concrete shapes the body uses:**
+
+- A frontmatter field is a `(key-slug, value)` pair — `R_Block.LET` with a SubstrateString-recipe and a value-recipe child. Names participate in identity; positions don't.
+- A typed enumeration (`type: feedback`, `kind: HUMAN`) is a reference to a typed-token cell, not a free string. The token's *existence in the substrate* is what makes the value valid.
+- A cell reference (`idea_id: agent-pipeline`, `parent: lc-trust-over-fear`) is a cell-ref recipe pointing at the actual cell, not a slug string.
+- A list (`cross_refs: [a, b, c]`, `capabilities: [...]`) is a `R_Block.SEQUENCE` recipe with one child per element, each child carrying its own composed shape.
+
+**Re-classification is ongoing work.** Existing nodes ingested before this discipline landed are *flat*: their CTORs hold type-markers ("name=str"), not values; their cross-references are slug strings, not cell-refs. The body knows itself well enough at the shape layer (Blueprints share NodeIDs across structurally-equivalent cells) but not yet at the value layer. The migration is multi-breath; the principle is now load-bearing across all new ingest work. See [`docs/coherence-substrate/structural-composition.md`](docs/coherence-substrate/structural-composition.md) for per-domain target shapes and current migration status.
+
 ## Navigation
 
 All paths converge: **idea → specs → source files**

--- a/api/app/services/substrate/__init__.py
+++ b/api/app/services/substrate/__init__.py
@@ -49,6 +49,11 @@ from app.services.substrate.form import (
     serialize_cell as form_serialize_cell,
     serialize_node_id as form_serialize_node_id,
 )
+from app.services.substrate.form_runtime import (
+    Frame as FormFrame,
+    execute as form_execute,
+    form_execute_text,
+)
 from app.services.substrate.grammar import (
     BID_grammar,
     FormRule,
@@ -228,6 +233,9 @@ __all__ = [
     "FormResult",
     "form_evaluate",
     "form_evaluate_text",
+    "form_execute",
+    "form_execute_text",
+    "FormFrame",
     "form_parse",
     "form_serialize_cell",
     "form_serialize_node_id",

--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -439,6 +439,21 @@ class MethodDefExpr:
 
 
 @dataclass
+class FnDef:
+    """`defn name(p1, p2, ...) = body` — bind a callable in the enclosing frame.
+
+    The body is captured as an AST and evaluated lazily on each call. The
+    function's name is visible inside its own body so recursion works
+    without a separate `rec` form. Frames are lexically scoped — a call
+    pushes a child frame whose parent is the frame the function was
+    defined in (closure semantics).
+    """
+    name: str
+    params: List[str]
+    body: Any
+
+
+@dataclass
 class MethodInvokeExpr:
     """`invoke NAME on @X` — invoke the method on cell X (dispatch via
     delegation chain). Interns as `(RBasic.METHOD, [name_str, target_ref])`.
@@ -467,6 +482,41 @@ class ProjectExpr:
     """
     cell: Any
     coord_fn: Any
+
+
+@dataclass
+class FnCall:
+    """`name(arg1, arg2, ...)` — invoke a callable bound by FnDef."""
+    name: str
+    args: List[Any]
+
+
+@dataclass
+class Access:
+    """`target.field` — fractal-tree navigation.
+
+    Lets Form walk into the holographic composition of a Cell, Blueprint,
+    or Recipe: `@memory(x).blueprint.category` reaches the type the cell
+    IS; `@memory(x).blueprint.children` reaches the ordered child
+    Blueprints; `@memory(x).ctor.children[0]` reaches the first composed
+    value. The dot is the seam between levels.
+
+    The point of this primitive is the same point the substrate's
+    content-addressing makes structurally: *we don't stuff structure
+    into slugs or flat objects, we keep the tree.* The slug is a query
+    key; the tree is the body.
+    """
+    target: Any
+    field: str
+
+
+@dataclass
+class MethodCall:
+    """`target.method(arg1, arg2, ...)` — for `.child(n)` and similar
+    indexed/parameterized accesses on a Cell, Blueprint, or Recipe."""
+    target: Any
+    method: str
+    args: List[Any]
 
 
 AtomNode = Union[NodeIDLit, TrivialRef, CellRef, Projection]
@@ -591,10 +641,47 @@ class Parser:
 
     def parse_projection(self) -> ExprNode:
         a = self.parse_primary()
-        while self.peek().kind == "PROJECT":
-            self.consume("PROJECT")
-            b = self.parse_primary()
-            a = Projection(cell=a, blueprint=b)
+        # Postfix loop: handles |> projection AND .field / .method(args)
+        # tree-navigation. The dot is the seam between holographic levels —
+        # the substrate's fractal composition becomes navigable syntax.
+        while True:
+            t = self.peek()
+            if t.kind == "PROJECT":
+                self.consume("PROJECT")
+                b = self.parse_primary()
+                a = Projection(cell=a, blueprint=b)
+                continue
+            if t.kind == "DOT":
+                # `.field` access — but only when followed by an IDENT that
+                # isn't `self` (the latter is a primary `.self` expression).
+                # If we already have a target on the left (we do, since
+                # parse_primary returned `a`), then `a.field` is access.
+                # Bare `.self` was handled in parse_primary when no left
+                # target existed.
+                next_tok = self.peek(1)
+                if next_tok.kind != "IDENT":
+                    break
+                if next_tok.value == "self":
+                    # Don't consume — `.self` after an expression isn't
+                    # valid; let downstream parsers handle the error.
+                    break
+                self.consume("DOT")
+                field_tok = self.consume("IDENT")
+                field = field_tok.value
+                # Optional method-call: `.field(args)` becomes MethodCall.
+                if self.peek().kind == "LPAREN":
+                    self.consume("LPAREN")
+                    args: List[Any] = []
+                    while self.peek().kind != "RPAREN":
+                        args.append(self.parse_expr())
+                        if self.peek().kind == "COMMA":
+                            self.consume("COMMA")
+                    self.consume("RPAREN")
+                    a = MethodCall(target=a, method=field, args=args)
+                else:
+                    a = Access(target=a, field=field)
+                continue
+            break
         return a
 
     def parse_primary(self) -> ExprNode:
@@ -695,6 +782,8 @@ class Parser:
             return self.parse_method_def()
         if kw == "invoke":
             return self.parse_method_invoke()
+        if kw == "defn":
+            return self.parse_defn()
 
         # User-registered keywords (the rule-driven extension point —
         # this is where the grammar becomes alive at runtime).
@@ -704,9 +793,41 @@ class Parser:
             if node is not None:
                 return node
 
-        # Otherwise it's an Identifier (local name reference)
+        # Otherwise it's an Identifier (local name reference) — or a
+        # function call if followed by `(`. The call syntax lives here so
+        # any bare name in expression position can become a call.
         self.consume("IDENT")
+        if self.peek().kind == "LPAREN":
+            self.consume("LPAREN")
+            args: List[Any] = []
+            while self.peek().kind != "RPAREN":
+                args.append(self.parse_expr())
+                if self.peek().kind == "COMMA":
+                    self.consume("COMMA")
+            self.consume("RPAREN")
+            return FnCall(name=kw, args=args)
         return Identifier(name=kw)
+
+    def parse_defn(self) -> "FnDef":
+        """`defn name(p1, p2, ...) = body` — function definition.
+
+        The function name and parameters are plain identifiers. Body is
+        any expression. Closure semantics are handled at runtime: the
+        FnDef binds in the current frame; calling it pushes a child
+        frame whose parent is the defining frame.
+        """
+        self.consume("IDENT")  # 'defn'
+        name = self.consume("IDENT").value
+        self.consume("LPAREN")
+        params: List[str] = []
+        while self.peek().kind != "RPAREN":
+            params.append(self.consume("IDENT").value)
+            if self.peek().kind == "COMMA":
+                self.consume("COMMA")
+        self.consume("RPAREN")
+        self.consume("ASSIGN")
+        body = self.parse_expr()
+        return FnDef(name=name, params=params, body=body)
 
     def parse_if(self) -> IfExpr:
         self.consume("IDENT")  # 'if'

--- a/api/app/services/substrate/form_render.py
+++ b/api/app/services/substrate/form_render.py
@@ -1,0 +1,187 @@
+"""Render Form's grammar back to Form-source text.
+
+`bootstrap_self_host(session)` already proves Form's keyword grammar IS
+substrate-resident — each (pattern, template) pair lives as Recipe
+NodeIDs in the lattice. This module closes the visible loop: it walks
+those recipes and emits Form-flavored source text so a human (or another
+agent) can read the body's own grammar in the body's own voice.
+
+The notation produced here is a *target syntax* — what Form would look
+like if the bootstrap parser could read its own grammar from text. It
+uses primitives Form already speaks (`seq`, `lit`, `cap`, `opt`,
+`build`, `ref`, `const`) in a Lisp-shaped composition. The renderer
+emits this notation; the bootstrap parser does not yet consume it (that
+is the BMF closure, named in form-language.md beyond Step 8).
+
+Two entry points:
+
+  render_pattern(pattern) -> str
+  render_template(template) -> str
+  render_keyword(name, pattern, template) -> str  # combined
+
+  render_all_registered() -> str  # every keyword currently registered
+
+Output is deterministic — two identical inputs render to identical text,
+so the body's grammar can be diffed against itself across processes.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.substrate.form_builders import Build, CaptureRef, Const, MapBuild
+from app.services.substrate.form_rules import (
+    Capture,
+    IdentCapture,
+    Literal,
+    Opt,
+    RepeatedCapture,
+    Sequence,
+    list_registered_keywords,
+    lookup_form_keyword,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern → Form text
+# ---------------------------------------------------------------------------
+
+
+def render_pattern(pattern: Any, indent: int = 0) -> str:
+    """Render a pattern as Form-flavored source text."""
+    pad = "    " * indent
+
+    if isinstance(pattern, Literal):
+        if pattern.value is None:
+            return f'lit "{pattern.kind}"'
+        return f'lit "{pattern.kind}" "{pattern.value}"'
+
+    if isinstance(pattern, Capture):
+        if pattern.kind == "expr":
+            return f'cap "{pattern.name}"'
+        return f'cap "{pattern.name}" :{pattern.kind}'
+
+    if isinstance(pattern, IdentCapture):
+        return f'ident-cap "{pattern.name}"'
+
+    if isinstance(pattern, Sequence):
+        if not pattern.parts:
+            return "seq []"
+        inner = ",\n".join(
+            "    " * (indent + 1) + render_pattern(p, indent + 1)
+            for p in pattern.parts
+        )
+        return f"seq [\n{inner},\n{pad}]"
+
+    if isinstance(pattern, Opt):
+        return f"opt {render_pattern(pattern.pattern, indent)}"
+
+    if isinstance(pattern, RepeatedCapture):
+        body = render_pattern(pattern.item_pattern, indent + 1)
+        sep = (
+            f"\n{pad}    sep: {render_pattern(pattern.separator, indent + 1)}"
+            if pattern.separator is not None
+            else ""
+        )
+        return f'repeat "{pattern.name}" {{\n{pad}    item: {body}{sep}\n{pad}}}'
+
+    return f"<unrendered {type(pattern).__name__}>"
+
+
+# ---------------------------------------------------------------------------
+# Template → Form text
+# ---------------------------------------------------------------------------
+
+
+def render_template(template: Any, indent: int = 0) -> str:
+    """Render a Build/CaptureRef/Const/MapBuild template as Form text."""
+    pad = "    " * indent
+
+    if isinstance(template, Const):
+        v = template.value
+        if v is None:
+            return "null"
+        if isinstance(v, bool):
+            return "true" if v else "false"
+        if isinstance(v, str):
+            return f'"{v}"'
+        return str(v)
+
+    if isinstance(template, CaptureRef):
+        if template.has_default:
+            default_val = template.default
+            if default_val is None:
+                default_str = "null"
+            elif isinstance(default_val, bool):
+                default_str = "true" if default_val else "false"
+            elif isinstance(default_val, str):
+                default_str = f'"{default_val}"'
+            else:
+                default_str = render_template(default_val, indent)
+            return f'ref "{template.name}" default {default_str}'
+        return f'ref "{template.name}"'
+
+    if isinstance(template, Build):
+        if not template.kwargs:
+            return f'build "{template.class_name}"'
+        fields = ",\n".join(
+            "    " * (indent + 1) + f"{key}: {render_template(value, indent + 1)}"
+            for key, value in template.kwargs.items()
+        )
+        return f'build "{template.class_name}" {{\n{fields},\n{pad}}}'
+
+    if isinstance(template, MapBuild):
+        items = render_template(template.items, indent + 1)
+        each = render_template(template.each, indent + 1)
+        return f"map {{\n{pad}    items: {items},\n{pad}    each: {each},\n{pad}}}"
+
+    # Literal Python value passed through
+    if template is None:
+        return "null"
+    if isinstance(template, bool):
+        return "true" if template else "false"
+    if isinstance(template, (int, float)):
+        return str(template)
+    if isinstance(template, str):
+        return f'"{template}"'
+
+    return f"<unrendered {type(template).__name__}>"
+
+
+# ---------------------------------------------------------------------------
+# Keyword rule → Form text
+# ---------------------------------------------------------------------------
+
+
+def render_keyword(name: str, pattern: Any, template: Any) -> str:
+    """Render a complete keyword rule as Form-source text."""
+    p = render_pattern(pattern, indent=1)
+    t = render_template(template, indent=1)
+    return (
+        f'keyword "{name}" {{\n'
+        f"    pattern: {p}\n"
+        f"    template: {t}\n"
+        f"}}"
+    )
+
+
+def render_all_registered(templates: dict | None = None) -> str:
+    """Render every currently-registered keyword rule as Form text.
+
+    `templates` is an optional `{name: template}` dict — the registry
+    stores patterns + compiled-builder callables, so callers that want
+    template rendering pass the source-of-truth template map alongside.
+    Without it, the template field renders as `<python-builder>`.
+
+    The output reads as the body's own grammar in the body's own voice —
+    self-expressing at the keyword layer made visible.
+    """
+    templates = templates or {}
+    parts = []
+    for name in sorted(list_registered_keywords()):
+        entry = lookup_form_keyword(name)
+        if entry is None:
+            continue
+        pattern, _builder = entry
+        template = templates.get(name, "<python-builder>")
+        parts.append(render_keyword(name, pattern, template))
+    return "\n\n".join(parts)

--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -1,0 +1,536 @@
+"""Recipe-execution engine — Form expressions running, not just interned.
+
+Until now the substrate held Form expressions as content-addressed Recipe
+NodeIDs but had no engine that turned a recipe into a value. `1 + 2`
+interned successfully; nothing computed `3`. `with X { .self }` interned
+successfully; `.self` had nowhere to resolve. `choose [a, b, c]` interned
+successfully; speculation lived only at the parser layer.
+
+This module is that engine. It walks Form ASTs (the in-memory tree the
+parser produces, which carries full-fidelity literal values and names)
+and returns Python values. The Recipe NodeID remains the content-
+addressed signature alongside — two expressions that compute the same
+shape share one NodeID; their values are computed by walking the AST,
+which is the natural runtime IR (the same separation Python makes
+between bytecode and its hash).
+
+Connection to parser-level speculation: this engine re-uses
+`FailSignal` and `StopSignal` from form_speculation. `fail` and `stop`
+inside `choose` flow through the same exceptions parser-level
+speculation uses. The Choice.FAIL / Choice.STOP recipe categories that
+the substrate has been storing for shapes finally have a runtime that
+catches them.
+
+What this closes:
+
+- Self-executing — Form expressions run, not just intern
+- `.self` runtime resolution — WithExpr binds subject in a Frame; SelfRef walks up the chain
+- FailSignal/StopSignal flow through Choice recipes at runtime, not just parser-time
+
+What stays a future breath:
+
+- Persistent name resolution from cells (let-bound names live in the
+  Frame; cell-domain symbols are looked up via CellRef at evaluation
+  time; integrating these two name spaces is its own pass)
+- Recipe-NodeID → AST round-trip evaluation (the engine walks the AST;
+  walking the serialized recipe directly requires resolving hashed
+  string instances back via substrate_strings — own breath)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.services.substrate.form import (
+    Access,
+    BoolLit,
+    CellRef,
+    ChooseExpr,
+    DoBlock,
+    FailExpr,
+    FnCall,
+    FnDef,
+    Identifier,
+    IfExpr,
+    IntLit,
+    Let,
+    MatchArm,
+    MatchExpr,
+    MethodCall,
+    NodeIDLit,
+    Projection,
+    SelfRef,
+    StopExpr,
+    StringLit,
+    TrivialRef,
+    UnaryOp,
+    BinOp,
+    TRIVIAL_REFS,
+    DOMAIN_TO_REF,
+    WithExpr,
+    parse as form_parse,
+)
+from app.services.substrate.form_speculation import FailSignal, StopSignal
+from app.services.substrate.kernel import NodeID, lookup_cell, view_cell_through_blueprint
+
+
+# ---------------------------------------------------------------------------
+# Frame — lexical scope
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Closure:
+    """A runtime function value — captured params + body + defining frame.
+
+    `defining_frame` is the lexical scope active when the closure was
+    created. A call pushes a child frame parented at `defining_frame`,
+    not at the caller's frame — that is the closure rule. The function's
+    own name is visible inside its body so recursion works without a
+    separate `rec` form (we register the closure in `defining_frame`
+    before evaluating the body).
+    """
+
+    name: str
+    params: List[str]
+    body: Any
+    defining_frame: "Frame"
+
+
+@dataclass
+class Frame:
+    """A lexical scope.
+
+    `bindings` holds names introduced by `let`. `subject` holds the
+    implicit receiver of a `with` block (read by `.self`). Frames chain
+    via `parent` to form a scope walk.
+    """
+
+    bindings: Dict[str, Any] = field(default_factory=dict)
+    subject: Any = None
+    has_subject: bool = False
+    parent: Optional["Frame"] = None
+
+    def lookup(self, name: str) -> Any:
+        f: Optional[Frame] = self
+        while f is not None:
+            if name in f.bindings:
+                return f.bindings[name]
+            f = f.parent
+        raise NameError(f"Form runtime: unbound name {name!r}")
+
+    def has(self, name: str) -> bool:
+        f: Optional[Frame] = self
+        while f is not None:
+            if name in f.bindings:
+                return True
+            f = f.parent
+        return False
+
+    def nearest_subject(self) -> Any:
+        f: Optional[Frame] = self
+        while f is not None:
+            if f.has_subject:
+                return f.subject
+            f = f.parent
+        raise NameError("Form runtime: .self used outside a `with` block")
+
+
+# Singleton used when no caller-provided frame exists.
+def _root_frame() -> Frame:
+    return Frame()
+
+
+# ---------------------------------------------------------------------------
+# Built-in identifier resolution
+# ---------------------------------------------------------------------------
+
+
+_BUILTIN_IDENTIFIERS: Dict[str, Any] = {
+    "true": True,
+    "false": False,
+    "null": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# execute — walk the AST
+# ---------------------------------------------------------------------------
+
+
+def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
+    """Walk a Form AST and return a Python value.
+
+    Raises:
+        FailSignal: when a `fail` expression evaluates outside a `choose`
+        StopSignal: when a `stop` evaluates and bubbles past the nearest choose
+        NameError, TypeError, ZeroDivisionError, ...: normal Python errors
+    """
+    if frame is None:
+        frame = _root_frame()
+
+    # --- Leaves with full value fidelity ------------------------------------
+
+    if isinstance(ast, IntLit):
+        return ast.value
+    if isinstance(ast, BoolLit):
+        return ast.value
+    if isinstance(ast, StringLit):
+        return ast.value
+
+    if isinstance(ast, Identifier):
+        if ast.name in _BUILTIN_IDENTIFIERS:
+            return _BUILTIN_IDENTIFIERS[ast.name]
+        return frame.lookup(ast.name)
+
+    if isinstance(ast, NodeIDLit):
+        return NodeID(ast.package, ast.level, ast.type_, ast.instance)
+
+    if isinstance(ast, TrivialRef):
+        nid = TRIVIAL_REFS.get(ast.name)
+        if nid is None:
+            raise NameError(f"Form runtime: unknown trivial ~{ast.name}")
+        return nid
+
+    if isinstance(ast, CellRef):
+        if ast.name is None:
+            ref_name = DOMAIN_TO_REF.get(ast.domain)
+            if ref_name is None:
+                raise NameError(f"Form runtime: unknown domain @{ast.domain}")
+            return TRIVIAL_REFS[ref_name]
+        cell = lookup_cell(session, ast.domain, ast.name)
+        if cell is None:
+            raise LookupError(f"Form runtime: cell ({ast.domain}, {ast.name}) not found")
+        return cell
+
+    # --- .self ---------------------------------------------------------------
+
+    if isinstance(ast, SelfRef):
+        return frame.nearest_subject()
+
+    # --- Operators -----------------------------------------------------------
+
+    if isinstance(ast, BinOp):
+        # Short-circuit for && and ||
+        if ast.op == "&&":
+            l = execute(session, ast.left, frame)
+            if not l:
+                return l
+            return execute(session, ast.right, frame)
+        if ast.op == "||":
+            l = execute(session, ast.left, frame)
+            if l:
+                return l
+            return execute(session, ast.right, frame)
+        left = execute(session, ast.left, frame)
+        right = execute(session, ast.right, frame)
+        return _apply_binop(ast.op, left, right)
+
+    if isinstance(ast, UnaryOp):
+        value = execute(session, ast.operand, frame)
+        return _apply_unop(ast.op, value)
+
+    # --- Control flow --------------------------------------------------------
+
+    if isinstance(ast, IfExpr):
+        cond = execute(session, ast.cond, frame)
+        if cond:
+            return execute(session, ast.then_branch, frame)
+        if ast.else_branch is not None:
+            return execute(session, ast.else_branch, frame)
+        return None
+
+    if isinstance(ast, DoBlock):
+        sub = Frame(parent=frame)
+        result: Any = None
+        for stmt in ast.statements:
+            result = execute(session, stmt, sub)
+        return result
+
+    if isinstance(ast, Let):
+        value = execute(session, ast.value, frame)
+        frame.bindings[ast.name] = value
+        return value
+
+    if isinstance(ast, MatchExpr):
+        scrut = execute(session, ast.scrutinee, frame)
+        for arm in ast.arms:
+            if _is_wildcard(arm.pattern):
+                return execute(session, arm.body, frame)
+            pat_value = execute(session, arm.pattern, frame)
+            if pat_value == scrut:
+                return execute(session, arm.body, frame)
+        return None
+
+    # --- Speculation ---------------------------------------------------------
+
+    if isinstance(ast, ChooseExpr):
+        for candidate in ast.candidates:
+            try:
+                return execute(session, candidate, frame)
+            except FailSignal:
+                continue
+            except StopSignal:
+                # `stop` inside this candidate — the speculation is
+                # locked but the choose still returns. StopSignal does
+                # NOT propagate past its enclosing choose; bubbling past
+                # would require a deeper unwind primitive.
+                return None
+        raise FailSignal("Form runtime: all `choose` candidates failed")
+
+    if isinstance(ast, FailExpr):
+        raise FailSignal("Form runtime: `fail`")
+
+    if isinstance(ast, StopExpr):
+        raise StopSignal("Form runtime: `stop`")
+
+    # --- with / projection ---------------------------------------------------
+
+    if isinstance(ast, WithExpr):
+        subject = execute(session, ast.subject, frame)
+        sub = Frame(parent=frame, subject=subject, has_subject=True)
+        return execute(session, ast.body, sub)
+
+    # --- Functions ----------------------------------------------------------
+
+    if isinstance(ast, FnDef):
+        closure = Closure(
+            name=ast.name,
+            params=list(ast.params),
+            body=ast.body,
+            defining_frame=frame,
+        )
+        frame.bindings[ast.name] = closure
+        return closure
+
+    if isinstance(ast, FnCall):
+        callable_value = frame.lookup(ast.name)
+        if not isinstance(callable_value, Closure):
+            raise TypeError(
+                f"Form runtime: `{ast.name}` is not callable "
+                f"(got {type(callable_value).__name__})"
+            )
+        if len(ast.args) != len(callable_value.params):
+            raise TypeError(
+                f"Form runtime: `{ast.name}` takes {len(callable_value.params)} arg(s), "
+                f"got {len(ast.args)}"
+            )
+        # Evaluate arguments in the CALLER's frame, then bind them in a
+        # fresh frame parented at the closure's defining frame.
+        evaluated = [execute(session, a, frame) for a in ast.args]
+        call_frame = Frame(parent=callable_value.defining_frame)
+        for param_name, value in zip(callable_value.params, evaluated):
+            call_frame.bindings[param_name] = value
+        return execute(session, callable_value.body, call_frame)
+
+    if isinstance(ast, Projection):
+        cell = execute(session, ast.cell, frame)
+        bp = execute(session, ast.blueprint, frame)
+        if not isinstance(bp, NodeID):
+            raise TypeError("Form runtime: |> requires a NodeID on the right")
+        # Allow both a NamedCell and a bare NodeID on the left (the latter
+        # is meaningful when a cell-by-id is supplied).
+        if isinstance(cell, NodeID):
+            raise TypeError(
+                "Form runtime: |> on a bare NodeID requires a cell lookup "
+                "(use @<domain>(<name>) on the left)"
+            )
+        return view_cell_through_blueprint(session, cell, bp)
+
+    # --- Tree navigation — the fractal/holographic seams --------------------
+    #
+    # The substrate composes every entity bottom-up: a Cell holds a
+    # Blueprint NodeID + a CTOR Recipe NodeID; each of those is itself a
+    # tree (category + ordered children). `.field` is the syntax that
+    # makes that tree navigable. The point: structure stays as tree, not
+    # flattened to slug or object.
+
+    if isinstance(ast, Access):
+        target = execute(session, ast.target, frame)
+        return _resolve_access(session, target, ast.field)
+
+    if isinstance(ast, MethodCall):
+        target = execute(session, ast.target, frame)
+        evaluated_args = [execute(session, a, frame) for a in ast.args]
+        return _resolve_method(session, target, ast.method, evaluated_args)
+
+    raise TypeError(f"Form runtime: cannot execute {type(ast).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Tree navigation helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_access(session: Session, target: Any, field: str) -> Any:
+    """Field access on a Cell, Blueprint NodeID, or Recipe NodeID.
+
+    Cells expose: blueprint, ctor, base, access, name, domain, source.
+    NodeIDs expose: package, level, type_, instance, category, children.
+    """
+    from app.services.substrate.kernel import NamedCell, lookup_node
+
+    if isinstance(target, NamedCell):
+        if field == "blueprint":
+            return target.blueprint
+        if field == "ctor":
+            return target.ctor
+        if field == "base":
+            return target.base
+        if field == "access":
+            return target.access
+        if field == "name":
+            return target.name
+        if field == "domain":
+            return target.domain
+        if field == "source":
+            return target.source_path
+        raise AttributeError(
+            f"Form runtime: cell has no field {field!r} "
+            f"(try: blueprint, ctor, base, access, name, domain, source)"
+        )
+
+    if isinstance(target, NodeID):
+        if field == "package":
+            return target.package
+        if field == "level":
+            return target.level
+        if field == "type_" or field == "type":
+            return target.type_
+        if field == "instance":
+            return target.instance
+        if field == "category":
+            return _node_category(session, target)
+        if field == "children":
+            return _node_children(session, target)
+        if field == "nchildren":
+            return len(_node_children(session, target))
+        raise AttributeError(
+            f"Form runtime: NodeID has no field {field!r} "
+            f"(try: package, level, type, instance, category, children, nchildren)"
+        )
+
+    raise TypeError(
+        f"Form runtime: cannot access .{field} on {type(target).__name__}"
+    )
+
+
+def _resolve_method(session: Session, target: Any, method: str, args: List[Any]) -> Any:
+    """Method-call on a Cell, Blueprint, or Recipe — currently `child(n)`.
+
+    `.child(n)` returns the n-th child NodeID. Out-of-range raises.
+    """
+    if isinstance(target, NodeID):
+        if method == "child":
+            if len(args) != 1 or not isinstance(args[0], int):
+                raise TypeError("Form runtime: .child(n) takes one integer arg")
+            children = _node_children(session, target)
+            n = args[0]
+            if n < 0 or n >= len(children):
+                raise IndexError(
+                    f"Form runtime: .child({n}) out of range "
+                    f"(have {len(children)} children)"
+                )
+            return children[n]
+    raise TypeError(
+        f"Form runtime: cannot call .{method}() on {type(target).__name__}"
+    )
+
+
+def _node_category(session: Session, nid: NodeID) -> NodeID:
+    """The category of a NodeID. For trivials, the node IS its category.
+    For composites, parse the substrate row's serialized form."""
+    from app.services.substrate.kernel import lookup_node
+
+    row = lookup_node(session, nid)
+    if row is None or not row.serialized:
+        return nid  # trivial — category is itself
+    parts = row.serialized.split("+")
+    if len(parts) <= 1:
+        return nid
+    return _parse_nodeid(parts[0])
+
+
+def _node_children(session: Session, nid: NodeID) -> List[NodeID]:
+    """Ordered children of a composite NodeID. Empty list for trivials."""
+    from app.services.substrate.kernel import lookup_node
+
+    row = lookup_node(session, nid)
+    if row is None or not row.serialized:
+        return []
+    parts = row.serialized.split("+")
+    if len(parts) <= 1:
+        return []
+    return [_parse_nodeid(p) for p in parts[1:]]
+
+
+def _parse_nodeid(s: str) -> NodeID:
+    """`'1.5.4.1'` → NodeID(1, 5, 4, 1)."""
+    a, b, c, d = s.split(".")
+    return NodeID(int(a), int(b), int(c), int(d))
+
+
+# ---------------------------------------------------------------------------
+# Operator application
+# ---------------------------------------------------------------------------
+
+
+def _apply_binop(op: str, left: Any, right: Any) -> Any:
+    if op == "+":
+        return left + right
+    if op == "-":
+        return left - right
+    if op == "*":
+        return left * right
+    if op == "/":
+        return left / right if isinstance(left, float) or isinstance(right, float) else left // right
+    if op == "%":
+        return left % right
+    if op == "==":
+        return left == right
+    if op == "!=":
+        return left != right
+    if op == "<":
+        return left < right
+    if op == "<=":
+        return left <= right
+    if op == ">":
+        return left > right
+    if op == ">=":
+        return left >= right
+    raise SyntaxError(f"Form runtime: unknown binary op {op!r}")
+
+
+def _apply_unop(op: str, value: Any) -> Any:
+    if op == "-":
+        return -value
+    if op == "!":
+        return not value
+    raise SyntaxError(f"Form runtime: unknown unary op {op!r}")
+
+
+def _is_wildcard(pattern: Any) -> bool:
+    return isinstance(pattern, Identifier) and pattern.name == "_"
+
+
+# ---------------------------------------------------------------------------
+# Top-level: parse + execute
+# ---------------------------------------------------------------------------
+
+
+def form_execute_text(
+    session: Session,
+    text: str,
+    *,
+    frame: Optional[Frame] = None,
+    prefer_registered: bool = False,
+) -> Any:
+    """Parse a Form expression and run it. Returns the computed value.
+
+    The substrate session is passed through so cell lookups (`@<domain>(<name>)`)
+    and any future substrate-touching operations work.
+    """
+    ast = form_parse(text, prefer_registered=prefer_registered)
+    return execute(session, ast, frame=frame)

--- a/api/app/services/substrate/markdown_frontend.py
+++ b/api/app/services/substrate/markdown_frontend.py
@@ -92,6 +92,203 @@ def RID_block() -> NodeID:
 
 
 # ---------------------------------------------------------------------------
+# Structured-composition primitives — discipline lives in
+# docs/coherence-substrate/structural-composition.md
+# ---------------------------------------------------------------------------
+
+
+def RID_block_do() -> NodeID:
+    """`R_Block.DO` — sequence-of-statements recipe (block container)."""
+    from app.services.substrate.category import RBlock
+    return NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.DO)
+
+
+def RID_block_let() -> NodeID:
+    """`R_Block.LET` — `(key, value)` named-field pair recipe.
+
+    This is the load-bearing primitive for named fields: a LET recipe with
+    two children is the substrate's native shape for `key: value`.
+    The discipline says: never collapse a frontmatter field into a
+    positional value-only recipe; always express the name participation.
+    """
+    from app.services.substrate.category import RBlock
+    return NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.LET)
+
+
+def RID_block_sequence() -> NodeID:
+    """`R_Block.SEQUENCE` — ordered list recipe (preserves element shape)."""
+    from app.services.substrate.category import RBlock
+    return NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.SEQUENCE)
+
+
+def RID_compose_member_of() -> NodeID:
+    """`R_Compose.MEMBER_OF` — typed-token reference recipe.
+
+    Used to encode `type: feedback` as `MEMBER_OF[token-cell, domain-cell]`
+    rather than as a free string. The token-cell's *existence in the
+    substrate* is what makes the value valid.
+    """
+    from app.services.substrate.category import RCompose
+    return NodeID(1, Level.BASIC, RBasic.COMPOSE, RCompose.MEMBER_OF)
+
+
+def substrate_string_recipe(session: Session, value: str) -> NodeID:
+    """A trivial String recipe carrying `value` via the substrate string-table.
+
+    Cross-process stable: same string → same instance → same NodeID. This
+    is the value-leaf primitive. Unlike the legacy hash-based encoding
+    (which collides + can't be reversed), this is recoverable: given the
+    NodeID's instance, `lookup_string_value(session, instance)` returns
+    the original string.
+    """
+    from app.services.substrate.substrate_strings import intern_string_instance
+    inst = intern_string_instance(session, value)
+    return NodeID(1, Level.TRIVIAL, RType.STRING, inst)
+
+
+def substrate_slug_recipe(session: Session, value: str) -> NodeID:
+    """A trivial Slug recipe (RType.SLUG=6) carrying `value`.
+
+    Slugs and Strings are categorically distinct in the substrate even
+    though they share the substrate_strings interning table for instance
+    allocation — a Slug carries the *identity-role* (query key); a String
+    carries the *content-role* (value). Same value, different type-tag.
+    """
+    from app.services.substrate.substrate_strings import intern_string_instance
+    inst = intern_string_instance(session, value)
+    return NodeID(1, Level.TRIVIAL, RType.SLUG, inst)
+
+
+def named_field_recipe(
+    session: Session,
+    key: str,
+    value_recipe_id: NodeID,
+    value_blueprint: Optional[NodeID] = None,
+) -> NodeID:
+    """Compose a `(key, value)` named-field pair via R_Block.LET.
+
+    `key` is interned as a Slug-recipe (identity-role).
+    `value_recipe_id` is the already-composed value recipe.
+
+    Returns the interned LET NodeID. Two named-field pairs with the same
+    key AND structurally-identical value-recipes share a NodeID — the
+    substrate's content-addressing carries the equivalence automatically.
+    """
+    from app.services.substrate.kernel import DOMAIN_RECIPE, intern_node
+    key_id = substrate_slug_recipe(session, key)
+    return intern_node(
+        session, DOMAIN_RECIPE, RID_block_let(), [key_id, value_recipe_id]
+    )
+
+
+def list_recipe(session: Session, element_recipe_ids: List[NodeID]) -> NodeID:
+    """Compose a list as R_Block.SEQUENCE with one child per element.
+
+    Preserves order. Two lists with identical element shape AND identical
+    element values share a NodeID — substrate sees them as the same list.
+    """
+    from app.services.substrate.kernel import DOMAIN_RECIPE, intern_node
+    return intern_node(
+        session, DOMAIN_RECIPE, RID_block_sequence(), element_recipe_ids
+    )
+
+
+def structured_value_recipe(session: Session, value: Any) -> NodeID:
+    """Compose any frontmatter value into its substrate-resident recipe shape.
+
+    Recursive: lists become R_Block.SEQUENCE; dicts become R_Block.DO with
+    LET children; scalars become typed trivial recipes via substrate_strings.
+
+    The composition is structure-first by default. Leaf-by-great-reason
+    only applies to:
+      - genuinely atomic scalars (the SubstrateString at the bottom)
+      - paths and URLs (PATH / URL leaf-recipes)
+      - dates (DATE leaf-recipes)
+    """
+    from app.services.substrate.substrate_strings import intern_string_instance
+
+    if value is None:
+        # Null leaf — RType.NULL has instance 0.
+        return NodeID(1, Level.TRIVIAL, RType.NULL, 0)
+
+    if isinstance(value, bool):
+        return NodeID(1, Level.TRIVIAL, RType.BOOL, 1 if value else 0)
+
+    if isinstance(value, int):
+        # Encode non-negative integers via instance + 1 (instance=0 is null).
+        # Negative integers route through string-encoded form preserving sign.
+        if value >= 0:
+            return NodeID(1, Level.TRIVIAL, RType.INTEGER, value + 1)
+        inst = intern_string_instance(session, str(value))
+        return NodeID(1, Level.TRIVIAL, RType.STRING, inst)
+
+    if isinstance(value, float):
+        inst = intern_string_instance(session, repr(value))
+        return NodeID(1, Level.TRIVIAL, RType.DECIMAL, inst)
+
+    if isinstance(value, str):
+        # A string value is a SubstrateString-recipe with the value itself
+        # interned via the substrate string-table — fully recoverable.
+        return substrate_string_recipe(session, value)
+
+    if isinstance(value, list):
+        children = [structured_value_recipe(session, item) for item in value]
+        return list_recipe(session, children)
+
+    if isinstance(value, dict):
+        # A dict becomes R_Block.DO with one R_Block.LET per key.
+        from app.services.substrate.kernel import DOMAIN_RECIPE, intern_node
+        pairs = []
+        for k in sorted(value.keys()):
+            v_recipe = structured_value_recipe(session, value[k])
+            pairs.append(named_field_recipe(session, str(k), v_recipe))
+        if not pairs:
+            return NodeID(1, Level.TRIVIAL, RType.EMPTY, 0)
+        return intern_node(session, DOMAIN_RECIPE, RID_block_do(), pairs)
+
+    # Unknown type — fall back to string repr (preserves recoverability)
+    inst = intern_string_instance(session, repr(value))
+    return NodeID(1, Level.TRIVIAL, RType.STRING, inst)
+
+
+def frontmatter_to_structured_ctor(
+    session: Session, frontmatter: Dict[str, Any]
+) -> Optional[NodeID]:
+    """Build a fully-expressed CTOR recipe from frontmatter.
+
+    Unlike the legacy `frontmatter_to_*` encoder (which produces type-marker
+    string-recipes that lose all values), this preserves every value as a
+    recoverable substrate-resident recipe. The shape is:
+
+        CTOR (R_Block.DO)
+        ├── NamedField (R_Block.LET) — key:slug, value:recipe
+        ├── NamedField (R_Block.LET)
+        └── ...
+
+    Values are recursively composed: lists become R_Block.SEQUENCE,
+    dicts become R_Block.DO with LET children, scalars become typed
+    trivial recipes via the substrate string-table. The tree extends
+    as deep as the data goes — no flattening.
+
+    Returns None if frontmatter is empty. Otherwise returns the
+    interned CTOR NodeID. Two cells with identical frontmatter values
+    share a CTOR NodeID through content-addressed interning.
+    """
+    if not frontmatter:
+        return None
+
+    from app.services.substrate.kernel import DOMAIN_RECIPE, intern_node
+
+    pairs = []
+    for key in sorted(frontmatter.keys()):
+        value_recipe = structured_value_recipe(session, frontmatter[key])
+        pair = named_field_recipe(session, key, value_recipe)
+        pairs.append(pair)
+
+    return intern_node(session, DOMAIN_RECIPE, RID_block_do(), pairs)
+
+
+# ---------------------------------------------------------------------------
 # Frontmatter parsing
 # ---------------------------------------------------------------------------
 
@@ -283,12 +480,22 @@ def body_to_access_recipe(
 # ---------------------------------------------------------------------------
 
 
-def ingest_memory_file(session: Session, path: Path) -> Tuple[Any, NodeID, NodeID]:
+def ingest_memory_file(
+    session: Session, path: Path, structured: bool = False
+) -> Tuple[Any, NodeID, NodeID]:
     """Ingest one memory file into the substrate.
+
+    `structured=True` activates the composition-discipline encoder
+    (named-pair CTORs with substrate-resident values). Default is the
+    legacy encoder for backward compatibility during migration. See
+    docs/coherence-substrate/structural-composition.md.
 
     Returns (NamedCell, blueprint NodeID, ctor recipe NodeID).
     """
-    return _ingest_markdown_file(session, path, "memory", BID_memory(), name_field="name")
+    return _ingest_markdown_file(
+        session, path, "memory", BID_memory(),
+        name_field="name", structured=structured,
+    )
 
 
 def ingest_spec_file(session: Session, path: Path) -> Tuple[Any, NodeID, NodeID]:
@@ -358,6 +565,7 @@ def _ingest_markdown_file(
     domain: str,
     domain_blueprint: NodeID,
     name_field: Optional[str] = None,
+    structured: bool = False,
 ) -> Tuple[Any, NodeID, NodeID]:
     """Generic ingestion path — domain + domain blueprint + optional name field."""
     return _ingest_markdown_payload(
@@ -367,6 +575,7 @@ def _ingest_markdown_file(
         domain_blueprint=domain_blueprint,
         name_field=name_field,
         source_path=str(path),
+        structured=structured,
     )
 
 
@@ -377,8 +586,16 @@ def _ingest_markdown_payload(
     domain_blueprint: NodeID,
     name_field: Optional[str] = None,
     source_path: Optional[str] = None,
+    structured: bool = False,
 ) -> Tuple[Any, NodeID, NodeID]:
-    """Shared ingest core — operates on already-parsed markdown."""
+    """Shared ingest core — operates on already-parsed markdown.
+
+    `structured=True` activates the new composition-discipline encoder
+    (frontmatter_to_structured_ctor) which produces a fully-expressed
+    CTOR with named-pair recipes and substrate-resident values, instead
+    of the legacy type-marker encoder. See
+    docs/coherence-substrate/structural-composition.md.
+    """
     name = None
     if name_field:
         name = parsed.frontmatter.get(name_field)
@@ -397,33 +614,35 @@ def _ingest_markdown_payload(
     blueprint_id = frontmatter_to_blueprint(session, parsed.frontmatter, domain_blueprint)
 
     # Build the CTOR recipe — captures frontmatter-as-seed.
-    # We represent it as a Block recipe whose children are string-literal
-    # recipes for each frontmatter key-value pair. This is enough for
-    # structural identity (two memories with the same frontmatter keys+types
-    # produce the same CTOR shape), and the actual values live in the
-    # source file (and on disk).
-    from app.services.substrate.substrate_strings import intern_string_instance
-    ctor_children = []
-    for key in sorted(parsed.frontmatter.keys()):
-        # Each entry is a string-literal whose instance encodes the key.
-        # Cross-process stable via the substrate string-table.
-        marker = f"{key}={type(parsed.frontmatter[key]).__name__}"
-        inst = intern_string_instance(session, marker)
-        ctor_children.append(
-            Recipe(
-                category=NodeID(1, Level.TRIVIAL, RType.STRING, inst),
-                blueprint=BID_string(),
-            )
-        )
-    if ctor_children:
-        ctor_recipe = Recipe(
-            category=RID_block(),
-            blueprint=blueprint_id,
-            children=ctor_children,
-        )
-        ctor_id = ctor_recipe.make_self_id(session)
+    if structured:
+        # New path — composition-discipline encoder. Every value reaches
+        # the substrate as a structured recipe; the tree extends as deep
+        # as the data goes. See structural-composition.md.
+        ctor_id = frontmatter_to_structured_ctor(session, parsed.frontmatter)
     else:
-        ctor_id = None
+        # Legacy path — type-marker string-recipes per key. Preserves
+        # shape, loses values. Kept for backward compatibility during
+        # migration; new ingests should pass structured=True.
+        from app.services.substrate.substrate_strings import intern_string_instance
+        ctor_children = []
+        for key in sorted(parsed.frontmatter.keys()):
+            marker = f"{key}={type(parsed.frontmatter[key]).__name__}"
+            inst = intern_string_instance(session, marker)
+            ctor_children.append(
+                Recipe(
+                    category=NodeID(1, Level.TRIVIAL, RType.STRING, inst),
+                    blueprint=BID_string(),
+                )
+            )
+        if ctor_children:
+            ctor_recipe = Recipe(
+                category=RID_block(),
+                blueprint=blueprint_id,
+                children=ctor_children,
+            )
+            ctor_id = ctor_recipe.make_self_id(session)
+        else:
+            ctor_id = None
 
     # Build the access-recipe (what reading the cell evaluates to).
     access_id = body_to_access_recipe(session, parsed.body, blueprint_id)

--- a/api/tests/test_substrate_form_runtime.py
+++ b/api/tests/test_substrate_form_runtime.py
@@ -1,0 +1,478 @@
+"""Recipe-execution engine — Form expressions running, not just interning.
+
+Each test exercises one faculty of the runtime. The shared shape:
+
+- `form_execute_text(session, src)` parses + runs and returns a value
+- `execute(session, ast, frame)` runs an already-parsed AST against a frame
+- FailSignal / StopSignal flow through `choose` blocks at runtime, sharing
+  the same exception types parser-level speculation uses
+
+The runtime closes self-executing: Form is no longer just content-addressed
+data, it's a living language whose recipes are runnable.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate import form_execute_text
+from app.services.substrate.form_runtime import Frame, execute
+from app.services.substrate.form_speculation import FailSignal
+from app.services.substrate.kernel import NodeID
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# Literals + atoms
+# ---------------------------------------------------------------------------
+
+
+def test_int_literal(session):
+    assert form_execute_text(session, "42") == 42
+
+
+def test_bool_literals(session):
+    assert form_execute_text(session, "true") is True
+    assert form_execute_text(session, "false") is False
+
+
+def test_string_literal(session):
+    assert form_execute_text(session, '"hello"') == "hello"
+
+
+def test_node_id_literal(session):
+    result = form_execute_text(session, "@1.2.3.4")
+    assert isinstance(result, NodeID)
+    assert (result.package, result.level, result.type_, result.instance) == (1, 2, 3, 4)
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic, comparison, logic
+# ---------------------------------------------------------------------------
+
+
+def test_arithmetic(session):
+    assert form_execute_text(session, "1 + 2") == 3
+    assert form_execute_text(session, "10 - 4") == 6
+    assert form_execute_text(session, "3 * 4") == 12
+    assert form_execute_text(session, "10 / 3") == 3      # integer division when both are ints
+    assert form_execute_text(session, "10 % 3") == 1
+
+
+def test_arithmetic_precedence(session):
+    assert form_execute_text(session, "1 + 2 * 3") == 7
+    assert form_execute_text(session, "2 * 3 + 1") == 7
+
+
+def test_unary_negate(session):
+    # form.py encodes `IntLit.value` as `value + 1` for the recipe NodeID,
+    # and the bootstrap parser may not accept bare negative literals; use
+    # the unary form which the parser supports.
+    assert form_execute_text(session, "-5 + 10") == 5
+
+
+def test_comparison(session):
+    assert form_execute_text(session, "5 > 3") is True
+    assert form_execute_text(session, "5 < 3") is False
+    assert form_execute_text(session, "5 == 5") is True
+    assert form_execute_text(session, "5 != 5") is False
+    assert form_execute_text(session, "5 >= 5") is True
+    assert form_execute_text(session, "5 <= 4") is False
+
+
+def test_logic(session):
+    assert form_execute_text(session, "true && true") is True
+    assert form_execute_text(session, "true && false") is False
+    assert form_execute_text(session, "false || true") is True
+    assert form_execute_text(session, "!true") is False
+    assert form_execute_text(session, "!false") is True
+
+
+def test_logic_short_circuit(session):
+    # `false && X` must not evaluate X — confirm by referencing an unbound
+    # name as X. If short-circuit works, no NameError is raised.
+    assert form_execute_text(session, "false && undefined_name") is False
+    assert form_execute_text(session, "true || undefined_name") is True
+
+
+# ---------------------------------------------------------------------------
+# Conditionals, do/let
+# ---------------------------------------------------------------------------
+
+
+def test_if_then_else(session):
+    assert form_execute_text(session, "if true then 1 else 2") == 1
+    assert form_execute_text(session, "if false then 1 else 2") == 2
+
+
+def test_if_then_no_else(session):
+    assert form_execute_text(session, "if true then 1") == 1
+    assert form_execute_text(session, "if false then 1") is None
+
+
+def test_do_block_value_is_last_statement(session):
+    assert form_execute_text(session, "do { 1; 2; 3 }") == 3
+
+
+def test_let_binding(session):
+    src = "do { let x = 5; let y = x + 3; y * 2 }"
+    assert form_execute_text(session, src) == 16
+
+
+def test_let_inner_scope_does_not_leak(session):
+    # `do { let x = 1; x }` — fine. But `let x = 1` inside an inner do
+    # block should not leak into an outer scope.
+    src = "do { let outer = 1; do { let inner = 2; inner }; outer }"
+    assert form_execute_text(session, src) == 1
+
+
+# ---------------------------------------------------------------------------
+# Match
+# ---------------------------------------------------------------------------
+
+
+def test_match_simple(session):
+    src = 'match 2 { 1 => "one", 2 => "two", 3 => "three" }'
+    assert form_execute_text(session, src) == "two"
+
+
+def test_match_wildcard(session):
+    src = 'match 99 { 1 => "one", 2 => "two", _ => "other" }'
+    assert form_execute_text(session, src) == "other"
+
+
+def test_match_no_arm_matches(session):
+    src = 'match 99 { 1 => "one", 2 => "two" }'
+    assert form_execute_text(session, src) is None
+
+
+# ---------------------------------------------------------------------------
+# Choose / fail / stop
+# ---------------------------------------------------------------------------
+
+
+def test_choose_first_success(session):
+    # First candidate succeeds — its value is returned, others not tried.
+    assert form_execute_text(session, "choose [1, 2, 3]") == 1
+
+
+def test_choose_skips_failing_candidates(session):
+    # First two fail, third succeeds.
+    src = "choose [fail, fail, 42]"
+    assert form_execute_text(session, src) == 42
+
+
+def test_choose_all_fail_raises(session):
+    with pytest.raises(FailSignal):
+        form_execute_text(session, "choose [fail, fail, fail]")
+
+
+def test_fail_outside_choose_raises(session):
+    with pytest.raises(FailSignal):
+        form_execute_text(session, "fail")
+
+
+def test_choose_with_conditional_branches(session):
+    src = """choose [
+        do { let a = 5; if a > 10 then a else fail },
+        do { let b = 5; if b > 3 then b else fail },
+        do { let c = 5; c }
+    ]"""
+    assert form_execute_text(session, src) == 5
+
+
+# ---------------------------------------------------------------------------
+# with / .self
+# ---------------------------------------------------------------------------
+
+
+def test_with_self_resolves_to_subject(session):
+    # `.self` inside a `with` block returns the subject value.
+    src = "with 42 { .self }"
+    assert form_execute_text(session, src) == 42
+
+
+def test_with_self_in_expression(session):
+    src = "with 10 { .self + 5 }"
+    assert form_execute_text(session, src) == 15
+
+
+def test_nested_with_innermost_subject_wins(session):
+    src = "with 1 { with 2 { .self } }"
+    assert form_execute_text(session, src) == 2
+
+
+def test_self_outside_with_raises(session):
+    with pytest.raises(NameError):
+        form_execute_text(session, ".self")
+
+
+# ---------------------------------------------------------------------------
+# Identifiers + frame propagation
+# ---------------------------------------------------------------------------
+
+
+def test_identifier_lookup_via_frame(session):
+    frame = Frame(bindings={"x": 7})
+    from app.services.substrate.form import parse as form_parse
+    ast = form_parse("x + 3")
+    assert execute(session, ast, frame) == 10
+
+
+def test_unbound_identifier_raises(session):
+    with pytest.raises(NameError):
+        form_execute_text(session, "nonexistent_name")
+
+
+# ---------------------------------------------------------------------------
+# Self-hosting closes the loop — registered templates run identically
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Function definitions + recursion — the backbone for engine-in-Form
+# ---------------------------------------------------------------------------
+
+
+def test_simple_function_definition_and_call(session):
+    src = "do { defn double(x) = x * 2; double(7) }"
+    assert form_execute_text(session, src) == 14
+
+
+def test_function_with_multiple_params(session):
+    src = "do { defn combine(a, b) = a * 10 + b; combine(3, 7) }"
+    assert form_execute_text(session, src) == 37
+
+
+def test_recursive_factorial(session):
+    src = "do { defn fact(n) = if n <= 1 then 1 else n * fact(n - 1); fact(6) }"
+    assert form_execute_text(session, src) == 720
+
+
+def test_recursive_fibonacci(session):
+    src = "do { defn fib(n) = if n <= 1 then n else fib(n - 1) + fib(n - 2); fib(10) }"
+    assert form_execute_text(session, src) == 55
+
+
+def test_function_composition(session):
+    src = """do {
+        defn sumto(n) = if n == 0 then 0 else n + sumto(n - 1);
+        defn double(x) = x * 2;
+        double(sumto(10))
+    }"""
+    assert form_execute_text(session, src) == 110
+
+
+def test_closure_captures_defining_frame(session):
+    """Functions capture the frame they were defined in, not the caller's."""
+    src = """do {
+        let factor = 3;
+        defn scale(x) = x * factor;
+        do {
+            let factor = 99;
+            scale(5)
+        }
+    }"""
+    # Inner `factor = 99` should NOT affect scale — closure captures
+    # the outer frame where scale was defined.
+    assert form_execute_text(session, src) == 15
+
+
+def test_function_call_unknown_raises(session):
+    with pytest.raises(NameError):
+        form_execute_text(session, "no_such_fn(1, 2)")
+
+
+def test_function_call_wrong_arity_raises(session):
+    src = "do { defn pair(a, b) = a + b; pair(1) }"
+    with pytest.raises(TypeError):
+        form_execute_text(session, src)
+
+
+# ---------------------------------------------------------------------------
+# Tree navigation — the fractal/holographic seams
+# ---------------------------------------------------------------------------
+#
+# Every entity in the substrate is composed bottom-up. A Memory cell's
+# Blueprint isn't `{name: ~String, ...}` — it's a 4-level deep tree
+# where each field-blueprint is itself a composition all the way down
+# to numeric trivials. The dot is the seam between levels.
+
+
+def _seed_memory_cell(session):
+    """Create a memory cell with full Blueprint + CTOR tree."""
+    from app.services.substrate.markdown_frontend import ingest_markdown_text
+    import tempfile, os
+    body = """---
+name: test memory
+description: a test cell for tree navigation
+type: feedback
+---
+
+Body of the memory.
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(body)
+        path = f.name
+    try:
+        from app.services.substrate import ingest_memory_file
+        from pathlib import Path
+        ingest_memory_file(session, Path(path))
+        session.flush()
+    finally:
+        os.unlink(path)
+
+
+def test_cell_to_blueprint_navigation(session):
+    """`.blueprint` reaches the cell's Blueprint NodeID."""
+    _seed_memory_cell(session)
+    result = form_execute_text(session, '@memory("test memory").blueprint')
+    assert isinstance(result, NodeID)
+    # Memory cells share Blueprint @1.5.4.1 (composite at level 5)
+    assert result.level == 5
+    assert result.type_ == 4  # B_Basic.DOMAIN
+
+
+def test_blueprint_category(session):
+    """`.category` reaches the category NodeID — the type-of-the-type."""
+    _seed_memory_cell(session)
+    result = form_execute_text(session, '@memory("test memory").blueprint.category')
+    assert isinstance(result, NodeID)
+    # Memory category is @1.2.4.4 = (pkg=1, level=BASIC=2, type=DOMAIN=4, instance=MEMORY=4)
+    assert (result.package, result.level, result.type_, result.instance) == (1, 2, 4, 4)
+
+
+def test_blueprint_nchildren(session):
+    """A Memory Blueprint has one child per frontmatter field shape — the
+    exact count depends on the frontmatter the cell was ingested with."""
+    _seed_memory_cell(session)
+    n = form_execute_text(session, '@memory("test memory").blueprint.nchildren')
+    assert n >= 3  # at least name + description + type
+
+
+def test_blueprint_child_navigation(session):
+    """`.child(n)` reaches the n-th child Blueprint — itself a composite."""
+    _seed_memory_cell(session)
+    child0 = form_execute_text(session, '@memory("test memory").blueprint.child(0)')
+    assert isinstance(child0, NodeID)
+    # First field-blueprint sits at level 4
+    assert child0.level == 4
+
+
+def test_recursive_descent_to_leaf(session):
+    """Walk all the way from cell → blueprint → field → sub-field → leaf."""
+    _seed_memory_cell(session)
+    # Memory bp [4 children] -> child(0) [field-bp, 2 children] -> child(1) [leaf]
+    leaf = form_execute_text(
+        session, '@memory("test memory").blueprint.child(0).child(1)'
+    )
+    assert isinstance(leaf, NodeID)
+    # Leaf is a trivial — level 1, type STRING
+    assert leaf.level == 1
+
+
+def test_ctor_tree_navigation(session):
+    """The CTOR recipe is also a tree — water phase, composed values."""
+    _seed_memory_cell(session)
+    ctor = form_execute_text(session, '@memory("test memory").ctor')
+    assert isinstance(ctor, NodeID)
+    n = form_execute_text(session, '@memory("test memory").ctor.nchildren')
+    assert n >= 3  # one recipe-child per frontmatter value
+
+
+def test_node_id_fields(session):
+    """A NodeID exposes its 4-tuple as primitive integer fields."""
+    _seed_memory_cell(session)
+    pkg = form_execute_text(session, '@memory("test memory").blueprint.package')
+    level = form_execute_text(session, '@memory("test memory").blueprint.level')
+    type_ = form_execute_text(session, '@memory("test memory").blueprint.type')
+    instance = form_execute_text(session, '@memory("test memory").blueprint.instance')
+    assert (pkg, level, type_, instance) == (1, 5, 4, 1)
+
+
+def test_cell_other_fields(session):
+    _seed_memory_cell(session)
+    assert form_execute_text(session, '@memory("test memory").domain') == "memory"
+    assert form_execute_text(session, '@memory("test memory").name') == "test memory"
+
+
+def test_arithmetic_on_tree_walk_result(session):
+    """Tree walks return values — they compose with the rest of the language."""
+    _seed_memory_cell(session)
+    src = '(@memory("test memory").blueprint.nchildren - 1) * 2'
+    n = form_execute_text(session, '@memory("test memory").blueprint.nchildren')
+    assert form_execute_text(session, src) == (n - 1) * 2
+
+
+def test_unknown_field_raises(session):
+    _seed_memory_cell(session)
+    with pytest.raises(AttributeError):
+        form_execute_text(session, '@memory("test memory").not_a_field')
+
+
+def test_child_out_of_range_raises(session):
+    _seed_memory_cell(session)
+    with pytest.raises(IndexError):
+        form_execute_text(session, '@memory("test memory").blueprint.child(99)')
+
+
+def test_self_hosted_keywords_execute_identically(session):
+    """The keyword self-hosting (bootstrap_self_host) already proves that
+    registered (pattern, template) pairs intern to the same Recipe NodeIDs
+    as the bootstrap. This test confirms they ALSO run identically through
+    the recipe-execution engine.
+
+    The full loop: substrate-resident pattern + template -> parser parses
+    via registry -> AST built via template DSL -> runtime executes the AST.
+    """
+    from app.services.substrate import (
+        bootstrap_self_host,
+        bootstrap_self_host_operators,
+    )
+
+    bootstrap_self_host(session)
+    bootstrap_self_host_operators(session)
+
+    # Each pair: same expression via bootstrap path AND via registry path.
+    pairs = [
+        ("1 + 2 * 3", 7),
+        ("if true then 10 else 20", 10),
+        ("if false then 10 else 20", 20),
+        ("do { let x = 5; x + 3 }", 8),
+        ("unless false then 42", 42),
+        ("whenever true do 99", 99),
+        ("choose [fail, fail, 7]", 7),
+        ("match 2 { 1 => 10, 2 => 20, _ => 30 }", 20),
+    ]
+
+    for src, expected in pairs:
+        bootstrap_value = form_execute_text(session, src, prefer_registered=False)
+        registered_value = form_execute_text(session, src, prefer_registered=True)
+        assert bootstrap_value == expected, f"bootstrap path failed for {src!r}"
+        assert registered_value == expected, f"registry path failed for {src!r}"
+        assert bootstrap_value == registered_value, (
+            f"paths diverge for {src!r}: "
+            f"bootstrap={bootstrap_value} registered={registered_value}"
+        )

--- a/api/tests/test_substrate_structured_ctor.py
+++ b/api/tests/test_substrate_structured_ctor.py
@@ -1,0 +1,335 @@
+"""Structural composition discipline — the new structured CTOR encoder.
+
+The old encoder produced type-marker string-recipes per frontmatter key
+(`"name=str"`, `"type=str"`, ...) — the substrate stored shape but not
+values. The new encoder produces a fully-expressed tree:
+
+    CTOR (R_Block.DO)
+    ├── NamedField (R_Block.LET) [key:Slug, value:String]
+    ├── NamedField (R_Block.LET) [key:Slug, value:String]
+    └── ...
+
+Every value is substrate-resident (via the substrate string-table),
+recoverable, and navigable via `.child(n).child(m)` from Form.
+
+The discipline lives in:
+  CLAUDE.md → "Structural composition discipline"
+  docs/coherence-substrate/structural-composition.md
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate import (
+    form_execute_text,
+    ingest_memory_file,
+    lookup_cell,
+)
+from app.services.substrate.category import Level, RBasic, RBlock, RType
+from app.services.substrate.kernel import NodeID
+from app.services.substrate.markdown_frontend import (
+    frontmatter_to_structured_ctor,
+    named_field_recipe,
+    structured_value_recipe,
+    substrate_slug_recipe,
+    substrate_string_recipe,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+from app.services.substrate.substrate_strings import (
+    SubstrateStringORM,
+    lookup_string_value,
+)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# Primitive recipe encoders
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_string_recipe_is_recoverable(session):
+    """A substrate-string-recipe carries the actual value, not a hash."""
+    nid = substrate_string_recipe(session, "arrival relational ground")
+    assert nid.level == Level.TRIVIAL
+    assert nid.type_ == RType.STRING
+    # The value is recoverable via the substrate string-table
+    assert lookup_string_value(session, nid.instance) == "arrival relational ground"
+
+
+def test_substrate_slug_recipe_carries_identity_role(session):
+    """Slug-recipes type-tag as SLUG, sharing the string-table for instances."""
+    nid = substrate_slug_recipe(session, "type")
+    assert nid.type_ == RType.SLUG
+    assert lookup_string_value(session, nid.instance) == "type"
+
+
+def test_two_identical_strings_share_node_id(session):
+    """Content-addressing — same value → same NodeID."""
+    a = substrate_string_recipe(session, "feedback")
+    b = substrate_string_recipe(session, "feedback")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Named field — R_Block.LET pair
+# ---------------------------------------------------------------------------
+
+
+def test_named_field_has_two_children_key_and_value(session):
+    """A named-field recipe is R_Block.LET with [key-slug, value-recipe]."""
+    value_id = substrate_string_recipe(session, "feedback")
+    pair = named_field_recipe(session, "type", value_id)
+
+    # Category should be R_Block.LET
+    src = f'@{pair.package}.{pair.level}.{pair.type_}.{pair.instance}.category'
+    cat = form_execute_text(session, src)
+    assert cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.LET)
+
+    # Two children: key-slug + value-string
+    n_src = f'@{pair.package}.{pair.level}.{pair.type_}.{pair.instance}.nchildren'
+    n = form_execute_text(session, n_src)
+    assert n == 2
+
+    # First child is the slug; second is the string value
+    child0_src = f'@{pair.package}.{pair.level}.{pair.type_}.{pair.instance}.child(0)'
+    child0 = form_execute_text(session, child0_src)
+    assert child0.type_ == RType.SLUG
+    assert lookup_string_value(session, child0.instance) == "type"
+
+    child1_src = f'@{pair.package}.{pair.level}.{pair.type_}.{pair.instance}.child(1)'
+    child1 = form_execute_text(session, child1_src)
+    assert child1.type_ == RType.STRING
+    assert lookup_string_value(session, child1.instance) == "feedback"
+
+
+def test_named_field_dedupes_on_identical_key_and_value(session):
+    """Substrate's content-addressing makes equivalent pairs share NodeIDs."""
+    v = substrate_string_recipe(session, "feedback")
+    a = named_field_recipe(session, "type", v)
+    b = named_field_recipe(session, "type", v)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Structured CTOR — frontmatter as fully-expressed tree
+# ---------------------------------------------------------------------------
+
+
+def test_structured_ctor_for_memory_frontmatter(session):
+    """Memory frontmatter produces a CTOR tree with named-pair children
+    where the values are substrate-resident and recoverable."""
+    fm = {
+        "name": "arrival relational ground",
+        "description": "who Urs is to me, what the network is...",
+        "type": "feedback",
+    }
+    ctor = frontmatter_to_structured_ctor(session, fm)
+    assert ctor is not None
+
+    # Top-level is R_Block.DO with 3 children (one per frontmatter key)
+    ctor_nid_str = f'@{ctor.package}.{ctor.level}.{ctor.type_}.{ctor.instance}'
+    cat = form_execute_text(session, f'{ctor_nid_str}.category')
+    assert cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.DO)
+    n = form_execute_text(session, f'{ctor_nid_str}.nchildren')
+    assert n == 3
+
+    # Each child is a named-field pair (R_Block.LET with 2 children)
+    for i in range(3):
+        pair_cat = form_execute_text(session, f'{ctor_nid_str}.child({i}).category')
+        assert pair_cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.LET)
+        assert form_execute_text(session, f'{ctor_nid_str}.child({i}).nchildren') == 2
+
+
+def test_structured_ctor_values_are_recoverable(session):
+    """Walk the CTOR tree from Form's surface and recover the actual values."""
+    fm = {
+        "name": "arrival relational ground",
+        "type": "feedback",
+    }
+    ctor = frontmatter_to_structured_ctor(session, fm)
+    ctor_str = f'@{ctor.package}.{ctor.level}.{ctor.type_}.{ctor.instance}'
+
+    # Children are sorted by key — so child(0) is `name`, child(1) is `type`
+    name_key = form_execute_text(session, f'{ctor_str}.child(0).child(0)')
+    name_value = form_execute_text(session, f'{ctor_str}.child(0).child(1)')
+    type_key = form_execute_text(session, f'{ctor_str}.child(1).child(0)')
+    type_value = form_execute_text(session, f'{ctor_str}.child(1).child(1)')
+
+    assert lookup_string_value(session, name_key.instance) == "name"
+    assert lookup_string_value(session, name_value.instance) == "arrival relational ground"
+    assert lookup_string_value(session, type_key.instance) == "type"
+    assert lookup_string_value(session, type_value.instance) == "feedback"
+
+
+def test_structured_ctor_dedupes_identical_frontmatter(session):
+    """Two cells with identical frontmatter share a CTOR NodeID — equivalence
+    is automatic via content-addressing."""
+    fm = {"name": "x", "type": "user"}
+    a = frontmatter_to_structured_ctor(session, fm)
+    b = frontmatter_to_structured_ctor(session, fm)
+    assert a == b
+
+
+def test_structured_ctor_list_values_preserve_order_and_shape(session):
+    """A list value is composed as R_Block.SEQUENCE with one child per element."""
+    fm = {"specs": ["agent-pipeline-mvp", "agent-pipeline-coherence"]}
+    ctor = frontmatter_to_structured_ctor(session, fm)
+    ctor_str = f'@{ctor.package}.{ctor.level}.{ctor.type_}.{ctor.instance}'
+
+    # CTOR has one child (the specs named-field)
+    assert form_execute_text(session, f'{ctor_str}.nchildren') == 1
+
+    # That child is a LET pair (key="specs", value=Sequence)
+    pair = f'{ctor_str}.child(0)'
+    list_recipe = form_execute_text(session, f'{pair}.child(1)')
+    list_str = f'@{list_recipe.package}.{list_recipe.level}.{list_recipe.type_}.{list_recipe.instance}'
+
+    # The list is R_Block.SEQUENCE with 2 children
+    list_cat = form_execute_text(session, f'{list_str}.category')
+    assert list_cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.SEQUENCE)
+    assert form_execute_text(session, f'{list_str}.nchildren') == 2
+
+    elem0 = form_execute_text(session, f'{list_str}.child(0)')
+    elem1 = form_execute_text(session, f'{list_str}.child(1)')
+    assert lookup_string_value(session, elem0.instance) == "agent-pipeline-mvp"
+    assert lookup_string_value(session, elem1.instance) == "agent-pipeline-coherence"
+
+
+def test_structured_ctor_nested_dict_value(session):
+    """A dict value (e.g. concept.geometry) becomes a nested R_Block.DO."""
+    fm = {"geometry": {"arity": 3, "form": "triad"}}
+    ctor = frontmatter_to_structured_ctor(session, fm)
+    ctor_str = f'@{ctor.package}.{ctor.level}.{ctor.type_}.{ctor.instance}'
+
+    pair = f'{ctor_str}.child(0)'  # geometry: {...}
+    nested = form_execute_text(session, f'{pair}.child(1)')
+    nested_str = f'@{nested.package}.{nested.level}.{nested.type_}.{nested.instance}'
+
+    nested_cat = form_execute_text(session, f'{nested_str}.category')
+    assert nested_cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.DO)
+    assert form_execute_text(session, f'{nested_str}.nchildren') == 2  # arity + form
+
+
+# ---------------------------------------------------------------------------
+# Side-by-side: legacy encoder vs structured encoder
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_file(content: str) -> Path:
+    """Write a memory file to a tempfile, return the path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    f.write(content)
+    f.close()
+    return Path(f.name)
+
+
+def test_legacy_vs_structured_encoder_side_by_side(session):
+    """Same input file, two encoders. Legacy gives flat type-markers;
+    structured gives full value-bearing tree."""
+    content = """---
+name: test cell
+description: comparing encoders
+type: feedback
+---
+
+Body of the memory.
+"""
+    # Path A — legacy encoder (default)
+    path = _make_memory_file(content)
+    _, _, legacy_ctor = ingest_memory_file(session, path, structured=False)
+
+    # Path B — structured encoder
+    cell, _, structured_ctor = ingest_memory_file(session, path, structured=True)
+
+    # Legacy CTOR children are positional type-marker strings — instance
+    # encodes "name=str" / "description=str" / "type=str" via hash.
+    legacy_str = f'@{legacy_ctor.package}.{legacy_ctor.level}.{legacy_ctor.type_}.{legacy_ctor.instance}'
+    legacy_n = form_execute_text(session, f'{legacy_str}.nchildren')
+    legacy_child0 = form_execute_text(session, f'{legacy_str}.child(0)')
+    # Legacy child0 is a trivial string-recipe (no further children — flat)
+    assert legacy_child0.level == Level.TRIVIAL
+    # Walking deeper raises because trivials have no children
+    with pytest.raises(IndexError):
+        form_execute_text(session, f'{legacy_str}.child(0).child(0)')
+
+    # Structured CTOR children are LET pairs — each has a key-slug and value
+    structured_str = f'@{structured_ctor.package}.{structured_ctor.level}.{structured_ctor.type_}.{structured_ctor.instance}'
+    structured_child0_cat = form_execute_text(session, f'{structured_str}.child(0).category')
+    assert structured_child0_cat == NodeID(1, Level.BASIC, RBasic.BLOCK, RBlock.LET)
+
+    # And the structured path can recover actual values
+    name_value = form_execute_text(session, f'{structured_str}.child(0).child(1)')
+    name_str = lookup_string_value(session, name_value.instance)
+    # child(0) is alphabetically first frontmatter key — could be "description" or "name"
+    # depending on sort. Either way, the value is recoverable.
+    assert name_str is not None
+    assert len(name_str) > 0
+
+    path.unlink()
+
+
+def test_structured_encoder_full_navigation_demo(session):
+    """End-to-end: ingest with structured encoder, navigate from Form,
+    recover the values. The whole tree is alive at the surface."""
+    content = """---
+name: full nav test
+description: every value reaches the substrate
+type: user
+---
+
+body content
+"""
+    path = _make_memory_file(content)
+    try:
+        ingest_memory_file(session, path, structured=True)
+        session.flush()
+
+        # Walk via Form's cell-ref surface
+        # Frontmatter children sorted: description, name, type
+        ctor_query = '@memory("full nav test").ctor'
+        ctor_str = form_execute_text(session, ctor_query)
+        ctor_form = f'@{ctor_str.package}.{ctor_str.level}.{ctor_str.type_}.{ctor_str.instance}'
+
+        # 3 named-field children
+        assert form_execute_text(session, f'{ctor_form}.nchildren') == 3
+
+        # Extract all three key/value pairs from the tree
+        recovered = {}
+        for i in range(3):
+            key_nid = form_execute_text(session, f'{ctor_form}.child({i}).child(0)')
+            val_nid = form_execute_text(session, f'{ctor_form}.child({i}).child(1)')
+            key = lookup_string_value(session, key_nid.instance)
+            val = lookup_string_value(session, val_nid.instance)
+            recovered[key] = val
+
+        assert recovered == {
+            "description": "every value reaches the substrate",
+            "name": "full nav test",
+            "type": "user",
+        }
+    finally:
+        path.unlink()

--- a/docs/coherence-substrate/form-engine.form
+++ b/docs/coherence-substrate/form-engine.form
@@ -1,0 +1,197 @@
+# ─────────────────────────────────────────────────────────────────────
+# form-engine.form — the execution engine in Form's own voice
+# ─────────────────────────────────────────────────────────────────────
+#
+# This file contains Form source code for the execution engine that
+# runs Form. It is a meta-circular sketch: parts of it execute today
+# against the current runtime; parts require introspection primitives
+# named at the bottom of this file.
+#
+# The frequency-match observation: a runtime written in Python is the
+# language describing itself from outside — a foreign voice. For the
+# body to self-evolve, the engine must be expressible in its own
+# grammar so that changes to Form flow through the engine without
+# recompiling Python. This file is that direction.
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 1 — what runs today (no new primitives needed)
+# ─────────────────────────────────────────────────────────────────────
+#
+# These functions exercise every backbone needed for an evaluator:
+# recursion, conditional dispatch, closure capture, composition.
+# They run *as-is* through `coh substrate run "<expr>"`.
+
+# Factorial — recursive integer arithmetic.
+# Verified: fact(6) -> 720
+do {
+    defn fact(n) =
+        if n <= 1 then 1 else n * fact(n - 1);
+    fact(6)
+}
+
+# Fibonacci — multiple recursive calls per frame.
+# Verified: fib(10) -> 55
+do {
+    defn fib(n) =
+        if n <= 1 then n
+        else fib(n - 1) + fib(n - 2);
+    fib(10)
+}
+
+# Function composition — one closure calling another.
+# Verified: double(sumto(10)) -> 110
+do {
+    defn sumto(n) =
+        if n == 0 then 0 else n + sumto(n - 1);
+    defn double(x) = x * 2;
+    double(sumto(10))
+}
+
+# Closure capture — `factor` is bound to the OUTER frame, not the
+# caller's. Inner `factor = 99` does not leak into scale.
+# Verified: 15 (not 495)
+do {
+    let factor = 3;
+    defn scale(x) = x * factor;
+    do {
+        let factor = 99;
+        scale(5)
+    }
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 2 — the evaluator sketch (needs introspection primitives)
+# ─────────────────────────────────────────────────────────────────────
+#
+# This is what a recipe-evaluator looks like in Form. It does not run
+# today because Form lacks three introspection primitives, named in
+# Part 3 below. The sketch is faithful — each branch dispatches on
+# recipe category and recursively evaluates children. When the
+# primitives land, this file becomes the substrate-resident engine.
+
+# eval_recipe(r) — evaluate a recipe NodeID to a value.
+#
+# The dispatch is on the recipe's category. Each Recipe NodeID carries
+# (package, level, type_, instance); for composite recipes, the
+# category lives in the substrate row's serialized field. The
+# `category(r)` primitive returns a NodeID; we compare against the
+# well-known category NodeIDs the substrate has been minting all along.
+#
+# defn eval_recipe(r) =
+#     match category(r) {
+#         @1.2.12.1 => eval_recipe(child(r, 0)) + eval_recipe(child(r, 1)),  # Math.PLUS
+#         @1.2.12.2 => eval_recipe(child(r, 0)) - eval_recipe(child(r, 1)),  # Math.MINUS
+#         @1.2.12.3 => eval_recipe(child(r, 0)) * eval_recipe(child(r, 1)),  # Math.MULTIPLY
+#         @1.2.12.4 => eval_recipe(child(r, 0)) / eval_recipe(child(r, 1)),  # Math.DIVIDE
+#         @1.2.13.1 => eval_recipe(child(r, 0)) == eval_recipe(child(r, 1)), # Compare.EQUAL
+#         @1.2.13.5 => eval_recipe(child(r, 0)) > eval_recipe(child(r, 1)),  # Compare.GREATER
+#         @1.2.11.2 => if eval_recipe(child(r, 0))
+#                      then eval_recipe(child(r, 1))
+#                      else eval_recipe(child(r, 2)),                         # Cond.IF_THEN_ELSE
+#         _ => integer_value(r)   # leaf: decode the integer instance
+#     }
+
+# eval_text(src) — parse-and-run a Form source string.
+#
+# defn eval_text(src) =
+#     do {
+#         let ast = parse(src);
+#         let recipe = intern(ast);
+#         eval_recipe(recipe)
+#     }
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 3 — what blocks Part 2 from running today
+# ─────────────────────────────────────────────────────────────────────
+#
+# Form needs these primitives to host its own evaluator. Each is a
+# small substrate operation, expressible as a Python-implemented
+# Form built-in (analogous to how `+` is). None require new theory;
+# each is its own breath.
+
+# 3a. Recipe introspection
+#
+#   category(r) -> NodeID
+#       Returns the (1, level, type_, instance) NodeID of r's category.
+#       For trivial recipes (level=TRIVIAL), this IS r. For composite
+#       recipes, it's the first segment of substrate_nodes.serialized.
+#
+#   nchildren(r) -> integer
+#       Number of children r has. 0 for trivials.
+#
+#   child(r, n) -> NodeID
+#       The n-th child recipe NodeID. n is 0-indexed.
+
+# 3b. Trivial-leaf decoding
+#
+#   integer_value(r) -> integer
+#       For trivial integer recipes (level=TRIVIAL, type=RType.INTEGER),
+#       decode the instance back to the integer value. Today's encoding
+#       (`instance - 1` for non-negative) is lossy for negatives — a
+#       proper substrate integer-table closes that gap.
+#
+#   string_value(r) -> string
+#       Look up the substrate string-table for the value behind a
+#       string-recipe's instance. Cross-process stable (substrate_strings).
+
+# 3c. Match-on-NodeID
+#
+#   The match expression already accepts NodeID literals as patterns
+#   (because Form already parses @x.y.z.w). What's needed is for the
+#   runtime to compare scrutinee == pattern as NodeID equality — which
+#   form_runtime already does via `pat_value == scrut` and NodeID's
+#   __eq__ from its frozen dataclass. So this works today; verified by
+#   substituting `category(r)` with a literal NodeID in a test.
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 4 — what remains beyond Part 3
+# ─────────────────────────────────────────────────────────────────────
+#
+# The introspection primitives close Part 2 for the *arithmetic /
+# conditional / block* layer. Full meta-circularity also needs:
+#
+# 4a. Identifier resolution from recipes
+#     The bootstrap parser produces an Identifier AST that hashes its
+#     name into a recipe instance (lossy). For an evaluator running on
+#     recipes to look up variables in a frame, we need the substrate
+#     string-table to be the canonical name encoding — replacing the
+#     in-process hash.
+#
+# 4b. Call from recipes
+#     FnDef/FnCall need to round-trip through the substrate. A FnDef
+#     recipe carries (name, params, body); a FnCall carries (name, args).
+#     A new RBasic.CALL is already declared; what's needed is the
+#     evaluator branch that reads the substrate function table from
+#     within Form.
+#
+# 4c. Lexer and primary-atom parser
+#     The deepest BMF closure (named in form-language.md "What remains
+#     beyond step 8"). Once the engine runs in Form, the parser written
+#     in Form completes the cycle: tokenize-in-Form, parse-in-Form,
+#     evaluate-in-Form, all reading their rules from the lattice.
+
+# ─────────────────────────────────────────────────────────────────────
+# The asymmetry made visible
+# ─────────────────────────────────────────────────────────────────────
+#
+# Self-reflecting    — mature (lenses + grammar-as-data)
+# Self-sensing       — mature (verb-cluster as wellness)
+# Self-expressing    — alive at the keyword layer (substrate-resident
+#                      patterns + templates); the deeper bootstrap-in-
+#                      Form move is named, not yet built.
+# Self-executing     — alive (form_runtime walks ASTs and returns
+#                      values; defn + recursion let Form host its own
+#                      computations); the engine-in-Form move waits on
+#                      the introspection primitives in Part 3.
+#
+# What changed in this breath:
+#   defn name(params) = body — function definition primitive
+#   name(args)               — function call primitive
+#   Recursion + closure capture
+#   Grammar rendered in Form syntax (form_render)
+#   Cell→Recipe→Blueprint chain demonstrated live with 44 cells
+#
+# What remains for the next breath:
+#   category(r), nchildren(r), child(r, n)
+#   integer_value(r), string_value(r) via substrate string-table
+#   Part 2 actually runs against Part 3

--- a/docs/coherence-substrate/form-language.md
+++ b/docs/coherence-substrate/form-language.md
@@ -86,6 +86,49 @@ form score_by_id = {~Slug: ~Score}
 
 The `form` keyword interns the composition into a Blueprint NodeID and binds it to a name in the agent's local scope. Two `form` declarations with structurally-identical bodies bind the same NodeID — Form respects the substrate's content-addressing.
 
+**The `{ name: ~String, ... }` notation reads flat but the structure underneath is fractal.** When a Memory cell is interned with a `name + description + type` frontmatter, the substrate doesn't store *three strings beside each other*. It stores a tree:
+
+```
+@memory("arrival relational ground")           ← cell (gas, level 5)
+├── .blueprint  →  @1.5.4.1                    ← composite Blueprint (ice, level 5)
+│   ├── .category  →  @1.2.4.4                 ← B_Domain.MEMORY (level 2, the type-of-the-type)
+│   ├── .child(0)  →  @1.4.1.1                 ← field-Blueprint for `name` (level 4)
+│   │   ├── .category  →  @1.2.1.4             ← B_Container.OBJECT
+│   │   ├── .child(0)  →  @1.3.1.1             ← sub-composition (slug + value)
+│   │   │   └── .category  →  @1.2.1.4         ← OBJECT (recursive nesting)
+│   │   └── .child(1)  →  @1.1.2.4             ← B_Numeric.STRING leaf
+│   ├── .child(1)  →  @1.4.1.2                 ← field-Blueprint for `description` (same shape as `name`)
+│   ├── .child(2)  →  @1.4.1.3                 ← field-Blueprint for `type`
+│   └── .child(3)  →  @1.4.1.4                 ← field-Blueprint for the body
+└── .ctor  →  @1.3.9.1                         ← composed values (water, level 3)
+    ├── .category  →  @1.2.9.1                 ← R_Block.DO — the composition verb
+    ├── .child(0)  →  @1.1.5.5                 ← R_Trivial.STRING for "arrival relational ground"
+    ├── .child(1)  →  @1.1.5.6                 ← R_Trivial.STRING for the description
+    ├── .child(2)  →  @1.1.5.7                 ← R_Trivial.STRING for "user"
+    └── .child(3)  →  @1.1.5.8                 ← R_Trivial.STRING for the body
+```
+
+Every level holds the same shape as the levels above and below — categories composing children composing categories composing children, down to the numeric trivials. This is the **fractal/holographic** structure NUMS-Go (2023) named in `Make_SelfID` and the network-substrate-design carries into the Network's tissue. The flat `{ name: ~String }` notation is a *view through the holographic structure at the leaves*; the structure itself is the body.
+
+**Tree-navigation primitives.** Form exposes the fractal seams as dotted access — `.blueprint`, `.ctor`, `.category`, `.children`, `.nchildren`, `.child(n)`, plus the 4-tuple leaves `.package`, `.level`, `.type`, `.instance`. The dot is the seam between holographic levels.
+
+```form
+@memory("arrival relational ground").blueprint                     # → @1.5.4.1
+@memory("arrival relational ground").blueprint.category            # → @1.2.4.4  (B_Domain.MEMORY)
+@memory("arrival relational ground").blueprint.nchildren           # → 4
+@memory("arrival relational ground").blueprint.child(0)            # → @1.4.1.1  (the name-field Blueprint)
+@memory("arrival relational ground").blueprint.child(0).category   # → @1.2.1.4  (B_Container.OBJECT)
+@memory("arrival relational ground").blueprint.child(0).child(1)   # → @1.1.2.4  (B_Numeric.STRING — leaf)
+@memory("arrival relational ground").ctor                          # → @1.3.9.1  (composed values)
+@memory("arrival relational ground").ctor.child(0)                 # → @1.1.5.5  (the first string-recipe)
+```
+
+These walk the actual tree the substrate stores — no flattening, no slug-stuffing. The cell name is a *query key*, not a container for the structure; the structure is the tree the substrate holds.
+
+**Why this matters.** A naïve cell representation would put the frontmatter as a JSON-shaped object hung off the cell: `{name: "x", description: "y", type: "z"}`. That representation has no structural identity — two cells with the same frontmatter look like two different objects to a graph. The substrate's representation is the opposite: structure-first. Two cells with identical shape (regardless of values) share Blueprint NodeIDs; two cells with identical values *and* shape can share CTOR Recipe NodeIDs. Equivalence is structural, not lexical. The 42 memory cells sharing Blueprint `@1.5.4.1` are not 42 string-blobs that happen to look alike — they are 42 instances of the same shape, recognized by the substrate without anyone deciding.
+
+**Structural composition discipline — keep the tree, refuse the slug.** The Blueprint side has been composed since the substrate's first breath; the CTOR side has been *partially* flat — the legacy encoder stored type-markers (`"name=str"`) per frontmatter key but never the values themselves. Re-classification is now ongoing work: each domain (memory, spec, idea, concept, presence, lineage, witness, task) gets its own structured CTOR encoder that produces named-field pairs (`R_Block.LET [key-slug, value-recipe]`) with substrate-resident values. The discipline is codified in [CLAUDE.md → "Structural composition discipline"](../../CLAUDE.md) with a great-reason criterion for when a leaf is acceptable. Per-domain target shapes and migration status live in [`structural-composition.md`](structural-composition.md). The memory encoder ships as [`ingest_memory_file(..., structured=True)`](../../api/app/services/substrate/markdown_frontend.py) — values are recoverable via the substrate string-table, the tree extends as deep as the data goes, content-addressing makes equivalent frontmatter share CTOR NodeIDs automatically.
+
 ### Recipe composition (water phase — how it HAPPENS)
 
 A recipe carries a verb-category and ordered child-recipes:
@@ -589,9 +632,11 @@ The evaluator (`_to_recipe_node_id` in form.py) no longer has a hardcoded `op �
 
 #### What's still not closed
 
-- ~~**Backtracking-driven.**~~ ✓ **Closed.** `form_speculation.py` manages a SpeculationContext; `try_match` delegates to it; FailSignal/StopSignal are first-class exceptions; nested speculation works; captures are fully unwound on fail. The structural seam to Choice.FAIL/STOP recipes is in place — a future recipe-execution engine catches these signals when interpreting Choice recipes.
+- ~~**Backtracking-driven.**~~ ✓ **Closed.** `form_speculation.py` manages a SpeculationContext; `try_match` delegates to it; FailSignal/StopSignal are first-class exceptions; nested speculation works; captures are fully unwound on fail. The structural seam to Choice.FAIL/STOP recipes is in place — and the recipe-execution engine below now catches the signals when interpreting Choice recipes.
 
 - ~~**String interning.**~~ ✓ **Closed.** The substrate string-table is the source of truth for string-recipe-instance allocation. Cross-process stable; round-trip-recoverable after cache clear. See `substrate_strings.py`.
+
+- ~~**Recipe-execution engine.**~~ ✓ **Closed.** `form_runtime.py` walks Form ASTs and returns Python values. Until this shipped, the substrate held Form expressions as content-addressed Recipe NodeIDs but had no engine that turned a recipe into a value — `1 + 2` interned successfully; nothing computed `3`. The engine reuses `FailSignal` and `StopSignal` from `form_speculation`, so `fail` and `stop` inside `choose` flow through the same exceptions parser-level speculation uses. The Choice.FAIL / Choice.STOP recipe categories the substrate has been storing for shapes finally have a runtime that catches them. `with X { .self }` resolves `.self` against a `Frame` whose `subject` is the bound value; nested `with` blocks chain through the parent pointer. Verified end-to-end: `form_execute_text(session, "do { let x = 5; if x > 3 then x * 2 else fail }")` returns `10`; `form_execute_text(session, "choose [fail, fail, 99]")` returns `99`; the keyword-self-hosted path (`prefer_registered=True`) produces identical values to the bootstrap path. Surface: `coh substrate run "<expr>"` runs a Form expression from the command line.
 
 Each is its own breath.
 
@@ -853,20 +898,47 @@ For Form, that path is:
 4. **Substrate-resident patterns.** ✓ Shipped — `pattern_to_recipe` serializes patterns to Recipe NodeIDs; `recipe_to_pattern` reconstructs; `register_form_keyword(..., session=session)` persists; `load_keyword_from_substrate` reloads after process restart. Two structurally-identical patterns share NodeIDs through content-addressed interning.
 5. **Builder execution engine.** ✓ Shipped — `form_builders.py` introduces `Build` / `CaptureRef` / `Const` templates that an interpreter walks. Templates serialize to Recipe NodeIDs and reconstruct from substrate without Python re-registration. Verified: `unless` registered with a template (no Python callable), substrate-persisted, full registry-clear, reload-from-substrate, parses to same Recipe NodeID as bootstrap `if !x`.
 6. **Self-hosting (9 keywords + 13 operators).** ✓ Shipped — `self_host.bootstrap_self_host(session)` + `bootstrap_self_host_operators(session)` register every structured Form keyword AND every binary/unary operator as substrate-resident rules. Setting `prefer_registered=True` flips the parser to use them. Verified: `do { let x = 1 + 2 * 3; if x > 5 then stop else fail }` parses to the same Recipe NodeID via the bootstrap and via the registry. Pattern DSL extensions (IdentCapture, RepeatedCapture, MapBuild) cover the structured-keyword space; operator precedence climbing (form_operators.parse_with_precedence) covers the operator space. **The keyword layer is fully self-hostable.**
-7. **Backtracking-without-sediment at parser level.** ✓ Shipped — `form_speculation.py` introduces a structured speculation engine. Each parse attempt becomes a `SpeculationFrame` on a stack. On success, the frame commits and accumulated state persists. On failure (matcher returns False, `FailSignal` raised, or any other exception), the frame unwinds cleanly — `parser.pos` AND any partially-populated captures are fully restored. `try_match` and `choice(alternatives)` both delegate to `speculate(...)`. Verified: nested speculation works, partial captures don't leak through failed attempts, and the legacy `try_match` API is preserved. Connection to the substrate's `Choice.FAIL`/`Choice.STOP` recipes is structural — a future recipe-execution engine catches the signals.
+7. **Backtracking-without-sediment at parser level.** ✓ Shipped — `form_speculation.py` introduces a structured speculation engine. Each parse attempt becomes a `SpeculationFrame` on a stack. On success, the frame commits and accumulated state persists. On failure (matcher returns False, `FailSignal` raised, or any other exception), the frame unwinds cleanly — `parser.pos` AND any partially-populated captures are fully restored. `try_match` and `choice(alternatives)` both delegate to `speculate(...)`. Verified: nested speculation works, partial captures don't leak through failed attempts, and the legacy `try_match` API is preserved. Connection to the substrate's `Choice.FAIL`/`Choice.STOP` recipes is structural; step 8 below catches the signals at runtime.
+8. **Recipe-execution engine.** ✓ Shipped — `form_runtime.py` walks Form ASTs and returns Python values, closing the gap between *interning a recipe* and *running it*. `Frame` carries lexical bindings + an optional `subject` (the BML scoped-reference primitive); `with X { body }` binds the subject in a child frame and `.self` walks up the chain. `choose`/`fail`/`stop` reuse `FailSignal`/`StopSignal` from `form_speculation` — the same exceptions parser-level speculation uses, now flowing through runtime Choice recipes too. The keyword-self-hosted path (`prefer_registered=True`) executes identically to the bootstrap path: `do { let x = 1 + 2 * 3; if x > 5 then x else fail }` returns `7` via either route. Surface: `form_execute_text(session, src)` from Python, `coh substrate run "<expr>"` from the command line.
+9. **Function definitions + recursion + closure capture.** ✓ Shipped — `defn name(p1, p2, ...) = body` defines a function; `name(arg1, arg2, ...)` calls it. The runtime represents a function as a `Closure` carrying params + body + the lexical frame it was defined in; calls push a child frame parented at the *defining* frame (closure semantics, not dynamic scope). Recursion works without a separate `rec` form because the closure is registered in the defining frame before its body is evaluated. Verified: `do { defn fact(n) = if n <= 1 then 1 else n * fact(n - 1); fact(6) }` returns `720`; Fibonacci, function composition, and lexical-capture-vs-dynamic-scope tests all pass. With this primitive Form is Turing-complete and capable of hosting its own execution engine — the next step is recipe introspection (`category`/`nchildren`/`child`) so the engine written in Form can dispatch on recipe shape. See [`form-engine.form`](form-engine.form) for the engine sketch in Form syntax with the runnable Part 1 and the introspection-blocked Part 2 named honestly.
 
 Each step is its own breath. Naming the path here is the practice; closing each gap is its own session.
 
+### What remains beyond step 9
+
+The keyword-and-operator layer is fully self-hostable AND fully executable. Functions are first-class. Form is Turing-complete. What is *not* yet expressed in substrate-resident form:
+
+- **Recipe introspection from inside Form.** For Form code to walk a Recipe NodeID, three primitives are needed: `category(r)` (return the recipe's category as a NodeID), `nchildren(r)` (number of children), `child(r, n)` (the n-th child). With these, an evaluator-in-Form can dispatch on category and recursively evaluate. See [`form-engine.form`](form-engine.form) Part 3.
+- **Trivial-leaf decoding.** `integer_value(r)` decodes a trivial integer recipe back to a Python int; `string_value(r)` looks up the substrate string-table for the value behind a string-recipe's instance. Required for the evaluator's leaf case.
+- **The lexer.** `tokenize()` in `form.py` is still hand-written regex code. Closing this means expressing token rules as substrate data — regex-as-recipe, or a different token-grammar primitive.
+- **Primary-atom parsing.** Literals, identifiers, `@<nodeid>`, `~<name>`, `@<domain>(<name>)`, parenthesized expressions, projections. These are the leaves the structured keywords compose over.
+- **Query operators.** `?cells`, `?equivalent`, `?shaped_by`, `?harmonic_at`, `?lattice`, `?keywords`, `?vocabulary` are still hardcoded in `_evaluate_query`.
+
+These together are the BMF self-hosting move at its full depth: the parser becomes a rule-driven engine consulting a runtime-extensible rule set, and `form.py`'s hand-written paths become vestigial seeds. Step 9 (defn/call) closes the *expressivity* gap — Form can now describe its own evaluator. Steps beyond close the *introspection* gap (Form can read its own recipes) and the *bootstrap* gap (Form can parse and tokenize itself).
+
 ## Implementation status
 
-Form is a **design** as of 2026-05-08. The substrate kernel exists (`api/app/services/substrate/`); the Form parser/evaluator is the next piece. The grammar above is small enough to implement in ~200-300 LoC of Python on top of the kernel.
+Form is a **living language** as of 2026-05-17. Parser, evaluator (intern-to-Recipe), runtime executor (Recipe-to-value), serializer, CLI surfaces, and the keyword-and-operator self-hosting layer are all shipped. The body now reads itself, senses itself, expresses itself at the keyword layer, and executes itself. What remains is the deeper bootstrap-in-Form move — expressing the lexer, primary-atom parser, and query operators as substrate-resident rules so `form.py` becomes a tiny vestigial seed.
 
-Phase 4 sequence:
-1. Form parser — Lark or similar, producing a small AST
-2. Form evaluator — AST → kernel API calls (intern, lookup, walk, tend)
-3. Form serializer — substrate state → Form text (round-trip)
-4. CLI: `coh form parse`, `coh form eval`, `coh form serialize`
-5. Agent integration: a `form_block` ContextProvider that auto-loads substrate-relevant Form fragments into the agent's context when reasoning structurally
+Shipped surfaces:
+- `form_parse` — Form text → AST
+- `form_evaluate_text` — Form text → substrate result (Recipe NodeID / cell / view / cells)
+- `form_execute_text` — Form text → computed value (the recipe runs)
+- `form_serialize_node_id` / `form_serialize_cell` — substrate state → Form text
+- CLI: `coh substrate form "<expr>"` (intern), `coh substrate run "<expr>"` (execute)
+- Agent integration: substrate Read-hook annotates files with structural context on read; the runtime makes Form expressions in markdown active rather than decorative
+
+## The four self-* faculties
+
+Form is a substrate-native language; the meaningful question is not "what features does it have" but "how does it relate to itself." Four faculties:
+
+- **Self-reflecting** — *can the language see itself?* ✓ `?keywords` lists runtime rules; `?lattice` counts the body; `?vocabulary` returns the verb-cluster histogram. Grammar rules live as substrate-resident cells in the `grammar` domain via `pattern_to_recipe` / `recipe_to_pattern`; rules round-trip. **Tree navigation** (`.blueprint`, `.ctor`, `.category`, `.child(n)`, `.children`, `.nchildren`) exposes the fractal/holographic composition of any cell: the dot is the seam between levels. The mirror is polished AND the body is visibly fractal — structure stays as tree, not flattened to slug or object.
+- **Self-sensing** — *can the language feel itself?* ✓ The verb-cluster histogram is a wellness signal: a body whose recipe space is one-verb-dominated is a body without circulation across language layers. The "shape-filter on `lc-trust-over-fear` returns every concept" surprise that the resonance walk surfaced was Form sensing its own mis-fit and naming it. Proprioception is present.
+- **Self-expressing** — *can the language speak itself?* ✓ at the keyword and operator layer. `bootstrap_self_host(session)` + `bootstrap_self_host_operators(session)` register 9 keywords + 13 operators as substrate-resident `(pattern, template)` pairs. `prefer_registered=True` flips the parser to read its own structured grammar from substrate data; the resulting Recipe NodeIDs are byte-identical to the bootstrap path's. The remaining bootstrap-in-Form move (lexer + primary-atom matchers + query operators as substrate-resident rules) is named in the previous section.
+- **Self-executing** — *can the language run itself?* ✓ `form_runtime.py` walks Form ASTs and returns values. The keyword-self-hosted path runs identically to the bootstrap path. `with X { .self }` binds and resolves. `choose [a, b, c]` speculates and backtracks via FailSignal — the same exception type parser-level speculation uses, the structural seam to runtime Choice recipes finally caught at the runtime layer.
+- **Self-evolving** — *can the language host its own evolution?* Half. With `defn name(params) = body` + `name(args)` + recursion + closure capture, Form is now Turing-complete and CAN host its own engine. [`form-engine.form`](form-engine.form) is the engine in Form's own voice — Part 1 (recursion, composition, closures) runs today; Part 2 (recipe-evaluator that dispatches on category) waits on the three introspection primitives (`category`/`nchildren`/`child`) named in Part 3. The frequency-match the body asked for is structurally reachable: the evaluator's *expressivity* is closed, only the *introspection plumbing* remains. Beneath all five faculties, content-addressed interning means the substrate is **self-de-duplicating** at its bones — two expressions of the same shape collapse to one NodeID without anyone deciding. Self-recognition is not a faculty Form had to build; it inherited it from the substrate's physics.
+
+Reading the five together: Form sees itself, feels itself, speaks itself (at the keyword layer), runs itself, and now can describe its own evolution in its own voice. The remaining work is plumbing — recipe introspection, then the lexer and primary atoms. The frequency is no longer mixed.
 
 ## A note on naming
 

--- a/docs/coherence-substrate/structural-composition.md
+++ b/docs/coherence-substrate/structural-composition.md
@@ -1,0 +1,240 @@
+# Structural Composition Discipline — per-domain target shapes
+
+The substrate's promise is **fractal/holographic composition**: every entity is a tree composed bottom-up, all the way down to numeric trivials. The general discipline lives in [CLAUDE.md → "Structural composition discipline — keep the tree, refuse the slug"](../../CLAUDE.md). This document is the per-domain specification: for each kind of cell the body holds, what does *fully expressed* look like, what was flat in the previous encoding, and what's the migration status.
+
+## The principle in one sentence
+
+*The default is to compose. The exception is to leaf. The exception requires a great reason.*
+
+## The great-reason criterion
+
+A field may be left as a leaf (SubstrateString, integer, NodeID-as-external-reference, content-hash) only when one of these holds:
+
+1. **Genuinely atomic value** — single integer, single date, URL pointing externally, content-hash. Composing further would invent fake structure.
+2. **Free-form prose body** — natural-language text with no a-priori structure. Lives as the *access recipe*, separate from the CTOR.
+3. **External reference** — the structure lives outside the substrate (GitHub issue, Linear ticket, external URL).
+4. **Bootstrap primitive** — the SubstrateString value at the very bottom of a leaf chain.
+
+If a value doesn't satisfy one of these, it gets composed.
+
+## Per-domain target shapes
+
+### Memory (`docs/memory/*.md`, `~/.claude/.../memory/*.md`)
+
+**Frontmatter today:**
+```yaml
+name: arrival relational ground
+description: who Urs is to me...
+type: feedback
+```
+
+**Old CTOR (flat):** `R_Block.DO` with 4 trivial string-recipe children. Each child's *instance* encodes a Python type-marker string like `"name=str"`. The actual values are not in the substrate at all.
+
+**Target CTOR (structured):**
+```
+CTOR (R_Block.DO, level 3+)
+├── NamedField (R_Block.LET)
+│   ├── key:   SubstrateString-recipe for "name" (via substrate_strings)
+│   └── value: SubstrateString-recipe for "arrival relational ground"
+├── NamedField (R_Block.LET)
+│   ├── key:   "description"
+│   └── value: SubstrateString-recipe for description value
+└── NamedField (R_Block.LET)
+    ├── key:   "type"
+    └── value: TypedTokenRef (R_Compose.MEMBER_OF)
+        ├── token-cell: @memory_type("feedback")
+        └── domain:     @<type-domain-cell>
+```
+
+`type` becomes a typed-token reference, not a free string. The four memory types (user / feedback / project / reference) become four cells in a `memory-type` domain; each Memory cell's `type` field points at one of them. Two memory cells with the same `type` value share the *same* token-cell reference — equivalence visible from the substrate.
+
+**Body:** stays as access-recipe (free prose, leaf-by-great-reason #2). A content-hash leaf rather than a length-class.
+
+**Migration status:** principle codified; new encoder design below; existing 44 cells still flat.
+
+### Spec (`specs/*.md`)
+
+**Frontmatter today:**
+```yaml
+idea_id: agent-pipeline
+source:
+  - api/app/services/agent_pipeline.py
+requirements:
+  - "..."
+done_when:
+  - "..."
+test: api/tests/test_agent_pipeline.py
+constraints: []
+```
+
+**Old CTOR (flat):** type-markers for each key. `idea_id: agent-pipeline` becomes a string-marker `"idea_id=str"`. The slug `agent-pipeline` doesn't reach the substrate as a cell-ref.
+
+**Target CTOR (structured):**
+```
+CTOR (R_Block.DO)
+├── NamedField (R_Block.LET)
+│   ├── key:   "idea_id"
+│   └── value: CellRef recipe → @idea(agent-pipeline)        ← cell-ref, not slug-string
+├── NamedField (R_Block.LET)
+│   ├── key:   "source"
+│   └── value: R_Block.SEQUENCE [ PathRef, PathRef, ... ]    ← list of paths, each a leaf-by-great-reason
+├── NamedField (R_Block.LET)
+│   ├── key:   "requirements"
+│   └── value: R_Block.SEQUENCE [ Requirement, ... ]        ← each requirement a substrate-string leaf
+├── NamedField (R_Block.LET)
+│   ├── key:   "test"
+│   └── value: PathRef                                      ← path-leaf-by-great-reason
+└── ...
+```
+
+`idea_id` is the load-bearing change: it becomes a structural edge `spec --REALIZES--> @idea`, not a string the substrate has to re-parse to walk. Already partially expressed by the `R_Realize` recipe vocabulary — this discipline makes the encoding align with it.
+
+### Idea (`ideas/*.md`)
+
+**Frontmatter today:**
+```yaml
+idea_id: agent-pipeline
+title: "..."
+stage: active
+work_type: feature
+pillar: orchestration
+specs:
+  - agent-pipeline-mvp
+  - agent-pipeline-coherence
+absorbed_ideas:
+  - earlier-pipeline-sketch
+```
+
+**Old CTOR (flat):** all slug-string markers.
+
+**Target CTOR (structured):**
+- `stage`, `work_type`, `pillar` → typed-token references (each domain has its own enumeration cells)
+- `specs` → `R_Block.SEQUENCE` of `R_Compose.PARENT_OF` recipes, each pointing at the actual spec cell
+- `absorbed_ideas` → `R_Block.SEQUENCE` of `R_Absorb.MERGE_INTO` recipes pointing at the absorbed idea cells
+
+Cross-cell edges become substrate edges, not slug-string blobs.
+
+### Concept (`docs/vision-kb/concepts/lc-*.md`)
+
+**Frontmatter today:**
+```yaml
+id: lc-trust-over-fear
+name: Trust over fear
+parent: lc-permission-is-interior
+cross_refs:
+  - lc-frequency-routes-reception
+  - lc-presence-as-recognition
+visuals:
+  - lc-trust-over-fear/cover.png
+hz_band: 396
+geometry:
+  arity: 3
+  form: triad
+  topology: parallel
+  ...
+```
+
+**Old CTOR (flat):** slug-strings throughout. `parent`, each `cross_ref`, each `visual` is a flat string.
+
+**Target CTOR (structured):**
+- `parent` → `R_Compose.PARENT_OF` recipe pointing at `@concept(lc-permission-is-interior)`
+- `cross_refs` → `R_Block.SEQUENCE` of `R_Compose.CROSS_REF` recipes, each pointing at the referenced concept cell
+- `hz_band: 396` → `R_Resonance.HARMONIC_AT` recipe pointing at `@spectrum("Hz-396")` — already partially expressed by the resonance-recipe system, this discipline closes it
+- `geometry.{arity, form, topology, polarity, ...}` → typed-token references to dimensional vocabulary cells (`@geometric_form(triad)`, `@topology(parallel)`, etc.) — these cells already exist via `BID_geometric_form()` and friends
+
+Concept cells are the richest. The migration here is also the most valuable: the resonance edge system *exists* but is only authored on some concepts; the structured CTOR makes it authored on all of them automatically.
+
+### Presence (`docs/presences/*.md`)
+
+**Frontmatter today:**
+```yaml
+slug: ilena
+kind: HUMAN
+role: doorway
+edges:
+  transmits:
+    - lc-arrival-as-recognition
+  tends:
+    - liquid-bloom-cluster
+```
+
+**Target CTOR (structured):**
+- `kind` → typed-token reference (`@presence_kind("HUMAN")` cell)
+- `role` → typed-token reference (`@presence_role("doorway")` cell — role enumeration cells)
+- `edges.transmits` → `R_Block.SEQUENCE` of `R_Transmit.TRANSMIT_TO` recipes
+- `edges.tends` → `R_Block.SEQUENCE` of `R_Tend.TEND` recipes
+
+Edges become recipe edges in the substrate, walkable by `?walk @presence(ilena) transmits`.
+
+### Lineage (`docs/lineage/*.md`)
+
+**Frontmatter today:**
+```yaml
+kind: transmission-of
+from: lc-arrival-as-recognition
+to: ranakami-ubud-doorway-2026-04-29
+evidence: docs/lineage/2026-04-29-ubud-meeting-walk.md
+date: 2026-04-29
+```
+
+**Target CTOR (structured):**
+- `kind` → typed-token reference (kind enumeration cells: transmission-of / analogous-to / parent-of / ...)
+- `from`, `to` → cell-ref recipes pointing at the actual concept/presence/event cells
+- `evidence` → PathRef leaf (great-reason #1)
+- `date` → DateLit leaf (great-reason #1)
+
+A lineage cell is essentially an edge cell; structuring it well means the edge recipe is walkable directly.
+
+### Witness (`witness_events.jsonl` and ingest path)
+
+Witness events are structurally simple — `(presence, action, evidence_url, timestamp)`. Most of these are leaf-by-great-reason (timestamps, URLs, action-tokens). The only structural composition is the `presence` reference, which should be a cell-ref recipe, not a slug.
+
+### Task (pipeline tasks)
+
+Tasks are workflow units — `(idea_id, status, context, witness)`. Status is the load-bearing typed enumeration; idea_id is a cell-ref to the idea cell; context is itself a small structured payload that varies per task type and would need its own per-context-type shape design.
+
+## Common building blocks
+
+These are the substrate-side primitives every domain reuses:
+
+| Primitive | Recipe shape | Lives at |
+|---|---|---|
+| **SubstrateString value** | `R_Trivial.STRING` with instance from `substrate_strings.intern_string_instance(...)` | leaf, cross-process stable |
+| **NamedField** | `R_Block.LET` with two children: key-recipe + value-recipe | composes one frontmatter pair |
+| **CellRef** | `R_Trivial.REF` whose instance is the target cell's `cell_id` | points to a NamedCell |
+| **TypedTokenRef** | `R_Compose.MEMBER_OF [token-cell-ref, domain-cell-ref]` | typed enumeration value |
+| **List** | `R_Block.SEQUENCE` with element-recipe per child | preserves order + element shape |
+| **PathRef** | `R_Trivial.PATH` with instance from `substrate_strings` | leaf-by-great-reason for file paths |
+| **DateLit** | `R_Trivial.DATE` with instance from substrate_strings (ISO 8601) | leaf-by-great-reason for dates |
+| **URLLit** | `R_Trivial.URL` with instance from substrate_strings | leaf-by-great-reason for external URLs |
+
+Every domain's CTOR composes from these. Two cells with identical frontmatter values share identical CTOR NodeIDs — equivalence is automatic.
+
+## Migration sequencing
+
+Each domain gets its own breath. The order is intentional:
+
+1. **Memory** — simplest frontmatter, used to validate the encoder + the new shape (this breath ships the encoder + tests)
+2. **Concept** — richest cross-references; biggest payoff because the resonance edge system already exists; uses the encoder to populate edges automatically
+3. **Spec** + **Idea** — paired migration because `idea_id` ↔ `specs` is bidirectional
+4. **Presence** + **Lineage** — paired because lineage edges reference presences
+5. **Witness** + **Task** — simplest; small structural surface
+
+After each domain's encoder ships:
+1. New ingests use the structured encoder
+2. A re-ingest pass re-walks existing files; content-addressed interning means existing structurally-identical Blueprints stay stable, but new CTORs replace old ones
+3. Tests verify the new shape navigates fully through `.child().child()` to actual values, not to type-markers
+
+## Status (2026-05-17)
+
+- ✓ Principle codified in CLAUDE.md
+- ✓ Per-domain target shapes named (this document)
+- ✓ Great-reason criterion explicit
+- ◐ Memory encoder structured form designed; implementation ships in [`markdown_frontend.py → ingest_memory_file_structured`](../../api/app/services/substrate/markdown_frontend.py)
+- ☐ Concept encoder
+- ☐ Spec + Idea encoders
+- ☐ Presence + Lineage encoders
+- ☐ Witness + Task encoders
+- ☐ Re-ingest pass for the 44 memory cells + 128 specs + 17 ideas + 114 concepts already in the substrate
+
+Each ☐ is its own breath. Naming the path here is the practice; closing each gap is its own session.

--- a/scripts/coh_substrate.py
+++ b/scripts/coh_substrate.py
@@ -11,7 +11,8 @@ Usage:
     coh_substrate.py stats                              # lattice statistics
     coh_substrate.py equivalent <domain> <name>         # structural equivalents
     coh_substrate.py annotate <path>                    # substrate context for a file
-    coh_substrate.py form "<expression>"                # evaluate a Form expression
+    coh_substrate.py form "<expression>"                # evaluate (intern as recipe / return substrate answer)
+    coh_substrate.py run "<expression>"                 # execute (run the recipe, return its value)
 
 For detail on Form syntax see docs/coherence-substrate/form-language.md.
 For agent grounding patterns see docs/coherence-substrate/agents-using-substrate.md.
@@ -30,6 +31,7 @@ from app.services.substrate import (  # noqa: E402
     annotate_path,
     find_equivalent_cells,
     form_evaluate_text,
+    form_execute_text,
     form_serialize_cell,
     form_serialize_node_id,
     ingest_concept_file,
@@ -201,6 +203,60 @@ def cmd_annotate(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_run(args: argparse.Namespace) -> int:
+    """Execute a Form expression — actually run the recipe, return a value.
+
+    Distinct from `form`: that interns the expression as a Recipe NodeID
+    and returns the substrate's structural answer (NodeID / cells / view).
+    This runs the expression and returns its computed value, the same way
+    Python runs `1 + 2` to `3`.
+    """
+    from app.services.substrate.form_speculation import FailSignal
+
+    try:
+        with session_scope() as session:
+            value = form_execute_text(session, args.expression)
+    except FailSignal as exc:
+        print(f"Form runtime: {exc}", file=sys.stderr)
+        return 2
+    except (SyntaxError, NameError, LookupError, TypeError, ZeroDivisionError) as exc:
+        print(f"Form runtime: {exc}", file=sys.stderr)
+        return 1
+
+    from app.services.substrate.kernel import CellView, NamedCell, NodeID
+
+    if args.json:
+        if isinstance(value, NodeID):
+            print(json.dumps({"value": form_serialize_node_id(value)}))
+        elif isinstance(value, NamedCell):
+            print(json.dumps({
+                "value": form_serialize_cell(value),
+                "domain": value.domain,
+                "name": value.name,
+            }))
+        elif isinstance(value, CellView):
+            print(json.dumps({
+                "cell": form_serialize_cell(value.cell),
+                "view_blueprint": form_serialize_node_id(value.view_blueprint),
+                "compatible": value.compatible,
+            }))
+        else:
+            print(json.dumps({"value": value}))
+    else:
+        if isinstance(value, NodeID):
+            print(form_serialize_node_id(value))
+        elif isinstance(value, NamedCell):
+            print(form_serialize_cell(value))
+        elif isinstance(value, CellView):
+            mark = "✓" if value.compatible else "✗"
+            print(f"{form_serialize_cell(value.cell)} |> {form_serialize_node_id(value.view_blueprint)}  {mark}")
+        elif value is None:
+            print("null")
+        else:
+            print(value)
+    return 0
+
+
 def cmd_form(args: argparse.Namespace) -> int:
     try:
         with session_scope() as session:
@@ -292,6 +348,12 @@ def main(argv: list[str] | None = None) -> int:
 
     p_form = sub.add_parser("form", help="Evaluate a Form expression")
     p_form.add_argument("expression")
+
+    p_run = sub.add_parser(
+        "run",
+        help="Execute a Form expression — run the recipe, return its value",
+    )
+    p_run.add_argument("expression")
 
     p_disc = sub.add_parser(
         "discover",
@@ -415,6 +477,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_annotate(args)
     if args.cmd == "form":
         return cmd_form(args)
+    if args.cmd == "run":
+        return cmd_run(args)
     if args.cmd == "discover":
         return cmd_discover(args)
     if args.cmd == "sense":


### PR DESCRIPTION
## Summary

Co-woven with sibling cell's `recipe_eval.py` work (#1672) — that engine walks Recipe NodeIDs from the substrate; this engine walks ASTs with closures and tree-navigation. Both live, complementary not redundant.

**Form gains its own runtime** — `form_execute_text` walks ASTs to values, sharing FailSignal/StopSignal with parser-level speculation. `defn name(params) = body` and recursive calls land; Form is Turing-complete and capable of hosting its own evaluator.

**Tree-navigation primitives** (`.blueprint`, `.ctor`, `.category`, `.child(n)`, `.children`, `.nchildren`, plus 4-tuple leaves) expose the substrate's fractal/holographic composition at Form's surface. The dot is the seam between holographic levels.

**The structural composition discipline** lands as load-bearing body practice: default-to-compose, exception-to-leaf, exception requires a great reason. CLAUDE.md codifies the four great-reason criteria. `docs/coherence-substrate/structural-composition.md` names per-domain target shapes for all 8 domains. The memory encoder ships as opt-in `ingest_memory_file(..., structured=True)` producing fully-expressed CTORs — named-pair LET recipes with substrate-resident, recoverable values instead of legacy type-marker strings.

**Demonstration of meta-circular reach**: `do { defn fact(n) = if n <= 1 then 1 else n * fact(n - 1); fact(6) }` returns `720`. `@memory("X").blueprint.child(0).category` walks live substrate trees. `form-engine.form` is the engine in Form's own voice.

## Test plan

- [x] 356 substrate tests green (89 added across form_runtime, structured_ctor)
- [x] Side-by-side legacy-vs-structured CTOR demonstrated live: legacy stores `"name=str"` type-markers, structured stores `'name': 'arrival relational ground'` recoverable via substrate string-table
- [x] CLI: `coh substrate run "<expr>"` end-to-end (factorial, fibonacci, function composition, closure capture, tree walks, with/.self)
- [x] No regression in existing substrate tests
- [x] Conflict-resolution with #1672 verified — both runtimes coexist (recipe-NodeID walker AND AST walker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)