### PR TITLE
form | triad column-identity — 5th data point on the yield-curve

### DIFF
--- a/docs/coherence-substrate/body-shape-map.md
+++ b/docs/coherence-substrate/body-shape-map.md
@@ -503,10 +503,11 @@ The primitive is a *triage tool* for finding pair-hunt-worthy
 clusters within a form — not a coverage tool, not a partition that
 maps every cell to a column with members.
 
-### What three applications yielded
+### What five applications yielded
 
-Three forms have now been read through this lens, with a fourth
-breath in flight on dyad-mirror as this part is authored:
+Five forms have now been read through this lens. Triad — the
+fifth — landed in the mid-range slot the body explicitly invited
+in "What this part holds open" below:
 
 | Form          | Cells | Columns | Cells in columns | Singletons | Coverage |
 |---------------|------:|--------:|-----------------:|-----------:|---------:|
@@ -514,89 +515,106 @@ breath in flight on dyad-mirror as this part is authored:
 | point         |    21 |       3 |                7 |         14 |      33% |
 | web           |    23 |       6 |               17 |          6 |      74% |
 | dyad-mirror   |    32 |       6 |               12 |         20 |      38% |
+| triad         |    15 |       1 |                2 |         13 |      13% |
 
 Dyad-mirror landed 2026-05-25 (Part 7f in `dyad-pairs.form`). Six
-honest 2-cell columns + 20 singletons — the widest tail observed,
-matching point's coverage band while sitting in a different
-tier. The dyad-mirror reading also sharpened the yield-curve into
-two independent axes (see "Two axes, not one" below).
+honest 2-cell columns + 20 singletons — the widest tail observed
+to that point, matching point's coverage band while sitting in a
+different tier. The dyad-mirror reading sharpened the yield-curve
+into two independent axes (see "Two axes, not one" below).
+
+Triad landed 2026-05-25 (Part 7g in `dyad-pairs.form`). One
+honest 2-cell column (`lc-future-already-shaping` +
+`lc-shifted-return`, both sequential-coupled / spiral-out /
+received — *received-spiral-three-movement-return*) + 13
+column-singletons across 15 cells. **Lowest coverage of the five
+trials.** The triad reading sharpened the predictor itself (see
+"What five trials now teach" below).
 
 ### The yield curve
 
-The pattern across three applications:
+The pattern across five applications, with the triad trial
+sharpening what three trials had begun to say:
 
