### PR TITLE
attune(form): fence self-hosted engine against silent rename drift

### DIFF
--- a/api/tests/test_substrate_form_self_hosted.py
+++ b/api/tests/test_substrate_form_self_hosted.py
@@ -1,17 +1,31 @@
-"""Form-level interpreter — proof that Form is expressive enough to
-walk its own Recipe NodeIDs and produce the same values the Python engine does.
+"""Form-level interpreter — proof that Form walks its own Recipe NodeIDs.
 
-The Form code below defines `ev` (and helpers) as Form `defn`s. It reads
-substrate state via the same `.category`, `.children`, `.type_`, `.instance`
-accessors any Form expression has, dispatches on category, recurses. No
-Python is involved in the dispatch — only the bootstrap-engine's leaf
-operations (arithmetic, comparison, conditional) carry it through.
+The evaluator source lives in `docs/coherence-substrate/form-engine.form`
+between `# >>> BEGIN engine` / `# >>> END engine` markers. The substrate
+holds its own interpreter; the test loads it from disk and runs it.
 
-This is the smallest concrete demonstration of self-hosting at the
-interpreter layer. The parser and the substrate-mutation runtime remain
-partially in Python (see self-hosted-eval.md for the honest map).
+Three lines of defense against drift:
+
+1. The dispatch table is flat NodeID literals (`@1.2.12.1` for MATH.PLUS,
+   etc.). If `RBasic.MATH` ever moves from 12 to anything else, the
+   literal stops matching the recipe Form produces — answers change,
+   tests fail.
+
+2. `test_form_engine_literals_match_python_enums` reads every `@l.t.i`
+   literal from the engine block and asserts each one points at the
+   `(Level.BASIC, RBasic.<verb>, instance)` triple a Python enum names.
+   Rename `RBasic.MATH` and this test names the wrong literal.
+
+3. `test_form_engine_matches_python_engine_over_random_expressions`
+   generates random arithmetic / logic / comparison expressions and
+   asserts both engines produce the same answer. Drift in semantics
+   shows up as a divergence.
 """
 from __future__ import annotations
+
+import random
+import re
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
@@ -19,11 +33,34 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.services.substrate import form_evaluate_text
+from app.services.substrate.category import (
+    Level,
+    RBasic,
+    RCompare,
+    RCond,
+    RLogic,
+    RMath,
+)
 from app.services.substrate.form_runtime import (
     form_execute_text,
     reset_runtime_registries,
 )
 from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+_ENGINE_PATH = Path(__file__).parent.parent.parent / "docs" / "coherence-substrate" / "form-engine.form"
+
+
+def _load_engine() -> str:
+    src = _ENGINE_PATH.read_text()
+    m = re.search(r"# >>> BEGIN engine\n(.*?)\n# >>> END engine", src, re.DOTALL)
+    if not m:
+        raise RuntimeError(
+            f"engine markers not found in {_ENGINE_PATH}; the test loads "
+            "the evaluator from disk and needs `# >>> BEGIN engine` / "
+            "`# >>> END engine` to bracket the source."
+        )
+    return m.group(1)
 
 
 @pytest.fixture
@@ -47,112 +84,182 @@ def session():
         reset_runtime_registries()
 
 
-# Form source for the self-hosted interpreter. Lives as a string so the
-# test can substitute the recipe NodeID under test. Real-world use would
-# read it from a .form file in `docs/coherence-substrate/`.
-
-_FORM_EVAL_SRC = """
-do {{
-  defn ev_math(node) = do {{
-    let a = ev(node.children[0]);
-    let b = ev(node.children[1]);
-    let op = node.category.instance;
-    if op == 1 then a + b
-    else if op == 2 then a - b
-    else if op == 3 then a * b
-    else if op == 4 then a / b
-    else if op == 5 then a % b
-    else 0
-  }};
-  defn ev_cmp(node) = do {{
-    let a = ev(node.children[0]);
-    let b = ev(node.children[1]);
-    let op = node.category.instance;
-    if op == 1 then a == b
-    else if op == 2 then a != b
-    else if op == 3 then a < b
-    else if op == 4 then a <= b
-    else if op == 5 then a > b
-    else if op == 6 then a >= b
-    else false
-  }};
-  defn ev_cond(node) = do {{
-    let c = ev(node.children[0]);
-    if c then ev(node.children[1])
-    else if node.category.instance == 2 then ev(node.children[2])
-    else null
-  }};
-  defn ev(node) = do {{
-    let ct = node.category.type_;
-    if ct == 12 then ev_math(node)
-    else if ct == 13 then ev_cmp(node)
-    else if ct == 11 then ev_cond(node)
-    else if ct == 3 then node.instance - 1
-    else if ct == 2 then (if node.instance == 1 then true else false)
-    else 0
-  }};
-  ev(@{nid})
-}}
-"""
-
-
 def _form_eval(session, expr: str):
-    """Helper: intern the expression via Python parser, then evaluate via
-    the Form-level interpreter."""
+    """Intern the expression, then evaluate via the Form-level engine."""
     nid = form_evaluate_text(session, expr).value
-    return form_execute_text(session, _FORM_EVAL_SRC.format(nid=nid))
+    engine = _load_engine()
+    return form_execute_text(session, f"do {{\n{engine}\n; ev(@{nid})\n}}")
 
 
-def test_form_eval_simple_arithmetic(session):
+# ---------------------------------------------------------------------------
+# Smoke tests — every category arm exercised at least once
+# ---------------------------------------------------------------------------
+
+
+def test_engine_plus(session):
     assert _form_eval(session, "1 + 2") == 3
 
 
-def test_form_eval_precedence(session):
+def test_engine_minus(session):
+    assert _form_eval(session, "10 - 4") == 6
+
+
+def test_engine_multiply(session):
+    assert _form_eval(session, "6 * 7") == 42
+
+
+def test_engine_divide(session):
+    assert _form_eval(session, "20 / 4") == 5
+
+
+def test_engine_modulo(session):
+    assert _form_eval(session, "17 % 5") == 2
+
+
+def test_engine_precedence(session):
     assert _form_eval(session, "1 + 2 * 3") == 7
     assert _form_eval(session, "(1 + 2) * 3") == 9
 
 
-def test_form_eval_subtraction(session):
-    assert _form_eval(session, "10 - 4") == 6
-
-
-def test_form_eval_division(session):
-    assert _form_eval(session, "20 / 4") == 5
-
-
-def test_form_eval_comparison_true(session):
-    assert _form_eval(session, "5 > 3") is True
-
-
-def test_form_eval_comparison_false(session):
-    assert _form_eval(session, "5 < 3") is False
-
-
-def test_form_eval_equality(session):
+def test_engine_equal(session):
     assert _form_eval(session, "7 == 7") is True
     assert _form_eval(session, "7 == 8") is False
 
 
-def test_form_eval_if_then_else_true_branch(session):
+def test_engine_not_equal(session):
+    assert _form_eval(session, "5 != 3") is True
+
+
+def test_engine_less(session):
+    assert _form_eval(session, "3 < 5") is True
+
+
+def test_engine_less_equal(session):
+    assert _form_eval(session, "5 <= 5") is True
+
+
+def test_engine_greater(session):
+    assert _form_eval(session, "5 > 3") is True
+
+
+def test_engine_greater_equal(session):
+    assert _form_eval(session, "5 >= 5") is True
+
+
+def test_engine_logic_and(session):
+    assert _form_eval(session, "true && true") is True
+    assert _form_eval(session, "true && false") is False
+
+
+def test_engine_logic_or(session):
+    assert _form_eval(session, "false || true") is True
+
+
+def test_engine_logic_not(session):
+    assert _form_eval(session, "!false") is True
+
+
+def test_engine_if_then_else(session):
     assert _form_eval(session, "if 5 > 3 then 100 else 200") == 100
-
-
-def test_form_eval_if_then_else_false_branch(session):
     assert _form_eval(session, "if 5 < 3 then 100 else 200") == 200
 
 
-def test_form_eval_nested_arithmetic_in_cond(session):
-    """The Form-level interpreter handles deep recursion through composite
-    recipes — this exercises ev_cond -> ev_math -> ev_math."""
-    assert _form_eval(session, "if (2 * 3) > (1 + 2) then (10 * 5) else (20 / 2)") == 50
+def test_engine_nested(session):
+    assert _form_eval(
+        session, "if (2 * 3) > (1 + 2) then (10 * 5) else (20 / 2)"
+    ) == 50
 
 
-def test_form_eval_matches_python_engine(session):
-    """Form-level result equals Python-level result for the same recipe.
+# ---------------------------------------------------------------------------
+# Drift sentinel — every literal in the engine block names a real enum
+# ---------------------------------------------------------------------------
 
-    The strong proof: two engines, identical answer. The Form interpreter
-    is reading the same substrate Python's engine reads."""
-    for expr in ["1 + 2", "5 * 3 - 2", "if 1 == 1 then 42 else 0"]:
+
+# Each tuple: (NodeID 4-tuple as it appears in form-engine.form,
+#              the Python enum value it must encode)
+_EXPECTED_LITERALS = [
+    ((1, 2, RBasic.MATH, RMath.PLUS),         "RBasic.MATH / RMath.PLUS"),
+    ((1, 2, RBasic.MATH, RMath.MINUS),        "RBasic.MATH / RMath.MINUS"),
+    ((1, 2, RBasic.MATH, RMath.MULTIPLY),     "RBasic.MATH / RMath.MULTIPLY"),
+    ((1, 2, RBasic.MATH, RMath.DIVIDE),       "RBasic.MATH / RMath.DIVIDE"),
+    ((1, 2, RBasic.MATH, RMath.MODULO),       "RBasic.MATH / RMath.MODULO"),
+    ((1, 2, RBasic.COMPARE, RCompare.EQUAL),         "RBasic.COMPARE / RCompare.EQUAL"),
+    ((1, 2, RBasic.COMPARE, RCompare.NOT_EQUAL),     "RBasic.COMPARE / RCompare.NOT_EQUAL"),
+    ((1, 2, RBasic.COMPARE, RCompare.LESS),          "RBasic.COMPARE / RCompare.LESS"),
+    ((1, 2, RBasic.COMPARE, RCompare.LESS_EQUAL),    "RBasic.COMPARE / RCompare.LESS_EQUAL"),
+    ((1, 2, RBasic.COMPARE, RCompare.GREATER),       "RBasic.COMPARE / RCompare.GREATER"),
+    ((1, 2, RBasic.COMPARE, RCompare.GREATER_EQUAL), "RBasic.COMPARE / RCompare.GREATER_EQUAL"),
+    ((1, 2, RBasic.LOGIC, RLogic.AND),       "RBasic.LOGIC / RLogic.AND"),
+    ((1, 2, RBasic.LOGIC, RLogic.OR),        "RBasic.LOGIC / RLogic.OR"),
+    ((1, 2, RBasic.LOGIC, RLogic.NOT),       "RBasic.LOGIC / RLogic.NOT"),
+    ((1, 2, RBasic.COND, RCond.IF_THEN),      "RBasic.COND / RCond.IF_THEN"),
+    ((1, 2, RBasic.COND, RCond.IF_THEN_ELSE), "RBasic.COND / RCond.IF_THEN_ELSE"),
+]
+
+
+def test_form_engine_literals_match_python_enums():
+    """If `RBasic.MATH` moves from 12 to anything else, the literal
+    `@1.2.12.1` in the engine block silently points at the wrong row.
+    This test catches that the moment it happens."""
+    engine = _load_engine()
+    found = set(
+        tuple(int(x) for x in m.groups())
+        for m in re.finditer(r"@(\d+)\.(\d+)\.(\d+)\.(\d+)", engine)
+    )
+    for nid_tuple, label in _EXPECTED_LITERALS:
+        assert nid_tuple in found, (
+            f"engine block is missing literal @{'.'.join(str(x) for x in nid_tuple)} "
+            f"({label}); did the dispatch table get out of sync with the enums?"
+        )
+    # Also assert the literals that ARE in the file all decode to known enums —
+    # catches the inverse drift (engine literal exists but no enum points at it).
+    known = {nid for nid, _ in _EXPECTED_LITERALS}
+    # Trivial-leaf literals (level=1) live in the `_` arm via runtime checks,
+    # not as match patterns — so the file holds only composite literals (level=2).
+    composite_literals = {nid for nid in found if nid[1] == Level.BASIC}
+    unknown = composite_literals - known
+    assert not unknown, (
+        f"engine block has literals not named by _EXPECTED_LITERALS: {unknown}. "
+        "Either add them to the test, or remove the stale arm."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parity sentinel — random expressions, both engines, equal answers
+# ---------------------------------------------------------------------------
+
+
+def _random_expr(rng: random.Random, depth: int) -> str:
+    if depth <= 0 or rng.random() < 0.3:
+        return str(rng.randint(1, 9))
+    op = rng.choice(["+", "-", "*"])  # avoid `/` (zero-div) and `%` (zero-mod)
+    a = _random_expr(rng, depth - 1)
+    b = _random_expr(rng, depth - 1)
+    return f"({a} {op} {b})"
+
+
+def test_form_engine_matches_python_engine_over_random_expressions(session):
+    """Two engines, identical answer — that's the strong proof, sampled
+    across a generated population rather than three handpicked exprs."""
+    rng = random.Random(20260517)
+    for _ in range(40):
+        expr = _random_expr(rng, depth=3)
         python_result = form_execute_text(session, expr)
         form_result = _form_eval(session, expr)
-        assert python_result == form_result, f"divergence on {expr!r}"
+        assert python_result == form_result, (
+            f"engine divergence on {expr!r}: python={python_result} form={form_result}"
+        )
+
+
+def test_form_engine_matches_python_engine_over_conditionals(session):
+    """Parity also for conditionals + comparisons, where the answer
+    type differs (bool vs int)."""
+    rng = random.Random(20260517)
+    for _ in range(20):
+        a = rng.randint(1, 9)
+        b = rng.randint(1, 9)
+        op = rng.choice(["==", "!=", "<", "<=", ">", ">="])
+        then_v = rng.randint(10, 99)
+        else_v = rng.randint(100, 999)
+        expr = f"if {a} {op} {b} then {then_v} else {else_v}"
+        assert _form_eval(session, expr) == form_execute_text(session, expr), expr

--- a/docs/coherence-substrate/form-engine.form
+++ b/docs/coherence-substrate/form-engine.form
@@ -3,34 +3,31 @@
 # ─────────────────────────────────────────────────────────────────────
 #
 # This file contains Form source code for the execution engine that
-# runs Form. It is a meta-circular sketch: parts of it execute today
-# against the current runtime; parts require introspection primitives
-# named at the bottom of this file.
+# runs Form. As of PR #1692 the arithmetic/comparison/conditional
+# core is meta-circular: Part 2 below is live, runnable code, walked
+# end-to-end by api/tests/test_substrate_form_self_hosted.py.
 #
-# The frequency-match observation: a runtime written in Python is the
-# language describing itself from outside — a foreign voice. For the
-# body to self-evolve, the engine must be expressible in its own
-# grammar so that changes to Form flow through the engine without
-# recompiling Python. This file is that direction.
+# A runtime written in Python is the language describing itself from
+# outside — a foreign voice. For the body to self-evolve, the engine
+# must be expressible in its own grammar so that changes to Form flow
+# through the engine without recompiling Python. That direction is
+# now a working artifact, not just a sketch.
 
 # ─────────────────────────────────────────────────────────────────────
-# Part 1 — what runs today (no new primitives needed)
+# Part 1 — backbones that have run since defn landed
 # ─────────────────────────────────────────────────────────────────────
 #
-# These functions exercise every backbone needed for an evaluator:
-# recursion, conditional dispatch, closure capture, composition.
-# They run *as-is* through `coh substrate run "<expr>"`.
+# Recursion, closure capture, conditional dispatch, composition.
+# These run as-is through `coh substrate form "<expr>"`.
 
-# Factorial — recursive integer arithmetic.
-# Verified: fact(6) -> 720
+# Factorial — recursive integer arithmetic.  fact(6) -> 720
 do {
     defn fact(n) =
         if n <= 1 then 1 else n * fact(n - 1);
     fact(6)
 }
 
-# Fibonacci — multiple recursive calls per frame.
-# Verified: fib(10) -> 55
+# Fibonacci — multiple recursive calls per frame.  fib(10) -> 55
 do {
     defn fib(n) =
         if n <= 1 then n
@@ -38,18 +35,8 @@ do {
     fib(10)
 }
 
-# Function composition — one closure calling another.
-# Verified: double(sumto(10)) -> 110
-do {
-    defn sumto(n) =
-        if n == 0 then 0 else n + sumto(n - 1);
-    defn double(x) = x * 2;
-    double(sumto(10))
-}
-
-# Closure capture — `factor` is bound to the OUTER frame, not the
-# caller's. Inner `factor = 99` does not leak into scale.
-# Verified: 15 (not 495)
+# Closure capture — `factor` is bound to the OUTER frame.
+# Inner `factor = 99` does not leak into scale.  Returns 15.
 do {
     let factor = 3;
     defn scale(x) = x * factor;
@@ -60,115 +47,99 @@ do {
 }
 
 # ─────────────────────────────────────────────────────────────────────
-# Part 2 — the evaluator sketch (needs introspection primitives)
+# Part 2 — the recipe evaluator, live (PR #1692)
 # ─────────────────────────────────────────────────────────────────────
 #
-# This is what a recipe-evaluator looks like in Form. It does not run
-# today because Form lacks three introspection primitives, named in
-# Part 3 below. The sketch is faithful — each branch dispatches on
-# recipe category and recursively evaluates children. When the
-# primitives land, this file becomes the substrate-resident engine.
+# Walks any Recipe NodeID by dispatching on `.category`. The dispatch
+# table below is flat: one arm per known (Level, RBasic.<verb>,
+# instance) NodeID, so any drift in the substrate's category numbers
+# is caught the moment a literal no longer matches the Python enum
+# (see test_form_engine_literals_match_python_enums).
+#
+# Encoding the body relies on:
+#   n.category        — NodeID of the category this recipe belongs to
+#   n.children[k]     — k-th child recipe NodeID
+#   n.instance        — trivial leaf payload
+#
+# These are field-accessors on the Form `node.` surface (form_runtime
+# §_node_category, §_node_children). They are the shape Part 3 of the
+# earlier sketch asked for, just spelled as `.field` instead of
+# `fn(node)`.
+#
+# The evaluator lives between the BEGIN/END markers so the self-hosted
+# test can extract and run it. Adding a category is mechanical: append
+# one arm here and one corresponding test expression.
 
-# eval_recipe(r) — evaluate a recipe NodeID to a value.
-#
-# The dispatch is on the recipe's category. Each Recipe NodeID carries
-# (package, level, type_, instance); for composite recipes, the
-# category lives in the substrate row's serialized field. The
-# `category(r)` primitive returns a NodeID; we compare against the
-# well-known category NodeIDs the substrate has been minting all along.
-#
-# defn eval_recipe(r) =
-#     match category(r) {
-#         @1.2.12.1 => eval_recipe(child(r, 0)) + eval_recipe(child(r, 1)),  # Math.PLUS
-#         @1.2.12.2 => eval_recipe(child(r, 0)) - eval_recipe(child(r, 1)),  # Math.MINUS
-#         @1.2.12.3 => eval_recipe(child(r, 0)) * eval_recipe(child(r, 1)),  # Math.MULTIPLY
-#         @1.2.12.4 => eval_recipe(child(r, 0)) / eval_recipe(child(r, 1)),  # Math.DIVIDE
-#         @1.2.13.1 => eval_recipe(child(r, 0)) == eval_recipe(child(r, 1)), # Compare.EQUAL
-#         @1.2.13.5 => eval_recipe(child(r, 0)) > eval_recipe(child(r, 1)),  # Compare.GREATER
-#         @1.2.11.2 => if eval_recipe(child(r, 0))
-#                      then eval_recipe(child(r, 1))
-#                      else eval_recipe(child(r, 2)),                         # Cond.IF_THEN_ELSE
-#         _ => integer_value(r)   # leaf: decode the integer instance
-#     }
-
-# eval_text(src) — parse-and-run a Form source string.
-#
-# defn eval_text(src) =
-#     do {
-#         let ast = parse(src);
-#         let recipe = intern(ast);
-#         eval_recipe(recipe)
-#     }
+# >>> BEGIN engine
+defn ev(n) = match n.category {
+    # RBasic.MATH (12) — arithmetic
+    @1.2.12.1 => ev(n.children[0]) + ev(n.children[1]),     # PLUS
+    @1.2.12.2 => ev(n.children[0]) - ev(n.children[1]),     # MINUS
+    @1.2.12.3 => ev(n.children[0]) * ev(n.children[1]),     # MULTIPLY
+    @1.2.12.4 => ev(n.children[0]) / ev(n.children[1]),     # DIVIDE
+    @1.2.12.5 => ev(n.children[0]) % ev(n.children[1]),     # MODULO
+    # RBasic.COMPARE (13) — relational
+    @1.2.13.1 => ev(n.children[0]) == ev(n.children[1]),    # EQUAL
+    @1.2.13.2 => ev(n.children[0]) != ev(n.children[1]),    # NOT_EQUAL
+    @1.2.13.3 => ev(n.children[0]) < ev(n.children[1]),     # LESS
+    @1.2.13.4 => ev(n.children[0]) <= ev(n.children[1]),    # LESS_EQUAL
+    @1.2.13.5 => ev(n.children[0]) > ev(n.children[1]),     # GREATER
+    @1.2.13.6 => ev(n.children[0]) >= ev(n.children[1]),    # GREATER_EQUAL
+    # RBasic.LOGIC (14) — boolean
+    @1.2.14.1 => ev(n.children[0]) && ev(n.children[1]),    # AND
+    @1.2.14.2 => ev(n.children[0]) || ev(n.children[1]),    # OR
+    @1.2.14.3 => !ev(n.children[0]),                         # NOT
+    # RBasic.COND (11) — conditional
+    @1.2.11.1 => if ev(n.children[0]) then ev(n.children[1]) else null,
+    @1.2.11.2 => if ev(n.children[0]) then ev(n.children[1]) else ev(n.children[2]),
+    # Trivial leaves — decode by category-instance under RType
+    _ => if n.category.level == 1 then
+            (if n.category.type_ == 3 then n.instance - 1                # INTEGER
+             else if n.category.type_ == 2 then (if n.instance == 1 then true else false)  # BOOL
+             else 0)
+         else 0
+}
+# >>> END engine
 
 # ─────────────────────────────────────────────────────────────────────
-# Part 3 — what blocks Part 2 from running today
+# Part 3 — primitives the engine reaches for (all live)
 # ─────────────────────────────────────────────────────────────────────
 #
-# Form needs these primitives to host its own evaluator. Each is a
-# small substrate operation, expressible as a Python-implemented
-# Form built-in (analogous to how `+` is). None require new theory;
-# each is its own breath.
-
-# 3a. Recipe introspection
+# Each item below was named as a future need in the earlier sketch.
+# All shipped as `.field` accessors on Form's `node.` surface:
 #
-#   category(r) -> NodeID
-#       Returns the (1, level, type_, instance) NodeID of r's category.
-#       For trivial recipes (level=TRIVIAL), this IS r. For composite
-#       recipes, it's the first segment of substrate_nodes.serialized.
+#   n.category   — NodeID of n's category (for trivials, n itself)
+#   n.children   — ordered list of child NodeIDs (empty for trivials)
+#   n.nchildren  — len(n.children)
+#   n.instance   — trivial leaf payload (raw int from the NodeID 4-tuple)
+#   n.level      — 1=TRIVIAL, 2=BASIC, 3+=COMPLEX_k
+#   n.type_      — RBasic / RType slot index
 #
-#   nchildren(r) -> integer
-#       Number of children r has. 0 for trivials.
-#
-#   child(r, n) -> NodeID
-#       The n-th child recipe NodeID. n is 0-indexed.
-
-# 3b. Trivial-leaf decoding
-#
-#   integer_value(r) -> integer
-#       For trivial integer recipes (level=TRIVIAL, type=RType.INTEGER),
-#       decode the instance back to the integer value. Today's encoding
-#       (`instance - 1` for non-negative) is lossy for negatives — a
-#       proper substrate integer-table closes that gap.
-#
-#   string_value(r) -> string
-#       Look up the substrate string-table for the value behind a
-#       string-recipe's instance. Cross-process stable (substrate_strings).
-
-# 3c. Match-on-NodeID
-#
-#   The match expression already accepts NodeID literals as patterns
-#   (because Form already parses @x.y.z.w). What's needed is for the
-#   runtime to compare scrutinee == pattern as NodeID equality — which
-#   form_runtime already does via `pat_value == scrut` and NodeID's
-#   __eq__ from its frozen dataclass. So this works today; verified by
-#   substituting `category(r)` with a literal NodeID in a test.
+# Match-on-NodeID works today because NodeID's frozen-dataclass __eq__
+# is what `match` compares; `@p.l.t.i` literals are first-class values.
 
 # ─────────────────────────────────────────────────────────────────────
 # Part 4 — what remains beyond Part 3
 # ─────────────────────────────────────────────────────────────────────
 #
-# The introspection primitives close Part 2 for the *arithmetic /
-# conditional / block* layer. Full meta-circularity also needs:
+# Full meta-circularity still wants:
 #
 # 4a. Identifier resolution from recipes
-#     The bootstrap parser produces an Identifier AST that hashes its
-#     name into a recipe instance (lossy). For an evaluator running on
-#     recipes to look up variables in a frame, we need the substrate
-#     string-table to be the canonical name encoding — replacing the
-#     in-process hash.
+#     The bootstrap parser hashes identifier names into recipe instances
+#     (lossy). For an evaluator running on recipes to look up variables
+#     in a frame, the substrate string-table needs to be the canonical
+#     name encoding — replacing the in-process hash.
 #
 # 4b. Call from recipes
-#     FnDef/FnCall need to round-trip through the substrate. A FnDef
-#     recipe carries (name, params, body); a FnCall carries (name, args).
-#     A new RBasic.CALL is already declared; what's needed is the
-#     evaluator branch that reads the substrate function table from
-#     within Form.
+#     FnDef / FnCall round-trip through the substrate. A FnDef recipe
+#     carries (name, params, body); a FnCall carries (name, args). The
+#     evaluator branch reading the substrate function table from within
+#     Form is the closing move.
 #
 # 4c. Lexer and primary-atom parser
-#     The deepest BMF closure (named in form-language.md "What remains
-#     beyond step 8"). Once the engine runs in Form, the parser written
-#     in Form completes the cycle: tokenize-in-Form, parse-in-Form,
-#     evaluate-in-Form, all reading their rules from the lattice.
+#     The deepest closure (named in form-language.md "What remains
+#     beyond step 8"). Once the engine runs in Form, a Form-level
+#     parser tokenize-in-Form / parse-in-Form completes the cycle.
 
 # ─────────────────────────────────────────────────────────────────────
 # The asymmetry made visible
@@ -177,21 +148,11 @@ do {
 # Self-reflecting    — mature (lenses + grammar-as-data)
 # Self-sensing       — mature (verb-cluster as wellness)
 # Self-expressing    — alive at the keyword layer (substrate-resident
-#                      patterns + templates); the deeper bootstrap-in-
+#                      patterns + templates); the bootstrap-parser-in-
 #                      Form move is named, not yet built.
-# Self-executing     — alive (form_runtime walks ASTs and returns
-#                      values; defn + recursion let Form host its own
-#                      computations); the engine-in-Form move waits on
-#                      the introspection primitives in Part 3.
+# Self-executing     — alive end-to-end for arithmetic / comparison /
+#                      logic / conditional / trivial-decode. Adding a
+#                      category is one arm here + one test expression.
 #
-# What changed in this breath:
-#   defn name(params) = body — function definition primitive
-#   name(args)               — function call primitive
-#   Recursion + closure capture
-#   Grammar rendered in Form syntax (form_render)
-#   Cell→Recipe→Blueprint chain demonstrated live with 44 cells
-#
-# What remains for the next breath:
-#   category(r), nchildren(r), child(r, n)
-#   integer_value(r), string_value(r) via substrate string-table
-#   Part 2 actually runs against Part 3
+# Each new breath extends the dispatch table. The body grows by
+# arms, not by Python.

--- a/docs/coherence-substrate/self-hosted-eval.md
+++ b/docs/coherence-substrate/self-hosted-eval.md
@@ -4,26 +4,29 @@ Form is a substrate-native DSL. The honest question — *"can the parser, interp
 
 ## What's self-hosted today
 
-### The interpreter for arithmetic/comparison/conditional core
+### The interpreter for arithmetic/comparison/logic/conditional core
 
-`api/tests/test_substrate_form_self_hosted.py` ships a working demonstration: a Form `defn ev(node)` that reads a Recipe NodeID through the substrate's `.category.type_`, `.category.instance`, `.children[i]`, `.instance` accessors, dispatches on category, and recurses. No Python in the dispatch — only the bootstrap engine's leaf operations carry it through.
+The engine source lives in [`docs/coherence-substrate/form-engine.form`](form-engine.form) between `# >>> BEGIN engine` / `# >>> END engine` markers. `api/tests/test_substrate_form_self_hosted.py` loads it from disk and runs it — the substrate holds its own interpreter as an on-disk artifact, not as a Python string. Drift is fenced three ways:
+
+1. **Flat NodeID-literal dispatch.** Each arm is `@1.2.12.1 => ...` (Level=BASIC, RBasic.MATH, RMath.PLUS) rather than a magic int. Walking a recipe whose category moved silently produces the wrong answer; the parity tests catch it.
+2. **Drift sentinel.** `test_form_engine_literals_match_python_enums` parses every `@l.t.i` literal in the engine block and asserts each one points at a known `(RBasic.<verb>, instance)` pair. Rename `RBasic.MATH` or add an unknown literal — the test fails immediately.
+3. **Property-based parity.** Random arithmetic / comparison / conditional expressions get evaluated by both engines and asserted equal (40 + 20 per run, fixed seed).
 
 ```form
-defn ev(node) = do {
-  let ct = node.category.type_;
-  if ct == 12 then ev_math(node)         -- MATH
-  else if ct == 13 then ev_cmp(node)     -- COMPARE
-  else if ct == 11 then ev_cond(node)    -- COND
-  else if ct == 3  then node.instance - 1  -- INTEGER trivial
-  else if ct == 2  then (if node.instance == 1 then true else false)  -- BOOL
-  else 0
-};
-ev(@<recipe-nid>)
+defn ev(n) = match n.category {
+  @1.2.12.1 => ev(n.children[0]) + ev(n.children[1]),     # MATH.PLUS
+  @1.2.12.2 => ev(n.children[0]) - ev(n.children[1]),     # MATH.MINUS
+  @1.2.13.5 => ev(n.children[0]) > ev(n.children[1]),     # COMPARE.GREATER
+  @1.2.14.1 => ev(n.children[0]) && ev(n.children[1]),    # LOGIC.AND
+  @1.2.11.2 => if ev(n.children[0]) then ev(n.children[1]) else ev(n.children[2]),
+  ...
+  _ => if n.category.level == 1 then (...trivial decode...) else 0
+}
 ```
 
-It produces identical answers to the Python engine for `1+2`, `5*3-2`, `if 1==1 then 42 else 0`, etc. The strong proof: two engines, identical answer, same substrate.
+It produces identical answers to the Python engine across MATH (×5), COMPARE (×6), LOGIC (×3), COND (×2), and trivial INTEGER / BOOL decode. Two engines, identical answer, same substrate.
 
-This is the smallest concrete demonstration that **Form is expressive enough to be its own interpreter** for the recipe categories it can read. Extending to STATE, CHOICE, METHOD, etc. is adding `if ct == N then …` branches — mechanical, not conceptual.
+Extending to STATE, CHOICE, METHOD, etc. is adding one arm here and one expected literal to `_EXPECTED_LITERALS` — mechanical, not conceptual.
 
 ### The keyword grammar
 
@@ -53,7 +56,7 @@ Arithmetic, comparison, conditional dispatch at the leaves — `a + b`, `a == b`
 
 | Layer | Today | Path to full self-hosting |
 |-------|-------|---------------------------|
-| **Interpreter** (recipe-walking) | Form (this PR — arithmetic/compare/cond proven; other categories mechanical) | Add `if ct == N` branches per category |
+| **Interpreter** (recipe-walking) | Form (on-disk `form-engine.form`; MATH / COMPARE / LOGIC / COND / trivial decode proven; drift-sentinel keeps literals in sync) | Add one match arm per new category, one entry in `_EXPECTED_LITERALS` |
 | **Keyword grammar** | Form (substrate-resident via `register_form_keyword`) | Already there |
 | **Pattern/builder templates** | Form (substrate-resident) | Already there |
 | **Bootstrap parser** | Python (`tokenize` + recursive descent) | Form-level parser needs string primitives + Token cell shape |
@@ -72,4 +75,4 @@ The bootstrap parser staying Python isn't a confession — it's a deliberate flo
 cd api && python -m pytest tests/test_substrate_form_self_hosted.py -v
 ```
 
-Eleven tests, all green. Each one runs a Form expression through Python's parser to produce a Recipe NodeID, then evaluates that NodeID through a *Form-level* interpreter, then checks the answer matches what the Python engine would produce. Two engines, identical answer, same substrate — that's the proof.
+Twenty tests, all green: smoke tests per dispatch arm, a drift sentinel that asserts every NodeID literal in `form-engine.form` matches a known Python enum, and property-based parity that runs random expressions through both engines. Two engines, identical answer, same substrate — that's the proof, and it's now armored against silent rename drift.


### PR DESCRIPTION
## Summary

Closes the three drift paths PR #1692 left open in the self-hosted Form interpreter.

- **Engine source moves to disk.** Lives in `docs/coherence-substrate/form-engine.form` between `# >>> BEGIN engine` / `# >>> END engine` markers. The test loads it from disk and runs it — the substrate holds its own interpreter as a real on-disk artifact. The file's previously-commented Part 2 sketch is replaced with live, runnable engine; Part 3 acknowledges the introspection primitives shipped as `.field` accessors.
- **Flat NodeID-literal dispatch.** Each arm is `@1.2.12.1 => ...` (Level.BASIC + RBasic.MATH + RMath.PLUS) instead of magic ints. The drift sentinel `test_form_engine_literals_match_python_enums` parses every literal in the engine block and asserts it points at a known Python enum — a rename of `RBasic.MATH` fails the test the moment it lands.
- **Property-based parity sentinel.** 40 random arithmetic expressions + 20 random conditionals get evaluated by both engines and asserted equal. Drift in semantics shows up immediately, not when someone happens to hand-write the failing case.
- **LOGIC dispatch added** (AND / OR / NOT) as proof that extending a category is mechanical: one arm in the .form file, one entry in `_EXPECTED_LITERALS`, one smoke test.

## Test plan

- [x] 20 self-hosted tests green (was 11 in #1692)
- [x] Full substrate suite green (534 tests)
- [x] Drift sentinel verified to catch: missing literals, unknown literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)