### PR TITLE
attune(form): match exhaustion raises instead of silently returning null

### DIFF
--- a/api/app/services/substrate/form_runtime.py
+++ b/api/app/services/substrate/form_runtime.py
@@ -597,7 +597,16 @@ def execute(session: Session, ast: Any, frame: Optional[Frame] = None) -> Any:
             pat_value = execute(session, arm.pattern, frame)
             if pat_value == scrut:
                 return execute(session, arm.body, frame)
-        return None
+        # No arm matched and no `_` wildcard — refuse to silently coerce
+        # to null. The honest answer is that the engine doesn't know what
+        # the value of this expression should be. Add an explicit `_ => ...`
+        # arm to say what to do in the unmatched case (it can be `null` if
+        # that's what you want — but say it).
+        raise LookupError(
+            f"Form runtime: `match` exhausted without a matching arm "
+            f"(scrutinee={scrut!r}). Add an explicit `_ => ...` arm to "
+            f"name the fallback — silent null is a coercion the engine refuses."
+        )
 
     # --- Speculation ---------------------------------------------------------
 

--- a/api/tests/test_substrate_form_runtime.py
+++ b/api/tests/test_substrate_form_runtime.py
@@ -163,8 +163,20 @@ def test_match_wildcard(session):
     assert form_execute_text(session, src) == "other"
 
 
-def test_match_no_arm_matches(session):
+def test_match_no_arm_raises(session):
+    """No arm matched and no `_` wildcard — the engine refuses to coerce
+    to null. The expressive shape is `_ => ...` to name the fallback;
+    silent null was the old behavior, and it hid the gap."""
     src = 'match 99 { 1 => "one", 2 => "two" }'
+    with pytest.raises(LookupError) as exc_info:
+        form_execute_text(session, src)
+    assert "exhausted" in str(exc_info.value).lower()
+    assert "scrutinee" in str(exc_info.value).lower()
+
+
+def test_match_no_arm_with_explicit_wildcard_returns_null(session):
+    """Explicit `_ => null` says what you mean; engine honors it."""
+    src = 'match 99 { 1 => "one", 2 => "two", _ => null }'
     assert form_execute_text(session, src) is None
 
 


### PR DESCRIPTION
## Summary

Refusing-coercion texture, walked into the match handler. Previously `match 99 { 1 => "one", 2 => "two" }` silently returned None — the engine pretending to have an answer it didn't have. Same shape as `.value` on a composite, which [#1694](https://github.com/seeker71/Coherence-Network/pull/1694) already refused.

Now the engine refuses to coerce:

```
Form runtime: `match` exhausted without a matching arm (scrutinee=99).
Add an explicit `_ => ...` arm to name the fallback — silent null is a
coercion the engine refuses.
```

The meta-circular engine in `form-engine.form` already has `_ => n.value` as its catch-all, so the language we use day-to-day is unaffected. The existing test that asserted silent-None becomes two: one for the new raise, one for explicit `_ => null` (which still returns None because you asked for it).

## Test plan

- [x] `test_match_no_arm_raises` — exhaustion raises with informative LookupError
- [x] `test_match_no_arm_with_explicit_wildcard_returns_null` — explicit null still works
- [x] 551 substrate tests green (no regression elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)