### PR TITLE
tend: Python + Go grammar expansion — bigger swings, less hedging

### DIFF
--- a/experiments/form-stdlib/grammars/go.bnf.fk
+++ b/experiments/form-stdlib/grammars/go.bnf.fk
@@ -69,6 +69,22 @@
     (let GO-BNF-SELECTOR   (make_nodeid 1 2 99 100))
     (let GO-BNF-FOR        (make_nodeid 1 2 99 101))
     (let GO-BNF-FIELD      (make_nodeid 1 2 99 102))
+    (let GO-BNF-SHORT-VAR  (make_nodeid 1 2 99 103))
+    (let GO-BNF-SWITCH     (make_nodeid 1 2 99 104))
+    (let GO-BNF-CASE       (make_nodeid 1 2 99 105))
+
+    (defn go-bnf-emit-short-var (caps)
+        (intern_node GO-BNF-SHORT-VAR
+                      (list (intern_trivial_string (cap-get caps "name"))
+                            (cap-get caps "value"))))
+
+    (defn go-bnf-emit-switch (caps)
+        (intern_node GO-BNF-SWITCH
+                      (list (cap-get caps "cond"))))
+
+    (defn go-bnf-emit-case (caps)
+        (intern_node GO-BNF-CASE
+                      (list (cap-get caps "val"))))
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Module-collection helpers
@@ -382,6 +398,7 @@
   operator ) RPAREN
   operator , COMMA
   operator ; SEMI
+  operator := COLONEQ
   operator : COLON
   operator . DOT
   operator == EQEQ
@@ -409,6 +426,9 @@
   keyword RETURN return
   keyword IF if
   keyword FOR for
+  keyword SWITCH switch
+  keyword CASE case
+  keyword DEFAULT default
   keyword INTERFACE interface
 }
 
@@ -424,7 +444,9 @@ rules {
   params        ::= first:param (COMMA param)* ;
   param         ::= name:IDENT type-name:IDENT             => go-bnf-emit-param ;
   block         ::= LBRACE statement* RBRACE               => go-bnf-emit-block ;
-  statement     ::= return-stmt | if-stmt | for-stmt | assign-stmt | expr-stmt ;
+  statement     ::= return-stmt | if-stmt | for-stmt | switch-stmt | short-var-stmt | assign-stmt | expr-stmt ;
+  short-var-stmt ::= name:IDENT COLONEQ value:expression       => go-bnf-emit-short-var ;
+  switch-stmt   ::= SWITCH cond:expression body:block          => go-bnf-emit-switch ;
   return-stmt   ::= RETURN expr:expression                 => go-bnf-emit-return-value ;
   if-stmt       ::= IF cond:expression body:block          => go-bnf-emit-if ;
   for-stmt      ::= FOR cond:expression body:block         => go-bnf-emit-for ;
@@ -477,7 +499,10 @@ rules {
               (list "go-bnf-emit-selector"    go-bnf-emit-selector)
               (list "go-bnf-emit-for"         go-bnf-emit-for)
               (list "go-bnf-emit-field"       go-bnf-emit-field)
-              (list "go-bnf-emit-struct-fields" go-bnf-emit-struct-fields)))
+              (list "go-bnf-emit-struct-fields" go-bnf-emit-struct-fields)
+              (list "go-bnf-emit-short-var"   go-bnf-emit-short-var)
+              (list "go-bnf-emit-switch"      go-bnf-emit-switch)
+              (list "go-bnf-emit-case"        go-bnf-emit-case)))
 
     (let go-bnf-grammar
         (load-bnf-grammar go-bnf-text go-bnf-registry))

--- a/experiments/form-stdlib/grammars/python.bnf.fk
+++ b/experiments/form-stdlib/grammars/python.bnf.fk
@@ -241,6 +241,47 @@
                             (cap-get caps "value"))))
 
     ;; ──────────────────────────────────────────────────────────────────
+    ;; Expanded Python emitters: call, attribute, if/while/for/return
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let PY-BNF-CALL    (make_nodeid 1 2 99 52))
+    (let PY-BNF-ATTR    (make_nodeid 1 2 99 53))
+    (let PY-BNF-IF      (make_nodeid 1 2 99 54))
+    (let PY-BNF-WHILE   (make_nodeid 1 2 99 55))
+    (let PY-BNF-FOR     (make_nodeid 1 2 99 56))
+    (let PY-BNF-RETURN  (make_nodeid 1 2 99 57))
+
+    (defn py-bnf-emit-call (caps)
+        (intern_node PY-BNF-CALL
+                      (list (intern_trivial_string (cap-get caps "name"))
+                            (cap-get caps "arg"))))
+
+    (defn py-bnf-emit-attr (caps)
+        (intern_node PY-BNF-ATTR
+                      (list (intern_trivial_string (cap-get caps "base"))
+                            (intern_trivial_string (cap-get caps "field")))))
+
+    (defn py-bnf-emit-if-stmt (caps)
+        (intern_node PY-BNF-IF
+                      (list (cap-get caps "cond")
+                            (cap-get caps "body"))))
+
+    (defn py-bnf-emit-while-stmt (caps)
+        (intern_node PY-BNF-WHILE
+                      (list (cap-get caps "cond")
+                            (cap-get caps "body"))))
+
+    (defn py-bnf-emit-for-stmt (caps)
+        (intern_node PY-BNF-FOR
+                      (list (intern_trivial_string (cap-get caps "var"))
+                            (cap-get caps "iter")
+                            (cap-get caps "body"))))
+
+    (defn py-bnf-emit-return-stmt (caps)
+        (intern_node PY-BNF-RETURN
+                      (list (cap-get caps "expr"))))
+
+    ;; ──────────────────────────────────────────────────────────────────
     ;; Part 3 — the BNF grammar text
     ;; ──────────────────────────────────────────────────────────────────
     ;; Reading aloud:
@@ -283,21 +324,41 @@
   keyword AND and
   keyword OR or
   keyword NOT not
+  keyword IF if
+  keyword ELSE else
+  keyword WHILE while
+  keyword FOR for
+  keyword IN in
+  keyword RETURN return
+  keyword CLASS class
+  keyword LAMBDA lambda
+  keyword TRUE True
+  keyword FALSE False
+  keyword NONE None
 }
 
 rules {
   module       ::= statement+                                  => py-bnf-emit-module ;
-  statement    ::= import-as | import-bare | from-stmt | def-stmt | assign-stmt ;
+  statement    ::= import-as | import-bare | from-stmt | def-stmt | if-stmt
+                 | while-stmt | for-stmt | return-stmt | assign-stmt | expr-stmt ;
   import-as    ::= IMPORT IDENT AS IDENT                       => py-bnf-emit-import-as ;
   import-bare  ::= IMPORT IDENT                                 => py-bnf-emit-import-bare ;
   from-stmt    ::= FROM IDENT IMPORT IDENT                      => py-bnf-emit-from-import ;
   def-stmt     ::= DEF IDENT LPAREN RPAREN COLON                => py-bnf-emit-def ;
+  if-stmt      ::= IF cond:expression COLON body:expression     => py-bnf-emit-if-stmt ;
+  while-stmt   ::= WHILE cond:expression COLON body:expression  => py-bnf-emit-while-stmt ;
+  for-stmt     ::= FOR var:IDENT IN iter:expression COLON body:expression => py-bnf-emit-for-stmt ;
+  return-stmt  ::= RETURN expr:expression                       => py-bnf-emit-return-stmt ;
   assign-stmt  ::= name:IDENT EQUALS value:expression           => py-bnf-emit-assign-expr ;
+  expr-stmt    ::= expression ;
   ;; BMF-style: ONE Expression rule + precedence DATA in Form code.
   expression   ::= lhs:primary-expr (op:binary-op rhs:primary-expr)* => py-bnf-emit-expression ;
   binary-op    ::= OR | AND | EQEQ | NEQ | LE | GE | LT | GT
                  | PLUS | MINUS | STARSTAR | SLASHSLASH | STAR | SLASH | PERCENT ;
-  primary-expr ::= int-lit | str-lit | ident-expr | paren-expr ;
+  ;; primary alternatives: call/attr first (most specific), then literals.
+  primary-expr ::= call-expr | attr-expr | int-lit | str-lit | ident-expr | paren-expr ;
+  call-expr    ::= name:IDENT LPAREN arg:expression RPAREN      => py-bnf-emit-call ;
+  attr-expr    ::= base:IDENT DOT field:IDENT                   => py-bnf-emit-attr ;
   paren-expr   ::= LPAREN expr:expression RPAREN                => py-bnf-emit-paren-expr ;
   int-lit      ::= value:INT                                    => py-bnf-emit-int-expr ;
   str-lit      ::= value:STRING                                 => py-bnf-emit-str-expr ;
@@ -323,6 +384,12 @@ rules {
               (list "py-bnf-emit-str-expr"         py-bnf-emit-str-expr)
               (list "py-bnf-emit-ident-expr"       py-bnf-emit-ident-expr)
               (list "py-bnf-emit-paren-expr"       py-bnf-emit-paren-expr)
+              (list "py-bnf-emit-call"             py-bnf-emit-call)
+              (list "py-bnf-emit-attr"             py-bnf-emit-attr)
+              (list "py-bnf-emit-if-stmt"          py-bnf-emit-if-stmt)
+              (list "py-bnf-emit-while-stmt"       py-bnf-emit-while-stmt)
+              (list "py-bnf-emit-for-stmt"         py-bnf-emit-for-stmt)
+              (list "py-bnf-emit-return-stmt"      py-bnf-emit-return-stmt)
               (list "py-bnf-emit-passthrough"      py-bnf-emit-passthrough)))
 
     (let py-bnf-grammar


### PR DESCRIPTION
## What this breath lands

Per @urs-muff's directive ("stop being slow, what are you afraid of?") — per-tongue grammar expansion across two languages in one move.

### Python (python.bnf.fk)
- Call expressions: \`f(x)\`
- Attribute access: \`obj.attr\`
- if-statement: \`if x: y\`
- while-statement: \`while x: y\`
- for-statement: \`for i in iter: body\`
- return-statement: \`return expr\`
- Expression-statement: bare expression as statement
- Keywords added: \`if/else/while/for/in/return/class/lambda/True/False/None\`

### Go (go.bnf.fk)
- Short variable declaration: \`x := 42\`
- Switch statement: \`switch x { }\`
- Operator \`:=\` declared before \`:\` so longest-match wins

## Operator order lesson

Engine.fk's \`try-operator\` walks the operators list in order — longer prefixes must come first to win longest-match. \`:=\` must precede \`:\`. Same shape as \`<=\` before \`<\`, \`==\` before \`=\`.

## Validation

| Test | Result | Go | Rust |
|------|--------|-----|------|
| tests/python-exec.fk | 7 | ✓ | ✓ |
| tests/python-expr.fk | 22 | ✓ | ✓ |
| tests/go-bnf.fk | 70 | ✓ | ✓ |

New shapes individually validated.

## What's still missing for FULL coverage

Each one focused breath:
- Python: f-strings, multi-line function bodies, classes, lambdas
- Go: methods, composite literals, slices/maps, interfaces, defer/go/select
- TypeScript: full statement grammar
- Rust: impl blocks, match, traits, lifetimes
- Real .tsx grammar using region streaming for embedded JSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)