### PR TITLE
attune(form): list/string indexing + ternary expressions

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -517,6 +517,30 @@ class FnCall:
 
 
 @dataclass
+class IndexExpr:
+    """`xs[i]` — index into a list, string, or dict.
+
+    Runtime returns `xs[i]` for the target value and resolved index. Chains
+    via the postfix loop in `parse_primary`: `xs[0][1]` becomes nested
+    IndexExprs.
+    """
+    target: Any
+    index: Any
+
+
+@dataclass
+class TernaryExpr:
+    """`cond ? then : else` — three-arm conditional in expression position.
+
+    Lower-precedence form of `if cond then a else b`; lives at the top
+    of the precedence ladder.
+    """
+    cond: Any
+    then_branch: Any
+    else_branch: Any
+
+
+@dataclass
 class Access:
     """`target.field` — fractal-tree navigation.
 
@@ -592,8 +616,25 @@ class Parser:
             from app.services.substrate.form_operators import _BINARY_OPERATORS
             if _BINARY_OPERATORS:
                 from app.services.substrate.form_operators import parse_with_precedence
-                return parse_with_precedence(self, 0)
-        return self.parse_or()
+                base = parse_with_precedence(self, 0)
+                return self._maybe_ternary(base)
+        base = self.parse_or()
+        return self._maybe_ternary(base)
+
+    def _maybe_ternary(self, cond: ExprNode) -> ExprNode:
+        """If a `?` follows, consume `then ? else`. Otherwise return cond as-is."""
+        if self.peek().kind == "QMARK":
+            # Only treat as ternary when `?` is followed by an expression — the
+            # query form `?cells` etc. parses inside parse_primary, never here.
+            # By the time we see a QMARK at expression-end position, it's a ternary.
+            self.consume("QMARK")
+            then_branch = self.parse_or()
+            if self.peek().kind != "COLON":
+                raise SyntaxError("Form: expected ':' after ternary `?` branch")
+            self.consume("COLON")
+            else_branch = self.parse_or()
+            return TernaryExpr(cond=cond, then_branch=then_branch, else_branch=else_branch)
+        return cond
 
     def parse_or(self) -> ExprNode:
         left = self.parse_and()
@@ -705,6 +746,16 @@ class Parser:
                     a = MethodCall(target=a, method=field, args=args)
                 else:
                     a = Access(target=a, field=field)
+                continue
+            if t.kind == "LBRACK":
+                # Postfix indexing: `target[index]`. Distinguish from a list
+                # literal in atom position by checking the LEFT context: at
+                # this point in parse_projection's postfix loop we always have
+                # a target on the left, so `[` must be indexing.
+                self.consume("LBRACK")
+                index = self.parse_expr()
+                self.consume("RBRACK")
+                a = IndexExpr(target=a, index=index)
                 continue
             break
         return a

--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -59,6 +59,7 @@ from app.services.substrate.form import (
     IfExpr,
     InverseExpr,
     IntLit,
+    IndexExpr,
     Let,
     MatchArm,
     MatchExpr,
@@ -76,6 +77,7 @@ from app.services.substrate.form import (
     SelfRef,
     StopExpr,
     StringLit,
+    TernaryExpr,
     TrivialRef,
     TryCatchExpr,
     UnaryOp,
@@ -497,6 +499,22 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
         if ast.else_branch is not None:
             return execute(session, ast.else_branch, frame)
         return None
+
+    if isinstance(ast, TernaryExpr):
+        if execute(session, ast.cond, frame):
+            return execute(session, ast.then_branch, frame)
+        return execute(session, ast.else_branch, frame)
+
+    if isinstance(ast, IndexExpr):
+        target = execute(session, ast.target, frame)
+        index = execute(session, ast.index, frame)
+        try:
+            return target[index]
+        except (KeyError, IndexError, TypeError) as e:
+            raise TypeError(
+                f"Form runtime: cannot index {type(target).__name__} with "
+                f"{type(index).__name__} ({index!r}): {e}"
+            )
 
     if isinstance(ast, DoBlock):
         sub = Frame(parent=frame)

--- a/api/tests/test_substrate_form_indexing_ternary.py
+++ b/api/tests/test_substrate_form_indexing_ternary.py
@@ -1,0 +1,135 @@
+"""List/string indexing + ternary expressions.
+
+Two gaps surfaced by running Form against the live substrate:
+
+- `do { let xs = [10, 20, 30]; xs[1] }` returned `[1]` instead of `20` —
+  the parser treated `xs[1]` as two separate atoms (the list and a new
+  list literal), making `xs[1]` semantically wrong.
+- `5 > 3 ? "big" : "small"` was a SyntaxError — no ternary support.
+
+Both close here. Postfix `[i]` chains through `parse_projection`'s postfix
+loop; ternary `?:` sits at the top of the precedence ladder via
+`_maybe_ternary`.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.form_runtime import (
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# ---------------------------------------------------------------------------
+# List indexing
+# ---------------------------------------------------------------------------
+
+
+def test_index_literal_list(session):
+    assert form_execute_text(session, "[10, 20, 30][0]") == 10
+    assert form_execute_text(session, "[10, 20, 30][2]") == 30
+
+
+def test_index_via_let_binding(session):
+    """The bug-fix case: `xs[1]` after a let-binding actually indexes."""
+    assert form_execute_text(
+        session, "do { let xs = [10, 20, 30]; xs[1] }"
+    ) == 20
+
+
+def test_nested_indexing(session):
+    """`xs[1][0]` chains the postfix indexing."""
+    assert form_execute_text(
+        session, "do { let xs = [[1, 2], [3, 4]]; xs[1][0] }"
+    ) == 3
+
+
+def test_string_indexing(session):
+    assert form_execute_text(session, '"hello"[0]') == "h"
+    assert form_execute_text(session, '"hello"[4]') == "o"
+
+
+def test_index_with_computed_index(session):
+    assert form_execute_text(
+        session, "do { let xs = [10, 20, 30]; xs[1 + 1] }"
+    ) == 30
+
+
+def test_index_out_of_range_raises(session):
+    with pytest.raises(TypeError):
+        form_execute_text(session, "[1, 2, 3][10]")
+
+
+# ---------------------------------------------------------------------------
+# Ternary
+# ---------------------------------------------------------------------------
+
+
+def test_ternary_true_branch(session):
+    assert form_execute_text(
+        session, '5 > 3 ? "big" : "small"'
+    ) == "big"
+
+
+def test_ternary_false_branch(session):
+    assert form_execute_text(
+        session, '5 < 3 ? "big" : "small"'
+    ) == "small"
+
+
+def test_ternary_with_computed_branches(session):
+    assert form_execute_text(
+        session, "do { let n = 5; n > 3 ? n * 2 : n }"
+    ) == 10
+
+
+def test_ternary_with_string_compare(session):
+    assert form_execute_text(
+        session, '"hello" == "hello" ? 1 : 0'
+    ) == 1
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+def test_ternary_with_indexing(session):
+    """ternary's branch can be an indexed expression."""
+    assert form_execute_text(
+        session, 'do { let xs = [10, 20, 30]; xs[0] > 5 ? xs[1] : xs[2] }'
+    ) == 20
+
+
+def test_indexing_with_method_dispatch(session):
+    """List indexing composes with the rest of expression syntax."""
+    # `len(xs[1])` — index gives a sub-list, len returns its length.
+    assert form_execute_text(
+        session, "do { let xs = [[1, 2, 3], [4, 5]]; len(xs[1]) }"
+    ) == 2


### PR DESCRIPTION
## Summary

Two gaps surfaced by running Form. Both close.

\`\`\`form
do { let xs = [10, 20, 30]; xs[1] }     # → 20    (was: [1] — bug)
xs[1][0]                                  # nested indexing chains
"hello"[0]                                # → "h"  (string indexing too)
5 > 3 ? "big" : "small"                  # → "big"
do { let n = 5; n > 3 ? n * 2 : n }     # → 10
\`\`\`

12 new tests; full 461-test substrate suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)