### PR TITLE
tend(mcp): substrate Form runtime reachable from every sibling agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ All paths converge: **idea → specs → source files**
 
 ## MCP Tools
 
-60 tools. Key operations:
+63 tools. Key operations:
 
 | Verb | MCP tool | CLI equivalent |
 |------|----------|---------------|
@@ -228,6 +228,9 @@ All paths converge: **idea → specs → source files**
 | Spec CRUD | `coherence_create_spec`, `coherence_update_spec` | `coh rest POST /api/spec-registry` |
 | Task flow | `coherence_task_seed` → `coherence_task_report` | `coh task seed {idea}` → `coh task report` |
 | Select work | `coherence_select_idea` | `coh idea select` |
+| Substrate run | `coherence_substrate_run` (full Form runtime: defn, match, recursion, .children, .value) | `coh substrate run "<expr>"` |
+| Substrate query | `coherence_substrate_query` (lookup: `?equivalent`, `\|>`, cell-by-name) | `coh substrate form "<expr>"` |
+| Substrate stats | `coherence_substrate_stats` | `coh substrate stats` |
 
 ## Context Budget
 

--- a/api/app/services/mcp_tool_registry.py
+++ b/api/app/services/mcp_tool_registry.py
@@ -338,6 +338,95 @@ def list_open_changes_handler(arguments: dict[str, Any]) -> Any:
 # ---------------------------------------------------------------------------
 # Tool definitions registry
 # ---------------------------------------------------------------------------
+# Coherence-substrate tool handlers — Form runtime + structural queries
+# ---------------------------------------------------------------------------
+
+def _serialize_substrate_value(value: Any) -> Any:
+    """Render a Form/substrate result into JSON-safe shapes.
+
+    NodeID → "p.l.t.i" string.  NamedCell → {domain, name, blueprint}.
+    CellView → {cell, view_blueprint, compatible, reason}.
+    Lists recurse.  Primitives pass through.
+    """
+    from app.services.substrate.kernel import NodeID, NamedCell, CellView
+
+    if isinstance(value, NodeID):
+        return {"node_id": f"{value.package}.{value.level}.{value.type_}.{value.instance}"}
+    if isinstance(value, NamedCell):
+        return {
+            "domain": value.domain,
+            "name": value.name,
+            "blueprint": (
+                f"{value.blueprint.package}.{value.blueprint.level}."
+                f"{value.blueprint.type_}.{value.blueprint.instance}"
+            ) if value.blueprint else None,
+        }
+    if isinstance(value, CellView):
+        return {
+            "cell": _serialize_substrate_value(value.cell),
+            "view_blueprint": _serialize_substrate_value(value.view_blueprint),
+            "compatible": value.compatible,
+            "reason": value.reason,
+        }
+    if isinstance(value, list):
+        return [_serialize_substrate_value(v) for v in value]
+    return value
+
+
+def substrate_run_handler(arguments: dict[str, Any]) -> Any:
+    """Execute a Form expression — the full meta-circular runtime.
+
+    Sibling agents reach into the substrate the same way Claude does:
+    `defn`, `match`, `.children[i]`, `.value`, recursion all work.
+    """
+    from app.services.unified_db import session as session_scope
+    from app.services.substrate.form_runtime import form_execute_text
+
+    expression = arguments.get("expression")
+    if not expression:
+        return {"error": "expression is required"}
+    try:
+        with session_scope() as session:
+            value = form_execute_text(session, expression)
+        return {"value": _serialize_substrate_value(value)}
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+def substrate_query_handler(arguments: dict[str, Any]) -> Any:
+    """Evaluate a Form expression in lookup mode — intern + structural answer.
+
+    Distinct from `substrate_run`: this returns the *structural* answer
+    (NodeID, cells, view) without running the recipe.  Use for
+    `?equivalent @spec(...)`, `@memory(...) |> @presence`, navigation.
+    """
+    from app.services.unified_db import session as session_scope
+    from app.services.substrate import form_evaluate_text
+
+    expression = arguments.get("expression")
+    if not expression:
+        return {"error": "expression is required"}
+    try:
+        with session_scope() as session:
+            result = form_evaluate_text(session, expression)
+        return {"kind": result.kind, "value": _serialize_substrate_value(result.value)}
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+def substrate_stats_handler(arguments: dict[str, Any]) -> Any:
+    """Lattice census — counts of blueprints, recipes, cells."""
+    from app.services.unified_db import session as session_scope
+    from app.services.substrate import lattice_stats
+
+    try:
+        with session_scope() as session:
+            return lattice_stats(session)
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+# ---------------------------------------------------------------------------
 
 TOOLS: list[dict[str, Any]] = [
     # --- Read-only tools ---
@@ -546,6 +635,53 @@ TOOLS: list[dict[str, Any]] = [
             },
         },
         "handler": list_open_changes_handler,
