### PR TITLE
tend: form binary artifacts — serialize/deserialize Recipe trees (goal step 4)

### DIFF
--- a/experiments/form-kernel-go/main.go
+++ b/experiments/form-kernel-go/main.go
@@ -848,6 +848,44 @@ func (k *Kernel) registerNatives() {
 		k.sourceAttr = make(map[NodeID]sourceLoc)
 		return Value{Kind: VNull}
 	})
+	// serialize-recipe — walk a Recipe tree, emit a flat byte list as
+	// Value::Int per byte. Format per node: 5 big-endian u32s
+	// (pkg, level, ty, inst, children_count) + recursive children.
+	// Trivials: children_count=0, NodeID encoded directly.
+	// Composites: (pkg, level, ty, inst) is the CATEGORY; the composite
+	// NodeID is reconstructed at deserialize via intern.
+	k.registerNative("serialize-recipe", catWitness(), func(k *Kernel, args []Value) Value {
+		bytes := []byte{}
+		bytes = serializeNid(k, args[0].Nid, bytes)
+		out := make([]Value, len(bytes))
+		for i, b := range bytes {
+			out[i] = Value{Kind: VInt, Int: int64(b)}
+		}
+		return Value{Kind: VList, List: out}
+	})
+	// deserialize-recipe — read byte list back into a Recipe tree.
+	// Composites re-intern so the resulting NodeIDs match the original
+	// identities by content-addressing.
+	k.registerNative("deserialize-recipe", catWitness(), func(k *Kernel, args []Value) Value {
+		bytes := make([]byte, len(args[0].List))
+		for i, v := range args[0].List {
+			bytes[i] = byte(v.Int)
+		}
+		nid, _ := deserializeNid(k, bytes, 0)
+		return Value{Kind: VNodeID, Nid: nid}
+	})
+	// write_file_bytes — sibling of read_file_bytes; writes a byte list.
+	k.registerNative("write_file_bytes", catCall(), func(_ *Kernel, args []Value) Value {
+		bytes := make([]byte, len(args[1].List))
+		for i, v := range args[1].List {
+			bytes[i] = byte(v.Int)
+		}
+		err := os.WriteFile(args[0].Str, bytes, 0644)
+		if err != nil {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: int64(len(bytes))}
+	})
 	k.registerNative("walk_recipe", catWitness(), func(k *Kernel, args []Value) Value {
 		env := NewFrame(nil)
 		return k.walk(args[0].Nid, env)
@@ -1615,4 +1653,68 @@ func runBench() {
 		)
 		_ = nativeResult // silence unused-write warning for the loop's last value
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Form binary artifact format helpers
+// ---------------------------------------------------------------------------
+// Per-node serialization: 5 big-endian u32s (pkg, level, ty, inst, count)
+// + recursive children. Sibling of the Rust kernel's serialize_nid /
+// deserialize_nid. Same byte layout.
+
+func pushU32(bytes []byte, v uint32) []byte {
+	return append(bytes, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+func readU32(bytes []byte, pos int) (uint32, int) {
+	v := (uint32(bytes[pos]) << 24) |
+		(uint32(bytes[pos+1]) << 16) |
+		(uint32(bytes[pos+2]) << 8) |
+		uint32(bytes[pos+3])
+	return v, pos + 4
+}
+
+func serializeNid(k *Kernel, nid NodeID, bytes []byte) []byte {
+	kids := k.children(nid)
+	if len(kids) == 0 {
+		// Trivial leaf — NodeID IS the value (inst encodes it).
+		bytes = pushU32(bytes, nid.Pkg)
+		bytes = pushU32(bytes, nid.Level)
+		bytes = pushU32(bytes, nid.Type)
+		bytes = pushU32(bytes, nid.Inst)
+		bytes = pushU32(bytes, 0)
+		return bytes
+	}
+	// Composite — serialize CATEGORY (not the intern-counter NodeID).
+	// The composite is reconstructed via k.intern(category, children).
+	cat := k.category(nid)
+	bytes = pushU32(bytes, cat.Pkg)
+	bytes = pushU32(bytes, cat.Level)
+	bytes = pushU32(bytes, cat.Type)
+	bytes = pushU32(bytes, cat.Inst)
+	bytes = pushU32(bytes, uint32(len(kids)))
+	for _, c := range kids {
+		bytes = serializeNid(k, c, bytes)
+	}
+	return bytes
+}
+
+func deserializeNid(k *Kernel, bytes []byte, pos int) (NodeID, int) {
+	var pkg, level, ty, inst, count uint32
+	pkg, pos = readU32(bytes, pos)
+	level, pos = readU32(bytes, pos)
+	ty, pos = readU32(bytes, pos)
+	inst, pos = readU32(bytes, pos)
+	count, pos = readU32(bytes, pos)
+	if count == 0 {
+		return NodeID{Pkg: pkg, Level: level, Type: ty, Inst: inst}, pos
+	}
+	category := NodeID{Pkg: pkg, Level: level, Type: ty, Inst: inst}
+	children := make([]NodeID, count)
+	for i := uint32(0); i < count; i++ {
+		var c NodeID
+		c, pos = deserializeNid(k, bytes, pos)
+		children[i] = c
+	}
+	return k.intern(category, children), pos
 }

--- a/experiments/form-kernel-rust/src/main.rs
+++ b/experiments/form-kernel-rust/src/main.rs
@@ -827,6 +827,41 @@ impl Kernel {
             k.source_attr.clear();
             Value::Null
         });
+        // serialize-recipe — walk a Recipe tree, emit a flat byte list
+        // (each byte as Value::Int). Format per node: 5 big-endian u32
+        // values (pkg, level, ty, inst, children_count) + recursively
+        // each child's serialization. Trivials have children_count=0.
+        // The substrate's content-addressing means deserialize re-
+        // creates the same NodeID via intern.
+        self.register_native("serialize-recipe", cat_witness(), |k, _, args| {
+            let mut bytes: Vec<u8> = Vec::new();
+            serialize_nid(k, args[0].as_nid(), &mut bytes);
+            Value::List(bytes.into_iter().map(|b| Value::Int(b as i64)).collect())
+        });
+        // deserialize-recipe — read flat byte list back into a Recipe
+        // tree, re-interning composites so the resulting NodeIDs
+        // collapse to the same identities as the original tree.
+        self.register_native("deserialize-recipe", cat_witness(), |k, _, args| {
+            let bytes: Vec<u8> = match &args[0] {
+                Value::List(xs) => xs.iter().map(|v| v.as_int() as u8).collect(),
+                _ => Vec::new(),
+            };
+            let (nid, _pos) = deserialize_nid(k, &bytes, 0);
+            Value::Nid(nid)
+        });
+        // write_file_bytes — write a list of byte-values to a path.
+        // Sibling of read_file_bytes (added with PNG binary parser).
+        self.register_native("write_file_bytes", cat_call(), |_, _, args| {
+            let path = args[0].as_str().to_string();
+            let bytes: Vec<u8> = match &args[1] {
+                Value::List(xs) => xs.iter().map(|v| v.as_int() as u8).collect(),
+                _ => Vec::new(),
+            };
+            match fs::write(&path, &bytes) {
+                Ok(_) => Value::Int(bytes.len() as i64),
+                Err(_) => Value::Int(-1),
+            }
+        });
         // walk_recipe — evaluate a NodeID in a fresh root frame. Returns
         // the value the recipe produces. Use case: Form code builds a
         // recipe via intern_node, then walks it to get the runtime result.
@@ -1757,4 +1792,83 @@ fn main() {
         }
     };
     std::process::exit(exit_code);
+}
+
+// ---------------------------------------------------------------------------
+// Form binary artifact format
+// ---------------------------------------------------------------------------
+// Each NodeID serializes to 20 bytes of (pkg, level, ty, inst, children_count)
+// as big-endian u32s, followed by recursive serialization of each child.
+// Trivials have children_count=0 (their value is encoded in inst, no
+// children follow). Composites have children_count>0 and the next that
+// many serialized NodeIDs are recursive sub-trees.
+//
+// Round-trip property: deserialize(serialize(nid)) === nid via the
+// substrate's content-addressing — same shape interns to same NodeID.
+
+fn push_u32(bytes: &mut Vec<u8>, v: u32) {
+    bytes.push((v >> 24) as u8);
+    bytes.push((v >> 16) as u8);
+    bytes.push((v >> 8) as u8);
+    bytes.push(v as u8);
+}
+
+fn read_u32(bytes: &[u8], pos: usize) -> (u32, usize) {
+    let v = ((bytes[pos] as u32) << 24)
+          | ((bytes[pos + 1] as u32) << 16)
+          | ((bytes[pos + 2] as u32) << 8)
+          | (bytes[pos + 3] as u32);
+    (v, pos + 4)
+}
+
+fn serialize_nid(k: &Kernel, nid: NodeID, bytes: &mut Vec<u8>) {
+    let kids = k.children(nid);
+    if kids.is_empty() {
+        // Trivial leaf — the NodeID IS the value (inst encodes it).
+        // Write the nid as-is.
+        push_u32(bytes, nid.pkg);
+        push_u32(bytes, nid.level);
+        push_u32(bytes, nid.ty);
+        push_u32(bytes, nid.inst);
+        push_u32(bytes, 0);
+    } else {
+        // Composite — the NodeID's inst is the intern-counter
+        // (recreated at deserialize time via re-intern). What we
+        // serialize is the CATEGORY (which determines the shape)
+        // plus the children. The composite NodeID itself will be
+        // reconstructed by k.intern(category, children).
+        let cat = k.category(nid);
+        push_u32(bytes, cat.pkg);
+        push_u32(bytes, cat.level);
+        push_u32(bytes, cat.ty);
+        push_u32(bytes, cat.inst);
+        push_u32(bytes, kids.len() as u32);
+        for c in kids {
+            serialize_nid(k, c, bytes);
+        }
+    }
+}
+
+fn deserialize_nid(k: &mut Kernel, bytes: &[u8], pos: usize) -> (NodeID, usize) {
+    let (pkg, p) = read_u32(bytes, pos);
+    let (level, p) = read_u32(bytes, p);
+    let (ty, p) = read_u32(bytes, p);
+    let (inst, p) = read_u32(bytes, p);
+    let (count, mut p) = read_u32(bytes, p);
+    if count == 0 {
+        // Trivial leaf — reconstruct NodeID directly. The substrate
+        // content-addresses these (same bytes = same NodeID).
+        return (NodeID { pkg, level, ty, inst }, p);
+    }
+    // Composite — (pkg, level, ty, inst) is the CATEGORY. Re-intern
+    // with reconstructed children to get back the same composite
+    // NodeID (intern is content-addressed: same shape = same id).
+    let category = NodeID { pkg, level, ty, inst };
+    let mut children = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let (c, np) = deserialize_nid(k, bytes, p);
+        children.push(c);
+        p = np;
+    }
+    (k.intern(category, children), p)
 }

