### PR TITLE
tend: POST /api/assets/register auto-fires IP registration + storage

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 203 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 205 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/models/asset.py
+++ b/api/app/models/asset.py
@@ -120,10 +120,24 @@ class AssetRegistrationCreate(BaseModel):
 
 
 class AssetRegistration(AssetRegistrationCreate):
-    """Registered asset with server-assigned id and timestamp."""
+    """Registered asset with server-assigned id and timestamp.
+
+    ``sp_ip_id``, ``ip_status``, and ``ip_reason`` are populated by the
+    auto-fire pipeline at registration time (see register_asset in
+    api/app/routers/assets.py). On success ``ip_status`` is ``registered``
+    and ``sp_ip_id`` carries the Story Protocol IP Asset id. On failure
+    ``ip_status`` is ``failed``, ``ip_reason`` names the cause, and
+    ``sp_ip_id`` stays None — the asset itself remains usable per spec
+    R1's escape hatch. Storage refs (``arweave_tx``, ``ipfs_cid``) are
+    inherited from AssetRegistrationCreate; the auto-fire fills them in
+    when the upload succeeds and leaves them None when it doesn't.
+    """
 
     id: str = Field(description="asset:<uuid> identifier")
     created_at: datetime
+    sp_ip_id: Optional[str] = None
+    ip_status: str = "pending"
+    ip_reason: Optional[str] = None
 
 
 class AssetIPRegistration(BaseModel):

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timezone
 from uuid import UUID, uuid4, uuid5, NAMESPACE_URL
 from decimal import Decimal
+from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +49,12 @@ from app.models.asset import (
 )
 from app.models.error import ErrorDetail
 from app.models.pagination import PaginatedResponse
-from app.services import graph_service, read_tracking_service
+from app.services import (
+    graph_service,
+    ip_registration_service,
+    permanent_storage_service,
+    read_tracking_service,
+)
 from app.services.locale_projection import project, project_many, resolve_caller_lang
 from app.services.story_protocol_bridge import (
     build_x402_payment_required_headers,
@@ -93,6 +99,9 @@ def _node_to_registration(node: dict) -> AssetRegistration:
         creation_cost_cc=creation_cost,
         metadata=props.get("metadata", {}) or {},
         created_at=created_at,
+        sp_ip_id=props.get("sp_ip_id"),
+        ip_status=props.get("ip_status", "pending"),
+        ip_reason=props.get("ip_reason"),
     )
 
 
@@ -179,6 +188,29 @@ async def create_asset(asset: AssetCreate) -> Asset:
     return asset_obj
 
 
+def _content_bytes_from_metadata(metadata: dict | None) -> bytes | None:
+    """Pull raw content bytes out of the registration metadata payload.
+
+    The MIME-aware register flow accepts ``content_base64`` (preferred,
+    for arbitrary bytes) or ``content`` (UTF-8 text shortcut). Returns
+    None when neither is present — the asset is still created, the
+    storage upload step just becomes a no-op.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    b64 = metadata.get("content_base64")
+    if isinstance(b64, str) and b64:
+        try:
+            return base64.b64decode(b64)
+        except (ValueError, base64.binascii.Error) as e:
+            log.warning("content_base64 decode failed: %s", e)
+            return None
+    text = metadata.get("content")
+    if isinstance(text, str) and text:
+        return text.encode("utf-8")
+    return None
+
+
 @router.post(
     "/assets/register",
     response_model=AssetRegistration,
@@ -194,13 +226,42 @@ async def register_asset(body: AssetRegistrationCreate) -> AssetRegistration:
     accepts CODE/MODEL/CONTENT/DATA taxonomy for pipeline contributions.
     This endpoint supports arbitrary MIME types so a renderer can pair
     with the asset by type. See specs/asset-renderer-plugin.md R1.
+
+    Per specs/story-protocol-integration.md R1, registration auto-fires
+    three downstream services after the asset node lands:
+
+      1. ``ip_registration_service.register_ip_asset`` — mints the
+         Story Protocol IP Asset id, surfaces as ``sp_ip_id``.
+      2. ``permanent_storage_service.upload_to_arweave`` — uploads
+         raw bytes (from ``metadata.content_base64`` or
+         ``metadata.content``), surfaces as ``arweave_tx``.
+      3. ``permanent_storage_service.upload_to_ipfs`` — same bytes,
+         surfaces as ``ipfs_cid``.
+
+    Failures in any subcall are isolated: the asset is still created
+    and usable. Failed IP registration → ``ip_status="failed"`` with
+    ``ip_reason`` set, ``sp_ip_id=None``. Failed storage → the
+    corresponding ref stays None. R1: "If registration fails, ip_status
+    is failed and the asset remains usable without IP registration."
+
+    **Sync now, async later.** The three subcalls run synchronously in
+    this iteration — the services are fast in-memory mocks and adding
+    a background queue would be ornament before the partner SDKs land.
+    When the real Story Protocol SDK + Irys/Bundlr arrive, the
+    expensive network calls move to a background worker (Celery, ARQ,
+    or FastAPI BackgroundTasks) and the handler returns immediately
+    with ``ip_status="pending"``.
     """
     registration_id = f"asset:{uuid4()}"
