### PR TITLE
tend: federation substrate canonical exchange — sovereign discovery without merge

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -32,9 +32,9 @@
 | Index | Files | Purpose |
 |---|---|---|
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 132 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 233 | API services — business logic and graph operations |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 234 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 207 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 209 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/models/federation.py
+++ b/api/app/models/federation.py
@@ -388,3 +388,98 @@ class CapabilityAlignment(BaseModel):
     shared_substrate_canonicals: list[str] = Field(default_factory=list)
     unique_to_self: dict[str, list[str]] = Field(default_factory=dict, description="Capabilities self has that peer lacks, keyed by capability kind.")
     unique_to_peer: dict[str, list[str]] = Field(default_factory=dict, description="Capabilities peer has that self lacks, keyed by capability kind.")
+
+
+# ---------------------------------------------------------------------------
+# Federated substrate canonical exchange — freedom-preserving discovery
+# ---------------------------------------------------------------------------
+#
+# Two instances meeting at the substrate altitude. Neither imports the
+# other; each exposes its interned canonical Blueprints, and content-
+# addressing (sha256 over name + role_slots) lets the peer test for
+# structural alignment without surrendering autonomy.
+#
+# Status taxonomy ("attestation outcome"):
+#   - "aligned"    — peer carries this canonical with the same content_hash
+#   - "diverged"   — peer carries this canonical name with a different hash
+#   - "discovered" — peer carries a canonical this instance does not have
+#
+# All three are sovereign attestations: alignment is not absorption,
+# divergence is not error, discovery is not import.
+
+ALIGNMENT_STATUSES = frozenset({"aligned", "diverged", "discovered"})
+
+
+class CanonicalShapeOut(BaseModel):
+    """One canonical recipe-shape as exposed across the federation wire."""
+    canonical_name: str
+    role_slots: list[str] = Field(default_factory=list)
+    modality_tags: list[str] = Field(default_factory=list)
+    blueprint: dict | None = Field(
+        default=None,
+        description="Blueprint NodeID as {package, level, type, instance} when this instance has interned the shape",
+    )
+    content_hash: str = Field(
+        description="sha256 hex of canonical_name + role_slots tuple — deterministic across instances",
+    )
+    interned: bool = Field(
+        default=False,
+        description="True when this instance carries the canonical cell locally",
+    )
+    member_count: int = Field(
+        default=0,
+        description="Number of per-modality cells sharing this canonical's Blueprint on this instance",
+    )
+
+
+class CanonicalShapesListResponse(BaseModel):
+    """Full inventory of this instance's canonical recipe-shapes."""
+    instance_id: str | None = None
+    canonicals: list[CanonicalShapeOut] = Field(default_factory=list)
+    count: int = 0
+
+
+class CanonicalDiscoverResponse(BaseModel):
+    """Single-shape lookup — does THIS instance carry this canonical?"""
+    canonical_name: str
+    found: bool
+    content_hash: str | None = None
+    blueprint: dict | None = None
+
+
+class PeerCanonicalEntry(BaseModel):
+    """One canonical as reported by a peer in an exchange payload."""
+    canonical_name: str = Field(min_length=1)
+    role_slots: list[str] = Field(default_factory=list)
+    modality_tags: list[str] = Field(default_factory=list)
+    content_hash: str = Field(min_length=1)
+
+
+class CanonicalExchangeRequest(BaseModel):
+    """Inbound: a peer's canonical inventory for structural attestation."""
+    peer_instance_id: str = Field(
+        min_length=1,
+        description="Sovereign identifier for the peer — used as the partition key in the attestation mirror",
+    )
+    peer_endpoint_url: str | None = None
+    canonicals: list[PeerCanonicalEntry] = Field(default_factory=list)
+
+
+class CanonicalAttestationOut(BaseModel):
+    """One attestation row — how this instance views a peer's canonical."""
+    peer_instance_id: str
+    canonical_name: str
+    peer_content_hash: str
+    local_content_hash: str | None = None
+    alignment_status: str = Field(description="aligned | diverged | discovered")
+    observed_at: str
+
+
+class CanonicalExchangeResponse(BaseModel):
+    """Outbound: the per-canonical attestation outcomes after an exchange."""
+    peer_instance_id: str
+    received: int = 0
+    aligned: int = 0
+    diverged: int = 0
+    discovered: int = 0
+    attestations: list[CanonicalAttestationOut] = Field(default_factory=list)

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel
 from app.middleware.traceability import traces_to
 
 from app.models.federation import (
+    CanonicalDiscoverResponse,
+    CanonicalExchangeRequest,
+    CanonicalExchangeResponse,
+    CanonicalShapesListResponse,
     CapabilityAlignment,
     CapabilityManifest,
     FederatedInstance,
@@ -38,7 +42,9 @@ from app.models.federation import (
     FederatedAggregationListResponse,
 )
 from app.services import federation_service
+from app.services import federation_substrate_service
 from app.services import openclaw_node_bridge_service
+from app.services import unified_db as _udb
 
 router = APIRouter()
 
@@ -380,6 +386,94 @@ async def get_federated_aggregates(strategy_type: str | None = Query(None)):
     """Return merged federated aggregation results."""
     aggregates = federation_service.list_federated_aggregates(strategy_type=strategy_type)
     return {"aggregates": aggregates}
+
+
+# ---------------------------------------------------------------------------
+# Substrate canonical exchange — freedom-preserving federation at the
+# substrate altitude. Each instance exposes its interned recipe-shape
+# canonicals; peers discover structural alignment via content-addressing
+# without forcing either side to merge.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/federation/substrate/canonicals",
+    response_model=CanonicalShapesListResponse,
+    summary="List this instance's interned canonical recipe-shapes (public read)",
+)
+async def list_substrate_canonicals() -> CanonicalShapesListResponse:
+    """Expose THIS instance's canonical recipe-shape inventory.
+
+    No auth required: canonicals are public structural shapes and the
+    content-hash is computed deterministically from the (canonical_name,
+    role_slots) declaration. Reading the inventory is reading public tissue.
+    """
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        return federation_substrate_service.local_canonicals(session)
+
+
+@router.get(
+    "/federation/substrate/canonicals/{name}/discover",
+    response_model=CanonicalDiscoverResponse,
+    summary="Lookup a single canonical on this instance — name + content_hash",
+)
+async def discover_substrate_canonical(name: str) -> CanonicalDiscoverResponse:
+    """Single-shape discovery — does this instance carry `name`?
+
+    Returns the content_hash even when not yet interned (the hash depends
+    on the declaration), so a peer can compare structural intent.
+    """
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        return federation_substrate_service.discover_local_canonical(session, name)
+
+
+@router.post(
+    "/federation/substrate/exchange",
+    response_model=CanonicalExchangeResponse,
+    status_code=200,
+    summary="Accept a peer's canonical inventory; record per-shape attestations",
+)
+async def exchange_substrate_canonicals(
+    body: CanonicalExchangeRequest,
+) -> CanonicalExchangeResponse:
+    """Sovereign exchange — record what the peer carries, never import.
+
+    Each peer-canonical lands as aligned / diverged / discovered in the
+    federation-mirror table. Local recipe-shape cells are not modified —
+    each instance keeps its lattice. Idempotent on
+    (peer_instance_id, canonical_name).
+    """
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        return federation_substrate_service.exchange_with_peer(
+            session,
+            peer_instance_id=body.peer_instance_id,
+            canonicals=body.canonicals,
+        )
+
+
+@router.get(
+    "/federation/substrate/attestations/{peer_instance_id}",
+    summary="Read attestations this instance holds about a peer",
+)
+async def list_substrate_attestations(peer_instance_id: str) -> dict:
+    """Return all attestations this instance carries about `peer_instance_id`.
+
+    A witness record — this instance's view of the peer at the moments
+    exchanges happened. Not authoritative about the peer's current state.
+    """
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        attestations = federation_substrate_service.list_attestations_for_peer(
+            session, peer_instance_id
+        )
+    return {
+        "peer_instance_id": peer_instance_id,
+        "attestations": [a.model_dump(mode="json") for a in attestations],
+        "count": len(attestations),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 233
+**Total files**: 234
 
 | File | Purpose |
 |---|---|
@@ -97,6 +97,7 @@
 | [fallback_witness_service.py](fallback_witness_service.py) | Fallback witness — honest record of when the body runs on reserve. |
 | [federation_push_service.py](federation_push_service.py) | Client-side push logic for federation measurement summaries (Spec 131). |
 | [federation_service.py](federation_service.py) | Federation service: receive, validate, and integrate remote instance data. |
+| [federation_substrate_service.py](federation_substrate_service.py) | federation_substrate_service — freedom-preserving canonical exchange. |
 | [field_story_mcp_tools.py](field_story_mcp_tools.py) | MCP registry entries for published field stories. |
 | [field_story_service.py](field_story_service.py) | Published field-story artifacts and contribution hooks. |
 | [field_view_attribution_adjustment_service.py](field_view_attribution_adjustment_service.py) | Living append-only adjustments for field-story view attribution flow. |

--- a/api/app/services/federation_service.py
+++ b/api/app/services/federation_service.py
@@ -180,6 +180,40 @@ class NodeStrategyEffectivenessRecord(Base):
     )
 
 
