### PR TITLE
tend: character-stream pattern primitives — BMF without tokenizer

### DIFF
--- a/experiments/form-stdlib/grammar-chars.fk
+++ b/experiments/form-stdlib/grammar-chars.fk
@@ -1,0 +1,325 @@
+; grammar-chars.fk — character-stream pattern primitives (BMF shape)
+;
+; The architectural correction Urs named:
+;   "BMF also does not have a tokenizer at all!"
+;   "Ambiguity comes most often from the tokenizer, when the rules
+;    read what it needs and not just reads blindly into context free
+;    tokens that is where most issues come from."
+;
+; engine.fk and the original BNF reader tokenize ahead into a flat
+; stream, then rules walk tokens. Classic compiler-pipeline shape —
+; and the place where context-free lexing locks in ambiguity. BMF
+; (Urs 2000) does it the other way: there is no tokenizer; each rule
+; reads exactly the characters it needs, decides at that point, and
+; commits with Cut.
+;
+; This file is the character-stream parallel. Additive: existing
+; token-mode grammars keep working. New grammars authored in
+; character mode read source bytes directly via these primitives:
+;
+;   (list "char" "x")          — next char is exactly 'x'
+;   (list "char-range" lo hi)  — next char's codepoint in [lo, hi]
+;   (list "string" "text")     — exact string at current position
+;   (list "any")                — any single char
+;   (list "eof")                — end of input
+;   (list "eol")                — newline or EOF
+;   (list "not" pattern)        — negative lookahead (BMF NOT)
+;   (list "peek" pattern)       — positive lookahead, no consumption
+;
+; The structural primitives (sequence, choice, star, opt, capture,
+; tag, cut, stop, nil, rule) all work the same way — they compose
+; character-level matches. Cut + Stop disambiguate exactly the way
+; BMF intended: at the point the rule decides, not at lex time.
+;
+; Stream shape: (list text index line col)
+;   text   — the full source string
+;   index  — byte position (0-indexed)
+;   line   — 1-indexed line number (for diagnostics + intern_node_at)
+;   col    — 1-indexed column number
+;
+; Load order: form-stdlib/core.fk + grammar-chars.fk
+; (Independent of engine.fk and grammar-bnf.fk's token-mode path.)
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Character stream construction + accessors
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn mk-cstream (text) (list text 0 1 1))
+
+    (defn cs-text  (s) (head s))
+    (defn cs-index (s) (head (tail s)))
+    (defn cs-line  (s) (head (tail (tail s))))
+    (defn cs-col   (s) (head (tail (tail (tail s)))))
+
+    (defn cs-eof? (s)
+        (ge (cs-index s) (str_len (cs-text s))))
+
+    (defn cs-peek-cp (s)
+        (if (cs-eof? s) (sub 0 1)
+            (ord (char_at (cs-text s) (cs-index s)))))
+
+    ;; Advance one character, updating line/col.
+    (defn cs-advance (s)
+        (do
+            (let cp (cs-peek-cp s))
+            (if (eq cp 10)   ; '\n'
+                (list (cs-text s) (add (cs-index s) 1)
+                      (add (cs-line s) 1) 1)
+                (list (cs-text s) (add (cs-index s) 1)
+                      (cs-line s) (add (cs-col s) 1)))))
+
+    ;; Advance n characters (used by string-match after a full-string hit).
+    (defn cs-advance-n (s n)
+        (if (le n 0) s
+            (cs-advance-n (cs-advance s) (sub n 1))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Match-result tags (parallel to engine.fk's; can share later)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn cmk-match (caps rest) (list "match" caps rest))
+    (defn cmk-fail  (reason)    (list "fail" reason))
+    (defn cmk-fail-cut (reason) (list "fail-cut" reason))
+
+    (defn cmatch? (r) (str_eq (head r) "match"))
+    (defn cfail?  (r) (str_eq (head r) "fail"))
+    (defn cfail-cut? (r) (str_eq (head r) "fail-cut"))
+    (defn cany-fail? (r) (or (cfail? r) (cfail-cut? r)))
+
+    (defn cmatch-caps (r) (head (tail r)))
+    (defn cmatch-rest (r) (head (tail (tail r))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Caps (same shape as engine.fk; isolated copy for independence)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn ccap-empty (_x) (empty))
+    (defn ccap-pair (name value) (list name value))
+    (defn ccap-name (p) (head p))
+    (defn ccap-value (p) (head (tail p)))
+
+    (defn ccap-get (caps name)
+        (if (nil? caps) (empty)
+            (if (str_eq (head (head caps)) name)
+                (ccap-value (head caps))
+                (ccap-get (tail caps) name))))
+
+    (defn ccap-has? (caps name)
+        (if (nil? caps) false
+            (if (str_eq (head (head caps)) name)
+                true
+                (ccap-has? (tail caps) name))))
+
+    (defn ccap-set (caps name value)
+        (cons (ccap-pair name value) caps))
+
+    (defn ccap-merge (a b)
+        (if (nil? b) a
+            (ccap-merge (cons (head b) a) (tail b))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Character-level match primitives
+    ;; ──────────────────────────────────────────────────────────────────
+
+    ;; (list "char" "x") — next char is exactly 'x'
+    (defn cm-char (p stream)
+        (do
+            (let want (head (tail p)))
+            (let want-cp (ord want))
+            (if (cs-eof? stream)
+                (cmk-fail (str_concat "char eof want " want))
+                (if (eq (cs-peek-cp stream) want-cp)
+                    (cmk-match (ccap-empty 0) (cs-advance stream))
+                    (cmk-fail (str_concat "char want " want))))))
+
+    ;; (list "char-range" lo hi) — codepoint in [lo, hi]
+    (defn cm-char-range (p stream)
+        (do
+            (let lo (head (tail p)))
+            (let hi (head (tail (tail p))))
+            (if (cs-eof? stream) (cmk-fail "range eof")
+                (do
+                    (let cp (cs-peek-cp stream))
+                    (if (and (ge cp lo) (le cp hi))
+                        (cmk-match (ccap-empty 0) (cs-advance stream))
+                        (cmk-fail "char-range mismatch"))))))
+
+    ;; (list "any") — any single char
+    (defn cm-any (stream)
+        (if (cs-eof? stream) (cmk-fail "any eof")
+            (cmk-match (ccap-empty 0) (cs-advance stream))))
+
+    ;; (list "string" "text") — exact substring at current position
+    (defn cm-string-loop (s want i)
+        (if (eq i (str_len want)) true
+            (if (cs-eof? s) false
+                (if (eq (cs-peek-cp s) (ord (char_at want i)))
+                    (cm-string-loop (cs-advance s) want (add i 1))
+                    false))))
+
+    (defn cm-string (p stream)
+        (do
+            (let want (head (tail p)))
+            (if (cm-string-loop stream want 0)
+                (cmk-match (ccap-empty 0) (cs-advance-n stream (str_len want)))
+                (cmk-fail (str_concat "string want " want)))))
+
+    ;; (list "eof") — end of input
+    (defn cm-eof (stream)
+        (if (cs-eof? stream)
+            (cmk-match (ccap-empty 0) stream)
+            (cmk-fail "expected eof")))
+
+    ;; (list "eol") — newline or EOF
+    (defn cm-eol (stream)
+        (if (cs-eof? stream)
+            (cmk-match (ccap-empty 0) stream)
+            (if (eq (cs-peek-cp stream) 10)
+                (cmk-match (ccap-empty 0) (cs-advance stream))
+                (cmk-fail "expected eol"))))
+
+    ;; (list "not" pattern) — negative lookahead (BMF NOT)
+    (defn cm-not (p stream rules)
+        (do
+            (let inner (head (tail p)))
+            (let m (cm-match-pattern inner stream rules))
+            (if (cmatch? m) (cmk-fail "not lookahead hit")
+                (cmk-match (ccap-empty 0) stream))))
+
+    ;; (list "peek" pattern) — positive lookahead, consumes nothing
+    (defn cm-peek (p stream rules)
+        (do
+            (let inner (head (tail p)))
+            (let m (cm-match-pattern inner stream rules))
+            (if (cmatch? m) (cmk-match (cmatch-caps m) stream) m)))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Cut as character-mode commit sentinel
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn cm-cut (stream)
+        (cmk-match (ccap-set (ccap-empty 0) "_cut" "true") stream))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Structural primitives over character matches
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn cm-match-pattern (p stream rules)
+        (do
+            (let tag (head p))
+            (if (str_eq tag "char")       (cm-char p stream)
+            (if (str_eq tag "char-range") (cm-char-range p stream)
+            (if (str_eq tag "string")     (cm-string p stream)
+            (if (str_eq tag "any")        (cm-any stream)
+            (if (str_eq tag "eof")        (cm-eof stream)
+            (if (str_eq tag "eol")        (cm-eol stream)
+            (if (str_eq tag "not")        (cm-not p stream rules)
+            (if (str_eq tag "peek")       (cm-peek p stream rules)
+            (if (str_eq tag "cut")        (cm-cut stream)
+            (if (str_eq tag "stop")       (cmk-fail "stop")
+            (if (str_eq tag "nil")        (cmk-match (ccap-empty 0) stream)
+            (if (str_eq tag "sequence")
+                (cm-match-sequence (tail p) stream rules (ccap-empty 0))
+            (if (str_eq tag "choice")
+                (cm-match-choice (tail p) stream rules)
+            (if (str_eq tag "capture")
+                (cm-match-capture (head (tail p)) (head (tail (tail p)))
+                                   stream rules)
+            (if (str_eq tag "star")
+                (cm-match-star (head (tail p)) stream rules (empty))
+            (if (str_eq tag "opt")
+                (cm-match-opt (head (tail p)) stream rules)
+            (if (str_eq tag "rule")
+                (cm-match-rule (head (tail p)) stream rules)
+                (cmk-fail (str_concat "unknown char-pattern: " tag)))))))))))))))))))))
+
+    (defn cm-match-sequence (children stream rules acc-caps)
+        (if (nil? children) (cmk-match acc-caps stream)
+            (do
+                (let m (cm-match-pattern (head children) stream rules))
+                (if (cfail-cut? m) m
+                (if (cfail? m)
+                    (if (ccap-has? acc-caps "_cut")
+                        (cmk-fail-cut (head (tail m)))
+                        m)
+                    (cm-match-sequence (tail children)
+                                        (cmatch-rest m) rules
+                                        (ccap-merge acc-caps (cmatch-caps m))))))))
+
+    (defn cm-match-choice (alternatives stream rules)
+        (if (nil? alternatives) (cmk-fail "no alternative matched")
+            (do
+                (let m (cm-match-pattern (head alternatives) stream rules))
+                (if (cmatch? m) m
+                (if (cfail-cut? m) (cmk-fail (head (tail m)))
+                    (cm-match-choice (tail alternatives) stream rules))))))
+
+    (defn cm-match-capture (name child stream rules)
+        (do
+            (let start (cs-index stream))
+            (let m (cm-match-pattern child stream rules))
+            (if (cany-fail? m) m
+                (do
+                    ;; Capture the text span from start to current index
+                    (let span-end (cs-index (cmatch-rest m)))
+                    (let span (substring (cs-text stream) start span-end))
+                    (cmk-match (ccap-set (cmatch-caps m) name span)
+                               (cmatch-rest m))))))
+
+    ;; substring helper (since cm- file is self-contained from core only)
+    (defn substring (s a b)
+        (if (ge a b) ""
+            (str_concat (char_at s a) (substring s (add a 1) b))))
+
+    (defn cm-match-star (child stream rules collected)
+        (do
+            (let m (cm-match-pattern child stream rules))
+            (if (cfail-cut? m) m
+            (if (cfail? m)
+                (cmk-match (ccap-set (ccap-empty 0) "items" collected) stream)
+                (cm-match-star child (cmatch-rest m) rules
+                                (cons (cmatch-caps m) collected))))))
+
+    (defn cm-match-opt (child stream rules)
+        (do
+            (let m (cm-match-pattern child stream rules))
+            (if (cfail-cut? m) m
+            (if (cfail? m) (cmk-match (ccap-empty 0) stream) m))))
+
+    ;; Rules: a (name pattern action-fn) tuple registry
+    (defn cm-find-rule (rules name)
+        (if (nil? rules) (empty)
+            (if (str_eq (head (head rules)) name)
+                (head rules)
+                (cm-find-rule (tail rules) name))))
+
+    (defn cm-match-rule (name stream rules)
+        (do
+            (let rule (cm-find-rule rules name))
+            (if (nil? rule) (cmk-fail (str_concat "no such rule: " name))
+                (do
+                    (let pattern (head (tail rule)))
+                    (let action (head (tail (tail rule))))
+                    (let m (cm-match-pattern pattern stream rules))
+                    (if (cany-fail? m) m
+                        (do
+                            (let recipe (action (cmatch-caps m)))
+                            (cmk-match (ccap-set (ccap-empty 0) "_result" recipe)
+                                       (cmatch-rest m))))))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Top-level: parse text via a rule set
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn cm-parse (text rules start-name)
+        (do
+            (let stream (mk-cstream text))
+            (let m (cm-match-pattern (list "rule" start-name) stream rules))
+            (if (cmatch? m)
+                (ccap-get (cmatch-caps m) "_result")
+                (do
+                    (print (str_concat "cm-parse: " (head (tail m))))
+                    (empty)))))
+
+    0)

--- a/experiments/form-stdlib/grammars/python-chars.bnf.fk
+++ b/experiments/form-stdlib/grammars/python-chars.bnf.fk
@@ -40,6 +40,8 @@
     (let PYC-CLASS        (make_nodeid 1 2 99 134))   ; (name)
     (let PYC-DOCSTRING    (make_nodeid 1 2 99 135))   ; (text)
     (let PYC-NAME-LIST    (make_nodeid 1 2 99 136))   ; list of name strings
+    (let PYC-DEF-FULL     (make_nodeid 1 2 99 137))   ; (name, params, ret-type)
+    (let PYC-PARAM-LIST   (make_nodeid 1 2 99 138))   ; opaque text for now
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Character-class helpers (codepoints)
@@ -247,6 +249,55 @@
                     (list "sequence" pyc-ident-start
                           (list "star" pyc-ident-cont)))))
 
+    ;; def-with-params: `def NAME (P1: T1, P2: T2) -> RT:`
+    ;;
+    ;; Discipline: parameters and types are read as opaque chars-up-to-
+    ;; matching-paren / chars-up-to-colon. Structural extraction of each
+    ;; param (name, type, default) is a later breath; this rule's job is
+    ;; recognizing the whole shape WITHOUT a tokenizer fighting it.
+    ;;
+    ;; Real-line target: from substrate_strings.py line 61:
+    ;;   def intern_string_instance(session: Session, value: str) -> int:
+
+    (let pyc-not-rparen
+        (list "not" (list "char" ")")))
+
+    (let pyc-not-colon
+        (list "not" (list "char" ":")))
+
+    (let pyc-paren-body
+        (list "star" (list "sequence" pyc-not-rparen (list "any"))))
+
+    (let pyc-return-arrow
+        (list "sequence"
+              pyc-skip-spaces
+              (list "string" "->")
+              pyc-skip-spaces
+              (list "capture" "ret"
+                    (list "star" (list "sequence" pyc-not-colon (list "any"))))))
+
+    (let pyc-def-full-rule
+        (list "sequence"
+              (list "string" "def")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "cut")
+              (list "capture" "name"
+                    (list "sequence" pyc-ident-start
+                          (list "star" pyc-ident-cont)))
+              pyc-skip-spaces
+              (list "char" "(")
+              (list "capture" "params" pyc-paren-body)
+              (list "char" ")")
+              (list "opt" pyc-return-arrow)
+              pyc-skip-spaces
+              (list "char" ":")))
+
+    (defn pyc-emit-def-full (caps)
+        (intern_node PYC-DEF-FULL
+                      (list (intern_trivial_string (pyc-cap-get caps "name"))
+                            (intern_trivial_string (pyc-cap-get caps "params"))
+                            (intern_trivial_string (pyc-cap-get caps "ret")))))
+
     ;; def-header: `def NAME ():`
     (let pyc-def-rule
         (list "sequence"
@@ -268,6 +319,7 @@
         (list
             (list "from_import"  pyc-from-import-rule  pyc-emit-from-import)
             (list "multi_import" pyc-multi-import-rule pyc-emit-multi-import)
+            (list "def_full"     pyc-def-full-rule     pyc-emit-def-full)
             (list "def_header"   pyc-def-rule          pyc-emit-def)
             (list "class_decl"   pyc-class-rule        pyc-emit-class)
             (list "docstring"    pyc-docstring-rule    pyc-emit-docstring)))
@@ -287,5 +339,8 @@
 
     (defn parse-py-docstring (text)
         (cm-parse text python-chars-rules "docstring"))
+
+    (defn parse-py-def-full (text)
+        (cm-parse text python-chars-rules "def_full"))
 
     0)

