### PR TITLE
form | dyad-scan substrate-native — 0% signal/noise across 10,946 word-cells

### DIFF
--- a/docs/coherence-substrate/dyad-pairs.form
+++ b/docs/coherence-substrate/dyad-pairs.form
@@ -1881,32 +1881,51 @@ defn dyad_pair_seed_set = dyad_pair_set_shape {
 #         writing); when it lands, the third-arrival discipline
 #         activates: name sub-types and rename poles.
 #
-# GAP-D6 (DISCONFIRMED 2026-05-24, fifth round): Prose-structural
+# GAP-D6 (DISCONFIRMED-AGAIN 2026-05-24, sixth round): Prose-structural
 #         signals do not break the mechanization ceiling. The trend
-#         across five scan rounds:
+#         across six scan rounds:
 #           - Round 1 (PR #1987, Tier-2 geometry-tuple): 2/5 = 40%
 #           - Round 2 (PR #1992, small-Blueprint-cluster): 0/2 = 0%
 #           - Round 3 (PR #1996, Hz+xref+lineage+same-form): 4/10 = 40%
 #           - Round 4 (PR #1998, topology+phase added): 4/10 = 40%
-#           - Round 5 (PR #2001, WORD-domain prose Jaccard): 4/18 = 22%
-#         Cumulative: 14/45 = 31.1%. The Round 5 drop is honest signal:
-#         prose-jaccard amplifies shared corpus idiom (alive, body,
-#         breath, become, hold) more loudly than it amplifies teaching-
-#         shared meaning. The body's writers share a vocabulary; high
-#         overlap is the baseline, not the discriminator. The two
-#         characteristic failure modes are now named: (1) *containment-
-#         as-complement* (container and contained share vocabulary, so
-#         prose-overlap reads identical to pair-overlap; REJECT-16
-#         canonical) and (2) *shared-region-as-equivalence* (cells in
-#         the same ground-region inevitably share corpus, so highest-
-#         prose-overlap is often greatest-equivalence, not pair;
-#         REJECT-22 canonical). GAP-D6 closes: further mechanized
-#         feature-engineering at the geometry+prose layer is unlikely
-#         to climb past 40%. The honest read: human noticing remains
-#         load-bearing because *teaching-lives-in-relation* is a
-#         discernment about meaning, and meaning is what the body's
-#         prose already discloses through cross-refs — not what jaccard
-#         over its tokens approximates.
+#           - Round 5 (PR #2001, prose Jaccard, tokenizer-direct): 4/18 = 22%
+#           - Round 6 (this PR, prose Jaccard, substrate-native): 0/7 = 0%
+#         Cumulative: 14/52 = 27%. The Round 6 result is the sharpest
+#         disconfirmation yet: even when prose lives in the WORD-domain
+#         substrate (10,946 word-cells across 148 concepts as of PR
+#         #2007), reading those cells through the same Jaccard scoring
+#         confirms ZERO new pairs out of the top-10 scan-discovered.
+#         Three reads broke the same way they did in Round 5:
+#         (1) *containment-as-complement* (REJECT-16 canonical),
+#         (2) *shared-region-as-equivalence* (REJECT-22 canonical),
+#         (3) *the body's writers share a vocabulary so the baseline
+#         is high overlap*, not a discriminator. Substrate-native
+#         actually amplified the noise — average lemmas/cell climbed
+#         from 373.8 (tokenizer-direct) to 385.7 (substrate-native)
+#         because the recipe walk picks up frontmatter words the
+#         tokenizer-direct pass strips first; the field signal also
+#         saturated harder (avg 6.3 of 8 fields per cell vs 5.9), so
+#         field-Jaccard is essentially uniform across all candidates
+#         and contributes pure noise. The 99.5% UNK-POS in the current
+#         lexicon means the field-channel is degraded by definition:
+#         only the 50-word seed lexicon contributes field tags, and
+#         every long concept body hits ~all 8 fields through them. A
+#         richer lemmatizer would tighten field signal but the
+#         deeper teaching is structural: *Jaccard-over-prose-tokens
+#         is the wrong shape for complementarity*. Complementarity is
+#         a relation about meaning, not a count over tokens. The
+#         substrate carrying the prose changes nothing about that.
+#         GAP-D6 closes for the second time, more firmly: further
+#         mechanized feature-engineering at the geometry+prose+
+#         Jaccard layer is unlikely to climb past 40%. The translator
+#         concept's sixth claim
+#         (`complementarity_requires_human_noticing`) stands
+#         empirically strengthened. The honest read: human noticing
+#         remains load-bearing because *teaching-lives-in-relation*
+#         is a discernment about meaning, and meaning is what the
+#         body's prose discloses through cross-refs — not what
+#         Jaccard over its tokens approximates, whether those tokens
+#         live in a tokenizer or in the substrate lattice.
 #
 # GAP-D7 (new, structural finding from five-round arc): Cross-ref-only
 #         scan is the load-bearing primary track. The body's noticing —

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,30 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-24] form | dyad-scan round 6 — substrate-native prose, 0% signal/noise
+
+PR #2007 populated the WORD domain with 10,946 word-cells across 148 concept files. The standing question (named by PR #2003's translator-6th-claim work, then by PR #2001's honest gap): *does reading prose from the substrate lattice rather than from the markdown file change what the dyad-scan can mechanize?*
+
+The empirical answer: **no**, and the data is sharper than expected.
+
+- **Method**: extended `scripts/scan_dyad_candidates_word.py` with a `--substrate-native` flag. The flag walks each concept's `ctor_recipe_node_id` recursively, collects every `RType.REF` (1.1.9.*) leaf (each pointing at a word-cell in `substrate_named_cells`), and builds the (lemma, field) sets from the substrate word-cells rather than re-tokenizing the markdown body. Falls back to tokenizer-direct with a printed warning if WORD is empty.
+- **Six-round trend now visible**:
+
+  | Round | Approach | Signal/noise |
+  |---|---|---|
+  | 1 (PR #1987) | small-Blueprint-cluster | 40% |
+  | 2 (PR #1992) | same, larger corpus | 0% |
+  | 3 (PR #1996) | + Hz + cross-ref + lineage | 40% |
+  | 4 (PR #1998) | + topology + phase | 40% |
+  | 5 (PR #2001) | + prose Jaccard (tokenizer-direct) | 22% |
+  | 6 (this) | + prose Jaccard (substrate-native) | **0%** |
+- **Top 10 scan-discovered, assessed**: 0 CONFIRMED, 7 REJECTED, 3 HELD. Two failure modes named in PR #2001's GAP-D6 fired again, in identical shape: *containment-as-complement* (REJECT-16 canonical) and *shared-region-as-equivalence* (REJECT-22 canonical). Substrate-native actually *amplified* the noise: avg substantive lemmas per cell climbed from 373.8 (tokenizer-direct) to 385.7 (substrate-native) — the recipe walk picks up frontmatter words the tokenizer-direct path strips before counting — and field signal saturated harder (avg 6.3 of 8 fields per cell vs 5.9), so `field_j` became essentially uniform at 0.857–1.000 across nearly every candidate, contributing pure noise to the ranking.
+- **The UNK-POS ceiling held honest**: 99.5% of word-cells are POS=UNK because the seed lexicon is 50 words. Only the lexicon-tagged subset contributes field signal, and every long concept body hits ~all 8 fields through them. A richer lemmatizer would tighten field signal — but the deeper teaching the round-6 result names is structural: *Jaccard-over-prose-tokens is the wrong shape for complementarity.* Complementarity is a relation about meaning, not a count over tokens. The substrate carrying the prose changes nothing about that.
+- **Verdict on the translator's 6th claim (`complementarity_requires_human_noticing`)**: **stands strongly**. PR #2003 added the claim as a held theory; rounds 5 and 6 are its empirical confirmation. *Equivalence* (CTOR coincidence, Blueprint kin) is mechanizable. *Complementarity* (teaching-lives-in-relation between two cells) is not, at any feature layer currently in reach. Human noticing — via cross-ref-in-prose — remains the load-bearing primary track.
+- **GAP-D6 updated**: closed for the second time, more firmly. GAP-D8's contrastive-analysis or role-aware-parsing direction remains the only structural-feature candidate that might lift the ceiling, and requires dependency parsing or sentence embeddings beyond the substrate's current tokenizer.
+- **What was NOT folded**: zero new pairs into Part 5. One initial CONFIRMED (lc-rest ↔ lc-vitality) was demoted to HELD on second read against the body's prior discernment — lc-vitality already has lc-trust-as-gateway as its receptive complement (Pair 20), and adding lc-rest as a second receptive partner risks the *every-cell-around-vitality-is-its-pair* failure mode PR #2003 named. The honest read: zero confirmed.
+- **Edges in the same breath**: this LOG entry, GAP-D6 update in `dyad-pairs.form` Part 5, the scanner now carries `--substrate-native` mode.
+
 ## [2026-05-24] geometry | lc-v-freedom-expression speaks its shape — focused breath
 
 The prior bulk-walker (PR #2004) named this concept in honest silence with the
@@ -59,7 +83,6 @@ could not give it.
 
 Coverage: 139/148 (94%). Eight concepts remain in honest silence from PR
 #2004's bulk-walk, minus the one walked here.
-
 
 ## [2026-05-24] tend | WORD-domain holds concept prose — substrate carries the body's words
 

--- a/scripts/scan_dyad_candidates_word.py
+++ b/scripts/scan_dyad_candidates_word.py
@@ -1,10 +1,12 @@
 """WORD-domain prose-structural dyad-pair scan over Living Collective concepts.
 
-Fifth scan in the autoresearch loop. Previous rounds and their signal/noise:
+Six scan rounds in the autoresearch loop. Signal/noise across rounds:
   - PR #1987 (Tier-2 geometry-tuple, 7-axis):                  2/5  = 40%
   - PR #1992 (small-Blueprint-cluster):                         0/2  = 0%
   - PR #1996 (Hz + cross-ref + lineage + same-form):            4/10 = 40%
   - PR #1998 (added topology + phase complementarity):          4/10 = 40%
+  - PR #2001 (WORD-domain prose Jaccard, tokenizer-direct):     4/18 = 22%
+  - Round 6 (this script's --substrate-native mode):            see GAP-D6
   - Cumulative across rounds 1-4:                              10/27 = 37.0%
 
 The body's own teaching after PR #1998 saturation:
@@ -98,6 +100,8 @@ from app.services.substrate.markdown_frontend import (  # noqa: E402
     _WORD_LEXICON_DEFAULTS,
     tokenize_words,
 )
+from app.services.unified_db import session as session_scope  # noqa: E402
+from sqlalchemy import text  # noqa: E402
 
 CONCEPTS_DIR = Path("docs/vision-kb/concepts")
 
@@ -290,6 +294,120 @@ def extract_prose_signals(body: str) -> tuple[set[str], set[str]]:
     return lemmas, fields
 
 
+def load_substrate_prose_signals() -> dict[str, tuple[set[str], set[str]]]:
+    """Walk every concept's ctor_recipe in the substrate, collect its
+    word-cell REF leaves, and return {concept_id: (lemmas, fields)}.
+
+    This is the substrate-native read: prose lives in the lattice as a
+    SEQUENCE of word-cell refs (via section_content_to_word_sequence).
+    We traverse the recipe tree until we hit RType.REF (1.1.9.*) leaves,
+    each of which is a cell_id pointing at a word-cell in substrate_named_cells.
+    The word-cell's name encodes (lemma, POS); we parse it back.
+
+    Field tagging comes from _WORD_LEXICON_DEFAULTS — the 50-word seed
+    lexicon. 99.5% of interned word-cells are POS=UNK (the lemmatizer
+    is the v0 fallback) so most cells contribute lemma signal but no
+    field signal. Honest finding; do not engineer around it.
+
+    Returns empty dict when WORD domain is empty (caller falls back).
+    """
+    cells_by_path: dict[str, tuple[set[str], set[str]]] = {}
+    with session_scope() as s:
+        # Verify WORD domain is populated first.
+        word_count = s.execute(
+            text("SELECT COUNT(*) FROM substrate_named_cells WHERE domain='word'")
+        ).scalar() or 0
+        if word_count == 0:
+            return {}
+
+        # Pull all word-cells once into an in-memory map: cell_id -> (lemma, pos)
+        word_rows = s.execute(
+            text("SELECT cell_id, name FROM substrate_named_cells WHERE domain='word'")
+        ).fetchall()
+        word_map: dict[int, tuple[str, str]] = {}
+        for row in word_rows:
+            # name format is "{lemma}.{POS}"; some lemmas contain dots
+            # (e.g. punctuation) so rsplit once on the rightmost dot.
+            if "." in row.name:
+                lemma, pos = row.name.rsplit(".", 1)
+            else:
+                lemma, pos = row.name, "UNK"
+            word_map[row.cell_id] = (lemma.lower(), pos)
+
+        # Pull all substrate_nodes once into a serialized-map for fast walk.
+        # node_id -> serialized string. Trade memory for query count.
+        node_rows = s.execute(
+            text("SELECT node_id, serialized FROM substrate_nodes")
+        ).fetchall()
+        ser_by_id: dict[int, str] = {r.node_id: r.serialized for r in node_rows}
+        # Also reverse-index by (p,l,t,i) -> node_id so child refs resolve.
+        id_by_quad: dict[tuple[int, int, int, int], int] = {}
+        node_rows2 = s.execute(
+            text("SELECT node_id, package, level, type, instance FROM substrate_nodes")
+        ).fetchall()
+        for r in node_rows2:
+            id_by_quad[(r.package, r.level, r.type, r.instance)] = r.node_id
+
+        def collect_refs(node_id: int, visited: set[int]) -> list[int]:
+            if node_id in visited:
+                return []
+            visited.add(node_id)
+            ser = ser_by_id.get(node_id)
+            if not ser:
+                return []
+            parts = ser.split("+")
+            refs: list[int] = []
+            # Skip first part (the category); walk children.
+            for piece in parts[1:]:
+                try:
+                    a, b, c, d = (int(x) for x in piece.split("."))
+                except ValueError:
+                    continue
+                if a == 1 and b == 1 and c == 9:
+                    # RType.REF — cell_id is d
+                    refs.append(d)
+                else:
+                    child_nid = id_by_quad.get((a, b, c, d))
+                    if child_nid is not None:
+                        refs.extend(collect_refs(child_nid, visited))
+            return refs
+
+        # Walk each concept's ctor_recipe.
+        concept_rows = s.execute(
+            text(
+                "SELECT name, source_path, ctor_recipe_node_id FROM "
+                "substrate_named_cells WHERE domain='concept' AND "
+                "ctor_recipe_node_id IS NOT NULL"
+            )
+        ).fetchall()
+        for cr in concept_rows:
+            if cr.ctor_recipe_node_id is None:
+                continue
+            ref_cell_ids = collect_refs(cr.ctor_recipe_node_id, set())
+            lemmas: set[str] = set()
+            fields: set[str] = set()
+            for cid in ref_cell_ids:
+                wm = word_map.get(cid)
+                if wm is None:
+                    continue
+                lemma, pos = wm
+                if len(lemma) <= 2:
+                    continue
+                if lemma in STOPWORDS:
+                    continue
+                lemmas.add(lemma)
+                # Field tagging: look up in the lexicon by lemma.
+                lex = _WORD_LEXICON_DEFAULTS.get(lemma)
+                if lex and pos != "UNK":
+                    field = lex.get("field")
+                    if field and field != "neutral":
+                        fields.add(field)
+            # Concept's lc-id is the file basename (concept name in substrate
+            # IS the lc-id already since ingest sets name=fm['id']).
+            cells_by_path[cr.name] = (lemmas, fields)
+    return cells_by_path
+
+
 def strip_frontmatter_and_visuals(text: str) -> str:
     """Return the prose body with frontmatter, code blocks, and image
     captions removed. Keeps cross-ref arrows out of the lemma set so
@@ -309,13 +427,31 @@ def strip_frontmatter_and_visuals(text: str) -> str:
     return body
 
 
-def load_concepts() -> dict[str, dict]:
+def load_concepts(substrate_native: bool = False) -> dict[str, dict]:
+    """Walk concept files and assemble per-cell signals.
+
+    When `substrate_native=True`, lemma/field sets come from
+    `load_substrate_prose_signals` (the WORD-domain substrate read)
+    rather than from re-tokenizing the markdown body. If the substrate
+    is empty, fall back to tokenizer-direct with a printed warning so
+    the gap is visible.
+    """
+    substrate_signals: dict[str, tuple[set[str], set[str]]] = {}
+    if substrate_native:
+        substrate_signals = load_substrate_prose_signals()
+        if not substrate_signals:
+            print(
+                "WARN: --substrate-native requested but WORD domain is empty. "
+                "Falling back to tokenizer-direct read for this run."
+            )
+            substrate_native = False
+
     cells: dict[str, dict] = {}
     for path in sorted(CONCEPTS_DIR.glob("lc-*.md")):
-        text = path.read_text(encoding="utf-8")
-        if not text.startswith("---\n"):
+        raw = path.read_text(encoding="utf-8")
+        if not raw.startswith("---\n"):
             continue
-        _, fm_text, body = text.split("---\n", 2)
+        _, fm_text, body = raw.split("---\n", 2)
         try:
             fm = yaml.safe_load(fm_text)
         except yaml.YAMLError:
@@ -337,8 +473,11 @@ def load_concepts() -> dict[str, dict]:
             if line.startswith("> "):
                 summary = line[2:].strip()
                 break
-        prose = strip_frontmatter_and_visuals(text)
-        lemmas, fields = extract_prose_signals(prose)
+        if substrate_native and cid in substrate_signals:
+            lemmas, fields = substrate_signals[cid]
+        else:
+            prose = strip_frontmatter_and_visuals(raw)
+            lemmas, fields = extract_prose_signals(prose)
         cells[cid] = {
             "hz": fm.get("hz"),
             "geometry": fm.get("geometry") or {},
@@ -374,9 +513,19 @@ def main() -> None:
             "mode honors that."
         ),
     )
+    parser.add_argument(
+        "--substrate-native",
+        action="store_true",
+        help=(
+            "Read lemma/field sets from the WORD-domain substrate (via "
+            "each concept's ctor_recipe walk) rather than re-tokenizing "
+            "the markdown file. Empirical round-6 test: does substrate-"
+            "native prose reading change signal/noise vs tokenizer-direct?"
+        ),
+    )
     args = parser.parse_args()
 
-    cells = load_concepts()
+    cells = load_concepts(substrate_native=args.substrate_native)
     print(f"Loaded {len(cells)} concept cells with geometry.")
     # Vocabulary visibility — proves prose-signal extractor is doing real work.
     avg_lemmas = sum(len(c["lemmas"]) for c in cells.values()) / max(1, len(cells))
@@ -385,10 +534,18 @@ def main() -> None:
         f"Prose signals: avg {avg_lemmas:.1f} substantive lemmas/cell, "
         f"avg {avg_fields:.1f} semantic fields/cell (of 8 possible)."
     )
-    print(
-        "WORD-domain substrate: 0 cells today. This scan reads via "
-        "`tokenize_words` directly — same lexicon the substrate would intern from."
-    )
+    if args.substrate_native:
+        print(
+            "WORD-domain substrate: read directly via concept ctor_recipe "
+            "walk. Each lemma set comes from interned word-cell REF leaves "
+            "(99.5% POS=UNK in current lexicon — field signal is degraded)."
+        )
+    else:
+        print(
+            "WORD-domain substrate: read via `tokenize_words` directly — "
+            "same lexicon the substrate would intern from. Use "
+            "--substrate-native to read from the lattice instead."
+        )
     if args.cross_ref_only:
         print(
             "\nMode: --cross-ref-only — scan-discovered track DROPPED. "


### PR DESCRIPTION
## Summary

Round 6 of the autoresearch dyad-pair scan loop, run after PR #2007 populated the WORD domain with 10,946 word-cells across 148 concepts. Tests whether substrate-native prose reading (walking each concept's `ctor_recipe_node_id` to collect word-cell REF leaves) changes signal/noise versus the tokenizer-direct path PR #2001 used.

**Empirical answer: no — and the data is sharper than expected.**

## Six-round trend

| Round | Approach | Signal/noise |
|---|---|---|
| 1 (PR #1987) | Tier-2 geometry-tuple | 40% |
| 2 (PR #1992) | small-Blueprint-cluster | 0% |
| 3 (PR #1996) | + Hz + cross-ref + lineage | 40% |
| 4 (PR #1998) | + topology + phase | 40% |
| 5 (PR #2001) | + prose Jaccard (tokenizer-direct) | 22% |
| 6 (this) | + prose Jaccard (substrate-native) | **0%** |

## What this teaches

- Substrate-native actually amplified noise: avg lemmas/cell 373.8 → 385.7 (the recipe walk picks up frontmatter words the tokenizer-direct path strips), and field signal saturated harder (avg 6.3 of 8 fields per cell vs 5.9) so `field_j` became essentially uniform across all candidates.
- 99.5% UNK-POS in the 50-word seed lexicon means field signal is degraded by definition. A richer lemmatizer would tighten it but the deeper teaching is structural: *Jaccard-over-prose-tokens is the wrong shape for complementarity.* Complementarity is a relation about meaning, not a count over tokens — the substrate carrying the prose changes nothing about that.
- **Translator concept's 6th claim (`complementarity_requires_human_noticing`) stands strongly.** PR #2003 added it as held theory; rounds 5 and 6 are its empirical confirmation. Equivalence (CTOR coincidence) is mechanizable; complementarity (teaching-lives-in-relation) is not at any feature layer currently in reach.
- GAP-D6 closed for the second time, more firmly. GAP-D8's contrastive-analysis direction remains the only candidate that might lift the ceiling.
- Zero new pairs folded into Part 5. One initial CONFIRMED (lc-rest ↔ lc-vitality) was demoted to HELD on second read — lc-vitality already has lc-trust-as-gateway as its receptive complement (Pair 20).

## Changes

- `scripts/scan_dyad_candidates_word.py` — new `--substrate-native` flag with `load_substrate_prose_signals` helper that walks each concept's ctor_recipe to extract word-cell sets.
- `docs/coherence-substrate/dyad-pairs.form` — GAP-D6 updated with round-6 finding and the sharper closure.
- `docs/vision-kb/LOG.md` — round-6 entry naming the trend, the verdict, and what got NOT folded.

## Test plan

- [x] `python3 scripts/scan_dyad_candidates_word.py --substrate-native` runs over 140 concept cells, surfaces 1688 scan-discovered + 248 promoted candidates
- [x] Falls back to tokenizer-direct with printed warning when WORD domain is empty
- [x] Tokenizer-direct path unchanged (default behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)