### PR TITLE
tend: three specs catch up to where the body actually evolved

### DIFF
--- a/specs/federation-aggregated-visibility.md
+++ b/specs/federation-aggregated-visibility.md
@@ -3,13 +3,19 @@ idea_id: federation-and-nodes
 status: active
 source:
   - file: api/app/routers/federation.py
-    symbols: [get_aggregated_node_stats, get_network_summary]
+    symbols: [get_aggregated_node_stats]
   - file: api/app/services/federation_service.py
-    symbols: [get_aggregated_node_stats, get_network_summary]
-  - file: api/app/models/federation.py
-    symbols: [NetworkSummaryResponse, AggregatedNodeStatsResponse]
+    symbols: [get_aggregated_node_stats]
   - file: web/app/nodes/page.tsx
-    symbols: [loadData, NodesPage, NetworkStatsSection]
+    symbols: [loadData, NodesPage]
+# Evolution note (2026-05-24): the `/api/federation/network-summary`
+# surface (get_network_summary, NetworkSummaryResponse,
+# AggregatedNodeStatsResponse, NetworkStatsSection) was removed during
+# the fleet-capability refactor in favour of `/api/federation/nodes/capabilities`
+# returning `FleetCapabilitySummary`. Aggregated stats live on at
+# `get_aggregated_node_stats`. If network-summary semantics return, they
+# want a new spec or a focused revival branch rather than reviving
+# these stale symbol claims.
 requirements:
   - "GET /api/federation/nodes/stats returns per-provider network-wide success rates, mean duration, per-node breakdown, and alerts — already implemented; must return correct shape"
   - "GET /api/federation/network-summary returns node counts (total, online, idle), fleet success rate, active providers, and total measurements in window"

--- a/specs/financial-integration.md
+++ b/specs/financial-integration.md
@@ -5,11 +5,21 @@ status: done
 priority: high
 source:
   - file: api/app/services/cc_economics_service.py
-    symbols: [treasury_status, exchange_rate]
+    symbols: [exchange_rate, supply, coherence_score]
   - file: api/app/services/cc_exchange_adapter.py
-    symbols: [swap, settlement]
+    symbols: [initiate_swap, confirm_swap, get_quote, list_adapters]
   - file: api/app/routers/cc_exchange.py
-    symbols: [swap_cc, get_rate, withdrawal]
+    symbols: [initiate_swap, get_quote, list_adapters, get_history]
+# Evolution note (2026-05-24): naming evolved during implementation.
+# Original spec called for `swap` / `settlement` / `swap_cc` / `get_rate` /
+# `withdrawal`; live surface uses `initiate_swap` / `confirm_swap` /
+# `get_quote` / adapter-routed history. `treasury_status` was never
+# implemented as a function — treasury health surfaces through
+# `cc_treasury_service.coherence_status()` (called from
+# community_pulse_service.py) and `coherence_score()` here. Fiat
+# off-ramp (`withdrawal`) is not in the current surface; the spec's
+# R8/R9 wants its own focused breath when withdrawal returns to the
+# roadmap.
 requirements:
   - "CC <> USDC exchange via Base L2 (using x402 facilitator infrastructure)"
   - "Treasury backing: every CC in circulation backed by real value (Arweave-stored proof)"

--- a/specs/memory-as-framebuffer-v0.md
+++ b/specs/memory-as-framebuffer-v0.md
@@ -7,17 +7,17 @@ source:
   - file: experiments/memory-as-framebuffer-v0/src/lib.rs
     symbols: [Tracked, track!, init_framebuffer, Framebuffer]
   - file: experiments/memory-as-framebuffer-v0/src/allocator.rs
-    symbols: [SlabFramebuffer, Cell, CellHandle, alloc_cell, free_cell]
+    symbols: [SlabFramebuffer, CellHandle, alloc_cell, free_cell]
   - file: experiments/memory-as-framebuffer-v0/src/snapshot.rs
-    symbols: [SnapshotThread, capture_frame, FrameRgba]
+    symbols: [SnapshotThread, capture_frame]
   - file: experiments/memory-as-framebuffer-v0/src/render.rs
-    symbols: [render_frame, type_palette, modulate_brightness, provenance_halo]
+    symbols: [render_frame, type_palette, modulate_brightness, provenance_halo, FrameRgba]
   - file: experiments/memory-as-framebuffer-v0/src/ffmpeg.rs
     symbols: [FfmpegPipe, spawn, write_frame, finalize]
   - file: experiments/memory-as-framebuffer-v0/examples/fizzbuzz.rs
     symbols: [fizzbuzz demo with 100 tracked u32 cells]
   - file: experiments/memory-as-framebuffer-v0/tests/smoke.rs
-    symbols: [test_fizzbuzz_produces_nonempty_mp4, test_two_distinct_pixel_colors]
+    symbols: [fizzbuzz_produces_watchable_mp4]
   - file: experiments/memory-as-framebuffer-v0/README.md
     symbols: [run instructions, expected visuals, v0/v1 boundary]
 requirements:


### PR DESCRIPTION
## Summary

Closes the three drifts the prior wellness tend ([#1916](https://github.com/seeker71/Coherence-Network/pull/1916)) named as follow-ups. Each was a real evolution the spec's source-map hadn't followed.

### (1) [memory-as-framebuffer-v0](specs/memory-as-framebuffer-v0.md)
Clean renames + path corrections:
- \`allocator.rs\` — removed dead \`Cell\` (CellHandle replaced it; CellHandle was already listed)
- \`snapshot.rs\` → \`render.rs\` — \`FrameRgba\` is re-exported from snapshot via \`pub use\` but defined in render; spec now points at the definition site
- \`tests/smoke.rs\` — \`test_fizzbuzz_produces_nonempty_mp4\` renamed to \`fizzbuzz_produces_watchable_mp4\`; \`test_two_distinct_pixel_colors\` removed (it never existed)

### (2) [federation-aggregated-visibility](specs/federation-aggregated-visibility.md)
The \`/api/federation/network-summary\` surface was scrapped during the fleet-capability refactor (replaced by \`/api/federation/nodes/capabilities\` returning \`FleetCapabilitySummary\`). Stale source-map symbols removed: \`get_network_summary\` × 2, \`NetworkSummaryResponse\`, \`AggregatedNodeStatsResponse\`, \`NetworkStatsSection\`. Survivors kept. Evolution note in the source: block so a future reader doesn't try to revive the dead surface.

### (3) [financial-integration](specs/financial-integration.md)
Naming evolved during implementation; spec hadn't caught up.
- \`swap\` → \`initiate_swap\`
- \`settlement\` → \`confirm_swap\`
- \`swap_cc\` → \`initiate_swap\` (router)
- \`get_rate\` → \`get_quote\`
- \`treasury_status\` was never built as a function — treasury health surfaces via \`cc_treasury_service.coherence_status()\` + \`community_pulse_service\`
- \`withdrawal\` (fiat off-ramp) isn't in the current surface; its requirements want their own focused breath when off-ramp returns to the roadmap

## Wellness delta

Symbol-resolution drift: **46 → 31** across 5 specs (was 7).

Remaining drifts are in different specs (each a separate focused breath):
- federation: \`loadData\` parser limitation (async function without export — TS pattern would help)
- memory-as-framebuffer-v1-pointers: \`render_pointer_cell\`
- multilingual-web: \`nextConfig\`
- + 2 others

The \`done_when\` entries in these specs still mention some removed symbol names via \`symbol_in_file(...)\` strings. No automated organ reads them (verified via grep); they're documentation. Walking those back requires deciding spec scope (status revisions, requirement rescopings) — out of scope for a tend breath.

## Test plan

- [ ] \`make wellness\` shows symbol-resolution count at 31 (or lower if other tends land in parallel)
- [ ] All three target specs are now absent from the \"specs with drift\" list

🤖 Generated with [Claude Code](https://claude.com/claude-code)