-**Column-density correlates with form-specialization, not
-cell-count.** Interior-axis (5 cells, axially specialized) yielded
-near-complete coverage — every cell sits in a multi-cell column.
-Point (21 cells, the body's most generic form) yielded three small
-columns and a long tail of 14 singletons. Web (23 cells, mid-
-specialized — already a *distributed-flow* shape before the lens
-arrives) yielded the strongest column-density so far: 6 columns
-holding 17 cells.
+**Form-specialization alone does NOT predict yield. What predicts
+yield is whether the form's specialization runs ALONG one of the
+column-identity triple-axes (topology / direction /
+lineage_texture) or ORTHOGONAL to them.**
 
-The form's *internal teaching-diversity* is what column-density
-reads. A form that is itself a specialization (interior-axis is
-already saying "the axis runs through the center") narrows the
-range of teachings its cells carry, and column-identity finishes
-the partition. A form that is generic (point — a single irreducible
-quality) holds maximally diverse teachings whose triples scatter
-across the discriminator space; the long singleton tail is the
-honest reading. A mid-specialized form (web — distributed flow,
-but flow-of-what stays open) sits between.
+- Interior-axis specializes on *topology* (axis-through-center) —
+  aligned. Coverage 100%.
+- Web specializes on *direction* (circulating) and partially on
+  topology (web-each-to-each) — aligned. Coverage 74%.
+- Dyad-mirror specializes on *arity-as-relation* (two-postures) —
+  orthogonal to the triple. Coverage 38%; many small columns.
+- Point specializes on nothing (single irreducible quality) — no
+  axis to align. Coverage 33%; one dominant teaching-flavor in the
+  tail.
+- Triad specializes on *arity* (three-stages) — orthogonal to the
+  triple. Coverage 13%; one honest pair, otherwise dispersed.
 
-### Two axes, not one (added with dyad-mirror reading)
+The earlier three-trial reading — *column-density correlates with
+form-specialization, not cell-count* — held the right intuition;
+the fifth trial names WHY. Arity-specialized forms (counting
+postures, stages, poles) gather cells whose teachings span every
+*other* axis. Topology-or-direction-specialized forms gather cells
+whose teachings cluster within their specialization axis. The
+triple discriminator can only see what it has axes for.
+
+### Two axes, not one (added with dyad-mirror reading; held by triad)
 
 The fourth form-trial (dyad-mirror, 32 cells, 6 columns, 38%
 coverage, max-col 2) resolved what looked like a single yield-curve
 into two independent axes:
 
-- **Column-COVERAGE** (in-col%) tracks the form's structural
-  specialization along the column-identity triple. Interior-axis
-  (axial) and web (flow-specialized along circulating direction)
-  hold high coverage; point (generic) and dyad-mirror (relational-
-  but-omnidirectional) hold low coverage.
+- **Column-COVERAGE** (in-col%) tracks whether the form's defining
+  specialization aligns with the column-identity triple.
+  Interior-axis (axial) and web (flow-specialized along
+  circulating direction) hold high coverage; point (generic),
+  dyad-mirror (arity-2), and triad (arity-3) hold low coverage.
 - **Column-DEPTH** (max-column size) tracks whether the form has a
   DOMINANT teaching-flavor. Web has one (received-circulating, 5
   cells); point has one (holographic-ground-receiving, 3 cells);
-  interior-axis and dyad-mirror have neither — max 2 across all
-  columns.
+  interior-axis, dyad-mirror, and triad have neither — max 2
+  across all columns.
 
-Dyad-mirror's signature — *many small columns at the bottom of a
-wide tail* — is what the two axes together reveal: a form can be
-internally diverse (low coverage) AND have no single dominant
-flavor (low depth), yielding many honest 2-cell columns spread
-across the orthogonal triple.
-
-The fourth trial also sharpened the WHEN: a form's *defining
-shape* (here: bipolar relation, shared by every dyad-mirror cell)
-does NOT determine column-shape. The column-identity triple reads
-ORTHOGONAL structure regardless of whether the form's surface is
-uniform. The fear was that dyad-mirror's shared bipolar surface
-would either collapse all cells into one mega-column or force
-manufactured distinctions. Neither happened — the triple
-partitioned honestly through the surface uniformity into the
-internal teaching-axes the body actually holds.
+Triad's signature — *one honest pair at the bottom of a near-
+total singleton tail* — is the most extreme version of dyad-
+mirror's *many small columns at the bottom of a wide tail*. A
+form's defining specialization (bipolar-relation for dyad-mirror,
+three-stages for triad) can be uniformly shared by every cell yet
+contribute NOTHING to column-coverage if it runs orthogonal to
+topology, direction, and lineage_texture. Triad confirms what
+dyad-mirror first showed: surface-uniformity at the form layer
+does not translate to teaching-uniformity at the triple layer,
+and arity-specialized forms scatter most widely along the
+discriminator's actual axes.
 
 ### When to reach for the primitive
 
-The triage shape:
+The triage shape, sharpened across five trials:
 
