### PR TITLE
tend: real Python file parses — 6 top-level constructs

### DIFF
--- a/experiments/form-samples/test_module.py
+++ b/experiments/form-samples/test_module.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from typing import Optional
+
+CONST = 42
+
+def add(a, b):
+    return a + b
+
+def main():
+    x = 10
+    y = 20
+    z = add(x, y)
+    print(z)

--- a/experiments/form-stdlib/grammars/python-full.bnf.fk
+++ b/experiments/form-stdlib/grammars/python-full.bnf.fk
@@ -107,6 +107,23 @@
             (if (cap-has? caps "_1") (cap-get caps "_1")
                 caps)))
 
+    ;; Module emitter: collect all statements from `statement+` into a
+    ;; single MODULE Recipe whose children are each statement's recipe.
+    (defn pyf-extract-stmts (items)
+        (if (nil? items) (empty)
+            (cons (cap-get (head items) "_result")
+                  (pyf-extract-stmts (tail items)))))
+
+    (defn pyf-emit-module (caps)
+        ;; `statement+` desugars to `(sequence statement (star statement))`.
+        ;; The first statement's _result lives in caps; subsequent
+        ;; statements' caps are in "items" (the star's list).
+        (do
+            (let first (cap-get caps "_result"))
+            (let items-caps (cap-get caps "items"))
+            (let rest-stmts (pyf-extract-stmts items-caps))
+            (intern_node PY-FULL-MODULE (cons first rest-stmts))))
+
     (defn pyf-emit-int (caps)
         (intern_node PY-FULL-INT
                       (list (intern_trivial_int
@@ -275,7 +292,7 @@
 }
 
 rules {
-  module       ::= statement ;
+  module       ::= statement+                                            => pyf-emit-module ;
   statement    ::= simple-stmt | compound-stmt ;
 
   ;; ── simple statements ─────────────────────────────────────────
@@ -445,7 +462,8 @@ rules {
               (list "pyf-emit-list-lit"    pyf-emit-list-lit)
               (list "pyf-emit-dict-lit"    pyf-emit-dict-lit)
               (list "pyf-emit-paren"       pyf-emit-paren)
-              (list "pyf-emit-decorator"   pyf-emit-decorator)))
+              (list "pyf-emit-decorator"   pyf-emit-decorator)
+              (list "pyf-emit-module"      pyf-emit-module)))
 
     (let py-full-grammar (load-bnf-grammar py-full-text py-full-registry))
 

--- a/experiments/form-stdlib/tests/real-file-parse.fk
+++ b/experiments/form-stdlib/tests/real-file-parse.fk
@@ -1,0 +1,31 @@
+; tests/real-file-parse.fk — parse a structured Python sample
+;
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python-full.bnf.fk
+;
+; Parses form-samples/test_module.py — a small real-shaped Python
+; module with: imports, constant, two function definitions, multi-stmt
+; function bodies, function calls.
+
+(do
+    (let src (read_file "form-samples/test_module.py"))
+    (print (str_concat "source: "
+                       (str_concat (int_to_str (str_len src)) " bytes")))
+
+    (let preprocessed (pyf-preprocess src))
+    (print (str_concat "preprocessed: "
+                       (str_concat (int_to_str (str_len preprocessed)) " bytes")))
+
+    ;; Show first 200 chars of preprocessed
+    (defn first-n (s n)
+        (if (le (str_len s) n) s
+            (substring s 0 n)))
+
+    (print "preprocessed preview:")
+    (print (first-n preprocessed 300))
+
+    (let result (parse-python-full-indented src))
+    (let kids (node_children result))
+    (print (str_concat "top-level constructs parsed: "
+                       (int_to_str (len kids))))
+
+    (str_len src))


### PR DESCRIPTION
Continuing on Urs's "yes, please".

Real Python source (form-samples/test_module.py) now parses end-to-end through python-full.bnf.fk with the indent preprocessor.

## What lands

```python
import os
import sys
from typing import Optional

CONST = 42

def add(a, b):
    return a + b

def main():
    x = 10
    y = 20
    z = add(x, y)
    print(z)
```

→ 6 top-level constructs parsed on Go kernel (Rust stack-overflows on the deep grammar; known existing limit).

## Changes

- `module` rule: `statement` → `statement+`
- New `pyf-emit-module` collects first + star-iterated items into a single `PY-FULL-MODULE` Recipe with all statements as children
- `tests/real-file-parse.fk` loads file from disk via `read_file`, preprocesses indentation, parses, reports counts

## Honest gap

`python-full.bnf.fk` still uses doc-band NodeIDs (@1.2.99.*) — to make the bytecode-execution path work for real files, the emitters need to produce universal Blueprints instead. Same rule shapes, different constants. Next breath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)