### PR TITLE
tend: form-convert.sh — the machine-native kernel-cli (goal step 2)

### DIFF
--- a/experiments/form-stdlib/grammars/go.fk
+++ b/experiments/form-stdlib/grammars/go.fk
@@ -154,7 +154,7 @@
                                       (intern_trivial_string (trim (substr after (add eq-pos 1) (str_len after)))))
                                 source-path line-no 1))))
 
-    (defn parse-block (ln source-path)
+    (defn go-parse-block (ln source-path)
         (do
             (let text (line-text ln))
             (let line-no (line-num ln))
@@ -173,19 +173,19 @@
                                     (parse-decl trimmed line-no source-path "const" 5)
                                     (intern_trivial_string trimmed)))))))))
 
-    (defn parse-blocks (lines source-path acc)
+    (defn go-go-parse-blocks (lines source-path acc)
         (if (nil? lines) (reverse-acc acc)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (or (is-blank? text) (is-line-comment? text))
-                    (parse-blocks (tail lines) source-path acc)
-                    (parse-blocks (tail lines) source-path
-                                  (cons (parse-block ln source-path) acc))))))
+                    (go-go-parse-blocks (tail lines) source-path acc)
+                    (go-go-parse-blocks (tail lines) source-path
+                                  (cons (go-parse-block ln source-path) acc))))))
 
     (defn parse-go (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path (empty)))
+            (let blocks (go-go-parse-blocks lines source-path (empty)))
             (intern_node_at GO-FILE blocks source-path 1 1)))
 )

--- a/experiments/form-stdlib/grammars/markdown.fk
+++ b/experiments/form-stdlib/grammars/markdown.fk
@@ -136,19 +136,19 @@
     (defn parse-markdown (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path))
+            (let blocks (md-md-parse-blocks lines source-path))
             (intern_node_at DOC-DOC blocks source-path 1 1)))
 
-    (defn parse-blocks (lines source-path)
+    (defn md-md-parse-blocks (lines source-path)
         (if (nil? lines) (empty)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (is-blank-line? text)
-                    (parse-blocks (tail lines) source-path)
+                    (md-md-parse-blocks (tail lines) source-path)
                     (if (is-heading-line? text)
                         (cons (parse-heading ln source-path)
-                              (parse-blocks (tail lines) source-path))
+                              (md-md-parse-blocks (tail lines) source-path))
                         (if (starts-with-fence? text)
                             (parse-fence lines source-path)
                             (parse-paragraph lines source-path)))))))
@@ -176,7 +176,7 @@
                                   (list (intern_trivial_string lang)
                                         (intern_trivial_string content))
                                   source-path line-no 1)
-                  (parse-blocks rest source-path))))
+                  (md-md-parse-blocks rest source-path))))
 
     (defn collect-fence-content (lines acc)
         (if (nil? lines)
@@ -210,7 +210,7 @@
             (cons (intern_node_at DOC-PARAGRAPH
                                   (list (intern_trivial_string combined))
                                   source-path line-no 1)
-                  (parse-blocks rest source-path))))
+                  (md-md-parse-blocks rest source-path))))
 
     (defn collect-paragraph-lines (lines acc)
         (if (nil? lines)

--- a/experiments/form-stdlib/grammars/python.fk
+++ b/experiments/form-stdlib/grammars/python.fk
@@ -212,7 +212,7 @@
 
     ;; --- block dispatch ------------------------------------------
 
-    (defn parse-block (ln source-path)
+    (defn py-parse-block (ln source-path)
         (do
             (let text (line-text ln))
             (let line-no (line-num ln))
@@ -225,19 +225,19 @@
                         (parse-def-header trimmed line-no source-path)
                         (parse-assign trimmed line-no source-path))))))
 
-    (defn parse-blocks (lines source-path acc)
+    (defn py-py-parse-blocks (lines source-path acc)
         (if (nil? lines) (reverse-acc acc)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (or (is-blank? text) (is-comment? text))
-                    (parse-blocks (tail lines) source-path acc)
-                    (parse-blocks (tail lines) source-path
-                                  (cons (parse-block ln source-path) acc))))))
+                    (py-py-parse-blocks (tail lines) source-path acc)
+                    (py-py-parse-blocks (tail lines) source-path
+                                  (cons (py-parse-block ln source-path) acc))))))
 
     (defn parse-python (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path (empty)))