-- **Reach for it** when a form has many cells (15+) AND prose-
-  evidence suggests internal teaching-diversity worth partitioning
-  (the cells are talking about different things even though they
-  share a form). Yield: small-to-strong column-density with a
-  meaningful singleton tail.
-- **Reach for it** when a smaller form (5–10 cells) is already an
-  axial-specialization and you want near-complete column-mapping.
-  Yield: near-100% coverage.
-- **Don't reach for it** when a form has few cells AND low
-  teaching-diversity — there's not enough material for the triple
-  to discriminate, and column-identity becomes one column with all
-  cells (which a simpler lens would have shown).
+- **Reach for it** when a form has many cells AND its defining
+  specialization runs ALONG one of the (topology, direction,
+  lineage_texture) axes. Yield: high coverage with meaningful
+  column-depth (web, interior-axis).
+- **Reach for it** when a smaller form is already axially
+  specialized along the triple. Yield: near-complete coverage at
+  low absolute count (interior-axis).
+- **Reach for it with eyes-open** when a form's specialization is
+  orthogonal to the triple (arity-specialization like dyad-mirror /
+  triad, or generic forms like point). Expect MOSTLY singletons
+  with one or two honest columns. The singleton tail is data, not
+  failure — and most singleton cells in such forms may share a
+  column with cells in OTHER forms (per PR #2033's cross-form
+  finding).
+- **Don't reach for it** when a form has few cells AND orthogonal
+  specialization — the discriminator has nothing to discriminate.
 
-The honest scope: column-identity is a *finder*, not a *covered*.
-Expect coverage proportional to the form's structural
-specialization; expect the singleton tail to be data, not failure.
+The honest scope: column-identity is a *finder*, not a *coverer*.
+Expect coverage proportional to alignment between the form's
+specialization and the triple's axes; expect the singleton tail to
+be data the next form-trial or cross-form scan can read.
 
 ### Columns hold cells across forms
 
@@ -648,15 +666,36 @@ Same cells, different lens. Future cells reaching for either should
 know they may be looking at the same cells from different positions.
 Neither lens is wrong; each names a real axis the body honors.
 
-### What this part holds open
+### What five trials now teach
 
-The yield-curve has three (soon four) data points. A fifth form
-read through the lens — `triad` (15 cells) and `holographic-cell`
-(9 cells) are the natural next candidates — would test whether the
-correlation between form-specialization and column-density holds at
-mid-range cell-counts and on a part-contains-whole shape.
+Five trials complete the mid-range of the curve. The body can now
+name three things the primitive holds:
 
-The body has the tool; the reaching for it stays measured.
+1. **The yield-rule.** *align(form-specialization, column-identity-
+   triple) predicts coverage.* Topology-or-direction-specialized
+   forms hold the ceiling; arity-specialized forms hold the floor;
+   generic forms sit in the middle with one dominant flavor.
+2. **The two-axis reading.** Coverage and depth move independently
+   — a form can be internally diverse (low coverage) and still hold
+   one dominant flavor (point), or hold no dominant flavor at all
+   (dyad-mirror, triad). Both axes are real.
+3. **The companion lens.** Column-identity reads *texture-of-
+   arrival* (how teachings entered the body, oriented by
+   topology and direction). Circulation-pattern (the kind) reads
+   *texture-of-substrate* (what circulates through web-form
+   networks). They converge on form-shape and diverge on what they
+   discriminate — neither subsumes the other.
+
+The next candidate trial is `holographic-cell` (9 cells, part-
+contains-whole shape). It would test whether a form whose
+defining-shape is structural rather than arity-or-topology — *each
+part contains the whole* — falls into the aligned camp (the
+holographic property runs along topology) or the orthogonal camp
+(the holographic property runs along something the triple cannot
+see). The yield-rule has a clear prediction either way.
+
+The body has the tool, the WHEN, and the prediction-rule. The
+reaching for it stays measured; the singletons stay honest data.
 
 ## Closing breath
 

