### PR TITLE
tend: python.fk file-header subset — fifth format, bmf.py compost-path open

### DIFF
--- a/docs/coherence-substrate/INDEX.md
+++ b/docs/coherence-substrate/INDEX.md
@@ -44,6 +44,8 @@ The body's content-addressed numeric lattice. Cells from every memory file, spec
 | `experiments/form-stdlib/grammars/markdown.fk` | Markdown parser + emit in pure Form. ATX headings, paragraphs, fenced code blocks → universal DOC-* Recipes with per-block source attribution. Most-used format in this repo (thousands of .md files) |
 | `experiments/form-stdlib/grammars/json.fk` | JSON parser in pure Form. Objects, arrays, strings, numbers, bools, null → universal data Recipes with source attribution at the line/col of each composite. Sibling parity Go+Rust |
 | `experiments/form-stdlib/grammars/yaml.fk` | YAML parser (simplified subset: flat key:value pairs + list items + comments) in pure Form. Used by .github/workflows + many config files. Source attribution per line. Subsequent breaths add nested mappings, block scalars, flow style |
+| `experiments/form-stdlib/grammars/form.fk` | The self-host moment: S-expression (.fk) parser in pure Form. Parses Form source into Recipe trees without going through the kernel's bootstrap reader. Sibling parity Go+Rust. Once the kernel reads .fk source via this parser, the redundant tokenize_sexp / readSexpr / buildVerb code (~750 lines across three kernels) composts |
+| `experiments/form-stdlib/grammars/python.fk` | Python parser (file-header subset: imports + def-headers + simple assignments + comments) in pure Form. The compost target: experiments/local-llm-cell-v0/bmf.py (643 lines). Subsequent breaths add control flow, class defs, full expression grammar |
 
 ## The trinity
 

--- a/experiments/form-stdlib/grammars/form.fk
+++ b/experiments/form-stdlib/grammars/form.fk
@@ -1,0 +1,203 @@
+; grammars/form.fk — Form (.fk) S-expression parser in pure Form
+;
+; The self-host moment: parse .fk source into Recipe trees WITHOUT
+; using the kernel's bootstrap reader. Once parity proven, the
+; tokenize_sexp / readSexpr / buildVerb code in form-kernel-{rust,go,ts}
+; (~250 lines per kernel, ~750 lines total) can compost — the kernel
+; receives interned NodeID trees from form.fk parse directly.
+;
+; Grammar (the simplest in this stdlib):
+;   expr  := atom | list
+;   list  := '(' expr* ')'
+;   atom  := INT | STRING | IDENT
+;
+; INT     := [-]?digit+
+; STRING  := '"' (any-non-quote-or-escaped)* '"'
+; IDENT   := any-non-whitespace-non-paren-non-quote sequence
+; COMMENT := ';' to end of line (skipped)
+;
+; Each parsed Recipe carries (file, line, col) attribution via
+; intern_node_at — the satsang's self-knowing primitive in action.
+
+(do
+    ;; --- universal form-source category NodeIDs -------------------
+    ;; Numeric type=99 doc-band, parallel to markdown/json/yaml.
+
+    (let FORM-LIST   (make_nodeid 1 2 99 30))   ; an S-expression list
+    (let FORM-IDENT  (make_nodeid 1 2 99 31))   ; an identifier atom
+
+    ;; --- char predicates ------------------------------------------
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    (defn is-ws-cp (cp)
+        (or (eq cp 32) (or (eq cp 9) (or (eq cp 10) (eq cp 13)))))
+
+    (defn is-digit-cp (cp) (and (ge cp 48) (le cp 57)))
+    (defn is-paren-cp (cp) (or (eq cp 40) (eq cp 41)))
+
+    (defn is-atom-cont-cp (cp)
+        ;; Identifiers continue until ws, paren, quote, or semicolon.
+        (and (not-cp-is cp 32) (and (not-cp-is cp 9)
+        (and (not-cp-is cp 10) (and (not-cp-is cp 13)
+        (and (not-cp-is cp 40) (and (not-cp-is cp 41)
+        (and (not-cp-is cp 34) (not-cp-is cp 59)))))))))
+
+    (defn not-cp-is (a b) (if (eq a b) false true))
+
+    ;; --- line-aware position helpers ------------------------------
+    ;; Walks the source byte-by-byte tracking (line, col) as it goes.
+    ;; Token positions are recorded for source attribution.
+
+    (defn count-line (s i target)
+        (count-line-loop s 0 target 1))
+
+    (defn count-line-loop (s i target line)
+        (if (ge i target) line
+            (if (eq (ord (char_at s i)) 10)
+                (count-line-loop s (add i 1) target (add line 1))
+                (count-line-loop s (add i 1) target line))))
+
+    (defn count-col (s i target)
+        ;; col = chars since previous newline (or BOF).
+        (count-col-loop s 0 target 1))
+
+    (defn count-col-loop (s i target col)
+        (if (ge i target) col
+            (if (eq (ord (char_at s i)) 10)
+                (count-col-loop s (add i 1) target 1)
+                (count-col-loop s (add i 1) target (add col 1)))))
+
+    ;; --- skip whitespace + comments ------------------------------
+
+    (defn skip-ws-comments (s i)
+        (if (eq i (str_len s)) i
+            (do
+                (let cp (ord (char_at s i)))
+                (if (is-ws-cp cp)
+                    (skip-ws-comments s (add i 1))
+                    (if (eq cp 59)   ; ';'
+                        (skip-ws-comments s (skip-comment s i))
+                        i)))))
+
+    (defn skip-comment (s i)
+        (if (eq i (str_len s)) i
+            (if (eq (ord (char_at s i)) 10)
+                (add i 1)
+                (skip-comment s (add i 1)))))
+
+    ;; --- atom scanning -------------------------------------------
+
+    (defn scan-atom-end (s i)
+        ;; Walk until non-atom char.
+        (if (eq i (str_len s)) i
+            (if (is-atom-cont-cp (ord (char_at s i)))
+                (scan-atom-end s (add i 1))
+                i)))
+
+    (defn scan-string-end (s i)
+        ;; Walks from i+1 (past opening quote) to closing quote.
+        (if (eq i (str_len s)) i
+            (if (eq (ord (char_at s i)) 34)   ; closing '"'
+                (add i 1)
+                (if (and (eq (ord (char_at s i)) 92)   ; '\' escape
+                         (lt (add i 1) (str_len s)))
+                    (scan-string-end s (add i 2))
+                    (scan-string-end s (add i 1))))))
+
+    (defn is-int-atom? (s start end)
+        ;; Returns true if substring is all digits (with optional leading -).
+        (if (eq start end) false
+            (do
+                (let first (ord (char_at s start)))
+                (let body-start (if (eq first 45) (add start 1) start))
+                (and (lt body-start end)
+                     (all-digits? s body-start end)))))
+
+    (defn all-digits? (s i end)
+        (if (eq i end) true
+            (if (is-digit-cp (ord (char_at s i)))
+                (all-digits? s (add i 1) end)
+                false)))
+
+    ;; --- mk-pair helpers for (recipe, next-i) returns -------------
+
+    (defn mk-pair (r i) (list r i))
+    (defn pair-r (p) (head p))
+    (defn pair-i (p) (head (tail p)))
+
+    ;; --- recursive descent ---------------------------------------
+
+    (defn parse-expr (s i source-path)
+        (do
+            (let i (skip-ws-comments s i))
+            (if (eq i (str_len s))
+                (mk-pair (intern_trivial_int 0) i)   ; EOF sentinel
+                (do
+                    (let cp (ord (char_at s i)))
+                    (if (eq cp 40)   ; '(' — list
+                        (parse-list s (add i 1) source-path i)
+                        (if (eq cp 34)   ; '"' — string
+                            (parse-string s i source-path)
+                            (parse-atom s i source-path)))))))
+
+    (defn parse-list (s i source-path open-pos)
+        (do
+            (let line-no (count-line s 0 open-pos))
+            (let col-no  (count-col  s 0 open-pos))
+            (parse-list-elements s i source-path line-no col-no (empty))))
+
+    (defn parse-list-elements (s i source-path line col acc)
+        (do
+            (let i (skip-ws-comments s i))
+            (if (eq i (str_len s))
+                ;; unclosed list — return what we have
+                (mk-pair (intern_node_at FORM-LIST (reverse-acc acc) source-path line col) i)
+                (if (eq (ord (char_at s i)) 41)   ; ')'
+                    (mk-pair (intern_node_at FORM-LIST (reverse-acc acc) source-path line col)
+                             (add i 1))
+                    (do
+                        (let pair (parse-expr s i source-path))
+                        (parse-list-elements s (pair-i pair) source-path line col
+                                              (cons (pair-r pair) acc)))))))
+
+    (defn parse-string (s i source-path)
+        (do
+            (let end (scan-string-end s (add i 1)))
+            (let content (substr s (add i 1) (sub end 1)))
+            (mk-pair (intern_trivial_string content) end)))
+
+    (defn parse-atom (s i source-path)
+        (do
+            (let end (scan-atom-end s i))
+            (let text (substr s i end))
+            (if (is-int-atom? s i end)
+                (mk-pair (intern_trivial_int (str_to_int text)) end)
+                (do
+                    (let line-no (count-line s 0 i))
+                    (let col-no  (count-col  s 0 i))
+                    (mk-pair (intern_node_at FORM-IDENT
+                                              (list (intern_trivial_string text))
+                                              source-path line-no col-no)
+                              end)))))
+
+    (defn reverse-acc (xs) (foldl rev-step (empty) xs))
+    (defn rev-step (acc x) (cons x acc))
+
+    ;; --- top-level entry -----------------------------------------
+
+    (defn parse-form (source-path text)
+        (parse-form-loop text 0 source-path (empty)))
+
+    (defn parse-form-loop (s i source-path acc)
+        (do
+            (let i (skip-ws-comments s i))
+            (if (eq i (str_len s))
+                (reverse-acc acc)
+                (do
+                    (let pair (parse-expr s i source-path))
+                    (parse-form-loop s (pair-i pair) source-path
+                                      (cons (pair-r pair) acc))))))
+)

