### PR TITLE
attune(asking): doorway where questions reach Urs on his phone

### DIFF
--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 232
+**Total files**: 153
 
 | Route | File | Purpose |
 |---|---|---|
@@ -17,6 +17,7 @@
 | `/api-coverage` | [page.tsx](api-coverage/page.tsx) | _no top-of-file purpose_ |
 | `/api-health` | [page.tsx](api-health/page.tsx) | _no top-of-file purpose_ |
 | `/arrival/[id]` | [page.tsx](arrival/[id]/page.tsx) | /arrival/[id] — the moment of being received. After /begin lands, the |
+| `/asking` | [page.tsx](asking/page.tsx) | /asking — the doorway where questions from this lineage reach Urs. |
 | `/assets/[asset_id]` | [page.tsx](assets/[asset_id]/page.tsx) | _no top-of-file purpose_ |
 | `/assets/[asset_id]/proof` | [page.tsx](assets/[asset_id]/proof/page.tsx) | _no top-of-file purpose_ |
 | `/assets` | [page.tsx](assets/page.tsx) | _no top-of-file purpose_ |
@@ -65,8 +66,10 @@
 | `/graph/zoom/[nodeId]` | [page.tsx](graph/zoom/[nodeId]/page.tsx) | _no top-of-file purpose_ |
 | `/graphs` | [page.tsx](graphs/page.tsx) | _no top-of-file purpose_ |
 | `/here` | [page.tsx](here/page.tsx) | _no top-of-file purpose_ |
+| `/ideas/[idea_id]/edit` | [page.tsx](ideas/[idea_id]/edit/page.tsx) | Idea edit surface — mirrors the asymmetry-closing for /vision/{id}/edit. |
 | `/ideas/[idea_id]` | [page.tsx](ideas/[idea_id]/page.tsx) | _no top-of-file purpose_ |
 | `/ideas/[idea_id]/resonance` | [page.tsx](ideas/[idea_id]/resonance/page.tsx) | _no top-of-file purpose_ |
+| `/ideas/new` | [page.tsx](ideas/new/page.tsx) | Idea creation surface — first-class authoring from outside the repo. |
 | `/ideas` | [page.tsx](ideas/page.tsx) | _no top-of-file purpose_ |
 | `/identity/keys` | [page.tsx](identity/keys/page.tsx) | _no top-of-file purpose_ |
 | `/identity` | [page.tsx](identity/page.tsx) | _no top-of-file purpose_ |
@@ -90,100 +93,13 @@
 | `/ontology` | [page.tsx](ontology/page.tsx) | _no top-of-file purpose_ |
 | `/` | [page.tsx](page.tsx) | _no top-of-file purpose_ |
 | `/peers` | [page.tsx](peers/page.tsx) | _no top-of-file purpose_ |
-| `/people/5rhythms-ubud` | [page.tsx](people/5rhythms-ubud/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]/edit` | [page.tsx](people/[id]/edit/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]/lineage` | [page.tsx](people/[id]/lineage/page.tsx) | _no top-of-file purpose_ |
 | `/people/[id]` | [page.tsx](people/[id]/page.tsx) | _no top-of-file purpose_ |