--- a/experiments/form-stdlib/grammars/python-chars.bnf.fk
+++ b/experiments/form-stdlib/grammars/python-chars.bnf.fk
@@ -1,0 +1,179 @@
+; grammars/python-chars.bnf.fk — Python grammar in character-mode (no
+; tokenizer). The BMF lineage Urs named twice:
+;
+;   "BMF also does not have a tokenizer at all!"
+;   "Ambiguity comes most often from the tokenizer, when the rules
+;    read what it needs and not just reads blindly into context free
+;    tokens that is where most issues come from."
+;
+; This grammar uses grammar-chars.fk's character-stream primitives.
+; Each rule reads exactly the characters it needs. Disambiguation
+; happens via Cut at the point the rule decides — not in a global
+; lex phase ahead of parsing.
+;
+; Subset covered in this breath (a meaningful starting tongue):
+;   • from-import: `from MODULE import NAME` (single name, no comma)
+;   • def-header: `def NAME():` (empty body marker)
+;   • Whitespace and comments handled per-rule (no global skip)
+;
+; What's deliberately NOT here yet (each = its own breath):
+;   • Multi-name imports, * imports, dotted imports
+;   • Function parameters + type annotations
+;   • Class declarations
+;   • Multi-statement function bodies (indent rules)
+;   • Triple-quoted strings, f-strings
+;   • Expressions beyond literal-ish atoms
+;   • Comprehensions, lambda, async, try/except
+;
+; Per-tongue ripening is the path. This file is the character-mode
+; FOUNDATION; subsequent breaths add features one shape at a time.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Substrate Blueprints for the emitted Recipes
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let PYC-MODULE       (make_nodeid 1 2 99 130))
+    (let PYC-IMPORT       (make_nodeid 1 2 99 131))   ; (module, name)
+    (let PYC-FROM-IMPORT  (make_nodeid 1 2 99 132))
+    (let PYC-DEF          (make_nodeid 1 2 99 133))   ; (name)
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Character-class helpers (codepoints)
+    ;; ──────────────────────────────────────────────────────────────────
+    ;;   '0'..'9' = 48..57
+    ;;   'A'..'Z' = 65..90
+    ;;   'a'..'z' = 97..122
+    ;;   '_' = 95
+    ;;   ' ' = 32   '\t' = 9   '\n' = 10
+    ;;   '.' = 46   '(' = 40   ')' = 41   ':' = 58
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Per-rule whitespace skipper — explicit, not a global pre-pass
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Reads zero-or-more spaces and tabs. NOT newlines — Python is
+    ;; line-sensitive; preserving newlines is what lets indentation
+    ;; rules (future breath) recognize statement boundaries.
+
+    (let pyc-space-char
+        (list "choice"
+              (list "char" " ")
+              (list "char" "	")))   ; tab
+
+    (let pyc-skip-spaces
+        (list "star" pyc-space-char))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Identifier: alpha/_ followed by alpha/digit/_
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (let pyc-ident-start
+        (list "choice"
+              (list "char-range" 65 90)     ; A-Z
+              (list "char-range" 97 122)    ; a-z
+              (list "char" "_")))
+
+    (let pyc-ident-cont
+        (list "choice"
+              (list "char-range" 65 90)
+              (list "char-range" 97 122)
+              (list "char-range" 48 57)     ; 0-9
+              (list "char" "_")))
+
+    (let pyc-ident
+        (list "capture" "ident"
+              (list "sequence" pyc-ident-start
+                    (list "star" pyc-ident-cont))))
+
+    ;; Dotted identifier (for module names like `app.services.foo`)
+    (let pyc-dotted-ident
+        (list "capture" "module"
+              (list "sequence"
+                    pyc-ident-start
+                    (list "star"
+                          (list "choice"
+                                pyc-ident-cont
+                                (list "char" "."))))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Emitters — caps come from rule's child match
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn pyc-cap-get (caps name)
+        (if (nil? caps) ""
+            (if (str_eq (head (head caps)) name)
+                (head (tail (head caps)))
+                (pyc-cap-get (tail caps) name))))
+
+    (defn pyc-emit-import (caps)
+        (intern_node PYC-IMPORT
+                      (list (intern_trivial_string (pyc-cap-get caps "module")))))
+
+    (defn pyc-emit-from-import (caps)
+        (intern_node PYC-FROM-IMPORT
+                      (list (intern_trivial_string (pyc-cap-get caps "module"))
+                            (intern_trivial_string (pyc-cap-get caps "name")))))
+
+    (defn pyc-emit-def (caps)
+        (intern_node PYC-DEF
+                      (list (intern_trivial_string (pyc-cap-get caps "name")))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Rules — each composes character-level primitives. The keyword
+    ;; rules read `import` / `from` / `def` literally, then Cut to
+    ;; commit (no backtracking past keyword recognition), then read
+    ;; what they need with exact character matches.
+    ;; ──────────────────────────────────────────────────────────────────
+
+    ;; from-import: `from MODULE import NAME`
+    ;;
+    ;; Rule shape:
+    ;;   "from" SP+ module:dotted-ident SP+ "import" SP+ name:ident
+    ;;
+    ;; Cut after `from` SP commits — the parser will not backtrack
+    ;; past this point if the rest fails. (Future Cut placement can
+    ;; come AFTER `import` once more import shapes land.)
+
+    (let pyc-from-import-rule
+        (list "sequence"
+              (list "string" "from")
+              (list "sequence" pyc-space-char pyc-skip-spaces)   ; SP+
+              (list "cut")
+              pyc-dotted-ident
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "string" "import")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "capture" "name"
+                    (list "sequence" pyc-ident-start
+                          (list "star" pyc-ident-cont)))))
+
+    ;; def-header: `def NAME ():`
+    (let pyc-def-rule
+        (list "sequence"
+              (list "string" "def")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "cut")
+              (list "capture" "name"
+                    (list "sequence" pyc-ident-start
+                          (list "star" pyc-ident-cont)))
+              pyc-skip-spaces
+              (list "char" "(")
+              pyc-skip-spaces
+              (list "char" ")")
+              pyc-skip-spaces
+              (list "char" ":")))
+
+    ;; The rules-list cm-parse consumes
+    (let python-chars-rules
+        (list
+            (list "from_import" pyc-from-import-rule pyc-emit-from-import)
+            (list "def_header"  pyc-def-rule         pyc-emit-def)))
+
+    ;; Entry points for callers
+    (defn parse-py-from-import (text)
+        (cm-parse text python-chars-rules "from_import"))
+
+    (defn parse-py-def-header (text)
+        (cm-parse text python-chars-rules "def_header"))
+
+    0)

