### PR TITLE
tend: permanent_storage_service — Arweave + IPFS + integrity (R3, R10)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 196 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 197 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/models/asset.py
+++ b/api/app/models/asset.py
@@ -124,3 +124,39 @@ class AssetRegistration(AssetRegistrationCreate):
 
     id: str = Field(description="asset:<uuid> identifier")
     created_at: datetime
+
+
+class AssetIPRegistration(BaseModel):
+    """The IP-registration record stored on an asset's graph node after
+    Story Protocol registration completes. See
+    specs/story-protocol-integration.md R1.
+
+    ``sp_ip_id`` is the on-chain IP Asset ID. ``ip_status`` is one of
+    ``pending`` | ``registered`` | ``failed``; failed registrations
+    leave the asset usable per R1's escape hatch.
+    """
+
+    asset_id: str
+    sp_ip_id: Optional[str] = None
+    ip_status: str = "pending"
+    registered_at: Optional[datetime] = None
+    reason: Optional[str] = None
+
+
+class StorageRecord(BaseModel):
+    """The permanent-storage record stored on an asset's graph node
+    after Arweave + IPFS upload completes. See
+    specs/story-protocol-integration.md R3 and R10.
+
+    ``content_hash`` is a SHA-256 hex digest of the raw bytes. The
+    Arweave and IPFS identifiers are content-addressed: same bytes
+    always produce the same id, which is what makes R10 integrity
+    verification tractable without re-hashing on every read.
+    """
+
+    asset_id: str
+    content_hash: str
+    arweave_tx_id: Optional[str] = None
+    ipfs_cid: Optional[str] = None
+    size_bytes: int = 0
+    uploaded_at: Optional[datetime] = None

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -167,7 +167,7 @@
 | [organism_influence_cc_service.py](organism_influence_cc_service.py) | Computed CC sensing for organism-scale influences. |
 | [page_lineage_service.py](page_lineage_service.py) | Public mapping of human web pages to idea ids (for ontology traversal). |
 | [peer_resonance_service.py](peer_resonance_service.py) | Peer resonance scoring shared by discovery and peer routes. |
-| [permanent_storage_service.py](permanent_storage_service.py) | Permanent storage service — Arweave + IPFS bundler integration (pending). |
+| [permanent_storage_service.py](permanent_storage_service.py) | Permanent storage service — Arweave + IPFS upload + integrity check (R3, R10). |
 | [persistence_contract_service.py](persistence_contract_service.py) | Global persistence contract checks for core domain data. |
 | [personal_feed_service.py](personal_feed_service.py) | Personal feed — the contributor's own corner of the organism. |
 | [pipeline_advance_service.py](pipeline_advance_service.py) | Pipeline auto-advance + auto-retry + smart escalation. |

--- a/api/app/services/permanent_storage_service.py
+++ b/api/app/services/permanent_storage_service.py
@@ -1,129 +1,274 @@
-"""Permanent storage service — Arweave + IPFS bundler integration (pending).
+"""Permanent storage service — Arweave + IPFS upload + integrity check (R3, R10).
 
-Per specs/story-protocol-integration.md R3. The spec describes
-permanent upload of asset content to Arweave via a bundler (Irys/
-Bundlr) and content-addressed retrieval via IPFS. The resulting
-`arweave_tx_id` and `ipfs_cid` are stored on the asset's graph node.
+Per specs/story-protocol-integration.md R3 and R10. The spec describes
+asynchronous upload of asset content to Arweave (via an Irys/Bundlr
+bundler) and to IPFS, recording the Arweave transaction id, the IPFS
+content identifier, and a SHA-256 content hash on the asset graph
+node. R10 returns the recomputed hash so callers can detect tamper.
 
-**Not yet wired.** The real implementation requires bundler service
-selection and a platform-owned funding wallet:
-  - Which bundler? Irys (formerly Bundlr) vs direct Arweave node
-  - Which IPFS gateway? Pinata / Web3.Storage / self-hosted
-  - Funding model? Platform pays bundler in AR / USDC per upload?
-  - Max file size? 50MB proposed in spec; larger needs chunked upload
+**Mock bundler, real interface.** This iteration holds upload state
+in module-level dicts and synthesizes deterministic content-addressed
+ids of the shape:
 
-Until those decisions land, this module provides the function
-signatures so the rest of the system can import and call. Functions
-raise `PermanentStoragePending` with a clear message so callers
-can mark the asset's storage refs as `pending` and retry once
-the service is live.
+  - ``arweave_tx_id = "ar:mock:" + sha256(content)[:16]``
+  - ``ipfs_cid = "Qm" + sha256(content)[:44]``  (CIDv0-shaped)
 
-Content integrity verification (`verify_content_integrity`) already
-exists in `story_protocol_bridge.verify_content_integrity()` and
-does NOT depend on the storage service — it can be called today
-against any already-stored `arweave_tx_id` or local content hash.
+The function signatures are the contract callers will use against the
+real Irys bundler and a real IPFS HTTP API (or a managed pinning
+service like Pinata / web3.storage) once partner selection lands;
+only the body that performs the network upload and the synchronous
+return will change. Persistence is a follow-up breath — when the
+StorageRecord PostgreSQL table arrives (see spec Data Model), the
+dicts move to rows behind the same surface.
+
+The three named functions the spec's `source:` block claims for this
+file:
+
+  - ``upload_to_arweave(content, metadata) -> dict``
+  - ``upload_to_ipfs(content) -> dict``
+  - ``verify_content_integrity(asset_id, expected_hash) -> dict``
+
+In the mock, ``verify_content_integrity`` recomputes the SHA-256 from
+the bytes held in-process for the asset. In production it would re-
+fetch the bytes from the Arweave gateway and the IPFS gateway and
+compare both recomputed hashes against the stored expected hash, so
+tamper at either surface is detectable independently.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
 
-class PermanentStoragePending(Exception):
-    """Raised when a permanent storage upload is invoked before the
-    bundler/IPFS integration lands."""
+# Module-level state — first iteration. Replaced by graph_service +
+# PostgreSQL persistence once the StorageRecord table lands.
+_arweave_uploads: Dict[str, Dict[str, Any]] = {}
+_ipfs_uploads: Dict[str, Dict[str, Any]] = {}
+_asset_storage: Dict[str, Dict[str, Any]] = {}
 
 
-@dataclass(frozen=True)
-class PermanentStorageResult:
-    """Shape the real implementation will return."""
-
-    arweave_tx_id: Optional[str]
-    ipfs_cid: Optional[str]
-    content_hash: str  # sha256:<hex>
-    uploaded_at: str   # ISO 8601
-    size_bytes: int
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
-def is_ready() -> bool:
-    """Return True once the Arweave bundler client and IPFS gateway
-    are configured. Returns False for the current partner-gated state.
-    """
-    return False
+def _sha256_hex(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _mint_arweave_tx_id(content_hash: str) -> str:
+    """Deterministic content-addressed mock Arweave transaction id.
+    Same content → same id (Arweave/Irys is itself content-addressed,
+    so a real bundler also returns the same id for re-upload of
+    identical bytes)."""
+    return f"ar:mock:{content_hash[:16]}"
+
+
+def _mint_ipfs_cid(content_hash: str) -> str:
+    """Deterministic CIDv0-shaped mock IPFS content id. Real IPFS
+    returns a base58-encoded multihash; this prefix marks the value as
+    a stub so nothing accidentally publishes it to a real gateway."""
+    return f"Qm{content_hash[:44]}"
 
 
 def upload_to_arweave(
     content: bytes,
+    metadata: Optional[dict] = None,
     *,
-    mime_type: str,
-    tags: Optional[dict] = None,
-) -> str:
-    """Upload raw content to Arweave via the configured bundler.
+    asset_id: Optional[str] = None,
+) -> dict:
+    """Upload bytes to Arweave via a (mocked) Irys bundler.
 
-    Returns the Arweave transaction ID on success. The caller is
-    responsible for computing the SHA-256 hash and storing it on
-    the asset node alongside the returned tx_id.
+    Returns ``{arweave_tx_id, content_hash, size_bytes, uploaded_at,
+    metadata}``. Content-addressed: same bytes always produce the same
+    ``arweave_tx_id``, matching the real bundler's behavior.
+
+    ``asset_id`` is optional — when provided, the upload is keyed by
+    asset so ``verify_content_integrity`` can later re-fetch the bytes
+    by asset id. Without it the upload is still recorded under its
+    content hash so de-duplication works.
     """
-    raise PermanentStoragePending(
-        "Arweave bundler integration is pending partner selection. "
-        "See specs/story-protocol-integration.md R3 for the contract."
-    )
+    if content is None:
+        raise ValueError("content is required")
+    if not isinstance(content, (bytes, bytearray)):
+        raise ValueError(
+            f"content must be bytes, got {type(content).__name__}"
+        )
+
+    raw = bytes(content)
+    content_hash = _sha256_hex(raw)
+    arweave_tx_id = _mint_arweave_tx_id(content_hash)
+    record = {
+        "arweave_tx_id": arweave_tx_id,
+        "content_hash": content_hash,
+        "size_bytes": len(raw),
+        "uploaded_at": _now_iso(),
+        "metadata": dict(metadata) if isinstance(metadata, dict) else {},
+    }
+    _arweave_uploads[arweave_tx_id] = {**record, "content": raw}
+    if asset_id:
+        _link_asset(
+            asset_id,
+            arweave_tx_id=arweave_tx_id,
+            content_hash=content_hash,
+            content=raw,
+        )
+    return dict(record)
 
 
 def upload_to_ipfs(
     content: bytes,
     *,
-    mime_type: str,
-) -> str:
-    """Upload content to IPFS via the configured gateway.
+    asset_id: Optional[str] = None,
+) -> dict:
+    """Upload bytes to IPFS via a (mocked) HTTP API / pinning service.
 
-    Returns the content identifier (CID) on success.
+    Returns ``{ipfs_cid, content_hash, size_bytes, uploaded_at}``.
+    Content-addressed: same bytes always produce the same ``ipfs_cid``,
+    matching the real IPFS behavior.
+
+    ``asset_id`` is optional — when provided, the upload is keyed by
+    asset so ``verify_content_integrity`` can later re-fetch the bytes
+    by asset id. Without it the upload is still recorded under its
+    CID so de-duplication works.
     """
