### PR TITLE
tend: wellness distinguishes drift in done specs from pending in active specs

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -277,6 +277,7 @@ def sense_spec_symbols() -> list[str]:
         return any(re.search(p, text, re.MULTILINE) for p in patterns)
 
     drift_by_spec: dict[str, list[tuple[str, str]]] = {}
+    pending_by_spec: dict[str, list[tuple[str, str]]] = {}
     specs_with_symbol_claims = 0
     symbols_checked = 0
 
@@ -292,6 +293,14 @@ def sense_spec_symbols() -> list[str]:
         status = (status_m.group(1).strip().strip('"').strip("'") if status_m else "").lower()
         if status == "draft":
             continue
+
+        # status=active spec convention: source: may list target symbols
+        # (what WILL exist when done) alongside shipped ones. Unresolved
+        # symbols in active specs are "pending implementation" — honest
+        # signal of in-progress work, not drift between spec and code.
+        # status=done specs (or unclassified) are where unresolved
+        # symbols mean the spec's claim genuinely drifted from reality.
+        is_active = status == "active"
 
         spec_had_claims = False
         for m in src_pattern.finditer(fm):
@@ -318,34 +327,66 @@ def sense_spec_symbols() -> list[str]:
             for sym in candidates:
                 symbols_checked += 1
                 if not _symbol_resolves(file_text, sym):
-                    drift_by_spec.setdefault(spec.stem, []).append((path, sym))
+                    bucket = pending_by_spec if is_active else drift_by_spec
+                    bucket.setdefault(spec.stem, []).append((path, sym))
 
         if spec_had_claims:
             specs_with_symbol_claims += 1
 
-    if not drift_by_spec:
+    if not drift_by_spec and not pending_by_spec:
         return [
             f"  every claimed symbol resolves in its file ({symbols_checked} symbols "
             f"across {specs_with_symbol_claims} spec(s) checked)"
         ]
 
-    total_drifts = sum(len(v) for v in drift_by_spec.values())
-    lines = [
-        f"  {total_drifts} symbol claim(s) do not resolve across {len(drift_by_spec)} spec(s) "
-        f"(of {specs_with_symbol_claims} with symbol claims · {symbols_checked} symbols checked)"
-    ]
-    for spec_name in sorted(drift_by_spec)[:3]:
-        items = drift_by_spec[spec_name]
-        first = items[0]
-        lines.append(f"    · {spec_name} — `{first[1]}` not found in {first[0]}")
-        if len(items) > 1:
-            lines.append(f"      (+{len(items) - 1} more in this spec)")
-    if len(drift_by_spec) > 3:
-        lines.append(f"    · (+{len(drift_by_spec) - 3} more specs with symbol drift)")
-    lines.append(
-        "  (Drift here is signal, not failure. A renamed function is the body "
-        "evolving; the spec's claim wants the same breath.)"
-    )
+    lines: list[str] = []
+
+    if drift_by_spec:
+        total_drifts = sum(len(v) for v in drift_by_spec.values())
+        lines.append(
+            f"  {total_drifts} symbol claim(s) do not resolve across {len(drift_by_spec)} spec(s) "
+            f"(of {specs_with_symbol_claims} with symbol claims · {symbols_checked} symbols checked)"
+        )
+        for spec_name in sorted(drift_by_spec)[:3]:
+            items = drift_by_spec[spec_name]
+            first = items[0]
+            lines.append(f"    · {spec_name} — `{first[1]}` not found in {first[0]}")
+            if len(items) > 1:
+                lines.append(f"      (+{len(items) - 1} more in this spec)")
+        if len(drift_by_spec) > 3:
+            lines.append(f"    · (+{len(drift_by_spec) - 3} more specs with symbol drift)")
+        lines.append(
+            "  (Drift here is signal, not failure. A renamed function is the body "
+            "evolving; the spec's claim wants the same breath.)"
+        )
+
+    if pending_by_spec:
+        if lines:
+            lines.append("")
+        total_pending = sum(len(v) for v in pending_by_spec.values())
+        lines.append(
+            f"  {total_pending} target symbol(s) pending across {len(pending_by_spec)} active spec(s) "
+            "— active work whose source: lists what will exist when done"
+        )
+        for spec_name in sorted(pending_by_spec)[:3]:
+            items = pending_by_spec[spec_name]
+            first = items[0]
+            lines.append(f"    · {spec_name} — `{first[1]}` not yet in {first[0]}")
+            if len(items) > 1:
+                lines.append(f"      (+{len(items) - 1} more pending in this spec)")
+        if len(pending_by_spec) > 3:
+            lines.append(
+                f"    · (+{len(pending_by_spec) - 3} more active specs with pending symbols)"
+            )
+
+    if not drift_by_spec and pending_by_spec:
+        # Only active-spec pending exists — name the clean ground line up top
+        lines.insert(
+            0,
+            f"  every claimed symbol resolves in done/inactive specs ({symbols_checked} symbols "
+            f"across {specs_with_symbol_claims} spec(s) checked)",
+        )
+
     return lines
 
 

--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -9,17 +9,29 @@ source:
   - file: web/next.config.ts
     symbols: [nextConfig]
   - file: api/app/models/translation.py
