### PR TITLE
tend: instance pulse — each instance shows its own breath

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -31,10 +31,10 @@
 
 | Index | Files | Purpose |
 |---|---|---|
-| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
+| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 132 | API routers — every HTTP endpoint surface |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 233 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 206 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 207 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -33,6 +33,7 @@ from app.routers import (
     gates,
     governance,
     health,
+    pulse,
     ideas,
     inventory,
     lenses,
@@ -691,6 +692,7 @@ app.include_router(openclaw_node_bridge.router, prefix="/api", tags=["federation
 app.include_router(friction.router, prefix="/api", tags=["friction"])
 app.include_router(gates.router, prefix="/api", tags=["gates"])
 app.include_router(health.router, prefix="/api", tags=["health"])
+app.include_router(pulse.router, prefix="/api", tags=["pulse"])
 app.include_router(value_lineage.router, prefix="/api", tags=["value-lineage"])
 app.include_router(runtime.router, prefix="/api", tags=["runtime"])
 app.include_router(inventory.router, prefix="/api", tags=["inventory"])

--- a/api/app/routers/INDEX.md
+++ b/api/app/routers/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 131
+**Total files**: 132
 
 | File | Purpose |
 |---|---|
@@ -111,6 +111,7 @@
 | [proprioception.py](proprioception.py) | Proprioception router — auto-sensing system state endpoints. |
 | [provider_stats.py](provider_stats.py) | Provider measurement stats endpoint. |
 | [providers.py](providers.py) | Task execution provider routes. |
+| [pulse.py](pulse.py) | Instance pulse routes — each coherence instance exposes its own breath. |
 | [push.py](push.py) | Web Push router — subscribe, unsubscribe, send. |
 | [reactions.py](reactions.py) | Reactions router — emoji + comment on any entity. |
 | [registry_discovery.py](registry_discovery.py) | Discovery registry submission inventory routes. |

--- a/api/app/routers/pulse.py
+++ b/api/app/routers/pulse.py
@@ -1,0 +1,61 @@
+"""Instance pulse routes — each coherence instance exposes its own breath.
+
+Federation honors sovereignty: every instance shows its breath to whoever
+chooses to look, but no central monitor controls it. These endpoints are
+windows, not hooks.
+
+  - GET /api/pulse/self  — this instance's current breath state
+  - GET /api/pulse/now   — alias matching the production witness URL shape
+  - GET /api/pulse/peers — most-recent observed pulses from watched peers
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from app.services import instance_pulse_service
+
+router = APIRouter()
+
+
+def _pulse_payload() -> dict[str, Any]:
+    if not instance_pulse_service.pulse_enabled():
+        raise HTTPException(status_code=404, detail="instance pulse disabled")
+    return instance_pulse_service.self_pulse()
+
+
+@router.get("/pulse/self", summary="This instance's current breath state")
+async def get_self_pulse() -> dict[str, Any]:
+    """Return this instance's current breath: overall, organs, uptime."""
+    return _pulse_payload()
+
+
+@router.get("/pulse/now", summary="Alias for /pulse/self matching the witness URL shape")
+async def get_pulse_now() -> dict[str, Any]:
+    """Alias for /pulse/self.
+
+    Mirrors the URL shape of the production witness at
+    ``pulse.coherencycoin.com/pulse/now`` so any instance's API can answer
+    the same question uniformly.
+    """
+    return _pulse_payload()
+
+
+@router.get("/pulse/peers", summary="Most-recent observed pulses from watched peers")
+async def get_peer_pulses() -> dict[str, Any]:
+    """Return the most-recent pulse observed from each peer this instance watches.
+
+    Each instance decides which peers to watch; no auto-discovery. This
+    endpoint reads from local storage of past observations and never makes
+    outbound calls.
+    """
+    if not instance_pulse_service.pulse_enabled():
+        raise HTTPException(status_code=404, detail="instance pulse disabled")
+    peers = instance_pulse_service.list_peer_pulses()
+    return {
+        "instance_id": instance_pulse_service.instance_id(),
+        "peers": peers,
+        "count": len(peers),
+    }

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 232
+**Total files**: 233
 
 | File | Purpose |
 |---|---|
@@ -139,6 +139,7 @@
 | [identity_providers.py](identity_providers.py) | Identity provider registry — single source of truth for all supported providers. |
 | [influence_teaching_translator_service.py](influence_teaching_translator_service.py) | Influence teaching translator for field story traces. |
 | [inspired_by_service.py](inspired_by_service.py) | Inspired-by resolver — turn a name (or URL) into a small subgraph. |
+| [instance_pulse_service.py](instance_pulse_service.py) | Instance pulse service — each coherence instance shows its own breath. |
 | [interest_service.py](interest_service.py) | Interest registration service — privacy-first community gathering. |
 | [inventory_service.py](inventory_service.py) | Unified inventory service for ideas, questions, specs, implementations, and usage. |
 | [investment_service.py](investment_service.py) | Investment service — positions, ROI projection, history. |

--- a/api/app/services/instance_pulse_service.py
+++ b/api/app/services/instance_pulse_service.py
@@ -1,0 +1,328 @@
+"""Instance pulse service — each coherence instance shows its own breath.
+
+Federation honors sovereignty: each instance exposes its breath to whoever
+chooses to look, but no central monitor controls it. The pulse endpoint is a
+window, not a hook. Other instances and external observers can sense an
+instance's aliveness without becoming its controller.
+
+This service runs lightweight, bounded organ checks (api, postgres, neo4j,
+substrate, schema) and synthesizes the overall state. Each check has a hard
+timeout so the pulse keeps breathing even when other organs don't.
+
+Companion to ``community_pulse_service`` (which senses the felt experience of
+the organism) and the production ``pulse.coherencycoin.com`` witness (which
+watches the production instance from outside). This is the per-instance
+self-attestation surface that makes federation possible.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from sqlalchemy import Index, String, Text, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.services import unified_db
+from app.services.unified_db import Base
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Identity + lifecycle
+# ---------------------------------------------------------------------------
+
+INSTANCE_STARTED_AT = datetime.now(timezone.utc)
+
+# Per-check timeout: each organ check must return within this window or be
+# marked silent. Keeps the pulse endpoint fast even under stress.
+ORGAN_TIMEOUT_S = 0.05
+
+
+def instance_id() -> str:
+    """Identifier for this coherence instance.
+
+    Defaults to "local" for development/test; production sets
+    FEDERATION_INSTANCE_ID. Sovereignty: the instance names itself.
+    """
+    return os.getenv("FEDERATION_INSTANCE_ID", "local")
+
+
+def uptime_seconds(now: datetime | None = None) -> int:
+    """Seconds since this instance process started."""
+    now = now or datetime.now(timezone.utc)
+    return max(0, int((now - INSTANCE_STARTED_AT).total_seconds()))
+
+
+def pulse_enabled() -> bool:
+    """An instance may disable its public pulse window for privacy.
+
+    Set ``FEDERATION_PULSE_DISABLED=1`` to refuse the visibility. The default
+    is to share: showing your breath is generosity, not surrender.
+    """
+    raw = os.getenv("FEDERATION_PULSE_DISABLED", "").strip().lower()
+    return raw not in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Peer pulse persistence — what we have observed from peers we chose to watch
+# ---------------------------------------------------------------------------
+
+class PeerPulseRecord(Base):
+    """Most-recent pulse observed from a peer instance.
+
+    Each instance decides which peers to watch via existing federation flows;
+    this table holds whatever the (separate) peer-poll job has captured. The
+    GET /api/pulse/peers endpoint reads from here without making any outbound
+    calls — readers see what the body has chosen to see, nothing forced.
+    """
+
+    __tablename__ = "peer_pulse_records"
+
+    peer_instance_id: Mapped[str] = mapped_column(String, primary_key=True)
+    last_pulse_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    observed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (Index("idx_ppr_observed_at", "observed_at"),)
+
+
+# ---------------------------------------------------------------------------
+# Organ checks — each returns (status, score, detail)
+# ---------------------------------------------------------------------------
+
+# Allow tests to inject custom check callables. None = use defaults.
+_check_overrides: dict[str, Callable[[], tuple[str, float, str | None]] | None] = {}
+_overrides_lock = threading.Lock()
+
+
+def set_organ_check(name: str, fn: Callable[[], tuple[str, float, str | None]] | None) -> None:
+    """Test hook: override a single organ's check function."""
+    with _overrides_lock:
+        if fn is None:
+            _check_overrides.pop(name, None)
+        else:
+            _check_overrides[name] = fn
+
+
+def reset_organ_checks() -> None:
+    """Test hook: clear all overrides."""
+    with _overrides_lock:
+        _check_overrides.clear()
+
+
+def _check_api() -> tuple[str, float, str | None]:
+    # If this function executes, the API process is responsive enough to
+    # answer its own pulse. That is the api organ's breathing.
+    return ("breathing", 1.0, None)
+
+
+def _check_postgres() -> tuple[str, float, str | None]:
+    try:
+        from sqlalchemy import text as _text
+        with unified_db.session() as sess:
+            sess.execute(_text("SELECT 1"))
+        return ("breathing", 1.0, None)
+    except Exception as exc:  # pragma: no cover - covered by mocked test
+        return ("silent", 0.0, f"postgres unreachable: {type(exc).__name__}")
+
+
+def _check_neo4j() -> tuple[str, float, str | None]:
+    try:
+        # Lazy import — the graph store is optional in some test environments.
+        from app.services import graph_store_service
+        store = graph_store_service.get_store()
+        if store is None:
+            return ("silent", 0.0, "graph store unavailable")
+        # A simple read; the count itself is incidental.
+        store.run_query("MATCH (n) RETURN count(n) AS c LIMIT 1")
+        return ("breathing", 1.0, None)
+    except Exception as exc:
+        return ("silent", 0.0, f"neo4j unreachable: {type(exc).__name__}")
+
+
+def _check_substrate() -> tuple[str, float, str | None]:
+    try:
+        from app.services.substrate import lattice_stats
+        with unified_db.session() as sess:
+            stats = lattice_stats(sess)
+        # If the substrate responds at all, it is breathing — emptiness is
+        # not silence.
+        if isinstance(stats, dict):
+            return ("breathing", 1.0, None)
+        return ("strained", 0.5, "substrate returned unexpected shape")
+    except Exception as exc:
+        return ("silent", 0.0, f"substrate unreadable: {type(exc).__name__}")
+
+
+def _check_schema() -> tuple[str, float, str | None]:
+    try:
+        from sqlalchemy import text as _text
+        with unified_db.session() as sess:
+            for table in ("contributions", "contributors", "assets"):
+                sess.execute(_text(f"SELECT 1 FROM {table} LIMIT 1"))
+        return ("breathing", 1.0, None)
+    except Exception as exc:
+        return ("silent", 0.0, f"core tables missing: {type(exc).__name__}")
+
+
+DEFAULT_CHECKS: dict[str, Callable[[], tuple[str, float, str | None]]] = {
+    "api": _check_api,
+    "postgres": _check_postgres,
+    "neo4j": _check_neo4j,
+    "substrate": _check_substrate,
+    "schema": _check_schema,
+}
+
+# Organs whose silence indicates a structural problem rather than an
+# auxiliary outage. If any of these go silent, overall drops below
+# "breathing" even if everything else is fine.
+CORE_ORGANS = frozenset({"api", "postgres"})
+
+
+# Shared executor so a single slow organ's still-running thread doesn't block
+# the response — we return on timeout and let the worker finish in the
+# background. Bounded pool size keeps a stuck check from spawning unbounded
+# threads under load.
+_check_pool = ThreadPoolExecutor(max_workers=8, thread_name_prefix="pulse-check")
+
+
+def _run_with_timeout(fn: Callable[[], tuple[str, float, str | None]]) -> tuple[str, float, str | None]:
+    """Run a check with a bounded timeout; treat overrun as silence.
+
+    On timeout the worker thread keeps running (Python has no safe way to
+    interrupt arbitrary code), but the response returns immediately. The
+    shared pool absorbs the orphan until it completes.
+    """
+    future = _check_pool.submit(fn)
+    try:
+        return future.result(timeout=ORGAN_TIMEOUT_S)
+    except FutureTimeout:
+        return ("silent", 0.0, f"check exceeded {int(ORGAN_TIMEOUT_S * 1000)}ms")
+    except Exception as exc:  # pragma: no cover - safety net
+        return ("silent", 0.0, f"check raised: {type(exc).__name__}")
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sample_organs() -> list[dict[str, Any]]:
+    """Run all organ checks (with timeout) and return their breath state."""
+    sampled_at = datetime.now(timezone.utc)
+    now_iso = _iso(sampled_at)
+
+    with _overrides_lock:
+        active = {name: _check_overrides.get(name) or default for name, default in DEFAULT_CHECKS.items()}
+
+    organs: list[dict[str, Any]] = []
+    for name, fn in active.items():
+        status, score, detail = _run_with_timeout(fn)
+        organs.append({
+            "name": name,
+            "status": status,
+            "last_breath_at": now_iso,
+            "score": round(float(score), 3),
+            "detail": detail,
+        })
+    return organs
+
+
+def synthesize_overall(organs: list[dict[str, Any]]) -> tuple[str, int]:
+    """Combine organ states into one overall breath.
+
+    Rules:
+      - All breathing → "breathing"
+      - Any core organ silent → "silent"
+      - Any organ silent or strained, core still healthy → "strained"
+    """
+    silences = sum(1 for o in organs if o["status"] != "breathing")
+    core_silent = any(
+        o["status"] == "silent" and o["name"] in CORE_ORGANS for o in organs
+    )
+    if core_silent:
+        return ("silent", silences)
+    if silences == 0:
+        return ("breathing", 0)
+    return ("strained", silences)
+
+
+def self_pulse() -> dict[str, Any]:
+    """Sample this instance's current breath state."""
+    started = time.perf_counter()
+    sampled_at = datetime.now(timezone.utc)
+    organs = sample_organs()
+    overall, silences = synthesize_overall(organs)
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+    return {
+        "instance_id": instance_id(),
+        "overall": overall,
+        "organs": organs,
+        "silences": silences,
+        "uptime_seconds": uptime_seconds(sampled_at),
+        "as_of": _iso(sampled_at),
+        "sample_duration_ms": elapsed_ms,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Peer pulse reads + writes
+# ---------------------------------------------------------------------------
+
+def record_peer_pulse(peer_id: str, pulse: dict[str, Any]) -> None:
+    """Store an observed pulse from a peer.
+
+    Used by the (out-of-scope) peer-poll job and by tests. Upserts a single
+    row per peer — only the most-recent observation is kept.
+    """
+    import json
+
+    payload = json.dumps(pulse, default=str)
+    now = datetime.now(timezone.utc)
+    with unified_db.session() as sess:
+        existing = sess.get(PeerPulseRecord, peer_id)
+        if existing is None:
+            sess.add(PeerPulseRecord(
+                peer_instance_id=peer_id,
+                last_pulse_json=payload,
+                observed_at=now,
+            ))
+        else:
+            existing.last_pulse_json = payload
+            existing.observed_at = now
+        sess.commit()
+
+
+def list_peer_pulses() -> list[dict[str, Any]]:
+    """Return the most-recent observed pulse from each watched peer."""
+    import json
+
+    out: list[dict[str, Any]] = []
+    try:
+        with unified_db.session() as sess:
+            rows = sess.query(PeerPulseRecord).order_by(
+                PeerPulseRecord.observed_at.desc()
+            ).all()
+            for row in rows:
+                try:
+                    pulse = json.loads(row.last_pulse_json or "{}")
+                except Exception:
+                    pulse = {}
+                out.append({
+                    "peer_instance_id": row.peer_instance_id,
+                    "observed_at": _iso(row.observed_at) if row.observed_at else None,
+                    "pulse": pulse,
+                })
+    except Exception as exc:
+        logger.warning("Failed to read peer pulses: %s", exc)
+    return out

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 206
+**Total files**: 207
 
 | File | Purpose |
 |---|---|
@@ -104,6 +104,7 @@
 | [test_import_lineage_edges.py](test_import_lineage_edges.py) | Lineage importer replays explicit graph edges from manifests. |
 | [test_inductive.py](test_inductive.py) | Tests for INDUCTIVE / CONSTRUCTOR / CHOICE — Python kernel. |
 | [test_inspired_by.py](test_inspired_by.py) | Flow-centric tests for the inspired-by resolver and /api/inspired-by. |
+| [test_instance_pulse.py](test_instance_pulse.py) | Acceptance tests for instance-pulse — per-instance breath sharing. |
 | [test_interest_registration.py](test_interest_registration.py) | Flow-centric tests for interest registration — privacy-first community gathering. |
 | [test_investments.py](test_investments.py) | Flow-centric tests for the investment surface — covers preview, portfolio, |
 | [test_ip_registration.py](test_ip_registration.py) | Flow tests for ip_registration_service — story-protocol-integration R1, R7. |

--- a/api/tests/test_instance_pulse.py
+++ b/api/tests/test_instance_pulse.py
@@ -1,0 +1,184 @@
+"""Acceptance tests for instance-pulse — per-instance breath sharing.
+
+Federation honors sovereignty: every instance exposes its own breath at
+/api/pulse/self (alias /api/pulse/now) without needing a central monitor.
+Watched-peer pulses surface at /api/pulse/peers.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services import instance_pulse_service
+
+BASE = "http://test"
+
+
+@pytest.fixture(autouse=True)
+def _reset_organ_overrides():
+    instance_pulse_service.reset_organ_checks()
+    yield
+    instance_pulse_service.reset_organ_checks()
+
+
+# ---------------------------------------------------------------------------
+# 1. /api/pulse/self returns overall state with required fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_self_pulse_returns_overall_state():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/pulse/self")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        for field in ("instance_id", "overall", "organs", "silences", "uptime_seconds", "as_of"):
+            assert field in body, f"missing field: {field}"
+        assert isinstance(body["organs"], list)
+        assert len(body["organs"]) >= 1
+        for organ in body["organs"]:
+            assert {"name", "status", "last_breath_at", "score"} <= set(organ.keys())
+
+
+# ---------------------------------------------------------------------------
+# 2. Overall = breathing when all organs breathe
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_self_pulse_breathing_when_api_healthy():
+    instance_pulse_service.set_organ_check("postgres", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("neo4j", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("substrate", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("schema", lambda: ("breathing", 1.0, None))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/pulse/self")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["overall"] == "breathing"
+        assert body["silences"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Strained when a non-core organ goes silent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_self_pulse_strained_when_organ_silent():
+    # Core organs still healthy, but neo4j times out / silences
+    instance_pulse_service.set_organ_check("postgres", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("neo4j", lambda: ("silent", 0.0, "timeout"))
+    instance_pulse_service.set_organ_check("substrate", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("schema", lambda: ("breathing", 1.0, None))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/pulse/self")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["overall"] == "strained"
+        assert body["silences"] >= 1
+        silent_names = [o["name"] for o in body["organs"] if o["status"] == "silent"]
+        assert "neo4j" in silent_names
+
+
+# ---------------------------------------------------------------------------
+# 4. /api/pulse/now is an alias for /api/pulse/self
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pulse_now_is_alias_for_self():
+    instance_pulse_service.set_organ_check("postgres", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("neo4j", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("substrate", lambda: ("breathing", 1.0, None))
+    instance_pulse_service.set_organ_check("schema", lambda: ("breathing", 1.0, None))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r_self = await c.get("/api/pulse/self")
+        r_now = await c.get("/api/pulse/now")
+
+    assert r_self.status_code == 200
+    assert r_now.status_code == 200
+    self_body = r_self.json()
+    now_body = r_now.json()
+
+    # Identity-bearing fields share shape and values; sampled-at-the-moment
+    # fields (as_of, sample_duration_ms, scores) can differ.
+    assert set(self_body.keys()) == set(now_body.keys())
+    assert self_body["instance_id"] == now_body["instance_id"]
+    assert {o["name"] for o in self_body["organs"]} == {o["name"] for o in now_body["organs"]}
+
+
+# ---------------------------------------------------------------------------
+# 5. /api/pulse/peers returns observed pulses
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pulse_peers_returns_observed_pulses():
+    peer_id = "peer-instance-alpha"
+    instance_pulse_service.record_peer_pulse(peer_id, {
+        "instance_id": peer_id,
+        "overall": "breathing",
+        "silences": 0,
+    })
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/pulse/peers")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["count"] >= 1
+        ids = [p["peer_instance_id"] for p in body["peers"]]
+        assert peer_id in ids
+        match = next(p for p in body["peers"] if p["peer_instance_id"] == peer_id)
+        assert match["pulse"]["overall"] == "breathing"
+
+
+# ---------------------------------------------------------------------------
+# 6. /api/pulse/peers returns empty list shape when nothing watched
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pulse_peers_empty_when_no_peers_watched():
+    # Clear any rows from prior tests in the same DB.
+    from app.services import unified_db
+    from app.services.instance_pulse_service import PeerPulseRecord
+    with unified_db.session() as sess:
+        sess.query(PeerPulseRecord).delete()
+        sess.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/pulse/peers")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 0
+        assert body["peers"] == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Pulse response stays fast — bounded organ timeouts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pulse_response_under_500ms():
+    # Even with one organ hanging, the bounded timeout keeps the endpoint
+    # responsive. Budget is generous (500ms) to absorb CI jitter while still
+    # proving the timeout fires (a real hang would block forever).
+    def _slow():
+        time.sleep(2.0)
+        return ("breathing", 1.0, None)
+
+    instance_pulse_service.set_organ_check("neo4j", _slow)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        started = time.perf_counter()
+        r = await c.get("/api/pulse/self")
+        elapsed_ms = (time.perf_counter() - started) * 1000
+
+    assert r.status_code == 200
+    # Five organs × ~50ms timeout = ~250ms ceiling; give CI 2x headroom.
+    assert elapsed_ms < 500, f"pulse took {elapsed_ms:.0f}ms"
+    body = r.json()
+    silent_names = [o["name"] for o in body["organs"] if o["status"] == "silent"]
+    assert "neo4j" in silent_names


### PR DESCRIPTION
## Summary

Every coherence instance now has its own breath-window. The production witness at `pulse.coherencycoin.com/pulse/now` keeps watching the production instance from outside; this lets any instance — community-run, sovereign, federated — show its own breath to chosen peers without becoming subject to a central control plane.

Four new endpoints, all on the instance's own API:

- `GET /api/pulse/self` — this instance's current breath: `instance_id`, `overall` (breathing/strained/silent), `organs` (api, postgres, neo4j, substrate, schema), `silences`, `uptime_seconds`, `as_of`.
- `GET /api/pulse/now` — alias matching the production witness URL shape so `https://api.<any-instance>.com/api/pulse/now` works uniformly.
- `GET /api/pulse/peers` — most-recent observed pulses from peers this instance has chosen to watch; reads what the local body has captured, never makes outbound calls, no auto-discovery.
- (write hook) `instance_pulse_service.record_peer_pulse(peer_id, pulse)` — for the separate peer-poll job to upsert observations into `peer_pulse_records`.

## Sovereignty in shape

- Each organ check is bounded (~50ms timeout) and dispatched onto a shared executor — a stuck organ marks itself silent and the response returns immediately. The pulse keeps breathing even when other organs don't.
- Overall synthesis: all breathing → `breathing`; non-core organ silent → `strained`; any core organ (api, postgres) silent → `silent`.
- An instance can refuse the window entirely via `FEDERATION_PULSE_DISABLED=1` — privacy belongs to the instance, not the network.
- `FEDERATION_INSTANCE_ID` env names this instance; default `local` for dev/test. The instance names itself.

## Test plan

- [x] `test_self_pulse_returns_overall_state` — required fields present
- [x] `test_self_pulse_breathing_when_api_healthy` — all organs healthy → breathing, silences=0
- [x] `test_self_pulse_strained_when_organ_silent` — non-core silent → strained
- [x] `test_pulse_now_is_alias_for_self` — shape parity
- [x] `test_pulse_peers_returns_observed_pulses` — seed PeerPulseRecord, read back
- [x] `test_pulse_peers_empty_when_no_peers_watched` — empty list shape
- [x] `test_pulse_response_under_500ms` — even with a 2s-hanging organ, response returns under bounded budget
- [x] `test_federation_layer.py` — 8/8 still green (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)