### PR TITLE
[codex] add transmission recipe composer

### DIFF
--- a/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json
+++ b/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json
@@ -1,0 +1,106 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/transmission-recipe-composer-20260524",
+  "commit_scope": "Add an interactive recipe-card composer to the public Transmission Recipes surface.",
+  "files_owned": [
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/vision/recipes/page.tsx",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json",
+      "cd web && npm ci",
+      "cd web && npm run build",
+      "Browser check: http://localhost:3112/vision/recipes desktop 1280x720, fill starter, edit source, copy card",
+      "Browser check: http://localhost:3112/vision/recipes mobile 390x844, composer visible and no main-content overflow",
+      "API_PORT=18100 WEB_PORT=3112 ./scripts/verify_worktree_local_web.sh --start",
+      "git diff --check"
+    ],
+    "summary": "Added an interactive recipe-card composer to /vision/recipes with nine atlas fields, three starter cards, completion progress, clear, and copy. Index check, evidence validation, diff check, production build, desktop/mobile browser interaction checks, and local worktree web/API validation passed. Wellness and pulse were breathing before implementation, with pre-existing source-map and symbol drift unrelated to this page."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "curl -sS --max-time 20 https://coherencycoin.com/vision/recipes"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; CI and public route validation remain pending until PR flow completes."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "db-backed-vision-hub-content",
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "transmission-recipe-composer-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "next-breath-request",
+        "cross-domain-recipe-vision"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "interactive-surface-implementation",
+        "browser-validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/vision/recipes/page.tsx",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "npm run build",
+    "./scripts/verify_worktree_local_web.sh --start",
+    "make wellness"
+  ],
+  "change_files": [
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json",
+    "docs/vision-kb/LOG.md",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/vision/recipes/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Visitors can use /vision/recipes to compose a recipe card, load starter cards, see completion progress, clear the card, and copy the card as plain text.",
+    "public_endpoints": [
+      "GET /vision/recipes"
+    ],
+    "test_flows": [
+      "Desktop browser check fills a starter card and copies the generated text.",
+      "Mobile browser check confirms the composer stacks correctly without main-content overflow.",
+      "Production build confirms the route compiles."
+    ]
+  }
+}

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,15 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-24] surface | Transmission Recipes composer
+
+The public recipe doorway can now produce a first artifact in the visitor's hands.
+
+- **New component**: `/vision/recipes` now carries an interactive recipe-card composer with the nine atlas fields, starter cards, coherence progress, clear, and copy.
+- **Embodiment**: a visitor can move from source to card without leaving the page.
+- **Concept edge**: [`lc-transmission-recipe-atlas`](concepts/lc-transmission-recipe-atlas.md) now names the composer as part of the public doorway.
+- **Discernment held**: starter cards preserve proof modes and claim boundaries instead of letting the metaphor outrun the destination domain.
+
 ## [2026-05-24] surface | Transmission Recipes public doorway
 
 The atlas now has a public web surface where a visitor can see the card, walk three complete payloads, and choose from novel pairings with real-world stakes.

--- a/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
+++ b/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
@@ -236,9 +236,9 @@ a source and sees multiple honest extractions:
 - **teaching payload** -- story arc, workshop flow, video score, song map
 
 The first public doorway is now `/vision/recipes`: a practical surface
-with the card, three runnable payloads, and novel pairings ready to
-become workshops, product flows, reliability rituals, and community
-tools.
+with an interactive card composer, three runnable payloads, and novel
+pairings ready to become workshops, product flows, reliability rituals,
+and community tools.
 
 The substrate-facing companion already exists in
 [`modality-as-recipe.form`](../../coherence-substrate/modality-as-recipe.form):
@@ -256,7 +256,8 @@ human-facing doorway: cards people can read, try, verify, and improve.
   -- the practical card walk with complete payloads, proof modes, and
   a first group practice.
 - **[/vision/recipes](/vision/recipes)**
