### PR TITLE
tend: wellness symbol resolver learns Rust; telemetry path correction

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -230,13 +230,20 @@ def sense_spec_symbols() -> list[str]:
     ident_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
     def _symbol_resolves(text: str, sym: str) -> bool:
-        # A handful of common declaration shapes across Python, TS, and Form.
+        # Common declaration shapes across Python, TS, Form, and Rust.
         # Note: every `export` form admits `default` between `export` and
         # the keyword — Next.js page components use that convention
         # (`export default function Home() {...}`); the body has dozens
         # of pages that name their default export this way. Without
         # `default` in the alternation, the lens would fire false-positive
         # drifts for every named default export.
+        #
+        # Rust patterns follow the same shape: optional visibility
+        # (`pub`, `pub(crate)`, `pub(super)`), optional `unsafe`/`async`,
+        # then the keyword. Generics (`<T: Trait>`) live after the
+        # identifier and don't affect the match — patterns end with
+        # `\b` after `sym`, so `pub struct Tracked<T: TrackedPrimitive>`
+        # resolves as cleanly as `pub struct Tracked`.
         patterns = [
             rf"\bdef\s+{re.escape(sym)}\b",            # python function
             rf"\bclass\s+{re.escape(sym)}\b",          # python class
@@ -247,6 +254,14 @@ def sense_spec_symbols() -> list[str]:
             rf"\bexport\s+(?:type|interface)\s+{re.escape(sym)}\b",
             rf"^\s*form\s+{re.escape(sym)}\b",         # Form shape
             rf"^\s*defn\s+{re.escape(sym)}\b",         # Form definition
+            # Rust — struct, enum, trait, type alias, fn, union, macro
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?(?:unsafe\s+)?(?:async\s+)?fn\s+{re.escape(sym)}\b",
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?struct\s+{re.escape(sym)}\b",
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?enum\s+{re.escape(sym)}\b",
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?trait\s+{re.escape(sym)}\b",
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?type\s+{re.escape(sym)}\b",
+            rf"\b(?:pub(?:\([^)]+\))?\s+)?union\s+{re.escape(sym)}\b",
+            rf"\bmacro_rules!\s+{re.escape(sym)}\b",
             rf"^{re.escape(sym)}\s*[:=]",              # top-level assignment / type alias
             rf"\b{re.escape(sym)}\s*=\s*\(",           # arrow function / lambda binding
         ]

--- a/specs/runtime-telemetry-db-precedence.md
+++ b/specs/runtime-telemetry-db-precedence.md
@@ -2,7 +2,7 @@
 idea_id: data-infrastructure
 status: done
 source:
-  - file: api/app/services/telemetry_persistence_service/__init__.py
+  - file: api/app/services/telemetry_persistence/__init__.py
     symbols: [backend_info(), checkpoint()]
 requirements:
   - "When a runtime database URL is configured, runtime telemetry events must be persisted to the database even if `RUNTIME_E"
@@ -12,9 +12,9 @@ done_when:
   - "When a runtime database URL is configured, runtime telemetry events must be persisted to the database even if `RUNTIM..."
   - "`GET /api/health/persistence` must not fail the global persistence contract due to runtime telemetry being file-route..."
   - "Add a regression test proving DB precedence when both `RUNTIME_DATABASE_URL` and `RUNTIME_EVENTS_PATH` are set."
-  - 'file_exists("api/app/services/telemetry_persistence_service/__init__.py")'
-  - 'symbol_in_file("api/app/services/telemetry_persistence_service/__init__.py", "backend_info")'
-  - 'symbol_in_file("api/app/services/telemetry_persistence_service/__init__.py", "checkpoint")'
+  - 'file_exists("api/app/services/telemetry_persistence/__init__.py")'
+  - 'symbol_in_file("api/app/services/telemetry_persistence/__init__.py", "backend_info")'
+  - 'symbol_in_file("api/app/services/telemetry_persistence/__init__.py", "checkpoint")'
   - 'pytest_passes("api/tests/test_runtime_event_store_precedence.py")'
 test: "cd api && pytest -q --ignore=tests/holdout tests/test_runtime_event_store_precedence.py"
 constraints:
@@ -23,7 +23,7 @@ constraints:
 ---
 
 > **Parent idea**: [data-infrastructure](../ideas/data-infrastructure.md)
-> **Source**: [`api/app/services/telemetry_persistence_service/__init__.py`](../api/app/services/telemetry_persistence_service/__init__.py)
+> **Source**: [`api/app/services/telemetry_persistence/__init__.py`](../api/app/services/telemetry_persistence/__init__.py)
 
 # Spec: Runtime Telemetry DB Precedence
 


### PR DESCRIPTION
## Summary

Two clean tends to drift the wellness check kept naming on resume:

### (1) Rust patterns in \`_symbol_resolves\`

The wellness symbol-resolution lens covered Python, TypeScript, and Form but not Rust. With three substantial Rust crates in the body ([memory-as-framebuffer-v0](experiments/memory-as-framebuffer-v0/), [form-kernel-rust](experiments/form-kernel-rust/), [form-question-kernels](experiments/form-question-kernels/rust/)) and several specs referencing their symbols, the noise was meaningful.

**Before:** 69 unresolved symbols across 7 specs (false-flagged \`Tracked\`, false-flagged everything that was a Rust struct/enum/trait/fn).
**After:** 46 unresolved symbols across 7 specs. The 23-symbol drop is the Rust false-positive rate.

The lens now reads: \`struct\`, \`enum\`, \`trait\`, \`type\`, \`union\`, \`fn\`, \`macro_rules!\`, with optional \`pub\` / \`pub(crate)\` / \`unsafe\` / \`async\` modifiers and generic suffixes (\`<T: Trait>\` lands after the identifier and doesn't affect the match because patterns end with \`\\b\`).

### (2) Telemetry persistence path correction

[runtime-telemetry-db-precedence](specs/runtime-telemetry-db-precedence.md) claimed \`api/app/services/telemetry_persistence_service/__init__.py\` but that directory does not exist. The actual package lives under \`api/app/services/telemetry_persistence/\` (no \`_service\`), re-exported by the single file [telemetry_persistence_service.py](api/app/services/telemetry_persistence_service.py). The spec's path is corrected in five places (source map, \`done_when\` file_exists, two \`symbol_in_file\` claims, the Source link in the prose preamble). \`backend_info()\` and \`checkpoint()\` resolve cleanly in the corrected file. Wellness \`source maps\` lens now reports aligned.

## Known remaining symbol-resolution drift (not this PR)

Each wants its own focused breath — real evolutions the spec hasn't followed yet, not parser limitations:

- [federation-aggregated-visibility](specs/federation-aggregated-visibility.md): \`get_network_summary\` and \`NetworkSummaryResponse\` were removed during the fleet-capability refactor; spec source-map and \`done_when\` both want updating.
- [financial-integration](specs/financial-integration.md): \`treasury_status\` was planned but never implemented; spec carries \`status: done\` with the \`symbol_in_file\` \`done_when\`, so either implementation finishes or the spec walks back to draft.
- [memory-as-framebuffer-v0](specs/memory-as-framebuffer-v0.md): \`Cell\`, \`alloc_cell\`, \`free_cell\` appear to be from an earlier API shape; \`SlabFramebuffer\` and \`CellHandle\` remain but the cell-level helpers have a new surface.

## Test plan

- [ ] \`make wellness\` after merge shows aligned source-maps
- [ ] Symbol resolution count is now ~46, with the named three specs identified as the remaining work
- [ ] No regression in the other wellness organs

🤖 Generated with [Claude Code](https://claude.com/claude-code)