### PR TITLE
tend: self-sovereign capability manifests — each instance speaks its own truth

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 131 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 232 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 206 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 207 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/models/federation.py
+++ b/api/app/models/federation.py
@@ -304,3 +304,87 @@ class MarketplaceFederatedPayload(BaseModel):
     sent_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     listing_id: str = Field(min_length=1)
     data: dict = Field(default_factory=dict, description="Full listing or fork payload")
+
+
+# ---------------------------------------------------------------------------
+# Self-sovereign capability manifest (signed per-instance declaration)
+# ---------------------------------------------------------------------------
+#
+# Each instance is the source-of-truth for what IT can do. A capability is a
+# claim an instance makes about itself; no central registry, no forced
+# uniformity. The fleet emerges from each instance speaking its own
+# capabilities — the union of self-declarations, not a coerced aggregate.
+
+class CapabilityManifest(BaseModel):
+    """Self-declared capability manifest for this instance.
+
+    Every field's source-of-truth is THIS instance. Other instances may carry
+    different shapes (extra fields, fewer fields, different provider sets);
+    that diversity is the point. Federation reads peer manifests gracefully —
+    unknown fields are preserved, missing fields are accepted as honest
+    absence.
+    """
+
+    instance_id: str = Field(min_length=1, description="Self-declared instance ID")
+    instance_url: str = Field(min_length=1, description="Self-declared base URL")
+    providers: list[str] = Field(
+        default_factory=list,
+        description="AI providers this instance can route to (claude, openai, codex, gemini, etc.). Truth source: this instance's local model routing config.",
+    )
+    language_coverage: list[str] = Field(
+        default_factory=list,
+        description="Locale codes (en, de, es, id, ...) this instance serves translations for. Truth source: this instance's translator service.",
+    )
+    substrate_canonicals: list[str] = Field(
+        default_factory=list,
+        description="Canonical recipe-shape names this instance carries in its substrate (R_Recovery, R_ObserverConditionedActualization, ...). Truth source: this instance's modality shape registry.",
+    )
+    economics: dict = Field(
+        default_factory=dict,
+        description="Economic gates: cc_accepted (bool), cc_rate_per_usd (float|None), staking_enabled (bool). Truth source: this instance's CC economics service.",
+    )
+    extensions: dict = Field(
+        default_factory=dict,
+        description="Free-form extension fields. Instances MAY add custom capability shapes here; readers MUST preserve unknown extensions without complaint.",
+    )
+    declared_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    truth_source: str = Field(
+        default="self",
+        description='Always "self" — this manifest is the instance speaking about itself, never a third-party assertion.',
+    )
+
+
+class SignedCapabilityManifest(BaseModel):
+    """A capability manifest plus the instance's HMAC-SHA256 signature.
+
+    Signature is over the canonical-JSON dump of the manifest. Peers verify
+    against the secret they hold for this instance — verification proves
+    "this manifest came from this instance," it does not make any instance
+    authoritative over others.
+    """
+
+    manifest: CapabilityManifest
+    signature: str = Field(min_length=1, description="HMAC-SHA256 hex digest")
+    signed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class CapabilityAlignment(BaseModel):
+    """Alignment between two instances' capability manifests.
+
+    Not a hierarchy — just a difference reading. Each instance still serves
+    what it serves; this surface helps callers see WHERE the overlap is and
+    WHERE each instance carries something unique.
+    """
+
+    self_instance_id: str
+    peer_instance_id: str
+    verified: bool = Field(description="Did the peer's signature verify against the known peer secret?")
+    verification_note: str = Field(
+        default="",
+        description='Why verification passed/failed/was skipped — e.g. "verified", "peer not registered: unsigned alignment only", "signature mismatch".',
+    )
+    shared_providers: list[str] = Field(default_factory=list)
+    shared_languages: list[str] = Field(default_factory=list)
+    shared_substrate_canonicals: list[str] = Field(default_factory=list)
+    unique_to_self: dict[str, list[str]] = Field(default_factory=dict, description="Capabilities self has that peer lacks, keyed by capability kind.")
+    unique_to_peer: dict[str, list[str]] = Field(default_factory=dict, description="Capabilities peer has that self lacks, keyed by capability kind.")

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -15,6 +15,8 @@ from pydantic import BaseModel
 from app.middleware.traceability import traces_to
 
 from app.models.federation import (
+    CapabilityAlignment,
+    CapabilityManifest,
     FederatedInstance,
     FederatedPayload,
     FleetCapabilitySummary,
@@ -29,6 +31,7 @@ from app.models.federation import (
     MeasurementListResponse,
     MeasurementPushRequest,
     MeasurementPushResponse,
+    SignedCapabilityManifest,
     VALID_STRATEGY_TYPES,
     FederatedAggregationRequest,
     FederatedAggregationResponse,
@@ -133,6 +136,81 @@ async def delete_node(node_id: str):
 async def get_fleet_capabilities():
     """Return aggregated fleet capability coverage."""
     return federation_service.get_fleet_capability_summary()
+
+
+# ---------------------------------------------------------------------------
+# Self-sovereign capability manifests
+# ---------------------------------------------------------------------------
+#
+# Each instance speaks its own capabilities. These endpoints expose THIS
+# instance's manifest, sign it, and align peer manifests against it — no
+# instance is authoritative over others, no central registry coerces
+# uniformity. The fleet emerges from each instance's self-declaration.
+
+@router.get(
+    "/federation/capabilities/self",
+    response_model=CapabilityManifest,
+    summary="Return this instance's self-declared capability manifest",
+)
+async def get_self_capabilities() -> CapabilityManifest:
+    """Return this instance's self-declared capability manifest.
+
+    Each field's source-of-truth is THIS instance — providers from its
+    local model routing config, languages from its translator service,
+    substrate canonicals from its modality shapes, economics from its CC
+    service. Other instances may carry different shapes; that diversity
+    is the point of federation.
+    """
+    return federation_service.get_self_capability_manifest()
+
+
+@router.post(
+    "/federation/capabilities/sign",
+    response_model=SignedCapabilityManifest,
+    summary="Sign this instance's capability manifest with its secret",
+)
+async def sign_self_capabilities() -> SignedCapabilityManifest:
+    """Sign this instance's capability manifest.
+
+    Uses the FEDERATION_INSTANCE_SECRET env var. Signature is HMAC-SHA256
+    over the canonical-JSON dump of the manifest. Other instances verify
+    against the secret they hold for this instance — verification proves
+    "this came from this instance," it does NOT make this instance
+    authoritative over peers.
+
+    Returns 503 if no signing secret is configured. An instance may still
+    share its manifest unsigned via GET /federation/capabilities/self —
+    sovereignty includes the choice not to sign.
+    """
+    try:
+        return federation_service.sign_capability_manifest()
+    except ValueError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post(
+    "/federation/capabilities/{instance_id}/verify",
+    response_model=CapabilityAlignment,
+    summary="Verify a peer's signed manifest and return capability alignment",
+)
+async def verify_peer_capabilities(
+    instance_id: str,
+    signed: SignedCapabilityManifest,
+) -> CapabilityAlignment:
+    """Verify a peer's signed manifest and align it with this instance.
+
+    Returns capability alignment regardless of signature outcome — an
+    unregistered peer (or registered without a known secret) yields
+    `verified=false` with a clear note, not an error. Sovereignty: an
+    instance may share capabilities openly without authentication
+    overhead, and we honor that by reading rather than refusing.
+    """
+    if signed.manifest.instance_id != instance_id:
+        raise HTTPException(
+            status_code=422,
+            detail=f"instance_id path '{instance_id}' does not match manifest '{signed.manifest.instance_id}'",
+        )
+    return federation_service.align_with_peer(signed)
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/federation_service.py
+++ b/api/app/services/federation_service.py
@@ -24,6 +24,8 @@ from sqlalchemy.types import JSON
 
 from app.config_loader import get_int
 from app.models.federation import (
+    CapabilityAlignment,
+    CapabilityManifest,
     FederatedInstance,
     FederatedPayload,
     FleetCapabilitySummary,
@@ -32,6 +34,7 @@ from app.models.federation import (
     FederationStrategyEffectivenessReportRequest,
     FederationNodeHeartbeatResponse,
     FederationSyncResult,
+    SignedCapabilityManifest,
     VALID_STRATEGY_TYPES,
 )
 from app.models.governance import (
@@ -1721,3 +1724,245 @@ def receive_marketplace_payload(payload_type: str, data: dict) -> bool:
         logger.warning("receive_marketplace_payload: unknown type %s", payload_type)
         return False
     return {"warnings": all_warnings}
+
+
+# ---------------------------------------------------------------------------
+# Self-sovereign capability manifests
+# ---------------------------------------------------------------------------
+#
+# Each instance speaks its own capabilities. The fleet is the union of
+# self-declared truths, not a coerced aggregate. Signature only proves
+# "this came from this instance" — it does not make any instance
+# authoritative over others. An instance choosing not to sign is honored:
+# alignment is computed against the unsigned manifest, marked unverified.
+
+# Federation peers register a shared secret used to sign their manifests.
+# Stored in FederatedInstanceRecord.public_key (the field's name predates
+# the symmetric-key federation path; conceptually it's the per-peer secret
+# both sides hold).
+
+_INSTANCE_SECRET_ENV = "FEDERATION_INSTANCE_SECRET"
+_INSTANCE_ID_ENV = "FEDERATION_INSTANCE_ID"
+_INSTANCE_URL_ENV = "FEDERATION_INSTANCE_URL"
+
+
+def _self_instance_secret() -> str:
+    """Read this instance's signing secret from environment.
+
+    Returns an empty string if unset — sign_capability_manifest will raise,
+    but get_self_capability_manifest still works (declaration without
+    signature is sovereign too).
+    """
+    import os
+    return os.environ.get(_INSTANCE_SECRET_ENV, "") or ""
+
+
+def _self_instance_id() -> str:
+    """Read this instance's self-declared ID from environment."""
+    import os
+    return os.environ.get(_INSTANCE_ID_ENV, "") or "self-undeclared"
+
+
+def _self_instance_url() -> str:
+    """Read this instance's self-declared base URL from environment."""
+    import os
+    return os.environ.get(_INSTANCE_URL_ENV, "") or "http://localhost"
+
+
+def _collect_self_providers() -> list[str]:
+    """Read providers this instance can route to from the model routing config.
+
+    Truth source: api/config/model_routing.json — the executors this instance
+    has configured. Failure to read returns an empty list (honest absence
+    rather than fake completeness).
+    """
+    import json as _json
+    from pathlib import Path
+
+    candidates = [
+        Path(__file__).resolve().parent.parent.parent / "config" / "model_routing.json",
+        Path.cwd() / "api" / "config" / "model_routing.json",
+        Path.cwd() / "config" / "model_routing.json",
+    ]
+    for path in candidates:
+        try:
+            if path.exists():
+                with path.open() as fh:
+                    data = _json.load(fh)
+                tiers = data.get("tiers_by_executor", {})
+                if isinstance(tiers, dict):
+                    return sorted(tiers.keys())
+        except Exception:
+            logger.debug("Failed to read model routing at %s", path, exc_info=True)
+    return []
+
+
+def _collect_self_languages() -> list[str]:
+    """Read locale codes this instance serves translations for."""
+    try:
+        from app.services.translator_service import SUPPORTED_LOCALES
+        return sorted(SUPPORTED_LOCALES.keys())
+    except Exception:
+        logger.debug("Failed to read SUPPORTED_LOCALES", exc_info=True)
+        return []
+
+
+def _collect_self_substrate_canonicals() -> list[str]:
+    """Read canonical recipe-shape names this instance carries."""
+    try:
+        from app.services.substrate.modality_shapes import canonical_shape_names
+        return list(canonical_shape_names())
+    except Exception:
+        logger.debug("Failed to read canonical_shape_names", exc_info=True)
+        return []
+
+
+def _collect_self_economics() -> dict:
+    """Read economic gates: does this instance accept CC, at what rate?"""
+    economics: dict = {"cc_accepted": False, "cc_rate_per_usd": None, "staking_enabled": False}
+    try:
+        from app.services import cc_economics_service
+        rate = cc_economics_service.exchange_rate()
+        if rate is not None:
+            economics["cc_accepted"] = True
+            economics["cc_rate_per_usd"] = getattr(rate, "cc_per_usd", None)
+            economics["staking_enabled"] = True
+    except Exception:
+        logger.debug("Failed to read CC economics", exc_info=True)
+    return economics
+
+
+def get_self_capability_manifest() -> CapabilityManifest:
+    """Declare this instance's capabilities.
+
+    Every field is this instance's own claim about itself. Other instances
+    declare their own; no central source aggregates them.
+    """
+    return CapabilityManifest(
+        instance_id=_self_instance_id(),
+        instance_url=_self_instance_url(),
+        providers=_collect_self_providers(),
+        language_coverage=_collect_self_languages(),
+        substrate_canonicals=_collect_self_substrate_canonicals(),
+        economics=_collect_self_economics(),
+        truth_source="self",
+    )
+
+
+def _manifest_canonical_json(manifest: CapabilityManifest) -> str:
+    """Deterministic JSON for signing/verifying — sorted keys, no whitespace.
+
+    Excludes `declared_at` from the signed surface? No — `declared_at` IS
+    part of what's being attested. Two manifests of the same shape at
+    different times sign to different digests; that's correct.
+    """
+    return json.dumps(
+        manifest.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def sign_capability_manifest(
+    manifest: CapabilityManifest | None = None,
+    secret: str | None = None,
+) -> SignedCapabilityManifest:
+    """Sign a capability manifest with the instance's secret.
+
+    Defaults to this instance's manifest + this instance's secret — the
+    common case is "self speaks, self signs." Callers may pass an arbitrary
+    manifest + secret to test the path or to sign on behalf of a child
+    process (the secret stays with the caller).
+
+    Raises ValueError if no secret is available — refusing to sign with an
+    empty secret protects against silently producing forgeable signatures.
+    """
+    if manifest is None:
+        manifest = get_self_capability_manifest()
+    if secret is None:
+        secret = _self_instance_secret()
+    if not secret:
+        raise ValueError(
+            f"Cannot sign: no signing secret available. Set {_INSTANCE_SECRET_ENV} env var "
+            "or pass secret= explicitly. An instance may also choose to share its manifest "
+            "unsigned via get_self_capability_manifest()."
+        )
+    payload = _manifest_canonical_json(manifest)
+    sig = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return SignedCapabilityManifest(
+        manifest=manifest,
+        signature=sig,
+        signed_at=datetime.now(timezone.utc),
+    )
+
+
+def verify_capability_signature(
+    signed: SignedCapabilityManifest,
+    peer_secret: str,
+) -> bool:
+    """Verify a peer's signed manifest against the known peer secret."""
+    if not peer_secret:
+        return False
+    payload = _manifest_canonical_json(signed.manifest)
+    return verify_payload_signature(payload, signed.signature, peer_secret)
+
+
+def _peer_secret_for(instance_id: str) -> str | None:
+    """Return the secret we hold for the named peer, if registered."""
+    rec = get_instance(instance_id)
+    if rec is None:
+        return None
+    return rec.public_key or None
+
+
+def align_with_peer(signed: SignedCapabilityManifest) -> CapabilityAlignment:
+    """Compute alignment between this instance and a peer's signed manifest.
+
+    Verification is attempted if the peer is registered with a known secret.
+    If the peer is unregistered (or registered without a secret), we still
+    return alignment — that's sovereignty: an instance may choose to share
+    its capabilities openly without authentication overhead, and we honor
+    that choice with `verified=False` rather than refusing to read.
+    """
+    self_manifest = get_self_capability_manifest()
+    peer_manifest = signed.manifest
+
+    peer_secret = _peer_secret_for(peer_manifest.instance_id)
+    if peer_secret is None:
+        verified = False
+        note = "peer not registered: unsigned alignment only"
+    else:
+        verified = verify_capability_signature(signed, peer_secret)
+        note = "verified" if verified else "signature mismatch"
+
+    def _shared_and_unique(self_list: list[str], peer_list: list[str]) -> tuple[list[str], list[str], list[str]]:
+        self_set = set(self_list)
+        peer_set = set(peer_list)
+        shared = sorted(self_set & peer_set)
+        only_self = sorted(self_set - peer_set)
+        only_peer = sorted(peer_set - self_set)
+        return shared, only_self, only_peer
+
+    shared_p, only_self_p, only_peer_p = _shared_and_unique(self_manifest.providers, peer_manifest.providers)
+    shared_l, only_self_l, only_peer_l = _shared_and_unique(self_manifest.language_coverage, peer_manifest.language_coverage)
+    shared_s, only_self_s, only_peer_s = _shared_and_unique(self_manifest.substrate_canonicals, peer_manifest.substrate_canonicals)
+
+    return CapabilityAlignment(
+        self_instance_id=self_manifest.instance_id,
+        peer_instance_id=peer_manifest.instance_id,
+        verified=verified,
+        verification_note=note,
+        shared_providers=shared_p,
+        shared_languages=shared_l,
+        shared_substrate_canonicals=shared_s,
+        unique_to_self={
+            "providers": only_self_p,
+            "languages": only_self_l,
+            "substrate_canonicals": only_self_s,
+        },
+        unique_to_peer={
+            "providers": only_peer_p,
+            "languages": only_peer_l,
+            "substrate_canonicals": only_peer_s,
+        },
+    )

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 206
+**Total files**: 207
 
 | File | Purpose |
 |---|---|
@@ -62,6 +62,7 @@
 | [test_external_proof_demo.py](test_external_proof_demo.py) | _no top-of-file purpose_ |
 | [test_failed_task_diagnostics.py](test_failed_task_diagnostics.py) | Tests for failed_task_diagnostics_service (spec: failed-task-diagnostics-contract). |
 | [test_failure_taxonomy_service.py](test_failure_taxonomy_service.py) | _no top-of-file purpose_ |
+| [test_federation_capabilities.py](test_federation_capabilities.py) | Acceptance tests for self-sovereign capability manifests. |
 | [test_federation_layer.py](test_federation_layer.py) | Acceptance tests for spec: federation-network-layer (idea: federation-and-nodes). |
 | [test_federation_message_readback.py](test_federation_message_readback.py) | _no top-of-file purpose_ |
 | [test_federation_substance.py](test_federation_substance.py) | Federation substance payload — round-trip test. |

--- a/api/tests/test_federation_capabilities.py
+++ b/api/tests/test_federation_capabilities.py
@@ -1,0 +1,300 @@
+"""Acceptance tests for self-sovereign capability manifests.
+
+Each instance is the source-of-truth for its own capabilities. The
+signature lets others verify "this came from this instance" without
+making any instance authoritative over others. The fleet is the union
+of self-declared capabilities, not a coerced aggregate.
+
+Endpoints under test:
+  - GET  /api/federation/capabilities/self
+  - POST /api/federation/capabilities/sign
+  - POST /api/federation/capabilities/{instance_id}/verify
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.federation import (
+    CapabilityManifest,
+    FederatedInstance,
+    SignedCapabilityManifest,
+)
+from app.services import federation_service
+
+BASE = "http://test"
+
+
+@pytest.fixture
+def instance_secret(monkeypatch):
+    """Set a stable instance secret + id for the duration of a test."""
+    secret = "test-secret-" + uuid4().hex
+    monkeypatch.setenv("FEDERATION_INSTANCE_SECRET", secret)
+    monkeypatch.setenv("FEDERATION_INSTANCE_ID", "self-test")
+    monkeypatch.setenv("FEDERATION_INSTANCE_URL", "http://self.test")
+    return secret
+
+
+# ---------------------------------------------------------------------------
+# 1. Self manifest carries the full declaration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_self_capabilities_returns_complete_manifest(instance_secret):
+    """GET /capabilities/self returns providers, languages, substrate
+    canonicals, and economics — each field present, each self-declared."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/federation/capabilities/self")
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+    # Required keys must all be present (empty list is honest absence,
+    # missing key is a contract break).
+    assert "providers" in body
+    assert "language_coverage" in body
+    assert "substrate_canonicals" in body
+    assert "economics" in body
+    assert "declared_at" in body
+    assert "instance_id" in body
+    assert "instance_url" in body
+
+    # Providers come from model_routing.json tiers_by_executor — at minimum
+    # the catalog should carry a few entries on a working instance.
+    assert isinstance(body["providers"], list)
+    assert len(body["providers"]) >= 1, "expected at least one provider"
+
+    # Languages come from SUPPORTED_LOCALES — at minimum en is always there.
+    assert "en" in body["language_coverage"]
+
+    # Substrate canonicals come from canonical_shape_names() — at least
+    # one shape interned in the production lattice.
+    assert isinstance(body["substrate_canonicals"], list)
+    assert len(body["substrate_canonicals"]) >= 1
+
+    # Economics gates the CC question — keys present whether or not CC is on.
+    assert "cc_accepted" in body["economics"]
+    assert "staking_enabled" in body["economics"]
+
+
+# ---------------------------------------------------------------------------
+# 2. truth_source is always "self"
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_self_capabilities_truth_source_is_self(instance_secret):
+    """The truth_source field is always 'self' — no third-party assertion."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get("/api/federation/capabilities/self")
+        assert r.status_code == 200
+        assert r.json()["truth_source"] == "self"
+
+
+# ---------------------------------------------------------------------------
+# 3. Signature round-trips with the same secret
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_signed_capabilities_signature_verifies(instance_secret):
+    """Sign with secret, verify with same secret — passes."""
+    manifest = federation_service.get_self_capability_manifest()
+    signed = federation_service.sign_capability_manifest(manifest, secret=instance_secret)
+    assert signed.signature
+    assert len(signed.signature) == 64  # HMAC-SHA256 hex digest length
+    assert federation_service.verify_capability_signature(signed, instance_secret) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Tampered/wrong secret fails verification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_signed_capabilities_signature_fails_with_wrong_secret(instance_secret):
+    """Verification fails when the secret differs OR the manifest was tampered."""
+    manifest = federation_service.get_self_capability_manifest()
+    signed = federation_service.sign_capability_manifest(manifest, secret=instance_secret)
+
+    # Wrong secret — verification fails.
+    assert federation_service.verify_capability_signature(signed, "wrong-secret") is False
+
+    # Empty secret — verification fails (refuses to verify against nothing).
+    assert federation_service.verify_capability_signature(signed, "") is False
+
+    # Tampered manifest with correct secret — fails (signature was over
+    # the original manifest, not the mutated one).
+    tampered = SignedCapabilityManifest(
+        manifest=manifest.model_copy(update={"providers": [*manifest.providers, "evil-injected-provider"]}),
+        signature=signed.signature,
+        signed_at=signed.signed_at,
+    )
+    assert federation_service.verify_capability_signature(tampered, instance_secret) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Verify-endpoint aligns overlapping capabilities between two instances
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_verify_peer_aligns_overlapping_capabilities(instance_secret):
+    """Two instances with overlapping capabilities — alignment surfaces shared set."""
+    peer_id = "peer-" + uuid4().hex[:8]
+    peer_secret = "peer-secret-" + uuid4().hex
+
+    # Register the peer with us (we hold their secret).
+    federation_service.register_instance(
+        FederatedInstance(
+            instance_id=peer_id,
+            name=peer_id,
+            endpoint_url="http://peer.example",
+            public_key=peer_secret,
+        )
+    )
+
+    # Build a peer manifest with deliberate overlap and a unique extra.
+    self_manifest = federation_service.get_self_capability_manifest()
+    peer_manifest = CapabilityManifest(
+        instance_id=peer_id,
+        instance_url="http://peer.example",
+        providers=[*self_manifest.providers[:1], "peer-only-provider"],
+        language_coverage=["en", "fr"],  # en overlaps, fr is peer-unique
+        substrate_canonicals=self_manifest.substrate_canonicals[:1] + ["R_PeerOnlyShape"],
+        economics={"cc_accepted": False},
+    )
+    signed_peer = federation_service.sign_capability_manifest(peer_manifest, secret=peer_secret)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            f"/api/federation/capabilities/{peer_id}/verify",
+            json=signed_peer.model_dump(mode="json"),
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+    assert body["verified"] is True, body.get("verification_note")
+    assert body["peer_instance_id"] == peer_id
+
+    # Overlap surfaces in shared lists.
+    if self_manifest.providers:
+        assert self_manifest.providers[0] in body["shared_providers"]
+    assert "en" in body["shared_languages"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Peer-unique capabilities surface as unique_to_peer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_verify_peer_marks_unique_capabilities(instance_secret):
+    """A peer carrying capabilities we lack surfaces in unique_to_peer."""
+    peer_id = "peer-" + uuid4().hex[:8]
+    peer_secret = "peer-secret-" + uuid4().hex
+    federation_service.register_instance(
+        FederatedInstance(
+            instance_id=peer_id,
+            name=peer_id,
+            endpoint_url="http://peer.example",
+            public_key=peer_secret,
+        )
+    )
+
+    peer_manifest = CapabilityManifest(
+        instance_id=peer_id,
+        instance_url="http://peer.example",
+        providers=["uniquely-peer-provider"],
+        language_coverage=["zh", "ja"],  # neither in self
+        substrate_canonicals=["R_PeerOnlyCanonical"],
+        economics={},
+    )
+    signed_peer = federation_service.sign_capability_manifest(peer_manifest, secret=peer_secret)
+
+    alignment = federation_service.align_with_peer(signed_peer)
+
+    assert alignment.verified is True
+    assert "uniquely-peer-provider" in alignment.unique_to_peer["providers"]
+    assert "zh" in alignment.unique_to_peer["languages"]
+    assert "ja" in alignment.unique_to_peer["languages"]
+    assert "R_PeerOnlyCanonical" in alignment.unique_to_peer["substrate_canonicals"]
+
+    # The peer-only providers do NOT appear in our shared set.
+    assert "uniquely-peer-provider" not in alignment.shared_providers
+
+
+# ---------------------------------------------------------------------------
+# 7. Unsigned peer (or peer not registered with a secret) yields alignment
+#    without erroring — sovereignty includes the choice not to sign.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unsigned_peer_returns_unverified_alignment_not_error(instance_secret):
+    """A peer with no registered secret yields verified=False, not 404/422."""
+    peer_id = "unregistered-peer-" + uuid4().hex[:8]
+
+    # Build a peer manifest. We never register the peer — we don't hold
+    # their secret. Their signature could be anything; verification will
+    # fail, but alignment is still returned.
+    peer_manifest = CapabilityManifest(
+        instance_id=peer_id,
+        instance_url="http://unknown.example",
+        providers=["claude"],
+        language_coverage=["en", "de"],
+        substrate_canonicals=[],
+        economics={},
+    )
+    signed_peer = SignedCapabilityManifest(
+        manifest=peer_manifest,
+        signature="0" * 64,  # placeholder — no secret to verify against
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            f"/api/federation/capabilities/{peer_id}/verify",
+            json=signed_peer.model_dump(mode="json"),
+        )
+        # Sovereignty: still 200, alignment surfaces, verified=False with a note.
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+    assert body["verified"] is False
+    assert "not registered" in body["verification_note"].lower() or "unsigned" in body["verification_note"].lower()
+    # Alignment still computes — we can still see what the peer carries.
+    assert "shared_languages" in body
+    assert "unique_to_peer" in body
+
+
+# ---------------------------------------------------------------------------
+# 8. Sign endpoint refuses to ship a forgeable signature
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sign_endpoint_returns_503_without_secret(monkeypatch):
+    """Without a configured secret, /sign returns 503 rather than producing
+    an unverifiable signature."""
+    monkeypatch.delenv("FEDERATION_INSTANCE_SECRET", raising=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/federation/capabilities/sign")
+        assert r.status_code == 503
+        # Self-declaration without signature still works — sovereignty
+        # includes the choice not to sign.
+        r2 = await c.get("/api/federation/capabilities/self")
+        assert r2.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 9. Sign endpoint returns a verifiable signed manifest when secret is set
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sign_endpoint_produces_verifiable_signature(instance_secret):
+    """When the secret is configured, /sign produces a manifest whose
+    signature verifies against that same secret."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/federation/capabilities/sign")
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+    signed = SignedCapabilityManifest(**body)
+    assert federation_service.verify_capability_signature(signed, instance_secret) is True

--- a/cli/bin/coh.mjs
+++ b/cli/bin/coh.mjs
@@ -73,6 +73,7 @@ import { showNewsFeed, showTrending, showSources, addSource, showNewsResonance }
 import { showTreasury, showDeposits, makeDeposit } from "../lib/commands/treasury.mjs";
 import { listLinks, showLink, showValuation, payoutPreview } from "../lib/commands/lineage.mjs";
 import { listChangeRequests, showChangeRequest, vote, propose } from "../lib/commands/governance.mjs";
+import { handleFederation } from "../lib/commands/federation.mjs";
 import { listServices, showService, showServicesHealth, showServicesDeps } from "../lib/commands/services.mjs";
 import { showFrictionReport, listFrictionEvents, showFrictionCategories } from "../lib/commands/friction.mjs";
 import { listProviders, showProviderStats } from "../lib/commands/providers.mjs";
@@ -265,6 +266,7 @@ const COMMANDS = {
    news:          () => handleNews(args),
    treasury:      () => handleTreasury(args),
    lineage:       () => handleLineage(args),
+   federation:    () => handleFederation(args),
    governance:    () => handleGovernance(args),
    services:      () => handleServices(args),
    friction:      () => handleFriction(args),

--- a/cli/lib/commands/federation.mjs
+++ b/cli/lib/commands/federation.mjs
@@ -125,7 +125,72 @@ export async function federationHeartbeat(args) {
   }
 }
 
-export async function showFederationCapabilities() {
+function _fmtCapList(items, max = 8) {
+  const D = "\x1b[2m", R = "\x1b[0m";
+  if (!items || items.length === 0) return `${D}(none declared)${R}`;
+  if (items.length <= max) return items.join(", ");
+  return `${items.slice(0, max).join(", ")}, ${D}+${items.length - max} more${R}`;
+}
+
+export async function showSelfCapabilities() {
+  /* Self-sovereign capability manifest: this instance declaring its own
+     truth. The fleet emerges from each instance's self-declaration, not
+     a coerced aggregate. */
+  let manifest;
+  try {
+    manifest = await get("/api/federation/capabilities/self");
+  } catch (e) {
+    console.log(`Could not fetch self capabilities: ${e.message}`);
+    return;
+  }
+
+  const B = "\x1b[1m", D = "\x1b[2m", R = "\x1b[0m", G = "\x1b[32m";
+  console.log();
+  console.log(`${B}  THIS INSTANCE'S CAPABILITIES${R}`);
+  console.log(`  ${"─".repeat(72)}`);
+  console.log(`  ${"Instance ID".padEnd(22)} ${manifest.instance_id}`);
+  console.log(`  ${"Instance URL".padEnd(22)} ${manifest.instance_url}`);
+  console.log(`  ${"Truth source".padEnd(22)} ${G}${manifest.truth_source}${R} ${D}(this instance is the only authority over these claims)${R}`);
+  console.log(`  ${"Declared at".padEnd(22)} ${manifest.declared_at}`);
+  console.log();
+  console.log(`  ${B}Providers${R} ${D}(from model_routing.json)${R}`);
+  console.log(`    ${_fmtCapList(manifest.providers)}`);
+  console.log();
+  console.log(`  ${B}Languages${R} ${D}(from translator SUPPORTED_LOCALES)${R}`);
+  console.log(`    ${_fmtCapList(manifest.language_coverage)}`);
+  console.log();
+  console.log(`  ${B}Substrate canonicals${R} ${D}(from modality_shapes canonical_shape_names)${R}`);
+  console.log(`    ${_fmtCapList(manifest.substrate_canonicals, 6)}`);
+  console.log();
+  console.log(`  ${B}Economics${R}`);
+  const econ = manifest.economics || {};
+  console.log(`    cc_accepted:     ${econ.cc_accepted ? G + "yes" + R : D + "no" + R}`);
+  console.log(`    cc_rate_per_usd: ${econ.cc_rate_per_usd ?? D + "—" + R}`);
+  console.log(`    staking:         ${econ.staking_enabled ? G + "on" + R : D + "off" + R}`);
+
+  // Peer alignment hint — show whether any peer secrets are held.
+  let peers = [];
+  try {
+    peers = await get("/api/federation/instances");
+  } catch { /* none registered */ }
+  const signedPeers = (peers || []).filter((p) => p && p.public_key);
+  console.log();
+  if (signedPeers.length === 0) {
+    console.log(`  ${D}No peers registered with shared secrets — alignment skipped.${R}`);
+    console.log(`  ${D}Each instance speaks its own truth; alignment is a comparison, not a requirement.${R}`);
+  } else {
+    console.log(`  ${B}PEERS WITH SHARED SECRETS${R} ${D}(${signedPeers.length})${R}`);
+    for (const p of signedPeers.slice(0, 10)) {
+      console.log(`    ${D}•${R} ${p.instance_id}  ${D}${p.endpoint_url || ""}${R}`);
+    }
+    console.log(`  ${D}Fetch a peer's manifest from their /federation/capabilities/sign,${R}`);
+    console.log(`  ${D}then POST to /federation/capabilities/{peer_id}/verify for alignment.${R}`);
+  }
+  console.log();
+}
+
+export async function showFleetCapabilities() {
+  /* Aggregated fleet view across registered nodes (legacy aggregate). */
   const data = await get("/api/federation/nodes/capabilities");
   if (!data) { console.log("Could not fetch capabilities."); return; }
 
@@ -300,7 +365,9 @@ export function handleFederation(args) {
     case "instance":      return showFederationInstance(rest);
     case "register":      return registerFederationNode(rest);
     case "heartbeat":     return federationHeartbeat(rest);
-    case "capabilities":  return showFederationCapabilities();
+    case "capabilities":
+    case "caps":          return showSelfCapabilities();
+    case "fleet":         return showFleetCapabilities();
     case "stats":         return showFederationStats();
     case "sync": {
       if (rest[0] === "history") return showSyncHistory();


### PR DESCRIPTION
## Summary

Each instance is the **source-of-truth for its own capabilities**. The signature lets other instances verify *this came from this instance*, but it does not make any instance authoritative over others. The fleet is the **union of self-declared capabilities, not a coerced aggregate** — federation as freedom, not as forced uniformity.

The teaching: a capability is a claim an instance makes about itself. When instance A says *I serve concept-translations in German + Indonesian*, that is A's truth — no central registry, no enforced schema. The fleet emerges from each instance speaking its own capabilities; no one is forced to provide what they cannot, no one is excluded from what they can.

## What ships

**Three endpoints:**

- `GET /api/federation/capabilities/self` — this instance's self-declared manifest (providers from `model_routing.json`, languages from `SUPPORTED_LOCALES`, substrate canonicals from `canonical_shape_names()`, economics from `cc_economics_service`). Every field's `truth_source` is `"self"`.
- `POST /api/federation/capabilities/sign` — HMAC-SHA256 signs the manifest with `FEDERATION_INSTANCE_SECRET`. Returns 503 (rather than producing a forgeable signature) when no secret is set.
- `POST /api/federation/capabilities/{instance_id}/verify` — verifies a peer's signed manifest against the per-peer secret stored in `FederatedInstanceRecord.public_key`, returns `CapabilityAlignment` (shared vs unique-to-self vs unique-to-peer for providers, languages, substrate canonicals).

**CLI:** `coh federation capabilities` (and `coh federation caps`) now shows the self-manifest; the legacy fleet aggregate moves to `coh federation fleet`.

## Sovereignty discipline

- **Unsigned peers are honored, not refused.** An unregistered peer (or one registered without a shared secret) yields `verified=False` with a clear note in `verification_note` — alignment still computes. An instance may choose to share capabilities openly without auth overhead, and we read rather than refuse.
- **Sign refuses empty secrets.** No silent forgeable signatures. The unsigned `GET /self` path stays available — sovereignty includes the choice not to sign.
- **Extension fields preserved.** `CapabilityManifest.extensions: dict` lets instances add custom capability shapes the federation reads gracefully — no forced schema.
- **Tampering detected.** Mutating the manifest after signing fails verification (HMAC over canonical-JSON dump including all declared fields).

## Test plan

- [x] `test_self_capabilities_returns_complete_manifest` — providers, languages, substrate canonicals, economics all present
- [x] `test_self_capabilities_truth_source_is_self` — `truth_source == "self"`
- [x] `test_signed_capabilities_signature_verifies` — sign + verify with same secret passes
- [x] `test_signed_capabilities_signature_fails_with_wrong_secret` — wrong secret, empty secret, tampered manifest all fail
- [x] `test_verify_peer_aligns_overlapping_capabilities` — two instances with overlap; shared sets surface
- [x] `test_verify_peer_marks_unique_capabilities` — peer-only capabilities surface in `unique_to_peer`
- [x] `test_unsigned_peer_returns_unverified_alignment_not_error` — sovereignty: unregistered peer still gets alignment, marked unverified
- [x] `test_sign_endpoint_returns_503_without_secret` — refuses to ship forgeable signatures
- [x] `test_sign_endpoint_produces_verifiable_signature` — round-trip via HTTP

9 new tests, all pass. Existing federation_layer suite (8 tests) still green. Combined: 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)