### PR TITLE
attune(form): string literals round-trip — no more lossy hash encoding

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -1345,8 +1345,13 @@ def _to_recipe_node_id(session: Session, ast: Any) -> NodeID:
     if isinstance(ast, BoolLit):
         return NodeID(1, Level.TRIVIAL, 2, 1 if ast.value else 0)  # RType.BOOL = 2
     if isinstance(ast, StringLit):
-        # Map literal string to an instance — same hash trick used elsewhere
-        inst = abs(hash(ast.value)) % (10**9) + 1
+        # Intern via the substrate string-table so `recipe_eval` can recover
+        # the value at runtime. The previous hash-derived encoding was lossy:
+        # `recipe_eval_text(s, '"hello"')` returned a NodeID instead of "hello".
+        # `intern_string_instance` allocates a sequential, cross-process-stable
+        # instance that `lookup_string_value` reverses.
+        from app.services.substrate.substrate_strings import intern_string_instance
+        inst = intern_string_instance(session, ast.value)
         return NodeID(1, Level.TRIVIAL, 5, inst)  # RType.STRING = 5
     if isinstance(ast, Identifier):
         # Bare name — encode as a placeholder LOCAL_ACCESS instance.

--- a/api/app/services/substrate/recipe_eval.py
+++ b/api/app/services/substrate/recipe_eval.py
@@ -137,15 +137,15 @@ def _parse_serialized(serialized: str) -> Tuple[NodeID, List[NodeID]]:
 # ---------------------------------------------------------------------------
 
 
-def _recover_trivial(node: NodeID) -> Any:
+def _recover_trivial(node: NodeID, session=None) -> Any:
     """Recover the runtime value of a trivial-leaf NodeID.
 
-    Form's IntLit/BoolLit/StringLit AST nodes encode their values as the
-    instance integer of a Level.TRIVIAL NodeID. This reverses that encoding
-    for the cases that are recoverable.
+    Form's IntLit/BoolLit/StringLit/NullLit AST nodes encode their values as
+    the instance integer of a Level.TRIVIAL NodeID. This reverses that encoding.
 
-    Returns a sentinel `_UNRECOVERABLE` for cases that can't be recovered
-    (e.g., StringLit instances are hash-derived and lossy).
+    StringLit recovery requires the session (string-table lookup); when called
+    without a session, strings return `_UNRECOVERABLE`. All other types are
+    pure-numeric and recover without the session.
     """
     if node.level != Level.TRIVIAL:
         return _UNRECOVERABLE
@@ -155,6 +155,11 @@ def _recover_trivial(node: NodeID) -> Any:
         return bool(node.instance)
     if node.type_ == RType.NULL:
         return None
+    if node.type_ == RType.STRING and session is not None:
+        from app.services.substrate.substrate_strings import lookup_string_value
+        value = lookup_string_value(session, node.instance)
+        if value is not None:
+            return value
     return _UNRECOVERABLE
 
 
@@ -188,7 +193,8 @@ def eval_recipe(
         ctx = ExecutionContext()
 
     # Trivial leaf — recoverable directly from the NodeID coordinates.
-    recovered = _recover_trivial(node)
+    # Pass session so StringLit instances can resolve via the string-table.
+    recovered = _recover_trivial(node, session=session)
     if recovered is not _UNRECOVERABLE:
         return recovered
 
@@ -425,7 +431,7 @@ def eval_text(session: Session, text: str) -> Any:
         return eval_recipe(session, result.value)
     if result.kind == "node_id":
         # Already a NodeID literal — try to recover, else return as-is.
-        recovered = _recover_trivial(result.value)
+        recovered = _recover_trivial(result.value, session=session)
         if recovered is not _UNRECOVERABLE:
             return recovered
         return eval_recipe(session, result.value)

--- a/api/tests/test_substrate_string_literal_recovery.py
+++ b/api/tests/test_substrate_string_literal_recovery.py
@@ -1,0 +1,65 @@
+"""String literals recover their value at runtime.
+
+The previous encoding was lossy: `StringLit` interned its instance as
+`abs(hash(value)) % 10**9 + 1`, so `recipe_eval_text(s, '"hello"')` returned
+a NodeID instead of the string. Switching to `intern_string_instance` /
+`lookup_string_value` makes the round-trip work.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+from app.services.substrate.recipe_eval import eval_text
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+def test_string_literal_round_trips(session):
+    assert eval_text(session, '"hello"') == "hello"
+
+
+def test_empty_string_round_trips(session):
+    assert eval_text(session, '""') == ""
+
+
+def test_repeated_string_dedupes_and_recovers(session):
+    """Two evals of the same string return the same value (and same NodeID)."""
+    a = eval_text(session, '"alpha"')
+    b = eval_text(session, '"alpha"')
+    assert a == b == "alpha"
+
+
+def test_distinct_strings_recover_distinctly(session):
+    """Different strings recover to their own values."""
+    a = eval_text(session, '"first"')
+    b = eval_text(session, '"second"')
+    assert a == "first"
+    assert b == "second"
+    assert a != b
+
+
+def test_string_with_unicode(session):
+    """Non-ASCII characters survive the round-trip."""
+    assert eval_text(session, '"café"') == "café"
+    assert eval_text(session, '"🌱"') == "🌱"


### PR DESCRIPTION
## Summary

\`StringLit\` interned its instance as a hash, making \`recipe_eval_text(s, '"hello"')\` return a NodeID instead of \"hello\". Switching to \`intern_string_instance\` makes the round-trip work.

\`\`\`python
recipe_eval_text(s, '"hello"')   # → "hello"  (was: NodeID(1, 1, 5, ...))
recipe_eval_text(s, '"café"')    # → "café"
recipe_eval_text(s, '"🌱"')      # → "🌱"
\`\`\`

## Test plan
- [x] 420 substrate tests green (415 prior + 5 new)
- [x] Basic round-trip, empty string, dedup, distinctness, unicode

🤖 Generated with [Claude Code](https://claude.com/claude-code)