### PR TITLE
tend: close story-protocol-integration symbol drift — 4 pending to 0

### DIFF
--- a/api/app/services/settlement_service.py
+++ b/api/app/services/settlement_service.py
@@ -32,7 +32,7 @@ def _filter_events_by_date(
     return [e for e in events if e.timestamp.date() == batch_date]
 
 
-def _compute_concept_pools(
+def compute_concept_distribution(
     total_cc: Decimal,
     tags: List[AssetConceptTag],
 ) -> List[ConceptPool]:
@@ -41,6 +41,10 @@ def _compute_concept_pools(
     Weights are scaled so the pool sums to total_cc even if the raw
     weights don't sum to 1.0. If an asset has no tags, a single
     'uncategorized' pool carries the full amount.
+
+    Public surface named in story-protocol-integration spec source: map
+    so other services (or settlement-adjacent flows like derivative
+    royalty distribution) can reuse the same concept-weighted split.
     """
     if total_cc == 0:
         return []
@@ -97,7 +101,7 @@ def run_daily_settlement(
         renderer_creator_share = base_renderer * multiplier
         host_node_share = base_host * multiplier
 
-        concept_pools = _compute_concept_pools(
+        concept_pools = compute_concept_distribution(
             asset_creator_share,
             list(asset_concept_tags.get(asset_id, [])),
         )

--- a/specs/story-protocol-integration.md
+++ b/specs/story-protocol-integration.md
@@ -14,7 +14,19 @@ source:
   - file: api/app/services/read_tracking_service.py
     symbols: [record_read(), get_daily_aggregates(), compute_cc_flow()]
   - file: api/app/services/settlement_service.py
-    symbols: [run_daily_settlement(), compute_concept_distribution(), settle_batch()]
+    symbols: [run_daily_settlement(), compute_concept_distribution()]
+# Evolution note (2026-05-24): the original spec named a third symbol
+# `settle_batch()` as a per-batch entry-point distinct from the daily
+# aggregator. During implementation the contract collapsed —
+# `run_daily_settlement()` carries the full path (filter events by
+# date, group by asset, apply evidence multiplier, split by concept
+# weight, return frozen `SettlementBatch`). The router calls it once
+# per `POST /api/settlement/run`; there is no remaining role for a
+# separate sub-batch primitive. Storage and retrieval live in the
+# sibling helpers `store_batch` / `get_batch` / `list_batches`. If a
+# finer-grained batching contract returns (e.g. hourly rollups,
+# concept-pool-only settlements), it wants a new spec rather than
+# reviving this name.
   - file: api/app/services/evidence_service.py
     symbols: [submit_evidence(), verify_evidence(), compute_evidence_bonus()]
   - file: api/app/services/value_lineage_service.py
@@ -26,7 +38,12 @@ source:
   - file: api/app/services/belief_service.py
     symbols: [get_belief_profile()]
   - file: api/app/routers/settlement.py
-    symbols: [trigger_settlement(), get_settlement_status()]
+    symbols: [run_settlement(), get_settlement()]
+# Evolution note (2026-05-24): handler names follow the URL pattern
+# they serve — `run_settlement` for `POST /api/settlement/run`,
+# `get_settlement` for `GET /api/settlement/{date}`. Original spec
+# proposed `trigger_settlement` / `get_settlement_status` before the
+# routes were finalized; the URL-aligned names landed instead.
   - file: api/app/routers/evidence.py
     symbols: [submit_evidence(), list_evidence()]
   - file: api/app/models/settlement.py
@@ -83,7 +100,6 @@ done_when:
   - 'file_exists("api/app/services/settlement_service.py")'
   - 'symbol_in_file("api/app/services/settlement_service.py", "run_daily_settlement")'
   - 'symbol_in_file("api/app/services/settlement_service.py", "compute_concept_distribution")'
-  - 'symbol_in_file("api/app/services/settlement_service.py", "settle_batch")'
   - 'file_exists("api/app/services/evidence_service.py")'
   - 'symbol_in_file("api/app/services/evidence_service.py", "submit_evidence")'
   - 'symbol_in_file("api/app/services/evidence_service.py", "verify_evidence")'
@@ -98,8 +114,8 @@ done_when:
   - 'file_exists("api/app/services/belief_service.py")'
   - 'symbol_in_file("api/app/services/belief_service.py", "get_belief_profile")'
   - 'file_exists("api/app/routers/settlement.py")'
-  - 'symbol_in_file("api/app/routers/settlement.py", "trigger_settlement")'
-  - 'symbol_in_file("api/app/routers/settlement.py", "get_settlement_status")'
+  - 'symbol_in_file("api/app/routers/settlement.py", "run_settlement")'
+  - 'symbol_in_file("api/app/routers/settlement.py", "get_settlement")'
   - 'file_exists("api/app/routers/evidence.py")'
   - 'symbol_in_file("api/app/routers/evidence.py", "submit_evidence")'
   - 'symbol_in_file("api/app/routers/evidence.py", "list_evidence")'


### PR DESCRIPTION
## Summary

The settlement work shipped under names that diverged from the spec's `source:` block. Closing the 4 pending symbols with the right resolution per symbol:

| Symbol | Choice | What happened |
|---|---|---|
| `settlement_service.compute_concept_distribution` | **A** — promote | Renamed private `_compute_concept_pools` to the public name the spec already claimed. Function purpose IS concept distribution; only private/public was the distinction. |
| `settlement_service.settle_batch` | **C** — remove + evolution note | Contract collapsed into `run_daily_settlement` during implementation — no remaining role for a separate sub-batch primitive. |
| `routers/settlement.run_settlement` (was `trigger_settlement`) | **B** — spec catches up | URL-aligned name `run_settlement` matches `POST /api/settlement/run`. |
| `routers/settlement.get_settlement` (was `get_settlement_status`) | **B** — spec catches up | URL-aligned name `get_settlement` matches `GET /api/settlement/{date}`. |

Evolution notes in the `source:` block follow PR #1917 style so the next reader sees what evolved rather than treating it as residue.

## Wellness

Before: `4 target symbol(s) pending across 1 active spec(s)` — all in `story-protocol-integration`.
After: `every claimed symbol resolves in its file (806 symbols across 101 spec(s) checked)`.

## Test plan

- [x] `cd api && pytest tests/test_settlement_flow.py tests/test_evidence_flow.py tests/test_ip_registration.py tests/test_story_protocol.py tests/test_permanent_storage.py tests/test_read_tracking.py tests/test_assets_content.py -v` — 97 passed in 5.25s
- [x] `python3 scripts/wellness_check.py` — symbol resolution clean
- [x] `python3 scripts/generate_repo_indexes.py` — already up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)