+class FederatedSubstrateAttestationRecord(Base):
+    """Federation-mirror table for substrate canonical attestations.
+
+    Each row is THIS instance's view of a peer's canonical at a moment in
+    time. Never authoritative for the peer; never authoritative over the
+    local lattice. Sovereignty preserved on both sides — the row only
+    records that an exchange happened and what was sensed.
+
+    alignment_status taxonomy:
+      - aligned    : peer carries this canonical and content_hash matches
+      - diverged   : peer carries this canonical name but content_hash differs
+      - discovered : peer carries a canonical this instance does not have
+    """
+
+    __tablename__ = "federation_substrate_attestations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    peer_instance_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    canonical_name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    peer_content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    local_content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    alignment_status: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    observed_at: Mapped[str] = mapped_column(String, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "idx_fsa_peer_canonical",
+            "peer_instance_id",
+            "canonical_name",
+            unique=True,
+        ),
+    )
+
+
 class FederatedAggregationRecord(Base):
     """Submissions for federated aggregation merging (Spec 143)."""
     __tablename__ = "federation_aggregations"

--- a/api/app/services/federation_substrate_service.py
+++ b/api/app/services/federation_substrate_service.py
@@ -1,0 +1,321 @@
+"""federation_substrate_service — freedom-preserving canonical exchange.
+
+Two coherence instances meeting at the substrate altitude. Each exposes
+its interned canonical recipe-shapes (the `recipe-shape` domain from
+`modality_shapes.CANONICAL_SHAPES`). Content-addressing — sha256 over the
+(canonical_name, role_slots) tuple — lets peers test for structural
+alignment without forcing import.
+
+The service has three movements:
+
+  - `local_canonicals()` — what this instance carries. Read-only.
+  - `discover_local(name)` — does this instance carry this canonical, and
+    what's its content_hash? Cheap single-shape lookup.
+  - `exchange_with_peer(payload)` — accept a peer's inventory and write
+    per-canonical attestations into `federation_substrate_attestations`.
+    Three outcomes per peer-canonical: aligned, diverged, discovered.
+
+What the service does NOT do:
+  - Import the peer's canonicals into the local lattice
+  - Modify any local recipe-shape cell
+  - Decide whether the peer is "right" — both sides stay sovereign
+
+The attestation mirror is each instance's view of its peers — a witness
+record, not authority. A later, separate operation (manual or governed)
+can choose to ingest a discovered shape; nothing here forces that.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+from sqlalchemy.orm import Session
+
+from app.models.federation import (
+    ALIGNMENT_STATUSES,
+    CanonicalAttestationOut,
+    CanonicalDiscoverResponse,
+    CanonicalExchangeResponse,
+    CanonicalShapeOut,
+    CanonicalShapesListResponse,
+    PeerCanonicalEntry,
+)
+from app.services import unified_db as _udb
+from app.services.federation_service import FederatedSubstrateAttestationRecord
+from app.services.substrate.kernel import (
+    NodeID,
+    find_equivalent_cells,
+    lookup_cell,
+)
+from app.services.substrate.modality_shapes import (
+    CANONICAL_SHAPES,
+    DOMAIN_RECIPE_SHAPE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Content-addressing — deterministic across instances
+# ---------------------------------------------------------------------------
+
+
+def canonical_content_hash(canonical_name: str, role_slots: Sequence[str]) -> str:
+    """sha256 hex of (canonical_name, role_slots) — the over-the-wire fingerprint.
+
+    Deterministic across instances: any two instances that have interned the
+    same canonical descriptor will compute the same hash, regardless of
+    when they interned it or what NodeID number it ended up with locally.
+
+    Encoding: name + NUL + slots joined by NUL. NUL is reserved out of
+    canonical names and role slots, so the boundary is unambiguous.
+    """
+    parts = [canonical_name, *role_slots]
+    payload = "\x00".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _node_id_to_dict(nid: NodeID | None) -> dict | None:
+    if nid is None:
+        return None
+    return {
+        "package": nid.package,
+        "level": nid.level,
+        "type": nid.type_,
+        "instance": nid.instance,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Local inventory — what THIS instance carries
+# ---------------------------------------------------------------------------
+
+
+def local_canonicals(
+    session: Session, *, instance_id: str | None = None
+) -> CanonicalShapesListResponse:
+    """Build the canonical-shape inventory for this instance.
+
+    Each entry carries its content_hash (always present — content-addressing
+    is structural, not dependent on interning). `interned`, `blueprint`,
+    and `member_count` reflect THIS instance's lattice state — a peer sees
+    them as the peer's own truth.
+    """
+    out: list[CanonicalShapeOut] = []
+    for canonical_name, role_slots, modality_tags in CANONICAL_SHAPES:
+        chash = canonical_content_hash(canonical_name, list(role_slots))
+        cell = lookup_cell(session, DOMAIN_RECIPE_SHAPE, canonical_name)
+        if cell is None:
+            out.append(
+                CanonicalShapeOut(
+                    canonical_name=canonical_name,
+                    role_slots=list(role_slots),
+                    modality_tags=list(modality_tags),
+                    blueprint=None,
+                    content_hash=chash,
+                    interned=False,
+                    member_count=0,
+                )
+            )
+            continue
+        members = find_equivalent_cells(session, cell.blueprint)
+        out.append(
+            CanonicalShapeOut(
+                canonical_name=canonical_name,
+                role_slots=list(role_slots),
+                modality_tags=list(modality_tags),
+                blueprint=_node_id_to_dict(cell.blueprint),
+                content_hash=chash,
+                interned=True,
+                member_count=len(members),
+            )
+        )
+    return CanonicalShapesListResponse(
+        instance_id=instance_id,
+        canonicals=out,
+        count=len(out),
+    )
+
+
+def discover_local_canonical(
+    session: Session, canonical_name: str
+) -> CanonicalDiscoverResponse:
+    """Single-shape lookup — does this instance carry `canonical_name`?
+
+    Returns `found=False` if either (a) the canonical isn't in
+    `CANONICAL_SHAPES` for this instance's build OR (b) it's declared but
+    not yet interned. The content_hash IS returned even when not interned
+    (it depends on the declaration, not the cell), so a peer can compare
+    structural intent even before either side completes interning.
+    """
+    for c_name, role_slots, _modality_tags in CANONICAL_SHAPES:
+        if c_name != canonical_name:
+            continue
+        chash = canonical_content_hash(canonical_name, list(role_slots))
+        cell = lookup_cell(session, DOMAIN_RECIPE_SHAPE, canonical_name)
+        if cell is None:
+            return CanonicalDiscoverResponse(
+                canonical_name=canonical_name,
+                found=False,
+                content_hash=chash,
+                blueprint=None,
+            )
+        return CanonicalDiscoverResponse(
+            canonical_name=canonical_name,
+            found=True,
+            content_hash=chash,
+            blueprint=_node_id_to_dict(cell.blueprint),
+        )
+    return CanonicalDiscoverResponse(
+        canonical_name=canonical_name,
+        found=False,
+        content_hash=None,
+        blueprint=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exchange — accept a peer's inventory and write attestations
+# ---------------------------------------------------------------------------
+
+
+def _local_hash_index() -> dict[str, str]:
+    """Build name → local content_hash map from CANONICAL_SHAPES.
+
+    Independent of session state — derived from this instance's build-time
+    canonical declarations. Same body running two processes computes the
+    same map.
+    """
+    return {
+        name: canonical_content_hash(name, list(role_slots))
+        for name, role_slots, _tags in CANONICAL_SHAPES
+    }
+
+
+def _classify_alignment(
+    peer_entry: PeerCanonicalEntry, local_hashes: dict[str, str]
+) -> tuple[str, str | None]:
+    """Return (alignment_status, local_content_hash) for one peer entry.
+
+    Pure function — no session, no DB. The exchange handler writes the
+    classification into the attestation mirror.
+    """
+    local_hash = local_hashes.get(peer_entry.canonical_name)
+    if local_hash is None:
+        return "discovered", None
+    if local_hash == peer_entry.content_hash:
+        return "aligned", local_hash
+    return "diverged", local_hash
+
+
+def exchange_with_peer(
+    session: Session,
+    peer_instance_id: str,
+    canonicals: Iterable[PeerCanonicalEntry],
+) -> CanonicalExchangeResponse:
+    """Record attestations for a peer's canonical inventory.
+
+    For each peer-canonical:
+      - Classify (aligned | diverged | discovered) by content_hash
+      - Upsert into federation_substrate_attestations keyed by
+        (peer_instance_id, canonical_name) so re-running is idempotent
+      - Refresh observed_at so the attestation reflects the most recent
+        exchange
+
+    Returns the per-canonical outcomes. Does NOT touch local recipe-shape
+    cells — sovereignty preserved.
+    """
+    local_hashes = _local_hash_index()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    attestations: list[CanonicalAttestationOut] = []
+    aligned = diverged = discovered = 0
+    received = 0
+
+    for peer_entry in canonicals:
+        received += 1
+        status, local_hash = _classify_alignment(peer_entry, local_hashes)
+        if status == "aligned":
+            aligned += 1
+        elif status == "diverged":
+            diverged += 1
+        else:
+            discovered += 1
+
+        existing = (
+            session.query(FederatedSubstrateAttestationRecord)
+            .filter_by(
+                peer_instance_id=peer_instance_id,
+                canonical_name=peer_entry.canonical_name,
+            )
+            .one_or_none()
+        )
+        if existing is None:
+            row = FederatedSubstrateAttestationRecord(
+                peer_instance_id=peer_instance_id,
+                canonical_name=peer_entry.canonical_name,
+                peer_content_hash=peer_entry.content_hash,
+                local_content_hash=local_hash,
+                alignment_status=status,
+                observed_at=now_iso,
+            )
+            session.add(row)
+        else:
+            existing.peer_content_hash = peer_entry.content_hash
+            existing.local_content_hash = local_hash
+            existing.alignment_status = status
+            existing.observed_at = now_iso
+
+        attestations.append(
+            CanonicalAttestationOut(
+                peer_instance_id=peer_instance_id,
+                canonical_name=peer_entry.canonical_name,
+                peer_content_hash=peer_entry.content_hash,
+                local_content_hash=local_hash,
+                alignment_status=status,
+                observed_at=now_iso,
+            )
+        )
+
+    session.flush()
+    return CanonicalExchangeResponse(
+        peer_instance_id=peer_instance_id,
+        received=received,
+        aligned=aligned,
+        diverged=diverged,
+        discovered=discovered,
+        attestations=attestations,
+    )
+
+
+def list_attestations_for_peer(
+    session: Session, peer_instance_id: str
+) -> list[CanonicalAttestationOut]:
+    """Read the attestation mirror for a single peer."""
+    rows = (
+        session.query(FederatedSubstrateAttestationRecord)
+        .filter_by(peer_instance_id=peer_instance_id)
+        .order_by(FederatedSubstrateAttestationRecord.canonical_name)
+        .all()
+    )
+    return [
+        CanonicalAttestationOut(
+            peer_instance_id=row.peer_instance_id,
+            canonical_name=row.canonical_name,
+            peer_content_hash=row.peer_content_hash,
+            local_content_hash=row.local_content_hash,
+            alignment_status=row.alignment_status,
+            observed_at=row.observed_at,
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "ALIGNMENT_STATUSES",
+    "canonical_content_hash",
+    "discover_local_canonical",
+    "exchange_with_peer",
+    "list_attestations_for_peer",
+    "local_canonicals",
+]

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 207
+**Total files**: 209
 
 | File | Purpose |
 |---|---|
@@ -66,6 +66,7 @@
 | [test_federation_layer.py](test_federation_layer.py) | Acceptance tests for spec: federation-network-layer (idea: federation-and-nodes). |
 | [test_federation_message_readback.py](test_federation_message_readback.py) | _no top-of-file purpose_ |
 | [test_federation_substance.py](test_federation_substance.py) | Federation substance payload — round-trip test. |
+| [test_federation_substrate_exchange.py](test_federation_substrate_exchange.py) | Acceptance tests for the federated substrate canonical exchange. |
 | [test_field_story_agent_surface.py](test_field_story_agent_surface.py) | _no top-of-file purpose_ |
 | [test_field_story_runtime_docs.py](test_field_story_runtime_docs.py) | _no top-of-file purpose_ |
 | [test_field_story_trace_index.py](test_field_story_trace_index.py) | _no top-of-file purpose_ |

--- a/api/tests/core_suite.txt
+++ b/api/tests/core_suite.txt
@@ -9,6 +9,7 @@ tests/test_external_proof_demo.py
 tests/test_failure_taxonomy_service.py
 tests/test_federation_layer.py
 tests/test_federation_substance.py
+tests/test_federation_substrate_exchange.py
 tests/test_flow_activity.py
 tests/test_flow_agent_lifecycle.py
 tests/test_flow_cli.py

--- a/api/tests/test_federation_substrate_exchange.py
+++ b/api/tests/test_federation_substrate_exchange.py
@@ -1,0 +1,463 @@
+"""Acceptance tests for the federated substrate canonical exchange.
+
+Two coherence instances meeting at the substrate altitude. Each exposes
+its interned canonical recipe-shapes; content-addressing lets peers
+test for structural alignment without forcing either to import the
+other's lattice.
+
+The tests demonstrate the freedom-preserving shape:
+
+- Both instances list their canonicals, each with a deterministic
+  content_hash (same canonical_name + role_slots → same hash anywhere).
+- Aligned: peer carries the same canonical with the same hash.
+- Diverged: peer carries the same canonical name but a different hash.
+- Discovered: peer carries a canonical this instance does not.
+- Exchange writes attestations into the federation-mirror table.
+- Exchange is idempotent and leaves local recipe-shape cells untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.federation import PeerCanonicalEntry
+from app.services import federation_service, federation_substrate_service
+from app.services import unified_db as _udb
+from app.services.federation_service import FederatedSubstrateAttestationRecord
+from app.services.federation_substrate_service import (
+    canonical_content_hash,
+    discover_local_canonical,
+    exchange_with_peer,
+    local_canonicals,
+)
+from app.services.substrate.kernel import lookup_cell
+from app.services.substrate.modality_shapes import (
+    CANONICAL_SHAPES,
+    DOMAIN_RECIPE_SHAPE,
+    intern_all_canonical_shapes,
+)
+
+BASE = "http://test"
+
+
+# ---------------------------------------------------------------------------
+# Fixture — intern the canonicals into the running app's DB once, and
+# clear the attestation mirror between tests so each test starts clean.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _interned_canonicals_and_clean_attestations():
+    """Ensure canonicals are interned and attestations table is empty."""
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        # Idempotent: if a previous test already interned, the upsert is a no-op.
+        intern_all_canonical_shapes(session)
+        # Wipe attestation rows so test ordering doesn't shift counts.
+        session.query(FederatedSubstrateAttestationRecord).delete()
+    yield
+    with _udb.session() as session:
+        session.query(FederatedSubstrateAttestationRecord).delete()
+
+
+# ---------------------------------------------------------------------------
+# 1. Inventory endpoint returns every declared canonical.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonicals_endpoint_lists_all_interned():
+    """GET /api/federation/substrate/canonicals returns one entry per CANONICAL_SHAPES."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/federation/substrate/canonicals")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["count"] == len(CANONICAL_SHAPES)
+        names_in_response = {entry["canonical_name"] for entry in body["canonicals"]}
+        for canonical_name, _role_slots, _modality_tags in CANONICAL_SHAPES:
+            assert canonical_name in names_in_response, (
+                f"canonical {canonical_name!r} missing from federation inventory"
+            )
+        # Every entry should be interned (the fixture interns them).
+        for entry in body["canonicals"]:
+            assert entry["interned"] is True
+            assert entry["member_count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Each entry carries a deterministic content_hash.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_carries_content_hash():
+    """Content-hash is present, hex-encoded, and matches the deterministic helper."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/federation/substrate/canonicals")
+        assert r.status_code == 200
+        body = r.json()
+
+    expected_hashes = {
+        name: canonical_content_hash(name, list(role_slots))
+        for name, role_slots, _tags in CANONICAL_SHAPES
+    }
+
+    for entry in body["canonicals"]:
+        chash = entry["content_hash"]
+        assert isinstance(chash, str) and len(chash) == 64, (
+            f"content_hash for {entry['canonical_name']} not a 64-char sha256 hex"
+        )
+        # Hex-only sanity.
+        int(chash, 16)
+        # Deterministic match against the pure-function helper.
+        assert chash == expected_hashes[entry["canonical_name"]], (
+            f"content_hash drift for {entry['canonical_name']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Discover endpoint: this instance carries the canonical → aligned shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_aligned():
+    """When two instances carry the same canonical, exchange marks it aligned."""
+    canonical_name = "R_Recovery"
+    role_slots = next(
+        list(slots) for name, slots, _tags in CANONICAL_SHAPES if name == canonical_name
+    )
+    peer_hash = canonical_content_hash(canonical_name, role_slots)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        # Single-shape discover endpoint on this instance.
+        r = await c.get(f"/api/federation/substrate/canonicals/{canonical_name}/discover")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["found"] is True
+        assert body["content_hash"] == peer_hash
+
+        # Exchange with a peer that carries the same canonical at the same hash.
+        r = await c.post(
+            "/api/federation/substrate/exchange",
+            json={
+                "peer_instance_id": "peer-aligned",
+                "canonicals": [
+                    {
+                        "canonical_name": canonical_name,
+                        "role_slots": role_slots,
+                        "modality_tags": [],
+                        "content_hash": peer_hash,
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert result["aligned"] == 1
+        assert result["diverged"] == 0
+        assert result["discovered"] == 0
+        assert result["attestations"][0]["alignment_status"] == "aligned"
+
+
+# ---------------------------------------------------------------------------
+# 4. Discover diverged: same name, different role_slots → different hash.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_diverged():
+    """A peer claiming a known canonical with a different shape registers as diverged."""
+    canonical_name = "R_Recovery"
+    divergent_hash = canonical_content_hash(canonical_name, ["mutated", "slots"])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/substrate/exchange",
+            json={
+                "peer_instance_id": "peer-diverged",
+                "canonicals": [
+                    {
+                        "canonical_name": canonical_name,
+                        "role_slots": ["mutated", "slots"],
+                        "modality_tags": [],
+                        "content_hash": divergent_hash,
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert result["aligned"] == 0
+        assert result["diverged"] == 1
+        assert result["discovered"] == 0
+        attestation = result["attestations"][0]
+        assert attestation["alignment_status"] == "diverged"
+        # Local hash present because this instance DOES carry R_Recovery.
+        assert attestation["local_content_hash"] is not None
+        assert attestation["peer_content_hash"] == divergent_hash
+        assert attestation["local_content_hash"] != divergent_hash
+
+
+# ---------------------------------------------------------------------------
+# 5. Discover unknown: peer has a canonical we don't → discovered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_unknown():
+    """A canonical this instance lacks is recorded as discovered (never imported)."""
+    unknown_name = "R_PeerExclusiveShape"
+    unknown_hash = canonical_content_hash(unknown_name, ["alpha", "beta"])
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        # discover endpoint reports not-found.
+        r = await c.get(f"/api/federation/substrate/canonicals/{unknown_name}/discover")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["found"] is False
+        assert body["content_hash"] is None  # we don't even have the declaration
+
+        # Exchange marks it discovered.
+        r = await c.post(
+            "/api/federation/substrate/exchange",
+            json={
+                "peer_instance_id": "peer-unknown",
+                "canonicals": [
+                    {
+                        "canonical_name": unknown_name,
+                        "role_slots": ["alpha", "beta"],
+                        "modality_tags": ["R_TagA"],
+                        "content_hash": unknown_hash,
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 200, r.text
+        result = r.json()
+        assert result["discovered"] == 1
+        attestation = result["attestations"][0]
+        assert attestation["alignment_status"] == "discovered"
+        assert attestation["local_content_hash"] is None
+        assert attestation["peer_content_hash"] == unknown_hash
+
+        # Sovereignty: the cell was NOT interned locally.
+        with _udb.session() as session:
+            cell = lookup_cell(session, DOMAIN_RECIPE_SHAPE, unknown_name)
+        assert cell is None, "exchange must not import peer canonicals"
+
+
+# ---------------------------------------------------------------------------
+# 6. Attestations land in the federation-mirror table.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_records_attestations():
+    """POST exchange creates FederatedSubstrateAttestationRecord rows."""
+    canonical_name = "R_ObserverConditionedActualization"
+    role_slots = next(
+        list(slots) for name, slots, _tags in CANONICAL_SHAPES if name == canonical_name
+    )
+    peer_hash = canonical_content_hash(canonical_name, role_slots)
+    peer_id = "peer-attestation-test"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/substrate/exchange",
+            json={
+                "peer_instance_id": peer_id,
+                "canonicals": [
+                    {
+                        "canonical_name": canonical_name,
+                        "role_slots": role_slots,
+                        "modality_tags": [],
+                        "content_hash": peer_hash,
+                    },
+                    {
+                        "canonical_name": "R_PeerOnly",
+                        "role_slots": ["one", "two"],
+                        "modality_tags": [],
+                        "content_hash": canonical_content_hash("R_PeerOnly", ["one", "two"]),
+                    },
+                ],
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        # Read back via the GET endpoint.
+        r = await c.get(f"/api/federation/substrate/attestations/{peer_id}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 2
+        statuses = {a["canonical_name"]: a["alignment_status"] for a in body["attestations"]}
+        assert statuses[canonical_name] == "aligned"
+        assert statuses["R_PeerOnly"] == "discovered"
+
+    # Direct DB read confirms the row presence.
+    with _udb.session() as session:
+        rows = (
+            session.query(FederatedSubstrateAttestationRecord)
+            .filter_by(peer_instance_id=peer_id)
+            .all()
+        )
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. Exchange is idempotent — re-running does not duplicate attestations.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_is_idempotent():
+    """Repeating an exchange refreshes attestations in place; no duplicate rows."""
+    canonical_name = "R_SustainedTension"
+    role_slots = next(
+        list(slots) for name, slots, _tags in CANONICAL_SHAPES if name == canonical_name
+    )
+    peer_hash = canonical_content_hash(canonical_name, role_slots)
+    peer_id = "peer-idempotent"
+
+    payload = {
+        "peer_instance_id": peer_id,
+        "canonicals": [
+            {
+                "canonical_name": canonical_name,
+                "role_slots": role_slots,
+                "modality_tags": [],
+                "content_hash": peer_hash,
+            }
+        ],
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r1 = await c.post("/api/federation/substrate/exchange", json=payload)
+        assert r1.status_code == 200
+        r2 = await c.post("/api/federation/substrate/exchange", json=payload)
+        assert r2.status_code == 200
+
+    with _udb.session() as session:
+        rows = (
+            session.query(FederatedSubstrateAttestationRecord)
+            .filter_by(peer_instance_id=peer_id, canonical_name=canonical_name)
+            .all()
+        )
+    assert len(rows) == 1, "duplicate attestation written on re-exchange"
+
+
+# ---------------------------------------------------------------------------
+# 8. Exchange leaves the local lattice unchanged — sovereignty preserved.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exchange_does_not_modify_local_lattice():
+    """Before and after a discovery-heavy exchange, local recipe-shape cells are identical."""
+    # Capture local lattice fingerprint before.
+    with _udb.session() as session:
+        before = local_canonicals(session)
+    before_map = {c.canonical_name: (c.content_hash, c.blueprint, c.member_count) for c in before.canonicals}
+
+    # Exchange a mixture: one aligned, one diverged, several discovered.
+    peer_payload = [
+        {
+            "canonical_name": "R_Recovery",
+            "role_slots": list(
+                next(slots for n, slots, _t in CANONICAL_SHAPES if n == "R_Recovery")
+            ),
+            "modality_tags": [],
+            "content_hash": canonical_content_hash(
+                "R_Recovery",
+                list(next(slots for n, slots, _t in CANONICAL_SHAPES if n == "R_Recovery")),
+            ),
+        },
+        {
+            "canonical_name": "R_MeetThenShift",
+            "role_slots": ["foreign", "shape"],
+            "modality_tags": [],
+            "content_hash": canonical_content_hash("R_MeetThenShift", ["foreign", "shape"]),
+        },
+        {
+            "canonical_name": "R_PeerNovel-A",
+            "role_slots": ["x", "y", "z"],
+            "modality_tags": ["R_TagAlpha"],
+            "content_hash": canonical_content_hash("R_PeerNovel-A", ["x", "y", "z"]),
+        },
+        {
+            "canonical_name": "R_PeerNovel-B",
+            "role_slots": ["m", "n"],
+            "modality_tags": [],
+            "content_hash": canonical_content_hash("R_PeerNovel-B", ["m", "n"]),
+        },
+    ]
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/substrate/exchange",
+            json={
+                "peer_instance_id": "peer-sovereign",
+                "canonicals": peer_payload,
+            },
+        )
+        assert r.status_code == 200
+
+    with _udb.session() as session:
+        after = local_canonicals(session)
+    after_map = {c.canonical_name: (c.content_hash, c.blueprint, c.member_count) for c in after.canonicals}
+
+    assert before_map == after_map, (
+        "local canonical inventory changed after exchange — sovereignty violated"
+    )
+
+    # And the peer's novel canonicals are NOT interned locally.
+    with _udb.session() as session:
+        for novel in ("R_PeerNovel-A", "R_PeerNovel-B"):
+            assert lookup_cell(session, DOMAIN_RECIPE_SHAPE, novel) is None, (
+                f"discovered peer canonical {novel!r} was imported — sovereignty violated"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Direct service-level tests — pure-function classifiers.
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_is_deterministic_and_distinguishing():
+    """Same input → same hash; different name or slots → different hash."""
+    h_a = canonical_content_hash("R_X", ["a", "b"])
+    h_b = canonical_content_hash("R_X", ["a", "b"])
+    assert h_a == h_b
+
+    h_c = canonical_content_hash("R_Y", ["a", "b"])
+    h_d = canonical_content_hash("R_X", ["a", "b", "c"])
+    h_e = canonical_content_hash("R_X", ["b", "a"])  # order matters
+    assert len({h_a, h_c, h_d, h_e}) == 4
+
+
+def test_classify_alignment_pure_function():
+    """exchange_with_peer's classifier returns the right status for each case."""
+    federation_service._ensure_schema()
+    with _udb.session() as session:
+        intern_all_canonical_shapes(session)
+        # Aligned
+        slots = list(next(slots for n, slots, _t in CANONICAL_SHAPES if n == "R_Recovery"))
+        result = exchange_with_peer(
+            session,
+            "peer-classify",
+            [
+                PeerCanonicalEntry(
+                    canonical_name="R_Recovery",
+                    role_slots=slots,
+                    modality_tags=[],
+                    content_hash=canonical_content_hash("R_Recovery", slots),
+                )
+            ],
+        )
+        assert result.aligned == 1
+        # Clean up so other tests don't see this row.
+        session.query(FederatedSubstrateAttestationRecord).filter_by(
+            peer_instance_id="peer-classify"
+        ).delete()

--- a/cli/lib/commands/federation.mjs
+++ b/cli/lib/commands/federation.mjs
@@ -17,6 +17,8 @@
  *   coh federation msg <node_id> <msg> — send message to a node
  *   coh federation msgs <node_id>      — read messages from a node
  *   coh federation broadcast <msg>     — broadcast to all nodes
+ *   coh federation substrate-canonicals       — list local canonical shapes
+ *   coh federation substrate-discover <url>   — exchange canonicals with a peer
  */
 
 import { get, post, del as apiDel } from "../api.mjs";
@@ -354,6 +356,114 @@ export async function broadcastFederation(args) {
   }
 }
 
+// ── Substrate canonical exchange — freedom-preserving discovery ──────
+
+export async function listSubstrateCanonicals() {
+  const data = await get("/api/federation/substrate/canonicals");
+  const canonicals = data?.canonicals || [];
+
+  const B = "\x1b[1m", D = "\x1b[2m", R = "\x1b[0m";
+  const G = "\x1b[32m", Y = "\x1b[33m";
+
+  console.log();
+  console.log(`${B}  LOCAL SUBSTRATE CANONICALS${R} (${canonicals.length})`);
+  console.log(`  ${"─".repeat(76)}`);
+
+  if (!canonicals.length) {
+    console.log(`  ${D}No canonicals declared.${R}`);
+    console.log();
+    return;
+  }
+
+  for (const c of canonicals) {
+    const name = truncate(c.canonical_name, 38).padEnd(40);
+    const hash = (c.content_hash || "").slice(0, 12);
+    const interned = c.interned ? `${G}interned${R}` : `${Y}declared${R}`;
+    const members = c.member_count != null ? ` ${D}members:${c.member_count}${R}` : "";
+    console.log(`  ${name} ${D}${hash}${R}  ${interned}${members}`);
+  }
+  console.log();
+}
+
+export async function substrateDiscoverPeer(args) {
+  // Two arg forms:
+  //   coh federation substrate-discover --peer-url <url> [--peer-id <id>]
+  //   coh federation substrate-discover <url>
+  let peerUrl = null;
+  let peerId = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--peer-url") { peerUrl = args[++i]; continue; }
+    if (args[i] === "--peer-id")  { peerId  = args[++i]; continue; }
+    if (!peerUrl && !args[i].startsWith("-")) peerUrl = args[i];
+  }
+  if (!peerUrl) {
+    console.log("Usage: coh federation substrate-discover --peer-url <url> [--peer-id <id>]");
+    return;
+  }
+  const trimmed = peerUrl.replace(/\/+$/, "");
+  if (!peerId) peerId = trimmed;
+
+  const B = "\x1b[1m", D = "\x1b[2m", R = "\x1b[0m";
+  const G = "\x1b[32m", Y = "\x1b[33m", C = "\x1b[36m";
+
+  let peerData;
+  try {
+    const res = await fetch(`${trimmed}/api/federation/substrate/canonicals`);
+    if (!res.ok) {
+      console.log(`Peer canonicals fetch failed: HTTP ${res.status}`);
+      return;
+    }
+    peerData = await res.json();
+  } catch (err) {
+    console.log(`Could not reach peer ${trimmed}: ${err.message}`);
+    return;
+  }
+
+  const peerCanonicals = (peerData?.canonicals || []).map((c) => ({
+    canonical_name: c.canonical_name,
+    role_slots: c.role_slots || [],
+    modality_tags: c.modality_tags || [],
+    content_hash: c.content_hash,
+  }));
+
+  // Send peer's inventory to our local exchange endpoint for attestation.
+  const result = await post("/api/federation/substrate/exchange", {
+    peer_instance_id: peerId,
+    peer_endpoint_url: trimmed,
+    canonicals: peerCanonicals,
+  });
+  if (!result) { console.log("Exchange failed."); return; }
+
+  console.log();
+  console.log(`${B}  SUBSTRATE DISCOVERY${R}  peer: ${C}${peerId}${R}`);
+  console.log(`  ${"─".repeat(76)}`);
+  console.log(`  received:   ${result.received}`);
+  console.log(`  ${G}aligned:    ${result.aligned}${R}   ${D}structurally identical${R}`);
+  console.log(`  ${Y}diverged:   ${result.diverged}${R}   ${D}same name, different shape${R}`);
+  console.log(`  ${C}discovered: ${result.discovered}${R}   ${D}peer carries, we do not${R}`);
+  console.log();
+
+  if (result.attestations?.length) {
+    const byStatus = { aligned: [], diverged: [], discovered: [] };
+    for (const a of result.attestations) {
+      (byStatus[a.alignment_status] || []).push(a);
+    }
+    for (const status of ["diverged", "discovered", "aligned"]) {
+      if (!byStatus[status].length) continue;
+      console.log(`  ${D}${status.toUpperCase()}${R}`);
+      for (const a of byStatus[status].slice(0, 20)) {
+        const name = truncate(a.canonical_name, 40).padEnd(42);
+        const ph = (a.peer_content_hash || "").slice(0, 10);
+        const lh = (a.local_content_hash || "—       ").slice(0, 10);
+        console.log(`    ${name} peer:${ph}  local:${lh}`);
+      }
+      console.log();
+    }
+  }
+  console.log(`  ${D}No local cells were modified — sovereignty preserved.${R}`);
+  console.log();
+}
+
 export function handleFederation(args) {
   const sub = args[0];
   const rest = args.slice(1);
@@ -378,6 +488,8 @@ export function handleFederation(args) {
     case "msgs":          return readFederationMessages(rest);
     case "messages":      return readFederationMessages(rest);
     case "broadcast":     return broadcastFederation(rest);
+    case "substrate-canonicals": return listSubstrateCanonicals();
+    case "substrate-discover":   return substrateDiscoverPeer(rest);
     default:
       return listFederationNodes();
   }


### PR DESCRIPTION
## Summary

Two coherence instances meeting at the substrate altitude. Neither becomes the authority. They exchange their canonical-shape inventories; matches happen by content-addressing (same composition → same NodeID); discoveries happen by difference; reconciliation is by *choice*, not coercion. Each instance keeps its sovereign lattice.

**This work makes federation what it should be: sovereign instances discovering structural alignment without surrendering autonomy. The substrate's content-addressing IS the protocol; the new endpoints expose it across the wire.**

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/federation/substrate/canonicals` | This instance's canonical recipe-shape inventory (public read; each entry carries a deterministic sha256 content_hash) |
| `GET` | `/api/federation/substrate/canonicals/{name}/discover` | Single-shape lookup — does this instance carry `{name}` and what is its content_hash? |
| `POST` | `/api/federation/substrate/exchange` | Accept a peer's inventory; record per-canonical attestations (aligned / diverged / discovered) |
| `GET` | `/api/federation/substrate/attestations/{peer_id}` | Read this instance's attestation mirror for one peer |

Content-hash = `sha256(canonical_name + NUL + role_slots joined by NUL)`. Same canonical declaration anywhere → same hash everywhere; that IS the wire protocol.

## Three outcomes per exchange

- **aligned** — peer carries this canonical with the same content_hash. Structural identity attested by content-addressing; no merge needed.
- **diverged** — peer carries this canonical name with a different hash. Both sovereign, neither wrong; the divergence is signal.
- **discovered** — peer carries a canonical this instance lacks. Recorded as discovered; never auto-imported. Optionally available to intern via a separate operation.

## What is preserved

- Each instance's local recipe-shape cells are never modified by an exchange.
- No central registry, no authoritative source-of-truth. Each instance's attestations are its own view of its peers.
- The new federation-mirror table (`federation_substrate_attestations`) is upsert-keyed on `(peer_instance_id, canonical_name)` — re-running an exchange refreshes in place, never duplicates.
- No auth required for the read endpoints: canonicals are public structural shapes; the content-hash is computed deterministically from the build-time declaration. Reading them is reading public tissue.

## CLI

```
coh federation substrate-canonicals
coh federation substrate-discover --peer-url https://api.peer.example.com [--peer-id <id>]
```

The discover command fetches the peer's canonicals, posts them to the local exchange endpoint, and prints alignment / divergence / discovery counts. Sovereignty preserved — no auto-import.

## Files

- `api/app/models/federation.py` — new Pydantic models for canonical exchange
- `api/app/services/federation_service.py` — `FederatedSubstrateAttestationRecord` ORM
- `api/app/services/federation_substrate_service.py` — service module (canonical_content_hash, local_canonicals, discover_local_canonical, exchange_with_peer, list_attestations_for_peer)
- `api/app/routers/federation.py` — four new endpoints
- `cli/lib/commands/federation.mjs` — `substrate-canonicals` + `substrate-discover` subcommands
- `api/tests/test_federation_substrate_exchange.py` — 10 tests, all green

## Test plan

- [x] `pytest tests/test_federation_substrate_exchange.py tests/test_federation_layer.py tests/test_modality_blueprints.py -v` → **36 passed**
- [x] Canonicals endpoint returns the full CANONICAL_SHAPES inventory with deterministic content_hashes
- [x] aligned / diverged / discovered classifications attested via three dedicated tests
- [x] Exchange is idempotent (re-running does not duplicate attestation rows)
- [x] Exchange does not modify the local lattice (sovereignty preserved)
- [x] `python3 scripts/generate_repo_indexes.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)