### PR TITLE
tend: ip_registration_service surface (register / get_status / record_derivative)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,11 +34,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 195 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 196 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 114 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 115 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -142,7 +142,7 @@
 | [interest_service.py](interest_service.py) | Interest registration service — privacy-first community gathering. |
 | [inventory_service.py](inventory_service.py) | Unified inventory service for ideas, questions, specs, implementations, and usage. |
 | [investment_service.py](investment_service.py) | Investment service — positions, ROI projection, history. |
-| [ip_registration_service.py](ip_registration_service.py) | IP registration service — Story Protocol SDK integration (pending). |
+| [ip_registration_service.py](ip_registration_service.py) | IP registration service — Story Protocol queue surface (first iteration). |
 | [lens_translation_service.py](lens_translation_service.py) | Idea lens translations — spec-181 style responses, cache, and ROI counters. |
 | [locale_projection.py](locale_projection.py) | Shared locale projection for API responses. |
 | [localized_errors.py](localized_errors.py) | Localized API error messages. |

--- a/api/app/services/ip_registration_service.py
+++ b/api/app/services/ip_registration_service.py
@@ -1,103 +1,173 @@
-"""IP registration service — Story Protocol SDK integration (pending).
+"""IP registration service — Story Protocol queue surface (first iteration).
 
-Per specs/story-protocol-integration.md R1. The spec describes async
-registration of an asset as an IP Asset on Story Protocol, returning
-an IP Asset ID stored on the asset's graph node.
+Per specs/story-protocol-integration.md R1 and R7. The spec describes
+async registration of an asset as an IP Asset on Story Protocol,
+returning an IP Asset ID stored on the asset's graph node, and a
+derivative-work royalty record using the 15/85 default split.
 
-**Not yet wired.** The real implementation requires the Story Protocol
-SDK and a partner-selection gate:
-  - Which chain? Story Protocol's own L2 on Base? Sepolia for testing?
-  - Which signer? Platform-owned hot wallet or per-contributor wallet?
-  - Which royalty module config? Default split vs configurable?
+**Mock SDK, real interface.** This iteration holds registration and
+derivative state in module-level dicts and synthesizes a deterministic
+`sp_ip_id` of the shape `sp:mock:<asset_id_prefix>`. The function
+signatures are the contract callers will use against the real Story
+Protocol SDK once partner selection (chain + signer + royalty module)
+lands; only the body that mints `sp_ip_id` and the synchronous return
+will change. Persistence is a follow-up breath — when the IPRegistration
+PostgreSQL table arrives (see spec Data Model), the dicts move to rows
+behind the same surface.
 
-Until those decisions land, this module provides the function
-signatures the rest of the system can import and call. Functions
-raise `IpRegistrationPending` with a clear message so callers can
-either check `is_ready()` first or catch the exception and fall
-back to marking the asset's `ip_status` as `pending`.
+The three named functions the spec's `source:` block claims for this
+file:
 
-Once partner selection completes:
-  - Replace `IpRegistrationPending` raises with real SDK calls
-  - Implement `register_ip_asset()` to call `sp.register_ip(...)`
-  - Implement `get_ip_status()` to query the chain
-  - Implement `record_derivative()` to wire the royalty module
+  - `register_ip_asset(asset_id, metadata) -> dict`
+  - `get_ip_status(asset_id) -> dict`
+  - `record_derivative(parent_asset_id, derivative_asset_id, derivative_type) -> dict`
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
 
