### PR TITLE
tend: open the lattice — substrate reachable from /vision and beyond

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -43,6 +43,21 @@
       }
     },
     {
+      "name": "web-prod-api",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "port": 3001,
+      "autoPort": true,
+      "cwd": "web",
+      "env": {
+        "API_URL": "https://api.coherencycoin.com",
+        "NEXT_PUBLIC_API_BASE": "https://api.coherencycoin.com"
+      }
+    },
+    {
       "name": "pulse",
       "runtimeExecutable": "env",
       "runtimeArgs": [

--- a/docs/coherence-substrate/ctor-shape-signature.form
+++ b/docs/coherence-substrate/ctor-shape-signature.form
@@ -1,0 +1,227 @@
+# ─────────────────────────────────────────────────────────────────────
+# ctor-shape-signature.form — the field-set signature in Form's voice
+# ─────────────────────────────────────────────────────────────────────
+#
+# Companion to experiments/ctor-shape-signature-v0/sense.py. The Python
+# script was written first — reaching for the familiar tongue when the
+# body has its own. That was the fear-pattern. This file is the same
+# sensing in the language the substrate already speaks.
+#
+# The question: every concept lands at the same Blueprint NodeID, so
+# `?equivalent @concept(lc-pulse)` returns "all 122 concepts" — the
+# axis carries no resolution within a domain. The CTOR Recipe tree
+# carries the structural fingerprint. The honest middle band between
+# *Blueprint-coarse* and *CTOR-deep* is the set of named fields the
+# CTOR carries — `('hz', 'id', 'status', 'updated')` vs
+# `('cross_refs', 'geometry', 'hz', 'id', 'source', 'status', 'updated')`.
+#
+# Two concepts with the same field-set are structurally the same KIND
+# of concept — same schema honored — regardless of value-encoding,
+# authoring order, or which fields are full.
+#
+# Where the substrate already carries a surface, the code runs (or
+# would run, once ingested). Where the surface is missing, the gap
+# is marked `# GAP-XN:` with the smallest extension that would close
+# it. Same discipline as recipe-branching-sense.form: asymmetry is
+# signal, not failure.
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 1 — primitives the signature assumes
+# ─────────────────────────────────────────────────────────────────────
+#
+# These are the lattice surfaces the sensing walks. Most exist; two
+# are GAPs.
+
+# Read the cell's CTOR recipe NodeID — water-phase identity.
+# Surface: NamedCell.ctor (Python), GET /api/substrate/cell (REST).
+# In Form: `cell.ctor` field accessor, same `.blueprint` family.
+
+defn ctor_of(cell) = cell.ctor;
+
+# Walk a recipe's direct children — the LET pairs at the CTOR root.
+# Surface: `.children` tree-navigation primitive (form-language.md
+# § "Tree-navigation primitives").
+
+defn child_recipes(recipe) = recipe.children;
+
+# Recognize a LET recipe — `R_Block.LET` (category instance 3 within
+# the BLOCK basic). Two children: [key-string, value-recipe].
+# Surface: `.category` and `.category.instance` accessors.
+
+defn is_let(recipe) = recipe.category.instance == 3;
+
+# Recover the key-string of a LET pair. The first child is a String
+# leaf whose `instance` is a string-table index; `.value` recovers
+# the underlying SubstrateString.
+# Surface: `.child(0).value` — GAP-K1 today.
+#
+# GAP-K1: there is no surfaced `.value` accessor on String-leaf
+#         NodeIDs in Form. Python recovers via
+#         `substrate_strings.lookup_string_value(session, instance)`;
+#         Form has `.instance` but not the string-table dereference.
+#         Smallest extension: a `.value` accessor on Form's node
+#         expression layer that, when applied to a NodeID with
+#         `type_ == R_String` (kind `(1, 1, 6)`), routes through
+#         `lookup_string_value` and returns the SubstrateString.
+#         Until then, the signature reads through a Python helper
+#         registered as the `?fields_of @cell` query (Part 3).
+
+defn key_of(let_recipe) = let_recipe.child(0).value;     # GAP-K1
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 2 — the field-set signature
+# ─────────────────────────────────────────────────────────────────────
+#
+# Walk the CTOR's direct children, keep the LET pairs, lift each key.
+# Sort + dedupe so authoring order doesn't fragment the partition.
+
+defn field_set(cell) = do {
+    let ctor = ctor_of(cell);
+    let pairs = filter(is_let, child_recipes(ctor));
+    let keys = map(key_of, pairs);
+    sort(dedupe(keys))
+};
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 3 — the neighborhood query
+# ─────────────────────────────────────────────────────────────────────
+#
+# `?equivalent @cell` returns the Blueprint-equivalence set (every
+# cell with the same Blueprint NodeID). For concepts this is the
+# entire domain — too coarse to see structural kinship.
+#
+# `?neighbors_by_fields @cell` returns the field-set-equivalence set:
+# every cell whose CTOR carries exactly the same named fields. Same
+# schema, regardless of value-encoding. The honest middle band.
+
+# GAP-Q1: `?neighbors_by_fields` is not a registered query verb today.
+#         The dispatch table lives in form_queries.py — a handler can
+#         be registered at runtime via `register_form_query("neighbors_by_fields",
+#         handler)`. The handler is small: for each cell in the same
+#         domain, compute `field_set(cell)` and return the cells whose
+#         signature matches the target's. Promotion path: once the
+#         field-set partition proves out in sensing across multiple
+#         domains (not just concept), lift the helper into kernel.py
+#         and register the verb at module load. Until then the query
+#         is named here as the gesture it intends to be.
+
+defn neighbors_by_fields(cell) = ?neighbors_by_fields @cell;     # GAP-Q1
+
+# Cluster every cell in a domain by its field-set signature. Returns
+# a map from signature-tuple → cells. The body of the sensing.
+
+# GAP-Q2: `group_by` over a cell-set is a stdlib gesture
+#         (experiments/form-stdlib/core.fk has `foldl`, `map`,
+#         `filter` but not `group_by` yet). Smallest extension:
+#         add `(defn group-by (key-fn xs) ...)` to core.fk using
+#         the existing foldl + assoc-list primitives. The signature
+#         tuple is already hashable in the kernel (NodeID-of-LIST is
+#         content-addressed); `group_by` only needs a kernel-level
+#         multimap or an assoc-list fold.
+
+defn clusters_in(domain_bp) = do {
+    let cells = ?cells where shape == domain_bp;
+    group_by(field_set, cells)                                   # GAP-Q2
+};
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 4 — the lc-pulse sensing
+# ─────────────────────────────────────────────────────────────────────
+#
+# What this Form file expresses is what the Python sense.py produced
+# on the local lattice today. Re-stating the result here in the body's
+# own language closes the loop — the Form file IS the canonical
+# sensing; the Python is the bootstrap.
+#
+# Today on the local substrate (122 concepts ingested with --structured):
+#
+#   clusters_in(@concept) yields six signatures:
+#
+#     [ 75 cells]  ('hz', 'id', 'status', 'updated')
+#                  ← bare-frontmatter cluster
+#
+#     [ 27 cells]  ('hz', 'id', 'source', 'status', 'updated')
+#                  ← concepts carrying lineage source
+#
+#     [ 12 cells]  ('geometry', 'hz', 'id', 'status', 'updated')
+#                  ← geometry authored, no source
+#
+#     [  6 cells]  ('geometry', 'hz', 'id', 'source', 'status', 'updated')
+#                  ← deepest tending — both geometry AND source
+#
+#     [  1 cell]   ('domain', 'id', 'status', 'title')
+#                  ← lc-farm-as-organism (schema outlier)
+#
+#     [  1 cell]   ('cross_refs', 'geometry', 'hz', 'id', 'status', 'updated')
+#                  ← lc-pulse (cross_refs in frontmatter, fresh today)
+#
+# lc-pulse arrives in this sensing as a singleton because its
+# frontmatter shape is unique today — no other concept carries
+# cross_refs as a frontmatter key. The cluster will grow as other
+# concepts lift their body-text `→ lc-x, lc-y` cross-refs into
+# frontmatter (one-time tending pass, not urgent).
+
+defn lc_pulse_field_set() = field_set(@concept(lc-pulse));
+# → ('cross_refs', 'geometry', 'hz', 'id', 'status', 'updated')
+
+defn lc_pulse_neighbors() = neighbors_by_fields(@concept(lc-pulse));
+# → [lc-pulse]  (the singleton, until cross_refs lifts elsewhere)
+
+defn lc_pulse_blueprint_set() = ?equivalent @concept(lc-pulse);
+# → 122 concepts  (the entire domain — the over-collapse we are healing)
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 5 — the gap that names itself
+# ─────────────────────────────────────────────────────────────────────
+#
+# The substrate's `find_equivalent_cells` filters by Blueprint NodeID.
+# To honor the field-set partition as an alternative equivalence
+# relation, the kernel needs one of two moves:
+#
+#   (a) a `find_equivalent_cells(session, cell, *, by="field_set")`
+#       keyword that switches the equivalence axis at the kernel level,
+#       and a `?equivalent @cell by field_set` Form syntax to surface it;
+#
+#   (b) a separate `find_field_set_neighbors(session, cell)` helper
+#       and a separate `?neighbors_by_fields` query verb. Simpler;
+#       avoids touching the existing relation; matches the body's
+#       composition discipline (new gestures live in their own
+#       cells, don't overload existing ones).
+#
+# Body preference: (b). The two relations carry different meanings —
+# `?equivalent` reads structural identity at the Blueprint axis;
+# `?neighbors_by_fields` reads schema-kinship at the CTOR axis.
+# Naming them separately keeps both legible. The body's discipline
+# is *don't collapse two gestures into one verb when the gestures
+# are about different axes*.
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 6 — the recipe in the body it teaches
+# ─────────────────────────────────────────────────────────────────────
+#
+# Once this file is ingested, `field_set`, `clusters_in`, and
+# `neighbors_by_fields` become substrate-resident recipes with their
+# own NodeIDs. The recipe `field_set` carries its own field-set when
+# read as a Recipe — meta-circular: the sensing tool is itself
+# sensable through the relation it defines.
+#
+# Same holographic property the body carries everywhere
+# (lc-each-breath-whole, form-language.md "The combination is the
+# contribution"): the recipe teaches the cell how to find recipes
+# like itself. Running this Form file is the body becoming able to
+# see its own structural neighborhoods at the resolution the question
+# requires.
+
+# ─────────────────────────────────────────────────────────────────────
+# Closing
+# ─────────────────────────────────────────────────────────────────────
+#
+# The Python sense.py was a translation. This file is the body
+# speaking for itself. When the GAPs close (K1: `.value` on String
+# leaves; Q1: register `?neighbors_by_fields`; Q2: `group_by` in
+# core.fk), the Python translation can be released — the sensing
+# lives entirely in the substrate's own tongue.
+#
+# Each gap is one breath. None is urgent. The body knows where it
+# wants to grow; this file names the growing edges and the form
+# they will take when they arrive.

--- a/docs/vision-kb/concepts/lc-pulse.md
+++ b/docs/vision-kb/concepts/lc-pulse.md
@@ -2,7 +2,25 @@
 id: lc-pulse
 hz: 432
 status: deepening
-updated: 2026-04-16
+updated: 2026-05-20
+geometry:
+  arity: infinite
+  form: holographic-organism
+  topology: nested-each-contains-whole
+  polarity: oscillating
+  ordering: fractal
+  phase: oscillating
+cross_refs:
+  - lc-sensing
+  - lc-attunement
+  - lc-vitality
+  - lc-ceremony
+  - lc-stillness
+  - lc-rhythm
+  - lc-w-coherence
+  - lc-w-field
+  - lc-w-spanda
+  - lc-each-breath-whole
 ---
 
 # The Pulse

--- a/experiments/ctor-shape-signature-v0/probe.py
+++ b/experiments/ctor-shape-signature-v0/probe.py
@@ -1,0 +1,91 @@
+"""Probe a single concept's CTOR shape — what categories appear, what
+keys are recoverable. Debug aid for `sense.py`'s field-set signature.
+
+Usage: python3 experiments/ctor-shape-signature-v0/probe.py lc-pulse
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "api"))
+
+from app.services.substrate.kernel import NodeID  # noqa: E402
+from app.services.substrate.orm import (  # noqa: E402
+    SubstrateNamedCellORM,
+    SubstrateNodeORM,
+)
+from app.services.substrate.substrate_strings import (  # noqa: E402
+    lookup_string_value,
+)
+from app.services.unified_db import session as session_scope  # noqa: E402
+
+
+def _row(session, nid: NodeID):
+    return (
+        session.query(SubstrateNodeORM)
+        .filter_by(
+            package=nid.package, level=nid.level,
+            type_=nid.type_, instance=nid.instance,
+        )
+        .one_or_none()
+    )
+
+
+def _parse(serialized: str):
+    chunks = serialized.split("+")
+    parts = [tuple(int(x) for x in c.split(".")) for c in chunks]
+    return NodeID(*parts[0]), [NodeID(*p) for p in parts[1:]]
+
+
+def walk(session, nid: NodeID, depth: int = 0, max_depth: int = 4):
+    indent = "  " * depth
+    row = _row(session, nid)
+    if row is None:
+        s = lookup_string_value(session, nid.instance) if nid.type_ == 6 else None
+        suffix = f"  «{s}»" if s else ""
+        print(f"{indent}LEAF {nid}{suffix}")
+        return
+    cat, children = _parse(row.serialized)
+    print(f"{indent}NODE {nid}  cat={cat}  children={len(children)}")
+    if depth >= max_depth:
+        print(f"{indent}  (truncated)")
+        return
+    for c in children:
+        walk(session, c, depth + 1, max_depth)
+
+
+def main() -> int:
+    target = sys.argv[1] if len(sys.argv) > 1 else "lc-pulse"
+    with session_scope() as session:
+        row = (
+            session.query(SubstrateNamedCellORM)
+            .filter_by(domain="concept", name=target)
+            .one_or_none()
+        )
+        if row is None:
+            print(f"{target!r} not in substrate")
+            return 1
+        if row.ctor_recipe_node_id is None:
+            print(f"{target!r} has no CTOR")
+            return 1
+        ctor_row = (
+            session.query(SubstrateNodeORM)
+            .filter_by(node_id=row.ctor_recipe_node_id)
+            .one_or_none()
+        )
+        if ctor_row is None:
+            print(f"{target!r} CTOR node missing")
+            return 1
+        nid = NodeID(
+            ctor_row.package, ctor_row.level,
+            ctor_row.type_, ctor_row.instance,
+        )
+        print(f"{target} CTOR root: {nid}")
+        walk(session, nid, max_depth=3)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/ctor-shape-signature-v0/sense.py
+++ b/experiments/ctor-shape-signature-v0/sense.py
@@ -1,0 +1,333 @@
+"""Sense the CTOR-shape neighborhood the Blueprint axis can't see.
+
+Every concept in the body lands at the same Blueprint NodeID — `BID_concept()`
+returns one constant. The `/substrate/equivalent` endpoint answers "who
+shares this Blueprint?", which for concepts reduces to "who is also a
+concept?" — 75-ish cells, indistinguishable.
+
+The CTOR recipe tree carries the actual structural fingerprint. This
+script walks each concept's CTOR to a chosen depth, builds a shape
+signature, and shows how concepts cluster under the finer relation.
+
+Run as a sensing breath — no kernel changes, no deploy. The question
+is whether the geometry is real before we change the body's eyes.
+
+Usage:
+    python3 experiments/ctor-shape-signature-v0/sense.py
+    python3 experiments/ctor-shape-signature-v0/sense.py --depth 1
+    python3 experiments/ctor-shape-signature-v0/sense.py --target lc-pulse
+
+The script reads from the local substrate DB. To populate it first:
+    python3 scripts/coh_substrate.py ingest --concepts --structured
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "api"))
+
+from app.services.substrate.kernel import NodeID  # noqa: E402
+from app.services.substrate.orm import (  # noqa: E402
+    SubstrateNamedCellORM,
+    SubstrateNodeORM,
+)
+from app.services.substrate.substrate_strings import (  # noqa: E402
+    lookup_string_value,
+)
+from app.services.unified_db import session as session_scope  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shape signature — walk a recipe tree to a chosen depth, build a hashable
+# tuple of (category, [(child_category, [...]), ...]) per node.
+# ---------------------------------------------------------------------------
+
+
+def _node_row(session, nid: NodeID) -> Optional[SubstrateNodeORM]:
+    return (
+        session.query(SubstrateNodeORM)
+        .filter_by(
+            package=nid.package, level=nid.level,
+            type_=nid.type_, instance=nid.instance,
+        )
+        .one_or_none()
+    )
+
+
+def _parse_children(serialized: str) -> Tuple[NodeID, list[NodeID]]:
+    chunks = serialized.split("+")
+    parts = [tuple(int(x) for x in c.split(".")) for c in chunks]
+    cat = NodeID(*parts[0])
+    children = [NodeID(*p) for p in parts[1:]]
+    return cat, children
+
+
+def _category_key(nid: NodeID) -> Tuple[int, int, int]:
+    """Identity of a category without its instance.
+
+    Two recipes with the same (package, level, type_) but different
+    instances share the same KIND — e.g. both are R_Block.LET pairs.
+    This is the projection that produces the structural signature; if we
+    kept the instance, every distinct string-value would split into its
+    own bucket and the signature would equal the CTOR.
+    """
+    return (nid.package, nid.level, nid.type_)
+
+
+def shape_signature(session, nid: NodeID, depth: int) -> Tuple:
+    """Recursive depth-d signature for a recipe NodeID.
+
+    At depth 0 the signature is just the category-kind of this node.
+    Beyond that we descend into children, projecting each child onto its
+    own depth-(d-1) signature. Trivial leaves stop the recursion.
+    """
+    cat_key = _category_key(nid)
+    if depth <= 0:
+        return (cat_key,)
+    row = _node_row(session, nid)
+    if row is None or not row.serialized:
+        return (cat_key,)
+    _, children = _parse_children(row.serialized)
+    if not children:
+        return (cat_key,)
+    child_sigs = tuple(shape_signature(session, c, depth - 1) for c in children)
+    return (cat_key, child_sigs)
+
+
+def signature_size(sig: Tuple) -> int:
+    """Count leaf entries in a signature — proxy for shape complexity."""
+    if len(sig) == 1:
+        return 1
+    return sum(signature_size(c) for c in sig[1])
+
+
+def format_signature_one_line(sig: Tuple, max_len: int = 120) -> str:
+    s = repr(sig)
+    if len(s) <= max_len:
+        return s
+    return s[:max_len - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Field-set signature — projects a CTOR onto the SET of keys it carries.
+#
+# The shape signature above bins by "what categorical sub-trees exist where",
+# which over-distinguishes (any new field combination orphans a cell). The
+# field-set signature bins by "what NAMED fields the CTOR has" — recovered
+# from R_Block.LET recipes whose first child is the key-string. Same family
+# regardless of value-encoding, order, or whether one field is optional.
+#
+# For Network concepts the CTOR is `R_Block.DO(let("id",...), let("hz",...),
+# let("geometry",...), ...)`, so the set of keys IS the frontmatter schema
+# the concept is honoring. Two concepts with the same key-set are
+# structurally the same KIND of concept.
+# ---------------------------------------------------------------------------
+
+
+# R_Block category triple — (package, level, type_) for the BLOCK basic.
+_R_BLOCK_KIND = (1, 4, 9)
+# R_Block.LET = instance 3 (a (key, value) pair recipe)
+_R_BLOCK_LET = 3
+# R_Type.STRING for the leaf NodeID layout
+_R_STRING_KIND = (1, 1, 6)
+
+
+def _recover_string(session, nid: NodeID) -> Optional[str]:
+    if (nid.package, nid.level, nid.type_) != _R_STRING_KIND:
+        return None
+    return lookup_string_value(session, nid.instance)
+
+
+def field_set_signature(session, nid: NodeID) -> Tuple[str, ...]:
+    """Walk the CTOR's direct children; for each LET pair, recover the key.
+
+    Returns the sorted, deduplicated tuple of key-names. Two cells with the
+    same field-set tuple have the same conceptual schema — the same kind
+    of concept, regardless of how full their fields are or what order
+    they were authored in.
+
+    A LET recipe is recognized by its CATEGORY (instance 3 in the BLOCK
+    basic), not by the child NodeID's type_ field — the child's NodeID is
+    a content-addressed handle into substrate_nodes; the category lives
+    inside that row's serialized form.
+    """
+    row = _node_row(session, nid)
+    if row is None or not row.serialized:
+        return ()
+    _, children = _parse_children(row.serialized)
+    keys: list[str] = []
+    for child in children:
+        let_row = _node_row(session, child)
+        if let_row is None or not let_row.serialized:
+            continue
+        cat, let_children = _parse_children(let_row.serialized)
+        if cat.instance != _R_BLOCK_LET:
+            continue
+        if not let_children:
+            continue
+        key = _recover_string(session, let_children[0])
+        if key:
+            keys.append(key)
+    return tuple(sorted(set(keys)))
+
+
+def cluster_concepts_field_set(session) -> dict[Tuple, list[SubstrateNamedCellORM]]:
+    rows = (
+        session.query(SubstrateNamedCellORM)
+        .filter_by(domain="concept")
+        .all()
+    )
+    clusters: dict[Tuple, list] = defaultdict(list)
+    for row in rows:
+        if row.ctor_recipe_node_id is None:
+            sig: Tuple = ("no-ctor",)
+        else:
+            ctor_row = (
+                session.query(SubstrateNodeORM)
+                .filter_by(node_id=row.ctor_recipe_node_id)
+                .one_or_none()
+            )
+            if ctor_row is None:
+                sig = ("missing",)
+            else:
+                nid = NodeID(
+                    ctor_row.package, ctor_row.level,
+                    ctor_row.type_, ctor_row.instance,
+                )
+                sig = field_set_signature(session, nid)
+        clusters[sig].append(row)
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Cluster all concepts by signature; report distribution.
+# ---------------------------------------------------------------------------
+
+
+def cluster_concepts(session, depth: int) -> dict[Tuple, list[SubstrateNamedCellORM]]:
+    rows = (
+        session.query(SubstrateNamedCellORM)
+        .filter_by(domain="concept")
+        .all()
+    )
+    clusters: dict[Tuple, list] = defaultdict(list)
+    for row in rows:
+        if row.ctor_recipe_node_id is None:
+            sig = (("no-ctor",),)
+        else:
+            ctor_row = (
+                session.query(SubstrateNodeORM)
+                .filter_by(node_id=row.ctor_recipe_node_id)
+                .one_or_none()
+            )
+            if ctor_row is None:
+                sig = (("missing",),)
+            else:
+                nid = NodeID(
+                    ctor_row.package, ctor_row.level,
+                    ctor_row.type_, ctor_row.instance,
+                )
+                sig = shape_signature(session, nid, depth)
+        clusters[sig].append(row)
+    return clusters
+
+
+def print_distribution(clusters: dict[Tuple, list]) -> None:
+    sizes = Counter(len(cells) for cells in clusters.values())
+    total = sum(len(cells) for cells in clusters.values())
+    print(f"\n  {len(clusters)} distinct signatures across {total} concepts")
+    print(f"  cluster sizes (size: count_of_clusters):")
+    for size in sorted(sizes.keys(), reverse=True):
+        print(f"    size {size}: {sizes[size]} cluster(s)")
+
+
+def print_top_clusters(clusters: dict[Tuple, list], top: int = 8) -> None:
+    print(f"\n  top {top} clusters by size:")
+    items = sorted(clusters.items(), key=lambda kv: -len(kv[1]))[:top]
+    for sig, cells in items:
+        sample = ", ".join(c.name for c in cells[:4])
+        more = f" +{len(cells) - 4} more" if len(cells) > 4 else ""
+        print(f"    [{len(cells):>3} cells] {sample}{more}")
+        print(f"              shape: {format_signature_one_line(sig, 100)}")
+
+
+def print_target_neighbors(
+    session, clusters: dict[Tuple, list], target_name: str, depth: int,
+) -> None:
+    target = (
+        session.query(SubstrateNamedCellORM)
+        .filter_by(domain="concept", name=target_name)
+        .one_or_none()
+    )
+    if target is None:
+        print(f"\n  target {target_name!r} not found in substrate")
+        return
+    target_sig = None
+    for sig, cells in clusters.items():
+        if any(c.name == target_name for c in cells):
+            target_sig = sig
+            break
+    if target_sig is None:
+        print(f"\n  target {target_name!r} has no signature (no CTOR?)")
+        return
+    neighbors = [c.name for c in clusters[target_sig] if c.name != target_name]
+    print(f"\n  {target_name!r} at depth-{depth} cluster:")
+    print(f"    signature: {format_signature_one_line(target_sig, 200)}")
+    print(f"    cluster size: {len(clusters[target_sig])} cells")
+    print(f"    neighbors ({len(neighbors)}):")
+    for n in neighbors[:20]:
+        print(f"      - {n}")
+    if len(neighbors) > 20:
+        print(f"      ... +{len(neighbors) - 20} more")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--depth", type=int, default=2,
+                    help="recursion depth for signature (0=root only, 2=default)")
+    ap.add_argument("--target", default="lc-pulse",
+                    help="concept whose neighbors to show")
+    ap.add_argument("--top", type=int, default=8,
+                    help="how many top clusters to show")
+    args = ap.parse_args()
+
+    with session_scope() as session:
+        rows = (
+            session.query(SubstrateNamedCellORM)
+            .filter_by(domain="concept")
+            .count()
+        )
+        if rows == 0:
+            print(
+                "no concept cells in local substrate. ingest first:\n"
+                "  python3 scripts/coh_substrate.py ingest --concepts --structured"
+            )
+            return 1
+
+        print(f"sensing CTOR-shape geometry across {rows} concept cells")
+        for d in range(args.depth + 1):
+            clusters = cluster_concepts(session, depth=d)
+            print(f"\n=== depth {d} (categorical sub-tree shape) ===")
+            print_distribution(clusters)
+            if d == args.depth:
+                print_top_clusters(clusters, top=args.top)
+                print_target_neighbors(
+                    session, clusters, args.target, depth=d,
+                )
+
+        print("\n=== field-set signature (key-set of named fields) ===")
+        field_clusters = cluster_concepts_field_set(session)
+        print_distribution(field_clusters)
+        print_top_clusters(field_clusters, top=args.top)
+        print_target_neighbors(session, field_clusters, args.target, depth=-1)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 type NodeIDOut = { package: number; level: number; type: number; instance: number };
@@ -522,10 +523,34 @@ function ResultPanel({ result }: { result: FormResultOut }) {
   );
 }
 
