### PR TITLE
attune(kernel): add question effect conformance harness

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,11 +34,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 128 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 228 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 55 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 175 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 176 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 50 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 154 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 104 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 105 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 175
+**Total files**: 176
 
 | File | Purpose |
 |---|---|
@@ -96,6 +96,7 @@
 | [test_import_lineage_edges.py](test_import_lineage_edges.py) | Lineage importer replays explicit graph edges from manifests. |
 | [test_inspired_by.py](test_inspired_by.py) | Flow-centric tests for the inspired-by resolver and /api/inspired-by. |
 | [test_interest_registration.py](test_interest_registration.py) | Flow-centric tests for interest registration — privacy-first community gathering. |
+| [test_kernel_conformance_harness.py](test_kernel_conformance_harness.py) | Executable kernel conformance harness for Form question effects. |
 | [test_knowledge_resonance.py](test_knowledge_resonance.py) | Acceptance tests for spec: knowledge-resonance-engine (idea: knowledge-and-resonance). |
 | [test_lens_translation_boundaries.py](test_lens_translation_boundaries.py) | _no top-of-file purpose_ |
 | [test_libretranslate_backend.py](test_libretranslate_backend.py) | LibreTranslate backend — verifies translation + glossary post-substitution. |

--- a/api/tests/test_kernel_conformance_harness.py
+++ b/api/tests/test_kernel_conformance_harness.py
@@ -1,0 +1,59 @@
+"""Executable kernel conformance harness for Form question effects."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS = REPO_ROOT / "scripts" / "verify_kernel_conformance.py"
+
+
+def _run_harness(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HARNESS), *args],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_python_kernel_passes_question_effect_vector() -> None:
+    result = _run_harness("--kernel", "python", "--json")
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    body = json.loads(result.stdout)
+    assert body["status"] == "pass"
+    assert body["surface"] == "form-question-effects"
+    assert body["kernels"][0]["kernel"] == "python"
+    assert body["kernels"][0]["status"] == "pass"
+    assert [case["name"] for case in body["kernels"][0]["cases"]] == [
+        "ask_opens_question",
+        "await_answer_reads_current_answer",
+        "await_answer_open_question_returns_null",
+    ]
+
+
+def test_rust_and_go_targets_are_explicitly_skipped_when_allowed() -> None:
+    result = _run_harness("--kernel", "rust", "--kernel", "go", "--allow-targets", "--json")
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    body = json.loads(result.stdout)
+    assert [(item["kernel"], item["status"]) for item in body["kernels"]] == [
+        ("rust", "skipped"),
+        ("go", "skipped"),
+    ]
+    assert all("conformance target" in item["reason"] for item in body["kernels"])
+
+
+def test_rust_target_fails_without_executable_runner() -> None:
+    result = _run_harness("--kernel", "rust", "--json")
+
+    assert result.returncode == 1
+    body = json.loads(result.stdout)
+    assert body["status"] == "fail"
+    assert "target-only" in body["error"]

--- a/docs/coherence-substrate/form-language.md
+++ b/docs/coherence-substrate/form-language.md
@@ -1042,7 +1042,7 @@ await_answer("question_abc123")
 
 `await_answer(question_id)` is non-blocking: it returns `null` while the question remains open and the answer string once the web page answers it. Suspension/resume around unanswered questions belongs to the sub-agent runner, not to the Form runtime hot path.
 
-This is a host-bound effect, so Rust and Go kernel work proves conformance by matching the emitted event transcript, not by sharing Python's in-memory queue. The shared vector is [`kernel-conformance/agent-question-effects.json`](kernel-conformance/agent-question-effects.json): Python is implemented here; Rust and Go are named as conformance targets until executable kernels exist.
+This is a host-bound effect, so Rust and Go kernel work proves conformance by matching the emitted event transcript, not by sharing Python's in-memory queue. The shared vector is [`kernel-conformance/agent-question-effects.json`](kernel-conformance/agent-question-effects.json), and the executable harness is `python3 scripts/verify_kernel_conformance.py --kernel python`: Python is implemented here; Rust and Go return target-only status until executable kernels exist.
 
 ## The four self-* faculties
 

--- a/docs/coherence-substrate/kernel-conformance/README.md
+++ b/docs/coherence-substrate/kernel-conformance/README.md
@@ -1,0 +1,13 @@
+# Kernel Conformance
+
+Kernel conformance vectors describe Form-visible behavior that every substrate kernel must match. They are not implementation claims. A kernel is only `implemented` when the vector names an executable runner and proof file.
+
+`agent-question-effects.json` covers the host-bound question effects:
+
+```bash
+python3 scripts/verify_kernel_conformance.py --kernel python
+python3 scripts/verify_kernel_conformance.py --kernel rust --allow-targets --json
+python3 scripts/verify_kernel_conformance.py --kernel go --allow-targets --json
+```
+
+Python runs the vector today. Rust and Go return explicit `skipped` target status until their executable runners are present. Without `--allow-targets`, asking for a target-only kernel fails so CI cannot accidentally treat a named target as shipped.

--- a/docs/coherence-substrate/kernel-conformance/agent-question-effects.json
+++ b/docs/coherence-substrate/kernel-conformance/agent-question-effects.json
@@ -2,6 +2,10 @@
   "version": 1,
   "surface": "form-question-effects",
   "description": "Host-bound Form effects for sub-agent human questions. Kernels conform by producing the same question records and event transcript.",
+  "harness": {
+    "command": "python3 scripts/verify_kernel_conformance.py --kernel python",
+    "target_command": "python3 scripts/verify_kernel_conformance.py --kernel rust --allow-targets --json"
+  },
   "host_channel": {
     "question_stream": "/api/agent/questions/stream",
     "answer_endpoint": "/api/agent/questions/{id}/answer",
@@ -80,17 +84,20 @@
     "python": {
       "status": "implemented",
       "entrypoint": "app.services.substrate.form_runtime.form_execute_text",
-      "proof": "api/tests/test_substrate_form_question_effects.py"
+      "proof": "api/tests/test_substrate_form_question_effects.py",
+      "harness": "scripts/verify_kernel_conformance.py --kernel python"
     },
     "rust": {
       "status": "conformance-target",
       "entrypoint": null,
-      "proof": null
+      "proof": null,
+      "harness": null
     },
     "go": {
       "status": "conformance-target",
       "entrypoint": null,
-      "proof": null
+      "proof": null,
+      "harness": null
     }
   }
 }

--- a/docs/system_audit/commit_evidence_2026-05-20_kernel_conformance_harness.json
+++ b/docs/system_audit/commit_evidence_2026-05-20_kernel_conformance_harness.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-05-20",
+  "thread_branch": "codex/kernel-conformance-harness-20260520",
+  "commit_scope": "Add an executable kernel conformance harness for the Form question-effect vector, with Python passing today and Rust/Go reported as target-only until real runners exist.",
+  "files_owned": [
+    "scripts/verify_kernel_conformance.py",
+    "api/tests/test_kernel_conformance_harness.py",
+    "docs/coherence-substrate/kernel-conformance/README.md",
+    "docs/coherence-substrate/kernel-conformance/agent-question-effects.json",
+    "docs/coherence-substrate/form-language.md",
+    "specs/form-question-effects-kernel-conformance.md",
+    "api/tests/INDEX.md",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-20_kernel_conformance_harness.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name], witness_started_at}'",
+      "make wellness",
+      "make prompt-guide",
+      "python3 scripts/context_budget.py --token-budget 60000 scripts/verify_kernel_conformance.py api/tests/test_kernel_conformance_harness.py specs/form-question-effects-kernel-conformance.md docs/coherence-substrate/form-language.md docs/coherence-substrate/kernel-conformance/agent-question-effects.json docs/coherence-substrate/kernel-conformance/README.md",
+      "python3 scripts/verify_kernel_conformance.py --kernel python --json",
+      "python3 scripts/verify_kernel_conformance.py --kernel rust --allow-targets --json",
+      "python3 scripts/verify_kernel_conformance.py --kernel rust --json",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_kernel_conformance_harness.py tests/test_substrate_form_question_effects.py -q",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_substrate_form_question_effects.py tests/test_kernel_conformance_harness.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q",
+      "ruff check scripts/verify_kernel_conformance.py api/tests/test_kernel_conformance_harness.py",
+      "python3 scripts/validate_spec_quality.py --file specs/form-question-effects-kernel-conformance.md",
+      "python3 -m json.tool docs/coherence-substrate/kernel-conformance/agent-question-effects.json >/dev/null",
+      "python3 scripts/generate_repo_indexes.py",
+      "git diff --check",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "Session-start pulse was breathing and arrival wellness passed. A fresh worktree was created from origin/main at 26e20a175. The conformance harness ran the Python kernel through all question-effect vector cases, returned explicit skipped target status for Rust with --allow-targets, and returned non-zero when Rust was requested without an executable runner. Focused tests passed: 13 tests across question effects, endpoint mode, SSE, and the harness. Focused Ruff, spec quality, JSON syntax, generated indexes, whitespace, wellness, local PR guard, and stale PR follow-through passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push and PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "No deploy attempted yet."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; CI, PR, and deployment checks are pending."
+  },
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "specs/form-question-effects-kernel-conformance.md"
+  ],
+  "task_ids": [
+    "kernel-conformance-harness-20260520"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/verify_kernel_conformance.py --kernel python",
+    "api/tests/test_kernel_conformance_harness.py::test_python_kernel_passes_question_effect_vector",
+    "api/tests/test_kernel_conformance_harness.py::test_rust_and_go_targets_are_explicitly_skipped_when_allowed",
+    "api/tests/test_kernel_conformance_harness.py::test_rust_target_fails_without_executable_runner",
+    "docs/coherence-substrate/kernel-conformance/agent-question-effects.json"
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "api/tests/INDEX.md",
+    "api/tests/test_kernel_conformance_harness.py",
+    "docs/coherence-substrate/form-language.md",
+    "docs/coherence-substrate/kernel-conformance/README.md",
+    "docs/coherence-substrate/kernel-conformance/agent-question-effects.json",
+    "docs/system_audit/commit_evidence_2026-05-20_kernel_conformance_harness.json",
+    "scripts/INDEX.md",
+    "scripts/verify_kernel_conformance.py",
+    "specs/form-question-effects-kernel-conformance.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 104
+**Total files**: 105
 
 | File | Purpose |
 |---|---|
@@ -107,6 +107,7 @@
 | [validate_spec_quality.py](validate_spec_quality.py) | !/usr/bin/env python3 |
 | [validate_workflow_references.py](validate_workflow_references.py) | !/usr/bin/env python3 |
 | [verify_hashes.py](verify_hashes.py) | !/usr/bin/env python3 |
+| [verify_kernel_conformance.py](verify_kernel_conformance.py) | Verify substrate kernel conformance vectors against executable runtimes. |
 | [viewport_audit.py](viewport_audit.py) | !/usr/bin/env python3 |
 | [wander.py](wander.py) | !/usr/bin/env python3 |
 | [wellness_check.py](wellness_check.py) | !/usr/bin/env python3 |

--- a/scripts/verify_kernel_conformance.py
+++ b/scripts/verify_kernel_conformance.py
@@ -1,0 +1,237 @@
+"""Verify substrate kernel conformance vectors against executable runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_ROOT = REPO_ROOT / "api"
+sys.path.insert(0, str(API_ROOT))
+
+from app.services.agent_question_service import (  # noqa: E402
+    answer_question,
+    get_question_events,
+    reset_agent_questions,
+)
+from app.services.substrate.form_runtime import (  # noqa: E402
+    form_execute_text,
+    reset_runtime_registries,
+)
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM  # noqa: E402
+from app.services.substrate.substrate_strings import SubstrateStringORM  # noqa: E402
+
+DEFAULT_VECTOR = (
+    REPO_ROOT
+    / "docs"
+    / "coherence-substrate"
+    / "kernel-conformance"
+    / "agent-question-effects.json"
+)
+
+
+class ConformanceError(AssertionError):
+    """Raised when a kernel result diverges from the conformance vector."""
+
+
+def load_vector(path: Path = DEFAULT_VECTOR) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _make_session() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    return sessionmaker(bind=engine, expire_on_commit=False)()
+
+
+def _replace_placeholders(text: str, *, question_id: str | None) -> str:
+    if question_id is None:
+        return text
+    return text.replace("${question_id}", question_id)
+
+
+def _assert_subset(expected: Any, actual: Any, path: str = "$") -> None:
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            raise ConformanceError(
+                f"{path}: expected object, got {type(actual).__name__}"
+            )
+        for key, value in expected.items():
+            if key not in actual:
+                raise ConformanceError(f"{path}: missing key {key!r}")
+            _assert_subset(value, actual[key], f"{path}.{key}")
+        return
+    if isinstance(expected, list):
+        if not isinstance(actual, list):
+            raise ConformanceError(
+                f"{path}: expected list, got {type(actual).__name__}"
+            )
+        if len(expected) != len(actual):
+            raise ConformanceError(
+                f"{path}: expected list length {len(expected)}, got {len(actual)}"
+            )
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            _assert_subset(expected_item, actual_item, f"{path}[{index}]")
+        return
+    if expected != actual:
+        raise ConformanceError(f"{path}: expected {expected!r}, got {actual!r}")
+
+
+def _run_python_case(session: Session, case: dict[str, Any]) -> dict[str, Any]:
+    reset_runtime_registries()
+    reset_agent_questions()
+    question_id: str | None = None
+    setup = case.get("setup") or {}
+
+    try:
+        if setup.get("open_question_form"):
+            opened = form_execute_text(session, str(setup["open_question_form"]))
+            question_id = opened["id"]
+            if "answer" in setup:
+                answer_question(
+                    question_id=question_id,
+                    answer=str(setup["answer"]),
+                    answered_by=str(setup.get("answered_by", "conformance")),
+                )
+
+        form = _replace_placeholders(str(case["form"]), question_id=question_id)
+        value = form_execute_text(session, form)
+        if isinstance(value, dict) and question_id is None:
+            question_id = str(value.get("id") or "")
+
+        _assert_subset(case.get("expected_value"), value, "$.expected_value")
+
+        events = get_question_events()
+        expected_events = case.get("expected_events") or []
+        if len(events) != len(expected_events):
+            raise ConformanceError(
+                f"events: expected {len(expected_events)}, got {len(events)}"
+            )
+        for index, expected_event in enumerate(expected_events):
+            _assert_subset(expected_event, events[index], f"$.expected_events[{index}]")
+
+        return {
+            "name": case["name"],
+            "status": "pass",
+            "question_id": question_id,
+            "events": [event["event_type"] for event in events],
+        }
+    finally:
+        reset_runtime_registries()
+        reset_agent_questions()
+
+
+def run_python_kernel(vector: dict[str, Any]) -> dict[str, Any]:
+    session = _make_session()
+    try:
+        cases = [_run_python_case(session, case) for case in vector.get("cases", [])]
+    finally:
+        session.close()
+    return {"kernel": "python", "status": "pass", "cases": cases}
+
+
+def run_kernel(
+    vector: dict[str, Any],
+    kernel_name: str,
+    *,
+    allow_targets: bool = False,
+) -> dict[str, Any]:
+    kernels = vector.get("kernels") or {}
+    kernel = kernels.get(kernel_name)
+    if kernel is None:
+        raise ConformanceError(f"unknown kernel {kernel_name!r}")
+
+    status = str(kernel.get("status") or "")
+    if kernel_name == "python" and status == "implemented":
+        return run_python_kernel(vector)
+
+    if status == "conformance-target":
+        result = {
+            "kernel": kernel_name,
+            "status": "skipped",
+            "reason": "kernel is a conformance target with no executable runner",
+        }
+        if allow_targets:
+            return result
+        raise ConformanceError(
+            f"{kernel_name} is target-only; add an executable runner before "
+            "requiring it in conformance"
+        )
+
+    raise ConformanceError(f"{kernel_name} has unsupported status {status!r}")
+
+
+def _selected_kernels(vector: dict[str, Any], requested: list[str]) -> list[str]:
+    if requested:
+        return requested
+    kernels = vector.get("kernels") or {}
+    return [
+        name
+        for name, data in kernels.items()
+        if str((data or {}).get("status") or "") == "implemented"
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run substrate kernel conformance vectors."
+    )
+    parser.add_argument("--vector", type=Path, default=DEFAULT_VECTOR)
+    parser.add_argument(
+        "--kernel",
+        action="append",
+        default=[],
+        help="Kernel to run. Defaults to implemented kernels only.",
+    )
+    parser.add_argument(
+        "--allow-targets",
+        action="store_true",
+        help="Return skipped for target-only kernels instead of failing.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    args = parser.parse_args(argv)
+
+    try:
+        vector = load_vector(args.vector)
+        results = [
+            run_kernel(vector, kernel, allow_targets=args.allow_targets)
+            for kernel in _selected_kernels(vector, args.kernel)
+        ]
+    except (ConformanceError, OSError, json.JSONDecodeError) as exc:
+        if args.json:
+            print(json.dumps({"status": "fail", "error": str(exc)}, indent=2))
+        else:
+            print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    payload = {
+        "status": "pass",
+        "surface": vector.get("surface"),
+        "kernels": results,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            print(f"{result['kernel']}: {result['status']}")
+            for case in result.get("cases", []):
+                print(f"  - {case['name']}: {case['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/form-question-effects-kernel-conformance.md
+++ b/specs/form-question-effects-kernel-conformance.md
@@ -10,6 +10,10 @@ source:
     symbols: [_serialize_substrate_value(), substrate_run_handler()]
   - file: api/tests/test_substrate_form_question_effects.py
     symbols: [test_form_ask_opens_question_and_emits_sse_event(), test_form_await_answer_reads_answer_when_present(), test_substrate_form_run_mode_returns_question_value()]
+  - file: api/tests/test_kernel_conformance_harness.py
+    symbols: [test_python_kernel_passes_question_effect_vector(), test_rust_and_go_targets_are_explicitly_skipped_when_allowed(), test_rust_target_fails_without_executable_runner()]
+  - file: scripts/verify_kernel_conformance.py
+    symbols: [run_kernel(), run_python_kernel(), main()]
   - file: docs/coherence-substrate/kernel-conformance/agent-question-effects.json
     symbols: [form-question-effects]
 requirements:
@@ -17,11 +21,12 @@ requirements:
   - "Form runtime exposes await_answer(question_id) so a sub-agent can poll the current human answer."
   - "POST /api/substrate/form accepts mode=run and returns computed Form runtime values as JSON-safe payloads."
   - "Rust and Go kernel work is represented by a shared conformance vector for the same opened/answered question sequence."
+  - "The shared conformance vector is executable by a harness that passes for Python and fails target-only Rust/Go unless explicitly allowed as skipped targets."
 done_when:
   - "Runtime tests prove ask opens a question, emits question_opened, and await_answer reads the answer."
   - "Endpoint test proves /api/substrate/form mode=run returns the opened question value."
-  - "Conformance vector names Python implemented, Rust target, and Go target behavior."
-test: "cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q"
+  - "Conformance harness proves Python passes the vector and Rust/Go are explicit target-only skips."
+test: "cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_kernel_conformance_harness.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q"
 constraints:
   - "Do not invent a second Form question syntax; use existing FnCall runtime execution."
   - "Do not claim Rust or Go kernels are implemented until executable kernel code exists."
@@ -45,6 +50,7 @@ The human question channel exists, streams to the web, and can be answered. This
 - [x] **R3**: `POST /api/substrate/form` accepts `mode="run"` and returns `kind="value"` with a JSON-safe runtime payload.
 - [x] **R4**: The MCP substrate run serializer recurses through dict values so question payloads can pass through tool output intact.
 - [x] **R5**: A kernel conformance vector names the expected `question_opened` and `question_answered` effects for Python, Rust, and Go kernel implementations.
+- [x] **R6**: `scripts/verify_kernel_conformance.py` consumes the conformance vector, passes the Python runtime, and treats Rust/Go as explicit target-only skips unless an executable runner is requested later.
 
 ## Research Inputs
 
@@ -100,14 +106,27 @@ The shared vector lives at `docs/coherence-substrate/kernel-conformance/agent-qu
 - one `await_answer(...)` case that must read the answer once the host question is answered;
 - kernel status markers for Python implemented, Rust conformance target, and Go conformance target.
 
+The harness is executable:
+
+```bash
+python3 scripts/verify_kernel_conformance.py --kernel python
+python3 scripts/verify_kernel_conformance.py --kernel rust --allow-targets --json
+python3 scripts/verify_kernel_conformance.py --kernel go --allow-targets --json
+```
+
+Rust and Go are not silently accepted. Without `--allow-targets`, invoking either target exits non-zero until that kernel has a runner.
+
 ## Files to Create/Modify
 
 - `api/app/services/substrate/form_runtime.py` - add host-bound question built-ins.
 - `api/app/routers/substrate.py` - add `mode="run"` and runtime value serialization.
 - `api/app/services/mcp_tool_registry.py` - recurse through dict-valued runtime output.
 - `api/tests/test_substrate_form_question_effects.py` - prove Form question effects and endpoint runtime mode.
+- `api/tests/test_kernel_conformance_harness.py` - prove the executable conformance harness.
+- `scripts/verify_kernel_conformance.py` - consume vector cases and validate kernel transcripts.
 - `docs/coherence-substrate/form-language.md` - document the Form-visible question effect.
 - `docs/coherence-substrate/kernel-conformance/agent-question-effects.json` - define the Rust/Go/Python behavior target.
+- `docs/coherence-substrate/kernel-conformance/README.md` - document the target-only harness contract.
 - `specs/form-question-effects-kernel-conformance.md` - this executable spec.
 
 ## Acceptance Tests
@@ -115,13 +134,17 @@ The shared vector lives at `docs/coherence-substrate/kernel-conformance/agent-qu
 - `api/tests/test_substrate_form_question_effects.py::test_form_ask_opens_question_and_emits_sse_event`
 - `api/tests/test_substrate_form_question_effects.py::test_form_await_answer_reads_answer_when_present`
 - `api/tests/test_substrate_form_question_effects.py::test_substrate_form_run_mode_returns_question_value`
+- `api/tests/test_kernel_conformance_harness.py::test_python_kernel_passes_question_effect_vector`
+- `api/tests/test_kernel_conformance_harness.py::test_rust_and_go_targets_are_explicitly_skipped_when_allowed`
+- `api/tests/test_kernel_conformance_harness.py::test_rust_target_fails_without_executable_runner`
 - `api/tests/test_substrate_form_endpoint.py::test_form_endpoint_rejects_unknown_mode`
 - `api/tests/test_agent_question_sse.py::test_agent_question_sse_replays_opened_event`
 
 ## Verification
 
 ```bash
-cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q
+python3 scripts/verify_kernel_conformance.py --kernel python
+cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_kernel_conformance_harness.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q
 python3 scripts/validate_spec_quality.py --file specs/form-question-effects-kernel-conformance.md
 ```
 
@@ -141,7 +164,7 @@ python3 scripts/validate_spec_quality.py --file specs/form-question-effects-kern
 ## Known Gaps and Follow-up Tasks
 
 - Follow-up task: add durable question persistence with replay across API restarts.
-- Follow-up task: add Rust and Go harnesses that consume the conformance vector and prove the same event transcript.
+- Follow-up task: replace the Rust and Go target-only harness entries with real runner commands that prove the same event transcript.
 - Follow-up task: teach sub-agent task execution to suspend and resume around unanswered Form questions.
 
 ## Task Card
@@ -153,15 +176,19 @@ files_allowed:
   - api/app/routers/substrate.py
   - api/app/services/mcp_tool_registry.py
   - api/tests/test_substrate_form_question_effects.py
+  - api/tests/test_kernel_conformance_harness.py
+  - scripts/verify_kernel_conformance.py
   - docs/coherence-substrate/form-language.md
+  - docs/coherence-substrate/kernel-conformance/README.md
   - docs/coherence-substrate/kernel-conformance/agent-question-effects.json
   - specs/form-question-effects-kernel-conformance.md
 done_when:
   - Runtime tests prove ask opens a question, emits question_opened, and await_answer reads the answer.
   - Endpoint test proves /api/substrate/form mode=run returns the opened question value.
-  - Conformance vector names Python implemented, Rust target, and Go target behavior.
+  - Conformance harness proves Python passes the vector and Rust/Go are explicit target-only skips.
 commands:
-  - cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q
+  - python3 scripts/verify_kernel_conformance.py --kernel python
+  - cd api && .venv/bin/pytest tests/test_substrate_form_question_effects.py tests/test_kernel_conformance_harness.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q
   - python3 scripts/validate_spec_quality.py --file specs/form-question-effects-kernel-conformance.md
 constraints:
   - No durable storage or database migration in this breath.


### PR DESCRIPTION
## Summary

- adds `scripts/verify_kernel_conformance.py` to execute the Form question-effect conformance vector
- proves the Python runtime passes all question-effect transcript cases
- makes Rust and Go target-only behavior explicit: skipped with `--allow-targets`, failing without an executable runner
- updates the vector, docs, spec, indexes, and commit evidence

## Proof

- `make wellness`
- `python3 scripts/verify_kernel_conformance.py --kernel python --json`
- `python3 scripts/verify_kernel_conformance.py --kernel rust --allow-targets --json`
- `python3 scripts/verify_kernel_conformance.py --kernel rust --json` (expected non-zero target-only failure)
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_substrate_form_question_effects.py tests/test_kernel_conformance_harness.py tests/test_substrate_form_endpoint.py tests/test_agent_question_sse.py -q`
- `ruff check scripts/verify_kernel_conformance.py api/tests/test_kernel_conformance_harness.py`
- `python3 scripts/validate_spec_quality.py --file specs/form-question-effects-kernel-conformance.md`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
