### PR TITLE
Dedupe cached parallel Form walk batches

### DIFF
--- a/docs/system_audit/commit_evidence_2026-05-25_form_async_cache_stats.json
+++ b/docs/system_audit/commit_evidence_2026-05-25_form_async_cache_stats.json
@@ -1,7 +1,7 @@
 {
   "date": "2026-05-25",
-  "thread_branch": "codex/form-async-hotspot-20260525",
-  "commit_scope": "Add Form-visible walk cache hit/miss statistics across the paired Go, Rust, and TypeScript kernels so cached async execution has a generic hotspot signal for later JIT and runtime comparison work.",
+  "thread_branch": "codex/form-async-batch-dedupe-20260525",
+  "commit_scope": "Deduplicate duplicate uncached roots inside cached parallel walk batches across the paired Go, Rust, and TypeScript kernels so a repeated NodeID is walked once, fanned out deterministically, and recorded as a batch-local cache hit.",
   "files_owned": [
     "form/form-kernel-go/main.go",
     "form/form-kernel-rust/src/main.rs",
@@ -21,7 +21,7 @@
       "cd form/form-kernel-ts && npm install",
       "cd form/form-kernel-ts && node --import ./node_modules/tsx/dist/loader.mjs src/parallel.test.ts && node --import ./node_modules/tsx/dist/loader.mjs src/inductive.test.ts && npm run check"
     ],
-    "notes": "Witness was strained with no ongoing silences and api/web/schema/audit_integrity non-breathing before edits. Prompt guide passed with zero blocking continuity risks. Wellness passed with aligned maps and Form Python dispatch coverage at 15/15. Source and binary Form artifacts returned 11 across Go, Rust, and TypeScript kernels, proving 4 cache hits + 4 cache misses + 3 structural cache entries after two cached parallel passes. Go race detector returned 11 on the same shape. Rust tests passed 30/30. TS parallel/inductive tests and typecheck passed after installing the local TS kernel dependencies in the fresh worktree."
+    "notes": "Witness was breathing with zero silences before edits. Prompt guide passed with zero blocking continuity risks. Wellness passed with aligned maps and Form Python dispatch coverage at 15/15. Source and binary Form artifacts returned 533 across Go, Rust, and TypeScript kernels, encoding 5 cache hits, 3 cache misses, and 3 structural cache entries after two cached parallel passes. The first pass walks only three unique roots and fans out the duplicate NodeID as a batch-local hit. Go race detector returned 533 on the same shape. Rust tests passed 30/30. TS parallel/inductive tests and typecheck passed after installing the local TS kernel dependencies in the fresh worktree."
   },
   "ci_validation": {
     "status": "pending",
@@ -33,7 +33,7 @@
   },
   "e2e_validation": {
     "status": "pass",
-    "expected_behavior_delta": "Form code can observe structural walk-cache hit/miss/size counters from the native kernels and use them as hotspot evidence for cached async recipe walks.",
+    "expected_behavior_delta": "Cached parallel Form walks avoid duplicate work inside a single batch by coalescing repeated uncached NodeIDs before worker dispatch, while preserving ordered output and hotspot counters.",
     "public_endpoints": [
       "form-kernel-go CLI",
       "form-kernel-rust CLI",
@@ -42,7 +42,7 @@
     "test_flows": [
       "Clear the walk cache.",
       "Run walk_parallel_cached twice over four pure roots with one duplicate.",
-      "Read walk-cache-stats from Form and confirm the three sibling kernels agree on hits + misses + cache size = 11 in source and binary execution."
+      "Read walk-cache-stats from Form and confirm the three sibling kernels agree on hits=5, misses=3, cache size=3 encoded as 533 in source and binary execution."
     ]
   },
   "phase_gate": {
@@ -58,7 +58,7 @@
     "form-control-flow-kernel-conformance"
   ],
   "task_ids": [
-    "form-async-cache-hotspot-stats-2026-05-25"
+    "form-async-cache-batch-dedupe-2026-05-25"
   ],
   "contributors": [
     {

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1314,9 +1314,15 @@ func (k *Kernel) registerNatives() {
 		}
 		sequential := func(cache bool) Value {
 			out := make([]Value, len(roots))
+			local := make(map[NodeID]Value)
 			for i, root := range roots {
 				if cache {
 					if cached, ok := k.walkCache[root]; ok {
+						k.walkCacheHits++
+						out[i] = cached
+						continue
+					}
+					if cached, ok := local[root]; ok {
 						k.walkCacheHits++
 						out[i] = cached
 						continue
@@ -1326,6 +1332,7 @@ func (k *Kernel) registerNatives() {
 				out[i] = k.walk(root, NewFrame(nil))
 				if cache {
 					k.walkCache[root] = out[i]
+					local[root] = out[i]
 				}
 			}
 			return Value{Kind: VList, List: out}
@@ -1343,12 +1350,18 @@ func (k *Kernel) registerNatives() {
 		}
 		out := make([]Value, len(roots))
 		jobs := make([]int, 0, len(roots))
+		first := make(map[NodeID]int)
+		fanout := make(map[int][]int)
 		for i, root := range roots {
 			if cached, ok := k.walkCache[root]; ok {
 				k.walkCacheHits++
 				out[i] = cached
+			} else if primary, ok := first[root]; ok {
+				k.walkCacheHits++
+				fanout[primary] = append(fanout[primary], i)
 			} else {
 				k.walkCacheMisses++
+				first[root] = i
 				jobs = append(jobs, i)
 			}
 		}
@@ -1371,6 +1384,9 @@ func (k *Kernel) registerNatives() {
 		wg.Wait()
 		for _, i := range jobs {
 			k.walkCache[roots[i]] = out[i]
+			for _, dup := range fanout[i] {
+				out[dup] = out[i]
+			}
 		}
 		return Value{Kind: VList, List: out}
 	}

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -972,9 +972,15 @@ fn native_walk_parallel_cached(k: &mut Kernel, _: &mut Arena, args: &[Value]) ->
     if workers <= 1 || roots.len() <= 1 || k.trace.is_some() {
         let cache_enabled = k.trace.is_none();
         let mut out = Vec::with_capacity(roots.len());
+        let mut local = HashMap::<NodeID, Value>::new();
         for root in &roots {
             if cache_enabled {
                 if let Some(v) = k.walk_cache.get(root).cloned() {
+                    k.walk_cache_hits += 1;
+                    out.push(v);
+                    continue;
+                }
+                if let Some(v) = local.get(root).cloned() {
                     k.walk_cache_hits += 1;
                     out.push(v);
                     continue;
@@ -986,6 +992,7 @@ fn native_walk_parallel_cached(k: &mut Kernel, _: &mut Arena, args: &[Value]) ->
             let value = walk(k, &mut sub_arena, *root, env);
             if cache_enabled {
                 k.walk_cache.insert(*root, value.clone());
+                local.insert(*root, value.clone());
             }
             out.push(value);
         }
@@ -994,12 +1001,18 @@ fn native_walk_parallel_cached(k: &mut Kernel, _: &mut Arena, args: &[Value]) ->
 
     let mut out: Vec<Option<Value>> = vec![None; roots.len()];
     let mut jobs = Vec::<(usize, NodeID)>::new();
+    let mut first = HashMap::<NodeID, usize>::new();
+    let mut fanout = HashMap::<usize, Vec<usize>>::new();
     for (idx, root) in roots.iter().copied().enumerate() {
         if let Some(v) = k.walk_cache.get(&root).cloned() {
             k.walk_cache_hits += 1;
             out[idx] = Some(v);
+        } else if let Some(primary) = first.get(&root).copied() {
+            k.walk_cache_hits += 1;
+            fanout.entry(primary).or_default().push(idx);
         } else {
             k.walk_cache_misses += 1;
+            first.insert(root, idx);
             jobs.push((idx, root));
         }
     }
@@ -1028,6 +1041,11 @@ fn native_walk_parallel_cached(k: &mut Kernel, _: &mut Arena, args: &[Value]) ->
             for (idx, root, value) in handle.join().expect("walk_parallel_cached worker panicked") {
                 k.walk_cache.insert(root, value.clone());
                 out[idx] = Some(value);
+                if let Some(dups) = fanout.get(&idx) {
+                    for dup in dups {
+                        out[*dup] = out[idx].clone();
+                    }
+                }
             }
         }
     }

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1379,6 +1379,7 @@ export class Kernel {
       const workers = Math.max(1, argInt(args, 1));
       const allPure = roots.every((root) => isParallelPure(k, root, new Set<string>()));
       const sequential = (cache: boolean): Value => {
+        const local = new Map<string, Value>();
         const list = roots.map((root) => {
           const key = nodeKey(root);
           if (cache) {
@@ -1387,10 +1388,18 @@ export class Kernel {
               k.walkCacheHits++;
               return cached;
             }
+            const localCached = local.get(key);
+            if (localCached !== undefined) {
+              k.walkCacheHits++;
+              return localCached;
+            }
             k.walkCacheMisses++;
           }
           const value = walk(k, root, new Frame(null));
-          if (cache) k.walkCache.set(key, value);
+          if (cache) {
+            k.walkCache.set(key, value);
+            local.set(key, value);
+          }
           return value;
         });
         return { kind: "list", list };
@@ -1405,14 +1414,24 @@ export class Kernel {
       }
       const out: Value[] = new Array(roots.length);
       const jobs: Array<[number, NodeID]> = [];
+      const first = new Map<string, number>();
+      const fanout = new Map<number, number[]>();
       for (let i = 0; i < roots.length; i++) {
         const root = roots[i]!;
-        const cached = k.walkCache.get(nodeKey(root));
+        const key = nodeKey(root);
+        const cached = k.walkCache.get(key);
         if (cached !== undefined) {
           k.walkCacheHits++;
           out[i] = cached;
+        } else if (first.has(key)) {
+          k.walkCacheHits++;
+          const primary = first.get(key)!;
+          const duplicates = fanout.get(primary) ?? [];
+          duplicates.push(i);
+          fanout.set(primary, duplicates);
         } else {
           k.walkCacheMisses++;
+          first.set(key, i);
           jobs.push([i, root]);
         }
       }
@@ -1425,6 +1444,9 @@ export class Kernel {
       }
       for (const [idx, root] of jobs) {
         k.walkCache.set(nodeKey(root), out[idx]!);
+        for (const dup of fanout.get(idx) ?? []) {
+          out[dup] = out[idx]!;
+        }
       }
       return { kind: "list", list: out };
     };

--- a/form/form-stdlib/tests/kernel-walk-cache-stats-band.fk
+++ b/form/form-stdlib/tests/kernel-walk-cache-stats-band.fk
@@ -1,8 +1,8 @@
 ; kernel-walk-cache-stats-band.fk - hotspot counters for cached async walks.
 ;
 ; Two passes over four roots with one duplicate produce:
-;   first pass: 0 hits, 4 misses, 3 cached roots
-;   second pass: 4 hits, 4 misses, 3 cached roots
+;   first pass: 1 batch-local hit, 3 misses, 3 cached roots
+;   second pass: 5 total hits, 3 misses, 3 cached roots
 
 (do
     (let PLUS (make_nodeid 1 2 12 1))
@@ -19,4 +19,4 @@
     (walk_parallel_cached (list r1 r2 r3 r1) 3)
     (walk_parallel_cached (list r1 r2 r3 r1) 3)
     (let stats (walk-cache-stats))
-    (add (nth stats 0) (add (nth stats 1) (nth stats 2))))
+    (add (mul (nth stats 0) 100) (add (mul (nth stats 1) 10) (nth stats 2))))


### PR DESCRIPTION
## Summary
- coalesce duplicate uncached NodeIDs inside walk_parallel_cached before worker dispatch
- fan the computed value back to every duplicate position while preserving ordered output
- count duplicate in-batch roots as cache hits instead of duplicate misses
- update the Form source/binary proof to encode hits=5, misses=3, size=3 as 533

## Proof
- curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != "breathing") | .name]}'
- make prompt-guide
- make wellness
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/kernel-walk-cache-stats-band.fk && ./validate.sh --binary form-stdlib/core.fk form-stdlib/tests/kernel-walk-cache-stats-band.fk
- cd form/form-kernel-go && go test ./... && go run -race . --expr '<cached parallel batch dedupe stats expression>'
- cd form/form-kernel-rust && cargo test --quiet
- cd form/form-kernel-ts && npm install && node --import ./node_modules/tsx/dist/loader.mjs src/parallel.test.ts && node --import ./node_modules/tsx/dist/loader.mjs src/inductive.test.ts && npm run check
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict