### PR TITLE
attune: vision-kb INDEX claims 141 concepts (not 142)

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-22 | **Concepts**: 142 | **Status**: 4 expanding, 83 seed, 54 deepening, 1 living | **Transmissions held**: 12 (10 integrated, 2 witnessed-without-absorption)
+> **Last maintained**: 2026-05-22 | **Concepts**: 141 | **Status**: 4 expanding, 82 seed, 54 deepening, 1 living | **Transmissions held**: 12 (10 integrated, 2 witnessed-without-absorption)
 
 ## How to use this KB
 


### PR DESCRIPTION
## Summary

- The 142nd `.md` under `docs/vision-kb/concepts/` is `lc-nourishing.de.md` — a German translation, not a separate concept
- Wellness count (which excludes language variants) reads 141; INDEX header was double-counting
- Seed status also drifted: body has 82, header claimed 83
- After: `4 expanding + 82 seed + 54 deepening + 1 living = 141` ✓

`make wellness` now reads `vision-kb/INDEX.md — aligned (141 concepts)`.

## Test plan

- [x] `python3 scripts/wellness_check.py` shows all three INDEX maps aligned
- [x] Status breakdown sums to canonical count

🤖 Generated with [Claude Code](https://claude.com/claude-code)