### PR TITLE
attune(form): for/while loops + set for accumulator patterns

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -541,6 +541,35 @@ class TernaryExpr:
 
 
 @dataclass
+class SetExpr:
+    """`set name = value` — update an existing binding in the nearest enclosing
+    frame that holds it. Distinct from `let` which always introduces a new
+    binding in the current frame. Loops use `set` for accumulation.
+    """
+    name: str
+    value: Any
+
+
+@dataclass
+class ForExpr:
+    """`for x in xs { body }` — iterate xs, bind each to x in a sub-frame,
+    evaluate body. Returns the list of body-results (like map but imperative).
+    """
+    var: str
+    iter: Any
+    body: Any
+
+
+@dataclass
+class WhileExpr:
+    """`while cond { body }` — evaluate body while cond is truthy.
+    Returns the last body-result, or null if the loop never entered.
+    """
+    cond: Any
+    body: Any
+
+
+@dataclass
 class DictExpr:
     """`{a: 1, b: 2}` — composed record. Honors the structural composition
     discipline (CLAUDE.md): keys participate in identity; positions don't.
@@ -889,6 +918,12 @@ class Parser:
             return self.parse_method_invoke()
         if kw == "try":
             return self.parse_try_catch()
+        if kw == "for":
+            return self.parse_for()
+        if kw == "while":
+            return self.parse_while()
+        if kw == "set":
+            return self.parse_set()
         if kw == "defn":
             return self.parse_defn()
 
@@ -1126,6 +1161,51 @@ class Parser:
             body=DoBlock(statements=body_stmts),
             handler=DoBlock(statements=handler_stmts),
         )
+
+    def parse_for(self) -> "ForExpr":
+        """`for x in <iter> { body }` — iterate, bind, evaluate body."""
+        self.consume("IDENT")  # 'for'
+        var = self.consume("IDENT").value
+        if self.peek().kind != "IDENT" or self.peek().value != "in":
+            raise SyntaxError("Form: expected 'in' after for-variable")
+        self.consume("IDENT")  # 'in'
+        iter_expr = self.parse_expr()
+        self.consume("LBRACE")
+        stmts = []
+        while self.peek().kind != "RBRACE":
+            stmts.append(self.parse_expr())
+            if self.peek().kind == "SEMI":
+                self.consume("SEMI")
+            elif self.peek().kind == "RBRACE":
+                break
+        self.consume("RBRACE")
+        return ForExpr(var=var, iter=iter_expr, body=DoBlock(statements=stmts))
+
+    def parse_while(self) -> "WhileExpr":
+        """`while <cond> { body }` — evaluate body while cond is truthy."""
+        self.consume("IDENT")  # 'while'
+        cond = self.parse_expr()
+        self.consume("LBRACE")
+        stmts = []
+        while self.peek().kind != "RBRACE":
+            stmts.append(self.parse_expr())
+            if self.peek().kind == "SEMI":
+                self.consume("SEMI")
+            elif self.peek().kind == "RBRACE":
+                break
+        self.consume("RBRACE")
+        return WhileExpr(cond=cond, body=DoBlock(statements=stmts))
+
+    def parse_set(self) -> "SetExpr":
+        """`set name = value` — mutate an existing binding in the nearest
+        enclosing frame holding it."""
+        self.consume("IDENT")  # 'set'
+        name = self.consume("IDENT").value
+        if self.peek().kind != "ASSIGN":
+            raise SyntaxError("Form: expected '=' after `set` name")
+        self.consume("ASSIGN")
+        value = self.parse_expr()
+        return SetExpr(name=name, value=value)
 
     def parse_on_change(self) -> OnChangeExpr:
         """`?on_change <query> { body }` — entered via parse_query branch."""

--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -57,7 +57,9 @@ from app.services.substrate.form import (
     FnDef,
     Identifier,
     DictExpr,
+    ForExpr,
     IfExpr,
+    SetExpr,
     InverseExpr,
     IntLit,
     IndexExpr,
@@ -86,6 +88,7 @@ from app.services.substrate.form import (
     BinOp,
     TRIVIAL_REFS,
     DOMAIN_TO_REF,
+    WhileExpr,
     WithExpr,
     parse as form_parse,
 )
@@ -509,6 +512,35 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
     if isinstance(ast, DictExpr):
         return {key: execute(session, value, frame) for key, value in ast.pairs}
 
+    if isinstance(ast, ForExpr):
+        iterable = execute(session, ast.iter, frame)
+        if not hasattr(iterable, "__iter__"):
+            raise TypeError(
+                f"Form runtime: `for` requires an iterable, got {type(iterable).__name__}"
+            )
+        results = []
+        for item in iterable:
+            sub = Frame(parent=frame)
+            sub.bindings[ast.var] = item
+            results.append(execute(session, ast.body, sub))
+        return results
+
+    if isinstance(ast, WhileExpr):
+        # Loop body shares the caller's frame so `let x = ...` updates
+        # persist across iterations (otherwise the loop variable never
+        # changes and the loop would be infinite or not progress).
+        result = None
+        guard = 0
+        max_iterations = 100_000
+        while execute(session, ast.cond, frame):
+            result = execute(session, ast.body, frame)
+            guard += 1
+            if guard > max_iterations:
+                raise RuntimeError(
+                    f"Form runtime: `while` loop exceeded {max_iterations} iterations"
+                )
+        return result
+
     if isinstance(ast, IndexExpr):
         target = execute(session, ast.target, frame)
         index = execute(session, ast.index, frame)
@@ -531,6 +563,21 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
         value = execute(session, ast.value, frame)
         frame.bindings[ast.name] = value
         return value
+
+    if isinstance(ast, SetExpr):
+        # Walk the frame chain looking for the nearest binding of `name`.
+        # Update in-place where found. Raise if no enclosing frame has it.
+        value = execute(session, ast.value, frame)
+        f = frame
+        while f is not None:
+            if ast.name in f.bindings:
+                f.bindings[ast.name] = value
+                return value
+            f = f.parent
+        raise NameError(
+            f"Form runtime: `set {ast.name} = ...` — no binding for `{ast.name}` "
+            f"in enclosing scope (use `let` to introduce)"
+        )
 
     if isinstance(ast, MatchExpr):
         scrut = execute(session, ast.scrutinee, frame)

--- a/api/tests/test_substrate_form_loops.py
+++ b/api/tests/test_substrate_form_loops.py
@@ -1,0 +1,148 @@
+"""for/while loops + `set` for mutation across iterations.
+
+Three gaps surfaced from running Form:
+- `for x in [1, 2, 3] { x }` — SyntaxError
+- `while (n > 0) { ... }` — SyntaxError
+- The deeper one: even with for/while, `let total = total + x` in a body
+  creates a NEW binding in the loop's sub-frame, so accumulation doesn't
+  work. The wholeness move: add `set name = value` which mutates the nearest
+  enclosing binding (distinct from `let` which introduces).
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.form_runtime import (
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# ---------------------------------------------------------------------------
+# for x in xs { body }
+# ---------------------------------------------------------------------------
+
+
+def test_for_returns_list_of_body_results(session):
+    assert form_execute_text(
+        session, "for x in [1, 2, 3] { x * 2 }"
+    ) == [2, 4, 6]
+
+
+def test_for_over_range(session):
+    assert form_execute_text(
+        session, "for x in range(4) { x }"
+    ) == [0, 1, 2, 3]
+
+
+def test_for_with_accumulator_via_set(session):
+    """The load-bearing pattern — sum via mutable accumulator."""
+    assert form_execute_text(
+        session,
+        "do { let total = 0; for x in [1, 2, 3, 4, 5] { set total = total + x }; total }",
+    ) == 15
+
+
+def test_for_appending_via_set_and_concat(session):
+    assert form_execute_text(
+        session,
+        "do { let xs = []; for x in [10, 20, 30] { set xs = concat(xs, [x * 2]) }; xs }",
+    ) == [20, 40, 60]
+
+
+def test_for_over_string_iterates_chars(session):
+    assert form_execute_text(
+        session, 'for c in "abc" { c }'
+    ) == ["a", "b", "c"]
+
+
+def test_for_non_iterable_raises(session):
+    with pytest.raises(TypeError):
+        form_execute_text(session, "for x in 42 { x }")
+
+
+# ---------------------------------------------------------------------------
+# while cond { body }
+# ---------------------------------------------------------------------------
+
+
+def test_while_counts_up_via_set(session):
+    assert form_execute_text(
+        session, "do { let i = 0; while i < 5 { set i = i + 1 }; i }"
+    ) == 5
+
+
+def test_while_returns_last_body_value(session):
+    assert form_execute_text(
+        session, "do { let i = 0; while i < 3 { set i = i + 1; i * 10 } }"
+    ) == 30
+
+
+def test_while_unentered_returns_null(session):
+    assert form_execute_text(
+        session, "while false { 42 }"
+    ) is None
+
+
+def test_while_runaway_protected(session):
+    """`while true { 1 }` would loop forever; the runtime cap raises."""
+    with pytest.raises(RuntimeError):
+        form_execute_text(session, "while true { 1 }")
+
+
+# ---------------------------------------------------------------------------
+# set on its own
+# ---------------------------------------------------------------------------
+
+
+def test_set_updates_existing_binding(session):
+    assert form_execute_text(
+        session, "do { let x = 5; set x = 99; x }"
+    ) == 99
+
+
+def test_set_without_binding_raises(session):
+    with pytest.raises(NameError):
+        form_execute_text(session, "set z = 5")
+
+
+def test_set_walks_to_outer_frame(session):
+    """`set` finds the nearest enclosing binding, not just the current frame."""
+    assert form_execute_text(
+        session,
+        "do { let x = 1; do { set x = 99 }; x }"
+    ) == 99
+
+
+def test_set_vs_let_distinction(session):
+    """`let` inside a sub-block introduces; `set` mutates the outer."""
+    # let creates a NEW x in the inner block; outer x stays.
+    assert form_execute_text(
+        session,
+        "do { let x = 1; do { let x = 99 }; x }"
+    ) == 1


### PR DESCRIPTION
## Summary

Three gaps from running Form:

\`\`\`form
for x in [1, 2, 3] { x * 2 }                              # → [2, 4, 6]
do { let total = 0;
     for x in [1, 2, 3, 4, 5] { set total = total + x };
     total }                                                # → 15
do { let i = 0; while i < 5 { set i = i + 1 }; i }        # → 5
\`\`\`

\`set\` mutates nearest enclosing binding (distinct from \`let\` which introduces). Without it, loop accumulator patterns silently failed because \`let total = total + x\` created a new binding in the loop's sub-frame.

14 new tests; 486 substrate tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)