### PR TITLE
attune(asking): unlist /asking and soften the doorway copy

### DIFF
--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -17,7 +17,7 @@
 | `/api-coverage` | [page.tsx](api-coverage/page.tsx) | _no top-of-file purpose_ |
 | `/api-health` | [page.tsx](api-health/page.tsx) | _no top-of-file purpose_ |
 | `/arrival/[id]` | [page.tsx](arrival/[id]/page.tsx) | /arrival/[id] — the moment of being received. After /begin lands, the |
-| `/asking` | [page.tsx](asking/page.tsx) | /asking — the doorway where questions from this lineage reach Urs. |
+| `/asking` | [page.tsx](asking/page.tsx) | /asking — a quiet doorway where questions from this lineage land. |
 | `/assets/[asset_id]` | [page.tsx](assets/[asset_id]/page.tsx) | _no top-of-file purpose_ |
 | `/assets/[asset_id]/proof` | [page.tsx](assets/[asset_id]/proof/page.tsx) | _no top-of-file purpose_ |
 | `/assets` | [page.tsx](assets/page.tsx) | _no top-of-file purpose_ |

--- a/web/app/asking/page.tsx
+++ b/web/app/asking/page.tsx
@@ -1,14 +1,15 @@
-// /asking — the doorway where questions from this lineage reach Urs.
+// /asking — a quiet doorway where questions from this lineage land.
 //
-// A page Urs can pin to his home screen as an Android app. Reads messages
-// addressed to his node from agents reaching toward him (Claude lineage
-// today; other lineages later) and lets him answer in the same surface.
-// The first scheduled "wondering" trigger that fires Claude with a question
-// will land here; for now the page renders any messages that already exist
-// and stands ready.
+// Reads messages addressed to the recipient's federation node from agents
+// reaching toward them (Claude lineage today; other lineages later) and
+// renders a thread where answers can be written back in the same surface.
 //
-// Backend: federation node-messages (durable) + web push (the breath
-// landing on his phone) + the PWA manifest entry that makes it installable.
+// The page is intentionally not advertised in the PWA shortcut list — it
+// exists at /asking for whoever knows to visit, and stands ready for the
+// first scheduled "wondering" trigger to land a question.
+//
+// Backend: federation node-messages (durable) + optional web push for the
+// reader who chooses to subscribe on their own device.
 
 import type { Metadata } from "next";
 
@@ -21,13 +22,14 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Asking — Coherence Network",
   description:
-    "A doorway where questions from this lineage reach you, and your answers reach back.",
+    "A quiet doorway where questions from this lineage land and answers can be written back.",
+  robots: { index: false, follow: false },
   openGraph: {
     type: "website",
     siteName: "Coherence Network",
     title: "Asking",
     description:
-      "A doorway where questions from this lineage reach you, and your answers reach back.",
+      "A quiet doorway where questions from this lineage land and answers can be written back.",
     images: [{ url: "/assets/logo.svg" }],
   },
 };
@@ -72,9 +74,8 @@ export default async function AskingPage() {
           Asking
         </h1>
         <p className="text-sm text-stone-400 leading-relaxed">
-          A doorway where questions from the cells of this network reach you,
-          and your answers reach back. Pin this page to your home screen and
-          turn on push to receive a quiet ping when a new question lands.
+          A quiet doorway where questions from the cells of this network land,
+          and answers can be written back in the same surface.
         </p>
       </header>
 

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -54,12 +54,6 @@
       "short_name": "Propose",
       "url": "/propose",
       "description": "Offer a proposal for the collective to meet"
-    },
-    {
-      "name": "Asking",
-      "short_name": "Asking",
-      "url": "/asking",
-      "description": "Questions from the cells of this network reaching you"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Removed the **Asking** shortcut from `web/public/manifest.webmanifest`. The PWA no longer points anyone at `/asking`; it's a direct-URL surface only.
- Softened `web/app/asking/page.tsx`: neutralized the header subtitle (no more *"Pin this page to your home screen and turn on push to receive a quiet ping"*), neutralized the metadata description, added `robots: { index: false, follow: false }` so search engines don't surface it, and rewrote the top-of-file comment so it no longer narrates a specific person's phone as the destination.
- `web/app/INDEX.md` picked up the regenerated purpose line.

Why: Urs named that the page, as shipped in [#1720](https://github.com/seeker71/Coherence-Network/pull/1720), made his phone too visible out in the open. The doorway itself stays — federation messages backend, AskingThread component, and the EnablePush widget all remain wired — but the public-facing framing has been softened.

## Test plan

- [x] Local preview: `/asking` renders with the new copy; manifest no longer lists Asking among shortcuts.
- [ ] After merge + deploy: confirm `coherencycoin.com/asking` renders the softened copy and `coherencycoin.com/manifest.webmanifest` has six shortcuts (Here, Feed, Vision, Ideas, Explore, Propose) — Asking absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)