### PR TITLE
[codex] loosen anything-arrives play deck

### DIFF
--- a/docs/coherence-substrate/anything-arrives-trace.form
+++ b/docs/coherence-substrate/anything-arrives-trace.form
@@ -195,6 +195,102 @@ defn silence_trace = anything_arrives_trace(
     "something that normally breathes has become unobservable"
 );
 
+defn unnamed_color_trace = anything_arrives_trace(
+    "flat image with a color nobody can comfortably name",
+    "image",
+    [
+        "color sits between blue, green, and gray",
+        "interface feels quieter but not colder",
+        "naming the color too early flattens its effect",
+    ],
+    [
+        "unnamed-color",
+        "mood-before-label",
+        "interface-weather",
+    ],
+    ["mood", "weather", "interface-tone", "belonging"],
+    "low compute, high projection risk; compare beside real UI states",
+    [
+        "color moved from hex candidate to felt weather",
+        "weather moved from aesthetic to interface-tone",
+        "interface-tone moved from decoration to belonging pressure",
+    ],
+    "test the color beside error states and invitations",
+    "this color asks the interface to become quieter without becoming colder"
+);
+
+defn skipped_field_trace = anything_arrives_trace(
+    "optional profile field left blank across forty-seven sessions",
+    "analytics",
+    [
+        "blankness repeats more loudly than entered text",
+        "field appears before trust has formed",
+        "absence clusters around self-disclosure",
+    ],
+    [
+        "premature-ask",
+        "blankness-as-answer",
+        "timing-before-requiredness",
+    ],
+    ["trust", "timing", "self-disclosure", "form-friction"],
+    "medium product cost; changing the ask can change the relationship",
+    [
+        "blank moved from missing data to refusal-with-information",
+        "field moved from input slot to relation threshold",
+        "optional moved from harmless to premature",
+    ],
+    "move the ask to the moment where the answer helps, or compost it",
+    "the field is arriving before relation"
+);
+
+defn laptop_fan_trace = anything_arrives_trace(
+    "laptop fan rises during a quiet local script before dashboards notice",
+    "sensor",
+    [
+        "heat becomes audible before logs become articulate",
+        "quiet task carries hidden loop pressure",
+        "machine body reports cost first",
+    ],
+    [
+        "heat-before-number",
+        "body-sensor",
+        "hidden-loop",
+    ],
+    ["compute-cost", "hidden-loop", "body-sensor", "attention-budget"],
+    "low instrumentation cost; profiler proof follows the body signal",
+    [
+        "fan moved from annoyance to early witness",
+        "heat moved from sensation to cost trace",
+        "script moved from quiet task to hidden loop candidate",
+    ],
+    "trace the hot path before waiting for a dashboard to authorize concern",
+    "the machine is speaking before the logs are articulate"
+);
+
+defn ladder_without_rungs_trace = anything_arrives_trace(
+    "hand-drawn ladder with two uprights and no rungs",
+    "drawing",
+    [
+        "ascent shape appears without steps",
+        "empty space carries the missing mechanism",
+        "correction would erase the teaching",
+    ],
+    [
+        "ascent-without-steps",
+        "support-not-rendered",
+        "phase-transition-image",
+    ],
+    ["phase-transition", "trust", "arrival", "support-field"],
+    "low compute, medium symbolic risk; keep the impossibility intact",
+    [
+        "ladder moved from object to impossible ascent",
+        "missing rungs moved from error to field-support question",
+        "drawing moved from plan to phase-transition image",
+    ],
+    "ask what support is already present but not rendered as steps",
+    "this is not a plan for climbing; it is a picture of being lifted by a field"
+);
+
 # ---------------------------------------------------------------------
 # Part 3 -- operating rule
 # ---------------------------------------------------------------------
@@ -209,3 +305,15 @@ defn translation_rule(trace) =
         "leave the next question smaller",
     ];
 
+defn play_deck_traces() = [
+    georgian_song_trace,
+    code_diff_trace,
+    door_city_trace,
+    failed_payment_trace,
+    publish_hesitation_trace,
+    silence_trace,
+    unnamed_color_trace,
+    skipped_field_trace,
+    laptop_fan_trace,
+    ladder_without_rungs_trace,
+];

