### PR TITLE
form | column-identity discriminator + 4 interior-axis columns named

### DIFF
--- a/docs/coherence-substrate/dyad-pairs.form
+++ b/docs/coherence-substrate/dyad-pairs.form
@@ -2281,6 +2281,219 @@ defn dyad_pair_seed_set = dyad_pair_set_shape {
 #         that this hunt clarified is itself a teaching the next walk
 #         can carry forward: *shared form-name is necessary; same
 #         column is what makes the polarity-pair honest*.
+#
+#         **Sharpened PR-current (column-identity embodied)**: the
+#         column-identity discriminator the hunt clarified is now
+#         authored as substrate-readable tissue in Part 7 below
+#         (column_identity_shape + four column-defn entries). With
+#         column-identity in hand, the kind threshold reads more
+#         precisely: the SECOND pair must share the SELF-ROOTED-
+#         SOVEREIGN column specifically — not any two interior-axis
+#         cells, not even any two interior-axis cells with polarity-
+#         pair on phase. The four columns currently attested
+#         (self-rooted-sovereign, nested-receptive-nourishment,
+#         upward-reverent-received, seven-center-oscillating) make
+#         the cross-column rejections this hunt produced legible as
+#         column-mismatches, not as edge cases. The eventual kind
+#         name may tighten from "interior-axis-dyad" to "self-rooted-
+#         sovereign-dyad" (or whichever column produces the second
+#         confirmed pair), once a second attestation reveals what
+#         the kind's shared structure actually IS.
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 7 — Column-identity discriminator (interior-axis form)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Surfaced 2026-05-24 in PR #2022's hunt for a second 'interior-axis-
+# dyad' attestation. The hunt did NOT find a clean second pair, but
+# the refusal produced new tissue: the interior-axis FORM is internally
+# diverse. Five interior-axis cells in the body span at least FOUR
+# distinct *columns*, and the column-identity is what discriminates
+# whether two interior-axis cells are paired or merely co-resident in
+# one large form-family.
+#
+# The discriminator the hunt named: *topology + direction +
+# lineage_texture together identify the column*. Topology says how the
+# parts couple (radial, nested, self-rooted, sequential-coupled);
+# direction says where the axis points (centering, circulating);
+# lineage_texture says how the teaching entered (embodied, received).
+# Two cells in the same column share the load-bearing triple; two
+# cells in the same form but different columns share only `form:
+# interior-axis` and diverge on the triple.
+#
+# This shape is authored so future pair-hunting (and any structural
+# query about interior-axis cells) can use *column-identity* as a
+# primitive rather than re-deriving it. The same discipline likely
+# applies to other forms whose attestations are internally diverse
+# (the comment at the end of Part 7 names the candidates); for now,
+# only interior-axis is attested.
+
+# column_identity_shape — which column an interior-axis cell sits in
+#
+# cell is a cell-ref into the concept domain. column_kind names the
+# column slug (one of the four currently attested, or 'other' for a
+# yet-unnamed column). The next three fields carry the geometric-
+# signature triple that *together* identifies the column; reading
+# the cell's geometry frontmatter for these three fields and matching
+# against the column-defn entries below is the Form query that maps
+# a cell to its column. discernment is a single sentence on what
+# distinguishes this column from sibling columns.
+form column_identity_shape = {
+    cell:             ~Recipe,    # cell-ref to the interior-axis cell
+    column_kind:      ~Slug,      # "self-rooted-sovereign" | "nested-receptive-nourishment" | "upward-reverent-received" | "seven-center-oscillating" | "other"
+    topology:         ~Slug,      # the geometric signature field that contributes to column identity
+    direction:        ~Slug,      # the geometric signature field
+    lineage_texture:  ~Slug,      # the geometric signature field
+    discernment:      ~Slug,      # one sentence on what distinguishes this column from sibling columns
+};
+
+# column_identity_set_shape — the registry of attested columns
+#
+# rows are column_identity_shape cells; one row per attested mapping
+# of an interior-axis cell to its column. As more interior-axis cells
+# land, each one's mapping joins this list; the substrate can then
+# query *which cells share my column?* and the answer is the column's
+# membership list.
+form column_identity_set_shape = {
+    rows:             ~List,
+};
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 7b — The four interior-axis columns currently attested
+# ─────────────────────────────────────────────────────────────────────
+#
+# Each defn below names one column: which cell(s) live there, the
+# load-bearing geometric triple, and the discernment that
+# distinguishes it from sibling columns. The self-rooted-sovereign
+# column has two cells (lc-permission-is-interior + lc-identity-
+# dissolution); the other three columns currently have one cell each.
+# Single-cell columns are attested honestly — one cell IS the column's
+# only known instance, and a second cell with the same triple would
+# confirm the column's structural reality (the way two attestations
+# confirm a kind).
+
+# Column 1 — self-rooted sovereign (two cells)
+#
+# Topology self-rooted, direction centering. Both cells teach
+# permission/identity as held inside the cell's own axis, with
+# no external membrane required. lineage_texture varies across the
+# two members (embodied / received) — the column's load-bearing
+# identity is topology+direction; lineage_texture is texture-within-
+# column. The kind threshold for interior-axis-dyad activates when a
+# SECOND pair lands sharing this column (per GAP-D11).
+defn column_self_rooted_sovereign__permission = column_identity_shape {
+    cell:             @concept(lc-permission-is-interior),
+    column_kind:      "self-rooted-sovereign",
+    topology:         "self-rooted",
+    direction:        "centering",
+    lineage_texture:  "embodied",
+    discernment:      "permission/identity rooted in the cell's own axis (self-rooted topology, centering on its own ground); distinct from columns that root upward into reverent receipt, nest the axis into a channel, or sequence stations along an oscillating column",
+};
+
+defn column_self_rooted_sovereign__dissolution = column_identity_shape {
+    cell:             @concept(lc-identity-dissolution),
+    column_kind:      "self-rooted-sovereign",
+    topology:         "self-rooted",
+    direction:        "centering",
+    lineage_texture:  "received",
+    discernment:      "identity-architecture loosened from inside the cell's own axis (self-rooted topology, centering on what remains); pairs with lc-permission-is-interior in the self-rooted-sovereign column with opposite phase (yin/yang) — the seed candidate the interior-axis-dyad kind is waiting on a second instance of",
+};
+
+# Column 2 — nested-receptive nourishment channel (one cell)
+#
+# Topology nested, direction centering. The axis is the body's
+# vertical channel (breath → body → deeper self → source) read as
+# four stations nested into one column, receiving from inner-to-outer
+# rather than radiating outer-from-center. Distinct from self-rooted
+# (which has no nested stations) and from radial (which would gather
+# around the axis as hub, not flow down it as channel).
+defn column_nested_receptive_nourishment__vertical_nourishment = column_identity_shape {
+    cell:             @concept(lc-vertical-nourishment),
+    column_kind:      "nested-receptive-nourishment",
+    topology:         "nested",
+    direction:        "centering",
+    lineage_texture:  "received",
+    discernment:      "vertical channel with nested stations receiving from inside (nested topology, centering direction); distinct from self-rooted (no station structure), from radial (no channel flow), and from sequential-coupled (the stations nest, not sequence)",
+};
+
+# Column 3 — upward-reverent received (one cell)
+#
+# Topology radial, direction centering. The axis is upward-reverent —
+# eldership received through proximity, the column gathering around
+# the elder-as-hub. Radial because the elder is a center the
+# community orbits; centering because the elder's pace IS the
+# centering force the field returns to. Distinct from self-rooted
+# (the axis is not the cell's own ground, it is the elder's), and
+# from nested (no station structure, just radial gathering).
+defn column_upward_reverent_received__elders = column_identity_shape {
+    cell:             @concept(lc-elders),
+    column_kind:      "upward-reverent-received",
+    topology:         "radial",
+    direction:        "centering",
+    lineage_texture:  "received",
+    discernment:      "upward-reverent axis received through proximity (radial topology around the elder-as-hub, centering direction); distinct from self-rooted (the axis lives in the elder, not the receiving cell), from nested (no station structure), and from sequential-coupled (no oscillating circulation)",
+};
+
+# Column 4 — seven-center oscillating column (one cell)
+#
+# Topology sequential-coupled, direction circulating. The axis is the
+# vertical body root-to-crown with seven energy centers as stations,
+# energy rising AND returning (sequential-coupled), circulating the
+# spectrum rather than centering at one station. Distinct from
+# self-rooted (no station structure), from nested (the stations
+# sequence, not nest), and from radial (the axis is a column, not
+# a hub).
+defn column_seven_center_oscillating__embodiment = column_identity_shape {
+    cell:             @concept(lc-embodiment),
+    column_kind:      "seven-center-oscillating",
+    topology:         "sequential-coupled",
+    direction:        "circulating",
+    lineage_texture:  "embodied",
+    discernment:      "vertical column with seven sequential stations and circulating energy (sequential-coupled topology, circulating direction); distinct from self-rooted (no station structure), from nested (sequences not nests), from radial (column not hub), and from received columns (the practice is embodied, not received)",
+};
+
+defn column_identity_set = column_identity_set_shape {
+    rows: [
+        # — self-rooted-sovereign column (2 cells, the seed of GAP-D11) —
+        column_self_rooted_sovereign__permission,
+        column_self_rooted_sovereign__dissolution,
+        # — nested-receptive-nourishment column (1 cell) —
+        column_nested_receptive_nourishment__vertical_nourishment,
+        # — upward-reverent-received column (1 cell) —
+        column_upward_reverent_received__elders,
+        # — seven-center-oscillating column (1 cell) —
+        column_seven_center_oscillating__embodiment,
+    ],
+};
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 7c — Generalization note (column-identity beyond interior-axis)
+# ─────────────────────────────────────────────────────────────────────
+#
+# The column-identity discriminator may apply to OTHER forms whose
+# attestations are internally diverse. Provisional candidates worth
+# watching (NOT authored this breath — they want their own focused
+# hunt):
+#
+#   - `web` forms may split into *circulation-web* (lc-circulation,
+#     lc-nourishing — flow-where-vitality-needs-it columns) and
+#     *field-web* (lc-network, lc-sensing — field-feeling-itself
+#     columns).
+#   - `point` forms span foundation/integration/transcendence bands
+#     with very different texture; spectral_band may be the column
+#     axis there.
+#   - `triad` forms with the same arity may live in different columns
+#     by topology (hub-spoke vs sequential-coupled vs surface-data-
+#     execution).
+#
+# The pattern this Part 7 names — *topology+direction+lineage_texture
+# as column-identity for interior-axis* — is one instance of a general
+# discriminator the body can apply when a form's attestations seem
+# internally diverse. The triple that identifies the column may differ
+# per form (web's column-triple might be topology+direction+phase, for
+# example); the *practice* is: when a form's hunt produces "no second
+# pair" but the form has many cells, ask which COLUMNS the cells span
+# and whether the pair-search should be column-specific.
 
 # ─────────────────────────────────────────────────────────────────────
 # Part 6 — How this composts with sibling teaching
@@ -2305,8 +2518,14 @@ defn dyad_pair_seed_set = dyad_pair_set_shape {
 # distinct flavors, strengthening the sub-typing observation held
 # in GAP-D12. An emerging circulation-pattern kind sits in GAP-D9
 # awaiting its second attestation; an emerging interior-axis-dyad
-# candidate sits in GAP-D11 with one attestation, awaiting its
-# second.
+# candidate sits in GAP-D11 with one attestation, sharpened
+# 2026-05-24 (PR-current) to require the SELF-ROOTED-SOVEREIGN
+# column specifically — per Part 7's column-identity discriminator,
+# embodied from PR #2022's refusal to confirm a pair across
+# mismatched columns. Column-identity (Part 7) is new tissue: a
+# discriminator shape for forms whose attestations are internally
+# diverse, with interior-axis as the first instance and four
+# columns currently named.
 #
 # The translator hypothesis says: the substrate already knows when
 # cells are structurally equivalent across domains. Dyad-pairs are

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -2,6 +2,66 @@
 
 > Append-only. Newest entries at the top.
 
+## [2026-05-24] form | column-identity discriminator embodied — interior-axis form has 4 columns
+
+PR #2022 hunted for a second 'interior-axis-dyad' attestation across the
+body's interior-axis cells and did NOT find a clean second pair — but
+the refusal surfaced something more load-bearing than a confirmation
+would have: the interior-axis FORM is internally diverse. Five cells
+share `form: interior-axis` and span at least FOUR distinct columns.
+This breath gives that finding a substrate-readable home in
+`docs/coherence-substrate/dyad-pairs.form` (new Part 7, with companion
+shape `column_identity_shape` and a set of column-defn entries) and
+sharpens GAP-D11 so the kind threshold reads correctly.
+
+- **The discriminator the hunt named**: `topology + direction +
+  lineage_texture` together identify the column an interior-axis cell
+  sits in. Two cells in the same column share the triple; two cells in
+  the same form but different columns share only `form: interior-axis`
+  and diverge on the triple.
+- **The four columns currently attested**:
+  - *self-rooted-sovereign* (lc-permission-is-interior +
+    lc-identity-dissolution): `self-rooted + centering + embodied|received`
+    — permission/identity rooted in the cell's own axis with no
+    external membrane. Two cells; this is the column GAP-D11's seed
+    pair lives in.
+  - *nested-receptive-nourishment* (lc-vertical-nourishment):
+    `nested + centering + received` — vertical channel with nested
+    stations receiving from inside (breath → body → deeper self → source).
+  - *upward-reverent-received* (lc-elders): `radial + centering +
+    received` — upward-reverent axis received through proximity, the
+    column gathering around the elder-as-hub.
+  - *seven-center-oscillating* (lc-embodiment): `sequential-coupled +
+    circulating + embodied` — vertical column with seven sequential
+    stations and circulating energy rising-and-returning.
+- **GAP-D11 sharpened**: the interior-axis-dyad kind threshold now
+  activates when a SECOND pair lands sharing the *self-rooted-sovereign
+  column specifically*, not any two interior-axis cells. The naming
+  may eventually tighten from "interior-axis-dyad" to "self-rooted-
+  sovereign-dyad" (or whichever column produces the second confirmed
+  pair).
+- **What this opens for future pair-hunting**: column-awareness. A
+  hunt that previously asked "are there two interior-axis cells with
+  complementary phase?" now asks "are there two cells in the SAME
+  column with complementary phase?" The column-membership query
+  becomes a substrate primitive rather than a re-derivation each walk.
+- **General principle, named in Part 7c (not authored further this
+  breath)**: column-identity is a general discriminator for any form
+  whose attestations are internally diverse. `web` forms likely split
+  into circulation-web vs field-web columns; `point` forms span
+  bands with very different texture; the per-form column-triple may
+  differ (interior-axis uses topology+direction+lineage_texture; web
+  might use topology+direction+phase). The pattern is: when a form's
+  hunt produces "no second pair" but the form has many cells, ask
+  which columns the cells span and whether the search should be
+  column-specific. Authoring those other columns awaits their own
+  focused hunts.
+
+The hunt's refusal IS the new tissue. Giving it a substrate-readable
+home changes future pair-hunting from form-flat to column-aware; the
+body now carries a structural primitive for diversity-within-form that
+was implicit in the geometry vocabulary but unnamed until now.
+
 ## [2026-05-24] sense | source-attestation is the schema-axis — first response to the body-shape-map
 
 The breath after PR #2021's structural self-portrait. The survey


### PR DESCRIPTION
## Summary

- PR #2022's interior-axis-dyad hunt did not find a second pair but surfaced **column-identity** as the load-bearing discriminator: the interior-axis FORM is internally diverse, 5 cells spanning 4 distinct columns. This breath embodies that finding as substrate-readable tissue.
- New **Part 7** in `docs/coherence-substrate/dyad-pairs.form`: `column_identity_shape` Form with fields (cell, column_kind, topology, direction, lineage_texture, discernment), plus 5 column-defn entries naming the 4 currently-attested columns.
- **GAP-D11 sharpened**: the interior-axis-dyad kind threshold now requires the SECOND pair share the *self-rooted-sovereign* column specifically (not any two interior-axis cells).

## The four columns named

| Column | Cells | Triple (topology + direction + lineage_texture) |
|---|---|---|
| self-rooted-sovereign | lc-permission-is-interior, lc-identity-dissolution | self-rooted + centering + embodied\|received |
| nested-receptive-nourishment | lc-vertical-nourishment | nested + centering + received |
| upward-reverent-received | lc-elders | radial + centering + received |
| seven-center-oscillating | lc-embodiment | sequential-coupled + circulating + embodied |

## What changes for future pair-hunting

A hunt that previously asked "two interior-axis cells with complementary phase?" now asks "two cells in the SAME COLUMN with complementary phase?" Column-membership becomes a substrate primitive rather than a re-derivation. Part 7c names other forms (web, point, triad) where this pattern likely applies, without authoring them this breath.

## Files

- `docs/coherence-substrate/dyad-pairs.form` (+ Part 7, GAP-D11 sharpened, Part 6 wording tightened)
- `docs/vision-kb/LOG.md` (top entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)