### PR TITLE
attune: recipe-distance gives BMF translator a fidelity number

### DIFF
--- a/experiments/form-stdlib/recipe-distance.fk
+++ b/experiments/form-stdlib/recipe-distance.fk
@@ -1,0 +1,134 @@
+; recipe-distance.fk — structural distance between two Recipes
+;
+; The BMF translator pipeline (parse → universal Recipe → emit) gives us
+; bidirectional translation but no measurement. This file adds the missing
+; primitive: a scalar that says how far apart two Recipes are.
+;
+; The substrate's content-addressed NodeID lattice is what makes this cheap.
+; Two Recipes interned with the same Blueprint + the same children intern
+; to the same NodeID — `node_eq` short-circuits entire subtrees to 0 cost.
+; When categories differ or children diverge, we walk the tree and count
+; mismatches. The score is the codec-style fidelity number we need so
+; multi-candidate translation can pick a winner with a number, not a vibe.
+;
+; Two variants live here in parallel so the evidence chooses, not us:
+;
+;   recipe-distance       — unweighted tree-edit count. One mismatch = 1.
+;                            Pure structural diff; treats root and leaf alike.
+;
+;   recipe-distance-w     — depth-weighted. Root-level mismatch costs more
+;                            than leaf-level mismatch (weight 8 at root,
+;                            decays to 1 by depth 7). Matches the substrate's
+;                            own composition discipline: shape-at-root carries
+;                            more information than shape-at-leaf.
+;
+; Both return an integer "cost"; pair with `recipe-size` to normalize.
+; Fidelity-in-parts-per-thousand is the readable form for tests.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Tree size — used as the denominator for normalized fidelity
+    ;; ──────────────────────────────────────────────────────────────────
+
+    (defn sum-sizes (xs)
+        (if (nil? xs) 0
+            (add (node-size (head xs)) (sum-sizes (tail xs)))))
+
+    (defn node-size (n)
+        (do
+            (let children (node_children n))
+            (if (nil? children) 1
+                (add 1 (sum-sizes children)))))
+
+    (defn recipe-size (a) (node-size a))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Variant 1 — unweighted tree-edit distance
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Walk both trees in lock-step. At each node:
+    ;;   - node_eq → 0 (content-addressed identity handles the subtree)
+    ;;   - category mismatch → +1
+    ;;   - recurse pairwise on children
+    ;;   - children-length mismatch → tail of the longer list counts as
+    ;;     pure insertion/deletion cost (each missing node = 1)
+
+    (defn children-dist (xs ys)
+        (if (nil? xs)
+            (sum-sizes ys)
+            (if (nil? ys)
+                (sum-sizes xs)
+                (add (recipe-distance (head xs) (head ys))
+                     (children-dist (tail xs) (tail ys))))))
+
+    (defn recipe-distance (a b)
+        (if (node_eq a b) 0
+            (do
+                (let cat-cost
+                    (if (node_eq (node_category a) (node_category b)) 0 1))
+                (add cat-cost
+                     (children-dist (node_children a) (node_children b))))))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Variant 2 — depth-weighted distance
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; A root Blueprint mismatch is a bigger lie than a leaf identifier
+    ;; swap. Weight decays from 8 (root) to 1 (depth ≥ 7). Linear decay
+    ;; keeps the arithmetic integer-clean — the kernel has no floats.
+
+    (defn weight-at (depth)
+        (if (lt depth 7) (sub 8 depth) 1))
+
+    (defn weighted-tail-cost (xs depth)
+        (if (nil? xs) 0
+            (add (mul (weight-at depth) (node-size (head xs)))
+                 (weighted-tail-cost (tail xs) depth))))
+
+    (defn weighted-children-dist (xs ys depth)
+        (if (nil? xs)
+            (weighted-tail-cost ys depth)
+            (if (nil? ys)
+                (weighted-tail-cost xs depth)
+                (add (recipe-distance-weighted (head xs) (head ys) depth)
+                     (weighted-children-dist (tail xs) (tail ys) depth)))))
+
+    (defn recipe-distance-weighted (a b depth)
+        (if (node_eq a b) 0
+            (do
+                (let cat-cost
+                    (if (node_eq (node_category a) (node_category b))
+                        0
+                        (weight-at depth)))
+                (add cat-cost
+                     (weighted-children-dist (node_children a)
+                                             (node_children b)
+                                             (add depth 1))))))
+
+    (defn recipe-distance-w (a b)
+        (recipe-distance-weighted a b 0))
+
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; Fidelity in parts-per-thousand — readable normalization
+    ;; ──────────────────────────────────────────────────────────────────
+    ;; 1000 = identical; 0 = maximally different. Denominator is the
+    ;; larger of the two tree sizes so insertion-only distance still
+    ;; produces a bounded score.
+
+    (defn recipe-fidelity-ppk (a b)
+        (do
+            (let d (recipe-distance a b))
+            (let denom (max2 (recipe-size a) (recipe-size b)))
+            (if (eq denom 0) 1000
+                (div (mul (sub denom d) 1000) denom))))
+
+    (defn recipe-fidelity-w-ppk (a b)
+        (do
+            (let d (recipe-distance-w a b))
+            (let sa (weighted-tail-cost (list a) 0))
+            (let sb (weighted-tail-cost (list b) 0))
+            (let denom (max2 sa sb))
+            (if (eq denom 0) 1000
+                (div (mul (sub denom d) 1000) denom))))
+
+    0)

