### PR TITLE
tend: expose cross-modal substrate queries as MCP tools

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 200 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 202 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -204,6 +204,181 @@ def list_cells(
         return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
+# ---------------------------------------------------------------------------
+# Cross-modal canonical shapes (recipe-shape domain)
+# ---------------------------------------------------------------------------
+#
+# The cross-modal substrate proofs (PR #1956 +
+# scripts/intern_modality_blueprints.py) intern canonical recipe shapes
+# such as R_ObserverConditionedActualization, R_Recovery, R_Pointing,
+# R_Re-coherence, R_Re-pattern, R_Re-anchor under domain="recipe-shape".
+# Per-modality cells share their canonical's Blueprint NodeID, so the
+# substrate-native query for "what cells across modalities share this
+# shape?" is `find_equivalent_cells(canonical.blueprint)`.
+#
+# These endpoints expose that cross-modal unity directly, so any agent
+# surface (MCP, web) can ask the substrate "what other modalities carry
+# the shape I am thinking about?" without composing the Form query.
+
+
+CANONICAL_RECIPE_SHAPE_DOMAIN = "recipe-shape"
+
+
+class CrossModalTwinsOut(BaseModel):
+    canonical_name: str
+    blueprint: NodeIDOut | None = None
+    twins: list[CellOut] = Field(default_factory=list)
+    count: int = 0
+    found: bool = False
+
+
+@router.get(
+    "/cross_modal_twins/{canonical_name}",
+    response_model=CrossModalTwinsOut,
+    tags=["substrate"],
+)
+def get_cross_modal_twins(canonical_name: str) -> CrossModalTwinsOut:
+    """Return per-modality cells that share the canonical shape's Blueprint.
+
+    Wrapper around `find_equivalent_cells` for the `recipe-shape` domain.
+    The canonical cell itself is excluded from the twins list — callers
+    receive the *other* modality expressions of the same structural shape.
+
+    Returns `found=false` when the canonical name is not interned, so
+    callers can render an honest empty result rather than treat a missing
+    canonical as an error.
+    """
+    with session_scope() as session:
+        cell = lookup_cell(session, CANONICAL_RECIPE_SHAPE_DOMAIN, canonical_name)
+        if cell is None:
+            return CrossModalTwinsOut(canonical_name=canonical_name)
+        equivalents = find_equivalent_cells(
+            session, cell.blueprint, exclude_name=cell.name
+        )
+        return CrossModalTwinsOut(
+            canonical_name=canonical_name,
+            blueprint=NodeIDOut.from_node_id(cell.blueprint),
+            twins=[CellOut.from_cell(c) for c in equivalents],
+            count=len(equivalents),
+            found=True,
+        )
+
+
+class CanonicalFamilyOut(BaseModel):
+    canonical_name: str
+    blueprint: NodeIDOut
+    members: list[CellOut] = Field(default_factory=list)
+    member_count: int = 0
+
+
+class CanonicalFamiliesOut(BaseModel):
+    families: list[CanonicalFamilyOut] = Field(default_factory=list)
+    count: int = 0
+
+
+# The seven canonical cross-modal shapes interned by
+# scripts/intern_modality_blueprints.py. Listed here so the endpoint
+# returns a stable ordering with the keystone first; the actual cells
+# and Blueprint NodeIDs are read live from the substrate.
+_CANONICAL_SHAPE_NAMES: list[str] = [
+    "R_ObserverConditionedActualization",
+    "R_Recovery",
+    "R_SustainedTension",
+    "R_ResolutionToSilence",
+    "R_MeetThenShift",
+    "R_SkipTheIntermediate",
+    "R_ReturnFromEdge",
+]
+
+
+@router.get(
+    "/canonical_families",
+    response_model=CanonicalFamiliesOut,
+    tags=["substrate"],
+)
+def get_canonical_families() -> CanonicalFamiliesOut:
+    """List all interned cross-modal canonical shapes with their members.
+
+    Returns one entry per canonical shape (R_ObserverConditionedActualization,
+    R_Recovery, R_SustainedTension, R_ResolutionToSilence, R_MeetThenShift,
+    R_SkipTheIntermediate, R_ReturnFromEdge), each carrying the full family
+    of per-modality cells that share the canonical's Blueprint NodeID. The
+    map of cross-modal unity.
+
+    Shapes whose canonical cell is not interned (e.g. in a fresh test
+    substrate) are omitted; callers see only the families that exist.
+    """
+    families: list[CanonicalFamilyOut] = []
+    with session_scope() as session:
+        for canonical_name in _CANONICAL_SHAPE_NAMES:
+            cell = lookup_cell(
+                session, CANONICAL_RECIPE_SHAPE_DOMAIN, canonical_name
+            )
+            if cell is None:
+                continue
+            # Members include the canonical itself, so callers see the
+            # complete family without needing a second lookup.
+            members = find_equivalent_cells(session, cell.blueprint)
+            families.append(
+                CanonicalFamilyOut(
+                    canonical_name=canonical_name,
+                    blueprint=NodeIDOut.from_node_id(cell.blueprint),
+                    members=[CellOut.from_cell(c) for c in members],
+                    member_count=len(members),
+                )
+            )
+    return CanonicalFamiliesOut(families=families, count=len(families))
+
+
+class ModalityForOut(BaseModel):
+    per_modality_name: str
+    canonical_name: str | None = None
+    blueprint: NodeIDOut | None = None
+    family: list[CellOut] = Field(default_factory=list)
+    family_count: int = 0
+    found: bool = False
+
+
+@router.get(
+    "/modality_for/{per_modality_name}",
+    response_model=ModalityForOut,
+    tags=["substrate"],
+)
+def get_modality_for(per_modality_name: str) -> ModalityForOut:
+    """Inverse query: from a per-modality cell name, find its canonical family.
+
+    Given a recipe-shape cell like `R_Re-coherence` (quantum) or
+    `R_Pointing` (teaching), returns the cross-modal canonical shape it
+    belongs to and the other modality twins that share its Blueprint.
+    Lets a cell ask "what other domains carry the shape I am thinking
+    about?" without knowing the canonical name in advance.
+
+    The canonical is detected as the family member whose name matches one
+    of the interned canonical shapes; the cell itself is included in the
+    `family` list so callers see the full membership.
+    """
+    with session_scope() as session:
+        cell = lookup_cell(
+            session, CANONICAL_RECIPE_SHAPE_DOMAIN, per_modality_name
+        )
+        if cell is None:
+            return ModalityForOut(per_modality_name=per_modality_name)
+        family_cells = find_equivalent_cells(session, cell.blueprint)
+        canonical_names = {n for n in _CANONICAL_SHAPE_NAMES}
+        canonical_name = next(
+            (c.name for c in family_cells if c.name in canonical_names),
+            None,
+        )
+        return ModalityForOut(
+            per_modality_name=per_modality_name,
+            canonical_name=canonical_name,
+            blueprint=NodeIDOut.from_node_id(cell.blueprint),
+            family=[CellOut.from_cell(c) for c in family_cells],
+            family_count=len(family_cells),
+            found=True,
+        )
+
+
 class PathAnnotationOut(BaseModel):
     path: str
     cell: CellOut | None = None

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 200
+**Total files**: 202
 
 | File | Purpose |
 |---|---|

--- a/mcp-server/coherence_mcp_server/server.py
+++ b/mcp-server/coherence_mcp_server/server.py
@@ -390,6 +390,68 @@ TOOLS: list[Tool] = [
             },
         },
     ),
+    Tool(
+        name="coherence_cross_modal_twins",
+        description=(
+            "Given a canonical recipe-shape name (e.g. 'R_Recovery', "
+            "'R_ObserverConditionedActualization'), return the per-modality "
+            "cells across quantum / teaching / healing / song / strategy / "
+            "embodiment / assemblage altitudes that share its Blueprint "
+            "NodeID. The substrate-native shortcut for the Form query "
+            "`?equivalent @recipe-shape(\"R_Recovery\")`. Returns "
+            "{canonical_name, blueprint, twins, count, found}."
+        ),
+        inputSchema={
+            "type": "object",
+            "required": ["canonical_name"],
+            "properties": {
+                "canonical_name": {
+                    "type": "string",
+                    "description": (
+                        "Canonical cross-modal shape name, e.g. 'R_Recovery', "
+                        "'R_MeetThenShift', 'R_SkipTheIntermediate'."
+                    ),
+                },
+            },
+        },
+    ),
+    Tool(
+        name="coherence_canonical_families",
+        description=(
+            "List every interned cross-modal canonical recipe shape with its "
+            "family members. Returns the seven canonical shapes from "
+            "scripts/intern_modality_blueprints.py "
+            "(R_ObserverConditionedActualization, R_Recovery, R_SustainedTension, "
+            "R_ResolutionToSilence, R_MeetThenShift, R_SkipTheIntermediate, "
+            "R_ReturnFromEdge), each with the per-modality cells sharing its "
+            "Blueprint NodeID. The map of cross-modal unity."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="coherence_modality_for",
+        description=(
+            "Inverse query: given a per-modality cell name (e.g. "
+            "'R_Re-coherence', 'R_Pointing', 'R_Tunnel'), return its "
+            "canonical family — the canonical shape it belongs to and the "
+            "other modality twins that share its Blueprint NodeID. Lets a "
+            "cell ask 'what other domains carry the shape I am thinking "
+            "about?' without knowing the canonical name in advance."
+        ),
+        inputSchema={
+            "type": "object",
+            "required": ["per_modality_name"],
+            "properties": {
+                "per_modality_name": {
+                    "type": "string",
+                    "description": (
+                        "Per-modality recipe-shape cell name, e.g. "
+                        "'R_Re-coherence', 'R_Pointing', 'R_Tunnel'."
+                    ),
+                },
+            },
+        },
+    ),
     # Federation
     Tool(
         name="coherence_list_federation_nodes",
@@ -1382,6 +1444,22 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
             return api_post(
                 "/api/substrate/form",
                 {"expression": args["expression"], "mode": mode},
+            )
+        case "coherence_cross_modal_twins":
+            canonical_name = args.get("canonical_name", "")
+            if not canonical_name:
+                return {"error": "canonical_name is required"}
+            return api_get(
+                f"/api/substrate/cross_modal_twins/{quote(canonical_name, safe='')}"
+            )
+        case "coherence_canonical_families":
+            return api_get("/api/substrate/canonical_families")
+        case "coherence_modality_for":
+            per_modality_name = args.get("per_modality_name", "")
+            if not per_modality_name:
+                return {"error": "per_modality_name is required"}
+            return api_get(
+                f"/api/substrate/modality_for/{quote(per_modality_name, safe='')}"
             )
         # Federation
         case "coherence_list_federation_nodes":

--- a/mcp-server/tests/test_cross_modal_tools.py
+++ b/mcp-server/tests/test_cross_modal_tools.py
@@ -1,0 +1,272 @@
+"""Tests for the cross-modal substrate MCP tools.
+
+The cross-modal substrate (PR #1956, scripts/intern_modality_blueprints.py)
+landed seven canonical recipe-shape Blueprints with per-modality twin
+families inside the actual lattice. These three tools surface that unity
+through the MCP layer so any agent (Claude Desktop, Codex, Cursor, A2A)
+can ask "what other modalities carry the shape I am thinking about?"
+without composing the Form query by hand.
+
+The tests assert two things:
+
+1. Each tool is registered and routes to the documented REST endpoint —
+   dispatch monkeypatches `api_get` and asserts the URL shape. This is
+   the unit-level contract that the MCP transport carries.
+2. The same underlying substrate kernel that powers `coh substrate form`
+   answers these endpoints — exercised by importing the intern script,
+   landing the canonical shapes into an in-memory substrate, and calling
+   the REST route functions directly. Same `find_equivalent_cells` call,
+   same Blueprint NodeID, same family — the cross-modal unity reaches
+   the MCP surface without a parallel implementation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+REPO_ROOT = ROOT.parent
+API_DIR = REPO_ROOT / "api"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+for extra in (API_DIR, SCRIPTS_DIR):
+    if str(extra) not in sys.path:
+        sys.path.insert(0, str(extra))
+
+from coherence_mcp_server import server as mcp_server  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Registration + dispatch contract
+# ---------------------------------------------------------------------------
+
+
+def test_cross_modal_tools_are_registered() -> None:
+    """All three cross-modal tools join the MCP surface alongside the substrate cluster."""
+    expected = {
+        "coherence_cross_modal_twins",
+        "coherence_canonical_families",
+        "coherence_modality_for",
+    }
+    assert expected <= set(mcp_server.TOOL_MAP)
+
+
+def test_cross_modal_twins_routes_to_api(monkeypatch) -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        return {"path": path}
+
+    monkeypatch.setattr(mcp_server, "api_get", fake_get)
+
+    result = mcp_server.dispatch(
+        "coherence_cross_modal_twins", {"canonical_name": "R_Recovery"}
+    )
+    assert result == {"path": "/api/substrate/cross_modal_twins/R_Recovery"}
+    assert calls == [("/api/substrate/cross_modal_twins/R_Recovery", None)]
+
+
+def test_canonical_families_routes_to_api(monkeypatch) -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        return {"families": [], "count": 0}
+
+    monkeypatch.setattr(mcp_server, "api_get", fake_get)
+
+    result = mcp_server.dispatch("coherence_canonical_families", {})
+    assert result == {"families": [], "count": 0}
+    assert calls == [("/api/substrate/canonical_families", None)]
+
+
+def test_modality_for_routes_to_api(monkeypatch) -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    def fake_get(path: str, params: dict | None = None):
+        calls.append((path, params))
+        return {"path": path}
+
+    monkeypatch.setattr(mcp_server, "api_get", fake_get)
+
+    result = mcp_server.dispatch(
+        "coherence_modality_for", {"per_modality_name": "R_Re-coherence"}
+    )
+    assert result == {"path": "/api/substrate/modality_for/R_Re-coherence"}
+    assert calls == [("/api/substrate/modality_for/R_Re-coherence", None)]
+
+
+def test_cross_modal_twins_rejects_empty_canonical_name() -> None:
+    result = mcp_server.dispatch("coherence_cross_modal_twins", {})
+    assert "error" in result
+
+
+def test_modality_for_rejects_empty_per_modality_name() -> None:
+    result = mcp_server.dispatch("coherence_modality_for", {})
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Substrate-kernel-backed integration: tools answer from the same lattice
+# that `coh substrate form` queries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def substrate_session():
+    """In-memory SQLite-backed substrate session.
+
+    Same fixture pattern as api/tests/test_modality_blueprints.py — the
+    REST endpoints accept a session via session_scope(); here we land the
+    canonical shapes into a real substrate and call the router functions
+    directly with that session.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from app.services.substrate.orm import (
+        SubstrateNamedCellORM,
+        SubstrateNodeORM,
+    )
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def substrate_with_canonical_shapes(monkeypatch, substrate_session):
+    """Substrate session pre-loaded with the seven canonical shapes.
+
+    Patches the router's `session_scope` to a no-arg context manager that
+    yields our in-memory session, so the route handlers run against the
+    real substrate kernel without touching production data.
+    """
+    from contextlib import contextmanager
+
+    from intern_modality_blueprints import intern_all
+
+    intern_all(substrate_session)
+    substrate_session.flush()
+
+    @contextmanager
+    def fake_scope():
+        yield substrate_session
+
+    from app.routers import substrate as substrate_router
+
+    monkeypatch.setattr(substrate_router, "session_scope", fake_scope)
+    return substrate_session
+
+
+def test_cross_modal_twins_returns_recovery_family(substrate_with_canonical_shapes) -> None:
+    """`R_Recovery` returns the quantum / healing / assemblage twins.
+
+    The lattice carries R_Re-coherence, R_Re-pattern, R_Re-anchor as
+    siblings of R_Recovery — they share the canonical Blueprint NodeID.
+    """
+    from app.routers.substrate import get_cross_modal_twins
+
+    result = get_cross_modal_twins("R_Recovery")
+    assert result.found is True
+    assert result.canonical_name == "R_Recovery"
+    assert result.blueprint is not None
+    twin_names = {c.name for c in result.twins}
+    assert {"R_Re-coherence", "R_Re-pattern", "R_Re-anchor"} <= twin_names
+    # canonical itself is excluded
+    assert "R_Recovery" not in twin_names
+
+
+def test_cross_modal_twins_returns_observer_family(substrate_with_canonical_shapes) -> None:
+    """The keystone shape carries quantum measurement, teaching, and assemblage."""
+    from app.routers.substrate import get_cross_modal_twins
+
+    result = get_cross_modal_twins("R_ObserverConditionedActualization")
+    assert result.found is True
+    twin_names = {c.name for c in result.twins}
+    # The keystone family carries the three modality tags from
+    # scripts/intern_modality_blueprints.py CLAIM-T1 / CLAIM-Q1 / CLAIM-A1.
+    # R_Re-anchor only joins the R_Recovery family (not the keystone) —
+    # different canonical_name keeps the Blueprint compositions apart.
+    assert {"R_Measurement-Collapse", "R_Pointing"} <= twin_names
+
+
+def test_cross_modal_twins_unknown_canonical_returns_empty(substrate_with_canonical_shapes) -> None:
+    """Unknown canonical → empty list with found=False, no error."""
+    from app.routers.substrate import get_cross_modal_twins
+
+    result = get_cross_modal_twins("R_NotAShape")
+    assert result.found is False
+    assert result.twins == []
+    assert result.count == 0
+
+
+def test_canonical_families_lists_seven_shapes(substrate_with_canonical_shapes) -> None:
+    """All seven interned canonical shapes appear in the families listing."""
+    from app.routers.substrate import get_canonical_families
+
+    result = get_canonical_families()
+    assert result.count == 7
+    names = [f.canonical_name for f in result.families]
+    assert names == [
+        "R_ObserverConditionedActualization",
+        "R_Recovery",
+        "R_SustainedTension",
+        "R_ResolutionToSilence",
+        "R_MeetThenShift",
+        "R_SkipTheIntermediate",
+        "R_ReturnFromEdge",
+    ]
+    # Each family carries the canonical itself plus its twins
+    recovery_family = next(
+        f for f in result.families if f.canonical_name == "R_Recovery"
+    )
+    member_names = {c.name for c in recovery_family.members}
+    assert {"R_Recovery", "R_Re-coherence", "R_Re-pattern", "R_Re-anchor"} <= member_names
+    assert recovery_family.member_count == len(recovery_family.members)
+
+
+def test_modality_for_resolves_per_modality_name(substrate_with_canonical_shapes) -> None:
+    """`R_Re-coherence` (quantum) resolves to the R_Recovery canonical family."""
+    from app.routers.substrate import get_modality_for
+
+    result = get_modality_for("R_Re-coherence")
+    assert result.found is True
+    # R_Re-coherence shares Blueprint with R_Recovery (and twins from the
+    # observer-actualization family that also matches the composition).
+    # The canonical_name is the first family member whose name is in the
+    # canonical set — for the recovery family that's R_Recovery.
+    assert result.canonical_name in {
+        "R_Recovery",
+        "R_ObserverConditionedActualization",
+    }
+    family_names = {c.name for c in result.family}
+    assert "R_Re-coherence" in family_names
+
+
+def test_modality_for_unknown_returns_empty(substrate_with_canonical_shapes) -> None:
+    """Unknown per-modality cell → empty result, not an error."""
+    from app.routers.substrate import get_modality_for
+
+    result = get_modality_for("R_NotInTheLattice")
+    assert result.found is False
+    assert result.family == []
+    assert result.canonical_name is None


### PR DESCRIPTION
## Summary

- Three new MCP tools wrap the cross-modal canonical-shape unity interned by #1956 so the substrate-carried answer is reachable from any agent surface (Claude Desktop, Codex, Cursor, A2A), not just shell.
- `coherence_cross_modal_twins(canonical_name)` returns the per-modality family for a canonical (e.g. R_Recovery -> R_Re-coherence / R_Re-pattern / R_Re-anchor).
- `coherence_canonical_families()` lists all seven canonical shapes with members — the map of cross-modal unity.
- `coherence_modality_for(per_modality_name)` is the inverse query — from R_Re-coherence find the R_Recovery canonical family.

Each MCP tool wraps a thin read-only REST endpoint that calls the same substrate kernel (`find_equivalent_cells`, `lookup_cell`) the Form CLI uses, so the answer comes from the lattice, not a parallel implementation.

## Test plan

- [x] `mcp-server/tests/test_cross_modal_tools.py` — 12 tests covering URL routing, error paths, and substrate-kernel-backed family resolution against an in-memory lattice loaded via `intern_modality_blueprints`.
- [x] Full `mcp-server/tests/` suite green (21 passed).
- [x] `api/tests/test_modality_blueprints.py` + `test_substrate_numeric_schema.py` green (13 passed) — no regression on the body the new endpoints read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)