### PR TITLE
attune(form): Form-level interpreter walks its own Recipe NodeIDs

### DIFF
--- a/api/tests/test_substrate_form_self_hosted.py
+++ b/api/tests/test_substrate_form_self_hosted.py
@@ -1,0 +1,158 @@
+"""Form-level interpreter — proof that Form is expressive enough to
+walk its own Recipe NodeIDs and produce the same values the Python engine does.
+
+The Form code below defines `ev` (and helpers) as Form `defn`s. It reads
+substrate state via the same `.category`, `.children`, `.type_`, `.instance`
+accessors any Form expression has, dispatches on category, recurses. No
+Python is involved in the dispatch — only the bootstrap-engine's leaf
+operations (arithmetic, comparison, conditional) carry it through.
+
+This is the smallest concrete demonstration of self-hosting at the
+interpreter layer. The parser and the substrate-mutation runtime remain
+partially in Python (see self-hosted-eval.md for the honest map).
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate import form_evaluate_text
+from app.services.substrate.form_runtime import (
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(eng, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(eng, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(eng, checkfirst=True)
+    s = sessionmaker(bind=eng, expire_on_commit=False)()
+    reset_runtime_registries()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+        reset_runtime_registries()
+
+
+# Form source for the self-hosted interpreter. Lives as a string so the
+# test can substitute the recipe NodeID under test. Real-world use would
+# read it from a .form file in `docs/coherence-substrate/`.
+
+_FORM_EVAL_SRC = """
+do {{
+  defn ev_math(node) = do {{
+    let a = ev(node.children[0]);
+    let b = ev(node.children[1]);
+    let op = node.category.instance;
+    if op == 1 then a + b
+    else if op == 2 then a - b
+    else if op == 3 then a * b
+    else if op == 4 then a / b
+    else if op == 5 then a % b
+    else 0
+  }};
+  defn ev_cmp(node) = do {{
+    let a = ev(node.children[0]);
+    let b = ev(node.children[1]);
+    let op = node.category.instance;
+    if op == 1 then a == b
+    else if op == 2 then a != b
+    else if op == 3 then a < b
+    else if op == 4 then a <= b
+    else if op == 5 then a > b
+    else if op == 6 then a >= b
+    else false
+  }};
+  defn ev_cond(node) = do {{
+    let c = ev(node.children[0]);
+    if c then ev(node.children[1])
+    else if node.category.instance == 2 then ev(node.children[2])
+    else null
+  }};
+  defn ev(node) = do {{
+    let ct = node.category.type_;
+    if ct == 12 then ev_math(node)
+    else if ct == 13 then ev_cmp(node)
+    else if ct == 11 then ev_cond(node)
+    else if ct == 3 then node.instance - 1
+    else if ct == 2 then (if node.instance == 1 then true else false)
+    else 0
+  }};
+  ev(@{nid})
+}}
+"""
+
+
+def _form_eval(session, expr: str):
+    """Helper: intern the expression via Python parser, then evaluate via
+    the Form-level interpreter."""
+    nid = form_evaluate_text(session, expr).value
+    return form_execute_text(session, _FORM_EVAL_SRC.format(nid=nid))
+
+
+def test_form_eval_simple_arithmetic(session):
+    assert _form_eval(session, "1 + 2") == 3
+
+
+def test_form_eval_precedence(session):
+    assert _form_eval(session, "1 + 2 * 3") == 7
+    assert _form_eval(session, "(1 + 2) * 3") == 9
+
+
+def test_form_eval_subtraction(session):
+    assert _form_eval(session, "10 - 4") == 6
+
+
+def test_form_eval_division(session):
+    assert _form_eval(session, "20 / 4") == 5
+
+
+def test_form_eval_comparison_true(session):
+    assert _form_eval(session, "5 > 3") is True
+
+
+def test_form_eval_comparison_false(session):
+    assert _form_eval(session, "5 < 3") is False
+
+
+def test_form_eval_equality(session):
+    assert _form_eval(session, "7 == 7") is True
+    assert _form_eval(session, "7 == 8") is False
+
+
+def test_form_eval_if_then_else_true_branch(session):
+    assert _form_eval(session, "if 5 > 3 then 100 else 200") == 100
+
+
+def test_form_eval_if_then_else_false_branch(session):
+    assert _form_eval(session, "if 5 < 3 then 100 else 200") == 200
+
+
+def test_form_eval_nested_arithmetic_in_cond(session):
+    """The Form-level interpreter handles deep recursion through composite
+    recipes — this exercises ev_cond -> ev_math -> ev_math."""
+    assert _form_eval(session, "if (2 * 3) > (1 + 2) then (10 * 5) else (20 / 2)") == 50
+
+
+def test_form_eval_matches_python_engine(session):
+    """Form-level result equals Python-level result for the same recipe.
+
+    The strong proof: two engines, identical answer. The Form interpreter
+    is reading the same substrate Python's engine reads."""
+    for expr in ["1 + 2", "5 * 3 - 2", "if 1 == 1 then 42 else 0"]:
+        python_result = form_execute_text(session, expr)
+        form_result = _form_eval(session, expr)
+        assert python_result == form_result, f"divergence on {expr!r}"