-    raise PermanentStoragePending(
-        "IPFS gateway integration is pending partner selection."
-    )
+    if content is None:
+        raise ValueError("content is required")
+    if not isinstance(content, (bytes, bytearray)):
+        raise ValueError(
+            f"content must be bytes, got {type(content).__name__}"
+        )
+
+    raw = bytes(content)
+    content_hash = _sha256_hex(raw)
+    ipfs_cid = _mint_ipfs_cid(content_hash)
+    record = {
+        "ipfs_cid": ipfs_cid,
+        "content_hash": content_hash,
+        "size_bytes": len(raw),
+        "uploaded_at": _now_iso(),
+    }
+    _ipfs_uploads[ipfs_cid] = {**record, "content": raw}
+    if asset_id:
+        _link_asset(
+            asset_id,
+            ipfs_cid=ipfs_cid,
+            content_hash=content_hash,
+            content=raw,
+        )
+    return dict(record)
 
 
-def upload(
-    content: bytes,
+def verify_content_integrity(asset_id: str, expected_hash: str) -> dict:
+    """Compare a stored content hash against a freshly recomputed one.
+
+    Returns ``{asset_id, integrity, arweave_hash, ipfs_hash,
+    expected_hash, arweave_tx_id, ipfs_cid, checked_at}``.
+
+    - ``integrity`` is ``"passed"`` when every surface that returned a
+      hash matches ``expected_hash`` (and at least one surface
+      returned a hash); ``"failed"`` otherwise (including when the
+      asset is unknown to this service).
+    - In this mock, the recomputed hashes come from the bytes held
+      in-process. In production, they come from re-fetching the bytes
+      from the Arweave gateway and the IPFS gateway respectively, so
+      tamper at either surface is detectable independently.
+
+    The dict surfaces both recomputed hashes so the caller can tell
+    *which* surface failed, not just that something did.
+    """
+    if not asset_id:
+        raise ValueError("asset_id is required")
+    if not expected_hash:
+        raise ValueError("expected_hash is required")
+
+    record = _asset_storage.get(asset_id)
+    if record is None:
+        return {
+            "asset_id": asset_id,
+            "integrity": "failed",
+            "reason": "no_storage_record",
+            "expected_hash": expected_hash,
+            "arweave_hash": None,
+            "ipfs_hash": None,
+            "arweave_tx_id": None,
+            "ipfs_cid": None,
+            "checked_at": _now_iso(),
+        }
+
+    arweave_content = record.get("arweave_content")
+    ipfs_content = record.get("ipfs_content")
+    arweave_hash = _sha256_hex(arweave_content) if arweave_content is not None else None
+    ipfs_hash = _sha256_hex(ipfs_content) if ipfs_content is not None else None
+
+    surfaces = []
+    if arweave_hash is not None:
+        surfaces.append(arweave_hash == expected_hash)
+    if ipfs_hash is not None:
+        surfaces.append(ipfs_hash == expected_hash)
+    integrity = "passed" if surfaces and all(surfaces) else "failed"
+
+    return {
+        "asset_id": asset_id,
+        "integrity": integrity,
+        "expected_hash": expected_hash,
+        "arweave_hash": arweave_hash,
+        "ipfs_hash": ipfs_hash,
+        "arweave_tx_id": record.get("arweave_tx_id"),
+        "ipfs_cid": record.get("ipfs_cid"),
+        "checked_at": _now_iso(),
+    }
+
+
+def get_storage_record(asset_id: str) -> Optional[dict]:
+    """Return the in-process storage record for an asset, or None.
+    Excludes the raw bytes so the return is JSON-safe."""
+    record = _asset_storage.get(asset_id)
+    if record is None:
+        return None
+    return {
+        "asset_id": asset_id,
+        "arweave_tx_id": record.get("arweave_tx_id"),
+        "ipfs_cid": record.get("ipfs_cid"),
+        "content_hash": record.get("content_hash"),
+        "size_bytes": record.get("size_bytes"),
+        "uploaded_at": record.get("uploaded_at"),
+    }
+
+
+def _link_asset(
+    asset_id: str,
     *,
-    mime_type: str,
-    tags: Optional[dict] = None,
-) -> PermanentStorageResult:
-    """Upload to both Arweave and IPFS in parallel; return the
-    combined result.
-
-    This is the recommended entry point — it ensures both storage
-    tiers are populated so the asset has permanent (Arweave) and
-    retrievable (IPFS) paths.
-    """
-    raise PermanentStoragePending(
-        "Permanent storage integration is pending partner selection."
-    )
-
-
-def verify_content_integrity(
-    expected_content_hash: str,
     arweave_tx_id: Optional[str] = None,
     ipfs_cid: Optional[str] = None,
-) -> dict:
-    """Fetch content from permanent storage and verify its SHA-256
-    hash matches the expected value.
+    content_hash: Optional[str] = None,
+    content: Optional[bytes] = None,
+) -> None:
+    """Merge per-asset storage record with one or both surface results.
 
-    Returns a dict with `arweave_match`, `ipfs_match`, and `overall_ok`.
-    Both `arweave_tx_id` and `ipfs_cid` are optional — pass what's
-    available. If neither is provided, raises ValueError.
-
-    The hashing half of this check is already implemented in
-    `app.services.story_protocol_bridge.verify_content_integrity()`
-    — once fetch is live, this function just fetches bytes from
-    the two sources and hands them to the bridge's pure hasher.
+    Stores the raw bytes per-surface so ``verify_content_integrity``
+    can detect tamper independently at Arweave and IPFS in production.
     """
-    if arweave_tx_id is None and ipfs_cid is None:
-        raise ValueError(
-            "at least one of arweave_tx_id or ipfs_cid must be provided"
-        )
-    raise PermanentStoragePending(
-        "Permanent storage integration is pending partner selection."
-    )
+    record = _asset_storage.setdefault(asset_id, {})
+    if arweave_tx_id is not None:
+        record["arweave_tx_id"] = arweave_tx_id
+        if content is not None:
+            record["arweave_content"] = content
+    if ipfs_cid is not None:
+        record["ipfs_cid"] = ipfs_cid
+        if content is not None:
+            record["ipfs_content"] = content
+    if content_hash is not None:
+        record["content_hash"] = content_hash
+    if content is not None:
+        record["size_bytes"] = len(content)
+    record["uploaded_at"] = _now_iso()
+
+
+def _reset_for_tests() -> None:
+    """Clear module-level state. Call from a pytest fixture so each
+    test starts on fresh ground."""
+    _arweave_uploads.clear()
+    _ipfs_uploads.clear()
+    _asset_storage.clear()

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 196
+**Total files**: 197
 
 | File | Purpose |
 |---|---|
@@ -120,6 +120,7 @@
 | [test_on_demand_attunement.py](test_on_demand_attunement.py) | Flow test for on-demand attunement. |
 | [test_onboarding.py](test_onboarding.py) | _no top-of-file purpose_ |
 | [test_peer_resonance_service.py](test_peer_resonance_service.py) | _no top-of-file purpose_ |
+| [test_permanent_storage.py](test_permanent_storage.py) | Flow tests for permanent_storage_service — story-protocol-integration R3, R10. |
 | [test_persistence_contract_config.py](test_persistence_contract_config.py) | _no top-of-file purpose_ |
 | [test_pipeline_router.py](test_pipeline_router.py) | Tests for the coherence-network-agent-pipeline spec |
 | [test_portfolio_governance.py](test_portfolio_governance.py) | Acceptance tests for spec: portfolio-governance-health (idea: portfolio-governance). |

--- a/api/tests/test_permanent_storage.py
+++ b/api/tests/test_permanent_storage.py
@@ -1,0 +1,154 @@
+"""Flow tests for permanent_storage_service — story-protocol-integration R3, R10.
+
+Exercises the three named functions the spec's `source:` block claims:
+upload_to_arweave, upload_to_ipfs, verify_content_integrity. The
+service holds state in module-level dicts in this iteration; each test
+starts fresh via the autouse reset fixture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from app.services import permanent_storage_service
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    permanent_storage_service._reset_for_tests()
+    yield
+    permanent_storage_service._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# upload_to_arweave
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_arweave_returns_tx_id():
+    result = permanent_storage_service.upload_to_arweave(
+        b"rammed-earth-kitchen-blueprint", {"type": "BLUEPRINT"}
+    )
+    assert "arweave_tx_id" in result
+    assert result["arweave_tx_id"].startswith("ar:mock:")
+    assert result["size_bytes"] == len(b"rammed-earth-kitchen-blueprint")
+
+
+def test_upload_to_arweave_deterministic():
+    content = b"identical bytes produce identical tx ids"
+    first = permanent_storage_service.upload_to_arweave(content)
+    second = permanent_storage_service.upload_to_arweave(content)
+    assert first["arweave_tx_id"] == second["arweave_tx_id"]
+    assert first["content_hash"] == second["content_hash"]
+
+
+def test_upload_to_arweave_includes_content_hash():
+    content = b"check the sha256 made it through"
+    expected = hashlib.sha256(content).hexdigest()
+    result = permanent_storage_service.upload_to_arweave(content)
+    assert result["content_hash"] == expected
+
+
+def test_upload_to_arweave_rejects_non_bytes():
+    with pytest.raises(ValueError, match="bytes"):
+        permanent_storage_service.upload_to_arweave("a string is not bytes")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# upload_to_ipfs
+# ---------------------------------------------------------------------------
+
+
+def test_upload_to_ipfs_returns_cid():
+    result = permanent_storage_service.upload_to_ipfs(b"glb-binary-payload")
+    assert "ipfs_cid" in result
+    assert result["ipfs_cid"].startswith("Qm")
+    assert result["size_bytes"] == len(b"glb-binary-payload")
+
+
+def test_upload_to_ipfs_deterministic():
+    content = b"same bytes to same cid"
+    first = permanent_storage_service.upload_to_ipfs(content)
+    second = permanent_storage_service.upload_to_ipfs(content)
+    assert first["ipfs_cid"] == second["ipfs_cid"]
+    assert first["content_hash"] == second["content_hash"]
+
+
+def test_upload_to_ipfs_includes_content_hash():
+    content = b"hash on the ipfs side too"
+    expected = hashlib.sha256(content).hexdigest()
+    result = permanent_storage_service.upload_to_ipfs(content)
+    assert result["content_hash"] == expected
+
+
+# ---------------------------------------------------------------------------
+# verify_content_integrity
+# ---------------------------------------------------------------------------
+
+
+def test_verify_content_integrity_passes_for_unchanged_content():
+    asset_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    content = b"the blueprint that the asset will commit to"
+    ar = permanent_storage_service.upload_to_arweave(
+        content, {"type": "BLUEPRINT"}, asset_id=asset_id
+    )
+    permanent_storage_service.upload_to_ipfs(content, asset_id=asset_id)
+
+    result = permanent_storage_service.verify_content_integrity(
+        asset_id, ar["content_hash"]
+    )
+    assert result["integrity"] == "passed"
+    assert result["expected_hash"] == ar["content_hash"]
+    assert result["arweave_hash"] == ar["content_hash"]
+    assert result["ipfs_hash"] == ar["content_hash"]
+
+
+def test_verify_content_integrity_fails_for_changed_hash():
+    asset_id = "asset-tamper-001"
+    content = b"original bytes the creator uploaded"
+    permanent_storage_service.upload_to_arweave(content, asset_id=asset_id)
+    permanent_storage_service.upload_to_ipfs(content, asset_id=asset_id)
+
+    wrong_hash = hashlib.sha256(b"different bytes someone is claiming").hexdigest()
+    result = permanent_storage_service.verify_content_integrity(asset_id, wrong_hash)
+    assert result["integrity"] == "failed"
+    assert result["expected_hash"] == wrong_hash
+    # The recomputed hashes are the real content's hash — they don't
+    # equal the wrong expected_hash, which is what trips the fail.
+    real_hash = hashlib.sha256(content).hexdigest()
+    assert result["arweave_hash"] == real_hash
+    assert result["ipfs_hash"] == real_hash
+
+
+def test_verify_returns_both_arweave_and_ipfs_hashes():
+    asset_id = "asset-dual-surface"
+    content = b"both surfaces report independently"
+    ar = permanent_storage_service.upload_to_arweave(content, asset_id=asset_id)
+    ipfs = permanent_storage_service.upload_to_ipfs(content, asset_id=asset_id)
+
+    result = permanent_storage_service.verify_content_integrity(
+        asset_id, ar["content_hash"]
+    )
+    assert result["arweave_hash"] is not None
+    assert result["ipfs_hash"] is not None
+    assert result["arweave_tx_id"] == ar["arweave_tx_id"]
+    assert result["ipfs_cid"] == ipfs["ipfs_cid"]
+
+
+def test_verify_unknown_asset_fails_closed():
+    result = permanent_storage_service.verify_content_integrity(
+        "never-uploaded", "abc123" * 10
+    )
+    assert result["integrity"] == "failed"
+    assert result["reason"] == "no_storage_record"
+    assert result["arweave_hash"] is None
+    assert result["ipfs_hash"] is None
+
+
+def test_verify_requires_asset_id_and_hash():
+    with pytest.raises(ValueError, match="asset_id"):
+        permanent_storage_service.verify_content_integrity("", "deadbeef")
+    with pytest.raises(ValueError, match="expected_hash"):
+        permanent_storage_service.verify_content_integrity("asset-x", "")


### PR DESCRIPTION
## Summary

- Lands the three named functions the spec's source: block claims for `api/app/services/permanent_storage_service.py`:
  - `upload_to_arweave(content, metadata) -> {arweave_tx_id, content_hash, ...}`
  - `upload_to_ipfs(content) -> {ipfs_cid, content_hash, ...}`
  - `verify_content_integrity(asset_id, expected_hash) -> {integrity, arweave_hash, ipfs_hash, ...}`
- Mock bundler / mock IPFS with deterministic content-addressed ids (`ar:mock:<hash16>`, `Qm<hash44>`); real Irys + pinning-service partner integration is the follow-up breath while this iteration locks down the contract surface tests rely on.
- Adds `StorageRecord` + `AssetIPRegistration` Pydantic models to `api/app/models/asset.py` per the spec's source: claim.
- 12 flow tests in `api/tests/test_permanent_storage.py`. Sibling suites stay green (71 passed across permanent_storage / ip_registration / evidence_flow / settlement_flow / story_protocol).

Closes 3 R3+R10 symbols (upload_to_arweave, upload_to_ipfs, verify_content_integrity) and 2 model symbols (StorageRecord, AssetIPRegistration).

## Test plan

- [x] `pytest tests/test_permanent_storage.py -v` — 12/12 pass
- [x] `pytest tests/test_permanent_storage.py tests/test_ip_registration.py tests/test_evidence_flow.py tests/test_settlement_flow.py tests/test_story_protocol.py -v` — 71/71 pass
- [x] `python3 scripts/generate_repo_indexes.py` ran clean

Generated with Claude Code