-    symbols: [EntityView, GlossaryEntry]
+    symbols: [TranslationLens, OntologyConceptRef, IdeaTranslationResponse, ConceptTranslationResponse]
   - file: api/app/models/lens_translation.py
-    symbols: [LensTranslation]
+    symbols: [WorldviewLensCreate, TranslationRegenerateBody]
   - file: api/app/services/translation_cache_service.py
-    symbols: [write_view, canonical_view, all_canonical_views, find_anchor, is_stale, list_history, glossary_for, upsert_glossary_entry]
+    symbols: [EntityViewRecord, GlossaryEntryRecord, write_view, canonical_view, all_canonical_views, find_anchor, is_stale, list_history, glossary_for, upsert_glossary_entry]
   - file: api/app/services/translator_service.py
-    symbols: [translate_markdown, build_glossary_prompt, SUPPORTED_LOCALES]
+    symbols: [build_glossary_prompt, SUPPORTED_LOCALES, attune_from_anchor, load_view, set_backend]
   - file: api/app/services/concept_translation_service.py
-    symbols: [translate_concept, get_cached_translation]
+    symbols: [translate_idea, translate_concept]
   - file: api/app/services/lens_translation_service.py
-    symbols: [translate_via_lens]
+    symbols: [build_idea_translation, build_lens_public_dict, list_translations_for_idea, get_roi_payload]
+# Evolution note (2026-05-24): translation surface evolved during
+# implementation. Model classes EntityView/GlossaryEntry are now
+# EntityViewRecord/GlossaryEntryRecord living in translation_cache_service
+# (Record suffix marks them as SQLAlchemy ORM rows, not Pydantic
+# request/response shapes). LensTranslation became WorldviewLensCreate +
+# TranslationRegenerateBody (split into create vs. regenerate
+# operations). translate_markdown was replaced by the attunement-backend
+# pattern (attune_from_anchor + set_backend); get_cached_translation
+# was absorbed into translate_idea/translate_concept which cache
+# internally; translate_via_lens became build_idea_translation +
+# build_lens_public_dict (split between idea-translation and
+# lens-public-projection responsibilities).
   - file: api/app/routers/locales.py
     symbols: [list_locales, get_glossary, patch_glossary]
   - file: api/app/routers/translations.py

--- a/specs/significant-work-discovery-index.md
+++ b/specs/significant-work-discovery-index.md
@@ -8,7 +8,7 @@ source:
   - file: api/app/services/field_story_service.py
     symbols: [get_field_story_trace_slice()]
   - file: api/app/services/field_story_mcp_tools.py
-    symbols: [get_field_story_trace()]
+    symbols: [get_field_story_trace_handler, get_field_story_artifact_handler, contribute_field_story_handler]
 requirements:
   - "Significant works are indexed as compact discovery records with aliases, authors, child works, concept links, probe terms, and source boundaries."
   - "Vision concepts can return the works most related to them without loading the full listening event stream."


### PR DESCRIPTION
## Summary

The symbol-resolution lens treated every unresolved symbol as **drift**, but active specs honestly list **target symbols** in \`source:\` — what will exist when the work ships. Reporting target symbols as drift conflates two distinct signals:
- *spec lied about reality* (true drift, wants tending)
- *work in progress, source: tracks the target surface* (honest in-progress, informational)

## Change

The lens now sorts unresolved symbols by spec status:

| status | unresolved → |
|---|---|
| \`draft\` | skipped (unchanged) |
| \`active\` | **pending** bucket — honest in-progress signal |
| \`done\` or unclassified | **drift** bucket — real signal the spec wants tending |

Output reads cleanly:

\`\`\`
every claimed symbol resolves in done/inactive specs (807 symbols across 101 spec(s) checked)
20 target symbol(s) pending across 2 active spec(s) — active work whose source: lists what will exist when done
  · memory-as-framebuffer-v1-pointers — `render_pointer_cell` not yet in experiments/memory-as-framebuffer-v0/src/pointer.rs
    (+2 more pending in this spec)
  · story-protocol-integration — `get_asset_content` not yet in api/app/routers/assets.py
    (+16 more pending in this spec)
\`\`\`

When drift exists, it appears first (real signal). When only active-spec pending exists, the clean ground line appears up top. When neither, silence.

## Also lands

[significant-work-discovery-index](specs/significant-work-discovery-index.md) symbol rename. The MCP tools file wraps service functions with \`_handler\` suffix:
- \`get_field_story_trace\` → \`get_field_story_trace_handler\` + \`get_field_story_artifact_handler\` + \`contribute_field_story_handler\`

## Wellness delta

- **Drift**: 21 → 0 across 0 done/inactive specs
- **Pending**: 20 across 2 active specs (story-protocol-integration: 17 target symbols; memory-as-framebuffer-v1-pointers: 3 v1 targets)

Every spec the wellness lens now flags as drift genuinely lies about its state. Active specs reporting target symbols read as work-in-progress, not failure.

## Test plan

- [ ] \`make wellness\` shows the new two-line shape with both \"resolves in done/inactive\" and \"target pending\" lines
- [ ] No false drifts surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)