### PR TITLE
tend: cell-stream.fk — blocks of input → native cells (the metabolic frame)

### DIFF
--- a/experiments/form-stdlib/cell-stream.fk
+++ b/experiments/form-stdlib/cell-stream.fk
@@ -1,0 +1,124 @@
+; cell-stream.fk — blocks of input → stream of native cells
+;
+; Urs's vision (2026-05-22): "find similar patterns to convert blocks
+; of input into form cells, that allows for streaming input to native
+; cells, and native cells can be observed, analyzed, traced, transmuted,
+; be nutrition, information, a parasite to be eaten and released, full
+; flexibility once we have cells streaming."
+;
+; The pattern recurs across input types — CSV rows, HTTP requests,
+; log lines, audio frames, WebSocket messages, git commits, db rows,
+; LLM tokens, sensor readings, PNG chunks, markdown blocks. Each one:
+;
+;   1. segment: locate the next block boundary in the input stream
+;   2. parse: extract fields from the block content
+;   3. compose: wrap fields as composed Recipe with Blueprint identity
+;   4. intern: enter the substrate (returns NodeID; content-addressed,
+;      so repeat-blocks collapse to the same cell)
+;   5. attribute: source location stamped via intern_node_at
+;   6. emit: NodeID flows into the downstream stream
+;
+; The only variation across input types is (1) the segmenter and (2)
+; the field encoder. Steps 3-6 are universal. This file provides the
+; universal frame; per-format adapters supply segmenter + encoder as
+; data. ONE engine, every input shape.
+;
+; Once cells are in the stream, downstream recipes can:
+;   - **observe**: subscribe + read; no mutation. Cell becomes signal.
+;   - **analyze**: aggregate / count / signature. Cell as evidence.
+;   - **trace**: walk cell-trace back to source line of emission.
+;   - **transmute**: produce a new cell with a different Blueprint
+;     while preserving content-addressed lineage to the source.
+;
+; The metabolic frame (Urs's words): a cell can be **nutrition** (fed
+; to a transmuter recipe), **information** (observed without consuming),
+; or a **parasite** (transient, no downstream re-reference → eventually
+; garbage-collected by the substrate's content-addressed deduplication).
+; The cell itself is universal; its role is determined by downstream.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 1 — pair-shaped result for segmenter return
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; A segmenter returns either:
+    ;;   (list "block" text next-pos line-no)  — one more block found
+    ;;   (list "eof")                          — stream exhausted
+    ;;
+    ;; The kind discriminator avoids needing a separate "is-eof?" call
+    ;; and matches the shape engine.fk / emit-engine.fk use for fail-
+    ;; vs-success sentinels.
+
+    (defn seg-kind (r) (head r))
+    (defn seg-text (r) (head (tail r)))
+    (defn seg-next (r) (head (tail (tail r))))
+    (defn seg-line (r) (head (tail (tail (tail r)))))
+
+    (defn mk-block (text next line) (list "block" text next line))
+    (defn mk-eof (_x)               (list "eof"))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 2 — stream-of-cells: the universal pipeline
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; (stream-of-cells input segmenter encoder source-path) → list of NodeIDs
+    ;;
+    ;; segmenter: (input pos) → seg-result
+    ;; encoder:   (block-text source-path line-no) → NodeID (interned cell)
+    ;;
+    ;; The engine walks the input via segmenter, invokes encoder per
+    ;; block, accumulates the emitted NodeIDs. In a true streaming
+    ;; runtime this would yield each cell lazily; the substrate's
+    ;; content-addressed intern means the cells are already "out
+    ;; there" once made — the list is just our handle to them.
+
+    (defn stream-of-cells (input segmenter encoder source-path)
+        (stream-loop input segmenter encoder source-path 0 (empty)))
+
+    (defn stream-loop (input segmenter encoder source-path pos acc)
+        (do
+            (let seg (segmenter input pos))
+            (if (str_eq (seg-kind seg) "eof")
+                (reverse-acc acc)
+                (do
+                    (let cell (encoder (seg-text seg) source-path (seg-line seg)))
+                    (stream-loop input segmenter encoder source-path
+                                  (seg-next seg) (cons cell acc))))))
+
+    (defn rev-step (acc x) (cons x acc))
+    (defn reverse-acc (xs) (foldl rev-step (empty) xs))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 3 — observe: read the stream without mutation
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; The simplest cell-as-information role: walk the stream, applying
+    ;; a side-effect-only observer to each cell. Returns the original
+    ;; stream untouched. Sibling of List.foreach.
+
+    (defn observe (cells observer)
+        (if (nil? cells) (empty)
+            (do
+                (observer (head cells))
+                (cons (head cells) (observe (tail cells) observer)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 4 — analyze: fold the stream into an aggregate
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Cell-as-evidence: aggregate signal across the stream. Returns
+    ;; the aggregate; the cells themselves remain in the substrate.
+
+    (defn analyze (cells init combine)
+        (if (nil? cells) init
+            (analyze (tail cells) (combine init (head cells)) combine)))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 5 — transmute: cell → new cell with different Blueprint
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Cell-as-nutrition: a transmuter recipe consumes each cell and
+    ;; emits a new cell (different Blueprint identity, same source
+    ;; lineage). The substrate's content-addressing means transmuted
+    ;; cells dedupe automatically across the stream.
+
+    (defn transmute (cells transmuter)
+        (if (nil? cells) (empty)
+            (cons (transmuter (head cells))
+                  (transmute (tail cells) transmuter))))
+)

--- a/experiments/form-stdlib/tests/cell-stream.fk
+++ b/experiments/form-stdlib/tests/cell-stream.fk
@@ -1,0 +1,181 @@
+; tests/cell-stream.fk — verify the streaming-cells abstraction across
+; two fundamentally different input shapes, then exercise observe +
+; analyze + transmute on the resulting stream.
+;
+; Strange-minimal fixture: ONE 9-character source `a,b,c|de|f`
+; processed two different ways:
+;
+;   1. As CSV-style line: split on `,` → 3 cell children (a, b, c | de | f)
+;      — wait, this won't segment naturally. Let me re-pick.
+;
+; Cleaner: TWO tiny fixtures driven through the SAME stream-of-cells
+; primitive with different (segmenter, encoder) pairs. The probe shows
+; ONE engine handles both newline-segmented text AND length-prefixed
+; binary-style — different input shapes, identical pipeline.
+;
+; Then for each stream: observe (count via side-effect), analyze
+; (accumulate via fold), transmute (emit new cells with new Blueprint).
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Universal cell categories for this test (numeric type=99 doc-band,
+    ;; instances 80+ to avoid clash with other grammar categories)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let CELL-LINE          (make_nodeid 1 2 99 80))   ; one text line
+    (let CELL-CHUNK         (make_nodeid 1 2 99 81))   ; one binary chunk
+    (let CELL-TRANSMUTED    (make_nodeid 1 2 99 82))   ; output of transmute
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Helpers (a subset of line-grammar.fk inlined to keep the test
+    ;; loadable without depending on that file yet)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Segmenter 1: NEWLINE-DELIMITED LINES
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; (input pos) → seg-result. Walks from pos until \n or EOF;
+    ;; returns the line text + position after the newline.
+    ;;
+    ;; Tracks current line number by counting newlines from BOF up to pos.
+
+    (defn count-newlines-to (s end)
+        (count-nl-loop s 0 end 1))
+
+    (defn count-nl-loop (s i end line)
+        (if (ge i end) line
+            (if (eq (ord (char_at s i)) 10)
+                (count-nl-loop s (add i 1) end (add line 1))
+                (count-nl-loop s (add i 1) end line))))
+
+    (defn line-segmenter (input pos)
+        (if (ge pos (str_len input))
+            (mk-eof 0)
+            (line-segment-loop input pos pos)))
+
+    (defn line-segment-loop (input start i)
+        (if (eq i (str_len input))
+            (mk-block (substr input start i) i
+                       (count-newlines-to input start))
+            (if (eq (ord (char_at input i)) 10)
+                (mk-block (substr input start i) (add i 1)
+                           (count-newlines-to input start))
+                (line-segment-loop input start (add i 1)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Segmenter 2: LENGTH-PREFIXED BINARY-STYLE CHUNKS
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Each chunk is a single decimal digit (length, 0-9) followed by
+    ;; that many data chars. Pure ASCII so the .fk reader doesn't fight us.
+    ;; "3abc2de1f" → chunks "abc", "de", "f".
+    ;;
+    ;; Line number for binary chunks: the chunk index (1-based).
+
+    (defn digit-to-int (c) (sub (ord c) 48))   ; ord('0') = 48
+
+    (defn chunk-segmenter (input pos)
+        (if (ge pos (str_len input))
+            (mk-eof 0)
+            (do
+                (let len (digit-to-int (char_at input pos)))
+                (let data-start (add pos 1))
+                (let data-end (add data-start len))
+                (mk-block (substr input data-start data-end) data-end
+                           (add pos 1)))))   ; "line" = chunk start position
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Encoder: block text → interned cell with the chosen category
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn line-encoder (block-text source-path line-no)
+        (intern_node_at CELL-LINE
+                         (list (intern_trivial_string block-text))
+                         source-path line-no 1))
+
+    (defn chunk-encoder (block-text source-path line-no)
+        (intern_node_at CELL-CHUNK
+                         (list (intern_trivial_string block-text))
+                         source-path line-no 1))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 1: line stream from "alpha\nbeta\ngamma"
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let line-source "alpha
+beta
+gamma")
+
+    (let line-cells (stream-of-cells line-source
+                                      line-segmenter line-encoder
+                                      "test.txt"))
+    (let probe-1 (len line-cells))                         ; → 3 cells
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 2: chunk stream from "3abc2de1f"
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let chunk-source "3abc2de1f")
+    (let chunk-cells (stream-of-cells chunk-source
+                                       chunk-segmenter chunk-encoder
+                                       "test.bin"))
+    (let probe-2 (len chunk-cells))                        ; → 3 cells
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 3: observe — side-effect walk, returns stream untouched.
+    ;; Uses int_to_str on cell-source as the "side effect" (print would
+    ;; pollute the test sum). Returns original stream length unchanged.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn null-observer (cell) cell)
+    (let observed (observe line-cells null-observer))
+    (let probe-3 (len observed))                           ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 4: analyze — fold the stream into an aggregate.
+    ;; Aggregate: count of cells whose first-child-string-length > 3.
+    ;; "alpha" (5), "beta" (4), "gamma" (5) → all three > 3 → result 3.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn first-child-len (cell)
+        (do
+            (let kids (node_children cell))
+            (if (nil? kids) 0
+                (str_len (node_value (head kids))))))
+
+    (defn count-long (acc cell)
+        (if (gt (first-child-len cell) 3) (add acc 1) acc))
+
+    (let probe-4 (analyze line-cells 0 count-long))        ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 5: transmute — each line-cell becomes a CELL-TRANSMUTED
+    ;; with the same content. The substrate's content-addressing
+    ;; dedupes identical transmuted-content cells automatically.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn line-to-transmuted (cell)
+        (do
+            (let kids (node_children cell))
+            (intern_node CELL-TRANSMUTED kids)))
+
+    (let transmuted (transmute line-cells line-to-transmuted))
+    (let probe-5 (len transmuted))                         ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 6: original cell carries source attribution
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let first-line-cell (head line-cells))
+    (let src (cell-source first-line-cell))
+    (let probe-6 (str_len src))                            ; → length "test.txt:1:1" = 12
+
+    ;; sum: 3 + 3 + 3 + 3 + 3 + 12 = 27
+    (add probe-1
+    (add probe-2
+    (add probe-3
+    (add probe-4
+    (add probe-5 probe-6))))))


### PR DESCRIPTION
**Urs's vision realized.** ONE primitive (`stream-of-cells`) converts any input stream to native cells in the substrate, parameterized by segmenter + encoder. Plus three metabolic verbs (`observe`, `analyze`, `transmute`) that operate on cell streams uniformly.

**Sibling parity at 27.** Two fundamentally different input shapes — newline-text `"alpha\nbeta\ngamma"` and length-prefixed-binary `"3abc2de1f"` — both produce 3 cells through the same primitive with different (segmenter, encoder) pairs.

**The metabolic frame:** cell as nutrition (fed to transmuter), information (observed), or parasite (transient, content-addressing dedupes). Cell is universal; role is downstream's choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)