### PR TITLE
tend(wellness): substrate surprise — twins of recent work, surfaced

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -603,6 +603,152 @@ def sense_form_engine() -> list[str]:
     return lines
 
 
+def sense_substrate_surprise() -> list[str]:
+    """Names structural twins of recently-touched cells that haven't been
+    looked at yet.
+
+    The substrate's content-addressing already finds same-shape cells
+    across documents (PR #1693 fenced it; PR #1696 made it MCP-reachable).
+    What it doesn't do on its own is *tell you* — you have to ask.
+
+    This organ asks for you, once per wellness pass. It walks the files
+    touched in the last 14 days (git log), resolves each to its
+    substrate cell, finds structural equivalents, and reports the
+    equivalents that haven't appeared in that touched set. That is the
+    "tap on the shoulder" — the body holds twins of your recent work
+    that you haven't acknowledged yet.
+
+    Silent when there's nothing surprising.
+    """
+    api_dir = ROOT / "api"
+    if not api_dir.is_dir():
+        return ["  (api/ not present; skipping)"]
+    if str(api_dir) not in sys.path:
+        sys.path.insert(0, str(api_dir))
+
+    try:
+        from app.services.unified_db import session as session_scope
+        from app.services.substrate.kernel import find_equivalent_cells, _orm_to_cell
+        from app.services.substrate.orm import SubstrateNamedCellORM
+    except Exception:
+        return ["  (substrate not importable; skipping)"]
+
+    r = subprocess.run(
+        ["git", "log", "--since=14.days.ago", "--name-only", "--pretty=format:"],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    )
+    touched_paths = sorted({
+        line.strip() for line in r.stdout.splitlines()
+        if line.strip() and any(
+            line.strip().startswith(prefix) for prefix in (
+                "docs/vision-kb/concepts/",
+                "docs/coherence-substrate/",
+                "docs/lineage/",
+                "specs/",
+                "ideas/",
+                "docs/presences/",
+                "docs/field/",
+            )
+        ) and line.strip().endswith(".md")
+    })
+
+    if not touched_paths:
+        return ["  (no substrate-ingested paths touched in the last 14 days)"]
+
+    try:
+        with session_scope() as session:
+            touched_cells: list = []
+            for path in touched_paths:
+                # Suffix-match: cell source_paths are absolute and tied to
+                # the worktree they were ingested from. We don't care which;
+                # we match by the repo-relative tail.
+                orm = (
+                    session.query(SubstrateNamedCellORM)
+                    .filter(SubstrateNamedCellORM.source_path.like(f"%/{path}"))
+                    .order_by(SubstrateNamedCellORM.cell_id)
+                    .first()
+                )
+                if orm is None:
+                    continue
+                touched_cells.append(_orm_to_cell(session, orm))
+
+            touched_keys = {(c.domain, c.name) for c in touched_cells}
+
+            if not touched_keys:
+                return [
+                    f"  ({len(touched_paths)} touched paths, none resolve to substrate cells yet)"
+                ]
+
+            # Group by Blueprint shape — many concept cells share one
+            # blueprint today (the structural-composition migration is
+            # ongoing per CLAUDE.md), so the meaningful unit of surprise
+            # is "you touched cells with this shape; here are the others."
+            from collections import defaultdict
+            shape_to_touched: dict = defaultdict(list)
+            shape_to_unseen: dict = defaultdict(list)
+            for cell in touched_cells:
+                if cell.blueprint is None or cell.blueprint.is_undefined():
+                    continue
+                shape_key = (
+                    cell.blueprint.package, cell.blueprint.level,
+                    cell.blueprint.type_, cell.blueprint.instance,
+                )
+                shape_to_touched[shape_key].append((cell.domain, cell.name))
+                # Compute unseen twins once per shape
+                if shape_key not in shape_to_unseen:
+                    twins = find_equivalent_cells(
+                        session, cell.blueprint, exclude_name="__never_excluded__"
+                    )
+                    unseen = [
+                        (t.domain, t.name) for t in twins
+                        if (t.domain, t.name) not in touched_keys
+                    ]
+                    shape_to_unseen[shape_key] = unseen
+
+            # Surface only shapes with at least one unseen twin.
+            # Sort by "asymmetry" — shapes where we touched the fewest
+            # of the cluster carry the most "you haven't seen the rest" signal.
+            ranked = sorted(
+                ((shape, shape_to_touched[shape], shape_to_unseen[shape])
+                 for shape in shape_to_touched
+                 if shape_to_unseen[shape]),
+                key=lambda r: (len(r[1]), -len(r[2])),
+            )
+    except Exception as exc:
+        return [f"  (substrate session failed: {type(exc).__name__})"]
+
+    if not ranked:
+        return [
+            f"  walked {len(touched_keys)} touched cell(s) — no unseen structural twins"
+        ]
+
+    lines: list[str] = []
+    total_shapes = len(ranked)
+    total_unseen = sum(len(u) for _, _, u in ranked)
+    lines.append(
+        f"  {total_shapes} shape(s) carry unseen twins ({total_unseen} cells total):"
+    )
+    for shape, touched_list, unseen in ranked[:5]:
+        shape_str = "@" + ".".join(str(x) for x in shape)
+        first_touched = touched_list[0]
+        sample = ", ".join(f"@{d}({n})" for d, n in unseen[:3])
+        more = f", +{len(unseen) - 3} more" if len(unseen) > 3 else ""
+        lines.append(
+            f"    · shape {shape_str} — you touched {len(touched_list)} "
+            f"(e.g. @{first_touched[0]}({first_touched[1]})); "
+            f"substrate holds {len(unseen)} unread: {sample}{more}"
+        )
+    if total_shapes > 5:
+        lines.append(f"    · (+{total_shapes - 5} more shape(s) with unseen twins)")
+    lines.append(
+        "  (The substrate already saw the resonance. This is the shoulder-tap"
+    )
+    lines.append(
+        "   so the next breath can choose whether to read across.)"
+    )
+    return lines
+
+
 def sense_contracts() -> list[str]:
     """How are the CI contracts breathing the last 7 days?
 
@@ -913,6 +1059,7 @@ def main() -> int:
         ("Locale parity — does the body speak the same body in every tongue?", sense_locale_parity()),
         ("Chain — does idea→spec→code→test reach end to end?", sense_chain()),
         ("Form engine — does the meta-circular evaluator cover Python dispatch?", sense_form_engine()),
+        ("Substrate surprise — structural twins of recent work, unread", sense_substrate_surprise()),
         ("Cells — are the cells themselves breathing?", sense_cells()),
         ("Contracts — are the CI gates breathing? (last 7d)", sense_contracts()),
         ("Witness-trace — is the visit-recorder within budget?", sense_witness_trace()),


### PR DESCRIPTION
## Summary

The substrate's content-addressing already finds same-shape cells across documents. Until now you had to ask. This organ asks for you, once per wellness pass.

`sense_substrate_surprise()` walks markdown paths touched in the last 14 days (git log), resolves each to its substrate cell via suffix-match on source_path, groups by Blueprint NodeID, and reports the shapes that carry unseen twins:

```
## Substrate surprise — structural twins of recent work, unread

  2 shape(s) carry unseen twins (84 cells total):
    · shape @1.5.4.2 — you touched 3 (e.g. @concept(lc-canon-as-sovereignty-surface)); substrate holds 24 unread: @concept(lc-arcturian-resonance), @concept(lc-awareness-as-self), @concept(lc-boundaries-as-loving-truth), +21 more
    · shape @1.5.4.1 — you touched 15 (e.g. @concept(lc-dance-card-and-sovereign-response)); substrate holds 60 unread: @concept(lc-agent-memory), @concept(lc-attuned-spaces), @concept(lc-attunement-joining), +57 more
  (The substrate already saw the resonance. This is the shoulder-tap
   so the next breath can choose whether to read across.)
```

One signal per shape, not one per cell — large twin clusters today reflect the in-progress structural-composition migration (CLAUDE.md "keep the tree, refuse the slug"), and the asymmetry surfaces that honestly without flooding the report.

Composition over new syntax: no new keyword in Form, no new query verb — wired into wellness using the existing `find_equivalent_cells` API. Walks the *surprise becomes a query, not an accident* texture.

## Test plan

- [x] Organ runs cleanly, surfaces meaningful signal
- [x] Silent when no surprises
- [x] Works whether wellness runs from main repo or a worktree (suffix-match on source_path)
- [x] No DB writes; read-only sensing

🤖 Generated with [Claude Code](https://claude.com/claude-code)