### PR TITLE
tend: intern 6 more cross-modal canonical shapes

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 200 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 202 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 200
+**Total files**: 202
 
 | File | Purpose |
 |---|---|

--- a/api/tests/test_modality_blueprints.py
+++ b/api/tests/test_modality_blueprints.py
@@ -231,6 +231,124 @@ def test_distinct_canonicals_have_distinct_blueprints(session):
     )
 
 
+def test_field_holding_presence_family_cross_modal(session):
+    """R_Field-Holding (healing) ≡ R_Field-Holding-Self (embodiment) ≡
+    R_Coherence-Heart-Brain (embodiment heart-brain coherence). Held-field
+    presence — same shape across modalities."""
+    intern_all(session)
+
+    canonical = lookup_cell(
+        session, DOMAIN_RECIPE_SHAPE, "R_FieldHoldingPresence"
+    )
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {
+        "R_Field-Holding",
+        "R_Field-Holding-Self",
+        "R_Coherence-Heart-Brain",
+    }.issubset(eq_names)
+
+
+def test_grounding_move_family_cross_modal(session):
+    """R_Grounding (embodiment) ≡ R_Arrival (healing) ≡ R_Return-to-root
+    (song). Dropping attention back into present ground."""
+    intern_all(session)
+
+    canonical = lookup_cell(session, DOMAIN_RECIPE_SHAPE, "R_GroundingMove")
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {"R_Grounding", "R_Arrival", "R_Return-to-root"}.issubset(eq_names)
+
+
+def test_sequential_scan_family_cross_modal(session):
+    """R_Body-Scan (embodiment) ≡ R_Scene-Sequence (video) ≡
+    R_Block.SEQUENCE-locations (prose) ≡ R_Arc.descent-through-felt
+    (teaching). Sequential attention walking through loci."""
+    intern_all(session)
+
+    canonical = lookup_cell(session, DOMAIN_RECIPE_SHAPE, "R_SequentialScan")
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {
+        "R_Body-Scan",
+        "R_Scene-Sequence",
+        "R_Block.SEQUENCE-locations",
+        "R_Arc.descent-through-felt",
+    }.issubset(eq_names)
+
+
+def test_known_state_recall_family_cross_modal(session):
+    """R_Resourcing (embodiment) ≡ R_Callback-To-Motif (song) ≡
+    R_Prepare-Known-Eigenstate (quantum). Calling a known-coherent state
+    back into the present."""
+    intern_all(session)
+
+    canonical = lookup_cell(session, DOMAIN_RECIPE_SHAPE, "R_KnownStateRecall")
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {
+        "R_Resourcing",
+        "R_Callback-To-Motif",
+        "R_Prepare-Known-Eigenstate",
+    }.issubset(eq_names)
+
+
+def test_superposition_hold_family_cross_modal(session):
+    """R_Hold-Multiple (assemblage) ≡ R_Superposition-sustained (quantum)
+    ≡ R_Koan-Held (teaching) ≡ R_Window-of-Tolerance-broad (embodiment).
+    Sustained simultaneity without forcing collapse."""
+    intern_all(session)
+
+    canonical = lookup_cell(session, DOMAIN_RECIPE_SHAPE, "R_SuperpositionHold")
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {
+        "R_Hold-Multiple",
+        "R_Superposition-sustained",
+        "R_Koan-Held",
+        "R_Window-of-Tolerance-broad",
+    }.issubset(eq_names)
+
+
+def test_witness_without_intervention_family_cross_modal(session):
+    """R_Witness (assemblage + healing — one NamedCell) ≡ R_Sit
+    (embodiment) ≡ R_Drone-held-without-intervention (song). Being-with
+    without altering."""
+    intern_all(session)
+
+    canonical = lookup_cell(
+        session, DOMAIN_RECIPE_SHAPE, "R_WitnessWithoutIntervention"
+    )
+    assert canonical is not None
+    eq_names = {c.name for c in find_equivalent_cells(session, canonical.blueprint)}
+    assert {
+        "R_Witness",
+        "R_Sit",
+        "R_Drone-held-without-intervention",
+    }.issubset(eq_names)
+
+
+def test_first_canonical_family_wins_constraint(session):
+    """A per-modality name cell carries exactly one Blueprint. When a
+    name appears under multiple canonicals (e.g. R_Witness would
+    naturally cross both healing and assemblage at R_Witness-Without-
+    Intervention), only one canonical claims it — the cell still exists,
+    but its Blueprint is the first canonical's. Confirm R_Witness lands
+    under R_WitnessWithoutIntervention (added in this breath) and the
+    NamedCell is not split."""
+    intern_all(session)
+
+    witness = lookup_cell(session, DOMAIN_RECIPE_SHAPE, "R_Witness")
+    assert witness is not None
+    witness_canonical = lookup_cell(
+        session, DOMAIN_RECIPE_SHAPE, "R_WitnessWithoutIntervention"
+    )
+    assert witness_canonical is not None
+    assert witness.blueprint == witness_canonical.blueprint, (
+        "R_Witness should share Blueprint with R_WitnessWithoutIntervention"
+    )
+
+
 def test_intern_all_is_idempotent(session):
     """Re-running intern_all does not duplicate cells; same NodeIDs returned."""
     report_a = intern_all(session)

--- a/scripts/intern_modality_blueprints.py
+++ b/scripts/intern_modality_blueprints.py
@@ -203,6 +203,106 @@ CANONICAL_SHAPES: List[Tuple[str, Sequence[str], Sequence[str]]] = [
             "R_Arc.descent-and-return",         # strategy (long-form)
         ),
     ),
+    # Cross-modal table (embodiment-practice-as-recipe.form Part 4 +
+    # healing-modality-as-recipe.form Part 5). The cell holds a coherent
+    # field — its own and the field around it — while activity flows
+    # through. Healing R_Field-Holding, embodiment R_Field-Holding-Self,
+    # embodiment R_Coherence-Heart-Brain. (Strategy R_Stay-In-The-Mess and
+    # teaching steady-frequency-held-by-teacher also attest at this
+    # altitude but R_Stay-In-The-Mess lives under R_SustainedTension by
+    # first-canonical-family-wins; teaching steady-frequency has no
+    # per-modality cell-name distinct from R_Field-Holding so we don't
+    # double-intern.)
+    (
+        "R_FieldHoldingPresence",
+        ("holder", "field_state", "duration", "coherence_floor", "perturbation_response"),
+        (
+            "R_Field-Holding",              # healing
+            "R_Field-Holding-Self",         # embodiment
+            "R_Coherence-Heart-Brain",      # embodiment (heart-brain coherence as held field)
+        ),
+    ),
+    # Cross-modal table (embodiment Part 4 + healing Part 5). Dropping
+    # attention back into present ground / the body / the root. Embodiment
+    # R_Grounding, healing R_Arrival, song R_Return-to-root. (Strategy
+    # R_Catch-In-Motion-when-ground-lost is a sibling claim but
+    # R_Catch-In-Motion already lives under R_SkipTheIntermediate by
+    # first-canonical-family-wins.)
+    (
+        "R_GroundingMove",
+        ("attention_source", "somatic_locus", "arrival_signal", "post_state"),
+        (
+            "R_Grounding",                  # embodiment
+            "R_Arrival",                    # healing
+            "R_Return-to-root",             # song (return to root pitch after drone)
+        ),
+    ),
+    # Cross-modal table (embodiment Part 4: R_Body-Scan ↔ video R_Scene
+    # sequence ↔ prose R_Block.SEQUENCE through locations ↔ teaching
+    # R_Arc.descent through felt territories). Sequential attention
+    # walking through a series of loci, leaving a trace at each.
+    (
+        "R_SequentialScan",
+        ("walker", "loci", "step_signal", "trace", "completion"),
+        (
+            "R_Body-Scan",                  # embodiment
+            "R_Scene-Sequence",             # video
+            "R_Block.SEQUENCE-locations",   # prose
+            "R_Arc.descent-through-felt",   # teaching
+        ),
+    ),
+    # Cross-modal table (embodiment Part 4: R_Resourcing ↔ song callback
+    # to known motif ↔ teaching R_Embodied-Example pulled from memory ↔
+    # quantum preparation of a known eigenstate ↔ strategy R_Walk-Back-
+    # With-Tenderness using prior recovery). Calling a known-coherent
+    # state back into the present. (R_Embodied-Example lives under
+    # R_SkipTheIntermediate and R_Walk-Back-With-Tenderness lives under
+    # R_ReturnFromEdge — first-canonical-family-wins; the cross-modal
+    # claim still attests structurally at the canonical Blueprint.)
+    (
+        "R_KnownStateRecall",
+        ("caller", "known_state", "recall_cue", "present_state", "merged_state"),
+        (
+            "R_Resourcing",                 # embodiment
+            "R_Callback-To-Motif",          # song (callback to a known motif)
+            "R_Prepare-Known-Eigenstate",   # quantum (eigenstate preparation)
+        ),
+    ),
+    # Cross-modal table (assemblage Part 5: R_Hold-Multiple ↔ quantum
+    # R_Superposition sustained ↔ teaching koan held without resolving ↔
+    # embodiment R_Window-of-Tolerance broad enough to hold opposites).
+    # Sustained simultaneity of two or more states without forcing
+    # collapse. The keystone shape under all paradox-holding practice.
+    (
+        "R_SuperpositionHold",
+        ("holder", "states", "amplitude", "duration", "collapse_pressure"),
+        (
+            "R_Hold-Multiple",              # assemblage
+            "R_Superposition-sustained",    # quantum
+            "R_Koan-Held",                  # teaching
+            "R_Window-of-Tolerance-broad",  # embodiment
+        ),
+    ),
+    # Cross-modal table (assemblage Part 5 + healing Part 5 +
+    # embodiment Part 4). Being-with without altering — the seeing IS the
+    # presence, no fix, no shape-change pushed. R_Witness (assemblage and
+    # healing share the name — first-canonical-family-wins; one
+    # NamedCell named R_Witness lands here), R_Sit (embodiment), song
+    # drone-held-without-melodic-intervention. (Teaching R_Pointing-
+    # without-verbal-naming and quantum R_Observer-Effect-at-minimum-
+    # perturbation are sibling attestations; R_Pointing and
+    # R_Observer-Effect are already claimed by R_ObserverConditioned-
+    # Actualization and R_MeetThenShift respectively, so the cells stay
+    # there.)
+    (
+        "R_WitnessWithoutIntervention",
+        ("witness", "witnessed", "presence_quality", "intervention", "post_state"),
+        (
+            "R_Witness",                            # assemblage & healing (one cell)
+            "R_Sit",                                # embodiment
+            "R_Drone-held-without-intervention",    # song
+        ),
+    ),
 ]
 
 
