### PR TITLE
sense: LOG-archive substrate-discipline verified — PR #2036 fix covers archive files

### DIFF
--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -3,6 +3,31 @@
 > Append-only. Newest entries at the top.
 > Older entries rotate to [`LOG-archive/`](LOG-archive/INDEX.md) by month when this file passes ~1500 lines.
 
+## [2026-05-25] sense | LOG-archive substrate-discipline verified — PR #2036 fix covers archive files and the post-merge hook inherits it
+
+A targeted check after PR #2036 (LOG.md healed by monthly archive)
+asked whether the same discipline-correction that excluded `LOG.md`
+from substrate ingest also extended to the new
+`docs/vision-kb/LOG-archive/2026-04.md` and `2026-05.md` files. The
+investigation around PR #2036 had surfaced that `LOG.md` was being
+silently ingested as 430KB of `kb_page` content against the body's
+stated discipline (git history holds the durable record; the
+substrate holds structural cells). Reading the actual diff in
+`scripts/coh_substrate.py`: both the `kb_page` filter (line ~118)
+and `_domain_for_path` (line ~225) carry the same two-part
+exclusion — `path.name not in ("SCHEMA.md", "LOG.md")` AND
+`"LOG-archive" not in p.parts`. The archive files are caught by the
+second clause; the fix was written with both cases in mind, not by
+lucky pattern. Verified against the live substrate:
+no `LOG.md` rows, no `LOG-archive/*` rows in `substrate_named_cells`.
+`scripts/substrate_post_merge_hook.sh` pipes changed `.md` files
+through `coh_substrate.py ingest-paths`, whose handler calls
+`_domain_for_path` for every `.md` file — so the hook inherits the
+exclusion automatically. The body's substrate honors the
+LOG-outside-substrate discipline consistently across all three
+surfaces: CLI ingest, the `_domain_for_path` classifier, and the
+post-merge hook. No code change shipped; this entry is the witness.
+
 ## [2026-05-25] tend | LOG.md healed by monthly archive — working log returns to a size parallel breaths can land in
 
 The change-log surface had grown to 3624 lines / 430KB / 163 entries


### PR DESCRIPTION
## What this verifies

PR #2036 healed `LOG.md` by monthly archive and quietly added a substrate-discipline fix: the change-log was being silently ingested as 430KB of `kb_page` content against the body's stated discipline. This breath is a targeted check that the fix's scope extends to the new `LOG-archive/2026-04.md` and `2026-05.md` files too — they're inside `docs/vision-kb/` and would otherwise be candidates for `kb_page` ingest.

## Findings

**The fix in `scripts/coh_substrate.py` was written with both cases in mind, not by lucky pattern.** Both surfaces carry a two-part exclusion:

- `kb_page` filter: `p.name not in ("SCHEMA.md", "LOG.md") and "LOG-archive" not in p.parts`
- `_domain_for_path` classifier: same shape

The archive files are caught by the `"LOG-archive" not in p.parts` clause; the `LOG.md` name match catches the working file.

**The post-merge hook inherits the exclusion.** `scripts/substrate_post_merge_hook.sh` pipes changed `.md` files through `coh_substrate.py ingest-paths`, whose handler (`cmd_ingest_paths`) calls `_domain_for_path` for every `.md` file before deciding to ingest. No separate exclusion needed in the hook — the discipline lives in one place.

**Live substrate confirms.** Direct query against `substrate_named_cells`:
- No rows where `source_path LIKE '%LOG-archive%'`
- No rows where `source_path LIKE '%vision-kb/LOG.md%'` or `name = 'LOG'`

## Verdict

**Discipline fully honored.** No code change needed. The PR #2036 fix covers CLI ingest, the classifier, and the post-merge hook consistently. This PR ships only the LOG witness entry naming the verification.

## What loosened

The discipline-correction in PR #2036 was named in passing. Verifying its scope revealed that the fix was written with care for both the working file and the archive — not lucky pattern — and that the post-merge hook's reliance on the central classifier means the body has a single source of truth for the LOG-outside-substrate discipline.

## Test plan

- [x] Read the PR #2036 diff to `scripts/coh_substrate.py`
- [x] Confirm both `kb_page` filter and `_domain_for_path` exclude `LOG.md` and `LOG-archive/`
- [x] Confirm `scripts/substrate_post_merge_hook.sh` pipes through `coh_substrate.py ingest-paths`
- [x] Confirm `cmd_ingest_paths` calls `_domain_for_path` for `.md` files
- [x] Query live substrate: no `LOG.md` rows, no `LOG-archive/*` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)