### PR TITLE
tend: multilingual-web spec catches up to the actual translation surface

### DIFF
--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -9,17 +9,29 @@ source:
   - file: web/next.config.ts
     symbols: [nextConfig]
   - file: api/app/models/translation.py
-    symbols: [EntityView, GlossaryEntry]
+    symbols: [TranslationLens, OntologyConceptRef, IdeaTranslationResponse, ConceptTranslationResponse]
   - file: api/app/models/lens_translation.py
-    symbols: [LensTranslation]
+    symbols: [WorldviewLensCreate, TranslationRegenerateBody]
   - file: api/app/services/translation_cache_service.py
-    symbols: [write_view, canonical_view, all_canonical_views, find_anchor, is_stale, list_history, glossary_for, upsert_glossary_entry]
+    symbols: [EntityViewRecord, GlossaryEntryRecord, write_view, canonical_view, all_canonical_views, find_anchor, is_stale, list_history, glossary_for, upsert_glossary_entry]
   - file: api/app/services/translator_service.py
-    symbols: [translate_markdown, build_glossary_prompt, SUPPORTED_LOCALES]
+    symbols: [build_glossary_prompt, SUPPORTED_LOCALES, attune_from_anchor, load_view, set_backend]
   - file: api/app/services/concept_translation_service.py
-    symbols: [translate_concept, get_cached_translation]
+    symbols: [translate_idea, translate_concept]
   - file: api/app/services/lens_translation_service.py
-    symbols: [translate_via_lens]
+    symbols: [build_idea_translation, build_lens_public_dict, list_translations_for_idea, get_roi_payload]
+# Evolution note (2026-05-24): translation surface evolved during
+# implementation. Model classes EntityView/GlossaryEntry are now
+# EntityViewRecord/GlossaryEntryRecord living in translation_cache_service
+# (Record suffix marks them as SQLAlchemy ORM rows, not Pydantic
+# request/response shapes). LensTranslation became WorldviewLensCreate +
+# TranslationRegenerateBody (split into create vs. regenerate
+# operations). translate_markdown was replaced by the attunement-backend
+# pattern (attune_from_anchor + set_backend); get_cached_translation
+# was absorbed into translate_idea/translate_concept which cache
+# internally; translate_via_lens became build_idea_translation +
+# build_lens_public_dict (split between idea-translation and
+# lens-public-projection responsibilities).
   - file: api/app/routers/locales.py
     symbols: [list_locales, get_glossary, patch_glossary]
   - file: api/app/routers/translations.py


### PR DESCRIPTION
## Summary

Six unresolved symbols, all mapped to current code:

**Model relocations** (Pydantic-shape → SQLAlchemy Record):
- \`EntityView\` → \`EntityViewRecord\` in [translation_cache_service.py](api/app/services/translation_cache_service.py)
- \`GlossaryEntry\` → \`GlossaryEntryRecord\` in same file

**Lens-translation split:**
- \`LensTranslation\` → split into \`WorldviewLensCreate\` + \`TranslationRegenerateBody\` (create vs. regenerate)
- \`translate_via_lens\` → split into \`build_idea_translation\` + \`build_lens_public_dict\` + \`list_translations_for_idea\`

**Caching absorbed:**
- \`translate_markdown\` → \`attune_from_anchor\` + \`set_backend\` (pluggable attunement backend)
- \`get_cached_translation\` → absorbed into \`translate_idea\` / \`translate_concept\` (internal caching)

Spec source: block now names every symbol that lives where it claims. Evolution note documents the renames.

## Wellness delta

Symbol-resolution drift: **27 → 21** across 3 specs (was 5). multilingual-web fully clean.

Remaining drifts each their own focused breath:
- [memory-as-framebuffer-v1-pointers](specs/memory-as-framebuffer-v1-pointers.md) — active-work-not-yet-built (target symbols listed before they exist; honest spec convention)
- [significant-work-discovery-index](specs/significant-work-discovery-index.md) — \`get_field_story_trace\`
- [story-protocol-integration](specs/story-protocol-integration.md) — \`get_asset_content\`

## Test plan

- [ ] \`make wellness\` after merge shows symbol-resolution count at 21 (or lower)
- [ ] multilingual-web absent from drift list

🤖 Generated with [Claude Code](https://claude.com/claude-code)