### PR TITLE
compost: remove range + nth kernel natives (2nd + 3rd of 9 composable composts)

### DIFF
--- a/experiments/form-kernel-go/main.go
+++ b/experiments/form-kernel-go/main.go
@@ -658,9 +658,8 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VInt, Int: 0}
 	})
-	k.registerNative("nth", catAccess(), func(_ *Kernel, args []Value) Value {
-		return args[0].List[args[1].Int]
-	})
+	// `nth` composted 2026-05-22 — sibling-parity with Rust kernel.
+	// Re-author in core.fk as needed: (defn nth (xs n) (if (eq n 0) (head xs) (nth (tail xs) (sub n 1))))
 	k.registerNative("empty", catListNat(), func(_ *Kernel, _ []Value) Value {
 		return Value{Kind: VList, List: []Value{}}
 	})
@@ -725,34 +724,8 @@ func (k *Kernel) registerNatives() {
 	// range(n) / range(a,b) / range(a,b,s) — eager list of integers.
 	// Matches CPython semantics for `for i in range(N):`.
 	// Sibling-parity with the Rust + TS kernels.
-	k.registerNative("range", catListNat(), func(_ *Kernel, args []Value) Value {
-		var start, stop, step int64
-		switch len(args) {
-		case 1:
-			start, stop, step = 0, args[0].Int, 1
-		case 2:
-			start, stop, step = args[0].Int, args[1].Int, 1
-		default:
-			start, stop, step = args[0].Int, args[1].Int, args[2].Int
-		}
-		if step == 0 {
-			return Value{Kind: VList, List: []Value{}}
-		}
-		out := []Value{}
-		i := start
-		if step > 0 {
-			for i < stop {
-				out = append(out, Value{Kind: VInt, Int: i})
-				i += step
-			}
-		} else {
-			for i > stop {
-				out = append(out, Value{Kind: VInt, Int: i})
-				i += step
-			}
-		}
-		return Value{Kind: VList, List: out}
-	})
+	// `range` composted 2026-05-22 — core.fk has (defn range (start end) ...).
+	// Sibling-parity with Rust kernel removal.
 	// File I/O
 	k.registerNative("read_file", catCall(), func(_ *Kernel, args []Value) Value {
 		b, err := os.ReadFile(args[0].Str)

--- a/experiments/form-kernel-rust/src/main.rs
+++ b/experiments/form-kernel-rust/src/main.rs
@@ -628,11 +628,11 @@ impl Kernel {
                 _ => Value::Int(0),
             }
         });
-        self.register_native("nth", cat_access(), |_, _, args| {
-            if let Value::List(xs) = &args[0] {
-                xs[args[1].as_int() as usize].clone()
-            } else { Value::Null }
-        });
+        // `nth` composted 2026-05-22 — unused in form-stdlib/, can be
+        // re-authored in core.fk as needed:
+        //   (defn nth (xs n)
+        //       (if (eq n 0) (head xs)
+        //           (nth (tail xs) (sub n 1))))
         self.register_native("empty", cat_list_nat(), |_, _, _| Value::List(vec![]));
         // min / max / sum — common Python builtins applied to a list.
         // sum returns the integer sum; min/max return the smallest/largest
@@ -694,22 +694,12 @@ impl Kernel {
         // the most common Python loop idiom. Same semantics as CPython's
         // range builtin (returning an eager list rather than a lazy
         // iterator, which the kernel doesn't yet have iterators for).
-        self.register_native("range", cat_list_nat(), |_, _, args| {
-            let (start, stop, step) = match args.len() {
-                1 => (0i64, args[0].as_int(), 1i64),
-                2 => (args[0].as_int(), args[1].as_int(), 1i64),
-                _ => (args[0].as_int(), args[1].as_int(), args[2].as_int()),
-            };
-            if step == 0 { return Value::List(vec![]); }
-            let mut out = Vec::new();
-            let mut i = start;
-            if step > 0 {
-                while i < stop { out.push(Value::Int(i)); i += step; }
-            } else {
-                while i > stop { out.push(Value::Int(i)); i += step; }
-            }
-            Value::List(out)
-        });
+        // `range` composted 2026-05-22 — core.fk's
+        //   (defn range (start end)
+        //       (if (ge start end) (empty)
+        //           (cons start (range (add start 1) end))))
+        // covers the (start, end) variant. Step variant can be re-
+        // authored in core.fk if/when needed (no current usage).
         self.register_native("read_file", cat_call(), |_, _, args| {
             match fs::read_to_string(args[0].as_str()) {
                 Ok(s) => Value::Str(s),


### PR DESCRIPTION
Mirror of sum compost (PR #1820). Both verified safe — sibling parity 220/53/208 across lists.fk/higher.fk/numeric.fk after removal.

Kernel native count: 24 → 22. Six more composable natives remain (len, min, max, abs, substring, _plus). len is trickier — core.fk's nil? depends on it.

Ran in parallel with 4 agent-shipped PRs (PNG, drop, large-file, markdown-stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)