### PR TITLE
attune: cross-link the value-attribution pair the substrate flagged

### DIFF
--- a/specs/asset-renderer-plugin.md
+++ b/specs/asset-renderer-plugin.md
@@ -446,11 +446,16 @@ python3 -m pytest api/tests/test_asset_renderer.py -x -v
 
 ## Out of Scope
 
-- Content upload and storage (Arweave/IPFS integration is a separate spec)
+- Content upload and storage — covered by [story-protocol-integration](story-protocol-integration.md) (Arweave/IPFS upload, hash computation, integrity verification)
+- IP registration and derivative tracking — covered by [story-protocol-integration](story-protocol-integration.md) (`ip_registration_service`)
 - Renderer marketplace UI (browsing/rating renderers)
 - Renderer versioning and migration (auto-upgrading assets to newer renderer versions)
-- Payment settlement (CC attribution is recorded, actual payout is handled by the distribution engine)
+- Payment settlement — CC attribution is recorded here on every render event; daily aggregation, concept-weighted distribution, Merkle chain, and evidence multiplier are covered by [story-protocol-integration](story-protocol-integration.md) (`settlement_service`, `evidence_service`)
 - Renderer code review or security audit process
+
+## Related specs (same `idea_id: value-attribution`)
+
+- [story-protocol-integration](story-protocol-integration.md) — the asset's lifecycle on the way in: IP registration, permanent storage, content delivery with x402 payment headers, daily settlement, evidence-backed multipliers. This spec carries the lifecycle on the way out: pluggable rendering, render-event logging, CC split between asset creator / renderer creator / host node.
 
 ## Risks and Assumptions
 

--- a/specs/story-protocol-integration.md
+++ b/specs/story-protocol-integration.md
@@ -142,6 +142,10 @@ constraints:
 
 Connect asset creation, content delivery, and value distribution to three external protocols: Story Protocol for IP registration and derivative royalties, x402 for HTTP-native micropayments on content reads, and Arweave/IPFS for permanent verifiable storage. Together these turn every community-contributed asset (blueprint, article, 3D model, research paper) into a registered intellectual property that earns CC when read, pays royalties when derived from, and persists permanently with cryptographic proof of integrity. Without this integration, assets live only on our server, have no on-chain provenance, and cannot participate in the broader IP economy.
 
+## Related specs (same `idea_id: value-attribution`)
+
+- [asset-renderer-plugin](asset-renderer-plugin.md) — the asset's lifecycle on the way out: pluggable MIME-typed renderers, render-event logging, and per-render CC split between asset creator / renderer creator / host node. This spec carries the lifecycle on the way in (IP registration, storage, settlement). Each render-event logged by `asset-renderer-plugin` flows into the daily aggregation handled by `settlement_service` here.
+
 ## Requirements
 
 - [ ] **R1**: When a contributor creates an asset via `POST /api/assets`, the system queues an async job that registers the asset as an IP Asset on Story Protocol, stores the returned IP Asset ID on the asset's graph node property `sp_ip_id`, and sets `ip_status` to `registered`. If registration fails, `ip_status` is `failed` and the asset remains usable without IP registration.


### PR DESCRIPTION
## Summary

The substrate-surprise wellness organ has flagged this pair for days — [asset-renderer-plugin](specs/asset-renderer-plugin.md) and [story-protocol-integration](specs/story-protocol-integration.md) share Blueprint \`@1.8.4.2\` and both carry \`idea_id: value-attribution\`, yet neither referenced the other.

Each is one half of a single coherent flow:

- **story-protocol-integration**: the asset's lifecycle ON THE WAY IN — IP registration, Arweave/IPFS storage, x402 content delivery, daily settlement, evidence-backed multipliers.
- **asset-renderer-plugin**: the asset's lifecycle ON THE WAY OUT — pluggable MIME-typed renderers, render-event logging, CC split between asset creator / renderer creator / host node.

asset-renderer's *Out of Scope* list was already pointing implicitly at story-protocol (\"Content upload and storage is a separate spec\", \"actual payout is handled by the distribution engine\"). This PR replaces those prose-only pointers with explicit markdown links and adds a small *Related specs* section to each. The render-event log produced by \`asset-renderer-plugin\` is the input to \`settlement_service\` in \`story-protocol-integration\`; naming that flow makes the integration attestable, not just inferable.

No content or contract changes — pure edges-as-vitality move. The relationship the substrate already saw becomes navigable by any reader of either spec.

## Test plan

- [ ] \`make wellness\` continues healthy
- [ ] The substrate-surprise organ continues to identify the pair as structurally equivalent, but a future reader who clicks either spec now finds the other directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)