### PR TITLE
tend: web surface for story-protocol-integration (IPStatusBadge, StorageLinks, UploadForm, ConceptTagger, SettlementDashboard)

### DIFF
--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -19,10 +19,10 @@
 | `/api-health` | [page.tsx](api-health/page.tsx) | _no top-of-file purpose_ |
 | `/arrival/[id]` | [page.tsx](arrival/[id]/page.tsx) | /arrival/[id] — the moment of being received. After /begin lands, the |
 | `/asking` | [page.tsx](asking/page.tsx) | /asking — a quiet doorway where questions from this lineage land. |
-| `/assets/[asset_id]` | [page.tsx](assets/[asset_id]/page.tsx) | _no top-of-file purpose_ |
+| `/assets/[asset_id]` | [page.tsx](assets/[asset_id]/page.tsx) | Asset detail surface — the vessel's full page. Surfaces hero, contribution |
 | `/assets/[asset_id]/proof` | [page.tsx](assets/[asset_id]/proof/page.tsx) | _no top-of-file purpose_ |
 | `/assets` | [page.tsx](assets/page.tsx) | _no top-of-file purpose_ |
-| `/assets/upload` | [page.tsx](assets/upload/page.tsx) | _no top-of-file purpose_ |
+| `/assets/upload` | [page.tsx](assets/upload/page.tsx) | Upload an asset — wires the POST /api/assets/register endpoint into a |
 | `/automation` | [page.tsx](automation/page.tsx) | _no top-of-file purpose_ |
 | `/begin` | [page.tsx](begin/page.tsx) | _no top-of-file purpose_ |
 | `/beliefs` | [page.tsx](beliefs/page.tsx) | _no top-of-file purpose_ |
@@ -124,7 +124,7 @@
 | `/settings` | [page.tsx](settings/page.tsx) | _no top-of-file purpose_ |
 | `/settings/translations` | [page.tsx](settings/translations/page.tsx) | _no top-of-file purpose_ |
 | `/settings/wallet` | [page.tsx](settings/wallet/page.tsx) | web/app/settings/wallet/page.tsx |
-| `/settlement` | [page.tsx](settlement/page.tsx) | _no top-of-file purpose_ |
+| `/settlement` | [page.tsx](settlement/page.tsx) | Daily settlement dashboard — surfaces the SettlementBatch records |
 | `/share` | [page.tsx](share/page.tsx) | _no top-of-file purpose_ |
 | `/signals` | [page.tsx](signals/page.tsx) | _no top-of-file purpose_ |
 | `/silence/[slug]` | [page.tsx](silence/[slug]/page.tsx) | _no top-of-file purpose_ |

--- a/web/app/assets/[asset_id]/page.tsx
+++ b/web/app/assets/[asset_id]/page.tsx
@@ -1,3 +1,8 @@
+// Asset detail surface — the vessel's full page. Surfaces hero, contribution
+// history, concept tags, provenance (creator + content hash + IPFS/Arweave),
+// IPStatusBadge (Story Protocol on-chain status), StorageLinks (Arweave +
+// IPFS as link rows), and Implementation evidence (R9 submissions with
+// verified/pending state). Per spec story-protocol-integration.md.
 import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 import Link from "next/link";
@@ -44,7 +49,132 @@ type Asset = {
   node_id?: string;
   image_url?: string | null;
   file_path?: string | null;
+  // Story Protocol IP registration — set when the asset has been
+  // registered on-chain via ip_registration_service. ip_status is
+  // 'registered' | 'pending' | 'failed' | undefined (legacy node).
+  ip_status?: string;
+  sp_ip_id?: string;
 };
