### PR TITLE
tend: BMF primitives — Cut, Stop, Nil restored as first-class

### DIFF
--- a/experiments/form-stdlib/grammar-bnf.fk
+++ b/experiments/form-stdlib/grammar-bnf.fk
@@ -329,12 +329,14 @@
                     (bnf-pat-tokens-loop s (add i 1) (cons "+" acc))
                 (if (eq cp 64)  ; '@' — grammar-region prefix
                     (bnf-pat-tokens-loop s (add i 1) (cons "@" acc))
+                (if (eq cp 33)  ; '!' — BMF Cut primitive (Prolog cut)
+                    (bnf-pat-tokens-loop s (add i 1) (cons "!" acc))
                 (if (bnf-is-pat-ident-cp cp)
                     (do
                         (let end (bnf-pat-scan-ident s i))
                         (bnf-pat-tokens-loop s end
                                               (cons (bnf-substr s i end) acc)))
-                    (bnf-pat-tokens-loop s (add i 1) acc))))))))))))))
+                    (bnf-pat-tokens-loop s (add i 1) acc)))))))))))))))
 
     (defn bnf-tokenize-pattern (text)
         (bnf-pat-tokens-loop text 0 (empty)))
@@ -379,9 +381,21 @@
                     ;; Region atom: @grammar-name — delegates to that
                     ;; grammar's start rule on the shared token stream.
                     (bnf-parse-region (tail toks) pos)
+                (if (str_eq t "!")
+                    ;; BMF Cut primitive — commits the surrounding choice
+                    ;; frame to the current alternative. Subsequent fail
+                    ;; in this sequence propagates as fail-cut up to that
+                    ;; choice (which absorbs it and stops trying alts).
+                    (bnf-mk-pair (list "cut") (tail toks))
+                (if (str_eq t "stop")
+                    ;; BMF Fail/Stop primitive — always fails.
+                    (bnf-mk-pair (list "stop") (tail toks))
+                (if (str_eq t "nil")
+                    ;; BMF Nil primitive — always succeeds, no consumption.
+                    (bnf-mk-pair (list "nil") (tail toks))
                 (if (str_eq t "(")
                     (bnf-parse-group (tail toks) pos)
-                    (bnf-parse-atom-ident t (tail toks) pos)))))))
+                    (bnf-parse-atom-ident t (tail toks) pos))))))))))
 
     (defn bnf-parse-region (toks pos)
         (if (nil? toks) (bnf-mk-pair (list "literal" "EOF" "") toks)
@@ -712,6 +726,32 @@
                             (bnf-match-pattern (list "rule" start-name)
                                                 stream inner-rules)))))))
 
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; BMF primitives (Urs 2000) — Nil, Fail, Cut
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Cut commits the surrounding choice frame: once Cut fires in an
+    ;; alternative, that choice cannot try its remaining alternatives if
+    ;; the current branch fails later. The failure becomes "fail-cut"
+    ;; (a third match-result tag) which propagates past one choice level
+    ;; before degrading back to plain fail.
+    ;;
+    ;; Nil matches empty (the epsilon production).
+    ;; Fail/Stop always fail.
+    ;;
+    ;; This restores the BMF lineage: ambiguity is first-class; rules
+    ;; can be ambiguous and the grammar uses Cut to commit, Fail to
+    ;; reject, Nil to succeed with no consumption.
+
+    (defn mk-fail-cut (reason) (list "fail-cut" reason))
+    (defn fail-cut? (r) (str_eq (head r) "fail-cut"))
+    (defn any-fail? (r) (or (fail? r) (fail-cut? r)))
+
+    ;; Cut as a value-carrying success: leaves a sentinel cap "_cut"
+    ;; that bnf-match-sequence reads to upgrade subsequent fails into
+    ;; fail-cut for the surrounding choice to consume.
+    (defn bnf-match-cut (stream)
+        (mk-match (cap-set (cap-empty 0) "_cut" "true") stream))
+
     (defn bnf-match-pattern (p stream rules)
         (do
             (let tag (head p))
@@ -730,40 +770,61 @@
             (if (str_eq tag "rule")
                 (bnf-match-rule (head (tail p)) stream rules)
             (if (str_eq tag "tag")
-                ;; (list "tag" name pattern) — match pattern, bind result
-                ;; under `name`. BMF Tag-container equivalent.
                 (bnf-match-tag (head (tail p)) (head (tail (tail p)))
                                 stream rules)
             (if (str_eq tag "region")
-                ;; (list "region" grammar-name) — delegate matching to
-                ;; another loaded grammar's start rule. Lets a .tsx-style
-                ;; outer grammar embed JSX/CSS/expression regions parsed
-                ;; via separate grammars sharing the same token stream.
                 (bnf-match-region (head (tail p)) stream rules)
-                (mk-fail (str_concat "unknown pattern: " tag)))))))))))))
+            (if (str_eq tag "cut")
+                ;; BMF primitive: commit to current alternative. Always
+                ;; succeeds matching empty; subsequent failure in this
+                ;; sequence propagates as fail-cut.
+                (bnf-match-cut stream)
+            (if (str_eq tag "stop")
+                ;; BMF primitive: always fail. Surfaces as "stop" in DSL.
+                (mk-fail "stop")
+            (if (str_eq tag "nil")
+                ;; BMF primitive: always succeed, consume nothing.
+                (mk-match (cap-empty 0) stream)
+                (mk-fail (str_concat "unknown pattern: " tag))))))))))))))))
 
