### PR TITLE
tend: dedupe duplicate test: frontmatter so wellness reads the proof

### DIFF
--- a/specs/data-driven-timeout-resume.md
+++ b/specs/data-driven-timeout-resume.md
@@ -28,8 +28,6 @@ done_when:
   - 'symbol_in_file("api/app/services/agent_execution_retry.py", "_resolve_retry_max")'
   - 'file_exists("api/app/services/agent_task_continuation_service.py")'
   - 'symbol_in_file("api/app/services/agent_task_continuation_service.py", "task")'
-test:
-  - "pytest -q api/tests/test_timeout_adaptive_service.py"
 test: "pytest -q api/tests/test_timeout_adaptive_service.py"
 ---
 

--- a/specs/identity-driven-onboarding-tofu.md
+++ b/specs/identity-driven-onboarding-tofu.md
@@ -22,8 +22,6 @@ done_when:
   - 'symbol_in_file("api/app/services/onboarding_service.py", "resolve_session")'
   - 'file_exists("api/app/routers/onboarding.py")'
   - 'symbol_in_file("api/app/routers/onboarding.py", "onboarding")'
-test:
-  - "pytest api/tests/test_onboarding.py -v"
 test: "pytest api/tests/test_onboarding.py -v"
 ---
 

--- a/specs/provider-usage-coalescing-timeout-resilience.md
+++ b/specs/provider-usage-coalescing-timeout-resilience.md
@@ -19,8 +19,6 @@ done_when:
   - 'symbol_in_file("api/app/models/automation_usage.py", "UsageAlert")'
   - 'symbol_in_file("api/app/models/automation_usage.py", "ProviderUsageOverview")'
   - 'symbol_in_file("api/app/models/automation_usage.py", "ProviderUsageSnapshot")'
-test:
-  - "pytest -q api/tests/test_automation_usage_api.py -k 'finalize_snapshot or coalesces or times_out'"
 test: "pytest -q api/tests/test_automation_usage_api.py -k 'finalize_snapshot or coalesces or times_out'"
 ---
 


### PR DESCRIPTION
## Summary

Three `status: done` specs each carried two `test:` keys (list + scalar with the same command). The wellness chain-organ regex matched the first `test:`, then stopped at the second `test:` line (since `test` matches `[a-z_]+`), capturing an empty group. Wellness bucketed all three as "no proof claimed."

All three honor **Path A** — the tests already exist and pass; the spec's claim just needed to be parseable:

| Spec | Test | Result |
|---|---|---|
| `data-driven-timeout-resume` | `tests/test_timeout_adaptive_service.py` | 4 passed |
| `identity-driven-onboarding-tofu` | `tests/test_onboarding.py` | 9 passed |
| `provider-usage-coalescing-timeout-resilience` | `tests/test_automation_usage_api.py -k 'finalize_snapshot or coalesces or times_out'` | 3 passed |

Kept the single-string form (dominant convention in `specs/`).

## Wellness before → after

```
before: chain healthy 99/129 ... 3 specs have no test: or proof:
after:  chain healthy 102/129 ... (no missing-proof line)
```

## Test plan

- [x] `python3 scripts/wellness_check.py` — "no proof claimed" count drops from 3 to 0
- [x] `cd api && pytest -q tests/test_timeout_adaptive_service.py tests/test_onboarding.py` — 13 passed
- [x] `cd api && pytest -q tests/test_automation_usage_api.py -k 'finalize_snapshot or coalesces or times_out'` — 3 passed