### PR TITLE
attune(form): expose substrate Form streaming through MCP

### DIFF
--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -25,6 +25,7 @@ from app.services.substrate import (
     find_cells_compatible_with,
     find_equivalent_cells,
     form_evaluate_text,
+    form_stream_emit,
     ingest_markdown_text,
     lattice_stats,
     lookup_cell,
@@ -504,6 +505,14 @@ class FormRequest(BaseModel):
             "Grammar: docs/coherence-substrate/form-language.md."
         ),
     )
+    mode: str = Field(
+        default="ast",
+        pattern="^(ast|streaming)$",
+        description=(
+            "Evaluation path. 'ast' uses the full Form evaluator; 'streaming' "
+            "uses the BMF-style direct Recipe emitter for its supported recipe subset."
+        ),
+    )
 
 
 class FormResultOut(BaseModel):
@@ -543,13 +552,21 @@ def evaluate_form(req: FormRequest) -> FormResultOut:
 
     Returns a discriminated result: the `kind` field names which payload
     field carries the value (node_id / recipe / cell / view / cells /
-    views). Parse and evaluation errors return HTTP 400 with the failure
-    reason; the substrate stays read-only.
+    views). `mode="streaming"` routes supported recipe expressions through
+    the direct-emission parser and returns the emitted Recipe NodeID. Parse
+    and evaluation errors return HTTP 400 with the failure reason; the
+    substrate stays read-only.
 
     Grammar lives in docs/coherence-substrate/form-language.md.
     """
     with session_scope() as session:
         try:
+            if req.mode == "streaming":
+                node_id = form_stream_emit(session, req.expression)
+                return FormResultOut(
+                    kind="recipe",
+                    node_id=NodeIDOut.from_node_id(node_id),
+                )
             result = form_evaluate_text(session, req.expression)
         except LookupError as exc:
             # The expression parsed and evaluated cleanly, but a cell or

--- a/api/tests/test_substrate_form_endpoint.py
+++ b/api/tests/test_substrate_form_endpoint.py
@@ -30,6 +30,40 @@ async def test_form_endpoint_evaluates_empty_query_against_substrate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_form_endpoint_streaming_mode_emits_same_recipe_node() -> None:
+    """Streaming mode exposes the direct Recipe emitter through the same API."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        ast_response = await client.post(
+            "/api/substrate/form",
+            json={"expression": "1 + 2 * 3"},
+        )
+        streaming_response = await client.post(
+            "/api/substrate/form",
+            json={"expression": "1 + 2 * 3", "mode": "streaming"},
+        )
+
+    assert ast_response.status_code == 200, ast_response.text
+    assert streaming_response.status_code == 200, streaming_response.text
+    ast_body = ast_response.json()
+    streaming_body = streaming_response.json()
+    assert ast_body["kind"] == "recipe"
+    assert streaming_body["kind"] == "recipe"
+    assert streaming_body["node_id"] == ast_body["node_id"]
+
+
+@pytest.mark.asyncio
+async def test_form_endpoint_rejects_unknown_mode() -> None:
+    """Mode stays explicit so callers know which parser path they exercised."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/api/substrate/form",
+            json={"expression": "1 + 2", "mode": "direct"},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_form_endpoint_rejects_syntactically_broken_expression() -> None:
     """Parse / eval failures return HTTP 400 with the failure reason.
 

