### PR TITLE
[codex] make recipes and substrate playable

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 198 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 199 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 198
+**Total files**: 199
 
 | File | Purpose |
 |---|---|

--- a/docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json
+++ b/docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json
@@ -1,0 +1,119 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/playable-recipes-substrate-20260524",
+  "commit_scope": "Make Transmission Recipes and the Form substrate playground more immediately playable for new visitors.",
+  "files_owned": [
+    "web/app/vision/recipes/page.tsx",
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/substrate/form/page.tsx",
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "api/tests/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "python3 scripts/context_budget.py web/app/vision/recipes/page.tsx web/app/vision/recipes/RecipeComposer.tsx web/app/substrate/form/page.tsx web/app/substrate/form/_components/FormPlayground.tsx web/components/SecondaryLayerNav.tsx web/components/site_header.tsx web/messages/en.json web/messages/de.json web/messages/es.json web/messages/id.json",
+      "cd web && npm ci",
+      "cd web && npm run build",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "Browser check: desktop /vision/recipes shows three-minute play path, spark buttons, starter cards, and Ask the lattice with no horizontal overflow",
+      "Browser check: desktop /substrate/form shows quest-led evaluator first, Evaluate returns a NodeID, and no horizontal overflow",
+      "Browser check: mobile 390px /vision/recipes and /substrate/form show playable controls with no horizontal overflow",
+      "API_PORT=18100 WEB_PORT=3120 ./scripts/verify_worktree_local_web.sh --start",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json",
+      "git diff --check"
+    ],
+    "summary": "Prompt guide, wellness, context budget, install, build, generated index refresh, desktop/mobile browser checks, and worktree web/API verification passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Browser check: https://coherencycoin.com/vision/recipes exposes the play path and spark buttons",
+      "Browser check: https://coherencycoin.com/substrate/form exposes quest-led evaluator and can evaluate a starter"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; CI and public route validation remain pending until PR and deploy follow-through complete."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "db-backed-vision-hub-content",
+    "knowledge-resonance-engine"
+  ],
+  "task_ids": [
+    "playable-recipes-substrate-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "new-visitor-playability-request"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "frontend-implementation",
+        "browser-validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "web/app/vision/recipes/page.tsx",
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/substrate/form/page.tsx",
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "api/tests/INDEX.md",
+    "MANIFEST.md",
+    "npm run build",
+    "./scripts/verify_worktree_local_web.sh --start",
+    "make wellness"
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "api/tests/INDEX.md",
+    "docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json",
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "web/app/substrate/form/page.tsx",
+    "web/app/vision/recipes/RecipeComposer.tsx",
+    "web/app/vision/recipes/page.tsx"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A new visitor can start from guided choices, create a recipe card, ask the substrate a starter question, evaluate it, and continue playing without reading full documentation first.",
+    "public_endpoints": [
+      "GET /vision/recipes",
+      "GET /substrate/form",
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "Desktop recipes page exposes three-minute play path, starter cards, spark buttons, and lattice bridge.",
+      "Desktop Form page exposes quest-led evaluator before the teaching block.",
+      "Form starter evaluates to a NodeID result.",
+      "Mobile recipes and Form pages keep playable controls visible without horizontal overflow.",
+      "Production build confirms route and component bundles compile."
+    ]
+  }
+}

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { ArrowRight, Play, RotateCcw, Sparkles } from "lucide-react";
 
 type NodeIDOut = { package: number; level: number; type: number; instance: number };
 
@@ -57,6 +58,49 @@ type ExampleGroup = {
   blurb: string;
   examples: Example[];
 };
