### PR TITLE
tend: Python expressions — BMF precedence + evaluator → real Python math

### DIFF
--- a/experiments/form-stdlib/grammars/python-exec.fk
+++ b/experiments/form-stdlib/grammars/python-exec.fk
@@ -35,9 +35,74 @@
     (let PY-EXEC-FROM-IMPORT  (make_nodeid 1 2 99 42))
     (let PY-EXEC-FUNCTION-DEF (make_nodeid 1 2 99 43))
     (let PY-EXEC-ASSIGN       (make_nodeid 1 2 99 44))
+    (let PY-EXEC-BIN-EXPR     (make_nodeid 1 2 99 47))
+    (let PY-EXEC-INT-EXPR     (make_nodeid 1 2 99 48))
+    (let PY-EXEC-STR-EXPR     (make_nodeid 1 2 99 49))
+    (let PY-EXEC-IDENT-EXPR   (make_nodeid 1 2 99 50))
+    (let PY-EXEC-PAREN-EXPR   (make_nodeid 1 2 99 51))
 
     (defn py-exec-is-module? (n)
         (node_eq (node_category n) PY-EXEC-MODULE))
+
+    (defn py-exec-is-int-expr? (n)
+        (node_eq (node_category n) PY-EXEC-INT-EXPR))
+    (defn py-exec-is-str-expr? (n)
+        (node_eq (node_category n) PY-EXEC-STR-EXPR))
+    (defn py-exec-is-ident-expr? (n)
+        (node_eq (node_category n) PY-EXEC-IDENT-EXPR))
+    (defn py-exec-is-bin-expr? (n)
+        (node_eq (node_category n) PY-EXEC-BIN-EXPR))
+    (defn py-exec-is-paren-expr? (n)
+        (node_eq (node_category n) PY-EXEC-PAREN-EXPR))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Expression evaluator — walks a parsed expression Recipe and
+    ;; returns an integer value (treating booleans as 0/1, identifiers
+    ;; resolved from env when they hold ints).
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn py-exec-apply-op (op lhs rhs)
+        (if (str_eq op "+") (add lhs rhs)
+        (if (str_eq op "-") (sub lhs rhs)
+        (if (str_eq op "*") (mul lhs rhs)
+        (if (str_eq op "/") (div lhs rhs)
+        (if (str_eq op "%") (mod lhs rhs)
+        (if (str_eq op "==") (if (eq lhs rhs) 1 0)
+        (if (str_eq op "!=") (if (eq lhs rhs) 0 1)
+        (if (str_eq op "<")  (if (lt lhs rhs) 1 0)
+        (if (str_eq op ">")  (if (gt lhs rhs) 1 0)
+        (if (str_eq op "<=") (if (le lhs rhs) 1 0)
+        (if (str_eq op ">=") (if (ge lhs rhs) 1 0)
+        (if (str_eq op "and") (if (and (gt lhs 0) (gt rhs 0)) 1 0)
+        (if (str_eq op "or")  (if (or (gt lhs 0) (gt rhs 0)) 1 0)
+            0))))))))))))))
+
+    (defn py-exec-env-lookup-int (env name)
+        (if (nil? env) 0
+            (if (str_eq (head (head env)) name)
+                (do
+                    (let v (head (tail (head env))))
+                    ;; Try parsing as int; non-ints return 0
+                    (str_to_int v))
+                (py-exec-env-lookup-int (tail env) name))))
+
+    (defn py-exec-eval-expr (expr env)
+        (if (py-exec-is-int-expr? expr)
+            (walk_recipe (head (node_children expr)))
+        (if (py-exec-is-str-expr? expr)
+            0   ; strings as ints fall back to 0
+        (if (py-exec-is-ident-expr? expr)
+            (py-exec-env-lookup-int env (node_value (head (node_children expr))))
+        (if (py-exec-is-paren-expr? expr)
+            (py-exec-eval-expr (head (node_children expr)) env)
+        (if (py-exec-is-bin-expr? expr)
+            (do
+                (let kids (node_children expr))
+                (let op (node_value (head kids)))
+                (let lhs-val (py-exec-eval-expr (head (tail kids)) env))
+                (let rhs-val (py-exec-eval-expr (head (tail (tail kids))) env))
+                (py-exec-apply-op op lhs-val rhs-val))
+            0))))))
 
     (defn py-exec-is-import? (n)
         (node_eq (node_category n) PY-EXEC-IMPORT))
@@ -93,9 +158,13 @@
             (if (py-exec-is-assign? stmt)
                 (do
                     (let name (node_value (head kids)))
-                    (let value (node_value (head (tail kids))))
-                    (print (str_concat "assign: " (str_concat name (str_concat " = " value))))
-                    (py-exec-env-bind env name value))
+                    (let value-expr (head (tail kids)))
+                    ;; Evaluate the expression Recipe (int arithmetic /
+                    ;; comparison / boolean / paren / ident lookup).
+                    (let value-int (py-exec-eval-expr value-expr env))
+                    (let value-str (int_to_str value-int))
+                    (print (str_concat "assign: " (str_concat name (str_concat " = " value-str))))
+                    (py-exec-env-bind env name value-str))
                 ;; unknown statement — pass through
                 env))))))
 

--- a/experiments/form-stdlib/grammars/python.bnf.fk
+++ b/experiments/form-stdlib/grammars/python.bnf.fk
@@ -50,6 +50,11 @@
     (let PY-BNF-ASSIGN       (make_nodeid 1 2 99 44))
     (let PY-BNF-IDENT        (make_nodeid 1 2 99 45))
     (let PY-BNF-NAME-PAIR    (make_nodeid 1 2 99 46))
+    (let PY-BNF-BIN-EXPR     (make_nodeid 1 2 99 47))
+    (let PY-BNF-INT-EXPR     (make_nodeid 1 2 99 48))
+    (let PY-BNF-STR-EXPR     (make_nodeid 1 2 99 49))
+    (let PY-BNF-IDENT-EXPR   (make_nodeid 1 2 99 50))
+    (let PY-BNF-PAREN-EXPR   (make_nodeid 1 2 99 51))
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Part 2 — emitter library
@@ -123,6 +128,90 @@
             (intern_node PY-BNF-MODULE all-stmts)))
 
     ;; ──────────────────────────────────────────────────────────────────