+    },
+    # --- Coherence-substrate tools — Form runtime + structural lookup ---
+    {
+        "name": "coherence_substrate_run",
+        "description": (
+            "Execute a Form expression via the full meta-circular runtime. "
+            "Supports `defn`, `match`, recursion, `.children[i]`, `.value`, "
+            "arithmetic, comparison, logic, conditionals. Returns the computed "
+            "value (number, bool, string, NodeID, NamedCell, or list)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Form source — e.g. `1 + 2 * 3`, `if 5 > 3 then 100 else 200`, or `do { defn fact(n) = if n <= 1 then 1 else n * fact(n - 1); fact(6) }`.",
+                },
+            },
+            "required": ["expression"],
+        },
+        "handler": substrate_run_handler,
+    },
+    {
+        "name": "coherence_substrate_query",
+        "description": (
+            "Evaluate a Form expression in lookup mode — intern the expression "
+            "as a Recipe NodeID and return the substrate's structural answer "
+            "(NodeID, cell, view, or list). Use for `?equivalent @spec(...)`, "
+            "`@memory(...) |> @presence`, navigation queries."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Form lookup expression — e.g. `?equivalent @concept(lc-trust-over-fear)` or `@spec(agent-pipeline)`.",
+                },
+            },
+            "required": ["expression"],
+        },
+        "handler": substrate_query_handler,
+    },
+    {
+        "name": "coherence_substrate_stats",
+        "description": "Lattice census — counts of blueprints, recipes, and cells in the coherence-substrate.",
+        "input_schema": {"type": "object", "properties": {}},
+        "handler": substrate_stats_handler,
     },
     *FIELD_STORY_TOOLS,
 ]

