### PR TITLE
attune(wellness): substrate shape-drift sensor — catch silent flatten regressions

### DIFF
--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -356,6 +356,140 @@ def get_histogram(domain: str) -> HistogramOut:
 
 
 # ---------------------------------------------------------------------------
+# Shape-health — does each cell's CTOR carry structured composition or
+# flat type-markers? Catches silent flatten regressions where aggregate
+# counts look stable while cell CTORs point at flat encodings.
+# ---------------------------------------------------------------------------
+
+
+class DomainShapeOut(BaseModel):
+    total: int
+    structured: int
+    flat: int
+    no_ctor: int
+    ratio: float  # structured / (structured + flat), 0..1
+
+
+class ShapeHealthOut(BaseModel):
+    overall: DomainShapeOut
+    domains: dict[str, DomainShapeOut]
+    flags: list[str]
+
+
+# A CTOR's serialized representation looks like
+#   "1.2.9.1+<child>+<child>+..."
+# where each `<child>` is a NodeID in `package.level.type.instance` form.
+# Structured CTORs have children at composite level (level >= 3, e.g.
+# `1.3.X.Y`) — each child is itself a composed (key, value) recipe.
+# Flat CTORs have children at trivial level (`1.1.X.Y`, level == 1) —
+# each child is a leaf recipe carrying a type-marker string.
+#
+# The discriminator: a CTOR is structured iff at least one direct child
+# is at level >= 2 (i.e. carries internal composition); flat iff every
+# direct child is at level 1 (trivial leaves only).
+
+
+@router.get("/shape_health", response_model=ShapeHealthOut, tags=["substrate"])
+def get_shape_health() -> ShapeHealthOut:
+    """Sense whether cells carry composed CTORs or flat type-markers.
+
+    The structural-composition discipline (CLAUDE.md → "Structural
+    composition discipline") promises every cell's CTOR is a tree of
+    R_Block.LET (key, value) pairs all the way down. The legacy flat
+    encoder produced CTORs whose children were trivial-string recipes
+    holding type-marker strings like "name=str".
+
+    Both shapes hash to NodeIDs that look superficially similar; the
+    lattice/stats endpoint reports the same recipe count whether cells
+    point at structured or flat CTORs. This endpoint distinguishes them
+    by examining each CTOR's direct children: a `+1.2.9.3` token in the
+    serialized representation means R_Block.LET is present (structured);
+    children that are only `+1.1.5.*` (trivial strings) mean flat.
+
+    Flags raised when ratio < 0.95 (5%+ of cells carry flat CTORs) so
+    the wellness check surfaces silent flatten regressions before they
+    compound.
+    """
+    with session_scope() as session:
+        cells = session.query(SubstrateNamedCellORM).all()
+
+        # Pre-fetch all CTOR node serialized strings in one batch.
+        ctor_ids = {c.ctor_recipe_node_id for c in cells if c.ctor_recipe_node_id}
+        ctor_nodes = (
+            session.query(SubstrateNodeORM)
+            .filter(SubstrateNodeORM.node_id.in_(ctor_ids))
+            .all()
+        ) if ctor_ids else []
+        ctor_serialized: dict[int, str] = {n.node_id: n.serialized for n in ctor_nodes}
+
+        def _classify(node_id: int | None) -> str:
+            if not node_id:
+                return "no_ctor"
+            serialized = ctor_serialized.get(node_id, "")
+            # Parse "category+child+child+..." into child NodeIDs and
+            # read each child's level (second integer in p.l.t.i form).
+            parts = serialized.split("+")
+            if len(parts) <= 1:
+                return "no_ctor"
+            child_levels: list[int] = []
+            for child in parts[1:]:
+                segments = child.split(".")
+                if len(segments) >= 2:
+                    try:
+                        child_levels.append(int(segments[1]))
+                    except ValueError:
+                        continue
+            if not child_levels:
+                return "no_ctor"
+            # Structured iff any direct child has level >= 2 (i.e. is itself
+            # a composed recipe). Flat iff every child is at level 1.
+            return "structured" if any(lv >= 2 for lv in child_levels) else "flat"
+
+        by_domain: dict[str, dict[str, int]] = {}
+        overall_counts = {"structured": 0, "flat": 0, "no_ctor": 0, "total": 0}
+        for cell in cells:
+            kind = _classify(cell.ctor_recipe_node_id)
+            bucket = by_domain.setdefault(
+                cell.domain, {"structured": 0, "flat": 0, "no_ctor": 0, "total": 0}
+            )
+            bucket[kind] += 1
+            bucket["total"] += 1
+            overall_counts[kind] += 1
+            overall_counts["total"] += 1
+
+        def _to_out(counts: dict[str, int]) -> DomainShapeOut:
+            denom = counts["structured"] + counts["flat"]
+            ratio = (counts["structured"] / denom) if denom > 0 else 1.0
+            return DomainShapeOut(
+                total=counts["total"],
+                structured=counts["structured"],
+                flat=counts["flat"],
+                no_ctor=counts["no_ctor"],
+                ratio=round(ratio, 4),
+            )
+
+        domains = {d: _to_out(c) for d, c in by_domain.items()}
+        overall = _to_out(overall_counts)
+
+        flags: list[str] = []
+        if overall.ratio < 0.95 and overall.flat > 0:
+            flags.append(
+                f"overall structured ratio {overall.ratio:.0%} — "
+                f"{overall.flat} of {overall.flat + overall.structured} "
+                f"cells carry flat CTORs; re-ingest with --structured"
+            )
+        for name, shape in domains.items():
+            if shape.ratio < 0.95 and shape.flat > 0:
+                flags.append(
+                    f"{name}: structured ratio {shape.ratio:.0%} — "
+                    f"{shape.flat} flat cells "
+                    f"(of {shape.flat + shape.structured})"
+                )
+
+        return ShapeHealthOut(overall=overall, domains=domains, flags=flags)
+
+
+# ---------------------------------------------------------------------------
 # Form-language evaluation — the substrate-native query DSL
 # ---------------------------------------------------------------------------
 

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -979,6 +979,72 @@ def sense_cells() -> list[str]:
     return findings
 
 