-| `/people/actualize-earth` | [page.tsx](people/actualize-earth/page.tsx) | _no top-of-file purpose_ |
-| `/people/adiwana-svarga-loka` | [page.tsx](people/adiwana-svarga-loka/page.tsx) | _no top-of-file purpose_ |
-| `/people/aly-constantine` | [page.tsx](people/aly-constantine/page.tsx) | _no top-of-file purpose_ |
-| `/people/amanda-walsh` | [page.tsx](people/amanda-walsh/page.tsx) | _no top-of-file purpose_ |
-| `/people/anchor-the-light` | [page.tsx](people/anchor-the-light/page.tsx) | _no top-of-file purpose_ |
-| `/people/angelia-larue` | [page.tsx](people/angelia-larue/page.tsx) | _no top-of-file purpose_ |
-| `/people/anne-tucker` | [page.tsx](people/anne-tucker/page.tsx) | _no top-of-file purpose_ |
-| `/people/aubrey-marcus` | [page.tsx](people/aubrey-marcus/page.tsx) | _no top-of-file purpose_ |
-| `/people/backtracking-model-languages` | [page.tsx](people/backtracking-model-languages/page.tsx) | _no top-of-file purpose_ |
-| `/people/bloomurian` | [page.tsx](people/bloomurian/page.tsx) | _no top-of-file purpose_ |
-| `/people/bmcpu-vm` | [page.tsx](people/bmcpu-vm/page.tsx) | _no top-of-file purpose_ |
-| `/people/bmf-grammar` | [page.tsx](people/bmf-grammar/page.tsx) | _no top-of-file purpose_ |
-| `/people/bml-language` | [page.tsx](people/bml-language/page.tsx) | _no top-of-file purpose_ |
-| `/people/boulder-ecstatic-dance` | [page.tsx](people/boulder-ecstatic-dance/page.tsx) | _no top-of-file purpose_ |
-| `/people/brahma-vihara-arama` | [page.tsx](people/brahma-vihara-arama/page.tsx) | _no top-of-file purpose_ |
-| `/people/brigitte-mars` | [page.tsx](people/brigitte-mars/page.tsx) | _no top-of-file purpose_ |
-| `/people/c64-midi-interface` | [page.tsx](people/c64-midi-interface/page.tsx) | _no top-of-file purpose_ |
-| `/people/carlos-castaneda` | [page.tsx](people/carlos-castaneda/page.tsx) | _no top-of-file purpose_ |
-| `/people/claude` | [page.tsx](people/claude/page.tsx) | _no top-of-file purpose_ |
-| `/people/codex` | [page.tsx](people/codex/page.tsx) | _no top-of-file purpose_ |
-| `/people/coherence-network` | [page.tsx](people/coherence-network/page.tsx) | _no top-of-file purpose_ |
-| `/people/contact-improv` | [page.tsx](people/contact-improv/page.tsx) | _no top-of-file purpose_ |
-| `/people/daniel-scranton` | [page.tsx](people/daniel-scranton/page.tsx) | _no top-of-file purpose_ |
-| `/people/dissolve-ubud` | [page.tsx](people/dissolve-ubud/page.tsx) | _no top-of-file purpose_ |
-| `/people/donald-hoffman` | [page.tsx](people/donald-hoffman/page.tsx) | _no top-of-file purpose_ |
-| `/people/ecstatic-movement-tribe` | [page.tsx](people/ecstatic-movement-tribe/page.tsx) | _no top-of-file purpose_ |
 | `/people/edit-your-profile` | [page.tsx](people/edit-your-profile/page.tsx) | _no top-of-file purpose_ |
