### PR TITLE
tend: Go universal emit + TS expression scaffolding — kernel walks Go too

### DIFF
--- a/experiments/form-stdlib/grammars/go.bnf.fk
+++ b/experiments/form-stdlib/grammars/go.bnf.fk
@@ -155,18 +155,13 @@
     ;; Expression emitters (literals + identifiers; binary/unary later)
     ;; ──────────────────────────────────────────────────────────────────
 
+    ;; Trivial Recipes — walk_recipe returns the value directly.
     (defn go-bnf-emit-int-expr (caps)
-        (intern_node GO-BNF-INT-EXPR
-                      (list (intern_trivial_int
-                              (str_to_int (cap-get caps "value"))))))
-
+        (intern_trivial_int (str_to_int (cap-get caps "value"))))
     (defn go-bnf-emit-str-expr (caps)
-        (intern_node GO-BNF-STR-EXPR
-                      (list (intern_trivial_string (cap-get caps "value")))))
-
+        (intern_trivial_string (cap-get caps "value")))
     (defn go-bnf-emit-ident-expr (caps)
-        (intern_node GO-BNF-IDENT-EXPR
-                      (list (intern_trivial_string (cap-get caps "name")))))
+        (intern_trivial_string (cap-get caps "name")))
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Binary expression precedence — left-fold over operator/operand
@@ -216,9 +211,9 @@
                                     inner))
                 inner)))
 
+    ;; Parens are syntactic — pass inner Recipe through unchanged.
     (defn go-bnf-emit-paren (caps)
-        (intern_node GO-BNF-PAREN-EXPR
-                      (list (cap-get caps "expr"))))
+        (cap-get caps "expr"))
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; BMF-style operator precedence: precedence-as-DATA, not as nested
@@ -256,6 +251,33 @@
     ;; Walks the list of (op rhs) items, recursively gathering tighter-
     ;; binding operators into the rhs before applying the current op.
     ;; Returns (folded-recipe remaining-items).
+    ;; Universal Blueprints — kernel walk_recipe evaluates these natively.
+    ;; Same shape Python landed in breath 15: per-tongue grammar emits
+    ;; universal Recipes, the form runtime executes them.
+    (let GO-UNIV-MATH-PLUS  (make_nodeid 1 2 12 1))
+    (let GO-UNIV-MATH-MINUS (make_nodeid 1 2 12 2))
+    (let GO-UNIV-MATH-MUL   (make_nodeid 1 2 12 3))
+    (let GO-UNIV-MATH-DIV   (make_nodeid 1 2 12 4))
+    (let GO-UNIV-CMP-EQ     (make_nodeid 1 2 13 1))
+    (let GO-UNIV-CMP-NEQ    (make_nodeid 1 2 13 2))
+    (let GO-UNIV-CMP-LT     (make_nodeid 1 2 13 3))
+    (let GO-UNIV-CMP-LE     (make_nodeid 1 2 13 4))
+    (let GO-UNIV-CMP-GT     (make_nodeid 1 2 13 5))
+    (let GO-UNIV-CMP-GE     (make_nodeid 1 2 13 6))
+
+    (defn go-bnf-op-to-blueprint (op)
+        (if (str_eq op "+") GO-UNIV-MATH-PLUS
+        (if (str_eq op "-") GO-UNIV-MATH-MINUS
+        (if (str_eq op "*") GO-UNIV-MATH-MUL
+        (if (str_eq op "/") GO-UNIV-MATH-DIV
+        (if (str_eq op "==") GO-UNIV-CMP-EQ
+        (if (str_eq op "!=") GO-UNIV-CMP-NEQ
+        (if (str_eq op "<")  GO-UNIV-CMP-LT
+        (if (str_eq op "<=") GO-UNIV-CMP-LE
+        (if (str_eq op ">")  GO-UNIV-CMP-GT
+        (if (str_eq op ">=") GO-UNIV-CMP-GE
+            GO-UNIV-MATH-PLUS)))))))))))
+
     (defn go-bnf-climb (lhs items table min-prec)
         (if (nil? items) (list lhs items)
             (do
@@ -271,10 +293,10 @@
                                                    (add op-prec 1)))
                         (let inner-rhs (head inner))
                         (let after-inner (head (tail inner)))
+                        ;; Universal Blueprint emission — kernel walks it.
                         (let new-lhs
-                            (intern_node GO-BNF-BIN-EXPR
-                                          (list (intern_trivial_string op)
-                                                lhs inner-rhs)))
+                            (intern_node (go-bnf-op-to-blueprint op)
+                                          (list lhs inner-rhs)))
                         (go-bnf-climb new-lhs after-inner table min-prec))))))
 
     (defn go-bnf-emit-bmf-fold (caps)

--- a/experiments/form-stdlib/grammars/typescript.bnf.fk
+++ b/experiments/form-stdlib/grammars/typescript.bnf.fk
@@ -37,6 +37,87 @@
             (let all-stmts (cons first-stmt (ts-bnf-collect-results rest-items)))
             (intern_node TS-BNF-MODULE all-stmts)))
 
