### PR TITLE
tend: verify_evidence + compute_evidence_bonus + list_evidence (R9)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 116 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 117 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/routers/evidence.py
+++ b/api/app/routers/evidence.py
@@ -2,19 +2,22 @@
 
 Endpoints:
   POST /api/evidence                          - Submit evidence for an asset
+  GET  /api/evidence?asset_id=...             - List submissions, optionally per asset
   POST /api/evidence/{evidence_id}/verify     - Run 2-of-3 factor verification
   GET  /api/evidence/{evidence_id}            - Fetch one submission
-  GET  /api/evidence/asset/{asset_id}         - List submissions + verifications
+  GET  /api/evidence/asset/{asset_id}         - Per-asset composite view (submissions + verifications + applicable multiplier)
 
-See specs/story-protocol-integration.md (R9).
+See specs/story-protocol-integration.md (R9). The two handler names
+the spec source: map claims for this file are `submit_evidence` and
+`list_evidence`; both are defined below as the public router surface.
 """
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.models.evidence import (
@@ -47,6 +50,23 @@ async def submit_evidence(body: EvidenceCreate) -> ImplementationEvidence:
     return evidence_service.submit_evidence(body)
 
 
+@router.get(
+    "",
+    response_model=List[ImplementationEvidence],
+    summary="List evidence submissions, optionally filtered by asset",
+)
+async def list_evidence(
+    asset_id: Optional[str] = Query(
+        default=None,
+        description="If set, restrict results to evidence for this asset.",
+    ),
+) -> List[ImplementationEvidence]:
+    """Return every evidence submission, or — with ``asset_id`` set —
+    just those for the named asset. Per spec R9 source: map.
+    """
+    return evidence_service.list_evidence(asset_id)
+
+
 @router.post(
     "/{evidence_id}/verify",
     response_model=EvidenceVerification,
@@ -57,7 +77,7 @@ async def verify_evidence(evidence_id: UUID) -> EvidenceVerification:
     Verified evidence applies a 5× CC multiplier via the
     applicable_multiplier_for_asset() lookup used by settlement.
     """
-    result = evidence_service.run_verification(evidence_id)
+    result = evidence_service.verify_evidence(evidence_id)
     if result is None:
         raise HTTPException(
             status_code=404,
@@ -93,7 +113,7 @@ async def list_for_asset(asset_id: str) -> EvidenceAssetView:
     multiplier = evidence_service.applicable_multiplier_for_asset(asset_id)
     return EvidenceAssetView(
         asset_id=asset_id,
-        submissions=evidence_service.list_evidence_for_asset(asset_id),
+        submissions=evidence_service.list_evidence(asset_id),
         verifications=evidence_service.list_verifications_for_asset(asset_id),
         cc_multiplier_applicable=str(multiplier),
     )

--- a/api/app/services/evidence_service.py
+++ b/api/app/services/evidence_service.py
@@ -55,11 +55,13 @@ def submit_evidence(body: EvidenceCreate) -> ImplementationEvidence:
     return evidence
 
 
-def run_verification(evidence_id: UUID) -> Optional[EvidenceVerification]:
+def verify_evidence(evidence_id: UUID) -> Optional[EvidenceVerification]:
     """Run 2-of-3 factor verification on a stored evidence record.
 
     Returns None if the evidence_id is not found. Otherwise stores
-    and returns the verification result.
+    and returns the verification result. Verified evidence carries
+    the 5× CC multiplier per spec R9; unverified evidence stays at
+    multiplier 1×.
     """
     record = _find(evidence_id)
     if record is None:
@@ -85,6 +87,29 @@ def run_verification(evidence_id: UUID) -> Optional[EvidenceVerification]:
     return result
 
 
+# Compatibility alias — older callers used this name. New code should
+# import verify_evidence directly per spec R9 source: map.
+run_verification = verify_evidence
+
+
+def compute_evidence_bonus(evidence_id: UUID) -> Decimal:
+    """Return the CC multiplier earned by a single piece of verified
+    evidence: ``Decimal("5")`` when the 2-of-3 factor rule passes,
+    ``Decimal("1")`` otherwise.
+
+    Per spec R9: verified implementation evidence triggers a 5× CC
+    multiplier on the asset's next settlement period. Settlement uses
+    :func:`applicable_multiplier_for_asset` to fold per-evidence
+    bonuses into the per-asset multiplier; this function exposes the
+    single-evidence value so callers can audit the contribution of
+    each submission independently.
+    """
+    verification = _VERIFICATIONS.get(evidence_id)
+    if verification is None or not verification.verified:
+        return Decimal("1")
+    return Decimal(verification.cc_multiplier_applicable)
+
+
 def get_evidence(evidence_id: UUID) -> Optional[ImplementationEvidence]:
     return _find(evidence_id)
 
@@ -93,8 +118,22 @@ def get_verification(evidence_id: UUID) -> Optional[EvidenceVerification]:
     return _VERIFICATIONS.get(evidence_id)
 
 
+def list_evidence(asset_id: Optional[str] = None) -> List[ImplementationEvidence]:
+    """Return evidence records, optionally filtered by asset.
+
+    With ``asset_id`` set, returns only submissions for that asset.
+    Without filter, returns every submission across every asset in
+    submission order per asset. Per spec R9 source: map.
+    """
+    if asset_id is not None:
+        return list(_EVIDENCE.get(asset_id, []))
+    return [record for records in _EVIDENCE.values() for record in records]
+
+
+# Compatibility alias — keep the older name working for callers that
+# already import it. New code should call list_evidence() directly.
 def list_evidence_for_asset(asset_id: str) -> List[ImplementationEvidence]:
-    return list(_EVIDENCE.get(asset_id, []))
+    return list_evidence(asset_id)
 
 
 def list_verifications_for_asset(asset_id: str) -> List[EvidenceVerification]:

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 116
+**Total files**: 117
 
 | File | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary
- Names the evidence service's verification entry to `verify_evidence` (with `run_verification` kept as compatibility alias) — what the `story-protocol-integration` spec source: map claims.
- Adds `compute_evidence_bonus(evidence_id) -> Decimal` returning 5× for verified evidence, 1× otherwise (spec R9).
- Adds `list_evidence(asset_id=None)` service surface and the matching `list_evidence` router handler at `GET /api/evidence?asset_id=...`.
- Four target symbols move pending → shipped: `submit_evidence` (already present), `verify_evidence`, `compute_evidence_bonus`, `list_evidence`.

## Test plan
- [x] `cd api && python -m pytest tests/test_evidence_flow.py -v` — 11 passed
- [x] `cd api && python -m pytest tests/test_story_protocol.py tests/test_settlement_flow.py tests/test_evidence_flow.py -q` — 48 passed
- [x] `python3 scripts/generate_repo_indexes.py` — INDEX/MANIFEST refreshed

Auto-merge on green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>