### PR TITLE
tend: close two-sided parent invariant in create_idea

### DIFF
--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -827,6 +827,16 @@ async def create_idea(data: IdeaCreate) -> IdeaWithScore:
     )
     if created is None:
         raise HTTPException(status_code=409, detail="Idea already exists")
+
+    # Two-sided parent invariant: when create includes parent_idea_id, form the
+    # reciprocal edge in the same breath. create_idea sets the child's own
+    # parent_idea_id field, but only set_parent_idea appends the child to the
+    # parent's child_idea_ids — symmetric with the PATCH path below.
+    if data.parent_idea_id:
+        idea_service.set_parent_idea(created.id, data.parent_idea_id)
+        refreshed = idea_service.get_idea(created.id)
+        if refreshed is not None:
+            return refreshed
     return created
 
 

--- a/api/tests/test_super_idea_rollup.py
+++ b/api/tests/test_super_idea_rollup.py
@@ -323,6 +323,36 @@ async def test_set_parent_idea_reparents_both_sides():
         assert super_b_after["child_idea_ids"].count(child) == 1
 
 
+@pytest.mark.asyncio
+async def test_create_idea_with_parent_forms_edge_immediately():
+    """POST /api/ideas with parent_idea_id must form the two-sided edge in one
+    breath — no follow-up PATCH required.
+
+    Strange-minimal case: one parent, one child created via POST carrying
+    parent_idea_id. With the bug, child.parent_idea_id is set but the parent's
+    child_idea_ids stays empty (the reciprocal edge was deferred to PATCH).
+    The single assertion that fails under the bug is the parent-side read.
+    """
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        parent_id = _uid("parent-create")
+        child_id = _uid("child-create")
+
+        await _create_idea(c, idea_id=parent_id, idea_type="super")
+        # No PATCH — the parent edge must land at POST time.
+        await _create_idea(c, idea_id=child_id, parent_idea_id=parent_id, idea_type="child")
+
+        # Child side: own pointer set.
+        child_body = (await c.get(f"/api/ideas/{child_id}")).json()
+        assert child_body["parent_idea_id"] == parent_id
+
+        # Parent side: child appears in child_idea_ids without any PATCH.
+        parent_body = (await c.get(f"/api/ideas/{parent_id}")).json()
+        assert child_id in parent_body["child_idea_ids"], (
+            "create_idea with parent_idea_id did not form the reciprocal edge; "
+            "parent.child_idea_ids is missing the child"
+        )
+
+
 # ---------------------------------------------------------------------------
 # idea-hierarchy-super-child spec — super-ideas excluded from pickup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- POST /api/ideas with `parent_idea_id` set the child's own pointer but never formed the reciprocal edge — the parent's `child_idea_ids` stayed empty until a follow-up PATCH ran `set_parent_idea`.
- The fix is symmetric with the existing PATCH path at line 863: after `create_idea` returns, call `set_parent_idea(created.id, data.parent_idea_id)` so both sides of the edge land in one breath.
- New flow-centric test in `test_super_idea_rollup.py` proves the parent side resolves immediately after POST, no PATCH required. Confirmed the test fails on main (bug reveals cleanly) and passes with the fix.

## What the invariant now guarantees

After `POST /api/ideas` returns 201 with `parent_idea_id` in the payload, both `child.parent_idea_id` and `parent.child_idea_ids` are coherent in the same breath — no second call needed.

## Test plan

- [x] `pytest api/tests/test_super_idea_rollup.py` — 14 passed (13 existing + 1 new)
- [x] `pytest api/tests/` — 372 passed in 35s, no regressions
- [x] Manually verified bug exists by stashing the router fix and running just the new test — fails as expected
- [ ] Verify in prod: POST a child idea with `parent_idea_id` then GET the parent — child appears in `child_idea_ids` without any PATCH

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>