+    ;; Python expression emitters — BMF-style precedence as DATA
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Python operator precedence (subset; standard left-assoc except **):
+    ;;   or       → 3
+    ;;   and      → 4
+    ;;   == != < > <= >= → 6
+    ;;   + -      → 11
+    ;;   * / // % → 12
+    ;;   **       → 14 (right-assoc — left-fold here as simplification)
+
+    (let py-bnf-binop-prec-table
+        (list
+            (list "or" 3) (list "and" 4)
+            (list "==" 6) (list "!=" 6)
+            (list "<"  6) (list ">"  6)
+            (list "<=" 6) (list ">=" 6)
+            (list "+" 11) (list "-" 11)
+            (list "*" 12) (list "/" 12) (list "//" 12) (list "%" 12)
+            (list "**" 14)))
+
+    (defn py-bnf-lookup-prec (table text)
+        (if (nil? table) 0
+            (if (str_eq (head (head table)) text)
+                (head (tail (head table)))
+                (py-bnf-lookup-prec (tail table) text))))
+
+    (defn py-bnf-climb (lhs items table min-prec)
+        (if (nil? items) (list lhs items)
+            (do
+                (let item (head items))
+                (let op (cap-get item "op"))
+                (let op-prec (py-bnf-lookup-prec table op))
+                (if (lt op-prec min-prec)
+                    (list lhs items)
+                    (do
+                        (let rhs (cap-get item "rhs"))
+                        (let rest-after (tail items))
+                        (let inner (py-bnf-climb rhs rest-after table
+                                                   (add op-prec 1)))
+                        (let inner-rhs (head inner))
+                        (let after-inner (head (tail inner)))
+                        (let new-lhs
+                            (intern_node PY-BNF-BIN-EXPR
+                                          (list (intern_trivial_string op)
+                                                lhs inner-rhs)))
+                        (py-bnf-climb new-lhs after-inner table min-prec))))))
+
+    (defn py-bnf-emit-expression (caps)
+        (do
+            (let lhs (cap-get caps "lhs"))
+            (let raw-items (cap-get caps "items"))
+            (if (nil? raw-items) lhs
+                (do
+                    (let ordered (py-bnf-reverse raw-items))
+                    (let result (py-bnf-climb lhs ordered
+                                               py-bnf-binop-prec-table 0))
+                    (head result)))))
+
+    (defn py-bnf-emit-int-expr (caps)
+        (intern_node PY-BNF-INT-EXPR
+                      (list (intern_trivial_int
+                              (str_to_int (cap-get caps "value"))))))
+
+    (defn py-bnf-emit-str-expr (caps)
+        (intern_node PY-BNF-STR-EXPR
+                      (list (intern_trivial_string (cap-get caps "value")))))
+
+    (defn py-bnf-emit-ident-expr (caps)
+        (intern_node PY-BNF-IDENT-EXPR
+                      (list (intern_trivial_string (cap-get caps "name")))))
+
+    (defn py-bnf-emit-paren-expr (caps)
+        (intern_node PY-BNF-PAREN-EXPR
+                      (list (cap-get caps "expr"))))
+
+    ;; py-bnf-emit-assign now takes an expression Recipe (not a string).
+    ;; The structured emit lets downstream tools (py-exec, py-emit) walk
+    ;; both the lhs (name) and the rhs (value Recipe).
+    (defn py-bnf-emit-assign-expr (caps)
+        (intern_node PY-BNF-ASSIGN
+                      (list (intern_trivial_string (cap-get caps "name"))
+                            (cap-get caps "value"))))
+
+    ;; ──────────────────────────────────────────────────────────────────
     ;; Part 3 — the BNF grammar text
     ;; ──────────────────────────────────────────────────────────────────
     ;; Reading aloud:
@@ -143,22 +232,47 @@
   operator ) RPAREN
   operator , COMMA
   operator : COLON
-  operator = EQUALS
   operator . DOT
+  operator == EQEQ
+  operator != NEQ
+  operator <= LE
+  operator >= GE
+  operator <  LT
+  operator >  GT
+  operator ** STARSTAR
+  operator // SLASHSLASH
+  operator =  EQUALS
+  operator +  PLUS
+  operator -  MINUS
+  operator *  STAR
+  operator /  SLASH
+  operator %  PERCENT
   keyword IMPORT import
   keyword FROM from
   keyword AS as
   keyword DEF def
+  keyword AND and
+  keyword OR or
+  keyword NOT not
 }
 
 rules {
-  module       ::= statement+                     => py-bnf-emit-module ;
+  module       ::= statement+                                  => py-bnf-emit-module ;
   statement    ::= import-as | import-bare | from-stmt | def-stmt | assign-stmt ;
-  import-as    ::= IMPORT IDENT AS IDENT          => py-bnf-emit-import-as ;
-  import-bare  ::= IMPORT IDENT                    => py-bnf-emit-import-bare ;
-  from-stmt    ::= FROM IDENT IMPORT IDENT         => py-bnf-emit-from-import ;
-  def-stmt     ::= DEF IDENT LPAREN RPAREN COLON   => py-bnf-emit-def ;
-  assign-stmt  ::= IDENT EQUALS INT                => py-bnf-emit-assign ;
+  import-as    ::= IMPORT IDENT AS IDENT                       => py-bnf-emit-import-as ;
+  import-bare  ::= IMPORT IDENT                                 => py-bnf-emit-import-bare ;
+  from-stmt    ::= FROM IDENT IMPORT IDENT                      => py-bnf-emit-from-import ;
+  def-stmt     ::= DEF IDENT LPAREN RPAREN COLON                => py-bnf-emit-def ;
+  assign-stmt  ::= name:IDENT EQUALS value:expression           => py-bnf-emit-assign-expr ;
+  ;; BMF-style: ONE Expression rule + precedence DATA in Form code.
+  expression   ::= lhs:primary-expr (op:binary-op rhs:primary-expr)* => py-bnf-emit-expression ;
+  binary-op    ::= OR | AND | EQEQ | NEQ | LE | GE | LT | GT
+                 | PLUS | MINUS | STARSTAR | SLASHSLASH | STAR | SLASH | PERCENT ;
+  primary-expr ::= int-lit | str-lit | ident-expr | paren-expr ;
+  paren-expr   ::= LPAREN expr:expression RPAREN                => py-bnf-emit-paren-expr ;
+  int-lit      ::= value:INT                                    => py-bnf-emit-int-expr ;
+  str-lit      ::= value:STRING                                 => py-bnf-emit-str-expr ;
+  ident-expr   ::= name:IDENT                                   => py-bnf-emit-ident-expr ;
 }")
 
     ;; ──────────────────────────────────────────────────────────────────
