### PR TITLE
tend: chain organ + spec test renames — drift vs pending for tests too

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -506,7 +506,8 @@ def sense_chain() -> list[str]:
     test_path_re = re.compile(r"\b(?:api/|mcp-server/)?tests/[\w/]+\.py")
     healthy = 0
     counted = 0  # non-draft specs we evaluated for chain reach
-    missing_tests: dict[str, list[str]] = {}
+    missing_tests: dict[str, list[str]] = {}     # done/inactive — drift
+    pending_tests: dict[str, list[str]] = {}     # active — work in progress
     no_test_declared: list[str] = []
     orphan_specs: list[str] = []
     operational_proof: list[str] = []  # specs honoring "proof: operational"
@@ -560,7 +561,11 @@ def sense_chain() -> list[str]:
             continue
         miss = [t for t in test_paths if not (ROOT / t).exists()]
         if miss:
-            missing_tests[spec.stem] = miss
+            # Active specs honestly list target tests before they're
+            # written; report those as pending, not drift. Done/
+            # inactive specs claiming missing tests are real drift.
+            bucket = pending_tests if status == "active" else missing_tests
+            bucket[spec.stem] = miss
             continue
 
         # Chain healthy if: idea_id present, source declared and present,
@@ -576,12 +581,21 @@ def sense_chain() -> list[str]:
         f"  chain healthy: {healthy}/{counted} non-draft specs reach idea→spec→code→test ({(healthy/counted*100) if counted else 0:.0f}%)"
     ]
     if missing_tests:
-        lines.append(f"  {len(missing_tests)} specs claim a test that doesn't exist on disk")
+        lines.append(f"  {len(missing_tests)} done/inactive spec(s) claim a test that doesn't exist on disk")
         for slug in sorted(missing_tests)[:3]:
             miss = ", ".join(missing_tests[slug][:2])
             lines.append(f"    · {slug} — {miss}")
         if len(missing_tests) > 3:
             lines.append(f"    · (+{len(missing_tests) - 3} more)")
+    if pending_tests:
+        lines.append(
+            f"  {len(pending_tests)} active spec(s) carry test paths not yet on disk — pending work"
+        )
+        for slug in sorted(pending_tests)[:3]:
+            miss = ", ".join(pending_tests[slug][:2])
+            lines.append(f"    · {slug} — {miss}")
+        if len(pending_tests) > 3:
+            lines.append(f"    · (+{len(pending_tests) - 3} more)")
     if operational_proof:
         lines.append(
             f"  {len(operational_proof)} spec(s) honor `proof: operational` — proven in production, not unit-tested"
@@ -590,7 +604,7 @@ def sense_chain() -> list[str]:
         lines.append(f"  {len(no_test_declared)} specs have no test: or proof: frontmatter (no proof claimed)")
     if orphan_specs:
         lines.append(f"  {len(orphan_specs)} orphan specs (no idea_id): {', '.join(orphan_specs)}")
-    if not missing_tests and not no_test_declared and not orphan_specs:
+    if not missing_tests and not pending_tests and not no_test_declared and not orphan_specs:
         lines.append("  chain reach is whole — every claim has its proof")
     return lines
 

--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -132,7 +132,7 @@ done_when:
   - 'symbol_in_file("docs/vision-kb/glossary/id.md", "anchor")'
   - 'pytest_passes("api/tests/test_locale.py")'
   - 'pytest_passes("api/tests/test_translation_cache.py")'
-test: "cd api && python -m pytest tests/test_locale.py tests/test_translation_cache.py -q && cd ../web && npm run test"
+test: "cd api && python -m pytest tests/test_translations_router.py tests/test_lens_translation_boundaries.py tests/test_libretranslate_backend.py -q && cd ../web && npm run test"
 constraints:
   - "Never mutate source markdown — translations are additive rows keyed by (target_lang, source_hash)"
   - "English is not privileged — source_lang is whatever the contributor wrote in; any locale can be source or target"

--- a/specs/story-protocol-integration.md
+++ b/specs/story-protocol-integration.md
@@ -123,7 +123,7 @@ done_when:
   - 'pytest_passes("api/tests/test_story_protocol.py")'
   - 'pytest_passes("api/tests/test_settlement.py")'
   - 'pytest_passes("api/tests/test_evidence.py")'
-test: "cd api && python -m pytest tests/test_story_protocol.py tests/test_settlement.py tests/test_evidence.py -q"
+test: "cd api && python -m pytest tests/test_story_protocol.py tests/test_settlement_flow.py tests/test_evidence_flow.py -q"
 constraints:
   - "No blockchain node required on infrastructure -- use Story Protocol SDK RPC and Arweave bundler services"
   - "Gas costs below $0.01 per asset registration (use Story Protocol Proof of Creativity on L2)"


### PR DESCRIPTION
## Summary

Same active-vs-done refinement as [#1923](https://github.com/seeker71/Coherence-Network/pull/1923), now for the chain organ. Plus two clean test renames.

## Spec renames (the body's tests moved; specs hadn't caught up)

**[story-protocol-integration](specs/story-protocol-integration.md)** — \`tests/test_settlement.py\` → \`test_settlement_flow.py\`, \`tests/test_evidence.py\` → \`test_evidence_flow.py\`. The renamed files self-identify in their docstrings as covering R8/R9 of this spec.

**[multilingual-web](specs/multilingual-web.md)** — \`tests/test_locale.py\` + \`tests/test_translation_cache.py\` → \`test_translations_router.py\` + \`test_lens_translation_boundaries.py\` + \`test_libretranslate_backend.py\`. Translation coverage moved into surface-specific test files as the system shipped.

## Chain organ refinement

| status | missing test → |
|---|---|
| \`draft\` | skipped (unchanged) |
| \`active\` | **pending work** bucket — informational |
| \`done\` or unclassified | **drift** bucket — real signal that wants tending |

**Before:**
\`\`\`
· 3 specs claim a test that doesn't exist on disk
    · multilingual-web — ...
    · runner-attendance-loop — ...
    · story-protocol-integration — ...
\`\`\`

**After:**
\`\`\`
· 1 active spec(s) carry test paths not yet on disk — pending work
    · runner-attendance-loop — api/tests/test_runner_attendance.py
\`\`\`

## Wellness delta

- Chain health: **75/117 (64%) → 99/129 (77%)**
- Drift in done/inactive specs: **0**
- Pending in active specs: **1** (runner-attendance-loop)

Together with the symbol-resolution refinement, the wellness lens now reports "drift" only when a spec's done-claim genuinely lies about reality. Active specs naming target surfaces (symbols or tests) read as work-in-progress.

## Test plan

- [ ] \`make wellness\` shows the new shape with "pending work" line instead of "claim a test that doesn't exist"
- [ ] No false drifts surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)