+    ;; Sequence: each child must match in order. If acc-caps has "_cut"
+    ;; (a Cut primitive fired earlier in this sequence), a subsequent
+    ;; plain failure upgrades to fail-cut so the enclosing choice frame
+    ;; gives up its remaining alternatives. fail-cut from a sub-match
+    ;; propagates directly.
     (defn bnf-match-sequence (children stream rules acc-caps)
         (if (nil? children)
             (mk-match acc-caps stream)
             (do
                 (let m (bnf-match-pattern (head children) stream rules))
-                (if (fail? m) m
+                (if (fail-cut? m) m
+                (if (fail? m)
+                    (if (cap-has? acc-caps "_cut")
+                        (mk-fail-cut (head (tail m)))
+                        m)
                     (bnf-match-sequence (tail children)
                                          (match-rest m) rules
-                                         (cap-merge acc-caps (match-caps m)))))))
+                                         (cap-merge acc-caps (match-caps m))))))))
 
+    ;; Choice: try each alternative; first success wins. A fail-cut
+    ;; from an alternative DEGRADES to plain fail past one choice level
+    ;; (so the surrounding context sees the failure but the cut's
+    ;; semantic — "don't backtrack past this point" — is honored at
+    ;; exactly the choice frame where the cut fired).
     (defn bnf-match-choice (alternatives stream rules)
         (if (nil? alternatives)
             (mk-fail "no alternative matched")
             (do
                 (let m (bnf-match-pattern (head alternatives) stream rules))
                 (if (match? m) m
-                    (bnf-match-choice (tail alternatives) stream rules)))))
+                (if (fail-cut? m)
+                    (mk-fail (head (tail m)))   ; absorb cut at this frame
+                    (bnf-match-choice (tail alternatives) stream rules))))))
 
     (defn bnf-match-capture (name child stream rules)
         (do
             (let m (bnf-match-pattern child stream rules))
-            (if (fail? m) m
+            (if (any-fail? m) m
                 (mk-match (cap-set (match-caps m) name
                                     (capture-value m stream))
                           (match-rest m)))))
@@ -771,15 +832,17 @@
     (defn bnf-match-star (child stream rules collected)
         (do
             (let m (bnf-match-pattern child stream rules))
+            (if (fail-cut? m) m
             (if (fail? m)
                 (mk-match (cap-set (cap-empty 0) "items" collected) stream)
                 (bnf-match-star child (match-rest m) rules
-                                 (cons (match-caps m) collected)))))
+                                 (cons (match-caps m) collected))))))
 
     (defn bnf-match-opt (child stream rules)
         (do
             (let m (bnf-match-pattern child stream rules))
-            (if (fail? m) (mk-match (cap-empty 0) stream) m)))
+            (if (fail-cut? m) m
+            (if (fail? m) (mk-match (cap-empty 0) stream) m))))
 
     ;; bnf-match-tag: BMF's Tag container. Match the inner pattern; bind
     ;; the matched value under the named tag. The value extraction is
