### PR TITLE
ship: docs/breath/** triggers Hostinger Auto Deploy

### DIFF
--- a/.github/workflows/hostinger-auto-deploy.yml
+++ b/.github/workflows/hostinger-auto-deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'web/**'
       - 'pulse/**'
       - 'deploy/hostinger/**'
+      - 'docs/breath/**'
       - 'scripts/verify_web_api_deploy.sh'
       - 'scripts/.gitnexus-pin'
       - '.github/workflows/hostinger-auto-deploy.yml'


### PR DESCRIPTION
Breath compositions are content the surface reads — they should self-deploy. Add docs/breath/** to the workflow path filter; this commit itself also touches .github/workflows/hostinger-auto-deploy.yml so it deploys, carrying the prior recompose (#1888) into the container along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)