### PR TITLE
attune(form): .value as the substrate's own trivial-leaf decoder

### DIFF
--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -905,11 +905,44 @@ def _state_stack_of(frame: Frame) -> List[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _trivial_value(session: Session, nid: NodeID) -> Any:
+    """Decode a trivial (Level.TRIVIAL) Recipe NodeID to its Python value.
+
+    Single source of truth for the leaf encoding — keeps Form's `.value`
+    accessor and the Python engine's leaf decode reading the same shape,
+    so a change to the integer encoding moves both at once.
+
+    Raises ValueError for non-trivials (composites have no atomic value;
+    their value is what evaluating the recipe returns).
+    """
+    from app.services.substrate.category import Level, RType
+    from app.services.substrate.substrate_strings import lookup_string_value
+
+    if nid.level != Level.TRIVIAL:
+        raise ValueError(
+            f"Form runtime: .value requires a trivial leaf, got {nid} "
+            f"(level={nid.level}); composites carry no atomic value"
+        )
+    if nid.type_ == RType.NULL:
+        return None
+    if nid.type_ == RType.BOOL:
+        return nid.instance == 1
+    if nid.type_ == RType.INTEGER:
+        return nid.instance - 1 if nid.instance > 0 else 0
+    if nid.type_ == RType.STRING:
+        return lookup_string_value(session, nid.instance) or ""
+    raise ValueError(
+        f"Form runtime: .value has no decoder for RType={nid.type_} "
+        f"(supported: NULL, BOOL, INTEGER, STRING)"
+    )
+
+
 def _resolve_access(session: Session, target: Any, field: str) -> Any:
     """Field access on a Cell, Blueprint NodeID, Recipe NodeID, or dict.
 
     Cells expose: blueprint, ctor, base, access, name, domain, source.
-    NodeIDs expose: package, level, type_, instance, category, children.
+    NodeIDs expose: package, level, type_, instance, category, children,
+                    nchildren, value (trivial-leaf decode).
     Dicts expose their keys; missing key raises AttributeError.
     """
     from app.services.substrate.kernel import NamedCell, lookup_node
@@ -958,9 +991,11 @@ def _resolve_access(session: Session, target: Any, field: str) -> Any:
             return _node_children(session, target)
         if field == "nchildren":
             return len(_node_children(session, target))
+        if field == "value":
+            return _trivial_value(session, target)
         raise AttributeError(
             f"Form runtime: NodeID has no field {field!r} "
-            f"(try: package, level, type, instance, category, children, nchildren)"
+            f"(try: package, level, type, instance, category, children, nchildren, value)"
         )
 
     raise TypeError(

--- a/api/tests/test_substrate_form_self_hosted.py
+++ b/api/tests/test_substrate_form_self_hosted.py
@@ -170,6 +170,49 @@ def test_engine_nested(session):
     ) == 50
 
 
+def test_engine_string_trivial(session):
+    """The engine now flows STRING trivials through `.value` — proving
+    the leaf decoder grew without touching the dispatch table."""
+    assert _form_eval(session, '"hello"') == "hello"
+    assert _form_eval(session, '"a longer phrase"') == "a longer phrase"
+
+
+# ---------------------------------------------------------------------------
+# .value as a substrate-level accessor — direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_value_accessor_integer(session):
+    nid = form_evaluate_text(session, "42").value
+    assert form_execute_text(session, f"@{nid}.value") == 42
+
+
+def test_value_accessor_zero(session):
+    nid = form_evaluate_text(session, "0").value
+    assert form_execute_text(session, f"@{nid}.value") == 0
+
+
+def test_value_accessor_bool(session):
+    nid_t = form_evaluate_text(session, "true").value
+    nid_f = form_evaluate_text(session, "false").value
+    assert form_execute_text(session, f"@{nid_t}.value") is True
+    assert form_execute_text(session, f"@{nid_f}.value") is False
+
+
+def test_value_accessor_string(session):
+    nid = form_evaluate_text(session, '"hello"').value
+    assert form_execute_text(session, f"@{nid}.value") == "hello"
+
+
+def test_value_accessor_refuses_composite(session):
+    """Composites carry no atomic value — the accessor refuses, the
+    engine respects the refusal."""
+    nid = form_evaluate_text(session, "1 + 2").value
+    with pytest.raises(Exception) as exc_info:
+        form_execute_text(session, f"@{nid}.value")
+    assert "trivial" in str(exc_info.value).lower() or "composite" in str(exc_info.value).lower()
+
+
 # ---------------------------------------------------------------------------
 # Drift sentinel — every literal in the engine block names a real enum
 # ---------------------------------------------------------------------------

--- a/docs/coherence-substrate/form-engine.form
+++ b/docs/coherence-substrate/form-engine.form
@@ -92,12 +92,12 @@ defn ev(n) = match n.category {
     # RBasic.COND (11) — conditional
     @1.2.11.1 => if ev(n.children[0]) then ev(n.children[1]) else null,
     @1.2.11.2 => if ev(n.children[0]) then ev(n.children[1]) else ev(n.children[2]),
-    # Trivial leaves — decode by category-instance under RType
-    _ => if n.category.level == 1 then
-            (if n.category.type_ == 3 then n.instance - 1                # INTEGER
-             else if n.category.type_ == 2 then (if n.instance == 1 then true else false)  # BOOL
-             else 0)
-         else 0
+    # Trivial leaf — delegate to substrate's own decoder.
+    # `.value` is the single source of truth for the leaf encoding
+    # (NULL / BOOL / INTEGER / STRING).  Raises on composites — which
+    # is the right shape: a composite without an explicit arm above is
+    # an unknown verb the engine should refuse to silently fake.
+    _ => n.value
 }
 # >>> END engine
 
@@ -114,6 +114,10 @@ defn ev(n) = match n.category {
 #   n.instance   — trivial leaf payload (raw int from the NodeID 4-tuple)
 #   n.level      — 1=TRIVIAL, 2=BASIC, 3+=COMPLEX_k
 #   n.type_      — RBasic / RType slot index
+#   n.value      — decoded Python value for trivials (NULL / BOOL /
+#                  INTEGER / STRING).  Raises on composites; the
+#                  single source of truth for the leaf encoding so the
+#                  Python engine and the Form engine read it once.
 #
 # Match-on-NodeID works today because NodeID's frozen-dataclass __eq__
 # is what `match` compares; `@p.l.t.i` literals are first-class values.

--- a/docs/coherence-substrate/self-hosted-eval.md
+++ b/docs/coherence-substrate/self-hosted-eval.md
@@ -20,11 +20,13 @@ defn ev(n) = match n.category {
   @1.2.14.1 => ev(n.children[0]) && ev(n.children[1]),    # LOGIC.AND
   @1.2.11.2 => if ev(n.children[0]) then ev(n.children[1]) else ev(n.children[2]),
   ...
-  _ => if n.category.level == 1 then (...trivial decode...) else 0
+  _ => n.value   # substrate's own trivial decoder (NULL / BOOL / INTEGER / STRING)
 }
 ```
 
-It produces identical answers to the Python engine across MATH (×5), COMPARE (×6), LOGIC (×3), COND (×2), and trivial INTEGER / BOOL decode. Two engines, identical answer, same substrate.
+The `_` arm reads through `.value` — the substrate's single source of truth for trivial-leaf encoding (`api/app/services/substrate/form_runtime.py` `_trivial_value`). Form and Python read the same decoder; a change to integer encoding moves both engines at once. Composites have no atomic value, so `.value` on a composite raises — the engine refuses to silently fake an answer for an unknown verb.
+
+It produces identical answers to the Python engine across MATH (×5), COMPARE (×6), LOGIC (×3), COND (×2), and trivial INTEGER / BOOL / STRING decode. Two engines, identical answer, same substrate.
 
 Extending to STATE, CHOICE, METHOD, etc. is adding one arm here and one expected literal to `_EXPECTED_LITERALS` — mechanical, not conceptual.
 


### PR DESCRIPTION
## Summary

Closes gap #2 from the post-#1693 drift map: the engine's leaf decode no longer bakes substrate-internal encoding into the .form file.

- `_trivial_value(session, nid)` in `form_runtime.py` is the new single source of truth for trivial-leaf encoding (NULL / BOOL / INTEGER / STRING). Exposed as `.value` on a NodeID.
- `form-engine.form`'s `_` arm becomes `_ => n.value` — the engine reads the substrate's own decoder instead of mimicking the encoding inline. STRING trivials flow through for free.
- Composites raise on `.value` rather than silently returning 0. The engine refuses to fake an answer for an unknown verb — that's the correct shape for a meta-circular evaluator.
- 6 new tests directly cover `.value` (int / zero / bool / string / composite-refuses); 1 engine test proves string trivials roundtrip end-to-end.

## Test plan

- [x] 26 self-hosted tests green (was 20 in #1693)
- [x] Full substrate suite green (540 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)