### PR TITLE
tend: bridge content reads to settlement via render-event hop

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 203 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 205 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/routers/assets.py
+++ b/api/app/routers/assets.py
@@ -469,7 +469,15 @@ async def get_asset_content(
 
     if _has_valid_payment(authorization):
         try:
-            read_tracking_service.record_read(asset_id=node_id)
+            # Forward read_type + cc_amount + payment token so the read
+            # event carries the paid-tier CC. The render-event bridge in
+            # record_read uses cc_amount as the settlement pool.
+            read_tracking_service.record_read(
+                asset_id=node_id,
+                read_type="paid",
+                payment_token=authorization,
+                cc_amount=float(cc_amount),
+            )
         except Exception as e:  # non-blocking — read tracking failure mustn't fail delivery
             log.warning("record_read failed for %s: %s", node_id, e)
         try:
@@ -499,9 +507,9 @@ async def get_asset_content(
         }
         return JSONResponse(content=body, status_code=402, headers=payment_headers)
 
-    # Free tier — preview served, read recorded as "free".
+    # Free tier — preview served, read recorded as "free" (cc_amount=0).
     try:
-        read_tracking_service.record_read(asset_id=node_id)
+        read_tracking_service.record_read(asset_id=node_id, read_type="free")
     except Exception as e:
         log.warning("record_read failed for %s: %s", node_id, e)
     preview = _free_tier_content(content_bytes, mime_type)

--- a/api/app/services/read_tracking_service.py
+++ b/api/app/services/read_tracking_service.py
@@ -256,6 +256,26 @@ def record_read(
     else:
         _READ_EVENTS[asset_id].append(event)
 
+    # Bridge to render_attribution_service so settlement sees this read.
+    # Settlement scans the render-events store; without this hop, content
+    # reads never reach the daily batch (PR #1963 e2e gap #3). Soft-fail
+    # so a missing or broken render-attribution layer cannot break read
+    # recording — the read itself is still durable in the backend above.
+    try:
+        from app.services import render_attribution_service as ras
+        ras.log_render_event(
+            asset_id=asset_id,
+            reader_id=effective_reader,
+            cc_amount=cc_amount,
+            concept_resonance=snapshot,
+            read_type=read_type,
+        )
+    except Exception as bridge_err:
+        log.warning(
+            "read_tracking: render_attribution bridge failed for asset_id=%s: %s",
+            asset_id, bridge_err,
+        )
+
     # DB-backed daily counter — best-effort, swallowed exceptions keep the
     # read path non-blocking even when the DB layer isn't ready (e.g. in
     # pure-logic unit tests that don't spin up unified_db).
@@ -846,7 +866,9 @@ def _reset_for_tests() -> None:
     """Clear the event log for the active backend. The DB-backed daily
     counter is untouched — the test session manages its own DB lifecycle.
     Both backends are cleared so tests can flip between them within a
-    single session without leaking state.
+    single session without leaking state. The render-events bridge is
+    also cleared so render events seeded by prior tests via the bridge
+    don't leak into the next test's settlement.
     """
     _READ_EVENTS.clear()
     try:
@@ -855,4 +877,10 @@ def _reset_for_tests() -> None:
     except Exception:
         # value_lineage may not be ready in pure-logic test envs that
         # don't spin up unified_db; that's fine.
+        pass
+    try:
+        from app.routers.render_events import _reset_events_for_tests
+        _reset_events_for_tests()
+    except Exception:
+        # render_events router may not be importable in pure-logic envs.
         pass

--- a/api/app/services/render_attribution_service.py
+++ b/api/app/services/render_attribution_service.py
@@ -12,19 +12,30 @@ Override precedence per spec:
 Pydantic validation on RenderCCSplit ensures the three shares sum to
 1.0 before any attribution is computed, so cc_pool always reconciles
 to the three returned amounts within decimal tolerance.
+
+Also carries the small bridge ``log_render_event`` that lets the
+read-tracking service materialize a render event from each content
+read. Settlement reads from the same ``_EVENTS`` dict the render-events
+router writes to, so the bridge closes the read → settlement loop
+without changing settlement's contract (story-protocol-integration
+R5+R8 — see PR #1963 e2e gap #3).
 """
 
 from __future__ import annotations
 
+import logging
 from decimal import Decimal
-from typing import NamedTuple, Optional
+from typing import Any, Mapping, NamedTuple, Optional
 
 from app.models.renderer import (
     DEFAULT_ASSET_CREATOR_SHARE,
     DEFAULT_HOST_NODE_SHARE,
     DEFAULT_RENDERER_CREATOR_SHARE,
     RenderCCSplit,
+    RenderEvent,
 )
+
+log = logging.getLogger(__name__)
 
 
 class RenderAttribution(NamedTuple):
@@ -70,3 +81,63 @@ def attribute_render_cc(
         cc_renderer_creator=cc_pool * split.renderer_creator,
         cc_host_node=cc_pool * split.host_node,
     )
+
+
+# ---------------------------------------------------------------------------
+# Bridge — content reads materialize render events
+# ---------------------------------------------------------------------------
+
+# "renderer_id" for events synthesized from direct content-delivery reads
+# (i.e. GET /api/assets/{id}/content). Distinct from registered renderer
+# plugins so analytics can tell the two apart; settlement aggregates both.
+CONTENT_DIRECT_RENDERER_ID = "content-direct"
+
+
+def log_render_event(
+    *,
+    asset_id: str,
+    renderer_id: str = CONTENT_DIRECT_RENDERER_ID,
+    reader_id: Optional[str] = None,
+    cc_amount: Any = 0,
+    concept_resonance: Optional[Mapping[str, float]] = None,
+    read_type: str = "free",
+    duration_ms: int = 0,
+    asset_override: Optional[RenderCCSplit] = None,
+    renderer_default: Optional[RenderCCSplit] = None,
+) -> RenderEvent:
+    """Materialize a render event from a read so settlement sees the read.
+
+    Inserts the event into ``app.routers.render_events._EVENTS`` — the
+    same dict ``app.routers.settlement`` scans when computing a daily
+    batch. The CC pool is the read's ``cc_amount`` (paid reads carry
+    positive CC; free reads carry 0 and contribute to ``read_count``
+    only). Splits default to the platform 80/15/5; an asset override
+    or renderer default may be supplied by the caller.
+
+    ``concept_resonance`` and ``read_type`` are accepted so the bridge
+    is symmetric with ``read_tracking_service.record_read``; the
+    current ``RenderEvent`` shape doesn't carry them, but the bridge
+    surface keeps the door open for a richer event without forcing a
+    caller change later.
+    """
+    pool = cc_amount if isinstance(cc_amount, Decimal) else Decimal(str(cc_amount or 0))
+    attribution = attribute_render_cc(
+        pool,
+        asset_override=asset_override,
+        renderer_default=renderer_default,
+    )
+    event = RenderEvent(
+        asset_id=asset_id,
+        renderer_id=renderer_id,
+        reader_id=reader_id or "anonymous",
+        duration_ms=int(duration_ms or 0),
+        cc_pool=pool,
+        cc_asset_creator=attribution.cc_asset_creator,
+        cc_renderer_creator=attribution.cc_renderer_creator,
+        cc_host_node=attribution.cc_host_node,
+    )
+    # Late import to avoid a hard cycle (router imports this service).
+    from app.routers.render_events import _EVENTS
+
+    _EVENTS[event.id] = event
+    return event

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 203
+**Total files**: 205
 
 | File | Purpose |
 |---|---|
@@ -133,6 +133,7 @@
 | [test_quotient.py](test_quotient.py) | Tests for the QUOTIENT arm — Python kernel. |
 | [test_read_tracking.py](test_read_tracking.py) | Flow tests for read_tracking_service — story-protocol-integration R5 + R6. |
 | [test_read_tracking_lineage_backend.py](test_read_tracking_lineage_backend.py) | Lineage-backend tests for read_tracking_service — story-protocol-integration R5. |
+| [test_read_tracking_settlement_bridge.py](test_read_tracking_settlement_bridge.py) | Tests for the read → render-event bridge. |
 | [test_registry_discovery.py](test_registry_discovery.py) | Tests for the mcp-skill-registry-submission spec. |
 | [test_release_gate_service.py](test_release_gate_service.py) | Tests for the pure-helper layer of release_gate_service (spec: release-gates). |
 | [test_render_events_router.py](test_render_events_router.py) | Tests for POST /api/render-events — the economic loop closure. |

--- a/api/tests/test_read_tracking_settlement_bridge.py
+++ b/api/tests/test_read_tracking_settlement_bridge.py
@@ -1,0 +1,132 @@
+"""Tests for the read → render-event bridge.
+
+Closes contract gap #3 from PR #1963: ``record_read`` now materializes
+a render event via ``render_attribution_service.log_render_event`` so
+settlement (which scans ``app.routers.render_events._EVENTS``) sees
+every content read without manual seeding. The four tests here cover:
+
+1. A single read seeds an _EVENTS row with the right asset_id + pool.
+2. Concept resonance is accepted through the bridge surface.
+3. Multiple reads on the same day aggregate through settlement.
+4. A failing bridge does not break read recording.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.routers.render_events import _EVENTS, _reset_events_for_tests
+from app.services import (
+    read_tracking_service,
+    render_attribution_service,
+    settlement_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    read_tracking_service._reset_for_tests()
+    _reset_events_for_tests()
+    settlement_service._reset_for_tests()
+    yield
+    read_tracking_service._reset_for_tests()
+    _reset_events_for_tests()
+    settlement_service._reset_for_tests()
+
+
+def test_record_read_seeds_render_event():
+    """A single record_read call lands one event in _EVENTS with the
+    matching asset_id and cc_amount as the pool."""
+    read_tracking_service.record_read(
+        "asset-bridge-1",
+        reader_id="reader-a",
+        read_type="paid",
+        cc_amount=0.25,
+    )
+
+    bridged = [e for e in _EVENTS.values() if e.asset_id == "asset-bridge-1"]
+    assert len(bridged) == 1
+    ev = bridged[0]
+    assert ev.reader_id == "reader-a"
+    assert ev.cc_pool == Decimal("0.25")
+    # Platform default 80/15/5 split reconciles to the pool.
+    assert ev.cc_asset_creator + ev.cc_renderer_creator + ev.cc_host_node == Decimal("0.25")
+    assert ev.renderer_id == render_attribution_service.CONTENT_DIRECT_RENDERER_ID
+
+
+def test_record_read_render_event_carries_reader_through_bridge():
+    """The reader id survives the bridge for analytics & uniqueness counts.
+    The current RenderEvent shape doesn't surface concept_resonance, but
+    the bridge accepts it without raising so the surface stays stable."""
+    snapshot = {"lc-land": 0.9, "lc-beauty": 0.1}
+    read_tracking_service.record_read(
+        "asset-bridge-2",
+        reader_id="reader-resonant",
+        read_type="paid",
+        cc_amount=0.10,
+        concept_resonance_snapshot=snapshot,
+    )
+
+    bridged = [e for e in _EVENTS.values() if e.asset_id == "asset-bridge-2"]
+    assert len(bridged) == 1
+    assert bridged[0].reader_id == "reader-resonant"
+    assert bridged[0].cc_pool == Decimal("0.10")
+
+
+def test_settlement_aggregates_reads_after_record_read():
+    """Multiple paid reads through record_read feed settlement directly —
+    no manual _EVENTS seeding required. This is the loop the e2e PR
+    flagged as broken."""
+    for i in range(3):
+        read_tracking_service.record_read(
+            "asset-bridge-3",
+            reader_id=f"reader-{i}",
+            read_type="paid",
+            cc_amount=0.10,
+        )
+
+    today = date.today()
+    events = list(_EVENTS.values())
+    batch = settlement_service.run_daily_settlement(
+        batch_date=today,
+        events=events,
+        asset_concept_tags={},
+        evidence_multipliers={},
+    )
+
+    assert batch.total_read_count == 3
+    # 3 reads × 0.10 CC pool = 0.30 CC total (no multiplier)
+    assert batch.total_cc_distributed == Decimal("0.30")
+    entry = next(e for e in batch.entries if e.asset_id == "asset-bridge-3")
+    assert entry.read_count == 3
+    assert entry.base_cc_pool == Decimal("0.30")
+
+
+def test_bridge_failure_does_not_break_record_read(monkeypatch):
+    """When the bridge raises, record_read still returns the event dict
+    and the read is still appended to the in-memory backend."""
+    def _boom(**kwargs):
+        raise RuntimeError("simulated bridge failure")
+
+    monkeypatch.setattr(
+        render_attribution_service, "log_render_event", _boom
+    )
+
+    event = read_tracking_service.record_read(
+        "asset-bridge-4",
+        reader_id="reader-resilient",
+        read_type="free",
+    )
+    assert event["asset_id"] == "asset-bridge-4"
+    assert event["reader_id"] == "reader-resilient"
+    # The read is still recorded in the memory backend even though the
+    # bridge raised — the loop drops one event for settlement but the
+    # read itself stays durable.
+    persisted = read_tracking_service.get_read_events("asset-bridge-4")
+    assert len(persisted) == 1
+    # And no event leaked into _EVENTS because the bridge raised before
+    # the insert (the function is monkeypatched at the module level).
+    assert not any(e.asset_id == "asset-bridge-4" for e in _EVENTS.values())

--- a/api/tests/test_story_protocol_e2e.py
+++ b/api/tests/test_story_protocol_e2e.py
@@ -4,7 +4,7 @@ Walks the full creator journey through the HTTP API in one shot:
 
     register asset  →  IP registration  →  permanent storage
         →  reader fetches content (free + paid + 402)
-        →  read tracking aggregates
+        →  read tracking aggregates (auto-seeds render events via bridge)
         →  evidence submission + 2-of-3 verification
         →  daily settlement (with 5× evidence multiplier)
         →  integrity verification
@@ -12,17 +12,18 @@ Walks the full creator journey through the HTTP API in one shot:
 
 The per-service flow tests prove the individual surfaces in isolation:
 
-  - test_ip_registration.py        — R1, R7
-  - test_evidence_flow.py          — R9
-  - test_settlement_flow.py        — R8
-  - test_permanent_storage.py      — R3, R10
-  - test_read_tracking.py          — R5, R6
-  - test_assets_content.py         — R4, R10
-  - test_story_protocol.py         — pure logic
+  - test_ip_registration.py                       — R1, R7
+  - test_evidence_flow.py                         — R9
+  - test_settlement_flow.py                       — R8
+  - test_permanent_storage.py                     — R3, R10
+  - test_read_tracking.py                         — R5, R6
+  - test_read_tracking_settlement_bridge.py       — bridge to settlement
+  - test_assets_content.py                        — R4, R10
+  - test_story_protocol.py                        — pure logic
 
-This file is additive coverage — it proves the seven pieces compose
-into a working user-facing flow. Two contract gaps the e2e walks
-around (and which are real signals for future tend work):
+This file is additive coverage — it proves the pieces compose into a
+working user-facing flow. One remaining contract gap the e2e still
+walks around:
 
   1. ``POST /api/assets/register`` does not currently auto-fire
      ``ip_registration_service.register_ip_asset`` or
@@ -30,25 +31,24 @@ around (and which are real signals for future tend work):
      The test invokes the services directly after registration and
      patches the resulting sp_ip_id / arweave_tx / ipfs_cid onto the
      graph node so the verification endpoint surfaces them.
-  2. ``read_tracking_service.record_read`` (fired by the content GET)
-     and the ``render_events`` store consumed by settlement are
-     decoupled — content reads do not auto-emit render events. The
-     test therefore POSTs to ``/api/render-events`` alongside each
-     content fetch to seed the settlement input.
+
+The read → settlement loop that previously required manual
+``_RENDER_EVENTS`` seeding is now closed by the
+``render_attribution_service.log_render_event`` bridge fired from
+``read_tracking_service.record_read``.
 """
 
 from __future__ import annotations
 
 import base64
 import hashlib
-from datetime import date, datetime, timezone
+from datetime import date
 from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.routers.render_events import _EVENTS as _RENDER_EVENTS
 from app.routers.render_events import _reset_events_for_tests
 from app.services import (
     evidence_service,
@@ -163,34 +163,6 @@ def _register_with_ip_and_storage(
     return uuid_str, node_id, registration, ip_record, {"arweave": arweave, "ipfs": ipfs}
 
 
-def _seed_render_event(
-    asset_node_id: str,
-    *,
-    day: date,
-    reader_id: str = "reader-x",
-    duration_ms: int = 10000,
-):
-    """Drop a render event directly into the in-process store at the
-    asset/day the settlement step will scan. The /api/render-events POST
-    route would also work; the direct path keeps test wall-time small."""
-    from app.models.renderer import RenderEvent
-
-    pool = Decimal(duration_ms) * Decimal("0.00001")
-    event = RenderEvent(
-        asset_id=asset_node_id,
-        renderer_id="r1",
-        reader_id=reader_id,
-        timestamp=datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc),
-        duration_ms=duration_ms,
-        cc_pool=pool,
-        cc_asset_creator=pool * Decimal("0.80"),
-        cc_renderer_creator=pool * Decimal("0.15"),
-        cc_host_node=pool * Decimal("0.05"),
-    )
-    _RENDER_EVENTS[event.id] = event
-    return event
-
-
 # ---------------------------------------------------------------------------
 # 1. Happy path — full creator → settlement with 5× evidence multiplier
 # ---------------------------------------------------------------------------
@@ -223,20 +195,16 @@ def test_full_creator_to_settlement_flow(client):
             "coherence:contributor:"
         )
 
-    # --- Side-effect: read_tracking_service saw all 3 reads ---
-    # Contract gap (2026-05-24): the content endpoint calls
-    # record_read(asset_id=...) without forwarding read_type/payment_token,
-    # so even paid reads land on the free counter. The aggregate total
-    # still rises by 3, which is what the e2e proves the pipeline counted.
+    # --- Side-effect: read_tracking_service saw all 3 reads as paid ---
+    # The content endpoint now forwards read_type="paid" + cc_amount, so
+    # the aggregate distinguishes paid from free and the render-event
+    # bridge gives settlement a non-zero pool per read.
     agg = read_tracking_service.get_daily_aggregates(asset_id=node_id)
     assert agg["per_asset"][node_id]["total"] == 3
+    assert agg["per_asset"][node_id]["paid_reads"] == 3
 
-    # --- Seed render events so settlement has something to aggregate ---
+    # --- Render events were auto-seeded by the bridge — no manual hop ---
     today = date.today()
-    for reader_n in range(3):
-        _seed_render_event(
-            node_id, day=today, reader_id=f"reader-{reader_n}", duration_ms=10000
-        )
 
     # --- Evidence submission — photos + GPS + attestations ---
     evidence_service.register_community_location(37.78, -122.41)
@@ -270,11 +238,12 @@ def test_full_creator_to_settlement_flow(client):
     batch = settle_response.json()
     assert batch["batch_date"] == today.isoformat()
     assert batch["total_read_count"] == 3
-    # 3 reads × 10000ms × 0.00001 = 0.30 base CC; × 5 multiplier = 1.50 CC distributed
-    assert Decimal(batch["total_cc_distributed"]) == Decimal("1.50000")
+    # 3 paid reads × 0.01 CC (DEFAULT_CONTENT_CC_AMOUNT) = 0.03 base CC;
+    # × 5 multiplier = 0.15 CC distributed.
+    assert Decimal(batch["total_cc_distributed"]) == Decimal("0.15")
     entry = next(e for e in batch["entries"] if e["asset_id"] == node_id)
     assert Decimal(entry["evidence_multiplier"]) == Decimal("5")
-    assert Decimal(entry["effective_cc_pool"]) == Decimal("1.50000")
+    assert Decimal(entry["effective_cc_pool"]) == Decimal("0.15")
     assert entry["read_count"] == 3
 
     # --- Integrity verification — passes against unchanged content ---
@@ -337,19 +306,18 @@ def test_free_tier_flow(client):
     assert agg["per_asset"][node_id]["free_reads"] == 1
     assert agg["per_asset"][node_id]["paid_reads"] == 0
 
-    # Settlement: a render event seeded for today aggregates without
-    # a multiplier (no verified evidence registered).
+    # Settlement: the free-tier read auto-seeded a render event via the
+    # bridge with cc_pool=0 (free reads carry no CC). The batch still
+    # counts the read; CC distributed is 0 with no multiplier.
     today = date.today()
-    _seed_render_event(node_id, day=today, duration_ms=10000)
-
     settle_body = client.post(
         "/api/settlement/run", json={"batch_date": today.isoformat()}
     ).json()
     assert settle_body["total_read_count"] == 1
-    # 1 read × 10000ms × 0.00001 = 0.10 CC — no multiplier
-    assert Decimal(settle_body["total_cc_distributed"]) == Decimal("0.10000")
+    assert Decimal(settle_body["total_cc_distributed"]) == Decimal("0")
     entry = next(e for e in settle_body["entries"] if e["asset_id"] == node_id)
     assert Decimal(entry["evidence_multiplier"]) == Decimal("1")
+    assert entry["read_count"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -389,9 +357,10 @@ def test_derivative_flow(client):
 
     # Settlement on the derivative — the royalty split lives at the IP
     # layer (record_derivative), not inside settlement's CC distribution
-    # in this iteration. Verify the settlement still aggregates the read.
+    # in this iteration. The single paid read already auto-seeded a
+    # render event via the bridge, so settlement aggregates without
+    # extra wiring.
     today = date.today()
-    _seed_render_event(deriv_node_id, day=today, duration_ms=10000)
     batch = client.post(
         "/api/settlement/run", json={"batch_date": today.isoformat()}
     ).json()


### PR DESCRIPTION
## Summary

Closes contract gap #3 from PR #1963's e2e investigation: settlement reads from `_RENDER_EVENTS`, but content reads via `read_tracking_service.record_read` were never seeding that store. The full creator-to-settlement loop was broken — only manual `_RENDER_EVENTS` seeding inside tests made it work.

- **Bridge**: `render_attribution_service.log_render_event` materializes a `RenderEvent` from a read; `read_tracking_service.record_read` calls it after recording. Settlement keeps scanning `_RENDER_EVENTS` unchanged.
- **Content endpoint forwarding**: `GET /api/assets/{id}/content` now passes `read_type="paid"|"free"`, `cc_amount`, and `payment_token` to `record_read` so paid reads carry CC into the bridged event.
- **Soft-fail**: bridge failures are caught — a broken render-attribution layer drops one settlement event but the read itself stays durable.
- **e2e simplification**: `test_story_protocol_e2e.py` drops `_seed_render_event()` and asserts the bridged numbers directly (3 paid reads × 0.01 cc × 5× multiplier = 0.15 CC distributed).

## Test plan

- [x] `tests/test_read_tracking_settlement_bridge.py` — 4 new tests cover: bridge seeds _EVENTS, reader id survives, settlement aggregates bridged reads, bridge failure does not break record_read
- [x] `tests/test_read_tracking.py` — 17 existing tests still pass
- [x] `tests/test_settlement_flow.py` — 13 existing tests still pass (existing manual `_EVENTS[e.id] = e` still works)
- [x] `tests/test_story_protocol_e2e.py` — 4 tests pass with simplified seeding
- [x] `tests/test_assets_content.py` — 10 tests pass with forwarded `read_type`
- [x] Broader sweep (115 tests across 10 files): all pass
- [x] Adjacent suites (creator economy, render-events router, renderer plugins, views/wallets): 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)