### PR TITLE
Attune grammar completion to Form-native BMF

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,11 +34,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 128 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 229 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 55 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 186 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 187 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 50 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 154 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 115 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 116 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 186
+**Total files**: 187
 
 | File | Purpose |
 |---|---|
@@ -85,6 +85,7 @@
 | [test_flow_reactions.py](test_flow_reactions.py) | Flow tests for reactions — emoji + comment across any entity. |
 | [test_flow_vitality.py](test_flow_vitality.py) | Flow-centric tests for the Workspace Vitality + related sensing |
 | [test_flow_workspaces.py](test_flow_workspaces.py) | Flow-centric tests for the Workspace tenant primitive. |
+| [test_form_native_grammar_contract.py](test_form_native_grammar_contract.py) | Form-native grammar contract: host parser bridges are not completion. |
 | [test_frequency_profile_contributor_alias.py](test_frequency_profile_contributor_alias.py) | Contributor profile aliases resolve through the generic graph profile path. |
 | [test_generate_visuals_manifest.py](test_generate_visuals_manifest.py) | _no top-of-file purpose_ |
 | [test_governance_change_flow.py](test_governance_change_flow.py) | Contributor onboarding + governed change flow (spec: |

--- a/api/tests/test_form_native_grammar_contract.py
+++ b/api/tests/test_form_native_grammar_contract.py
@@ -1,0 +1,79 @@
+"""Form-native grammar contract: host parser bridges are not completion."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "form_native_grammar_contract.py"
+FORM_CLI = ROOT / "scripts" / "form_cli.py"
+
+
+def _contract_module():
+    spec = importlib.util.spec_from_file_location("form_native_grammar_contract", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_audit_separates_declared_grammar_from_native_stream() -> None:
+    report = _contract_module().audit()
+
+    rows = {row["extension"]: row for row in report["extensions"]}
+    assert rows["png"]["grammar_declared"] is True
+    assert rows["png"]["form_native_stream"] is False
+    assert "png" in report["summary"]["binary_declared_not_native"]
+
+
+def test_audit_names_host_bridges_as_debt() -> None:
+    report = _contract_module().audit()
+
+    assert "python" in report["host_bridges"]
+    assert "ast.parse" in report["host_bridges"]["python"]
+    assert report["summary"]["form_native_stream_extensions"] == 0
+
+
+def test_form_cli_refuses_host_bridge_by_default(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.json"
+    sample.write_text('{"ok": true}\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(FORM_CLI), "convert", "in", "--tongue", "json", str(sample)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "host-language bridge" in result.stderr
+
+
+def test_form_cli_host_bridge_requires_explicit_flag(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.json"
+    sample.write_text('{"ok": true}\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(FORM_CLI),
+            "convert",
+            "--allow-host-bridge",
+            "in",
+            "--tongue",
+            "json",
+            str(sample),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert '"source_tongue": "json"' in result.stdout

--- a/docs/coherence-substrate/python-grammar.form
+++ b/docs/coherence-substrate/python-grammar.form
@@ -18,24 +18,20 @@
 #   - language-cells.md (the N+M cross-language pattern Python was
 #     already named in)
 #
-# Python's stdlib `ast` module gives source attribution FOR FREE on
-# every AST node: lineno, col_offset, end_lineno, end_col_offset. The
-# parser stamps `source_attribution_shape` from those fields directly
-# — no custom tracking needed. (Same gesture as the framebuffer's
-# `track!` macro at the memory altitude; Python's ast carries the
-# equivalent natively.)
-#
-# This is the structural-prose declaration. The executable parse+emit
-# wires through Python's `ast.parse` / `ast.unparse` in scripts/form_cli.py.
+# The contract is Form-native BMF transmutation: source bytes stream
+# through token-streamer.form, match rules declared here, and emit
+# Form-native cells with source_attribution stamped from token spans.
+# Host-language syntax-tree bridges are compatibility probes only;
+# they do not count as parser completion.
 
 # ─────────────────────────────────────────────────────────────────────
 # Part 1 — module-level Blueprints
 # ─────────────────────────────────────────────────────────────────────
 #
 # A Python module is a sequence of top-level statements. The Blueprint
-# tree mirrors the ast.Module structure: a top-level `body` list, each
-# entry one of the statement shapes below, plus type_ignores for type-
-# checking comments.
+# tree is the Form-native target shape: a top-level `body` list, each
+# entry one statement shape below, plus type_ignores for type-checking
+# comments.
 
 form py_module_shape = {
     body:          ~List,                # [statement_shape]
@@ -48,9 +44,9 @@ form py_module_shape = {
 # Part 2 — statement-level Blueprints
 # ─────────────────────────────────────────────────────────────────────
 #
-# Each statement is one ast node-type. The list below covers the
-# common surface; rarer node types (Match, TryStar, AsyncWith, etc.)
-# follow the same shape and land as the body needs them.
+# Each statement is one Form-native Python source shape. The list below
+# covers the common surface; rarer source forms (Match, TryStar,
+# AsyncWith, etc.) follow the same shape and land as the body needs them.
 
 form py_function_def_shape = {
     name:          ~Slug,
@@ -309,36 +305,32 @@ defn python_grammar = grammar_shape {
     modality:           modality_shape { name: "text-tree", domain: "code" },
     ingest_pattern:     ?rule py_module,
     parse_into:         ~Blueprint @py_module_shape,
-    # capture_rules is a courtesy declaration; the executable parse
-    # routes through Python's `ast.parse` host intrinsic (GAP-PY1 below).
     capture_rules:      [
         rule(py_module,        "module → top-level stmt*",              module_node),
         rule(py_function_def,  "def name(args) -> type: body",          fn_def_node),
         rule(py_class_def,     "class Name(bases, **kw): body",         class_def_node),
         rule(py_assign,        "targets = value [# type_comment]",      assign_node),
         rule(py_call,          "func(args, **keywords)",                call_node),
-        # ... (full mapping in scripts/form_cli.py via ast.parse)
+        # Each additional Python construct lands here as a BMF rule,
+        # not as a host parser delegation.
     ],
-    pre_pipeline:       [],
-    # ast nodes carry lineno / col_offset / end_lineno / end_col_offset
-    # natively — the parser stamps source_attribution_shape from those
-    # fields directly. Per lc-the-recipe-remembers-its-source.
+    pre_pipeline:       [
+        ?stage(token_stream, produces: ~List @token_shape),
+    ],
+    # The tokenizer carries line/column/byte spans; semantic actions
+    # stamp source_attribution_shape from the matched span. Per
+    # lc-the-recipe-remembers-its-source.
     stamps_attribution: true,
 };
 
 defn python_emit = emission_template_shape {
     modality:      modality_shape { name: "text-tree", domain: "code" },
     emit_from:     ~Blueprint @py_module_shape,
-    # Emit routes through `ast.unparse` (Python 3.9+) on a reconstructed
-    # ast.Module. The Form recipe names the operation; the host carries
-    # the AST→source mechanics. Round-trip discipline: parse(unparse(x))
-    # ≈ x at the semantic altitude (whitespace + comment normalization
-    # tolerated; structural identity preserved).
     emit_pattern:  ?walker {
         on py_module:        emit_module,
         on py_function_def:  emit_function_def,
         on py_class_def:     emit_class_def,
-        # ... (full walker in scripts/form_cli.py)
+        # Each walker emits Python source bytes from Form cells.
     },
     format_rules: [
         ("indent_spaces",     4),
@@ -353,10 +345,7 @@ defn python_lang = language_cell_shape {
     version:           "3.12",
     grammar:           python_grammar,
     emission_template: python_emit,
-    stdlib_bindings: [
-        ("parse_ast",   @recipe(parse_via_ast_module)),
-        ("emit_ast",    @recipe(emit_via_ast_unparse)),
-    ],
+    stdlib_bindings:   [],
     numeric_defaults: [
         ("indent",            4),
         ("max_line_length",   100),
@@ -384,17 +373,18 @@ defn python_lang = language_cell_shape {
 #   surfaces every place the substrate_dispatch bridge wires a recipe.
 #   Substrate queries replace grep for source-level structural concerns.
 #
-# - **Source attribution from ast lineno gives perfect navigation.**
+# - **Source attribution from token spans gives perfect navigation.**
 #   organ.Cell.perceive() at line 336 carries
 #   `source_attribution.start_line == 336` in its Form recipe. The
 #   recipe-branching-sense loop can navigate from a firing back to the
 #   line of Python that authored it — without leaving the lattice.
 #
-# - **Round-trip via ast.unparse.** Python source → Form tree →
-#   Python source preserves structure (whitespace and comments
-#   normalize per ast.unparse's conventions). Cells that transform
-#   Python through the Form layer (e.g. add a decorator, rename a
-#   function, refactor a class) round-trip cleanly.
+# - **Round-trip through Form emit.** Python source → Form cells →
+#   Python source preserves structure at the semantic altitude, while
+#   comments and non-token whitespace remain sibling annotations. Cells
+#   that transform Python through the Form layer (e.g. add a decorator,
+#   rename a function, refactor a class) round-trip through emit walkers,
+#   not a host syntax-tree printer.
 #
 # - **Cross-language structural equivalence.** A Python function and
 #   its TypeScript port that compile to the same recipe NodeIDs are
@@ -422,7 +412,7 @@ defn python_lang = language_cell_shape {
 # ─────────────────────────────────────────────────────────────────────
 #
 # GAP-PY1 (FIRST CLOSURE LANDED 2026-05-21): the import-statement
-#          family is now parsed via real BMF rules, not ast.parse.
+#          family is now parsed via real BMF rules.
 #          experiments/local-llm-cell-v0/bmf.py carries:
 #            - Tokenizer (char-by-char, not a regex-over-ast wrapper)
 #            - Pattern primitives: Literal / Capture / Sequence / Opt /
@@ -434,19 +424,19 @@ defn python_lang = language_cell_shape {
 #              aliased, multi-name, relative-N-dot, relative-with-module)
 #          experiments/local-llm-cell-v0/bmf_python_demo.py verifies
 #          13/13 import variations parse through BMF and produce Form
-#          objects structurally equivalent to the ast.parse path.
+#          objects structurally equivalent to the old host bridge.
 #          Source attribution stamped natively by the BMF tokenizer
-#          (token line/col), not borrowed from ast.parse.
+#          (token line/col), not borrowed from a host syntax tree.
 #
 #          Remaining: every other Python construct (def, class,
 #          assignments, control flow, expressions). Each is one
 #          BMF rule per breath, using the same primitives. The
-#          AST delegate shrinks; the BMF surface grows; the
+#          host bridge shrinks; the BMF surface grows; the
 #          self-hosting boundary moves with every rule landed.
 #
 #          The original GAP-PY1 framing still holds for the rest of
-#          Python's grammar — AST is the bootstrap that carries the
-#          uncovered constructs until BMF rules land for them.
+#          Python's grammar — the old bridge carries uncovered
+#          constructs only when explicitly requested for parity probes.
 #          Walking Python's grammar into the substrate, one
 #          construct at a time:
 #            - `import os` → Rule(Sequence([Literal("KW","import"),
@@ -458,25 +448,23 @@ defn python_lang = language_cell_shape {
 #                                                       Literal("OP",":"),
 #                                                       Capture("body","block")]),
 #                                              action=@recipe(build_py_function_def))
-#          As rules land in the grammar cell-domain, the AST delegate
+#          As rules land in the grammar cell-domain, the host bridge
 #          shrinks. The self-hosting boundary moves; the bootstrap
 #          becomes vestigial. Same path the body has walked for every
 #          other host intrinsic — Newton sqrt instead of math.sqrt,
 #          Taylor exp instead of math.exp, form_native.cosine wired
-#          as runtime default. AST today; BMF tomorrow; one rule
-#          per breath.
+#          as runtime default. BMF is the parser path; one rule per
+#          breath.
 #
-# GAP-PY2: Comments + non-token whitespace are erased by ast.parse.
-#          ast.unparse synthesizes idiomatic whitespace on emit; the
-#          round-trip is semantically identical but not byte-identical.
-#          A future tokenize-aware extension would preserve comments
-#          as sibling annotations (similar to how libcst handles them);
-#          today the body works at the AST altitude.
+# GAP-PY2: Comments + non-token whitespace need explicit sibling
+#          annotation shapes. The token stream already sees them;
+#          the rule set still needs to attach them to the emitted
+#          Form cells.
 #
 # GAP-PY3: Python 3.12's PEP 695 type parameters (`def f[T](x: T) -> T`)
 #          and the `type` statement land as `type_params` lists in the
-#          shapes above; the emit half assumes Python 3.12+ ast.unparse.
-#          For 3.11- emission the format_rules need a downgrade pass.
+#          shapes above; the emit half needs version-aware format
+#          rules for 3.11- emission.
 #
 # GAP-PY4: Match statements (PEP 634) land as py_match_shape (not
 #          shown above for brevity; the body's Python source rarely
@@ -486,8 +474,8 @@ defn python_lang = language_cell_shape {
 # GAP-PY5: Walrus operator (`:=`), positional-only markers (`/`),
 #          keyword-only markers (`*`) — the py_arguments_shape carries
 #          them via posonlyargs / kwonlyargs / kw_defaults; the walrus
-#          is py_named_expr_shape (not shown for brevity). All
-#          ast-supported; the Blueprints land as the body uses them.
+#          is py_named_expr_shape (not shown for brevity). The
+#          Blueprints land as the body uses them.
 #
 # GAP-PY6: Type comments (`# type: ignore`, `# type: List[int]`) ride
 #          on individual statements via `type_comment` slots. The
@@ -500,9 +488,10 @@ defn python_lang = language_cell_shape {
 #
 #   # Parse a Python file into a Form object tree:
 #   form_cli convert in --tongue python experiments/local-llm-cell-v0/organ.py
+#     # refuses host bridges unless --allow-host-bridge is explicit
 #
 #   # Round-trip:
-#   form_cli convert in --tongue python <file> > /tmp/tree.json
+#   form_cli convert --allow-host-bridge in --tongue python <file> > /tmp/tree.json
 #   form_cli convert out --tongue python /tmp/tree.json > /tmp/roundtrip.py
 #
 #   # Substrate queries (once auto-ingest runs):

--- a/docs/system_audit/commit_evidence_2026-05-21_form_native_grammar_contract.json
+++ b/docs/system_audit/commit_evidence_2026-05-21_form_native_grammar_contract.json
@@ -1,0 +1,98 @@
+{
+  "date": "2026-05-21",
+  "thread_branch": "codex/form-native-bmf-stream",
+  "commit_scope": "Make Form-native BMF stream transmutation the grammar completion contract and demote host parsers to explicit parity bridges.",
+  "files_owned": [
+    "scripts/form_cli.py",
+    "scripts/form_cli_demo.sh",
+    "scripts/grammar_coverage.py",
+    "scripts/form_native_grammar_contract.py",
+    "api/tests/test_form_native_grammar_contract.py",
+    "docs/coherence-substrate/python-grammar.form",
+    "api/tests/INDEX.md",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-21_form_native_grammar_contract.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "python3 scripts/form_native_grammar_contract.py",
+      "python3 scripts/grammar_coverage.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_form_native_grammar_contract.py tests/test_substrate_grammar.py",
+      "python3 scripts/form_cli.py convert --allow-host-bridge in --tongue json docs/presence-content/bmf-grammar.json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"source_tongue\"], d[\"tree\"][\"category\"])'",
+      "/opt/homebrew/bin/ruff check scripts/form_native_grammar_contract.py api/tests/test_form_native_grammar_contract.py",
+      "python3 scripts/generate_repo_indexes.py",
+      "git rebase --autostash origin/main",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-21_form_native_grammar_contract.json",
+      "git diff --check",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "The default convert path now refuses host parser bridges and requires --allow-host-bridge for temporary parity probes. The new audit reports 11 declared grammar extensions, 0 Form-native stream extensions, host bridges for json/markdown/python, and binary grammars declared but not native for jpg/png. Focused tests, ruff, diff check, local PR guard, and follow-through pass."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation is complete; CI and deployment validation remain pending."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "form-native-grammar-contract"
+  ],
+  "task_ids": [
+    "form-native-bmf-stream-20260521"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "grammar-contract-correction"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/form_native_grammar_contract.py",
+    "api/tests/test_form_native_grammar_contract.py",
+    "docs/coherence-substrate/grammar.form",
+    "docs/coherence-substrate/token-streamer.form",
+    "docs/coherence-substrate/python-grammar.form"
+  ],
+  "change_files": [
+    "scripts/form_cli.py",
+    "scripts/form_cli_demo.sh",
+    "scripts/grammar_coverage.py",
+    "scripts/form_native_grammar_contract.py",
+    "api/tests/test_form_native_grammar_contract.py",
+    "docs/coherence-substrate/python-grammar.form",
+    "api/tests/INDEX.md",
+    "scripts/INDEX.md",
+    "MANIFEST.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 115
+**Total files**: 116
 
 | File | Purpose |
 |---|---|
@@ -46,6 +46,7 @@
 | [export_vision_image_prompts.py](export_vision_image_prompts.py) | !/usr/bin/env python3 |
 | [external_proof_demo.py](external_proof_demo.py) | !/usr/bin/env python3 |
 | [form_cli.py](form_cli.py) | !/usr/bin/env python3 |
+| [form_native_grammar_contract.py](form_native_grammar_contract.py) | !/usr/bin/env python3 |
 | [frequency_references.py](frequency_references.py) | Frequency reference corpus for the Living Collective scoring engine. |
 | [generate_curated_translations.py](generate_curated_translations.py) | !/usr/bin/env python3 |
 | [generate_repo_indexes.py](generate_repo_indexes.py) | !/usr/bin/env python3 |

--- a/scripts/form_cli.py
+++ b/scripts/form_cli.py
@@ -35,7 +35,7 @@ Examples:
         '[1.0, 0.0, 0.0]' '[1.0, 0.0, 0.0]'
     # → 1.0
 
-    form_cli convert in --tongue json data.json | \\
+    form_cli convert --allow-host-bridge in --tongue json data.json | \\
         form_cli convert out --tongue json /dev/stdin
     # round-trip JSON → Form object → JSON
 """
@@ -236,6 +236,15 @@ def _convert_in_json(input_path: Path) -> dict:
 def _convert_out_json(form_object: dict) -> str:
     tree = form_object.get("tree", form_object)
     return json.dumps(_form_tree_to_json(tree), indent=2)
+
+
+def _host_bridge_refusal(tongue: str) -> None:
+    _die(
+        f"tongue '{tongue}' still uses a host-language bridge. "
+        "Parser completion now means: stream bytes through grammar authored "
+        "in .form and emit Form-native cells without Python/AST delegation. "
+        "Use --allow-host-bridge only for temporary parity probes."
+    )
 
 
 # ─── markdown tongue ─────────────────────────────────────────────────────
@@ -754,14 +763,20 @@ def _convert_out_python(form_object: dict) -> str:
 def cmd_convert(args: argparse.Namespace) -> int:
     if args.direction == "in":
         if args.tongue == "json":
+            if not args.allow_host_bridge:
+                _host_bridge_refusal(args.tongue)
             form_obj = _convert_in_json(Path(args.input))
             print(json.dumps(form_obj, indent=2))
             return 0
         if args.tongue in ("md", "markdown"):
+            if not args.allow_host_bridge:
+                _host_bridge_refusal(args.tongue)
             form_obj = _convert_in_markdown(Path(args.input))
             print(json.dumps(form_obj, indent=2))
             return 0
         if args.tongue in ("py", "python"):
+            if not args.allow_host_bridge:
+                _host_bridge_refusal(args.tongue)
             form_obj = _convert_in_python(Path(args.input))
             print(json.dumps(form_obj, indent=2))
             return 0
@@ -952,6 +967,11 @@ def main() -> int:
     p_conv.add_argument("input", help="path to input file (or /dev/stdin)")
     p_conv.add_argument("--tongue", default="json",
                         help="Language cell name (default: json)")
+    p_conv.add_argument(
+        "--allow-host-bridge",
+        action="store_true",
+        help="permit temporary Python/stdlib parser bridges for parity probes",
+    )
     p_conv.set_defaults(func=cmd_convert)
 
     p_gen = sub.add_parser("generate", help="extract recipes from .form into .recipelib")

--- a/scripts/form_cli_demo.sh
+++ b/scripts/form_cli_demo.sh
@@ -45,7 +45,7 @@ echo "$SEP"
 cat > "$TMPDIR/input.json" <<EOF
 {"name": "test", "values": [1, 2.5, "three", true, null], "nested": {"depth": 1}}
 EOF
-python3 scripts/form_cli.py convert in --tongue json "$TMPDIR/input.json" > "$TMPDIR/form_obj.json"
+python3 scripts/form_cli.py convert --allow-host-bridge in --tongue json "$TMPDIR/input.json" > "$TMPDIR/form_obj.json"
 echo "  category at top of tree:" \
      "$(python3 -c "import json; d=json.load(open('$TMPDIR/form_obj.json')); print(d['tree']['category'])")"
 echo "  child count:" \

--- a/scripts/form_native_grammar_contract.py
+++ b/scripts/form_native_grammar_contract.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Audit Form-native grammar status without counting host parser bridges as done."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GRAMMAR_DIR = REPO_ROOT / "docs" / "coherence-substrate"
+FORM_CLI = REPO_ROOT / "scripts" / "form_cli.py"
+
+EXTENSION_TO_GRAMMAR = {
+    "json": "json-grammar.form",
+    "jsonl": "json-grammar.form",
+    "yaml": "yaml-grammar.form",
+    "yml": "yaml-grammar.form",
+    "md": "markdown-grammar.form",
+    "py": "python-grammar.form",
+    "rs": "rust-grammar.form",
+    "go": "go-grammar.form",
+    "png": "png-grammar.form",
+    "jpg": "image-grammar.form",
+    "jpeg": "image-grammar.form",
+    "gif": "image-grammar.form",
+    "svg": "image-grammar.form",
+    "webp": "image-grammar.form",
+    "mp3": "audio-grammar.form",
+    "wav": "audio-grammar.form",
+    "flac": "audio-grammar.form",
+    "ogg": "audio-grammar.form",
+    "m4a": "audio-grammar.form",
+}
+
+BINARY_EXTENSIONS = {
+    "png", "jpg", "jpeg", "gif", "webp", "mp3", "wav", "flac", "ogg", "m4a"
+}
+
+HOST_BRIDGE_PATTERNS = {
+    "json": ["json.loads", "json.dumps"],
+    "markdown": ["_HEADING_RE", "_md_parse_blocks", "_convert_in_markdown"],
+    "python": ["import ast", "ast.parse", "ast.unparse", "_convert_in_python"],
+}
+
+
+def _repo_extensions() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    skip_parts = {".git", "node_modules", ".claude", ".next", ".venv", "__pycache__", "dist", "build"}
+    for path in REPO_ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(REPO_ROOT).parts
+        if any(part in skip_parts for part in rel_parts):
+            continue
+        ext = path.suffix.lstrip(".").lower()
+        if ext:
+            counts[ext] = counts.get(ext, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
+def _existing_grammars() -> set[str]:
+    return {path.name for path in GRAMMAR_DIR.glob("*-grammar.form")}
+
+
+def _native_stream_cells() -> set[str]:
+    cells: set[str] = set()
+    if not FORM_CLI.exists():
+        return cells
+    text = FORM_CLI.read_text(encoding="utf-8")
+    for match in re.finditer(r"if args\.tongue(?: in)? .*?\"([a-z]+)\"", text):
+        cells.add(match.group(1))
+    # The current CLI entries are host bridges, not native stream cells.
+    return cells - set(HOST_BRIDGE_PATTERNS)
+
+
+def _host_bridges() -> dict[str, list[str]]:
+    if not FORM_CLI.exists():
+        return {}
+    text = FORM_CLI.read_text(encoding="utf-8")
+    found: dict[str, list[str]] = {}
+    for tongue, patterns in HOST_BRIDGE_PATTERNS.items():
+        hits = [pattern for pattern in patterns if pattern in text]
+        if hits:
+            found[tongue] = hits
+    return found
+
+
+def audit() -> dict[str, Any]:
+    counts = _repo_extensions()
+    existing = _existing_grammars()
+    native_stream = _native_stream_cells()
+    host_bridges = _host_bridges()
+    rows = []
+    for ext, count in counts.items():
+        if count < 2:
+            continue
+        grammar = EXTENSION_TO_GRAMMAR.get(ext)
+        grammar_declared = bool(grammar and grammar in existing)
+        tongue = (grammar or "").replace("-grammar.form", "") if grammar else None
+        rows.append({
+            "extension": ext,
+            "count": count,
+            "grammar": grammar if grammar_declared else None,
+            "grammar_declared": grammar_declared,
+            "binary": ext in BINARY_EXTENSIONS,
+            "form_native_stream": bool(tongue and tongue in native_stream),
+            "host_bridge": tongue in host_bridges if tongue else False,
+            "unmapped": ext not in EXTENSION_TO_GRAMMAR,
+        })
+    return {
+        "contract": (
+            "Complete means bytes stream through grammar authored in .form "
+            "and emit Form-native cells; host parser bridges are debt."
+        ),
+        "grammar_files": sorted(existing),
+        "host_bridges": host_bridges,
+        "extensions": rows,
+        "summary": {
+            "declared_grammar_extensions": sum(1 for row in rows if row["grammar_declared"]),
+            "form_native_stream_extensions": sum(1 for row in rows if row["form_native_stream"]),
+            "host_bridge_tongues": sorted(host_bridges),
+            "binary_declared_not_native": [
+                row["extension"] for row in rows
+                if row["binary"] and row["grammar_declared"] and not row["form_native_stream"]
+            ],
+            "missing_grammar_extensions": [
+                row["extension"] for row in rows
+                if not row["grammar_declared"]
+            ],
+        },
+    }
+
+
+def print_text(report: dict[str, Any]) -> None:
+    print("Form-native grammar contract")
+    print("=" * 36)
+    print(report["contract"])
+    print()
+    summary = report["summary"]
+    print(f"declared grammar extensions: {summary['declared_grammar_extensions']}")
+    print(f"Form-native stream extensions: {summary['form_native_stream_extensions']}")
+    print(f"host parser bridges: {', '.join(summary['host_bridge_tongues']) or 'none'}")
+    print(
+        "binary grammars declared but not native: "
+        f"{', '.join(summary['binary_declared_not_native']) or 'none'}"
+    )
+    print()
+    print("Top extension status:")
+    for row in report["extensions"][:30]:
+        if row["form_native_stream"]:
+            status = "native-stream"
+        elif row["host_bridge"]:
+            status = "host-bridge"
+        elif row["grammar_declared"]:
+            status = "declared-only"
+        elif row["unmapped"]:
+            status = "unmapped"
+        else:
+            status = "missing-grammar"
+        grammar = row["grammar"] or "-"
+        print(f"  {row['extension']:<8} {row['count']:>5}  {grammar:<24} {status}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--fail-on-host-bridges",
+        action="store_true",
+        help="exit non-zero while any host parser bridge remains",
+    )
+    args = parser.parse_args()
+
+    report = audit()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_text(report)
+    if args.fail_on_host_bridges and report["host_bridges"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/grammar_coverage.py
+++ b/scripts/grammar_coverage.py
@@ -14,10 +14,11 @@ Two modes:
                           path (or '— gap'), and wiring status
   --gaps               — only the extensions with no Form grammar yet
 
-The wiring column tracks whether the grammar is also reachable through
-`form_cli convert --tongue <name>` today (json is wired; the rest
-are .form skeletons named in their files but not yet plumbed into the
-CLI's tongue dispatch).
+The bridge column tracks whether `form_cli convert --allow-host-bridge`
+can still parse the tongue through a temporary host-language bridge.
+That bridge is useful for parity probes, but it is not Form-native
+completion. Use `scripts/form_native_grammar_contract.py` for the
+stricter BMF stream-to-cell contract.
 """
 
 from __future__ import annotations
@@ -31,9 +32,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GRAMMARS_DIR = REPO_ROOT / "docs" / "coherence-substrate"
 
-# Map known file-extension → (grammar_filename, language_cell_name).
-# A nil grammar_filename means "no Form grammar yet". A nil cli_tongue
-# means "grammar exists but not wired into form_cli convert yet".
+# Map known file-extension → (grammar_filename, host_bridge_name).
+# A nil grammar_filename means "no Form grammar yet". A nil host bridge
+# means no temporary `form_cli convert --allow-host-bridge` path exists.
 EXTENSION_MAP = {
     "json":  ("json-grammar.form",   "json"),
     "yaml":  ("yaml-grammar.form",   None),
@@ -102,7 +103,7 @@ def _classify(ext: str, counts: Counter, existing: set[str]) -> dict:
         "count":           n,
         "grammar":         grammar if grammar_present else None,
         "grammar_named":   grammar,         # named in the map, may not exist yet
-        "cli_wired":       cli_tongue,
+        "host_bridge":      cli_tongue,
         "unknown":         ext not in EXTENSION_MAP,
     }
 
@@ -115,7 +116,7 @@ def print_summary(counts: Counter, existing: set[str]) -> None:
         rows.append(_classify(ext, counts, existing))
 
     ext_w = max(6, max((len(r["ext"]) for r in rows), default=6))
-    print(f"{'ext':<{ext_w}}  {'count':>6}  {'grammar':<32}  {'cli wired':<12}  status")
+    print(f"{'ext':<{ext_w}}  {'count':>6}  {'grammar':<32}  {'host bridge':<12}  status")
     print("-" * (ext_w + 6 + 32 + 12 + 14 + 6))
     for r in rows:
         if r["grammar"]:
@@ -127,15 +128,15 @@ def print_summary(counts: Counter, existing: set[str]) -> None:
         else:
             status = "gap"
         grammar = r["grammar"] or "—"
-        cli = r["cli_wired"] or "—"
+        cli = r["host_bridge"] or "—"
         print(f"{r['ext']:<{ext_w}}  {r['count']:>6}  {grammar:<32}  {cli:<12}  {status}")
 
     covered = sum(1 for r in rows if r["grammar"])
     gaps = sum(1 for r in rows if not r["grammar"])
     print()
     print(f"summary: {covered} extensions covered by a .form grammar, "
-          f"{gaps} gaps. {sum(1 for r in rows if r['cli_wired'])} wired "
-          f"into form_cli convert.")
+          f"{gaps} gaps. {sum(1 for r in rows if r['host_bridge'])} temporary "
+          f"host bridge(s).")
 
 
 def print_gaps(counts: Counter, existing: set[str]) -> None:


### PR DESCRIPTION
## Summary\n- make host parser bridges opt-in for form_cli convert via --allow-host-bridge\n- add a Form-native grammar contract audit that separates .form declarations, host bridges, native stream status, and binary gaps\n- retune python-grammar.form around token-stream/BMF transmutation instead of host syntax-tree completion\n\n## Proof\n- make prompt-guide\n- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q tests/test_form_native_grammar_contract.py tests/test_substrate_grammar.py\n- /opt/homebrew/bin/ruff check scripts/form_native_grammar_contract.py api/tests/test_form_native_grammar_contract.py\n- python3 scripts/form_native_grammar_contract.py\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict