### PR TITLE
ship: sync MCP/skill registry submission assets into api container

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -188,6 +188,33 @@ sync_substrate_content() {
     docker compose cp "$REPO_DIR/docs/registry-submissions.json" \
       api:/app/docs/registry-submissions.json 2>&1 | tee -a "$LOG_FILE"
   fi
+
+  # Registry submission assets the validator checks per-item. The body
+  # already carries glama.json, server.json, smithery.yaml, pulsemcp.json,
+  # the MCP package README, SKILL.md, .cursor/skills/, the root README,
+  # and docs/shared/ecosystem-table.md at the repo root. Inside the api
+  # container these surfaces live under /app/, where the validator
+  # resolves repo-root via parents[2]. Sync them so the live endpoint
+  # sees the same readiness the local validator sees.
+  docker compose exec -T api sh -lc 'rm -rf /app/mcp-server /app/skills /app/.cursor/skills /app/docs/shared' \
+    2>&1 | tee -a "$LOG_FILE" || true
+  if [[ -d "$REPO_DIR/mcp-server" ]]; then
+    docker compose cp "$REPO_DIR/mcp-server" api:/app/mcp-server 2>&1 | tee -a "$LOG_FILE"
+  fi
+  if [[ -d "$REPO_DIR/skills" ]]; then
+    docker compose cp "$REPO_DIR/skills" api:/app/skills 2>&1 | tee -a "$LOG_FILE"
+  fi
+  if [[ -d "$REPO_DIR/.cursor/skills" ]]; then
+    docker compose exec -T api sh -lc 'mkdir -p /app/.cursor' \
+      2>&1 | tee -a "$LOG_FILE" || true
+    docker compose cp "$REPO_DIR/.cursor/skills" api:/app/.cursor/skills 2>&1 | tee -a "$LOG_FILE"
+  fi
+  if [[ -d "$REPO_DIR/docs/shared" ]]; then
+    docker compose cp "$REPO_DIR/docs/shared" api:/app/docs/shared 2>&1 | tee -a "$LOG_FILE"
+  fi
+  if [[ -f "$REPO_DIR/README.md" ]]; then
+    docker compose cp "$REPO_DIR/README.md" api:/app/README.md 2>&1 | tee -a "$LOG_FILE"
+  fi
 }
 
 run_substrate_ingest() {


### PR DESCRIPTION
## Summary

- The repo already carries every registry submission asset the validator checks: `mcp-server/glama.json`, `mcp-server/server.json`, `mcp-server/smithery.yaml`, `mcp-server/pulsemcp.json`, `mcp-server/package.json`, `mcp-server/README.md`, `skills/coherence-network/SKILL.md`, `.cursor/skills/`, `docs/shared/ecosystem-table.md`, root `README.md`. Local validator: **9/9 submission_ready, core_requirement_met=true**.
- Live `/api/discovery/registry-submissions` returned `core_requirement_met=false` because `deploy/hostinger/auto-deploy.sh` synced only `docs/registry-submissions.json` into `/app/`. Inside the container the validator's per-item `required_files` (relative to `/app/`) were unreachable.
- This change extends `sync_substrate_content` to copy `mcp-server/`, `skills/`, `.cursor/skills/`, `docs/shared/`, and `README.md` into `/app/` alongside the inventory file. Asset content stays unchanged — the file system inside the container now mirrors what the local validator already sees.

## Test plan

- [ ] CI green
- [ ] After merge + Hostinger Auto Deploy completes, `curl https://api.coherencycoin.com/api/discovery/registry-submissions | jq '.summary'` returns `submission_ready_count: 9`, `core_requirement_met: true`.
- [ ] Witness `https://pulse.coherencycoin.com/pulse/now` stays breathing through the deploy.
- [ ] Spec `specs/mcp-skill-registry-submission.md` notes attuned to live state in a follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>