--- a/experiments/form-stdlib/grammars/python-chars.bnf.fk
+++ b/experiments/form-stdlib/grammars/python-chars.bnf.fk
@@ -37,6 +37,9 @@
     (let PYC-IMPORT       (make_nodeid 1 2 99 131))   ; (module, name)
     (let PYC-FROM-IMPORT  (make_nodeid 1 2 99 132))
     (let PYC-DEF          (make_nodeid 1 2 99 133))   ; (name)
+    (let PYC-CLASS        (make_nodeid 1 2 99 134))   ; (name)
+    (let PYC-DOCSTRING    (make_nodeid 1 2 99 135))   ; (text)
+    (let PYC-NAME-LIST    (make_nodeid 1 2 99 136))   ; list of name strings
 
     ;; ──────────────────────────────────────────────────────────────────
     ;; Character-class helpers (codepoints)
@@ -125,6 +128,103 @@
     ;; what they need with exact character matches.
     ;; ──────────────────────────────────────────────────────────────────
 
+    ;; Comma + spaces (used inside multi-name import lists)
+    (let pyc-comma-spaces
+        (list "sequence"
+              pyc-skip-spaces
+              (list "char" ",")
+              pyc-skip-spaces))
+
+    ;; Triple-quote docstring: """ ... """ — reads characters until
+    ;; matching close-triple. Uses (not "\"\"\"") to ensure we stop at
+    ;; the close marker. This is the Urs-corrected shape: the rule
+    ;; reads exactly what it needs (chars NOT closing the triple).
+    (let pyc-not-triple
+        (list "not" (list "string" "\"\"\"")))
+
+    (let pyc-doc-body-char
+        (list "sequence" pyc-not-triple (list "any")))
+
+    (let pyc-docstring-rule
+        (list "sequence"
+              (list "string" "\"\"\"")
+              (list "cut")
+              (list "capture" "body"
+                    (list "star" pyc-doc-body-char))
+              (list "string" "\"\"\"")))
+
+    (defn pyc-emit-docstring (caps)
+        (intern_node PYC-DOCSTRING
+                      (list (intern_trivial_string (pyc-cap-get caps "body")))))
+
+    ;; class-decl: `class NAME:` or `class NAME(BASE):`
+    ;; Cut after `class` SP commits — keyword recognized.
+    (let pyc-bases-block
+        (list "opt"
+              (list "sequence"
+                    (list "char" "(")
+                    pyc-skip-spaces
+                    ;; Read any chars up to ')' — bases are captured
+                    ;; opaquely for now (typed base lists are a later
+                    ;; breath; the rule that matters is "find the colon").
+                    (list "star"
+                          (list "sequence"
+                                (list "not" (list "char" ")"))
+                                (list "any")))
+                    (list "char" ")"))))
+
+    (let pyc-class-rule
+        (list "sequence"
+              (list "string" "class")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "cut")
+              (list "capture" "name"
+                    (list "sequence" pyc-ident-start
+                          (list "star" pyc-ident-cont)))
+              pyc-skip-spaces
+              pyc-bases-block
+              pyc-skip-spaces
+              (list "char" ":")))
+
+    (defn pyc-emit-class (caps)
+        (intern_node PYC-CLASS
+                      (list (intern_trivial_string (pyc-cap-get caps "name")))))
+
+    ;; multi-import: `from MODULE import N1, N2, N3` — head + zero or
+    ;; more comma-separated additional names. The emit produces a
+    ;; PYC-FROM-IMPORT with module + comma-joined name string (a
+    ;; structured name-list Recipe is next breath when we wire
+    ;; star-captures to collect into a list children).
+
+    (let pyc-multi-import-rule
+        (list "sequence"
+              (list "string" "from")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "cut")
+              pyc-dotted-ident
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              (list "string" "import")
+              (list "sequence" pyc-space-char pyc-skip-spaces)
+              ;; capture the entire name list as text (commas + spaces
+              ;; preserved) — the rule reads exactly to end-of-line or
+              ;; end-of-input. Inner structure can be extracted in a
+              ;; later breath without changing this grammar's emit.
+              (list "capture" "names"
+                    (list "sequence"
+                          ;; first name
+                          (list "sequence" pyc-ident-start
+                                (list "star" pyc-ident-cont))
+                          ;; zero or more comma-separated more names
+                          (list "star"
+                                (list "sequence" pyc-comma-spaces
+                                      (list "sequence" pyc-ident-start
+                                            (list "star" pyc-ident-cont))))))))
+
+    (defn pyc-emit-multi-import (caps)
+        (intern_node PYC-FROM-IMPORT
+                      (list (intern_trivial_string (pyc-cap-get caps "module"))
+                            (intern_trivial_string (pyc-cap-get caps "names")))))
+
     ;; from-import: `from MODULE import NAME`
     ;;
     ;; Rule shape:
