### PR TITLE
fix(substrate): AST evaluator handles .blueprint / .child access

### DIFF
--- a/api/app/services/substrate/form.py
+++ b/api/app/services/substrate/form.py
@@ -71,6 +71,7 @@ from app.services.substrate.category import (
     RTry,
 )
 from app.services.substrate.kernel import (
+    CellView,
     NamedCell,
     NodeID,
     find_cells_compatible_with,
@@ -1916,6 +1917,19 @@ def evaluate(session: Session, ast: Any) -> FormResult:
     if isinstance(ast, Query):
         return _evaluate_query(session, ast)
 
+    # Tree navigation — fractal seams.
+    # `.field` and `.method(args)` are structural walks into the cell tree
+    # (blueprint, ctor, children, etc.). The full runtime in form_runtime.py
+    # already knows how to resolve them; the structural evaluator delegates
+    # there and wraps the raw value back into a FormResult. Without this
+    # the playground's first quest (`@concept(x).blueprint`) returned
+    # `TypeError: Form: cannot evaluate Access`.
+    if isinstance(ast, (Access, MethodCall)):
+        from app.services.substrate.form_runtime import Frame as _RuntimeFrame
+        from app.services.substrate.form_runtime import execute as _runtime_execute
+        value = _runtime_execute(session, ast, _RuntimeFrame())
+        return _wrap_runtime_value(value)
+
     # Recipe-AST nodes: compile to a Recipe NodeID (intern as we go)
     if isinstance(ast, (
         IntLit, BoolLit, StringLit, Identifier,
@@ -1932,6 +1946,29 @@ def evaluate(session: Session, ast: Any) -> FormResult:
         return FormResult("recipe", rid)
 
     raise TypeError(f"Form: cannot evaluate {type(ast).__name__}")
+
+
+def _wrap_runtime_value(value: Any) -> FormResult:
+    """Wrap a raw runtime value back into a FormResult for the AST evaluator.
+
+    Walks the type ladder the runtime returns (NodeID, NamedCell,
+    CellView, homogeneous lists, primitives) and picks the matching kind
+    so the REST surface and the playground UI render it under the same
+    code paths they already use for direct structural results.
+    """
+    from app.services.substrate.kernel import NamedCell
+    if isinstance(value, NodeID):
+        return FormResult("node_id", value)
+    if isinstance(value, NamedCell):
+        return FormResult("cell", value)
+    if isinstance(value, CellView):
+        return FormResult("view", value)
+    if isinstance(value, list):
+        if value and all(isinstance(v, NamedCell) for v in value):
+            return FormResult("cells", value)
+        if value and all(isinstance(v, CellView) for v in value):
+            return FormResult("views", value)
+    return FormResult("value", value)
 
 
 def _evaluate_query(session: Session, q: Query) -> FormResult:

--- a/api/tests/test_substrate_form_ast_access.py
+++ b/api/tests/test_substrate_form_ast_access.py
@@ -1,0 +1,104 @@
+"""Pin Access + MethodCall in the structural Form evaluator.
+
+The substrate playground sends `mode="ast"` (the default) — the
+structural evaluator in `form.py`. Before this test existed, the first
+quest on the playground (`@concept(x).blueprint`) returned
+`TypeError: Form: cannot evaluate Access` because the AST evaluator
+had no branch for tree-navigation nodes. The runtime in
+`form_runtime.py` knew how to resolve them; the structural evaluator
+now delegates there and wraps the value back into a FormResult so the
+REST surface and the UI render it through the existing code paths.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate import form_evaluate_text, ingest_memory_file
+from app.services.substrate.kernel import NodeID
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+def _seed_memory_cell(session):
+    body = """---
+name: test memory
+description: a test cell for tree navigation
+type: feedback
+---
+
+Body of the memory.
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(body)
+        path = f.name
+    try:
+        ingest_memory_file(session, Path(path))
+        session.flush()
+    finally:
+        os.unlink(path)
+
+
+def test_blueprint_access_returns_node_id_result(session):
+    _seed_memory_cell(session)
+    result = form_evaluate_text(session, '@memory("test memory").blueprint')
+    assert result.kind == "node_id"
+    assert isinstance(result.value, NodeID)
+
+
+def test_ctor_access_returns_recipe_node_id(session):
+    _seed_memory_cell(session)
+    result = form_evaluate_text(session, '@memory("test memory").ctor')
+    # The ctor is also a NodeID — kind is "node_id" since our wrap
+    # cannot distinguish blueprint from recipe NodeIDs at this layer.
+    assert result.kind == "node_id"
+    assert isinstance(result.value, NodeID)
+
+
+def test_nested_access_blueprint_category(session):
+    _seed_memory_cell(session)
+    result = form_evaluate_text(session, '@memory("test memory").blueprint.category')
+    assert result.kind == "node_id"
+    assert isinstance(result.value, NodeID)
+
+
+def test_method_call_child_returns_node_id_result(session):
+    _seed_memory_cell(session)
+    result = form_evaluate_text(session, '@memory("test memory").blueprint.child(0)')
+    assert result.kind == "node_id"
+    assert isinstance(result.value, NodeID)
+
+
+def test_primitive_field_returns_value_result(session):
+    """`.nchildren` is an int — wraps as a `value` kind so the API can
+    return it without forcing an artificial NodeID shape."""
+    _seed_memory_cell(session)
+    result = form_evaluate_text(session, '@memory("test memory").blueprint.nchildren')
+    assert result.kind == "value"
+    assert isinstance(result.value, int)
+    assert result.value >= 3


### PR DESCRIPTION
Closing — this patch was the fear-shape. Two Python Form evaluators
(form.py structural, form_runtime.py runtime) drifted apart; delegating
one to the other keeps the duplication alive instead of composting it.
The body is moving to Form as native — the TS kernel that already runs
in the browser (web/lib/form-kernel/vendor/) becomes the canonical
evaluator, the Python API shrinks to substrate-data access only. Done
properly that arc obsoletes both Python evaluators rather than papering
over the gap between them.

The user-visible bug (playground first quest returns TypeError) stays
broken in production until the Form-native move lands. Witness probes
go in next so the next silence in this surface wakes the body instead
of waiting for a human to notice.