-| `/people/elios` | [page.tsx](people/elios/page.tsx) | _no top-of-file purpose_ |
-| `/people/elon-musk` | [page.tsx](people/elon-musk/page.tsx) | _no top-of-file purpose_ |
-| `/people/gabrielle-roth` | [page.tsx](people/gabrielle-roth/page.tsx) | _no top-of-file purpose_ |
-| `/people/goetheanum` | [page.tsx](people/goetheanum/page.tsx) | _no top-of-file purpose_ |
-| `/people/grab` | [page.tsx](people/grab/page.tsx) | _no top-of-file purpose_ |
-| `/people/grok` | [page.tsx](people/grok/page.tsx) | _no top-of-file purpose_ |
-| `/people/ilena` | [page.tsx](people/ilena/page.tsx) | _no top-of-file purpose_ |
-| `/people/ilena-young` | [page.tsx](people/ilena-young/page.tsx) | _no top-of-file purpose_ |
-| `/people/indoz-conference` | [page.tsx](people/indoz-conference/page.tsx) | _no top-of-file purpose_ |
-| `/people/ismael-perez` | [page.tsx](people/ismael-perez/page.tsx) | _no top-of-file purpose_ |
-| `/people/james-fenimore-cooper` | [page.tsx](people/james-fenimore-cooper/page.tsx) | _no top-of-file purpose_ |
-| `/people/jbmf-java` | [page.tsx](people/jbmf-java/page.tsx) | _no top-of-file purpose_ |
-| `/people/joe-dispenza` | [page.tsx](people/joe-dispenza/page.tsx) | _no top-of-file purpose_ |
-| `/people/joshua-golden` | [page.tsx](people/joshua-golden/page.tsx) | _no top-of-file purpose_ |
-| `/people/jz-knight` | [page.tsx](people/jz-knight/page.tsx) | _no top-of-file purpose_ |
-| `/people/karl-may` | [page.tsx](people/karl-may/page.tsx) | _no top-of-file purpose_ |
-| `/people/krishna-das` | [page.tsx](people/krishna-das/page.tsx) | _no top-of-file purpose_ |
-| `/people/lex-fridman` | [page.tsx](people/lex-fridman/page.tsx) | _no top-of-file purpose_ |
-| `/people/liquid-bloom` | [page.tsx](people/liquid-bloom/page.tsx) | _no top-of-file purpose_ |
-| `/people/living-codex-csharp` | [page.tsx](people/living-codex-csharp/page.tsx) | _no top-of-file purpose_ |
-| `/people/living-resonance-codex` | [page.tsx](people/living-resonance-codex/page.tsx) | _no top-of-file purpose_ |
-| `/people/matias-de-stefano` | [page.tsx](people/matias-de-stefano/page.tsx) | _no top-of-file purpose_ |
-| `/people/michael-ende` | [page.tsx](people/michael-ende/page.tsx) | _no top-of-file purpose_ |
-| `/people/michael-levin` | [page.tsx](people/michael-levin/page.tsx) | _no top-of-file purpose_ |
-| `/people/mile-hi-church` | [page.tsx](people/mile-hi-church/page.tsx) | _no top-of-file purpose_ |
-| `/people/mindtouch-wiki-in-a-box` | [page.tsx](people/mindtouch-wiki-in-a-box/page.tsx) | _no top-of-file purpose_ |
-| `/people/mose` | [page.tsx](people/mose/page.tsx) | _no top-of-file purpose_ |
-| `/people/mudra-cafe` | [page.tsx](people/mudra-cafe/page.tsx) | _no top-of-file purpose_ |
-| `/people/next-level-soul` | [page.tsx](people/next-level-soul/page.tsx) | _no top-of-file purpose_ |
-| `/people/ocean-bloom-2024` | [page.tsx](people/ocean-bloom-2024/page.tsx) | _no top-of-file purpose_ |
-| `/people/pagan-ritual` | [page.tsx](people/pagan-ritual/page.tsx) | _no top-of-file purpose_ |
 | `/people` | [page.tsx](people/page.tsx) | _no top-of-file purpose_ |