@@ -166,14 +266,26 @@
     ;; The rules-list cm-parse consumes
     (let python-chars-rules
         (list
-            (list "from_import" pyc-from-import-rule pyc-emit-from-import)
-            (list "def_header"  pyc-def-rule         pyc-emit-def)))
+            (list "from_import"  pyc-from-import-rule  pyc-emit-from-import)
+            (list "multi_import" pyc-multi-import-rule pyc-emit-multi-import)
+            (list "def_header"   pyc-def-rule          pyc-emit-def)
+            (list "class_decl"   pyc-class-rule        pyc-emit-class)
+            (list "docstring"    pyc-docstring-rule    pyc-emit-docstring)))
 
     ;; Entry points for callers
     (defn parse-py-from-import (text)
         (cm-parse text python-chars-rules "from_import"))
 
+    (defn parse-py-multi-import (text)
+        (cm-parse text python-chars-rules "multi_import"))
+
     (defn parse-py-def-header (text)
         (cm-parse text python-chars-rules "def_header"))
+
+    (defn parse-py-class-decl (text)
+        (cm-parse text python-chars-rules "class_decl"))
+
+    (defn parse-py-docstring (text)
+        (cm-parse text python-chars-rules "docstring"))
 
     0)

--- a/experiments/form-stdlib/tests/grammar-chars.fk
+++ b/experiments/form-stdlib/tests/grammar-chars.fk
@@ -1,0 +1,72 @@
+; tests/grammar-chars.fk — character-stream architecture proof
+;
+; preludes: form-stdlib/grammar-chars.fk
+;
+; Demonstrates rules consuming characters directly with no tokenizer
+; phase. The architectural correction from Urs:
+;   "BMF also does not have a tokenizer at all!"
+;   "Ambiguity comes most often from the tokenizer, when the rules
+;    read what it needs and not just reads blindly into context free
+;    tokens that is where most issues come from."
+;
+; Each probe exercises one primitive shape, proving the BMF lineage
+; works end-to-end on the sibling kernels.
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 1 — exact character match
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn ce-1 (caps) (intern_trivial_int 1))
+    (let r1 (list (list "start" (list "char" "a") ce-1)))
+    (let p1 (cm-parse "a" r1 "start"))
+    (let probe-1 (walk_recipe p1))                ; → 1
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 2 — character range (digit)
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn ce-2 (caps) (intern_trivial_int 2))
+    (let r2 (list (list "start" (list "char-range" 48 57) ce-2)))
+    (let p2 (cm-parse "5" r2 "start"))
+    (let probe-2 (walk_recipe p2))                ; → 2
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 3 — string literal match
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn ce-3 (caps) (intern_trivial_int 3))
+    (let r3 (list (list "start" (list "string" "def") ce-3)))
+    (let p3 (cm-parse "def" r3 "start"))
+    (let probe-3 (walk_recipe p3))                ; → 3
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Probe 4 — sequence: capture name span
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Reads "def hello": match "def", a space, then captures
+    ;; one-or-more alpha chars as "name".
+
+    (defn ce-4 (caps)
+        (intern_trivial_string (cap-get caps "name")))
+
+    (defn cap-get (caps name)   ; local alias since core's cap-get may differ
+        (if (nil? caps) ""
+            (if (str_eq (head (head caps)) name)
+                (head (tail (head caps)))
+                (cap-get (tail caps) name))))
+
+    (let alpha-char (list "char-range" 97 122))   ; a-z
+    (let r4 (list
+        (list "start"
+              (list "sequence"
+                    (list "string" "def")
+                    (list "char" " ")
+                    (list "capture" "name"
+                          (list "sequence" alpha-char (list "star" alpha-char))))
+              ce-4)))
+    (let p4 (cm-parse "def hello" r4 "start"))
+    (let probe-4 (str_len (node_value p4)))       ; → 5 (capture spans only
+                                                   ;     the inner sequence's
+                                                   ;     match: "hello")
+    ;; Sum: 1 + 2 + 3 + 5 = 11
+    (add probe-1 (add probe-2 (add probe-3 probe-4))))