@@ -173,7 +287,13 @@ rules {
               (list "py-bnf-emit-from-import"      py-bnf-emit-from-import)
               (list "py-bnf-emit-def"              py-bnf-emit-def)
               (list "py-bnf-emit-assign"           py-bnf-emit-assign)
+              (list "py-bnf-emit-assign-expr"      py-bnf-emit-assign-expr)
               (list "py-bnf-emit-module"           py-bnf-emit-module)
+              (list "py-bnf-emit-expression"      py-bnf-emit-expression)
+              (list "py-bnf-emit-int-expr"         py-bnf-emit-int-expr)
+              (list "py-bnf-emit-str-expr"         py-bnf-emit-str-expr)
+              (list "py-bnf-emit-ident-expr"       py-bnf-emit-ident-expr)
+              (list "py-bnf-emit-paren-expr"       py-bnf-emit-paren-expr)
               (list "py-bnf-emit-passthrough"      py-bnf-emit-passthrough)))
 
     (let py-bnf-grammar

--- a/experiments/form-stdlib/tests/python-expr.fk
+++ b/experiments/form-stdlib/tests/python-expr.fk
@@ -1,0 +1,60 @@
+; tests/python-expr.fk — exercise Python expression evaluation
+;
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python.bnf.fk form-stdlib/grammars/python-exec.fk
+;
+; Probes: parse Python assignments where the rhs is an expression,
+; then execute through py-exec-eval-expr (precedence-aware arithmetic
+; + comparison + boolean), check the value bound in env matches the
+; expected integer.
+
+(do
+    (defn first-stmt (root) (head (node_children root)))
+
+    ;; Probe 1: x = 1 + 2 — straightforward addition
+    (let r1 (parse-python-bnf "t.py" "x = 1 + 2"))
+    (let stmt-1 (first-stmt r1))
+    (let value-1 (head (tail (node_children stmt-1))))
+    (let probe-1 (py-exec-eval-expr value-1 (empty)))    ; → 3
+
+    ;; Probe 2: y = 1 + 2 * 3 — precedence (mul tighter than add)
+    (let r2 (parse-python-bnf "t.py" "y = 1 + 2 * 3"))
+    (let stmt-2 (first-stmt r2))
+    (let value-2 (head (tail (node_children stmt-2))))
+    (let probe-2 (py-exec-eval-expr value-2 (empty)))    ; → 7
+
+    ;; Probe 3: z = (1 + 2) * 3 — parens override precedence
+    (let r3 (parse-python-bnf "t.py" "z = (1 + 2) * 3"))
+    (let stmt-3 (first-stmt r3))
+    (let value-3 (head (tail (node_children stmt-3))))
+    (let probe-3 (py-exec-eval-expr value-3 (empty)))    ; → 9
+
+    ;; Probe 4: comparison — q = 5 == 5 → 1
+    (let r4 (parse-python-bnf "t.py" "q = 5 == 5"))
+    (let stmt-4 (first-stmt r4))
+    (let value-4 (head (tail (node_children stmt-4))))
+    (let probe-4 (py-exec-eval-expr value-4 (empty)))    ; → 1
+
+    ;; Probe 5: comparison less-than — r = 3 < 7 → 1
+    (let r5 (parse-python-bnf "t.py" "r = 3 < 7"))
+    (let stmt-5 (first-stmt r5))
+    (let value-5 (head (tail (node_children stmt-5))))
+    (let probe-5 (py-exec-eval-expr value-5 (empty)))    ; → 1
+
+    ;; Probe 6: boolean and — s = 1 and 0 → 0
+    (let r6 (parse-python-bnf "t.py" "s = 1 and 0"))
+    (let stmt-6 (first-stmt r6))
+    (let value-6 (head (tail (node_children stmt-6))))
+    (let probe-6 (py-exec-eval-expr value-6 (empty)))    ; → 0
+
+    ;; Probe 7: full execution via py-execute — the env binds x = 42
+    (let r7 (parse-python-bnf "t.py" "x = 6 * 7"))
+    (let count-7 (py-execute r7))                       ; prints x = 42
+    (let probe-7 count-7)                                ; → 1 (env-bind count)
+
+    ;; Sum: 3 + 7 + 9 + 1 + 1 + 0 + 1 = 22
+    (add probe-1
+         (add probe-2
+              (add probe-3
+                   (add probe-4
+                        (add probe-5
+                             (add probe-6 probe-7)))))))


### PR DESCRIPTION
## What this breath lands

The BMF-style precedence-as-data shape from #1848 ports to Python. **Real Python arithmetic + comparison + boolean now READ + UNDERSTAND + EXECUTE through the form-native kernel.**

### Grammar
- Operator tokens: \`== != <= >= < > + - * / // % **\`
- Keywords: \`and\` / \`or\` / \`not\`
- New rules: \`expression\`, \`binary-op\`, \`primary-expr\`, \`paren-expr\`, \`int-lit\`, \`str-lit\`, \`ident-expr\`
- \`assign-stmt\` now takes expression on rhs

### Precedence table (Form code, not rule structure)
\`\`\`form
(let py-bnf-binop-prec-table
  (list (list "or" 3) (list "and" 4)
        (list "==" 6) (list "!=" 6) ...
        (list "+" 11) (list "-" 11)
        (list "*" 12) (list "/" 12) (list "//" 12) (list "%" 12)
        (list "**" 14)))
\`\`\`

### Evaluator (python-exec.fk)
- \`py-exec-eval-expr\` — walks expression Recipe → integer
- \`py-exec-apply-op\` — applies + - * / % == != < > <= >= and or
- Identifiers resolve from env

The assign branch now evaluates the rhs before binding. \`x = 6 * 7\` prints \`assign: x = 42\`.

## Validation

| Test | Result | Go | Rust |
|------|--------|-----|------|
| tests/python-expr.fk | **22** | ✓ | ✓ |
| tests/python-exec.fk | 7 | ✓ | ✓ |

Seven probes:
- \`1 + 2\` → **3**
- \`1 + 2 * 3\` → **7** (precedence — mul tighter)
- \`(1 + 2) * 3\` → **9** (parens override)
- \`5 == 5\` → **1**
- \`3 < 7\` → **1**
- \`1 and 0\` → **0**
- \`py-execute of x = 6 * 7\` → env binds x = 42

TS-kernel hits stack limit on this larger grammar (same gap as #1841).

## What's still missing for FULL Python

- Function calls in expressions (\`f(x, y)\`)
- Attribute access (\`obj.attr\`)
- Indexing / slicing
- Lambda expressions
- F-strings (region streaming)
- Multi-statement function bodies (indent tokenizer)
- If/while/for statements
- Classes
- List/dict/set literals
- Unary operators (\`- + not\`)

Architecture sustains every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)