### PR TITLE
tend: federated value flow — CC across instances without surrendering authority

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -32,9 +32,9 @@
 | Index | Files | Purpose |
 |---|---|---|
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 132 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 234 | API services — business logic and graph operations |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 235 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 209 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 210 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |

--- a/api/app/models/federation.py
+++ b/api/app/models/federation.py
@@ -483,3 +483,194 @@ class CanonicalExchangeResponse(BaseModel):
     diverged: int = 0
     discovered: int = 0
     attestations: list[CanonicalAttestationOut] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Federated value flow — freedom-preserving CC distribution across instances
+# ---------------------------------------------------------------------------
+#
+# Asset on instance A is mirrored to instance B. B serves a read; B sends A
+# an attribution envelope. At settlement time, A computes B's share and sends
+# B a settlement envelope. Each instance stays sovereign over what it knows:
+# A holds the truth about its assets, B holds the truth about its readers.
+# Neither commands the other — both sides may decline. The fleet's value
+# flow is the union of self-declared exchanges, not a central ledger.
+
+
+VALUE_ATTESTATION_STATUSES = frozenset({"received", "verified", "settled", "rejected"})
+
+# Default split when a federated read settles: 80% to the creator, 20% to
+# the serving instance. Inspired by the asset-renderer-plugin 85/15 share —
+# the serving instance carries delivery cost the same way a renderer does.
+DEFAULT_FEDERATED_CREATOR_SHARE = 0.80
+DEFAULT_FEDERATED_SERVING_SHARE = 0.20
+
+
+class AssetMirrorManifest(BaseModel):
+    """Manifest a peer sends when asking to mirror one of our assets.
+
+    The peer holds the local asset id; the manifest declares origin so
+    later read-attributions can address us as authoritative. Sovereignty:
+    we still choose whether to accept; the manifest is a request, not a
+    command.
+    """
+    local_asset_id: str = Field(min_length=1, description="The asset id on the mirroring instance (the one receiving the manifest)")
+    origin_instance_id: str = Field(min_length=1, description="Instance that authored the asset")
+    origin_asset_id: str = Field(min_length=1, description="Asset id as known to its origin instance")
+    origin_url: str = Field(min_length=1, description="URL on the origin instance where the asset lives")
+    origin_payment_address: str | None = Field(
+        default=None,
+        description="Creator's payment address on the origin instance — where settlement CC flows",
+    )
+    mirrored_at: str | None = None
+
+
+class AssetMirrorRecord(BaseModel):
+    """Round-tripped mirror record — what we store and return."""
+    local_asset_id: str
+    origin_instance_id: str
+    origin_asset_id: str
+    origin_url: str
+    origin_payment_address: str | None = None
+    mirrored_at: str
+
+
+class ReadAttributionEnvelope(BaseModel):
+    """Signed envelope a serving instance sends to an origin instance.
+
+    `signature` is HMAC-SHA256 over the canonical-JSON dump of the envelope
+    excluding the signature itself. The origin verifies against the secret
+    it holds for the serving instance (stored in
+    `FederatedInstanceRecord.public_key`).
+    """
+    asset_origin_id: str = Field(min_length=1, description="The asset id as known to the origin instance")
+    reader_instance_id: str = Field(min_length=1, description="ID of the instance that served the read")
+    reader_subject: str | None = Field(
+        default=None,
+        description="Opaque reader subject on the serving instance (may be hashed or anonymous)",
+    )
+    read_type: str = Field(default="free", description="free | paid")
+    cc_amount: float = Field(default=0.0, ge=0.0)
+    concept_resonance: dict[str, float] | None = None
+    observed_at: str = Field(description="ISO 8601 UTC timestamp when the read happened")
+    signature: str = Field(min_length=1)
+
+
+class ReadAttributionAck(BaseModel):
+    """What the origin instance returns after recording an attribution."""
+    asset_origin_id: str
+    reader_instance_id: str
+    status: str = Field(description="received | verified | rejected")
+    federated_reader_id: str | None = Field(
+        default=None,
+        description="The reader_id under which this read was recorded locally",
+    )
+    note: str | None = None
+
+
+class FederatedReadAttestationOut(BaseModel):
+    """One stored federated read attestation, as exposed via the API."""
+    id: int
+    asset_origin_id: str
+    reader_instance_id: str
+    reader_subject: str | None = None
+    read_type: str
+    cc_amount: float
+    observed_at: str
+    received_at: str
+    status: str
+    signature_verified: bool
+
+
+class FederatedReadAttestationListResponse(BaseModel):
+    asset_origin_id: str | None = None
+    reader_instance_id: str | None = None
+    attestations: list[FederatedReadAttestationOut] = Field(default_factory=list)
+    count: int = 0
+
+
+class SettlementShareEnvelope(BaseModel):
+    """Signed envelope an origin instance sends to a serving instance.
+
+    The origin computed the serving instance's share from attestations it
+    received during the period; the envelope declares the amount and the
+    constituent reads. Sovereignty: the serving instance verifies, then
+    stores in its inbox; downstream CC transfer is a separate breath.
+    """
+    origin_instance_id: str = Field(min_length=1, description="Instance computing the settlement (the asset's home)")
+    serving_instance_id: str = Field(min_length=1, description="Instance receiving the share (read-server)")
+    period_start: str = Field(description="ISO 8601 UTC inclusive start of the settlement period")
+    period_end: str = Field(description="ISO 8601 UTC exclusive end of the settlement period")
+    read_count: int = Field(ge=0)
+    cc_amount_to_serving: float = Field(ge=0.0)
+    cc_amount_to_creator: float = Field(ge=0.0)
+    serving_share: float = Field(ge=0.0, le=1.0)
+    creator_share: float = Field(ge=0.0, le=1.0)
+    asset_breakdown: list[dict] = Field(
+        default_factory=list,
+        description="Per-asset entries: {asset_origin_id, read_count, cc_amount_to_serving}",
+    )
+    signature: str = Field(min_length=1)
+
+
+class SettlementShareAck(BaseModel):
+    """Acknowledgement returned by the serving instance after inbox storage."""
+    inbox_id: int
+    origin_instance_id: str
+    status: str = Field(description="received | verified | rejected")
+    note: str | None = None
+
+
+class SettlementInboxEntryOut(BaseModel):
+    """One inbox entry — a settlement envelope the serving side received."""
+    id: int
+    origin_instance_id: str
+    period_start: str
+    period_end: str
+    read_count: int
+    cc_amount_to_serving: float
+    cc_amount_to_creator: float
+    received_at: str
+    status: str
+    signature_verified: bool
+
+
+class SettlementInboxListResponse(BaseModel):
+    origin_instance_id: str | None = None
+    entries: list[SettlementInboxEntryOut] = Field(default_factory=list)
+    count: int = 0
+
+
+class ComputeFederatedSharesRequest(BaseModel):
+    """Trigger a settlement-share computation across federated peers for a period.
+
+    The request says *which* period; the service computes per-peer envelopes
+    from this instance's stored federated read attestations.
+    """
+    period_start: str = Field(description="ISO 8601 UTC inclusive period start")
+    period_end: str = Field(description="ISO 8601 UTC exclusive period end")
+    serving_share: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Override the default serving-side share (default 0.20)",
+    )
+    serving_instance_id: str | None = Field(
+        default=None,
+        description="If set, only compute for this peer; otherwise compute for every peer with attestations in the window",
+    )
+    mark_settled: bool = Field(
+        default=True,
+        description="If true, attestations included in the envelope flip to status=settled",
+    )
+
+
+class ComputeFederatedSharesResponse(BaseModel):
+    period_start: str
+    period_end: str
+    envelopes: list[SettlementShareEnvelope] = Field(default_factory=list)
+    serving_share: float
+    creator_share: float
+    total_cc_to_serving: float = 0.0
+    total_cc_to_creator: float = 0.0
+    attestations_settled: int = 0

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -15,14 +15,19 @@ from pydantic import BaseModel
 from app.middleware.traceability import traces_to
 
 from app.models.federation import (
+    AssetMirrorManifest,
+    AssetMirrorRecord,
     CanonicalDiscoverResponse,
     CanonicalExchangeRequest,
     CanonicalExchangeResponse,
     CanonicalShapesListResponse,
     CapabilityAlignment,
     CapabilityManifest,
+    ComputeFederatedSharesRequest,
+    ComputeFederatedSharesResponse,
     FederatedInstance,
     FederatedPayload,
+    FederatedReadAttestationListResponse,
     FleetCapabilitySummary,
     FederationNodeHeartbeatRequest,
     FederationNodeHeartbeatResponse,
@@ -35,6 +40,11 @@ from app.models.federation import (
     MeasurementListResponse,
     MeasurementPushRequest,
     MeasurementPushResponse,
+    ReadAttributionAck,
+    ReadAttributionEnvelope,
+    SettlementInboxListResponse,
+    SettlementShareAck,
+    SettlementShareEnvelope,
     SignedCapabilityManifest,
     VALID_STRATEGY_TYPES,
     FederatedAggregationRequest,
@@ -43,6 +53,8 @@ from app.models.federation import (
 )
 from app.services import federation_service
 from app.services import federation_substrate_service
+from app.services import federation_value_flow_service
+from app.services.federation_value_flow_service import SignatureRejection
 from app.services import openclaw_node_bridge_service
 from app.services import unified_db as _udb
 
@@ -474,6 +486,176 @@ async def list_substrate_attestations(peer_instance_id: str) -> dict:
         "attestations": [a.model_dump(mode="json") for a in attestations],
         "count": len(attestations),
     }
+
+
+# ---------------------------------------------------------------------------
+# Federated value flow — freedom-preserving CC distribution across instances
+# ---------------------------------------------------------------------------
+#
+# Asset on instance A is mirrored to instance B. B serves a read; B sends A
+# a signed read-attribution envelope. At settlement, A computes B's serving
+# share and sends B a signed settlement envelope (B logs it in its inbox).
+# Each instance is the source-of-truth for its own truths:
+#   - A is authoritative for its assets (origin_asset_id, payment address).
+#   - B is authoritative for its readers (reader_subject).
+# Neither commands the other; attestations are exchanged, not commanded.
+
+
+@router.post(
+    "/federation/value/mirror-asset",
+    response_model=AssetMirrorRecord,
+    status_code=201,
+    summary="Record that we are hosting an asset whose authority lives on another instance",
+)
+async def mirror_asset(manifest: AssetMirrorManifest) -> AssetMirrorRecord:
+    """Record a federation mirror. Idempotent: re-mirroring updates origin fields.
+
+    The mirror table is THIS instance's view of which of our assets actually
+    live somewhere else's authority. Sovereignty: we choose to host; the
+    origin instance remains authoritative for what the asset IS.
+    """
+    return federation_value_flow_service.mirror_asset(manifest)
+
+
+@router.get(
+    "/federation/value/mirrors",
+    response_model=list[AssetMirrorRecord],
+    summary="List federation mirrors (assets here whose authority lives elsewhere)",
+)
+async def list_mirrors(
+    origin_instance_id: str | None = Query(default=None),
+) -> list[AssetMirrorRecord]:
+    """List mirrors, optionally filtered by origin instance."""
+    return federation_value_flow_service.list_mirrors(origin_instance_id=origin_instance_id)
+
+
+@router.post(
+    "/federation/value/read-attribution",
+    response_model=ReadAttributionAck,
+    status_code=201,
+    summary="Accept a signed read-attribution envelope from a serving instance",
+)
+async def receive_read_attribution(
+    envelope: ReadAttributionEnvelope,
+) -> ReadAttributionAck:
+    """Accept an attribution envelope from a peer that served one of our assets.
+
+    Verifies the signature against the secret we hold for the serving
+    instance. On success: records the attestation and bridges the read
+    into local read-tracking under a federated reader_id so settlement
+    sees it. On signature failure: 401 with no record.
+
+    Sovereignty: this instance is authoritative for the asset; the peer is
+    authoritative for the reader. Federation is opt-in on both sides — an
+    unregistered peer is refused (no shared secret = no verifiable claim).
+    """
+    try:
+        return federation_value_flow_service.receive_read_attribution(envelope)
+    except SignatureRejection as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+@router.get(
+    "/federation/value/read-attestations",
+    response_model=FederatedReadAttestationListResponse,
+    summary="List read attestations received from peers",
+)
+async def list_read_attestations(
+    asset_origin_id: str | None = Query(default=None),
+    reader_instance_id: str | None = Query(default=None),
+    status: str | None = Query(
+        default=None,
+        description="Filter: received | verified | settled | rejected",
+    ),
+) -> FederatedReadAttestationListResponse:
+    """List federated read attestations stored locally.
+
+    Each attestation is one signed envelope received from a peer. The
+    received-attestations table is our durable claim that the read
+    happened — even if the peer goes offline later.
+    """
+    return federation_value_flow_service.list_read_attestations(
+        asset_origin_id=asset_origin_id,
+        reader_instance_id=reader_instance_id,
+        status=status,
+    )
+
+
+@router.post(
+    "/federation/value/settlement-share/compute",
+    response_model=ComputeFederatedSharesResponse,
+    summary="Compute per-peer settlement envelopes from federated read attestations",
+)
+async def compute_federated_shares(
+    request: ComputeFederatedSharesRequest,
+) -> ComputeFederatedSharesResponse:
+    """Compute settlement envelopes for federated reads in the window.
+
+    For each peer with attestations in [period_start, period_end), produce
+    one signed envelope declaring the peer's serving share. Envelopes are
+    stored in the outbox; transport to the peer is the caller's choice.
+    Default serving share is 20%; an asset-owner may override per request.
+    """
+    return federation_value_flow_service.compute_federated_shares(request)
+
+
+@router.get(
+    "/federation/value/settlement-share/outbox",
+    response_model=list[SettlementShareEnvelope],
+    summary="List settlement envelopes we have computed for peers",
+)
+async def list_outbox(
+    serving_instance_id: str | None = Query(default=None),
+) -> list[SettlementShareEnvelope]:
+    """Walk the outbox of envelopes WE signed for peers.
+
+    Useful both for audit (what did we attest we owed?) and re-transport
+    (peer didn't ack the first time → fetch and re-POST to the peer's
+    `/api/federation/value/settlement-share` endpoint).
+    """
+    return federation_value_flow_service.list_outbox(
+        serving_instance_id=serving_instance_id
+    )
+
+
+@router.post(
+    "/federation/value/settlement-share",
+    response_model=SettlementShareAck,
+    status_code=201,
+    summary="Accept a settlement envelope from a peer that owes us a serving fee",
+)
+async def receive_settlement_share(
+    envelope: SettlementShareEnvelope,
+) -> SettlementShareAck:
+    """Accept a settlement envelope from a peer (we are the serving instance).
+
+    Verifies the signature against the secret we hold for the origin.
+    On success: logs into the inbox. On failure: 401 with no record.
+    CC transfer itself is a downstream breath — the inbox is the durable
+    claim that the peer attested to this share.
+    """
+    try:
+        return federation_value_flow_service.receive_settlement_share(envelope)
+    except SignatureRejection as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+@router.get(
+    "/federation/value/settlement-share/inbox",
+    response_model=SettlementInboxListResponse,
+    summary="List settlement envelopes received from peers (we are owed)",
+)
+async def list_inbox(
+    origin_instance_id: str | None = Query(default=None),
+) -> SettlementInboxListResponse:
+    """Walk the inbox of envelopes peers signed and sent to us.
+
+    Each entry is a peer's attestation that they owe us a serving fee for
+    a period. The downstream CC settlement step reads from here.
+    """
+    return federation_value_flow_service.list_inbox(
+        origin_instance_id=origin_instance_id
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 234
+**Total files**: 235
 
 | File | Purpose |
 |---|---|
@@ -98,6 +98,7 @@
 | [federation_push_service.py](federation_push_service.py) | Client-side push logic for federation measurement summaries (Spec 131). |
 | [federation_service.py](federation_service.py) | Federation service: receive, validate, and integrate remote instance data. |
 | [federation_substrate_service.py](federation_substrate_service.py) | federation_substrate_service — freedom-preserving canonical exchange. |
+| [federation_value_flow_service.py](federation_value_flow_service.py) | federation_value_flow_service — freedom-preserving CC distribution across instances. |
 | [field_story_mcp_tools.py](field_story_mcp_tools.py) | MCP registry entries for published field stories. |
 | [field_story_service.py](field_story_service.py) | Published field-story artifacts and contribution hooks. |
 | [field_view_attribution_adjustment_service.py](field_view_attribution_adjustment_service.py) | Living append-only adjustments for field-story view attribution flow. |

--- a/api/app/services/federation_value_flow_service.py
+++ b/api/app/services/federation_value_flow_service.py
@@ -1,0 +1,817 @@
+"""federation_value_flow_service — freedom-preserving CC distribution across instances.
+
+When an asset on instance A is mirrored to instance B and a reader on B reads
+it, value can flow back to A's creator without either side surrendering
+authority. The service has three movements:
+
+  - `mirror_asset(manifest)` — record that we are hosting an asset whose
+    authority lives on another instance. We hold local_asset_id; the origin
+    instance holds the truth about the asset's identity and the creator's
+    payment address.
+
+  - `receive_read_attribution(envelope)` — the serving instance sends us a
+    signed attribution envelope for one read of one of our assets. We verify
+    the signature with the secret we hold for that peer, record the
+    attestation, and bridge it into read_tracking so settlement sees it.
+
+  - `compute_federated_shares(period_start, period_end)` — at settlement
+    time we walk our received attestations and produce one signed envelope
+    per peer (the share owed for serving our content). Envelopes are stored
+    in the outgoing log; transport to the peer is the caller's choice
+    (sync POST, batched push, or a future on-chain settlement).
+
+  - `receive_settlement_share(envelope)` — symmetric: when a peer settles
+    OUR serving fee, we verify and log into the inbox.
+
+What this service does NOT do:
+  - Move CC on a chain — that's a separate, downstream breath
+  - Decide whether to mirror — that's the human/maintainer choice
+  - Coerce a peer into accepting attestations — peers may decline
+  - Hold authority over a peer's reader data — `reader_subject` is opaque
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+from sqlalchemy import Boolean, Float, Index, Integer, String, Text, inspect, text
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from app.models.federation import (
+    AssetMirrorManifest,
+    AssetMirrorRecord,
+    ComputeFederatedSharesRequest,
+    ComputeFederatedSharesResponse,
+    DEFAULT_FEDERATED_CREATOR_SHARE,
+    DEFAULT_FEDERATED_SERVING_SHARE,
+    FederatedReadAttestationListResponse,
+    FederatedReadAttestationOut,
+    ReadAttributionAck,
+    ReadAttributionEnvelope,
+    SettlementInboxEntryOut,
+    SettlementInboxListResponse,
+    SettlementShareAck,
+    SettlementShareEnvelope,
+)
+from app.services import federation_service, unified_db as _udb
+from app.services.unified_db import Base
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ORM models
+# ---------------------------------------------------------------------------
+
+
+class FederatedAssetMirrorRecord(Base):
+    """An asset hosted here whose authority lives on another instance.
+
+    Each row says: this local_asset_id is a mirror of origin_asset_id on
+    origin_instance_id. We carry origin_url for direct linking and
+    origin_payment_address so settlement envelopes know where the creator
+    receives CC. Sovereignty: we hold the local row, but the origin
+    instance is authoritative for what the asset IS.
+    """
+
+    __tablename__ = "federation_asset_mirrors"
+
+    local_asset_id: Mapped[str] = mapped_column(String, primary_key=True)
+    origin_instance_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    origin_asset_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    origin_url: Mapped[str] = mapped_column(String, nullable=False)
+    origin_payment_address: Mapped[str | None] = mapped_column(String, nullable=True)
+    mirrored_at: Mapped[str] = mapped_column(String, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "idx_fam_origin",
+            "origin_instance_id",
+            "origin_asset_id",
+        ),
+    )
+
+
+class FederatedReadAttestationRecord(Base):
+    """A read of one of our assets, attested by the serving instance.
+
+    The serving instance signs the envelope with the secret we share with
+    them; we verify on receipt. status taxonomy:
+
+      - received : stored without signature verification (peer secret missing)
+      - verified : signature checked and matches
+      - settled  : included in an outgoing settlement envelope to the peer
+      - rejected : signature failed verification (envelope discarded — kept
+                   here only when explicitly stored for audit; the default
+                   path returns 401 and stores nothing)
+    """
+
+    __tablename__ = "federation_read_attestations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    asset_origin_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    reader_instance_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    reader_subject: Mapped[str | None] = mapped_column(String, nullable=True)
+    read_type: Mapped[str] = mapped_column(String, nullable=False, default="free")
+    cc_amount: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    concept_resonance_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    observed_at: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    received_at: Mapped[str] = mapped_column(String, nullable=False)
+    signature: Mapped[str] = mapped_column(String, nullable=False)
+    signature_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="received", index=True)
+
+    __table_args__ = (
+        Index(
+            "idx_fra_reader_observed",
+            "reader_instance_id",
+            "observed_at",
+        ),
+    )
+
+
+class FederatedSettlementInboxRecord(Base):
+    """A settlement envelope received from a peer that owes us a serving fee.
+
+    The peer (origin instance for some asset we served) computed our share
+    from attestations we sent them and posted this envelope. We verify the
+    signature and store; actual CC transfer is downstream — the inbox is a
+    durable record of what we are owed.
+    """
+
+    __tablename__ = "federation_settlement_inbox"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    origin_instance_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    serving_instance_id: Mapped[str] = mapped_column(String, nullable=False)
+    period_start: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    period_end: Mapped[str] = mapped_column(String, nullable=False)
+    read_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cc_amount_to_serving: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    cc_amount_to_creator: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    asset_breakdown_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    signature: Mapped[str] = mapped_column(String, nullable=False)
+    signature_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    received_at: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="received", index=True)
+
+
+class FederatedSettlementOutboxRecord(Base):
+    """A settlement envelope we computed and signed, owed to a peer.
+
+    Symmetric with the inbox: when we are origin, the peer is the serving
+    side. We log what we sent so we can audit and re-send if the transport
+    failed.
+    """
+
+    __tablename__ = "federation_settlement_outbox"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    serving_instance_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    period_start: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    period_end: Mapped[str] = mapped_column(String, nullable=False)
+    read_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cc_amount_to_serving: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    cc_amount_to_creator: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    asset_breakdown_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    signature: Mapped[str] = mapped_column(String, nullable=False)
+    computed_at: Mapped[str] = mapped_column(String, nullable=False)
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_schema() -> None:
+    _udb.ensure_schema()
+
+
+def _session() -> Session:
+    return _udb.session()
+
+
+# ---------------------------------------------------------------------------
+# Signing — symmetric HMAC-SHA256
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_attribution_payload(envelope: ReadAttributionEnvelope) -> str:
+    """Deterministic JSON for signing/verifying a read-attribution envelope.
+
+    Sorted keys, no whitespace. The signature field is excluded — it cannot
+    sign itself.
+    """
+    dump = envelope.model_dump(mode="json")
+    dump.pop("signature", None)
+    return json.dumps(dump, sort_keys=True, separators=(",", ":"))
+
+
+def sign_read_attribution(
+    envelope_without_signature: dict,
+    secret: str,
+) -> str:
+    """Compute the HMAC-SHA256 signature for a read-attribution envelope.
+
+    `envelope_without_signature` is the full dict EXCEPT the signature
+    field; the caller is the serving instance signing what it is about to
+    send. The pair (envelope dict, signature) is what travels.
+    """
+    if not secret:
+        raise ValueError("Cannot sign read attribution: secret is empty")
+    payload = json.dumps(
+        envelope_without_signature, sort_keys=True, separators=(",", ":")
+    )
+    return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_read_attribution(envelope: ReadAttributionEnvelope, secret: str) -> bool:
+    """Verify the signature on a read-attribution envelope."""
+    if not secret:
+        return False
+    payload = _canonical_attribution_payload(envelope)
+    return federation_service.verify_payload_signature(payload, envelope.signature, secret)
+
+
+def _canonical_settlement_payload(envelope: SettlementShareEnvelope) -> str:
+    dump = envelope.model_dump(mode="json")
+    dump.pop("signature", None)
+    return json.dumps(dump, sort_keys=True, separators=(",", ":"))
+
+
+def sign_settlement_share(envelope_without_signature: dict, secret: str) -> str:
+    if not secret:
+        raise ValueError("Cannot sign settlement share: secret is empty")
+    payload = json.dumps(
+        envelope_without_signature, sort_keys=True, separators=(",", ":")
+    )
+    return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_settlement_share(envelope: SettlementShareEnvelope, secret: str) -> bool:
+    if not secret:
+        return False
+    payload = _canonical_settlement_payload(envelope)
+    return federation_service.verify_payload_signature(
+        payload, envelope.signature, secret
+    )
+
+
+# ---------------------------------------------------------------------------
+# Federated reader id encoding
+# ---------------------------------------------------------------------------
+
+FEDERATED_READER_PREFIX = "federated:"
+
+
+def federated_reader_id(reader_instance_id: str, reader_subject: str | None) -> str:
+    """The reader_id under which a federated read is recorded locally.
+
+    Encoding: `federated:<instance_id>:<subject>`. The local read-tracking
+    service treats this opaquely — aggregations work, settlement sees the
+    read, and the prefix lets us identify federated reads later for the
+    settlement-share computation.
+    """
+    subject = reader_subject or "anonymous"
+    return f"{FEDERATED_READER_PREFIX}{reader_instance_id}:{subject}"
+
+
+def is_federated_reader_id(reader_id: str | None) -> bool:
+    return bool(reader_id) and reader_id.startswith(FEDERATED_READER_PREFIX)
+
+
+def parse_federated_reader_id(reader_id: str) -> tuple[str, str] | None:
+    """Return (instance_id, subject) for a federated reader_id, or None."""
+    if not is_federated_reader_id(reader_id):
+        return None
+    rest = reader_id[len(FEDERATED_READER_PREFIX) :]
+    if ":" not in rest:
+        return rest, "anonymous"
+    instance_id, subject = rest.split(":", 1)
+    return instance_id, subject
+
+
+# ---------------------------------------------------------------------------
+# Mirror operation — peer asks us to host their asset
+# ---------------------------------------------------------------------------
+
+
+def mirror_asset(manifest: AssetMirrorManifest) -> AssetMirrorRecord:
+    """Record a federation mirror for an asset we are hosting.
+
+    Idempotent: a second call with the same local_asset_id updates the
+    origin fields. The mirror table is THIS instance's view of which of
+    our assets actually live somewhere else's authority; nothing about
+    this call touches the origin instance.
+    """
+    _ensure_schema()
+    now_iso = manifest.mirrored_at or _now_iso()
+    with _session() as session:
+        existing = (
+            session.query(FederatedAssetMirrorRecord)
+            .filter_by(local_asset_id=manifest.local_asset_id)
+            .one_or_none()
+        )
+        if existing is None:
+            row = FederatedAssetMirrorRecord(
+                local_asset_id=manifest.local_asset_id,
+                origin_instance_id=manifest.origin_instance_id,
+                origin_asset_id=manifest.origin_asset_id,
+                origin_url=manifest.origin_url,
+                origin_payment_address=manifest.origin_payment_address,
+                mirrored_at=now_iso,
+            )
+            session.add(row)
+        else:
+            existing.origin_instance_id = manifest.origin_instance_id
+            existing.origin_asset_id = manifest.origin_asset_id
+            existing.origin_url = manifest.origin_url
+            existing.origin_payment_address = manifest.origin_payment_address
+            existing.mirrored_at = now_iso
+        session.flush()
+    return AssetMirrorRecord(
+        local_asset_id=manifest.local_asset_id,
+        origin_instance_id=manifest.origin_instance_id,
+        origin_asset_id=manifest.origin_asset_id,
+        origin_url=manifest.origin_url,
+        origin_payment_address=manifest.origin_payment_address,
+        mirrored_at=now_iso,
+    )
+
+
+def get_mirror(local_asset_id: str) -> AssetMirrorRecord | None:
+    _ensure_schema()
+    with _session() as session:
+        row = (
+            session.query(FederatedAssetMirrorRecord)
+            .filter_by(local_asset_id=local_asset_id)
+            .one_or_none()
+        )
+        if row is None:
+            return None
+        return AssetMirrorRecord(
+            local_asset_id=row.local_asset_id,
+            origin_instance_id=row.origin_instance_id,
+            origin_asset_id=row.origin_asset_id,
+            origin_url=row.origin_url,
+            origin_payment_address=row.origin_payment_address,
+            mirrored_at=row.mirrored_at,
+        )
+
+
+def list_mirrors(origin_instance_id: str | None = None) -> list[AssetMirrorRecord]:
+    _ensure_schema()
+    with _session() as session:
+        q = session.query(FederatedAssetMirrorRecord)
+        if origin_instance_id:
+            q = q.filter_by(origin_instance_id=origin_instance_id)
+        rows = q.order_by(FederatedAssetMirrorRecord.local_asset_id).all()
+        return [
+            AssetMirrorRecord(
+                local_asset_id=r.local_asset_id,
+                origin_instance_id=r.origin_instance_id,
+                origin_asset_id=r.origin_asset_id,
+                origin_url=r.origin_url,
+                origin_payment_address=r.origin_payment_address,
+                mirrored_at=r.mirrored_at,
+            )
+            for r in rows
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Read attribution — peer tells us about a read of our asset
+# ---------------------------------------------------------------------------
+
+
+class SignatureRejection(Exception):
+    """Raised when a federation envelope's signature cannot be verified."""
+
+
+def receive_read_attribution(envelope: ReadAttributionEnvelope) -> ReadAttributionAck:
+    """Accept a signed read-attribution envelope from a serving instance.
+
+    Verifies the signature against the secret we hold for the serving
+    instance. On success, records the attestation, bridges the read into
+    read_tracking_service under a federated reader_id, and returns ack.
+    On signature failure, raises SignatureRejection — nothing is stored.
+
+    Sovereignty notes:
+      - We are authoritative for the asset_origin_id; the envelope's
+        reader_instance_id is authoritative for the reader.
+      - If the peer is not registered, the secret is missing and we
+        reject the envelope. Federation is opt-in on both sides.
+    """
+    _ensure_schema()
+    peer = federation_service.get_instance(envelope.reader_instance_id)
+    peer_secret = (peer.public_key if peer else None) or None
+
+    if peer_secret is None:
+        raise SignatureRejection(
+            f"Cannot verify read attribution: peer {envelope.reader_instance_id!r} "
+            f"is not registered or has no signing secret on file."
+        )
+
+    if not verify_read_attribution(envelope, peer_secret):
+        raise SignatureRejection(
+            f"Read attribution signature did not verify for peer "
+            f"{envelope.reader_instance_id!r}."
+        )
+
+    now_iso = _now_iso()
+    reader_id = federated_reader_id(envelope.reader_instance_id, envelope.reader_subject)
+    resonance_dict = dict(envelope.concept_resonance) if envelope.concept_resonance else None
+
+    with _session() as session:
+        row = FederatedReadAttestationRecord(
+            asset_origin_id=envelope.asset_origin_id,
+            reader_instance_id=envelope.reader_instance_id,
+            reader_subject=envelope.reader_subject,
+            read_type=envelope.read_type,
+            cc_amount=float(envelope.cc_amount),
+            concept_resonance_json=(
+                json.dumps(resonance_dict) if resonance_dict else None
+            ),
+            observed_at=envelope.observed_at,
+            received_at=now_iso,
+            signature=envelope.signature,
+            signature_verified=True,
+            status="verified",
+        )
+        session.add(row)
+        session.flush()
+
+    # Bridge into read_tracking so settlement sees this read like any other.
+    # Soft-fail: federation accounting still works even if the local
+    # read-tracking layer is unreachable during this call.
+    try:
+        from app.services import read_tracking_service
+
+        read_tracking_service.record_read(
+            envelope.asset_origin_id,
+            reader_id=reader_id,
+            read_type=envelope.read_type,
+            cc_amount=float(envelope.cc_amount),
+            concept_resonance_snapshot=resonance_dict,
+        )
+    except Exception as exc:
+        logger.warning(
+            "federation_value_flow: read_tracking bridge failed for asset=%s reader=%s: %s",
+            envelope.asset_origin_id,
+            reader_id,
+            exc,
+        )
+
+    return ReadAttributionAck(
+        asset_origin_id=envelope.asset_origin_id,
+        reader_instance_id=envelope.reader_instance_id,
+        status="verified",
+        federated_reader_id=reader_id,
+        note="signature verified and read bridged to local read-tracking",
+    )
+
+
+def list_read_attestations(
+    asset_origin_id: str | None = None,
+    reader_instance_id: str | None = None,
+    status: str | None = None,
+) -> FederatedReadAttestationListResponse:
+    _ensure_schema()
+    with _session() as session:
+        q = session.query(FederatedReadAttestationRecord)
+        if asset_origin_id:
+            q = q.filter_by(asset_origin_id=asset_origin_id)
+        if reader_instance_id:
+            q = q.filter_by(reader_instance_id=reader_instance_id)
+        if status:
+            q = q.filter_by(status=status)
+        rows = q.order_by(FederatedReadAttestationRecord.observed_at).all()
+        out = [
+            FederatedReadAttestationOut(
+                id=r.id,
+                asset_origin_id=r.asset_origin_id,
+                reader_instance_id=r.reader_instance_id,
+                reader_subject=r.reader_subject,
+                read_type=r.read_type,
+                cc_amount=float(r.cc_amount or 0),
+                observed_at=r.observed_at,
+                received_at=r.received_at,
+                status=r.status,
+                signature_verified=bool(r.signature_verified),
+            )
+            for r in rows
+        ]
+    return FederatedReadAttestationListResponse(
+        asset_origin_id=asset_origin_id,
+        reader_instance_id=reader_instance_id,
+        attestations=out,
+        count=len(out),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Settlement share computation — we are origin; peer served our content
+# ---------------------------------------------------------------------------
+
+
+def _in_period(observed_at: str, period_start: str, period_end: str) -> bool:
+    """observed_at lies in [period_start, period_end)."""
+    return period_start <= observed_at < period_end
+
+
+def compute_federated_shares(
+    request: ComputeFederatedSharesRequest,
+) -> ComputeFederatedSharesResponse:
+    """Compute per-peer settlement envelopes for federated reads in a window.
+
+    We are the asset's origin; peers served our content and earned a share.
+    For each peer with attestations in the window:
+
+      1. Sum total CC across their reads of our assets
+      2. Compute their share = total * serving_share
+      3. Compute the creator's share = total * creator_share
+      4. Sign the envelope with the secret we share with the peer
+      5. Store in the outbox; optionally flip attestations to status=settled
+      6. Return envelopes — caller transports them
+    """
+    _ensure_schema()
+    serving_share = (
+        request.serving_share
+        if request.serving_share is not None
+        else DEFAULT_FEDERATED_SERVING_SHARE
+    )
+    creator_share = 1.0 - serving_share
+
+    envelopes: list[SettlementShareEnvelope] = []
+    total_to_serving = 0.0
+    total_to_creator = 0.0
+    settled_count = 0
+
+    with _session() as session:
+        q = session.query(FederatedReadAttestationRecord).filter(
+            FederatedReadAttestationRecord.observed_at >= request.period_start,
+            FederatedReadAttestationRecord.observed_at < request.period_end,
+            FederatedReadAttestationRecord.status.in_(("received", "verified")),
+        )
+        if request.serving_instance_id:
+            q = q.filter_by(reader_instance_id=request.serving_instance_id)
+        rows = q.all()
+
+        # Group by serving instance, then by asset.
+        by_peer: dict[str, list[FederatedReadAttestationRecord]] = {}
+        for r in rows:
+            by_peer.setdefault(r.reader_instance_id, []).append(r)
+
+        self_instance_id = federation_service._self_instance_id()
+
+        for peer_instance_id, peer_rows in by_peer.items():
+            peer = federation_service.get_instance(peer_instance_id)
+            peer_secret = (peer.public_key if peer else None) or None
+            if not peer_secret:
+                logger.warning(
+                    "federation_value_flow: skipping settlement for peer %s: no signing secret on file",
+                    peer_instance_id,
+                )
+                continue
+
+            per_asset: dict[str, dict] = {}
+            peer_total = 0.0
+            for r in peer_rows:
+                entry = per_asset.setdefault(
+                    r.asset_origin_id,
+                    {"asset_origin_id": r.asset_origin_id, "read_count": 0, "cc_amount_total": 0.0},
+                )
+                entry["read_count"] += 1
+                entry["cc_amount_total"] += float(r.cc_amount or 0)
+                peer_total += float(r.cc_amount or 0)
+
+            cc_to_serving = round(peer_total * serving_share, 8)
+            cc_to_creator = round(peer_total * creator_share, 8)
+
+            breakdown = [
+                {
+                    "asset_origin_id": entry["asset_origin_id"],
+                    "read_count": entry["read_count"],
+                    "cc_amount_to_serving": round(
+                        entry["cc_amount_total"] * serving_share, 8
+                    ),
+                }
+                for entry in sorted(per_asset.values(), key=lambda e: e["asset_origin_id"])
+            ]
+
+            unsigned = {
+                "origin_instance_id": self_instance_id,
+                "serving_instance_id": peer_instance_id,
+                "period_start": request.period_start,
+                "period_end": request.period_end,
+                "read_count": len(peer_rows),
+                "cc_amount_to_serving": cc_to_serving,
+                "cc_amount_to_creator": cc_to_creator,
+                "serving_share": serving_share,
+                "creator_share": creator_share,
+                "asset_breakdown": breakdown,
+            }
+            signature = sign_settlement_share(unsigned, peer_secret)
+            envelope = SettlementShareEnvelope(**unsigned, signature=signature)
+
+            session.add(
+                FederatedSettlementOutboxRecord(
+                    serving_instance_id=peer_instance_id,
+                    period_start=request.period_start,
+                    period_end=request.period_end,
+                    read_count=len(peer_rows),
+                    cc_amount_to_serving=cc_to_serving,
+                    cc_amount_to_creator=cc_to_creator,
+                    asset_breakdown_json=json.dumps(breakdown),
+                    signature=signature,
+                    computed_at=_now_iso(),
+                )
+            )
+
+            if request.mark_settled:
+                for r in peer_rows:
+                    r.status = "settled"
+                    settled_count += 1
+
+            envelopes.append(envelope)
+            total_to_serving += cc_to_serving
+            total_to_creator += cc_to_creator
+
+        session.flush()
+
+    return ComputeFederatedSharesResponse(
+        period_start=request.period_start,
+        period_end=request.period_end,
+        envelopes=envelopes,
+        serving_share=serving_share,
+        creator_share=creator_share,
+        total_cc_to_serving=round(total_to_serving, 8),
+        total_cc_to_creator=round(total_to_creator, 8),
+        attestations_settled=settled_count,
+    )
+
+
+def list_outbox(
+    serving_instance_id: str | None = None,
+) -> list[SettlementShareEnvelope]:
+    """Walk the settlement outbox — envelopes WE computed and signed."""
+    _ensure_schema()
+    with _session() as session:
+        q = session.query(FederatedSettlementOutboxRecord)
+        if serving_instance_id:
+            q = q.filter_by(serving_instance_id=serving_instance_id)
+        rows = q.order_by(FederatedSettlementOutboxRecord.computed_at).all()
+        self_id = federation_service._self_instance_id()
+        return [
+            SettlementShareEnvelope(
+                origin_instance_id=self_id,
+                serving_instance_id=r.serving_instance_id,
+                period_start=r.period_start,
+                period_end=r.period_end,
+                read_count=r.read_count,
+                cc_amount_to_serving=float(r.cc_amount_to_serving or 0),
+                cc_amount_to_creator=float(r.cc_amount_to_creator or 0),
+                serving_share=DEFAULT_FEDERATED_SERVING_SHARE,
+                creator_share=DEFAULT_FEDERATED_CREATOR_SHARE,
+                asset_breakdown=json.loads(r.asset_breakdown_json) if r.asset_breakdown_json else [],
+                signature=r.signature,
+            )
+            for r in rows
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Settlement inbox — peer settled OUR serving fee
+# ---------------------------------------------------------------------------
+
+
+def receive_settlement_share(envelope: SettlementShareEnvelope) -> SettlementShareAck:
+    """Accept a settlement envelope FROM a peer who owes us a serving fee.
+
+    Verifies the signature against the secret we hold for the origin
+    instance. Records into the inbox. CC transfer itself is downstream —
+    the inbox is the durable claim that the peer attested this share.
+    """
+    _ensure_schema()
+    origin = federation_service.get_instance(envelope.origin_instance_id)
+    origin_secret = (origin.public_key if origin else None) or None
+    if origin_secret is None:
+        raise SignatureRejection(
+            f"Cannot verify settlement share: origin {envelope.origin_instance_id!r} "
+            f"is not registered or has no signing secret on file."
+        )
+    if not verify_settlement_share(envelope, origin_secret):
+        raise SignatureRejection(
+            f"Settlement share signature did not verify for origin "
+            f"{envelope.origin_instance_id!r}."
+        )
+
+    now_iso = _now_iso()
+    with _session() as session:
+        row = FederatedSettlementInboxRecord(
+            origin_instance_id=envelope.origin_instance_id,
+            serving_instance_id=envelope.serving_instance_id,
+            period_start=envelope.period_start,
+            period_end=envelope.period_end,
+            read_count=envelope.read_count,
+            cc_amount_to_serving=float(envelope.cc_amount_to_serving),
+            cc_amount_to_creator=float(envelope.cc_amount_to_creator),
+            asset_breakdown_json=json.dumps(envelope.asset_breakdown),
+            signature=envelope.signature,
+            signature_verified=True,
+            received_at=now_iso,
+            status="verified",
+        )
+        session.add(row)
+        session.flush()
+        inbox_id = row.id
+
+    return SettlementShareAck(
+        inbox_id=inbox_id,
+        origin_instance_id=envelope.origin_instance_id,
+        status="verified",
+        note="signature verified and envelope logged to inbox",
+    )
+
+
+def list_inbox(
+    origin_instance_id: str | None = None,
+) -> SettlementInboxListResponse:
+    _ensure_schema()
+    with _session() as session:
+        q = session.query(FederatedSettlementInboxRecord)
+        if origin_instance_id:
+            q = q.filter_by(origin_instance_id=origin_instance_id)
+        rows = q.order_by(FederatedSettlementInboxRecord.received_at).all()
+        entries = [
+            SettlementInboxEntryOut(
+                id=r.id,
+                origin_instance_id=r.origin_instance_id,
+                period_start=r.period_start,
+                period_end=r.period_end,
+                read_count=r.read_count,
+                cc_amount_to_serving=float(r.cc_amount_to_serving or 0),
+                cc_amount_to_creator=float(r.cc_amount_to_creator or 0),
+                received_at=r.received_at,
+                status=r.status,
+                signature_verified=bool(r.signature_verified),
+            )
+            for r in rows
+        ]
+    return SettlementInboxListResponse(
+        origin_instance_id=origin_instance_id,
+        entries=entries,
+        count=len(entries),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test reset
+# ---------------------------------------------------------------------------
+
+
+def _reset_for_tests() -> None:
+    """Clear all federation value-flow rows. Used by test fixtures."""
+    _ensure_schema()
+    with _session() as session:
+        session.query(FederatedAssetMirrorRecord).delete()
+        session.query(FederatedReadAttestationRecord).delete()
+        session.query(FederatedSettlementInboxRecord).delete()
+        session.query(FederatedSettlementOutboxRecord).delete()
+
+
+__all__ = [
+    "DEFAULT_FEDERATED_CREATOR_SHARE",
+    "DEFAULT_FEDERATED_SERVING_SHARE",
+    "FEDERATED_READER_PREFIX",
+    "FederatedAssetMirrorRecord",
+    "FederatedReadAttestationRecord",
+    "FederatedSettlementInboxRecord",
+    "FederatedSettlementOutboxRecord",
+    "SignatureRejection",
+    "compute_federated_shares",
+    "federated_reader_id",
+    "get_mirror",
+    "is_federated_reader_id",
+    "list_inbox",
+    "list_mirrors",
+    "list_outbox",
+    "list_read_attestations",
+    "mirror_asset",
+    "parse_federated_reader_id",
+    "receive_read_attribution",
+    "receive_settlement_share",
+    "sign_read_attribution",
+    "sign_settlement_share",
+    "verify_read_attribution",
+    "verify_settlement_share",
+]

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 209
+**Total files**: 210
 
 | File | Purpose |
 |---|---|
@@ -67,6 +67,7 @@
 | [test_federation_message_readback.py](test_federation_message_readback.py) | _no top-of-file purpose_ |
 | [test_federation_substance.py](test_federation_substance.py) | Federation substance payload — round-trip test. |
 | [test_federation_substrate_exchange.py](test_federation_substrate_exchange.py) | Acceptance tests for the federated substrate canonical exchange. |
+| [test_federation_value_flow.py](test_federation_value_flow.py) | Acceptance tests for the federated value flow. |
 | [test_field_story_agent_surface.py](test_field_story_agent_surface.py) | _no top-of-file purpose_ |
 | [test_field_story_runtime_docs.py](test_field_story_runtime_docs.py) | _no top-of-file purpose_ |
 | [test_field_story_trace_index.py](test_field_story_trace_index.py) | _no top-of-file purpose_ |

--- a/api/tests/test_federation_value_flow.py
+++ b/api/tests/test_federation_value_flow.py
@@ -1,0 +1,472 @@
+"""Acceptance tests for the federated value flow.
+
+When an asset on instance A is mirrored to instance B and B serves a read
+of A's content, value should flow back to A's creator without either
+side surrendering authority.
+
+The tests demonstrate the freedom-preserving shape:
+
+- Mirror an asset and the origin fields persist (A authoritative for assets).
+- Receive a signed read-attribution from a serving peer, verify, bridge it
+  into local read-tracking under a federated reader_id.
+- Reject envelopes with bad or missing signatures — 401, nothing stored.
+- Settlement-share computation walks federated attestations, produces
+  per-peer envelopes signed with the secret we share with each peer.
+- Outgoing envelopes land in our outbox; incoming envelopes (a peer settling
+  OUR serving fee) land in our inbox after signature verification.
+- Local-reader assertions still work alongside federated reads — federation
+  does not displace the existing read path; it sits next to it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.models.federation import (
+    AssetMirrorManifest,
+    ComputeFederatedSharesRequest,
+    FederatedInstance,
+    ReadAttributionEnvelope,
+    SettlementShareEnvelope,
+)
+from app.services import (
+    federation_service,
+    federation_value_flow_service,
+    read_tracking_service,
+)
+from app.services.federation_value_flow_service import (
+    FEDERATED_READER_PREFIX,
+    SignatureRejection,
+    federated_reader_id,
+    is_federated_reader_id,
+    parse_federated_reader_id,
+    sign_read_attribution,
+    sign_settlement_share,
+)
+
+BASE = "http://test"
+
+# Peer secrets used by the tests. The serving instance ("peer-b") signs
+# read-attribution envelopes; the origin instance ("peer-a") signs
+# settlement-share envelopes.
+PEER_B_SECRET = "peer-b-test-secret"
+PEER_A_SECRET = "peer-a-test-secret"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_offset(seconds: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_value_flow_state(monkeypatch):
+    """Reset value-flow tables and register the two test peers.
+
+    The origin instance (self) is configured via FEDERATION_INSTANCE_ID so
+    settlement envelopes carry a deterministic origin_instance_id. Both
+    peers register with their shared secret in `public_key` (the field is
+    historically named, but functions as the symmetric federation secret).
+    """
+    monkeypatch.setenv("FEDERATION_INSTANCE_ID", "self-instance")
+    monkeypatch.setenv("FEDERATION_INSTANCE_SECRET", "self-instance-secret")
+
+    federation_service._ensure_schema()
+    federation_value_flow_service._reset_for_tests()
+    read_tracking_service._reset_for_tests()
+
+    federation_service.register_instance(
+        FederatedInstance(
+            instance_id="peer-b",
+            name="Peer B (serving instance)",
+            endpoint_url="https://peer-b.example",
+            public_key=PEER_B_SECRET,
+            registered_at=_iso_now(),
+        )
+    )
+    federation_service.register_instance(
+        FederatedInstance(
+            instance_id="peer-a",
+            name="Peer A (origin instance)",
+            endpoint_url="https://peer-a.example",
+            public_key=PEER_A_SECRET,
+            registered_at=_iso_now(),
+        )
+    )
+
+    yield
+
+    federation_value_flow_service._reset_for_tests()
+    read_tracking_service._reset_for_tests()
+
+
+def _signed_attribution(
+    *,
+    asset_origin_id: str,
+    reader_instance_id: str,
+    reader_subject: str | None = "reader-42",
+    read_type: str = "paid",
+    cc_amount: float = 1.0,
+    observed_at: str | None = None,
+    secret: str = PEER_B_SECRET,
+    concept_resonance: dict | None = None,
+) -> ReadAttributionEnvelope:
+    unsigned = {
+        "asset_origin_id": asset_origin_id,
+        "reader_instance_id": reader_instance_id,
+        "reader_subject": reader_subject,
+        "read_type": read_type,
+        "cc_amount": cc_amount,
+        "concept_resonance": concept_resonance,
+        "observed_at": observed_at or _iso_now(),
+    }
+    signature = sign_read_attribution(unsigned, secret)
+    return ReadAttributionEnvelope(**unsigned, signature=signature)
+
+
+# ---------------------------------------------------------------------------
+# 1. Mirror records the origin fields verbatim.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mirror_asset_records_origin():
+    """POST mirror creates a FederatedAssetMirrorRecord with origin fields."""
+    payload = {
+        "local_asset_id": "local-asset-1",
+        "origin_instance_id": "peer-a",
+        "origin_asset_id": "origin-asset-1",
+        "origin_url": "https://peer-a.example/assets/origin-asset-1",
+        "origin_payment_address": "wallet:creator-on-peer-a",
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/federation/value/mirror-asset", json=payload)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["local_asset_id"] == "local-asset-1"
+        assert body["origin_instance_id"] == "peer-a"
+        assert body["origin_asset_id"] == "origin-asset-1"
+        assert body["origin_url"] == payload["origin_url"]
+        assert body["origin_payment_address"] == "wallet:creator-on-peer-a"
+        assert body["mirrored_at"]
+
+        # The list endpoint surfaces it.
+        r = await c.get("/api/federation/value/mirrors")
+        assert r.status_code == 200
+        mirrors = r.json()
+        assert len(mirrors) == 1
+        assert mirrors[0]["local_asset_id"] == "local-asset-1"
+
+
+# ---------------------------------------------------------------------------
+# 2. Signed read-attribution: stored + bridged into read tracking.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_attribution_envelope_recorded():
+    """A signed envelope from a registered peer verifies, stores, and bridges."""
+    envelope = _signed_attribution(
+        asset_origin_id="my-asset-1",
+        reader_instance_id="peer-b",
+        reader_subject="reader-99",
+        cc_amount=2.5,
+        concept_resonance={"lc-trust-over-fear": 0.8},
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/value/read-attribution",
+            json=envelope.model_dump(mode="json"),
+        )
+        assert r.status_code == 201, r.text
+        ack = r.json()
+        assert ack["status"] == "verified"
+        assert ack["federated_reader_id"] == "federated:peer-b:reader-99"
+
+        # The attestation surfaces in the list endpoint.
+        r = await c.get(
+            "/api/federation/value/read-attestations",
+            params={"asset_origin_id": "my-asset-1"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        att = body["attestations"][0]
+        assert att["signature_verified"] is True
+        assert att["status"] == "verified"
+        assert att["cc_amount"] == 2.5
+
+    # Bridge confirmed: read_tracking sees the read under the federated id.
+    events = read_tracking_service.get_read_events("my-asset-1")
+    assert len(events) == 1
+    bridged = events[0]
+    assert bridged["reader_id"] == "federated:peer-b:reader-99"
+    assert bridged["cc_amount"] == 2.5
+    assert bridged["read_type"] == "paid"
+
+
+# ---------------------------------------------------------------------------
+# 3. Bad signature: 401, nothing stored.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_attribution_rejects_unverifiable_signature():
+    """A tampered or unsigned envelope is rejected with no side effects."""
+    envelope = _signed_attribution(
+        asset_origin_id="my-asset-2",
+        reader_instance_id="peer-b",
+        reader_subject="reader-99",
+        cc_amount=1.0,
+    )
+    payload = envelope.model_dump(mode="json")
+    # Tamper: bump cc_amount after signing — signature no longer matches.
+    payload["cc_amount"] = 999.0
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/federation/value/read-attribution", json=payload)
+        assert r.status_code == 401, r.text
+
+        # Nothing stored.
+        r = await c.get(
+            "/api/federation/value/read-attestations",
+            params={"asset_origin_id": "my-asset-2"},
+        )
+        assert r.status_code == 200
+        assert r.json()["count"] == 0
+
+    # No bridged read either.
+    assert read_tracking_service.get_read_events("my-asset-2") == []
+
+    # Unregistered peer → also rejected.
+    unregistered = _signed_attribution(
+        asset_origin_id="my-asset-2",
+        reader_instance_id="peer-z-unknown",
+        reader_subject="reader-1",
+        secret="some-other-secret",
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/value/read-attribution",
+            json=unregistered.model_dump(mode="json"),
+        )
+        assert r.status_code == 401, r.text
+
+
+# ---------------------------------------------------------------------------
+# 4. Settlement computation walks federated reads for the period.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settlement_share_computes_for_federated_reads():
+    """Seed federated attestations, run compute, assert per-peer share."""
+    period_start = _iso_offset(-3600)
+    period_end = _iso_offset(3600)
+    observed = _iso_offset(0)
+
+    # Two reads of two of our assets, served by peer-b.
+    for asset_origin_id, cc in [("my-asset-1", 4.0), ("my-asset-2", 6.0)]:
+        env = _signed_attribution(
+            asset_origin_id=asset_origin_id,
+            reader_instance_id="peer-b",
+            reader_subject="reader-7",
+            cc_amount=cc,
+            observed_at=observed,
+        )
+        federation_value_flow_service.receive_read_attribution(env)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/value/settlement-share/compute",
+            json={
+                "period_start": period_start,
+                "period_end": period_end,
+                "mark_settled": True,
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["serving_share"] == 0.20
+        assert body["creator_share"] == 0.80
+        assert body["attestations_settled"] == 2
+        assert len(body["envelopes"]) == 1
+        env = body["envelopes"][0]
+        assert env["origin_instance_id"] == "self-instance"
+        assert env["serving_instance_id"] == "peer-b"
+        assert env["read_count"] == 2
+        # 10 CC total → 2 to serving, 8 to creator.
+        assert env["cc_amount_to_serving"] == 2.0
+        assert env["cc_amount_to_creator"] == 8.0
+        # Asset breakdown is per-asset, sorted by asset_origin_id.
+        assert len(env["asset_breakdown"]) == 2
+        assert env["asset_breakdown"][0]["asset_origin_id"] == "my-asset-1"
+        assert env["asset_breakdown"][0]["cc_amount_to_serving"] == 0.8
+        assert env["asset_breakdown"][1]["cc_amount_to_serving"] == 1.2
+
+
+# ---------------------------------------------------------------------------
+# 5. Outgoing settlement envelopes land in our outbox, signed for the peer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settlement_share_envelope_stored_in_outbox():
+    """Computed envelopes are durable in the outbox and verifiable by the peer's secret."""
+    period_start = _iso_offset(-3600)
+    period_end = _iso_offset(3600)
+    observed = _iso_offset(0)
+
+    env = _signed_attribution(
+        asset_origin_id="my-asset-3",
+        reader_instance_id="peer-b",
+        reader_subject="reader-5",
+        cc_amount=5.0,
+        observed_at=observed,
+    )
+    federation_value_flow_service.receive_read_attribution(env)
+
+    federation_value_flow_service.compute_federated_shares(
+        ComputeFederatedSharesRequest(
+            period_start=period_start,
+            period_end=period_end,
+        )
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.get(
+            "/api/federation/value/settlement-share/outbox",
+            params={"serving_instance_id": "peer-b"},
+        )
+        assert r.status_code == 200, r.text
+        envelopes = r.json()
+        assert len(envelopes) == 1
+        out = envelopes[0]
+        assert out["serving_instance_id"] == "peer-b"
+        assert out["read_count"] == 1
+        # 5 CC → 1 to serving, 4 to creator.
+        assert out["cc_amount_to_serving"] == 1.0
+        assert out["cc_amount_to_creator"] == 4.0
+        assert out["signature"]
+
+    # The signature is verifiable with the peer's secret — the peer (B)
+    # could now POST this envelope back to their own inbox endpoint.
+    envelope_model = SettlementShareEnvelope(**out)
+    assert federation_value_flow_service.verify_settlement_share(
+        envelope_model, PEER_B_SECRET
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Inbox receives signed envelopes from peers who owe us a serving fee.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_federated_settlement_inbox_lists_incoming():
+    """A peer's signed settlement envelope verifies and lands in our inbox."""
+    period_start = _iso_offset(-3600)
+    period_end = _iso_offset(3600)
+
+    unsigned = {
+        "origin_instance_id": "peer-a",
+        "serving_instance_id": "self-instance",
+        "period_start": period_start,
+        "period_end": period_end,
+        "read_count": 4,
+        "cc_amount_to_serving": 1.2,
+        "cc_amount_to_creator": 4.8,
+        "serving_share": 0.20,
+        "creator_share": 0.80,
+        "asset_breakdown": [
+            {
+                "asset_origin_id": "peer-a-asset-1",
+                "read_count": 4,
+                "cc_amount_to_serving": 1.2,
+            }
+        ],
+    }
+    signature = sign_settlement_share(unsigned, PEER_A_SECRET)
+    envelope = {**unsigned, "signature": signature}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post(
+            "/api/federation/value/settlement-share",
+            json=envelope,
+        )
+        assert r.status_code == 201, r.text
+        ack = r.json()
+        assert ack["status"] == "verified"
+        assert ack["inbox_id"] >= 1
+
+        # Inbox listing shows the entry.
+        r = await c.get(
+            "/api/federation/value/settlement-share/inbox",
+            params={"origin_instance_id": "peer-a"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        entry = body["entries"][0]
+        assert entry["origin_instance_id"] == "peer-a"
+        assert entry["signature_verified"] is True
+        assert entry["cc_amount_to_serving"] == 1.2
+
+    # Tampering on inbound is rejected.
+    bad = dict(envelope)
+    bad["cc_amount_to_serving"] = 9999.0
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as c:
+        r = await c.post("/api/federation/value/settlement-share", json=bad)
+        assert r.status_code == 401, r.text
+
+
+# ---------------------------------------------------------------------------
+# 7. Sovereignty: local reads remain untouched by federation work.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sovereignty_local_reads_unchanged_after_federation_work():
+    """Local-reader assertions still work alongside federated ones."""
+    # Local read.
+    read_tracking_service.record_read(
+        "asset-xyz",
+        reader_id="local-reader-1",
+        read_type="paid",
+        cc_amount=3.0,
+    )
+    # Federated read of the same asset.
+    env = _signed_attribution(
+        asset_origin_id="asset-xyz",
+        reader_instance_id="peer-b",
+        reader_subject="reader-9",
+        read_type="paid",
+        cc_amount=1.5,
+    )
+    federation_value_flow_service.receive_read_attribution(env)
+
+    events = read_tracking_service.get_read_events("asset-xyz")
+    assert len(events) == 2
+    reader_ids = {e["reader_id"] for e in events}
+    assert "local-reader-1" in reader_ids
+    assert "federated:peer-b:reader-9" in reader_ids
+
+    local_only = [
+        e for e in events if not is_federated_reader_id(e["reader_id"])
+    ]
+    fed_only = [e for e in events if is_federated_reader_id(e["reader_id"])]
+    assert len(local_only) == 1
+    assert len(fed_only) == 1
+    assert local_only[0]["cc_amount"] == 3.0
+    assert fed_only[0]["cc_amount"] == 1.5
+
+    # Parser round-trip.
+    parsed = parse_federated_reader_id(fed_only[0]["reader_id"])
+    assert parsed == ("peer-b", "reader-9")


### PR DESCRIPTION
## Summary

When content moves across sovereign instances, value can move with it without anyone surrendering authority. Each instance is the source-of-truth for its own truths (A: assets, B: readers); attestations are exchanged, not commanded; the fleet is the union of self-declared value flows.

Story-protocol's read tracking and settlement currently happen entirely within one instance. Without a federation protocol, creators are forced to choose ONE instance to host their work — exactly the unfreedom the federation principle warns against. This PR closes that gap.

## Endpoints

| Verb | Path | Purpose |
|---|---|---|
| POST | `/api/federation/value/mirror-asset` | Record we are hosting an asset whose authority lives on another instance |
| GET  | `/api/federation/value/mirrors` | List our federation mirrors |
| POST | `/api/federation/value/read-attribution` | Accept a signed envelope from a serving peer; bridge into local read-tracking under `reader_id=federated:<instance>:<subject>` |
| GET  | `/api/federation/value/read-attestations` | List received read attestations |
| POST | `/api/federation/value/settlement-share/compute` | Walk federated attestations in a window; sign per-peer envelopes; log in outbox |
| GET  | `/api/federation/value/settlement-share/outbox` | List envelopes we computed |
| POST | `/api/federation/value/settlement-share` | Accept a peer's signed settlement envelope; verify and log to inbox |
| GET  | `/api/federation/value/settlement-share/inbox` | List envelopes peers sent us |

All payloads carry HMAC-SHA256 signatures using the secret peers share via `FederatedInstanceRecord.public_key` (the same pattern the capability-manifest signing landed in PR #1976). Bad signature → 401, nothing stored. Unregistered peer → 401 (federation is opt-in on both sides).

## Sovereignty preserved

- A is authoritative for its assets; B is authoritative for its readers (`reader_subject` is opaque to A).
- Mirror is an explicit choice — no automatic asset pull.
- Compute does not auto-transmit envelopes; the caller chooses transport.
- CC transfer itself is downstream — the outbox/inbox are durable attestations, not on-chain settlement.
- Default split is 80% creator / 20% serving (inspired by the asset-renderer-plugin 85/15 split — the serving instance carries delivery cost the same way a renderer does); asset owners may override per request.

## Test plan

- [x] Run `cd api && pytest tests/test_federation_value_flow.py tests/test_federation_layer.py tests/test_federation_substrate_exchange.py tests/test_federation_capabilities.py tests/test_read_tracking.py tests/test_settlement_flow.py tests/test_story_protocol_e2e.py` — 67 pass
- [x] `test_mirror_asset_records_origin` — mirror record persists with origin fields
- [x] `test_read_attribution_envelope_recorded` — signed envelope verifies and bridges into read-tracking
- [x] `test_read_attribution_rejects_unverifiable_signature` — tampered envelope 401, no record, no bridge
- [x] `test_settlement_share_computes_for_federated_reads` — 10 CC across two assets → 2 to serving, 8 to creator
- [x] `test_settlement_share_envelope_stored_in_outbox` — outbox envelope is peer-verifiable with their secret
- [x] `test_federated_settlement_inbox_lists_incoming` — peer's signed envelope verifies and lands; tampered envelope rejected
- [x] `test_sovereignty_local_reads_unchanged_after_federation_work` — local + federated reads coexist; `is_federated_reader_id` discriminates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)