### PR TITLE
form: expose binary sensing to form recipes

### DIFF
--- a/docs/system_audit/commit_evidence_20260525_form_binary_sensing.json
+++ b/docs/system_audit/commit_evidence_20260525_form_binary_sensing.json
@@ -1,0 +1,77 @@
+{
+  "date": "2026-05-25",
+  "thread_branch": "codex/cpython-parity-harness-20260525",
+  "commit_scope": "Expose Form binary artifact sensing to Form recipes across sibling kernels and repair Python BMF scanner cases found while preparing roundtrip diagnostics.",
+  "files_owned": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-stdlib/grammars/python-bmf.fk",
+    "form/form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk",
+      "cd form && tmpdir=$(mktemp -d /tmp/formbin-sense.XXXXXX) && ./form-kernel-go/bin-go --emit-binary \"$tmpdir/fib.fkb\" form-samples/fib.fk && printf '(do (let root (read_form_binary \"%s\")) (let cat (node_category root)) (add (node_pkg cat) (add (node_level cat) (add (node_type cat) (node_inst cat)))))\\n' \"$tmpdir/fib.fkb\" > \"$tmpdir/read.fk\" && ./validate.sh form-stdlib/core.fk \"$tmpdir/read.fk\""
+    ],
+    "notes": "Sibling kernels agree on the Python BMF scanner band and on reading a compiled .fkb artifact from Form code, inspecting the loaded root category node fields."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote PR checks pending after push."
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "notes": "No web/API deployment surface changed."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local proof is complete; CI proof remains after PR checks."
+  },
+  "idea_ids": [
+    "idea-realization-engine"
+  ],
+  "spec_ids": [
+    "form-question-effects-kernel-conformance"
+  ],
+  "task_ids": [
+    "form-binary-sensing-20260525"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Form binary sensing: read_form_binary plus node_pkg/node_level/node_type/node_inst agree across Go/Rust/TypeScript kernels on a compiled fib.fk artifact.",
+    "Python BMF scanner band: underscores in integer literals and quote-specific empty/string handling agree across sibling kernels.",
+    "The implementation contains no handwritten Python solution code; the only Python file touched is this process evidence JSON path requirement."
+  ],
+  "change_files": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-stdlib/grammars/python-bmf.fk",
+    "form/form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk",
+    "docs/system_audit/commit_evidence_20260525_form_binary_sensing.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1023,6 +1023,17 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VList, List: out}
 	})
+	k.registerNative("read_form_binary", catCall(), func(k *Kernel, args []Value) Value {
+		b, err := os.ReadFile(args[0].Str)
+		if err != nil {
+			return Value{Kind: VNull}
+		}
+		root, err := deserializeArtifact(k, b)
+		if err != nil {
+			return Value{Kind: VNull}
+		}
+		return Value{Kind: VNodeID, Nid: root}
+	})
 	k.registerNative("file_size", catCall(), func(_ *Kernel, args []Value) Value {
 		info, err := os.Stat(args[0].Str)
 		if err != nil {
@@ -1114,6 +1125,18 @@ func (k *Kernel) registerNatives() {
 	})
 	k.registerNative("node_value", catWitness(), func(k *Kernel, args []Value) Value {
 		return k.trivialValue(args[0].Nid)
+	})
+	k.registerNative("node_pkg", catWitness(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VInt, Int: int64(args[0].Nid.Pkg)}
+	})
+	k.registerNative("node_level", catWitness(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VInt, Int: int64(args[0].Nid.Level)}
+	})
+	k.registerNative("node_type", catWitness(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VInt, Int: int64(args[0].Nid.Type)}
+	})
+	k.registerNative("node_inst", catWitness(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VInt, Int: int64(args[0].Nid.Inst)}
 	})
 	// node_eq — compare two NodeIDs structurally. Sibling to Rust's node_eq.
 	// Form code (emit-engine.fk lookup-template) uses this for category

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -1309,6 +1309,15 @@ impl Kernel {
                 Err(_) => Value::Null,
             }
         });