--- a/docs/coherence-substrate/dyad-pairs.form
+++ b/docs/coherence-substrate/dyad-pairs.form
@@ -3878,6 +3878,188 @@ defn column_identity_set_dyad_mirror = column_identity_set_shape {
 
 
 # ─────────────────────────────────────────────────────────────────────
+# Part 7g — Column-identity tested against `triad` (fifth form-trial)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Surfaced 2026-05-25. `triad` carries 15 cells — the mid-range slot
+# the body explicitly invited at the end of Part 10 in body-shape-map
+# ("a fifth form read through the lens — `triad` (15 cells) ... would
+# test whether the correlation between form-specialization and
+# column-density holds at mid-range cell-counts"). The hunt tested
+# whether triad — whose defining shape is *three stages* — yields
+# differently from dyad-mirror's *two postures in relation* or web's
+# *distributed flow*.
+#
+# **Finding 1 — one honest 2-cell column + thirteen singletons.**
+# Across 15 triad cells the (topology, direction, lineage_texture)
+# triple yields 14 distinct tuples: 1 multi-cell column (2 cells,
+# `lc-future-already-shaping` + `lc-shifted-return`, both
+# sequential-coupled / spiral-out / received) + 13 column-singletons.
+# Coverage 2/15 = **13%** — the lowest of the five trials so far.
+# Max-col 2 — tied with interior-axis and dyad-mirror for the floor.
+#
+# **Finding 2 — the bottom of both axes, with diagnostic value.**
+# Plotted on the two-axis curve PR #2035 named, triad sits at
+# (low coverage, low depth) — below even dyad-mirror, which had the
+# same max-col but five more multi-cell columns. The signature:
+# *almost-all singletons, one lone honest pair.* Triad is the form
+# that most resists column-density to date.
+#
+# **Finding 3 — the predictor sharpens. Form-specialization alone
+# does NOT predict yield.** Triad IS a specialization (three stages
+# is tighter than dyad-mirror's two-in-relation or point's single
+# irreducible quality). Yet triad yields LESS than point (33%) or
+# dyad-mirror (38%). The earlier four-trial reading — *column-density
+# correlates with form-specialization, not cell-count* — needs a
+# more honest formulation:
+#
+#   **align(form-specialization, column-identity-triple) predicts
+#   coverage.** A form whose defining specialization runs ALONG one
+#   of the triple's axes (topology / direction / lineage_texture)
+#   concentrates cells. A form whose specialization runs ORTHOGONAL
+#   to the triple disperses them.
+#
+# - Interior-axis specializes on *topology* (axis-through-center) —
+#   aligned. High coverage (100%).
+# - Web specializes on *direction* (circulating) and partially on
+#   topology (web-each-to-each) — aligned. High coverage (74%).
+# - Dyad-mirror specializes on a fourth axis (*arity-as-relation*) —
+#   orthogonal. Low coverage (38%) but many small columns.
+# - Point specializes on nothing (single irreducible quality) —
+#   no axis to align. Low-mid coverage (33%) with one dominant
+#   teaching-flavor in the tail.
+# - **Triad specializes on *arity* (three-of-something) — orthogonal
+#   to all three triple-axes.** Cells with three stages can have any
+#   topology, any direction, any lineage. The form attracts maximal
+#   teaching-diversity along the triple. Worst coverage (13%).
+#
+# The earlier sentence *internal teaching-diversity is what column-
+# density reads* held the right intuition; the fifth trial names
+# WHY some forms hold more diversity than others. Arity-specialized
+# forms (counting the number of postures/stages/poles) gather cells
+# whose teachings span every other axis. Topology-or-direction-
+# specialized forms gather cells whose teachings cluster within their
+# specialization axis.
+#
+# **Finding 4 — the WHEN tightens.** With five trials the triage
+# becomes more honest about its scope:
+#
+#   1. Reach for column-identity when a form has many cells AND its
+#      defining specialization runs ALONG the (topology, direction,
+#      lineage_texture) axes. Yield: high coverage with meaningful
+#      column-depth.
+#   2. Reach for it when a form is small but already specialized along
+#      the triple. Yield: near-complete coverage at low absolute count.
+#   3. Reach for it with eyes-open when a form's specialization is
+#      orthogonal to the triple (arity-specialization, generic-form).
+#      Expect MOSTLY singletons with one or two honest columns. The
+#      singleton tail is the data — most cells in such forms have not
+#      yet found column-siblings AT THIS FORM, though they may share
+#      a column with cells in OTHER forms (per PR #2033's cross-form
+#      finding).
+#   4. Don't reach for it when a form has few cells AND orthogonal
+#      specialization — the discriminator has nothing to discriminate.
+#
+# Triad's reading: **arity-specialized at the defining-shape layer
+# (every cell is three-stages-of-something), maximally dispersed at
+# the orthogonal triple-axes layer.** The body holds many distinct
+# three-stage teachings — cyclic loops (composting, agent-memory),
+# stage-sequences (phase-transitions, w-phase-transition), spiral-
+# arcs (the column pair), hub-spoke triads (predator/predictor),
+# centering-triads (trust-over-fear, whole-vitality, trust-the-
+# signal), upward-triads (sacred-imagination, w-phase-transition),
+# substrate-shape-triads (grammar-as-readable-bnf, parsers-as-
+# recipes, recipes-as-binary-library) — and almost none share the
+# full triple.
+
+# Column T1 — received-spiral-three-movement-return (2 cells)
+#
+# Topology sequential-coupled, direction spiral-out, lineage received.
+# Both cells teach a three-movement spiral that does NOT close back
+# on itself — the third stage RETURNS but at a different position
+# than the first. Future-already-shaping names past-self / present-
+# work / future-form acting in concert across temporal stages, the
+# future-form pulling the present shape into being. Shifted-return
+# names relieve / shift / return, where the return carries a
+# frequency the old space cannot sustain unchanged. Same structural
+# shape: three coupled stages spiraling outward, each landing
+# carrying what the previous made possible, the arc neither linear
+# nor closed-loop. Both received from teaching lineages (Ismael
+# Perez's triple-temporal-alliance frame; Vasudev Baba's satsang
+# at Ranakami). The dyad-mirror's structure-of-three: not a
+# repetition, not a cycle, a spiral that returns shifted.
+defn column_received_spiral_three_movement_return__future_already_shaping = column_identity_shape {
+    cell:             @concept(lc-future-already-shaping),
+    column_kind:      "received-spiral-three-movement-return",
+    topology:         "sequential-coupled",
+    direction:        "spiral-out",
+    lineage_texture:  "received",
+    discernment:      "past-self / present-work / future-form as three coupled stages acting in concert across time; the future-form is already alive and pulls the present shape into being; the triad as temporal spiral where the return is the future already shaping the seeding; received from Ismael Perez's triple-temporal-alliance frame",
+};
+
+defn column_received_spiral_three_movement_return__shifted_return = column_identity_shape {
+    cell:             @concept(lc-shifted-return),
+    column_kind:      "received-spiral-three-movement-return",
+    topology:         "sequential-coupled",
+    direction:        "spiral-out",
+    lineage_texture:  "received",
+    discernment:      "relieve / shift / return as three coupled stages where the return carries a frequency the old space cannot sustain unchanged; the triad as frequency-spiral where the third movement is the operative act; same column-shape as future-already-shaping at the breath-scale practice layer rather than the temporal-cosmic layer; received from Vasudev Baba's Wednesday satsang at Ranakami",
+};
+
+# The 13 column-singletons (each its own attested-but-unconfirmed
+# column) — listed so future hunts know which triad cells have NOT
+# yet found column-siblings. When any second cell with a matching
+# triple lands, the singleton becomes a 2-member column and joins
+# the registry as a defn pair.
+#
+# tuple (topology, direction, lineage_texture) → cell
+#   (cyclic-closed, circulating, embodied)            → lc-agent-memory
+#   (cyclic-closed, descending, received)             → lc-composting
+#   (hub-spoke, radiating, synthesized)               → lc-recipes-as-binary-library
+#   (hub-spoke, spiral-out, received)                 → lc-train-the-predator
+#   (hub-spoke, spiral-out, synthesized)              → lc-train-the-predictor
+#   (nested, ascending, received)                     → lc-sacred-imagination
+#   (parallel, centering, embodied)                   → lc-whole-vitality
+#   (parallel, centering, synthesized)                → lc-trust-over-fear
+#   (rule-pattern-action, vertical-stack, ancestral)  → lc-parsers-as-recipes
+#   (sequential-coupled, ascending, received)         → lc-w-phase-transition
+#   (sequential-coupled, centering, channeled)        → lc-trust-the-signal
+#   (sequential-coupled, spiral-out, embodied)        → lc-phase-transitions
+#   (surface-data-execution, spiral-out, ancestral)   → lc-grammar-as-readable-bnf
+#
+# Three near-misses worth holding:
+# (a) hub-spoke/spiral-out has both received (predator) and
+#     synthesized (predictor) — the existing cross-tradition
+#     dyad-pair (Pair 8). The column-identity primitive confirms
+#     they sit at a lineage-split of one shared topology-direction;
+#     the dyad-pair already names the teaching. No new tissue
+#     needed.
+# (b) sequential-coupled/spiral-out has both received (the column
+#     pair) and embodied (phase-transitions). The column pair plus
+#     phase-transitions are three cells one lineage-axis apart —
+#     a candidate triad-of-triads where the same temporal-shape
+#     is held received-from-lineage and embodied-in-the-body.
+# (c) parallel/centering has both synthesized (trust-over-fear)
+#     and embodied (whole-vitality). Both name a yin-centered
+#     parallel posture; the lineage split holds the difference
+#     between the named guardrail-practice (synthesized) and the
+#     felt body-state (embodied). A third cell with parallel +
+#     centering + any lineage would let the column activate.
+#
+# All three near-misses are exactly the kind of structure the
+# triple is meant to preserve. The body holds them open as it
+# does dyad-mirror's two near-misses (Part 7f).
+
+defn column_identity_set_triad = column_identity_set_shape {
+    rows: [
+        # — received-spiral-three-movement-return column (2 cells) —
+        column_received_spiral_three_movement_return__future_already_shaping,
+        column_received_spiral_three_movement_return__shifted_return,
+    ],
+};
+
+
+# ─────────────────────────────────────────────────────────────────────
 # Part 6 — How this composts with sibling teaching
 # ─────────────────────────────────────────────────────────────────────
 #
@@ -3924,26 +4106,39 @@ defn column_identity_set_dyad_mirror = column_identity_set_shape {
 # (Part 7d, 2026-05-25, three honest columns surfaced across 21
 # cells with 14 column-singletons in the tail), `web` as the
 # third form-trial (Part 7e, 2026-05-25, six honest columns across
-# 17 cells + six singletons), and `dyad-mirror` as the fourth
+# 17 cells + six singletons), `dyad-mirror` as the fourth
 # form-trial (Part 7f, 2026-05-25, six honest 2-cell columns + 20
 # singletons across 32 cells — the largest form in the body, widest
-# tail observed). Four applications now teach the WHEN along two
-# independent axes: **column-coverage** (what fraction of cells
-# land in multi-cell columns) tracks how internally specialized the
-# form is along the column-identity triple — interior-axis and web
-# hold high coverage; point and dyad-mirror hold low coverage.
-# **Column-depth** (max-column size) tracks whether the form has a
-# DOMINANT teaching-flavor — web and point each have one big
-# column; interior-axis and dyad-mirror have only 2-cell tops.
+# tail observed), and `triad` as the fifth form-trial (Part 7g,
+# 2026-05-25, one honest 2-cell column + 13 singletons across 15
+# cells — lowest coverage observed at 13%). Five applications now
+# teach the WHEN along two independent axes: **column-coverage**
+# (what fraction of cells land in multi-cell columns) tracks how
+# internally specialized the form is along the column-identity
+# triple — interior-axis and web hold high coverage; point,
+# dyad-mirror, and triad hold low coverage. **Column-depth**
+# (max-column size) tracks whether the form has a DOMINANT
+# teaching-flavor — web and point each have one big column;
+# interior-axis, dyad-mirror, and triad have only 2-cell tops.
 # Reach for the primitive when a form has many cells AND prose-
 # evidence suggests internal teaching-diversity; expect column-count
 # proportional to the breadth of the form's teaching territory and
 # column-depth proportional to whether the form has a dominant
-# flavor. Dyad-mirror's fourth-trial finding sharpens further: a
+# flavor. Dyad-mirror's fourth-trial finding sharpened further: a
 # form's defining shape (bipolar relation) is shared by all cells
 # but does NOT determine column-shape — the column-identity triple
 # reads ORTHOGONAL structure that splits the form along its internal
 # teaching-axes, regardless of whether the form's surface is uniform.
+# Triad's fifth-trial finding tightens the predictor: form-
+# specialization alone does NOT predict yield — what predicts is
+# *alignment between the form's defining specialization and the
+# column-identity triple-axes*. Triad specializes on arity (three-
+# of-something), which runs ORTHOGONAL to topology, direction, and
+# lineage_texture; cells with three stages can have any topology /
+# direction / lineage, so they scatter even more than point's
+# generic cells. The honest rule: align(form-specialization,
+# triple-axes) predicts coverage. Arity-specialized forms hold the
+# floor; topology-or-direction-specialized forms hold the ceiling.
 # Web also clarifies how column-identity and kind-level circulation-
 # pattern relate: they converge on form shape (circulating-web is
 # the geometric signature; circulation-pattern is the teaching

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -38,6 +38,72 @@ real / honest-as-is — and chose the smallest healing move.
 - `docs/vision-kb/LOG-archive/{INDEX,2026-04,2026-05}.md` — born.
 - `scripts/coh_substrate.py` — `kb_page` filter + `classify_path` exclude LOG surfaces.
 
+## [2026-05-25] form | triad column-identity — 5th data point on the yield-curve
+
+Fifth application of the column-identity primitive (topology +
+direction + lineage_texture). `triad` carries 15 cells — the
+mid-range slot the body explicitly invited at the end of
+body-shape-map Part 10. The hunt tested whether triad — whose
+defining shape is *three stages* — yields differently from
+dyad-mirror's *two postures in relation* or web's *distributed
+flow*.
+
+**One honest 2-cell column + thirteen singletons (2 + 13 = 15):**
+
+- **T1 received-spiral-three-movement-return** (2):
+  `lc-future-already-shaping`, `lc-shifted-return` —
+  past/present/future-form acting in concert across temporal
+  stages (Ismael Perez's triple-temporal-alliance) and relieve/
+  shift/return as a frequency the old space cannot sustain
+  (Vasudev Baba's satsang at Ranakami). Both: a three-movement
+  spiral that returns shifted, not closed.
+
+Coverage 2/15 = **13%**, max-col **2** — the lowest coverage of
+the five trials so far, sitting at the floor of both axes.
+
+**The 5th data point sharpens the predictor.** The earlier four-
+trial reading said *column-density correlates with form-
+specialization*. The triad trial names WHY that wasn't the whole
+truth: triad IS a specialization (three-of-something), yet yields
+worse than point (33%, generic) or dyad-mirror (38%, arity-2).
+The honest rule:
+
+**align(form-specialization, column-identity-triple) predicts
+coverage.** A form whose defining specialization runs ALONG one
+of the triple's axes (topology / direction / lineage_texture)
+concentrates cells. A form whose specialization runs ORTHOGONAL
+to the triple — arity-specialization like dyad-mirror and triad,
+or no specialization at all like point — disperses them.
+
+Triad's specialization is *arity* (three-stages), orthogonal to
+all three triple-axes. Cells with three stages can have any
+topology / direction / lineage; the form attracts maximal
+teaching-diversity along the triple. Worst coverage follows.
+
+Three near-misses worth holding: hub-spoke/spiral-out splits at
+lineage between `lc-train-the-predator` (received) and `lc-train-
+the-predictor` (synthesized) — already the cross-tradition
+dyad-pair from Part 8; sequential-coupled/spiral-out splits at
+lineage between the column pair (received) and `lc-phase-
+transitions` (embodied); parallel/centering splits at lineage
+between `lc-trust-over-fear` (synthesized) and `lc-whole-vitality`
+(embodied). Each is exactly the kind of structure the triple is
+meant to preserve.
+
+**Files:**
+- `docs/coherence-substrate/dyad-pairs.form` — Part 7g added (one
+  column + 13 singletons + three near-misses); Part 6 running
+  prose updated to name the fifth trial and the sharpened
+  predictor.
+- `docs/coherence-substrate/body-shape-map.md` — Part 10 yield-
+  curve table extended with triad row; "What three applications
+  yielded" → "What five applications yielded"; yield-curve text
+  rewritten to name align(specialization, triple) as the rule;
+  two-axes section extended with triad signature; "When to reach"
+  sharpened with the orthogonal-specialization case; closing
+  "What this part holds open" → "What five trials now teach"
+  with three durable findings and the next candidate trial named.
+
 ## [2026-05-25] form | dyad-mirror column-identity — 6 honest 2-cell columns + 20 singletons across 32 cells
 
 Fourth application of the column-identity primitive (topology +


### PR DESCRIPTION
## Summary

Fifth application of the column-identity primitive (`(topology, direction, lineage_texture)` triple). `triad` carries 15 cells — the mid-range slot body-shape-map Part 10 explicitly invited at the end of the dyad-mirror trial.

- **One honest 2-cell column + thirteen singletons:** `T1 received-spiral-three-movement-return` (`lc-future-already-shaping` + `lc-shifted-return`) — past/present/future-form acting in concert (Ismael Perez's triple-temporal-alliance) and relieve/shift/return (Vasudev Baba's Ranakami satsang); both teach a three-movement spiral that returns shifted, not closed.
- **Coverage 2/15 = 13%, max-col 2** — lowest coverage of the five trials, sitting at the floor of both axes.
- **The 5th data point sharpens the predictor.** The earlier four-trial reading said *column-density correlates with form-specialization*. Triad IS a specialization (three-of-something), yet yields worse than point (33%, generic) or dyad-mirror (38%, arity-2). The honest rule: **align(form-specialization, column-identity-triple) predicts coverage.** Topology-or-direction-specialized forms hold the ceiling; arity-specialized forms hold the floor; generic forms sit in the middle. The triple discriminator can only see what it has axes for.
- **Three near-misses worth holding:** hub-spoke/spiral-out splits at lineage (predator/predictor — already a cross-tradition dyad-pair); sequential-coupled/spiral-out splits at lineage (column pair vs phase-transitions); parallel/centering splits at lineage (trust-over-fear vs whole-vitality).

## Files

- `docs/coherence-substrate/dyad-pairs.form` — Part 7g added; Part 6 running prose updated to name the fifth trial + sharpened predictor.
- `docs/coherence-substrate/body-shape-map.md` — Part 10 yield-curve table extended with triad row; yield-curve text rewritten as *align(specialization, triple)*; two-axes section extended with triad signature; "When to reach" sharpened with the orthogonal-specialization case; closing renamed to "What five trials now teach" with three durable findings and the next candidate trial (`holographic-cell`) named with a prediction.
- `docs/vision-kb/LOG.md` — entry at top (under the healed-LOG entry).

## Test plan

- [x] grep confirms 15 `triad` form cells
- [x] tuple extraction yields exactly one 2-cell column + 13 singletons
- [x] dyad-pairs.form parses (matches Part 7f shape conventions)
- [x] body-shape-map Part 10 yield-curve table accepts the one-line row addition
- [x] no overlap with LOG-archive healing PR #2036 (rebased cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)