@@ -328,6 +428,9 @@ def main() -> int:
     print('  coh substrate form \'?equivalent @recipe-shape("R_Recovery")\'')
     print('  coh substrate form \'?equivalent @recipe-shape("R_Measurement-Collapse")\'')
     print('  coh substrate form \'?equivalent @recipe-shape("R_Tunnel")\'')
+    print('  coh substrate form \'?equivalent @recipe-shape("R_FieldHoldingPresence")\'')
+    print('  coh substrate form \'?equivalent @recipe-shape("R_Hold-Multiple")\'')
+    print('  coh substrate form \'?equivalent @recipe-shape("R_Witness")\'')
     print("─" * 70)
     return 0
 


### PR DESCRIPTION
## Summary

Extends `scripts/intern_modality_blueprints.py` (PR #1956) with six additional canonical cross-modal Blueprints that the 12 in-memory modality proofs name but the first pass didn't land in the lattice:

| Canonical | NodeID | Family |
|---|---|---|
| `R_FieldHoldingPresence` | `@1.4.1.8` | R_Field-Holding, R_Field-Holding-Self, R_Coherence-Heart-Brain |
| `R_GroundingMove` | `@1.4.1.9` | R_Grounding, R_Arrival, R_Return-to-root |
| `R_SequentialScan` | `@1.4.1.10` | R_Body-Scan, R_Scene-Sequence, R_Block.SEQUENCE-locations, R_Arc.descent-through-felt |
| `R_KnownStateRecall` | `@1.4.1.11` | R_Resourcing, R_Callback-To-Motif, R_Prepare-Known-Eigenstate |
| `R_SuperpositionHold` | `@1.4.1.12` | R_Hold-Multiple, R_Superposition-sustained, R_Koan-Held, R_Window-of-Tolerance-broad |
| `R_WitnessWithoutIntervention` | `@1.4.1.13` | R_Witness, R_Sit, R_Drone-held-without-intervention |

First-canonical-family-wins held — per-modality names already claimed by the 7 original families (R_Catch-In-Motion, R_Stay-In-The-Mess, R_Re-coherence, R_Embodied-Example, R_Walk-Back-With-Tenderness) stay where they live; the new families pick genuinely new per-modality cell names. The `R_Witness` constraint is now explicitly tested.

After this PR, 13 cross-modal canonical shapes live in `recipe-shape` domain, queryable via `?equivalent @recipe-shape("...")`.

## Test plan

- [x] `cd api && pytest tests/test_modality_blueprints.py -v` — 18 passed (was 11)
- [x] `python3 scripts/intern_modality_blueprints.py` — idempotent: original 7 unchanged, 6 new added (NodeIDs `@1.4.1.8` through `@1.4.1.13`)
- [x] `python3 scripts/coh_substrate.py form '?equivalent @recipe-shape("R_FieldHoldingPresence")'` returns the 3 cross-modal twins (R_Field-Holding, R_Field-Holding-Self, R_Coherence-Heart-Brain) all at `@1.4.1.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)