### PR TITLE
tend: ingest-paths reaches every git-tracked file via ARTIFACT fallback

### DIFF
--- a/scripts/coh_substrate.py
+++ b/scripts/coh_substrate.py
@@ -2156,6 +2156,7 @@ def cmd_ingest_paths(args: argparse.Namespace) -> int:
 
     from app.services.substrate import (
         ingest_concept_file,
+        ingest_git_artifact,
         ingest_guide_file,
         ingest_idea_file,
         ingest_kb_page_file,
@@ -2182,25 +2183,51 @@ def cmd_ingest_paths(args: argparse.Namespace) -> int:
         "kb_page": ingest_kb_page_file,
     }
 
+    def _as_artifact(session, path):
+        # Fallback: ingest any git-tracked file as an ARTIFACT cell.
+        # Closes the gap where .form shape-files, scripts, and configs
+        # could not reach the substrate via this CLI even though
+        # ingest_git_artifact has handled them since BDomain.ARTIFACT
+        # shipped 2026-05-20.
+        import hashlib
+
+        data = path.read_bytes()
+        content_hash = hashlib.sha256(data).hexdigest()[:16]
+        size_bytes = len(data)
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        _cell, bp_id, _ctor = ingest_git_artifact(
+            session,
+            path=str(path),
+            content_hash=content_hash,
+            size_bytes=size_bytes,
+            mtime=mtime,
+        )
+        kind = path.suffix.lstrip(".") or "other"
+        return kind, bp_id
+
     structured = not getattr(args, "flat", False)
     success = skipped = failed = 0
     with session_scope() as session:
         for path in paths:
-            if not path.exists() or path.is_dir() or path.suffix != ".md":
+            if not path.exists() or path.is_dir():
                 skipped += 1
                 continue
-            domain = _domain_for_path(path)
-            if domain is None:
-                skipped += 1
-                continue
+
+            domain = _domain_for_path(path) if path.suffix == ".md" else None
             try:
-                # Resolve to absolute so source_path stays consistent across
-                # callers (the hook, manual annotate, the file-only path).
-                cell, bp_id, ctor_id = DOMAIN_INGESTERS[domain](
-                    session, path.resolve(), structured=structured
-                )
-                success += 1
-                print(f"  [{domain}] {path.name}: bp={bp_id}")
+                if domain is not None:
+                    cell, bp_id, ctor_id = DOMAIN_INGESTERS[domain](
+                        session, path.resolve(), structured=structured
+                    )
+                    success += 1
+                    print(f"  [{domain}] {path.name}: bp={bp_id}")
+                else:
+                    kind, bp_id = _as_artifact(session, path.resolve())
+                    success += 1
+                    print(f"  [artifact:{kind}] {path.name}: bp={bp_id}")
             except Exception as exc:
                 failed += 1
                 print(f"  ! failed {path.name}: {exc}", file=sys.stderr)

--- a/scripts/substrate_post_merge_hook.sh
+++ b/scripts/substrate_post_merge_hook.sh
@@ -33,17 +33,19 @@ fi
 
 CHANGED_MD=$(git diff --name-only --diff-filter=AM "$RANGE" -- '*.md' 2>/dev/null || true)
 
-# Source files the substrate carries as ARTIFACT cells. Limited to the
-# surfaces /api/substrate/page resolves against — page.tsx, layouts,
-# components/lib, routers, services. Wider trees can ingest via
-# `coh_substrate.py ingest --artifacts <glob>` when needed.
+# Source files the substrate carries as ARTIFACT cells. Web/API surfaces
+# /api/substrate/page resolves against (page.tsx, layouts, components/lib,
+# routers, services), plus substrate-native shape-files (.form) and
+# stdlib/kernel sources (.fk) so the substrate sees its own teaching tissue.
 CHANGED_CODE=$(git diff --name-only --diff-filter=AM "$RANGE" -- \
     'web/app/**/page.tsx' \
     'web/app/**/layout.tsx' \
     'web/components/**/*.tsx' \
     'web/lib/**/*.ts' \
     'api/app/routers/*.py' \
-    'api/app/services/*.py' 2>/dev/null || true)
+    'api/app/services/*.py' \
+    'docs/coherence-substrate/*.form' \
+    'experiments/form-stdlib/**/*.fk' 2>/dev/null || true)
 
 CHANGED=$(printf "%s\n%s" "$CHANGED_MD" "$CHANGED_CODE" | sed '/^$/d')
 


### PR DESCRIPTION
## Summary

The shape-files in [docs/coherence-substrate/*.form](docs/coherence-substrate/) (the twelve modality recipes + the encoder-decoder meta) were composted into the body but invisible to the substrate. \`coh_substrate.py ingest-paths\` explicitly skipped any non-\`.md\` path at [coh_substrate.py:1732 in the prior revision](scripts/coh_substrate.py), even though \`ingest_git_artifact\` has handled \`.form\`/\`.py\`/\`.yaml\`/\`.json\`/\`.fk\` since [BDomain.ARTIFACT shipped](api/app/services/substrate/category.py) on 2026-05-20. The gap was at the CLI surface, not in the encoder.

**Change:**
- [cmd_ingest_paths](scripts/coh_substrate.py): when a path isn't \`.md\` or has no md-domain detected, fall through to \`ingest_git_artifact\` with sha256-content-hash + size + mtime. Existing \`.md\` flow unchanged.
- [substrate_post_merge_hook.sh](scripts/substrate_post_merge_hook.sh): extend the change-detection glob to include \`docs/coherence-substrate/*.form\` and \`experiments/form-stdlib/**/*.fk\` so the substrate sees its own teaching tissue as it lands.

**Verified locally:** the five recent shape-files (quantum-physics, embodiment-practice, encoder-decoder, healing-modality, assemblage-shift) now ingest as ARTIFACT cells sharing Blueprint \`@1.5.4.1\`, structurally equivalent to each other and to every other artifact carrying the same five-field shape. \`coh_substrate.py annotate\` and \`?equivalent\` resolve them directly.

## Test plan

- [ ] After merge, post-merge hook auto-ingests any \`.form\`/\`.fk\` files in the merge range
- [ ] \`make wellness\` continues healthy
- [ ] Spot-check: \`coh_substrate.py annotate docs/coherence-substrate/modality-as-recipe.form\` returns a cell with domain=artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)