### PR TITLE
tend: EXECUTE half — walker turns Python Recipes into actions

### DIFF
--- a/experiments/form-kernel-ts/src/kernel.ts
+++ b/experiments/form-kernel-ts/src/kernel.ts
@@ -1006,6 +1006,18 @@ export class Kernel {
     this.registerNative("node_value", catWitness(), (k, args) =>
       k.trivialValue(argNodeID(args, 0)),
     );
+    // node_eq — structural compare of two NodeIDs by their four
+    // components. Sibling parity with Go's node_eq + Rust's node_eq.
+    this.registerNative("node_eq", catWitness(), (_k, args) => {
+      const a = argNodeID(args, 0);
+      const b = argNodeID(args, 1);
+      const equal =
+        a.pkg === b.pkg &&
+        a.level === b.level &&
+        a.type === b.type &&
+        a.inst === b.inst;
+      return { kind: "bool", bool: equal };
+    });
     this.registerNative("walk_recipe", catWitness(), (k, args) =>
       walk(k, argNodeID(args, 0), new Frame(null)),
     );

--- a/experiments/form-stdlib/grammars/python-exec.fk
+++ b/experiments/form-stdlib/grammars/python-exec.fk
@@ -1,0 +1,113 @@
+; grammars/python-exec.fk — minimal EXECUTE walker for Python BNF
+; recipes
+;
+; Companion to grammars/python.bnf.fk. Walks the parsed Recipe tree
+; statement-by-statement and performs the operation each Recipe stands
+; for. Demonstrates the read → understand → execute pipeline the
+; four-language goal points at:
+;
+;   text → tokenize-with-config → tokens
+;   tokens → bnf-parse → Recipe tree (universal Blueprints)
+;   Recipe tree → py-execute → side effects + return value
+;
+; This file handles the subset python.bnf.fk parses (file-header
+; statements). Each Recipe NodeID becomes one execution arm:
+;
+;   PY-BNF-IMPORT      → records `imported: <module>` (or with alias)
+;   PY-BNF-FROM-IMPORT → records `from <module>` import
+;   PY-BNF-FUNCTION-DEF→ records `defined: <name>`
+;   PY-BNF-ASSIGN      → binds <name> in the env, returns its value
+;
+; The walker maintains a simple env (list of (name value) pairs).
+; Return value: the count of statements executed — a deterministic
+; integer that lets sibling kernels validate byte-identical behavior.
+;
+; A second breath can extend the grammar to function bodies + calls;
+; this file's walker grows alongside without architecture changes.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Recipe-shape predicates — keyed by Blueprint NodeID
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let PY-EXEC-IMPORT       (make_nodeid 1 2 99 41))
+    (let PY-EXEC-FROM-IMPORT  (make_nodeid 1 2 99 42))
+    (let PY-EXEC-FUNCTION-DEF (make_nodeid 1 2 99 43))
+    (let PY-EXEC-ASSIGN       (make_nodeid 1 2 99 44))
+
+    (defn py-exec-is-import? (n)
+        (node_eq (node_category n) PY-EXEC-IMPORT))
+
+    (defn py-exec-is-from-import? (n)
+        (node_eq (node_category n) PY-EXEC-FROM-IMPORT))
+
+    (defn py-exec-is-function-def? (n)
+        (node_eq (node_category n) PY-EXEC-FUNCTION-DEF))
+
+    (defn py-exec-is-assign? (n)
+        (node_eq (node_category n) PY-EXEC-ASSIGN))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Env — a simple (name value) association list
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn py-exec-env-empty (_x) (empty))
+
+    (defn py-exec-env-bind (env name value)
+        (cons (list name value) env))
+
+    (defn py-exec-env-lookup (env name)
+        (if (nil? env) ""
+            (if (str_eq (head (head env)) name)
+                (head (tail (head env)))
+                (py-exec-env-lookup (tail env) name))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Execute one statement Recipe — returns the new env
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn py-exec-stmt (stmt env)
+        (do
+            (let kids (node_children stmt))
+            (if (py-exec-is-import? stmt)
+                (do
+                    (let mod-name (node_value (head kids)))
+                    (let alias (node_value (head (tail kids))))
+                    (let bound (if (str_eq alias "") mod-name alias))
+                    (print (str_concat "import: " mod-name))
+                    (py-exec-env-bind env bound mod-name))
+            (if (py-exec-is-from-import? stmt)
+                (do
+                    (let mod-name (node_value (head kids)))
+                    (print (str_concat "from-import: " mod-name))
+                    env)
+            (if (py-exec-is-function-def? stmt)
+                (do
+                    (let fn-name (node_value (head kids)))
+                    (print (str_concat "def: " fn-name))
+                    (py-exec-env-bind env fn-name "<function>"))
+            (if (py-exec-is-assign? stmt)
+                (do
+                    (let name (node_value (head kids)))
+                    (let value (node_value (head (tail kids))))
+                    (print (str_concat "assign: " (str_concat name (str_concat " = " value))))
+                    (py-exec-env-bind env name value))
+                ;; unknown statement — pass through
+                env))))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; py-execute: walk a parsed Python module and run each statement
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Convention: the input is the result of parse-python-bnf (one
+    ;; root Recipe). For a single-statement module, the root IS the
+    ;; statement Recipe. For multi-statement (later breath), it's a
+    ;; sequence whose children are statements. This first cut handles
+    ;; single-statement; the helper scales transparently when grammar
+    ;; widens to `statement*`.
+
+    (defn py-execute (root)
+        (do
+            (let final-env (py-exec-stmt root (py-exec-env-empty 0)))
+            (len final-env)))
+
+    0)

--- a/experiments/form-stdlib/tests/python-exec.fk
+++ b/experiments/form-stdlib/tests/python-exec.fk
@@ -1,0 +1,36 @@
+; tests/python-exec.fk — exercise the EXECUTE pipeline on Python BNF
+; recipes
+;
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python.bnf.fk form-stdlib/grammars/python-exec.fk
+;
+; Proof of the read → understand → execute arc: source text becomes
+; tokens, tokens become Recipes, Recipes become actions. The walker
+; prints what it did and returns an env-binding count the sibling
+; kernels validate byte-identically.
+
+(do
+    ;; Probe 1: import os → executes one import, env grows by 1
+    (let result-1 (parse-python-bnf "t.py" "import os"))
+    (let count-1 (py-execute result-1))                ; → 1
+
+    ;; Probe 2: import os as system → executes import, binds `system`
+    (let result-2 (parse-python-bnf "t.py" "import os as system"))
+    (let count-2 (py-execute result-2))                ; → 1
+
+    ;; Probe 3: x = 42 → executes assign, env grows by 1
+    (let result-3 (parse-python-bnf "t.py" "x = 42"))
+    (let count-3 (py-execute result-3))                ; → 1
+
+    ;; Probe 4: def main(): → executes def, env grows by 1
+    (let result-4 (parse-python-bnf "t.py" "def main():"))
+    (let count-4 (py-execute result-4))                ; → 1
+
+    ;; Probe 5: from typing import List → executes from-import (no env bind)
+    (let result-5 (parse-python-bnf "t.py" "from typing import List"))
+    (let count-5 (py-execute result-5))                ; → 0
+
+    ;; Sum: 1 + 1 + 1 + 1 + 0 = 4
+    (add count-1
+         (add count-2
+              (add count-3
+                   (add count-4 count-5)))))


### PR DESCRIPTION
## The third verb lands

With breaths 1-5, source text became tokens became Recipe trees with universal Blueprints — *read + understand*. This breath turns Recipes into actions — *execute*. The four-language goal's full arc is now demonstrated end-to-end:

\`\`\`
text → tokenize-with-config → tokens
tokens → bnf-parse → Recipe tree (universal Blueprints)
Recipe tree → py-execute → side effects + env-bindings
\`\`\`

## What landed

**[grammars/python-exec.fk](experiments/form-stdlib/grammars/python-exec.fk)** — a Recipe-tree walker that dispatches by Blueprint NodeID and performs the operation each statement stands for:

| Recipe | Action |
|--------|--------|
| \`PY-BNF-IMPORT\` | prints \`import: <module>\`, binds module in env |
| \`PY-BNF-FROM-IMPORT\` | prints \`from-import: <module>\` |
| \`PY-BNF-FUNCTION-DEF\` | prints \`def: <name>\`, binds in env |
| \`PY-BNF-ASSIGN\` | prints \`assign: <name> = <value>\`, binds in env |

The walker maintains a (name value) env list and returns the env-binding count.

**TS-kernel parity gap closed:** \`node_eq\` native added to \`form-kernel-ts/src/kernel.ts\`, matching Go's and Rust's structural NodeID comparison. Without it, the walker's blueprint-dispatch predicates can't fire on TS.

## Validation

| Kernel | Result | Output |
|--------|--------|--------|
| Go | 4 ✓ | byte-identical |
| Rust | 4 ✓ | byte-identical |
| TypeScript | 4 ✓ | byte-identical |

Print output (every kernel):
\`\`\`
import: os
import: os
assign: x = 42
def: main
from-import: typing
4
\`\`\`

## Where the goal stands after 6 breaths

- ✓ **READ** — engine.fk's tokenizer handles strings, comments, multi-quote keywords
- ✓ **UNDERSTAND** — Python/TS/Rust/Go grammars parse to universal Blueprints (file-header subset on all four)
- ✓ **EXECUTE** — walker dispatches Recipes to actions on all three sibling kernels

**What remains toward FULL coverage per tongue:** expression grammar (precedence climbing), multi-statement modules, function-body execute (calls, locals, returns), language-specific lexical extensions (f-strings, raw strings, template literals). Each is a per-tongue extension that drops into the architecture this breath proves end-to-end. The shape is sustained; remaining work is breadth, not depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)