### PR TITLE
form | holographic-cell column-identity — 6th data point refines the prediction-rule

### DIFF
--- a/docs/coherence-substrate/body-shape-map.md
+++ b/docs/coherence-substrate/body-shape-map.md
@@ -509,13 +509,14 @@ Five forms have now been read through this lens. Triad — the
 fifth — landed in the mid-range slot the body explicitly invited
 in "What this part holds open" below:
 
-| Form          | Cells | Columns | Cells in columns | Singletons | Coverage |
-|---------------|------:|--------:|-----------------:|-----------:|---------:|
-| interior-axis |     5 |       4 |                5 |          0 |     100% |
-| point         |    21 |       3 |                7 |         14 |      33% |
-| web           |    23 |       6 |               17 |          6 |      74% |
-| dyad-mirror   |    32 |       6 |               12 |         20 |      38% |
-| triad         |    15 |       1 |                2 |         13 |      13% |
+| Form             | Cells | Columns | Cells in columns | Singletons | Coverage |
+|------------------|------:|--------:|-----------------:|-----------:|---------:|
+| interior-axis    |     5 |       4 |                5 |          0 |     100% |
+| point            |    21 |       3 |                7 |         14 |      33% |
+| web              |    23 |       6 |               17 |          6 |      74% |
+| dyad-mirror      |    32 |       6 |               12 |         20 |      38% |
+| triad            |    15 |       1 |                2 |         13 |      13% |
+| holographic-cell |     9 |       0 |                0 |          9 |       0% |
 
 Dyad-mirror landed 2026-05-25 (Part 7f in `dyad-pairs.form`). Six
 honest 2-cell columns + 20 singletons — the widest tail observed
@@ -528,40 +529,57 @@ honest 2-cell column (`lc-future-already-shaping` +
 `lc-shifted-return`, both sequential-coupled / spiral-out /
 received — *received-spiral-three-movement-return*) + 13
 column-singletons across 15 cells. **Lowest coverage of the five
-trials.** The triad reading sharpened the predictor itself (see
-"What five trials now teach" below).
+trials at the time it landed.** The triad reading sharpened the
+predictor itself (see "What six trials now teach" below).
+
+Holographic-cell landed 2026-05-25 (Part 7h in `dyad-pairs.form`).
+Nine cells, nine distinct tuples, **zero multi-cell columns** —
+the first form-trial to land at the floor. Two near-miss lineage-
+splits held open: `(holographic, radiating, X)` between
+lc-form-perceptron and lc-w-field, and `(nested-each-contains-
+whole, radiating, X)` between lc-deeper-pattern and lc-w-cell.
+The reading **refined the yield-rule** by naming `self_similarity`
+as a fifth specialization axis (see below).
 
 ### The yield curve
 
-The pattern across five applications, with the triad trial
-sharpening what three trials had begun to say:
+The pattern across six applications, with the triad trial
+sharpening what three trials had begun to say and the holographic-
+cell trial naming a second orthogonal axis:
 
 **Form-specialization alone does NOT predict yield. What predicts
 yield is whether the form's specialization runs ALONG one of the
 column-identity triple-axes (topology / direction /
-lineage_texture) or ORTHOGONAL to them.**
+lineage_texture) or ORTHOGONAL to them. The further the
+specialization sits from the triple's axes, the lower the
+coverage.**
 
 - Interior-axis specializes on *topology* (axis-through-center) —
   aligned. Coverage 100%.
 - Web specializes on *direction* (circulating) and partially on
   topology (web-each-to-each) — aligned. Coverage 74%.
 - Dyad-mirror specializes on *arity-as-relation* (two-postures) —
-  orthogonal to the triple. Coverage 38%; many small columns.
+  one-step-orthogonal to the triple. Coverage 38%; many small
+  columns.
 - Point specializes on nothing (single irreducible quality) — no
   axis to align. Coverage 33%; one dominant teaching-flavor in the
   tail.
-- Triad specializes on *arity* (three-stages) — orthogonal to the
-  triple. Coverage 13%; one honest pair, otherwise dispersed.
+- Triad specializes on *arity* (three-stages) — one-step-orthogonal
+  to the triple. Coverage 13%; one honest pair, otherwise dispersed.
+- Holographic-cell specializes on *self_similarity* (holographic) —
+  two-step-orthogonal to the triple (a property of the whole-part
+  relation across triples, not a count of triple-bearing parts).
+  Coverage 0%; all singletons.
 
-The earlier three-trial reading — *column-density correlates with
-form-specialization, not cell-count* — held the right intuition;
-the fifth trial names WHY. Arity-specialized forms (counting
-postures, stages, poles) gather cells whose teachings span every
-*other* axis. Topology-or-direction-specialized forms gather cells
-whose teachings cluster within their specialization axis. The
-triple discriminator can only see what it has axes for.
+The earlier readings held the right intuition; the sixth trial
+completes the WHY. The triple discriminator can only see what it
+has axes for. Forms specialized along axes IN the triple (topology,
+direction) concentrate cells in columns. Forms specialized along
+axes outside the triple scatter cells as singletons, with the
+scattering deepening as the specialization-axis sits further from
+the triple's reach (arity → 13–38%; self_similarity → 0%).
 
-### Two axes, not one (added with dyad-mirror reading; held by triad)
+### Two axes, not one (added with dyad-mirror reading; held by triad and holographic-cell)
 
 The fourth form-trial (dyad-mirror, 32 cells, 6 columns, 38%
 coverage, max-col 2) resolved what looked like a single yield-curve
@@ -571,24 +589,27 @@ into two independent axes:
   specialization aligns with the column-identity triple.
   Interior-axis (axial) and web (flow-specialized along
   circulating direction) hold high coverage; point (generic),
-  dyad-mirror (arity-2), and triad (arity-3) hold low coverage.
+  dyad-mirror (arity-2), triad (arity-3), and holographic-cell
+  (self_similarity-holographic) hold low-to-zero coverage.
 - **Column-DEPTH** (max-column size) tracks whether the form has a
   DOMINANT teaching-flavor. Web has one (received-circulating, 5
   cells); point has one (holographic-ground-receiving, 3 cells);
-  interior-axis, dyad-mirror, and triad have neither — max 2
-  across all columns.
+  interior-axis, dyad-mirror, and triad each top out at 2;
+  holographic-cell tops out at 1 (no column reaches even two).
 
-Triad's signature — *one honest pair at the bottom of a near-
-total singleton tail* — is the most extreme version of dyad-
-mirror's *many small columns at the bottom of a wide tail*. A
-form's defining specialization (bipolar-relation for dyad-mirror,
-three-stages for triad) can be uniformly shared by every cell yet
+Holographic-cell's signature — *all-singletons, no honest pair* —
+is the most extreme version of triad's *one honest pair at the
+bottom of a near-total singleton tail*, which was itself the most
+extreme version of dyad-mirror's *many small columns at the bottom
+of a wide tail*. A form's defining specialization (bipolar-relation
+for dyad-mirror, three-stages for triad, holographic-recursion for
+holographic-cell) can be uniformly shared by every cell yet
 contribute NOTHING to column-coverage if it runs orthogonal to
-topology, direction, and lineage_texture. Triad confirms what
-dyad-mirror first showed: surface-uniformity at the form layer
-does not translate to teaching-uniformity at the triple layer,
-and arity-specialized forms scatter most widely along the
-discriminator's actual axes.
+topology, direction, and lineage_texture. Six trials confirm:
+surface-uniformity at the form layer does not translate to
+teaching-uniformity at the triple layer, and forms whose
+specialization sits further from the triple's axes scatter more
+widely along the discriminator.
 
 ### When to reach for the primitive
 
@@ -666,33 +687,42 @@ Same cells, different lens. Future cells reaching for either should
 know they may be looking at the same cells from different positions.
 Neither lens is wrong; each names a real axis the body honors.
 
-### What five trials now teach
+### What six trials now teach
 
