### PR TITLE
tend: activate WORD domain — 71 canonical word-cells in the lattice

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,11 +34,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 132 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 237 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 212 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 213 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 124 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 125 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/services/substrate/canonical_lexicon.py
+++ b/api/app/services/substrate/canonical_lexicon.py
@@ -1,0 +1,264 @@
+"""canonical_lexicon — the body's most-alive words, interned as WORD cells.
+
+The single source of truth for the curated canonical lexicon that lives in
+the substrate under `domain="word"`. Mirrors the structure of
+`modality_shapes` (canonical descriptors + intern helper + intern-all), so
+both `scripts/intern_canonical_words.py` (the CLI wrapper) and any future
+router/MCP surface that needs to enumerate the canonical word-cells share
+one list.
+
+The teaching this module attests:
+
+    A word is the smallest unit of KB content. Its Blueprint composes from
+    (lemma, POS, hz, semantic_field). Once the substrate carries the body's
+    most-alive words as cells, prose round-trips become real (not just
+    in-memory stand-in via `scripts/prose_recipe_roundtrip.py`), and
+    cross-modal queries like "what concept-cells share semantic_field with
+    this word?" become a structural walk.
+
+Three pools of words are curated here:
+
+1. **Body lexicon** — every entry in `_WORD_LEXICON_DEFAULTS` from
+   `markdown_frontend.py`. These are the words the body's existing
+   tokenizer already resolves; interning them as cells means the prose
+   encoder (`section_content_to_word_sequence`) starts hitting canonical
+   cells instead of fresh-per-occurrence Blueprints.
+
+2. **Canonical recipe-shape names** — the 13 cross-modal canonical shapes
+   from `modality_shapes.CANONICAL_SHAPES` (R_Recovery, R_Pointing, ...).
+   Each becomes a word-cell whose semantic_field is "consciousness" and
+   whose hz comes from the shape's altitude (recipe-shapes name structural
+   moves of awareness; 741 Hz is the consciousness band).
+
+3. **Frequency-anchor terms** — the multilingual-web spec R17 anchor words:
+   tending, ripening, wholeness, coherence, resonance, stewardship,
+   kinship, belonging. These carry the body's vocabulary across locales;
+   interning them with their canonical (hz, semantic_field) gives every
+   translation work a substrate anchor to attach to.
+
+4. **Round-trip sentence words** — already covered by pool 1
+   (`_WORD_LEXICON_DEFAULTS` includes "the", "choice", "point", "becomes",
+   "visible"), but called out explicitly so the round-trip teaching's
+   five words are visible in the canonical list.
+
+Run:
+    python3 scripts/intern_canonical_words.py
+
+Idempotent: re-running interns the same cells (NamedCell upsert via
+`make_cell` + content-addressing on the four-axis Blueprint).
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.services.substrate.kernel import NodeID
+from app.services.substrate.markdown_frontend import (
+    _WORD_LEXICON_DEFAULTS,
+    ingest_word_cell,
+    lemma_pos_key,
+)
+from app.services.substrate.modality_shapes import CANONICAL_SHAPES
+
+
+# ---------------------------------------------------------------------------
+# Domain — word cells live in the WORD domain (BDomain.WORD = 15)
+# ---------------------------------------------------------------------------
+DOMAIN_WORD = "word"
+
+
+# ---------------------------------------------------------------------------
+# Hz vocabulary — mirrors the body's existing solfeggio mapping
+# ---------------------------------------------------------------------------
+#
+# From markdown_frontend.py's lexicon header (line ~1647):
+#
+#   174 Hz — ground        (what the body stands on)
+#   396 Hz — tending       (liberation-from-fear, care)
+#   417 Hz — transmutation (phase-change, undoing, becoming)
+#   528 Hz — vitality      (circulation, repair, miracle)
+#   639 Hz — transmission  (relationship between cells, lineage)
+#   741 Hz — consciousness (perception, choice, sensing)
+#   852 Hz — resonance     (intuition, returning to spectral order)
+#   963 Hz — wholeness     (oneness, undivided)
+#   432 Hz — neutral       (universal carrier; function words)
+#
+# Each field name maps to its Hz so the recipe-shape and anchor pools can
+# request a field and the lexicon computes the Hz.
+FIELD_HZ: Dict[str, int] = {
+    "ground": 174,
+    "tending": 396,
+    "transmutation": 417,
+    "vitality": 528,
+    "transmission": 639,
+    "consciousness": 741,
+    "resonance": 852,
+    "wholeness": 963,
+    "neutral": 432,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pool 2 — canonical recipe-shape names as WORD cells
+# ---------------------------------------------------------------------------
+#
+# Each cross-modal canonical shape (R_Recovery, R_Pointing, ...) lands as a
+# word-cell with POS=NOUN and field="consciousness" (recipe-shapes name
+# structural moves of awareness; 741 Hz is the consciousness band the body
+# already uses for choice/point/visible/assemble/listen).
+#
+# The lemma is the bare canonical name without the `R_` prefix — kept as a
+# pronounceable noun ("Recovery", "Pointing", "Tunnel") so prose written
+# about these shapes resolves to the same word-cell as the shape-name
+# itself. The `R_` prefix lives only on the recipe-shape cell in the
+# `recipe-shape` domain (already shipped by `intern_modality_blueprints.py`).
+
+RECIPE_SHAPE_FIELD = "consciousness"
+
+
+def _recipe_shape_word_entries() -> List[Tuple[str, str, int, str]]:
+    """Return (lemma, POS, hz, field) entries for every canonical recipe-shape.
+
+    Drawn from `modality_shapes.CANONICAL_SHAPES` so the lexicon stays in
+    sync with the cross-modal canonical list as it grows.
+    """
+    hz = FIELD_HZ[RECIPE_SHAPE_FIELD]
+    entries: List[Tuple[str, str, int, str]] = []
+    for canonical_name, _slots, _tags in CANONICAL_SHAPES:
+        # canonical_name shape: "R_Recovery", "R_ObserverConditionedActualization"
+        # The lemma is the pronounceable noun: drop the R_ prefix and
+        # normalize to lowercase for lemma-storage. The cell name will be
+        # `{lemma}.NOUN` per `lemma_pos_key`.
+        if canonical_name.startswith("R_"):
+            lemma = canonical_name[2:].lower()
+        else:
+            lemma = canonical_name.lower()
+        entries.append((lemma, "NOUN", hz, RECIPE_SHAPE_FIELD))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Pool 3 — multilingual-web R17 frequency-anchor terms
+# ---------------------------------------------------------------------------
+#
+# The eight anchor words named in spec multilingual-web R17. Each carries
+# its body-tuned (hz, semantic_field). These are the words translation work
+# attaches per-locale word-cells to — the canonical English anchors live
+# here.
+ANCHOR_TERMS: List[Tuple[str, str, int, str]] = [
+    # surface/lemma,  POS,    hz,  field
+    ("tending",       "VERB", 396, "tending"),
+    ("ripening",      "VERB", 528, "vitality"),
+    ("wholeness",     "NOUN", 963, "wholeness"),
+    ("coherence",     "NOUN", 852, "resonance"),
+    ("resonance",     "NOUN", 852, "resonance"),
+    ("stewardship",   "NOUN", 396, "tending"),
+    ("kinship",       "NOUN", 639, "transmission"),
+    ("belonging",     "NOUN", 639, "transmission"),
+    # The verb form of ripen — pairs with "ripening" so both surface forms
+    # resolve to a canonical cell.
+    ("ripen",         "VERB", 528, "vitality"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Pool composition — the full canonical word list
+# ---------------------------------------------------------------------------
+
+
+def canonical_word_entries() -> List[Tuple[str, str, int, str]]:
+    """Return the full canonical lexicon — every word the body interns.
+
+    Each entry is (lemma, POS, hz, semantic_field). De-duplicated by
+    (lemma, POS); first-occurrence wins so the body-lexicon's tuned
+    (hz, field) takes precedence over a recipe-shape/anchor entry that
+    happens to share the same lemma.
+
+    Order matters only for the dedupe — the substrate's content-addressing
+    makes the resulting cells stable regardless of insertion order.
+    """
+    seen: set[Tuple[str, str]] = set()
+    entries: List[Tuple[str, str, int, str]] = []
+
+    def add(lemma: str, pos: str, hz: int, field: str) -> None:
+        key = (lemma.lower(), pos.upper())
+        if key in seen:
+            return
+        seen.add(key)
+        entries.append((lemma, pos, hz, field))
+
+    # Pool 1 — body lexicon. Iterate in insertion order; the dict carries
+    # surface forms (becomes, becoming, become) sharing a lemma. Dedupe
+    # collapses them to one (lemma, POS) cell.
+    for _surface, entry in _WORD_LEXICON_DEFAULTS.items():
+        add(entry["lemma"], entry["pos"], int(entry["hz"]), entry["field"])
+
+    # Pool 2 — canonical recipe-shape names.
+    for lemma, pos, hz, field in _recipe_shape_word_entries():
+        add(lemma, pos, hz, field)
+
+    # Pool 3 — anchor terms.
+    for lemma, pos, hz, field in ANCHOR_TERMS:
+        add(lemma, pos, hz, field)
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Interning
+# ---------------------------------------------------------------------------
+
+
+def intern_canonical_word(
+    session: Session,
+    lemma: str,
+    pos: str,
+    hz: int,
+    semantic_field: str,
+) -> Tuple[str, NodeID]:
+    """Intern one canonical word-cell. Returns (cell_name, blueprint_id).
+
+    Wraps `ingest_word_cell` so the canonical-lexicon path shares the same
+    encoder the prose tokenizer uses. Idempotent via content-addressing —
+    same (lemma, POS, hz, field) returns the same cell on re-run.
+    """
+    cell, blueprint_id, _ctor_id = ingest_word_cell(
+        session,
+        lemma=lemma,
+        pos=pos,
+        hz=hz,
+        semantic_field=semantic_field,
+    )
+    return cell.name, blueprint_id
+
+
+def intern_all_canonical_words(
+    session: Session,
+) -> List[Tuple[str, str, NodeID]]:
+    """Intern every entry in the canonical lexicon.
+
+    Each report entry is `(cell_name, lemma_pos_key, blueprint_node_id)`.
+    Idempotent: re-running returns the same cell names and Blueprint NodeIDs
+    (NamedCell upsert via `make_cell` + content-addressing on the four-axis
+    Blueprint).
+    """
+    report: List[Tuple[str, str, NodeID]] = []
+    for lemma, pos, hz, field in canonical_word_entries():
+        cell_name, blueprint_id = intern_canonical_word(
+            session, lemma, pos, hz, field
+        )
+        expected = lemma_pos_key(lemma, pos)
+        report.append((cell_name, expected, blueprint_id))
+    return report
+
+
+__all__ = [
+    "ANCHOR_TERMS",
+    "DOMAIN_WORD",
+    "FIELD_HZ",
+    "RECIPE_SHAPE_FIELD",
+    "canonical_word_entries",
+    "intern_all_canonical_words",
+    "intern_canonical_word",
+]

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 212
+**Total files**: 213
 
 | File | Purpose |
 |---|---|
@@ -36,6 +36,7 @@
 | [test_awareness_node_daemon.py](test_awareness_node_daemon.py) | _no top-of-file purpose_ |
 | [test_breath_service.py](test_breath_service.py) | Tests for Breath-Aware Lifecycle — gas/water/ice phase distribution. |
 | [test_bridge_notifications.py](test_bridge_notifications.py) | Flow-centric integration tests for Cross-Domain Bridge Notifications. |
+| [test_canonical_words.py](test_canonical_words.py) | Tests for the canonical-word lexicon interner. |
 | [test_cc_economics.py](test_cc_economics.py) | Tests for CC Economics and Value Coherence. |
 | [test_cc_exchange.py](test_cc_exchange.py) | Tests for the CC ↔ External Exchange bridge. |
 | [test_cc_scoring.py](test_cc_scoring.py) | Tests for the coherence-algorithm-spec (specs/coherence-algorithm-spec.md). |

--- a/api/tests/test_canonical_words.py
+++ b/api/tests/test_canonical_words.py
@@ -1,0 +1,370 @@
+"""Tests for the canonical-word lexicon interner.
+
+The teaching: a word is the smallest unit of KB content. Its Blueprint
+composes from (lemma, POS, hz, semantic_field). `canonical_lexicon` curates
+the body's most-alive words — body-tuned function words, anchor terms from
+spec multilingual-web R17, and the cross-modal canonical recipe-shape names
+— and the interner lands them as `domain="word"` cells.
+
+These tests exercise the interner against an in-memory SQLite-backed
+substrate (same pattern as `test_modality_blueprints.py` and
+`test_substrate_word_domain.py`). They assert:
+
+- Every canonical entry lands as a `domain="word"` cell whose
+  cell-name follows the `{lemma}.{POS}` convention.
+- Re-running the interner adds no new cells (idempotent via
+  content-addressing on the four-axis Blueprint).
+- Two words sharing semantic_field share at least one resonance edge —
+  queryable as semantic-field twins via the HARMONIC_AT @<hz> signature
+  authored by `ingest_word_cell`.
+- Every canonical recipe-shape name from `modality_shapes.CANONICAL_SHAPES`
+  has a word-cell counterpart (lemma is the bare shape name, no R_ prefix).
+- The three anchor families (tending/transmutation/vitality/etc.) all land
+  with their body-tuned Hz, not the neutral fallback.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from app.services.substrate.canonical_lexicon import (
+    ANCHOR_TERMS,
+    DOMAIN_WORD,
+    FIELD_HZ,
+    RECIPE_SHAPE_FIELD,
+    canonical_word_entries,
+    intern_all_canonical_words,
+    intern_canonical_word,
+)
+from app.services.substrate.kernel import find_equivalent_cells, lookup_cell
+from app.services.substrate.markdown_frontend import (
+    _WORD_LEXICON_DEFAULTS,
+    ingest_word_cell,
+    lemma_pos_key,
+)
+from app.services.substrate.resonance import cell_resonance_signature
+from app.services.substrate.modality_shapes import CANONICAL_SHAPES
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+from app.services.substrate.substrate_strings import SubstrateStringORM
+
+from intern_canonical_words import intern_all  # noqa: E402
+
+
+@pytest.fixture
+def session():
+    """In-memory SQLite session with substrate tables only."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+# ---------------------------------------------------------------------------
+# Entry list — the canonical lexicon shape
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_word_entries_is_deduped_by_lemma_pos():
+    """No (lemma, POS) pair appears twice in the canonical list."""
+    entries = canonical_word_entries()
+    keys = [(lemma.lower(), pos.upper()) for lemma, pos, _hz, _field in entries]
+    assert len(keys) == len(set(keys)), (
+        "canonical lexicon contains a duplicate (lemma, POS) — dedupe broken"
+    )
+
+
+def test_canonical_word_entries_covers_round_trip_sentence():
+    """The five words from 'The choice point becomes visible.' all live in
+    the canonical lexicon — the prose-as-recipe round-trip stays grounded."""
+    entries = {(lemma.lower(), pos.upper()) for lemma, pos, _hz, _field in canonical_word_entries()}
+    assert ("the",     "DET")  in entries, "DET 'the' missing — round-trip word"
+    assert ("choice",  "NOUN") in entries, "NOUN 'choice' missing — round-trip word"
+    assert ("point",   "NOUN") in entries, "NOUN 'point' missing — round-trip word"
+    assert ("become",  "VERB") in entries, "VERB 'become' missing — round-trip word"
+    assert ("visible", "ADJ")  in entries, "ADJ 'visible' missing — round-trip word"
+
+
+def test_canonical_word_entries_covers_body_lexicon():
+    """Every (lemma, POS) in `_WORD_LEXICON_DEFAULTS` appears in the canonical
+    list — the prose tokenizer's existing vocabulary lifts intact."""
+    canonical = {
+        (lemma.lower(), pos.upper()) for lemma, pos, _hz, _field in canonical_word_entries()
+    }
+    body = {
+        (entry["lemma"].lower(), entry["pos"].upper())
+        for entry in _WORD_LEXICON_DEFAULTS.values()
+    }
+    missing = body - canonical
+    assert not missing, f"body-lexicon entries missing from canonical: {missing!r}"
+
+
+def test_canonical_word_entries_covers_anchor_terms():
+    """Every anchor term lands in the canonical list with its body-tuned field."""
+    canonical = {
+        (lemma.lower(), pos.upper()): (hz, field)
+        for lemma, pos, hz, field in canonical_word_entries()
+    }
+    for lemma, pos, _hz, field in ANCHOR_TERMS:
+        key = (lemma.lower(), pos.upper())
+        assert key in canonical, f"anchor term {key!r} missing from canonical lexicon"
+        # First-occurrence wins — the body lexicon may have already tuned
+        # this word at a different (hz, field). We assert the canonical
+        # entry carries SOME tuning, not the specific anchor value, so the
+        # body-tuned value is honored when it exists.
+        assert canonical[key][1] in FIELD_HZ, (
+            f"anchor term {key!r} interns with unknown semantic_field "
+            f"{canonical[key][1]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-running adds nothing new
+# ---------------------------------------------------------------------------
+
+
+def test_intern_lexicon_is_idempotent(session):
+    """Re-running the interner produces no new cells; same Blueprint NodeIDs."""
+    report_a = intern_all_canonical_words(session)
+    report_b = intern_all_canonical_words(session)
+
+    assert len(report_a) == len(report_b)
+    for (name_a, key_a, bp_a), (name_b, key_b, bp_b) in zip(report_a, report_b):
+        assert name_a == name_b
+        assert key_a == key_b
+        assert bp_a == bp_b, (
+            f"{name_a!r} Blueprint drift across re-intern — content-addressing broken"
+        )
+
+    # Cell count stable: count of word-cells before == after second run.
+    word_cells = session.query(SubstrateNamedCellORM).filter_by(
+        domain=DOMAIN_WORD
+    ).count()
+    intern_all_canonical_words(session)
+    word_cells_after = session.query(SubstrateNamedCellORM).filter_by(
+        domain=DOMAIN_WORD
+    ).count()
+    assert word_cells == word_cells_after, (
+        f"third intern grew cell count: {word_cells} → {word_cells_after}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Domain — every interned cell lives in the WORD domain
+# ---------------------------------------------------------------------------
+
+
+def test_word_cells_have_word_domain(session):
+    """Every cell interned by the canonical lexicon has domain='word'."""
+    report = intern_all_canonical_words(session)
+    for cell_name, _key, _bp in report:
+        cell = lookup_cell(session, DOMAIN_WORD, cell_name)
+        assert cell is not None, f"canonical word {cell_name!r} not interned"
+        assert cell.domain == DOMAIN_WORD, (
+            f"canonical word {cell_name!r} has domain {cell.domain!r}, "
+            f"expected {DOMAIN_WORD!r}"
+        )
+
+
+def test_cell_name_follows_lemma_pos_convention(session):
+    """Interned cell names match `lemma_pos_key(lemma, POS)` exactly."""
+    report = intern_all_canonical_words(session)
+    for cell_name, expected_key, _bp in report:
+        assert cell_name == expected_key, (
+            f"cell name {cell_name!r} drifted from {expected_key!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Semantic-field twins — words tagged 'consciousness' share resonance edges
+# ---------------------------------------------------------------------------
+
+
+def test_words_with_same_semantic_field_aligned(session):
+    """Two 'consciousness' words share at least one HARMONIC_AT resonance edge.
+
+    The substrate's content-addressing makes the HARMONIC_AT @741 edge a
+    shared structural target for every consciousness-band word. Both
+    'choice.NOUN' and 'visible.ADJ' fire at 741 Hz; their cell resonance
+    signatures must intersect.
+    """
+    intern_all_canonical_words(session)
+
+    choice = lookup_cell(session, DOMAIN_WORD, "choice.NOUN")
+    visible = lookup_cell(session, DOMAIN_WORD, "visible.ADJ")
+    assert choice is not None and visible is not None, (
+        "consciousness-band canonical words missing from lattice"
+    )
+
+    sig_choice = cell_resonance_signature(session, choice.cell_id)
+    sig_visible = cell_resonance_signature(session, visible.cell_id)
+    assert sig_choice & sig_visible, (
+        "two consciousness-field words should share at least one resonance "
+        "edge target (the HARMONIC_AT @741 from the geometry signature)"
+    )
+
+
+def test_words_with_different_semantic_field_distinct(session):
+    """Two words at different Hz bands have distinct CTORs.
+
+    All word-cells share the WORD-domain Blueprint NodeID (`BID_word()`) —
+    the four axes (lemma, POS, hz, semantic_field) live in the CTOR, not
+    the Blueprint. So structural identity at the cell level is carried by
+    the CTOR, while the Blueprint expresses "this is a word."
+
+    Two words at different Hz bands have distinct CTORs (different lemma,
+    different hz, different field). They share the SAME Blueprint
+    NodeID, which is correct: both are word-cells.
+    """
+    intern_all_canonical_words(session)
+
+    choice = lookup_cell(session, DOMAIN_WORD, "choice.NOUN")        # 741 / consciousness
+    breath = lookup_cell(session, DOMAIN_WORD, "breath.NOUN")        # 396 / tending
+    assert choice is not None and breath is not None
+    # CTORs are distinct — content-addressing on the four-axis tuple keeps
+    # them apart.
+    assert choice.ctor != breath.ctor, (
+        "words at different (lemma, hz, field) should not share CTOR"
+    )
+    # Both share the WORD-domain Blueprint — every word is a word.
+    assert choice.blueprint == breath.blueprint
+
+
+# ---------------------------------------------------------------------------
+# Canonical recipe-shape names have word-cell counterparts
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_recipe_shape_names_have_word_cells(session):
+    """Every name in CANONICAL_SHAPES has a word-cell counterpart.
+
+    The lemma is the bare shape name (R_Recovery → 'recovery.NOUN'). The
+    canonical recipe-shape cell in domain='recipe-shape' lives elsewhere
+    (interned by `intern_modality_blueprints.py`); this test verifies the
+    word-cell anchor for prose written about the shape.
+    """
+    intern_all_canonical_words(session)
+
+    for canonical_name, _slots, _tags in CANONICAL_SHAPES:
+        lemma = canonical_name[2:] if canonical_name.startswith("R_") else canonical_name
+        cell_name = lemma_pos_key(lemma, "NOUN")
+        cell = lookup_cell(session, DOMAIN_WORD, cell_name)
+        assert cell is not None, (
+            f"recipe-shape word-cell {cell_name!r} (from {canonical_name!r}) "
+            f"not interned"
+        )
+        assert cell.domain == DOMAIN_WORD
+
+
+def test_recipe_shape_word_cells_fire_in_consciousness_band(session):
+    """Recipe-shape word-cells all fire at 741 Hz (consciousness field).
+
+    Recipe-shapes name structural moves of awareness; 741 Hz is the body's
+    consciousness band. Two canonical recipe-shape word-cells should both
+    carry the HARMONIC_AT @741 resonance edge — the substrate's structural
+    recognition that both fire in the same band.
+    """
+    intern_all_canonical_words(session)
+
+    # Sample two recipe-shape word-cells. Both lemmas are bare canonical
+    # names (R_Recovery → 'recovery', R_GroundingMove → 'groundingmove').
+    recovery = lookup_cell(session, DOMAIN_WORD, "recovery.NOUN")
+    grounding = lookup_cell(session, DOMAIN_WORD, "groundingmove.NOUN")
+    assert recovery is not None, "recovery.NOUN canonical recipe-shape word missing"
+    assert grounding is not None, "groundingmove.NOUN canonical recipe-shape word missing"
+
+    sig_recovery = cell_resonance_signature(session, recovery.cell_id)
+    sig_grounding = cell_resonance_signature(session, grounding.cell_id)
+    # Both share the HARMONIC_AT @741 edge.
+    assert sig_recovery & sig_grounding, (
+        "two recipe-shape word-cells should share the consciousness-band "
+        "HARMONIC_AT @741 resonance edge"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor terms — multilingual-web R17 vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_terms_intern_with_field_tuned_hz(session):
+    """Each anchor term lands at SOME tuned (hz, field) — not the UNK
+    fallback at 432/neutral.
+
+    The body lexicon takes precedence on collisions; for anchor-unique
+    terms (wholeness, kinship, belonging, stewardship), the entry comes
+    straight from `ANCHOR_TERMS`.
+    """
+    intern_all_canonical_words(session)
+
+    anchor_unique = ["wholeness.NOUN", "kinship.NOUN", "belonging.NOUN",
+                     "stewardship.NOUN"]
+    for cell_name in anchor_unique:
+        cell = lookup_cell(session, DOMAIN_WORD, cell_name)
+        assert cell is not None, f"anchor word {cell_name!r} not interned"
+        # The HARMONIC_AT edge fires the word at its Hz; confirm at least
+        # one resonance edge was authored.
+        sig = cell_resonance_signature(session, cell.cell_id)
+        assert len(sig) >= 1, (
+            f"anchor word {cell_name!r} missing HARMONIC_AT resonance edge"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Script wrapper alias — `intern_all` works through the CLI module
+# ---------------------------------------------------------------------------
+
+
+def test_script_intern_all_alias_matches_module(session):
+    """`scripts/intern_canonical_words.intern_all` is `intern_all_canonical_words`."""
+    report_script = intern_all(session)
+    # Re-run via module — same NodeIDs.
+    report_module = intern_all_canonical_words(session)
+    assert len(report_script) == len(report_module)
+    for (name_a, _key_a, bp_a), (name_b, _key_b, bp_b) in zip(report_script, report_module):
+        assert name_a == name_b
+        assert bp_a == bp_b
+
+
+# ---------------------------------------------------------------------------
+# Single-word intern helper
+# ---------------------------------------------------------------------------
+
+
+def test_intern_canonical_word_returns_cell_name_and_blueprint(session):
+    """`intern_canonical_word` returns (cell_name, blueprint_id) and lands
+    a `domain='word'` cell with the expected name."""
+    name, blueprint = intern_canonical_word(
+        session, "wholeness", "NOUN", FIELD_HZ["wholeness"], "wholeness",
+    )
+    assert name == "wholeness.NOUN"
+    cell = lookup_cell(session, DOMAIN_WORD, "wholeness.NOUN")
+    assert cell is not None
+    assert cell.blueprint == blueprint
+    assert cell.domain == DOMAIN_WORD
+
+
+def test_recipe_shape_field_is_consciousness_band():
+    """Recipe-shape word-cells fire in the consciousness band (741 Hz)."""
+    assert RECIPE_SHAPE_FIELD == "consciousness"
+    assert FIELD_HZ[RECIPE_SHAPE_FIELD] == 741

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 124
+**Total files**: 125
 
 | File | Purpose |
 |---|---|
@@ -69,6 +69,7 @@
 | [influence_teaching_translator.py](influence_teaching_translator.py) | !/usr/bin/env python3 |
 | [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | !/usr/bin/env python3 |
 | [ingest_audible_history.py](ingest_audible_history.py) | !/usr/bin/env python3 |
+| [intern_canonical_words.py](intern_canonical_words.py) | !/usr/bin/env python3 |
 | [intern_modality_blueprints.py](intern_modality_blueprints.py) | !/usr/bin/env python3 |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
 | [local_runner.py](local_runner.py) | !/usr/bin/env python3 |

--- a/scripts/intern_canonical_words.py
+++ b/scripts/intern_canonical_words.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""intern_canonical_words.py — CLI wrapper for the canonical lexicon interner.
+
+The canonical-lexicon source-of-truth lives in
+`api/app/services/substrate/canonical_lexicon` so both this CLI and any
+future router/MCP surface that needs to enumerate the body's canonical
+word-cells share one list. This script is the I/O wrapper that opens a
+database session and calls `intern_all_canonical_words`.
+
+Re-exports `canonical_word_entries`, `intern_canonical_word`, and
+`intern_all` (alias for `intern_all_canonical_words`) so callers that
+imported from this script keep working — same pattern as
+`scripts/intern_modality_blueprints.py`.
+
+Run:
+    python3 scripts/intern_canonical_words.py
+
+Idempotent: re-running interns the same cells (NamedCell upsert via
+`make_cell` + content-addressing on the four-axis Blueprint). Reports
+per-pool counts and verifies one query through the lattice.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "api"))
+
+from app.services.substrate.canonical_lexicon import (  # noqa: E402
+    ANCHOR_TERMS,
+    DOMAIN_WORD,
+    canonical_word_entries,
+    intern_all_canonical_words,
+    intern_canonical_word,
+)
+from app.services.substrate.kernel import (  # noqa: E402
+    find_equivalent_cells,
+    lookup_cell,
+)
+from app.services.substrate.markdown_frontend import (  # noqa: E402
+    _WORD_LEXICON_DEFAULTS,
+)
+from app.services.substrate.modality_shapes import CANONICAL_SHAPES  # noqa: E402
+from app.services.unified_db import session as session_scope  # noqa: E402
+
+
+# Backward-compatible alias — historical callers (tests, hooks) import
+# `intern_all` from this script. The substrate module exports the same
+# function under its longer, self-describing name.
+intern_all = intern_all_canonical_words
+
+
+def main() -> int:
+    print("─" * 70)
+    print("intern_canonical_words — landing the body's lexicon in the substrate")
+    print("─" * 70)
+
+    entries = canonical_word_entries()
+    body_lexicon_count = len({
+        (e["lemma"].lower(), e["pos"].upper())
+        for e in _WORD_LEXICON_DEFAULTS.values()
+    })
+    recipe_shape_count = len(CANONICAL_SHAPES)
+    anchor_count = len(ANCHOR_TERMS)
+
+    print()
+    print(f"  Pool 1 — body lexicon            : {body_lexicon_count:>4} unique (lemma, POS)")
+    print(f"  Pool 2 — canonical recipe-shapes : {recipe_shape_count:>4} entries")
+    print(f"  Pool 3 — anchor terms            : {anchor_count:>4} entries")
+    print(f"  ─────────────────────────────────────────────────")
+    print(f"  Total after dedupe               : {len(entries):>4} canonical words")
+    print()
+
+    with session_scope() as session:
+        report = intern_all_canonical_words(session)
+        session.flush()
+
+        # Verify one cell from each pool round-trips.
+        verifications = [
+            "choice.NOUN",          # Pool 1 — round-trip sentence word
+            "recovery.NOUN",        # Pool 2 — canonical recipe-shape word
+            "wholeness.NOUN",       # Pool 3 — anchor term
+        ]
+        print("Verification — lookup_cell + ?equivalent on canonical samples:")
+        for name in verifications:
+            cell = lookup_cell(session, DOMAIN_WORD, name)
+            if cell is None:
+                print(f"  ✗ {name:<24} MISSING — canonical interner did not land")
+                continue
+            equivalents = find_equivalent_cells(session, cell.blueprint)
+            eq_count = len({c.name for c in equivalents})
+            print(
+                f"  ✓ {name:<24} @{cell.blueprint}  "
+                f"?equivalent → {eq_count} cell(s)"
+            )
+
+        # Surface the consciousness-field family — every 741-Hz/consciousness
+        # word now shares a HARMONIC_AT @741 resonance edge through the
+        # word-cell's geometry signature.
+        consciousness_count = sum(
+            1 for (_l, _p, hz, field) in entries
+            if field == "consciousness"
+        )
+        print()
+        print(
+            f"  Consciousness-field words  : {consciousness_count} "
+            f"(all share HARMONIC_AT @741)"
+        )
+
+        session.commit()
+
+    print()
+    print("─" * 70)
+    print("Done. The body's lexicon now lives in the real substrate.")
+    print("Query examples:")
+    print("  coh substrate form '?equivalent @word(choice.NOUN)'")
+    print("  coh substrate form '?equivalent @word(recovery.NOUN)'")
+    print("  coh substrate form '?equivalent @word(wholeness.NOUN)'")
+    print(
+        "  coh substrate form "
+        "'?equivalent @word(choice.NOUN) where harmonic_at == @spectrum(\"Hz-741\")'"
+    )
+    print("─" * 70)
+    return 0
+
+
+__all__ = [
+    "canonical_word_entries",
+    "intern_all",
+    "intern_all_canonical_words",
+    "intern_canonical_word",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Mirrors `scripts/intern_modality_blueprints.py` (PR #1956) for the WORD domain (`BDomain.WORD = 15`). Lands 71 deduped canonical word-cells across three pools:

- **Pool 1 (50)** — body's existing `_WORD_LEXICON_DEFAULTS` (every (lemma, POS) the prose tokenizer already resolves)
- **Pool 2 (13)** — canonical recipe-shape names from `modality_shapes.CANONICAL_SHAPES`, lifted as NOUN word-cells at 741 Hz (consciousness)
- **Pool 3 (9)** — multilingual-web R17 frequency-anchor terms: tending, ripening, wholeness, coherence, resonance, stewardship, kinship, belonging — each at its body-tuned (hz, semantic_field)

The canonical lexicon lives at `api/app/services/substrate/canonical_lexicon.py` so future router/MCP surfaces share one list. `scripts/intern_canonical_words.py` is the CLI wrapper mirroring `intern_modality_blueprints`'s I/O pattern.

## What this unlocks

- Prose ingest resolves common words to canonical WORD cells, not fresh blueprints per occurrence
- 19 consciousness-field words share `HARMONIC_AT @741` — semantic-field twin queries become structural walks
- `coh substrate form '?equivalent @word(recovery.NOUN)'` returns the 70 sibling word-cells; per-cell distinction lives in the CTOR (four-axis content-addressing); the domain Blueprint `@1.5.4.1` (`BID_word()`) is shared by every word-cell
- Closes the bootstrap arc started by `docs/coherence-substrate/prose-as-recipe.form` + `scripts/prose_recipe_roundtrip.py` — words now live as substrate cells alongside the recipe-shapes that compose them

## Test plan

- [x] `pytest tests/test_canonical_words.py tests/test_modality_blueprints.py tests/test_substrate_word_domain.py -v` — 51/51 pass
- [x] `python3 scripts/intern_canonical_words.py` — first run lands 71 cells
- [x] Re-run is idempotent (same Blueprint NodeIDs, no new cells)
- [x] `coh substrate form '?equivalent @word(recovery.NOUN)'` returns 70 sibling word-cells
- [x] `python3 scripts/generate_repo_indexes.py` — INDEX files updated in same commit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)