### PR TITLE
attune(form): built-in functions — len, head, tail, map, filter, fold, range, str, int

### DIFF
--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -308,6 +308,92 @@ _BUILTIN_IDENTIFIERS: Dict[str, Any] = {
 }
 
 
+# Built-in functions — invokable from FnCall when the name isn't bound to a Closure.
+# Each value is a Python callable receiving the evaluated positional args.
+def _builtin_map(fn, xs):
+    if not isinstance(xs, list):
+        raise TypeError("Form runtime: map expects a list as second argument")
+    if isinstance(fn, Closure):
+        return [_invoke_closure(fn, [x]) for x in xs]
+    if callable(fn):
+        return [fn(x) for x in xs]
+    raise TypeError("Form runtime: map expects a callable as first argument")
+
+
+def _builtin_filter(pred, xs):
+    if not isinstance(xs, list):
+        raise TypeError("Form runtime: filter expects a list as second argument")
+    if isinstance(pred, Closure):
+        return [x for x in xs if _invoke_closure(pred, [x])]
+    if callable(pred):
+        return [x for x in xs if pred(x)]
+    raise TypeError("Form runtime: filter expects a callable as first argument")
+
+
+def _builtin_fold(fn, init, xs):
+    if not isinstance(xs, list):
+        raise TypeError("Form runtime: fold expects a list as third argument")
+    acc = init
+    if isinstance(fn, Closure):
+        for x in xs:
+            acc = _invoke_closure(fn, [acc, x])
+        return acc
+    if callable(fn):
+        for x in xs:
+            acc = fn(acc, x)
+        return acc
+    raise TypeError("Form runtime: fold expects a callable as first argument")
+
+
+def _invoke_closure(closure: "Closure", args: list) -> Any:
+    """Helper: invoke a Form Closure (with proper frame chaining) from a built-in.
+
+    Pulls the active session out via a module-level slot the execute() loop
+    populates before each call. This keeps the built-in API session-agnostic
+    while still allowing closures (which need the session for substrate ops)
+    to execute correctly.
+    """
+    if len(args) != len(closure.params):
+        raise TypeError(
+            f"Form runtime: closure `{closure.name}` takes {len(closure.params)} arg(s), "
+            f"got {len(args)}"
+        )
+    call_frame = Frame(parent=closure.defining_frame)
+    for name, value in zip(closure.params, args):
+        call_frame.bindings[name] = value
+    sess = _CURRENT_SESSION[0]
+    if sess is None:
+        raise RuntimeError("Form runtime: no active session for closure invocation")
+    return execute(sess, closure.body, call_frame)
+
+
+# Per-call session slot for built-ins that invoke closures.
+_CURRENT_SESSION: list = [None]
+
+
+_BUILTIN_FUNCTIONS: Dict[str, Any] = {
+    # List ops
+    "len": lambda x: len(x),
+    "head": lambda xs: xs[0] if xs else None,
+    "tail": lambda xs: xs[1:] if xs else [],
+    "reverse": lambda xs: list(reversed(xs)) if isinstance(xs, list) else xs[::-1],
+    "concat": lambda a, b: a + b,
+    "map": _builtin_map,
+    "filter": _builtin_filter,
+    "fold": _builtin_fold,
+    "range": lambda *args: list(range(*args)),
+    # Type coercion
+    "str": lambda x: str(x),
+    "int": lambda x: int(x),
+    "bool": lambda x: bool(x),
+    # Numeric
+    "min": lambda *xs: min(*xs) if len(xs) > 1 else min(xs[0]),
+    "max": lambda *xs: max(*xs) if len(xs) > 1 else max(xs[0]),
+    "sum": lambda xs: sum(xs),
+    "abs": lambda x: abs(x),
+}
+
+
 # ---------------------------------------------------------------------------
 # execute — walk the AST
 # ---------------------------------------------------------------------------
@@ -476,6 +562,15 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
         return closure
 
     if isinstance(ast, FnCall):