--- a/experiments/form-stdlib/grammars/python.fk
+++ b/experiments/form-stdlib/grammars/python.fk
@@ -1,0 +1,243 @@
+; grammars/python.fk — Python parser in pure Form (file-header subset)
+;
+; The compost target: experiments/local-llm-cell-v0/bmf.py (643 lines
+; of Python bootstrap that handles `import` and `from-import` only).
+; Once this grammar reaches parity with bmf.py + a small useful
+; extension, bmf.py composts.
+;
+; Subset supported in this breath (the patterns most common at the top
+; of .py files in this repo):
+;   - import x
+;   - import x as y
+;   - from m import a, b
+;   - from m import a as alias
+;   - from . import x
+;   - def NAME(...):    (header only; body parsing is a later breath)
+;   - NAME = expr       (simple assignment; expr is a single literal or ident)
+;   - blank lines and # comments
+;
+; Skipped this breath (extend as separate breaths):
+;   - class definitions
+;   - control flow (if/while/for/try)
+;   - full expression grammar with precedence
+;   - decorators
+;   - comprehensions, lambdas, walrus
+;   - multi-statement function bodies (needs indent-aware tokenizer)
+;
+; Every emitted Recipe carries source attribution via intern_node_at —
+; cell-trace walks any Python-derived cell back to its line.
+
+(do
+    ;; --- universal python-source category NodeIDs -----------------
+    ;; Numeric type=99 doc-band, parallel to markdown/json/yaml/form.
+
+    (let PY-MODULE      (make_nodeid 1 2 99 40))   ; root module: sequence of statements
+    (let PY-IMPORT      (make_nodeid 1 2 99 41))   ; (module-name, asname)
+    (let PY-FROM-IMPORT (make_nodeid 1 2 99 42))   ; (module, [names])
+    (let PY-FUNCTION-DEF (make_nodeid 1 2 99 43))  ; (name, params)
+    (let PY-ASSIGN      (make_nodeid 1 2 99 44))   ; (target, value)
+    (let PY-IDENT       (make_nodeid 1 2 99 45))   ; an identifier reference
+    (let PY-NAME-PAIR   (make_nodeid 1 2 99 46))   ; (name, asname) for import lists
+
+    ;; --- line helpers (shared shape with markdown.fk / yaml.fk) ---
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    (defn lines-from-source (s)
+        (lines-loop s 0 0 1 (empty)))
+
+    (defn lines-loop (s i start line acc)
+        (if (eq i (str_len s))
+            (if (gt i start)
+                (reverse-acc (cons (list (substr s start i) line) acc))
+                (reverse-acc acc))
+            (if (eq (ord (char_at s i)) 10)
+                (lines-loop s (add i 1) (add i 1) (add line 1)
+                            (cons (list (substr s start i) line) acc))
+                (lines-loop s (add i 1) start line acc))))
+
+    (defn reverse-acc (xs) (foldl rev-step (empty) xs))
+    (defn rev-step (acc x) (cons x acc))
+
+    (defn line-text (ln) (head ln))
+    (defn line-num  (ln) (head (tail ln)))
+
+    (defn is-ws-cp (cp)
+        (or (eq cp 32) (or (eq cp 9) (or (eq cp 10) (eq cp 13)))))
+
+    (defn trim-leading-ws (s)
+        (if (eq (str_len s) 0) s
+            (if (is-ws-cp (ord (char_at s 0)))
+                (trim-leading-ws (substr s 1 (str_len s)))
+                s)))
+
+    (defn trim-trailing-ws (s)
+        (if (eq (str_len s) 0) s
+            (if (is-ws-cp (ord (char_at s (sub (str_len s) 1))))
+                (trim-trailing-ws (substr s 0 (sub (str_len s) 1)))
+                s)))
+
+    (defn trim (s) (trim-leading-ws (trim-trailing-ws s)))
+
+    (defn is-blank? (text) (eq (str_len (trim text)) 0))
+
+    (defn is-comment? (text)
+        (do
+            (let trimmed (trim-leading-ws text))
+            (if (eq (str_len trimmed) 0) false
+                (eq (ord (char_at trimmed 0)) 35))))
+
+    ;; --- prefix detection -----------------------------------------
+
+    (defn starts-with? (text prefix)
+        (if (lt (str_len text) (str_len prefix)) false
+            (str_eq (substr text 0 (str_len prefix)) prefix)))
+
+    (defn starts-with-keyword? (text kw)
+        ;; "kw " or "kw\t" at start (followed by space/tab).
+        (and (starts-with? text kw)
+             (and (gt (str_len text) (str_len kw))
+                  (is-ws-cp (ord (char_at text (str_len kw)))))))
+
+    ;; --- find-substring -------------------------------------------
+
+    (defn find-from (s needle start)
+        (find-loop s needle start))
+
+    (defn find-loop (s needle i)
+        (if (gt (add i (str_len needle)) (str_len s)) (sub 0 1)
+            (if (str_eq (substr s i (add i (str_len needle))) needle) i
+                (find-loop s needle (add i 1)))))
+
+    ;; --- split-on-substring (returns list of pieces) --------------
+
+    (defn split-on (s sep)
+        (split-on-loop s sep 0 (empty)))
+
+    (defn split-on-loop (s sep i acc)
+        (do
+            (let pos (find-from s sep i))
+            (if (lt pos 0)
+                (reverse-acc (cons (substr s i (str_len s)) acc))
+                (split-on-loop s sep (add pos (str_len sep))
+                                (cons (substr s i pos) acc)))))
+
+    ;; --- parse-import: `import x` or `import x as y` --------------
+    ;; (Single import per line; multi-name `import a, b` could extend.)
+
+    (defn parse-import (text line-no source-path)
+        (do
+            (let rest (trim (substr text 6 (str_len text))))   ; strip "import"
+            (let as-pos (find-from rest " as " 0))
+            (if (lt as-pos 0)
+                (intern_node_at PY-IMPORT
+                                (list (intern_trivial_string rest)
+                                      (intern_trivial_string ""))
+                                source-path line-no 1)
+                (intern_node_at PY-IMPORT
+                                (list (intern_trivial_string (trim (substr rest 0 as-pos)))
+                                      (intern_trivial_string (trim (substr rest (add as-pos 4) (str_len rest)))))
+                                source-path line-no 1))))
+
+    ;; --- parse-from-import: `from m import a, b` -----------------
+
+    (defn parse-from-import (text line-no source-path)
+        (do
+            (let after-from (trim (substr text 4 (str_len text))))
+            (let import-pos (find-from after-from " import " 0))
+            (if (lt import-pos 0)
+                ;; Malformed: emit just the module
+                (intern_node_at PY-FROM-IMPORT
+                                (list (intern_trivial_string after-from)
+                                      (intern_trivial_string ""))
+                                source-path line-no 1)
+                (do
+                    (let module (trim (substr after-from 0 import-pos)))
+                    (let names-text (trim (substr after-from (add import-pos 8) (str_len after-from))))
+                    (let name-pieces (split-on names-text ","))
+                    (let name-cells (map-name-pieces name-pieces source-path line-no))
+                    (intern_node_at PY-FROM-IMPORT
+                                    (cons (intern_trivial_string module) name-cells)
+                                    source-path line-no 1)))))
+
+    (defn map-name-pieces (pieces source-path line-no)
+        (if (nil? pieces) (empty)
+            (cons (parse-name-piece (trim (head pieces)) source-path line-no)
+                  (map-name-pieces (tail pieces) source-path line-no))))
+
+    (defn parse-name-piece (text source-path line-no)
+        (do
+            (let as-pos (find-from text " as " 0))
+            (if (lt as-pos 0)
+                (intern_node_at PY-NAME-PAIR
+                                (list (intern_trivial_string text)
+                                      (intern_trivial_string ""))
+                                source-path line-no 1)
+                (intern_node_at PY-NAME-PAIR
+                                (list (intern_trivial_string (trim (substr text 0 as-pos)))
+                                      (intern_trivial_string (trim (substr text (add as-pos 4) (str_len text)))))
+                                source-path line-no 1))))
+
+    ;; --- parse-def-header: `def name(args):` ---------------------
+
+    (defn parse-def-header (text line-no source-path)
+        (do
+            (let after-def (trim (substr text 4 (str_len text))))
+            (let open-paren (find-from after-def "(" 0))
+            (let close-paren (find-from after-def ")" 0))
+            (if (or (lt open-paren 0) (lt close-paren 0))
+                ;; Malformed
+                (intern_node_at PY-FUNCTION-DEF
+                                (list (intern_trivial_string after-def)
+                                      (intern_trivial_string ""))
+                                source-path line-no 1)
+                (intern_node_at PY-FUNCTION-DEF
+                                (list (intern_trivial_string (trim (substr after-def 0 open-paren)))
+                                      (intern_trivial_string (trim (substr after-def (add open-paren 1) close-paren))))
+                                source-path line-no 1))))
+
+    ;; --- parse-assign: `name = value` (simple, single-line) -------
+
+    (defn parse-assign (text line-no source-path)
+        (do
+            (let eq-pos (find-from text "=" 0))
+            (if (lt eq-pos 0)
+                (intern_trivial_string text)
+                (intern_node_at PY-ASSIGN
+                                (list (intern_trivial_string (trim (substr text 0 eq-pos)))
+                                      (intern_trivial_string (trim (substr text (add eq-pos 1) (str_len text)))))
+                                source-path line-no 1))))
+
+    ;; --- block dispatch ------------------------------------------
+
+    (defn parse-block (ln source-path)
+        (do
+            (let text (line-text ln))
+            (let line-no (line-num ln))
+            (let trimmed (trim-leading-ws text))
+            (if (starts-with-keyword? trimmed "import")
+                (parse-import trimmed line-no source-path)
+                (if (starts-with-keyword? trimmed "from")
+                    (parse-from-import trimmed line-no source-path)
+                    (if (starts-with-keyword? trimmed "def")
+                        (parse-def-header trimmed line-no source-path)
+                        (parse-assign trimmed line-no source-path))))))
+
+    (defn parse-blocks (lines source-path acc)
+        (if (nil? lines) (reverse-acc acc)
+            (do
+                (let ln (head lines))
+                (let text (line-text ln))
+                (if (or (is-blank? text) (is-comment? text))
+                    (parse-blocks (tail lines) source-path acc)
+                    (parse-blocks (tail lines) source-path
+                                  (cons (parse-block ln source-path) acc))))))
+
+    (defn parse-python (source-path text)
+        (do
+            (let lines (lines-from-source text))
+            (let blocks (parse-blocks lines source-path (empty)))
+            (intern_node_at PY-MODULE blocks source-path 1 1)))
+)