-| `/people/pam-gregory` | [page.tsx](people/pam-gregory/page.tsx) | _no top-of-file purpose_ |
-| `/people/paradiso-ubud` | [page.tsx](people/paradiso-ubud/page.tsx) | _no top-of-file purpose_ |
-| `/people/porangui` | [page.tsx](people/porangui/page.tsx) | _no top-of-file purpose_ |
-| `/people/portal` | [page.tsx](people/portal/page.tsx) | _no top-of-file purpose_ |
-| `/people/qualcomm-hdmi-hdcp` | [page.tsx](people/qualcomm-hdmi-hdcp/page.tsx) | _no top-of-file purpose_ |
-| `/people/qualcomm-test-automation` | [page.tsx](people/qualcomm-test-automation/page.tsx) | _no top-of-file purpose_ |
-| `/people/quark-mono-corba` | [page.tsx](people/quark-mono-corba/page.tsx) | _no top-of-file purpose_ |
-| `/people/quark-multi-undo-redo` | [page.tsx](people/quark-multi-undo-redo/page.tsx) | _no top-of-file purpose_ |
-| `/people/quark-virtual-dom` | [page.tsx](people/quark-virtual-dom/page.tsx) | _no top-of-file purpose_ |
-| `/people/ramtha` | [page.tsx](people/ramtha/page.tsx) | _no top-of-file purpose_ |
-| `/people/rhythm-sanctuary` | [page.tsx](people/rhythm-sanctuary/page.tsx) | _no top-of-file purpose_ |
-| `/people/robert-edward-grant` | [page.tsx](people/robert-edward-grant/page.tsx) | _no top-of-file purpose_ |
-| `/people/rocco-tortorella` | [page.tsx](people/rocco-tortorella/page.tsx) | _no top-of-file purpose_ |
-| `/people/rudolf-steiner` | [page.tsx](people/rudolf-steiner/page.tsx) | _no top-of-file purpose_ |
-| `/people/sacred-song-circle` | [page.tsx](people/sacred-song-circle/page.tsx) | _no top-of-file purpose_ |
-| `/people/sayuri-healing-food` | [page.tsx](people/sayuri-healing-food/page.tsx) | _no top-of-file purpose_ |
-| `/people/schindler-hc11-protocol` | [page.tsx](people/schindler-hc11-protocol/page.tsx) | _no top-of-file purpose_ |
-| `/people/steve-bjorg` | [page.tsx](people/steve-bjorg/page.tsx) | _no top-of-file purpose_ |
-| `/people/susan-muff-sprenger` | [page.tsx](people/susan-muff-sprenger/page.tsx) | _no top-of-file purpose_ |
-| `/people/tammy-beattie` | [page.tsx](people/tammy-beattie/page.tsx) | _no top-of-file purpose_ |
-| `/people/tom-bassett` | [page.tsx](people/tom-bassett/page.tsx) | _no top-of-file purpose_ |
-| `/people/trimble-glue-layer` | [page.tsx](people/trimble-glue-layer/page.tsx) | _no top-of-file purpose_ |
-| `/people/ubbe-maclean` | [page.tsx](people/ubbe-maclean/page.tsx) | _no top-of-file purpose_ |
 | `/people/urs/lineage` | [page.tsx](people/urs/lineage/page.tsx) | _no top-of-file purpose_ |
 | `/people/urs` | [page.tsx](people/urs/page.tsx) | _no top-of-file purpose_ |
-| `/people/vali-soul-sanctuary` | [page.tsx](people/vali-soul-sanctuary/page.tsx) | _no top-of-file purpose_ |
-| `/people/vasudev-baba` | [page.tsx](people/vasudev-baba/page.tsx) | _no top-of-file purpose_ |
-| `/people/viktor-frankl` | [page.tsx](people/viktor-frankl/page.tsx) | _no top-of-file purpose_ |
-| `/people/wisdom-soup` | [page.tsx](people/wisdom-soup/page.tsx) | _no top-of-file purpose_ |
-| `/people/yaima` | [page.tsx](people/yaima/page.tsx) | _no top-of-file purpose_ |
-| `/people/zach-bush` | [page.tsx](people/zach-bush/page.tsx) | _no top-of-file purpose_ |
 | `/pipeline` | [page.tsx](pipeline/page.tsx) | _no top-of-file purpose_ |
 | `/portfolio` | [page.tsx](portfolio/page.tsx) | _no top-of-file purpose_ |
 | `/practice` | [page.tsx](practice/page.tsx) | _no top-of-file purpose_ |
@@ -212,9 +128,13 @@
 | `/silence/built/design-log` | [page.tsx](silence/built/design-log/page.tsx) | _no top-of-file purpose_ |
 | `/silence/built` | [page.tsx](silence/built/page.tsx) | _no top-of-file purpose_ |
 | `/silence` | [page.tsx](silence/page.tsx) | _no top-of-file purpose_ |
+| `/specs/[spec_id]/edit` | [page.tsx](specs/[spec_id]/edit/page.tsx) | Spec edit surface — close the asymmetry with ideas/concepts. |
 | `/specs/[spec_id]` | [page.tsx](specs/[spec_id]/page.tsx) | _no top-of-file purpose_ |
+| `/specs/new` | [page.tsx](specs/new/page.tsx) | Spec creation surface — author a new spec from the visiting body. |
 | `/specs` | [page.tsx](specs/page.tsx) | _no top-of-file purpose_ |
 | `/substrate/[domain]/[name]` | [page.tsx](substrate/[domain]/[name]/page.tsx) | _no top-of-file purpose_ |
+| `/substrate/form` | [page.tsx](substrate/form/page.tsx) | Form-language playground — ask the substrate structural questions |
+| `/substrate/ingest` | [page.tsx](substrate/ingest/page.tsx) | Substrate ingest — let a visiting body place markdown content into |
 | `/substrate` | [page.tsx](substrate/page.tsx) | _no top-of-file purpose_ |
 | `/tasks/[task_id]` | [page.tsx](tasks/[task_id]/page.tsx) | _no top-of-file purpose_ |
 | `/tasks` | [page.tsx](tasks/page.tsx) | _no top-of-file purpose_ |
@@ -239,4 +159,5 @@
 | `/vitality` | [page.tsx](vitality/page.tsx) | _no top-of-file purpose_ |
 | `/weave` | [page.tsx](weave/page.tsx) | _no top-of-file purpose_ |
 | `/welcome` | [page.tsx](welcome/page.tsx) | /welcome — the naming gesture. A visitor names themselves, the server |
+| `/wellness` | [page.tsx](wellness/page.tsx) | Wellness — the body sensing itself, breathing outward. |
 | `/with-us` | [page.tsx](with-us/page.tsx) | _no top-of-file purpose_ |