+
+type Quest = {
+  label: string;
+  audience: string;
+  expr: string;
+  showcases: string;
+  nextMove: string;
+};
+
+const QUESTS: Quest[] = [
+  {
+    label: "Ask what a teaching is shaped like",
+    audience: "first-time visitor",
+    expr: "@concept(lc-trust-over-fear).blueprint",
+    showcases:
+      "A concept's Blueprint NodeID is its structural identity. This is the quickest way to see that the substrate is answering with shape, not prose.",
+    nextMove: "Change the concept id, then ask ?equivalent on the same cell.",
+  },
+  {
+    label: "Find structural kin",
+    audience: "researcher",
+    expr: "?equivalent @concept(lc-trust-over-fear)",
+    showcases:
+      "Structural equivalents share a Blueprint NodeID even when their names, domains, or words differ.",
+    nextMove: "Open any returned cell and ask for its .ctor.",
+  },
+  {
+    label: "Read the body's count",
+    audience: "steward",
+    expr: "?lattice",
+    showcases:
+      "A lattice snapshot gives the count-level framebuffer: blueprints, recipes, cells, and relationships currently interned.",
+    nextMove: "Run ?vocabulary next to see which recipe categories are circulating.",
+  },
+  {
+    label: "Make code become a recipe",
+    audience: "builder",
+    expr: "do { let x = 5; let y = x + 3; y * 2 }",
+    showcases:
+      "Form interns code as a Recipe NodeID. Two expressions with the same structure converge on the same identity.",
+    nextMove: "Change one number and watch the recipe identity change.",
+  },
+];
 
 // Curated tour of every unique Form construct. Each example is runnable
 // against the live substrate. Grouped so the reader can sense the