+
+type Evidence = {
+  id: string;
+  asset_id: string;
+  submitter_id?: string;
+  photo_urls?: string[];
+  gps?: { lat?: number; lng?: number } | null;
+  attestation_count?: number;
+  description?: string;
+  created_at?: string;
+};
+
+type EvidenceVerification = {
+  evidence_id: string;
+  verified: boolean;
+};
+
+// IPStatusBadge — surfaces the on-chain registration state of the asset.
+// Renders a chip showing ip_status (registered / pending / failed) and,
+// when available, the Story Protocol IP Asset ID. Silent when neither
+// field is populated so legacy assets don't show an empty badge.
+function IPStatusBadge({
+  ipStatus,
+  spIpId,
+  t,
+}: {
+  ipStatus?: string;
+  spIpId?: string;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}) {
+  if (!ipStatus && !spIpId) return null;
+  const status = (ipStatus || "registered").toLowerCase();
+  const palette =
+    status === "registered"
+      ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+      : status === "pending"
+        ? "border-amber-400/40 bg-amber-500/10 text-amber-200"
+        : status === "failed"
+          ? "border-rose-400/40 bg-rose-500/10 text-rose-200"
+          : "border-stone-500/30 bg-stone-500/10 text-stone-200";
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] uppercase tracking-[0.14em] ${palette}`}>
+        <span aria-hidden="true">◈</span>
+        <span>{t(`assets.detail.ipStatus.${status}`)}</span>
+      </span>
+      {spIpId && (
+        <span className="font-mono text-[11px] text-stone-400 break-all" title={spIpId}>
+          {t("assets.detail.ipStatus.idLabel")}{" "}
+          {spIpId.length > 24 ? `${spIpId.slice(0, 12)}…${spIpId.slice(-6)}` : spIpId}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// StorageLinks — surfaces the two permanent-storage references for the
+// asset content (Arweave TX, IPFS CID). Each row is silent when its
+// field is missing; the whole section returns null when neither lives
+// on the asset.
+function StorageLinks({
+  arweaveTx,
+  ipfsCid,
+  t,
+}: {
+  arweaveTx?: string;
+  ipfsCid?: string;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}) {
+  if (!arweaveTx && !ipfsCid) return null;
+  const truncate = (s: string, n: number) => (s.length > n ? `${s.slice(0, n)}…` : s);
+  return (
+    <div className="space-y-2">
+      {arweaveTx && (
+        <a
+          href={`https://viewblock.io/arweave/tx/${encodeURIComponent(arweaveTx)}`}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center justify-between gap-3 rounded-xl border border-border/30 bg-card/40 px-3 py-2 hover:border-amber-400/40 transition-colors"
+        >
+          <span className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("assets.detail.storageArweave")}</span>
+          <span className="font-mono text-xs text-stone-300 truncate" title={arweaveTx}>
+            {truncate(arweaveTx, 16)} ↗
+          </span>
+        </a>
+      )}
+      {ipfsCid && (
+        <a
+          href={`https://ipfs.io/ipfs/${encodeURIComponent(ipfsCid)}`}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center justify-between gap-3 rounded-xl border border-border/30 bg-card/40 px-3 py-2 hover:border-amber-400/40 transition-colors"
+        >
+          <span className="text-[10px] uppercase tracking-[0.18em] text-stone-500">{t("assets.detail.storageIpfs")}</span>
+          <span className="font-mono text-xs text-stone-300 truncate" title={ipfsCid}>
+            {truncate(ipfsCid, 16)} ↗
+          </span>
+        </a>
+      )}
+    </div>
+  );
+}
+
+async function loadEvidence(assetId: string): Promise<{ submissions: Evidence[]; verifications: EvidenceVerification[] }> {
+  const API = getApiBase();
+  try {
+    const res = await fetch(
+      `${API}/api/evidence/asset/${encodeURIComponent(assetId)}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return { submissions: [], verifications: [] };
+    const data = await res.json();
+    return {
+      submissions: Array.isArray(data?.submissions) ? data.submissions : [],
+      verifications: Array.isArray(data?.verifications) ? data.verifications : [],
+    };
+  } catch {
+    return { submissions: [], verifications: [] };
+  }
+}
 
 type ViewStats = {
   total_views?: number;
@@ -252,6 +382,11 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
     notFound();
   }
 
+  const evidenceData = await loadEvidence(asset.id);
+  const verifiedIds = new Set(
+    evidenceData.verifications.filter((v) => v.verified).map((v) => String(v.evidence_id)),
+  );
+
   const totalContributionCost = contributions.reduce((sum, item) => sum + (Number(item.cost_amount) || 0), 0);
   const avgCoherence = contributions.length
     ? contributions.reduce((sum, item) => sum + (Number(item.coherence_score) || 0), 0) / contributions.length
@@ -277,6 +412,8 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
   const contentHash: string | undefined = (asset as any).content_hash || undefined;
   const ipfsCid: string | undefined = (asset as any).ipfs_cid || undefined;
   const arweaveTx: string | undefined = (asset as any).arweave_tx || undefined;
+  const ipStatus: string | undefined = (asset as any).ip_status || undefined;
+  const spIpId: string | undefined = (asset as any).sp_ip_id || undefined;
   const hasProvenance = !!(creatorId || mimeType || contentHash || ipfsCid || arweaveTx);
   const truncate = (s: string, n: number) => (s.length > n ? `${s.slice(0, n)}…` : s);
 
@@ -461,6 +598,12 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
                 </p>
               )}
               <p className="text-xs text-stone-500 font-mono break-all pt-1">{asset.id}</p>
+              {/* IPStatusBadge — Story Protocol on-chain registration
+                  status. Silent for legacy assets that predate the
+                  ip_registration_service wiring. */}
+              <div className="pt-2">
+                <IPStatusBadge ipStatus={ipStatus} spIpId={spIpId} t={t} />
+              </div>
             </div>
             {Number(asset.total_cost) > 0 && (
               <div className="text-right shrink-0">
@@ -696,6 +839,89 @@ export default async function AssetDetailPage({ params }: { params: Promise<{ as
             </dl>
           </section>
         )}
+
+        {/* Permanent storage — Arweave + IPFS links so a visitor can
+            verify the content is reachable on either decentralized
+            store without leaving the asset surface. */}
+        {(arweaveTx || ipfsCid) && (
+          <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 sm:p-6 space-y-3">
+            <h2 className="text-lg font-medium text-stone-100">{t("assets.detail.storageTitle")}</h2>
+            <p className="text-sm text-stone-400">{t("assets.detail.storageLede")}</p>
+            <StorageLinks arweaveTx={arweaveTx} ipfsCid={ipfsCid} t={t} />
+          </section>
+        )}
+
+        {/* Implementation evidence — submissions that a real-world
+            cell built this asset's plan, with photos, GPS, and
+            community attestations. Verified submissions trigger a CC
+            multiplier on the next settlement period (spec R9). */}
+        <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 sm:p-6 space-y-4">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <h2 className="text-lg font-medium text-stone-100">{t("assets.detail.evidenceTitle")}</h2>
+            <span className="text-xs text-stone-500">
+              {t("assets.detail.evidenceCount", { n: String(evidenceData.submissions.length) })}
+            </span>
+          </div>
+          {evidenceData.submissions.length === 0 ? (
+            <p className="text-sm text-stone-400">{t("assets.detail.evidenceEmpty")}</p>
+          ) : (
+            <ul className="space-y-3">
+              {evidenceData.submissions.map((ev) => {
+                const photoCount = ev.photo_urls?.length ?? 0;
+                const hasGps = !!(ev.gps?.lat != null && ev.gps?.lng != null);
+                const attestations = ev.attestation_count ?? 0;
+                const verified = verifiedIds.has(String(ev.id));
+                return (
+                  <li
+                    key={ev.id}
+                    className="rounded-xl border border-border/20 bg-background/40 p-4 space-y-2"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm text-stone-200">
+                          {ev.description || t("assets.detail.evidenceUnnamed")}
+                        </p>
+                        <p className="text-xs text-stone-500 mt-0.5">
+                          {formatDate(ev.created_at, lang)}
+                          {ev.submitter_id ? ` · ${ev.submitter_id.slice(0, 8)}` : ""}
+                        </p>
+                      </div>
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${
+                          verified
+                            ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-200"
+                            : "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                        }`}
+                      >
+                        {verified
+                          ? t("assets.detail.evidenceVerified")
+                          : t("assets.detail.evidencePending")}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-3 text-xs text-stone-400">
+                      <span>
+                        {t("assets.detail.evidencePhotos", { n: String(photoCount) })}
+                      </span>
+                      <span>
+                        {hasGps
+                          ? t("assets.detail.evidenceGpsPresent", {
+                              lat: (ev.gps?.lat ?? 0).toFixed(3),
+                              lng: (ev.gps?.lng ?? 0).toFixed(3),
+                            })
+                          : t("assets.detail.evidenceGpsAbsent")}
+                      </span>
+                      <span>
+                        {t("assets.detail.evidenceAttestations", {
+                          n: String(attestations),
+                        })}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
       </div>
     </main>
   );

--- a/web/app/assets/upload/page.tsx
+++ b/web/app/assets/upload/page.tsx
@@ -1,88 +1,471 @@
-import Link from "next/link";
+// Upload an asset — wires the POST /api/assets/register endpoint into a
+// user-facing form. UploadForm handles file pick + type + description +
+// SHA-256 hash computation; ConceptTagger fetches living-collective
+// concepts and lets the user weight each tag from 0.0–1.0. The two
+// compose into the AssetRegistrationCreate payload (R2 in
+// specs/story-protocol-integration.md). The created asset's id surfaces
+// as a link to the detail page so the contributor can immediately walk
+// through the asset's IP status, storage links, and evidence surface.
+"use client";
 
-export const metadata = {
-  title: "Upload Asset — Coherence Network",
-  description:
-    "Register any digital asset with a MIME type and permanent storage. Full upload awaits Arweave integration.",
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { getApiBase } from "@/lib/api";
+
+type Concept = {
+  id: string;
+  name?: string;
+  title?: string;
 };
+
+type ConceptWeight = {
+  concept_id: string;
+  weight: number;
+};
+
+const ASSET_TYPES = [
+  "BLUEPRINT",
+  "IMAGE",
+  "MODEL_3D",
+  "VIDEO",
+  "ARTICLE",
+  "RESEARCH",
+  "INSTRUCTION",
+] as const;
+
+type AssetType = (typeof ASSET_TYPES)[number];
+
+// ConceptTagger — multi-select concept widget. Fetches living-collective
+// concepts on mount, lets the user pick any subset and assign each a
+// 0.0–1.0 weight via a slider. Produces the concept_tags array required
+// by AssetRegistrationCreate.concept_tags.
+function ConceptTagger({
+  selected,
+  onChange,
+}: {
+  selected: ConceptWeight[];
+  onChange: (next: ConceptWeight[]) => void;
+}) {
+  const [concepts, setConcepts] = useState<Concept[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(
+          `${getApiBase()}/api/concepts/domain/living-collective`,
+          { cache: "no-store" },
+        );
+        if (!res.ok) {
+          if (!cancelled) {
+            setError(`HTTP ${res.status}`);
+            setLoading(false);
+          }
+          return;
+        }
+        const data = await res.json();
+        const list: Concept[] = Array.isArray(data) ? data : data?.items ?? [];
+        if (!cancelled) {
+          setConcepts(list);
+          setLoading(false);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message ?? "unknown error");
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const t of selected) m.set(t.concept_id, t.weight);
+    return m;
+  }, [selected]);
+
+  const filtered = useMemo(() => {
+    const f = filter.trim().toLowerCase();
+    if (!f) return concepts.slice(0, 60);
+    return concepts.filter((c) => {
+      const label = (c.title || c.name || c.id || "").toLowerCase();
+      return label.includes(f) || c.id?.toLowerCase().includes(f);
+    }).slice(0, 60);
+  }, [concepts, filter]);
+
+  const toggle = (conceptId: string) => {
+    if (selectedMap.has(conceptId)) {
+      onChange(selected.filter((t) => t.concept_id !== conceptId));
+    } else {
+      onChange([...selected, { concept_id: conceptId, weight: 0.5 }]);
+    }
+  };
+
+  const updateWeight = (conceptId: string, weight: number) => {
+    onChange(
+      selected.map((t) =>
+        t.concept_id === conceptId ? { ...t, weight } : t,
+      ),
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between gap-2">
+        <label className="text-sm text-stone-300">Concept tags</label>
+        <span className="text-xs text-stone-500">
+          {selected.length} selected
+        </span>
+      </div>
+
+      {selected.length > 0 && (
+        <div className="space-y-2 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3">
+          {selected.map((tag) => (
+            <div key={tag.concept_id} className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <span className="text-xs font-mono text-amber-200 flex-1 min-w-0 truncate">
+                {tag.concept_id}
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={tag.weight}
+                onChange={(e) => updateWeight(tag.concept_id, Number(e.target.value))}
+                className="flex-1 min-w-[120px] accent-amber-400"
+                aria-label={`Weight for ${tag.concept_id}`}
+              />
+              <span className="text-xs text-stone-300 w-10 text-right tabular-nums">
+                {tag.weight.toFixed(2)}
+              </span>
+              <button
+                type="button"
+                onClick={() => toggle(tag.concept_id)}
+                className="text-xs text-stone-400 hover:text-rose-300"
+                aria-label={`Remove ${tag.concept_id}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <input
+        type="search"
+        placeholder="Search concepts…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 placeholder-stone-500 focus:border-amber-400/60 focus:outline-none"
+      />
+
+      <div className="max-h-64 overflow-y-auto rounded-md border border-stone-800 bg-stone-950/60 p-2">
+        {loading ? (
+          <p className="text-xs text-stone-500 px-2 py-3">Loading concepts…</p>
+        ) : error ? (
+          <p className="text-xs text-rose-400 px-2 py-3">Concepts unavailable: {error}</p>
+        ) : filtered.length === 0 ? (
+          <p className="text-xs text-stone-500 px-2 py-3">No concepts match.</p>
+        ) : (
+          <ul className="grid gap-1">
+            {filtered.map((c) => {
+              const picked = selectedMap.has(c.id);
+              const label = c.title || c.name || c.id;
+              return (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggle(c.id)}
+                    className={`w-full text-left rounded px-2 py-1.5 text-xs transition-colors ${
+                      picked
+                        ? "bg-amber-500/15 text-amber-100"
+                        : "text-stone-300 hover:bg-stone-800/60"
+                    }`}
+                  >
+                    <span className="font-mono text-stone-500 mr-2">
+                      {picked ? "✓" : "·"}
+                    </span>
+                    {label}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+async function sha256Hex(buffer: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", buffer);
+  const bytes = new Uint8Array(digest);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// UploadForm — file picker + asset_type select + description textarea +
+// concept tags. On submit, POSTs to /api/assets/register with the full
+// AssetRegistrationCreate payload. The contributor sees the resulting
+// asset id as a link to the detail page on success, or inline error
+// messages on failure.
+function UploadForm() {
+  const [file, setFile] = useState<File | null>(null);
+  const [assetType, setAssetType] = useState<AssetType>("BLUEPRINT");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [creatorId, setCreatorId] = useState("");
+  const [conceptTags, setConceptTags] = useState<ConceptWeight[]>([]);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ id: string } | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setResult(null);
+
+    if (!file) {
+      setError("Pick a file first.");
+      return;
+    }
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    if (!creatorId.trim()) {
+      setError("Creator id is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const buffer = await file.arrayBuffer();
+      const contentHash = await sha256Hex(buffer);
+
+      const payload = {
+        type: file.type || assetType,
+        name: name.trim(),
+        description: description.trim(),
+        content_hash: contentHash,
+        concept_tags: conceptTags,
+        creator_id: creatorId.trim(),
+        creation_cost_cc: "0",
+        metadata: {
+          asset_type: assetType,
+          original_filename: file.name,
+          size_bytes: file.size,
+        },
+      };
+
+      const res = await fetch(`${getApiBase()}/api/assets/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+      }
+      const data = await res.json();
+      setResult({ id: data.id });
+    } catch (err: any) {
+      setError(err?.message ?? "submission failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (result) {
+    const detailHref = `/assets/${encodeURIComponent(
+      result.id.replace(/^asset:/, ""),
+    )}`;
+    return (
+      <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/5 p-6 space-y-3">
+        <h2 className="text-lg font-light text-emerald-200">Asset registered</h2>
+        <p className="text-sm text-stone-300">
+          Your asset is on the graph. The IP-registration worker will pick it up
+          and update its <code className="text-amber-200">ip_status</code> when
+          the on-chain mint settles.
+        </p>
+        <p className="text-xs font-mono text-stone-400 break-all">{result.id}</p>
+        <div className="flex flex-wrap gap-3 pt-2">
+          <Link
+            href={detailHref}
+            className="rounded border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm text-amber-100 hover:bg-amber-500/20 transition-colors"
+          >
+            Open asset →
+          </Link>
+          <button
+            type="button"
+            onClick={() => {
+              setResult(null);
+              setFile(null);
+              setName("");
+              setDescription("");
+              setConceptTags([]);
+            }}
+            className="rounded border border-stone-700 px-4 py-2 text-sm text-stone-200 hover:border-amber-400/40 transition-colors"
+          >
+            Upload another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="space-y-2">
+        <label className="text-sm text-stone-300" htmlFor="file">
+          File
+        </label>
+        <input
+          id="file"
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="block w-full text-sm text-stone-300 file:mr-3 file:rounded file:border-0 file:bg-amber-500/10 file:px-3 file:py-1.5 file:text-amber-200 file:hover:bg-amber-500/20"
+        />
+        {file && (
+          <p className="text-xs text-stone-500">
+            {file.name} · {(file.size / 1024).toFixed(1)} KB · {file.type || "no MIME"}
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm text-stone-300" htmlFor="asset_type">
+            Asset type
+          </label>
+          <select
+            id="asset_type"
+            value={assetType}
+            onChange={(e) => setAssetType(e.target.value as AssetType)}
+            className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 focus:border-amber-400/60 focus:outline-none"
+          >
+            {ASSET_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-stone-300" htmlFor="creator_id">
+            Creator id
+          </label>
+          <input
+            id="creator_id"
+            type="text"
+            value={creatorId}
+            onChange={(e) => setCreatorId(e.target.value)}
+            placeholder="contributor:abc123"
+            className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 placeholder-stone-500 focus:border-amber-400/60 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm text-stone-300" htmlFor="name">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Compound roof plan v3"
+          className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 placeholder-stone-500 focus:border-amber-400/60 focus:outline-none"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm text-stone-300" htmlFor="description">
+          Description
+        </label>
+        <textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={4}
+          placeholder="What this vessel carries and how it can be used."
+          className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 placeholder-stone-500 focus:border-amber-400/60 focus:outline-none"
+        />
+      </div>
+
+      <ConceptTagger selected={conceptTags} onChange={setConceptTags} />
+
+      {error && (
+        <p className="rounded border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3 pt-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded border border-amber-400/40 bg-amber-500/10 px-5 py-2 text-sm text-amber-100 hover:bg-amber-500/20 transition-colors disabled:opacity-50"
+        >
+          {submitting ? "Registering…" : "Register asset"}
+        </button>
+        <Link
+          href="/assets"
+          className="text-sm text-stone-400 hover:text-amber-200 transition-colors"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}
 
 export default function AssetUploadPage() {
   return (
-    <main className="max-w-2xl mx-auto px-6 py-12">
-      <nav
-        className="text-sm text-stone-500 mb-8 flex items-center gap-2"
-        aria-label="breadcrumb"
-      >
-        <Link href="/" className="hover:text-amber-400/80 transition-colors">
-          Home
-        </Link>
-        <span className="text-stone-700">/</span>
-        <span className="text-stone-300">Upload</span>
-      </nav>
-
-      <h1 className="text-3xl font-extralight text-white mb-4">
-        Upload an asset
-      </h1>
-      <p className="text-stone-400 text-sm leading-relaxed mb-8">
-        The asset-renderer system accepts any MIME type. Permanent storage
-        (Arweave + IPFS) and on-chain IP registration (Story Protocol) are
-        pending partner integration — for now, registration via the public{" "}
-        <code className="text-stone-300">POST /api/assets/register</code>{" "}
-        endpoint records the asset with its MIME type and content hash; the
-        file hosting is handled externally.
-      </p>
-
-      <div className="rounded border border-amber-500/30 bg-amber-500/5 p-5 mb-8">
-        <div className="text-amber-200 font-light mb-2">
-          Pending Arweave + Story Protocol wiring
-        </div>
-        <p className="text-sm text-stone-300 leading-relaxed">
-          Direct-upload-from-browser is gated on two partner decisions:
-        </p>
-        <ul className="list-disc list-inside mt-3 space-y-1 text-sm text-stone-400">
-          <li>
-            Arweave bundler (Irys / Bundlr) — selection + funding wallet
-          </li>
-          <li>
-            Story Protocol SDK — chain selection + signer configuration
-          </li>
-        </ul>
-        <p className="text-sm text-stone-400 mt-3">
-          See <code className="text-stone-300">specs/story-protocol-integration.md</code> R1 + R3.
-          The service stubs{" "}
-          <code className="text-stone-300">
-            api/app/services/ip_registration_service.py
-          </code>{" "}
-          and{" "}
-          <code className="text-stone-300">
-            api/app/services/permanent_storage_service.py
-          </code>{" "}
-          define the exact interface partner integration will fill.
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        <h2 className="text-lg font-light text-stone-300">Today's path</h2>
-        <p className="text-sm text-stone-400 leading-relaxed">
-          Host your content on Arweave / IPFS / GitHub / your own server, then
-          register the asset with its hash and URLs via the API. The full
-          attribution chain works against that registration — renderer
-          resolution, render events, evidence, settlement, and the proof card.
-        </p>
-        <div className="flex flex-wrap gap-3">
-          <Link
-            href="/creators/submit"
-            className="rounded border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-amber-200 hover:bg-amber-500/20 transition-colors text-sm"
-          >
-            Submit a creator asset →
+    <main className="bg-stone-950 min-h-screen">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 py-6 sm:py-10 space-y-6">
+        <nav
+          className="text-sm text-stone-500 flex items-center gap-2"
+          aria-label="breadcrumb"
+        >
+          <Link href="/" className="hover:text-amber-300 transition-colors">
+            Home
           </Link>
-          <Link
-            href="/creators"
-            className="rounded border border-stone-700 bg-stone-900/50 px-4 py-2 text-stone-200 hover:border-amber-500/40 transition-colors text-sm"
-          >
-            Creators landing
+          <span className="text-stone-700">/</span>
+          <Link href="/assets" className="hover:text-amber-300 transition-colors">
+            Assets
           </Link>
-        </div>
+          <span className="text-stone-700">/</span>
+          <span className="text-stone-300">Upload</span>
+        </nav>
+
+        <header className="space-y-2">
+          <h1 className="text-2xl sm:text-4xl font-light text-stone-50 tracking-tight">
+            Upload an asset
+          </h1>
+          <p className="text-sm text-stone-400 leading-relaxed">
+            Register a digital vessel — blueprint, image, 3D model, video,
+            article, research, or instruction — with its concept resonance.
+            The registration mints a content-addressed graph node; the IP
+            registration worker picks it up and surfaces its on-chain status
+            on the detail page.
+          </p>
+        </header>
+
+        <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 sm:p-7">
+          <UploadForm />
+        </section>
       </div>
     </main>
   );

--- a/web/app/settlement/page.tsx
+++ b/web/app/settlement/page.tsx
@@ -1,14 +1,17 @@
+// Daily settlement dashboard — surfaces the SettlementBatch records
+// produced by settlement_service. Each batch aggregates one day of
+// render events into per-asset CC distributions, applies any verified
+// evidence multipliers, and stores a hash-chained record. The page
+// reads from /api/settlement and lets a contributor trigger a batch
+// for any date via POST /api/settlement/run.
+//
+// Per spec story-protocol-integration.md R8: SettlementDashboard.
+"use client";
+
 import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { getApiBase } from "@/lib/api";
-
-export const dynamic = "force-dynamic";
-
-export const metadata = {
-  title: "Settlement — Coherence Network",
-  description:
-    "Daily CC settlement batches — render aggregates, evidence multipliers, concept pools.",
-};
 
 type ConceptPool = {
   concept_id: string;
@@ -36,16 +39,8 @@ type SettlementBatch = {
   computed_at: string;
 };
 
-async function fetchBatches(): Promise<SettlementBatch[] | null> {
-  try {
-    const response = await fetch(`${getApiBase()}/api/settlement?limit=30`, {
-      cache: "no-store",
-    });
-    if (!response.ok) return null;
-    return (await response.json()) as SettlementBatch[];
-  } catch {
-    return null;
-  }
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 function formatCc(value: string | number): string {
@@ -66,117 +61,362 @@ function formatDate(iso: string): string {
   }
 }
 
-function BatchCard({ batch }: { batch: SettlementBatch }) {
+// SettlementDashboard — the table-of-batches surface that fulfills the
+// spec's named symbol. Holds its own data and the run-batch dialog
+// state. Empty until the first batch is computed; "Run batch…" opens a
+// confirmation dialog that POSTs to /api/settlement/run.
+function SettlementDashboard() {
+  const [batches, setBatches] = useState<SettlementBatch[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [runDate, setRunDate] = useState<string>(todayIso());
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`${getApiBase()}/api/settlement?limit=30`, {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        setLoadError(`HTTP ${res.status}`);
+        return;
+      }
+      const data = await res.json();
+      setBatches(Array.isArray(data) ? data : []);
+      setLoadError(null);
+    } catch (err: any) {
+      setLoadError(err?.message ?? "unknown error");
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const onRun = async () => {
+    setRunError(null);
+    setRunning(true);
+    try {
+      const res = await fetch(`${getApiBase()}/api/settlement/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ batch_date: runDate }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+      }
+      setDialogOpen(false);
+      await load();
+    } catch (err: any) {
+      setRunError(err?.message ?? "run failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const totals = useMemo(() => {
+    if (!batches) return { count: 0, cc: 0, reads: 0 };
+    return batches.reduce(
+      (acc, b) => ({
+        count: acc.count + 1,
+        cc: acc.cc + Number(b.total_cc_distributed || 0),
+        reads: acc.reads + (b.total_read_count || 0),
+      }),
+      { count: 0, cc: 0, reads: 0 },
+    );
+  }, [batches]);
+
   return (
-    <div className="rounded border border-stone-800 bg-stone-950/40 p-4">
-      <div className="flex items-baseline justify-between mb-3">
-        <div>
-          <div className="text-lg font-light text-white">
-            {formatDate(batch.batch_date)}
-          </div>
-          <div className="text-xs text-stone-500">
-            {batch.total_read_count} read
-            {batch.total_read_count === 1 ? "" : "s"} across{" "}
-            {batch.entries.length} asset
-            {batch.entries.length === 1 ? "" : "s"}
-          </div>
+    <div className="space-y-6">
+      {/* Summary strip */}
+      <div className="grid gap-3 grid-cols-2 sm:grid-cols-3">
+        <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-stone-500">
+            Batches
+          </p>
+          <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">
+            {batches === null ? "—" : totals.count}
+          </p>
         </div>
-        <div className="text-right">
-          <div className="text-amber-400/80 font-light">
-            {formatCc(batch.total_cc_distributed)}
-          </div>
-          <div className="text-xs text-stone-500 uppercase tracking-wide">
-            distributed
-          </div>
+        <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-amber-500/10 to-amber-500/5 p-4">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-amber-400/80">
+            CC distributed
+          </p>
+          <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">
+            {batches === null ? "—" : formatCc(totals.cc)}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-emerald-500/10 to-emerald-500/5 p-4 col-span-2 sm:col-span-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-emerald-400/80">
+            Reads aggregated
+          </p>
+          <p className="mt-2 text-2xl sm:text-3xl font-light text-stone-100">
+            {batches === null ? "—" : totals.reads.toLocaleString()}
+          </p>
         </div>
       </div>
-      {batch.entries.length > 0 && (
-        <div className="space-y-1 text-xs">
-          {batch.entries.slice(0, 8).map((e) => (
-            <div
-              key={e.asset_id}
-              className="flex items-center justify-between text-stone-400"
-            >
-              <span className="truncate">{e.asset_id}</span>
-              <span className="flex items-center gap-3">
-                <span>{e.read_count} reads</span>
-                {Number(e.evidence_multiplier) > 1 && (
-                  <span className="text-amber-400/80">
-                    ×{Number(e.evidence_multiplier).toFixed(1)}
-                  </span>
-                )}
-                <span className="text-stone-300">
-                  {formatCc(e.effective_cc_pool)}
-                </span>
-              </span>
+
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-medium text-stone-100">
+          Settlement batches
+        </h2>
+        <button
+          type="button"
+          onClick={() => {
+            setRunError(null);
+            setDialogOpen(true);
+          }}
+          className="rounded border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm text-amber-100 hover:bg-amber-500/20 transition-colors"
+        >
+          Run batch…
+        </button>
+      </div>
+
+      {loadError && (
+        <p className="rounded border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          Could not load batches: {loadError}
+        </p>
+      )}
+
+      {batches === null && !loadError ? (
+        <p className="text-sm text-stone-400">Loading batches…</p>
+      ) : batches && batches.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-stone-700 bg-stone-900/30 p-6 text-center">
+          <p className="text-sm text-stone-300">
+            No settlement batches yet.
+          </p>
+          <p className="text-xs text-stone-500 mt-1">
+            Run a batch for any date to materialize one. Once render events
+            accumulate against an asset, the batch carries non-zero CC.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-2xl border border-border/30 bg-card/30">
+          <table className="w-full text-sm">
+            <thead className="bg-stone-900/40 text-stone-400">
+              <tr>
+                <th className="text-left px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  Date
+                </th>
+                <th className="text-right px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  Assets
+                </th>
+                <th className="text-right px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  Reads
+                </th>
+                <th className="text-right px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  CC out
+                </th>
+                <th className="text-right px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  Multipliers
+                </th>
+                <th className="text-left px-4 py-2 text-[10px] uppercase tracking-[0.14em] font-medium">
+                  Batch id
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {batches!.flatMap((batch) => {
+                const open = expandedId === batch.id;
+                const multipliers = batch.entries.filter(
+                  (e) => Number(e.evidence_multiplier) > 1,
+                ).length;
+                const rows = [
+                  <tr
+                    key={batch.id}
+                    className="border-t border-stone-800/40 hover:bg-stone-900/30 cursor-pointer"
+                    onClick={() => setExpandedId(open ? null : batch.id)}
+                  >
+                    <td className="px-4 py-3 text-stone-200">
+                      <span
+                        className="mr-2 text-stone-500"
+                        aria-hidden="true"
+                      >
+                        {open ? "▾" : "▸"}
+                      </span>
+                      {formatDate(batch.batch_date)}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-stone-300">
+                      {batch.entries.length}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-stone-300">
+                      {batch.total_read_count.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-amber-200">
+                      {formatCc(batch.total_cc_distributed)}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums text-stone-400">
+                      {multipliers > 0 ? `${multipliers}` : "—"}
+                    </td>
+                    <td
+                      className="px-4 py-3 font-mono text-xs text-stone-500 truncate max-w-[160px]"
+                      title={batch.id}
+                    >
+                      {batch.id.slice(0, 8)}…
+                    </td>
+                  </tr>,
+                ];
+                if (open) {
+                  rows.push(
+                    <tr key={`${batch.id}-detail`}>
+                      <td colSpan={6} className="px-4 py-4 bg-stone-950/40">
+                        {batch.entries.length === 0 ? (
+                          <p className="text-xs text-stone-500">
+                            No entries — no reads on this date.
+                          </p>
+                        ) : (
+                          <div className="space-y-2">
+                            {batch.entries.map((entry) => (
+                              <div
+                                key={entry.asset_id}
+                                className="flex flex-wrap items-center justify-between gap-3 text-xs"
+                              >
+                                <Link
+                                  href={`/assets/${encodeURIComponent(entry.asset_id.replace(/^asset:/, ""))}`}
+                                  className="font-mono text-stone-300 hover:text-amber-200 truncate max-w-xs"
+                                  title={entry.asset_id}
+                                >
+                                  {entry.asset_id
+                                    .replace(/^asset:/, "")
+                                    .slice(0, 16)}
+                                  …
+                                </Link>
+                                <span className="text-stone-400 tabular-nums">
+                                  {entry.read_count} reads
+                                </span>
+                                <span className="text-stone-400 tabular-nums">
+                                  ×{Number(entry.evidence_multiplier).toFixed(2)}
+                                </span>
+                                <span className="text-amber-200 tabular-nums">
+                                  {formatCc(entry.effective_cc_pool)}
+                                </span>
+                              </div>
+                            ))}
+                            <p className="text-[10px] text-stone-500 pt-1">
+                              computed at {batch.computed_at}
+                            </p>
+                          </div>
+                        )}
+                      </td>
+                    </tr>,
+                  );
+                }
+                return rows;
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Confirmation dialog */}
+      {dialogOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => !running && setDialogOpen(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-border/30 bg-stone-950 p-6 space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-medium text-stone-100">
+              Run settlement batch
+            </h3>
+            <p className="text-sm text-stone-400">
+              Aggregates render events for the chosen date, applies verified
+              evidence multipliers, and stores a hash-chained record. In
+              production this is irreversible.
+            </p>
+            <div className="space-y-2">
+              <label
+                className="text-xs uppercase tracking-[0.14em] text-stone-500"
+                htmlFor="run_date"
+              >
+                Batch date
+              </label>
+              <input
+                id="run_date"
+                type="date"
+                value={runDate}
+                onChange={(e) => setRunDate(e.target.value)}
+                className="w-full rounded-md border border-stone-700 bg-stone-900/60 px-3 py-2 text-sm text-stone-200 focus:border-amber-400/60 focus:outline-none"
+              />
             </div>
-          ))}
-          {batch.entries.length > 8 && (
-            <div className="text-stone-600 text-xs">
-              + {batch.entries.length - 8} more
+            {runError && (
+              <p className="rounded border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+                {runError}
+              </p>
+            )}
+            <div className="flex flex-wrap justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => setDialogOpen(false)}
+                disabled={running}
+                className="rounded border border-stone-700 px-4 py-2 text-sm text-stone-200 hover:border-amber-400/40 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onRun}
+                disabled={running}
+                className="rounded border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm text-amber-100 hover:bg-amber-500/20 transition-colors disabled:opacity-50"
+              >
+                {running ? "Running…" : "Confirm + run"}
+              </button>
             </div>
-          )}
+          </div>
         </div>
       )}
     </div>
   );
 }
 
-export default async function SettlementDashboardPage() {
-  const batches = await fetchBatches();
-
+export default function SettlementPage() {
   return (
-    <main className="max-w-3xl mx-auto px-6 py-12">
-      <nav
-        className="text-sm text-stone-500 mb-8 flex items-center gap-2"
-        aria-label="breadcrumb"
-      >
-        <Link href="/" className="hover:text-amber-400/80 transition-colors">
-          Home
-        </Link>
-        <span className="text-stone-700">/</span>
-        <span className="text-stone-300">Settlement</span>
-      </nav>
+    <main className="bg-stone-950 min-h-screen">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 py-6 sm:py-10 space-y-6">
+        <nav
+          className="text-sm text-stone-500 flex items-center gap-2"
+          aria-label="breadcrumb"
+        >
+          <Link href="/" className="hover:text-amber-300 transition-colors">
+            Home
+          </Link>
+          <span className="text-stone-700">/</span>
+          <span className="text-stone-300">Settlement</span>
+        </nav>
 
-      <h1 className="text-3xl font-extralight text-white mb-2">Settlement</h1>
-      <p className="text-stone-400 text-sm leading-relaxed mb-8">
-        Daily CC distribution batches. Each batch aggregates render events,
-        applies the evidence-verification multiplier (up to 5× per verified
-        asset), and splits CC across asset creator, renderer creator, and host
-        node shares — then distributes the creator's share across the asset's
-        concept pools by tag weight.
-      </p>
+        <header className="space-y-2">
+          <h1 className="text-2xl sm:text-4xl font-light text-stone-50 tracking-tight">
+            Daily settlement
+          </h1>
+          <p className="text-sm text-stone-400 leading-relaxed">
+            Each batch aggregates one day of reads into per-asset CC pools,
+            applies verified evidence multipliers, and writes a hash-chained
+            record. Press a row to see the per-asset split.
+          </p>
+        </header>
 
-      {!batches && (
-        <div className="rounded border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-200">
-          Could not reach the settlement API.
-        </div>
-      )}
+        <SettlementDashboard />
 
-      {batches && batches.length === 0 && (
-        <div className="rounded border border-stone-800 bg-stone-950/40 p-6 text-stone-400 text-sm">
-          No settlement batches computed yet. A batch is produced each day the
-          daily settlement job runs (<code>POST /api/settlement/run</code>).
-          Once render events accumulate against an asset, the first batch will
-          appear here.
-        </div>
-      )}
-
-      {batches && batches.length > 0 && (
-        <div className="space-y-4">
-          {batches.map((batch) => (
-            <BatchCard key={batch.id} batch={batch} />
-          ))}
-        </div>
-      )}
-
-      <p className="text-xs text-stone-500 mt-8">
-        Settlement math lives at{" "}
-        <code className="text-stone-400">
-          api/app/services/settlement_service.py
-        </code>
-        . See <code className="text-stone-400">story-protocol-integration.md</code> R8.
-      </p>
+        <p className="text-xs text-stone-500">
+          Settlement math lives at{" "}
+          <code className="text-stone-400">
+            api/app/services/settlement_service.py
+          </code>
+          . See{" "}
+          <code className="text-stone-400">
+            story-protocol-integration.md
+          </code>{" "}
+          R8.
+        </p>
+      </div>
     </main>
   );
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -836,7 +836,27 @@
       "statWitnessed": "Witnessed",
       "statWitnessedDays": "{n} contributor · 90d",
       "statWitnessedDaysPlural": "{n} contributors · 90d",
-      "statWitnessedHint": "views over 90 days"
+      "statWitnessedHint": "views over 90 days",
+      "ipStatus": {
+        "registered": "IP registered",
+        "pending": "IP pending",
+        "failed": "IP registration failed",
+        "idLabel": "Story Protocol id:"
+      },
+      "storageTitle": "Permanent storage",
+      "storageLede": "The content is pinned to two decentralized stores so it stays reachable even if our host goes quiet.",
+      "storageArweave": "Arweave",
+      "storageIpfs": "IPFS",
+      "evidenceTitle": "Implementation evidence",
+      "evidenceCount": "{n} submission(s)",
+      "evidenceEmpty": "No implementation evidence yet. Submissions land here when a cell builds from this vessel and shares photos, GPS, or community attestations.",
+      "evidenceUnnamed": "Evidence submission",
+      "evidenceVerified": "Verified ×5",
+      "evidencePending": "Pending",
+      "evidencePhotos": "{n} photo(s)",
+      "evidenceGpsPresent": "GPS {lat}, {lng}",
+      "evidenceGpsAbsent": "No GPS",
+      "evidenceAttestations": "{n} attestation(s)"
     },
     "notFound": {
       "eyebrow": "A vessel not in the body",


### PR DESCRIPTION
## Summary

Wires the recently-shipped backend services (`ip_registration_service` #1931, `evidence_service` #1934, `settlement_service`, `permanent_storage_service` #1940, `read_tracking_service` #1942) into three user-facing surfaces named by the `specs/story-protocol-integration.md` source: map. Five spec symbols move from pending to shipped: **IPStatusBadge, StorageLinks, UploadForm, ConceptTagger, SettlementDashboard**.

## What ships

- **`web/app/assets/[asset_id]/page.tsx`** — adds `IPStatusBadge` (Story Protocol on-chain status chip rendered in the hero, surfaces `ip_status` + truncated `sp_ip_id`), `StorageLinks` (Arweave + IPFS rows in a dedicated **Permanent storage** section), and **Implementation evidence** (per-submission cards with photo count, GPS, attestation count, and verified/pending state — fetched from `GET /api/evidence/asset/{id}`).
- **`web/app/assets/upload/page.tsx`** — replaces the placeholder with a working `UploadForm` + `ConceptTagger`. Browser-side SHA-256 via SubtleCrypto, asset_type select (BLUEPRINT / IMAGE / MODEL_3D / VIDEO / ARTICLE / RESEARCH / INSTRUCTION), and a multi-select concept widget with per-tag 0.0–1.0 weight sliders that produces the `concept_tags: [{concept_id, weight}]` array required by R2. POSTs to `/api/assets/register`, then links straight to the new asset detail page on success.
- **`web/app/settlement/page.tsx`** — extracts `SettlementDashboard` as a client component: summary strip (batch count, CC distributed, reads aggregated), batch table with expandable per-asset splits showing evidence multipliers, and a **Run batch…** confirmation dialog that POSTs to `/api/settlement/run` with the chosen date. Empty state when no batches exist yet.

## i18n

16 new keys under `assets.detail.{ipStatus,storage*,evidence*}` added to `web/messages/en.json`. Other locales auto-translate via the multilingual-web pass.

## Test plan

- [ ] Open `/assets/{id}` post-deploy, confirm IPStatusBadge appears only when `ip_status` or `sp_ip_id` is present.
- [ ] Confirm Permanent storage section appears only when arweave_tx or ipfs_cid is present.
- [ ] Submit evidence via API, refresh detail page, confirm it appears in the Evidence section.
- [ ] `/assets/upload` — pick a file, tag concepts, submit, follow the success link.
- [ ] `/settlement` — empty state, then trigger a batch via the dialog, confirm the table populates.
- [ ] Both 1440 and 390 viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)