### PR TITLE
tend: BNF surface aligns to BMF (::= + ;) + namespace convention

### DIFF
--- a/docs/coherence-substrate/form-namespaces.md
+++ b/docs/coherence-substrate/form-namespaces.md
@@ -1,0 +1,124 @@
+# Form Namespaces — Slash-Path Convention
+
+## What this is
+
+A naming discipline that prevents the name-collision pattern the body has
+hit twice now (`is-ws-cp` 1-arg in `line-grammar.fk` vs 2-arg in
+`engine.fk`; analogous collisions waiting between any two files whose
+helpers happen to converge on the same friendly name).
+
+The convention adds zero kernel work — the Form bootstrap reader already
+accepts `/` inside identifiers, so `engine/is-ws?` is just an identifier.
+The discipline is in *how we name*, not *what the kernel parses*.
+
+## The rule
+
+**Every Form file declares its module namespace at the top.** Every
+internal helper is prefixed with `<module>/`. Only exported public names
+live in the global namespace.
+
+```
+; engine.fk — module: engine
+(do
+    (defn engine/is-ws-cp (cp ws-set) ...)   ; private helper
+    (defn engine/scan-while-cfg (s i p) ...) ; private helper
+
+    ;; Exported public surface — no prefix:
+    (defn tokenize-with-config (text cfg) ...)
+    (defn match-pattern (p stream) ...)
+    (defn parse (text grammar) ...)
+)
+```
+
+```
+; grammar-bnf.fk — module: bnf
+(do
+    (defn bnf/lines (s) ...)             ; private
+    (defn bnf/trim (s) ...)              ; private
+    (defn bnf/match-pattern (p s r) ...) ; private — companion to engine.fk's
+
+    ;; Exported public surface:
+    (defn load-bnf-grammar (text registry) ...)
+    (defn bnf-parse (text grammar) ...)
+)
+```
+
+## Three principles
+
+**1. Private helpers always carry the module prefix.** No exceptions for
+"obvious utility" names like `trim`, `lines`, `substr`, `is-ws?`. These
+are exactly the names that collide. Prefix them.
+
+**2. Public exports live in the global namespace and are deliberately
+chosen to be unique.** When two modules export the same operation
+(e.g., both `match-pattern`), the older one keeps the name and the newer
+one prefixes — `bnf-match-pattern` rather than re-exporting `match-pattern`.
+
+**3. References across modules go through public names.** A file never
+reaches into another file's `module/` private namespace. If you find
+yourself wanting `engine/scan-while-cfg` from outside engine.fk, either
+the function needs to be promoted to the public surface or a public
+wrapper needs to exist.
+
+## What about `defn` vs `defn-private`?
+
+A future kernel could add an automatic-prefix form:
+
+```
+(module bnf
+    (defn lines (s) ...)
+    (defn trim (s) ...)
+    (export load-bnf-grammar bnf-parse))
+```
+
+The kernel would rewrite internal defns to `bnf/lines`, `bnf/trim` and
+expose only the listed exports. That removes the manual-prefix discipline
+and makes references-from-outside structurally impossible.
+
+This is a later breath. For now the slash-prefix convention is enough,
+and adopting it now means the future `(module ...)` form is a no-op
+migration (the names are already in the right shape).
+
+## What about kernel natives + parse-time verbs?
+
+These stay unqualified — `cons`, `head`, `tail`, `eq`, `add`, `str_eq`,
+`intern_node`, `walk_recipe`, etc. They are the substrate's primitive
+vocabulary, not module exports. They never collide with module names
+because every module's helpers carry a `<module>/` prefix.
+
+## What this resolves
+
+Two collisions the body hit by 2026-05-22:
+
+1. **`is-ws-cp` (1-arg in `line-grammar.fk`, 2-arg in `engine.fk`)** —
+   loading both files together corrupted `engine.fk`'s `next-token`
+   which expected the 2-arg signature.
+2. **Earlier collision** (Urs flagged this is the second time) — the
+   pattern is reliable, the prefix discipline blocks it.
+
+## Migration path
+
+- New code lands with prefixes from the start.
+- Existing files migrate as they're touched. The `engine.fk` and
+  `line-grammar.fk` migration is the natural first move — engine.fk's
+  internals become `engine/*` and `line-grammar.fk`'s become `lg/*`.
+  After that, both files can be loaded together without surprise.
+- Tests update their `; preludes:` headers as files migrate (this is
+  free since the kernel-validator already supports the header).
+
+## Lineage
+
+- **Go** — uppercase-public / lowercase-private at the file altitude;
+  package paths in import statements. The discipline this convention
+  borrows from.
+- **Python** — single-underscore-leading private convention; module
+  paths via `import`. The discipline at the same altitude in a different
+  shape.
+- **Clojure** — namespaced keywords `:my-ns/keyword`; the slash
+  separator we're borrowing.
+- **CSS BEM** — `module__element--modifier`. Long-form prefix discipline
+  proves the pattern scales to large codebases.
+
+The convention chosen here is the lightest one that resolves the
+collision pattern *without kernel changes* and *with a clear migration
+path* to a future `(module ...)` form when that becomes load-bearing.

