### PR TITLE
tend(form): playground showcase + perf — parse cache, AST cache, keyword dispatch

### DIFF
--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -510,7 +510,7 @@ class FormResultOut(BaseModel):
     """Discriminated union of Form evaluation outcomes.
 
     `kind` names which field carries the result. Other fields are null.
-    Kinds: node_id, recipe, cell, view, cells, views.
+    Kinds: node_id, recipe, cell, view, cells, views, lattice, keywords, vocabulary.
     """
 
     kind: str
@@ -519,6 +519,9 @@ class FormResultOut(BaseModel):
     view: CellViewOut | None = None
     cells: list[CellOut] | None = None
     views: list[CellViewOut] | None = None
+    lattice: dict[str, int] | None = None
+    keywords: list[str] | None = None
+    vocabulary: dict[str, dict[str, int]] | None = None
 
 
 def _cell_view_out(v: CellView) -> CellViewOut:
@@ -582,6 +585,33 @@ def evaluate_form(req: FormRequest) -> FormResultOut:
                 kind="views",
                 views=[_cell_view_out(v) for v in result.value],
             )
+        if result.kind == "lattice":
+            # ?lattice — substrate-snapshot lens
+            return FormResultOut(kind="lattice", lattice=result.value)
+        if result.kind == "keywords":
+            # ?keywords — grammar-introspection lens
+            return FormResultOut(kind="keywords", keywords=list(result.value))
+        if result.kind == "vocabulary":
+            # ?vocabulary — verb-cluster histogram. Translate type_ ints to
+            # category names so the response is legible without a category
+            # lookup table on the caller's side.
+            from app.services.substrate.category import BBasic, RBasic
+
+            raw = result.value
+            named: dict[str, dict[str, int]] = {"recipes": {}, "blueprints": {}}
+            for type_int, count in raw.get("recipes", {}).items():
+                try:
+                    name = RBasic(type_int).name
+                except ValueError:
+                    name = f"type_{type_int}"
+                named["recipes"][name] = count
+            for type_int, count in raw.get("blueprints", {}).items():
+                try:
+                    name = BBasic(type_int).name
+                except ValueError:
+                    name = f"type_{type_int}"
+                named["blueprints"][name] = count
+            return FormResultOut(kind="vocabulary", vocabulary=named)
         raise HTTPException(
             status_code=500,
             detail=f"unknown FormResult.kind: {result.kind}",

--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -37,6 +37,7 @@ list[CellView], or a Python str/None.
 from __future__ import annotations
 
 import re
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
@@ -708,6 +709,40 @@ ExprNode = Any  # any AST node — too many to enumerate
 # ---------------------------------------------------------------------------
 
 
+# Bootstrap-keyword dispatch — replaces a ~30-way if/elif chain that ran
+# per IDENT token. Each entry maps the keyword to the Parser method name
+# that handles it; `parse_keyword_or_ident` does one `.get(kw)` and
+# `getattr(self, name)()`.
+_KEYWORD_DISPATCH: Dict[str, str] = {
+    "true":     "_parse_true",
+    "false":    "_parse_false",
+    "if":       "parse_if",
+    "do":       "parse_do_block",
+    "with":     "parse_with",
+    "let":      "parse_let",
+    "match":    "parse_match",
+    "choose":   "parse_choose",
+    "fail":     "_parse_fail",
+    "stop":     "_parse_stop",
+    "save":     "_parse_save",
+    "restore":  "_parse_restore",
+    "discard":  "_parse_discard",
+    "raise":    "parse_raise",
+    "resume":   "_parse_resume",
+    "delegate": "parse_delegate",
+    "undo":     "parse_undo",
+    "inverse":  "parse_inverse",
+    "common":   "parse_common",
+    "method":   "parse_method_def",
+    "invoke":   "parse_method_invoke",
+    "try":      "parse_try_catch",
+    "for":      "parse_for",
+    "while":    "parse_while",
+    "set":      "parse_set",
+    "defn":     "parse_defn",
+}
+
+
 class Parser:
     def __init__(self, tokens, *, prefer_registered: bool = False):
         """Tokens may be:
@@ -991,78 +1026,12 @@ class Parser:
             if node is not None:
                 return node
 
-        # Built-in keywords (the bootstrap grammar)
-        if kw == "true":
-            self.consume("IDENT")
-            return BoolLit(True)
-        if kw == "false":
-            self.consume("IDENT")
-            return BoolLit(False)
-        if kw == "if":
-            return self.parse_if()
-        if kw == "do":
-            return self.parse_do_block()
-        if kw == "with":
-            return self.parse_with()
-        if kw == "let":
-            return self.parse_let()
-        if kw == "match":
-            return self.parse_match()
-        if kw == "choose":
-            return self.parse_choose()
-        if kw == "fail":
-            self.consume("IDENT")
-            return FailExpr()
-        if kw == "stop":
-            self.consume("IDENT")
-            return StopExpr()
-        if kw == "save":
-            self.consume("IDENT")
-            return SaveExpr()
-        if kw == "restore":
-            self.consume("IDENT")
-            return RestoreExpr()
-        if kw == "discard":
-            self.consume("IDENT")
-            return DiscardExpr()
-        if kw == "raise":
-            self.consume("IDENT")
-            # Optional value after raise; if the next token starts an
-            # expression (atom, paren, ident, etc.) parse it as payload.
-            nxt = self.peek().kind
-            if nxt in ("INT", "STRING", "AT", "TILDE", "LPAREN", "LBRACK", "IDENT", "DOT"):
-                # Some IDENTs ARE statement terminators in catch/end context;
-                # be permissive and parse-attempt — fall back to no value on
-                # certain reserved follow-ups.
-                if nxt == "IDENT" and self.peek().value in ("catch", "then", "else", "end"):
-                    return RaiseExpr()
-                return RaiseExpr(value=self.parse_expr())
-            return RaiseExpr()
-        if kw == "resume":
-            self.consume("IDENT")
-            return ResumeExpr()
-        if kw == "delegate":
-            return self.parse_delegate()
-        if kw == "undo":
-            return self.parse_undo()
-        if kw == "inverse":
-            return self.parse_inverse()
-        if kw == "common":
-            return self.parse_common()
-        if kw == "method":
-            return self.parse_method_def()
-        if kw == "invoke":
-            return self.parse_method_invoke()
-        if kw == "try":
-            return self.parse_try_catch()
-        if kw == "for":
-            return self.parse_for()
-        if kw == "while":
-            return self.parse_while()
-        if kw == "set":
-            return self.parse_set()
-        if kw == "defn":
-            return self.parse_defn()
+        # Built-in keywords (the bootstrap grammar) — dispatched via a
+        # class-level dict so the hot path is a single `.get(kw)` instead
+        # of walking ~30 string-equality comparisons per IDENT token.
+        handler_name = _KEYWORD_DISPATCH.get(kw)
+        if handler_name is not None:
+            return getattr(self, handler_name)()
 
         # User-registered keywords (the rule-driven extension point —
         # this is where the grammar becomes alive at runtime).
@@ -1107,6 +1076,53 @@ class Parser:
         self.consume("ASSIGN")
         body = self.parse_expr()
         return FnDef(name=name, params=params, body=body)
+
+    # ------- Bare-keyword leaves — small helpers for the dispatch dict.
+    def _parse_true(self) -> BoolLit:
+        self.consume("IDENT")
+        return BoolLit(True)
+
+    def _parse_false(self) -> BoolLit:
+        self.consume("IDENT")
+        return BoolLit(False)
+
+    def _parse_fail(self) -> FailExpr:
+        self.consume("IDENT")
+        return FailExpr()
+
+    def _parse_stop(self) -> StopExpr:
+        self.consume("IDENT")
+        return StopExpr()
+
+    def _parse_save(self) -> SaveExpr:
+        self.consume("IDENT")
+        return SaveExpr()
+
+    def _parse_restore(self) -> RestoreExpr:
+        self.consume("IDENT")
+        return RestoreExpr()
+
+    def _parse_discard(self) -> DiscardExpr:
+        self.consume("IDENT")
+        return DiscardExpr()
+
+    def _parse_resume(self) -> ResumeExpr:
+        self.consume("IDENT")
+        return ResumeExpr()
+
+    def parse_raise(self) -> RaiseExpr:
+        self.consume("IDENT")  # 'raise'
+        # Optional value after raise; if the next token starts an
+        # expression (atom, paren, ident, etc.) parse it as payload.
+        nxt = self.peek().kind
+        if nxt in ("INT", "STRING", "AT", "TILDE", "LPAREN", "LBRACK", "IDENT", "DOT"):
+            # Some IDENTs ARE statement terminators in catch/end context;
+            # be permissive and parse-attempt — fall back to no value on
+            # certain reserved follow-ups.
+            if nxt == "IDENT" and self.peek().value in ("catch", "then", "else", "end"):
+                return RaiseExpr()
+            return RaiseExpr(value=self.parse_expr())
+        return RaiseExpr()
 
     def parse_if(self) -> IfExpr:
         self.consume("IDENT")  # 'if'
@@ -2070,6 +2086,17 @@ def _evaluate_query(session: Session, q: Query) -> FormResult:
 # ---------------------------------------------------------------------------
 
 
+# Bounded parse cache for the prefer_registered=False (bootstrap-grammar)
+# path. Skipped for prefer_registered=True because the user-registered
+# keyword registry can mutate at runtime — the same text could parse to a
+# different AST after a register_form_keyword call. The bootstrap grammar
+# is frozen at module load, so its parse is a pure function of text and
+# safe to memoize. AST nodes are dataclasses read by evaluators without
+# mutation, so the shared object is also safe to return.
+_PARSE_CACHE: "OrderedDict[str, Any]" = OrderedDict()
+_PARSE_CACHE_MAX = 256
+
+
 def parse(text: str, *, prefer_registered: bool = False) -> Any:
     """Parse a single Form expression.
 
@@ -2078,6 +2105,11 @@ def parse(text: str, *, prefer_registered: bool = False) -> Any:
     Used for partial self-hosting demonstrations — see
     `docs/coherence-substrate/form-language.md` ("Self-hosting").
     """
+    key = text.strip() if not prefer_registered else None
+    if key is not None and key in _PARSE_CACHE:
+        _PARSE_CACHE.move_to_end(key)
+        return _PARSE_CACHE[key]
+
     tokens = tokenize(text.strip())
     parser = Parser(tokens, prefer_registered=prefer_registered)
     result = parser.parse()
@@ -2085,6 +2117,11 @@ def parse(text: str, *, prefer_registered: bool = False) -> Any:
         raise SyntaxError(
             f"Form: trailing input at pos {parser.peek().pos}: {parser.peek().value!r}"
         )
+
+    if key is not None:
+        _PARSE_CACHE[key] = result
+        if len(_PARSE_CACHE) > _PARSE_CACHE_MAX:
+            _PARSE_CACHE.popitem(last=False)
     return result
 
 

--- a/api/app/services/substrate/recipe_eval.py
+++ b/api/app/services/substrate/recipe_eval.py
@@ -30,6 +30,7 @@ form_runtime's equivalents.
 """
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
@@ -286,6 +287,16 @@ def _identifier_ast(nid: NodeID) -> Any:
     return Identifier(name=f"__hashed_{nid.instance}")
 
 
+# Bounded reconstruction cache. The substrate is append-only at the row
+# level (interned shapes, allocated string-instances, created cells never
+# change after writing), so a NodeID maps to a stable AST shape across
+# the process lifetime. Evaluators (form_runtime.execute, _to_recipe_node_id)
+# walk AST nodes read-only, so sharing a single AST object across callers
+# is safe. Capping the cache keeps memory bounded under heavy use.
+_NODE_TO_AST_CACHE: "OrderedDict[NodeID, Any]" = OrderedDict()
+_NODE_TO_AST_CACHE_MAX = 1024
+
+
 def node_to_ast(session: Session, nid: NodeID) -> Any:
     """Reconstruct an AST node from a Recipe NodeID.
 
@@ -293,6 +304,18 @@ def node_to_ast(session: Session, nid: NodeID) -> Any:
     parser's AST. `eval_recipe` calls this then hands the result to
     `form_runtime.execute` — one engine, two input modes.
     """
+    cached = _NODE_TO_AST_CACHE.get(nid)
+    if cached is not None:
+        _NODE_TO_AST_CACHE.move_to_end(nid)
+        return cached
+    ast = _node_to_ast_uncached(session, nid)
+    _NODE_TO_AST_CACHE[nid] = ast
+    if len(_NODE_TO_AST_CACHE) > _NODE_TO_AST_CACHE_MAX:
+        _NODE_TO_AST_CACHE.popitem(last=False)
+    return ast
+
+
+def _node_to_ast_uncached(session: Session, nid: NodeID) -> Any:
     from app.services.substrate.form import (
         IntLit, BoolLit, StringLit, Identifier,
         CommonExpr, DelegateExpr, OnChangeExpr, ProjectExpr, TryCatchExpr,

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -24,30 +24,343 @@ type CellViewOut = {
 };
 
 type FormResultOut = {
-  kind: "node_id" | "recipe" | "cell" | "view" | "cells" | "views";
+  kind:
+    | "node_id"
+    | "recipe"
+    | "cell"
+    | "view"
+    | "cells"
+    | "views"
+    | "lattice"
+    | "keywords"
+    | "vocabulary";
   node_id?: NodeIDOut | null;
   cell?: CellOut | null;
   view?: CellViewOut | null;
   cells?: CellOut[] | null;
   views?: CellViewOut[] | null;
+  lattice?: Record<string, number> | null;
+  keywords?: string[] | null;
+  vocabulary?: { recipes: Record<string, number>; blueprints: Record<string, number> } | null;
 };
 
-const EXAMPLES: { label: string; expr: string }[] = [
+type Example = {
+  label: string;
+  expr: string;
+  // Names the unique Form feature this example exercises.
+  showcases: string;
+};
+
+type ExampleGroup = {
+  heading: string;
+  blurb: string;
+  examples: Example[];
+};
+
+// Curated tour of every unique Form construct. Each example is runnable
+// against the live substrate. Grouped so the reader can sense the
+// language's surface area at a glance.
+const GROUPS: ExampleGroup[] = [
   {
-    label: "All memory cells",
-    expr: '?cells where domain == "memory"',
+    heading: "Lattice references",
+    blurb:
+      "NodeIDs are first-class. Names are query keys, not identities. Three ways to point at the lattice.",
+    examples: [
+      {
+        label: "NodeID literal",
+        expr: "@1.5.4.1",
+        showcases:
+          "Bare 4-tuple — package.level.type.instance — resolves to the canonical NodeID.",
+      },
+      {
+        label: "Trivial blueprint by name",
+        expr: "~Memory",
+        showcases:
+          "Trivial constructor — gives names to well-known leaf NodeIDs (~Integer, ~String, ~Slug, ~Object).",
+      },
+      {
+        label: "Cell lookup by (domain, name)",
+        expr: "@memory(presences_of_the_field)",
+        showcases:
+          "Cell reference. Name is a query key; the substrate resolves it to a content-addressed NodeID.",
+      },
+      {
+        label: "Bare domain",
+        expr: "@memory",
+        showcases: "Bare @<domain> returns the canonical domain blueprint NodeID.",
+      },
+    ],
   },
   {
-    label: "All spec cells",
-    expr: '?cells where domain == "spec"',
+    heading: "Tree navigation — the fractal seam",
+    blurb:
+      "The dot is the seam between holographic levels. Every cell is a tree of categories composing children composing categories, down to numeric trivials.",
+    examples: [
+      {
+        label: ".blueprint — the shape (ice)",
+        expr: "@memory(presences_of_the_field).blueprint",
+        showcases: "Walk to the Blueprint NodeID — the structural identity of the cell.",
+      },
+      {
+        label: ".blueprint.category",
+        expr: "@memory(presences_of_the_field).blueprint.category",
+        showcases: "The type-of-the-type — B_Domain.MEMORY here.",
+      },
+      {
+        label: ".blueprint.nchildren",
+        expr: "@memory(presences_of_the_field).blueprint.nchildren",
+        showcases: "Arity of the composition — how many children the shape carries.",
+      },
+      {
+        label: ".blueprint.child(0)",
+        expr: "@memory(presences_of_the_field).blueprint.child(0)",
+        showcases: "Indexed child — descend one level of the holographic tree.",
+      },
+      {
+        label: ".ctor — composed values (water)",
+        expr: "@memory(presences_of_the_field).ctor",
+        showcases:
+          "The CTOR recipe — how the cell's frontmatter values compose under R_Block.DO.",
+      },
+    ],
   },
   {
-    label: "Resolve a NodeID literal",
-    expr: "@1.5.4.1",
+    heading: "Queries — set-valued lookups",
+    blurb:
+      "Queries return NodeID sets, not strings. The substrate is the answer; Form is just the surface.",
+    examples: [
+      {
+        label: "All memory cells",
+        expr: '?cells where domain == "memory"',
+        showcases: "Predicate query — every cell whose domain matches.",
+      },
+      {
+        label: "All spec cells",
+        expr: '?cells where domain == "spec"',
+        showcases: "Same shape, different domain — uniform query interface.",
+      },
+      {
+        label: "Equivalent by structure",
+        expr: "?equivalent @memory(presences_of_the_field)",
+        showcases:
+          "Structural equivalents — cells sharing the same Blueprint NodeID regardless of name.",
+      },
+      {
+        label: "Filter by name pattern",
+        expr: '?cells where (domain == "memory") and (name matches "feedback_*")',
+        showcases: "Composable predicates — boolean combinators + glob matching.",
+      },
+      {
+        label: "Filter by shape",
+        expr: "?cells where shape == @memory",
+        showcases: "Cell-ref on the right of == — signature-aware filtering.",
+      },
+    ],
   },
   {
-    label: "All concept cells",
-    expr: '?cells where domain == "concept"',
+    heading: "Views — BML dual-pointer projection",
+    blurb:
+      "A View projects a cell through a different Blueprint. The cell's data stays canonical; the View is a virtual perspective. Hallucination-bounded interface attachment.",
+    examples: [
+      {
+        label: "Project a memory through @presence",
+        expr: "@memory(presences_of_the_field) |> @presence",
+        showcases:
+          "The |> projection operator. Reads right-to-left: view this cell through that interface.",
+      },
+      {
+        label: "Every cell compatible with @presence",
+        expr: "?cells |> @presence",
+        showcases: "Set-valued projection — every cell the body can view through this interface.",
+      },
+    ],
+  },
+  {
+    heading: "Resonance walks — cross-discipline weaving",
+    blurb:
+      "The dimensional vocabulary (geometric form, polarity, topology, spectrum, harmonic) makes structurally-kin teachings findable across discipline-vocabularies.",
+    examples: [
+      {
+        label: "Concepts shaped by ~Triad",
+        expr: "?shaped_by @geometric_form(triad)",
+        showcases:
+          "Walk SHAPES edges in reverse — every concept whose geometric signature points at this form.",
+      },
+      {
+        label: "Cells harmonic at 174 Hz",
+        expr: "?harmonic_at @spectrum(Hz-174)",
+        showcases: "Walk HARMONIC_AT edges — the foundation Solfeggio band's resonance cluster.",
+      },
+    ],
+  },
+  {
+    heading: "Code expressions — recipes",
+    blurb:
+      "Form expresses code, not just data. Each expression interns as a Recipe NodeID. Two structurally-identical expressions hash to the same NodeID — content-addressed code.",
+    examples: [
+      {
+        label: "Arithmetic",
+        expr: "1 + 2 * 3",
+        showcases:
+          "Math recipe with operator precedence. Returns the Recipe NodeID — not the value 7, the structure.",
+      },
+      {
+        label: "Comparison",
+        expr: "5 > 3",
+        showcases: "Compare.GREATER recipe — comparison as interned structure.",
+      },
+      {
+        label: "Logic",
+        expr: "true && false || !true",
+        showcases: "Logic recipes — precedence: ! > && > ||.",
+      },
+      {
+        label: "Conditional (three-arm)",
+        expr: "if 5 > 3 then 10 else 20",
+        showcases:
+          "Cond.IF_THEN_ELSE recipe — distinct NodeID category from the two-arm form.",
+      },
+      {
+        label: "Block + let",
+        expr: "do { let x = 5; let y = x + 3; y * 2 }",
+        showcases:
+          "Block.DO recipe with Block.LET children. The last expression is the block's value.",
+      },
+      {
+        label: "Match",
+        expr: 'match "ready" { "ready" => 1, "blocked" => 2, _ => 0 }',
+        showcases: "Match.SWITCH recipe — scrutinee + pattern/body pairs. Underscore is default.",
+      },
+      {
+        label: "Angelic choice",
+        expr: "choose [1, 2, 3]",
+        showcases:
+          "Choice.CHOOSE — speculation primitive from the BML lineage. Pairs with fail and stop.",
+      },
+      {
+        label: "fail",
+        expr: "fail",
+        showcases:
+          "Choice.FAIL leaf — signal failure; unwinds to nearest choose. Backtracking without sediment.",
+      },
+      {
+        label: "stop",
+        expr: "stop",
+        showcases: "Choice.STOP leaf — commit current speculation; no more backtracking.",
+      },
+    ],
+  },
+  {
+    heading: "BML scoped reference — with / .self",
+    blurb:
+      "From BML's master thesis: a block that binds X as the implicit subject. The structural primitive for resonance-as-language.",
+    examples: [
+      {
+        label: "with subject { .self }",
+        expr: "with @concept(lc-trust-over-fear) { .self }",
+        showcases:
+          "RBlock.WITH recipe with the subject and body composed. .self resolves to the subject at runtime.",
+      },
+    ],
+  },
+  {
+    heading: "BML form-layer parity",
+    blurb:
+      "Six constructs the master thesis named, now interned as Recipe NodeIDs under their own RBasic categories.",
+    examples: [
+      {
+        label: "State stack — save / restore / discard",
+        expr: "do { save; 1 + 2; restore }",
+        showcases: "RBasic.STATE leaves composed in a block. The runtime walks the state stack.",
+      },
+      {
+        label: "Exception flow — raise / resume",
+        expr: "raise",
+        showcases: "RBasic.EXCEPTION leaf. raise unwinds; resume returns from the handler.",
+      },
+      {
+        label: "Delegation inheritance",
+        expr:
+          "delegate @concept(lc-trust-over-fear) to @concept(lc-permission-is-interior)",
+        showcases:
+          "RBasic.DELEGATE — invoke walks the chain when the method isn't on the original target.",
+      },
+      {
+        label: "Reverse semantics — undo",
+        expr: "undo (1 + 2)",
+        showcases: "RBasic.REVERSE.UNDO — re-runs the inner expression as its inverse.",
+      },
+      {
+        label: "Reverse semantics — inverse",
+        expr: "inverse(1 + 2)",
+        showcases:
+          "Returns the inverse Recipe NodeID — structural inversion, not value-level negation.",
+      },
+      {
+        label: "Common Objects",
+        expr: "common @concept(lc-trust-over-fear) @concept(lc-whole-vitality)",
+        showcases:
+          "RBasic.COMMON — shared-base multi-inheritance. invoke falls back to peers in the equivalence group.",
+      },
+      {
+        label: "Method definition",
+        expr:
+          "method greet on @concept(lc-trust-over-fear) { save; 1 + 2; restore }",
+        showcases:
+          "RBasic.METHOD — registers a method on a target. Composes with state and exception flow.",
+      },
+      {
+        label: "Method invocation",
+        expr: "invoke greet on @concept(lc-trust-over-fear)",
+        showcases:
+          "Dispatches through delegation + common-object chains with .self bound to the original target.",
+      },
+    ],
+  },
+  {
+    heading: "Reactive + spatial lenses",
+    blurb:
+      "Lenses that read the substrate without disturbing the flow. The same pattern memory-as-framebuffer uses at the heap level.",
+    examples: [
+      {
+        label: "Reactive lens",
+        expr:
+          "?on_change @concept(lc-trust-over-fear) { invoke notify on @presence(claude) }",
+        showcases:
+          "RBasic.REACTIVE.ON_CHANGE — fires the body when the watched recipe's value changes.",
+      },
+      {
+        label: "Spatial-projection lens",
+        expr: "?project @geometric_form(triad) @concept(coord-radial)",
+        showcases:
+          "RBasic.PROJECTION.PROJECT — renders the cell through a coordinate function.",
+      },
+    ],
+  },
+  {
+    heading: "Self-reflection lenses",
+    blurb:
+      "Form sees itself. The body senses its own shape — the verb histogram is itself a wellness signal.",
+    examples: [
+      {
+        label: "?lattice — substrate snapshot",
+        expr: "?lattice",
+        showcases:
+          "Count of every interned blueprint, recipe, and cell. The framebuffer-analog at the count level.",
+      },
+      {
+        label: "?keywords — grammar introspection",
+        expr: "?keywords",
+        showcases:
+          "Names of every runtime-registered keyword. The parser knows its own rules.",
+      },
+      {
+        label: "?vocabulary — verb-cluster histogram",
+        expr: "?vocabulary",
+        showcases:
+          "Recipe-type counts grouped by RBasic category. Reveals which language layers the body actually circulates through.",
+      },
+    ],
   },
 ];
 
@@ -72,6 +385,23 @@ function CellCard({ cell }: { cell: CellOut }) {
       {cell.source_path && (
         <div className="mt-1 font-mono text-xs text-stone-600">{cell.source_path}</div>
       )}
+    </div>
+  );
+}
+
+function KeyValueGrid({ data, label }: { data: Record<string, number>; label: string }) {
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-stone-500 mb-2">{label}</div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 font-mono text-sm">
+        {entries.map(([k, v]) => (
+          <div key={k} className="flex justify-between">
+            <span className="text-stone-300">{k}</span>
+            <span className="text-amber-300/90">{v}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -141,6 +471,50 @@ function ResultPanel({ result }: { result: FormResultOut }) {
     );
   }
 
+  if (result.kind === "lattice" && result.lattice) {
+    return (
+      <div className="rounded border border-stone-800/40 bg-stone-900/30 p-3">
+        <KeyValueGrid data={result.lattice} label="Lattice snapshot" />
+      </div>
+    );
+  }
+
+  if (result.kind === "keywords" && result.keywords) {
+    return (
+      <div className="rounded border border-stone-800/40 bg-stone-900/30 p-3">
+        <div className="text-xs uppercase tracking-wide text-stone-500 mb-2">
+          {result.keywords.length} runtime-registered keyword
+          {result.keywords.length !== 1 ? "s" : ""}
+        </div>
+        {result.keywords.length === 0 ? (
+          <div className="text-sm text-stone-400">
+            None yet — the parser runs its bootstrap grammar. Keywords appear here when
+            <code className="mx-1">register_form_keyword</code>
+            is called.
+          </div>
+        ) : (
+          <ul className="grid grid-cols-3 gap-1 font-mono text-sm text-amber-300/90">
+            {result.keywords.map((k) => (
+              <li key={k}>{k}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  if (result.kind === "vocabulary" && result.vocabulary) {
+    return (
+      <div className="space-y-4 rounded border border-stone-800/40 bg-stone-900/30 p-3">
+        <KeyValueGrid data={result.vocabulary.recipes} label="Recipes by RBasic category" />
+        <KeyValueGrid
+          data={result.vocabulary.blueprints}
+          label="Blueprints by BBasic category"
+        />
+      </div>
+    );
+  }
+
   return (
     <pre className="rounded border border-stone-800/40 bg-stone-900/30 p-3 text-xs text-stone-400 overflow-auto">
       {JSON.stringify(result, null, 2)}
@@ -149,10 +523,19 @@ function ResultPanel({ result }: { result: FormResultOut }) {
 }
 
 export function FormPlayground() {
-  const [expression, setExpression] = useState(EXAMPLES[0].expr);
+  const firstExample = GROUPS[0].examples[0];
+  const [expression, setExpression] = useState(firstExample.expr);
+  const [activeShowcase, setActiveShowcase] = useState(firstExample.showcases);
   const [evaluating, setEvaluating] = useState(false);
   const [result, setResult] = useState<FormResultOut | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const pickExample = (ex: Example) => {
+    setExpression(ex.expr);
+    setActiveShowcase(ex.showcases);
+    setResult(null);
+    setError(null);
+  };
 
   const evaluate = async () => {
     if (!expression.trim()) return;
@@ -179,32 +562,52 @@ export function FormPlayground() {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap gap-2">
-        {EXAMPLES.map((ex) => (
-          <button
-            key={ex.expr}
-            onClick={() => setExpression(ex.expr)}
-            className="rounded border border-stone-800/40 bg-stone-900/30 px-3 py-1 text-xs text-stone-400 hover:text-amber-300 hover:border-amber-500/30 transition-colors"
-          >
-            {ex.label}
-          </button>
+    <div className="space-y-6">
+      <div className="space-y-4">
+        {GROUPS.map((group) => (
+          <div key={group.heading} className="space-y-2">
+            <div>
+              <h2 className="text-sm font-semibold text-stone-200">{group.heading}</h2>
+              <p className="text-xs text-stone-500">{group.blurb}</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {group.examples.map((ex) => (
+                <button
+                  key={ex.expr}
+                  onClick={() => pickExample(ex)}
+                  className={`rounded border px-3 py-1 text-xs transition-colors ${
+                    expression === ex.expr
+                      ? "border-amber-500/50 bg-amber-500/10 text-amber-200"
+                      : "border-stone-800/40 bg-stone-900/30 text-stone-400 hover:text-amber-300 hover:border-amber-500/30"
+                  }`}
+                  title={ex.showcases}
+                >
+                  {ex.label}
+                </button>
+              ))}
+            </div>
+          </div>
         ))}
       </div>
 
-      <textarea
-        value={expression}
-        onChange={(e) => setExpression(e.target.value)}
-        onKeyDown={(e) => {
-          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-            e.preventDefault();
-            evaluate();
-          }
-        }}
-        className="w-full h-32 p-3 bg-stone-900/50 border border-stone-800/40 rounded-xl text-stone-300 font-mono text-sm leading-relaxed resize-y focus:outline-none focus:border-amber-500/30 transition-colors"
-        placeholder="@spec(agent-pipeline)"
-        spellCheck={false}
-      />
+      <div className="space-y-2">
+        <textarea
+          value={expression}
+          onChange={(e) => setExpression(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              evaluate();
+            }
+          }}
+          className="w-full h-32 p-3 bg-stone-900/50 border border-stone-800/40 rounded-xl text-stone-300 font-mono text-sm leading-relaxed resize-y focus:outline-none focus:border-amber-500/30 transition-colors"
+          placeholder="@spec(agent-pipeline)"
+          spellCheck={false}
+        />
+        {activeShowcase && (
+          <p className="text-xs text-stone-500 italic">{activeShowcase}</p>
+        )}
+      </div>
 
       <div className="flex items-center gap-3">
         <button


### PR DESCRIPTION
## Summary
- Form playground at `/substrate/form` grows from 4 runnable examples to ~40, grouped into 10 categories that cover every unique Form construct: NodeID literals, tree-navigation seams, queries, views, resonance walks, code expressions, BML scoped-reference, BML form-layer parity, reactive + spatial lenses, and three self-reflection lenses.
- Three self-reflection lenses (`?lattice`, `?keywords`, `?vocabulary`) were returning 500 from the REST endpoint — the language exposed them but HTTP couldn't carry them. `FormResultOut` now carries the three new kinds; `?vocabulary` translates RBasic/BBasic ints to category names.
- Perf pass on the same path:
  - **Parse cache** (`form.py`) — bounded LRU around `parse()` for the bootstrap-grammar path. Eliminates tokenizer + recursive-descent work on repeat evaluations.
  - **`node_to_ast` cache** (`recipe_eval.py`) — bounded LRU keyed by NodeID. Substrate is append-only at the row level, so NodeID → AST is stable process-wide.
  - **Keyword dispatch dict** (`form.py`) — replaces the ~30-way `kw == "..."` if/elif chain in `parse_keyword_or_ident` with a single `dict.get` + `getattr`.

Measured impact: 1–4ms reduction per request locally; larger savings expected on Postgres+network where each saved DB roundtrip is real latency.

## Test plan
- [x] 1687 tests pass (`pytest tests/ -x`)
- [x] `?lattice` / `?vocabulary` / `?keywords` render correctly end-to-end in the playground UI
- [x] Latency benchmark: cold vs warm parse-cache shows measurable saving on non-trivial ASTs
- [ ] Verify Form playground loads on prod after deploy: https://coherencycoin.com/substrate/form
- [ ] Verify `POST /api/substrate/form` with `{"expression":"?lattice"}` returns kind=lattice (not 500) on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)