+        self.register_native("read_form_binary", cat_call(), |k, _, args| {
+            match fs::read(args[0].as_str()) {
+                Ok(bytes) => match deserialize_artifact(k, &bytes) {
+                    Ok(root) => Value::Nid(root),
+                    Err(_) => Value::Null,
+                },
+                Err(_) => Value::Null,
+            }
+        });
         self.register_native("file_size", cat_call(), |_, _, args| {
             match fs::metadata(args[0].as_str()) {
                 Ok(meta) => Value::Int(meta.len() as i64),
@@ -1412,6 +1421,18 @@ impl Kernel {
         });
         self.register_native("node_value", cat_witness(), |k, _, args| {
             k.trivial_value(args[0].as_nid())
+        });
+        self.register_native("node_pkg", cat_witness(), |_, _, args| {
+            Value::Int(args[0].as_nid().pkg as i64)
+        });
+        self.register_native("node_level", cat_witness(), |_, _, args| {
+            Value::Int(args[0].as_nid().level as i64)
+        });
+        self.register_native("node_type", cat_witness(), |_, _, args| {
+            Value::Int(args[0].as_nid().ty as i64)
+        });
+        self.register_native("node_inst", cat_witness(), |_, _, args| {
+            Value::Int(args[0].as_nid().inst as i64)
         });
         // node_eq — compare two NodeIDs structurally without coercing to int.
         // The kernel's `eq` (RCMP_EQ) does as_int on both operands, which

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1167,6 +1167,16 @@ export class Kernel {
         return { kind: "null" };
       }
     });