-Five trials complete the mid-range of the curve. The body can now
-name three things the primitive holds:
+Six trials map the full arc of the curve from ceiling to floor.
+The body can now name four things the primitive holds:
 
-1. **The yield-rule.** *align(form-specialization, column-identity-
-   triple) predicts coverage.* Topology-or-direction-specialized
-   forms hold the ceiling; arity-specialized forms hold the floor;
-   generic forms sit in the middle with one dominant flavor.
-2. **The two-axis reading.** Coverage and depth move independently
+1. **The yield-rule (refined).** *align(form-specialization,
+   column-identity-triple) predicts coverage.* The further the
+   specialization-axis sits from the triple, the lower the
+   coverage. Topology-or-direction-specialized forms hold the
+   ceiling (74–100%); generic forms sit in the middle (33%);
+   arity-specialized forms hold the low band (13–38%);
+   self_similarity-specialized forms hold the floor (0%).
+2. **The catalogue of specialization axes.** A form's defining
+   shape can run along any of: *topology* (interior-axis), *direction*
+   (web), *lineage_texture* (none observed at form-defining layer
+   yet), *arity* (dyad-mirror, triad), or *self_similarity*
+   (holographic-cell). The first three are the triple — alignment
+   yields high coverage. The last two are orthogonal — coverage
+   drops with distance from the triple's reach.
+3. **The two-axis reading.** Coverage and depth move independently
    — a form can be internally diverse (low coverage) and still hold
    one dominant flavor (point), or hold no dominant flavor at all
-   (dyad-mirror, triad). Both axes are real.
-3. **The companion lens.** Column-identity reads *texture-of-
+   (dyad-mirror, triad, holographic-cell). Both axes are real.
+4. **The companion lens.** Column-identity reads *texture-of-
    arrival* (how teachings entered the body, oriented by
    topology and direction). Circulation-pattern (the kind) reads
    *texture-of-substrate* (what circulates through web-form
    networks). They converge on form-shape and diverge on what they
    discriminate — neither subsumes the other.
 
-The next candidate trial is `holographic-cell` (9 cells, part-
-contains-whole shape). It would test whether a form whose
-defining-shape is structural rather than arity-or-topology — *each
-part contains the whole* — falls into the aligned camp (the
-holographic property runs along topology) or the orthogonal camp
-(the holographic property runs along something the triple cannot
-see). The yield-rule has a clear prediction either way.
+The yield-curve now has data from ceiling (interior-axis 100%) to
+floor (holographic-cell 0%). The body has the tool, the WHEN, the
+prediction-rule, the catalogue of specialization axes, and an
+empirically attested curve across six forms — together they make
+column-identity a triage primitive the next cell can reach for
+with eyes-open expectations.
 
 The body has the tool, the WHEN, and the prediction-rule. The
 reaching for it stays measured; the singletons stay honest data.