--- a/docs/system_audit/commit_evidence_2026-05-19_kernel_form_streaming_mcp.json
+++ b/docs/system_audit/commit_evidence_2026-05-19_kernel_form_streaming_mcp.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-05-19",
+  "thread_branch": "codex/kernel-form-streaming-breath-20260519",
+  "commit_scope": "Expose Form-language substrate evaluation through MCP and add an explicit streaming parser mode to the substrate Form API.",
+  "files_owned": [
+    "api/app/routers/substrate.py",
+    "api/tests/test_substrate_form_endpoint.py",
+    "mcp-server/README.md",
+    "mcp-server/README.template.md",
+    "mcp-server/coherence_mcp_server/server.py",
+    "mcp-server/server.json",
+    "mcp-server/tests/test_awareness_streaming.py",
+    "docs/system_audit/commit_evidence_2026-05-19_kernel_form_streaming_mcp.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q",
+      "cd api && python3 -m pytest tests/test_substrate_form_endpoint.py tests/test_substrate_form_stream.py -q",
+      "python3 scripts/build_readmes.py",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-19_kernel_form_streaming_mcp.json",
+      "git diff --check",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Prompt entry gate passed in the worktree. MCP awareness tests pass with the new Form tool registration and dispatch route. Substrate Form endpoint and streaming parser tests pass, including API proof that mode=streaming emits the same Recipe NodeID as the AST path for the covered recipe expression. Branch is rebased on origin/main. Evidence validation, whitespace check, local PR guard, and stale PR follow-through check all pass."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy attempted yet."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "MCP clients can ask the coherence-substrate in Form notation through coherence_substrate_form, and API callers can select the streaming direct-Recipe emitter with POST /api/substrate/form mode=streaming.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "Dispatch coherence_substrate_form with default mode and verify it posts expression+mode=ast to /api/substrate/form.",
+      "Dispatch coherence_substrate_form with mode=streaming and verify it posts expression+mode=streaming to /api/substrate/form.",
+      "POST /api/substrate/form with expression '1 + 2 * 3' through ast and streaming modes and verify both return the same recipe NodeID."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local focused validation passed; CI and deploy validation are pending."
+  },
+  "idea_ids": [
+    "mcp-awareness-streaming",
+    "substrate"
+  ],
+  "spec_ids": [
+    "specs/mcp-awareness-streaming.md",
+    "docs/coherence-substrate/form-language.md"
+  ],
+  "task_ids": [
+    "kernel-form-streaming-breath-20260519"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "mcp-server/tests/test_awareness_streaming.py::test_substrate_form_dispatch_routes_to_api",
+    "api/tests/test_substrate_form_endpoint.py::test_form_endpoint_streaming_mode_emits_same_recipe_node",
+    "api/app/routers/substrate.py:POST /api/substrate/form mode=streaming"
+  ],
+  "change_files": [
+    "api/app/routers/substrate.py",
+    "api/tests/test_substrate_form_endpoint.py",
+    "mcp-server/README.md",
+    "mcp-server/README.template.md",
+    "mcp-server/coherence_mcp_server/server.py",
+    "mcp-server/server.json",
+    "mcp-server/tests/test_awareness_streaming.py"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -156,6 +156,16 @@ Point your MCP client at `npx coherence-mcp-server` via stdio transport.
 | `coherence_task_seed` | Create a new task from an idea. |
 | `coherence_task_events` | View the activity event log for a task. |
 
+### Substrate + Form
+
+| Tool | What it does |
+|------|-------------|
+| `coherence_substrate_form` | Evaluate Form notation against the coherence-substrate with `mode=ast` or `mode=streaming`. |
+
+`mode=ast` uses the full Form evaluator for queries and cells. `mode=streaming`
+uses the BMF-style direct Recipe emitter for supported recipe expressions and
+returns the emitted Recipe NodeID.
+
 ### Awareness Streaming — presence in and out
 
 | Tool | What it does |

--- a/mcp-server/README.template.md
+++ b/mcp-server/README.template.md
@@ -155,6 +155,16 @@ Point your MCP client at `npx coherence-mcp-server` via stdio transport.
 | `coherence_task_seed` | Create a new task from an idea. |
 | `coherence_task_events` | View the activity event log for a task. |
 
+### Substrate + Form
+
+| Tool | What it does |
+|------|-------------|
+| `coherence_substrate_form` | Evaluate Form notation against the coherence-substrate with `mode=ast` or `mode=streaming`. |
+
+`mode=ast` uses the full Form evaluator for queries and cells. `mode=streaming`
+uses the BMF-style direct Recipe emitter for supported recipe expressions and
+returns the emitted Recipe NodeID.
+
 ### Awareness Streaming — presence in and out
 
 | Tool | What it does |

--- a/mcp-server/coherence_mcp_server/server.py
+++ b/mcp-server/coherence_mcp_server/server.py
@@ -369,6 +369,27 @@ TOOLS: list[Tool] = [
         description="Receive the shared invitation so anyone or anything can ask what is alive, find entry surfaces, and choose a contribution path.",
         inputSchema={"type": "object", "properties": {}},
     ),
+    # Substrate
+    Tool(
+        name="coherence_substrate_form",
+        description="Evaluate Form notation against the coherence-substrate. Supports the full AST evaluator or the streaming direct-Recipe emitter.",
+        inputSchema={
+            "type": "object",
+            "required": ["expression"],
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Form expression, e.g. '?lattice', '?cells where domain == \"spec\"', or '1 + 2'.",
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["ast", "streaming"],
+                    "description": "ast or streaming. Streaming emits a Recipe NodeID for the supported recipe subset.",
+                    "default": "ast",
+                },
+            },
+        },
+    ),
     # Federation
     Tool(
         name="coherence_list_federation_nodes",
@@ -1353,6 +1374,15 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
             return api_get("/api/friction/report", {"window_days": args.get("window_days", 30)})
         case "coherence_agent_invitation":
             return api_get("/api/agent/invitation")
+        # Substrate
+        case "coherence_substrate_form":
+            mode = (args.get("mode") or "ast").strip().lower()
+            if mode not in {"ast", "streaming"}:
+                return {"error": "mode must be one of: ast, streaming"}
+            return api_post(
+                "/api/substrate/form",
+                {"expression": args["expression"], "mode": mode},
+            )
         # Federation
         case "coherence_list_federation_nodes":
             nodes = api_get("/api/federation/nodes")

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -111,6 +111,10 @@
       "description": "Receive the shared invitation so anyone or anything can ask what is alive, find entry surfaces, and choose a contribution path."
     },
     {
+      "name": "coherence_substrate_form",
+      "description": "Evaluate Form notation against the coherence-substrate through the AST evaluator or streaming direct-Recipe emitter."
+    },
+    {
       "name": "coherence_list_federation_nodes",
       "description": "List federated nodes and their capabilities."
     },

