### PR TITLE
tend: federation peer-poll job — the heartbeat each instance chooses

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -32,13 +32,13 @@
 | Index | Files | Purpose |
 |---|---|---|
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 132 | API routers — every HTTP endpoint surface |
-| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 237 | API services — business logic and graph operations |
+| [api/app/services/INDEX.md](api/app/services/INDEX.md) | 238 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 213 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 214 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 157 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 125 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 126 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -51,6 +51,7 @@ from app.models.federation import (
     FederatedAggregationResponse,
     FederatedAggregationListResponse,
 )
+from app.services import federation_peer_poll_service
 from app.services import federation_service
 from app.services import federation_substrate_service
 from app.services import federation_value_flow_service
@@ -486,6 +487,62 @@ async def list_substrate_attestations(peer_instance_id: str) -> dict:
         "attestations": [a.model_dump(mode="json") for a in attestations],
         "count": len(attestations),
     }
+
+
+# ---------------------------------------------------------------------------
+# Peer-poll job — the federation's heartbeat
+# ---------------------------------------------------------------------------
+#
+# A manual trigger for the peer-poll service. Production runs this on a
+# schedule (see scripts/federation_peer_poll.py for the cron-installable
+# CLI); this endpoint exists so an operator can fire a poll out-of-band or
+# integration tests can drive the loop. The endpoint reads from peers via
+# their public read-only surfaces (pulse, capabilities, canonicals) and
+# never writes to them — sovereignty is preserved on both sides.
+
+
+@router.post(
+    "/federation/peers/poll",
+    summary="Trigger a peer-poll cycle — read each peer's pulse, manifest, canonicals",
+)
+async def trigger_peer_poll(
+    instance_id: str | None = Query(
+        default=None,
+        description="Optional: poll only this peer. Default: all registered peers.",
+    ),
+) -> dict:
+    """Manually trigger the peer-poll job for one peer or all peers.
+
+    Internal-use: there is no auth layer on this endpoint at the API tier;
+    production deployments should restrict it at the proxy layer or rely on
+    the scheduled `scripts/federation_peer_poll.py` cron job. Each peer's
+    poll is bounded and isolated — one failing peer does not break the rest.
+    """
+    if instance_id is not None:
+        result = await federation_peer_poll_service.poll_peer(instance_id)
+        return {
+            "polled": 1,
+            "results": {instance_id: result.to_dict()},
+        }
+    results = await federation_peer_poll_service.poll_all_peers()
+    return {
+        "polled": len(results),
+        "results": {pid: r.to_dict() for pid, r in results.items()},
+    }
+
+
+@router.get(
+    "/federation/peers/last-polled",
+    summary="Per-peer freshest observation timestamp from poll cycles",
+)
+async def list_peer_last_polled() -> dict:
+    """Return the most-recent successful poll timestamp for each peer.
+
+    Used by the web /federation page to show "last polled" alongside each
+    peer card. Values are ISO 8601 UTC; a peer that has never been
+    successfully polled is absent from the map.
+    """
+    return federation_peer_poll_service.list_last_polled()
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/INDEX.md
+++ b/api/app/services/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 237
+**Total files**: 238
 
 | File | Purpose |
 |---|---|
@@ -96,6 +96,7 @@
 | [failed_task_diagnostics_service.py](failed_task_diagnostics_service.py) | Failed-task diagnostics: error classification and completeness tracking. Spec 113. |
 | [failure_taxonomy_service.py](failure_taxonomy_service.py) | Shared failure taxonomy for consistent bucketing and signatures. |
 | [fallback_witness_service.py](fallback_witness_service.py) | Fallback witness — honest record of when the body runs on reserve. |
+| [federation_peer_poll_service.py](federation_peer_poll_service.py) | federation_peer_poll_service — the federation's heartbeat. |
 | [federation_push_service.py](federation_push_service.py) | Client-side push logic for federation measurement summaries (Spec 131). |
 | [federation_service.py](federation_service.py) | Federation service: receive, validate, and integrate remote instance data. |
 | [federation_substrate_service.py](federation_substrate_service.py) | federation_substrate_service — freedom-preserving canonical exchange. |

