### PR TITLE
attune(form): string interpolation + multiline strings

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -172,7 +172,9 @@ _TOKEN_PATTERNS = [
     ("RBRACK", r"\]"),
     ("LPAREN", r"\("),
     ("RPAREN", r"\)"),
-    ("STRING", r'"([^"\\]|\\.)*"'),
+    # Triple-quoted multiline strings come FIRST so the alternation matches
+    # them before the single-quote rule. Non-greedy across any character.
+    ("STRING", r'"""[\s\S]*?"""|"([^"\\]|\\.)*"'),
     ("INT", r"\d+"),
     ("IDENT", r"[A-Za-z_][A-Za-z_0-9\-]*"),
 ]
@@ -938,7 +940,14 @@ class Parser:
         if t.kind == "INT":
             return IntLit(int(self.consume("INT").value))
         if t.kind == "STRING":
-            return StringLit(_unquote(self.consume("STRING").value))
+            raw = self.consume("STRING").value
+            body = _unquote(raw)
+            # If the body contains a `${...}` marker, parse as interpolation
+            # — yields a concat chain `str(expr) + "..." + ...`. Otherwise
+            # a plain StringLit.
+            if "${" in body:
+                return _interpolated_to_ast(body)
+            return StringLit(value=body)
         if t.kind == "LPAREN":
             self.consume("LPAREN")
             inner = self.parse_expr()
@@ -1532,9 +1541,74 @@ class Parser:
 
 
 def _unquote(s: str) -> str:
+    # Triple-quoted strings strip both ends together.
+    if s.startswith('"""') and s.endswith('"""'):
+        return s[3:-3]
     if s.startswith('"') and s.endswith('"'):
         return s[1:-1].replace('\\"', '"').replace("\\\\", "\\")
     return s
+
+
+def _parse_interpolated(text: str):
+    """Parse a string body for `${...}` interpolation markers.
+
+    Returns a list alternating literal-string and expression-AST. When there
+    are no markers, returns `[text]` (a single string).
+
+    Each `${...}` is parsed as a Form expression using a nested parser.
+    The result composes into a chain of `BinOp("+", ...)` with `str(expr)`
+    coercion around each expression — surfaces the natural concatenation.
+    """
+    parts: list = []
+    i = 0
+    while i < len(text):
+        # Find next `${`
+        start = text.find("${", i)
+        if start < 0:
+            if i < len(text):
+                parts.append(text[i:])
+            break
+        if start > i:
+            parts.append(text[i:start])
+        # Walk to matching `}` (balanced)
+        depth = 1
+        j = start + 2
+        while j < len(text) and depth > 0:
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if depth != 0:
+            raise SyntaxError(f"Form: unterminated `${{...}}` in string literal")
+        expr_src = text[start + 2 : j]
+        # Recursively parse the embedded expression.
+        parts.append(parse(expr_src))
+        i = j + 1
+    return parts
+
+
+def _interpolated_to_ast(text: str):
+    """Build the AST for an interpolated string body.
+
+    No markers -> StringLit(text).
+    Markers -> chain of `str(expr) + "..." + str(expr) + ...` via BinOp("+").
+    """
+    parts = _parse_interpolated(text)
+    if len(parts) == 1 and isinstance(parts[0], str):
+        return StringLit(value=parts[0])
+    # Build the concat chain. Each non-string part is coerced via FnCall("str", [expr]).
+    def make(part):
+        if isinstance(part, str):
+            return StringLit(value=part)
+        return FnCall(name="str", args=[part])
+    nodes = [make(p) for p in parts]
+    acc = nodes[0]
+    for n in nodes[1:]:
+        acc = BinOp(op="+", left=acc, right=n)
+    return acc
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_substrate_form_string_interp.py
+++ b/api/tests/test_substrate_form_string_interp.py
@@ -1,0 +1,123 @@
+"""String interpolation and multiline strings.
+
+Two tactical gaps from the named follow-on list:
+
+- "hello {dollar}{open}name{close}" desugars at parse-time to a concat
+  chain of str(expr) and string literals — so the surface stays natural
+  while the runtime gets a BinOp tree it already knows how to evaluate.
+- Triple-quoted multiline strings extend the STRING regex to capture
+  any content (including newlines) between the markers.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.form_runtime import form_execute_text, reset_runtime_registries
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_plain_string_still_works(session):
+    assert form_execute_text(session, '"hello"') == "hello"
+
+
+def test_interpolation_with_arithmetic(session):
+    assert form_execute_text(session, '"hello ${1 + 2}"') == "hello 3"
+
+
+def test_interpolation_with_let_binding(session):
+    assert form_execute_text(
+        session, 'do { let name = "world"; "hello ${name}" }'
+    ) == "hello world"
+
+
+def test_interpolation_alone(session):
+    # Whole-string interpolation case.
+    assert form_execute_text(session, '"${5 * 6}"') == "30"
+
+
+def test_multiple_interpolations(session):
+    assert form_execute_text(
+        session,
+        'do { let x = 10; "x is ${x} and 2x is ${x * 2}" }',
+    ) == "x is 10 and 2x is 20"
+
+
+def test_interpolation_at_start(session):
+    assert form_execute_text(
+        session, '"${1} apple"'
+    ) == "1 apple"
+
+
+def test_interpolation_in_method_body(session):
+    # Interpolation works inside methods, with .self visible.
+    from app.services.substrate import BID_concept, make_cell
+    make_cell(session, name="lc-greet", domain="concept", blueprint=BID_concept())
+    session.commit()
+    form_execute_text(
+        session, 'method label on @concept(lc-greet) { "${.self.name}!" }'
+    )
+    assert form_execute_text(
+        session, "invoke label on @concept(lc-greet)"
+    ) == "lc-greet!"
+
+
+def test_unterminated_interpolation_raises(session):
+    with pytest.raises(SyntaxError):
+        form_execute_text(session, '"hello ${missing"')
+
+
+# ---------------------------------------------------------------------------
+# Multiline strings — """..."""
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_string_captures_newlines(session):
+    v = form_execute_text(session, '"""line 1\nline 2\nline 3"""')
+    assert v == "line 1\nline 2\nline 3"
+
+
+def test_multiline_string_with_internal_quotes(session):
+    # Triple-quoted strings allow embedded single double-quotes without escape.
+    v = form_execute_text(session, '"""he said "hi" and left"""')
+    assert v == 'he said "hi" and left'
+
+
+def test_multiline_string_empty(session):
+    assert form_execute_text(session, '""""""') == ""
+
+
+def test_multiline_string_with_interpolation(session):
+    # Interpolation markers work inside triple-quoted strings too.
+    assert form_execute_text(
+        session,
+        'do { let n = 7; """value:\n  ${n}\n""" }',
+    ) == "value:\n  7\n"


### PR DESCRIPTION
## Summary

Two tactical gaps from the follow-on list close together.

\`\`\`form
"hello \${1 + 2}"                                  # → "hello 3"
do { let n = "world"; "hello \${n}" }              # → "hello world"
"\${5 * 6}"                                        # → "30"
"""line 1
line 2"""                                          # → multiline preserved
do { let n = 7; """value:
  \${n}
""" }                                              # → interp inside multiline
\`\`\`

## Implementation

- STRING regex grows an alternative for triple-quoted bodies (non-greedy across newlines)
- _unquote strips both quote styles
- Parser detects \`\${...}\` markers in string bodies and routes through \`_interpolated_to_ast\` which builds a BinOp("+") chain wrapping non-string parts in FnCall("str", [expr])
- Balanced-brace walking handles \`\${dict-literal {...}}\` correctly
- No new runtime branch — the existing BinOp + str() built-in does the work

12 new tests; 514 substrate tests green (502 prior + 12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)