-class IpRegistrationPending(Exception):
-    """Raised when IP registration is invoked before Story Protocol
-    SDK integration lands."""
+# Module-level state — first iteration. Replaced by graph_service +
+# PostgreSQL persistence once the IPRegistration table lands.
+_registrations: Dict[str, Dict[str, Any]] = {}
+_derivatives: Dict[str, Dict[str, Any]] = {}
 
 
-@dataclass(frozen=True)
-class IpRegistrationResult:
-    """Shape the real implementation will return."""
-
-    sp_ip_id: str
-    tx_hash: str
-    royalty_module_address: Optional[str]
-    registered_at: str  # ISO 8601
+# Royalty split defaults from spec R7.
+DEFAULT_ROYALTY_SPLIT = {"parent": 0.15, "derivative": 0.85}
 
 
-def is_ready() -> bool:
-    """Return True once the Story Protocol SDK is wired and a signer
-    is configured. Returns False for the current partner-gated state.
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mint_sp_ip_id(asset_id: str) -> str:
+    """Deterministic mock IP Asset ID. The real SDK returns an
+    on-chain hex address; this prefix marks the value as a stub so
+    nothing accidentally pushes it to a real chain."""
+    prefix = asset_id[:8] if len(asset_id) >= 8 else asset_id
+    return f"sp:mock:{prefix}"
+
+
+def _validate_metadata(metadata: Any) -> Optional[str]:
+    """Return None if metadata is acceptable, otherwise a reason string.
+
+    Acceptable metadata is a dict (possibly empty). Non-dict values,
+    or a dict carrying a sentinel `_force_failure` key, transition the
+    registration to `failed`. The sentinel exists for the test that
+    proves the failure path without needing a real SDK error."""
+    if metadata is None:
+        return None
+    if not isinstance(metadata, dict):
+        return f"metadata must be a dict, got {type(metadata).__name__}"
+    if metadata.get("_force_failure"):
+        reason = metadata.get("_force_failure_reason", "forced failure")
+        return str(reason)
+    return None
+
+
+def register_ip_asset(asset_id: str, metadata: Optional[dict] = None) -> dict:
+    """Queue (and, in this iteration, immediately complete) an IP Asset
+    registration with Story Protocol.
+
+    Returns a dict with `asset_id`, `sp_ip_id`, `ip_status`, and
+    `registered_at`. On malformed metadata the status is `failed` and
+    the dict carries a `reason` field; `sp_ip_id` is None in that case.
+
+    Idempotent: registering the same `asset_id` twice returns the
+    existing record. To re-register, callers must clear state via
+    `_reset_for_tests()` (production will offer an explicit retry path).
     """
-    return False
+    if not asset_id:
+        raise ValueError("asset_id is required")
+
+    existing = _registrations.get(asset_id)
+    if existing is not None:
+        return dict(existing)
+
+    failure_reason = _validate_metadata(metadata)
+    now = _now_iso()
+    if failure_reason is not None:
+        record = {
+            "asset_id": asset_id,
+            "sp_ip_id": None,
+            "ip_status": "failed",
+            "reason": failure_reason,
+            "registered_at": None,
+            "queued_at": now,
+            "metadata": metadata if isinstance(metadata, dict) else {},
+        }
+    else:
+        record = {
+            "asset_id": asset_id,
+            "sp_ip_id": _mint_sp_ip_id(asset_id),
+            "ip_status": "registered",
+            "registered_at": now,
+            "queued_at": now,
+            "metadata": metadata or {},
+        }
+    _registrations[asset_id] = record
+    return dict(record)
 
 
-def register_ip_asset(
-    asset_id: str,
-    creator_id: str,
-    *,
-    content_hash: str,
-    metadata: Optional[dict] = None,
-) -> IpRegistrationResult:
-    """Register an asset as an IP Asset on Story Protocol.
+def get_ip_status(asset_id: str) -> dict:
+    """Return the current IP registration record for `asset_id`.
 
-    Returns an IpRegistrationResult with the on-chain IP Asset ID,
-    transaction hash, and royalty module address. The caller stores
-    `sp_ip_id` on the asset's graph node under property `sp_ip_id`
-    and flips `ip_status` from `pending` to `registered`.
+    For unknown assets returns `{"asset_id": asset_id,
+    "ip_status": "not_registered"}` so callers can treat absence as a
+    first-class state rather than handling a None.
     """
-    raise IpRegistrationPending(
-        "Story Protocol SDK integration is pending partner selection. "
-        "See specs/story-protocol-integration.md R1 for the contract."
-    )
-
-
-def get_ip_status(sp_ip_id: str) -> dict:
-    """Query the on-chain status of a registered IP Asset.
-
-    Returns a dict with fields the settlement service reads to confirm
-    the asset's IP Asset is confirmed and accruing royalties.
-    """
-    raise IpRegistrationPending(
-        "Story Protocol SDK integration is pending partner selection."
-    )
+    record = _registrations.get(asset_id)
+    if record is None:
+        return {"asset_id": asset_id, "ip_status": "not_registered"}
+    return dict(record)
 
 
 def record_derivative(
-    child_asset_id: str,
-    parent_sp_ip_id: str,
+    parent_asset_id: str,
+    derivative_asset_id: str,
+    derivative_type: str,
     *,
-    royalty_split_parent: float = 0.15,
-    royalty_split_child: float = 0.85,
-) -> IpRegistrationResult:
-    """Register a derivative work with the royalty module.
+    royalty_split: Optional[Dict[str, float]] = None,
+) -> dict:
+    """Record a derivative-work relationship with the parent IP Asset.
 