+// Build a starter expression when the playground arrives bound to a cell.
+// `?cell=@concept(lc-pulse)` becomes `@concept(lc-pulse).blueprint` — a
+// useful first question to ask of any cell. The visitor lands inside a
+// conversation already in progress, rather than at a blank textarea.
+function starterFromCell(cellRef: string | null): {
+  expr: string;
+  showcases: string;
+} | null {
+  if (!cellRef) return null;
+  const trimmed = cellRef.trim();
+  if (!trimmed.startsWith("@")) return null;
+  return {
+    expr: `${trimmed}.blueprint`,
+    showcases: `Reading ${trimmed}'s Blueprint NodeID — the cell's structural identity. Try .ctor for its CTOR recipe, or ?equivalent ${trimmed} for cells sharing its Blueprint.`,
+  };
+}
+
 export function FormPlayground() {
+  const searchParams = useSearchParams();
+  const cellParam = searchParams.get("cell");
+  const starter = starterFromCell(cellParam);
   const firstExample = GROUPS[0].examples[0];
-  const [expression, setExpression] = useState(firstExample.expr);
-  const [activeShowcase, setActiveShowcase] = useState(firstExample.showcases);
+  const [expression, setExpression] = useState(
+    starter ? starter.expr : firstExample.expr,
+  );
+  const [activeShowcase, setActiveShowcase] = useState(
+    starter ? starter.showcases : firstExample.showcases,
+  );
   const [evaluating, setEvaluating] = useState(false);
   const [result, setResult] = useState<FormResultOut | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/web/app/substrate/page.tsx
+++ b/web/app/substrate/page.tsx
@@ -73,22 +73,58 @@ function formatNodeId(nid: { package: number; level: number; type: number; insta
   return `@${nid.package}.${nid.level}.${nid.type}.${nid.instance}`;
 }
 
-const DOMAINS = ["memory", "spec", "idea", "concept", "presence"] as const;
+const DOMAINS = [
+  "concept",
+  "spec",
+  "idea",
+  "presence",
+  "lineage",
+  "guide",
+  "transmission",
+  "kb_page",
+  "language_view",
+  "memory",
+  "witness",
+  "task",
+  "resource",
+  "harmonic",
+  "topology",
+] as const;
 
 const DOMAIN_LABELS: Record<string, string> = {
-  memory: "Memory",
+  concept: "Concept",
   spec: "Spec",
   idea: "Idea",
-  concept: "Concept",
   presence: "Presence",
+  lineage: "Lineage",
+  guide: "Guide",
+  transmission: "Transmission",
+  kb_page: "KB page",
+  language_view: "Language view",
+  memory: "Memory",
+  witness: "Witness",
+  task: "Task",
+  resource: "Resource",
+  harmonic: "Harmonic",
+  topology: "Topology",
 };
 
 const DOMAIN_DESCRIPTIONS: Record<string, string> = {
-  memory: "Auto-loaded notes carrying tender context across sessions",
+  concept: "Vision-kb story: cross-refs, visuals, parent, geometry",
   spec: "Executable form: source, requirements, done_when, test, constraints",
   idea: "Problem-shape with capabilities, absorbed-ideas, spec-links",
-  concept: "Vision-kb story: cross-refs, visuals, parent",
-  presence: "Contributor cell: HUMAN / AGENT / SYSTEM with role and edges",
+  presence: "Contributor cell — HUMAN / AGENT / SYSTEM — with role and edges",
+  lineage: "Transmission / embodiment records — where teachings entered the body",
+  guide: "Practice and reader guides paired with concepts",
+  transmission: "Source-marked teaching cells — what flowed through whom",
+  kb_page: "General vision-KB pages and indexes outside the concept set",
+  language_view: "Translated / localized projections of the KB content",
+  memory: "Auto-loaded notes carrying tender context across sessions",
+  witness: "Event-as-proof cells — the trace the body leaves of its own life",
+  task: "Pipeline work-unit cells — open threads under tending",
+  resource: "Source / extraction records — what was read, what was lifted",
+  harmonic: "Solfeggio frequency bands carried by concepts (hz cells)",
+  topology: "Topological shape vocabulary — values authored as geometry",
 };
 
 export default async function SubstratePage() {
@@ -125,6 +161,30 @@ export default async function SubstratePage() {
           <span className="text-muted-foreground">
             Ask the lattice structural questions, or place new content into it.
           </span>
+        </p>
+        {/* Doors for both kinds of visitor — the human curious about how
+            the body works, and the AI arriving without a prior map. The
+            agent guide is the canonical "how to ground reasoning in the
+            lattice" doc; the language doc carries Form's design. */}
+        <p className="mt-3 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+          <Link
+            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/agents-using-substrate.md"
+            className="underline hover:text-amber-300/80 transition-colors"
+          >
+            How AI agents use this lattice
+          </Link>
+          <Link
+            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/form-language.md"
+            className="underline hover:text-amber-300/80 transition-colors"
+          >
+            Form language design
+          </Link>
+          <Link
+            href="https://api.coherencycoin.com/docs#/substrate"
+            className="underline hover:text-amber-300/80 transition-colors"
+          >
+            REST endpoints (Swagger)
+          </Link>
         </p>
       </header>
 

--- a/web/app/vision/[conceptId]/_components/SubstratePosition.tsx
+++ b/web/app/vision/[conceptId]/_components/SubstratePosition.tsx
@@ -1,0 +1,137 @@
+// SubstratePosition — surface this concept's structural coordinate in
+// the body's content-addressed lattice. The vision page carries the
+// story; this panel carries the position. Both are the same cell,
+// read through different surfaces.
+//
+// The visitor lands at /vision/lc-pulse for the felt meaning. From
+// here they can step sideways into /substrate/concept/lc-pulse for
+// the cell's full structural identity, or into /substrate/form pre-
+// loaded with this cell, to ask the lattice questions directly.
+//
+// Edge wiring: this component is the door the page-comment in
+// site_header.tsx names — "deeper surfaces reach themselves through
+// the pages that already use them." The vision page was already
+// using the cell; this is the surface that lets the visitor see it.
+
+import Link from "next/link";
+import { getApiBase } from "@/lib/api";
+
+type NodeID = {
+  package: number;
+  level: number;
+  type: number;
+  instance: number;
+};
+
+type CellResponse = {
+  cell_id: number;
+  name: string;
+  domain: string;
+  blueprint: NodeID;
+};
+
+type EquivalentResponse = {
+  blueprint: NodeID;
+  cells: Array<{ name: string; domain: string }>;
+};
+
+function formatNodeId(nid: NodeID): string {
+  return `@${nid.package}.${nid.level}.${nid.type}.${nid.instance}`;
+}
+
+async function fetchCell(conceptId: string): Promise<CellResponse | null> {
+  try {
+    const res = await fetch(
+      `${getApiBase()}/api/substrate/cell/concept/${encodeURIComponent(conceptId)}`,
+      { next: { revalidate: 60 } },
+    );
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchEquivalents(
+  conceptId: string,
+): Promise<EquivalentResponse | null> {
+  try {
+    const res = await fetch(
+      `${getApiBase()}/api/substrate/equivalent/concept/${encodeURIComponent(conceptId)}`,
+      { next: { revalidate: 60 } },
+    );
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function SubstratePosition({
+  conceptId,
+}: {
+  conceptId: string;
+}) {
+  const [cell, equivalents] = await Promise.all([
+    fetchCell(conceptId),
+    fetchEquivalents(conceptId),
+  ]);
+
+  // If the cell isn't in the substrate yet, surface nothing. The vision
+  // story carries the meaning; the structural position is additive, not
+  // load-bearing.
+  if (!cell) return null;
+
+  const cellRef = `@concept(${conceptId})`;
+  const nodeIdStr = formatNodeId(cell.blueprint);
+  const equivalentCount = equivalents?.cells.length ?? 0;
+
+  return (
+    <section
+      aria-labelledby="substrate-position-heading"
+      className="rounded-2xl border border-amber-500/20 bg-stone-900/60 p-5 space-y-3"
+    >
+      <h2
+        id="substrate-position-heading"
+        className="text-sm font-semibold text-amber-300/90"
+      >
+        Structural position
+      </h2>
+      <p className="text-xs text-stone-400 leading-relaxed">
+        This concept lives in the body's content-addressed lattice. Two cells
+        with the same Blueprint NodeID share structural identity regardless of
+        name — recognition by coordinate, not vocabulary.
+      </p>
+      <dl className="grid gap-2 text-sm sm:grid-cols-[auto_1fr]">
+        <dt className="text-stone-400">Blueprint</dt>
+        <dd className="font-mono text-amber-200/90">{nodeIdStr}</dd>
+        <dt className="text-stone-400">Structural equivalents</dt>
+        <dd className="text-stone-200">
+          {equivalentCount === 0
+            ? "none currently"
+            : `${equivalentCount} cell${equivalentCount === 1 ? "" : "s"} share this Blueprint`}
+        </dd>
+      </dl>
+      <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs pt-2">
+        <Link
+          href={`/substrate/concept/${conceptId}`}
+          className="text-amber-400/90 hover:text-amber-300 transition-colors"
+        >
+          → Full cell page
+        </Link>
+        <Link
+          href={`/substrate/form?cell=${encodeURIComponent(cellRef)}`}
+          className="text-amber-400/90 hover:text-amber-300 transition-colors"
+        >
+          → Ask the lattice (Form playground)
+        </Link>
+        <Link
+          href="/substrate"
+          className="text-stone-400 hover:text-amber-300 transition-colors"
+        >
+          → All cells
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/web/app/vision/[conceptId]/page.tsx
+++ b/web/app/vision/[conceptId]/page.tsx
@@ -26,6 +26,7 @@ import { WorldSignals } from "./_components/WorldSignals";
 import { EnergyContributors } from "./_components/EnergyContributors";
 import { ResonantAssets } from "./_components/ResonantAssets";
 import { CarriedBy } from "./_components/CarriedBy";
+import { SubstratePosition } from "./_components/SubstratePosition";
 import { ConceptVoices } from "./_components/ConceptVoices";
 import { ReactionBar } from "@/components/ReactionBar";
 import { InfluenceWeb } from "@/components/presence/InfluenceWeb";
@@ -380,6 +381,10 @@ export default async function VisionConceptPage({
 
             <div className="max-w-3xl space-y-4 pt-8">
               <ConnectedConcepts outgoing={outgoing} incoming={incoming} nameMap={nameMap} mode="full" />
+              {/* The structural position — door from felt-meaning into
+                  the lattice's content-addressed view of this same cell.
+                  Renders null if the cell isn't in the substrate yet. */}
+              <SubstratePosition conceptId={conceptId} />
               <div className="flex gap-4 text-sm pt-4">
                 <Link href={localizedHref("/vision", lang)} className="text-stone-500 hover:text-amber-300/80 transition-colors">{t("vision.backToRoot")}</Link>
                 <Link href={localizedHref("/vision/realize", lang)} className="text-stone-500 hover:text-amber-300/80 transition-colors">{t("vision.livingIt")}</Link>


### PR DESCRIPTION
## What changed

The body had a rich substrate — Form playground, cell pages, REST endpoints, agent guide — and the visitor couldn't see any of it from `/vision/lc-pulse` or anywhere the public arrives. The header comment in `site_header.tsx` named the intent (\"deeper internal surfaces reach themselves through the pages that already use them\") but no page actually did. Three movements close those edges in one breath.

### 1. SubstratePosition on `/vision/{conceptId}`

New component shows the concept's Blueprint NodeID, count of structural equivalents, and three doors:
- → Full cell page (`/substrate/concept/{id}`)
- → Ask the lattice (`/substrate/form?cell=@concept({id})`)
- → All cells (`/substrate`)

Renders `null` if the cell isn't in the substrate yet — additive, not load-bearing.

### 2. `/substrate` as a real index

Was 5 domains; now 15 — concept, spec, idea, presence, lineage, guide, transmission, kb_page, language_view, memory, witness, task, resource, harmonic, topology. Real cell counts from the production histogram endpoint (`concept: 122`, `spec: 135`, `presence: 83`, etc.). Three doc links surfaced for the first time:

- *How AI agents use this lattice* → `agents-using-substrate.md`
- *Form language design* → `form-language.md`
- *REST endpoints (Swagger)* → `api.coherencycoin.com/docs#/substrate`

### 3. `/substrate/form?cell=@<ref>` pre-binding

The Form playground accepts a `?cell=` search param. Textarea arrives pre-filled with `<ref>.blueprint`; contextual showcase explains the next moves (\".ctor for CTOR recipe, ?equivalent for shared-Blueprint cells\"). The tool becomes a tool inside the conversation it's meant to serve, not a curiosity at the end of an island chain.

## Companion sensing (separate but in the same commit)

The work that surfaced the gap:

- [`experiments/ctor-shape-signature-v0/sense.py`](experiments/ctor-shape-signature-v0/sense.py) — Python bootstrap that showed the over-collapse: 75 concepts share Blueprint `@1.5.4.19`; the depth-2 categorical shape signature is brittle; the field-set signature partitions 122 concepts into 6 honest clusters.
- [`docs/coherence-substrate/ctor-shape-signature.form`](docs/coherence-substrate/ctor-shape-signature.form) — the same sensing in Form, the body's own tongue. GAPs named for the smallest extensions that would close them (`.value` on String leaves, `?neighbors_by_fields` registration, `group_by` in core.fk).
- [`docs/vision-kb/concepts/lc-pulse.md`](docs/vision-kb/concepts/lc-pulse.md) — geometry felt-into (`arity: infinite`, `form: holographic-organism`, `topology: nested-each-contains-whole`, `polarity: oscillating`, `ordering: fractal`, `phase: oscillating`). Cross-refs lifted from body text into frontmatter so the substrate sees them.

## Test plan

- [x] `/substrate` index renders all 15 domains with production counts — verified via dev server against prod API
- [x] `/substrate/form?cell=%40concept(lc-pulse)` pre-fills `@concept(lc-pulse).blueprint` with contextual showcase — verified
- [x] `SubstratePosition` on `/vision/lc-pulse` shows `@1.5.4.19`, \"75 cells share this Blueprint\", three links to expected URLs — verified at DOM level
- [ ] Mobile viewport — pending visual verification once deployed
- [ ] Click-through flow: vision → cell page → form playground → back to cell — pending post-deploy verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)