### PR TITLE
tend: chain organ tolerates duplicate test: keys + warns

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 199 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 200 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 199
+**Total files**: 200
 
 | File | Purpose |
 |---|---|
@@ -206,4 +206,5 @@
 | [test_verification.py](test_verification.py) | Flow-centric tests for the public verification framework. |
 | [test_views_and_wallets.py](test_views_and_wallets.py) | Flow-centric tests for view tracking, wallet integration, and discovery rewards. |
 | [test_vision_content.py](test_vision_content.py) | _no top-of-file purpose_ |
+| [test_wellness_chain_duplicates.py](test_wellness_chain_duplicates.py) | Regression test: the chain organ tolerates duplicate ``test:`` keys. |
 | [test_worktree_continuity_guard.py](test_worktree_continuity_guard.py) | _no top-of-file purpose_ |

--- a/api/tests/test_wellness_chain_duplicates.py
+++ b/api/tests/test_wellness_chain_duplicates.py
@@ -1,0 +1,91 @@
+"""Regression test: the chain organ tolerates duplicate ``test:`` keys.
+
+A spec frontmatter that carried two ``test:`` keys (YAML list form
+followed by a scalar, or vice versa) used to silently break the chain
+organ — its regex stopped at the second ``test:`` line and captured an
+empty group, mis-classifying the spec as "no proof claimed."
+
+The fix: ``re.findall`` with a lookahead terminator concatenates every
+``test:`` block, and the duplicate is surfaced as a soft warning so the
+next author cleans up the YAML smell.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_wellness(monkeypatch, root: Path):
+    """Import ``scripts/wellness_check.py`` with ``ROOT`` pointed at ``root``."""
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "scripts" / "wellness_check.py"
+    spec = importlib.util.spec_from_file_location("wellness_check_under_test", src)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["wellness_check_under_test"] = mod
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "ROOT", root)
+    return mod
+
+
+def _write_spec(specs_dir: Path, stem: str, frontmatter: str) -> None:
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    (specs_dir / f"{stem}.md").write_text(f"---\n{frontmatter}\n---\n\nbody\n")
+
+
+def test_duplicate_test_keys_do_not_false_no_proof(monkeypatch, tmp_path):
+    """Two ``test:`` keys still read as proof-claimed, and the warning fires."""
+    specs_dir = tmp_path / "specs"
+    src_path = tmp_path / "api" / "app" / "foo.py"
+    src_path.parent.mkdir(parents=True)
+    src_path.write_text("# present")
+    test_path = tmp_path / "api" / "tests" / "test_foo.py"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text("def test_foo(): pass")
+
+    _write_spec(
+        specs_dir,
+        "dup-test-keys",
+        "status: done\n"
+        "idea_id: foo\n"
+        "source:\n"
+        "  - file: api/app/foo.py\n"
+        "test:\n"
+        "  - cd api && pytest tests/test_foo.py\n"
+        "test: cd api && pytest tests/test_foo.py\n",
+    )
+
+    mod = _load_wellness(monkeypatch, tmp_path)
+    out = "\n".join(mod.sense_chain())
+
+    assert "no proof claimed" not in out, out
+    assert "duplicate `test:` keys" in out, out
+    assert "dup-test-keys" in out, out
+
+
+def test_single_test_key_emits_no_duplicate_warning(monkeypatch, tmp_path):
+    """A clean single ``test:`` key keeps the warning silent."""
+    specs_dir = tmp_path / "specs"
+    src_path = tmp_path / "api" / "app" / "foo.py"
+    src_path.parent.mkdir(parents=True)
+    src_path.write_text("# present")
+    test_path = tmp_path / "api" / "tests" / "test_foo.py"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text("def test_foo(): pass")
+
+    _write_spec(
+        specs_dir,
+        "clean-test-key",
+        "status: done\n"
+        "idea_id: foo\n"
+        "source:\n"
+        "  - file: api/app/foo.py\n"
+        "test: cd api && pytest tests/test_foo.py\n",
+    )
+
+    mod = _load_wellness(monkeypatch, tmp_path)
+    out = "\n".join(mod.sense_chain())
+
+    assert "duplicate `test:` keys" not in out, out
+    assert "no proof claimed" not in out, out

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -511,6 +511,7 @@ def sense_chain() -> list[str]:
     no_test_declared: list[str] = []
     orphan_specs: list[str] = []
     operational_proof: list[str] = []  # specs honoring "proof: operational"
+    duplicate_test_keys: list[str] = []  # YAML smell — two `test:` keys in one frontmatter
 
     for spec in sorted(specs_dir.glob("*.md")):
         if spec.name in ("INDEX.md", "TEMPLATE.md", "MANIFEST.md"):
@@ -544,9 +545,19 @@ def sense_chain() -> list[str]:
         proof_value = (proof_m.group(1).strip().strip('"').strip("'").lower() if proof_m else "")
         is_operational = proof_value == "operational"
 
-        # test: declaration (string or list) — extract test paths via the same regex coh_substrate uses
-        test_section_m = re.search(r"^test\s*:(.*?)(?:\n[a-z_]+\s*:|---|$)", fm, re.MULTILINE | re.DOTALL)
-        test_text = (test_section_m.group(1) if test_section_m else "")
+        # test: declaration (string or list) — extract test paths from EVERY
+        # `^test:` block. A YAML frontmatter with two `test:` keys (list form
+        # followed by scalar, or vice versa) used to break the old single-shot
+        # regex: it matched the first `test:` and stopped at the next
+        # `^[a-z_]+:` line, which `test:` itself satisfies, leaving the captured
+        # group empty. `findall` with a lookahead terminator concatenates all
+        # `test:` block bodies, and the duplicate is surfaced as a soft warning.
+        test_blocks = re.findall(
+            r"^test\s*:(.*?)(?=\n[a-z_]+\s*:|^---|\Z)", fm, re.MULTILINE | re.DOTALL
+        )
+        if len(test_blocks) > 1:
+            duplicate_test_keys.append(spec.stem)
+        test_text = "\n".join(test_blocks)
         def _resolve_test_path(p: str) -> str:
             # Already explicit: leave alone (api/tests/... or mcp-server/tests/...)
             if p.startswith("api/") or p.startswith("mcp-server/"):
@@ -604,6 +615,13 @@ def sense_chain() -> list[str]:
         lines.append(f"  {len(no_test_declared)} specs have no test: or proof: frontmatter (no proof claimed)")
     if orphan_specs:
         lines.append(f"  {len(orphan_specs)} orphan specs (no idea_id): {', '.join(orphan_specs)}")
+    if duplicate_test_keys:
+        sample = ", ".join(sorted(duplicate_test_keys)[:3])
+        more = f" (+{len(duplicate_test_keys) - 3} more)" if len(duplicate_test_keys) > 3 else ""
+        lines.append(
+            f"  {len(duplicate_test_keys)} spec(s) carry duplicate `test:` keys — "
+            f"deduplicate to one canonical form: {sample}{more}"
+        )
     if not missing_tests and not pending_tests and not no_test_declared and not orphan_specs:
         lines.append("  chain reach is whole — every claim has its proof")
     return lines


### PR DESCRIPTION
## Why

PR #1952 deduped three specs that carried two `test:` keys, but the
underlying regex in `scripts/wellness_check.py` still has the bug.
Any future duplicate would silently re-trigger "no proof claimed."

## What

**Regex fix** (`sense_chain`):

```python
# before — matched first ^test: only, stopped at next [a-z_]+: (which test itself matches)
test_section_m = re.search(r"^test\s*:(.*?)(?:\n[a-z_]+\s*:|---|$)", fm, re.MULTILINE | re.DOTALL)
test_text = (test_section_m.group(1) if test_section_m else "")

# after — matches EVERY ^test: block via lookahead terminator
test_blocks = re.findall(
    r"^test\s*:(.*?)(?=\n[a-z_]+\s*:|^---|\Z)", fm, re.MULTILINE | re.DOTALL
)
if len(test_blocks) > 1:
    duplicate_test_keys.append(spec.stem)
test_text = "\n".join(test_blocks)
```

**Soft warning** at the bottom of the chain organ surfaces specs with duplicate `test:` keys so authors clean up the YAML smell.

**Test** (`api/tests/test_wellness_chain_duplicates.py`) asserts both:
- duplicate-key spec is NOT mis-classified as no-proof
- the duplicate-keys warning IS emitted
- a clean single-key spec emits no warning

## Verified

- `pytest tests/test_wellness_chain_duplicates.py` — 2 passed
- `python3 scripts/wellness_check.py` — chain healthy 102/129 (unchanged), no false warnings (PR #1952 already deduped)

## Test plan

- [x] Unit test covers duplicate-key + clean-key cases
- [x] Wellness output unchanged on current repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)