--- a/experiments/form-stdlib/grammar-bnf.fk
+++ b/experiments/form-stdlib/grammar-bnf.fk
@@ -9,7 +9,9 @@
 ; being ~250 lines of imperative dispatch and become ~30 lines of
 ; declarative rules a human can scan.
 ;
-; The surface:
+; The surface follows BMF (Urs 2000, docs/presences/bmf-grammar.md):
+; rules use `::=` to introduce a pattern and `;` to terminate it. A
+; rule's pattern may span multiple lines until the terminating `;`.
 ;
 ;   tokens {
 ;     whitespace 32 9 10 13
@@ -28,21 +30,26 @@
 ;   }
 ;
 ;   rules {
-;     json     := value
-;     value    := object | array | STRING | INT | TRUE | FALSE | NULL
-;     pair     := STRING COLON value             => emit-pair
-;     object   := LBRACE pairs RBRACE            => emit-object
-;     pairs    := pair (COMMA pair)*             => emit-list
-;     array    := LBRACK elements RBRACK         => emit-array
-;     elements := value (COMMA value)*           => emit-list
+;     json     ::= value ;
+;     value    ::= object | array | STRING | INT | TRUE | FALSE | NULL ;
+;     pair     ::= STRING COLON value             => emit-pair  ;
+;     object   ::= LBRACE pairs RBRACE            => emit-object ;
+;     pairs    ::= pair (COMMA pair)*             => emit-list   ;
+;     array    ::= LBRACK elements RBRACK         => emit-array  ;
+;     elements ::= value (COMMA value)*           => emit-list   ;
 ;   }
 ;
 ; Reading rules:
-;   `:=` is "is composed of"; `=>` is "becomes (via emitter)"
-;   `|` separates alternatives, `*` is zero-or-more, `?` is optional,
-;   `(...)` groups. Pattern atoms are token KINDs (uppercase) or rule
-;   names (lowercase). String literals are not used in rule patterns —
-;   the tokens block names every literal once.
+;   `::=` is "is composed of"; `=>` is "becomes (via emitter)"; `;`
+;   terminates a rule. `|` separates alternatives, `*` is zero-or-more,
+;   `?` is optional, `(...)` groups. Pattern atoms are token KINDs
+;   (uppercase) or rule names (lowercase). String literals are not used
+;   in rule patterns — the tokens block names every literal once.
+;
+; Naming: per docs/coherence-substrate/form-namespaces.md, internal
+; helpers carry a `bnf-` prefix (older form of the slash-namespace
+; convention; this file pre-dates the convention doc and will migrate
+; to `bnf/...` in a follow-on breath once engine.fk migrates in lockstep).
 ;
 ; Output (engine.fk-compatible):
 ;   token-config — same shape engine.fk's tokenize-with-config consumes
@@ -125,12 +132,15 @@
 
     (defn bnf-line-text (ln) (head ln))
 
-    ;; comment marker: ';' (Form-native) — same convention as .fk files
+    ;; comment marker: ';' (Form-native) followed by any content. A
+    ;; standalone `;` is the BMF rule terminator and must NOT be flagged
+    ;; as a comment here — the rule-flusher in Part 9 will pick it up
+    ;; when it lands at the end of an accumulated rule buffer.
     (defn bnf-is-comment? (text)
         (do
             (let trimmed (bnf-trim-leading-ws text))
-            (if (eq (str_len trimmed) 0) false
-                (eq (ord (char_at trimmed 0)) 59))))   ; ';' = 59
+            (if (le (str_len trimmed) 1) false
+                (eq (ord (char_at trimmed 0)) 59))))   ; ';' = 59 + has more content
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Part 2 — block detection
@@ -412,11 +422,27 @@
                 (list (bnf-substr text 0 pos)
                       (bnf-substr text (add pos (str_len sep)) (str_len text))))))
 
