### PR TITLE
tend: multi-statement TS / Rust / Go — three more tongues parse real files

### DIFF
--- a/experiments/form-stdlib/grammars/go.bnf.fk
+++ b/experiments/form-stdlib/grammars/go.bnf.fk
@@ -10,11 +10,25 @@
 ;   - "string" / `raw` literals
 
 (do
+    (let GO-BNF-MODULE  (make_nodeid 1 2 99 79))
     (let GO-BNF-PACKAGE (make_nodeid 1 2 99 80))
     (let GO-BNF-IMPORT  (make_nodeid 1 2 99 81))
     (let GO-BNF-FUNC    (make_nodeid 1 2 99 82))
     (let GO-BNF-TYPE    (make_nodeid 1 2 99 83))
     (let GO-BNF-VAR     (make_nodeid 1 2 99 84))
+
+    (defn go-bnf-rev-step (acc x) (cons x acc))
+    (defn go-bnf-reverse (xs) (foldl go-bnf-rev-step (empty) xs))
+    (defn go-bnf-collect-results (items)
+        (if (nil? items) (empty)
+            (cons (cap-get (head items) "_result")
+                  (go-bnf-collect-results (tail items)))))
+    (defn go-bnf-emit-module (caps)
+        (do
+            (let first-stmt (cap-get caps "_result"))
+            (let rest-items (go-bnf-reverse (cap-get caps "items")))
+            (let all-stmts (cons first-stmt (go-bnf-collect-results rest-items)))
+            (intern_node GO-BNF-MODULE all-stmts)))
 
     (defn go-bnf-emit-package (caps)
         ;; PACKAGE IDENT — _2=name
@@ -74,7 +88,7 @@
 }
 
 rules {
-  module      ::= statement ;
+  module      ::= statement+ => go-bnf-emit-module ;
   statement   ::= package-stmt | import-stmt | func-stmt | type-stmt | var-stmt ;
   package-stmt ::= PACKAGE IDENT                          => go-bnf-emit-package ;
   import-stmt  ::= IMPORT STRING                           => go-bnf-emit-import ;
@@ -88,7 +102,8 @@ rules {
               (list "go-bnf-emit-import"      go-bnf-emit-import)
               (list "go-bnf-emit-func"        go-bnf-emit-func)
               (list "go-bnf-emit-type-struct" go-bnf-emit-type-struct)
-              (list "go-bnf-emit-var"         go-bnf-emit-var)))
+              (list "go-bnf-emit-var"         go-bnf-emit-var)
+              (list "go-bnf-emit-module"      go-bnf-emit-module)))
 
     (let go-bnf-grammar
         (load-bnf-grammar go-bnf-text go-bnf-registry))

--- a/experiments/form-stdlib/grammars/rust.bnf.fk
+++ b/experiments/form-stdlib/grammars/rust.bnf.fk
@@ -10,11 +10,25 @@
 ;   - "string" literals
 
 (do
+    (let RS-BNF-MODULE    (make_nodeid 1 2 99 69))
     (let RS-BNF-USE       (make_nodeid 1 2 99 70))
     (let RS-BNF-PUB-USE   (make_nodeid 1 2 99 71))
     (let RS-BNF-MOD       (make_nodeid 1 2 99 72))
     (let RS-BNF-FN        (make_nodeid 1 2 99 73))
     (let RS-BNF-STRUCT    (make_nodeid 1 2 99 74))
+
+    (defn rs-bnf-rev-step (acc x) (cons x acc))
+    (defn rs-bnf-reverse (xs) (foldl rs-bnf-rev-step (empty) xs))
+    (defn rs-bnf-collect-results (items)
+        (if (nil? items) (empty)
+            (cons (cap-get (head items) "_result")
+                  (rs-bnf-collect-results (tail items)))))
+    (defn rs-bnf-emit-module (caps)
+        (do
+            (let first-stmt (cap-get caps "_result"))
+            (let rest-items (rs-bnf-reverse (cap-get caps "items")))
+            (let all-stmts (cons first-stmt (rs-bnf-collect-results rest-items)))
+            (intern_node RS-BNF-MODULE all-stmts)))
 
     (defn rs-bnf-emit-use (caps)
         ;; USE IDENT SEMI — _2=path-leaf-name (multi-segment lost here;
@@ -80,7 +94,7 @@
 }
 
 rules {
-  module      ::= statement ;
+  module      ::= statement+ => rs-bnf-emit-module ;
   statement   ::= pub-use | use-stmt | mod-stmt | pub-fn | fn-stmt | struct-stmt ;
   pub-use     ::= PUB USE IDENT SEMI               => rs-bnf-emit-pub-use ;
   use-stmt    ::= USE IDENT SEMI                    => rs-bnf-emit-use ;
@@ -96,7 +110,8 @@ rules {
               (list "rs-bnf-emit-mod"     rs-bnf-emit-mod)
               (list "rs-bnf-emit-pub-fn"  rs-bnf-emit-pub-fn)
               (list "rs-bnf-emit-fn"      rs-bnf-emit-fn)
-              (list "rs-bnf-emit-struct"  rs-bnf-emit-struct)))
+              (list "rs-bnf-emit-struct"  rs-bnf-emit-struct)
+              (list "rs-bnf-emit-module"  rs-bnf-emit-module)))
 
     (let rs-bnf-grammar
         (load-bnf-grammar rs-bnf-text rs-bnf-registry))

