### PR TITLE
tend: multi-statement Python — actual files parse + execute end-to-end

### DIFF
--- a/experiments/form-stdlib/grammars/python-exec.fk
+++ b/experiments/form-stdlib/grammars/python-exec.fk
@@ -30,10 +30,14 @@
     ;; Recipe-shape predicates — keyed by Blueprint NodeID
     ;; ──────────────────────────────────────────────────────────────────
 
+    (let PY-EXEC-MODULE       (make_nodeid 1 2 99 40))
     (let PY-EXEC-IMPORT       (make_nodeid 1 2 99 41))
     (let PY-EXEC-FROM-IMPORT  (make_nodeid 1 2 99 42))
     (let PY-EXEC-FUNCTION-DEF (make_nodeid 1 2 99 43))
     (let PY-EXEC-ASSIGN       (make_nodeid 1 2 99 44))
+
+    (defn py-exec-is-module? (n)
+        (node_eq (node_category n) PY-EXEC-MODULE))
 
     (defn py-exec-is-import? (n)
         (node_eq (node_category n) PY-EXEC-IMPORT))
@@ -105,9 +109,23 @@
     ;; single-statement; the helper scales transparently when grammar
     ;; widens to `statement*`.
 
+    ;; py-exec-iter-stmts: walk a list of statement Recipes, threading
+    ;; the env. Returns the final env after the last statement.
+    (defn py-exec-iter-stmts (stmts env)
+        (if (nil? stmts) env
+            (py-exec-iter-stmts (tail stmts)
+                                 (py-exec-stmt (head stmts) env))))
+
+    ;; py-execute: walk the root Recipe. If it's a module (composite of
+    ;; statements), iterate its children. Otherwise treat it as a single
+    ;; statement Recipe (backward-compat for one-statement parses).
     (defn py-execute (root)
         (do
-            (let final-env (py-exec-stmt root (py-exec-env-empty 0)))
+            (let final-env
+                (if (py-exec-is-module? root)
+                    (py-exec-iter-stmts (node_children root)
+                                         (py-exec-env-empty 0))
+                    (py-exec-stmt root (py-exec-env-empty 0))))
             (len final-env)))
 
     0)

--- a/experiments/form-stdlib/grammars/python.bnf.fk
+++ b/experiments/form-stdlib/grammars/python.bnf.fk
@@ -102,6 +102,26 @@
 
     (defn py-bnf-emit-passthrough (caps) caps)
 
+    ;; py-bnf-emit-module: collect the leading statement plus every
+    ;; statement in `items` (from the `statement*` portion of the `+`
+    ;; sugar) into one PY-BNF-MODULE recipe whose children are the
+    ;; statement Recipes in source order.
+    (defn py-bnf-collect-results (items)
+        (if (nil? items) (empty)
+            (cons (cap-get (head items) "_result")
+                  (py-bnf-collect-results (tail items)))))
+
+    ;; Reverse a list — star collects items in reverse order via cons.
+    (defn py-bnf-rev-step (acc x) (cons x acc))
+    (defn py-bnf-reverse (xs) (foldl py-bnf-rev-step (empty) xs))
+
+    (defn py-bnf-emit-module (caps)
+        (do
+            (let first-stmt (cap-get caps "_result"))
+            (let rest-items (py-bnf-reverse (cap-get caps "items")))
+            (let all-stmts (cons first-stmt (py-bnf-collect-results rest-items)))
+            (intern_node PY-BNF-MODULE all-stmts)))
+
     ;; ──────────────────────────────────────────────────────────────────
     ;; Part 3 — the BNF grammar text
     ;; ──────────────────────────────────────────────────────────────────
