### PR TITLE
tend: pulse witnesses the substrate badge + form evaluator

### DIFF
--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -70,6 +70,8 @@ UPSTREAM_API_VITALITY = "api_vitality"  # {API_BASE}/api/workspaces/coherence-ne
 UPSTREAM_WEB_ROOT = "web_root"         # {WEB_BASE}/
 UPSTREAM_WEB_PULSE = "web_pulse"       # {WEB_BASE}/pulse
 UPSTREAM_WEB_VITALITY = "web_vitality"  # {WEB_BASE}/vitality
+UPSTREAM_API_SUBSTRATE_PAGE = "api_substrate_page"   # {API_BASE}/api/substrate/page?route=/
+UPSTREAM_API_SUBSTRATE_FORM = "api_substrate_form"   # POST {API_BASE}/api/substrate/form
 
 
 # Error boundary marker rendered by the Next.js root error.tsx
@@ -290,6 +292,64 @@ def extract_api_ideas(r: "UpstreamResult") -> OrganVerdict:
     return OrganVerdict(True)
 
 
+def extract_substrate_page(r: "UpstreamResult") -> OrganVerdict:
+    """Substrate badge resolver: /api/substrate/page?route=/ returns a real path.
+
+    The ⋄ badge in the web layout calls this endpoint to reveal what
+    cells compose the current page. Before this organ existed, the
+    resolver silently returned `{"source_path": null, "note": "no
+    page.tsx resolves for this route"}` on every page in production
+    because the API container ships only `api/` + `scripts/` and the
+    resolver walked `web/app/` from disk. The badge has shipped to prod
+    showing "page.tsx not found" for an unknown length of time before
+    a user on mobile finally surfaced it.
+
+    The witness now flags this on its own. A healthy response carries
+    `source_path: "web/app/page.tsx"` for the home route. A null
+    source_path or a missing key both register as silence.
+    """
+    if not _is_ok(r.status):
+        return OrganVerdict(False, f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    source_path = body.get("source_path")
+    if not source_path:
+        note = body.get("note") or "no source_path resolved"
+        return OrganVerdict(False, f"badge sees no page: {note}")
+    return OrganVerdict(True)
+
+
+def extract_substrate_form(r: "UpstreamResult") -> OrganVerdict:
+    """Substrate Form evaluator: POST /api/substrate/form returns kind=node_id.
+
+    Probes with `@concept(lc-pulse).blueprint` — a known-good
+    expression against the Living Collective root, the warmest cell
+    in the lattice. A healthy substrate returns
+    `{"kind": "node_id", "node_id": {...}}`. A 4xx with a TypeError
+    detail (the AST evaluator missing a branch for tree-navigation
+    nodes) or a 404 (lc-pulse missing from the body) both register
+    as real silence.
+
+    This organ keeps tension on the playground's primary surface so
+    the next regression in Form evaluation wakes the body instead of
+    waiting for a visitor to notice the first quest is broken.
+    """
+    if r.status == 0:
+        return OrganVerdict(False, r.error or "transport failure")
+    if r.status >= 400:
+        body = _require_body(r)
+        detail = (body or {}).get("detail") if body else None
+        return OrganVerdict(False, f"HTTP {r.status}: {detail}" if detail else f"HTTP {r.status}")
+    body = _require_body(r)
+    if body is None:
+        return OrganVerdict(False, "empty response body")
+    kind = body.get("kind")
+    if kind != "node_id":
+        return OrganVerdict(False, f"kind={kind!r}, expected 'node_id'")
+    return OrganVerdict(True)
+
+
 def extract_api_vitality(r: "UpstreamResult") -> OrganVerdict:
     """/api/workspaces/coherence-network/vitality returns the expected signals shape.
 
@@ -393,6 +453,31 @@ ORGANS: list[Organ] = [
         upstream=UPSTREAM_API_VITALITY,
         extractor=extract_api_vitality,
         latency_threshold_ms=1500,
+    ),
+    Organ(
+        name="substrate_badge",
+        label="Substrate badge",
+        description=(
+            "GET /api/substrate/page?route=/ — the resolver that lets the ⋄ "
+            "badge on every page name its own cell. Silenced for an unknown "
+            "length of time before a visitor on mobile caught it."
+        ),
+        upstream=UPSTREAM_API_SUBSTRATE_PAGE,
+        extractor=extract_substrate_page,
+        latency_threshold_ms=1500,
+    ),
+    Organ(
+        name="substrate_form",
+        label="Substrate Form",
+        description=(
+            "POST /api/substrate/form — the playground's primary surface. "
+            "Tested with @concept(lc-pulse).blueprint, the warmest cell in the "
+            "Living Collective. A regression here is the silence the first "
+            "quest button was suffering."
+        ),
+        upstream=UPSTREAM_API_SUBSTRATE_FORM,
+        extractor=extract_substrate_form,
+        latency_threshold_ms=2000,
     ),
 ]
 

--- a/pulse/pulse_app/probe.py
+++ b/pulse/pulse_app/probe.py
@@ -41,7 +41,11 @@ class UpstreamResult:
 
 
 async def _probe_upstream(
-    client: httpx.AsyncClient, url: str, kind: str
+    client: httpx.AsyncClient,
+    url: str,
+    kind: str,
+    method: str = "GET",
+    json_body: dict[str, Any] | None = None,
 ) -> UpstreamResult:
     """Fetch one upstream once, return a shared UpstreamResult.
 
@@ -49,12 +53,18 @@ async def _probe_upstream(
     response text for content-marker checks). JSON responses for
     "text" upstreams still parse successfully; that's fine.
 
+    `method` defaults to GET. Pass "POST" with `json_body` for endpoints
+    that need a request payload (e.g. the substrate Form evaluator).
+
     We swallow all exceptions deliberately: a probe failure is a signal,
     not an error in the monitor.
     """
     start = time.perf_counter()
     try:
-        resp = await client.get(url)
+        if method == "POST":
+            resp = await client.post(url, json=json_body)
+        else:
+            resp = await client.get(url)
         elapsed = int((time.perf_counter() - start) * 1000)
         body: dict[str, Any] | None = None
         text: str | None = None
@@ -129,18 +139,45 @@ def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
     )
 
 
-def _build_url(upstream: str, api_base: str, web_base: str) -> tuple[str, str]:
-    """Map an upstream label to (url, kind). See organs.py for the labels."""
+def _build_url(
+    upstream: str, api_base: str, web_base: str
+) -> tuple[str, str, str, dict[str, Any] | None]:
+    """Map an upstream label to (url, kind, method, json_body).
+
+    See organs.py for the labels. Most entries are GETs and keep
+    json_body=None; the substrate Form evaluator needs a POST with a
+    known-good expression so the witness keeps tension on it.
+    """
     api = api_base.rstrip("/")
     web = web_base.rstrip("/")
-    mapping: dict[str, tuple[str, str]] = {
-        "api_health": (f"{api}/api/health", "json"),
-        "api_ready": (f"{api}/api/ready", "json"),
-        "api_ideas": (f"{api}/api/ideas", "json"),
-        "api_vitality": (f"{api}/api/workspaces/coherence-network/vitality", "json"),
-        "web_root": (f"{web}/", "text"),
-        "web_pulse": (f"{web}/pulse", "text"),
-        "web_vitality": (f"{web}/vitality", "text"),
+    mapping: dict[str, tuple[str, str, str, dict[str, Any] | None]] = {
+        "api_health": (f"{api}/api/health", "json", "GET", None),
+        "api_ready": (f"{api}/api/ready", "json", "GET", None),
+        "api_ideas": (f"{api}/api/ideas", "json", "GET", None),
+        "api_vitality": (
+            f"{api}/api/workspaces/coherence-network/vitality", "json", "GET", None,
+        ),
+        "web_root": (f"{web}/", "text", "GET", None),
+        "web_pulse": (f"{web}/pulse", "text", "GET", None),
+        "web_vitality": (f"{web}/vitality", "text", "GET", None),
+        # Substrate badge resolver — the surface that broke silently on
+        # every page (the user noticed via mobile on the home page). Probe
+        # the home route specifically because it's the most-visited and
+        # the resolver's simplest path; if `/` doesn't resolve, none do.
+        "api_substrate_page": (
+            f"{api}/api/substrate/page?route=/", "json", "GET", None,
+        ),
+        # Substrate Form evaluator — the playground's primary surface.
+        # The known-good expression is one that any healthy lattice
+        # carries (lc-pulse is the Living Collective root). A 4xx/5xx
+        # here means the structural evaluator regressed or the cell
+        # disappeared from the body — either is a real silence.
+        "api_substrate_form": (
+            f"{api}/api/substrate/form",
+            "json",
+            "POST",
+            {"expression": "@concept(lc-pulse).blueprint"},
+        ),
     }
     if upstream not in mapping:
         raise ValueError(f"unknown upstream label: {upstream}")
@@ -166,8 +203,10 @@ async def probe_all(
     try:
         results: dict[str, UpstreamResult] = {}
         for upstream in upstreams_in_use():
-            url, kind = _build_url(upstream, api_base, web_base)
-            results[upstream] = await _probe_upstream(client, url, kind)
+            url, kind, method, json_body = _build_url(upstream, api_base, web_base)
+            results[upstream] = await _probe_upstream(
+                client, url, kind, method=method, json_body=json_body
+            )
 
         return [_apply(o, results[o.upstream], ts) for o in ORGANS]
     finally:

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -48,6 +48,35 @@ HEALTHY_IDEAS = {
     "summary": {"count": 2},
 }
 
+HEALTHY_SUBSTRATE_PAGE = {
+    "route": "/",
+    "source_path": "web/app/page.tsx",
+    "in_substrate": True,
+    "source": None,
+    "twins": [],
+    "twins_count": 0,
+    "twins_kind": "tsx",
+    "kind": "tsx",
+    "note": None,
+}
+
+BROKEN_SUBSTRATE_PAGE = {
+    "route": "/",
+    "source_path": None,
+    "in_substrate": False,
+    "source": None,
+    "twins": [],
+    "twins_count": 0,
+    "twins_kind": None,
+    "kind": None,
+    "note": "no page.tsx resolves for this route",
+}
+
+HEALTHY_SUBSTRATE_FORM = {
+    "kind": "node_id",
+    "node_id": {"package": 1, "level": 5, "type": 4, "instance": 1},
+}
+
 HEALTHY_VITALITY = {
     "workspace_id": "coherence-network",
     "vitality_score": 0.69,
@@ -104,6 +133,10 @@ def _handler(
     web_pulse_body=HEALTHY_PULSE_HTML,
     web_vitality_status=200,
     web_vitality_body=HEALTHY_VITALITY_HTML,
+    substrate_page_body=None,
+    substrate_page_status=200,
+    substrate_form_body=None,
+    substrate_form_status=200,
 ):
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -129,6 +162,26 @@ def _handler(
             return httpx.Response(
                 vitality_api_status,
                 content=json.dumps(vitality_api_body if vitality_api_body is not None else HEALTHY_VITALITY),
+                headers={"content-type": "application/json"},
+            )
+        if path == "/api/substrate/page":
+            return httpx.Response(
+                substrate_page_status,
+                content=json.dumps(
+                    substrate_page_body
+                    if substrate_page_body is not None
+                    else HEALTHY_SUBSTRATE_PAGE
+                ),
+                headers={"content-type": "application/json"},
+            )
+        if path == "/api/substrate/form":
+            return httpx.Response(
+                substrate_form_status,
+                content=json.dumps(
+                    substrate_form_body
+                    if substrate_form_body is not None
+                    else HEALTHY_SUBSTRATE_FORM
+                ),
                 headers={"content-type": "application/json"},
             )
         if path == "/":
@@ -157,10 +210,52 @@ async def test_all_healthy():
     expected = {
         "api", "web", "postgres", "neo4j", "schema", "audit_integrity",
         "page_pulse", "page_vitality", "endpoint_ideas", "endpoint_vitality",
+        "substrate_badge", "substrate_form",
     }
     assert set(by.keys()) == expected
     for name, sample in by.items():
         assert sample.ok is True, f"{name} not ok: {sample.detail}"
+
+
+@pytest.mark.asyncio
+async def test_substrate_badge_flags_silence_when_resolver_returns_no_path():
+    """The real production silence: source_path=null with the not-found note.
+
+    This is the shape `/api/substrate/page?route=/` returned on every
+    page for an unknown length of time. The witness now lights up.
+    """
+    by = await _run(_handler(substrate_page_body=BROKEN_SUBSTRATE_PAGE))
+    sample = by["substrate_badge"]
+    assert sample.ok is False
+    assert sample.detail is not None
+    assert "no page.tsx" in sample.detail
+
+
+@pytest.mark.asyncio
+async def test_substrate_form_flags_silence_on_eval_typeerror():
+    """The playground first-quest TypeError shape — 400 with a detail string."""
+    eval_failure = {"detail": "form parse/eval failed: TypeError: Form: cannot evaluate Access"}
+    by = await _run(
+        _handler(
+            substrate_form_status=400,
+            substrate_form_body=eval_failure,
+        )
+    )
+    sample = by["substrate_form"]
+    assert sample.ok is False
+    assert sample.detail is not None
+    assert "HTTP 400" in sample.detail
+    assert "TypeError" in sample.detail
+
+
+@pytest.mark.asyncio
+async def test_substrate_form_flags_unexpected_kind():
+    """A 200 response with the wrong shape (kind != node_id) is still silence."""
+    surprise = {"kind": "value", "value": 42}
+    by = await _run(_handler(substrate_form_body=surprise))
+    sample = by["substrate_form"]
+    assert sample.ok is False
+    assert "kind='value'" in (sample.detail or "")
 
 
 @pytest.mark.asyncio
@@ -405,8 +500,8 @@ async def test_slow_probe_flags_strained_not_silent(monkeypatch):
     # Rewrite the test to inject a slow latency by monkey-patching the probe helper.
     original = probe._probe_upstream
 
-    async def slow_probe(client, url, kind):
-        r = await original(client, url, kind)
+    async def slow_probe(client, url, kind, method="GET", json_body=None):
+        r = await original(client, url, kind, method=method, json_body=json_body)
         # Replace with a 3-second latency on the api_health upstream
         if url.endswith("/api/health"):
             return probe.UpstreamResult(


### PR DESCRIPTION
## Why now

The body had two surfaces silently broken in production for an unknown
length of time before a visitor on mobile finally surfaced them:

- The substrate badge on every page returned "no page.tsx resolves for
  this route"
- The Form playground's first quest returned TypeError

Both fell through pulse's existing organs (api health, page loads, a
couple endpoints) because none of them probed these surfaces. Pulse
didn't know to look. The check that catches this kind of thing belongs
in the body, not in a future agent's careful click-through.

## What this adds

Two organs:

- **`substrate_badge`** — `GET /api/substrate/page?route=/`. Flags when
  the resolver returns null `source_path` or the not-found note. Will
  fire amber against today's prod until #2052's manifest fix lands.
- **`substrate_form`** — `POST /api/substrate/form` with
  `@concept(lc-pulse).blueprint`. Flags 4xx with TypeError detail, 404,
  or unexpected `kind`. Will fire amber against today's prod until the
  Form-native move lands.

To make the Form probe possible, the probe layer learned POST: the
upstream mapping now returns `(url, kind, method, json_body)` and
`_probe_upstream` accepts `method` + `json_body` (both default to GET /
None, so every existing call site is unchanged).

## Test plan

- [x] 67 pulse tests pass (was 64; adds 3 new focused tests)
- [x] `test_substrate_badge_flags_silence_when_resolver_returns_no_path`
      replays the exact production response shape
- [x] `test_substrate_form_flags_silence_on_eval_typeerror` replays
      the exact 400 + detail shape the playground was returning
- [x] `test_substrate_form_flags_unexpected_kind` covers shape-drift
      (a 200 with the wrong shape is still a silence)
- [ ] After merge + deploy of the pulse container:
      `curl https://pulse.coherencycoin.com/pulse/now | jq '.organs[]
      | select(.name == "substrate_badge" or .name == "substrate_form")'`
      shows both organs reporting (amber until the underlying surfaces
      are fixed).

## Direction this points

This is the witness half of the Form-native move you named — the body
senses where the kernel is wrong, before it ships the kernel fix. The
substrate badge fix (PR #2052) clears the `substrate_badge` probe
straightforwardly. The `substrate_form` probe stays amber as honest
tension until either the Python AST evaluator is converged with the
runtime (a temporary patch I closed as #2053) or, more healthily, the
TS kernel becomes the canonical evaluator and the Python API shrinks to
substrate-data access only.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_