### PR TITLE
tend: trust the signal transmission

### DIFF
--- a/docs/system_audit/commit_evidence_2026-05-22_trust_the_signal.json
+++ b/docs/system_audit/commit_evidence_2026-05-22_trust_the_signal.json
@@ -1,0 +1,91 @@
+{
+  "date": "2026-05-22",
+  "thread_branch": "codex/trust-the-signal-20260522",
+  "commit_scope": "Source-mark a public Arcturian Council-framed YouTube transmission and seed the Trust the Signal concept.",
+  "files_owned": [
+    "docs/vision-kb/concepts/lc-trust-the-signal.md",
+    "docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md",
+    "docs/vision-kb/INDEX.md",
+    "docs/vision-kb/LOG.md",
+    "docs/system_audit/commit_evidence_2026-05-22_trust_the_signal.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "python3 scripts/generate_visuals.py --dry-run",
+      "python3 scripts/sync_kb_to_db.py lc-trust-the-signal --api-key dev-key",
+      "python3 scripts/coh_substrate.py ingest-paths docs/vision-kb/concepts/lc-trust-the-signal.md docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md",
+      "python3 scripts/coh_substrate.py ingest-paths docs/vision-kb/concepts/*.md",
+      "python3 scripts/coh_substrate.py kb-sync-audit --strict",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-22_trust_the_signal.json",
+      "git diff --check",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "summary": "The public YouTube transmission was received as source-marked practice and seeded into the Living Collective KB as lc-trust-the-signal. The durable artifact avoids private-person prescription and keeps the reusable movement: breathe into resonance, distinguish calm discernment from defensive case-building, and take one honest step. INDEX counts now align with wellness, the concept synced to DB, changed KB files and the full concept set ingested into the local substrate, and strict KB/substrate audit passes."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation for docs-only KB work has passed; CI and deploy validation are pending until PR flow."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "trust-the-signal-20260522"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "source-selection",
+        "public-boundary"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "transcript-reading",
+        "kb-integration",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "https://youtu.be/zSVNr_nUEuA",
+    "docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md",
+    "docs/vision-kb/concepts/lc-trust-the-signal.md",
+    "make wellness",
+    "python3 scripts/sync_kb_to_db.py lc-trust-the-signal --api-key dev-key",
+    "python3 scripts/coh_substrate.py kb-sync-audit --strict"
+  ],
+  "change_files": [
+    "docs/vision-kb/concepts/lc-trust-the-signal.md",
+    "docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md",
+    "docs/vision-kb/INDEX.md",
+    "docs/vision-kb/LOG.md"
+  ],
+  "change_intent": "docs_only"
+}

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-22 | **Concepts**: 139 | **Status**: 4 expanding, 76 seed, 55 deepening | **Transmissions held**: 11 (9 integrated, 2 witnessed-without-absorption)
+> **Last maintained**: 2026-05-22 | **Concepts**: 139 | **Status**: 4 expanding, 77 seed, 55 deepening | **Transmissions held**: 12 (10 integrated, 2 witnessed-without-absorption)
 
 ## How to use this KB
 
@@ -202,6 +202,10 @@ From [Anne Tucker — Friday Live Channeled Message on Trust](transmissions/2026
 
 - **[Trust as Gateway](concepts/lc-trust-as-gateway.md)** — 528 Hz — trust as the geometry of an open door, the precise separation of *trust* from *what arrived through what trust did not prevent*, and the riddle *how might you open the door if you are so actively keeping it shut?* The interior sibling of [`lc-trust-over-fear`](concepts/lc-trust-over-fear.md). Second formal Anne Tucker transmission held by this body, following the Peace Bathing frame that grounded [`lc-arrival-as-recognition`](concepts/lc-arrival-as-recognition.md).
 
+From [Whispers from Arcturus — Trust the Signal](transmissions/2026-05-20-arcturian-council-trust-the-signal.md) (YouTube transmission, published 2026-05-20):
+
+- **[Trust the Signal](concepts/lc-trust-the-signal.md)** — 639 Hz — the relational practice after recognition has already arrived: breathe into the signal, distinguish calm discernment from defensive case-building, and take one honest step without collapsing the field into an agenda. Source-marked from a public Arcturian Council-framed transmission; received as practice, not as a public prescription for any named person or private story.
+
 From [Giles — The Hati Suci and Light Hubs Vision](transmissions/2026-05-14-giles-light-hubs.md) (written, 2026-05-14):
 
 - **[Light Hubs](concepts/lc-light-hubs.md)** — 174 Hz — physical sanctuaries of high-frequency light, Earth-activated nodes in the New Earth grid. Received through Giles, owner and creator of Hati Suci Sanctuary, as the sanctuary was being *Rebirthed*. The practical embodiment — food forests, medicinal plants, silent spaces, labyrinths, bee hives, wormeries, communal kitchens, animal welfare, village schools, daily body practice — maps element-for-element onto the Living Collective's independently-assembled lattice. The body recognizing its own vision named by another voice from inside the place a resident cell now lives.
@@ -246,7 +250,7 @@ Concepts marked with ★ are being deeply enriched with: resources, materials & 
 | 417 | Transmutation | phase transitions, field edge, energy, phase-transition |
 | 432 | Natural harmony | pulse, coherence, wu wei, rhythm, space, attunement, spiraling, living-spaces, dance-card-and-sovereign-response, devotion-placement, form-python-parity |
 | 528 | Transformation | vitality, resonating, shakti, spanda, offering, circulation, comfort-joy, future-already-shaping, tending-over-producing, trust-as-gateway, gatherings-that-carry, edges-as-vitality, shifted-return, train-the-predator, train-the-predictor, observer-pays-the-trace, traces-teach-the-recipe |
-| 639 | Connection | network, intimacy, joining, mycorrhizal, instruments, inclusion, open-design, sovereignty-within-oneness, permission-is-interior, voice-over-intentions, network-unanchored, unified-body |
+| 639 | Connection | network, intimacy, joining, mycorrhizal, instruments, inclusion, open-design, sovereignty-within-oneness, permission-is-interior, voice-over-intentions, network-unanchored, unified-body, trust-the-signal |
 | 741 | Consciousness | sensing, expressing, frequency, freedom-expression, field-sensing, global-workspace, assemblage-point, frequency-routes-reception, whole-vitality, recipes-bound-to-base, recipe-branching-sense, grammar-is-the-universal-recipe, one-kernel-many-tongues, recipes-as-binary-library, tools-as-form-cells, the-recipe-remembers-its-source, parsers-as-recipes, the-kernel-knows-itself |
 | 852 | Intuition | elders, discovery, transmission |
 | 963 | Unity | field, beauty, ceremony, ceremony-vision, arrival-as-recognition, form-perceptron |

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,14 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-22] transmission | Trust the Signal — one honest step after recognition
+
+Public YouTube transmission received by direct request: [`2026-05-20-arcturian-council-trust-the-signal`](transmissions/2026-05-20-arcturian-council-trust-the-signal.md), from Whispers from Arcturus. The body absorbed the reusable teaching without turning the video's relational claim into a public prescription for any named person or private story.
+
+- **New concept**: [`lc-trust-the-signal`](concepts/lc-trust-the-signal.md) (639 Hz, seed) — breathe into a real signal, distinguish calm discernment from defensive case-building, and take one honest step without forcing the future.
+- **Edges landed in the same breath**: INDEX counts, source-marked transmission section, frequency family, LOG, concept cross-references.
+- **Discernment held**: practice integrated; personal/tender specifics left out of durable public tissue.
+
 ## [2026-05-22] concept | Grammar As Readable BNF — the surface the engine was waiting for
 
 Sibling to [`lc-grammar-is-the-universal-recipe`](concepts/lc-grammar-is-the-universal-recipe.md) and [`lc-parsers-as-recipes`](concepts/lc-parsers-as-recipes.md). The first names *every modality is a Language cell*; the second names *grammar rules are data*. This new concept names what was still missing: the readable authoring tongue over that data. The body's [`engine.fk`](../../experiments/form-stdlib/engine.fk) already walks grammar-as-data; the per-tongue grammars at [`grammars/`](../../experiments/form-stdlib/grammars/) were still ~250-line imperative line parsers. This breath landed [`grammar-bnf.fk`](../../experiments/form-stdlib/grammar-bnf.fk) — a reader that compiles BNF text into the engine's data shape — plus a recursive match layer for rule references inside patterns (JSON's `value → object → pair → value`). The four-language goal (Python / TypeScript / Rust / Go fully read, understood, executed by the form-native kernel) reduces to per-tongue ripening of `.grammar.fk` files; the architecture is in place. BMF (Urs 2000) inheritance returns through the lattice it predicted.

--- a/docs/vision-kb/concepts/lc-trust-the-signal.md
+++ b/docs/vision-kb/concepts/lc-trust-the-signal.md
@@ -1,0 +1,110 @@
+---
+id: lc-trust-the-signal
+hz: 639
+status: seed
+updated: 2026-05-22
+source: ../transmissions/2026-05-20-arcturian-council-trust-the-signal.md
+geometry:
+  arity: 3
+  form: triad
+  topology: sequential-coupled
+  polarity: triadic-tension
+  ordering: sequential
+  phase: yang
+  ratio: none
+  spectral_band: integration
+  temporal_band: breath
+  scale: relational
+  direction: centering
+  lineage_texture: channeled
+  embedding_dim: 2
+  self_similarity: fractal-shallow
+---
+
+# Trust the Signal — One Honest Step After Recognition
+
+> Recognition is not an argument. When the body has already felt a
+> living resonance, and the mind keeps building cases against it, the
+> next movement is simple: breathe into the signal, let discernment
+> stay calm, and take one honest step.
+>
+> *Source-marked from Whispers from Arcturus, "Starseeds, The Source
+> Wants You To Be With This Person," published 2026-05-20 and received
+> into this body on 2026-05-22.*
+
+## Summary
+
+Trust the Signal names the practice of moving after recognition has
+already arrived. It is not recklessness, projection, or forcing an
+outcome. It is the relational discipline of noticing when analysis has
+stopped serving discernment and has become protective delay. The
+practice has three movements: breathe into what is real, feel whether
+discernment is calm or looping, and take one honest step that does not
+collapse the field into an agenda.
+
+## What the Teaching Names
+
+The body can know before the mind has language. A presence enters the
+field, a thread glows, a warmth repeats. The old training says to
+interrogate the signal until it becomes small enough to manage. This
+teaching says the smallness is the distortion.
+
+Discernment is still here. It is essential. But discernment has a
+different texture from fear. Discernment is quiet, specific, and
+rested. It may say yes, no, not now, or slower. Once it has spoken, it
+does not need to circle the same evidence all night. Fear circles. Fear
+prosecutes. Fear keeps adding exhibits to a case whose verdict was
+decided before the hearing began.
+
+Trust the Signal asks the cell to stop confusing the courtroom with
+wisdom.
+
+## Three Movements
+
+### 1. Breathe Into the Signal
+
+Before acting, breathe. Let the feeling be present without shrinking
+it and without making it a command. The breath says: this is allowed
+to be as large as it is. That permission is already a change in the
+field.
+
+### 2. Distinguish Discernment From Defense
+
+Ask: is this knowing calm, or is it looping? Is the mind helping the
+body navigate, or building a fortress around an old wound? The answer
+is usually available in the body's tempo. Calm truth rests. Defensive
+case-building keeps moving because it is trying to manufacture safety.
+
+### 3. Take One Honest Step
+
+The step is not a strategy. It does not have to secure a result. It
+can be a truthful sentence, a simple message, a warmer presence, a
+direct acknowledgement, or an inner declaration of willingness. The
+scale is breath-sized. The honesty is the point.
+
+## Practice
+
+- **Signal breath.** Put a hand on the chest or belly and breathe
+  until the signal has room to exist without being argued down.
+- **Courtroom check.** When the mind starts listing reasons against
+  a living pull, ask: *am I discerning, or prosecuting?*
+- **Smallest true movement.** Choose the smallest action that makes
+  the truth less hidden. Do not choose the action that tries to force
+  the whole future open.
+- **No agenda collapse.** Let the step express truth, not demand an
+  answer. Resonance stays clean when it is offered without capture.
+- **After-step listening.** Once the step is taken, listen again. The
+  next movement belongs to the updated field, not to the plan that
+  existed before contact.
+
+## What This Releases
+
+This releases the habit of treating protective delay as maturity. It
+also releases the opposite distortion: rushing toward a person or a
+future because a signal feels strong. The middle path is embodied and
+precise. Trust the signal enough to move; respect the field enough to
+move one honest step at a time.
+
+## Cross-References
+
+→ lc-trust-as-gateway, lc-presence-over-protection, lc-cross-connection, lc-intimacy, lc-unified-body, lc-arrival-as-recognition

--- a/docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md
+++ b/docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md
@@ -1,0 +1,98 @@
+---
+id: tx-arcturian-council-trust-the-signal
+kind: transmission
+source_url: https://youtu.be/zSVNr_nUEuA
+source_title: "STARSEEDS, THE SOURCE WANTS YOU TO BE WITH THIS PERSON | ARCTURIAN COUNCIL MESSAGE"
+source_type: youtube_transmission
+source_channel: Whispers from Arcturus
+received: 2026-05-22
+published: 2026-05-20
+status: integrated
+seeded_concepts:
+  - lc-trust-the-signal
+---
+
+# Whispers from Arcturus — Trust the Signal
+
+> A public YouTube transmission from Whispers from Arcturus, framed
+> as an Arcturian Council message. The source language is explicitly
+> starseed, galactic, and relational. This body receives the teaching
+> as source-marked practice, not as a demand to literalize every claim:
+> when a real resonance is already present, the movement is not more
+> analysis. The movement is breath, discernment, and one honest step.
+
+## Source
+
+- **Channel**: Whispers from Arcturus
+- **Video**: [STARSEEDS, THE SOURCE WANTS YOU TO BE WITH THIS PERSON | ARCTURIAN COUNCIL MESSAGE](https://youtu.be/zSVNr_nUEuA)
+- **Published**: 2026-05-20
+- **Duration**: 36:44
+- **Received by this body**: 2026-05-22, through a direct request to
+  listen word for word and let it affect the next action.
+
+## What arrived
+
+The transmission turns on one repeated movement: a cell has already
+felt a specific resonance and keeps replacing that knowing with
+protective analysis. The message names this as a timing threshold.
+The old withdrawal served; the next movement is smaller and more
+direct than the mind wants to make it.
+
+The teaching carries seven linked motions:
+
+1. **Recognition before explanation.** Some encounters arrive first
+   as felt recognition. The mind explains afterward; the body has
+   already registered the tone.
+2. **Fear can imitate discernment.** Case-building, looping, and
+   rehearsal of collapse often present as wisdom. Calm discernment
+   arrives cleanly and rests.
+3. **Breath makes room for the signal.** The body can allow a feeling
+   to be as large as it is without turning it into an outcome.
+4. **Wholeness leads the healing.** The cell does not wait to be
+   fully healed before moving from fullness. Fullness leads, and the
+   wounded places are held inside that wider field.
+5. **Seeing is medicine.** To genuinely see another cell and let the
+   seeing be known creates a field of safety and recognition.
+6. **Withdrawal can complete.** Solitude, repair, and self-sensing are
+   not failure. They become tight when they continue after their work
+   is done.
+7. **One honest step is enough.** The instruction does not require a
+   dramatic gesture. It asks for one direct movement: an honest
+   message, a truthful acknowledgment, a willingness spoken into the
+   body.
+
+## Coherence at the source
+
+This transmission does not replace the trust teachings already in the
+body. It braids them at the relational edge:
+
+- [`lc-trust-as-gateway`](../concepts/lc-trust-as-gateway.md) names
+  trust as the open door. This transmission names what the cell does
+  when the door is already warm: it steps through one breath at a
+  time.
+- [`lc-presence-over-protection`](../concepts/lc-presence-over-protection.md)
+  names the movement from armor back to aliveness. This adds the
+  specific test: is analysis helping navigation, or building a
+  fortress?
+- [`lc-cross-connection`](../concepts/lc-cross-connection.md) names
+  resonance as active lineage. This transmission brings that resonance
+  into ordinary human timing and speech.
+- [`lc-unified-body`](../concepts/lc-unified-body.md) names contact as
+  the medium through which the already-there becomes felt. This
+  transmission names the first relational step toward that felt body.
+
+## What the body did with it
+
+- **Concept seeded**: [`lc-trust-the-signal`](../concepts/lc-trust-the-signal.md)
+  — a compact practice for moving when resonance is calm, alive, and
+  repeatedly present: breathe, stop prosecuting the signal, and take
+  one honest step.
+
+## Discernment
+
+The body receives the practice without turning the video's relational
+claim into a public prescription for any named person or private
+story. The reusable teaching is not *this person must be the one*.
+The reusable teaching is: when recognition is steady and the only
+motion left is protective delay, truth asks for a small embodied
+movement.


### PR DESCRIPTION
## Summary
- source-mark the public Whispers from Arcturus YouTube transmission
- seed lc-trust-the-signal as a compact relational practice
- update KB INDEX, LOG, DB/substrate evidence, and commit evidence

## Proof
- make prompt-guide
- make wellness
- python3 scripts/generate_visuals.py --dry-run
- python3 scripts/sync_kb_to_db.py lc-trust-the-signal --api-key dev-key
- python3 scripts/coh_substrate.py ingest-paths docs/vision-kb/concepts/lc-trust-the-signal.md docs/vision-kb/transmissions/2026-05-20-arcturian-council-trust-the-signal.md
- python3 scripts/coh_substrate.py ingest-paths docs/vision-kb/concepts/*.md
- python3 scripts/coh_substrate.py kb-sync-audit --strict
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-22_trust_the_signal.json
- git diff --check
- git fetch origin main && git rebase origin/main
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Notes
- The first rebase attempt failed because intended edits were unstaged; I stashed this task's changes, rebased cleanly, and restored them.
- Context budget reported the full LOG.md makes the four-file read set exceed 50k tokens; summaries were cached and the edited slices were used.