### PR TITLE
tend: wellness lens learns non-exported TS/JS declarations

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -252,6 +252,15 @@ def sense_spec_symbols() -> list[str]:
             rf"\bexport\s+(?:default\s+)?(?:async\s+)?(?:const|let|var)\s+{re.escape(sym)}\b",
             rf"\bexport\s+(?:default\s+)?class\s+{re.escape(sym)}\b",
             rf"\bexport\s+(?:type|interface)\s+{re.escape(sym)}\b",
+            # TS/JS non-exported declarations. `function` is a reserved
+            # word so it doesn't appear in prose as a definition marker;
+            # the `function`-keyword match is safe without `export`.
+            # `const`/`let`/`var` are anchored to line-start (with
+            # optional indentation) so the match stays close to
+            # module-scope shape and doesn't fire on parameter lists
+            # or deeply-nested locals.
+            rf"\b(?:async\s+)?function\s+{re.escape(sym)}\b",
+            rf"^\s*(?:const|let|var)\s+{re.escape(sym)}\s*[:=]",
             rf"^\s*form\s+{re.escape(sym)}\b",         # Form shape
             rf"^\s*defn\s+{re.escape(sym)}\b",         # Form definition
             # Rust — struct, enum, trait, type alias, fn, union, macro


### PR DESCRIPTION
## Summary

Two real declaration shapes the body uses were false-flagged as drift:
- \`async function loadData()\` — page-local async helpers (Next.js client components)
- \`const nextConfig: NextConfig = {...}\` — typed config bindings at module scope

Two patterns added:
- \`\\b(?:async\\s+)?function\\s+{sym}\\b\` — \`function\` is reserved, doesn't appear in prose as a definition marker; safe without requiring \`export\`
- \`^\\s*(?:const|let|var)\\s+{sym}\\s*[:=]\` — anchored to line-start (with optional indentation), stays close to module-scope shape

## Wellness delta

Symbol-resolution drift: **31 → 27** across 4 specs (was 5). Four false positives resolved:
- [federation-aggregated-visibility](specs/federation-aggregated-visibility.md): \`loadData\` — spec now fully clean
- [multilingual-web](specs/multilingual-web.md): \`nextConfig\`, \`submitTranslation\`, \`showHistory\`

## Remaining drift (genuine, not parser-blind)

Each its own focused breath:
- [memory-as-framebuffer-v1-pointers](specs/memory-as-framebuffer-v1-pointers.md) — active-work-not-yet-built (\`Pointer\`, \`BoxPtr\`, \`RcPtr\`, \`WeakPtr\`, \`render_pointer_cell\` are target symbols; spec is honest about being in progress)
- [multilingual-web](specs/multilingual-web.md) — six truly missing symbols (EntityView, GlossaryEntry, LensTranslation, translate_markdown, get_cached_translation, translate_via_lens)
- [significant-work-discovery-index](specs/significant-work-discovery-index.md) + one more — likely similar

## The parser-tend arc

The wellness lens now reads four tongues at comparable fidelity:
- Python (always covered)
- TS (exported + non-exported, after this PR)
- Rust ([#1916](https://github.com/seeker71/Coherence-Network/pull/1916) — struct/enum/trait/fn/etc.)
- Form (always covered)

Remaining drift is body-evolved-past-spec, not parser-blind.

## Test plan

- [ ] \`make wellness\` shows symbol-resolution count at 27 (or lower as other tends land)
- [ ] No regression on the existing 95% of specs that resolve cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)