### PR TITLE
[codex] make transmission recipes shareable

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 194 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 195 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 194
+**Total files**: 195
 
 | File | Purpose |
 |---|---|
@@ -188,6 +188,7 @@
 | [test_substrate_string_literal_recovery.py](test_substrate_string_literal_recovery.py) | String literals recover their value at runtime. |
 | [test_substrate_strings.py](test_substrate_strings.py) | Tests for the substrate string-table — cross-process-stable interning. |
 | [test_substrate_structured_ctor.py](test_substrate_structured_ctor.py) | Structural composition discipline — the new structured CTOR encoder. |
+| [test_substrate_surprise_adjacency.py](test_substrate_surprise_adjacency.py) | Tests for the substrate-surprise adjacency refinement. |
 | [test_substrate_vocabulary_commute.py](test_substrate_vocabulary_commute.py) | `?vocabulary` lens + commutative resonance edges. |
 | [test_substrate_word_domain.py](test_substrate_word_domain.py) | Tests for the WORD domain — prose-as-recipe encoder + tokenizer + lookup. |
 | [test_super_idea_rollup.py](test_super_idea_rollup.py) | Tests for super-idea rollup criteria (spec: super-idea-rollup-criteria). |

--- a/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json
+++ b/docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json
@@ -1,0 +1,110 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/transmission-recipe-share-20260524",
+  "commit_scope": "Add local restore and explicit share-link support to the Transmission Recipes composer.",
+  "files_owned": [
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "api/tests/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json",
+      "cd web && npm ci",
+      "cd web && npm run build",
+      "Browser check: http://localhost:3113/vision/recipes desktop autosave, share-link copy, URL restore",
+      "Browser check: http://localhost:3113/vision/recipes mobile share controls visible and no main-content overflow",
+      "API_PORT=18100 WEB_PORT=3113 ./scripts/verify_worktree_local_web.sh --start",
+      "git diff --check"
+    ],
+    "summary": "Pulse, prompt guide, wellness, index check/regeneration, evidence validation, diff whitespace check, production build, desktop/mobile browser restore/share checks, and local API/web contract passed. Browser proof verified shared URL restore, clipboard fallback state, and no main-content overflow."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "curl -sS --max-time 20 https://coherencycoin.com/vision/recipes"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; CI and public route validation remain pending until PR and deploy flow complete."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "db-backed-vision-hub-content",
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "transmission-recipe-share-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "next-breath-request",
+        "cross-domain-recipe-vision"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "interactive-surface-implementation",
+        "browser-validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "docs/vision-kb/LOG.md",
+    "api/tests/INDEX.md",
+    "MANIFEST.md",
+    "npm run build",
+    "./scripts/verify_worktree_local_web.sh --start",
+    "make wellness"
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "api/tests/INDEX.md",
+    "docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json",
+    "docs/vision-kb/LOG.md",
+    "docs/vision-kb/concepts/lc-transmission-recipe-atlas.md",
+    "web/app/vision/recipes/RecipeComposer.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Visitors can leave and return to their in-progress recipe card, and can explicitly copy a share URL that reopens the same recipe card.",
+    "public_endpoints": [
+      "GET /vision/recipes"
+    ],
+    "test_flows": [
+      "Desktop browser check creates a card, copies a share link, opens it in a fresh tab, and verifies restored card content.",
+      "Mobile browser check confirms share controls are visible without main-content overflow.",
+      "Production build confirms the route compiles."
+    ]
+  }
+}

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -11,6 +11,15 @@ Two paired concepts land together — the *what* and the *how* of an open-ended 
 - **Edges landed in the same breath**: INDEX entries beside `lc-form-perceptron`, frequency-family rows (528, 741), concept count updated, reciprocal cross-references between the two new concepts and into `lc-form-perceptron`, `lc-act-without-penalty`, `lc-grammar-is-the-universal-recipe`, `lc-transmission-recipe-atlas`, `lc-edges-as-vitality`.
 - **Discernment held**: Grant's claim is held by Grant, not by this body; the substrate-bridge is testable, and the runtime is what keeps the test honest. Either outcome — equivalences emerge or they don't — deepens what the body knows.
 
+## [2026-05-24] surface | Transmission Recipes remembers and shares
+
+The public recipe composer now lets a card survive the first breath and travel by consent.
+
+- **Composer deepened**: `/vision/recipes` autosaves the current recipe card in the visitor's browser and restores it on return.
+- **Share link**: the composer can copy a URL carrying the current card text, reopening the same source, lens, proof, boundary, and next embodiment.
+- **Privacy boundary**: card text only leaves the browser when the visitor chooses the share-link action.
+- **Concept edge**: [`lc-transmission-recipe-atlas`](concepts/lc-transmission-recipe-atlas.md) now names local restore and explicit share.
+
 ## [2026-05-24] surface | Transmission Recipes composer
 
 The public recipe doorway can now produce a first artifact in the visitor's hands.

--- a/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
+++ b/docs/vision-kb/concepts/lc-transmission-recipe-atlas.md
@@ -238,7 +238,9 @@ a source and sees multiple honest extractions:
 The first public doorway is now `/vision/recipes`: a practical surface
 with an interactive card composer, three runnable payloads, and novel
 pairings ready to become workshops, product flows, reliability rituals,
-and community tools.
+and community tools. The composer remembers a draft in the visitor's
+browser and can create a share link that carries the card text when the
+visitor explicitly copies it.
 
 The substrate-facing companion already exists in
 [`modality-as-recipe.form`](../../coherence-substrate/modality-as-recipe.form):
@@ -256,8 +258,8 @@ human-facing doorway: cards people can read, try, verify, and improve.
   -- the practical card walk with complete payloads, proof modes, and
   a first group practice.
 - **[/vision/recipes](/vision/recipes)**
-  -- the public page for composing a card and walking the payloads and
-  novel pairings.
+  -- the public page for composing, restoring, sharing, and walking the
+  payloads and novel pairings.
 - **[modality-as-recipe.form](../../coherence-substrate/modality-as-recipe.form)**
   -- substrate shape for multiple recipe extractions from one source.
 - **[song-as-recipe.form](../../coherence-substrate/song-as-recipe.form)**

--- a/web/app/vision/recipes/RecipeComposer.tsx
+++ b/web/app/vision/recipes/RecipeComposer.tsx
@@ -1,8 +1,8 @@
 // Interactive recipe-card composer for the Transmission Recipes page.
 "use client";
 
-import { useMemo, useState } from "react";
-import { Check, Clipboard, RotateCcw, Wand2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Check, Clipboard, Link2, RotateCcw, Wand2 } from "lucide-react";
 
 type RecipeField =
   | "source"
@@ -33,6 +33,8 @@ const emptyCard: ComposerCard = {
   claimBoundary: "",
   nextEmbodiment: "",
 };
+
+const storageKey = "coherence.transmissionRecipe.card.v1";
 
 const fields: Array<{ id: RecipeField; label: string; placeholder: string; rows?: number }> = [
   {
@@ -147,6 +149,55 @@ function formatCard(card: ComposerCard): string {
   ].join("\n");
 }
 
+function hasCardContent(card: ComposerCard): boolean {
+  return fields.some((field) => card[field.id].trim());
+}
+
+function encodeCard(card: ComposerCard): string {
+  const json = JSON.stringify(card);
+  return btoa(unescape(encodeURIComponent(json)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeCard(value: string | null): ComposerCard | null {
+  if (!value) return null;
+  try {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const parsed = JSON.parse(decodeURIComponent(escape(atob(padded)))) as Partial<ComposerCard>;
+    return fields.reduce<ComposerCard>(
+      (acc, field) => ({
+        ...acc,
+        [field.id]: typeof parsed[field.id] === "string" ? parsed[field.id] : "",
+      }),
+      { ...emptyCard },
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    if (!navigator.clipboard?.writeText) throw new Error("Clipboard API unavailable");
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    textarea.remove();
+    return copied;
+  }
+}
+
 function completeness(card: ComposerCard): number {
   const filled = fields.filter((field) => card[field.id].trim()).length;
   return Math.round((filled / fields.length) * 100);
@@ -155,18 +206,72 @@ function completeness(card: ComposerCard): number {
 export function RecipeComposer() {
   const [card, setCard] = useState<ComposerCard>(emptyCard);
   const [copied, setCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [restored, setRestored] = useState<"url" | "local" | null>(null);
+  const [hydrated, setHydrated] = useState(false);
   const formatted = useMemo(() => formatCard(card), [card]);
   const completion = completeness(card);
+  const hasContent = hasCardContent(card);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const sharedCard = decodeCard(params.get("recipe"));
+    if (sharedCard) {
+      setCard(sharedCard);
+      setRestored("url");
+      setHydrated(true);
+      return;
+    }
+
+    const savedCard = decodeCard(window.localStorage.getItem(storageKey));
+    if (savedCard) {
+      setCard(savedCard);
+      setRestored("local");
+    }
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (hasContent) {
+      window.localStorage.setItem(storageKey, encodeCard(card));
+    } else {
+      window.localStorage.removeItem(storageKey);
+    }
+  }, [card, hasContent, hydrated]);
 
   function updateField(field: RecipeField, value: string) {
     setCard((current) => ({ ...current, [field]: value }));
     setCopied(false);
+    setLinkCopied(false);
   }
 
   async function copyCard() {
     if (!formatted.trim()) return;
-    await navigator.clipboard.writeText(formatted);
-    setCopied(true);
+    const copiedToClipboard = await writeClipboard(formatted);
+    setCopied(copiedToClipboard);
+    setLinkCopied(false);
+  }
+
+  async function copyShareLink() {
+    if (!hasContent) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set("recipe", encodeCard(card));
+    url.hash = "composer";
+    const copiedToClipboard = await writeClipboard(url.toString());
+    setLinkCopied(copiedToClipboard);
+    setCopied(false);
+  }
+
+  function clearCard() {
+    setCard(emptyCard);
+    setCopied(false);
+    setLinkCopied(false);
+    setRestored(null);
+    window.localStorage.removeItem(storageKey);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("recipe");
+    window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
   }
 
   return (
@@ -189,6 +294,8 @@ export function RecipeComposer() {
                 onClick={() => {
                   setCard(starter.card);
                   setCopied(false);
+                  setLinkCopied(false);
+                  setRestored(null);
                 }}
                 className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg border border-stone-800/70 bg-stone-900/40 px-3 py-2 text-sm text-stone-300 transition-colors hover:border-violet-500/35 hover:text-violet-200"
               >
@@ -209,6 +316,15 @@ export function RecipeComposer() {
                 style={{ width: `${completion}%` }}
               />
             </div>
+            <p className="mt-3 text-xs leading-relaxed text-stone-500">
+              {restored === "url"
+                ? "Opened from a shared link. Edits now save in this browser."
+                : restored === "local"
+                  ? "Restored from this browser. Share link only moves the card when you copy it."
+                  : hasContent
+                    ? "Saved in this browser. Share link carries this card text in the URL."
+                    : "Drafts save in this browser once a field has content."}
+            </p>
           </div>
         </div>
 
@@ -234,14 +350,20 @@ export function RecipeComposer() {
               <div className="flex gap-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    setCard(emptyCard);
-                    setCopied(false);
-                  }}
+                  onClick={clearCard}
                   className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-stone-800/70 bg-stone-950/40 text-stone-400 transition-colors hover:border-amber-500/35 hover:text-amber-200"
                   aria-label="Clear recipe card"
                 >
                   <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={copyShareLink}
+                  disabled={!hasContent}
+                  className="inline-flex h-10 items-center gap-2 rounded-lg border border-violet-500/25 bg-violet-500/10 px-3 text-sm font-medium text-violet-200 transition-colors hover:bg-violet-500/20 disabled:cursor-not-allowed disabled:border-stone-800 disabled:bg-stone-950/40 disabled:text-stone-600"
+                >
+                  {linkCopied ? <Check className="h-4 w-4" aria-hidden="true" /> : <Link2 className="h-4 w-4" aria-hidden="true" />}
+                  {linkCopied ? "Link copied" : "Share link"}
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- add browser-local restore and explicit share-link support to the Transmission Recipes composer
- document the privacy boundary and concept/log edge
- refresh generated repo indexes required by the local index gate

## Proof
- PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
- make wellness
- python3 scripts/generate_repo_indexes.py --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_transmission_recipe_share.json
- cd web && npm ci
- cd web && npm run build
- Browser desktop/mobile checks for URL restore, share copy state, and no overflow
- API_PORT=18100 WEB_PORT=3113 ./scripts/verify_worktree_local_web.sh --start
- git diff --check
- git fetch origin main && git rebase origin/main
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict