### PR TITLE
tend: get_asset_content + verification — story-protocol R4 + R10

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 196 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 197 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -1,9 +1,13 @@
 """Assets router — backed by graph_nodes (type=asset)."""
 from __future__ import annotations
 
+import base64
+import logging
 from datetime import datetime, timezone
 from uuid import UUID, uuid4, uuid5, NAMESPACE_URL
 from decimal import Decimal
+
+log = logging.getLogger(__name__)
 
 # Stable namespace for deriving asset UUIDs from slug-shaped graph
 # node ids. Resolver-minted and KB-seeded asset nodes carry slug ids
@@ -32,7 +36,8 @@ def _stable_asset_id(node: dict) -> UUID:
     except (ValueError, AttributeError):
         return uuid5(ASSET_NS, str(node.get("id", "")))
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
+from fastapi.responses import JSONResponse
 
 from app.models.asset import (
     Asset,
@@ -43,8 +48,13 @@ from app.models.asset import (
 )
 from app.models.error import ErrorDetail
 from app.models.pagination import PaginatedResponse
-from app.services import graph_service
+from app.services import graph_service, read_tracking_service
 from app.services.locale_projection import project, project_many, resolve_caller_lang
+from app.services.story_protocol_bridge import (
+    build_x402_payment_required_headers,
+    compute_content_hash,
+    verify_content_integrity,
+)
 
 router = APIRouter()
 
@@ -297,3 +307,274 @@ async def list_assets(
         for item in items:
             project(item, "asset", str(item.id), target_lang, title_field="description", body_field="description")
     return PaginatedResponse(items=items, total=result.get("total", len(items)), limit=limit, offset=offset)
+
+
+# ---------------------------------------------------------------------------
+# Content delivery + x402 (spec R4)
+# ---------------------------------------------------------------------------
+
+# Default micropayment amount per content read. The cc-economics service
+# will calibrate this once usage data arrives; today the value is the
+# placeholder named in specs/story-protocol-integration.md API contract.
+DEFAULT_CONTENT_CC_AMOUNT = Decimal("0.01")
+DEFAULT_PAYMENT_NETWORK = "coherence-cc"
+# Free-tier text truncation point — keeps the preview useful (a paragraph
+# or so) without giving away the body. Image assets emit a watermark
+# label rather than truncating bytes.
+FREE_TIER_TEXT_PREVIEW_CHARS = 280
+
+
+def _find_asset_node(asset_id: UUID) -> dict | None:
+    """Lookup mirroring ``get_asset`` — direct hit on ``asset:<uuid>``
+    then walk all asset nodes matching ``_stable_asset_id``. Returns
+    None if no node resolves to this UUID."""
+    node = graph_service.get_node(f"asset:{asset_id}")
+    if node:
+        return node
+    result = graph_service.list_nodes(type="asset", limit=1000)
+    for n in result.get("items", []):
+        if _stable_asset_id(n) == asset_id:
+            return n
+    return None
+
+
+def _extract_content_bytes(node: dict) -> tuple[bytes, str]:
+    """Resolve the raw content for an asset node, plus the MIME type.
+
+    Search order:
+      1. ``metadata.content_base64`` — set by the upload flow when the
+         caller hands us the bytes directly.
+      2. ``metadata.content`` — text content stored as a plain string.
+      3. ``description`` — fallback so even bare-metadata nodes (the
+         resolver-minted ones from KB seeds) have *some* content to
+         serve. The hash on the node will not match this fallback;
+         the verification endpoint will surface that honestly.
+
+    MIME defaults to ``text/plain`` and is overridden by
+    ``mime_type`` on the node if present.
+    """
+    metadata = node.get("metadata") or {}
+    mime_type = node.get("mime_type") or "text/plain"
+
+    b64 = metadata.get("content_base64")
+    if isinstance(b64, str) and b64:
+        try:
+            return base64.b64decode(b64), mime_type
+        except (ValueError, base64.binascii.Error):
+            pass
+
+    text = metadata.get("content")
+    if isinstance(text, str) and text:
+        return text.encode("utf-8"), mime_type
+
+    description = node.get("description") or ""
+    return description.encode("utf-8"), mime_type
+
+
+def _is_image_mime(mime_type: str) -> bool:
+    return mime_type.lower().startswith("image/")
+
+
+def _free_tier_content(content: bytes, mime_type: str) -> str:
+    """Free-tier rendering. Images return a watermark label, text
+    returns a truncation. Binary types collapse to a short notice so
+    we never serve undefined bytes."""
+    if _is_image_mime(mime_type):
+        return f"[free-tier preview: watermarked {mime_type}]"
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return f"[free-tier preview: {len(content)}-byte {mime_type}]"
+    if len(text) <= FREE_TIER_TEXT_PREVIEW_CHARS:
+        return text
+    return text[:FREE_TIER_TEXT_PREVIEW_CHARS] + "…"
+
+
+def _has_valid_payment(authorization: str | None) -> bool:
+    """First-iteration x402 token check. Any non-empty Bearer token
+    counts as paid; real facilitator verification (signature check
+    against the x402 chain) lands in a follow-up PR per the
+    Phase 6 plan in specs/story-protocol-integration.md."""
+    if not authorization:
+        return False
+    parts = authorization.strip().split(None, 1)
+    if len(parts) != 2:
+        return False
+    scheme, token = parts
+    return scheme.lower() == "bearer" and bool(token.strip())
+
+
+def _payment_address(node: dict) -> str:
+    """Resolve the asset's payment address. Prefers an explicit
+    ``payment_address`` on the node; falls back to a ``coherence:contributor:<creator_id>``
+    form for nodes that only know who made them."""
+    explicit = node.get("payment_address")
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    creator_id = node.get("creator_id")
+    if isinstance(creator_id, str) and creator_id:
+        return f"coherence:contributor:{creator_id}"
+    return "coherence:contributor:unknown"
+
+
+@router.get(
+    "/assets/{asset_id}/content",
+    summary="Get asset content with x402 payment headers",
+    responses={
+        402: {"description": "Payment required — content gated"},
+        404: {"model": ErrorDetail, "description": "Asset not found"},
+    },
+)
+async def get_asset_content(
+    asset_id: UUID,
+    authorization: str | None = Header(default=None),
+) -> Response:
+    """Serve asset content with x402 payment headers (spec R4).
+
+    Three flows:
+      - **Paid** — valid Bearer token in ``Authorization``: full content,
+        ``read_type="paid"``, ``cc_charged`` set, all four
+        ``X-Payment-*`` headers present.
+      - **Free tier** — no token, asset has ``free_tier_enabled``: a
+        truncated/watermarked preview is served at 200 with the same
+        payment headers (informational, so the reader knows the price
+        of the upgrade). ``read_type="free"``.
+      - **Payment required** — no token, asset has
+        ``requires_payment=True`` and free tier is disabled: 402 with
+        the payment headers as the price quote. No read recorded.
+
+    Every served read (paid or free) calls
+    ``read_tracking_service.record_read`` so settlement aggregations
+    later see the event per spec R5.
+    """
+    node = _find_asset_node(asset_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    requires_payment = bool(node.get("requires_payment", False))
+    free_tier_enabled = bool(node.get("free_tier_enabled", True))
+    cc_amount = Decimal(str(node.get("cc_amount") or DEFAULT_CONTENT_CC_AMOUNT))
+    payment_address = _payment_address(node)
+    network = node.get("payment_network") or DEFAULT_PAYMENT_NETWORK
+
+    payment_headers = build_x402_payment_required_headers(
+        amount_cc=cc_amount,
+        payment_address=payment_address,
+        network=network,
+    )
+
+    content_bytes, mime_type = _extract_content_bytes(node)
+    asset_id_str = str(asset_id)
+    node_id = node.get("id") or f"asset:{asset_id}"
+
+    if _has_valid_payment(authorization):
+        try:
+            read_tracking_service.record_read(asset_id=node_id)
+        except Exception as e:  # non-blocking — read tracking failure mustn't fail delivery
+            log.warning("record_read failed for %s: %s", node_id, e)
+        try:
+            content = content_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            content = base64.b64encode(content_bytes).decode("ascii")
+        body = {
+            "asset_id": asset_id_str,
+            "content_type": mime_type,
+            "content": content,
+            "tier": "paid",
+            "cc_charged": str(cc_amount),
+            "read_type": "paid",
+        }
+        return JSONResponse(content=body, status_code=200, headers=payment_headers)
+
+    if requires_payment and not free_tier_enabled:
+        # 402 — content is gated, no token, no free tier.
+        body = {
+            "asset_id": asset_id_str,
+            "error": "payment_required",
+            "payment_info": {
+                "amount_cc": str(cc_amount),
+                "address": payment_address,
+                "network": network,
+            },
+        }
+        return JSONResponse(content=body, status_code=402, headers=payment_headers)
+
+    # Free tier — preview served, read recorded as "free".
+    try:
+        read_tracking_service.record_read(asset_id=node_id)
+    except Exception as e:
+        log.warning("record_read failed for %s: %s", node_id, e)
+    preview = _free_tier_content(content_bytes, mime_type)
+    body = {
+        "asset_id": asset_id_str,
+        "content_type": mime_type,
+        "content": preview,
+        "tier": "free",
+        "read_type": "free",
+        "full_content_available": True,
+        "payment_info": {
+            "amount_cc": str(cc_amount),
+            "address": payment_address,
+            "network": network,
+        },
+    }
+    return JSONResponse(content=body, status_code=200, headers=payment_headers)
+
+
+# ---------------------------------------------------------------------------
+# Content verification (spec R10)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/assets/{asset_id}/verification",
+    summary="Verify asset content integrity against stored hash",
+    responses={404: {"model": ErrorDetail, "description": "Asset not found"}},
+)
+async def get_asset_verification(asset_id: UUID) -> dict:
+    """Return content-hash + storage refs + recomputed hash (spec R10).
+
+    Recomputes the SHA-256 of the currently-stored content and compares
+    against the node's ``content_hash``. ``integrity`` is
+    ``"verified"`` when they match, ``"failed"`` when they don't, and
+    ``"no_hash"`` when the node has no stored hash to compare against.
+
+    The recompute runs locally against the content we already serve —
+    the Arweave/IPFS fetch half of the integrity check lives in
+    ``permanent_storage_service.verify_content_integrity`` and is
+    gated on the partner-storage bring-up. The Arweave TX and IPFS CID
+    are surfaced here as references regardless.
+    """
+    node = _find_asset_node(asset_id)
+    if not node:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    expected_hash = node.get("content_hash") or ""
+    content_bytes, _ = _extract_content_bytes(node)
+    recomputed_hash = compute_content_hash(content_bytes)
+
+    if not expected_hash:
+        integrity = "no_hash"
+    else:
+        result = verify_content_integrity(expected_hash, content_bytes)
+        integrity = "verified" if result.ok else "failed"
+
+    arweave_tx = node.get("arweave_tx") or node.get("arweave_tx_id")
+    ipfs_cid = node.get("ipfs_cid")
+    sp_ip_id = node.get("sp_ip_id")
+
+    return {
+        "asset_id": str(asset_id),
+        "content_hash": expected_hash or None,
+        "recomputed_hash": recomputed_hash,
+        "integrity": integrity,
+        "arweave_tx_id": arweave_tx,
+        "arweave_url": f"https://arweave.net/{arweave_tx}" if arweave_tx else None,
+        "ipfs_cid": ipfs_cid,
+        "ipfs_url": f"https://ipfs.io/ipfs/{ipfs_cid}" if ipfs_cid else None,
+        "sp_ip_id": sp_ip_id,
+        "sp_explorer_url": (
+            f"https://explorer.story.foundation/ip/{sp_ip_id}" if sp_ip_id else None
+        ),
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 196
+**Total files**: 197
 
 | File | Purpose |
 |---|---|
@@ -26,6 +26,7 @@
 | [test_asset_registration.py](test_asset_registration.py) | Tests for POST /api/assets/register and GET /api/assets/{id}/registration. |
 | [test_asset_renderer.py](test_asset_renderer.py) | Tests for the asset-renderer-plugin spec pure-logic pieces. |
 | [test_assets.py](test_assets.py) | Tests for the assets-api spec (specs/assets-api.md). |
+| [test_assets_content.py](test_assets_content.py) | Tests for GET /api/assets/{id}/content + /verification — spec R4 and R10. |
 | [test_attribution_middleware.py](test_attribution_middleware.py) | Tests for the attribution middleware. |
 | [test_audit_vision_image_candidates.py](test_audit_vision_image_candidates.py) | _no top-of-file purpose_ |
 | [test_auth_keys_api.py](test_auth_keys_api.py) | Tests for the /api/auth/keys HTTP layer. |

--- a/api/tests/test_assets_content.py
+++ b/api/tests/test_assets_content.py
@@ -1,0 +1,242 @@
+"""Tests for GET /api/assets/{id}/content + /verification — spec R4 and R10.
+
+Covers the content-delivery endpoint (paid vs free-tier vs 402) with
+x402 payment headers, and the verification endpoint that recomputes
+the SHA-256 content hash against what the node stores.
+
+Reads are recorded via ``read_tracking_service.record_read`` so the
+daily aggregates surface the event the same way settlement will see
+it during the daily batch (spec R5).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import graph_service, read_tracking_service
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _sha256_hex(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _register_asset(
+    client: TestClient,
+    *,
+    content: bytes = b"the full body of the article",
+    mime_type: str = "text/plain",
+    requires_payment: bool = False,
+    free_tier_enabled: bool = True,
+    creator_id: str = "contributor-alpha",
+    extra_metadata: dict | None = None,
+) -> str:
+    """Register an asset with the given content and gating, then patch
+    the node's ``requires_payment`` / ``free_tier_enabled`` / payment-
+    address properties directly so the content endpoint sees them.
+
+    Returns the stable UUID string of the asset (the form the
+    ``/api/assets/{id}/content`` route expects).
+    """
+    content_b64 = base64.b64encode(content).decode("ascii")
+    metadata = {"content_base64": content_b64}
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    payload = {
+        "type": mime_type,
+        "name": "test-asset",
+        "description": "test asset for content delivery",
+        "content_hash": _sha256_hex(content),
+        "concept_tags": [],
+        "creator_id": creator_id,
+        "creation_cost_cc": "0.00",
+        "metadata": metadata,
+    }
+    response = client.post("/api/assets/register", json=payload)
+    assert response.status_code == 201, response.text
+    registration_id = response.json()["id"]  # "asset:<uuid>"
+
+    # Patch the gating fields onto the node — register doesn't accept
+    # these in its first-iteration contract, so we set them directly.
+    graph_service.update_node(
+        registration_id,
+        properties={
+            "requires_payment": requires_payment,
+            "free_tier_enabled": free_tier_enabled,
+            "payment_address": f"coherence:contributor:{creator_id}",
+        },
+    )
+
+    # The stable UUID the GET endpoint expects is the suffix after
+    # "asset:" in the registration id.
+    return registration_id.removeprefix("asset:")
+
+
+# ---------------------------------------------------------------------------
+# get_asset_content — R4
+# ---------------------------------------------------------------------------
+
+
+def test_get_asset_content_paid_serves_full(client):
+    full = b"the entire content body, every byte of it"
+    asset_id = _register_asset(client, content=full)
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={"Authorization": "Bearer x402-token-abc"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tier"] == "paid"
+    assert body["read_type"] == "paid"
+    assert body["content"] == full.decode("utf-8")
+    assert Decimal(body["cc_charged"]) > 0
+
+
+def test_get_asset_content_free_serves_limited(client):
+    full = b"a" * 1000  # long enough to be truncated by free-tier preview
+    asset_id = _register_asset(
+        client, content=full, requires_payment=False, free_tier_enabled=True
+    )
+    response = client.get(f"/api/assets/{asset_id}/content")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tier"] == "free"
+    assert body["read_type"] == "free"
+    # Truncated — full content NOT returned
+    assert len(body["content"]) < len(full)
+    assert body["payment_info"]["amount_cc"]
+    assert body["payment_info"]["address"]
+
+
+def test_get_asset_content_requires_payment_returns_402(client):
+    asset_id = _register_asset(
+        client,
+        content=b"members-only content",
+        requires_payment=True,
+        free_tier_enabled=False,
+    )
+    response = client.get(f"/api/assets/{asset_id}/content")
+    assert response.status_code == 402
+    # x402 headers must be present on the 402 response
+    assert response.headers.get("X-Payment-Amount")
+    assert response.headers.get("X-Payment-Currency") == "CC"
+    assert response.headers.get("X-Payment-Address")
+    assert response.headers.get("X-Payment-Network")
+
+
+def test_get_asset_content_returns_x402_headers(client):
+    asset_id = _register_asset(client, content=b"hello world")
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={"Authorization": "Bearer token"},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("X-Payment-Amount")
+    assert response.headers.get("X-Payment-Currency") == "CC"
+    address = response.headers.get("X-Payment-Address")
+    assert address and address.startswith("coherence:contributor:")
+    network = response.headers.get("X-Payment-Network")
+    assert network  # spec calls for coherence-cc; any non-empty value carries the contract
+
+
+def test_get_asset_content_404_for_unknown_asset(client):
+    response = client.get(
+        "/api/assets/00000000-0000-4000-8000-000000000000/content"
+    )
+    assert response.status_code == 404
+
+
+def test_get_asset_content_records_usage_event(client):
+    asset_id = _register_asset(client, content=b"event-tracking content")
+    # Baseline: read the daily-aggregate row before the call.
+    asset_node_id = f"asset:{asset_id}"
+    before = read_tracking_service.get_daily_reads(asset_node_id, date.today())
+    before_count = before["read_count"] if before else 0
+
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={"Authorization": "Bearer token"},
+    )
+    assert response.status_code == 200
+
+    after = read_tracking_service.get_daily_reads(asset_node_id, date.today())
+    assert after is not None
+    assert after["read_count"] == before_count + 1
+
+
+# ---------------------------------------------------------------------------
+# get_asset_verification — R10
+# ---------------------------------------------------------------------------
+
+
+def test_get_asset_verification_passes_for_intact_content(client):
+    content = b"this content's hash matches what was registered"
+    asset_id = _register_asset(client, content=content)
+    response = client.get(f"/api/assets/{asset_id}/verification")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["integrity"] == "verified"
+    assert body["content_hash"] == _sha256_hex(content)
+    assert body["recomputed_hash"] == body["content_hash"]
+
+
+def test_get_asset_verification_fails_for_tampered_content(client):
+    content = b"original content"
+    asset_id = _register_asset(client, content=content)
+
+    # Tamper: rewrite the stored content but leave the registered hash
+    # in place — recompute should diverge.
+    tampered_b64 = base64.b64encode(b"replacement content").decode("ascii")
+    graph_service.update_node(
+        f"asset:{asset_id}",
+        properties={"metadata": {"content_base64": tampered_b64}},
+    )
+
+    response = client.get(f"/api/assets/{asset_id}/verification")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["integrity"] == "failed"
+    assert body["content_hash"] != body["recomputed_hash"]
+
+
+def test_get_asset_verification_404_for_unknown_asset(client):
+    response = client.get(
+        "/api/assets/00000000-0000-4000-8000-000000000000/verification"
+    )
+    assert response.status_code == 404
+
+
+def test_get_asset_verification_returns_both_arweave_and_ipfs_hashes(client):
+    content = b"asset with storage refs"
+    asset_id = _register_asset(
+        client,
+        content=content,
+        extra_metadata={},
+    )
+    # Patch storage refs onto the node so the verification response
+    # surfaces them per spec R10.
+    graph_service.update_node(
+        f"asset:{asset_id}",
+        properties={
+            "arweave_tx": "ar-tx-deadbeef",
+            "ipfs_cid": "bafybeigtest",
+        },
+    )
+    response = client.get(f"/api/assets/{asset_id}/verification")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["arweave_tx_id"] == "ar-tx-deadbeef"
+    assert body["ipfs_cid"] == "bafybeigtest"
+    assert body["arweave_url"].endswith("ar-tx-deadbeef")
+    assert body["ipfs_url"].endswith("bafybeigtest")


### PR DESCRIPTION
## Summary

- `GET /api/assets/{id}/content` — serves asset content with x402 payment headers (`X-Payment-Amount`, `X-Payment-Currency: CC`, `X-Payment-Address`, `X-Payment-Network`). Bearer Authorization = paid full content; no token + free-tier = truncated/watermarked preview; no token + `requires_payment=True` + free tier off = 402 with headers as price quote. Every served read records to `read_tracking_service` (R5).
- `GET /api/assets/{id}/verification` — recomputes SHA-256 against stored content, surfaces `arweave_tx_id` + `ipfs_cid` + `sp_ip_id` with public URLs. `integrity = verified | failed | no_hash`. The partner-gated Arweave/IPFS fetch half stays in `permanent_storage_service.verify_content_integrity`.
- Real x402 facilitator verification is Phase 6 — this lands the header shape and the routing so the rest of the system can build against the surface.

## Test plan

- [x] `pytest tests/test_assets_content.py -v` — 10 new tests pass (paid, free, 402, headers, 404, usage event, hash match, hash tamper, storage refs).
- [x] Broader sweep: `pytest tests/test_assets_content.py tests/test_story_protocol.py tests/test_evidence_flow.py tests/test_settlement_flow.py tests/test_ip_registration.py tests/test_assets.py tests/test_asset_registration.py -q` → 87 passed.

Closes the `get_asset_content()` and (de-facto-new) `get_asset_verification()` symbols from `specs/story-protocol-integration.md` source: block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)