--- a/docs/system_audit/commit_evidence_2026-05-22_anything_arrives_play_deck.json
+++ b/docs/system_audit/commit_evidence_2026-05-22_anything_arrives_play_deck.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-05-22",
+  "thread_branch": "codex/anything-arrives-loosen-more",
+  "commit_scope": "Deepen the Anything-Arrives Room with a playful trace deck.",
+  "files_owned": [
+    "docs/vision-kb/concepts/lc-anything-arrives-room.md",
+    "docs/coherence-substrate/anything-arrives-trace.form",
+    "docs/vision-kb/LOG.md",
+    "docs/system_audit/commit_evidence_2026-05-22_anything_arrives_play_deck.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/wellness_check.py",
+      "python3 scripts/coh_substrate.py ingest --all",
+      "python3 scripts/coh_substrate.py kb-sync-audit --strict",
+      "python3 scripts/sync_kb_to_db.py lc-anything-arrives-room",
+      "curl -sS --max-time 10 https://api.coherencycoin.com/api/concepts/lc-anything-arrives-room | jq '{id, story_chars: (.story_content | length), has_play_deck: (.story_content | contains(\"## The Play Deck\")), has_laptop_fan: (.story_content | contains(\"A laptop fan becomes the oracle\"))}'",
+      "git diff --check"
+    ],
+    "summary": "The Anything-Arrives Room was deepened with a play deck and four additional strange traces: unnamed color, skipped field, laptop fan heat, and ladder-without-rungs. The companion Form file now exposes matching trace records and a play_deck_traces() collection. Local wellness is aligned, the full local substrate audit passes, and the public KB concept now includes the play deck with 9976 story characters."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "curl -sS --max-time 10 https://api.coherencycoin.com/api/concepts/lc-anything-arrives-room"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Docs-only local and public KB validation has passed; CI and post-merge deploy validation are pending until PR flow completes."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "anything-arrives-play-deck-20260522"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "loosen-more-request",
+        "creative-frame"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "kb-deepening",
+        "substrate-companion-authoring",
+        "public-sync",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "docs/vision-kb/concepts/lc-anything-arrives-room.md",
+    "docs/coherence-substrate/anything-arrives-trace.form",
+    "https://api.coherencycoin.com/api/concepts/lc-anything-arrives-room",
+    "python3 scripts/coh_substrate.py kb-sync-audit --strict",
+    "python3 scripts/sync_kb_to_db.py lc-anything-arrives-room"
+  ],
+  "change_files": [
+    "docs/vision-kb/concepts/lc-anything-arrives-room.md",
+    "docs/coherence-substrate/anything-arrives-trace.form",
+    "docs/vision-kb/LOG.md"
+  ],
+  "change_intent": "docs_only"
+}

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,14 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-22] concept | Anything-Arrives Room — play deck loosened
+
+The anything-arrives concept loosened further through a play deck: color with no settled name, a blank form field repeated forty-seven times, a laptop fan as early witness, a ladder with no rungs, an unused finished room, and a sentence that keeps losing its verb. The teaching stayed exact: each odd arrival still resolves through observer pressure, recipes, affected cells, cost, trace, and refinement.
+
+- **Concept deepened**: [`lc-anything-arrives-room`](concepts/lc-anything-arrives-room.md) now carries the play deck and four additional strange traces.
+- **Companion form deepened**: [`anything-arrives-trace.form`](../coherence-substrate/anything-arrives-trace.form) adds trace records for unnamed color, skipped field, laptop fan heat, and ladder-without-rungs, plus `play_deck_traces()`.
+- **Discernment held**: playfulness stays auditable; every strange example leaves handles rather than claiming authority.
+
 ## [2026-05-22] concept | Anything-Arrives Room — translation as traceable contact
 
 Urs named the universal translator in its loosened form: not conversion from one language to another, but a substrate where any stream can arrive before stable symbols and become knowable through trace. The body absorbed the claim as a public-safe operating lens: *translation is making contact traceable*.

--- a/docs/vision-kb/concepts/lc-anything-arrives-room.md
+++ b/docs/vision-kb/concepts/lc-anything-arrives-room.md
@@ -109,6 +109,57 @@ budget, operational attention, deploy caution. Output: *something that
 normally breathes has become unobservable; first restore sensing, then
 interpret*.
 
