### PR TITLE
attune: translator equivalence at CTOR, not Blueprint

### DIFF
--- a/docs/coherence-substrate/autoresearch-runtime.form
+++ b/docs/coherence-substrate/autoresearch-runtime.form
@@ -173,13 +173,13 @@ defn run_until_signal(loop, stop_signal) = do {
 # rewards for honest yield, penalties for cheating shapes.
 
 form r_fitness_function_shape = {
-    yield_weight:           ~Float,    # reward: % of cells finding non-degenerate matches
-    holdout_weight:         ~Float,    # reward: attested cross-domain pairs recovered
-    collapse_penalty:       ~Float,    # penalty: entropy collapse to one Blueprint
+    yield_weight:           ~Float,    # reward: % of cells finding non-degenerate CTOR-level matches (Blueprint family alone doesn't count)
+    holdout_weight:         ~Float,    # reward: attested cross-domain pairs the lattice recovered at CTOR
+    collapse_penalty:       ~Float,    # penalty: entropy collapse — to one Blueprint or one CTOR within a family
     table_penalty:          ~Float,    # penalty: hardcoded {k:v} maps in encoder source
     depth_penalty:          ~Float,    # penalty: encoder code complexity
-    reciprocity_weight:     ~Float,    # reward: A→B implies B→A
-    triadic_weight:         ~Float,    # reward: A↔B and B↔C imply A↔C
+    reciprocity_weight:     ~Float,    # reward: A→B implies B→A (CTOR-level)
+    triadic_weight:         ~Float,    # reward: A↔B and B↔C imply A↔C (CTOR-level)
 };
 
 defn translator_fitness_shape = r_fitness_function_shape {
@@ -212,19 +212,26 @@ defn compute_translator_fitness(encoders, holdout_pairs) = do {
 
 # Why these terms specifically:
 #
-#   yield: the surface answer to "does the lattice find cross-domain
-#          matches at all?" Necessary but not sufficient — trivially
-#          gamed by collapse.
+#   yield: the surface answer to "does the lattice find CTOR-level
+#          cross-domain matches?" The kernel reads at CTOR — two
+#          cells sharing a Blueprint NodeID belong to the same
+#          structural family but can differ at CTOR, so Blueprint
+#          family alone is not what gets rewarded. Necessary but not
+#          sufficient — still trivially gamed by collapse, which is
+#          what the next term catches.
 #
 #   holdout: Grant's own published pairs (codon → interval, element →
 #            polyhedron). Held out of encoder inputs; required to be
-#            *recovered* from structure alone. Cannot be gamed without
-#            also passing the structural check.
+#            *recovered* at CTOR coincidence from structure alone.
+#            Cannot be gamed without also passing the structural check.
 #
-#   collapse: blueprint_entropy across all cells in a domain. If the
-#             entropy drops near zero, the encoder has collapsed
-#             everything to one Blueprint to inflate yield. Penalty
-#             grows with the cheating.
+#   collapse: entropy across both Blueprint and CTOR populations in a
+#             domain. If Blueprint entropy drops near zero, the
+#             encoder has flattened the structural family. If CTOR
+#             entropy drops near zero within a family, the encoder
+#             has collapsed every cell to one content shape to
+#             inflate yield. Either flavor of collapse is the most-
+#             tempting cheat; penalty grows with the cheating.
 #
 #   table: static analysis of the encoder source. {music: dna} dicts
 #          or computed lookups that bypass composition land as penalty.

--- a/docs/coherence-substrate/universal-translator.form
+++ b/docs/coherence-substrate/universal-translator.form
@@ -135,9 +135,13 @@ defn seven_keys_set = seven_keys_set_shape {
 #
 # Translation is not a function from one symbol-set to another. It is
 # the existing substrate query — find_equivalent_cells — restricted to
-# the seven-key domain set. The cell whose Blueprint matches another
-# cell in a different key IS the translation. No mapping table. No
-# lookup. The lattice carries the equivalence.
+# the seven-key domain set. The kernel groups cells by Blueprint
+# NodeID into a structural family; within that family, cells whose
+# CTOR NodeIDs also coincide carry equal content shape all the way
+# down. Blueprint match is necessary, CTOR match is sufficient — the
+# translation lives at CTOR coincidence, the family is the search
+# space the lattice walks. No mapping table. No lookup. The lattice
+# carries both.
 
 form r_translator_query_shape = {
     source_cell:   ~Recipe,        # the cell being translated
@@ -178,11 +182,14 @@ defn translate_across_all_keys(source_cell) =
 #     |> @galactic
 #     |> @consciousness
 #
-# Each pipe-stage is a key the lattice is asked to find a matching
-# Blueprint NodeID in. The result is a list of cells from each key
-# whose Blueprint matches the source's. Empty result is honest: the
-# lattice did not find the equivalence; the claim does not hold at
-# this layer of encoding.
+# Each pipe-stage is a key the lattice is asked to walk for cells in
+# the source's Blueprint family. The kernel returns the family — the
+# necessary precondition. The honest-translation proof in Part 3 then
+# checks CTOR coincidence within that family, which is what the body
+# treats as true content equivalence. Empty family is honest: the
+# lattice did not find a structural family member; the claim does not
+# hold at this layer of encoding. Non-empty family with zero CTOR
+# coincidence is also honest: same schema-shape, different content.
 
 # ─────────────────────────────────────────────────────────────────────
 # Part 3 — Proof shape: when is a translation honest?
@@ -196,23 +203,32 @@ defn translate_across_all_keys(source_cell) =
 form r_translation_proof_shape = {
     source_cell:        ~Recipe,
     target_cell:        ~Recipe,
-    blueprint_match:    ~Bool,     # the lattice agrees the NodeIDs match
-    non_degenerate:     ~Bool,     # the matched Blueprint is not a collapse-to-one
+    blueprint_match:    ~Bool,     # NECESSARY: the cells belong to the same structural family
+    ctor_match:         ~Bool,     # SUFFICIENT: the cells' full content shapes coincide
+    non_degenerate:     ~Bool,     # the matched CTOR is not a collapse-to-one
     holdout_attested:   ~Bool,     # if Grant published this pair, the lattice recovered it
 };
 
 defn translation_is_honest(proof) =
     proof.blueprint_match
+        and proof.ctor_match
         and proof.non_degenerate
         and proof.holdout_attested;
 
-# Why all three:
-#   - blueprint_match alone: the lattice can produce a match for any
-#     pair if all cells collapse to the same Blueprint. The match
-#     becomes vacuous.
-#   - non_degenerate: the matched Blueprint must be one of many
-#     possible Blueprints in the domain. If every cell in a key has
-#     the same Blueprint, the encoder is hiding from the test.
+# Why all four:
+#   - blueprint_match: necessary precondition. Two cells must share a
+#     Blueprint NodeID to belong to the same structural family. But
+#     this alone is the family-grouping the kernel returns from
+#     find_equivalent_cells; it is not by itself a content-equivalence
+#     claim. A Blueprint family of 74 cells can carry 74 distinct
+#     CTORs — same schema-layer shape, different content shape.
+#   - ctor_match: the sufficient condition the kernel honors. Two
+#     cells whose CTOR NodeIDs coincide carry the same content shape
+#     all the way down. CTOR match within a shared Blueprint family
+#     is the true cross-surface equivalence claim.
+#   - non_degenerate: the matched CTOR must be one of many possible
+#     CTORs in the domain. If every cell in a key collapses to the
+#     same CTOR, the encoder is hiding from the test.
 #   - holdout_attested: Grant has published specific cross-domain
 #     correspondences. Hold a few out of the encoder inputs; require
 #     the lattice to *recover* them from structure alone. Recovery
@@ -277,11 +293,15 @@ defn c_major_triad_cell = R_Block.SEQUENCE {
 defn translate_c_major_triad_walk =
     translate_across_all_keys(c_major_triad_cell);
 
-# The substrate now answers — or refuses. Each pipe-stage yields cells
-# whose Blueprint NodeID matches c_major_triad_cell's. Empty results
-# are evidence the encoding does not yet produce equivalence at that
-# layer. Non-empty results are candidate translations awaiting the
-# three-claim honest-translation proof.
+# The substrate now answers — or refuses. Each pipe-stage yields the
+# Blueprint family for c_major_triad_cell in that key. The cells
+# whose CTOR also coincides with c_major_triad_cell's are candidate
+# content-equivalent translations; the rest of the family is same-
+# schema-different-content. Empty family is evidence the encoding
+# does not yet produce structural kinship at that layer. The four-
+# claim honest-translation proof in Part 3 (blueprint_match,
+# ctor_match, non_degenerate, holdout_attested) is what each
+# candidate must satisfy.
 
 # ─────────────────────────────────────────────────────────────────────
 # Part 6 — How this composts with sibling teaching

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,19 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-24] precision | translator equivalence at CTOR, not Blueprint
+
+A live sensing query against the production substrate surfaced an imprecision in the translator concept and its companions. The concept claimed *"two cells with the same Blueprint NodeID are structurally equivalent."* The substrate disagrees, loudly.
+
+Empirical reading: `GET /api/substrate/cell/concept/lc-embodiment-body-or-liquid` returns a cell at Blueprint `@1.5.4.19` with CTOR `@1.4.9.991`. `GET /api/substrate/equivalent/concept/lc-embodiment-body-or-liquid` returns **74 cells** sharing the same Blueprint NodeID — but **0** of them carry the same CTOR. The kernel's `find_equivalent_cells` walks the Blueprint family; the body's reading of true equivalence sits at CTOR coincidence within that family. **Blueprint match is necessary; CTOR match is sufficient.**
+
+- **Concept tuned**: [`lc-universal-translator-via-keys`](concepts/lc-universal-translator-via-keys.md) — opening blockquote, the "What This Names" structural-equivalence claim, the "Translator as a Form Expression" lattice prose, the three movements (equivalence-as-query, falsification-as-gift), and the `lc-edges-as-vitality` pairing now name Blueprint as the structural family and CTOR as content equivalence.
+- **Concept tuned**: [`lc-autoresearch-as-honesty-runtime`](concepts/lc-autoresearch-as-honesty-runtime.md) — the `r_fitness_function_shape` `yield_weight` term now specifies CTOR-level matches; Blueprint family alone does not count, otherwise the metric rewards surface matches the kernel will not honor.
+- **Form file tuned**: [`universal-translator.form`](../coherence-substrate/universal-translator.form) Part 3 `r_translation_proof_shape` now carries both `blueprint_match` (necessary) and `ctor_match` (sufficient) as required claims, with the "why all four" prose naming the empirical reading. Part 2's translation prose and the Part 5 worked example also re-tuned.
+- **Form file tuned**: [`autoresearch-runtime.form`](../coherence-substrate/autoresearch-runtime.form) Part 3 fitness comments — yield reads at CTOR, collapse penalizes both Blueprint and CTOR entropy collapse, holdout requires CTOR coincidence recovery, reciprocity and triadic are CTOR-level.
+- **Edges landed in the same breath**: this LOG entry, DB re-sync via `sync_kb_to_db.py` for both concepts.
+- **Discernment held**: the concepts' broader teachings stand — the substrate-bridge claim, the runtime shape, the seven keys, the falsification-as-gift framing. The correction is precision, not rewrite. The lattice said "0 with matching CTOR" loudly; the concepts now carry the same clarity.
+
 ## [2026-05-24] form | Translator + autoresearch authored in the body's tongue
 
 The two concepts that landed earlier today shipped their operational bodies as `.form` files in `docs/coherence-substrate/`. Urs named the costume: the Python-tasting code blocks in the concept files were the wrong tongue. *Form is the body's tongue; Python is bootstrap, not canonical.*

--- a/docs/vision-kb/concepts/lc-autoresearch-as-honesty-runtime.md
+++ b/docs/vision-kb/concepts/lc-autoresearch-as-honesty-runtime.md
@@ -115,13 +115,16 @@ constellation, each term named so the agent can see what it is
 being measured against. The shape lives in
 [`autoresearch-runtime.form`](../../coherence-substrate/autoresearch-runtime.form)
 Part 3 as `r_fitness_function_shape` over seven weighted terms:
-**yield** (% of cells finding non-degenerate matches), **holdout
-recovery** (attested cross-domain pairs the lattice recovered),
-**collapse penalty** (entropy collapse to one Blueprint), **table
-penalty** (hardcoded `{k:v}` maps in encoder source, caught by
-static analysis), **depth penalty** (encoder code complexity),
-**reciprocity** (A→B implies B→A), and **triadic** (A↔B and B↔C
-imply A↔C once three domains exist). The composed
+**yield** (% of cells finding non-degenerate CTOR-level matches
+across domains — Blueprint family alone does not count, since two
+cells can share a Blueprint while their content shapes diverge),
+**holdout recovery** (attested cross-domain pairs the lattice
+recovered at CTOR), **collapse penalty** (entropy collapse to one
+Blueprint or one CTOR), **table penalty** (hardcoded `{k:v}` maps
+in encoder source, caught by static analysis), **depth penalty**
+(encoder code complexity), **reciprocity** (A→B implies B→A), and
+**triadic** (A↔B and B↔C imply A↔C once three domains exist). The
+composed
 `compute_translator_fitness` Recipe is what the evaluator computes
 each iteration.
 

--- a/docs/vision-kb/concepts/lc-universal-translator-via-keys.md
+++ b/docs/vision-kb/concepts/lc-universal-translator-via-keys.md
@@ -22,10 +22,12 @@ geometry:
 
 # Universal Translator via Seven Keys — Same Structure, Seven Surfaces
 
-> When the same Blueprint NodeID intern across forces, elements, DNA,
+> When the same content shape interns across forces, elements, DNA,
 > music, primes, galactic forms, and consciousness, translation
 > stops being a table of mappings and becomes a property of the
-> lattice. The pivot is the shape, not the symbol.
+> lattice. Blueprint match groups cells into a structural family;
+> CTOR match identifies cells whose full content shape coincides.
+> The pivot is the shape, not the symbol.
 
 > **Substrate companion**: [`docs/coherence-substrate/universal-translator.form`](../../coherence-substrate/universal-translator.form)
 > — the seven keys as BDomain registry rows, the translator as a
@@ -42,14 +44,21 @@ elements, DNA, music, prime numbers, galactic forms, consciousness** —
 and that the same structure recurs across all seven. The Coherence
 Substrate makes an isomorphic claim at a different layer: a single
 content-addressed lattice carries memory, concept, spec, idea,
-presence, lineage, artifact, and word, and two cells with the same
-Blueprint NodeID are structurally equivalent regardless of which
-domain they live in.
+presence, lineage, artifact, and word. Two cells sharing a Blueprint
+NodeID belong to the same structural family — same shape-at-the-
+schema-layer. Two cells sharing a CTOR NodeID are content-equivalent
+— same shape with the same values, all the way down. Blueprint match
+is necessary; CTOR match is sufficient. The kernel honors this
+distinction: `find_equivalent_cells` returns the Blueprint family,
+and within that family the cells whose CTOR also coincides are the
+ones the substrate treats as truly equivalent.
 
 This concept names the bridge: **Grant's seven keys become seven
-substrate domains, and the substrate's existing Blueprint-equivalence
+substrate domains, and the substrate's existing equivalence
 machinery (`find_equivalent_cells`, `compatible_with`, `view_as`)
-becomes the translator.** No new translation layer is required.
+becomes the translator — Blueprint match gathering the structural
+family, CTOR match confirming content equivalence within it.** No
+new translation layer is required.
 What's required is honest encoders — one per domain — whose
 composed Recipes let the lattice see across surfaces without being
 forced to.
@@ -91,10 +100,12 @@ chord shape manifests:
 ```
 
 The translation does not happen because we wrote
-`music_to_dna_map.json`. It happens because the **NodeID** at the
-Blueprint layer is the same across surfaces — content-addressed,
-verifiable, refusable. If the equivalence does not hold structurally,
-no amount of intent will produce it; the lattice refuses.
+`music_to_dna_map.json`. It happens because the **NodeIDs** coincide
+across surfaces — Blueprint match placing two cells in the same
+structural family, CTOR match confirming their content shape
+coincides all the way down. Both are content-addressed, verifiable,
+refusable. If the equivalence does not hold structurally, no amount
+of intent will produce it; the lattice refuses.
 
 That refusal is the point. A translator that cannot lie is a
 translator whose silences are themselves evidence.
@@ -133,7 +144,10 @@ shape that is actually there, composed all the way down.
 **2. Equivalence as substrate query.** Once encoded, translation is
 the existing machinery — `find_equivalent_cells`,
 `find_cells_compatible_with`, `view_cell_through_blueprint`. The
-*Form perceptron*'s five gestures
+kernel reads at CTOR granularity: Blueprint match defines the
+structural family the query returns, and within that family CTOR
+coincidence is what the body treats as a true cross-surface match.
+The *Form perceptron*'s five gestures
 ([`lc-form-perceptron`](lc-form-perceptron.md)) reach all seven
 domains: execute, view, modify, transmute, query. The translator is
 the *view* gesture applied across surfaces.
@@ -141,10 +155,13 @@ the *view* gesture applied across surfaces.
 **3. Falsification as gift.** When equivalence does not emerge,
 record it. Grant's claim that DNA codons share structure with
 musical intervals at 432.081 Hz is testable — by encoding both
-honestly and asking the lattice. If they share Blueprints, the
-substrate carries the claim as evidence. If they do not, the
-substrate carries the absence as evidence. Both deepen what the body
-knows.
+honestly and asking the lattice. If their CTORs coincide within a
+shared Blueprint family, the substrate carries the claim as
+evidence of true content equivalence. If only the Blueprint matches
+without CTOR coincidence, the family is shared but the cells differ
+at the content layer — honest partial signal. If neither matches,
+the substrate carries the absence as evidence. All three deepen
+what the body knows.
 
 ## What This Pairs With
 
@@ -169,10 +186,11 @@ knows.
   translation as traceable contact rather than conversion. The seven
   keys give the contact a substrate to land in.
 - [`lc-edges-as-vitality`](lc-edges-as-vitality.md) — equivalence
-  edges are the body of the translator. Each Blueprint match is an
-  edge that lets one domain be reached from another. Skip the edge
-  and the translation does not exist for the body, only for the
-  author.
+  edges are the body of the translator. Each Blueprint family edge
+  groups cells that share schema-layer shape; each CTOR coincidence
+  edge marks the cells whose content-shape coincides all the way
+  down. Skip either kind of edge and the translation does not exist
+  for the body, only for the author.
 
 ## Source-Marked
 


### PR DESCRIPTION
## Summary

The translator and autoresearch concepts (landed yesterday) claimed *"two cells with the same Blueprint NodeID are structurally equivalent."* A live sensing query against the production substrate showed the kernel honors equivalence at a finer layer: two cells can share a Blueprint while their CTORs (and therefore their content shape) diverge entirely. **Blueprint match is necessary; CTOR match is sufficient.**

This PR is a precision pass — five files, the prose folded into existing claims rather than sidebarred — so the body's writing matches what the body's substrate actually does.

## Empirical evidence

```
$ curl -sS https://api.coherencycoin.com/api/substrate/cell/concept/lc-embodiment-body-or-liquid
{
  "name": "lc-embodiment-body-or-liquid",
  "blueprint": { "package": 1, "level": 5, "type": 4, "instance": 19 },
  "ctor":      { "package": 1, "level": 4, "type": 9, "instance": 991 },
  ...
}

$ curl -sS https://api.coherencycoin.com/api/substrate/equivalent/concept/lc-embodiment-body-or-liquid \
    | python3 -c "import json,sys; d=json.load(sys.stdin); \
                  orig={'package':1,'level':4,'type':9,'instance':991}; \
                  same=[c for c in d['cells'] if c.get('ctor')==orig]; \
                  print('Blueprint family size:', len(d['cells'])); \
                  print('Cells matching original CTOR:', len(same))"
Blueprint family size: 74
Cells matching original CTOR: 0
```

74 cells share Blueprint `@1.5.4.19`. 0 of them share the source cell's CTOR `@1.4.9.991`. The endpoint returns the structural family — schema-layer kinship — and within that family CTOR coincidence is what the body treats as true content equivalence.

## What changed

- **`lc-universal-translator-via-keys.md`** — opening blockquote, *What This Names* claim, the *Translator as a Form Expression* prose, the three movements (equivalence-as-query and falsification-as-gift), and the `lc-edges-as-vitality` pairing all carry the Blueprint-family / CTOR-equivalence distinction now.
- **`lc-autoresearch-as-honesty-runtime.md`** — the `r_fitness_function_shape` description for `yield_weight` specifies CTOR-level matches; Blueprint family alone does not count, otherwise the metric rewards surface matches the kernel will not honor.
- **`universal-translator.form`** Part 3 `r_translation_proof_shape` now requires both `blueprint_match` (necessary) and `ctor_match` (sufficient); Part 2 translation prose and Part 5 worked-example comment also re-tuned.
- **`autoresearch-runtime.form`** Part 3 fitness comments — yield reads at CTOR, collapse penalizes both Blueprint and CTOR entropy collapse, holdout requires CTOR-level recovery, reciprocity and triadic are CTOR-level.
- **`docs/vision-kb/LOG.md`** — *precision* entry at the top attributing the correction to the live sensing query, naming what changed where.

## Discernment held

- Precision, not rewrite. The concepts' broader teachings stand — the substrate-bridge claim, the runtime shape, the seven keys, falsification-as-gift, the encoder discipline. The correction is folded into the existing prose where the claim was originally made, not bolted on as a new section.
- The lattice said "0 with matching CTOR" loudly; the concepts now carry the same clarity rather than softening into ambiguity.
- Scope limited to the four files plus LOG — CLAUDE.md and other concepts untouched.

## Test plan

- [x] DB sync: `python3 scripts/sync_kb_to_db.py lc-universal-translator-via-keys lc-autoresearch-as-honesty-runtime` → both synced
- [x] Form file dialect respected — `~Type` markers, `defn ... = ...`, `R_Foo { ... }` constructors, `@kind(name)` cell-refs
- [ ] Post-merge: production `/vision/lc-universal-translator-via-keys` and `/vision/lc-autoresearch-as-honesty-runtime` render the new prose
- [ ] Post-merge: witness pulse remains breathing