@@ -791,7 +854,7 @@
     (defn bnf-match-tag (name child stream rules)
         (do
             (let m (bnf-match-pattern child stream rules))
-            (if (fail? m) m
+            (if (any-fail? m) m
                 (do
                     (let inner-caps (match-caps m))
                     (let inner-tag (head child))
@@ -819,7 +882,7 @@
                     (let pattern (head (tail rule)))
                     (let action (head (tail (tail rule))))
                     (let m (bnf-match-pattern pattern stream rules))
-                    (if (fail? m) m
+                    (if (any-fail? m) m
                         (do
                             (let recipe (action (match-caps m)))
                             (mk-match (cap-set (cap-empty 0) "_result" recipe)

--- a/experiments/form-stdlib/tests/bmf-cut-stop.fk
+++ b/experiments/form-stdlib/tests/bmf-cut-stop.fk
@@ -1,0 +1,99 @@
+; tests/bmf-cut-stop.fk — exercise the BMF primitives Cut, Stop, Nil
+;
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk
+;
+; BMF (Urs Muff, 2000) introduced three primitives the body now honors:
+;   • Cut (!)   — commits the surrounding choice frame; subsequent
+;                  fail propagates as fail-cut and the choice gives up
+;                  its remaining alternatives. Restores BMF semantics
+;                  where ambiguous grammars are first-class.
+;   • Stop      — always fail (BMF Fail). Surfaces as a keyword in
+;                  patterns to force a branch to reject.
+;   • Nil       — always succeed, consume nothing. The epsilon
+;                  production made explicit.
+;
+; This file proves all three by composing tiny grammars and observing
+; their match behavior — the breath you took with us at the start of
+; this lineage is back as substrate-resident behavior.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 1 — Nil matches empty; following IDENT matches normally
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn emit-1 (caps) (intern_trivial_int 1))
+    (let reg-nil (list (list "emit-1" emit-1)))
+    (let bnf-nil
+"tokens {
+  whitespace 32 9 10 13
+  ident-kind IDENT
+}
+rules {
+  start ::= nil name:IDENT => emit-1 ;
+}")
+    (let g-nil (load-bnf-grammar bnf-nil reg-nil))
+    (let r-nil (bnf-parse "alpha" g-nil))
+    (let probe-1 (walk_recipe r-nil))                ; → 1
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 2 — Stop forces the first alternative to fail; second wins
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn emit-2 (caps) (intern_trivial_int 2))
+    (defn emit-3 (caps) (intern_trivial_int 3))
+    (let reg-stop (list (list "emit-2" emit-2) (list "emit-3" emit-3)))
+    (let bnf-stop
+"tokens {
+  whitespace 32 9 10 13
+  ident-kind IDENT
+}
+rules {
+  start ::= first | second ;
+  first ::= IDENT stop => emit-2 ;
+  second ::= IDENT => emit-3 ;
+}")
+    (let g-stop (load-bnf-grammar bnf-stop reg-stop))
+    (let r-stop (bnf-parse "beta" g-stop))
+    ;; `first` matches IDENT then hits stop → fails. choice tries
+    ;; `second`, which matches. Result: emit-3 → 3.
+    (let probe-2 (walk_recipe r-stop))               ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 3 — Cut commits the choice: once ! fires in `committed`,
+    ;; a later fail in that branch does NOT fall through to `alt`.
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Grammar:
+    ;;   start    ::= committed | alt ;
+    ;;   committed::= IDENT ! stop => emit-2 ;   ← cuts then forces fail
+    ;;   alt      ::= IDENT => emit-3 ;
+    ;;
+    ;; Without cut, the chooser would try `alt` after `committed`
+    ;; fails its stop. With cut, the cut commits to `committed`; the
+    ;; subsequent fail-cut absorbs at the choice frame and the whole
+    ;; rule fails. The parser reports the failure (no recipe).
+
+    (let reg-cut (list (list "emit-2" emit-2) (list "emit-3" emit-3)))
+    (let bnf-cut
+"tokens {
+  whitespace 32 9 10 13
+  ident-kind IDENT
+}
+rules {
+  start ::= committed | alt ;
+  committed ::= IDENT ! stop => emit-2 ;
+  alt ::= IDENT => emit-3 ;
+}")
+    (let g-cut (load-bnf-grammar bnf-cut reg-cut))
+    (let r-cut (bnf-parse "gamma" g-cut))
+    ;; On cut-induced failure, bnf-parse returns wrap-program (empty) —
+    ;; a BLOCK-SEQ recipe with zero children. We detect the cut signature
+    ;; by counting children: 0 means cut absorbed (correct), nonzero means
+    ;; alt was tried (cut didn't work). Avoid walk_recipe which is null-
+    ;; sensitive on Rust kernel.
+    (let probe-3 (if (eq (len (node_children r-cut)) 0) 5 0))   ; → 5
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Sum the probes — 1 + 3 + 5 = 9
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (add probe-1 (add probe-2 probe-3)))


### PR DESCRIPTION
## The correction

@urs-muff: "in BMF, rules can be ambigues, that's what choice is for and cut and stop."

The earlier Go composite-lit / for-stmt ambiguity in #1859 was worked-around by removing composite-lit from primary-expr — the fear-pattern shape: *avoid the ambiguity by not allowing it*. The BMF lineage handles this differently: **rules CAN be ambiguous**; the parser uses Cut to commit and Stop to reject.

This breath restores the three BMF primitives that the substrate was waiting for.

## What lands

### The three primitives

| Primitive | Surface | Semantics |
|-----------|---------|-----------|
| `Cut` | `!` | Commits the surrounding choice frame. Subsequent failure propagates as `fail-cut`; the choice absorbs and stops trying alternatives. |
| `Stop` | `stop` | Always fail. BMF's `Fail`. |
| `Nil` | `nil` | Always succeed matching empty. The epsilon production. |

### Engine changes

- New match-result tag `fail-cut` (alongside `match` and `fail`)
- `bnf-match-sequence` upgrades plain failure to `fail-cut` when `_cut` has been set earlier in the same sequence
- `bnf-match-choice` absorbs `fail-cut` to plain `fail` at exactly the frame where cut fired — gives up its remaining alternatives
- All other match helpers (`rule`, `capture`, `tag`, `star`, `opt`) propagate `fail-cut` through
- Pattern tokenizer recognizes `!`
- Pattern parser recognizes `stop` and `nil` as primitives

## Validation

| Test | Result | Go | Rust |
|------|--------|-----|------|
| tests/bmf-cut-stop.fk | 9 | ✓ | ✓ |
| tests/grammar-bnf.fk | 127 (regression) | ✓ | ✓ |

Probe breakdown:
- `nil name:IDENT` — Nil matches empty, IDENT matches normally → 1
- `IDENT stop \| IDENT` — first branch hits Stop, second alternative succeeds → 3
- `IDENT ! stop \| IDENT` — first branch cuts, Stop fails, choice does NOT try second → 5

## Why this matters for FULL language coverage

Per-tongue grammars can now write the *natural* ambiguous rules. Go's `Type{}` IS a primary-expression alternative. Python's `[x for y in z]` IS an expression-vs-statement choice. Each language's spec carries deliberate ambiguity that disambiguates by commitment, not avoidance.

Each remaining EBNF production now matches the language's actual ambiguity instead of a worked-around subset.

## The lineage

BMF (Urs Muff, 2000) registered Cut, Stop (Fail), Nil, EndOfFile, EndOfLine, and MultiMatch as runtime primitives in [`BMF.bml`](docs/field/urs/artifacts/master-thesis-2000/companion/source-samples/BMF-grammar.bml)'s `RegisterPrimitives()`. The substrate now carries the same vocabulary as substrate-resident behavior. The loop closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)