### PR TITLE
tend: forward read-event metadata from /assets/{id}/content

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 203 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 204 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -390,18 +390,67 @@ def _free_tier_content(content: bytes, mime_type: str) -> str:
     return text[:FREE_TIER_TEXT_PREVIEW_CHARS] + "…"
 
 
-def _has_valid_payment(authorization: str | None) -> bool:
-    """First-iteration x402 token check. Any non-empty Bearer token
-    counts as paid; real facilitator verification (signature check
-    against the x402 chain) lands in a follow-up PR per the
-    Phase 6 plan in specs/story-protocol-integration.md."""
+def _extract_bearer_token(authorization: str | None) -> str | None:
+    """Pull the raw token out of an ``Authorization: Bearer <token>``
+    header. Returns ``None`` when the header is absent or malformed.
+    Paid reads are exactly the ones where this returns a non-empty
+    token; the first-iteration x402 contract is presence of a Bearer
+    token, with real facilitator verification landing in a follow-up."""
     if not authorization:
-        return False
+        return None
     parts = authorization.strip().split(None, 1)
     if len(parts) != 2:
-        return False
+        return None
     scheme, token = parts
-    return scheme.lower() == "bearer" and bool(token.strip())
+    if scheme.lower() != "bearer":
+        return None
+    token = token.strip()
+    return token or None
+
+
+def _resolve_reader_id(
+    request: Request, payment_token: str | None
+) -> str | None:
+    """Determine the reader id for the read event.
+
+    Order of trust:
+      1. Explicit ``X-Reader-Id`` header — set by clients that already
+         know who their user is.
+      2. Synthetic ``paid:<token-prefix>`` for paid reads — the real
+         x402 facilitator integration will replace this with the
+         token's subject claim once the verification path lands.
+      3. ``None`` — anonymous free reads have no reader.
+    """
+    explicit = request.headers.get("X-Reader-Id")
+    if explicit:
+        return explicit
+    if payment_token:
+        return f"paid:{payment_token[:8]}"
+    return None
+
+
+def _parse_concept_resonance(raw: str | None) -> dict[str, float] | None:
+    """Parse the ``X-Concept-Resonance`` header into a snapshot dict.
+
+    The header carries a JSON object of ``{concept_id: weight}``. Any
+    non-numeric weight is skipped — record_read accepts ``None`` if the
+    whole payload is unparseable so the read path stays non-blocking."""
+    if not raw:
+        return None
+    import json
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    snapshot: dict[str, float] = {}
+    for k, v in parsed.items():
+        try:
+            snapshot[str(k)] = float(v)
+        except (TypeError, ValueError):
+            continue
+    return snapshot or None
 
 
 def _payment_address(node: dict) -> str:
@@ -427,6 +476,7 @@ def _payment_address(node: dict) -> str:
 )
 async def get_asset_content(
     asset_id: UUID,
+    request: Request,
     authorization: str | None = Header(default=None),
 ) -> Response:
     """Serve asset content with x402 payment headers (spec R4).
@@ -467,9 +517,30 @@ async def get_asset_content(
     asset_id_str = str(asset_id)
     node_id = node.get("id") or f"asset:{asset_id}"
 
-    if _has_valid_payment(authorization):
+    # Read-event metadata — extract once, forward to record_read in both
+    # the paid and the free branch so get_daily_aggregates partitions
+    # correctly between paid_reads and free_reads.
+    payment_token = _extract_bearer_token(authorization)
+    is_paid = payment_token is not None
+    read_type = "paid" if is_paid else "free"
+    reader_id = _resolve_reader_id(request, payment_token)
+    concept_resonance_snapshot = _parse_concept_resonance(
+        request.headers.get("X-Concept-Resonance")
+    )
+    # Paid reads carry the asset's cc_amount; free reads carry zero so
+    # the settlement layer doesn't credit the creator for a preview.
+    event_cc_amount = float(cc_amount) if is_paid else 0.0
+
+    if is_paid:
         try:
-            read_tracking_service.record_read(asset_id=node_id)
+            read_tracking_service.record_read(
+                asset_id=node_id,
+                reader_id=reader_id,
+                read_type=read_type,
+                payment_token=payment_token,
+                cc_amount=event_cc_amount,
+                concept_resonance_snapshot=concept_resonance_snapshot,
+            )
         except Exception as e:  # non-blocking — read tracking failure mustn't fail delivery
             log.warning("record_read failed for %s: %s", node_id, e)
         try:
@@ -501,7 +572,14 @@ async def get_asset_content(
 
     # Free tier — preview served, read recorded as "free".
     try:
-        read_tracking_service.record_read(asset_id=node_id)
+        read_tracking_service.record_read(
+            asset_id=node_id,
+            reader_id=reader_id,
+            read_type=read_type,
+            payment_token=payment_token,
+            cc_amount=event_cc_amount,
+            concept_resonance_snapshot=concept_resonance_snapshot,
+        )
     except Exception as e:
         log.warning("record_read failed for %s: %s", node_id, e)
     preview = _free_tier_content(content_bytes, mime_type)

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 203
+**Total files**: 204
 
 | File | Purpose |
 |---|---|

--- a/api/tests/test_assets_content.py
+++ b/api/tests/test_assets_content.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 from datetime import date
 from decimal import Decimal
 
@@ -24,7 +25,12 @@ from app.services import graph_service, read_tracking_service
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    # Reset the in-process read event log so paid/free aggregate
+    # assertions in this module don't see events bled in from earlier
+    # tests in the session.
+    read_tracking_service._reset_for_tests()
+    yield TestClient(app)
+    read_tracking_service._reset_for_tests()
 
 
 def _sha256_hex(content: bytes) -> str:
@@ -173,6 +179,115 @@ def test_get_asset_content_records_usage_event(client):
     after = read_tracking_service.get_daily_reads(asset_node_id, date.today())
     assert after is not None
     assert after["read_count"] == before_count + 1
+
+
+# ---------------------------------------------------------------------------
+# Read event forwarding — paid vs free, cc_amount, concept resonance
+# ---------------------------------------------------------------------------
+
+
+def test_paid_read_records_paid_type(client):
+    """A request with a Bearer token lands in the paid counter, not
+    the free counter, in get_daily_aggregates."""
+    asset_id = _register_asset(client, content=b"paid-bucket content")
+    node_id = f"asset:{asset_id}"
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={"Authorization": "Bearer x402-paid-token"},
+    )
+    assert response.status_code == 200
+    assert response.json()["read_type"] == "paid"
+
+    agg = read_tracking_service.get_daily_aggregates(asset_id=node_id)
+    assert agg["per_asset"][node_id]["paid_reads"] == 1
+    assert agg["per_asset"][node_id]["free_reads"] == 0
+    assert agg["paid_reads"] == 1
+    assert agg["free_reads"] == 0
+
+
+def test_free_read_records_free_type(client):
+    """An anonymous request (no Authorization) lands in the free
+    counter and leaves paid_reads at zero."""
+    asset_id = _register_asset(
+        client,
+        content=b"free-tier preview content",
+        requires_payment=False,
+        free_tier_enabled=True,
+    )
+    node_id = f"asset:{asset_id}"
+    response = client.get(f"/api/assets/{asset_id}/content")
+    assert response.status_code == 200
+    assert response.json()["read_type"] == "free"
+
+    agg = read_tracking_service.get_daily_aggregates(asset_id=node_id)
+    assert agg["per_asset"][node_id]["free_reads"] == 1
+    assert agg["per_asset"][node_id]["paid_reads"] == 0
+
+
+def test_paid_read_records_cc_amount(client):
+    """The recorded event carries cc_amount = asset's cc_amount when
+    paid; free reads record cc_amount = 0."""
+    # Patch a custom cc_amount onto the node so we can assert the
+    # forwarded value isn't just the default.
+    asset_id = _register_asset(client, content=b"cc-amount carrier")
+    graph_service.update_node(
+        f"asset:{asset_id}", properties={"cc_amount": "0.25"}
+    )
+    node_id = f"asset:{asset_id}"
+
+    client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={"Authorization": "Bearer x402-cc-amount-token"},
+    )
+    paid_events = read_tracking_service.get_read_events(node_id)
+    assert len(paid_events) == 1
+    assert paid_events[0]["read_type"] == "paid"
+    assert paid_events[0]["cc_amount"] == pytest.approx(0.25)
+
+    # Free read on the same asset records cc_amount = 0.
+    client.get(f"/api/assets/{asset_id}/content")
+    events = read_tracking_service.get_read_events(node_id)
+    free_event = next(e for e in events if e["read_type"] == "free")
+    assert free_event["cc_amount"] == 0.0
+
+
+def test_concept_resonance_forwarded(client):
+    """An X-Concept-Resonance header (JSON ``{concept_id: weight}``)
+    lands on the read event's concept_resonance_snapshot."""
+    asset_id = _register_asset(client, content=b"resonance-carrying content")
+    node_id = f"asset:{asset_id}"
+    resonance = {"lc-space": 0.8, "lc-energy": 0.4}
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={
+            "Authorization": "Bearer x402-resonance",
+            "X-Concept-Resonance": json.dumps(resonance),
+        },
+    )
+    assert response.status_code == 200
+
+    events = read_tracking_service.get_read_events(node_id)
+    assert len(events) == 1
+    snapshot = events[0]["concept_resonance_snapshot"]
+    assert snapshot is not None
+    assert snapshot["lc-space"] == pytest.approx(0.8)
+    assert snapshot["lc-energy"] == pytest.approx(0.4)
+
+
+def test_explicit_reader_id_header_forwarded(client):
+    """An X-Reader-Id header overrides the synthetic paid:<prefix> id."""
+    asset_id = _register_asset(client, content=b"reader-id carrier")
+    node_id = f"asset:{asset_id}"
+    response = client.get(
+        f"/api/assets/{asset_id}/content",
+        headers={
+            "Authorization": "Bearer x402-token",
+            "X-Reader-Id": "reader:alice",
+        },
+    )
+    assert response.status_code == 200
+    events = read_tracking_service.get_read_events(node_id)
+    assert events[0]["reader_id"] == "reader:alice"
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_story_protocol_e2e.py
+++ b/api/tests/test_story_protocol_e2e.py
@@ -223,13 +223,15 @@ def test_full_creator_to_settlement_flow(client):
             "coherence:contributor:"
         )
 
-    # --- Side-effect: read_tracking_service saw all 3 reads ---
-    # Contract gap (2026-05-24): the content endpoint calls
-    # record_read(asset_id=...) without forwarding read_type/payment_token,
-    # so even paid reads land on the free counter. The aggregate total
-    # still rises by 3, which is what the e2e proves the pipeline counted.
+    # --- Side-effect: read_tracking_service saw all 3 reads as paid ---
+    # Closed 2026-05-24: get_asset_content now forwards read_type,
+    # payment_token, cc_amount, and concept_resonance_snapshot to
+    # record_read, so paid reads land on the paid counter and the
+    # daily aggregate partitions cleanly between paid/free.
     agg = read_tracking_service.get_daily_aggregates(asset_id=node_id)
     assert agg["per_asset"][node_id]["total"] == 3
+    assert agg["per_asset"][node_id]["paid_reads"] == 3
+    assert agg["per_asset"][node_id]["free_reads"] == 0
 
     # --- Seed render events so settlement has something to aggregate ---
     today = date.today()


### PR DESCRIPTION
## Summary

Closes contract gap #2 from the e2e investigation in #1963. The content endpoint was calling `record_read(asset_id=...)` without forwarding `read_type`, `payment_token`, `cc_amount`, or `concept_resonance_snapshot`, so paid reads landed on the free counter in `get_daily_aggregates` and the paid/free split was meaningless.

`get_asset_content` now extracts the full read-event metadata once and forwards it in both the paid and the free branch:

- `read_type` derived from Bearer-token presence
- `payment_token` = raw Bearer value
- `reader_id` from `X-Reader-Id` header, else synthetic `paid:<token-prefix>` for paid reads, else `None`
- `concept_resonance_snapshot` from `X-Concept-Resonance` JSON header
- `cc_amount` = asset's `cc_amount` when paid, `0` when free

After this fix, `get_daily_aggregates` correctly partitions reads by type.

## Changes

- `api/app/routers/assets.py` — three new helpers (`_extract_bearer_token`, `_resolve_reader_id`, `_parse_concept_resonance`); endpoint forwards full metadata; legacy `_has_valid_payment` composted (its truth lives in `_extract_bearer_token` now)
- `api/tests/test_assets_content.py` — 5 new tests (paid type, free type, cc_amount, concept resonance forwarding, explicit reader_id)
- `api/tests/test_story_protocol_e2e.py` — tightened the e2e paid-counter assertion from "total >= 3" to explicit `paid_reads=3, free_reads=0`

## Test plan

- [x] `pytest tests/test_assets_content.py tests/test_read_tracking.py tests/test_story_protocol_e2e.py -v` — 35 passed
- [x] Broader regression across the story-protocol arc — 106 passed (`test_settlement_flow`, `test_ip_registration`, `test_evidence_flow`, `test_permanent_storage`, `test_story_protocol`)