### PR TITLE
tend: cell-stream drop — parasite metabolism made explicit

### DIFF
--- a/experiments/form-stdlib/cell-stream.fk
+++ b/experiments/form-stdlib/cell-stream.fk
@@ -176,4 +176,36 @@
                 (let s2 (head (tail paired-state)))
                 (list (h1 s1 cell) (h2 s2 cell))))
         combined)
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Part 8 — drop: cell-as-parasite made explicit
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; The fourth metabolic role completes the set. Until now parasite
+    ;; was implicit — any cell with no downstream re-reference falls out
+    ;; of circulation and the substrate's content-addressing dedupes /
+    ;; garbage-collects it. drop names this relation directly: cells
+    ;; were necessary to flow through the parser but carry no downstream
+    ;; meaning. Eaten and released.
+    ;;
+    ;; (drop cells) walks the stream, consuming each cell and returning
+    ;; 0 — nothing of value flows downstream. The intent is the value:
+    ;; the verb says "these were parasites" so the next reader doesn't
+    ;; have to infer absence-of-handler.
+    ;;
+    ;; (drop-handler state cell) is the walk-stream variant — fold the
+    ;; stream while dropping each cell, returning the count of cells
+    ;; eaten. Useful for measuring throughput, parser-validation-only
+    ;; flows, or as the zero-element of combine-handlers when one
+    ;; downstream needs the cell and another doesn't.
+    ;;
+    ;; The four metabolic verbs (nutrition=transmute, information=observe,
+    ;; evidence=analyze, parasite=drop) cover every relation a downstream
+    ;; can have with a cell. The role is determined by the verb chosen;
+    ;; the cell itself stays universal.
+
+    (defn drop (cells)
+        (if (nil? cells) 0
+            (drop (tail cells))))
+
+    (defn drop-handler (state cell) (add state 1))
 )

--- a/experiments/form-stdlib/tests/cell-drop.fk
+++ b/experiments/form-stdlib/tests/cell-drop.fk
@@ -1,0 +1,59 @@
+; tests/cell-drop.fk — verify the parasite metabolism (drop + drop-handler).
+;
+; Strange-minimal: ONE 9-character source `"3abc2de1f"` (3 length-prefixed
+; chunks) drives BOTH probes — proves the same stream that nutrition /
+; information / evidence verbs metabolize can also be dropped explicitly.
+;
+;   Probe A: walk-stream + drop-handler  → 3 cells eaten (count returned)
+;   Probe B: drop (stream-of-cells ...)  → 0 (nothing flows downstream)
+;
+; The four cell-roles closed: nutrition, information, evidence, parasite.
+
+(do
+    ;; Reuse the chunk-segmenter / chunk-encoder shape from cell-stream.fk.
+    (let CELL-CHUNK (make_nodeid 1 2 99 81))
+
+    (defn substr (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substr s (add a 1) b))))
+
+    (defn digit-to-int (c) (sub (ord c) 48))
+
+    (defn chunk-segmenter (input pos)
+        (if (ge pos (str_len input))
+            (mk-eof 0)
+            (do
+                (let len (digit-to-int (char_at input pos)))
+                (let data-start (add pos 1))
+                (let data-end (add data-start len))
+                (mk-block (substr input data-start data-end) data-end
+                           (add pos 1)))))
+
+    (defn chunk-encoder (block-text source-path line-no)
+        (intern_node_at CELL-CHUNK
+                         (list (intern_trivial_string block-text))
+                         source-path line-no 1))
+
+    (let chunk-source "3abc2de1f")
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe A: walk-stream + drop-handler → cells are eaten in-place,
+    ;; never materialized as a list. The handler folds count.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let probe-a (walk-stream chunk-source
+                               chunk-segmenter chunk-encoder
+                               "test.bin" 0 drop-handler))    ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe B: build the stream first, then drop the list. The verb
+    ;; returns 0 — nothing of value flows downstream from a parasite.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let chunk-cells (stream-of-cells chunk-source
+                                       chunk-segmenter chunk-encoder
+                                       "test.bin"))
+    (let probe-b (drop chunk-cells))                          ; → 0
+
+    ;; sum: 3 + 0 = 3
+    (add probe-a probe-b))


### PR DESCRIPTION
## Summary

The fourth cell-role completes the set. Until now parasite was implicit — any cell with no downstream re-reference falls out of circulation and the substrate's content-addressing dedupes / garbage-collects it. `drop` names this relation directly: cells were necessary to flow through the parser but carry no downstream meaning. Eaten and released.

```
(drop cells)               → 0, consumes the stream
(drop-handler state cell)  → state+1, walk-stream variant for counting
```

The four metabolic verbs now cover every relation a downstream can have with a cell:

| Role | Verb |
|------|------|
| nutrition | `transmute` (cell consumed, new cell emitted) |
| information | `observe` (cell read, untouched) |
| evidence | `analyze` (fold into aggregate) |
| **parasite** | **`drop` (eaten, nothing flows downstream)** |

The role is determined by the verb chosen; the cell itself stays universal.

## Test plan

- [x] Strange-minimal probe in `tests/cell-drop.fk`: one 9-char chunk source `"3abc2de1f"` drives both probes
  - walk-stream + drop-handler → 3 (cells eaten via push-style fold)
  - drop on stream-of-cells → 0 (no value flows downstream)
  - sum: 3
- [x] Go kernel: `3`
- [x] Rust kernel: `3`
- [x] Sibling parity confirmed

Co-authored-by: urs-muff <urs.muff@merly.ai>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>