--- a/experiments/form-stdlib/tests/form-binary.fk
+++ b/experiments/form-stdlib/tests/form-binary.fk
@@ -1,0 +1,36 @@
+; tests/form-binary.fk — Recipe serialize/deserialize round-trip
+
+(do
+    (let CAT-PLUS     (make_nodeid 1 2 12 1))
+    (let CAT-MULTIPLY (make_nodeid 1 2 12 3))
+
+    (let leaf (intern_trivial_int 42))
+    (let leaf-bytes (serialize-recipe leaf))
+    (let leaf-restored (deserialize-recipe leaf-bytes))
+    (let probe-1 (if (node_eq leaf leaf-restored) 1 0))
+    (let probe-2 (len leaf-bytes))
+
+    (let plus (intern_node CAT-PLUS (list (intern_trivial_int 7) (intern_trivial_int 3))))
+    (let plus-bytes (serialize-recipe plus))
+    (let plus-restored (deserialize-recipe plus-bytes))
+    (let probe-3 (if (node_eq plus plus-restored) 1 0))
+    (let probe-4 (len plus-bytes))
+
+    (let nested (intern_node CAT-MULTIPLY
+                              (list (intern_trivial_int 5)
+                                    (intern_node CAT-PLUS
+                                                  (list (intern_trivial_int 4)
+                                                        (intern_trivial_int 6))))))
+    (let nested-bytes (serialize-recipe nested))
+    (let nested-restored (deserialize-recipe nested-bytes))
+    (let probe-5 (if (node_eq nested nested-restored) 1 0))
+    (let probe-6 (len nested-bytes))
+
+    (let path "/tmp/form-binary-test.bin")
+    (let written (write_file_bytes path plus-bytes))
+    (let probe-7 written)
+    (let loaded (read_file_bytes path))
+    (let loaded-recipe (deserialize-recipe loaded))
+    (let probe-8 (if (node_eq plus loaded-recipe) 1 0))
+
+    (add probe-1 (add probe-2 (add probe-3 (add probe-4 (add probe-5 (add probe-6 (add probe-7 probe-8))))))))


### PR DESCRIPTION
**Compile-once-run-many.** Recipe trees → bytes → Recipe trees with identical NodeIDs via content-addressing.

Three new kernel natives: `serialize-recipe`, `deserialize-recipe`, `write_file_bytes`. Format: 5 big-endian u32s per node (pkg, level, ty, inst, children_count) + recursive children. Trivials self-encode in inst; composites re-intern via category.

**Sibling parity at 244** on Go + Rust. Trivials (20 bytes), composites (60 bytes), nested (100 bytes), filesystem round-trip — all verified.

**Goal almost complete:** ✓ kernel-cli ✓ source→cells ✓ binary artifacts ✓ source coordinates ✓ traceability ✓ observer-side tracing ✓ framebuffer ✓ hot-spot+flow. Still: JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)