-    Configures the parent/child royalty split so future CC flows
-    attribute proportionally. Default 15%/85% per spec R7.
+    Stores the parent → derivative edge with a royalty split. Default
+    is `{"parent": 0.15, "derivative": 0.85}` per spec R7; callers
+    pass `royalty_split={"parent": X, "derivative": Y}` to override.
+    The split must sum to 1.0 within a small tolerance.
+
+    Returns the recorded relationship as a dict.
     """
-    if abs(royalty_split_parent + royalty_split_child - 1.0) > 0.001:
-        raise ValueError(
-            "royalty_split_parent + royalty_split_child must sum to 1.0"
-        )
-    raise IpRegistrationPending(
-        "Story Protocol royalty module integration is pending partner selection."
-    )
+    if not parent_asset_id or not derivative_asset_id:
+        raise ValueError("parent_asset_id and derivative_asset_id are required")
+    if parent_asset_id == derivative_asset_id:
+        raise ValueError("a derivative cannot be its own parent")
+    if not derivative_type:
+        raise ValueError("derivative_type is required")
+
+    split = dict(royalty_split) if royalty_split else dict(DEFAULT_ROYALTY_SPLIT)
+    if set(split.keys()) != {"parent", "derivative"}:
+        raise ValueError("royalty_split must have keys 'parent' and 'derivative'")
+    total = split["parent"] + split["derivative"]
+    if abs(total - 1.0) > 0.001:
+        raise ValueError(f"royalty_split must sum to 1.0, got {total}")
+
+    record = {
+        "parent_asset_id": parent_asset_id,
+        "derivative_asset_id": derivative_asset_id,
+        "derivative_type": derivative_type,
+        "royalty_split": split,
+        "recorded_at": _now_iso(),
+    }
+    _derivatives[derivative_asset_id] = record
+    return dict(record)
+
+
+def _reset_for_tests() -> None:
+    """Clear module-level state. Call from a pytest fixture so each
+    test starts on fresh ground."""
+    _registrations.clear()
+    _derivatives.clear()

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 195
+**Total files**: 196
 
 | File | Purpose |
 |---|---|
@@ -104,6 +104,7 @@
 | [test_inspired_by.py](test_inspired_by.py) | Flow-centric tests for the inspired-by resolver and /api/inspired-by. |
 | [test_interest_registration.py](test_interest_registration.py) | Flow-centric tests for interest registration — privacy-first community gathering. |
 | [test_investments.py](test_investments.py) | Flow-centric tests for the investment surface — covers preview, portfolio, |
+| [test_ip_registration.py](test_ip_registration.py) | Flow tests for ip_registration_service — story-protocol-integration R1, R7. |
 | [test_kernel_conformance_harness.py](test_kernel_conformance_harness.py) | Executable kernel conformance harness for Form question effects. |
 | [test_knowledge_resonance.py](test_knowledge_resonance.py) | Acceptance tests for spec: knowledge-resonance-engine (idea: knowledge-and-resonance). |
 | [test_lens_translation_boundaries.py](test_lens_translation_boundaries.py) | _no top-of-file purpose_ |

--- a/api/tests/test_ip_registration.py
+++ b/api/tests/test_ip_registration.py
@@ -1,0 +1,105 @@
+"""Flow tests for ip_registration_service — story-protocol-integration R1, R7.
+
+Exercises the three named functions the spec's `source:` block claims:
+register_ip_asset, get_ip_status, record_derivative. The service holds
+state in module-level dicts in this iteration; each test starts fresh
+via the autouse reset fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import ip_registration_service
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    ip_registration_service._reset_for_tests()
+    yield
+    ip_registration_service._reset_for_tests()
+
+
+def test_register_ip_asset_returns_sp_ip_id():
+    result = ip_registration_service.register_ip_asset(
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890", {"type": "BLUEPRINT"}
+    )
+    assert result["ip_status"] == "registered"
+    assert result["sp_ip_id"] == "sp:mock:a1b2c3d4"
+    assert result["registered_at"] is not None
+    assert result["asset_id"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+def test_register_ip_asset_failure_with_malformed_metadata():
+    result = ip_registration_service.register_ip_asset(
+        "asset-xyz", "not-a-dict"  # type: ignore[arg-type]
+    )
+    assert result["ip_status"] == "failed"
+    assert result["sp_ip_id"] is None
+    assert "dict" in result["reason"]
+
+
+def test_register_ip_asset_failure_via_force_sentinel():
+    result = ip_registration_service.register_ip_asset(
+        "asset-zzz", {"_force_failure": True, "_force_failure_reason": "SDK timeout"}
+    )
+    assert result["ip_status"] == "failed"
+    assert result["reason"] == "SDK timeout"
+
+
+def test_get_ip_status_unregistered():
+    status = ip_registration_service.get_ip_status("never-seen")
+    assert status == {"asset_id": "never-seen", "ip_status": "not_registered"}
+
+
+def test_get_ip_status_after_registration():
+    ip_registration_service.register_ip_asset("asset-001", {"type": "ARTICLE"})
+    status = ip_registration_service.get_ip_status("asset-001")
+    assert status["ip_status"] == "registered"
+    assert status["sp_ip_id"] == "sp:mock:asset-00"
+
+
+def test_record_derivative_default_royalty_split():
+    result = ip_registration_service.record_derivative(
+        "parent-asset", "child-asset", "improvement"
+    )
+    assert result["royalty_split"] == {"parent": 0.15, "derivative": 0.85}
+    assert result["derivative_type"] == "improvement"
+    assert result["parent_asset_id"] == "parent-asset"
+    assert result["derivative_asset_id"] == "child-asset"
+
+
+def test_record_derivative_custom_royalty_split():
+    result = ip_registration_service.record_derivative(
+        "parent-asset",
+        "child-asset",
+        "translation",
+        royalty_split={"parent": 0.30, "derivative": 0.70},
+    )
+    assert result["royalty_split"] == {"parent": 0.30, "derivative": 0.70}
+
+
+def test_record_derivative_rejects_self_parent():
+    with pytest.raises(ValueError, match="own parent"):
+        ip_registration_service.record_derivative("same", "same", "remix")
+
+
+def test_record_derivative_rejects_unbalanced_split():
+    with pytest.raises(ValueError, match="sum to 1.0"):
+        ip_registration_service.record_derivative(
+            "p", "d", "extension", royalty_split={"parent": 0.5, "derivative": 0.4}
+        )
+
+
+def test_register_is_idempotent():
+    first = ip_registration_service.register_ip_asset("asset-idem", {"v": 1})
+    second = ip_registration_service.register_ip_asset("asset-idem", {"v": 2})
+    assert first["sp_ip_id"] == second["sp_ip_id"]
+    assert first["registered_at"] == second["registered_at"]
+    # Re-registration returns the existing record; second metadata is ignored.
+    assert second["metadata"] == {"v": 1}
+
+
+def test_register_rejects_empty_asset_id():
+    with pytest.raises(ValueError, match="asset_id"):
+        ip_registration_service.register_ip_asset("", {})

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 114
+**Total files**: 115
 
 | File | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary

First concrete service for `story-protocol-integration` pending work. Lands `register_ip_asset`, `get_ip_status`, `record_derivative` in `api/app/services/ip_registration_service.py` — the three named symbols the spec's `source:` block claims for R1 (async IP registration queue) and R7 (derivative royalty split).

This iteration holds state in module-level dicts and mints deterministic mock `sp_ip_id` of shape `sp:mock:<asset_id_prefix>`. The function signatures are the contract callers will use against the real Story Protocol SDK once partner selection (chain + signer + royalty module) lands; only the body that mints the id and the synchronous return change. Persistence (PostgreSQL `IPRegistration` table) is a follow-up breath.

## Symbols closed

Closes 3 of 17 pending target symbols in `specs/story-protocol-integration.md`:

- `api/app/services/ip_registration_service.py::register_ip_asset`
- `api/app/services/ip_registration_service.py::get_ip_status`
- `api/app/services/ip_registration_service.py::record_derivative`

Remaining 14 pending symbols span `permanent_storage_service`, `read_tracking_service`, `evidence_service` (router half), web surfaces, and router wiring — each gated on its own partner integration or live behind separate task.

## Test plan

- [x] `cd api && pytest tests/test_ip_registration.py -v` — 11 passed
- [x] `cd api && pytest tests/test_story_protocol.py -q` — 24 passed (sibling pure-logic tests still green)

## Test coverage

- Register returns `sp_ip_id` with `ip_status=registered`
- Malformed metadata → `failed` with `reason`
- Forced-failure sentinel → `failed` with custom reason
- `get_ip_status` of unknown asset → `not_registered`
- `get_ip_status` after registration → matches stored record
- Default derivative split is 15/85 per R7
- Custom royalty split respected
- Self-parent derivative rejected
- Unbalanced split rejected
- `register` is idempotent (same asset_id returns existing record)
- Empty `asset_id` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)