--- a/experiments/form-stdlib/tests/recipe-distance.fk
+++ b/experiments/form-stdlib/tests/recipe-distance.fk
@@ -1,0 +1,99 @@
+; tests/recipe-distance.fk — calibrate and discriminate the metric
+;
+; Three claims to prove with numbers (not vibes):
+;
+;   1. CALIBRATION — same source parsed twice has distance 0.
+;      The metric must agree with structural identity.
+;
+;   2. ROUND-TRIP — parse(emit(parse(src), python)) ≈ parse(src).
+;      The lossless path stays lossless under the metric.
+;      If this is nonzero, the emitter is losing structure
+;      that the parser captured.
+;
+;   3. DISCRIMINATION — two semantically different sources produce
+;      nonzero distance. The metric distinguishes shapes.
+;
+; The numbers print so the kernel trace shows the actual ladder.
+;
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python-universal.bnf.fk form-stdlib/emit-engine.fk form-stdlib/emit.fk form-stdlib/emits/python.fk form-stdlib/emits/go.fk form-stdlib/recipe-distance.fk
+
+(do
+    (let NL "
+")
+
+    ;; Two Python sources — same shape, different identifiers + operator.
+    ;; Strange-minimal choice: smallest pair that exercises identifier
+    ;; difference AND operator difference at once. If the metric can tell
+    ;; these apart, it can tell most things apart.
+    (let src-add "def add(a, b): return a + b")
+    (let src-mul "def mul(x, y): return x * y")
+
+    (let recipe-add  (parse-python-universal src-add))
+    (let recipe-add2 (parse-python-universal src-add))
+    (let recipe-mul  (parse-python-universal src-mul))
+
+    (let registry
+        (list (list "python" python-templates)
+              (list "go"     go-templates)))
+
+    ;; Round-trip: Python → universal → Python → universal again
+    (let emitted-py (emit-to "python" recipe-add registry))
+    (let recipe-rt  (parse-python-universal emitted-py))
+
+    ;; Cross-language: Python → universal → Go → (we can't re-parse Go
+    ;; through python-universal grammar; structural distance still works
+    ;; if we re-parse Go through go-universal — but that's a separate
+    ;; test once go-universal parser exists. For now: emit Go is a
+    ;; string-level translator output; the metric proves recipe-rt.)
+
+    ;; ── claim 1: calibration ──
+    (let d-self        (recipe-distance recipe-add recipe-add2))
+    (let d-self-w      (recipe-distance-w recipe-add recipe-add2))
+    (let fid-self      (recipe-fidelity-ppk recipe-add recipe-add2))
+
+    ;; ── claim 2: round-trip fidelity ──
+    (let d-rt          (recipe-distance recipe-add recipe-rt))
+    (let d-rt-w        (recipe-distance-w recipe-add recipe-rt))
+    (let fid-rt        (recipe-fidelity-ppk recipe-add recipe-rt))
+
+    ;; ── claim 3: discrimination ──
+    (let d-diff        (recipe-distance recipe-add recipe-mul))
+    (let d-diff-w      (recipe-distance-w recipe-add recipe-mul))
+    (let fid-diff      (recipe-fidelity-ppk recipe-add recipe-mul))
+
+    ;; Sizes for context
+    (let size-add (recipe-size recipe-add))
+    (let size-mul (recipe-size recipe-mul))
+    (let size-rt  (recipe-size recipe-rt))
+
+    (print "── recipe sizes ──")
+    (print (str_concat "add: " (int_to_str size-add)))
+    (print (str_concat "mul: " (int_to_str size-mul)))
+    (print (str_concat "rt:  " (int_to_str size-rt)))
+    (print "")
+
+    (print "── claim 1: calibration (same source twice) ──")
+    (print (str_concat "  unweighted distance: " (int_to_str d-self)))
+    (print (str_concat "  weighted   distance: " (int_to_str d-self-w)))
+    (print (str_concat "  fidelity (ppk):      " (int_to_str fid-self)))
+    (print "  expected: 0 / 0 / 1000")
+    (print "")
+
+    (print "── claim 2: round-trip (parse→emit→parse, python) ──")
+    (print (str_concat "  unweighted distance: " (int_to_str d-rt)))
+    (print (str_concat "  weighted   distance: " (int_to_str d-rt-w)))
+    (print (str_concat "  fidelity (ppk):      " (int_to_str fid-rt)))
+    (print "  expected: 0 / 0 / 1000 (if emitter is structure-preserving)")
+    (print "")
+
+    (print "── claim 3: discrimination (add vs mul) ──")
+    (print (str_concat "  unweighted distance: " (int_to_str d-diff)))
+    (print (str_concat "  weighted   distance: " (int_to_str d-diff-w)))
+    (print (str_concat "  fidelity (ppk):      " (int_to_str fid-diff)))
+    (print "  expected: > 0 / > 0 / < 1000 (metric must discriminate)")
+    (print "")
+
+    ;; Deterministic kernel return value: sum all three distances + the
+    ;; calibration term. If calibration breaks, this number shifts in a
+    ;; predictable way; if discrimination breaks, d-diff goes to 0.
+    (add d-self (add d-rt d-diff)))

--- a/experiments/form-stdlib/tests/translator-bidirectional.fk
+++ b/experiments/form-stdlib/tests/translator-bidirectional.fk
@@ -1,6 +1,6 @@
 ; tests/translator-bidirectional.fk — verify bidirectional translation
 ;
-; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python-universal.bnf.fk form-stdlib/grammars/go-universal.bnf.fk form-stdlib/emit-engine.fk form-stdlib/emit.fk form-stdlib/emits/python.fk form-stdlib/emits/go.fk form-stdlib/emits/typescript.fk
+; preludes: form-stdlib/engine.fk form-stdlib/grammar-bnf.fk form-stdlib/grammars/python-universal.bnf.fk form-stdlib/grammars/go-universal.bnf.fk form-stdlib/emit-engine.fk form-stdlib/emit.fk form-stdlib/emits/python.fk form-stdlib/emits/go.fk form-stdlib/emits/typescript.fk form-stdlib/recipe-distance.fk
 ;
 ; The verifiable bidirectional translator:
 ;
@@ -8,6 +8,12 @@
 ;   Go source     → parse → universal Recipe → emit Python (Go → Python)
 ;
 ; Both directions through the SAME universal vocabulary.
+;
+; Measurement: recipe-distance (see form-stdlib/recipe-distance.fk) gives
+; a structural-fidelity number per translation hop. A clean lossless hop
+; reads as fidelity=1000ppk (distance=0). When recipes diverge under
+; cross-language translation, the number says by how much — the BMF
+; pipeline becomes a measured codec, not just a rewriter.
 
 (do
     (let NL "
@@ -45,6 +51,21 @@
     (print go-src)
     (print "  ↓")
     (print go-roundtrip)
+    (print "")
+
+    ;; ── measurement ──
+    ;; Re-parse the round-tripped Go output back to a Recipe and compute
+    ;; structural distance against the original Recipe. A structure-
+    ;; preserving emitter+parser pair produces distance=0 / fidelity=1000.
+    ;; This is the codec-style number the BMF pipeline was missing.
+    (let go-rt-recipe (parse-go-universal go-roundtrip))
+    (let d-go-rt (recipe-distance recipe-from-go go-rt-recipe))
+    (let fid-go-rt (recipe-fidelity-ppk recipe-from-go go-rt-recipe))
+
+    (print "── round-trip fidelity (Go → universal → Go → universal) ──")
+    (print (str_concat "  distance:        " (int_to_str d-go-rt)))
+    (print (str_concat "  fidelity (ppk):  " (int_to_str fid-go-rt)))
+    (print (str_concat "  source size:     " (int_to_str (recipe-size recipe-from-go))))
     (print "")
 
     (add (str_len py-to-go) (add (str_len go-to-py) (str_len go-roundtrip))))


### PR DESCRIPTION
## Summary

The Form translator BMF pipeline (parse → universal Recipe → emit) already does the structural half — any source grammar to any target through shared Blueprint vocabulary. What was missing: **measurement**. A translation came out as a string with no number attached, so two candidate translations couldn't be compared and a lossy hop couldn't be told from a faithful one. This is the load-bearing primitive cross-domain translation needs to rest on top of.

- `experiments/form-stdlib/recipe-distance.fk` — structural distance + fidelity-in-parts-per-thousand, built on the substrate natives (`node_eq`, `node_category`, `node_children`)
- Two variants in parallel: unweighted (tree-edit count) and depth-weighted (root mismatch costs more than leaf). The evidence picks, not the author.
- `tests/translator-bidirectional.fk` now consumes the metric: the Go round-trip hop numerically attests as structure-preserving (d=0, fidelity=1000ppk).

## Numbers from the new test

| claim | unweighted d | weighted d | fidelity (ppk) |
|---|---|---|---|
| calibration (same source twice) | 0 | 0 | 1000 |
| round-trip (parse→emit→parse, python) | 0 | 0 | 1000 |
| discrimination (`add` vs `mul`) | 5 | 28 | 444 |

The weighted and unweighted scores diverging on the discrimination case is the evidence we wanted to see — the choice between metric variants carries real signal.

## Why this lands

Once recipes carry a fidelity score, the rest of what we've been pointing at becomes mechanical:
- multi-candidate selection (pick the recipe with highest fidelity at lowest cost)
- observer-weighted scoring (weight tree positions by what the caller cares about)
- cross-domain lift/project (search the universal lattice with a real objective function)

None of those need new architecture — they need this number. It's the codec PSNR for Form.

## Test plan

- [x] Go kernel runs the new test, all three claims pass
- [x] Rust kernel agrees on every metric number (unicode-print drift in unrelated header lines is pre-existing)
- [x] Augmented `translator-bidirectional.fk` shows Go round-trip d=0
- [ ] TS kernel: pre-existing stack limit on grammar tests (same as `translator-roundtrip.fk` before this change) — not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)