+        # Built-in first, then frame lookup, so the body can override
+        # `len`/`map`/etc. with a user defn if it chooses.
+        if ast.name in _BUILTIN_FUNCTIONS and not frame.has(ast.name):
+            evaluated = [execute(session, a, frame) for a in ast.args]
+            _CURRENT_SESSION[0] = session
+            try:
+                return _BUILTIN_FUNCTIONS[ast.name](*evaluated)
+            finally:
+                _CURRENT_SESSION[0] = None
         callable_value = frame.lookup(ast.name)
         if not isinstance(callable_value, Closure):
             raise TypeError(

--- a/api/tests/test_substrate_form_builtins.py
+++ b/api/tests/test_substrate_form_builtins.py
@@ -1,0 +1,160 @@
+"""Built-in functions in Form runtime — list ops, type coercion, numerics.
+
+Previous gap: `len([1, 2, 3])` raised NameError "unbound name 'len'". Form
+had no built-in functions; only user-defined closures and operators worked.
+This adds `_BUILTIN_FUNCTIONS` registry that FnCall consults before frame
+lookup; user `defn`-bound names still shadow built-ins.
+
+Higher-order built-ins (map, filter, fold) invoke user-defined Closures
+correctly by threading the active session via a module-level slot.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.form_runtime import (
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# ---------------------------------------------------------------------------
+# List ops
+# ---------------------------------------------------------------------------
+
+
+def test_len_list(session):
+    assert form_execute_text(session, "len([1, 2, 3])") == 3
+
+
+def test_len_string(session):
+    assert form_execute_text(session, 'len("hello")') == 5
+
+
+def test_head_returns_first(session):
+    assert form_execute_text(session, "head([10, 20, 30])") == 10
+
+
+def test_tail_returns_rest(session):
+    assert form_execute_text(session, "tail([10, 20, 30])") == [20, 30]
+
+
+def test_reverse(session):
+    assert form_execute_text(session, "reverse([1, 2, 3])") == [3, 2, 1]
+
+
+def test_concat(session):
+    assert form_execute_text(session, "concat([1, 2], [3, 4])") == [1, 2, 3, 4]
+
+
+def test_sum(session):
+    assert form_execute_text(session, "sum([1, 2, 3, 4, 5])") == 15
+
+
+def test_range_one_arg(session):
+    assert form_execute_text(session, "range(5)") == [0, 1, 2, 3, 4]
+
+
+def test_range_two_args(session):
+    assert form_execute_text(session, "range(2, 8)") == [2, 3, 4, 5, 6, 7]
+
+
+# ---------------------------------------------------------------------------
+# Higher-order: map / filter / fold with user-defined closures
+# ---------------------------------------------------------------------------
+
+
+def test_map_with_closure(session):
+    v = form_execute_text(
+        session, "do { defn double(n) = n * 2; map(double, [1, 2, 3]) }"
+    )
+    assert v == [2, 4, 6]
+
+
+def test_filter_with_closure(session):
+    v = form_execute_text(
+        session,
+        "do { defn even(n) = n % 2 == 0; filter(even, [1, 2, 3, 4, 5]) }",
+    )
+    assert v == [2, 4]
+
+
+def test_fold_with_closure(session):
+    v = form_execute_text(
+        session,
+        "do { defn add(a, b) = a + b; fold(add, 0, [1, 2, 3, 4]) }",
+    )
+    assert v == 10
+
+
+# ---------------------------------------------------------------------------
+# Type coercion
+# ---------------------------------------------------------------------------
+
+
+def test_str_of_int(session):
+    assert form_execute_text(session, "str(42)") == "42"
+
+
+def test_int_of_string(session):
+    assert form_execute_text(session, 'int("123")') == 123
+
+
+def test_bool_truthy(session):
+    assert form_execute_text(session, "bool(1)") is True
+
+
+def test_bool_falsy(session):
+    assert form_execute_text(session, "bool(0)") is False
+
+
+# ---------------------------------------------------------------------------
+# User defn shadows built-in
+# ---------------------------------------------------------------------------
+
+
+def test_user_defn_shadows_builtin(session):
+    """A locally-bound name takes precedence over a built-in of the same name."""
+    v = form_execute_text(
+        session, 'do { defn len(x) = 99; len([1, 2, 3]) }'
+    )
+    assert v == 99
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+def test_abs(session):
+    assert form_execute_text(session, "abs(-5)") == 5
+
+
+def test_min_max(session):
+    assert form_execute_text(session, "min(3, 1, 2)") == 1
+    assert form_execute_text(session, "max(3, 1, 2)") == 3


### PR DESCRIPTION
## Summary

Form gains a standard-library layer. \`len\`, \`map\`, \`filter\`, \`fold\`, \`range\`, \`head\`, \`tail\`, \`reverse\`, \`concat\`, \`str\`, \`int\`, \`bool\`, \`min\`, \`max\`, \`sum\`, \`abs\`. Higher-order built-ins invoke user-defined closures correctly.

\`\`\`form
len([1, 2, 3])                                              # → 3
do { defn double(n) = n * 2; map(double, [1, 2, 3]) }      # → [2, 4, 6]
do { defn even(n) = n % 2 == 0; filter(even, [1..5]) }     # → [2, 4]
do { defn add(a, b) = a + b; fold(add, 0, [1, 2, 3, 4]) }  # → 10
\`\`\`

User \`defn\` shadows built-ins (test_user_defn_shadows_builtin).

## Test plan
- [x] 449 substrate tests green (430 prior + 19 new)
- [x] List ops, type coercion, numerics all verified
- [x] Higher-order built-ins invoke user closures
- [x] User defn shadows built-in correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)