### PR TITLE
ship: mirror api/mcp_server.py into /app/api/ to flip MCP registries to ready

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -215,6 +215,17 @@ sync_substrate_content() {
   if [[ -f "$REPO_DIR/README.md" ]]; then
     docker compose cp "$REPO_DIR/README.md" api:/app/README.md 2>&1 | tee -a "$LOG_FILE"
   fi
+  # The registry inventory references the MCP entry point at its repo-
+  # relative path (api/mcp_server.py). Inside the container the file
+  # lives at /app/mcp_server.py because the api directory is the
+  # container root. Mirror it under /app/api/ so the validator's
+  # source_paths check resolves the same in both layouts.
+  if [[ -f "$REPO_DIR/api/mcp_server.py" ]]; then
+    docker compose exec -T api sh -lc 'mkdir -p /app/api' \
+      2>&1 | tee -a "$LOG_FILE" || true
+    docker compose cp "$REPO_DIR/api/mcp_server.py" api:/app/api/mcp_server.py \
+      2>&1 | tee -a "$LOG_FILE"
+  fi
 }
 
 run_substrate_ingest() {


### PR DESCRIPTION
## Summary

- Previous PR #1879 synced the registry asset surfaces (`mcp-server/`, `skills/`, `.cursor/skills/`, `docs/shared/`, `README.md`) into `/app/` and lifted three skill registries to `submission_ready`. The six MCP registries still report `missing_files: ["api/mcp_server.py"]`.
- The container's api directory IS `/app/`, so the MCP entry point lives at `/app/mcp_server.py`, not `/app/api/mcp_server.py`. The registry inventory references it at its canonical repo-relative path `api/mcp_server.py`.
- Mirroring the file at deploy under `/app/api/` makes the container layout match the repo-relative paths the validator inspects. All nine registries should resolve to `submission_ready` after this lands.

## Test plan

- [ ] CI green
- [ ] After Hostinger Auto Deploy completes, `curl https://api.coherencycoin.com/api/discovery/registry-submissions | jq '.summary'` returns `submission_ready_count: 9`, `core_requirement_met: true`.
- [ ] Witness stays breathing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>