### PR TITLE
feat: form-kernel-rust serves HTTP — proof the kernel can be the doorway

### DIFF
--- a/form/form-kernel-rust/README.md
+++ b/form/form-kernel-rust/README.md
@@ -8,6 +8,21 @@ cargo run --release --quiet -- --expr "(add 2 (mul 3 4))"       # → 14
 cargo run --release --quiet -- --bench                          # benchmark suite
 ```
 
+## `serve` — kernel-as-HTTP-listener (proof-of-shape)
+
+```bash
+cargo build --release
+./target/release/form-kernel-rust serve --port 8001 --routes examples/routes.fk
+# in another shell:
+curl http://127.0.0.1:8001/hello            # → Hello from the kernel
+curl 'http://127.0.0.1:8001/echo?msg=foo'   # → foo
+python3 test_serve.py                       # full pass: /hello, /echo, /missing → 404
+```
+
+A 50-line raw `std::net::TcpListener` listens on a port, parses the request line into Form values (method, path, query alist), looks up a handler closure from `routes.fk`'s top-level `routes` binding, walks the closure, and writes the returned value back as the response body. No hyper, no actix, no async runtime — the kernel's existing socket primitives' siblings.
+
+This is **gesture not replacement** for Breath 8 of [`../kernel-roadmap.md`](../kernel-roadmap.md). The body's primary HTTP doorway stays FastAPI; this exists so the body can feel "kernel CAN listen" before betting more of the stack on it. No middleware, no pydantic, no OpenAPI, no auth — those live behind the FastAPI surface that is still the right tool for that job.
+
 Sibling: [`../form-kernel-go/`](../form-kernel-go/). Comparison + runtime numbers: [`../kernel-comparison.md`](../kernel-comparison.md).
 
 Source upstream:

--- a/form/form-kernel-rust/examples/routes.fk
+++ b/form/form-kernel-rust/examples/routes.fk
@@ -1,0 +1,29 @@
+; routes.fk — proof-of-shape route map for `form-kernel-rust serve`.
+;
+; Each route is (path handler-closure). The serve subcommand passes the
+; query alist (a list of (key value) string pairs) to 1-arg handlers, or
+; nothing to 0-arg handlers. The handler's return value becomes the HTTP
+; response body via Value::display().
+;
+;   curl http://127.0.0.1:8001/hello       → "Hello from the kernel"
+;   curl http://127.0.0.1:8001/echo?msg=foo → "foo"
+
+; Tiny assoc — find the value for `key` in an alist of (k v) pairs.
+; Returns "" if missing so the response body stays a string.
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+(defn route_hello ()
+  "Hello from the kernel")
+
+(defn route_echo (q)
+  (assoc "msg" q))
+
+(let routes
+  (list
+    (list "/hello" route_hello)
+    (list "/echo"  route_echo)))

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -3609,6 +3609,7 @@ Subcommands:
   query <path>                         parse any file as a Form object tree
   trace [--expr \"...\" | <file.fk>]     run with arm-dispatch tracing
   fetch <url>                          GET a URL (network resource)
+  serve --port <p> --routes <file.fk>  HTTP/1.0 listener dispatching to Form recipes
 
 Source adapter modes:
   <file.fk> [more.fk ...]              run .fk files
@@ -3616,6 +3617,261 @@ Source adapter modes:
   --bench                              benchmark run
   --numeric-bench                      numeric kernel comparison"
     );
+}
+
+// ---------------------------------------------------------------------------
+// `serve` — proof-of-shape kernel-as-HTTP-listener
+// ---------------------------------------------------------------------------
+//
+// The deepest move toward Breath 8 of `form/kernel-roadmap.md`: a tiny
+// HTTP/1.0 listener that lives *inside* the kernel binary, parses the
+// request into Form values, looks up a handler closure from a routes.fk
+// file's top-level `routes` binding, walks the closure, and writes the
+// returned value back as the response body.
+//
+// This is gesture, not replacement. FastAPI remains the body's primary
+// doorway; this exists so the body can feel "kernel CAN be the HTTP
+// layer" before betting more of the stack on it. ~50 lines of raw
+// `std::net` HTTP/1.0 — no hyper, no actix, no async runtime. The whole
+// dependency footprint is what already shipped (ureq for `fetch`).
+//
+// routes.fk shape:
+//   (defn route_hello () "Hello from the kernel")
+//   (defn route_echo (q) (dict_get q "msg"))
+//   (let routes (list
+//     (list "/hello" route_hello)
+//     (list "/echo"  route_echo)))
+//
+// A 1-arg handler receives the query as a List of (key value) pairs
+// (an alist; `dict_get` reads from it). A 0-arg handler receives no
+// argument. The walker turns either return value into a string for
+// the response body via `Value::display()`.
+
+fn cli_serve(args: &[String]) -> i32 {
+    // --port <p> --routes <file.fk>
+    let mut port: u16 = 8001;
+    let mut routes_path: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--port" => {
+                if i + 1 >= args.len() {
+                    eprintln!("serve: --port requires an argument");
+                    return 2;
+                }
+                port = match args[i + 1].parse() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        eprintln!("serve: --port must be a number");
+                        return 2;
+                    }
+                };
+                i += 2;
+            }
+            "--routes" => {
+                if i + 1 >= args.len() {
+                    eprintln!("serve: --routes requires an argument");
+                    return 2;
+                }
+                routes_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            other => {
+                eprintln!("serve: unknown argument: {}", other);
+                return 2;
+            }
+        }
+    }
+    let routes_path = match routes_path {
+        Some(p) => p,
+        None => {
+            eprintln!("serve: --routes <file.fk> is required");
+            return 2;
+        }
+    };
+    let src = match fs::read_to_string(&routes_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("serve: read {}: {}", routes_path, e);
+            return 1;
+        }
+    };
+
+    // Load the routes file into a long-lived kernel + arena. The root
+    // frame holds the `routes` binding after the file runs; each request
+    // gets a child frame so handler-local lets don't pollute the root.
+    let mut k = Kernel::new();
+    let root = read_root_from_source(&mut k, &src);
+    let mut arena = Arena::new();
+    let root_env = arena.new_frame(None);
+    k.active_roots = vec![root];
+    let _ = walk(&mut k, &mut arena, root, root_env);
+
+    let routes_name = k.intern_string("routes").inst;
+    let routes_val = match arena.lookup(root_env, routes_name) {
+        Some(v) => v,
+        None => {
+            eprintln!("serve: {} must bind a top-level `routes` list", routes_path);
+            return 1;
+        }
+    };
+    let route_pairs: Vec<(String, Arc<Closure>)> = match &routes_val {
+        Value::List(xs) => xs
+            .iter()
+            .map(|row| match row {
+                Value::List(ys) if ys.len() == 2 => {
+                    let path = match &ys[0] {
+                        Value::Str(s) => s.clone(),
+                        _ => panic!("serve: route key must be a string"),
+                    };
+                    let cl = match &ys[1] {
+                        Value::Closure(c) => c.clone(),
+                        _ => panic!("serve: route value for {} must be a closure", path),
+                    };
+                    (path, cl)
+                }
+                _ => panic!("serve: each route must be (path closure)"),
+            })
+            .collect(),
+        _ => {
+            eprintln!("serve: `routes` must be a list of (path closure) pairs");
+            return 1;
+        }
+    };
+
+    let listener = match TcpListener::bind(("127.0.0.1", port)) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("serve: bind 127.0.0.1:{}: {}", port, e);
+            return 1;
+        }
+    };
+    eprintln!(
+        "form-kernel-rust serve: listening on 127.0.0.1:{} ({} route{})",
+        port,
+        route_pairs.len(),
+        if route_pairs.len() == 1 { "" } else { "s" }
+    );
+    for r in &route_pairs {
+        eprintln!("  {}", r.0);
+    }
+
+    for incoming in listener.incoming() {
+        let mut stream = match incoming {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // Read up to 8 KiB of request — enough for line + headers; this
+        // is HTTP/1.0, no chunked bodies, no keep-alive.
+        let mut buf = [0u8; 8192];
+        let n = match stream.read(&mut buf) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let req = String::from_utf8_lossy(&buf[..n]).to_string();
+        let (method, path, query) = parse_request_line(&req);
+
+        let body: String;
+        let status: &str;
+        if method != "GET" {
+            status = "405 Method Not Allowed";
+            body = format!("method not allowed: {}\n", method);
+        } else if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
+            // Build the query alist as Value::List of (key, value) pairs.
+            let q_alist = Value::List(
+                query
+                    .iter()
+                    .map(|(k, v)| Value::List(vec![Value::Str(k.clone()), Value::Str(v.clone())]))
+                    .collect(),
+            );
+            let cl = cl.clone();
+            let call_frame = arena.new_frame_with_capacity(Some(cl.env), cl.params.len());
+            if cl.params.len() == 1 {
+                arena.bind(call_frame, cl.params[0], q_alist);
+            } else if cl.params.len() != 0 {
+                status = "500 Internal Server Error";
+                body = format!(
+                    "handler for {} wants {} params; serve passes 0 or 1\n",
+                    path,
+                    cl.params.len()
+                );
+                let _ = stream.write_all(http_response(status, &body).as_bytes());
+                continue;
+            }
+            let result = walk(&mut k, &mut arena, cl.body, call_frame);
+            status = "200 OK";
+            body = result.display();
+        } else {
+            status = "404 Not Found";
+            body = format!("no route for {}\n", path);
+        }
+        let _ = stream.write_all(http_response(status, &body).as_bytes());
+    }
+    0
+}
+
+// Parse the request line "GET /path?k=v HTTP/1.0" into (method, path, query).
+// Query string is decoded as a flat list of (key, value) pairs — sufficient
+// for the proof-of-shape; no percent-decoding beyond '+' → ' '.
+fn parse_request_line(req: &str) -> (String, String, Vec<(String, String)>) {
+    let line = req.lines().next().unwrap_or("");
+    let mut parts = line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let target = parts.next().unwrap_or("/").to_string();
+    let (path, qs) = match target.find('?') {
+        Some(i) => (target[..i].to_string(), target[i + 1..].to_string()),
+        None => (target, String::new()),
+    };
+    let mut query = Vec::new();
+    if !qs.is_empty() {
+        for pair in qs.split('&') {
+            let (k, v) = match pair.find('=') {
+                Some(i) => (pair[..i].to_string(), pair[i + 1..].to_string()),
+                None => (pair.to_string(), String::new()),
+            };
+            query.push((url_decode(&k), url_decode(&v)));
+        }
+    }
+    (method, path, query)
+}
+
+fn url_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(h), Some(l)) = (hi, lo) {
+                    out.push(((h * 16 + l) as u8) as char);
+                    i += 3;
+                } else {
+                    out.push(bytes[i] as char);
+                    i += 1;
+                }
+            }
+            other => {
+                out.push(other as char);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+fn http_response(status: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.0 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status,
+        body.len(),
+        body
+    )
 }
 
 fn cli_list(args: &[String]) -> i32 {
@@ -3998,6 +4254,7 @@ fn main_with_args(args: Vec<String>) -> i32 {
         "query" => cli_query(&args[1..]),
         "trace" => cli_trace(&args[1..]),
         "fetch" => cli_fetch(&args[1..]),
+        "serve" => cli_serve(&args[1..]),
         _ => {
             // Source adapter: --expr or <file.fk> [more.fk ...]
             let src = if args[0] == "--expr" {

--- a/form/form-kernel-rust/test_serve.py
+++ b/form/form-kernel-rust/test_serve.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Proof-of-shape test for `form-kernel-rust serve`.
+
+Spawns the kernel binary as an HTTP listener, curls the two demo routes,
+asserts the responses match what the Form recipes return. The point is
+not coverage breadth — it is the body's own attestation that "kernel
+listens on a port, dispatches via Form, replies with the recipe's value"
+works end-to-end with no FastAPI in the path.
+
+Run from this directory:
+    cargo build --release
+    python3 test_serve.py
+"""
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "routes.fk"
+
+
+def free_port() -> int:
+    """Ask the kernel for an unused port; close it before the kernel binds."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def get(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=2.0) as r:
+        return r.read().decode("utf-8")
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    port = free_port()
+    proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(port), "--routes", str(ROUTES)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        wait_for_port(port)
+
+        hello = get(f"http://127.0.0.1:{port}/hello")
+        assert hello == "Hello from the kernel", f"/hello → {hello!r}"
+
+        echo = get(f"http://127.0.0.1:{port}/echo?msg=foo")
+        assert echo == "foo", f"/echo → {echo!r}"
+
+        echo_sp = get(f"http://127.0.0.1:{port}/echo?msg=hello+world")
+        assert echo_sp == "hello world", f"/echo+space → {echo_sp!r}"
+
+        # 404 path
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/missing", timeout=2.0)
+            raise AssertionError("/missing should have 404'd")
+        except urllib.error.HTTPError as e:
+            assert e.code == 404, f"/missing → {e.code}"
+
+        print(f"ok — kernel served /hello, /echo, 404 on 127.0.0.1:{port}")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The gesture

**The kernel can serve HTTP.** This PR adds `form-kernel-rust serve --port 8001 --routes routes.fk` — one Rust binary listening on a port, parsing requests, dispatching to Form recipes, returning the result. **No FastAPI in the path** for the demo routes.

Mark clearly: this is **gesture, not replacement**. The existing FastAPI HTTP listener stays as the body's primary doorway. This is the proof that the kernel CAN listen, so the body experiences the move before betting more of the stack on it. The FastAPI doorway becomes the body's *choice*, not its *constraint*.

Builds on **#2056** (foundation). Independent of #2059's bridge-and-shell-out path — this is a parallel surface.

## What this adds

### Subcommand: `serve`

```
form-kernel-rust serve --port 8001 --routes routes.fk
```

The HTTP listener uses **raw `std::net::TcpListener` + ~50 lines of HTTP/1.0 parsing**. No `hyper`, no `actix-web`, no `async`. Zero new dependencies in `Cargo.toml`.

### Routes as Form recipes

`form/form-kernel-rust/examples/routes.fk`:

```form
(defn route_hello () "Hello from the kernel")
(defn route_echo (q) (assoc q "msg"))
(let routes (list ("/hello" route_hello) ("/echo" route_echo)))
```

The kernel walks the route map on each request, dispatches to the matching recipe, and walks the recipe's result for the response body.

### Demo routes — verified live

- `GET /hello` → `"Hello from the kernel"` (200)
- `GET /echo?msg=foo` → `"foo"` (200, with `+`→space url-decoding)
- `GET /missing` → `404 Not Found`

`form/form-kernel-rust/test_serve.py` spawns the kernel as a subprocess, curls each route, asserts the responses. Passes locally.

### Sibling-kernel parity intact

`form/validate.sh`: **130/130 samples agree** across Go, Rust, TypeScript kernels. The `serve` subcommand is additive — touches no walker arms or natives — so sibling parity is unchanged.

## Files touched

- `form/form-kernel-rust/src/main.rs` — `cli_serve`, `parse_request_line`, `url_decode`, `http_response`; wired `"serve"` into the dispatcher
- `form/form-kernel-rust/examples/routes.fk` — `route_hello`, `route_echo` + a tiny Form `assoc` helper
- `form/form-kernel-rust/test_serve.py` — subprocess + curl + assert
- `form/form-kernel-rust/README.md` — usage section + the "gesture not replacement" framing

## Honest pending — what would close the gap to FastAPI replacement

Named explicitly, not promised:

- **POST / PUT bodies** — only GET is parsed today
- **Keep-alive + concurrency** — current loop is one connection at a time
- **Response-type negotiation** — always `text/plain` via `Value::display()`; no JSON serialization
- **Status codes from the recipe** — currently 200/404/405 are kernel-side; recipes can't return their own
- **Substrate-write surface as routes** — e.g. `POST /api/ideas` would need the recipe to mutate state through kernel primitives
- **Sibling parity for `serve`** — Rust-only this breath; Go and TS kernels don't carry the subcommand
- **Actual port of any existing FastAPI route** — the demo routes are toys; porting a real route is the next breath

This PR stops at: **one Rust kernel binary listening on one port, dispatching to one Form recipe per route, no FastAPI in the path.** Exactly the shape Breath 8 names as the deeper move past Breath 6's "embed in api/."

## Test plan

- [x] `cargo build --release` succeeds with zero new dependencies
- [x] `./form-kernel-rust serve --port 8001 --routes examples/routes.fk` starts a listener
- [x] All three demo routes return correct responses (verified via `test_serve.py`)
- [x] `./form/validate.sh` — 130/130 sibling-kernel samples agree
- [ ] After merge: someone tries porting a real FastAPI route to a recipe via this surface and reports what the friction is — that's the real test plan

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_