### PR TITLE
tend: walk-stream + combine-handlers — push streaming for grammar rules

### DIFF
--- a/experiments/form-stdlib/cell-stream.fk
+++ b/experiments/form-stdlib/cell-stream.fk
@@ -121,4 +121,59 @@
         (if (nil? cells) (empty)
             (cons (transmuter (head cells))
                   (transmute (tail cells) transmuter))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 6 — walk-stream: PUSH-style streaming (no intermediate list)
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Urs's teaching (2026-05-22): "for grammar rules, if each rule
+    ;; can generate cells and place them inside the stream of cells
+    ;; flowing through that keeps the overall footprint minimal and the
+    ;; energy is used for just what is in front of us right now."
+    ;;
+    ;; stream-of-cells (Part 2) builds a list — the cells exist in
+    ;; memory all at once after parsing. walk-stream collapses parse
+    ;; + observe + analyze into ONE pass: each cell is emitted to a
+    ;; handler immediately, never materialized into an intermediate
+    ;; list. Memory footprint = current parser state + current state
+    ;; threaded through, regardless of stream length.
+    ;;
+    ;; Signature:
+    ;;   (walk-stream input segmenter encoder source-path init-state handler)
+    ;;     handler: (state cell) → new-state
+    ;;   → final-state
+    ;;
+    ;; SAX-style not DOM-style. The cell is "in front of us right now";
+    ;; once handled, it falls away. Downstream gets each cell exactly
+    ;; once, in arrival order.
+
+    (defn walk-stream (input segmenter encoder source-path init-state handler)
+        (walk-loop input segmenter encoder source-path 0 init-state handler))
+
+    (defn walk-loop (input segmenter encoder source-path pos state handler)
+        (do
+            (let seg (segmenter input pos))
+            (if (str_eq (seg-kind seg) "eof")
+                state
+                (do
+                    (let cell (encoder (seg-text seg) source-path (seg-line seg)))
+                    (let new-state (handler state cell))
+                    (walk-loop input segmenter encoder source-path
+                                (seg-next seg) new-state handler)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 7 — combine-handlers: subscriber composition
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Multiple downstream metabolizers can attach to one cell stream.
+    ;; combine-handlers takes two handlers, returns one that calls both
+    ;; in sequence on each cell. Each receives the SAME cell; their
+    ;; states are paired in a list. Chain N handlers by repeated
+    ;; combine for higher arities.
+
+    (defn combine-handlers (h1 h2)
+        (defn combined (paired-state cell)
+            (do
+                (let s1 (head paired-state))
+                (let s2 (head (tail paired-state)))
+                (list (h1 s1 cell) (h2 s2 cell))))
+        combined)
 )

--- a/experiments/form-stdlib/tests/walk-stream.fk
+++ b/experiments/form-stdlib/tests/walk-stream.fk
@@ -1,0 +1,64 @@
+; tests/walk-stream.fk — verify push-style streaming with combined handlers.
+;
+; Strange-minimal probe: ONE input stream through ONE walk-stream call
+; with TWO handlers combined (count + sum-of-lengths). Verifies each
+; cell is seen by both handlers exactly once, no intermediate list is
+; materialized, and the final state captures both aggregates in one pass.
+
+(do
+    (let CELL-CHUNK (make_nodeid 1 2 99 81))
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    (defn digit-to-int (c) (sub (ord c) 48))
+
+    (defn chunk-segmenter (input pos)
+        (if (ge pos (str_len input))
+            (mk-eof 0)
+            (do
+                (let len (digit-to-int (char_at input pos)))
+                (let data-start (add pos 1))
+                (let data-end (add data-start len))
+                (mk-block (substr input data-start data-end) data-end
+                           (add pos 1)))))
+
+    (defn chunk-encoder (block-text source-path line-no)
+        (intern_node_at CELL-CHUNK
+                         (list (intern_trivial_string block-text))
+                         source-path line-no 1))
+
+    (defn handler-count (state cell) (add state 1))
+
+    (defn first-child-text-len (cell)
+        (do
+            (let kids (node_children cell))
+            (if (nil? kids) 0
+                (str_len (node_value (head kids))))))
+
+    (defn handler-len-sum (state cell) (add state (first-child-text-len cell)))
+
+    (let combined (combine-handlers handler-count handler-len-sum))
+
+    (let source "3abc2de1f4hell")
+
+    (let final-state (walk-stream source
+                                   chunk-segmenter chunk-encoder
+                                   "stream.bin"
+                                   (list 0 0)
+                                   combined))
+
+    (let count (head final-state))
+    (let len-sum (head (tail final-state)))
+
+    (let probe-1 count)                                    ; → 4
+    (let probe-2 len-sum)                                  ; → 10
+    (let probe-3 (len final-state))                        ; → 2
+
+    (let pulled (stream-of-cells source chunk-segmenter chunk-encoder
+                                  "stream.bin"))
+    (let probe-4 (len pulled))                             ; → 4
+
+    ;; sum: 4 + 10 + 2 + 4 = 20
+    (add probe-1 (add probe-2 (add probe-3 probe-4))))


### PR DESCRIPTION
**The cell is in front of us right now.** Push-streaming primitive — grammar rules emit cells per match, no intermediate tree. SAX-style not DOM-style.

`walk-stream` collapses parse+observe+analyze into one walk. `combine-handlers` lets multiple metabolizers subscribe to one cell stream — each receives the same cell, each maintains its own state slot.

**Strange-minimal probe at sum 20** on Go AND Rust: 4-chunk input, one walk with combined (count + length-sum) handler, both aggregates accumulated in synchronized per-cell calls.

Subsequent breaths: refactor engine.fk's parse-loop to use walk-stream so grammar rules emit per match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)