+    asset_uuid = registration_id.removeprefix("asset:")
     now = datetime.now(timezone.utc)
     concept_tags_serializable = [
         {"concept_id": t.concept_id, "weight": t.weight}
         for t in body.concept_tags
     ]
+
+    # Step 1 — create the graph node. Any later subcall failure leaves
+    # this in place so the asset is recoverable.
     graph_service.create_node(
         id=registration_id,
         type="asset",
@@ -220,19 +281,86 @@ async def register_asset(body: AssetRegistrationCreate) -> AssetRegistration:
             "created_at": now.isoformat(),
         },
     )
+
+    # Step 2 — auto-fire IP registration. Isolated from the asset
+    # creation so a failed registration still leaves the asset usable.
+    sp_ip_id: str | None = None
+    ip_status = "pending"
+    ip_reason: str | None = None
+    try:
+        ip_record = ip_registration_service.register_ip_asset(
+            asset_uuid,
+            {"type": body.type, "name": body.name},
+        )
+        sp_ip_id = ip_record.get("sp_ip_id")
+        ip_status = ip_record.get("ip_status", "pending")
+        ip_reason = ip_record.get("reason")
+    except Exception as e:  # don't fail registration on IP failure (R1)
+        log.warning(
+            "auto-fire IP registration failed for %s: %s", registration_id, e
+        )
+        ip_status = "failed"
+        ip_reason = str(e)
+
+    # Step 3 — auto-fire permanent storage uploads. Isolated per surface
+    # so a failure on one (Arweave) doesn't block the other (IPFS).
+    arweave_tx_id: str | None = body.arweave_tx
+    ipfs_cid: str | None = body.ipfs_cid
+    content_bytes = _content_bytes_from_metadata(body.metadata)
+    if content_bytes is not None:
+        try:
+            arweave = permanent_storage_service.upload_to_arweave(
+                content_bytes,
+                {"name": body.name, "type": body.type},
+                asset_id=asset_uuid,
+            )
+            arweave_tx_id = arweave.get("arweave_tx_id") or arweave_tx_id
+        except Exception as e:
+            log.warning(
+                "auto-fire Arweave upload failed for %s: %s", registration_id, e
+            )
+        try:
+            ipfs = permanent_storage_service.upload_to_ipfs(
+                content_bytes, asset_id=asset_uuid
+            )
+            ipfs_cid = ipfs.get("ipfs_cid") or ipfs_cid
+        except Exception as e:
+            log.warning(
+                "auto-fire IPFS upload failed for %s: %s", registration_id, e
+            )
+
+    # Step 4 — patch the auto-fire results onto the node so downstream
+    # endpoints (content delivery, verification) surface them.
+    patch: dict[str, Any] = {
+        "sp_ip_id": sp_ip_id,
+        "ip_status": ip_status,
+        "ip_reason": ip_reason,
+        "arweave_tx": arweave_tx_id,
+        "ipfs_cid": ipfs_cid,
+    }
+    try:
+        graph_service.update_node(registration_id, properties=patch)
+    except Exception as e:
+        log.warning(
+            "failed to patch auto-fire results onto %s: %s", registration_id, e
+        )
+
     return AssetRegistration(
         id=registration_id,
         type=body.type,
         name=body.name,
         description=body.description,
         content_hash=body.content_hash,
-        arweave_tx=body.arweave_tx,
-        ipfs_cid=body.ipfs_cid,
+        arweave_tx=arweave_tx_id,
+        ipfs_cid=ipfs_cid,
         concept_tags=body.concept_tags,
         creator_id=body.creator_id,
         creation_cost_cc=body.creation_cost_cc,
         metadata=body.metadata,
         created_at=now,
+        sp_ip_id=sp_ip_id,
+        ip_status=ip_status,
+        ip_reason=ip_reason,
     )
 
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 203
+**Total files**: 205
 
 | File | Purpose |
 |---|---|
@@ -27,6 +27,7 @@
 | [test_asset_renderer.py](test_asset_renderer.py) | Tests for the asset-renderer-plugin spec pure-logic pieces. |
 | [test_assets.py](test_assets.py) | Tests for the assets-api spec (specs/assets-api.md). |
 | [test_assets_content.py](test_assets_content.py) | Tests for GET /api/assets/{id}/content + /verification — spec R4 and R10. |
+| [test_assets_register_auto_fires.py](test_assets_register_auto_fires.py) | Auto-fire wiring tests for POST /api/assets/register. |
 | [test_attribution_middleware.py](test_attribution_middleware.py) | Tests for the attribution middleware. |
 | [test_audit_vision_image_candidates.py](test_audit_vision_image_candidates.py) | _no top-of-file purpose_ |
 | [test_auth_keys_api.py](test_auth_keys_api.py) | Tests for the /api/auth/keys HTTP layer. |

--- a/api/tests/test_assets_register_auto_fires.py
+++ b/api/tests/test_assets_register_auto_fires.py
@@ -1,0 +1,155 @@
+"""Auto-fire wiring tests for POST /api/assets/register.
+
+Closes contract gap #1 from PR #1963's e2e investigation: the register
+endpoint now fires `ip_registration_service.register_ip_asset` and
+`permanent_storage_service.upload_to_arweave/upload_to_ipfs` after the
+asset node lands, and surfaces the resulting `sp_ip_id`, `arweave_tx`,
+and `ipfs_cid` on the response + the graph node.
+
+Per spec story-protocol-integration.md R1: "If registration fails,
+ip_status is failed and the asset remains usable without IP registration."
+That escape hatch is what tests 3 and 4 prove.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import (
+    graph_service,
+    ip_registration_service,
+    permanent_storage_service,
+)
+
+
+@pytest.fixture
+def client():
+    """TestClient with the auto-fire services reset for isolation."""
+    ip_registration_service._reset_for_tests()
+    permanent_storage_service._reset_for_tests()
+    yield TestClient(app)
+    ip_registration_service._reset_for_tests()
+    permanent_storage_service._reset_for_tests()
+
+
+def _payload(content: bytes = b"the body of the article") -> dict:
+    """Build a minimal register payload carrying real content bytes."""
+    return {
+        "type": "text/plain",
+        "name": "auto-fire-test-asset",
+        "description": "asset under auto-fire register test",
+        "content_hash": "sha256:placeholder",
+        "concept_tags": [{"concept_id": "lc-land", "weight": 1.0}],
+        "creator_id": "contributor:alice",
+        "creation_cost_cc": "0.00",
+        "metadata": {"content_base64": base64.b64encode(content).decode("ascii")},
+    }
+
+
+def test_register_auto_fires_ip_registration(client):
+    """Register lands sp_ip_id + ip_status=registered on the response
+    and on the graph node — no manual service call needed."""
+    response = client.post("/api/assets/register", json=_payload())
+    assert response.status_code == 201, response.text
+    body = response.json()
+
+    assert body["sp_ip_id"] is not None
+    assert body["sp_ip_id"].startswith("sp:mock:")
+    assert body["ip_status"] == "registered"
+    assert body.get("ip_reason") in (None, "")
+
+    # Side-effect: the same record is on the graph node.
+    node = graph_service.get_node(body["id"])
+    assert node["sp_ip_id"] == body["sp_ip_id"]
+    assert node["ip_status"] == "registered"
+
+    # Side-effect: the IP service holds the record under the asset uuid.
+    asset_uuid = body["id"].removeprefix("asset:")
+    ip_status = ip_registration_service.get_ip_status(asset_uuid)
+    assert ip_status["ip_status"] == "registered"
+    assert ip_status["sp_ip_id"] == body["sp_ip_id"]
+
+
+def test_register_auto_fires_storage_upload(client):
+    """Register with content_base64 lands arweave_tx + ipfs_cid on the
+    response and the graph node — uploads happened, no manual call."""
+    content = b"the original blueprint, full bytes preserved"
+    response = client.post("/api/assets/register", json=_payload(content))
+    assert response.status_code == 201, response.text
+    body = response.json()
+
+    assert body["arweave_tx"] is not None
+    assert body["arweave_tx"].startswith("ar:mock:")
+    assert body["ipfs_cid"] is not None
+    assert body["ipfs_cid"].startswith("Qm")
+
+    # Side-effect: same on the node so /verification can surface them.
+    node = graph_service.get_node(body["id"])
+    assert node["arweave_tx"] == body["arweave_tx"]
+    assert node["ipfs_cid"] == body["ipfs_cid"]
+
+    # Side-effect: storage service can locate the asset by uuid.
+    asset_uuid = body["id"].removeprefix("asset:")
+    record = permanent_storage_service.get_storage_record(asset_uuid)
+    assert record is not None
+    assert record["arweave_tx_id"] == body["arweave_tx"]
+    assert record["ipfs_cid"] == body["ipfs_cid"]
+
+
+def test_register_survives_ip_registration_failure(client, monkeypatch):
+    """Mock register_ip_asset to raise — the asset is still created and
+    usable; ip_status=failed, ip_reason is set, sp_ip_id is None. Per
+    spec R1, the asset remains usable without IP registration."""
+
+    def _boom(asset_id, metadata=None):
+        raise RuntimeError("simulated SDK outage")
+
+    monkeypatch.setattr(
+        ip_registration_service, "register_ip_asset", _boom
+    )
+
+    response = client.post("/api/assets/register", json=_payload())
+    assert response.status_code == 201, response.text
+    body = response.json()
+
+    # Asset created — id present, the legacy fields all populated.
+    assert body["id"].startswith("asset:")
+    assert body["sp_ip_id"] is None
+    assert body["ip_status"] == "failed"
+    assert "simulated SDK outage" in (body.get("ip_reason") or "")
+
+    # Asset is still usable — GET /api/assets/{uuid} resolves it.
+    asset_uuid = body["id"].removeprefix("asset:")
+    get_response = client.get(f"/api/assets/{asset_uuid}")
+    assert get_response.status_code == 200
+
+
+def test_register_survives_storage_failure(client, monkeypatch):
+    """Mock upload_to_arweave to raise — the asset is created, the
+    arweave/ipfs refs stay None (or whatever the caller passed in), IP
+    registration still fires successfully. One surface failing must not
+    take down the others."""
+
+    def _boom(content, metadata=None, *, asset_id=None):
+        raise RuntimeError("simulated bundler outage")
+
+    monkeypatch.setattr(
+        permanent_storage_service, "upload_to_arweave", _boom
+    )
+
+    response = client.post("/api/assets/register", json=_payload())
+    assert response.status_code == 201, response.text
+    body = response.json()
+
+    # Arweave failed → tx stays None. IPFS still succeeded.
+    assert body["arweave_tx"] is None
+    assert body["ipfs_cid"] is not None
+    assert body["ipfs_cid"].startswith("Qm")
+
+    # IP registration still happened.
+    assert body["sp_ip_id"] is not None
+    assert body["ip_status"] == "registered"

--- a/api/tests/test_story_protocol_e2e.py
+++ b/api/tests/test_story_protocol_e2e.py
@@ -21,20 +21,21 @@ The per-service flow tests prove the individual surfaces in isolation:
   - test_story_protocol.py         — pure logic
 
 This file is additive coverage — it proves the seven pieces compose
-into a working user-facing flow. Two contract gaps the e2e walks
-around (and which are real signals for future tend work):
+into a working user-facing flow.
 
-  1. ``POST /api/assets/register`` does not currently auto-fire
-     ``ip_registration_service.register_ip_asset`` or
-     ``permanent_storage_service.upload_to_arweave/upload_to_ipfs``.
-     The test invokes the services directly after registration and
-     patches the resulting sp_ip_id / arweave_tx / ipfs_cid onto the
-     graph node so the verification endpoint surfaces them.
-  2. ``read_tracking_service.record_read`` (fired by the content GET)
-     and the ``render_events`` store consumed by settlement are
-     decoupled — content reads do not auto-emit render events. The
-     test therefore POSTs to ``/api/render-events`` alongside each
-     content fetch to seed the settlement input.
+Gap closed (2026-05-24): ``POST /api/assets/register`` now auto-fires
+``ip_registration_service.register_ip_asset`` and
+``permanent_storage_service.upload_to_arweave/upload_to_ipfs`` per spec
+R1; the helper below reads the resulting sp_ip_id / arweave_tx /
+ipfs_cid straight off the response body. Focused coverage for the
+wiring lives in ``test_assets_register_auto_fires.py``.
+
+One remaining contract gap the e2e still walks around:
+``read_tracking_service.record_read`` (fired by the content GET) and
+the ``render_events`` store consumed by settlement are decoupled —
+content reads do not auto-emit render events. The test therefore POSTs
+to ``/api/render-events`` alongside each content fetch to seed the
+settlement input.
 """
 
 from __future__ import annotations
@@ -101,11 +102,13 @@ def _register_with_ip_and_storage(
     requires_payment: bool = False,
     free_tier_enabled: bool = True,
 ) -> tuple[str, str, dict, dict, dict]:
-    """Register an asset, fire IP registration + storage uploads, patch
-    the resulting refs onto the graph node, and patch payment gating.
+    """Register an asset — auto-fire pipeline lands sp_ip_id, arweave_tx
+    and ipfs_cid on the response. Patches payment gating onto the node
+    since those settings aren't part of the registration contract.
 
     Returns: (uuid_str, node_id, registration_body, ip_record, storage_pair)
-    where storage_pair is ``{"arweave": ..., "ipfs": ...}``.
+    where ``ip_record`` and ``storage_pair`` reshape the auto-fire results
+    into the shapes the rest of the e2e expects.
     """
     if concept_tags is None:
         concept_tags = [
@@ -124,43 +127,42 @@ def _register_with_ip_and_storage(
         "metadata": {"content_base64": content_b64},
     }
 
-    # Step 1 — register asset
+    # Register — IP registration + Arweave + IPFS auto-fire inside the
+    # handler. All three refs land on the response.
     response = client.post("/api/assets/register", json=payload)
     assert response.status_code == 201, response.text
     registration = response.json()
     node_id = registration["id"]
     uuid_str = node_id.removeprefix("asset:")
 
-    # Step 2 — IP registration fires
-    ip_record = ip_registration_service.register_ip_asset(
-        uuid_str, {"type": "text/plain", "name": registration["name"]}
-    )
-    assert ip_record["ip_status"] == "registered"
-    assert ip_record["sp_ip_id"] is not None
+    assert registration["ip_status"] == "registered"
+    assert registration["sp_ip_id"] is not None
+    assert registration["arweave_tx"] is not None
+    assert registration["arweave_tx"].startswith("ar:mock:")
+    assert registration["ipfs_cid"] is not None
+    assert registration["ipfs_cid"].startswith("Qm")
 
-    # Step 3 — permanent storage upload (Arweave + IPFS)
-    arweave = permanent_storage_service.upload_to_arweave(
-        content, {"name": registration["name"]}, asset_id=uuid_str
-    )
-    ipfs = permanent_storage_service.upload_to_ipfs(content, asset_id=uuid_str)
-    assert arweave["arweave_tx_id"].startswith("ar:mock:")
-    assert ipfs["ipfs_cid"].startswith("Qm")
-    assert arweave["content_hash"] == ipfs["content_hash"]
+    ip_record = {
+        "sp_ip_id": registration["sp_ip_id"],
+        "ip_status": registration["ip_status"],
+    }
+    storage_pair = {
+        "arweave": {"arweave_tx_id": registration["arweave_tx"]},
+        "ipfs": {"ipfs_cid": registration["ipfs_cid"]},
+    }
 
-    # Patch the IP + storage refs and payment gating onto the node so the
-    # downstream endpoints (content delivery, verification) surface them.
+    # Payment gating isn't part of the registration contract — patch it
+    # onto the node so the content-delivery endpoint sees the test's
+    # intended payment posture.
     graph_service.update_node(
         node_id,
         properties={
-            "sp_ip_id": ip_record["sp_ip_id"],
-            "arweave_tx": arweave["arweave_tx_id"],
-            "ipfs_cid": ipfs["ipfs_cid"],
             "requires_payment": requires_payment,
             "free_tier_enabled": free_tier_enabled,
             "payment_address": f"coherence:contributor:{creator_id}",
         },
     )
-    return uuid_str, node_id, registration, ip_record, {"arweave": arweave, "ipfs": ipfs}
+    return uuid_str, node_id, registration, ip_record, storage_pair
 
 
 def _seed_render_event(


### PR DESCRIPTION
## Summary

Closes contract gap #1 surfaced by the story-protocol e2e in PR #1963. `POST /api/assets/register` now auto-fires three downstream services after the asset node lands:

- `ip_registration_service.register_ip_asset` → `sp_ip_id`, `ip_status`
- `permanent_storage_service.upload_to_arweave` → `arweave_tx`
- `permanent_storage_service.upload_to_ipfs` → `ipfs_cid`

All three refs land on the response body and on the graph node, so `/verification` and `/content` surfaces see them without callers having to wire them up by hand. Per spec R1's escape hatch ("if registration fails, ip_status is failed and the asset remains usable"), each subcall is isolated in try/except — one failure (or all three) leaves the asset created and usable.

**Sync now, async later.** The three subcalls run synchronously since the services are fast in-memory mocks. When the real Story Protocol SDK + Irys/Bundlr arrive, the expensive network calls move to a background worker and the handler returns immediately with `ip_status="pending"`.

The e2e helper in `test_story_protocol_e2e.py` drops its manual orchestration — registration's response now carries everything it used to patch by hand. Only payment-gating fields (which aren't part of the registration contract) are still patched onto the node.

## Test plan

- [x] `pytest tests/test_assets_register_auto_fires.py` — 4 new focused tests (happy IP, happy storage, IP failure isolation, storage failure isolation)
- [x] `pytest tests/test_story_protocol_e2e.py` — 4 e2e tests still green after simplification
- [x] `pytest tests/test_ip_registration.py tests/test_permanent_storage.py tests/test_story_protocol.py tests/test_assets.py tests/test_assets_content.py` — all regression suites green
- [x] 74 tests total, 14s wall time

## Follow-up wiring noticed

- Contract gap #2 from PR #1963 remains open: `read_tracking_service.record_read` (fired by content GET) and the `render_events` store consumed by settlement are decoupled — content reads do not auto-emit render events. The e2e still POSTs to `/api/render-events` alongside each content fetch to seed settlement input. That's its own breath.
- `read_tracking_service.record_read` is called without forwarding `read_type` / payment token, so paid reads land on the free counter (the e2e already notes this as a contract gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)