### PR TITLE
tend: line-grammar.fk digest — shared helpers extracted from 8 grammars

### DIFF
--- a/experiments/form-stdlib/line-grammar.fk
+++ b/experiments/form-stdlib/line-grammar.fk
@@ -1,0 +1,158 @@
+; line-grammar.fk — the shared helpers every line-based grammar reaches for
+;
+; Digested from 6 file-header grammars (markdown.fk, json.fk, yaml.fk,
+; python.fk, typescript.fk, rust.fk, go.fk) shipped Oct 2026-05-21
+; through 2026-05-22 morning. Each grammar duplicated ~50 lines of
+; lines-from-source / trim / is-blank? / find-from / split-on / etc.
+; Extracted here so the grammars become thin: just their unique
+; dispatch + emission logic.
+;
+; What the digest revealed:
+;   1. Line-based parsing is the dominant pattern for text formats —
+;      tokens are lines, not individual characters.
+;   2. The numeric type=99 doc-band emerged organically and works.
+;   3. Source attribution flows through every grammar without resistance
+;      (intern_node_at on every line-derived Recipe).
+;   4. Comment styles vary (// for ts/rust/go, # for python/yaml, ; for
+;      form) but the SHAPE is identical: "trim leading ws, check first
+;      char". Each grammar defines its own is-comment? via the shared
+;      starts-with? / char_at primitives — no parameterization needed.
+;   5. The form .fk language is sufficient for all 8 grammars without
+;      needing any kernel extensions beyond intern_node_at + node_eq.
+;
+; This file lives at form-stdlib/line-grammar.fk (one level above
+; grammars/) so all per-tongue grammars can load it as a shared layer
+; between core.fk and the grammar itself.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; string slicing
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; character predicates (codepoint-level)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn is-ws-cp (cp)
+        (or (eq cp 32) (or (eq cp 9) (or (eq cp 10) (eq cp 13)))))
+
+    (defn is-digit-cp (cp) (and (ge cp 48) (le cp 57)))
+
+    (defn is-alpha-cp (cp)
+        (or (and (ge cp 65) (le cp 90))
+            (or (and (ge cp 97) (le cp 122))
+                (eq cp 95))))
+
+    (defn is-ident-cont-cp (cp)
+        (or (is-alpha-cp cp) (is-digit-cp cp)))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; whitespace trimming
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn trim-leading-ws (s)
+        (if (eq (str_len s) 0) s
+            (if (is-ws-cp (ord (char_at s 0)))
+                (trim-leading-ws (substr s 1 (str_len s)))
+                s)))
+
+    (defn trim-trailing-ws (s)
+        (if (eq (str_len s) 0) s
+            (if (is-ws-cp (ord (char_at s (sub (str_len s) 1))))
+                (trim-trailing-ws (substr s 0 (sub (str_len s) 1)))
+                s)))
+
+    (defn trim (s) (trim-leading-ws (trim-trailing-ws s)))
+
+    (defn is-blank? (text) (eq (str_len (trim text)) 0))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; lines-from-source: byte stream → list of (text, line-num) pairs
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Splits on \n. The newline char itself is not included in the
+    ;; resulting line text. Line numbers are 1-indexed. A trailing
+    ;; newline produces no extra empty line; a source without trailing
+    ;; newline still emits its final partial line.
+
+    (defn rev-step (acc x) (cons x acc))
+    (defn reverse-acc (xs) (foldl rev-step (empty) xs))
+
+    (defn lines-from-source (s)
+        (lines-loop s 0 0 1 (empty)))
+
+    (defn lines-loop (s i start line acc)
+        (if (eq i (str_len s))
+            (if (gt i start)
+                (reverse-acc (cons (list (substr s start i) line) acc))
+                (reverse-acc acc))
+            (if (eq (ord (char_at s i)) 10)
+                (lines-loop s (add i 1) (add i 1) (add line 1)
+                            (cons (list (substr s start i) line) acc))
+                (lines-loop s (add i 1) start line acc))))
+
+    (defn line-text (ln) (head ln))
+    (defn line-num  (ln) (head (tail ln)))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; prefix detection
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn starts-with? (text prefix)
+        (if (lt (str_len text) (str_len prefix)) false
+            (str_eq (substr text 0 (str_len prefix)) prefix)))
+
+    ;; starts-with-keyword? — like starts-with? but requires that the
+    ;; character immediately after the prefix is whitespace, so we don't
+    ;; match `funky` as starting-with-keyword `fun`. Returns false if
+    ;; the prefix exactly equals the whole text (no separator).
+    (defn starts-with-keyword? (text kw)
+        (and (starts-with? text kw)
+             (and (gt (str_len text) (str_len kw))
+                  (is-ws-cp (ord (char_at text (str_len kw)))))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; substring search
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn find-from (s needle start)
+        (find-loop s needle start))
+
+    (defn find-loop (s needle i)
+        (if (gt (add i (str_len needle)) (str_len s)) (sub 0 1)
+            (if (str_eq (substr s i (add i (str_len needle))) needle) i
+                (find-loop s needle (add i 1)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; split on substring
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Splits text on every occurrence of sep. Empty leading/trailing
+    ;; pieces are preserved (matches Python's str.split semantics).
+
+    (defn split-on (s sep)
+        (split-on-loop s sep 0 (empty)))
+
+    (defn split-on-loop (s sep i acc)
+        (do
+            (let pos (find-from s sep i))
+            (if (lt pos 0)
+                (reverse-acc (cons (substr s i (str_len s)) acc))
+                (split-on-loop s sep (add pos (str_len sep))
+                                (cons (substr s i pos) acc)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; pick-min: smallest non-negative value, with fallback
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Used by grammars to find the earliest of multiple delimiters
+    ;; (e.g. "where does this identifier end? at the first space or
+    ;; brace, whichever comes first").
+
+    (defn pick-min (a b fallback)
+        (if (lt a 0)
+            (if (lt b 0) fallback b)
+            (if (lt b 0) a
+                (if (lt a b) a b))))
+)

--- a/experiments/form-stdlib/tests/line-grammar.fk
+++ b/experiments/form-stdlib/tests/line-grammar.fk
@@ -1,0 +1,71 @@
+; tests/line-grammar.fk — exercise the shared line-grammar helpers with
+; the strangest minimal fixture that covers the most boundaries.
+;
+; The user's teaching (2026-05-22): "for testing, think of the simplest
+; most strange edge case that can cover most boundary conditions in
+; the most simple expression."
+;
+; The fixture chosen: "  ,  \n\n,abc,\n" (12 characters).
+;
+; What this single fixture exercises:
+;   - lines-from-source: 4 lines including blank-in-middle, leading ws,
+;     and trailing newline (which produces no extra empty line)
+;   - line-num counting at line-1 / line-2 / line-3 boundaries
+;   - trim: "  ,  " → "," (strips both ends)
+;   - is-blank?: line 2 ("") returns true; line 1 ("  ,  ") returns false
+;     despite all-whitespace-except-one-comma
+;   - find-from: locate "abc" inside ",abc," at position 1
+;   - split-on: ",abc," split on "," yields ["", "abc", ""] (empty
+;     leading + trailing pieces preserved)
+;   - starts-with?: ",abc," starts-with "," is true; starts-with "x" false
+;
+; Probes sum a single number per sibling kernel. Identical sums = parity.
+
+(do
+    (let strange "  ,  \n\n,abc,\n")
+
+    ;; --- probe 1: lines-from-source count -------------------------
+    (let lines (lines-from-source strange))
+    (let probe-1 (len lines))                              ; → 3 ("  ,  ", "", ",abc,")
+
+    ;; --- probe 2: trim removes whitespace from line 1 -------------
+    ;; Line 1 is "  ,  " (5 chars). trim → "," (1 char).
+    (let line-1 (line-text (head lines)))
+    (let probe-2 (str_len (trim line-1)))                  ; → 1
+
+    ;; --- probe 3: line 2 is blank (after trim) --------------------
+    (let line-2 (line-text (head (tail lines))))
+    (let probe-3 (if (is-blank? line-2) 7 0))              ; → 7 (chose a distinctive value)
+
+    ;; --- probe 4: find "abc" inside line 3 ------------------------
+    (let line-3 (line-text (head (tail (tail lines)))))
+    (let probe-4 (find-from line-3 "abc" 0))               ; → 1 (position of 'a' in ",abc,")
+
+    ;; --- probe 5: split-on "," yields 3 pieces --------------------
+    ;; ",abc," → ["", "abc", ""] = 3 elements
+    (let pieces (split-on line-3 ","))
+    (let probe-5 (len pieces))                             ; → 3
+
+    ;; --- probe 6: starts-with? boundary ---------------------------
+    ;; ",abc," starts-with "," is true (probe value 11)
+    (let probe-6 (if (starts-with? line-3 ",") 11 0))     ; → 11
+
+    ;; --- probe 7: starts-with-keyword? requires separator ---------
+    ;; "abc" starts-with-keyword? "abc" → false (no char after kw)
+    (let probe-7 (if (starts-with-keyword? "abc" "abc") 0 13))  ; → 13
+
+    ;; --- probe 8: pick-min picks smallest non-negative ------------
+    (let probe-8 (pick-min 5 2 99))                        ; → 2
+    (let probe-9 (pick-min -1 7 99))                       ; → 7
+    (let probe-10 (pick-min -1 -1 99))                     ; → 99
+
+    ;; sum: 3 + 1 + 7 + 1 + 3 + 11 + 13 + 2 + 7 + 99 = 147
+    (add probe-1
+    (add probe-2
+    (add probe-3
+    (add probe-4
+    (add probe-5
+    (add probe-6
+    (add probe-7
+    (add probe-8
+    (add probe-9 probe-10))))))))))


### PR DESCRIPTION
**Digest breath** — after 8 file-header grammars in a row, the duplication wanted extraction. ~135 lines of shared helpers, used by every line-based grammar, now lives one level above form-stdlib/grammars/.

**Strange-minimal test:** fixture `"  ,  \n\n,abc,\n"` (12 characters) probes 10 boundary conditions through 8 helpers in one expression. Sum 147 on Go AND Rust.

**What the digest revealed:**
1. Line-based parsing dominates text formats
2. Numeric type=99 doc-band emerged organically and works
3. Source attribution flows through every grammar without resistance
4. Comment styles vary but SHAPE is identical — no parameterization needed
5. .fk is sufficient for all 8 grammars (only intern_node_at + node_eq added to kernel)
6. ~50 lines × 5 file-header grammars = ~250 lines of duplication this extraction will collapse

Each subsequent breath will be DIFFERENT — refactor an existing grammar to use this, ship png.fk binary (different tokenization model), compost a composable kernel native, or wire form.fk into the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)