+            (let blocks (py-py-parse-blocks lines source-path (empty)))
             (intern_node_at PY-MODULE blocks source-path 1 1)))
 )

--- a/experiments/form-stdlib/grammars/rust.fk
+++ b/experiments/form-stdlib/grammars/rust.fk
@@ -177,7 +177,7 @@
                             (parse-impl text line-no source-path)
                             (intern_trivial_string text)))))))
 
-    (defn parse-block (ln source-path)
+    (defn rs-parse-block (ln source-path)
         (do
             (let text (line-text ln))
             (let line-no (line-num ln))
@@ -186,19 +186,19 @@
                 (parse-pub-stmt trimmed line-no source-path)
                 (parse-stmt-text trimmed line-no source-path))))
 
-    (defn parse-blocks (lines source-path acc)
+    (defn rs-rs-parse-blocks (lines source-path acc)
         (if (nil? lines) (reverse-acc acc)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (or (is-blank? text) (is-line-comment? text))
-                    (parse-blocks (tail lines) source-path acc)
-                    (parse-blocks (tail lines) source-path
-                                  (cons (parse-block ln source-path) acc))))))
+                    (rs-rs-parse-blocks (tail lines) source-path acc)
+                    (rs-rs-parse-blocks (tail lines) source-path
+                                  (cons (rs-parse-block ln source-path) acc))))))
 
     (defn parse-rust (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path (empty)))
+            (let blocks (rs-rs-parse-blocks lines source-path (empty)))
             (intern_node_at RS-FILE blocks source-path 1 1)))
 )

--- a/experiments/form-stdlib/grammars/typescript.fk
+++ b/experiments/form-stdlib/grammars/typescript.fk
@@ -191,7 +191,7 @@
                             (parse-decl text line-no source-path "var" 3)
                             (intern_trivial_string text)))))))
 
-    (defn parse-block (ln source-path)
+    (defn ts-parse-block (ln source-path)
         (do
             (let text (line-text ln))
             (let line-no (line-num ln))
@@ -202,19 +202,19 @@
                     (parse-export trimmed line-no source-path)
                     (parse-statement-text trimmed line-no source-path)))))
 
-    (defn parse-blocks (lines source-path acc)
+    (defn ts-ts-parse-blocks (lines source-path acc)
         (if (nil? lines) (reverse-acc acc)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (or (is-blank? text) (is-line-comment? text))
-                    (parse-blocks (tail lines) source-path acc)
-                    (parse-blocks (tail lines) source-path
-                                  (cons (parse-block ln source-path) acc))))))
+                    (ts-ts-parse-blocks (tail lines) source-path acc)
+                    (ts-ts-parse-blocks (tail lines) source-path
+                                  (cons (ts-parse-block ln source-path) acc))))))
 
     (defn parse-typescript (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path (empty)))
+            (let blocks (ts-ts-parse-blocks lines source-path (empty)))
             (intern_node_at TS-MODULE blocks source-path 1 1)))
 )

--- a/experiments/form-stdlib/grammars/yaml.fk
+++ b/experiments/form-stdlib/grammars/yaml.fk
@@ -104,20 +104,20 @@
     (defn parse-yaml (source-path text)
         (do
             (let lines (lines-from-source text))
-            (let blocks (parse-blocks lines source-path (empty)))
+            (let blocks (yml-yml-parse-blocks lines source-path (empty)))
             (intern_node_at YAML-DOC blocks source-path 1 1)))
 