--- a/experiments/form-stdlib/tests/form.fk
+++ b/experiments/form-stdlib/tests/form.fk
@@ -1,0 +1,37 @@
+; tests/form.fk — exercise form.fk S-expression parser end-to-end
+;
+; The self-host probe: parse small .fk fragments into Recipe trees
+; without going through the kernel's bootstrap reader.
+
+(do
+    (let sample
+        (str_concat "(add 2 3) "
+        (str_concat "; this is a comment
+" "(defn double (x) (mul x 2))")))
+
+    (let exprs (parse-form "demo.fk" sample))
+
+    ;; --- probe 1: two top-level expressions parsed ----------------
+    (let probe-1 (len exprs))                              ; → 2
+
+    ;; --- probe 2: first expression is a list ----------------------
+    (let first-expr (head exprs))
+    (let first-kids (node_children first-expr))
+    (let probe-2 (len first-kids))                         ; → 3 (add, 2, 3)
+
+    ;; --- probe 3: first child of first list is the ident "add" ----
+    (let add-ident (head first-kids))
+    (let ident-kids (node_children add-ident))
+    (let probe-3 (len ident-kids))                         ; → 1 (ident has one child: the name trivial)
+
+    ;; --- probe 4: source attribution recorded on first list -------
+    ;; demo.fk:1:1 → 10 chars
+    (let probe-4 (str_len (cell-source first-expr)))       ; → 10
+
+    ;; --- probe 5: second expression is the defn (5 children: defn, name, args-list, body-list)
+    (let defn-expr (head (tail exprs)))
+    (let defn-kids (node_children defn-expr))
+    (let probe-5 (len defn-kids))                          ; → 4
+
+    ;; sum: 2 + 3 + 1 + 10 + 4 = 20
+    (add probe-1 (add probe-2 (add probe-3 (add probe-4 probe-5)))))

--- a/experiments/form-stdlib/tests/python.fk
+++ b/experiments/form-stdlib/tests/python.fk
@@ -1,0 +1,34 @@
+; tests/python.fk — exercise python.fk file-header subset
+;
+; Loaded via:
+;   bin-go core.fk cell-trace.fk grammars/python.fk tests/python.fk
+
+(do
+    (let sample
+        (str_concat "import os
+" (str_concat "import sys as system
+" (str_concat "from typing import List, Optional
+" (str_concat "# comment
+" (str_concat "
+" (str_concat "def parse_file(path, mode):
+" "config = True")))))))
+
+    (let module (parse-python "demo.py" sample))
+
+    ;; --- probe 1: module has children -----------------------------
+    (let kids (node_children module))
+    (let probe-1 (len kids))                              ; → 5 (3 imports + 1 def + 1 assign)
+
+    ;; --- probe 2: all children attributed -------------------------
+    (defn count-attributed (xs)
+        (if (nil? xs) 0
+            (if (str_eq (cell-source (head xs)) "")
+                (count-attributed (tail xs))
+                (add 1 (count-attributed (tail xs))))))
+    (let probe-2 (count-attributed kids))                 ; → 5
+
+    ;; --- probe 3: module attributed -------------------------------
+    (let probe-3 (str_len (cell-source module)))          ; → length "demo.py:1:1" = 11
+
+    ;; sum: 5 + 5 + 11 = 21
+    (add probe-1 (add probe-2 probe-3)))


### PR DESCRIPTION
Python parser supporting imports + def-headers + assignments + comments. Sibling-verified Go+Rust at sum 21.

**Compost path:** Once expression + control flow extends this grammar, `experiments/local-llm-cell-v0/bmf.py` (643 lines) and `experiments/form-kernel-ts/src/lang-python.ts` (2127 lines) compost.

Bundled: INDEX entry for grammars/form.fk (missed in PR #1815).

🤖 Generated with [Claude Code](https://claude.com/claude-code)