### PR TITLE
Embed client-side Form kernel playground

### DIFF
--- a/docs/system_audit/commit_evidence_20260524_client_form_kernel_ui.json
+++ b/docs/system_audit/commit_evidence_20260524_client_form_kernel_ui.json
@@ -1,0 +1,95 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/client-form-kernel-ui-20260524",
+  "commit_scope": "Embed the TypeScript Form kernel into the substrate Form Playground so visitors can run text-encoded .fk binaries locally in the browser.",
+  "files_owned": [
+    "experiments/form-kernel-ts/src/kernel.ts",
+    "experiments/form-kernel-ts/src/main.ts",
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "web/lib/form-kernel/",
+    "web/lib/form-kernel/client.ts",
+    "web/next.config.ts",
+    "web/tsconfig.json",
+    "web/tests/form-kernel-client.test.ts"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm run test -- form-kernel-client.test.ts",
+      "cd web && npm run build",
+      "cd experiments/form-kernel-ts && npm run check",
+      "cd experiments/form-kernel-ts && npm run kernel -- --expr '(add 1 2)'"
+    ],
+    "notes": "Focused browser-facing kernel tests passed, Next build passed, TS kernel package typechecked, and CLI kernel still returned 3 for (add 1 2). Browser verification opened /substrate/form at localhost:3116 and ran the local .fk arithmetic binary to result 7 with trace output visible."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Not pushed yet."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Not deployed yet."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A visitor on /substrate/form can run a text-encoded .fk Form binary locally in the browser using the embedded TypeScript kernel and see the result, root NodeID, elapsed walks, and hot RBasic dispatch arms without calling the API.",
+    "public_endpoints": [
+      "/substrate/form"
+    ],
+    "test_flows": [
+      "Open http://localhost:3116/substrate/form, click Run locally in the Local TS kernel lane, verify result 7 and RBasic.MATH trace appears.",
+      "Resize to 390x900 and verify the local kernel lane stacks without text overlap."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local proof is complete; CI and deploy proof remain after push/PR."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "form-question-effects-kernel-conformance"
+  ],
+  "task_ids": [
+    "client-form-kernel-ui-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Vitest: web/tests/form-kernel-client.test.ts passed 2 tests.",
+    "Next build: /substrate/form compiled with local TS kernel import.",
+    "Playwright MCP: localhost:3116/substrate/form local runner returned result 7 and displayed RBasic.MATH trace.",
+    "TS kernel CLI: experiments/form-kernel-ts npm run kernel -- --expr '(add 1 2)' returned 3."
+  ],
+  "change_files": [
+    "experiments/form-kernel-ts/src/kernel.ts",
+    "experiments/form-kernel-ts/src/main.ts",
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "web/lib/form-kernel/",
+    "web/lib/form-kernel/client.ts",
+    "web/next.config.ts",
+    "web/tsconfig.json",
+    "web/tests/form-kernel-client.test.ts"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/experiments/form-kernel-ts/src/kernel.ts
+++ b/experiments/form-kernel-ts/src/kernel.ts
@@ -12,8 +12,6 @@
 // Aligned with api/app/services/substrate/category.py and the Go/Rust
 // kernels. Cross-kernel NodeID agreement is the conformance contract.
 
-import { readFileSync } from "node:fs";
-
 // ---------------------------------------------------------------------------
 // Substrate — NodeID + Recipe + intern table
 // ---------------------------------------------------------------------------
@@ -194,6 +192,16 @@ export function nodeKey(n: NodeID): string {
 // keys is well-optimized and BigInt conversions in inner loops are slow.
 
 export type NativeFn = (k: Kernel, args: Value[]) => Value;
+
+// KernelHost — optional effects supplied by the embedding runtime.
+// Browser callers omit these and keep evaluation local/in-memory. CLI callers
+// pass Node adapters so the same kernel can still read files and write traces.
+export interface KernelHost {
+  readonly readTextFile?: (path: string) => string;
+  readonly readBinaryFile?: (path: string) => Uint8Array;
+  readonly writeStdout?: (text: string) => void;
+  readonly writeStderr?: (text: string) => void;
+}
 
 // NativeEntry — a native's function plus the Form category it expresses.
 // Carries Blueprint attribution into the kernel: when the walker dispatches
@@ -445,7 +453,7 @@ export class Kernel {
   // Surfaces the structural shape of evaluated Python at its own altitude.
   ctorCounts?: Map<string, number>;
 
-  constructor() {
+  constructor(private readonly host: KernelHost = {}) {
     this.registerNatives();
   }
 
@@ -789,7 +797,7 @@ export class Kernel {
 
     this.registerNative("print", catCall(), (_k, args) => {
       const parts = args.map((a) => this.renderForPrint(a));
-      process.stdout.write(parts.join(" ") + "\n");
+      this.host.writeStdout?.(parts.join(" ") + "\n");
       return { kind: "null" };
     });
     // String ops
@@ -943,7 +951,9 @@ export class Kernel {
     // File I/O
     this.registerNative("read_file", catCall(), (_k, args) => {
       try {
-        return { kind: "str", str: readFileSync(argStr(args, 0), "utf8") };
+        const readTextFile = this.host.readTextFile;
+        if (!readTextFile) return { kind: "null" };
+        return { kind: "str", str: readTextFile(argStr(args, 0)) };
       } catch {
         return { kind: "null" };
       }
@@ -954,7 +964,9 @@ export class Kernel {
     // char_at + ord; binary grammars walk a byte-list with nth.
     this.registerNative("read_file_bytes", catCall(), (_k, args) => {
       try {
-        const buf = readFileSync(argStr(args, 0));
+        const readBinaryFile = this.host.readBinaryFile;
+        if (!readBinaryFile) return { kind: "null" };
+        const buf = readBinaryFile(argStr(args, 0));
         const out: Value[] = new Array(buf.length);
         for (let i = 0; i < buf.length; i++) {
           out[i] = { kind: "int", int: buf[i]! };
@@ -1062,13 +1074,13 @@ export class Kernel {
     this.registerNative("trace", catUndefined(), (_k, args) => {
       if (args.length >= 2) {
         const label = args[0]?.kind === "str" ? args[0].str : "trace";
-        process.stderr.write(
+        this.host.writeStderr?.(
           `[trace ${label}] ${this.renderForPrint(args[1] ?? { kind: "null" })}\n`,
         );
         return args[1] ?? { kind: "null" };
       }
       const v = args[0] ?? { kind: "null" };
-      process.stderr.write(`[trace] ${this.renderForPrint(v)}\n`);
+      this.host.writeStderr?.(`[trace] ${this.renderForPrint(v)}\n`);
       return v;
     });
   }

--- a/experiments/form-kernel-ts/src/main.ts
+++ b/experiments/form-kernel-ts/src/main.ts
@@ -5,6 +5,7 @@
 //   tsx src/main.ts --bench
 //   tsx src/main.ts path/to/file.fk
 
+import { readFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { resolve as pathResolve, basename } from "node:path";
@@ -15,6 +16,15 @@ import { compileNode } from "./compiler.ts";
 import { runNumericBench } from "./numeric-bench.ts";
 import { evalPython, parsePython } from "./lang-python.ts";
 import { emitFk } from "./lang-python-fk.ts";
+
+function makeKernel(): Kernel {
+  return new Kernel({
+    readTextFile: (path) => readFileSync(path, "utf8"),
+    readBinaryFile: (path) => new Uint8Array(readFileSync(path)),
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+  });
+}
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -55,7 +65,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const k = new Kernel();
+  const k = makeKernel();
   const frame = new Frame(null);
 
   if (args[0] === "--expr") {
@@ -115,7 +125,7 @@ async function runTrace(args: string[]): Promise<void> {
     src = await readFile(args[0]!, "utf8");
   }
 
-  const k = new Kernel();
+  const k = makeKernel();
   k.trace = new Trace();
   const frame = new Frame(null);
   const node = readAll(k, src);
@@ -146,7 +156,7 @@ async function runPythonTrace(args: string[]): Promise<void> {
   }
   const src = await readFile(args[0]!, "utf8");
 
-  const k = new Kernel();
+  const k = makeKernel();
   // Phase 1 — parse. The Python source becomes a NodeID tree in the
   // substrate. Parsing IS substrate-write work (intern_node calls);
   // tracing it here would surface the parser's structural shape, but we
@@ -208,7 +218,7 @@ async function runPythonCompile(args: string[]): Promise<void> {
   const outArg = args[1];
   const src = await readFile(inPath, "utf8");
 
-  const k = new Kernel();
+  const k = makeKernel();
   const tree = parsePython(k, src);
   const fk = emitFk(k, tree);
 
@@ -244,7 +254,7 @@ async function runPythonRun(args: string[]): Promise<void> {
   const src = await readFile(inPath, "utf8");
 
   // Compile in-memory.
-  const k = new Kernel();
+  const k = makeKernel();
   const tree = parsePython(k, src);
   const fk = emitFk(k, tree);
 

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -3,7 +3,12 @@
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowRight, Play, RotateCcw, Sparkles } from "lucide-react";
+import { ArrowRight, Cpu, Play, RotateCcw, Sparkles } from "lucide-react";
+import {
+  LOCAL_FORM_EXAMPLES,
+  runLocalFormBinary,
+  type LocalFormRun,
+} from "@/lib/form-kernel/client";
 
 type NodeIDOut = { package: number; level: number; type: number; instance: number };
 
@@ -567,6 +572,166 @@ function ResultPanel({ result }: { result: FormResultOut }) {
   );
 }
 
+function LocalKernelPanel() {
+  const firstExample = LOCAL_FORM_EXAMPLES[0];
+  const [binary, setBinary] = useState(firstExample.source);
+  const [activeNote, setActiveNote] = useState(firstExample.note);
+  const [localRun, setLocalRun] = useState<LocalFormRun | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const pickLocalExample = (example: (typeof LOCAL_FORM_EXAMPLES)[number]) => {
+    setBinary(example.source);
+    setActiveNote(example.note);
+    setLocalRun(null);
+    setLocalError(null);
+  };
+
+  const runLocal = () => {
+    if (!binary.trim()) return;
+    setLocalError(null);
+    setLocalRun(null);
+    try {
+      setLocalRun(runLocalFormBinary(binary));
+    } catch (e: unknown) {
+      setLocalError(e instanceof Error ? e.message : "Local kernel failed");
+    }
+  };
+
+  const hotArms = localRun ? localRun.trace.arms.slice(0, 5) : [];
+
+  return (
+    <section
+      className="grid gap-5 rounded-xl border border-teal-500/20 bg-teal-500/5 p-4 lg:grid-cols-[0.9fr_1.1fr]"
+      aria-labelledby="local-kernel-heading"
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.22em] text-teal-300/75">
+            Local TS kernel
+          </p>
+          <h2 id="local-kernel-heading" className="text-2xl font-light text-stone-100">
+            Run a Form binary in this browser.
+          </h2>
+          <p className="text-sm leading-relaxed text-stone-400">
+            This lane does not call the API. The TypeScript kernel parses the text-encoded
+            <code className="mx-1">.fk</code>
+            binary, walks the recipe, and reports the local trace from this tab.
+          </p>
+        </div>
+
+        <div className="grid gap-2">
+          {LOCAL_FORM_EXAMPLES.map((example) => (
+            <button
+              key={example.label}
+              type="button"
+              onClick={() => pickLocalExample(example)}
+              className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                binary === example.source
+                  ? "border-teal-400/50 bg-teal-500/10 text-teal-100"
+                  : "border-stone-800/50 bg-stone-950/35 text-stone-300 hover:border-teal-500/35 hover:text-teal-200"
+              }`}
+            >
+              <span className="flex items-center gap-2 text-sm font-medium">
+                <Cpu className="h-4 w-4 text-teal-300/80" aria-hidden="true" />
+                {example.label}
+              </span>
+              <span className="mt-1 block text-xs leading-relaxed text-stone-500">
+                {example.note}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-4 rounded-xl border border-stone-800/50 bg-stone-950/35 p-4">
+        <div className="space-y-2">
+          <label htmlFor="local-form-binary" className="text-xs uppercase tracking-[0.18em] text-stone-500">
+            .fk binary
+          </label>
+          <textarea
+            id="local-form-binary"
+            value={binary}
+            onChange={(e) => {
+              setBinary(e.target.value);
+              setActiveNote("Run the edited binary locally and compare the trace.");
+            }}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                runLocal();
+              }
+            }}
+            className="h-44 w-full resize-y rounded-xl border border-stone-800/50 bg-stone-950/80 p-3 font-mono text-sm leading-relaxed text-stone-300 transition-colors focus:border-teal-500/40 focus:outline-none"
+            spellCheck={false}
+          />
+          <p className="text-xs leading-relaxed text-stone-500">{activeNote}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={runLocal}
+            disabled={!binary.trim()}
+            className="inline-flex items-center gap-2 rounded-xl border border-teal-500/20 bg-teal-500/10 px-5 py-2.5 text-sm font-medium text-teal-200 transition-all hover:border-teal-500/30 hover:bg-teal-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Play className="h-4 w-4" aria-hidden="true" />
+            Run locally
+          </button>
+          <span className="text-xs text-stone-600">⌘↩ to run in-tab</span>
+        </div>
+
+        {localError && (
+          <div className="whitespace-pre-wrap rounded-xl border border-red-800/30 bg-red-900/10 p-3 text-sm text-red-300">
+            {localError}
+          </div>
+        )}
+
+        {localRun && (
+          <div className="space-y-3 rounded-xl border border-stone-800/50 bg-stone-900/25 p-3">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-stone-500">Result</div>
+                <div className="mt-1 font-mono text-lg text-teal-200">{localRun.result}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-stone-500">Root</div>
+                <div className="mt-1 font-mono text-sm text-stone-300">{localRun.root}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-stone-500">Walks</div>
+                <div className="mt-1 font-mono text-sm text-stone-300">
+                  {localRun.trace.total_walks} · {localRun.elapsedMs.toFixed(2)} ms
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-stone-800/40 bg-stone-950/45 p-3">
+              <div className="mb-2 text-xs uppercase tracking-wide text-stone-500">
+                Hot dispatch arms
+              </div>
+              <div className="grid gap-1 font-mono text-xs text-stone-300 sm:grid-cols-2">
+                {hotArms.map((arm) => (
+                  <div key={arm.arm_ty} className="flex justify-between gap-3">
+                    <span>RBasic.{arm.arm_name}</span>
+                    <span className="text-teal-200">{arm.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {(localRun.stdout || localRun.stderr) && (
+              <pre className="max-h-40 overflow-auto rounded-lg border border-stone-800/40 bg-stone-950/45 p-3 text-xs text-stone-400">
+                {localRun.stdout}
+                {localRun.stderr}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 // Build a starter expression when the playground arrives bound to a cell.
 // `?cell=@concept(lc-pulse)` becomes `@concept(lc-pulse).blueprint` — a
 // useful first question to ask of any cell. The visitor lands inside a
@@ -741,6 +906,8 @@ export function FormPlayground() {
           {result && <ResultPanel result={result} />}
         </div>
       </section>
+
+      <LocalKernelPanel />
 
       <section className="space-y-4" aria-labelledby="form-atlas-heading">
         <div>

--- a/web/lib/form-kernel/client.ts
+++ b/web/lib/form-kernel/client.ts
@@ -1,0 +1,103 @@
+// Browser-facing bridge into the TypeScript Form kernel.
+import {
+  Frame,
+  Kernel,
+  Trace,
+  nodeKey,
+  walk,
+  type NodeID,
+} from "../../../experiments/form-kernel-ts/src/kernel.ts";
+import { readAll } from "../../../experiments/form-kernel-ts/src/reader.ts";
+
+export type LocalFormRun = {
+  source: string;
+  result: string;
+  root: string;
+  rootCategory: string;
+  stdout: string;
+  stderr: string;
+  elapsedMs: number;
+  trace: LocalFormTrace;
+};
+
+export type LocalFormTrace = {
+  total_walks: number;
+  arms: Array<{ arm_ty: number; arm_name: string; count: number }>;
+  variants: Array<{
+    arm_ty: number;
+    arm_inst: number;
+    arm_name: string;
+    arm_variant_name: string;
+    count: number;
+  }>;
+  choice_attempts: number;
+  choice_successes: number;
+  choice_failures: number;
+  choice_success_rate: number;
+};
+
+export type LocalFormExample = {
+  label: string;
+  source: string;
+  note: string;
+};
+
+export const LOCAL_FORM_EXAMPLES: LocalFormExample[] = [
+  {
+    label: "Arithmetic binary",
+    source: "(add 1 (mul 2 3))",
+    note: "Walks a tiny .fk binary locally and returns 7 without the API.",
+  },
+  {
+    label: "Recursive recipe",
+    source: `(do
+  (defn fact (n)
+    (if (le n 1)
+      1
+      (mul n (fact (sub n 1)))))
+  (fact 8))`,
+    note: "Defines and executes a recursive Form function inside the browser kernel.",
+  },
+  {
+    label: "Binary codec shape",
+    source: `(do
+  (let bytes (list 70 111 114 109))
+  (add (len bytes) (nth bytes 0)))`,
+    note: "Treats bytes as a Form list, the path used by file grammars and local codecs.",
+  },
+  {
+    label: "Kernel self-witness",
+    source: `(do
+  (let n (make_nodeid 1 5 4 1))
+  (if (node_eq n (make_nodeid 1 5 4 1)) 1 0))`,
+    note: "Creates NodeIDs in local memory and asks the kernel to compare them structurally.",
+  },
+];
+
+function formatNodeId(n: NodeID): string {
+  return `@${nodeKey(n)}`;
+}
+
+export function runLocalFormBinary(source: string): LocalFormRun {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const kernel = new Kernel({
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+  });
+  kernel.trace = new Trace();
+  const start = performance.now();
+  const root = readAll(kernel, source);
+  const value = walk(kernel, root, new Frame(null));
+  const elapsedMs = performance.now() - start;
+  return {
+    source,
+    result: kernel.render(value),
+    root: formatNodeId(root),
+    rootCategory: formatNodeId(kernel.category(root)),
+    stdout: stdout.join(""),
+    stderr: stderr.join(""),
+    elapsedMs,
+    trace: kernel.trace.toJSON() as LocalFormTrace,
+  };
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,4 +1,8 @@
 import type { NextConfig } from "next";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 
 const securityHeaders = [
   {
@@ -25,6 +29,12 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    externalDir: true,
+  },
+  turbopack: {
+    root: repoRoot,
+  },
   /**
    * Routing-layer redirects for retired surfaces.
    *

--- a/web/tests/form-kernel-client.test.ts
+++ b/web/tests/form-kernel-client.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  LOCAL_FORM_EXAMPLES,
+  runLocalFormBinary,
+} from "../lib/form-kernel/client";
+
+describe("browser-facing Form kernel", () => {
+  it("runs a text-encoded .fk binary locally", () => {
+    const run = runLocalFormBinary("(add 1 (mul 2 3))");
+
+    expect(run.result).toBe("7");
+    expect(run.root).toMatch(/^@1\./);
+    expect(run.trace.total_walks).toBeGreaterThan(0);
+  });
+
+  it("keeps recursive recipes executable in the embedded TS kernel", () => {
+    const run = runLocalFormBinary(LOCAL_FORM_EXAMPLES[1].source);
+
+    expect(run.result).toBe("40320");
+    expect(run.trace.total_walks).toBeGreaterThan(10);
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": [
       "dom",
       "dom.iterable",
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- make the TypeScript Form kernel host-pluggable so it can run without Node-only imports in browser bundles
- add a browser-facing local Form runner and visible Local TS kernel lane on /substrate/form
- cover local .fk execution with focused Vitest tests and commit evidence

## Proof
- cd web && npm run test -- form-kernel-client.test.ts
- cd web && npm run build
- cd experiments/form-kernel-ts && npm run check
- cd experiments/form-kernel-ts && npm run kernel -- --expr '(add 1 2)'
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- Playwright MCP: localhost:3116/substrate/form local runner returned 7 with RBasic.MATH trace on desktop/mobile