### PR TITLE
tend: framebuffer trace surface — observer pays the cost (goal step 3)

### DIFF
--- a/experiments/form-kernel-go/main.go
+++ b/experiments/form-kernel-go/main.go
@@ -832,6 +832,22 @@ func (k *Kernel) registerNatives() {
 			{Kind: VInt, Int: int64(loc.Col)},
 		}}
 	})
+	// framebuffer-events — return all NodeIDs with source attribution.
+	// The source_attr side-map IS the framebuffer. Observer-side
+	// tracing: emitter pays one hashmap insert per intern_node_at;
+	// observer pays the cost of walking this list when it analyzes.
+	k.registerNative("framebuffer-events", catWitness(), func(k *Kernel, _ []Value) Value {
+		out := make([]Value, 0, len(k.sourceAttr))
+		for nid := range k.sourceAttr {
+			out = append(out, Value{Kind: VNodeID, Nid: nid})
+		}
+		return Value{Kind: VList, List: out}
+	})
+	// framebuffer-clear — reset the framebuffer for bounded windows.
+	k.registerNative("framebuffer-clear", catWitness(), func(k *Kernel, _ []Value) Value {
+		k.sourceAttr = make(map[NodeID]sourceLoc)
+		return Value{Kind: VNull}
+	})
 	k.registerNative("walk_recipe", catWitness(), func(k *Kernel, args []Value) Value {
 		env := NewFrame(nil)
 		return k.walk(args[0].Nid, env)

--- a/experiments/form-kernel-rust/src/main.rs
+++ b/experiments/form-kernel-rust/src/main.rs
@@ -808,6 +808,25 @@ impl Kernel {
                 None => Value::List(vec![]),
             }
         });
+        // framebuffer-events — return all NodeIDs that have source
+        // attribution recorded. The substrate's source_attr side-map
+        // IS the framebuffer: every intern_node_at write becomes a
+        // discoverable trace event. Observer-side tracing: the
+        // EMITTER pays only the side-map write (~O(1)); the OBSERVER
+        // pays the cost of walking + filtering this list when it
+        // wants to analyze hot-spots or flow.
+        self.register_native("framebuffer-events", cat_witness(), |k, _, _| {
+            Value::List(
+                k.source_attr.keys().copied().map(Value::Nid).collect()
+            )
+        });
+        // framebuffer-clear — reset the framebuffer. Useful for
+        // bounded observation windows (subscribe → do work →
+        // analyze → clear → next window).
+        self.register_native("framebuffer-clear", cat_witness(), |k, _, _| {
+            k.source_attr.clear();
+            Value::Null
+        });
         // walk_recipe — evaluate a NodeID in a fresh root frame. Returns
         // the value the recipe produces. Use case: Form code builds a
         // recipe via intern_node, then walks it to get the runtime result.

--- a/experiments/form-stdlib/tests/tracer.fk
+++ b/experiments/form-stdlib/tests/tracer.fk
@@ -1,0 +1,52 @@
+; tests/tracer.fk — verify observer-side tracing on the framebuffer.
+;
+; Strange-minimal: emit 5 cells with attributions across 2 files,
+; observe the framebuffer, verify count + hotspot.
+
+(do
+    ;; Helper: emit a cell with attribution at a given file/line
+    (defn emit-at (file line)
+        (do
+            (let CAT (make_nodeid 1 2 12 1))
+            (intern_node_at CAT
+                            (list (intern_trivial_int line))
+                            file line 1)))
+
+    ;; --- Probe 1: with-trace gives bounded window -----------------
+    ;; Clear, emit 3 cells, return events
+    (defn emit-three (_x)
+        (do
+            (emit-at "a.py" 1)
+            (emit-at "a.py" 2)
+            (emit-at "b.py" 5)))
+
+    (let events (with-trace emit-three))
+    (let probe-1 (len events))                              ; → 3
+
+    ;; --- Probe 2: count-by-file groups correctly ------------------
+    (let buckets (count-by-file events))
+    (let probe-2 (len buckets))                             ; → 2 (a.py, b.py)
+
+    ;; --- Probe 3: hotspot is a.py with count 2 --------------------
+    (let hot (hotspots events))
+    (let probe-3 (head (tail hot)))                         ; → 2
+
+    ;; --- Probe 4: hotspot file is a.py (str_len = 4) --------------
+    (let probe-4 (str_len (head hot)))                      ; → 4
+
+    ;; --- Probe 5: flow returns 3 source strings -------------------
+    (let flow-list (flow events))
+    (let probe-5 (len flow-list))                           ; → 3
+
+    ;; --- Probe 6: emitter pays no extra cost when no observer -----
+    ;; framebuffer-clear → emit 100 cells → framebuffer-events length 100
+    ;; Demonstrates the recording is bounded to the work, not free-flowing.
+    (framebuffer-clear)
+    (emit-at "x.fk" 1)
+    (emit-at "x.fk" 2)
+    (emit-at "x.fk" 3)
+    (emit-at "x.fk" 4)
+    (let probe-6 (len (framebuffer-events)))                ; → 4
+
+    ;; sum: 3 + 2 + 2 + 4 + 3 + 4 = 18
+    (add probe-1 (add probe-2 (add probe-3 (add probe-4 (add probe-5 probe-6))))))

