### PR TITLE
attune(form): list literals execute, raise carries values, catch sees them

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -377,7 +377,12 @@ class DiscardExpr:
 
 @dataclass
 class RaiseExpr:
-    """`raise` — raise an exception (distinct from speculation `fail`)."""
+    """`raise` or `raise <value>` — raise an exception with an optional payload.
+
+    When the payload is provided, the catch handler sees it as `.self` —
+    the raised value becomes the implicit subject of the catch block.
+    """
+    value: Any = None
 
 
 @dataclass
@@ -791,6 +796,16 @@ class Parser:
             return DiscardExpr()
         if kw == "raise":
             self.consume("IDENT")
+            # Optional value after raise; if the next token starts an
+            # expression (atom, paren, ident, etc.) parse it as payload.
+            nxt = self.peek().kind
+            if nxt in ("INT", "STRING", "AT", "TILDE", "LPAREN", "LBRACK", "IDENT", "DOT"):
+                # Some IDENTs ARE statement terminators in catch/end context;
+                # be permissive and parse-attempt — fall back to no value on
+                # certain reserved follow-ups.
+                if nxt == "IDENT" and self.peek().value in ("catch", "then", "else", "end"):
+                    return RaiseExpr()
+                return RaiseExpr(value=self.parse_expr())
             return RaiseExpr()
         if kw == "resume":
             self.consume("IDENT")

--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -326,6 +326,11 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
 
     # --- Leaves with full value fidelity ------------------------------------
 
+    # List literal (`[1, 2, 3]`) — parser returns a Python list of ExprNodes;
+    # runtime evaluates each item and yields a Python list.
+    if isinstance(ast, list):
+        return [execute(session, item, frame) for item in ast]
+
     if isinstance(ast, IntLit):
         return ast.value
     if isinstance(ast, BoolLit):
@@ -548,7 +553,10 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
     # --- BML exception-flow — raise / resume --------------------------------
 
     if isinstance(ast, RaiseExpr):
-        raise RaiseSignal()
+        payload = None
+        if getattr(ast, "value", None) is not None:
+            payload = execute(session, ast.value, frame)
+        raise RaiseSignal(payload)
 
     if isinstance(ast, ResumeExpr):
         # `resume` on its own is a marker; in a try-frame it returns control
@@ -655,8 +663,14 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
         try:
             sub = Frame(parent=frame)
             return execute(session, ast.body, sub)
-        except RaiseSignal:
-            sub = Frame(parent=frame)
+        except RaiseSignal as sig:
+            # The raised payload (if any) is bound as the catch frame's
+            # subject so `.self` inside catch resolves to the raised value.
+            sub = Frame(
+                parent=frame,
+                subject=sig.payload,
+                has_subject=sig.payload is not None,
+            )
             return execute(session, ast.handler, sub)
 
     # --- Delegation declaration --------------------------------------------

--- a/api/tests/test_substrate_raise_value_list_literals.py
+++ b/api/tests/test_substrate_raise_value_list_literals.py
@@ -1,0 +1,111 @@
+"""List literals execute, raise carries values, catch sees them as .self.
+
+Three gaps surfaced from running Form expressions against the live substrate:
+- `[1, 2, 3]` raised TypeError "cannot execute list" — no runtime handler
+- `raise <value>` was a SyntaxError — parser only accepted bare `raise`
+- `try { raise X } catch { ... }` couldn't see the raised value
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.form_runtime import (
+    RaiseSignal,
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# ---------------------------------------------------------------------------
+# List literals execute
+# ---------------------------------------------------------------------------
+
+
+def test_list_of_ints_evaluates(session):
+    assert form_execute_text(session, "[1, 2, 3]") == [1, 2, 3]
+
+
+def test_list_of_expressions_evaluates_each(session):
+    assert form_execute_text(session, "[1 + 1, 2 + 2, 3 + 3]") == [2, 4, 6]
+
+
+def test_empty_list_evaluates(session):
+    assert form_execute_text(session, "[]") == []
+
+
+def test_nested_list_evaluates(session):
+    assert form_execute_text(session, "[[1, 2], [3, 4]]") == [[1, 2], [3, 4]]
+
+
+# ---------------------------------------------------------------------------
+# raise with value
+# ---------------------------------------------------------------------------
+
+
+def test_raise_with_string_value(session):
+    with pytest.raises(RaiseSignal) as exc_info:
+        form_execute_text(session, 'raise "oops"')
+    assert exc_info.value.payload == "oops"
+
+
+def test_raise_with_int_value(session):
+    with pytest.raises(RaiseSignal) as exc_info:
+        form_execute_text(session, "raise 42")
+    assert exc_info.value.payload == 42
+
+
+def test_raise_with_no_value_stays_compatible(session):
+    """Bare `raise` still works (back-compat)."""
+    with pytest.raises(RaiseSignal) as exc_info:
+        form_execute_text(session, "raise")
+    assert exc_info.value.payload is None
+
+
+# ---------------------------------------------------------------------------
+# Catch sees the raised value as .self
+# ---------------------------------------------------------------------------
+
+
+def test_catch_sees_raised_string(session):
+    assert form_execute_text(
+        session, 'try { raise "oops" } catch { .self }'
+    ) == "oops"
+
+
+def test_catch_sees_raised_int_and_can_compute(session):
+    assert form_execute_text(
+        session, "try { raise 42 } catch { .self + 1 }"
+    ) == 43
+
+
+def test_catch_without_payload_falls_through(session):
+    """Bare raise without value — catch returns whatever the handler computes
+    independent of .self (which would error if used)."""
+    assert form_execute_text(
+        session, "try { raise } catch { 99 }"
+    ) == 99


### PR DESCRIPTION
## Summary

Three gaps surfaced by running Form against the live substrate. All close here.

\`\`\`form
[1, 2, 3]                       # → [1, 2, 3]   (was: TypeError)
[1 + 1, 2 + 2, 3 + 3]           # → [2, 4, 6]
raise "oops"                    # raises RaiseSignal with payload="oops"  (was: SyntaxError)
try { raise 42 } catch { .self + 1 }   # → 43   (catch sees raised value as .self)
\`\`\`

## Test plan
- [x] Full 430 substrate tests green (420 prior + 10 new)
- [x] Lists: ints, exprs, empty, nested
- [x] raise: with string, with int, bare (back-compat)
- [x] catch: sees string, sees int, no-value path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)