+    this.registerNative("read_form_binary", catCall(), (k, args) => {
+      try {
+        return {
+          kind: "nodeid",
+          nodeid: deserializeRecipeArtifact(k, readFileSync(argStr(args, 0))),
+        };
+      } catch {
+        return { kind: "null" };
+      }
+    });
     this.registerNative("file_size", catCall(), (_k, args) => {
       try {
         return { kind: "int", int: statSync(argStr(args, 0)).size };
@@ -1290,6 +1300,22 @@ export class Kernel {
     this.registerNative("node_value", catWitness(), (k, args) =>
       k.trivialValue(argNodeID(args, 0)),
     );
+    this.registerNative("node_pkg", catWitness(), (_k, args) => ({
+      kind: "int",
+      int: argNodeID(args, 0).pkg,
+    }));
+    this.registerNative("node_level", catWitness(), (_k, args) => ({
+      kind: "int",
+      int: argNodeID(args, 0).level,
+    }));
+    this.registerNative("node_type", catWitness(), (_k, args) => ({
+      kind: "int",
+      int: argNodeID(args, 0).type,
+    }));
+    this.registerNative("node_inst", catWitness(), (_k, args) => ({
+      kind: "int",
+      int: argNodeID(args, 0).inst,
+    }));
     this.registerNative("node_source", catWitness(), (k, args) => {
       const loc = k.sourceAttr.get(nodeKey(argNodeID(args, 0)));
       if (!loc) return { kind: "list", list: [] };

--- a/form/form-stdlib/grammars/python-bmf.fk
+++ b/form/form-stdlib/grammars/python-bmf.fk
@@ -181,8 +181,8 @@
         (if (fsc-source-cursor-end? cursor)
             (list value cursor)
             (if (and (fsc-source-cursor-prefix? cursor quote)
-                     (fsc-source-cursor-prefix? (fsc-source-cursor-advance cursor) quote)
-                     (fsc-source-cursor-prefix? (fsc-source-cursor-advance (fsc-source-cursor-advance cursor)) quote))
+                     (and (fsc-source-cursor-prefix? (fsc-source-cursor-advance cursor) quote)
+                          (fsc-source-cursor-prefix? (fsc-source-cursor-advance (fsc-source-cursor-advance cursor)) quote)))
                 (list value (fsc-source-advance-n cursor 3))
                 (python-source-scan-triple-string-loop
                     (fsc-source-cursor-advance cursor)
@@ -190,17 +190,24 @@
                     (str_concat value (fsc-source-cursor-char cursor))))))
 
     (defn python-source-scan-string-at (start quote string-kind)
-        (if (and (fsc-source-cursor-prefix? start quote)
-                 (fsc-source-cursor-prefix? (fsc-source-cursor-advance start) quote)
-                 (fsc-source-cursor-prefix? (fsc-source-cursor-advance (fsc-source-cursor-advance start)) quote))
-            (do
-                (let body-start (fsc-source-advance-n start 3))
-                (let read (python-source-scan-triple-string-loop body-start quote ""))
-                (fsc-scan-result (fsc-source-object string-kind (nth read 0) start (nth read 1)) (nth read 1)))
-            (do
-                (let body-start (fsc-source-cursor-advance start))
-                (let read (python-source-scan-string-loop body-start quote ""))
-                (fsc-scan-result (fsc-source-object string-kind (nth read 0) start (nth read 1)) (nth read 1)))))
+        (do
+            (let open-quote (fsc-source-cursor-char start))
+            (if (and (fsc-source-cursor-prefix? start open-quote)
+                     (and (fsc-source-cursor-prefix? (fsc-source-cursor-advance start) open-quote)
+                          (fsc-source-cursor-prefix? (fsc-source-cursor-advance (fsc-source-cursor-advance start)) open-quote)))
+                (do
+                    (let body-start (fsc-source-advance-n start 3))
+                    (let read (python-source-scan-triple-string-loop body-start open-quote ""))
+                    (fsc-scan-result (fsc-source-object string-kind (nth read 0) start (nth read 1)) (nth read 1)))
+                (do
+                    (let body-start (fsc-source-cursor-advance start))
+                    (if (str_eq (fsc-source-cursor-char body-start) open-quote)
+                        (fsc-scan-result
+                            (fsc-source-object string-kind "" start (fsc-source-cursor-advance body-start))
+                            (fsc-source-cursor-advance body-start))
+                        (do
+                            (let read (python-source-scan-string-loop body-start open-quote ""))
+                            (fsc-scan-result (fsc-source-object string-kind (nth read 0) start (nth read 1)) (nth read 1))))))))
 
     (defn python-source-prefixed-string-prefix-len (cursor)
         (do
@@ -231,6 +238,27 @@
     (defn python-source-prefixed-string-start? (cursor)
         (gt (python-source-prefixed-string-prefix-len cursor) 0))
 
+    (defn python-source-int-char? (ch)
+        (or (fsc-digit? ch) (str_eq ch "_")))
+
+    (defn python-source-scan-int-loop (cursor value)
+        (if (fsc-source-cursor-end? cursor)
+            (list value cursor)
+            (do
+                (let ch (fsc-source-cursor-char cursor))
+                (if (python-source-int-char? ch)
+                    (python-source-scan-int-loop
+                        (fsc-source-cursor-advance cursor)
+                        (str_concat value ch))
+                    (list value cursor)))))
+
+    (defn python-source-scan-int (start)
+        (do
+            (let read (python-source-scan-int-loop start ""))
+            (fsc-scan-result
+                (fsc-source-object "py-int" (nth read 0) start (nth read 1))
+                (nth read 1))))
+
     (defn python-source-scan-next (cursor)
         (do
             (let start (python-source-scan-skip cursor))
@@ -243,7 +271,7 @@
             (if (python-source-quote? ch)
                 (python-source-scan-string-at start ch "py-string")
             (if (fsc-digit? ch)
-                (fsc-source-scan-int start "py-int")
+                (python-source-scan-int start)
             (if (fsc-source-name-start-char? ch)
                 (fsc-source-scan-name start python-source-keywords "py-keyword" "py-name")
                 (fsc-source-scan-op start "py-op" python-source-ops))))))))

--- a/form/form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk
+++ b/form/form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk
@@ -33,12 +33,14 @@ four'''
     left //= 3
     ok := True
     tail = ...
+    big = 1_000_000
+    quoted = \"'approve' or 'reject'\"
 ")
     (let source-objects (python-source-scan-text source))
 
     (sum
         (list
-            (score-int (len source-objects) 49 100)
+            (score-int (len source-objects) 55 100)
             (score-str (scanner-real-kind source-objects 0) "py-op" 200)
             (score-str (scanner-real-value source-objects 0) "@" 300)
             (score-str (scanner-real-kind source-objects 2) "py-keyword" 400)
@@ -66,4 +68,8 @@ four" 1100)
             (score-str (scanner-real-value source-objects 45) "True" 2300)
             (score-str (scanner-real-value source-objects 48) "..." 2400)
             (score-int (fsc-repo-text-line-number (scanner-real-span source-objects 0)) 2 2400)
-            (score-int (fsc-repo-text-line-number (scanner-real-span source-objects 48)) 16 2500))))
+            (score-int (fsc-repo-text-line-number (scanner-real-span source-objects 48)) 16 2500)
+            (score-str (scanner-real-kind source-objects 51) "py-int" 2600)
+            (score-str (scanner-real-value source-objects 51) "1_000_000" 2700)
+            (score-str (scanner-real-kind source-objects 54) "py-string" 2800)
+            (score-str (scanner-real-value source-objects 54) "'approve' or 'reject'" 2900))))


### PR DESCRIPTION
## Summary\n- Add Form-callable binary artifact loading in Go/Rust/TypeScript kernels via read_form_binary.\n- Add node_pkg/node_level/node_type/node_inst sensing primitives so Form recipes can inspect loaded artifact nodes without host-side emitters.\n- Repair Python BMF scanner handling for quote-specific strings and underscore integer literals discovered during roundtrip work.\n\n## Proof\n- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/tests/python-bmf-scanner-real-syntax-band.fk\n- cd form && tmpdir=/tmp/formbin-sense.72nEhX && ./form-kernel-go/bin-go --emit-binary "/fib.fkb" form-samples/fib.fk && printf '(do (let root (read_form_binary "%s")) (let cat (node_category root)) (add (node_pkg cat) (add (node_level cat) (add (node_type cat) (node_inst cat)))))\n' "/fib.fkb" > "/read.fk" && ./validate.sh form-stdlib/core.fk "/read.fk"\n- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260525_form_binary_sensing.json\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict