### PR TITLE
[codex] add transmission recipes surface

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -37,7 +37,7 @@
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 194 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 156 | Web routes — every visible page in the app |
+| [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 113 | Scripts — operational tools, generators, syncers |
 
 ## Convention

--- a/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_surface.json
+++ b/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_surface.json
@@ -1,0 +1,111 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/transmission-recipe-surface-20260524",
+  "commit_scope": "Add a public Transmission Recipes web surface and link it from the Living Collective vision hub.",
+  "files_owned": [
+    "web/app/vision/recipes/page.tsx",
+    "web/app/vision/page.tsx",
+    "web/app/INDEX.md",
+    "MANIFEST.md",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_surface.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "git diff --check",
+      "make wellness",
+      "cd web && npm ci",
+      "cd web && npm run build",
+      "Browser check: http://localhost:3110/vision/recipes desktop 1280x720",
+      "Browser check: http://localhost:3110/vision/recipes mobile 390x844",
+      "API_PORT=18100 WEB_PORT=3111 ./scripts/verify_worktree_local_web.sh --start"
+    ],
+    "summary": "Added /vision/recipes with the recipe-card fields, three complete payloads, six novel pairings, and existing visual assets. Linked it from /vision and named the route in the Transmission Recipe Atlas concept and LOG. Production build, local worktree web/API validation, index check, diff check, and desktop/mobile browser checks passed. Wellness is breathing overall with pre-existing source-map and symbol drift unrelated to this page."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "curl -sS --max-time 10 https://coherencycoin.com/vision/recipes"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; CI and post-merge public route validation remain pending until PR flow completes."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "db-backed-vision-hub-content",
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "transmission-recipe-surface-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "next-step-request",
+        "cross-domain-recipe-vision"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "web-surface-implementation",
+        "vision-hub-linking",
+        "browser-validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "web/app/vision/recipes/page.tsx",
+    "web/app/vision/page.tsx",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "npm run build",
+    "./scripts/verify_worktree_local_web.sh --start",
+    "make wellness"
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_surface.json",
+    "docs/vision-kb/LOG.md",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "web/app/INDEX.md",
+    "web/app/vision/page.tsx",
+    "web/app/vision/recipes/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Visitors can open /vision/recipes from the Living Collective hub and see a public Transmission Recipes surface with a hero, recipe-card fields, runnable payloads, novel pairings, and links back to the atlas concept.",
+    "public_endpoints": [
+      "GET /vision",
+      "GET /vision/recipes",
+      "GET /vision/lc-transmission-recipe-atlas"
+    ],
+    "test_flows": [
+      "Desktop browser check at http://localhost:3110/vision/recipes confirmed hero, payload text, links, image loading, and no main-content overflow.",
+      "Mobile browser check at 390x844 confirmed hero, payload section, responsive stacking, image loading in the payload viewport, and no main-content overflow.",
+      "Local worktree web/API validation passed with API_PORT=18100 WEB_PORT=3111 ./scripts/verify_worktree_local_web.sh --start."
+    ]
+  }
+}

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,15 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-24] surface | Transmission Recipes public doorway
+
+The atlas now has a public web surface where a visitor can see the card, walk three complete payloads, and choose from novel pairings with real-world stakes.
+
+- **New route**: `/vision/recipes` -- Transmission Recipes page with the card fields, The Repair Wake, Onboarding as Ceremony, Metric Spellbreaker, and six next pairings.
+- **Hub doorway**: `/vision` now links directly to the recipes page beside the concept garden entry.
+- **Concept edge**: [`lc-transmission-recipe-atlas`](concepts/lc-transmission-recipe-atlas.md) now names the public doorway.
+- **Discernment held**: every pairing keeps proof in the destination domain and names claim boundaries through the card shape.
+
 ## [2026-05-24] guide | Transmission Recipe Atlas — first usable walk
 
 The atlas moved from concept into practice: a source can now be walked into a complete recipe card with enough structure for another person to run it.

--- a/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
+++ b/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
@@ -235,6 +235,11 @@ a source and sees multiple honest extractions:
 - **community payload** -- governance check, moderation protocol, culture tending
 - **teaching payload** -- story arc, workshop flow, video score, song map
 
+The first public doorway is now `/vision/recipes`: a practical surface
+with the card, three runnable payloads, and novel pairings ready to
+become workshops, product flows, reliability rituals, and community
+tools.
+
 The substrate-facing companion already exists in
 [`modality-as-recipe.form`](../../coherence-substrate/modality-as-recipe.form):
 many recipe extractions can attach to one source cell, and structural
@@ -250,6 +255,8 @@ human-facing doorway: cards people can read, try, verify, and improve.
 - **[Transmission Recipe Atlas guide](../guides/transmission-recipe-atlas-guide.md)**
   -- the practical card walk with complete payloads, proof modes, and
   a first group practice.
+- **[/vision/recipes](/vision/recipes)**
+  -- the public page for walking the card, payloads, and novel pairings.
 - **[modality-as-recipe.form](../../coherence-substrate/modality-as-recipe.form)**
   -- substrate shape for multiple recipe extractions from one source.
 - **[song-as-recipe.form](../../coherence-substrate/song-as-recipe.form)**

--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 156
+**Total files**: 157
 
 | Route | File | Purpose |
 |---|---|---|
@@ -159,6 +159,7 @@
 | `/vision/lived` | [page.tsx](vision/lived/page.tsx) | _no top-of-file purpose_ |
 | `/vision` | [page.tsx](vision/page.tsx) | _no top-of-file purpose_ |
 | `/vision/realize` | [page.tsx](vision/realize/page.tsx) | _no top-of-file purpose_ |
+| `/vision/recipes` | [page.tsx](vision/recipes/page.tsx) | Transmission recipe public surface - runnable payloads and cross-domain pairings. |
 | `/vitality` | [page.tsx](vitality/page.tsx) | _no top-of-file purpose_ |
 | `/weave` | [page.tsx](weave/page.tsx) | _no top-of-file purpose_ |
 | `/welcome` | [page.tsx](welcome/page.tsx) | /welcome — the naming gesture. A visitor names themselves, the server |

--- a/web/app/vision/page.tsx
+++ b/web/app/vision/page.tsx
@@ -541,22 +541,40 @@ export default async function VisionPage({
          arriving with a specific concept in mind can find it without
          scrolling through the curated narrative first. */}
       <section className="max-w-3xl mx-auto px-6 pb-12">
-        <Link
-          href={localizedHref("/concepts/garden?domain=living-collective", lang)}
-          className="group flex items-center justify-between gap-3 rounded-2xl border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 hover:border-amber-500/30 px-5 py-4 transition-all"
-        >
-          <div className="space-y-0.5">
-            <p className="text-[11px] uppercase tracking-[0.18em] text-amber-300/70 font-medium">
-              {t("visionIndex.gardenStripEyebrow")}
-            </p>
-            <p className="text-base text-stone-200 group-hover:text-amber-100 transition-colors">
-              {t("visionIndex.gardenStripBody")}
-            </p>
-          </div>
-          <span className="text-amber-400/70 group-hover:text-amber-300 text-2xl transition-colors shrink-0">
-            →
-          </span>
-        </Link>
+        <div className="grid gap-3">
+          <Link
+            href={localizedHref("/concepts/garden?domain=living-collective", lang)}
+            className="group flex items-center justify-between gap-3 rounded-2xl border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 hover:border-amber-500/30 px-5 py-4 transition-all"
+          >
+            <div className="space-y-0.5">
+              <p className="text-[11px] uppercase tracking-[0.18em] text-amber-300/70 font-medium">
+                {t("visionIndex.gardenStripEyebrow")}
+              </p>
+              <p className="text-base text-stone-200 group-hover:text-amber-100 transition-colors">
+                {t("visionIndex.gardenStripBody")}
+              </p>
+            </div>
+            <span className="text-amber-400/70 group-hover:text-amber-300 text-2xl transition-colors shrink-0">
+              →
+            </span>
+          </Link>
+          <Link
+            href={localizedHref("/vision/recipes", lang)}
+            className="group flex items-center justify-between gap-3 rounded-2xl border border-teal-500/20 bg-teal-500/5 hover:bg-teal-500/10 hover:border-teal-500/30 px-5 py-4 transition-all"
+          >
+            <div className="space-y-0.5">
+              <p className="text-[11px] uppercase tracking-[0.18em] text-teal-300/70 font-medium">
+                Transmission recipes
+              </p>
+              <p className="text-base text-stone-200 group-hover:text-teal-100 transition-colors">
+                Turn a song, story, failure, video, or spec into a payload someone can run.
+              </p>
+            </div>
+            <span className="text-teal-400/70 group-hover:text-teal-300 text-2xl transition-colors shrink-0">
+              →
+            </span>
+          </Link>
+        </div>
       </section>
 
       {/* How It Knows */}

--- a/web/app/vision/recipes/page.tsx
+++ b/web/app/vision/recipes/page.tsx
@@ -1,0 +1,331 @@
+// Transmission recipe public surface - runnable payloads and cross-domain pairings.
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight, ClipboardCheck, RotateCcw, ShieldCheck, Sparkles } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Transmission Recipes | The Living Collective",
+  description:
+    "A practical atlas for extracting recipes from songs, stories, failures, specs, rituals, videos, and embodied practices, then transposing them into useful payloads.",
+};
+
+type RecipePayload = {
+  title: string;
+  source: string;
+  lens: string;
+  recipe: string;
+  impact: string;
+  proof: string;
+  image: string;
+  steps: string[];
+};
+
+type Pairing = {
+  source: string;
+  destination: string;
+  payload: string;
+  impact: string;
+};
+
+const recipeCard = [
+  "source",
+  "observed",
+  "observer lens",
+  "recipe",
+  "transposed into",
+  "payload",
+  "proof mode",
+  "claim boundary",
+  "next embodiment",
+];
+
+const payloads: RecipePayload[] = [
+  {
+    title: "The Repair Wake",
+    source: "A failed deploy where a hidden dependency was trusted without a witness.",
+    lens: "Reliability engineer and grief steward.",
+    recipe: "rupture -> witness -> name what died -> repair smallest contract -> change one future habit",
+    impact:
+      "Incident review becomes a repair ceremony with a prevention task, an explicit owner, and a seven-day return.",
+    proof:
+      "The same rupture does not repeat for 30 days, one contract is repaired, and blame language decreases in the review notes.",
+    image: "/visuals/network-knowledge-sharing.png",
+    steps: [
+      "0-5 min: timeline only",
+      "5-10 min: what the system showed",
+      "10-15 min: what assumption died",
+      "15-25 min: smallest broken contract and owner",
+      "25-35 min: prevention task and return witness",
+    ],
+  },
+  {
+    title: "Onboarding As Ceremony",
+    source: "A dance track whose arc teaches arrival, pulse, invitation, build, release, and return.",
+    lens: "Product designer and dancer.",
+    recipe: "arrive -> entrain -> choose -> intensify -> release -> integrate",
+    impact:
+      "A first-time visitor leaves with one recipe they made, instead of a documentation wall they skimmed.",
+    proof:
+      "The visitor can explain the system in their own words, show the first card, and return to the artifact.",
+    image: "/visuals/life-song-circle.png",
+    steps: [
+      "Arrive: what are you tending?",
+      "Pulse: choose one source that feels alive",
+      "Invitation: name the lens",
+      "Build: extract the state-change verbs",
+      "Return: commit one next embodiment",
+    ],
+  },
+  {
+    title: "Metric Spellbreaker",
+    source: "Observer and measurement teachings held as strategy metaphor, with clear claim boundaries.",
+    lens: "Strategy steward and claim-boundary keeper.",
+    recipe: "possibility field -> metric choice -> behavior collapse -> hidden cost -> counter-metric",
+    impact:
+      "A team sees what a metric will reward, hide, punish, and sacrifice before it becomes culture.",
+    proof:
+      "A review catches one distortion before policy changes, or the team retires a metric whose hidden cost is no longer acceptable.",
+    image: "/visuals/09-field-intelligence.png",
+    steps: [
+      "Primary metric",
+      "What it makes visible",
+      "What it hides",
+      "Who pays if this becomes culture",
+      "Counter-metric and kill condition",
+    ],
+  },
+];
+
+const pairings: Pairing[] = [
+  {
+    source: "Camera language",
+    destination: "Public trust architecture",
+    payload: "A truth storyboard for evidence pages: wide shot for context, close-up for claim, still frame for proof.",
+    impact: "Civic groups and open-source teams can show what happened without overwhelming readers with raw archives.",
+  },
+  {
+    source: "Fermentation",
+    destination: "Contributor onboarding",
+    payload: "Starter-culture incubation: one tiny issue, one named maintainer, one warm handoff, one return after seven days.",
+    impact: "New contributors become metabolized by the project instead of dropped into a queue.",
+  },
+  {
+    source: "Martial arts kata",
+    destination: "Deployment rehearsal",
+    payload: "A five-move release kata: stance, environment check, dry run, witnessed deploy, recovery posture.",
+    impact: "Teams build embodied release memory before the real incident pressure arrives.",
+  },
+  {
+    source: "Healing intake",
+    destination: "Bug triage",
+    payload: "A symptom-to-system intake that asks what changed, what hurts, what still functions, and what support is needed.",
+    impact: "Maintainers respond to the whole failure pattern instead of only the loudest symptom.",
+  },
+  {
+    source: "Prayer beads",
+    destination: "Backlog tending",
+    payload: "A review strand: touch each task once, bless, delete, delegate, defer, or do the next honest action.",
+    impact: "Backlogs become circulatory systems again instead of silent storage for avoided decisions.",
+  },
+  {
+    source: "Story as recipe",
+    destination: "Climate adaptation workshops",
+    payload: "A local myth-to-action map: danger, helper, threshold, sacrifice, gift, return with a public commitment.",
+    impact: "Residents can move from climate anxiety into place-specific commitments that carry emotional meaning.",
+  },
+];
+
+function RecipeCard() {
+  return (
+    <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-5">
+      <div className="flex items-center gap-3">
+        <ClipboardCheck className="h-5 w-5 text-amber-300/80" aria-hidden="true" />
+        <h2 className="text-xl font-light text-stone-100">The card</h2>
+      </div>
+      <dl className="mt-5 grid gap-2 sm:grid-cols-3">
+        {recipeCard.map((field) => (
+          <div key={field} className="rounded-md border border-stone-800/70 bg-stone-950/40 px-3 py-2">
+            <dt className="text-xs uppercase tracking-[0.16em] text-stone-500">{field}</dt>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function PayloadArticle({ payload }: { payload: RecipePayload }) {
+  return (
+    <article className="grid overflow-hidden rounded-lg border border-stone-800/50 bg-stone-900/25 md:grid-cols-[0.86fr_1.14fr]">
+      <div className="relative min-h-[240px] overflow-hidden">
+        <Image src={payload.image} alt="" fill className="object-cover" sizes="(max-width: 768px) 100vw, 40vw" />
+        <div className="absolute inset-0 bg-gradient-to-t from-stone-950/85 via-stone-950/15 to-transparent" />
+      </div>
+      <div className="space-y-5 p-5 md:p-7">
+        <div className="space-y-2">
+          <h3 className="text-2xl font-extralight text-white">{payload.title}</h3>
+          <p className="text-sm leading-relaxed text-stone-400">{payload.source}</p>
+        </div>
+        <div className="grid gap-3 text-sm md:grid-cols-2">
+          <p className="rounded-md border border-stone-800/60 bg-stone-950/30 p-3 text-stone-400">
+            <span className="block text-xs uppercase tracking-[0.16em] text-teal-300/70">Lens</span>
+            {payload.lens}
+          </p>
+          <p className="rounded-md border border-stone-800/60 bg-stone-950/30 p-3 text-stone-400">
+            <span className="block text-xs uppercase tracking-[0.16em] text-violet-300/70">Recipe</span>
+            {payload.recipe}
+          </p>
+        </div>
+        <div className="space-y-2">
+          {payload.steps.map((step) => (
+            <div key={step} className="flex gap-3 text-sm text-stone-300">
+              <RotateCcw className="mt-0.5 h-4 w-4 shrink-0 text-amber-300/65" aria-hidden="true" />
+              <span>{step}</span>
+            </div>
+          ))}
+        </div>
+        <div className="grid gap-3 text-sm md:grid-cols-2">
+          <p className="leading-relaxed text-stone-400">
+            <span className="block text-xs uppercase tracking-[0.16em] text-stone-500">Impact</span>
+            {payload.impact}
+          </p>
+          <p className="leading-relaxed text-stone-400">
+            <span className="block text-xs uppercase tracking-[0.16em] text-stone-500">Proof</span>
+            {payload.proof}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function TransmissionRecipesPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-stone-950 via-stone-950 to-stone-900 text-stone-100">
+      <section className="relative overflow-hidden border-b border-stone-800/40">
+        <div className="absolute inset-0">
+          <Image
+            src="/visuals/practice-storytelling-elder.png"
+            alt=""
+            fill
+            priority
+            className="object-cover opacity-35"
+            sizes="100vw"
+          />
+          <div className="absolute inset-0 bg-gradient-to-r from-stone-950 via-stone-950/82 to-stone-950/40" />
+          <div className="absolute inset-0 bg-gradient-to-t from-stone-950 via-transparent to-stone-950/50" />
+        </div>
+        <div className="relative mx-auto grid min-h-[72vh] max-w-6xl content-end px-6 pb-14 pt-32 md:pb-20">
+          <div className="max-w-3xl space-y-6">
+            <p className="text-sm uppercase tracking-[0.3em] text-amber-300/75">Transmission Recipe Atlas</p>
+            <h1 className="text-4xl font-extralight tracking-tight text-white md:text-7xl">
+              Extract the recipe. Move the medicine.
+            </h1>
+            <p className="max-w-2xl text-lg font-light leading-relaxed text-stone-300 md:text-xl">
+              A song, outage, teaching, camera angle, body practice, spec, or strategy failure can carry
+              a state-change pattern. The atlas turns that pattern into a payload someone can run.
+            </p>
+            <div className="flex flex-wrap gap-3 pt-2">
+              <Link
+                href="#payloads"
+                className="inline-flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-5 py-3 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/20"
+              >
+                Walk the payloads
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
+                href="/vision/lc-transmission-recipe-atlas"
+                className="inline-flex items-center gap-2 rounded-lg border border-stone-700/70 bg-stone-900/45 px-5 py-3 text-sm font-medium text-stone-300 transition-colors hover:border-teal-500/35 hover:text-teal-200"
+              >
+                Read the concept
+                <Sparkles className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-8 px-6 py-16 md:grid-cols-[0.9fr_1.1fr] md:py-24">
+        <div className="space-y-5">
+          <p className="text-sm uppercase tracking-[0.24em] text-stone-500">How it walks</p>
+          <h2 className="text-3xl font-extralight text-stone-100 md:text-4xl">
+            Observation becomes responsibility when the lens is named.
+          </h2>
+          <p className="text-base leading-relaxed text-stone-400">
+            The move is not to claim that every domain is the same. The move is to own the observation,
+            state the boundary, and give the destination domain its own proof.
+          </p>
+        </div>
+        <RecipeCard />
+      </section>
+
+      <section id="payloads" className="border-y border-stone-800/35">
+        <div className="mx-auto max-w-6xl space-y-8 px-6 py-16 md:py-24">
+          <div className="max-w-3xl space-y-4">
+            <p className="text-sm uppercase tracking-[0.24em] text-amber-300/70">Three runnable payloads</p>
+            <h2 className="text-3xl font-extralight text-stone-100 md:text-4xl">Small enough to try. Serious enough to matter.</h2>
+            <p className="leading-relaxed text-stone-400">
+              Each payload names the source, the lens, the transposition, and the proof native to its destination.
+            </p>
+          </div>
+          <div className="space-y-6">
+            {payloads.map((payload) => (
+              <PayloadArticle key={payload.title} payload={payload} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-8 px-6 py-16 md:py-24">
+        <div className="max-w-3xl space-y-4">
+          <p className="text-sm uppercase tracking-[0.24em] text-teal-300/70">Novel pairings</p>
+          <h2 className="text-3xl font-extralight text-stone-100 md:text-4xl">Unexpected sources can carry public value.</h2>
+          <p className="leading-relaxed text-stone-400">
+            These are ready to become workshops, product flows, reliability rituals, and community tools.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {pairings.map((pairing) => (
+            <article key={`${pairing.source}-${pairing.destination}`} className="rounded-lg border border-stone-800/55 bg-stone-900/20 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.18em] text-stone-500">{pairing.source}</p>
+                  <h3 className="mt-2 text-lg font-light text-stone-100">{pairing.destination}</h3>
+                </div>
+                <ShieldCheck className="mt-1 h-5 w-5 shrink-0 text-teal-300/70" aria-hidden="true" />
+              </div>
+              <p className="mt-4 text-sm leading-relaxed text-stone-400">{pairing.payload}</p>
+              <p className="mt-4 border-t border-stone-800/60 pt-4 text-sm leading-relaxed text-stone-500">{pairing.impact}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-t border-stone-800/35">
+        <div className="mx-auto max-w-3xl space-y-6 px-6 py-16 text-center md:py-20">
+          <p className="text-sm uppercase tracking-[0.24em] text-stone-500">Next embodiment</p>
+          <h2 className="text-3xl font-extralight text-stone-100">Run one recipe where the stakes are real.</h2>
+          <p className="leading-relaxed text-stone-400">
+            Pick a live source this week. Name the lens. Build the smallest payload. Let proof belong to the destination,
+            not to the metaphor.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3 pt-2">
+            <Link
+              href="/vision/lc-transmission-recipe-atlas"
+              className="inline-flex items-center gap-2 rounded-lg border border-teal-500/25 bg-teal-500/10 px-5 py-3 text-sm font-medium text-teal-200 transition-colors hover:bg-teal-500/20"
+            >
+              Open the atlas story
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+            <Link
+              href="/vision"
+              className="inline-flex items-center gap-2 rounded-lg border border-stone-700/70 bg-stone-900/45 px-5 py-3 text-sm font-medium text-stone-300 transition-colors hover:border-amber-500/35 hover:text-amber-200"
+            >
+              Return to the vision
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed

- Added `/vision/recipes`, a public Transmission Recipes surface with the recipe card, three runnable payloads, and six novel cross-domain pairings.
- Linked the new surface from the `/vision` hub next to the concept garden doorway.
- Updated the Transmission Recipe Atlas concept and KB log to name the public doorway.
- Added commit evidence for the runtime feature.

## Why

The atlas was real in the KB, but not yet visible as a public practice surface. This makes the unlock concrete: visitors can see how a song, failure, spec, video, or practice becomes a useful payload with honest proof boundaries.

## Validation

- `python3 scripts/generate_repo_indexes.py --check`
- `git diff --check`
- `make wellness`
- `cd web && npm ci`
- `cd web && npm run build`
- Browser check: `/vision/recipes` at desktop 1280x720
- Browser check: `/vision/recipes` at mobile 390x844
- `API_PORT=18100 WEB_PORT=3111 ./scripts/verify_worktree_local_web.sh --start`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_surface.json`
- `git fetch origin main && git rebase origin/main`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