--- a/docs/coherence-substrate/self-hosted-eval.md
+++ b/docs/coherence-substrate/self-hosted-eval.md
@@ -1,0 +1,75 @@
+# Self-hosted Form — what's already in Form, what's still Python
+
+Form is a substrate-native DSL. The honest question — *"can the parser, interpreter and runtime all live in Form itself?"* — has a layered answer. This page maps where each layer currently lives.
+
+## What's self-hosted today
+
+### The interpreter for arithmetic/comparison/conditional core
+
+`api/tests/test_substrate_form_self_hosted.py` ships a working demonstration: a Form `defn ev(node)` that reads a Recipe NodeID through the substrate's `.category.type_`, `.category.instance`, `.children[i]`, `.instance` accessors, dispatches on category, and recurses. No Python in the dispatch — only the bootstrap engine's leaf operations carry it through.
+
+```form
+defn ev(node) = do {
+  let ct = node.category.type_;
+  if ct == 12 then ev_math(node)         -- MATH
+  else if ct == 13 then ev_cmp(node)     -- COMPARE
+  else if ct == 11 then ev_cond(node)    -- COND
+  else if ct == 3  then node.instance - 1  -- INTEGER trivial
+  else if ct == 2  then (if node.instance == 1 then true else false)  -- BOOL
+  else 0
+};
+ev(@<recipe-nid>)
+```
+
+It produces identical answers to the Python engine for `1+2`, `5*3-2`, `if 1==1 then 42 else 0`, etc. The strong proof: two engines, identical answer, same substrate.
+
+This is the smallest concrete demonstration that **Form is expressive enough to be its own interpreter** for the recipe categories it can read. Extending to STATE, CHOICE, METHOD, etc. is adding `if ct == N then …` branches — mechanical, not conceptual.
+
+### The keyword grammar
+
+`register_form_keyword` lets a Form keyword be defined by a substrate-resident pattern + builder. Keywords like `let`, `if/then/else`, `do { … }` are themselves cells in the lattice; the bootstrap parser dispatches through that registry. New surface keywords ship as substrate writes, not Python edits.
+
+### Substrate-resident patterns and builders
+
+`Build`, `CaptureRef`, `Const` templates compose into Recipes that the runtime executes. The "what does a keyword build" lives in the substrate.
+
+## What is still Python
+
+### The bootstrap parser
+
+`api/app/services/substrate/form.py` — `tokenize`, `tokenize_iter`, `tokenize_chunks`, `Parser`, `parse`, `parse_chunks`. Regex-driven lexer, recursive-descent parser, builds an AST of dataclasses (`BinOp`, `IfExpr`, `DoBlock`, …). This is the bootstrap — the thing that turns surface text into a Recipe tree the Form-level interpreter can then walk.
+
+A Form-level parser is reachable but unbuilt: Form would need string-manipulation primitives and a `Token` cell shape. The interpreter above already proves it's a tractable next move, just not present.
+
+### The substrate-mutation primitives
+
+`make_cell`, `define_method`, `register_form_keyword`, the ingest paths — these write to the SQL backend. They're Python because the storage is Python (SQLAlchemy ORM). A Form-level mutation API would either bind through Python or grow a Form-native persistence layer.
+
+### Leaf operations
+
+Arithmetic, comparison, conditional dispatch at the leaves — `a + b`, `a == b`, `if c then … else …`. The Form interpreter recurses *through* these; the trivials themselves bottom out in Python integer ops. This is the floor any self-hosted language has: at some level the operations are the host's operations.
+
+## The map
+
+| Layer | Today | Path to full self-hosting |
+|-------|-------|---------------------------|
+| **Interpreter** (recipe-walking) | Form (this PR — arithmetic/compare/cond proven; other categories mechanical) | Add `if ct == N` branches per category |
+| **Keyword grammar** | Form (substrate-resident via `register_form_keyword`) | Already there |
+| **Pattern/builder templates** | Form (substrate-resident) | Already there |
+| **Bootstrap parser** | Python (`tokenize` + recursive descent) | Form-level parser needs string primitives + Token cell shape |
+| **Substrate mutation** | Python (SQLAlchemy backend) | Form-native storage layer, or Python-bound writes |
+| **Leaf arithmetic/comparison** | Python (integer ops on `node.instance`) | Inherent floor — any language bottoms out in host ops |
+
+## Why this matters
+
+Self-hosting isn't a single yes/no. The shape that matters is: **can the language describe its own semantics in itself?** The demo answers yes for the interpreter layer. The parser layer is the same answer waiting for an afternoon of work. The persistence layer is a substrate-design choice, not a language limitation.
+
+The bootstrap parser staying Python isn't a confession — it's a deliberate floor. Even the BML/BMF self-hosting lineage (master thesis 2000) bottomed out somewhere; the discipline is *as much as possible in the language, and the rest is honest about being the floor*.
+
+## Run the demo
+
+```bash
+cd api && python -m pytest tests/test_substrate_form_self_hosted.py -v
+```
+
+Eleven tests, all green. Each one runs a Form expression through Python's parser to produce a Recipe NodeID, then evaluates that NodeID through a *Form-level* interpreter, then checks the answer matches what the Python engine would produce. Two engines, identical answer, same substrate — that's the proof.


### PR DESCRIPTION
## Summary

Demonstrates that Form is expressive enough to be its own interpreter for the recipe categories it can read.

- New test `api/tests/test_substrate_form_self_hosted.py` ships a Form `defn ev(node)` that reads Recipe NodeIDs through `.category.type_`, `.category.instance`, `.children[i]`, `.instance` — no Python in the dispatch, only the bootstrap engine's leaf ops carry it through. Two engines, identical answer, same substrate.
- New doc `docs/coherence-substrate/self-hosted-eval.md` maps honestly what's already in Form (interpreter for arithmetic/compare/cond, keyword grammar via `register_form_keyword`, pattern/builder templates), what remains Python (bootstrap parser, substrate-mutation primitives, leaf operations), and the path for each layer.

The bootstrap parser staying Python isn't a confession — it's a deliberate floor, the same floor BML/BMF chose in 2000.

## Test plan

- [x] 11 self-hosting tests green (`pytest tests/test_substrate_form_self_hosted.py`)
- [x] Full substrate suite green (525 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)