--- a/experiments/form-stdlib/grammars/typescript.bnf.fk
+++ b/experiments/form-stdlib/grammars/typescript.bnf.fk
@@ -16,11 +16,26 @@
 
 (do
     ;; Universal Blueprints for TS file-header shapes
+    (let TS-BNF-MODULE      (make_nodeid 1 2 99 59))
     (let TS-BNF-IMPORT      (make_nodeid 1 2 99 60))
     (let TS-BNF-IMPORT-NS   (make_nodeid 1 2 99 61))
     (let TS-BNF-IMPORT-DEF  (make_nodeid 1 2 99 62))
     (let TS-BNF-EXPORT-CONST (make_nodeid 1 2 99 63))
     (let TS-BNF-EXPORT-FN   (make_nodeid 1 2 99 64))
+
+    ;; Helpers used by the multi-statement module emitter
+    (defn ts-bnf-rev-step (acc x) (cons x acc))
+    (defn ts-bnf-reverse (xs) (foldl ts-bnf-rev-step (empty) xs))
+    (defn ts-bnf-collect-results (items)
+        (if (nil? items) (empty)
+            (cons (cap-get (head items) "_result")
+                  (ts-bnf-collect-results (tail items)))))
+    (defn ts-bnf-emit-module (caps)
+        (do
+            (let first-stmt (cap-get caps "_result"))
+            (let rest-items (ts-bnf-reverse (cap-get caps "items")))
+            (let all-stmts (cons first-stmt (ts-bnf-collect-results rest-items)))
+            (intern_node TS-BNF-MODULE all-stmts)))
 
     ;; Emitters
     (defn ts-bnf-emit-import-named (caps)
@@ -81,7 +96,7 @@
 }
 
 rules {
-  module        ::= statement ;
+  module        ::= statement+ => ts-bnf-emit-module ;
   statement     ::= import-named | import-ns | import-default | export-const | export-fn ;
   import-named  ::= IMPORT LBRACE IDENT RBRACE FROM STRING        => ts-bnf-emit-import-named ;
   import-ns     ::= IMPORT STAR AS IDENT FROM STRING               => ts-bnf-emit-import-ns ;
@@ -95,7 +110,8 @@ rules {
               (list "ts-bnf-emit-import-ns"      ts-bnf-emit-import-ns)
               (list "ts-bnf-emit-import-default" ts-bnf-emit-import-default)
               (list "ts-bnf-emit-export-const"   ts-bnf-emit-export-const)
-              (list "ts-bnf-emit-export-fn"      ts-bnf-emit-export-fn)))
+              (list "ts-bnf-emit-export-fn"      ts-bnf-emit-export-fn)
+              (list "ts-bnf-emit-module"         ts-bnf-emit-module)))
 
     (let ts-bnf-grammar
         (load-bnf-grammar ts-bnf-text ts-bnf-registry))

--- a/experiments/form-stdlib/tests/go-bnf.fk
+++ b/experiments/form-stdlib/tests/go-bnf.fk
@@ -1,40 +1,39 @@
-; tests/go-bnf.fk — exercise go.bnf.fk
+; tests/go-bnf.fk — exercise go.bnf.fk with multi-stmt
 ;
 ; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/go.bnf.fk
 
 (do
-    ;; Probe 1: package main
+    (defn first-stmt (root) (head (node_children root)))
+
     (let r1 (parse-go-bnf "t.go" "package main"))
-    (let kids-1 (node_children r1))
-    (let pkg-name (node_value (head kids-1)))
-    (let probe-1 (str_len pkg-name))                       ; → 4 ("main")
+    (let pkg-name (node_value (head (node_children (first-stmt r1)))))
+    (let probe-1 (str_len pkg-name))
 
-    ;; Probe 2: import "fmt"
     (let r2 (parse-go-bnf "t.go" "import \"fmt\""))
-    (let kids-2 (node_children r2))
-    (let imp-path (node_value (head kids-2)))
-    (let probe-2 (str_len imp-path))                       ; → 3 ("fmt")
+    (let imp-path (node_value (head (node_children (first-stmt r2)))))
+    (let probe-2 (str_len imp-path))
 
-    ;; Probe 3: func main()
     (let r3 (parse-go-bnf "t.go" "func main()"))
-    (let kids-3 (node_children r3))
-    (let fn-name (node_value (head kids-3)))
-    (let probe-3 (str_len fn-name))                        ; → 4 ("main")
+    (let fn-name (node_value (head (node_children (first-stmt r3)))))
+    (let probe-3 (str_len fn-name))
 
-    ;; Probe 4: type Kernel struct
     (let r4 (parse-go-bnf "t.go" "type Kernel struct"))
-    (let kids-4 (node_children r4))
-    (let type-name (node_value (head kids-4)))
-    (let probe-4 (str_len type-name))                      ; → 6 ("Kernel")
+    (let type-name (node_value (head (node_children (first-stmt r4)))))
+    (let probe-4 (str_len type-name))
 
-    ;; Probe 5: var Version = 1
     (let r5 (parse-go-bnf "t.go" "var Version = 1"))
-    (let kids-5 (node_children r5))
-    (let var-name (node_value (head kids-5)))
-    (let probe-5 (str_len var-name))                       ; → 7 ("Version")
+    (let var-name (node_value (head (node_children (first-stmt r5)))))
+    (let probe-5 (str_len var-name))
 
-    ;; Sum: 4 + 3 + 4 + 6 + 7 = 24
+    ;; Probe 6 — multi-statement Go file (4 statements)
+    (let r6 (parse-go-bnf "t.go" "package main
+import \"fmt\"
+type Kernel struct
+func main()"))
+    (let probe-6 (len (node_children r6)))               ; → 4
+
     (add probe-1
          (add probe-2
               (add probe-3
-                   (add probe-4 probe-5)))))
+                   (add probe-4
+                        (add probe-5 probe-6))))))

--- a/experiments/form-stdlib/tests/rust-bnf.fk
+++ b/experiments/form-stdlib/tests/rust-bnf.fk
@@ -1,40 +1,38 @@
-; tests/rust-bnf.fk — exercise rust.bnf.fk
+; tests/rust-bnf.fk — exercise rust.bnf.fk with multi-stmt
 ;
 ; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/rust.bnf.fk
 
 (do
-    ;; Probe 1: use std;
+    (defn first-stmt (root) (head (node_children root)))
+
     (let r1 (parse-rust-bnf "t.rs" "use std;"))
-    (let kids-1 (node_children r1))
-    (let path-val (node_value (head kids-1)))
-    (let probe-1 (str_len path-val))                       ; → 3 ("std")
+    (let path-val (node_value (head (node_children (first-stmt r1)))))
+    (let probe-1 (str_len path-val))
 
-    ;; Probe 2: pub use crate;
     (let r2 (parse-rust-bnf "t.rs" "pub use crate;"))
-    (let kids-2 (node_children r2))
-    (let pub-path (node_value (head kids-2)))
-    (let probe-2 (str_len pub-path))                       ; → 5 ("crate")
+    (let pub-path (node_value (head (node_children (first-stmt r2)))))
+    (let probe-2 (str_len pub-path))
 
-    ;; Probe 3: mod helper;
     (let r3 (parse-rust-bnf "t.rs" "mod helper;"))
-    (let kids-3 (node_children r3))
-    (let mod-name (node_value (head kids-3)))
-    (let probe-3 (str_len mod-name))                       ; → 6 ("helper")
+    (let mod-name (node_value (head (node_children (first-stmt r3)))))
+    (let probe-3 (str_len mod-name))
 
-    ;; Probe 4: pub fn run()
     (let r4 (parse-rust-bnf "t.rs" "pub fn run()"))
-    (let kids-4 (node_children r4))
-    (let fn-name (node_value (head kids-4)))
-    (let probe-4 (str_len fn-name))                        ; → 3 ("run")
+    (let fn-name (node_value (head (node_children (first-stmt r4)))))
+    (let probe-4 (str_len fn-name))
 
-    ;; Probe 5: struct Recipe
     (let r5 (parse-rust-bnf "t.rs" "struct Recipe"))
-    (let kids-5 (node_children r5))
-    (let st-name (node_value (head kids-5)))
-    (let probe-5 (str_len st-name))                        ; → 6 ("Recipe")
+    (let st-name (node_value (head (node_children (first-stmt r5)))))
+    (let probe-5 (str_len st-name))
 
-    ;; Sum: 3 + 5 + 6 + 3 + 6 = 23
+    ;; Probe 6 — multi-statement (3 statements)
+    (let r6 (parse-rust-bnf "t.rs" "use std;
+mod helper;
+struct Recipe"))
+    (let probe-6 (len (node_children r6)))               ; → 3
+
     (add probe-1
          (add probe-2
               (add probe-3
-                   (add probe-4 probe-5)))))
+                   (add probe-4
+                        (add probe-5 probe-6))))))

--- a/experiments/form-stdlib/tests/typescript-bnf.fk
+++ b/experiments/form-stdlib/tests/typescript-bnf.fk
@@ -1,39 +1,38 @@
-; tests/typescript-bnf.fk — exercise typescript.bnf.fk
+; tests/typescript-bnf.fk — exercise typescript.bnf.fk with multi-stmt
 ;
 ; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/typescript.bnf.fk
 
 (do
-    ;; Probe 1: import { NodeID } from './substrate';
+    (defn first-stmt (root) (head (node_children root)))
+
     (let r1 (parse-typescript-bnf "t.ts" "import { NodeID } from \"./substrate\""))
-    (let kids-1 (node_children r1))
-    (let probe-1 (len kids-1))                              ; → 2
+    (let kids-1 (node_children (first-stmt r1)))
+    (let probe-1 (len kids-1))
 
-    ;; Probe 2: import * as fs from 'fs';
     (let r2 (parse-typescript-bnf "t.ts" "import * as fs from \"fs\""))
-    (let kids-2 (node_children r2))
-    (let alias-val (node_value (head kids-2)))
-    (let probe-2 (str_len alias-val))                       ; → 2 ("fs")
+    (let alias-val (node_value (head (node_children (first-stmt r2)))))
+    (let probe-2 (str_len alias-val))
 
-    ;; Probe 3: import React from 'react';
     (let r3 (parse-typescript-bnf "t.ts" "import React from \"react\""))
-    (let kids-3 (node_children r3))
-    (let name-val (node_value (head kids-3)))
-    (let probe-3 (str_len name-val))                        ; → 5 ("React")
+    (let name-val (node_value (head (node_children (first-stmt r3)))))
+    (let probe-3 (str_len name-val))
 
-    ;; Probe 4: export const VERSION = 1;
     (let r4 (parse-typescript-bnf "t.ts" "export const VERSION = 1"))
-    (let kids-4 (node_children r4))
-    (let const-name (node_value (head kids-4)))
-    (let probe-4 (str_len const-name))                      ; → 7 ("VERSION")
+    (let const-name (node_value (head (node_children (first-stmt r4)))))
+    (let probe-4 (str_len const-name))
 
-    ;; Probe 5: export function init(): void
     (let r5 (parse-typescript-bnf "t.ts" "export function init(): void"))
-    (let kids-5 (node_children r5))
-    (let fn-name (node_value (head kids-5)))
-    (let probe-5 (str_len fn-name))                         ; → 4 ("init")
+    (let fn-name (node_value (head (node_children (first-stmt r5)))))
+    (let probe-5 (str_len fn-name))
 
-    ;; Sum: 2 + 2 + 5 + 7 + 4 = 20
+    ;; Probe 6 — multi-statement (3 statements)
+    (let r6 (parse-typescript-bnf "t.ts" "import React from \"react\"
+export const VERSION = 1
+export function init(): void"))
+    (let probe-6 (len (node_children r6)))               ; → 3
+
     (add probe-1
          (add probe-2
               (add probe-3
-                   (add probe-4 probe-5)))))
+                   (add probe-4
+                        (add probe-5 probe-6))))))


### PR DESCRIPTION
## What this breath lands

Same shape Python landed in #1844 sweeps across the other three tongues. Each grammar's \`module ::= statement\` becomes \`module ::= statement+ => <tongue>-bnf-emit-module\`. Each gains its own MODULE Blueprint plus rev / collect / emit helpers. The remaining rules are unchanged.

## Validation

| Test | Result | Go | Rust |
|------|--------|-----|------|
| typescript-bnf.fk | 23 | ✓ | ✓ |
| rust-bnf.fk | 26 | ✓ | ✓ |
| go-bnf.fk | 28 | ✓ | ✓ |

TS-kernel limit stands (stack overflow on larger grammars from #1841 — not regressed by this breath). Python still validates on TS at 7.

## Per @urs-muff's redirect

> "tree-sitter is using lexing based grammar, if we can find the BNF version of the grammar that is much closer to what BMF supports for all the languages"

Pure BNF/EBNF spec grammars by tongue:
- **Go** — golang.org/ref/spec (EBNF, ~100 productions, the cleanest)
- **Python** — CPython's \`Grammar/python.gram\` (PEG, ~500 rules)
- **Rust** — Rust Reference (EBNF per chapter)
- **TypeScript** — TS spec (EBNF, longest)

The per-tongue grammars in this PR remain at file-header parity with the predecessor line parsers. Full-coverage import from each language's official spec grammar is the next breath beyond this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)