### PR TITLE
[codex] Accept Next CSS chunk assets in deploy verify

### DIFF
--- a/docs/system_audit/commit_evidence_2026-05-23_next16_css_verify.json
+++ b/docs/system_audit/commit_evidence_2026-05-23_next16_css_verify.json
@@ -1,0 +1,92 @@
+{
+  "date": "2026-05-23",
+  "thread_branch": "codex/verify-next16-css-assets-20260523",
+  "commit_scope": "Update public deploy verification to recognize Next 16 stylesheet assets emitted under /_next/static/chunks.",
+  "files_owned": [
+    "scripts/verify_web_api_deploy.sh",
+    "scripts/test_verify_web_api_css_assets.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-23_next16_css_verify.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "bash scripts/test_verify_web_api_css_assets.sh",
+      "bash -n scripts/verify_web_api_deploy.sh scripts/test_verify_web_api_css_assets.sh",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-23_next16_css_verify.json",
+      "git diff --check"
+    ],
+    "summary": "The deploy verifier now treats both legacy /_next/static/css/*.css and Next 16 /_next/static/chunks/*.css stylesheet links as valid public CSS assets. A shell fixture proves extraction and de-duplication for both path shapes."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ]
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Public deploy verification accepts reachable Next 16 CSS chunk assets instead of failing when no /_next/static/css path exists.",
+    "public_endpoints": [
+      "https://coherencycoin.com/",
+      "https://coherencycoin.com/_next/static/chunks/0c2gci3ey8-6~.css"
+    ],
+    "test_flows": [
+      "fixture: extract_next_css_paths returns css and chunks stylesheet paths once each",
+      "production: verify_web_api_deploy.sh completes after pulse settles"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation is complete. CI/PR validation remains pending until the branch is pushed and checked."
+  },
+  "idea_ids": [
+    "pipeline-reliability"
+  ],
+  "spec_ids": [
+    "public-verification-framework"
+  ],
+  "task_ids": [
+    "next16-css-verify-20260523"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "attention-prioritization"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "bash scripts/test_verify_web_api_css_assets.sh",
+    "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+  ],
+  "change_files": [
+    "scripts/verify_web_api_deploy.sh",
+    "scripts/test_verify_web_api_css_assets.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/scripts/test_verify_web_api_css_assets.sh
+++ b/scripts/test_verify_web_api_css_assets.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+VERIFY_WEB_API_DEPLOY_SOURCE_ONLY=1 source "$ROOT_DIR/scripts/verify_web_api_deploy.sh" "http://api.example" "http://web.example"
+source_tmp_dir="$TMP_DIR"
+trap 'rm -rf "$fixture_dir" "$source_tmp_dir"' EXIT
+
+html_file="$fixture_dir/root.html"
+cat >"$html_file" <<'HTML'
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/_next/static/css/legacy.css" />
+    <link rel="stylesheet" href="/_next/static/chunks/next16-shell.css" data-precedence="next" />
+    <link rel="stylesheet" href="/_next/static/chunks/next16-shell.css" data-precedence="next" />
+  </head>
+  <body></body>
+</html>
+HTML
+
+css_paths=()
+while IFS= read -r css_path; do
+  css_paths+=("$css_path")
+done < <(extract_next_css_paths "$html_file")
+
+test "${#css_paths[@]}" -eq 2
+test "${css_paths[0]}" = "/_next/static/css/legacy.css"
+test "${css_paths[1]}" = "/_next/static/chunks/next16-shell.css"
+
+echo "PASS: Next CSS asset extraction supports css and chunks paths"

--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -289,6 +289,11 @@ for organ in strained:
 PY
 }
 
+extract_next_css_paths() {
+  local html_file="$1"
+  grep -Eo '/_next/static/(css|chunks)/[^"]+\.css' "$html_file" | awk '!seen[$0]++'
+}
+
 check_web_css_assets() {
   local web_root_url="$1"
   local html_file="$TMP_DIR/web_root.body.html"
@@ -311,7 +316,7 @@ check_web_css_assets() {
   local css_line
   while IFS= read -r css_line; do
     [[ -n "$css_line" ]] && css_paths+=("$css_line")
-  done < <(grep -Eo '/_next/static/css/[^"]+\.css' "$html_file" | awk '!seen[$0]++')
+  done < <(extract_next_css_paths "$html_file")
 
   if [[ "${#css_paths[@]}" -eq 0 ]]; then
     echo "FAIL: no Next CSS assets found in web root HTML"


### PR DESCRIPTION
## Summary
- update public deploy CSS verification to accept Next 16 stylesheet links under /_next/static/chunks
- keep legacy /_next/static/css support
- add a shell fixture test for extraction and de-duplication

## Validation
- bash scripts/test_verify_web_api_css_assets.sh
- bash -n scripts/verify_web_api_deploy.sh scripts/test_verify_web_api_css_assets.sh
- python3 scripts/generate_repo_indexes.py --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-23_next16_css_verify.json
- git diff --check
- ./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com
- PATH=/Users/ursmuff/source/Coherence-Network/api/.venv/bin:$PATH python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main

## Why
After the Next 16 deploy, production served reachable CSS as /_next/static/chunks/*.css. The old verifier only matched /_next/static/css/*.css, causing a false deployment failure even while the stylesheet assets were present and reachable.