### PR TITLE
compost: remove sum native from kernel (first of 9 composable composts)

### DIFF
--- a/docs/coherence-substrate/kernel-minimality-audit.md
+++ b/docs/coherence-substrate/kernel-minimality-audit.md
@@ -50,7 +50,7 @@ recipes are fully typed with hardware types.* — Urs, 2026-05-22 night.
 | `len` | Recursive: `(defn len (xs) (if (nil? xs) 0 (add 1 (len (tail xs)))))` |
 | `nth` | Recursive: `(defn nth (xs n) (if (eq n 0) (head xs) (nth (tail xs) (sub n 1))))` |
 | `range` | Recursive: `(defn range (a b) (if (ge a b) (empty) (cons a (range (add a 1) b))))` |
-| `sum` | Foldl: `(defn sum (xs) (foldl plus 0 xs))` — already in core.fk |
+| ~~`sum`~~ | **COMPOSTED 2026-05-22** — core.fk's `(defn sum (xs) (foldl plus 0 xs))` covers it; lists.fk/higher.fk/numeric.fk tests verified sibling-parity-identical (220/53/208) after removal |
 | `min` | Foldl: `(defn min (xs) (foldl min2 (head xs) (tail xs)))` |
 | `max` | Foldl: `(defn max (xs) (foldl max2 (head xs) (tail xs)))` |
 | `abs` | Conditional: `(defn abs (n) (if (negative? n) (sub 0 n) n))` — already in core.fk |

--- a/experiments/form-kernel-go/main.go
+++ b/experiments/form-kernel-go/main.go
@@ -690,14 +690,10 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VInt, Int: args[0].Int}
 	})
-	k.registerNative("sum", catMethod(), func(_ *Kernel, args []Value) Value {
-		if args[0].Kind == VList {
-			var total int64
-			for _, v := range args[0].List { total += v.Int }
-			return Value{Kind: VInt, Int: total}
-		}
-		return Value{Kind: VInt, Int: 0}
-	})
+	// `sum` composted from the kernel native list 2026-05-22 —
+	// core.fk's (defn sum (xs) (foldl plus 0 xs)) covers it via the
+	// existing foldl + plus primitives. First of 9 composable natives
+	// named in kernel-minimality-audit.md.
 	k.registerNative("abs", catMethod(), func(_ *Kernel, args []Value) Value {
 		n := args[0].Int
 		if n < 0 { n = -n }

--- a/experiments/form-kernel-rust/src/main.rs
+++ b/experiments/form-kernel-rust/src/main.rs
@@ -656,14 +656,11 @@ impl Kernel {
             }
             Value::Int(args[0].as_int())
         });
-        self.register_native("sum", cat_method(), |_, _, args| {
-            if let Value::List(xs) = &args[0] {
-                let mut total: i64 = 0;
-                for v in xs { total += v.as_int(); }
-                return Value::Int(total);
-            }
-            Value::Int(0)
-        });
+        // `sum` composted from the kernel native list 2026-05-22 —
+        // core.fk's `(defn sum (xs) (foldl plus 0 xs))` covers it
+        // via the existing `foldl` + `plus` primitives. Kernel
+        // minimality audit (kernel-minimality-audit.md) named this
+        // one of 9 composable natives; this is the first compost.
         self.register_native("abs", cat_method(), |_, _, args| {
             let n = args[0].as_int();
             Value::Int(if n < 0 { -n } else { n })


### PR DESCRIPTION
**Different breath, inside-out.** After eight grammars + one digest, this breath moves to the innermost layer: compost a composable kernel native.

`sum` removed from both Go and Rust kernel native lists. core.fk's `(defn sum (xs) (foldl plus 0 xs))` covers it.

**Strange-minimal test:** the existing test suite IS the probe. If the kernel removal is safe, unchanged tests pass identically. Sibling-verified Go AND Rust:
- lists.fk: 220 → 220
- higher.fk: 53 → 53
- numeric.fk: 208 → 208

The kernel goes from 25 → 24 truly-primitive natives. 8 more composable composts remain (len, nth, range, min, max, abs, substring, _plus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)