+    ;; bnf-parse-rule-line: BMF-style surface
+    ;;   "name ::= pattern => action ;"
+    ;; → ("name", "pattern", "action")
+    ;;
+    ;; The terminating `;` is stripped if present. Action half (`=>`)
+    ;; is optional. Pattern half is everything between `::=` and either
+    ;; `=>` or `;` (whichever comes first).
+    (defn bnf-strip-semi (text)
+        (do
+            (let trimmed (bnf-trim text))
+            (let n (str_len trimmed))
+            (if (eq n 0) trimmed
+                (if (eq (ord (char_at trimmed (sub n 1))) 59)   ; ';' = 59
+                    (bnf-trim (bnf-substr trimmed 0 (sub n 1)))
+                    trimmed))))
+
     (defn bnf-parse-rule-line (text)
         (do
-            (let def-split (bnf-split-on text ":="))
+            (let def-split (bnf-split-on text "::="))
             (let name (bnf-trim (head def-split)))
-            (let body (head (tail def-split)))
+            (let body (bnf-strip-semi (head (tail def-split))))
             (let act-split (bnf-split-on body "=>"))
             (let pattern-text (bnf-trim (head act-split)))
             (let action-name (bnf-trim (head (tail act-split))))
@@ -461,32 +487,79 @@
     ;; Part 9 — top-level reader: text → grammar data tuple
     ;; ──────────────────────────────────────────────────────────────────
 
-    (defn bnf-read-loop (lines state tok-st rules registry)
+    ;; bnf-find-semi: position of next `;` in text, or -1 if none. Skips
+    ;; semicolons inside line comments (`;` followed by another comment-
+    ;; making char would itself be a comment, but BMF rules don't use
+    ;; `;` for anything other than terminator so this is straightforward).
+    (defn bnf-find-semi (s i)
+        (if (ge i (str_len s)) (sub 0 1)
+            (if (eq (ord (char_at s i)) 59) i
+                (bnf-find-semi s (add i 1)))))
+
+    ;; bnf-flush-rules: pull all complete rules out of the accumulated
+    ;; buffer (each terminated by `;`). Returns (new-rules-prepended,
+    ;; remaining-buffer-after-last-semi).
+    (defn bnf-flush-rules (buffer rules registry)
+        (do
+            (let pos (bnf-find-semi buffer 0))
+            (if (lt pos 0)
+                (list rules buffer)
+                (do
+                    (let rule-text (bnf-substr buffer 0 (add pos 1)))
+                    (let remaining (bnf-substr buffer (add pos 1) (str_len buffer)))
+                    (let trimmed (bnf-trim rule-text))
+                    (if (or (eq (str_len trimmed) 0)
+                            (str_eq trimmed ";"))
+                        (bnf-flush-rules remaining rules registry)
+                        (bnf-flush-rules remaining
+                                          (cons (bnf-build-rule trimmed registry) rules)
+                                          registry))))))
+
+    ;; bnf-read-loop carries an extra accumulator: rule-buf, the text
+    ;; collected since the last `;` terminator. Inside "rules" state,
+    ;; every non-blank/non-comment line appends to rule-buf and any
+    ;; complete rules (terminated by `;`) are flushed into the rules
+    ;; list. The buffer carries over multiple lines so rule patterns
+    ;; can span as many lines as the author prefers.
+    (defn bnf-read-loop (lines state tok-st rule-buf rules registry)
         (if (nil? lines)
-            (list (bnf-finalize-token-config tok-st) (bnf-reverse rules))
+            (do
+                (let flush (bnf-flush-rules rule-buf rules registry))
+                (list (bnf-finalize-token-config tok-st)
+                      (bnf-reverse (head flush))))
             (do
                 (let ln (head lines))
                 (let text (bnf-line-text ln))
                 (let trimmed (bnf-trim text))
                 (if (or (bnf-is-blank? trimmed) (bnf-is-comment? trimmed))
-                    (bnf-read-loop (tail lines) state tok-st rules registry)
+                    (bnf-read-loop (tail lines) state tok-st rule-buf rules registry)
                 (if (str_eq state "outside")
                     (if (bnf-block-open? trimmed "tokens")
-                        (bnf-read-loop (tail lines) "tokens" tok-st rules registry)
+                        (bnf-read-loop (tail lines) "tokens" tok-st rule-buf rules registry)
                     (if (bnf-block-open? trimmed "rules")
-                        (bnf-read-loop (tail lines) "rules" tok-st rules registry)
-                        (bnf-read-loop (tail lines) state tok-st rules registry)))
+                        (bnf-read-loop (tail lines) "rules" tok-st rule-buf rules registry)
+                        (bnf-read-loop (tail lines) state tok-st rule-buf rules registry)))
                 (if (str_eq state "tokens")
                     (if (bnf-block-close? trimmed)
-                        (bnf-read-loop (tail lines) "outside" tok-st rules registry)
+                        (bnf-read-loop (tail lines) "outside" tok-st rule-buf rules registry)
                         (bnf-read-loop (tail lines) state
                                         (bnf-tok-line-step tok-st (bnf-fields trimmed))
-                                        rules registry))
+                                        rule-buf rules registry))
+                    ;; "rules" state
                     (if (bnf-block-close? trimmed)
-                        (bnf-read-loop (tail lines) "outside" tok-st rules registry)
-                        (bnf-read-loop (tail lines) state tok-st
-                                        (cons (bnf-build-rule trimmed registry) rules)
-                                        registry))))))))
+                        (do
+                            (let flush (bnf-flush-rules rule-buf rules registry))
+                            (bnf-read-loop (tail lines) "outside" tok-st
+                                            (head (tail flush))
+                                            (head flush)
+                                            registry))
+                        (do
+                            (let appended (str_concat rule-buf (str_concat " " trimmed)))
+                            (let flush (bnf-flush-rules appended rules registry))
+                            (bnf-read-loop (tail lines) state tok-st
+                                            (head (tail flush))
+                                            (head flush)
+                                            registry)))))))))
 
     ;; load-bnf-grammar: text + emitter registry → engine-compatible
     ;; grammar tuple: ((tokens token-config) (rules parse-rules))