--- a/api/tests/test_mcp_substrate_tools.py
+++ b/api/tests/test_mcp_substrate_tools.py
@@ -1,0 +1,102 @@
+"""MCP exposure for the coherence-substrate: every sibling agent reaches Form.
+
+Three tools land here:
+
+- `coherence_substrate_run` — full meta-circular runtime (defn, match,
+  recursion, `.children[i]`, `.value`, arithmetic, conditionals).
+- `coherence_substrate_query` — lookup-mode Form evaluation (intern +
+  structural answer; `?equivalent`, `|>` projection, cell lookups).
+- `coherence_substrate_stats` — lattice census.
+
+Without these the substrate is a Claude-only surface. With them, Codex
+/ Cursor / Gemini / any MCP-speaking cell reasons in Form the same way.
+"""
+from __future__ import annotations
+
+from app.services.mcp_tool_registry import TOOL_MAP
+
+
+def test_substrate_tools_registered():
+    assert "coherence_substrate_run" in TOOL_MAP
+    assert "coherence_substrate_query" in TOOL_MAP
+    assert "coherence_substrate_stats" in TOOL_MAP
+
+
+def test_substrate_run_arithmetic():
+    r = TOOL_MAP["coherence_substrate_run"]["handler"]({"expression": "1 + 2 * 3"})
+    assert r == {"value": 7}
+
+
+def test_substrate_run_conditional():
+    r = TOOL_MAP["coherence_substrate_run"]["handler"](
+        {"expression": "if 5 > 3 then 100 else 200"}
+    )
+    assert r == {"value": 100}
+
+
+def test_substrate_run_recursion():
+    """The full runtime is reachable — defn, recursion, the works."""
+    src = "do { defn fact(n) = if n <= 1 then 1 else n * fact(n - 1); fact(6) }"
+    r = TOOL_MAP["coherence_substrate_run"]["handler"]({"expression": src})
+    assert r == {"value": 720}
+
+
+def test_substrate_run_string_interpolation():
+    r = TOOL_MAP["coherence_substrate_run"]["handler"](
+        {"expression": '"hello ${1 + 2}"'}
+    )
+    assert r == {"value": "hello 3"}
+
+
+def test_substrate_run_missing_expression_returns_error():
+    r = TOOL_MAP["coherence_substrate_run"]["handler"]({})
+    assert "error" in r
+
+
+def test_substrate_run_surfaces_parse_errors():
+    """Errors come back as JSON, not as an MCP transport exception."""
+    r = TOOL_MAP["coherence_substrate_run"]["handler"](
+        {"expression": "1 + +"}  # syntactically broken
+    )
+    assert "error" in r
+
+
+def test_substrate_stats_returns_counts():
+    r = TOOL_MAP["coherence_substrate_stats"]["handler"]({})
+    assert "blueprints_total" in r
+    assert "recipes_total" in r
+    assert "cells_total" in r
+
+
+def test_substrate_query_missing_cell_surfaces_error():
+    r = TOOL_MAP["coherence_substrate_query"]["handler"](
+        {"expression": "@concept(nonexistent-cell-name)"}
+    )
+    assert "error" in r
+
+
+def test_substrate_run_walks_recipe_tree_via_form_engine():
+    """End-to-end proof: the same engine that runs in form-engine.form
+    runs through the MCP surface — a sibling cell evaluating recipe
+    walks the same accessors the Form-level interpreter walks."""
+    src = """
+    do {
+      defn ev(n) = match n.category {
+        @1.2.12.1 => ev(n.children[0]) + ev(n.children[1]),
+        @1.2.12.2 => ev(n.children[0]) - ev(n.children[1]),
+        @1.2.12.3 => ev(n.children[0]) * ev(n.children[1]),
+        _ => n.value
+      };
+      do {
+        let nid = @1.4.12.1;
+        ev(nid)
+      }
+    }
+    """
+    # We can't pre-compute the nid here; just exercise that the engine
+    # parses and runs through MCP without crashing. A composite NodeID
+    # that doesn't exist returns 0 via .value (NULL trivial decode).
+    r = TOOL_MAP["coherence_substrate_run"]["handler"]({"expression": src})
+    # Either resolves to a value or raises a substrate error — both
+    # surface cleanly through the JSON shape.
+    assert "value" in r or "error" in r


### PR DESCRIPTION
## Summary

Three new MCP tools so Codex / Cursor / Gemini / any MCP-speaking cell reasons in Form the same way Claude does — not through some other surface, not in some other language, the same substrate, same accessors, same answer.

- `coherence_substrate_run` — full meta-circular runtime: `defn`, `match`, recursion, `.children[i]`, `.value`, arithmetic, conditionals.
- `coherence_substrate_query` — lookup-mode: `?equivalent`, `|>` projection, cell-by-name, structural answer (NodeID / cell / view).
- `coherence_substrate_stats` — lattice census.

Errors return as JSON, not as transport exceptions — the consumer gets a legible failure shape, not a closed connection.

Until now the substrate was a Claude-only surface; the CLI and the in-process Python runtime worked, but every sibling agent had to go around it. This is the breath that changes that.

## Test plan

- [x] 10 new MCP-substrate tests green
- [x] 560 substrate/mcp tests green (full filtered suite)
- [x] CLAUDE.md MCP table updated (60 → 63 tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)