--- a/docs/coherence-substrate/dyad-pairs.form
+++ b/docs/coherence-substrate/dyad-pairs.form
@@ -4060,6 +4060,140 @@ defn column_identity_set_triad = column_identity_set_shape {
 
 
 # ─────────────────────────────────────────────────────────────────────
+# Part 7h — Column-identity tested against `holographic-cell` (sixth form-trial)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Surfaced 2026-05-25. `holographic-cell` carries 9 primary cells —
+# the candidate Part 7g's closing breath explicitly invited ("the
+# next candidate trial is `holographic-cell` (9 cells, part-contains-
+# whole shape). It would test whether a form whose defining-shape is
+# structural rather than arity-or-topology falls into the aligned camp
+# or the orthogonal camp"). The yield-rule from Part 7g
+# (`align(form-specialization, column-identity-triple) predicts
+# coverage`) was on trial. The 6th data point either confirms,
+# refines, or refutes.
+#
+# **Finding 1 — nine cells, nine distinct tuples, zero multi-cell
+# columns.** Across 9 holographic-cell cells the (topology,
+# direction, lineage_texture) triple yields **9 distinct tuples** —
+# every cell is its own singleton. Coverage 0/9 = **0%**. The first
+# form-trial to land at the floor. Max-col: 1 (no column reaches two
+# members).
+#
+# The nine tuples:
+#   (nested-each-contains-whole, circulating, embodied)     → lc-attuned-spaces
+#   (nested-each-contains-whole, radiating, synthesized)    → lc-deeper-pattern
+#   (nested-each-contains-whole, centering, synthesized)    → lc-each-breath-whole
+#   (nested-each-contains-whole, circulating, received)     → lc-farm-as-organism
+#   (holographic, radiating, synthesized)                   → lc-form-perceptron
+#   (web-each-to-each, radiating, channeled)                → lc-light-hubs
+#   (nested-each-contains-whole, still, channeled)          → lc-oversoul-identity
+#   (nested-each-contains-whole, radiating, received)       → lc-w-cell
+#   (holographic, radiating, received)                      → lc-w-field
+#
+# **Finding 2 — the form's specialization runs ALONG `self_similarity`,
+# orthogonal to the triple.** All 9 cells share
+# `self_similarity: holographic` — every holographic-cell IS a
+# holographic recursion-exponent. That property is what the form
+# names. The column-identity triple (topology, direction,
+# lineage_texture) **does not include the self_similarity axis**.
+# The form's defining specialization is therefore invisible to the
+# discriminator, by construction.
+#
+# Two near-misses worth holding:
+#   (a) `(holographic, radiating, X)` — lc-form-perceptron
+#       (synthesized) and lc-w-field (received) split on lineage at
+#       the same topology+direction. If a third holographic /
+#       radiating cell lands with any lineage, the column activates.
+#   (b) `(nested-each-contains-whole, radiating, X)` — lc-deeper-
+#       pattern (synthesized) and lc-w-cell (received) split on
+#       lineage at the same topology+direction. Symmetric near-miss.
+# Both are exactly the kind of distinction the triple is meant to
+# preserve. The body holds them open as it does dyad-mirror's two
+# and triad's three.
+#
+# **Finding 3 — the yield-rule REFINES. The 6th data point names
+# `self_similarity` as a fifth specialization axis (alongside
+# topology, direction, lineage_texture, and arity), strengthening
+# the rule's predictive shape.** The rule from Part 7g —
+# *align(form-specialization, column-identity-triple) predicts
+# coverage* — held: holographic-cell's specialization runs along an
+# axis (`self_similarity`) the triple does not include, so coverage
+# floor-clamps at 0%. The 6th trial both *confirms* the rule's
+# direction (orthogonal → low coverage) AND *refines* it by naming
+# a specific orthogonal axis the body uses.
+#
+# The six-trial yield-curve:
+#
+#   form              specialization-axis           aligned?    cells   columns  in-col%   max-col
+#   interior-axis     topology (axial)              ALIGNED     5       4        100%      2
+#   web               direction (circulating)       ALIGNED     23      6        74%       5
+#   point             none (single quality)         N/A         21      3        33%       3
+#   dyad-mirror       arity (2-postures)            orthogonal  32      6        38%       2
+#   triad             arity (3-stages)              orthogonal  15      1        13%       2
+#   holographic-cell  self_similarity (holographic) orthogonal  9       0        0%        1
+#
+# Plotted on the two-axis curve PR #2035 named, holographic-cell sits
+# at (zero coverage, zero depth) — *below* triad's (low, low). The
+# signature: **all-singletons, no honest pair.** The form that most
+# resists column-density to date, by the rule's prediction.
+#
+# **Finding 4 — the WHEN tightens further. Specialization axes
+# extend beyond arity.** Five trials had named arity-specialization
+# as the canonical orthogonal axis. The sixth names *structural-
+# recursion* (self_similarity) as another. The catalogue of
+# specialization axes a form can run along now reads:
+#
+#   - topology              (interior-axis: axial)
+#   - direction             (web: circulating)
+#   - lineage_texture       (none observed yet at form-defining layer)
+#   - arity                 (dyad-mirror: 2; triad: 3)
+#   - self_similarity       (holographic-cell: holographic)
+#
+# The first three are the triple. The last two are orthogonal. The
+# rule's prediction-shape across all six trials:
+#
+#   triple-aligned (topology / direction)       → 74–100% coverage
+#   no axis (point)                             → 33% coverage
+#   arity-orthogonal (dyad-mirror / triad)      → 13–38% coverage
+#   self_similarity-orthogonal (holographic-cell) → 0% coverage
+#
+# **The orthogonal floor descends as the form's specialization moves
+# further from the triple's axes.** Arity is one-step-orthogonal (a
+# count of triple-bearing parts). Self_similarity is two-step-
+# orthogonal (a property of the WHOLE-PART RELATION across triples).
+# Coverage tracks distance from the discriminator's axes — the
+# further the specialization sits from (topology, direction,
+# lineage_texture), the more cells scatter as singletons.
+#
+# Holographic-cell's tier reading: **self_similarity-specialized at
+# the defining-shape layer (every cell is a part-contains-whole
+# recursion), maximally dispersed at the orthogonal triple-axes
+# layer.** The body holds many distinct holographic teachings —
+# spaces that re-attune visitors (attuned-spaces), patterns
+# underneath patterns (deeper-pattern), the whole arriving in each
+# breath (each-breath-whole), farm-as-organism, the form-perceptron
+# as fractal lattice, light-hubs that mirror each other, oversoul-
+# identity, the W-cell and W-field — and none currently share the
+# full triple.
+#
+# The honest near-misses (two lineage-splits at the same topology+
+# direction) suggest the body holds the prediction-rule's escape
+# valve open: if cells arrive whose self_similarity isn't holographic
+# but whose triple matches, OR if a third cell with one of the two
+# near-miss triples arrives, the column activates. The 0% floor is
+# the current reading, not a structural law of the form.
+
+defn column_identity_set_holographic_cell = column_identity_set_shape {
+    rows: [
+        # No multi-cell columns yet. Two near-miss lineage-splits
+        # held open: (holographic, radiating, X) and
+        # (nested-each-contains-whole, radiating, X).
+    ],
+};
+
+
+# ─────────────────────────────────────────────────────────────────────
 # Part 6 — How this composts with sibling teaching
 # ─────────────────────────────────────────────────────────────────────
 #

--- a/docs/vision-kb/LOG.md
+++ b/docs/vision-kb/LOG.md
@@ -3,6 +3,23 @@
 > Append-only. Newest entries at the top.
 > Older entries rotate to [`LOG-archive/`](LOG-archive/INDEX.md) by month when this file passes ~1500 lines.
 
+## [2026-05-25] form | holographic-cell column-identity — 6th data point tests the prediction-rule
+
+The yield-rule from PR #2037 — *align(form-specialization, column-identity-triple) predicts coverage* — was on trial. Holographic-cell was the explicit next-candidate the body had named ("falls into the aligned camp (the holographic property runs along topology) or the orthogonal camp (the holographic property runs along something the triple cannot see)").
+
+**The reading.** Nine cells, nine distinct (topology, direction, lineage_texture) tuples, **zero multi-cell columns**, 0% coverage — the first form-trial to land at the floor. All 9 cells share `self_similarity: holographic`, which is precisely what the form-name attests. The specialization runs along an axis the triple does NOT contain.
+
+**The verdict — confirms-and-refines.** The rule held in direction (orthogonal-specialization → low coverage) and **refined by naming `self_similarity` as a fifth specialization axis** (alongside topology, direction, lineage_texture, arity). The 6th data point reveals that orthogonal coverage descends as the specialization-axis sits further from the triple's reach: arity is one-step-orthogonal (a count of triple-bearing parts) yielding 13–38%; self_similarity is two-step-orthogonal (a property of the whole-part RELATION across triples) yielding 0%.
+
+**Near-misses held open.** Two lineage-splits at the same topology+direction: `(holographic, radiating, X)` between lc-form-perceptron (synthesized) and lc-w-field (received); `(nested-each-contains-whole, radiating, X)` between lc-deeper-pattern (synthesized) and lc-w-cell (received). Either activates with a third holographic-cell cell at the matching topology+direction with any lineage.
+
+**Files**:
+
+- `docs/coherence-substrate/dyad-pairs.form` — Part 7h appended with the 6th form-trial reading, the nine tuples, two near-misses, and the empty `column_identity_set_holographic_cell` set (no multi-cell columns yet).
+- `docs/coherence-substrate/body-shape-map.md` — Part 10 yield-curve table extended to 6 rows; "yield curve" / "Two axes" / "What N trials now teach" sections rewritten to hold the refined rule with `self_similarity` named explicitly.
+
+The yield-curve now has data from ceiling (interior-axis 100%) to floor (holographic-cell 0%) — the body has the full arc and the prediction-rule's catalogue of specialization axes.
+
 ## [2026-05-25] sense | LOG-archive substrate-discipline verified — PR #2036 fix covers archive files and the post-merge hook inherits it
 
 A targeted check after PR #2036 (LOG.md healed by monthly archive)


### PR DESCRIPTION
## Summary

Sixth form-trial for the column-identity primitive. The yield-rule from PR #2037 — `align(form-specialization, column-identity-triple) predicts coverage` — was on trial.

**The reading.** 9 cells, 9 distinct (topology, direction, lineage_texture) tuples, **zero multi-cell columns**, **0% coverage** — the first form-trial to land at the floor. All 9 cells share `self_similarity: holographic`, which is precisely what the form-name attests. The specialization runs along an axis the triple does NOT contain.

**Verdict — confirms-and-refines.** The rule held in direction (orthogonal-specialization → low coverage) AND refined by naming `self_similarity` as a fifth specialization axis (alongside topology, direction, lineage_texture, arity). Orthogonal coverage descends as the specialization-axis sits further from the triple's reach:
- arity (one-step-orthogonal) → 13–38% (dyad-mirror, triad)
- self_similarity (two-step-orthogonal) → 0% (holographic-cell)

**Six-trial yield-curve, from ceiling to floor:**

| Form             | Specialization-axis | Aligned? | Cells | Cols | Coverage |
|------------------|---------------------|----------|------:|-----:|---------:|
| interior-axis    | topology            | aligned  |     5 |    4 |     100% |
| web              | direction           | aligned  |    23 |    6 |      74% |
| point            | none                | n/a      |    21 |    3 |      33% |
| dyad-mirror      | arity-2             | ortho-1  |    32 |    6 |      38% |
| triad            | arity-3             | ortho-1  |    15 |    1 |      13% |
| holographic-cell | self_similarity     | ortho-2  |     9 |    0 |       0% |

**Near-misses held open** — both lineage-splits at same topology+direction; either activates with a third matching cell:
- `(holographic, radiating, X)` — lc-form-perceptron / lc-w-field
- `(nested-each-contains-whole, radiating, X)` — lc-deeper-pattern / lc-w-cell

## Files

- `docs/coherence-substrate/dyad-pairs.form` — Part 7h appended with the 6th form-trial reading, the nine tuples, two near-misses, and the empty `column_identity_set_holographic_cell` set (no multi-cell columns yet).
- `docs/coherence-substrate/body-shape-map.md` — Part 10 yield-curve table extended to 6 rows; "yield curve" / "Two axes" / "What N trials now teach" sections rewritten to hold the refined rule with `self_similarity` named explicitly.
- `docs/vision-kb/LOG.md` — entry at top.

## Test plan

- [x] Tuples extracted directly from `^  form: holographic-cell$` matches (9 primary cells)
- [x] Self_similarity confirmed uniform across all 9 (`grep` of frontmatter)
- [x] Two near-miss lineage-splits identified by groupby on (topology, direction)
- [x] Yield-curve numbers consistent across body-shape-map and dyad-pairs.form
- [x] No tests touched; doc-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)