@@ -494,7 +567,7 @@
         (do
             (let lines (bnf-lines text))
             (let initial-st (bnf-tok-state-empty 0))
-            (let parts (bnf-read-loop lines "outside" initial-st (empty) registry))
+            (let parts (bnf-read-loop lines "outside" initial-st "" (empty) registry))
             (let tokens (head parts))
             (let rules (head (tail parts)))
             (list (list "tokens" tokens)

--- a/experiments/form-stdlib/grammars/json.bnf.fk
+++ b/experiments/form-stdlib/grammars/json.bnf.fk
@@ -111,11 +111,11 @@
 }
 
 rules {
-  json     := value
-  value    := STRING | INT | TRUE | FALSE | NULL
-  pair     := STRING COLON value
-  object   := LBRACE RBRACE
-  array    := LBRACK RBRACK
+  json     ::= value ;
+  value    ::= STRING | INT | TRUE | FALSE | NULL ;
+  pair     ::= STRING COLON value ;
+  object   ::= LBRACE RBRACE ;
+  array    ::= LBRACK RBRACK ;
 }")
 
     ;; ──────────────────────────────────────────────────────────────────

--- a/experiments/form-stdlib/tests/grammar-bnf.fk
+++ b/experiments/form-stdlib/tests/grammar-bnf.fk
@@ -30,7 +30,7 @@
     ;; Probe 2 — rule-line splitter
     ;; ──────────────────────────────────────────────────────────────────
 
-    (let p4-parts (bnf-parse-rule-line "pair := STRING COLON value => emit-pair"))
+    (let p4-parts (bnf-parse-rule-line "pair ::= STRING COLON value => emit-pair ;"))
     (let probe-4 (if (and (str_eq (head p4-parts) "pair")
                           (str_eq (head (tail (tail p4-parts))) "emit-pair"))
                      1 0))                              ; → 1
@@ -60,7 +60,7 @@
            digit-kind INT
          }
          rules {
-           start := INT => emit-int
+           start ::= INT => emit-int ;
          }")
 
     (let grammar-1 (load-bnf-grammar bnf-text-1 registry-1))
@@ -96,8 +96,8 @@
            digit-kind INT
          }
          rules {
-           start := inner => emit-start
-           inner := INT => emit-inner
+           start ::= inner => emit-start ;
+           inner ::= INT => emit-inner ;
          }")
 
     (let grammar-2 (load-bnf-grammar bnf-text-2 registry-2))