--- a/experiments/form-stdlib/tests/python-chars.fk
+++ b/experiments/form-stdlib/tests/python-chars.fk
@@ -59,10 +59,35 @@
     ;; "Substrate string-table.\nCross-process stable." = 45
     (let probe-7 (str_len body))
 
-    ;; Sum: 14 + 23 + 22 + 3 + 20 + 18 + 45 = 145
+    ;; Probe 8: def with params + types + return — the literal line
+    ;; from substrate_strings.py:61
+    (let p8 (parse-py-def-full
+              "def intern_string_instance(session: Session, value: str) -> int:"))
+    (let kids-8 (node_children p8))
+    (let dname (node_value (head kids-8)))
+    (let dparams (node_value (head (tail kids-8))))
+    (let dret (node_value (head (tail (tail kids-8)))))
+    ;; name "intern_string_instance" = 22
+    ;; params "session: Session, value: str" = 28
+    ;; ret "int" = 3
+    ;; sum = 53
+    (let probe-8 (add (str_len dname)
+                       (add (str_len dparams) (str_len dret))))
+
+    ;; Probe 9: def with no return annotation (just params)
+    (let p9 (parse-py-def-full "def list_strings(session: Session):"))
+    (let kids-9 (node_children p9))
+    (let dname9 (node_value (head kids-9)))
+    (let dret9 (node_value (head (tail (tail kids-9)))))
+    ;; "list_strings" = 12, ret = "" (no arrow), total = 12
+    (let probe-9 (add (str_len dname9) (str_len dret9)))
+
+    ;; Sum: 145 + 53 + 12 = 210
     (add probe-1
          (add probe-2
               (add probe-3
                    (add probe-4
                         (add probe-5
-                             (add probe-6 probe-7)))))))
+                             (add probe-6
+                                  (add probe-7
+                                       (add probe-8 probe-9))))))))))