+    ;; Universal Blueprints — same shape Python + Go use
+    (let TS-UNIV-MATH-PLUS  (make_nodeid 1 2 12 1))
+    (let TS-UNIV-MATH-MINUS (make_nodeid 1 2 12 2))
+    (let TS-UNIV-MATH-MUL   (make_nodeid 1 2 12 3))
+    (let TS-UNIV-MATH-DIV   (make_nodeid 1 2 12 4))
+    (let TS-UNIV-CMP-EQ     (make_nodeid 1 2 13 1))
+    (let TS-UNIV-CMP-NEQ    (make_nodeid 1 2 13 2))
+    (let TS-UNIV-CMP-LT     (make_nodeid 1 2 13 3))
+    (let TS-UNIV-CMP-LE     (make_nodeid 1 2 13 4))
+    (let TS-UNIV-CMP-GT     (make_nodeid 1 2 13 5))
+    (let TS-UNIV-CMP-GE     (make_nodeid 1 2 13 6))
+
+    (defn ts-bnf-op-to-blueprint (op)
+        (if (str_eq op "+") TS-UNIV-MATH-PLUS
+        (if (str_eq op "-") TS-UNIV-MATH-MINUS
+        (if (str_eq op "*") TS-UNIV-MATH-MUL
+        (if (str_eq op "/") TS-UNIV-MATH-DIV
+        (if (str_eq op "==") TS-UNIV-CMP-EQ
+        (if (str_eq op "===") TS-UNIV-CMP-EQ
+        (if (str_eq op "!=") TS-UNIV-CMP-NEQ
+        (if (str_eq op "!==") TS-UNIV-CMP-NEQ
+        (if (str_eq op "<")  TS-UNIV-CMP-LT
+        (if (str_eq op "<=") TS-UNIV-CMP-LE
+        (if (str_eq op ">")  TS-UNIV-CMP-GT
+        (if (str_eq op ">=") TS-UNIV-CMP-GE
+            TS-UNIV-MATH-PLUS)))))))))))))
+
+    (let ts-bnf-binop-prec-table
+        (list
+            (list "||" 4) (list "&&" 5)
+            (list "==" 8) (list "!=" 8) (list "===" 8) (list "!==" 8)
+            (list "<"  9) (list ">"  9) (list "<=" 9) (list ">=" 9)
+            (list "+" 11) (list "-" 11)
+            (list "*" 12) (list "/" 12) (list "%" 12)))
+
+    (defn ts-bnf-lookup-prec (table text)
+        (if (nil? table) 0
+            (if (str_eq (head (head table)) text)
+                (head (tail (head table)))
+                (ts-bnf-lookup-prec (tail table) text))))
+
+    (defn ts-bnf-climb (lhs items table min-prec)
+        (if (nil? items) (list lhs items)
+            (do
+                (let item (head items))
+                (let op (cap-get item "op"))
+                (let op-prec (ts-bnf-lookup-prec table op))
+                (if (lt op-prec min-prec)
+                    (list lhs items)
+                    (do
+                        (let rhs (cap-get item "rhs"))
+                        (let rest-after (tail items))
+                        (let inner (ts-bnf-climb rhs rest-after table
+                                                   (add op-prec 1)))
+                        (let inner-rhs (head inner))
+                        (let after-inner (head (tail inner)))
+                        (let new-lhs
+                            (intern_node (ts-bnf-op-to-blueprint op)
+                                          (list lhs inner-rhs)))
+                        (ts-bnf-climb new-lhs after-inner table min-prec))))))
+
+    (defn ts-bnf-emit-expression (caps)
+        (do
+            (let lhs (cap-get caps "lhs"))
+            (let raw-items (cap-get caps "items"))
+            (if (nil? raw-items) lhs
+                (do
+                    (let ordered (ts-bnf-reverse raw-items))
+                    (let result (ts-bnf-climb lhs ordered
+                                               ts-bnf-binop-prec-table 0))
+                    (head result)))))
+
+    (defn ts-bnf-emit-int-lit (caps)
+        (intern_trivial_int (str_to_int (cap-get caps "value"))))
+    (defn ts-bnf-emit-str-lit (caps)
+        (intern_trivial_string (cap-get caps "value")))
+    (defn ts-bnf-emit-ident-expr (caps)
+        (intern_trivial_string (cap-get caps "name")))
+    (defn ts-bnf-emit-paren (caps)
+        (cap-get caps "expr"))
+
     ;; Emitters
     (defn ts-bnf-emit-import-named (caps)
         ;; IMPORT LBRACE IDENT RBRACE FROM STRING — _3=name, _6=module

--- a/experiments/form-stdlib/tests/go-bnf.fk
+++ b/experiments/form-stdlib/tests/go-bnf.fk
@@ -53,47 +53,33 @@ const Tag = 2
 func main() { }"))
     (let probe-8 (len (node_children r8)))                    ; → 6 top-level decls
 
-    ;; Probe 9 — expression parsing with precedence: `1 + 2 * 3` should
-    ;; parse as BIN(+, 1, BIN(*, 2, 3))
+    ;; Probe 9 — `1 + 2 * 3` walks via universal MATH Blueprints to 7
+    ;; (precedence honored — mul tighter than add).
     (let r9 (parse-go-bnf "t.go" "func f() { return 1 + 2 * 3 }"))
     (let func9 (first-stmt r9))
     (let body9 (head (tail (node_children func9))))
     (let return-stmt-9 (head (node_children body9)))
     (let return-expr-9 (head (node_children return-stmt-9)))
-    (let probe-9 (if (node_eq (node_category return-expr-9)
-                              (make_nodeid 1 2 99 95))
-                     1 0))                                ; → 1 (BIN-EXPR)
+    (let probe-9 (walk_recipe return-expr-9))             ; → 7
 
-    ;; Probe 10 — parenthesized expression
+    ;; Probe 10 — parenthesized `(1 + 2)` walks to 3
     (let r10 (parse-go-bnf "t.go" "func g() { return (1 + 2) }"))
     (let func10 (first-stmt r10))
     (let body10 (head (tail (node_children func10))))
     (let return-stmt-10 (head (node_children body10)))
     (let return-expr-10 (head (node_children return-stmt-10)))
-    (let probe-10 (if (node_eq (node_category return-expr-10)
-                               (make_nodeid 1 2 99 97))
-                      1 0))                               ; → 1 (PAREN-EXPR)
+    (let probe-10 (walk_recipe return-expr-10))           ; → 3
 
     ;; Probe 11 — comparison expression in if condition
     (let r11 (parse-go-bnf "t.go" "func h() { if x == 1 { } }"))
     (let probe-11 (len (node_children r11)))              ; → 1
 
-    ;; Probe 12 — verify precedence: `1 + 2 * 3` should parse as
-    ;; BIN(+, 1, BIN(*, 2, 3)) — outer op is +, inner-right is BIN(*).
-    ;; This proves BMF-style precedence-as-data fold works correctly.
-    (let r12 (parse-go-bnf "t.go" "func k() { return 1 + 2 * 3 }"))
+    ;; Probe 12 — `(2 + 3) * 4` walks to 20 (parens force precedence)
+    (let r12 (parse-go-bnf "t.go" "func k() { return (2 + 3) * 4 }"))
     (let body12 (head (tail (node_children (first-stmt r12)))))
     (let return-12 (head (node_children body12)))
     (let outer-expr (head (node_children return-12)))
-    ;; outer-expr is BIN-EXPR; children: op-text, lhs, rhs
-    (let outer-kids (node_children outer-expr))
-    (let outer-op (node_value (head outer-kids)))         ; "+"
-    (let outer-rhs (head (tail (tail outer-kids))))        ; should be BIN-EXPR (*)
-    (let inner-kids (node_children outer-rhs))
-    (let inner-op (node_value (head inner-kids)))         ; "*"
-    (let probe-12 (if (and (str_eq outer-op "+")
-                            (str_eq inner-op "*"))
-                      1 0))                               ; → 1
+    (let probe-12 (walk_recipe outer-expr))               ; → 20
 
     ;; Probe 13 — function with typed parameters
     (let r13 (parse-go-bnf "t.go" "func add(a int, b int) { return a }"))
@@ -126,7 +112,9 @@ func main() { }"))
     (let r17 (parse-go-bnf "t.go" "type Kernel struct { name string }"))
     (let probe-17 (len (node_children r17)))              ; → 1
 
-    ;; Sum: 4 + 3 + 3 + 6 + 7 + 4 + 1 + 6 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 43
+    ;; Sum: 4 + 3 + 3 + 6 + 7 + 4 + 1 + 6 + 7 + 3 + 1 + 20 + 1 + 1 + 1 + 1 + 1 = 70
+    ;; Probes 9, 10, 12 now compute via walk_recipe — universal MATH
+    ;; Blueprints evaluate the parsed Go expressions natively.
     (add probe-1
          (add probe-2
               (add probe-3


### PR DESCRIPTION
## What this breath lands

Direct continuation of #1851 (per @urs-muff: "form runtime IS the executor"). Go's expression grammar now emits universal MATH/COMPARE Blueprints — same shape Python landed on.

### Go changes
- \`go-bnf-op-to-blueprint\` maps op-text → universal NodeID: \`+ → MATH-PLUS\`, \`* → MATH-MUL\`, \`== → COMPARE-EQ\`, etc.
- \`go-bnf-climb\` interns universal Recipes (drops \`GO-BNF-BIN-EXPR\`)
- \`go-bnf-emit-int/str/ident\` return bare trivials
- \`go-bnf-emit-paren\` passes inner Recipe through

The result: **parsed Go expressions walk_recipe natively.** Tests probe this directly:
- \`1 + 2 * 3\` walks to **7**
- \`(2 + 3) * 4\` walks to **20**

### TypeScript scaffolding
\`ts-bnf-emit-expression\` + \`ts-bnf-climb\` + \`ts-bnf-op-to-blueprint\` + TS precedence table now defined alongside the existing file-header rules. Grammar-rules hook-up comes in the next breath when full TS expressions land.

## Validation

| Test | Result | Go | Rust |
|------|--------|-----|------|
| tests/go-bnf.fk | **70** | ✓ | ✓ |
| tests/typescript-bnf.fk | 23 | ✓ | ✓ |
| tests/python-exec.fk | 7 | ✓ | ✓ |
| tests/python-expr.fk | 22 | ✓ | ✓ |

Two tongues (Python + Go) now emit universal Recipes. The kernel walks them. **No per-language eval layer.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)