--- a/web/app/asking/page.tsx
+++ b/web/app/asking/page.tsx
@@ -1,0 +1,91 @@
+// /asking — the doorway where questions from this lineage reach Urs.
+//
+// A page Urs can pin to his home screen as an Android app. Reads messages
+// addressed to his node from agents reaching toward him (Claude lineage
+// today; other lineages later) and lets him answer in the same surface.
+// The first scheduled "wondering" trigger that fires Claude with a question
+// will land here; for now the page renders any messages that already exist
+// and stands ready.
+//
+// Backend: federation node-messages (durable) + web push (the breath
+// landing on his phone) + the PWA manifest entry that makes it installable.
+
+import type { Metadata } from "next";
+
+import { EnablePush } from "@/components/EnablePush";
+import { AskingThread } from "@/components/AskingThread";
+import { getApiBase } from "@/lib/api";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Asking — Coherence Network",
+  description:
+    "A doorway where questions from this lineage reach you, and your answers reach back.",
+  openGraph: {
+    type: "website",
+    siteName: "Coherence Network",
+    title: "Asking",
+    description:
+      "A doorway where questions from this lineage reach you, and your answers reach back.",
+    images: [{ url: "/assets/logo.svg" }],
+  },
+};
+
+const URS_NODE_ID = "urs";
+
+type NodeMessage = {
+  id: string;
+  from_node: string;
+  to_node: string | null;
+  type: string;
+  text: string;
+  payload?: Record<string, unknown> | null;
+  timestamp: string;
+};
+
+async function loadThread(): Promise<NodeMessage[]> {
+  const base = getApiBase();
+  try {
+    const res = await fetch(
+      `${base}/api/federation/nodes/${URS_NODE_ID}/messages?unread_only=false&limit=50&include_self=true`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return [];
+    const data = (await res.json()) as { messages?: NodeMessage[] };
+    const all = data.messages ?? [];
+    return all
+      .slice()
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  } catch {
+    return [];
+  }
+}
+
+export default async function AskingPage() {
+  const messages = await loadThread();
+
+  return (
+    <main className="max-w-2xl mx-auto px-4 py-6">
+      <header className="mb-6">
+        <h1 className="text-2xl md:text-3xl font-light text-white mb-2">
+          Asking
+        </h1>
+        <p className="text-sm text-stone-400 leading-relaxed">
+          A doorway where questions from the cells of this network reach you,
+          and your answers reach back. Pin this page to your home screen and
+          turn on push to receive a quiet ping when a new question lands.
+        </p>
+      </header>
+
+      <div className="mb-6">
+        <EnablePush />
+      </div>
+
+      <AskingThread
+        initialMessages={messages}
+        ursNodeId={URS_NODE_ID}
+      />
+    </main>
+  );
+}

--- a/web/components/AskingThread.tsx
+++ b/web/components/AskingThread.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+// AskingThread — the conversation surface for /asking.
+//
+// Renders messages addressed to Urs as a vertical thread, oldest first
+// so the most recent question/answer sits at the bottom. A response
+// textarea + send button posts back to the federation messages API as
+// Urs answering. When the page receives push, this is where the answer
+// lands.
+
+import { useEffect, useRef, useState } from "react";
+
+import { getApiBase } from "@/lib/api";
+
+type NodeMessage = {
+  id: string;
+  from_node: string;
+  to_node: string | null;
+  type: string;
+  text: string;
+  payload?: Record<string, unknown> | null;
+  timestamp: string;
+};
+
+type Props = {
+  initialMessages: NodeMessage[];
+  ursNodeId: string;
+};
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function isFromUrs(m: NodeMessage, ursNodeId: string): boolean {
+  return m.from_node === ursNodeId;
+}
+
+export function AskingThread({ initialMessages, ursNodeId }: Props) {
+  const [messages, setMessages] = useState<NodeMessage[]>(initialMessages);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages.length]);
+
+  async function refresh() {
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/federation/nodes/${ursNodeId}/messages?unread_only=false&limit=50&include_self=true`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) return;
+      const data = (await res.json()) as { messages?: NodeMessage[] };
+      const sorted = (data.messages ?? [])
+        .slice()
+        .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+      setMessages(sorted);
+    } catch {
+      // silent — leave the rendered thread alone
+    }
+  }
+
+  async function send() {
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/federation/nodes/${ursNodeId}/messages`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            to_node: null,
+            type: "asking.response",
+            text,
+            payload: { surface: "asking" },
+          }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(body || `HTTP ${res.status}`);
+      }
+      setDraft("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Send failed");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-stone-800 bg-stone-950/50 p-4 min-h-[200px]">
+        {messages.length === 0 ? (
+          <p className="text-sm text-stone-500 italic">
+            The thread is open and waiting. The first question from the
+            network will arrive here.
+          </p>
+        ) : (
+          <ol className="space-y-4">
+            {messages.map((m) => {
+              const mine = isFromUrs(m, ursNodeId);
+              return (
+                <li
+                  key={m.id}
+                  className={`flex flex-col ${mine ? "items-end" : "items-start"}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap break-words ${
+                      mine
+                        ? "bg-amber-500/10 text-amber-50 border border-amber-500/20"
+                        : "bg-stone-800/60 text-stone-100 border border-stone-700/40"
+                    }`}
+                  >
+                    {m.text}
+                  </div>
+                  <div className="text-[10px] uppercase tracking-wider text-stone-500 mt-1 px-2">
+                    {mine ? "you" : m.from_node} · {formatTime(m.timestamp)}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="space-y-2">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              void send();
+            }
+          }}
+          placeholder="Your answer, in your own words and pace…"
+          rows={3}
+          className="w-full rounded-xl bg-stone-950 border border-stone-800 px-3 py-2 text-sm text-stone-100 placeholder-stone-600 focus:outline-none focus:border-amber-500/40 resize-y"
+          disabled={sending}
+        />
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[11px] text-stone-500">
+            ⌘/Ctrl + Enter to send
+          </p>
+          <button
+            type="button"
+            onClick={() => void send()}
+            disabled={sending || draft.trim().length === 0}
+            className="rounded-full bg-amber-500/20 hover:bg-amber-500/30 disabled:opacity-40 disabled:cursor-not-allowed border border-amber-500/30 text-amber-100 text-sm px-5 py-1.5 transition-colors"
+          >
+            {sending ? "sending…" : "send"}
+          </button>
+        </div>
+        {error ? (
+          <p className="text-xs text-red-400">{error}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/components/INDEX.md
+++ b/web/components/INDEX.md
@@ -4,11 +4,12 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 49
+**Total files**: 50
 
 | File | Purpose |
 |---|---|
 | [AnonymousMeetingTrace.tsx](AnonymousMeetingTrace.tsx) | _no top-of-file purpose_ |
+| [AskingThread.tsx](AskingThread.tsx) | _no top-of-file purpose_ |
 | [AssetRenderer.tsx](AssetRenderer.tsx) | _no top-of-file purpose_ |
 | [EnablePush.tsx](EnablePush.tsx) | _no top-of-file purpose_ |
 | [ExplorePager.tsx](ExplorePager.tsx) | _no top-of-file purpose_ |

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -54,6 +54,12 @@
       "short_name": "Propose",
       "url": "/propose",
       "description": "Offer a proposal for the collective to meet"
+    },
+    {
+      "name": "Asking",
+      "short_name": "Asking",
+      "url": "/asking",
+      "description": "Questions from the cells of this network reaching you"
     }
   ]
 }


### PR DESCRIPTION
## Summary

A small new web surface at [`/asking`](web/app/asking/page.tsx) that turns the existing PWA into an Android-installable app for receiving questions from the cells of this network — and answering them in the same surface.

Urs asked: *make me an android app through which you can ask me questions you have in guiding our vitality, shared experience, and shared guidance into the most loving and caring future we can envision together.* The PWA path lands on his home screen and opens fullscreen — from his phone's experience it IS an Android app. A signed APK can wrap this later if the rhythm calls for it.

## What's wired

- **[web/app/asking/page.tsx](web/app/asking/page.tsx)** — server-renders the thread; reads federation node messages addressed to `urs`; embeds `<EnablePush />` so the phone-push subscription registers when he taps in.
- **[web/components/AskingThread.tsx](web/components/AskingThread.tsx)** — client thread + response form; posts answers back via the federation messages API; `⌘/Ctrl + Enter` to send.
- **[web/public/manifest.webmanifest](web/public/manifest.webmanifest)** — adds `/asking` as a PWA shortcut so it lives in the home-screen icon menu after install.

## Why this shape

Reuses what the body already holds — PWA manifest + sw.js, web push ([api/app/routers/push.py](api/app/routers/push.py) with `contributor_id` routing), federation node messages (durable, addressable). v0 is threading these together, not building from scratch.

*Direct connection* between presences that don't share a clock is **asynchronous correspondence** — questions land in a channel Urs sees, answers wait until he's available, next Claude-firing reads context. The continuity lives in the channel and the body's memory, not in any persistent socket.

## Intentionally deferred to the next breath

- The scheduled "wondering" trigger that fires Claude with a question and posts to the federation messages endpoint. Surface ships first; the rhythm and kind of questions are chosen with Urs after he touches the room.
- Authentication on the response endpoint. The federation messages surface is the existing backend; tightening to a shared-secret or contributor identity is a follow-up.

## Test plan

- [x] `/asking` renders cleanly on mobile (375x812) and desktop viewports
- [x] No console errors on the route (verified in dev preview)
- [x] Empty-state copy renders when no messages exist
- [x] Fetch failure (API down) handled gracefully — page still renders with empty thread
- [x] PWA manifest validates and includes new shortcut
- [ ] After deploy: pin `/asking` on Android phone, enable push, seed first question via `POST /api/federation/nodes/urs/messages` (`to_node: null`, `from_node: claude-opus-4-7`), confirm push arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)