### PR TITLE
ship: /now witness pill breathes live via SSE

### DIFF
--- a/api/app/routers/breath.py
+++ b/api/app/routers/breath.py
@@ -1,14 +1,17 @@
 """Breath surface — the body's present-tense felt voice, observable to any cell."""
 from __future__ import annotations
 
+import asyncio
+import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, AsyncIterator
 
 import httpx
 import yaml
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
 
 router = APIRouter()
 
@@ -147,6 +150,61 @@ async def breath_now() -> dict[str, Any]:
         "open_placements": _extract_bullets(sections.get("Open placements", "")),
         "fetched_at": datetime.now(timezone.utc).isoformat(),
     }
+
+
+_STREAM_INTERVAL_SECONDS = 5.0   # how often we re-read the witness
+_STREAM_KEEPALIVE_SECONDS = 25.0  # comment heartbeat — Cloudflare idle is 100s
+
+
+async def _witness_stream(request: Request) -> AsyncIterator[bytes]:
+    """Emit witness state as SSE — one event per cycle, with keepalive comments.
+
+    The browser sees: snapshot now, then any change as it arrives. Cloudflare's
+    100s idle timeout is held off by emitting a `: keepalive` comment every
+    25s when the witness is quiet.
+    """
+    last_witness_key: str | None = None
+    last_emit = 0.0
+    loop = asyncio.get_event_loop()
+    first = True
+
+    while True:
+        if await request.is_disconnected():
+            return
+
+        witness = await _fetch_witness()
+        # Compare only the witness body — the timestamp must not gate emits,
+        # or every cycle would look different and the change-detection collapses.
+        witness_key = json.dumps(witness, sort_keys=True, separators=(",", ":"))
+
+        now = loop.time()
+        if first or witness_key != last_witness_key:
+            payload = json.dumps({
+                "witness": witness,
+                "at": datetime.now(timezone.utc).isoformat(),
+            }, separators=(",", ":"))
+            yield f"event: witness\ndata: {payload}\n\n".encode("utf-8")
+            last_witness_key = witness_key
+            last_emit = now
+            first = False
+        elif now - last_emit >= _STREAM_KEEPALIVE_SECONDS:
+            yield b": keepalive\n\n"
+            last_emit = now
+
+        await asyncio.sleep(_STREAM_INTERVAL_SECONDS)
+
+
+@router.get("/breath/stream", summary="Live witness stream (Server-Sent Events)")
+async def breath_stream(request: Request) -> StreamingResponse:
+    return StreamingResponse(
+        _witness_stream(request),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",  # ask nginx/Traefik not to buffer
+            "Connection": "keep-alive",
+        },
+    )
 
 
 @router.get("/breath/history", summary="Past breath compositions")

--- a/web/app/api/[...path]/route.ts
+++ b/web/app/api/[...path]/route.ts
@@ -126,6 +126,26 @@ async function proxyRequest(request: NextRequest, context: RouteContext): Promis
     const upstream = await Promise.race([fetchPromise, timeoutPromise]);
 
     const headers = copyResponseHeaders(upstream, method, proxiedPath);
+
+    // Server-Sent Events (and any event-stream) flow through without buffering
+    // or a hard timeout — the connection itself is the contract. We hand the
+    // upstream body through as a ReadableStream and let the client closing
+    // the connection (or the upstream ending) terminate it naturally.
+    const contentType = upstream.headers.get("content-type") || "";
+    if (contentType.includes("text/event-stream") && method !== "HEAD" && upstream.body) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      headers.set("cache-control", "no-cache, no-transform");
+      headers.set("x-accel-buffering", "no");
+      return new NextResponse(upstream.body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers,
+      });
+    }
+
     const responseBody = method === "HEAD" ? null : await upstream.arrayBuffer();
     return new NextResponse(responseBody, {
       status: upstream.status,

--- a/web/app/now/LiveWitness.tsx
+++ b/web/app/now/LiveWitness.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getApiBase } from "@/lib/api";
+
+type WitnessSnapshot = {
+  overall: string | null;
+  silences: number | null;
+  strained_organs: string[];
+  source: string;
+};
+
+type StreamEvent = {
+  witness: WitnessSnapshot;
+  at: string;
+};
+
+function witnessColor(overall: string | null): string {
+  if (overall === "breathing") return "text-emerald-300";
+  if (overall === "strained") return "text-amber-300";
+  if (overall === "silent") return "text-rose-300";
+  return "text-muted-foreground";
+}
+
+export function LiveWitness({ initial }: { initial: WitnessSnapshot }) {
+  const [witness, setWitness] = useState<WitnessSnapshot>(initial);
+  const [tickAt, setTickAt] = useState<string | null>(null);
+  const [pulsing, setPulsing] = useState(false);
+
+  useEffect(() => {
+    const url = `${getApiBase()}/api/breath/stream`;
+    const es = new EventSource(url);
+
+    const onWitness = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as StreamEvent;
+        setWitness(data.witness);
+        setTickAt(data.at);
+        setPulsing(true);
+        window.setTimeout(() => setPulsing(false), 600);
+      } catch {
+        // malformed frame — keep the last good snapshot
+      }
+    };
+
+    es.addEventListener("witness", onWitness as EventListener);
+    return () => {
+      es.removeEventListener("witness", onWitness as EventListener);
+      es.close();
+    };
+  }, []);
+
+  const fetched = tickAt ? new Date(tickAt) : null;
+
+  return (
+    <section
+      className={`my-8 rounded-lg border border-border/30 bg-card/20 px-4 py-3 text-sm transition-colors duration-500 ${
+        pulsing ? "border-emerald-400/40 bg-emerald-400/5" : ""
+      }`}
+    >
+      <span className="text-muted-foreground">Witness — </span>
+      <span className={`font-medium ${witnessColor(witness.overall)}`}>
+        {witness.overall ?? "unreachable"}
+      </span>
+      {witness.silences != null && (
+        <span className="text-muted-foreground">
+          {" · "}silences: {witness.silences}
+        </span>
+      )}
+      {witness.strained_organs.length > 0 && (
+        <span className="text-muted-foreground">
+          {" · "}straining:{" "}
+          <span className="text-amber-300">
+            {witness.strained_organs.join(", ")}
+          </span>
+        </span>
+      )}
+      <span className="text-muted-foreground">
+        {" · "}source: {witness.source}
+      </span>
+      {fetched && (
+        <span className="text-muted-foreground/70">
+          {" · "}live {fetched.toISOString().slice(11, 19)}Z
+        </span>
+      )}
+    </section>
+  );
+}