--- a/api/app/services/federation_peer_poll_service.py
+++ b/api/app/services/federation_peer_poll_service.py
@@ -1,0 +1,561 @@
+"""federation_peer_poll_service — the federation's heartbeat.
+
+Each instance decides which peers to know, polls them on its own schedule,
+records what they willingly share. No instance is polled without its
+consent (the peer remains free to refuse / throttle / 404), no peer is
+forced to reciprocate (this service never writes to peers — it only reads
+what peers willingly share via their public read-only endpoints).
+
+Three things land in local tissue from a successful poll:
+
+  - PeerPulseRecord (shipped in instance_pulse_service) — peer's
+    `/api/pulse/now` response, upserted by peer_instance_id.
+  - PeerCapabilityRecord (this module) — peer's
+    `/api/federation/capabilities/self`, the manifest the peer self-declares.
+  - federation_substrate_attestations (via federation_substrate_service) —
+    peer's `/api/federation/substrate/canonicals`, classified per-canonical
+    as aligned / diverged / discovered.
+
+What the service does NOT do:
+  - POST/PUT/DELETE to peers — every outbound is a GET
+  - Retry aggressively when a peer refuses — 401/403/404 is the peer
+    naming a boundary; we honor it the same as a timeout
+  - Import peer canonicals into the local lattice — the exchange records
+    attestations only; sovereignty is preserved on both sides
+  - Couple peers together — one failing peer's exception is caught and
+    bounded; the rest of the loop continues
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import httpx
+from sqlalchemy import DateTime, Index, String, Text
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from app.models.federation import PeerCanonicalEntry
+from app.services import federation_service
+from app.services import federation_substrate_service
+from app.services import instance_pulse_service
+from app.services import unified_db as _udb
+from app.services.unified_db import Base
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ORM — what we record from a successful capability poll
+# ---------------------------------------------------------------------------
+
+class PeerCapabilityRecord(Base):
+    """Most-recent capability manifest observed from a peer.
+
+    One row per peer_instance_id — the manifest evolves as the peer's own
+    truth changes, and this is the latest snapshot the network has seen.
+    Stored as opaque JSON so unknown extension fields round-trip without
+    loss; readers can decode whatever shape the peer chose to share.
+    """
+
+    __tablename__ = "peer_capability_records"
+
+    peer_instance_id: Mapped[str] = mapped_column(String, primary_key=True)
+    manifest_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    observed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (Index("idx_pcr_observed_at", "observed_at"),)
+
+
+# ---------------------------------------------------------------------------
+# Result shape — one row per peer per poll
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PeerPollResult:
+    """Outcome of one poll cycle for one peer.
+
+    Each endpoint is independent — a peer may share pulse but refuse
+    capabilities, or share both but lack canonicals. Each `*_status` is one
+    of:
+      - "ok"            : the GET returned 2xx and was recorded
+      - "not_sharing"   : the peer returned 401/403/404 — sovereign refusal
+      - "unreachable"   : timeout, connection error, DNS failure
+      - "error"         : the peer returned 5xx or the response didn't parse
+      - "skipped"       : we did not attempt (e.g. peer has no endpoint_url)
+    """
+
+    peer_instance_id: str
+    endpoint_url: str | None = None
+    polled_at: str = ""
+    pulse_status: str = "skipped"
+    capabilities_status: str = "skipped"
+    substrate_status: str = "skipped"
+    aligned: int = 0
+    diverged: int = 0
+    discovered: int = 0
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "peer_instance_id": self.peer_instance_id,
+            "endpoint_url": self.endpoint_url,
+            "polled_at": self.polled_at,
+            "pulse_status": self.pulse_status,
+            "capabilities_status": self.capabilities_status,
+            "substrate_status": self.substrate_status,
+            "aligned": self.aligned,
+            "diverged": self.diverged,
+            "discovered": self.discovered,
+            "notes": list(self.notes),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tuning knobs
+# ---------------------------------------------------------------------------
+
+# Per-endpoint timeout. Short enough that one slow peer doesn't stall the
+# whole loop; long enough that a healthy peer on a slow link still answers.
+DEFAULT_TIMEOUT_S = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Schema helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_schema() -> None:
+    """Ensure peer_capability_records and dependent tables exist.
+
+    federation_service._ensure_schema() also runs the federation tables;
+    instance_pulse_service uses Base.metadata.create_all via unified_db so
+    the PeerPulseRecord table is present too.
+    """
+    federation_service._ensure_schema()
+    _udb.ensure_schema()
+
+
+@contextmanager
+def _session() -> Session:
+    with _udb.session() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Status classification — keep it small and explicit
+# ---------------------------------------------------------------------------
+
+
+def _classify_http_response(response: httpx.Response) -> str:
+    """Map an HTTP status code to one of our outcome buckets.
+
+    401/403/404 are honored as sovereign refusal, not failure. 5xx is
+    flagged as error so a healthy peer's bad day stays visible. 2xx is ok;
+    anything else also lands in error so we don't silently classify
+    unexpected codes as success.
+    """
+    if 200 <= response.status_code < 300:
+        return "ok"
+    if response.status_code in (401, 403, 404):
+        return "not_sharing"
+    return "error"
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint pollers — each returns a (status, parsed_body_or_none)
+# ---------------------------------------------------------------------------
+
+
+async def _poll_pulse(
+    client: httpx.AsyncClient, base_url: str, result: PeerPollResult
+) -> dict[str, Any] | None:
+    url = f"{base_url}/api/pulse/now"
+    try:
+        response = await client.get(url)
+    except httpx.TimeoutException:
+        result.pulse_status = "unreachable"
+        result.notes.append("pulse: timeout")
+        return None
+    except httpx.RequestError as exc:
+        result.pulse_status = "unreachable"
+        result.notes.append(f"pulse: {type(exc).__name__}")
+        return None
+
+    status = _classify_http_response(response)
+    result.pulse_status = status
+    if status != "ok":
+        result.notes.append(f"pulse: HTTP {response.status_code}")
+        return None
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        result.pulse_status = "error"
+        result.notes.append("pulse: response was not JSON")
+        return None
+    if not isinstance(body, dict):
+        result.pulse_status = "error"
+        result.notes.append("pulse: response was not a JSON object")
+        return None
+    return body
+
+
+async def _poll_capabilities(
+    client: httpx.AsyncClient, base_url: str, result: PeerPollResult
+) -> dict[str, Any] | None:
+    url = f"{base_url}/api/federation/capabilities/self"
+    try:
+        response = await client.get(url)
+    except httpx.TimeoutException:
+        result.capabilities_status = "unreachable"
+        result.notes.append("capabilities: timeout")
+        return None
+    except httpx.RequestError as exc:
+        result.capabilities_status = "unreachable"
+        result.notes.append(f"capabilities: {type(exc).__name__}")
+        return None
+
+    status = _classify_http_response(response)
+    result.capabilities_status = status
+    if status != "ok":
+        result.notes.append(f"capabilities: HTTP {response.status_code}")
+        return None
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        result.capabilities_status = "error"
+        result.notes.append("capabilities: response was not JSON")
+        return None
+    if not isinstance(body, dict):
+        result.capabilities_status = "error"
+        result.notes.append("capabilities: response was not a JSON object")
+        return None
+    return body
+
+
+async def _poll_canonicals(
+    client: httpx.AsyncClient, base_url: str, result: PeerPollResult
+) -> list[dict[str, Any]] | None:
+    url = f"{base_url}/api/federation/substrate/canonicals"
+    try:
+        response = await client.get(url)
+    except httpx.TimeoutException:
+        result.substrate_status = "unreachable"
+        result.notes.append("substrate: timeout")
+        return None
+    except httpx.RequestError as exc:
+        result.substrate_status = "unreachable"
+        result.notes.append(f"substrate: {type(exc).__name__}")
+        return None
+
+    status = _classify_http_response(response)
+    result.substrate_status = status
+    if status != "ok":
+        result.notes.append(f"substrate: HTTP {response.status_code}")
+        return None
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        result.substrate_status = "error"
+        result.notes.append("substrate: response was not JSON")
+        return None
+    if not isinstance(body, dict):
+        result.substrate_status = "error"
+        result.notes.append("substrate: response was not a JSON object")
+        return None
+    canonicals = body.get("canonicals")
+    if not isinstance(canonicals, list):
+        result.substrate_status = "error"
+        result.notes.append("substrate: 'canonicals' missing or not a list")
+        return None
+    return canonicals
+
+
+# ---------------------------------------------------------------------------
+# Local recording — keep each write isolated from the next
+# ---------------------------------------------------------------------------
+
+
+def _record_capability_manifest(peer_instance_id: str, manifest: dict[str, Any]) -> None:
+    """Upsert one row per peer with the freshest manifest payload."""
+    payload = json.dumps(manifest, default=str)
+    now = datetime.now(timezone.utc)
+    with _session() as session:
+        existing = session.get(PeerCapabilityRecord, peer_instance_id)
+        if existing is None:
+            session.add(
+                PeerCapabilityRecord(
+                    peer_instance_id=peer_instance_id,
+                    manifest_json=payload,
+                    observed_at=now,
+                )
+            )
+        else:
+            existing.manifest_json = payload
+            existing.observed_at = now
+
+
+def _entries_from_canonicals(raw_canonicals: list[dict[str, Any]]) -> list[PeerCanonicalEntry]:
+    """Coerce loose JSON canonicals into PeerCanonicalEntry models.
+
+    Malformed entries are dropped rather than failing the whole exchange —
+    a single bad row from a peer shouldn't break the alignment record for
+    the canonicals that DID round-trip cleanly.
+    """
+    entries: list[PeerCanonicalEntry] = []
+    for raw in raw_canonicals:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("canonical_name")
+        chash = raw.get("content_hash")
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(chash, str) or not chash:
+            continue
+        role_slots = raw.get("role_slots") or []
+        modality_tags = raw.get("modality_tags") or []
+        if not isinstance(role_slots, list):
+            role_slots = []
+        if not isinstance(modality_tags, list):
+            modality_tags = []
+        try:
+            entries.append(
+                PeerCanonicalEntry(
+                    canonical_name=name,
+                    role_slots=[str(s) for s in role_slots],
+                    modality_tags=[str(t) for t in modality_tags],
+                    content_hash=chash,
+                )
+            )
+        except Exception:
+            # Validation rejected this row — skip rather than fail the batch.
+            continue
+    return entries
+
+
+def _record_substrate_alignment(
+    peer_instance_id: str,
+    raw_canonicals: list[dict[str, Any]],
+    result: PeerPollResult,
+) -> None:
+    entries = _entries_from_canonicals(raw_canonicals)
+    if not entries:
+        result.notes.append("substrate: peer shared no usable canonicals")
+        return
+    with _session() as session:
+        response = federation_substrate_service.exchange_with_peer(
+            session,
+            peer_instance_id=peer_instance_id,
+            canonicals=entries,
+        )
+    result.aligned = response.aligned
+    result.diverged = response.diverged
+    result.discovered = response.discovered
+
+
+# ---------------------------------------------------------------------------
+# Public surface — poll one peer, poll all peers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_base_url(endpoint_url: str | None) -> str | None:
+    if not endpoint_url:
+        return None
+    return endpoint_url.rstrip("/")
+
+
+async def poll_peer(
+    instance_id: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> PeerPollResult:
+    """Poll one peer's three read-only endpoints; record what they share.
+
+    The `client` argument is optional — tests inject a mock transport; in
+    production the service opens its own AsyncClient with the configured
+    timeout. Either way, every outbound is a GET; the service never writes
+    to the peer.
+    """
+    _ensure_schema()
+    peer = federation_service.get_instance(instance_id)
+    polled_at = datetime.now(timezone.utc).isoformat()
+    result = PeerPollResult(
+        peer_instance_id=instance_id,
+        endpoint_url=None,
+        polled_at=polled_at,
+    )
+    if peer is None:
+        result.notes.append("peer not registered locally")
+        return result
+
+    base_url = _normalize_base_url(peer.endpoint_url)
+    result.endpoint_url = base_url
+    if base_url is None:
+        result.notes.append("peer has no endpoint_url")
+        return result
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(timeout=timeout_s)
+
+    try:
+        pulse_body = await _poll_pulse(client, base_url, result)
+        if pulse_body is not None:
+            try:
+                instance_pulse_service.record_peer_pulse(instance_id, pulse_body)
+            except Exception as exc:
+                result.pulse_status = "error"
+                result.notes.append(f"pulse: local write failed ({type(exc).__name__})")
+
+        cap_body = await _poll_capabilities(client, base_url, result)
+        if cap_body is not None:
+            try:
+                _record_capability_manifest(instance_id, cap_body)
+            except Exception as exc:
+                result.capabilities_status = "error"
+                result.notes.append(
+                    f"capabilities: local write failed ({type(exc).__name__})"
+                )
+
+        canonicals = await _poll_canonicals(client, base_url, result)
+        if canonicals is not None:
+            try:
+                _record_substrate_alignment(instance_id, canonicals, result)
+            except Exception as exc:
+                result.substrate_status = "error"
+                result.notes.append(
+                    f"substrate: local write failed ({type(exc).__name__})"
+                )
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    return result
+
+
+async def poll_all_peers(
+    *,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    instance_ids: Iterable[str] | None = None,
+) -> dict[str, PeerPollResult]:
+    """Iterate over registered peers; return per-peer results.
+
+    Each peer's poll is wrapped in its own try/except so one failing peer
+    cannot break the rest of the loop. `instance_ids` lets a caller (or
+    test) narrow the loop to a specific subset; default is "every
+    registered instance."
+    """
+    _ensure_schema()
+    if instance_ids is None:
+        targets = [inst.instance_id for inst in federation_service.list_instances()]
+    else:
+        targets = list(instance_ids)
+
+    results: dict[str, PeerPollResult] = {}
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        for peer_id in targets:
+            try:
+                results[peer_id] = await poll_peer(peer_id, client=client)
+            except Exception as exc:
+                logger.warning(
+                    "poll_peer raised for %s: %s", peer_id, exc, exc_info=True
+                )
+                fallback = PeerPollResult(
+                    peer_instance_id=peer_id,
+                    polled_at=datetime.now(timezone.utc).isoformat(),
+                )
+                fallback.notes.append(f"poll: {type(exc).__name__}")
+                results[peer_id] = fallback
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Read surface — last-polled timestamp per peer
+# ---------------------------------------------------------------------------
+
+
+def get_last_capability_observation(peer_instance_id: str) -> str | None:
+    """ISO timestamp of the most recent successful capability poll, or None."""
+    _ensure_schema()
+    with _session() as session:
+        row = session.get(PeerCapabilityRecord, peer_instance_id)
+        if row is None or row.observed_at is None:
+            return None
+        return row.observed_at.astimezone(timezone.utc).isoformat()
+
+
+def list_last_polled() -> dict[str, str | None]:
+    """Map peer_instance_id → freshest observation across pulse + capabilities.
+
+    The web /federation page uses this to show one "last polled" timestamp
+    per peer card without re-fetching every record. The freshest of the
+    three sources wins; if a peer has never been successfully polled, the
+    value is None.
+    """
+    _ensure_schema()
+    out: dict[str, datetime] = {}
+    with _session() as session:
+        # Capability observations
+        for row in session.query(PeerCapabilityRecord).all():
+            if row.observed_at is None:
+                continue
+            ts = row.observed_at
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            existing = out.get(row.peer_instance_id)
+            if existing is None or ts > existing:
+                out[row.peer_instance_id] = ts
+        # Pulse observations
+        from app.services.instance_pulse_service import PeerPulseRecord
+
+        for row in session.query(PeerPulseRecord).all():
+            if row.observed_at is None:
+                continue
+            ts = row.observed_at
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            existing = out.get(row.peer_instance_id)
+            if existing is None or ts > existing:
+                out[row.peer_instance_id] = ts
+    return {pid: ts.isoformat() for pid, ts in out.items()}
+
+
+# ---------------------------------------------------------------------------
+# Test reset
+# ---------------------------------------------------------------------------
+
+
+def _reset_for_tests() -> None:
+    """Clear peer-poll local tissue so each test starts from clean ground."""
+    _ensure_schema()
+    with _session() as session:
+        session.query(PeerCapabilityRecord).delete()
+        from app.services.instance_pulse_service import PeerPulseRecord
+
+        session.query(PeerPulseRecord).delete()
+        from app.services.federation_service import (
+            FederatedSubstrateAttestationRecord,
+        )
+
+        session.query(FederatedSubstrateAttestationRecord).delete()
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_S",
+    "PeerCapabilityRecord",
+    "PeerPollResult",
+    "get_last_capability_observation",
+    "list_last_polled",
+    "poll_all_peers",
+    "poll_peer",
+]

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 213
+**Total files**: 214
 
 | File | Purpose |
 |---|---|
@@ -67,6 +67,7 @@
 | [test_federation_capabilities.py](test_federation_capabilities.py) | Acceptance tests for self-sovereign capability manifests. |
 | [test_federation_layer.py](test_federation_layer.py) | Acceptance tests for spec: federation-network-layer (idea: federation-and-nodes). |
 | [test_federation_message_readback.py](test_federation_message_readback.py) | _no top-of-file purpose_ |
+| [test_federation_peer_poll.py](test_federation_peer_poll.py) | Acceptance tests for federation_peer_poll_service — the heartbeat. |
 | [test_federation_substance.py](test_federation_substance.py) | Federation substance payload — round-trip test. |
 | [test_federation_substrate_exchange.py](test_federation_substrate_exchange.py) | Acceptance tests for the federated substrate canonical exchange. |
 | [test_federation_value_flow.py](test_federation_value_flow.py) | Acceptance tests for the federated value flow. |

--- a/api/tests/test_federation_peer_poll.py
+++ b/api/tests/test_federation_peer_poll.py
@@ -1,0 +1,391 @@
+"""Acceptance tests for federation_peer_poll_service — the heartbeat.
+
+The federation now has a heartbeat. Each instance chooses its peers and
+polls their public read-only surfaces (pulse, capabilities, canonicals).
+These tests demonstrate the freedom-preserving shape:
+
+  - A successful poll records pulse, capability manifest, and substrate
+    alignment (one PeerPulseRecord, one PeerCapabilityRecord, one row per
+    canonical in the federation-mirror table).
+  - A peer that refuses (401/403/404) is honored — recorded as
+    "not_sharing" with no retry.
+  - A peer that times out is honored — recorded as "unreachable".
+  - A failing peer never breaks the rest of the loop.
+  - The poll never writes to the peer — every outbound is a GET.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from app.models.federation import FederatedInstance
+from app.services import (
+    federation_peer_poll_service,
+    federation_service,
+    instance_pulse_service,
+)
+from app.services import unified_db as _udb
+from app.services.federation_peer_poll_service import (
+    PeerCapabilityRecord,
+    PeerPollResult,
+    poll_all_peers,
+    poll_peer,
+)
+from app.services.federation_service import (
+    FederatedSubstrateAttestationRecord,
+)
+from app.services.instance_pulse_service import PeerPulseRecord
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_peer_poll_tissue():
+    """Each test starts from clean ground."""
+    federation_peer_poll_service._reset_for_tests()
+    yield
+    federation_peer_poll_service._reset_for_tests()
+
+
+def _register_peer(
+    instance_id: str = "peer-a",
+    endpoint_url: str = "https://peer-a.example.test",
+) -> FederatedInstance:
+    """Register a peer the poll loop can find."""
+    return federation_service.register_instance(
+        FederatedInstance(
+            instance_id=instance_id,
+            name=instance_id,
+            endpoint_url=endpoint_url,
+            public_key=None,
+            registered_at=datetime.now(timezone.utc).isoformat(),
+            last_sync_at=None,
+            trust_level="pending",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock transports — each test scripts exactly the HTTP responses it needs
+# ---------------------------------------------------------------------------
+
+
+def _ok_pulse_body() -> dict:
+    return {
+        "instance_id": "peer-a",
+        "overall": "breathing",
+        "organs": [{"name": "api", "status": "breathing", "score": 1.0}],
+        "silences": 0,
+        "uptime_seconds": 42,
+        "as_of": "2026-05-24T00:00:00Z",
+        "sample_duration_ms": 3,
+    }
+
+
+def _ok_capabilities_body() -> dict:
+    return {
+        "instance_id": "peer-a",
+        "instance_url": "https://peer-a.example.test",
+        "providers": ["claude", "openai"],
+        "language_coverage": ["en"],
+        "substrate_canonicals": ["R_Recovery"],
+        "economics": {"cc_accepted": True},
+        "extensions": {},
+        "declared_at": "2026-05-24T00:00:00Z",
+        "truth_source": "self",
+    }
+
+
+def _ok_canonicals_body() -> dict:
+    return {
+        "instance_id": "peer-a",
+        "canonicals": [
+            {
+                "canonical_name": "R_Recovery",
+                "role_slots": ["from", "to"],
+                "modality_tags": ["narrative"],
+                "content_hash": "a" * 64,
+                "blueprint": None,
+                "interned": True,
+                "member_count": 3,
+            },
+            {
+                "canonical_name": "R_PeerDiscoveredOnly",
+                "role_slots": ["only_on_peer"],
+                "modality_tags": [],
+                "content_hash": "b" * 64,
+                "blueprint": None,
+                "interned": True,
+                "member_count": 1,
+            },
+        ],
+    }
+
+
+def _route_handler(routes: dict[str, httpx.Response]):
+    """Build an MockTransport handler that dispatches by URL suffix."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        for suffix, response in routes.items():
+            if request.url.path.endswith(suffix):
+                # Sovereignty discipline: every outbound MUST be a GET.
+                assert request.method == "GET", (
+                    f"peer-poll attempted {request.method} on {request.url} — "
+                    "the service is read-only by contract"
+                )
+                return response
+        return httpx.Response(status_code=404, json={"detail": "no route"})
+
+    return handler
+
+
+def _mock_client(routes: dict[str, httpx.Response]) -> httpx.AsyncClient:
+    transport = httpx.MockTransport(_route_handler(routes))
+    return httpx.AsyncClient(transport=transport, timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Pulse is recorded on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_records_pulse():
+    """A successful pulse GET upserts a PeerPulseRecord."""
+    _register_peer("peer-a")
+    routes = {
+        "/api/pulse/now": httpx.Response(200, json=_ok_pulse_body()),
+        "/api/federation/capabilities/self": httpx.Response(200, json=_ok_capabilities_body()),
+        "/api/federation/substrate/canonicals": httpx.Response(200, json=_ok_canonicals_body()),
+    }
+    async with _mock_client(routes) as client:
+        result = await poll_peer("peer-a", client=client)
+
+    assert result.pulse_status == "ok"
+    pulses = instance_pulse_service.list_peer_pulses()
+    assert len(pulses) == 1
+    assert pulses[0]["peer_instance_id"] == "peer-a"
+    assert pulses[0]["pulse"]["overall"] == "breathing"
+
+
+# ---------------------------------------------------------------------------
+# 2. Capability manifest is recorded on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_records_capabilities():
+    """A successful capabilities GET upserts a PeerCapabilityRecord."""
+    _register_peer("peer-a")
+    routes = {
+        "/api/pulse/now": httpx.Response(200, json=_ok_pulse_body()),
+        "/api/federation/capabilities/self": httpx.Response(200, json=_ok_capabilities_body()),
+        "/api/federation/substrate/canonicals": httpx.Response(200, json=_ok_canonicals_body()),
+    }
+    async with _mock_client(routes) as client:
+        result = await poll_peer("peer-a", client=client)
+
+    assert result.capabilities_status == "ok"
+    with _udb.session() as session:
+        row = session.get(PeerCapabilityRecord, "peer-a")
+        assert row is not None
+        manifest = json.loads(row.manifest_json)
+        assert manifest["providers"] == ["claude", "openai"]
+        assert manifest["substrate_canonicals"] == ["R_Recovery"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Substrate alignment attestations are written
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_records_substrate_alignment():
+    """A successful canonicals GET drives federation_substrate_service.exchange_with_peer."""
+    _register_peer("peer-a")
+    routes = {
+        "/api/pulse/now": httpx.Response(200, json=_ok_pulse_body()),
+        "/api/federation/capabilities/self": httpx.Response(200, json=_ok_capabilities_body()),
+        "/api/federation/substrate/canonicals": httpx.Response(200, json=_ok_canonicals_body()),
+    }
+    async with _mock_client(routes) as client:
+        result = await poll_peer("peer-a", client=client)
+
+    assert result.substrate_status == "ok"
+    # Two canonicals shared: R_Recovery (we carry it, but hash differs from
+    # our deterministic hash → diverged) and R_PeerDiscoveredOnly (peer-only
+    # → discovered). Both record attestations; neither imports into our
+    # lattice.
+    assert result.aligned + result.diverged + result.discovered == 2
+
+    with _udb.session() as session:
+        rows = (
+            session.query(FederatedSubstrateAttestationRecord)
+            .filter_by(peer_instance_id="peer-a")
+            .all()
+        )
+    canonical_names = {row.canonical_name for row in rows}
+    assert "R_Recovery" in canonical_names
+    assert "R_PeerDiscoveredOnly" in canonical_names
+
+
+# ---------------------------------------------------------------------------
+# 4. Timeout is honored — no exception escapes, no record written
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_handles_timeout_gracefully():
+    """A timeout on any endpoint marks 'unreachable' and continues."""
+    _register_peer("peer-a")
+
+    def timeout_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("simulated timeout", request=request)
+
+    transport = httpx.MockTransport(timeout_handler)
+    async with httpx.AsyncClient(transport=transport, timeout=5.0) as client:
+        result = await poll_peer("peer-a", client=client)
+
+    assert result.pulse_status == "unreachable"
+    assert result.capabilities_status == "unreachable"
+    assert result.substrate_status == "unreachable"
+    # No silent crash — the result is structured and tells us why.
+    assert any("timeout" in n.lower() for n in result.notes)
+    # No tissue written for an unreachable peer.
+    assert instance_pulse_service.list_peer_pulses() == []
+    with _udb.session() as session:
+        assert session.get(PeerCapabilityRecord, "peer-a") is None
+
+
+# ---------------------------------------------------------------------------
+# 5. 403 is honored as sovereign refusal — no retry, no record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_handles_403_gracefully():
+    """A peer that refuses is recorded as 'not_sharing'; nothing is forced."""
+    _register_peer("peer-a")
+    routes = {
+        "/api/pulse/now": httpx.Response(403, json={"detail": "not shared"}),
+        "/api/federation/capabilities/self": httpx.Response(404, json={"detail": "not shared"}),
+        "/api/federation/substrate/canonicals": httpx.Response(401, json={"detail": "not shared"}),
+    }
+    async with _mock_client(routes) as client:
+        result = await poll_peer("peer-a", client=client)
+
+    assert result.pulse_status == "not_sharing"
+    assert result.capabilities_status == "not_sharing"
+    assert result.substrate_status == "not_sharing"
+    # Nothing recorded — the peer named a boundary; we honor it.
+    assert instance_pulse_service.list_peer_pulses() == []
+    with _udb.session() as session:
+        assert session.get(PeerCapabilityRecord, "peer-a") is None
+        rows = (
+            session.query(FederatedSubstrateAttestationRecord)
+            .filter_by(peer_instance_id="peer-a")
+            .all()
+        )
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Per-peer isolation — one failing peer doesn't break the others
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_all_peers_continues_after_individual_failure(monkeypatch):
+    """Three peers, one fails internally — the other two still get polled."""
+    _register_peer("peer-ok-1", endpoint_url="https://peer-ok-1.example.test")
+    _register_peer("peer-bad", endpoint_url="https://peer-bad.example.test")
+    _register_peer("peer-ok-2", endpoint_url="https://peer-ok-2.example.test")
+
+    real_poll_peer = federation_peer_poll_service.poll_peer
+
+    async def poll_peer_with_boom(instance_id, **kwargs):
+        if instance_id == "peer-bad":
+            raise RuntimeError("simulated mid-poll crash")
+        # The good peers get a fully-mocked client.
+        routes = {
+            "/api/pulse/now": httpx.Response(200, json=_ok_pulse_body()),
+            "/api/federation/capabilities/self": httpx.Response(
+                200, json=_ok_capabilities_body()
+            ),
+            "/api/federation/substrate/canonicals": httpx.Response(
+                200, json=_ok_canonicals_body()
+            ),
+        }
+        async with _mock_client(routes) as client:
+            return await real_poll_peer(instance_id, client=client)
+
+    monkeypatch.setattr(
+        federation_peer_poll_service, "poll_peer", poll_peer_with_boom
+    )
+
+    results = await poll_all_peers()
+
+    assert set(results.keys()) == {"peer-ok-1", "peer-bad", "peer-ok-2"}
+    assert results["peer-ok-1"].pulse_status == "ok"
+    assert results["peer-ok-2"].pulse_status == "ok"
+    # The crashing peer gets a structured fallback, not an exception.
+    assert any("RuntimeError" in n for n in results["peer-bad"].notes)
+
+
+# ---------------------------------------------------------------------------
+# 7. Sovereignty discipline — the poll never POSTs / PUTs / DELETEs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_does_not_write_to_peer():
+    """Every outbound request the service makes is a GET.
+
+    The MockTransport asserts request.method == 'GET' on every call; if
+    the service ever tries to POST/PUT/DELETE, the assert fires and the
+    test fails. The contract is enforced at the wire.
+    """
+    _register_peer("peer-a")
+    seen_methods: list[str] = []
+
+    def recording_handler(request: httpx.Request) -> httpx.Response:
+        seen_methods.append(request.method)
+        assert request.method == "GET", (
+            f"peer-poll attempted {request.method} on {request.url} — "
+            "the service is read-only by contract"
+        )
+        if request.url.path.endswith("/api/pulse/now"):
+            return httpx.Response(200, json=_ok_pulse_body())
+        if request.url.path.endswith("/api/federation/capabilities/self"):
+            return httpx.Response(200, json=_ok_capabilities_body())
+        if request.url.path.endswith("/api/federation/substrate/canonicals"):
+            return httpx.Response(200, json=_ok_canonicals_body())
+        return httpx.Response(404, json={})
+
+    transport = httpx.MockTransport(recording_handler)
+    async with httpx.AsyncClient(transport=transport, timeout=5.0) as client:
+        await poll_peer("peer-a", client=client)
+
+    assert seen_methods == ["GET", "GET", "GET"]
+    assert all(m == "GET" for m in seen_methods)
+
+
+# ---------------------------------------------------------------------------
+# 8. Unregistered peer yields a clean PeerPollResult, never raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_peer_unregistered_returns_structured_result():
+    """Polling a peer we never registered is a noop with a clear note."""
+    result = await poll_peer("not-registered-anywhere")
+    assert isinstance(result, PeerPollResult)
+    assert result.pulse_status == "skipped"
+    assert any("not registered" in n for n in result.notes)

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 125
+**Total files**: 126
 
 | File | Purpose |
 |---|---|
@@ -46,6 +46,7 @@
 | [export_lineage.py](export_lineage.py) | !/usr/bin/env python3 |
 | [export_vision_image_prompts.py](export_vision_image_prompts.py) | !/usr/bin/env python3 |
 | [external_proof_demo.py](external_proof_demo.py) | !/usr/bin/env python3 |
+| [federation_peer_poll.py](federation_peer_poll.py) | !/usr/bin/env python3 |
 | [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | !/usr/bin/env python3 |
 | [form_cli.py](form_cli.py) | !/usr/bin/env python3 |
 | [form_native_grammar_contract.py](form_native_grammar_contract.py) | !/usr/bin/env python3 |

--- a/scripts/federation_peer_poll.py
+++ b/scripts/federation_peer_poll.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""federation_peer_poll — fire one peer-poll cycle from the command line.
+
+The federation's heartbeat. Each instance decides which peers to know and
+polls their public read-only surfaces (pulse, capabilities, canonicals).
+Nothing here writes to peers — every outbound is a GET; the discipline of
+sovereignty is enforced by the service, not by the runner.
+
+Run once locally:
+    python3 scripts/federation_peer_poll.py
+
+Poll only one peer:
+    python3 scripts/federation_peer_poll.py --peer <instance_id>
+
+Install as a cron job on the VPS (every 5 minutes):
+
+    # Edit the system crontab
+    crontab -e
+
+    # Add a line — uses the API container's python; logs land in /var/log
+    # so silent failure surfaces somewhere visible.
+    */5 * * * * cd /docker/coherence-network/repo \\
+        && docker compose exec -T api python3 scripts/federation_peer_poll.py \\
+        >> /var/log/federation_peer_poll.log 2>&1
+
+Exit codes:
+    0 — every peer polled (some may be unreachable; that is sovereign refusal)
+    1 — at least one peer raised an unhandled error (separately from
+        the per-endpoint statuses, which the service catches and records)
+    2 — invalid CLI argument
+
+The cron job does not block local API behavior; failures are bounded per
+peer. If the witness at pulse.coherencycoin.com shows no fresh federation
+silence after a deploy, the heartbeat is healthy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Add the api/ directory to sys.path so the service imports resolve when
+# the script is invoked from the repo root (and inside the api container).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_API_ROOT = _REPO_ROOT / "api"
+if str(_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_API_ROOT))
+
+
+def _format_summary(results: dict) -> str:
+    """One-line-per-peer human summary."""
+    if not results:
+        return "no peers registered — federation has no chosen kin yet"
+    lines = [f"polled {len(results)} peer(s):"]
+    for peer_id, r in results.items():
+        align = f"aligned={r.aligned} diverged={r.diverged} discovered={r.discovered}"
+        lines.append(
+            f"  {peer_id}: "
+            f"pulse={r.pulse_status} "
+            f"capabilities={r.capabilities_status} "
+            f"substrate={r.substrate_status} {align}"
+        )
+        for note in r.notes:
+            lines.append(f"    note: {note}")
+    return "\n".join(lines)
+
+
+async def _run(peer: str | None, as_json: bool) -> int:
+    # Late import so --help works even if the api environment isn't loaded.
+    from app.services import federation_peer_poll_service
+
+    if peer is not None:
+        result = await federation_peer_poll_service.poll_peer(peer)
+        results = {peer: result}
+    else:
+        results = await federation_peer_poll_service.poll_all_peers()
+
+    if as_json:
+        payload = {pid: r.to_dict() for pid, r in results.items()}
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(_format_summary(results))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fire one peer-poll cycle and print a summary.",
+    )
+    parser.add_argument(
+        "--peer",
+        default=None,
+        help="Optional instance_id; default polls all registered peers",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human summary",
+    )
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_run(args.peer, args.json))
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:  # pragma: no cover - top-level safety
+        print(f"federation_peer_poll: unhandled error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/app/federation/page.tsx
+++ b/web/app/federation/page.tsx
@@ -96,6 +96,8 @@ type AttestationsResponse = {
   count: number;
 };
 
+type LastPolledResponse = Record<string, string | null>;
+
 type AssetMirrorRecord = {
   local_asset_id: string;
   origin_instance_id: string;
@@ -271,6 +273,7 @@ export default async function FederationPage() {
     selfCaps,
     instances,
     peerPulses,
+    lastPolled,
     mirrors,
     attestations,
     outbox,
@@ -280,6 +283,7 @@ export default async function FederationPage() {
     fetchJson<CapabilityManifest>(`${apiBase}/api/federation/capabilities/self`),
     fetchJson<FederatedInstance[]>(`${apiBase}/api/federation/instances`),
     fetchJson<PeerPulsesResponse>(`${apiBase}/api/pulse/peers`),
+    fetchJson<LastPolledResponse>(`${apiBase}/api/federation/peers/last-polled`),
     fetchJson<AssetMirrorRecord[]>(`${apiBase}/api/federation/value/mirrors`),
     fetchJson<FederatedReadAttestationListResponse>(
       `${apiBase}/api/federation/value/read-attestations`
@@ -291,6 +295,8 @@ export default async function FederationPage() {
       `${apiBase}/api/federation/value/settlement-share/inbox`
     ),
   ]);
+
+  const lastPolledMap: LastPolledResponse = lastPolled ?? {};
 
   const mirrorList = Array.isArray(mirrors) ? mirrors : [];
   const attestationList = attestations?.attestations ?? [];
@@ -505,6 +511,10 @@ export default async function FederationPage() {
                     </p>
                     <p>
                       {t("federation.peerObservedAt")}: {formatTimestamp(pulse?.observed_at)}
+                    </p>
+                    <p>
+                      {t("federation.peerLastPolled")}:{" "}
+                      {formatTimestamp(lastPolledMap[peer.instance_id] ?? null)}
                     </p>
                   </div>
                   <PeerVerifyButton

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1012,6 +1012,7 @@
     "peersEmpty": "No peers registered yet — sovereign by default.",
     "peerPulseUnknown": "no pulse yet",
     "peerObservedAt": "Last observed",
+    "peerLastPolled": "Last polled",
     "verify": "Verify signature",
     "verifying": "Verifying…",
     "verified": "signature verified",


### PR DESCRIPTION
## The federation now has a heartbeat

Each instance decides which peers to know, polls them on its own schedule,
records what they willingly share. No instance is polled without its
consent; no peer is forced to reciprocate. The fleet's view emerges from
each instance's chosen knowing.

## What the poll job does

Reads three public read-only endpoints per peer:

- `/api/pulse/now` → upserts a `PeerPulseRecord` (table shipped in #1974)
- `/api/federation/capabilities/self` → upserts a `PeerCapabilityRecord` (new)
- `/api/federation/substrate/canonicals` → records per-canonical alignment
  via `federation_substrate_service.exchange_with_peer` (#1975)

Each endpoint is bounded by a 5-second timeout. Each peer's poll is wrapped
in its own try/except so one failing peer never breaks the rest of the
loop. Every outbound request is a GET — the service never POSTs, PUTs, or
DELETEs to a peer (a test enforces this at the wire).

## Honoring sovereignty

- 401 / 403 / 404 are recorded as `not_sharing` — no retry, no escalation.
  The peer named a boundary; we honor it the same as a timeout.
- Timeouts / connection errors record `unreachable` — no exception escapes.
- The peer's canonicals never import into our lattice; only attestations
  are written. Both sides keep their own recipe-shape cells.
- An instance choosing not to register peers gets an empty poll — sovereign
  by default.

## What this PR adds

- `api/app/services/federation_peer_poll_service.py` — `poll_peer`,
  `poll_all_peers`, `PeerCapabilityRecord` ORM, `_reset_for_tests`
- `POST /api/federation/peers/poll` — manual trigger (single peer or all)
- `GET /api/federation/peers/last-polled` — freshest observation per peer
- `scripts/federation_peer_poll.py` — CLI for cron; install snippet in
  the docstring (every 5 minutes via `docker compose exec api python3 ...`)
- `web/app/federation/page.tsx` — `Last polled` line on each peer card
- `web/messages/en.json` — `federation.peerLastPolled`
- 8 acceptance tests in `api/tests/test_federation_peer_poll.py`

## Test plan

- [x] `pytest tests/test_federation_peer_poll.py` — 8/8 pass
- [x] `pytest tests/test_federation_peer_poll.py tests/test_federation_layer.py tests/test_federation_substrate_exchange.py tests/test_federation_capabilities.py tests/test_instance_pulse.py` — 42/42 pass
- [x] `python3 scripts/federation_peer_poll.py --help` works
- [x] `python3 scripts/generate_repo_indexes.py` — INDEXes regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)