@@ -132,7 +152,7 @@
 }
 
 rules {
-  module       ::= statement ;
+  module       ::= statement+                     => py-bnf-emit-module ;
   statement    ::= import-as | import-bare | from-stmt | def-stmt | assign-stmt ;
   import-as    ::= IMPORT IDENT AS IDENT          => py-bnf-emit-import-as ;
   import-bare  ::= IMPORT IDENT                    => py-bnf-emit-import-bare ;
@@ -153,6 +173,7 @@ rules {
               (list "py-bnf-emit-from-import"      py-bnf-emit-from-import)
               (list "py-bnf-emit-def"              py-bnf-emit-def)
               (list "py-bnf-emit-assign"           py-bnf-emit-assign)
+              (list "py-bnf-emit-module"           py-bnf-emit-module)
               (list "py-bnf-emit-passthrough"      py-bnf-emit-passthrough)))
 
     (let py-bnf-grammar

--- a/experiments/form-stdlib/tests/python-bnf.fk
+++ b/experiments/form-stdlib/tests/python-bnf.fk
@@ -1,75 +1,80 @@
 ; tests/python-bnf.fk — exercise python.bnf.fk's BNF-driven Python
-; file-header parser on the native kernel.
+; parser on the native kernel.
 ;
 ; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python.bnf.fk
 ;
-; The proof: the same Python file-header subset grammars/python.fk
-; parses by hand-coded line dispatch is now expressible declaratively
-; as a ~20-line BNF grammar that engine.fk walks.
+; With multi-statement support (`module ::= statement+`), the parser
+; wraps every parse in a PY-BNF-MODULE root whose children are the
+; statement Recipes. These probes unwrap to the first statement and
+; then check the statement's own children.
 
 (do
+    ;; Helper: pull the first statement out of the module wrapper.
+    (defn first-stmt (root)
+        (head (node_children root)))
+
     ;; ──────────────────────────────────────────────────────────────────
-    ;; Probe 1 — `import os` parses to a PY-BNF-IMPORT recipe with two
-    ;; children (module-name + empty-alias)
+    ;; Probe 1 — `import os` → module wrapping ONE import statement
     ;; ──────────────────────────────────────────────────────────────────
 
     (let result-1 (parse-python-bnf "test.py" "import os"))
-    (let kids-1 (node_children result-1))
-    (let probe-1 (len kids-1))                          ; → 2 children
+    (let stmt-1 (first-stmt result-1))
+    (let kids-1 (node_children stmt-1))
+    (let probe-1 (len kids-1))                          ; → 2
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Probe 2 — `import os as system` parses with alias bound
     ;; ──────────────────────────────────────────────────────────────────
 
     (let result-2 (parse-python-bnf "test.py" "import os as system"))
-    (let kids-2 (node_children result-2))
-    ;; Second child is the alias trivial string "system"
-    (let alias-node (head (tail kids-2)))
-    (let alias-val (node_value alias-node))
-    (let probe-2 (str_len alias-val))                   ; → 6 ("system")
+    (let stmt-2 (first-stmt result-2))
+    (let kids-2 (node_children stmt-2))
+    (let alias-val (node_value (head (tail kids-2))))
+    (let probe-2 (str_len alias-val))                   ; → 6
 
     ;; ──────────────────────────────────────────────────────────────────
-    ;; Probe 3 — `from typing import List` parses to a from-import
+    ;; Probe 3 — `from typing import List`
     ;; ──────────────────────────────────────────────────────────────────
 
     (let result-3 (parse-python-bnf "test.py" "from typing import List"))
-    (let kids-3 (node_children result-3))
+    (let stmt-3 (first-stmt result-3))
+    (let kids-3 (node_children stmt-3))
     (let module-val (node_value (head kids-3)))
     (let probe-3 (str_len module-val))                  ; → 6 ("typing")
 
     ;; ──────────────────────────────────────────────────────────────────
-    ;; Probe 4 — `def main():` parses to a function-def
+    ;; Probe 4 — `def main():`
     ;; ──────────────────────────────────────────────────────────────────
 
     (let result-4 (parse-python-bnf "test.py" "def main():"))
-    (let kids-4 (node_children result-4))
+    (let stmt-4 (first-stmt result-4))
+    (let kids-4 (node_children stmt-4))
     (let name-val (node_value (head kids-4)))
     (let probe-4 (str_len name-val))                    ; → 4 ("main")
 
     ;; ──────────────────────────────────────────────────────────────────
-    ;; Probe 5 — `x = 42` parses to an assignment
+    ;; Probe 5 — `x = 42`
     ;; ──────────────────────────────────────────────────────────────────
 
     (let result-5 (parse-python-bnf "test.py" "x = 42"))
-    (let kids-5 (node_children result-5))
+    (let stmt-5 (first-stmt result-5))
+    (let kids-5 (node_children stmt-5))
     (let name-val-5 (node_value (head kids-5)))
     (let probe-5 (str_len name-val-5))                  ; → 1 ("x")
 
     ;; ──────────────────────────────────────────────────────────────────
-    ;; Probe 6 — comments and whitespace are skipped at tokenize-time
-    ;; so `# header comment\nimport os` parses identically to `import os`
+    ;; Probe 6 — multi-statement module (the actual `+` postfix proof)
     ;; ──────────────────────────────────────────────────────────────────
 
-    (let result-6 (parse-python-bnf "test.py" "# top of file
-import os"))
-    (let kids-6 (node_children result-6))
-    (let probe-6 (len kids-6))                          ; → 2
+    (let result-6 (parse-python-bnf "test.py"
+"import os
+import sys
+x = 42
+def main():"))
+    (let probe-6 (len (node_children result-6)))        ; → 4
 
-    ;; ──────────────────────────────────────────────────────────────────
     ;; Sum — sibling kernels must agree
-    ;; 2 + 6 + 6 + 4 + 1 + 2 = 21
-    ;; ──────────────────────────────────────────────────────────────────
-
+    ;; 2 + 6 + 6 + 4 + 1 + 4 = 23
     (add probe-1
          (add probe-2
               (add probe-3

--- a/experiments/form-stdlib/tests/python-exec.fk
+++ b/experiments/form-stdlib/tests/python-exec.fk
@@ -3,34 +3,30 @@
 ;
 ; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python.bnf.fk form-stdlib/grammars/python-exec.fk
 ;
-; Proof of the read → understand → execute arc: source text becomes
-; tokens, tokens become Recipes, Recipes become actions. The walker
-; prints what it did and returns an env-binding count the sibling
-; kernels validate byte-identically.
+; Proof of the read → understand → execute arc on multi-statement
+; Python sources. Each input parses to a PY-BNF-MODULE wrapper whose
+; children are the statement Recipes; py-execute iterates them.
 
 (do
-    ;; Probe 1: import os → executes one import, env grows by 1
+    ;; Probe 1: single-statement file
     (let result-1 (parse-python-bnf "t.py" "import os"))
     (let count-1 (py-execute result-1))                ; → 1
 
-    ;; Probe 2: import os as system → executes import, binds `system`
-    (let result-2 (parse-python-bnf "t.py" "import os as system"))
-    (let count-2 (py-execute result-2))                ; → 1
+    ;; Probe 2: two-statement file
+    (let result-2 (parse-python-bnf "t.py" "import os
+import sys"))
+    (let count-2 (py-execute result-2))                ; → 2
 
-    ;; Probe 3: x = 42 → executes assign, env grows by 1
-    (let result-3 (parse-python-bnf "t.py" "x = 42"))
-    (let count-3 (py-execute result-3))                ; → 1
+    ;; Probe 3: full file-header subset — five statements
+    (let result-3 (parse-python-bnf "t.py" "# top of file
+import os
+from typing import List
+def main():
+x = 42
+import sys as system"))
+    (let count-3 (py-execute result-3))                ; → 4
+    ;; from-import doesn't bind; only 4 of 5 statements add bindings
 
-    ;; Probe 4: def main(): → executes def, env grows by 1
-    (let result-4 (parse-python-bnf "t.py" "def main():"))
-    (let count-4 (py-execute result-4))                ; → 1
-
-    ;; Probe 5: from typing import List → executes from-import (no env bind)
-    (let result-5 (parse-python-bnf "t.py" "from typing import List"))
-    (let count-5 (py-execute result-5))                ; → 0
-
-    ;; Sum: 1 + 1 + 1 + 1 + 0 = 4
+    ;; Sum: 1 + 2 + 4 = 7
     (add count-1
-         (add count-2
-              (add count-3
-                   (add count-4 count-5)))))
+         (add count-2 count-3)))


### PR DESCRIPTION
## The first multi-statement-aware tongue

\`module ::= statement+\` uses the BMF \`+\` postfix sugar (PR #1843) to accept one or more statements in source order. \`py-bnf-emit-module\` collects the leading capture plus every iteration's \`_result\` from the star's items list (reversed since star accumulates via cons), wraps the lot in a \`PY-BNF-MODULE\` Recipe.

The walker's complementary change: when the root is a module-composite, \`py-execute\` calls \`node_children\` and iterates each statement through \`py-exec-iter-stmts\`. Single-statement still works — the module wraps one child.

## Validation

| Test | Result | Kernels |
|------|--------|---------|
| tests/python-bnf.fk | 23 | Go ✓ Rust ✓ TS ✓ |
| tests/python-exec.fk | 7 | Go ✓ Rust ✓ TS ✓ |

**Output for the full file-header subset** (byte-identical on Go/Rust/TS):

\`\`\`
# top of file
import os                  → import: os
from typing import List    → from-import: typing
def main():                → def: main
x = 42                     → assign: x = 42
import sys as system       → import: sys
\`\`\`

## What this means for the goal

Real Python source files (file-headers thereof) now read + understand + **EXECUTE** end-to-end on three sibling kernels. The arc the four-language goal points at is no longer a one-statement demonstration — it scales to the whole file. The remaining tongues (TS / Rust / Go) absorb the same multi-statement pattern with the identical \`module ::= statement+\` line in their own grammars; per-tongue update breath, not architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)