--- a/experiments/form-stdlib/tests/python-chars.fk
+++ b/experiments/form-stdlib/tests/python-chars.fk
@@ -1,0 +1,39 @@
+; tests/python-chars.fk — Python in character-mode end-to-end
+;
+; preludes: form-stdlib/grammar-chars.fk form-stdlib/grammars/python-chars.bnf.fk
+;
+; Proves the BMF-shape Python grammar parses real Python lines via
+; rules-read-characters discipline. No tokenizer phase.
+
+(do
+    ;; Probe 1: from-import line — `from typing import Optional`
+    (let p1 (parse-py-from-import "from typing import Optional"))
+    (let kids-1 (node_children p1))
+    (let mod-1 (node_value (head kids-1)))
+    (let name-1 (node_value (head (tail kids-1))))
+    ;; "typing" (6) + "Optional" (8) = 14
+    (let probe-1 (add (str_len mod-1) (str_len name-1)))
+
+    ;; Probe 2: dotted module — `from app.services.unified_db import Base`
+    (let p2 (parse-py-from-import "from app.services.unified_db import Base"))
+    (let kids-2 (node_children p2))
+    (let mod-2 (node_value (head kids-2)))
+    ;; "app.services.unified_db" = 23
+    (let probe-2 (str_len mod-2))
+
+    ;; Probe 3: def header — `def intern_string_instance():`
+    (let p3 (parse-py-def-header "def intern_string_instance():"))
+    (let kids-3 (node_children p3))
+    (let name-3 (node_value (head kids-3)))
+    ;; "intern_string_instance" = 22
+    (let probe-3 (str_len name-3))
+
+    ;; Probe 4: def with leading whitespace tolerance
+    (let p4 (parse-py-def-header "def foo (  )  :"))
+    (let kids-4 (node_children p4))
+    (let name-4 (node_value (head kids-4)))
+    ;; "foo" = 3
+    (let probe-4 (str_len name-4))
+
+    ;; Sum: 14 + 23 + 22 + 3 = 62
+    (add probe-1 (add probe-2 (add probe-3 probe-4))))

--- a/experiments/form-stdlib/tests/python-chars.fk
+++ b/experiments/form-stdlib/tests/python-chars.fk
@@ -35,5 +35,34 @@
     ;; "foo" = 3
     (let probe-4 (str_len name-4))
 
-    ;; Sum: 14 + 23 + 22 + 3 = 62
-    (add probe-1 (add probe-2 (add probe-3 probe-4))))
+    ;; Probe 5: multi-name import — `from typing import Optional, List, Dict`
+    (let p5 (parse-py-multi-import "from typing import Optional, List, Dict"))
+    (let kids-5 (node_children p5))
+    (let names-5 (node_value (head (tail kids-5))))
+    ;; "Optional, List, Dict" = 20 chars
+    (let probe-5 (str_len names-5))
+
+    ;; Probe 6: class declaration — `class SubstrateStringORM(Base):`
+    (let p6 (parse-py-class-decl "class SubstrateStringORM(Base):"))
+    (let kids-6 (node_children p6))
+    (let cname (node_value (head kids-6)))
+    ;; "SubstrateStringORM" = 18
+    (let probe-6 (str_len cname))
+
+    ;; Probe 7: docstring — three-line """ ... """
+    (let docstring-text
+        (str_concat "\"\"\"Substrate string-table." (str_concat "
+" "Cross-process stable.\"\"\"")))
+    (let p7 (parse-py-docstring docstring-text))
+    (let kids-7 (node_children p7))
+    (let body (node_value (head kids-7)))
+    ;; "Substrate string-table.\nCross-process stable." = 45
+    (let probe-7 (str_len body))
+
+    ;; Sum: 14 + 23 + 22 + 3 + 20 + 18 + 45 = 145
+    (add probe-1
+         (add probe-2
+              (add probe-3
+                   (add probe-4
+                        (add probe-5
+                             (add probe-6 probe-7)))))))


### PR DESCRIPTION
## The correction

@urs-muff, back-to-back:

> "BMF also does not have a tokenizer at all!"
>
> "Ambiguity comes most often from the tokenizer, when the rules read what it needs and not just reads blindly into context free tokens that is where most issues come from."

The earlier path — engine.fk + grammar-bnf.fk — tokenizes ahead into a flat token stream, then rules walk tokens. That's classic compiler-pipeline shape, and exactly where context-free lexing locks in ambiguity.

BMF (2000) does it the other way: there is no tokenizer; each rule reads exactly the characters it needs, decides at that point, commits with Cut.

This breath restores the character-stream architecture.

## What lands

### `grammar-chars.fk` — character-mode engine

Self-contained on `core.fk` (~280 lines). Stream shape: `(text, index, line, col)`.

**Character-level primitives:**

| Form | Match |
|------|-------|
| `(char "x")` | next char is exactly `x` |
| `(char-range lo hi)` | codepoint in `[lo, hi]` |
| `(string "text")` | exact substring at current position |
| `(any)` | any single char |
| `(eof)` | end of input |
| `(eol)` | newline or EOF |
| `(not pattern)` | negative lookahead (BMF NOT) |
| `(peek pattern)` | positive lookahead, no consumption |

**Structural primitives** (sequence, choice, star, opt, capture, tag, cut, stop, nil, rule) compose character-level matches the same way they composed token-level matches. Cut + Stop + Nil propagate via the same `fail-cut` tag the token-mode engine learned in #1860.

### `tests/grammar-chars.fk`

| Probe | Validates | Result |
|-------|-----------|--------|
| `(char "a")` | single char | 1 |
| `(char-range 48 57)` matching "5" | codepoint range | 2 |
| `(string "def")` | exact text | 3 |
| `(sequence alpha (star alpha))` captured | span-capture | 5 |

Both Go and Rust kernels return **11** (byte-identical).

## What this opens for FULL language coverage

- Per-tongue grammars can read characters directly, matching the language spec's actual lexical decisions **in context**.
  - f-strings: a single rule reads the boundary characters and switches to expression mode inside `{...}`
  - Triple-quoted strings: the rule decides when the close-triple is found
  - Keyword vs ident boundary: read `def`, then peek to confirm what follows is not an ident continuation char
- Ambiguity stops being locked into a global tokenizer phase. The `for x {` vs `Type{}` ambiguity that breath 23 worked around by rule placement can now resolve by the rule reading exactly what it needs.

## Coexistence

The token-mode `engine.fk` path stays. Existing grammars continue to work. New grammars can be authored character-mode from the start. Migration is one tongue at a time, one breath at a time.

## The lineage

BMF (Urs Muff, 2000) had no tokenizer phase by design. The substrate now carries the same shape. The loop closes — again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)