@@ -544,20 +588,32 @@ export function FormPlayground() {
   const searchParams = useSearchParams();
   const cellParam = searchParams.get("cell");
   const starter = starterFromCell(cellParam);
-  const firstExample = GROUPS[0].examples[0];
+  const firstQuest = QUESTS[0];
   const [expression, setExpression] = useState(
-    starter ? starter.expr : firstExample.expr,
+    starter ? starter.expr : firstQuest.expr,
   );
   const [activeShowcase, setActiveShowcase] = useState(
-    starter ? starter.showcases : firstExample.showcases,
+    starter ? starter.showcases : firstQuest.showcases,
+  );
+  const [nextMove, setNextMove] = useState(
+    starter ? "Run it, then replace .blueprint with .ctor or prepend ?equivalent." : firstQuest.nextMove,
   );
   const [evaluating, setEvaluating] = useState(false);
   const [result, setResult] = useState<FormResultOut | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const pickQuest = (quest: Quest) => {
+    setExpression(quest.expr);
+    setActiveShowcase(quest.showcases);
+    setNextMove(quest.nextMove);
+    setResult(null);
+    setError(null);
+  };
+
   const pickExample = (ex: Example) => {
     setExpression(ex.expr);
     setActiveShowcase(ex.showcases);
+    setNextMove("Edit one symbol, run it again, and compare the returned shape.");
     setResult(null);
     setError(null);
   };
@@ -587,8 +643,112 @@ export function FormPlayground() {
   };
 
   return (
-    <div className="space-y-6">
-      <div className="space-y-4">
+    <div className="space-y-8">
+      <section className="grid gap-5 lg:grid-cols-[0.85fr_1.15fr]" aria-labelledby="form-play-heading">
+        <div className="space-y-4 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.22em] text-amber-300/75">Play first</p>
+            <h2 id="form-play-heading" className="text-2xl font-light text-stone-100">
+              Pick a question. Press Evaluate. Change one word.
+            </h2>
+            <p className="text-sm leading-relaxed text-stone-400">
+              These are live substrate questions with a real answer. No setup, no repo clone, no grammar study first.
+            </p>
+          </div>
+          <div className="grid gap-2">
+            {QUESTS.map((quest) => (
+              <button
+                key={quest.expr}
+                type="button"
+                onClick={() => pickQuest(quest)}
+                className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                  expression === quest.expr
+                    ? "border-amber-500/50 bg-amber-500/10 text-amber-100"
+                    : "border-stone-800/50 bg-stone-950/35 text-stone-300 hover:border-amber-500/35 hover:text-amber-200"
+                }`}
+              >
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <Sparkles className="h-4 w-4 text-amber-300/75" aria-hidden="true" />
+                  {quest.label}
+                </span>
+                <span className="mt-1 block text-xs uppercase tracking-[0.16em] text-stone-500">
+                  {quest.audience}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-xl border border-stone-800/50 bg-stone-900/25 p-4">
+          <div className="space-y-2">
+            <label htmlFor="form-expression" className="text-xs uppercase tracking-[0.18em] text-stone-500">
+              Expression
+            </label>
+            <textarea
+              id="form-expression"
+              value={expression}
+              onChange={(e) => {
+                setExpression(e.target.value);
+                setNextMove("Run it, read the returned shape, then change one part and run again.");
+              }}
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                  e.preventDefault();
+                  evaluate();
+                }
+              }}
+              className="h-32 w-full resize-y rounded-xl border border-stone-800/50 bg-stone-950/60 p-3 font-mono text-sm leading-relaxed text-stone-300 transition-colors focus:border-amber-500/40 focus:outline-none"
+              placeholder="@spec(agent-pipeline)"
+              spellCheck={false}
+            />
+            {activeShowcase && <p className="text-xs leading-relaxed text-stone-500">{activeShowcase}</p>}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              onClick={evaluate}
+              disabled={evaluating || !expression.trim()}
+              className="inline-flex items-center gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-5 py-2.5 text-sm font-medium text-amber-300/90 transition-all hover:border-amber-500/30 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Play className="h-4 w-4" aria-hidden="true" />
+              {evaluating ? "Evaluating..." : "Evaluate"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                pickQuest(firstQuest);
+              }}
+              className="inline-flex items-center gap-2 rounded-xl border border-stone-800/60 bg-stone-950/35 px-4 py-2.5 text-sm text-stone-400 transition-colors hover:border-stone-700 hover:text-stone-200"
+            >
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+              Reset
+            </button>
+            <span className="text-xs text-stone-600">⌘↩ to evaluate</span>
+          </div>
+
+          {nextMove && (
+            <div className="rounded-lg border border-teal-500/20 bg-teal-500/5 p-3 text-sm leading-relaxed text-teal-100/80">
+              <span className="font-medium text-teal-200">Next move:</span> {nextMove}
+            </div>
+          )}
+
+          {error && (
+            <div className="whitespace-pre-wrap rounded-xl border border-red-800/30 bg-red-900/10 p-3 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          {result && <ResultPanel result={result} />}
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby="form-atlas-heading">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-stone-500">Expression atlas</p>
+          <h2 id="form-atlas-heading" className="mt-2 text-xl font-light text-stone-200">
+            Keep playing with the deeper grammar.
+          </h2>
+        </div>
         {GROUPS.map((group) => (
           <div key={group.heading} className="space-y-2">
             <div>
@@ -613,45 +773,14 @@ export function FormPlayground() {
             </div>
           </div>
         ))}
+      </section>
+
+      <div className="rounded-xl border border-stone-800/50 bg-stone-900/25 p-4 text-sm leading-relaxed text-stone-400">
+        <Link href="/vision/recipes" className="inline-flex items-center gap-2 text-amber-200 hover:text-amber-100">
+          Turn this structural question into a transmission recipe
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
       </div>
-
-      <div className="space-y-2">
-        <textarea
-          value={expression}
-          onChange={(e) => setExpression(e.target.value)}
-          onKeyDown={(e) => {
-            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-              e.preventDefault();
-              evaluate();
-            }
-          }}
-          className="w-full h-32 p-3 bg-stone-900/50 border border-stone-800/40 rounded-xl text-stone-300 font-mono text-sm leading-relaxed resize-y focus:outline-none focus:border-amber-500/30 transition-colors"
-          placeholder="@spec(agent-pipeline)"
-          spellCheck={false}
-        />
-        {activeShowcase && (
-          <p className="text-xs text-stone-500 italic">{activeShowcase}</p>
-        )}
-      </div>
-
-      <div className="flex items-center gap-3">
-        <button
-          onClick={evaluate}
-          disabled={evaluating || !expression.trim()}
-          className="px-5 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20 text-amber-300/90 hover:bg-amber-500/20 hover:border-amber-500/30 transition-all text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {evaluating ? "Evaluating..." : "Evaluate"}
-        </button>
-        <span className="text-xs text-stone-600">⌘↩ to evaluate</span>
-      </div>
-
-      {error && (
-        <div className="rounded-xl border border-red-800/30 bg-red-900/10 p-3 text-sm text-red-300 whitespace-pre-wrap">
-          {error}
-        </div>
-      )}
-
-      {result && <ResultPanel result={result} />}
     </div>
   );
 }

--- a/web/app/substrate/form/page.tsx
+++ b/web/app/substrate/form/page.tsx
@@ -24,14 +24,36 @@ export default function FormPlaygroundPage() {
       </nav>
 
       <header className="mb-8 space-y-4">
-        <h1 className="text-2xl font-semibold">Form playground</h1>
-        <p className="text-sm text-muted-foreground">
-          Form is the substrate's native query language. NodeIDs are first-class;
-          names are query keys, not identities. Type an expression, evaluate, and
-          the lattice answers in its own shape.
+        <p className="text-sm uppercase tracking-[0.22em] text-amber-400/80">Substrate playground</p>
+        <h1 className="text-3xl font-light tracking-tight text-stone-100 md:text-5xl">Ask the lattice one real question.</h1>
+        <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
+          Form is the substrate's native query language. Pick a starter question, evaluate it, then change one word
+          and watch how the returned shape changes.
         </p>
 
-        <div className="rounded-xl border border-stone-800/40 bg-stone-900/30 p-4 space-y-3 text-sm text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
+          Full teaching:{" "}
+          <Link
+            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/form-language.md#the-perception-this-opens--reading-this-as-a-human-reading-this-as-an-llm"
+            className="underline hover:text-amber-400/80"
+          >
+            The perception this opens
+          </Link>
+          {" · "}
+          Grammar:{" "}
+          <Link
+            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/form-language.md"
+            className="underline hover:text-amber-400/80"
+          >
+            docs/coherence-substrate/form-language.md
+          </Link>
+        </p>
+      </header>
+
+      <FormPlayground />
+
+      <section className="mt-10 rounded-xl border border-stone-800/40 bg-stone-900/30 p-4 space-y-3 text-sm text-muted-foreground" aria-labelledby="form-perception-heading">
+        <h2 id="form-perception-heading" className="text-lg font-light text-stone-200">What the playground is showing</h2>
           <p>
             Most languages bind meaning to symbols by convention —{" "}
             <em>"tree"</em> means a plant because we agreed. Form binds meaning to{" "}
@@ -60,28 +82,7 @@ export default function FormPlaygroundPage() {
               </p>
             </div>
           </div>
-        </div>
-
-        <p className="text-sm text-muted-foreground">
-          Full teaching:{" "}
-          <Link
-            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/form-language.md#the-perception-this-opens--reading-this-as-a-human-reading-this-as-an-llm"
-            className="underline hover:text-amber-400/80"
-          >
-            The perception this opens
-          </Link>
-          {" · "}
-          Grammar:{" "}
-          <Link
-            href="https://github.com/seeker71/Coherence-Network/blob/main/docs/coherence-substrate/form-language.md"
-            className="underline hover:text-amber-400/80"
-          >
-            docs/coherence-substrate/form-language.md
-          </Link>
-        </p>
-      </header>
-
-      <FormPlayground />
+      </section>
     </main>
   );
 }

--- a/web/app/vision/recipes/RecipeComposer.tsx
+++ b/web/app/vision/recipes/RecipeComposer.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Check, Clipboard, Link2, RotateCcw, Wand2 } from "lucide-react";
+import { Check, Clipboard, Link2, RotateCcw, Sparkles, Wand2 } from "lucide-react";
 
 type RecipeField =
   | "source"
@@ -19,7 +19,14 @@ type ComposerCard = Record<RecipeField, string>;
 
 type Starter = {
   title: string;
+  promise: string;
   card: ComposerCard;
+};
+
+type Spark = {
+  label: string;
+  field: RecipeField;
+  value: string;
 };
 
 const emptyCard: ComposerCard = {
@@ -93,6 +100,7 @@ const fields: Array<{ id: RecipeField; label: string; placeholder: string; rows?
 const starters: Starter[] = [
   {
     title: "Repair Wake",
+    promise: "Turn a failure into one repaired future habit.",
     card: {
       source: "a failed deploy where a hidden dependency was trusted without a witness",
       observed: "alert fatigue, unclear owner, fast patch, repeated surprise, quiet shame afterward",
@@ -107,6 +115,7 @@ const starters: Starter[] = [
   },
   {
     title: "Dance Onboarding",
+    promise: "Turn a song arc into a first-run experience.",
     card: {
       source: "an ecstatic dance track with arrival, pulse, invitation, build, release, and return",
       observed: "the body understands the arc before the mind explains the arc",
@@ -121,6 +130,7 @@ const starters: Starter[] = [
   },
   {
     title: "Metric Spellbreaker",
+    promise: "Turn measurement pressure into a clearer decision.",
     card: {
       source: "measurement and observer teachings held as strategy metaphor",
       observed: "what gets measured becomes visible; what is unmeasured becomes easier to sacrifice",
@@ -132,6 +142,39 @@ const starters: Starter[] = [
       claimBoundary: "quantum language is metaphor here, not physics proof",
       nextEmbodiment: "run before adopting any growth, reach, impact, or productivity metric",
     },
+  },
+];
+
+const sparks: Spark[] = [
+  {
+    label: "Song -> workshop",
+    field: "source",
+    value: "a song whose build, drop, silence, and return teach how a group changes state",
+  },
+  {
+    label: "Video -> proof page",
+    field: "observed",
+    value: "wide shot gives context, close-up carries claim, still frame lets proof rest long enough to inspect",
+  },
+  {
+    label: "Practice -> product",
+    field: "observerLens",
+    value: "embodiment facilitator + product designer",
+  },
+  {
+    label: "Spec -> ceremony",
+    field: "recipe",
+    value: "intention -> constraints -> smallest test -> witnessed run -> proof note -> next breath",
+  },
+  {
+    label: "Create a real artifact",
+    field: "payload",
+    value: "a one-page field kit someone can run with a group this week",
+  },
+  {
+    label: "Bound the claim",
+    field: "claimBoundary",
+    value: "this is a practice analogy; it supports attention and does not replace domain expertise or consent",
   },
 ];
 
@@ -246,6 +289,19 @@ export function RecipeComposer() {
     setLinkCopied(false);
   }
 
+  function applySpark(spark: Spark) {
+    setCard((current) => {
+      const existing = current[spark.field].trim();
+      return {
+        ...current,
+        [spark.field]: existing ? `${existing}; ${spark.value}` : spark.value,
+      };
+    });
+    setCopied(false);
+    setLinkCopied(false);
+    setRestored(null);
+  }
+
   async function copyCard() {
     if (!formatted.trim()) return;
     const copiedToClipboard = await writeClipboard(formatted);
@@ -286,6 +342,27 @@ export function RecipeComposer() {
             </p>
           </div>
 
+          <div className="grid gap-3 rounded-lg border border-violet-500/20 bg-violet-500/5 p-4 text-sm text-stone-300">
+            <div className="flex items-center gap-2 text-violet-200">
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+              <span className="font-medium">Three-minute play path</span>
+            </div>
+            <ol className="grid gap-2 sm:grid-cols-3">
+              <li className="rounded-md border border-stone-800/60 bg-stone-950/35 p-3">
+                <span className="block text-xs uppercase tracking-[0.16em] text-stone-500">1. Pick</span>
+                Start with a card below.
+              </li>
+              <li className="rounded-md border border-stone-800/60 bg-stone-950/35 p-3">
+                <span className="block text-xs uppercase tracking-[0.16em] text-stone-500">2. Bend</span>
+                Change one field to fit your real source.
+              </li>
+              <li className="rounded-md border border-stone-800/60 bg-stone-950/35 p-3">
+                <span className="block text-xs uppercase tracking-[0.16em] text-stone-500">3. Move</span>
+                Copy it, share it, or run it this week.
+              </li>
+            </ol>
+          </div>
+
           <div className="grid gap-2 sm:grid-cols-3">
             {starters.map((starter) => (
               <button
@@ -297,12 +374,36 @@ export function RecipeComposer() {
                   setLinkCopied(false);
                   setRestored(null);
                 }}
-                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg border border-stone-800/70 bg-stone-900/40 px-3 py-2 text-sm text-stone-300 transition-colors hover:border-violet-500/35 hover:text-violet-200"
+                className="flex min-h-[88px] flex-col items-start justify-center gap-2 rounded-lg border border-stone-800/70 bg-stone-900/40 px-3 py-3 text-left text-sm text-stone-300 transition-colors hover:border-violet-500/35 hover:text-violet-200"
               >
-                <Wand2 className="h-4 w-4 text-violet-300/70" aria-hidden="true" />
-                {starter.title}
+                <span className="inline-flex items-center gap-2 font-medium text-stone-100">
+                  <Wand2 className="h-4 w-4 text-violet-300/70" aria-hidden="true" />
+                  {starter.title}
+                </span>
+                <span className="text-xs leading-relaxed text-stone-500">{starter.promise}</span>
               </button>
             ))}
+          </div>
+
+          <div className="space-y-3 rounded-lg border border-stone-800/60 bg-stone-900/25 p-4">
+            <div>
+              <h3 className="text-sm font-medium text-stone-200">Spark buttons</h3>
+              <p className="mt-1 text-xs leading-relaxed text-stone-500">
+                Use these when the blank field feels too open. Each one drops a usable phrase into one part of the card.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {sparks.map((spark) => (
+                <button
+                  key={`${spark.field}-${spark.label}`}
+                  type="button"
+                  onClick={() => applySpark(spark)}
+                  className="rounded-lg border border-stone-800/70 bg-stone-950/40 px-3 py-2 text-xs text-stone-300 transition-colors hover:border-amber-500/35 hover:text-amber-200"
+                >
+                  {spark.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           <div className="rounded-lg border border-stone-800/60 bg-stone-900/25 p-4">

--- a/web/app/vision/recipes/page.tsx
+++ b/web/app/vision/recipes/page.tsx
@@ -369,6 +369,13 @@ export default function TransmissionRecipesPage() {
                 Read the concept
                 <Sparkles className="h-4 w-4" aria-hidden="true" />
               </Link>
+              <Link
+                href="/substrate/form?cell=@concept(lc-transmission-recipe-atlas)"
+                className="inline-flex items-center gap-2 rounded-lg border border-teal-500/25 bg-teal-500/10 px-5 py-3 text-sm font-medium text-teal-200 transition-colors hover:bg-teal-500/20"
+              >
+                Ask the lattice
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a three-minute play path, starter promises, and spark buttons to the Transmission Recipe composer
- move the Form playground workbench before the teaching block and add quest-led starter questions
- link recipes into the Form playground and refresh generated indexes

## Proof
- PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
- make wellness
- python3 scripts/context_budget.py web/app/vision/recipes/page.tsx web/app/vision/recipes/RecipeComposer.tsx web/app/substrate/form/page.tsx web/app/substrate/form/_components/FormPlayground.tsx web/components/SecondaryLayerNav.tsx web/components/site_header.tsx web/messages/en.json web/messages/de.json web/messages/es.json web/messages/id.json
- cd web && npm ci
- cd web && npm run build
- python3 scripts/generate_repo_indexes.py --check
- Browser checks: desktop/mobile /vision/recipes and /substrate/form; starter Form evaluation returns NodeID; no horizontal overflow
- API_PORT=18100 WEB_PORT=3120 ./scripts/verify_worktree_local_web.sh --start
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-24_playable_recipes_substrate.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict