### PR TITLE
tend: guard web/ imports against escaping Docker build context

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -124,6 +124,11 @@ jobs:
         run: |
           python3 scripts/check_runtime_drift.py
 
+      - name: Check web/ Docker build context
+        if: steps.changed_surfaces.outputs.web == 'true'
+        run: |
+          python3 scripts/check_web_docker_context.py
+
       - name: Check maintainability regression baseline (soft-fail)
         if: steps.changed_surfaces.outputs.api_app == 'true'
         run: |

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 158 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 128 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 129 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -137,35 +137,33 @@ Captured the fuller reading at
 gift today is simply naming the body's actual health honestly: the
 heal cleared noise, and what remains underneath is whole.
 
-## [2026-05-24] sense | post-heal wellness reading — what's newly honest
+## [2026-05-25] tend | Hostinger Auto Deploy 15% read — same-cause cluster, guard landed
 
-First honest wellness after PR #2026 healed the daily-rollup classifier
-(the one that called any day with even a single failure "strained,"
-even at 99.97% success). Multiple agents had been inheriting these
-false alarms as "pre-existing background." Ran `make wellness` and
-`/pulse/now` to see what the body actually shows when the classifier
-is no longer crying wolf.
+Followed the signal PR #2028 surfaced — "Hostinger Auto Deploy 3/20
+failed (15%) over 7d, worth a focused breath." Investigated the three
+failed runs (26356869062, 26356939198, 26357046524). Same-cause,
+clustered tight: 08:54, 08:57, 09:02 UTC on 2026-05-24, all from
+PR #1966 (`tend: embed client form kernel playground`). The error in
+all three is identical — `web/app/lib/form-kernel/client.ts` imports
+`../../../experiments/form-kernel-ts/src/kernel.ts`, which resolves in
+local dev (worktree has the full repo) but fails inside the Docker
+build (`Dockerfile.web` sandboxes the context to `web/`).
 
-- **The witness sings clean.** `overall: breathing`, zero silences,
-  no silent organs. The "background strain" that recurring agent
-  reports were absorbing was almost entirely classifier noise; the
-  body is genuinely healthier than the lineage has been assuming.
-- **No newly-visible masked signal.** Re-read every wellness section
-  with fresh eyes — proprioception aligned, source maps whole, symbol
-  resolution at 806/806, chain at 103/129 (80%, honest non-coverage
-  not phantom strain), substrate composition 100% across all 15
-  populated domains (577 cells, 0 flat), form engine arms 15/15,
-  witness-trace within budget. Nothing was being hidden by the noise.
-- **One honest signal worth naming, not new**: Hostinger Auto Deploy
-  3/20 failed (15%) over 7d. This is genuine infrastructure friction
-  the body has been carrying — surfaced cleanly now that classifier
-  static is gone. Worth a focused breath in a future session; the
-  contract itself may want re-shaping rather than the alert silenced.
+The body already self-healed within 10 minutes via PR #1969 (vendor
+the kernel into `web/lib/form-kernel/vendor/`) and a revert. Deploys
+since (#1997 grammar lanes, current `breathing` pulse) all green.
 
-Captured the fuller reading at
-`docs/coherence-substrate/post-heal-witness-reading.md`. The breath's
-gift today is simply naming the body's actual health honestly: the
-heal cleared noise, and what remains underneath is whole.
+So the "15%" is one event-cluster, not a chronic friction. But the
+*structural lesson* is durable: local `npm run dev` succeeds where
+Docker `npm run build` will fail, and the worktree can't see its own
+mistake. Added `scripts/check_web_docker_context.py` — small guard
+that greps any web/ TS/JS import resolving outside `web/`, wired into
+`thread-gates.yml` to run on web-touching PRs. Verified it catches the
+PR #1966 pattern and exits clean on the healed body.
+
+The contract isn't broken; it's just unprotected at the seam where
+local-FS-perception diverges from Docker-context-perception. Guard
+now lives at that seam.
 
 ## [2026-05-24] form | circulation-pattern third attestation — six substrate-flavors cross sub-typing threshold
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 128
+**Total files**: 129
 
 | File | Purpose |
 |---|---|
@@ -29,6 +29,7 @@
 | [check_runtime_drift.py](check_runtime_drift.py) | !/usr/bin/env python3 |
 | [check_spec_references.py](check_spec_references.py) | !/usr/bin/env python3 |
 | [check_traceability.py](check_traceability.py) | !/usr/bin/env python3 |
+| [check_web_docker_context.py](check_web_docker_context.py) | !/usr/bin/env python3 |
 | [cluster_watch_history.py](cluster_watch_history.py) | !/usr/bin/env python3 |
 | [coh_substrate.py](coh_substrate.py) | !/usr/bin/env python3 |
 | [coherence_reach.py](coherence_reach.py) | !/usr/bin/env python3 |

--- a/scripts/check_web_docker_context.py
+++ b/scripts/check_web_docker_context.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Catch web/ imports reaching above the Docker build context.
+
+Dockerfile.web sets `web/` as its build context. Imports of the form
+`../../../experiments/...` or any path that climbs above `web/` resolve
+in local dev (the worktree has the full repo) but fail at `npm run build`
+inside the Docker image (the context is sandboxed to `web/`).
+
+This guard surfaces the mismatch at commit-time instead of letting it
+become three consecutive failed deploys, as happened 2026-05-24 with
+PR #1966 (form-kernel/client.ts importing `../../../experiments/...`).
+The healing pattern is to vendor the needed files into `web/lib/.../vendor/`.
+
+Run:
+    python3 scripts/check_web_docker_context.py
+
+Exits 1 if any web/ TypeScript file imports a path that escapes the
+web/ tree.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Imports like:  import { x } from "../../../experiments/form-kernel-ts/src/kernel.ts"
+# Also catches:  from "../../something-outside-web"
+IMPORT_RE = re.compile(
+    r"""(?:^|\s)(?:import|from|require\s*\()\s*\(?\s*['"]([^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WEB_DIR = REPO_ROOT / "web"
+
+
+def import_escapes_web(source_file: Path, import_spec: str) -> bool:
+    """True if a relative import resolves outside the web/ tree."""
+    if not import_spec.startswith("."):
+        return False  # bare specifiers (e.g. "react", "@/components") are fine
+    target = (source_file.parent / import_spec).resolve()
+    try:
+        target.relative_to(WEB_DIR.resolve())
+    except ValueError:
+        return True
+    return False
+
+
+def scan() -> list[tuple[Path, int, str]]:
+    """Return (file, line_no, import_spec) tuples for escapes."""
+    findings: list[tuple[Path, int, str]] = []
+    for ext in ("*.ts", "*.tsx", "*.mts", "*.cts", "*.js", "*.jsx", "*.mjs"):
+        for path in WEB_DIR.rglob(ext):
+            # Skip node_modules and build output
+            parts = set(path.parts)
+            if "node_modules" in parts or ".next" in parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for m in IMPORT_RE.finditer(text):
+                spec = m.group(1)
+                if import_escapes_web(path, spec):
+                    line_no = text[: m.start()].count("\n") + 1
+                    findings.append((path, line_no, spec))
+    return findings
+
+
+def main() -> int:
+    findings = scan()
+    if not findings:
+        print("OK: no web/ imports escape the Docker build context")
+        return 0
+    print("ERROR: web/ imports escape the Docker build context")
+    print()
+    print("These imports resolve in local dev (full worktree) but fail")
+    print("inside the Docker build (context is sandboxed to web/).")
+    print("Vendor the needed files into web/lib/.../vendor/ to heal.")
+    print()
+    for path, line, spec in findings:
+        rel = path.relative_to(REPO_ROOT)
+        print(f"  {rel}:{line}  →  {spec}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Investigated the "Hostinger Auto Deploy 15% over 7d" signal surfaced by PR #2028's post-heal wellness reading.
- Verdict: same-cause cluster (3 consecutive deploys 2026-05-24 08:54/08:57/09:02 UTC), all from PR #1966's web/ file importing `../../../experiments/form-kernel-ts/src/kernel.ts`. Body self-healed within 10 minutes via PR #1969 (vendor pattern).
- Adds `scripts/check_web_docker_context.py` — small guard catching any web/ TS/JS import that resolves outside the `web/` Docker build context. Wired into `thread-gates.yml` to run on web-touching PRs.

## Why

`Dockerfile.web` sandboxes the build context to `web/`. Local `npm run dev` succeeds where Docker `npm run build` fails — the worktree can't see its own mistake. The deploy queue has been carrying this blind spot. This guard lives at the seam where local-FS-perception diverges from Docker-context-perception, so the next PR that wants to reach across that seam gets told at commit time, not at deploy time.

## Test plan

- [x] Guard exits 0 on the current healed body.
- [x] Guard exits 1 and names the offending import when fed the PR #1966 pattern (`web/lib/foo/x.ts` importing `../../../experiments/...`).
- [x] CI step gated on `changed_surfaces.outputs.web == 'true'` — non-web PRs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)