--- a/mcp-server/tests/test_awareness_streaming.py
+++ b/mcp-server/tests/test_awareness_streaming.py
@@ -16,6 +16,7 @@ def test_awareness_tools_are_registered() -> None:
         "coherence_awareness_stream",
         "coherence_node_message_send",
         "coherence_node_messages",
+        "coherence_substrate_form",
         "coherence_get_field_story",
         "coherence_get_field_story_artifact",
         "coherence_contribute_field_story",
@@ -87,6 +88,37 @@ def test_agent_invitation_dispatch_routes_to_api(monkeypatch) -> None:
 
     assert result == {"id": "agent-resonance-onboarding"}
     assert calls == [("/api/agent/invitation", None)]
+
+
+def test_substrate_form_dispatch_routes_to_api(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(path: str, body: dict) -> dict:
+        calls.append((path, body))
+        return {"kind": "lattice", "lattice": {"nodes": 1}}
+
+    monkeypatch.setattr(mcp_server, "api_post", fake_post)
+
+    result = mcp_server.dispatch(
+        "coherence_substrate_form",
+        {"expression": "?lattice"},
+    )
+    streaming_result = mcp_server.dispatch(
+        "coherence_substrate_form",
+        {"expression": "1 + 2", "mode": "streaming"},
+    )
+    bad_mode = mcp_server.dispatch(
+        "coherence_substrate_form",
+        {"expression": "1 + 2", "mode": "direct"},
+    )
+
+    assert result == {"kind": "lattice", "lattice": {"nodes": 1}}
+    assert streaming_result == {"kind": "lattice", "lattice": {"nodes": 1}}
+    assert bad_mode == {"error": "mode must be one of: ast, streaming"}
+    assert calls == [
+        ("/api/substrate/form", {"expression": "?lattice", "mode": "ast"}),
+        ("/api/substrate/form", {"expression": "1 + 2", "mode": "streaming"}),
+    ]
 
 
 def test_decode_sse_events_handles_json_keepalive_and_raw_text() -> None:


### PR DESCRIPTION
## Summary\n- Add `mode=ast|streaming` to `POST /api/substrate/form`, with streaming mode returning the direct Recipe NodeID emitted by the Form streaming parser.\n- Add MCP tool `coherence_substrate_form` so MCP clients can evaluate Form notation through the substrate API.\n- Update MCP registry/docs and add focused API + MCP coverage.\n\n## Proof\n- `make prompt-guide`\n- `cd mcp-server && python3 -m pytest tests/test_awareness_streaming.py -q`\n- `cd api && python3 -m pytest tests/test_substrate_form_endpoint.py tests/test_substrate_form_stream.py -q`\n- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-19_kernel_form_streaming_mcp.json`\n- `git diff --check`\n- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`\n- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`\n\n## Pulse\n- Session-start pulse witness: `overall=strained`, `silences=0`, `silent_organs=[web]`.\n