+def sense_substrate_shape() -> list[str]:
+    """Sense whether substrate cells carry composed CTORs or flat type-markers.
+
+    The structural-composition discipline promises every cell's CTOR is a
+    tree of R_Block.LET (key, value) pairs. The legacy flat encoder
+    produced CTORs of trivial-string recipes carrying type-marker strings
+    like "name=str". Aggregate counts (cells/blueprints/recipes) look
+    stable across either encoding — content-addressing means orphaned
+    structured recipes stay in the lattice while cells re-point at flat
+    encodings. This sense distinguishes the two by querying
+    /api/substrate/shape_health and flags any silent flatten regression.
+
+    Silent when ratio ≥ 95% across all domains. Speaks the moment any
+    domain drops below.
+    """
+    import urllib.request
+    import urllib.error
+
+    api = os.environ.get("COHERENCE_API_BASE", "https://api.coherencycoin.com")
+    try:
+        req = urllib.request.Request(
+            f"{api}/api/substrate/shape_health",
+            headers={"User-Agent": "wellness-check/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as r:
+            health = json.load(r)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+        return [f"  (could not reach {api}/api/substrate/shape_health — {e})"]
+
+    overall = health.get("overall", {})
+    domains = health.get("domains", {}) or {}
+    flags = health.get("flags", []) or []
+
+    lines: list[str] = []
+    total = overall.get("total", 0)
+    structured = overall.get("structured", 0)
+    flat = overall.get("flat", 0)
+    no_ctor = overall.get("no_ctor", 0)
+    ratio = overall.get("ratio", 1.0)
+
+    lines.append(
+        f"  {total:,} cells · {structured:,} structured · {flat:,} flat · "
+        f"{no_ctor:,} no-ctor · {ratio:.0%} composed"
+    )
+
+    if not flags:
+        lines.append("  composition discipline holding across every domain.")
+    else:
+        lines.append("")
+        for f in flags:
+            lines.append(f"  · {f}")
+
+    nonempty = [(name, d) for name, d in domains.items() if d.get("total", 0) > 0]
+    if nonempty:
+        lines.append("")
+        for name, d in sorted(nonempty, key=lambda kv: -kv[1].get("total", 0)):
+            r = d.get("ratio", 1.0)
+            t = d.get("total", 0)
+            s = d.get("structured", 0)
+            fl = d.get("flat", 0)
+            marker = " ✓" if r >= 0.95 and fl == 0 else " ⚠" if fl > 0 else ""
+            lines.append(f"  {name}: {s}/{t} composed ({r:.0%}){marker}")
+
+    return lines
+
+
 def sense_witness_trace() -> list[str]:
     """How is the witness-trace breathing?
 
@@ -1062,6 +1128,7 @@ def main() -> int:
         ("Substrate surprise — structural twins of recent work, unread", sense_substrate_surprise()),
         ("Cells — are the cells themselves breathing?", sense_cells()),
         ("Contracts — are the CI gates breathing? (last 7d)", sense_contracts()),
+        ("Substrate shape — do cell CTORs carry composition or flat type-markers?", sense_substrate_shape()),
         ("Witness-trace — is the visit-recorder within budget?", sense_witness_trace()),
     ]
 


### PR DESCRIPTION
## Summary

The prevention move that closes the regression-pattern loop we surfaced in PR #1700 and PR #1701. Aggregate stats (cells/blueprints/recipes) look stable whether cells carry structured or flat CTORs because content-addressing keeps orphaned recipes interned even when cells re-point at flat encodings. That masking is exactly what let the deploy-script and post-merge-hook regressions hide. This breath gives the body an organ that sees what aggregate counts cannot.

## Changes

- **New endpoint** `GET /api/substrate/shape_health` ([api/app/routers/substrate.py](api/app/routers/substrate.py)): walks every cell, parses each CTOR's serialized representation, classifies as `structured` (any direct child at level ≥ 2 — composed recipe) / `flat` (all direct children at level 1 — trivial-string leaves) / `no_ctor`. Returns per-domain counts + overall ratio + flags when ratio < 95%.
- **New wellness sense** `sense_substrate_shape()` ([scripts/wellness_check.py](scripts/wellness_check.py)): hits the endpoint and reports composition coverage with a per-domain breakdown. Silent when discipline holds across every domain; speaks the moment any drops below 95%.
- **Registered** in wellness `main()` between Contracts and Witness-trace.

## How it sees what stats can't

The serialized representation of a CTOR like `1.2.9.1+1.3.9.1+1.3.9.2+...` tells us each child's level. Structured composition produces children at composite level (1.3.X.Y) — each is itself a (key, value) recipe. Flat type-marker encoding produces children at trivial level (1.1.5.X) — each is a string-recipe carrying \"name=str\" or similar. The lattice/stats endpoint hashes both shapes to the same recipe count; this endpoint reads the actual structural class.

## Test plan

- [x] Local smoke test: mix of 59 structured presences + 1 explicitly-flat lineage cell → endpoint reports overall ratio 98%, flags lineage domain
- [ ] After deploy, `make wellness` shows the new section with production substrate's composition coverage (expected: 100% structured across all domains)
- [ ] Manually re-ingest one cell with `--legacy-flat` in a test environment and confirm the flag fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)