--- a/experiments/form-stdlib/tracer.fk
+++ b/experiments/form-stdlib/tracer.fk
@@ -1,0 +1,126 @@
+; tracer.fk — observer-side trace analysis on the framebuffer
+;
+; The goal's tracing piece: "minimal tracing overhead that put the
+; tracing cost on the observer / tracer not the tracing emitting
+; recipe coordinates (optionally) into the memory substrate
+; (framebuffer) that can be used for hot-spot and flow analysis."
+;
+; The framebuffer IS the source_attr side-map in the kernel. The
+; emitter pays ONE hashmap insert per `intern_node_at` call (already
+; the existing cost — no new overhead). Observers pay the cost of
+; walking `framebuffer-events` and aggregating when they want
+; analysis. Zero-observer flows pay nothing beyond the side-map
+; write that was already happening.
+;
+; This file provides the observer vocabulary:
+;   - hotspots: which source lines authored the most cells?
+;   - flow: ordered sequence of cell creations in this observation window
+;   - with-trace: window helper — clear, do work, return events
+;   - count-by-file: aggregate by source file
+;   - count-by-line: aggregate by source (file:line)
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; with-trace: bounded observation window
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Clear the framebuffer, run the work-recipe, return the events
+    ;; that were emitted during it. Caller analyzes the returned list.
+    ;;
+    ;; Usage:
+    ;;   (let events (with-trace (fn (_) (parse-markdown "foo.md" text))))
+    ;;   (let hot (hotspots events))
+
+    (defn with-trace (work-fn)
+        (do
+            (framebuffer-clear)
+            (work-fn 0)
+            (framebuffer-events)))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; count-by-file: aggregate cell-count per source file
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; For each cell in events, pull its node_source (file, line, col),
+    ;; group by file, return list of (file, count) pairs.
+
+    (defn cell-file (cell)
+        (do
+            (let src (node_source cell))
+            (if (nil? src) "" (head src))))
+
+    (defn cell-line (cell)
+        (do
+            (let src (node_source cell))
+            (if (nil? src) 0 (head (tail src)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; bucket: simple associative list of (key, count)
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Caller folds events into a bucket via bucket-add. bucket-get
+    ;; looks up a key. bucket-keys returns just the keys.
+
+    (defn bucket-empty (_x) (empty))
+
+    (defn bucket-add (bucket key)
+        (bucket-add-loop bucket key (empty)))
+
+    (defn bucket-add-loop (bucket key seen)
+        (if (nil? bucket)
+            ;; key not found — add fresh entry with count 1
+            (reverse-acc-list (cons (list key 1) seen))
+            (do
+                (let entry (head bucket))
+                (if (str_eq (head entry) key)
+                    ;; increment this entry's count, append rest unchanged
+                    (concat-lists
+                        (reverse-acc-list seen)
+                        (cons (list key (add (head (tail entry)) 1))
+                              (tail bucket)))
+                    (bucket-add-loop (tail bucket) key (cons entry seen))))))
+
+    (defn reverse-acc-list (xs)
+        (if (nil? xs) (empty)
+            (concat-lists (reverse-acc-list (tail xs)) (list (head xs)))))
+
+    (defn concat-lists (a b)
+        (if (nil? a) b
+            (cons (head a) (concat-lists (tail a) b))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; count-by-file: fold events into file-keyed bucket
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn count-by-file-step (bucket cell)
+        (bucket-add bucket (cell-file cell)))
+
+    (defn count-by-file (events)
+        (foldl count-by-file-step (empty) events))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; hotspots: top file by count
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Returns (file, count) for the file with the most cells.
+
+    (defn hot-max-step (current entry)
+        (if (gt (head (tail entry)) (head (tail current)))
+            entry current))
+
+    (defn hotspots (events)
+        (do
+            (let buckets (count-by-file events))
+            (if (nil? buckets) (list "" 0)
+                (foldl hot-max-step (head buckets) (tail buckets)))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; flow: ordered list of source-strings for each event
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Maps each event to its "file:line:col" source string. Useful
+    ;; for replaying the order of cell creations.
+
+    (defn flow-source (cell)
+        (cell-source cell))   ; from cell-trace.fk
+
+    (defn flow (events)
+        (if (nil? events) (empty)
+            (cons (flow-source (head events))
+                  (flow (tail events)))))
+)


### PR DESCRIPTION
**The tracing goal piece.** The source_attr side-map IS the framebuffer. Emitter pays nothing new; observer pays only when walking.

Two new kernel natives: `framebuffer-events` (list all attributed NodeIDs), `framebuffer-clear` (reset window).

`experiments/form-stdlib/tracer.fk`: `with-trace` (bounded window), `hotspots` (busiest file), `flow` (ordered source strings), `count-by-file`.

**Sibling parity at 18** on Go + Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)