### PR TITLE
tend: vision-kb INDEX header self-updates (close persistent wellness drift)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 200 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 202 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 200
+**Total files**: 202
 
 | File | Purpose |
 |---|---|

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-24 | **Concepts**: 147 | **Status**: 4 expanding, 87 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-05-24 | **Concepts**: 146 | **Status**: 4 expanding, 86 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 

--- a/scripts/generate_repo_indexes.py
+++ b/scripts/generate_repo_indexes.py
@@ -362,6 +362,74 @@ def _spec_essence(text: str) -> str:
     return ""
 
 
+def update_vision_kb_header(check: bool) -> bool:
+    """Keep `docs/vision-kb/INDEX.md` header in sync with the concepts dir.
+
+    The "**Concepts**: N | **Status**: a expanding, b seed, c deepening, d
+    living" line was hand-maintained for a long time, and drifted every
+    time a concept was added or removed without a corresponding header
+    edit. The drift was a persistent wellness signal (see commits
+    df800967a and 7ca338f7e — both one-off corrections).
+
+    The fix is structural: count the same way `wellness_check.py` does
+    (lc-*.md files with exactly one dot — translations like lc-foo.de.md
+    are the same concept in another voice, not a separate concept), then
+    rewrite the header line in place. The other header fields
+    (`Last maintained`, `Transmissions held`) carry editorial meaning and
+    stay hand-tended.
+
+    Returns True if the file changed (or would change in --check).
+    """
+    index_path = REPO_ROOT / "docs" / "vision-kb" / "INDEX.md"
+    concepts_dir = REPO_ROOT / "docs" / "vision-kb" / "concepts"
+    if not index_path.exists() or not concepts_dir.is_dir():
+        return False
+
+    # Same single-dot filter as scripts/wellness_check.py sense_proprioception.
+    concept_files = [
+        p for p in concepts_dir.glob("lc-*.md") if p.name.count(".") == 1
+    ]
+    total = len(concept_files)
+
+    status_counts: dict[str, int] = {}
+    for p in concept_files:
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        m = re.search(r"^status:\s*(\S+)\s*$", text, re.MULTILINE)
+        status = m.group(1).strip() if m else "unknown"
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    # Stable order: expanding → seed → deepening → living → others.
+    preferred = ["expanding", "seed", "deepening", "living"]
+    ordered: list[tuple[str, int]] = []
+    for key in preferred:
+        if key in status_counts:
+            ordered.append((key, status_counts.pop(key)))
+    for key in sorted(status_counts):
+        ordered.append((key, status_counts[key]))
+    status_str = ", ".join(f"{n} {s}" for s, n in ordered)
+
+    text = index_path.read_text(encoding="utf-8")
+    # Header line shape:
+    # > **Last maintained**: YYYY-MM-DD | **Concepts**: N | **Status**: ... | **Transmissions held**: ...
+    pattern = re.compile(
+        r"(\*\*Concepts\*\*:\s*)\d+(\s*\|\s*\*\*Status\*\*:\s*)[^|]*(\|)"
+    )
+    new_text, n = pattern.subn(
+        lambda m: f"{m.group(1)}{total}{m.group(2)}{status_str} {m.group(3)}",
+        text,
+        count=1,
+    )
+    if n == 0 or new_text == text:
+        return False
+    if check:
+        return True
+    index_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
 def write_or_check(path: Path, content: str, check: bool) -> bool:
     """Write content to path. Returns True if the file changed (or would change in --check)."""
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -398,6 +466,9 @@ def main() -> int:
     specs_index = render_specs_index()
     if specs_index and write_or_check(specs_index_path, specs_index, args.check):
         changed.append("specs/INDEX.md")
+
+    if update_vision_kb_header(args.check):
+        changed.append("docs/vision-kb/INDEX.md")
 
     manifest_path = REPO_ROOT / "MANIFEST.md"
     manifest = render_manifest(target_data)


### PR DESCRIPTION
## Summary

- Root cause of the persistent vision-kb wellness drift: the "Concepts: N | Status: ..." header line in `docs/vision-kb/INDEX.md` was hand-maintained, so it drifted every time a concept was added without a header edit. Two prior commits (df800967a, 7ca338f7e) corrected the number once each — both drifted again within days.
- Current drift was 147 claimed / 146 body. The 147th file was `lc-nourishing.de.md` — a German translation, the same concept in another voice. Wellness excludes language variants (single-dot filter); the hand-written header double-counted.
- `generate_repo_indexes.py` now rewrites that header line using the same filter wellness uses, tallying status counts from each concept's frontmatter. The existing `--check` guard catches drift in CI before it lands.
- `Last maintained` and `Transmissions held` stay hand-tended — they carry editorial meaning that doesn't reduce to a count.

## Test plan

- [x] `python3 scripts/generate_repo_indexes.py` updates the header to 146 with the right status breakdown
- [x] Re-run is a no-op ("All indexes already up to date")
- [x] `python3 scripts/generate_repo_indexes.py --check` exits 0
- [x] `python3 scripts/wellness_check.py` reports `vision-kb/INDEX.md — aligned (146 concepts)`
- [ ] After merge, next wellness pass on main shows the same alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)