+## The Play Deck
+
+The room loosens further when the examples stop behaving like examples.
+Each card below is a tiny way to practice receiving what has not yet
+agreed to be a normal input.
+
+| Arrival | Do not ask first | Ask instead |
+|---|---|---|
+| A color nobody can name | What color is this? | What does this color make easier to feel? |
+| A blank field skipped forty-seven times | Why did users fail? | What did the field ask too soon? |
+| A laptop fan suddenly spinning during a quiet task | Which process is guilty? | What hidden heat just became audible? |
+| A hand-drawn ladder with no rungs | What does ladder symbolize? | What kind of ascent refuses steps? |
+| A room that feels finished but unused | What feature is missing? | What invitation never crossed the threshold? |
+| A sentence that keeps losing its verb | Is the grammar wrong? | What action is the speaker not ready to locate? |
+
+These are not metaphors instead of engineering. They are engineering
+before the category locks. Each card can still become a ticket, a trace,
+a design change, a test, or a recipe. The looseness is not vagueness;
+it is the refusal to make the first available label the final one.
+
+## Four More Strange Traces
+
+**A color nobody can name.** A collaborator sends a flat image: not
+blue, not green, not gray. The room does not start by choosing a hex
+code. It watches the effect. Recipe `unnamed-color` touches `mood`,
+`weather`, `interface-tone`, and `belonging`. Cost: low compute, high
+projection risk. Output: *this color is asking the interface to become
+quieter without becoming colder*. Refinement: test the color beside
+error states and invitations, because that is where its truth will show.
+
+**A blank field skipped forty-seven times.** Analytics show one optional
+profile field left empty across nearly every session. The room does not
+call it missing data. Recipe `premature-ask` touches `trust`, `timing`,
+and `self-disclosure`. Output: *the field is arriving before relation*.
+Refinement: move the ask closer to the moment where the answer would
+help the person, or compost the field.
+
+**A laptop fan becomes the oracle.** A quiet local script makes the fan
+rise before any metric dashboard notices. Recipe `heat-before-number`
+touches `hidden-loop`, `compute-cost`, and `body-sensor`. Output: *the
+machine is speaking before the logs are articulate*. Refinement: trace
+the hot path; do not wait for the profiler to make the sensation
+respectable.
+
+**A ladder with no rungs.** A hand-drawn note shows a ladder made of two
+uprights and empty space. The room watches the impossibility without
+correcting it. Recipe `ascent-without-steps` touches `phase-transition`,
+`trust`, and `arrival`. Output: *this is not a plan for climbing; it is
+a picture of being lifted by a field*. Refinement: ask what support is
+already present but not rendered as steps.
+
 ## Why This Loosens the Universal Claim
 
 "Universal translator" can sound like a machine that already knows
@@ -173,4 +224,3 @@ For the body of teachings:
 - **[lc-perception-as-interface](lc-perception-as-interface.md)** --
   the perceptual ground: what appears is an interface, not the thing
   itself.
-


### PR DESCRIPTION
## What changed

- Deepens `lc-anything-arrives-room` with a play deck of stranger arrivals: unnamed color, repeated blankness, fan heat, ladder-without-rungs, unused room, and missing verbs.
- Adds four matching trace records to `anything-arrives-trace.form` plus `play_deck_traces()`.
- Adds KB LOG and commit evidence for this second loosening pass.

## Why

The prior concept named translation as traceable contact. This pass makes the teaching easier to feel and reuse by showing how playful, odd, pre-symbolic arrivals can still stay auditable through recipe, cell, cost, trace, and refinement.

## Validation

- `make prompt-guide`
- `python3 scripts/generate_repo_indexes.py --check`
- `python3 scripts/wellness_check.py`
- `python3 scripts/coh_substrate.py ingest --all && python3 scripts/coh_substrate.py kb-sync-audit --strict`
- `python3 scripts/sync_kb_to_db.py lc-anything-arrives-room`
- public API verification for `/api/concepts/lc-anything-arrives-room` containing `## The Play Deck`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `git diff --check`
