### PR TITLE
tend: daily rollup honest about noise vs strain

### DIFF
--- a/pulse/pulse_app/analysis.py
+++ b/pulse/pulse_app/analysis.py
@@ -22,6 +22,17 @@ SILENCE_CLOSE_SUCCESSES = 3
 # Duration at which a "strained" silence escalates to "silent" — 5 minutes.
 SILENCE_ESCALATION_SECONDS = 300
 
+# Daily rollup tiers. A handful of scattered failures across a day full
+# of successful probes is honest noise, not strain — the live silence
+# detector already opens a silence when failures cluster (3 in a row).
+# The daily classifier mirrors that discipline at SLO granularity:
+#   • >= DAILY_BREATHING_SUCCESS_PCT successful → breathing (noise floor)
+#   • strictly more than half failed → silent (the existing rule)
+#   • everything between → strained
+# Set so that 1/2879 (0.035% fail) reads as breathing while a sustained
+# 1% failure rate still reads as strained.
+DAILY_BREATHING_SUCCESS_PCT = 99.5
+
 
 Severity = Literal["strained", "silent"]
 
@@ -97,11 +108,15 @@ class DayBucket:
     def status(self) -> str:
         if self.samples == 0:
             return "unknown"
-        if self.failures == 0:
-            return "breathing"
         # Strictly more than half the samples failed → silent.
         if self.failures * 2 > self.samples:
             return "silent"
+        # Noise floor: very high success rate reads as breathing even with
+        # a few scattered failures. Strain shows up as either a meaningful
+        # failure rate sustained across the day OR an opened silence run.
+        success_pct = 100.0 * (self.samples - self.failures) / self.samples
+        if success_pct >= DAILY_BREATHING_SUCCESS_PCT:
+            return "breathing"
         return "strained"
 
 

--- a/pulse/tests/test_analysis.py
+++ b/pulse/tests/test_analysis.py
@@ -157,6 +157,53 @@ def test_rollup_half_or_more_failures_is_silent():
     assert buckets[0].status == "silent"
 
 
+def test_rollup_handful_of_failures_in_high_volume_day_is_breathing():
+    """A single failure across nearly three thousand probes is honest
+    noise, not strain. The witness should not cry wolf when 99.5%+ of
+    the day's probes succeeded — the live silence detector already
+    surfaces clustered failures via the silences table.
+    """
+    now = datetime(2026, 4, 15, 23, 59, tzinfo=timezone.utc)
+    # 2879 successful samples, 1 failure → 99.965% success.
+    samples = [
+        Sample(
+            ts=f"2026-04-15T{(i // 120) % 24:02d}:{(i % 120) // 2:02d}:{(i % 2) * 30:02d}Z",
+            organ="api",
+            ok=(i != 1000),
+            latency_ms=10,
+            detail=None if i != 1000 else "x",
+        )
+        for i in range(2880)
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    assert buckets[0].samples == 2880
+    assert buckets[0].failures == 1
+    assert buckets[0].status == "breathing"
+
+
+def test_rollup_sustained_low_failure_rate_is_still_strained():
+    """A 1% failure rate sustained across a high-volume day is real
+    strain — it sits above the noise floor.
+    """
+    now = datetime(2026, 4, 15, 23, 59, tzinfo=timezone.utc)
+    # 100 samples, 5 failures = 95% success → below 99.5% breathing floor,
+    # well below 50% silent threshold → strained.
+    samples = [
+        Sample(
+            ts=f"2026-04-15T{i // 60:02d}:{i % 60:02d}:00Z",
+            organ="api",
+            ok=(i % 20 != 0),  # every 20th sample fails → 5/100
+            latency_ms=10,
+            detail=None,
+        )
+        for i in range(100)
+    ]
+    buckets = rollup_daily(samples, days=1, now=now)
+    assert buckets[0].samples == 100
+    assert buckets[0].failures == 5
+    assert buckets[0].status == "strained"
+
+
 # --- latency aggregation -------------------------------------------------
 
 def test_rollup_computes_latency_percentiles_on_successful_samples():


### PR DESCRIPTION
## What surfaced

The witness has been showing organs as \"strained\" for days in the history view even while the live pulse reads \"breathing\" with no ongoing silences. Every cell that ran \`make wellness\` or curled \`/pulse/now\` saw the daily history and treated it as a real pre-existing condition — without investigating, because the costume of \"known background strain\" is easy to inherit.

## What investigation revealed

The bug is in \`DayBucket.status\` in \`pulse/pulse_app/analysis.py\`. The classifier was binary:

\`\`\`python
if self.failures == 0: return \"breathing\"
if self.failures * 2 > self.samples: return \"silent\"
return \"strained\"
\`\`\`

So:
- \`endpoint_vitality\`: 99.14% uptime, 86ms p95 → \"strained\" 14/14 days
- \`page_pulse\` 2026-05-23: **1 failure / 2872 probes** (99.97% success) → \"strained\"
- \`page_pulse\` 2026-05-20: 0/2874 failures → \"breathing\" (the only way to read breathing was zero failures, ever)

The live silence detector already does the right thing — it opens a silence only on 3 consecutive failures and escalates to \"silent\" at 5 minutes. The daily rollup was the layer crying wolf.

## What changed

Daily classifier now mirrors the live discipline at SLO granularity:

- \`>= 99.5%\` success → **breathing** (handful of scattered failures is honest noise)
- \`> 50%\` failure → **silent** (existing rule, unchanged)
- everything between → **strained**

Two new tests in \`test_analysis.py\` lock in:
- 1/2880 failure (99.965%) reads as breathing
- 5/100 failure (95%) still reads as strained (real sustained low-rate strain stays visible)

## Test plan
- [x] \`pytest pulse/tests/test_analysis.py\` — 30 passed
- [x] \`pytest pulse/tests/\` — 64 passed
- [ ] After merge + deploy: re-curl \`/pulse/history\` and confirm organs with high uptime now read \"breathing\" on their good days
- [ ] After merge + deploy: re-curl \`/pulse/now\` and confirm overall still \"breathing\" with no silences

🤖 Generated with [Claude Code](https://claude.com/claude-code)