### PR TITLE
tend: add grammar lanes to form playground

### DIFF
--- a/docs/system_audit/commit_evidence_20260524_grammar_lanes_form_playground.json
+++ b/docs/system_audit/commit_evidence_20260524_grammar_lanes_form_playground.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-05-24",
+  "thread_branch": "codex/grammar-lanes-form-playground-20260524",
+  "commit_scope": "Add four Grammar Lanes to the substrate Form Playground so visitors can create BML action, Python-to-Form, grammar-builder, and cross-modality recipe payloads.",
+  "files_owned": [
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "web/lib/form-kernel/grammar-lanes.ts",
+    "web/tests/grammar-lanes.test.ts"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm run test -- grammar-lanes.test.ts form-kernel-client.test.ts",
+      "cd web && npm run build",
+      "cd web && node <playwright viewport script>"
+    ],
+    "notes": "Focused Vitest passed 6 tests across grammar-lanes and embedded kernel client. Next build passed. Playwright verified the Grammar Lanes section on /substrate/form at desktop 1440px and mobile 390px with no horizontal overflow."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Not pushed yet."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Not deployed yet."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A visitor on /substrate/form can switch between BML / Action Language, Python => Form, Grammar Builder, and Cross-Modality Recipe lanes, edit source input, see a Form-facing payload, and load executable action/Python expressions into the evaluator.",
+    "public_endpoints": [
+      "/substrate/form"
+    ],
+    "test_flows": [
+      "Open http://localhost:3118/substrate/form, scroll to Grammar Lanes, verify all four lane buttons are visible.",
+      "Click Python => Form and verify the generated payload contains method integration_breath.",
+      "Click Grammar Builder and verify the generated payload contains grammar @concept(local-grammar-lane).",
+      "Click Cross-Modality Recipe and verify the generated payload contains recipe \"teaching recipe\".",
+      "Measure mobile viewport scrollWidth at 390px and verify it equals innerWidth."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local proof is complete; CI and deploy proof remain after push/PR."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "form-question-effects-kernel-conformance"
+  ],
+  "task_ids": [
+    "grammar-lanes-form-playground-20260524"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Vitest: grammar-lanes.test.ts and form-kernel-client.test.ts passed 6 tests.",
+    "Next build: /substrate/form compiled with Grammar Lanes panel.",
+    "Playwright: desktop and mobile viewport checks found all four lanes and no mobile horizontal overflow."
+  ],
+  "change_files": [
+    "web/app/substrate/form/_components/FormPlayground.tsx",
+    "web/lib/form-kernel/grammar-lanes.ts",
+    "web/tests/grammar-lanes.test.ts",
+    "docs/system_audit/commit_evidence_20260524_grammar_lanes_form_playground.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowRight, Cpu, Play, RotateCcw, Sparkles } from "lucide-react";
@@ -9,6 +9,19 @@ import {
   runLocalFormBinary,
   type LocalFormRun,
 } from "@/lib/form-kernel/client";
+import {
+  ACTION_LANGUAGE_STARTER,
+  CROSS_MODALITY_STARTER,
+  GRAMMAR_ACTION_STARTER,
+  GRAMMAR_CAPTURES_STARTER,
+  GRAMMAR_PATTERN_STARTER,
+  PYTHON_FORM_STARTER,
+  compileActionLanguage,
+  compileCrossModalityRecipe,
+  compileGrammarBuilder,
+  compilePythonToForm,
+  type GrammarLaneId,
+} from "@/lib/form-kernel/grammar-lanes";
 
 type NodeIDOut = { package: number; level: number; type: number; instance: number };
 
@@ -732,6 +745,270 @@ function LocalKernelPanel() {
   );
 }
 
+const GRAMMAR_LANES: Array<{
+  id: GrammarLaneId;
+  label: string;
+  audience: string;
+  description: string;
+}> = [
+  {
+    id: "action",
+    label: "BML / Action Language",
+    audience: "embodied command",
+    description: "Run delegate, raise, undo, with, and invoke as action-shaped Form.",
+  },
+  {
+    id: "python",
+    label: "Python => Form",
+    audience: "code translation",
+    description: "Paste a tiny Python function and watch the recipe skeleton appear.",
+  },
+  {
+    id: "builder",
+    label: "Grammar Builder",
+    audience: "new grammar",
+    description: "Define a pattern, captures, and semantic action in one living rule.",
+  },
+  {
+    id: "modality",
+    label: "Cross-Modality Recipe",
+    audience: "source extraction",
+    description: "Turn story, song, video, or source into a transferable recipe.",
+  },
+];
+
+const RECIPE_KINDS = [
+  "teaching recipe",
+  "movement recipe",
+  "implementation recipe",
+  "verification recipe",
+];
+
+function GrammarLanesPanel({
+  onLoadExpression,
+}: {
+  onLoadExpression: (expr: string, showcases: string, nextMove: string) => void;
+}) {
+  const [activeLane, setActiveLane] = useState<GrammarLaneId>("action");
+  const [actionCommand, setActionCommand] = useState(ACTION_LANGUAGE_STARTER);
+  const [pythonSource, setPythonSource] = useState(PYTHON_FORM_STARTER);
+  const [pattern, setPattern] = useState(GRAMMAR_PATTERN_STARTER);
+  const [captures, setCaptures] = useState(GRAMMAR_CAPTURES_STARTER);
+  const [semanticAction, setSemanticAction] = useState(GRAMMAR_ACTION_STARTER);
+  const [modalitySource, setModalitySource] = useState(CROSS_MODALITY_STARTER);
+  const [recipeKind, setRecipeKind] = useState(RECIPE_KINDS[0]);
+
+  const output = useMemo(() => {
+    if (activeLane === "python") return compilePythonToForm(pythonSource);
+    if (activeLane === "builder") {
+      return compileGrammarBuilder(pattern, captures, semanticAction);
+    }
+    if (activeLane === "modality") {
+      return compileCrossModalityRecipe(modalitySource, recipeKind);
+    }
+    return compileActionLanguage(actionCommand);
+  }, [
+    activeLane,
+    actionCommand,
+    captures,
+    modalitySource,
+    pattern,
+    pythonSource,
+    recipeKind,
+    semanticAction,
+  ]);
+
+  return (
+    <section
+      className="grid max-w-full gap-5 overflow-hidden rounded-xl border border-violet-300/70 bg-violet-50/80 p-4 dark:border-violet-500/20 dark:bg-violet-500/5 lg:grid-cols-[0.85fr_1.15fr]"
+      aria-labelledby="grammar-lanes-heading"
+    >
+      <div className="min-w-0 space-y-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.22em] text-violet-600 dark:text-violet-300/75">
+            Grammar lanes
+          </p>
+          <h2 id="grammar-lanes-heading" className="text-2xl font-light text-stone-950 dark:text-stone-100">
+            Let new grammars surface here.
+          </h2>
+          <p className="text-sm leading-relaxed text-stone-700 dark:text-stone-400">
+            Each lane turns a different source shape into a Form-facing recipe. Edit the
+            input, read the generated payload, then load the pieces that already execute
+            through the evaluator.
+          </p>
+        </div>
+
+        <div className="grid gap-2">
+          {GRAMMAR_LANES.map((lane) => (
+            <button
+              key={lane.id}
+              type="button"
+              onClick={() => setActiveLane(lane.id)}
+              className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                activeLane === lane.id
+                  ? "border-violet-500/60 bg-violet-100/80 text-stone-950 dark:border-violet-400/50 dark:bg-violet-500/10 dark:text-violet-100"
+                  : "border-stone-300/70 bg-white/75 text-stone-800 hover:border-violet-400/60 hover:text-violet-800 dark:border-stone-800/50 dark:bg-stone-950/35 dark:text-stone-300 dark:hover:border-violet-500/35 dark:hover:text-violet-200"
+              }`}
+            >
+              <span className="flex items-center gap-2 text-sm font-medium">
+                <Sparkles className="h-4 w-4 text-violet-600 dark:text-violet-300/80" aria-hidden="true" />
+                {lane.label}
+              </span>
+              <span className="mt-1 block text-xs uppercase tracking-[0.16em] text-stone-600 dark:text-stone-500">
+                {lane.audience}
+              </span>
+              <span className="mt-1 block text-xs leading-relaxed text-stone-700 dark:text-stone-500">
+                {lane.description}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-w-0 space-y-4 rounded-xl border border-stone-300/70 bg-white/75 p-4 dark:border-stone-800/50 dark:bg-stone-950/35">
+        {activeLane === "action" && (
+          <div className="space-y-2">
+            <label htmlFor="grammar-action" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+              Embodied command
+            </label>
+            <textarea
+              id="grammar-action"
+              value={actionCommand}
+              onChange={(e) => setActionCommand(e.target.value)}
+              className="h-28 w-full min-w-0 resize-y rounded-xl border border-stone-300 bg-white p-3 font-mono text-sm leading-relaxed text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              spellCheck={false}
+            />
+          </div>
+        )}
+
+        {activeLane === "python" && (
+          <div className="space-y-2">
+            <label htmlFor="grammar-python" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+              Python function
+            </label>
+            <textarea
+              id="grammar-python"
+              value={pythonSource}
+              onChange={(e) => setPythonSource(e.target.value)}
+              className="h-40 w-full min-w-0 resize-y rounded-xl border border-stone-300 bg-white p-3 font-mono text-sm leading-relaxed text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              spellCheck={false}
+            />
+          </div>
+        )}
+
+        {activeLane === "builder" && (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <label htmlFor="grammar-pattern" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+                Pattern
+              </label>
+              <input
+                id="grammar-pattern"
+                value={pattern}
+                onChange={(e) => setPattern(e.target.value)}
+                className="w-full min-w-0 rounded-xl border border-stone-300 bg-white p-3 font-mono text-sm text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="grammar-captures" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+                Captures
+              </label>
+              <input
+                id="grammar-captures"
+                value={captures}
+                onChange={(e) => setCaptures(e.target.value)}
+                className="w-full min-w-0 rounded-xl border border-stone-300 bg-white p-3 font-mono text-sm text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="grammar-action-builder" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+                Semantic action
+              </label>
+              <input
+                id="grammar-action-builder"
+                value={semanticAction}
+                onChange={(e) => setSemanticAction(e.target.value)}
+                className="w-full min-w-0 rounded-xl border border-stone-300 bg-white p-3 font-mono text-sm text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              />
+            </div>
+          </div>
+        )}
+
+        {activeLane === "modality" && (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <label htmlFor="recipe-kind" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+                Recipe kind
+              </label>
+              <select
+                id="recipe-kind"
+                value={recipeKind}
+                onChange={(e) => setRecipeKind(e.target.value)}
+                className="w-full min-w-0 rounded-xl border border-stone-300 bg-white p-3 text-sm text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              >
+                {RECIPE_KINDS.map((kind) => (
+                  <option key={kind} value={kind}>
+                    {kind}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="modality-source" className="text-xs uppercase tracking-[0.18em] text-stone-600 dark:text-stone-500">
+                Source fragment
+              </label>
+              <textarea
+                id="modality-source"
+                value={modalitySource}
+                onChange={(e) => setModalitySource(e.target.value)}
+                className="h-36 w-full min-w-0 resize-y rounded-xl border border-stone-300 bg-white p-3 text-sm leading-relaxed text-stone-900 transition-colors focus:border-violet-500/60 focus:outline-none dark:border-stone-800/50 dark:bg-stone-950/80 dark:text-stone-300 dark:focus:border-violet-500/40"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3 rounded-xl border border-stone-300/70 bg-white/70 p-3 dark:border-stone-800/50 dark:bg-stone-900/25">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-stone-600 dark:text-stone-500">
+              {output.title}
+            </div>
+            <p className="mt-1 text-sm leading-relaxed text-stone-700 dark:text-stone-400">{output.summary}</p>
+          </div>
+          <pre className="max-h-72 max-w-full overflow-auto whitespace-pre-wrap break-words rounded-lg border border-stone-800/40 bg-stone-950/60 p-3 text-xs leading-relaxed text-violet-100/90">
+            {output.form}
+          </pre>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {output.steps.map((step) => (
+              <div
+                key={step}
+                className="rounded-lg border border-stone-300/70 bg-stone-50 px-3 py-2 text-xs text-stone-700 dark:border-stone-800/40 dark:bg-stone-950/45 dark:text-stone-400"
+              >
+                {step}
+              </div>
+            ))}
+          </div>
+          {output.loadableExpression && (
+            <button
+              type="button"
+              onClick={() =>
+                onLoadExpression(
+                  output.loadableExpression ?? output.form,
+                  `${output.title} generated this Form expression. Run it, then edit one binding and compare the returned shape.`,
+                  "Run it in the evaluator, then change one noun or verb and run again.",
+                )
+              }
+              className="inline-flex items-center gap-2 rounded-xl border border-violet-500/30 bg-violet-100 px-4 py-2 text-sm font-medium text-violet-800 transition-all hover:border-violet-500/50 hover:bg-violet-200 dark:border-violet-500/20 dark:bg-violet-500/10 dark:text-violet-200 dark:hover:border-violet-500/30 dark:hover:bg-violet-500/20"
+            >
+              <Play className="h-4 w-4" aria-hidden="true" />
+              Load into evaluator
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 // Build a starter expression when the playground arrives bound to a cell.
 // `?cell=@concept(lc-pulse)` becomes `@concept(lc-pulse).blueprint` — a
 // useful first question to ask of any cell. The visitor lands inside a
@@ -779,6 +1056,14 @@ export function FormPlayground() {
     setExpression(ex.expr);
     setActiveShowcase(ex.showcases);
     setNextMove("Edit one symbol, run it again, and compare the returned shape.");
+    setResult(null);
+    setError(null);
+  };
+
+  const loadGeneratedExpression = (expr: string, showcases: string, next: string) => {
+    setExpression(expr);
+    setActiveShowcase(showcases);
+    setNextMove(next);
     setResult(null);
     setError(null);
   };
@@ -908,6 +1193,8 @@ export function FormPlayground() {
       </section>
 
       <LocalKernelPanel />
+
+      <GrammarLanesPanel onLoadExpression={loadGeneratedExpression} />
 
       <section className="space-y-4" aria-labelledby="form-atlas-heading">
         <div>

--- a/web/lib/form-kernel/grammar-lanes.ts
+++ b/web/lib/form-kernel/grammar-lanes.ts
@@ -1,0 +1,194 @@
+// Grammar lane compilers for the Form playground.
+
+export type GrammarLaneId = "action" | "python" | "builder" | "modality";
+
+export type GrammarLaneOutput = {
+  title: string;
+  form: string;
+  summary: string;
+  steps: string[];
+  loadableExpression?: string;
+};
+
+export const ACTION_LANGUAGE_STARTER =
+  "delegate @concept(lc-trust-over-fear) to @concept(lc-permission-is-interior)";
+
+export const PYTHON_FORM_STARTER = `def integration_breath(signal, practice):
+    if signal > 3:
+        return practice + signal
+    return practice`;
+
+export const GRAMMAR_PATTERN_STARTER =
+  "when {trigger} arises, offer {practice} for {duration}";
+
+export const GRAMMAR_CAPTURES_STARTER = "trigger, practice, duration";
+
+export const GRAMMAR_ACTION_STARTER =
+  "emit movement_recipe(trigger, practice, duration)";
+
+export const CROSS_MODALITY_STARTER = `A facilitator tells the story of a stuck team:
+first they name the contraction, then each person mirrors one sentence,
+then the group commits one reversible action and one verification breath.`;
+
+const ACTION_VERBS = new Set(["delegate", "raise", "undo", "with", "invoke"]);
+
+function cleanLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}
+
+function parseCaptures(value: string): string[] {
+  return value
+    .split(/[,|\n]/)
+    .map((part) => part.trim().replace(/^\{|\}$/g, ""))
+    .filter(Boolean);
+}
+
+function indent(value: string, spaces = 2): string {
+  const pad = " ".repeat(spaces);
+  return value
+    .split("\n")
+    .map((line) => `${pad}${line}`)
+    .join("\n");
+}
+
+export function compileActionLanguage(command: string): GrammarLaneOutput {
+  const source = command.trim() || ACTION_LANGUAGE_STARTER;
+  const verb = source.split(/\s+/)[0]?.toLowerCase() || "invoke";
+  const recognized = ACTION_VERBS.has(verb);
+  const form = recognized
+    ? source
+    : `invoke ${source.replace(/\s+/g, "_")} on @concept(lc-trust-over-fear)`;
+
+  return {
+    title: "BML / Action Language",
+    form,
+    loadableExpression: form,
+    summary:
+      "Action phrases become embodied Form commands that can be loaded into the evaluator and walked as recipes.",
+    steps: [
+      `verb: ${recognized ? verb : "invoke"}`,
+      "bind subject / target",
+      "walk delegation, exception, reverse, or method dispatch",
+      "return a Recipe NodeID or runtime value",
+    ],
+  };
+}
+
+function parsePythonFunction(source: string): {
+  name: string;
+  args: string[];
+  returns: string[];
+} {
+  const lines = cleanLines(source || PYTHON_FORM_STARTER);
+  const header = lines.find((line) => line.startsWith("def ")) || "def recipe(input):";
+  const match = header.match(/^def\s+([A-Za-z_][\w]*)\s*\(([^)]*)\)\s*:/);
+  const name = match?.[1] || "recipe";
+  const args = (match?.[2] || "input")
+    .split(",")
+    .map((arg) => arg.trim())
+    .filter(Boolean);
+  const returns = lines
+    .filter((line) => line.startsWith("return "))
+    .map((line) => line.replace(/^return\s+/, "").trim());
+  return { name, args, returns: returns.length ? returns : ["input"] };
+}
+
+export function compilePythonToForm(source: string): GrammarLaneOutput {
+  const parsed = parsePythonFunction(source);
+  const bindings = parsed.args
+    .map((arg, index) => `let ${arg} = .arg${index};`)
+    .join("\n");
+  const body = parsed.returns.length === 1
+    ? parsed.returns[0]
+    : `if ${parsed.returns[0]} then ${parsed.returns[0]} else ${
+        parsed.returns[parsed.returns.length - 1]
+      }`;
+  const form = `method ${parsed.name} on @concept(local-python-form) {\n${indent(
+    `do {\n${indent(bindings, 4)}\n    ${body}\n  }`,
+    2,
+  )}\n}`;
+
+  return {
+    title: "Python => Form",
+    form,
+    loadableExpression: form,
+    summary:
+      "A tiny Python function becomes a method-shaped Form recipe skeleton with arguments, body, and return expression visible.",
+    steps: [
+      `function: ${parsed.name}`,
+      `captures: ${parsed.args.join(", ") || "none"}`,
+      "map Python args to .arg slots",
+      "preserve the return shape as the Form body",
+    ],
+  };
+}
+
+export function compileGrammarBuilder(
+  pattern: string,
+  captures: string,
+  semanticAction: string,
+): GrammarLaneOutput {
+  const parsedCaptures = parseCaptures(captures || GRAMMAR_CAPTURES_STARTER);
+  const patternText = pattern.trim() || GRAMMAR_PATTERN_STARTER;
+  const actionText = semanticAction.trim() || GRAMMAR_ACTION_STARTER;
+  const captureRows = parsedCaptures
+    .map((capture) => `capture ${capture} as @field(${capture})`)
+    .join("\n");
+  const form = `grammar @concept(local-grammar-lane) {\n${indent(
+    `pattern ${quote(patternText)}\n${captureRows}\naction { ${actionText} }`,
+    2,
+  )}\n}`;
+
+  return {
+    title: "Grammar Builder",
+    form,
+    summary:
+      "A human-readable pattern becomes a grammar rule with named captures and one semantic action.",
+    steps: [
+      "recognize pattern",
+      `capture ${parsedCaptures.length} field${parsedCaptures.length === 1 ? "" : "s"}`,
+      "bind captures into a semantic action",
+      "emit a reusable grammar cell",
+    ],
+  };
+}
+
+export function compileCrossModalityRecipe(
+  source: string,
+  recipeKind: string,
+): GrammarLaneOutput {
+  const kind = recipeKind || "teaching recipe";
+  const text = (source.trim() || CROSS_MODALITY_STARTER).replace(/\s+/g, " ");
+  const channels =
+    kind === "movement recipe"
+      ? ["gesture", "breath", "tempo", "somatic cue"]
+      : kind === "implementation recipe"
+        ? ["intent", "interface", "state change", "proof"]
+        : kind === "verification recipe"
+          ? ["claim", "observable", "command", "witness"]
+          : ["story beat", "intonation", "image", "turning point"];
+  const form = `recipe ${quote(kind)} {\n${indent(
+    `source ${quote(text)}\nchannels [${channels.map(quote).join(", ")}]\nextract core_sequence\ncompose steps\nverify embodied_transfer`,
+    2,
+  )}\n}`;
+
+  return {
+    title: "Cross-Modality Recipe",
+    form,
+    summary:
+      "A story, song, video, or source excerpt becomes a reusable recipe that preserves channel, sequence, and verification.",
+    steps: [
+      `mode: ${kind}`,
+      `channels: ${channels.join(", ")}`,
+      "extract repeatable sequence",
+      "verify the transfer in another medium",
+    ],
+  };
+}

--- a/web/tests/grammar-lanes.test.ts
+++ b/web/tests/grammar-lanes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileActionLanguage,
+  compileCrossModalityRecipe,
+  compileGrammarBuilder,
+  compilePythonToForm,
+} from "../lib/form-kernel/grammar-lanes";
+
+describe("grammar lane compilers", () => {
+  it("keeps BML action language loadable as Form", () => {
+    const out = compileActionLanguage(
+      "delegate @concept(lc-trust-over-fear) to @concept(lc-permission-is-interior)",
+    );
+
+    expect(out.loadableExpression).toContain("delegate @concept");
+    expect(out.steps).toContain("verb: delegate");
+  });
+
+  it("turns a Python function into a method-shaped recipe skeleton", () => {
+    const out = compilePythonToForm(`def add_one(x):
+    return x + 1`);
+
+    expect(out.form).toContain("method add_one");
+    expect(out.form).toContain("let x = .arg0;");
+    expect(out.form).toContain("x + 1");
+  });
+
+  it("builds a grammar rule with captures and semantic action", () => {
+    const out = compileGrammarBuilder(
+      "when {trigger} appears, offer {practice}",
+      "trigger, practice",
+      "emit teaching_recipe(trigger, practice)",
+    );
+
+    expect(out.form).toContain('pattern "when {trigger} appears, offer {practice}"');
+    expect(out.form).toContain("capture trigger as @field(trigger)");
+    expect(out.form).toContain("emit teaching_recipe(trigger, practice)");
+  });
+
+  it("extracts cross-modal recipe channels by recipe kind", () => {
+    const out = compileCrossModalityRecipe("Name the claim, run the proof.", "verification recipe");
+
+    expect(out.form).toContain('"verification recipe"');
+    expect(out.form).toContain('"claim"');
+    expect(out.form).toContain("verify embodied_transfer");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Grammar Lanes section to /substrate/form with BML/action, Python => Form, grammar builder, and cross-modality recipe lanes
- add deterministic compiler helpers for each lane and focused Vitest coverage
- tighten mobile constraints and light-mode contrast for the new playground section

## Proof
- cd web && npm run test -- grammar-lanes.test.ts form-kernel-client.test.ts
- cd web && npm run build
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260524_grammar_lanes_form_playground.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- Playwright viewport check: /substrate/form at 1440px and 390px, all four lanes visible, mobile scrollWidth == innerWidth