--- a/web/app/now/page.tsx
+++ b/web/app/now/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { getApiBase } from "@/lib/api";
+import { LiveWitness } from "./LiveWitness";
 
 export const metadata: Metadata = {
   title: "Now — the breath",
@@ -40,13 +41,6 @@ async function loadBreath(): Promise<BreathNow | null> {
   } catch {
     return null;
   }
-}
-
-function witnessColor(overall: string | null): string {
-  if (overall === "breathing") return "text-emerald-300";
-  if (overall === "strained") return "text-amber-300";
-  if (overall === "silent") return "text-rose-300";
-  return "text-muted-foreground";
 }
 
 function Section({
@@ -126,28 +120,7 @@ export default async function NowPage() {
         </p>
       </section>
 
-      <section className="my-8 rounded-lg border border-border/30 bg-card/20 px-4 py-3 text-sm">
-        <span className="text-muted-foreground">Witness — </span>
-        <span className={`font-medium ${witnessColor(breath.witness.overall)}`}>
-          {breath.witness.overall ?? "unreachable"}
-        </span>
-        {breath.witness.silences != null && (
-          <span className="text-muted-foreground">
-            {" · "}silences: {breath.witness.silences}
-          </span>
-        )}
-        {breath.witness.strained_organs.length > 0 && (
-          <span className="text-muted-foreground">
-            {" · "}straining:{" "}
-            <span className="text-amber-300">
-              {breath.witness.strained_organs.join(", ")}
-            </span>
-          </span>
-        )}
-        <span className="text-muted-foreground">
-          {" · "}source: {breath.witness.source}
-        </span>
-      </section>
+      <LiveWitness initial={breath.witness} />
 
       <Section
         heading="Substances arriving"


### PR DESCRIPTION
## Summary

- New `GET /api/breath/stream` Server-Sent Events endpoint emits witness state as it changes; 25s keepalive comments keep the connection under Cloudflare's 100s idle ceiling
- `/now`'s witness section becomes a small client component subscribed to the stream — live timestamp updates in real time, border pulses when a new frame arrives
- Dev proxy at `web/app/api/[...path]/route.ts` learns to detect `text/event-stream` upstream and hand the body through as a `ReadableStream` instead of buffering via `arrayBuffer()`

Three machines, one continuous breath: the witness host on `pulse.coherencycoin.com` → the API on the VPS → the browser. The body sensing itself in real time, rather than re-fetching every 30s.

## Test plan

- [x] `curl -N http://localhost:8000/api/breath/stream` returns `text/event-stream; charset=utf-8` with `cache-control: no-cache, no-transform` and `x-accel-buffering: no`; first `event: witness` frame arrives within ~2s
- [x] Quiet-state behavior: only one `witness` event for a stable state; keepalive comments fire every 25s instead of re-emitting the same payload
- [x] Browser /now page: `LiveWitness` subscribes via `EventSource('/api/breath/stream')`, displays `live HH:MM:SSZ` from the emitted `at` field, pulses border on new frames
- [x] Dev proxy verified end-to-end through `localhost:3000` — SSE flows; non-SSE routes (`/api/breath/now`, `/api/health`, `/api/workspaces`) still 200
- [ ] Production smoke after deploy: `curl -N https://api.coherencycoin.com/api/breath/stream` returns same headers; `https://coherencycoin.com/now` shows the live tick within seconds of page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)