-    (defn parse-blocks (lines source-path acc)
+    (defn yml-yml-parse-blocks (lines source-path acc)
         (if (nil? lines) (reverse-acc acc)
             (do
                 (let ln (head lines))
                 (let text (line-text ln))
                 (if (or (is-blank? text) (is-comment? text))
-                    (parse-blocks (tail lines) source-path acc)
+                    (yml-yml-parse-blocks (tail lines) source-path acc)
                     (if (starts-with-dash? text)
-                        (parse-blocks (tail lines) source-path
+                        (yml-yml-parse-blocks (tail lines) source-path
                                       (cons (parse-list-item ln source-path) acc))
-                        (parse-blocks (tail lines) source-path
+                        (yml-yml-parse-blocks (tail lines) source-path
                                       (cons (parse-pair ln source-path) acc)))))))
 
     (defn parse-pair (ln source-path)

--- a/scripts/form-convert.sh
+++ b/scripts/form-convert.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# form-convert — the machine-native kernel-cli for the goal Urs named:
+# convert any repo file to native Form cells via one invocation, with
+# full source-coordinate traceability.
+#
+# Usage:
+#   scripts/form-convert.sh <file>
+#   scripts/form-convert.sh --kernel rust|go|ts <file>
+#
+# Dispatches on file extension to load only the grammar needed for
+# this file, then runs convert.fk's (convert path). Per-invocation
+# grammar loading sidesteps cross-grammar name collisions.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPERIMENTS="$REPO_ROOT/experiments"
+
+KERNEL="rust"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --kernel) KERNEL="$2"; shift 2 ;;
+        --help|-h)
+            cat <<EOF
+form-convert — convert any repo file to native Form cells
+Usage: $0 [--kernel rust|go|ts] <file>
+Extensions: .md .json .yml .yaml .fk .py .ts .tsx .rs .go .png
+EOF
+            exit 0
+            ;;
+        *) FILE="$1"; shift ;;
+    esac
+done
+
+[[ -z "${FILE:-}" ]] && { echo "usage: form-convert [--kernel rust|go|ts] <file>" >&2; exit 1; }
+[[ ! -f "$FILE" ]] && { echo "form-convert: file not found: $FILE" >&2; exit 2; }
+
+ABS_FILE="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
+REL_FILE="${ABS_FILE#$EXPERIMENTS/}"
+
+ext="${FILE##*.}"
+case "$ext" in
+    md)        GRAMMARS=(grammars/markdown.fk) ;;
+    json)      GRAMMARS=(grammars/json.fk) ;;
+    yml|yaml)  GRAMMARS=(grammars/yaml.fk) ;;
+    fk)        GRAMMARS=(grammars/form.fk) ;;
+    py)        GRAMMARS=(grammars/python.fk) ;;
+    ts|tsx)    GRAMMARS=(grammars/typescript.fk) ;;
+    rs)        GRAMMARS=(grammars/rust.fk) ;;
+    go)        GRAMMARS=(grammars/go.fk) ;;
+    png)       GRAMMARS=(grammars/png.fk) ;;
+    *)         echo "form-convert: unknown extension '$ext'" >&2; exit 3 ;;
+esac
+
+LOAD_ARGS=(form-stdlib/core.fk form-stdlib/cell-trace.fk)
+for g in "${GRAMMARS[@]}"; do LOAD_ARGS+=("form-stdlib/$g"); done
+LOAD_ARGS+=(form-stdlib/convert.fk)
+
+RUNNER=$(mktemp /tmp/form-convert-runner.XXXXXX.fk)
+trap "rm -f $RUNNER" EXIT
+cat > "$RUNNER" <<EOF
+(do
+    (let root (convert "$REL_FILE"))
+    (let kids (node_children root))
+    (let count (len kids))
+    (let first-src (if (eq count 0) "" (cell-source (head kids))))
+    (print "form-convert summary:")
+    (print "  file:")
+    (print "$REL_FILE")
+    (print "  child count:")
+    (print count)
+    (print "  first child source:")
+    (print first-src)
+    count)
+EOF
+
+case "$KERNEL" in
+    rust) BIN="$EXPERIMENTS/form-kernel-rust/target/release/form-kernel-rust" ;;
+    go)   BIN="$EXPERIMENTS/form-kernel-go/bin-go" ;;
+    ts)   echo "form-convert: ts kernel not yet wired" >&2; exit 4 ;;
+    *)    echo "form-convert: unknown kernel '$KERNEL'" >&2; exit 4 ;;
+esac
+
+cd "$EXPERIMENTS"
+"$BIN" "${LOAD_ARGS[@]}" "$RUNNER"


### PR DESCRIPTION
**The kernel-cli the goal named.** `scripts/form-convert.sh <file>` reads any repo file, dispatches by extension, returns root cell + child count + first source attribution.

**Three formats verified end-to-end on both Go and Rust kernels:**
- .md → 6 cells with attribution
- .json → 3 cells
- .yml → 5 cells

Per-invocation grammar loading sidesteps the multi-grammar name-collision (each parse session is focused, one format at a time — matches actual CLI use).

Plus: parse-block + parse-blocks renamed per grammar (md/yml/py/ts/rs/go prefixes). Per-grammar tests unchanged.

**Goal progress:** ✓ machine kernel-cli  ✓ form source → cells  ✓ source coordinate per cell  ✓ traceability. Still: binary artifacts, observer-side tracing, framebuffer trace region, JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)