-  -- the public page for walking the card, payloads, and novel pairings.
+  -- the public page for composing a card and walking the payloads and
+  novel pairings.
 - **[modality-as-recipe.form](../../coherence-substrate/modality-as-recipe.form)**
   -- substrate shape for multiple recipe extractions from one source.
 - **[song-as-recipe.form](../../coherence-substrate/song-as-recipe.form)**

--- a/web/app/vision/recipes/RecipeComposer.tsx
+++ b/web/app/vision/recipes/RecipeComposer.tsx
@@ -1,0 +1,264 @@
+// Interactive recipe-card composer for the Transmission Recipes page.
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Clipboard, RotateCcw, Wand2 } from "lucide-react";
+
+type RecipeField =
+  | "source"
+  | "observed"
+  | "observerLens"
+  | "recipe"
+  | "transposedInto"
+  | "payload"
+  | "proofMode"
+  | "claimBoundary"
+  | "nextEmbodiment";
+
+type ComposerCard = Record<RecipeField, string>;
+
+type Starter = {
+  title: string;
+  card: ComposerCard;
+};
+
+const emptyCard: ComposerCard = {
+  source: "",
+  observed: "",
+  observerLens: "",
+  recipe: "",
+  transposedInto: "",
+  payload: "",
+  proofMode: "",
+  claimBoundary: "",
+  nextEmbodiment: "",
+};
+
+const fields: Array<{ id: RecipeField; label: string; placeholder: string; rows?: number }> = [
+  {
+    id: "source",
+    label: "source",
+    placeholder: "a song, outage, teaching, video, spec, body practice, conversation",
+  },
+  {
+    id: "observed",
+    label: "observed",
+    placeholder: "sequence, rhythm, rupture, gesture, repeated phrase, body state",
+    rows: 3,
+  },
+  {
+    id: "observerLens",
+    label: "observer lens",
+    placeholder: "engineer + dancer, facilitator + witness, strategist + boundary keeper",
+  },
+  {
+    id: "recipe",
+    label: "recipe",
+    placeholder: "arrive -> notice -> intensify -> release -> integrate",
+    rows: 2,
+  },
+  {
+    id: "transposedInto",
+    label: "transposed into",
+    placeholder: "incident review, onboarding, workshop, governance, healing practice",
+  },
+  {
+    id: "payload",
+    label: "payload",
+    placeholder: "the artifact someone can actually run",
+    rows: 2,
+  },
+  {
+    id: "proofMode",
+    label: "proof mode",
+    placeholder: "behavior changes, test passes, retention, repeat rupture absent, state shift",
+    rows: 2,
+  },
+  {
+    id: "claimBoundary",
+    label: "claim boundary",
+    placeholder: "what this is not claiming",
+    rows: 2,
+  },
+  {
+    id: "nextEmbodiment",
+    label: "next embodiment",
+    placeholder: "one real place to run it this week",
+    rows: 2,
+  },
+];
+
+const starters: Starter[] = [
+  {
+    title: "Repair Wake",
+    card: {
+      source: "a failed deploy where a hidden dependency was trusted without a witness",
+      observed: "alert fatigue, unclear owner, fast patch, repeated surprise, quiet shame afterward",
+      observerLens: "reliability engineer + grief steward",
+      recipe: "rupture -> witness -> name what died -> repair smallest contract -> change one future habit",
+      transposedInto: "engineering incident review",
+      payload: "The Repair Wake",
+      proofMode: "prevention task completed; repeat incident absent for 30 days; owner explicit",
+      claimBoundary: "organizational repair practice, not therapy or clinical trauma work",
+      nextEmbodiment: "run after the next near-miss, not only after a severe outage",
+    },
+  },
+  {
+    title: "Dance Onboarding",
+    card: {
+      source: "an ecstatic dance track with arrival, pulse, invitation, build, release, and return",
+      observed: "the body understands the arc before the mind explains the arc",
+      observerLens: "product designer + dancer",
+      recipe: "arrive -> entrain -> choose -> intensify -> release -> integrate",
+      transposedInto: "first-run product onboarding",
+      payload: "a seven-minute entry flow from live source to first recipe card",
+      proofMode: "first recipe created; user can explain the system; user returns to the artifact",
+      claimBoundary: "design analogy; no measured entrainment claim",
+      nextEmbodiment: "prototype the flow on one page before making it a product surface",
+    },
+  },
+  {
+    title: "Metric Spellbreaker",
+    card: {
+      source: "measurement and observer teachings held as strategy metaphor",
+      observed: "what gets measured becomes visible; what is unmeasured becomes easier to sacrifice",
+      observerLens: "strategy steward + claim-boundary keeper",
+      recipe: "possibility field -> metric choice -> behavior collapse -> hidden cost -> counter-metric",
+      transposedInto: "KPI design",
+      payload: "Metric Spellbreaker canvas",
+      proofMode: "fewer metric-induced harms; clearer tradeoffs; review catches distortions",
+      claimBoundary: "quantum language is metaphor here, not physics proof",
+      nextEmbodiment: "run before adopting any growth, reach, impact, or productivity metric",
+    },
+  },
+];
+
+function formatCard(card: ComposerCard): string {
+  return [
+    `source: ${card.source}`,
+    `observed: ${card.observed}`,
+    `observer lens: ${card.observerLens}`,
+    `recipe: ${card.recipe}`,
+    `transposed into: ${card.transposedInto}`,
+    `payload: ${card.payload}`,
+    `proof mode: ${card.proofMode}`,
+    `claim boundary: ${card.claimBoundary}`,
+    `next embodiment: ${card.nextEmbodiment}`,
+  ].join("\n");
+}
+
+function completeness(card: ComposerCard): number {
+  const filled = fields.filter((field) => card[field.id].trim()).length;
+  return Math.round((filled / fields.length) * 100);
+}
+
+export function RecipeComposer() {
+  const [card, setCard] = useState<ComposerCard>(emptyCard);
+  const [copied, setCopied] = useState(false);
+  const formatted = useMemo(() => formatCard(card), [card]);
+  const completion = completeness(card);
+
+  function updateField(field: RecipeField, value: string) {
+    setCard((current) => ({ ...current, [field]: value }));
+    setCopied(false);
+  }
+
+  async function copyCard() {
+    if (!formatted.trim()) return;
+    await navigator.clipboard.writeText(formatted);
+    setCopied(true);
+  }
+
+  return (
+    <section id="composer" className="border-y border-stone-800/35 bg-stone-950/35">
+      <div className="mx-auto grid max-w-6xl gap-8 px-6 py-16 md:grid-cols-[0.95fr_1.05fr] md:py-24">
+        <div className="space-y-6">
+          <div className="space-y-4">
+            <p className="text-sm uppercase tracking-[0.24em] text-violet-300/70">Make one now</p>
+            <h2 className="text-3xl font-extralight text-stone-100 md:text-4xl">Give the pattern a handle.</h2>
+            <p className="leading-relaxed text-stone-400">
+              Choose a live source, sign the lens, and leave with a card that can move into the world.
+            </p>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-3">
+            {starters.map((starter) => (
+              <button
+                key={starter.title}
+                type="button"
+                onClick={() => {
+                  setCard(starter.card);
+                  setCopied(false);
+                }}
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg border border-stone-800/70 bg-stone-900/40 px-3 py-2 text-sm text-stone-300 transition-colors hover:border-violet-500/35 hover:text-violet-200"
+              >
+                <Wand2 className="h-4 w-4 text-violet-300/70" aria-hidden="true" />
+                {starter.title}
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-lg border border-stone-800/60 bg-stone-900/25 p-4">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-xs uppercase tracking-[0.18em] text-stone-500">Card coherence</span>
+              <span className="text-sm text-stone-300">{completion}%</span>
+            </div>
+            <div className="mt-3 h-2 overflow-hidden rounded-full bg-stone-800">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-amber-400 via-teal-300 to-violet-300 transition-all"
+                style={{ width: `${completion}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {fields.map((field) => (
+              <label key={field.id} className={field.rows && field.rows > 2 ? "sm:col-span-2" : ""}>
+                <span className="mb-1.5 block text-xs uppercase tracking-[0.16em] text-stone-500">{field.label}</span>
+                <textarea
+                  value={card[field.id]}
+                  onChange={(event) => updateField(field.id, event.target.value)}
+                  rows={field.rows ?? 1}
+                  placeholder={field.placeholder}
+                  className="block min-h-11 w-full resize-y rounded-lg border border-stone-800/70 bg-stone-950/55 px-3 py-2 text-sm leading-relaxed text-stone-200 outline-none transition-colors placeholder:text-stone-700 focus:border-amber-400/45"
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className="rounded-lg border border-teal-500/20 bg-teal-500/5 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h3 className="text-lg font-light text-stone-100">Recipe card</h3>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCard(emptyCard);
+                    setCopied(false);
+                  }}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-stone-800/70 bg-stone-950/40 text-stone-400 transition-colors hover:border-amber-500/35 hover:text-amber-200"
+                  aria-label="Clear recipe card"
+                >
+                  <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={copyCard}
+                  className="inline-flex h-10 items-center gap-2 rounded-lg border border-teal-500/25 bg-teal-500/10 px-3 text-sm font-medium text-teal-200 transition-colors hover:bg-teal-500/20"
+                >
+                  {copied ? <Check className="h-4 w-4" aria-hidden="true" /> : <Clipboard className="h-4 w-4" aria-hidden="true" />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+            <pre className="mt-4 max-h-[360px] overflow-auto whitespace-pre-wrap rounded-lg border border-stone-800/70 bg-stone-950/60 p-4 text-xs leading-relaxed text-stone-300">
+              {formatted}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/app/vision/recipes/page.tsx
+++ b/web/app/vision/recipes/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, ClipboardCheck, RotateCcw, ShieldCheck, Sparkles } from "lucide-react";
+import { RecipeComposer } from "./RecipeComposer";
 
 export const metadata: Metadata = {
   title: "Transmission Recipes | The Living Collective",
@@ -227,6 +228,13 @@ export default function TransmissionRecipesPage() {
             </p>
             <div className="flex flex-wrap gap-3 pt-2">
               <Link
+                href="#composer"
+                className="inline-flex items-center gap-2 rounded-lg border border-violet-500/25 bg-violet-500/10 px-5 py-3 text-sm font-medium text-violet-200 transition-colors hover:bg-violet-500/20"
+              >
+                Make a card
+                <ClipboardCheck className="h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
                 href="#payloads"
                 className="inline-flex items-center gap-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-5 py-3 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/20"
               >
@@ -258,6 +266,8 @@ export default function TransmissionRecipesPage() {
         </div>
         <RecipeCard />
       </section>
+
+      <RecipeComposer />
 
       <section id="payloads" className="border-y border-stone-800/35">
         <div className="mx-auto max-w-6xl space-y-8 px-6 py-16 md:py-24">


### PR DESCRIPTION
## What changed

- Added an interactive recipe-card composer to `/vision/recipes`.
- The composer includes the nine atlas fields, three starter cards, a completion meter, clear, and copy-to-clipboard.
- Linked the hero directly to the composer.
- Updated the Transmission Recipe Atlas concept, KB log, and commit evidence.

## Why

The public recipes page could show the practice, but the next breath was to let a visitor produce an artifact immediately. This turns the page from a gallery into a small instrument.

## Validation

- `curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != "breathing") | .name]}'`
- `PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide`
- `make wellness`
- `python3 scripts/generate_repo_indexes.py --check`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_composer.json`
- `git diff --check`
- `cd web && npm ci`
- `cd web && npm run build`
- Browser check: `/vision/recipes` desktop 1280x720, starter load, source edit, copy state, no main-content overflow
- Browser check: `/vision/recipes` mobile 390x844, starter load, responsive stacking, no main-content overflow
- `API_PORT=18100 WEB_PORT=3112 ./scripts/verify_worktree_local_web.sh --start`
- `git fetch origin main && git rebase origin/main`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