@@ -105,13 +105,41 @@
     (let probe-7 (walk_recipe result-2))                ; → 17
 
     ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 6 — multi-line rule (BMF surface: `;` terminator lets a
+    ;; rule's pattern span as many lines as the author prefers)
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; The rule spans three lines; the parser must join them on `;`.
+
+    (defn emit-multi (caps)
+        (intern_trivial_int (str_to_int (cap-get caps "_1"))))
+
+    (let registry-3 (list (list "emit-multi" emit-multi)))
+
+    (let bnf-text-3
+        "tokens {
+           whitespace 32 9 10 13
+           digit-kind INT
+         }
+         rules {
+           start ::=
+               INT
+               => emit-multi
+               ;
+         }")
+
+    (let grammar-3 (load-bnf-grammar bnf-text-3 registry-3))
+    (let result-3 (bnf-parse "55" grammar-3))
+    (let probe-8 (walk_recipe result-3))                ; → 55
+
+    ;; ──────────────────────────────────────────────────────────────────
     ;; Sum the probes — sibling kernels must agree on every digit
     ;; ──────────────────────────────────────────────────────────────────
-    ;; 3 + 3 + 5 + 1 + 1 + 42 + 17 = 72
+    ;; 3 + 3 + 5 + 1 + 1 + 42 + 17 + 55 = 127
 
     (add probe-1
          (add probe-2
               (add probe-3
                    (add probe-4
                         (add probe-5
-                             (add probe-6 probe-7)))))))
+                             (add probe-6
+                                  (add probe-7 probe-8))))))))


### PR DESCRIPTION
## What this breath lands

Three of @urs-muff's redirects landed in this breath:

### 1. BMF surface — the lineage as the starting place

Rule syntax shifts from `:=` to `::=` (proper BNF/BMF from Urs's 2000 master's thesis) and gains a `;` terminator. The terminator unlocks **multi-line rule patterns** — a rule's pattern may span as many lines as the author prefers until the closing `;`:

\`\`\`
rules {
  start ::=
      INT
      => emit-multi
      ;

  pair  ::= STRING COLON value => emit-pair ;
}
\`\`\`

Mirrors `BMF-grammar.bml`'s surface directly. The `=>` action arrow is a modern improvement on BMF's separate `#process` form.

### 2. Form namespace convention

[`docs/coherence-substrate/form-namespaces.md`](docs/coherence-substrate/form-namespaces.md) names the discipline that resolves the `is-ws-cp` 1-arg-vs-2-arg collision the body hit twice. Slash-prefix per file: `engine/is-ws-cp`, `bnf/lines`. Form's bootstrap reader already accepts `/` in identifiers, so this is pure naming discipline with no kernel work. A future `(module ...)` form would auto-prefix; for now the prefix is explicit.

The full migration of engine.fk and grammars/*.fk to slash-namespaces is a follow-on breath — it touches many tests in lockstep and the doc names the migration shape explicitly.

### 3. The `;` ambiguity resolved

Form's `;` is a comment marker. BMF's `;` is a rule terminator. Cleanest resolution: `;` followed by content is a comment; `;` alone (or just whitespace + `;`) is the rule terminator. The rule-flusher in Part 9 picks up terminators from accumulated buffer state across multi-line patterns.

## Per-kernel validation

`grammar-bnf.fk` passes **127** on Go / Rust / TypeScript (was 72; the additional 55 is the new multi-line probe). No new test divergences introduced; the 24 pre-existing failures are TypeScript-kernel native gaps (`intern_node_at`) tracked separately.

## What stays for follow-on breaths

- Full slash-namespace migration of `engine.fk` + `grammars/*.fk`
- Tree-sitter grammar import for Python / TypeScript / Rust / Go (@urs-muff: "we just need the full grammar which you can find on tree-sitter or other places")
- NUMS.Go execution engine + name resolution borrowed (@urs-muff: "we can certainly borrow things that are proving to work and do not have to start from scratch")
- Region-aware streaming (CSS inside .tsx, expression-grammar inside Python f-strings)

## Test plan

- [x] `tests/grammar-bnf.fk` → 127 on all 3 sibling kernels
- [x] BMF `::=` and `;` terminator parsed correctly
- [x] Multi-line rule (`start ::= INT => emit-multi ;` split across 4 lines) parses correctly
- [x] No new test divergences in `form-kernel-validate.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)