### PR TITLE
feat: ts-adapter bootstrap — TS → .fk → form-kernel-rust, three-way parity

### DIFF
--- a/form/form-kernel-ts/seedbank/ts-adapter/README.md
+++ b/form/form-kernel-ts/seedbank/ts-adapter/README.md
@@ -1,0 +1,96 @@
+# TypeScript Adapter — bootstrap breath
+
+This adapter closes the smallest honest seam for TypeScript through the
+Form pipeline:
+
+```
+TypeScript source (.ts)
+  → parseTypeScript  (lang-ts.ts)            — TS subset → Form tree
+  → emitFk           (lang-ts-fk.ts)         — Form tree → .fk S-expression
+  → form-kernel-rust (native binary)         — walks the .fk, no host runtime
+```
+
+Three-way parity gate (`scripts/parity_suite.sh`):
+
+1. **node**       — the canonical TypeScript runtime, after tsc strips types
+2. **ts-eval**    — our captured-recipe walker (no .fk, no kernel)
+3. **ts-run**     — emit .fk + execute via `form-kernel-rust`
+
+All three converge on the printed value of the file's final bare expression.
+
+## CTOR vocabulary — cross-language identity
+
+The CTOR names in `lang-ts.ts` are the same as `lang-python.ts`:
+`lambda`, `param`, `add`, `int-literal`, `def`, `call`, etc. A TS
+`(x) => x + 1` and a Python `lambda x: x + 1` produce the same recipe
+sub-tree, intern to the same NodeID by content-addressing, and become
+the same dispatch when the kernel walks them. Cross-language identity
+is what earns the N+M transpilation savings the language-cells
+architecture promises.
+
+## What this breath ships
+
+- Arrow functions: `(x) => x + 1`, `(a, b) => { return a + b; }`
+- `function` declarations: `function fact(n) { return ... }`
+- `const` / `let` / `var` bindings (no destructuring)
+- `if` / `else` / `else if` statements + ternary `c ? a : b`
+- Arithmetic: `+ - * / %`, unary `-`, `!`
+- Comparison: `== === != !== < <= > >=`
+- Logic: `&& || !`
+- Function calls, return, recursion
+- Number / string / boolean / null / undefined literals, identifiers
+- Block `{ ... }`, expression statement
+- Type annotations on parameters parse-and-ignore (`(x: number) => ...`)
+
+## What is pending — named honestly, not faked
+
+Each of these is its own breath; the goal here was the *seam*, not coverage:
+
+- Classes / `new` / `this` / `super`
+- Interfaces, type aliases, generics
+- `import` / `export` / modules
+- `async` / `await` / Promises
+- JSX / TSX
+- Destructuring (object / array / rest)
+- Spread operator
+- Template literals (backtick strings work as plain strings; no `${}`)
+- Regex literals
+- `switch` / `case`
+- `try` / `catch` / `throw`
+- Optional chaining (`?.`), nullish coalescing (`??`)
+- `for` / `for-of` / `for-in` / `while` / `do-while`
+- Method calls and property access (`obj.method()`, `obj.prop`)
+
+## CLI
+
+From `form/form-kernel-ts/`:
+
+```bash
+# Emit .fk source (default output path is foo.fk)
+npx tsx seedbank/ts-adapter/src/main.ts ts-compile foo.ts
+npx tsx seedbank/ts-adapter/src/main.ts ts-compile foo.ts -      # → stdout
+
+# Parse + execute via the native form-kernel-rust binary
+npx tsx seedbank/ts-adapter/src/main.ts ts-run foo.ts
+
+# Parse + walk via the TS captured-recipe evaluator (no .fk round-trip)
+npx tsx seedbank/ts-adapter/src/main.ts ts-eval foo.ts
+
+# Same as ts-eval but with arm-dispatch tracing → JSON report
+npx tsx seedbank/ts-adapter/src/main.ts ts-trace foo.ts
+```
+
+## Running the parity suite
+
+```bash
+cd form/form-kernel-ts
+./seedbank/ts-adapter/scripts/parity_suite.sh
+```
+
+When `form-kernel-rust` is not built locally, the suite reports two-way
+parity (node + ts-eval) and notes the third runtime is skipped. Build
+the kernel for the full three-way check:
+
+```bash
+cd form/form-kernel-rust && cargo build --release
+```

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_accumulator_demo.fk
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_accumulator_demo.fk
@@ -1,0 +1,1 @@
+(do (defn loop (i acc) (if (ge i 10) acc (loop (_plus i 1) (_plus acc i)))) (loop 0 0))

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_accumulator_demo.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_accumulator_demo.ts
@@ -1,0 +1,10 @@
+// ts_accumulator_demo.ts — recursion-as-loop. The kernel has no loop arm,
+// so accumulator passing is the form-native way to iterate. Same pattern
+// the python-adapter uses to lower while-loops; here we write it directly
+// in TS so the parity check exercises the whole emission path.
+
+function loop(i, acc) {
+    return i >= 10 ? acc : loop(i + 1, acc + i);
+}
+
+loop(0, 0)

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arith_demo.fk
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arith_demo.fk
@@ -1,0 +1,1 @@
+(do (let a 7) (let b 3) (let c (_plus (mul a b) (sub a b))) c)

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arith_demo.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arith_demo.ts
@@ -1,0 +1,10 @@
+// ts_arith_demo.ts — pure-arithmetic round trip; the simplest closing breath
+// through the TS → .fk → kernel pipeline.
+//
+// The trailing bare expression is the value all three runtimes converge on.
+
+const a = 7;
+const b = 3;
+const c = a * b + (a - b);
+
+c

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arrow_demo.fk
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arrow_demo.fk
@@ -1,0 +1,1 @@
+(do (defn _lambda_0 (x) (mul x 2)) (defn _lambda_1 (n) (mul n n)) (defn _lambda_2 (a b) (_plus a b)) (let double _lambda_0) (let sq _lambda_1) (let add _lambda_2) (add (double 5) (sq 6)))

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arrow_demo.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_arrow_demo.ts
@@ -1,0 +1,9 @@
+// ts_arrow_demo.ts — arrow functions captured as CTOR.lambda_, lifted to
+// module-level defns the kernel can bind. Companion shape to Python's
+// `lambda x: x + 1`.
+
+const double = (x) => x * 2;
+const sq = (n) => n * n;
+const add = (a, b) => a + b;
+
+add(double(5), sq(6))

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_composition_demo.fk
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_composition_demo.fk
@@ -1,0 +1,1 @@
+(do (defn classify (n) (if (lt n 0) (sub 0 1) (if (eq n 0) 0 1))) (defn abs (n) (if (lt n 0) (sub 0 n) n)) (defn combine (a b) (_plus (mul (classify a) (abs b)) (mul (classify b) (abs a)))) (_plus (combine (sub 0 3) 5) (combine 7 (sub 0 2))))

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_composition_demo.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_composition_demo.ts
@@ -1,0 +1,23 @@
+// ts_composition_demo.ts — multi-function composition with branching.
+// Exercises the full CPS-lowering path for nested if/else with early
+// returns inside a function body.
+
+function classify(n) {
+    if (n < 0) {
+        return -1;
+    } else if (n === 0) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+function abs(n) {
+    return n < 0 ? -n : n;
+}
+
+function combine(a, b) {
+    return classify(a) * abs(b) + classify(b) * abs(a);
+}
+
+combine(-3, 5) + combine(7, -2)

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_recursion_demo.fk
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_recursion_demo.fk
@@ -1,0 +1,1 @@
+(do (defn fact (n) (if (lt n 2) 1 (mul n (fact (sub n 1))))) (fact 8))

--- a/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_recursion_demo.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/examples/ts_recursion_demo.ts
@@ -1,0 +1,10 @@
+// ts_recursion_demo.ts — function declaration with recursion. Cross-language
+// identity test: this compiles to the same CTOR.def_/CTOR.call shape as
+// the Python `def fact(n)`; the .fk emission and the kernel arm trace
+// agree across siblings.
+
+function fact(n) {
+    return n < 2 ? 1 : n * fact(n - 1);
+}
+
+fact(8)

--- a/form/form-kernel-ts/seedbank/ts-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/ts-adapter/scripts/parity_suite.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# parity_suite.sh — three-way parity gate for the TS adapter.
+#
+# Every shipped demo runs through:
+#   1. tsc transpile + node — the canonical TypeScript runtime
+#   2. ts-eval — our captured-recipe TS walker (no .fk, no kernel binary)
+#   3. ts-run  — emit .fk, execute via form-kernel-rust native binary
+# All three must agree on the printed value of the final bare expression.
+#
+# Add new files to PARITY_FILES as they're ripened. Run from
+# form/form-kernel-ts/.
+
+set -euo pipefail
+
+PARITY_FILES=(
+    "seedbank/ts-adapter/examples/ts_arith_demo.ts"
+    "seedbank/ts-adapter/examples/ts_recursion_demo.ts"
+    "seedbank/ts-adapter/examples/ts_arrow_demo.ts"
+    "seedbank/ts-adapter/examples/ts_accumulator_demo.ts"
+    "seedbank/ts-adapter/examples/ts_composition_demo.ts"
+)
+
+RUST_BIN="$(cd "$(dirname "$0")/.." && pwd)/../../../form-kernel-rust/target/release/form-kernel-rust"
+HAS_RUST_BIN=0
+if [[ -x "$RUST_BIN" ]]; then
+    HAS_RUST_BIN=1
+else
+    echo "note: form-kernel-rust not built at $RUST_BIN" >&2
+    echo "      ts-run column will be skipped. Build with:" >&2
+    echo "      cd ../../../form-kernel-rust && cargo build --release" >&2
+    echo ""
+fi
+
+PASS=0
+FAIL=0
+
+# node-eval wraps the file's last bare expression in console.log() and
+# runs it through node. The file is valid JS (the adapter supports a TS
+# subset that is also a JS subset), so direct `node --input-type=module`
+# works without a TS transpile step. This is the canonical runtime —
+# the seam our captured-recipe walker and our .fk emitter both have to
+# agree with.
+node_eval() {
+    local f="$1"
+    node --input-type=module -e "$(node -e "
+        const fs = require('fs');
+        const src = fs.readFileSync('$f', 'utf8');
+        const lines = src.split('\n');
+        let lastIdx = -1;
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const t = lines[i].trim();
+            if (t === '' || t.startsWith('//') || t === '}' || t.endsWith(';')) continue;
+            lastIdx = i;
+            break;
+        }
+        if (lastIdx >= 0) {
+            lines[lastIdx] = 'console.log(' + lines[lastIdx] + ')';
+        }
+        process.stdout.write(lines.join('\n'));
+    ")" 2>&1 | tail -1
+}
+
+for f in "${PARITY_FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        echo "  SKIP $f (file missing)"
+        continue
+    fi
+
+    node_result=$(node_eval "$f")
+
+    ts_result=$(npx tsx seedbank/ts-adapter/src/main.ts ts-eval "$f" 2>&1 | tail -1)
+
+    if [[ "$HAS_RUST_BIN" -eq 1 ]]; then
+        fk_path="${f%.ts}.fk"
+        npx tsx seedbank/ts-adapter/src/main.ts ts-compile "$f" "$fk_path" >/dev/null 2>&1
+        rust_result=$("$RUST_BIN" "$fk_path" 2>&1 | tail -1)
+        if [[ "$node_result" == "$ts_result" && "$node_result" == "$rust_result" ]]; then
+            echo "  OK   $f  → $node_result"
+            PASS=$((PASS + 1))
+        else
+            echo "  FAIL $f"
+            echo "       node: $node_result"
+            echo "       ts:   $ts_result"
+            echo "       rust: $rust_result"
+            FAIL=$((FAIL + 1))
+        fi
+    else
+        if [[ "$node_result" == "$ts_result" ]]; then
+            echo "  OK   $f  → $node_result  (2-way, rust skipped)"
+            PASS=$((PASS + 1))
+        else
+            echo "  FAIL $f"
+            echo "       node: $node_result"
+            echo "       ts:   $ts_result"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+done
+
+echo ""
+echo "parity_suite: $PASS passing, $FAIL failing"
+exit $FAIL

--- a/form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts-fk.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts-fk.ts
@@ -1,0 +1,360 @@
+// lang-ts-fk.ts — emit kernel-native .fk S-expression source from a
+// parsed TypeScript Form tree.
+//
+//   TypeScript source bytes
+//     → parseTypeScript (lang-ts.ts)         — TS parser → Form tree
+//     → emitFk (this file)                   — Form tree → kernel-native .fk
+//     → form-kernel-rust binary              — walks the .fk, no host runtime
+//
+// CTOR vocabulary is shared with the Python adapter, so the emission
+// rules below are intentionally parallel to lang-python-fk.ts. Arrow
+// functions emit as `defn` (the kernel's statement-level binder), with
+// lifting for inline lambdas — same shape as Python's lifted lambdas.
+
+import { Kernel, Level, Triv, type NodeID } from "../../../src/kernel.ts";
+import { capturedCtor, capturedChildren } from "../../../src/languages.ts";
+import { CTOR } from "./lang-ts.ts";
+
+export interface EmitFkOptions {
+  source_comments?: boolean;
+}
+
+let lambdaCounter = 0;
+let liftedDefns: string[] = [];
+
+// Walk a subtree to see if it contains a `return` along any path.
+// Used by emitDefBody to know whether an if-statement short-circuits.
+function containsReturn(k: Kernel, n: NodeID): boolean {
+  if (n.level === Level.TRIVIAL) return false;
+  const ctor = capturedCtor(k, n);
+  if (ctor === CTOR.return_) return true;
+  if (ctor === CTOR.def_ || ctor === CTOR.lambda_) return false;
+  for (const c of capturedChildren(k, n)) {
+    if (containsReturn(k, c)) return true;
+  }
+  return false;
+}
+
+function containsStringLiteral(k: Kernel, n: NodeID): boolean {
+  if (n.level === Level.TRIVIAL) return n.type === Triv.STRING;
+  const ctor = capturedCtor(k, n);
+  if (ctor === CTOR.str_literal) return true;
+  if (ctor === CTOR.def_ || ctor === CTOR.lambda_) return false;
+  for (const c of capturedChildren(k, n)) {
+    if (containsStringLiteral(k, c)) return true;
+  }
+  return false;
+}
+
+// CPS-style emission of a TS function body (block of statements).
+// Mirrors emitDefBody from the Python adapter: early returns
+// short-circuit; if-without-else falls through to the remaining stmts.
+function emitDefBody(k: Kernel, bodyNode: NodeID, opts: EmitFkOptions): string {
+  const bodyCtor = capturedCtor(k, bodyNode);
+  const stmts =
+    bodyCtor === CTOR.block ? capturedChildren(k, bodyNode) : [bodyNode];
+  return emitStmtSeq(k, stmts, 0, opts);
+}
+
+function emitStmtSeq(
+  k: Kernel,
+  stmts: readonly NodeID[],
+  start: number,
+  opts: EmitFkOptions,
+): string {
+  if (start >= stmts.length) return "false"; // implicit fallthrough → null
+  const stmt = stmts[start]!;
+  const ctor = capturedCtor(k, stmt);
+  const kids = capturedChildren(k, stmt);
+
+  if (ctor === CTOR.return_) {
+    return emit(k, kids[0]!, opts);
+  }
+
+  if (ctor === CTOR.if_) {
+    return emitIfInDefBody(k, kids, stmts, start, opts);
+  }
+
+  if (ctor === CTOR.assign) {
+    const target = emitIdent(k, kids[0]!);
+    const value = emit(k, kids[1]!, opts);
+    const rest = emitStmtSeq(k, stmts, start + 1, opts);
+    return `(do (let ${target} ${value}) ${rest})`;
+  }
+
+  // Side-effect statement — emit then continue.
+  const sideEffect = emit(k, stmt, opts);
+  const rest = emitStmtSeq(k, stmts, start + 1, opts);
+  return start + 1 >= stmts.length
+    ? sideEffect
+    : `(do ${sideEffect} ${rest})`;
+}
+
+function emitIfInDefBody(
+  k: Kernel,
+  ifKids: readonly NodeID[],
+  stmts: readonly NodeID[],
+  start: number,
+  opts: EmitFkOptions,
+): string {
+  let i = ifKids.length;
+  let elseAcc: string;
+  if (i % 2 === 1) {
+    const elseNode = ifKids[i - 1]!;
+    elseAcc = emitBlockInDefBody(k, elseNode, stmts, start + 1, opts);
+    i -= 1;
+  } else {
+    elseAcc = emitStmtSeq(k, stmts, start + 1, opts);
+  }
+  while (i >= 2) {
+    const body = ifKids[i - 1]!;
+    const cond = ifKids[i - 2]!;
+    const condStr = emit(k, cond, opts);
+    const thenStr = emitBlockInDefBody(k, body, stmts, start + 1, opts);
+    elseAcc = `(if ${condStr} ${thenStr} ${elseAcc})`;
+    i -= 2;
+  }
+  return elseAcc;
+}
+
+function emitBlockInDefBody(
+  k: Kernel,
+  blockNode: NodeID,
+  outerStmts: readonly NodeID[],
+  outerStart: number,
+  opts: EmitFkOptions,
+): string {
+  const blockCtor = capturedCtor(k, blockNode);
+  const blockStmts =
+    blockCtor === CTOR.block ? capturedChildren(k, blockNode) : [blockNode];
+
+  if (containsReturn(k, blockNode)) {
+    return emitStmtSeq(k, blockStmts, 0, opts);
+  }
+  const sideEffectStrs = blockStmts.map((s) => emit(k, s, opts));
+  const outerRest = emitStmtSeq(k, outerStmts, outerStart, opts);
+  return sideEffectStrs.length === 0
+    ? outerRest
+    : `(do ${sideEffectStrs.join(" ")} ${outerRest})`;
+}
+
+export function emitFk(k: Kernel, tree: NodeID, opts: EmitFkOptions = {}): string {
+  lambdaCounter = 0;
+  liftedDefns = [];
+  const body = emit(k, tree, opts);
+  if (liftedDefns.length === 0) return body;
+  const isBareDo = body.startsWith("(do ") && body.endsWith(")");
+  if (isBareDo) {
+    const inner = body.slice(4, body.length - 1);
+    return `(do ${liftedDefns.join(" ")} ${inner})`;
+  }
+  return `(do ${liftedDefns.join(" ")} ${body})`;
+}
+
+function emit(k: Kernel, n: NodeID, opts: EmitFkOptions): string {
+  if (n.level === Level.TRIVIAL) {
+    return emitTrivial(k, n);
+  }
+  const ctor = capturedCtor(k, n);
+  const kids = capturedChildren(k, n);
+  switch (ctor) {
+    case CTOR.module: {
+      const parts = kids.map((c: NodeID) => emit(k, c, opts));
+      if (parts.length === 1) return parts[0]!;
+      return `(do ${parts.join(" ")})`;
+    }
+    case CTOR.expr_stmt:
+      return emit(k, kids[0]!, opts);
+
+    case CTOR.int_literal:
+    case CTOR.float_literal:
+    case CTOR.bool_literal:
+    case CTOR.str_literal:
+      return emitTrivial(k, kids[0]!);
+
+    case CTOR.none_literal:
+      // No null literal in the kernel reader; honest fallback to "false"
+      // (same as Python None). Carries TS truthiness across the seam.
+      return "false";
+
+    case CTOR.ident: {
+      const t = kids[0]!;
+      if (t.level === Level.TRIVIAL && t.type === Triv.STRING) {
+        return k.strs[t.inst] ?? "?ident";
+      }
+      return "?ident";
+    }
+
+    case CTOR.add: {
+      const polymorphicNeeded =
+        containsStringLiteral(k, kids[0]!) || containsStringLiteral(k, kids[1]!);
+      const op = polymorphicNeeded ? "_plus" : "add";
+      return `(${op} ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    }
+    case CTOR.sub: return `(sub ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.mul: return `(mul ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.div: return `(div ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.mod: return `(mod ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.neg: return `(sub 0 ${emit(k, kids[0]!, opts)})`;
+
+    case CTOR.eq: return `(eq ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.ne: return `(ne ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.lt: return `(lt ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.le: return `(le ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.gt: return `(gt ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.ge: return `(ge ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+
+    case CTOR.and_: return `(and ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.or_:  return `(or ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)})`;
+    case CTOR.not_: return `(not ${emit(k, kids[0]!, opts)})`;
+
+    case CTOR.if_: {
+      // Ternary (expression form): exactly 3 kids, middle is NOT a block.
+      const isExpr =
+        kids.length === 3 && capturedCtor(k, kids[1]!) !== CTOR.block;
+      if (isExpr) {
+        return `(if ${emit(k, kids[0]!, opts)} ${emit(k, kids[1]!, opts)} ${emit(k, kids[2]!, opts)})`;
+      }
+      // Statement form
+      const stmts: string[] = [];
+      let i = 0;
+      while (i + 1 < kids.length) {
+        stmts.push(emit(k, kids[i]!, opts));
+        stmts.push(emit(k, kids[i + 1]!, opts));
+        i += 2;
+      }
+      const elseBranch =
+        i < kids.length ? emit(k, kids[i]!, opts) : "false";
+      let acc = elseBranch;
+      for (let j = stmts.length - 2; j >= 0; j -= 2) {
+        acc = `(if ${stmts[j]} ${stmts[j + 1]} ${acc})`;
+      }
+      return acc;
+    }
+
+    case CTOR.block: {
+      const parts = kids.map((c: NodeID) => emit(k, c, opts));
+      if (parts.length === 1) return parts[0]!;
+      return `(do ${parts.join(" ")})`;
+    }
+
+    case CTOR.return_:
+      return emit(k, kids[0]!, opts);
+
+    case CTOR.def_: {
+      const name = emitIdent(k, kids[0]!);
+      const paramNodes = capturedChildren(k, kids[1]!);
+      const paramNames = paramNodes.map((p: NodeID) => emitIdent(k, p));
+      const body = emitDefBody(k, kids[2]!, opts);
+      return `(defn ${name} (${paramNames.join(" ")}) ${body})`;
+    }
+
+    case CTOR.lambda_: {
+      // Arrow function: `(x) => expr` or `(x) => { ... }`.
+      // Lift to module-level defn with a synthesized name, same as
+      // python-adapter's lambda treatment.
+      const paramNodes = capturedChildren(k, kids[0]!);
+      const paramNames = paramNodes.map((p: NodeID) => emitIdent(k, p));
+      const bodyNode = kids[1]!;
+      const bodyCtor = capturedCtor(k, bodyNode);
+      // If body is a block, run it through the def-body CPS lowering so
+      // early-return short-circuits work. If it's a bare expression,
+      // emit it directly.
+      const bodyStr =
+        bodyCtor === CTOR.block
+          ? emitDefBody(k, bodyNode, opts)
+          : emit(k, bodyNode, opts);
+      const name = `_lambda_${lambdaCounter++}`;
+      liftedDefns.push(`(defn ${name} (${paramNames.join(" ")}) ${bodyStr})`);
+      return name;
+    }
+
+    case CTOR.call: {
+      const calleeNode = kids[0]!;
+      const argsNode = kids[1];
+      const argNodes = argsNode !== undefined ? capturedChildren(k, argsNode) : [];
+      const argStrs = argNodes.map((a: NodeID) => emit(k, a, opts));
+      if (capturedCtor(k, calleeNode) === CTOR.ident) {
+        const calleeName = emitIdent(k, calleeNode);
+        return argStrs.length === 0
+          ? `(${calleeName})`
+          : `(${calleeName} ${argStrs.join(" ")})`;
+      }
+      throw new Error(
+        "emitFk: call with non-ident callee not yet supported (lambdas/method-chains/etc.)",
+      );
+    }
+
+    case CTOR.list_literal: {
+      const parts = kids.map((c: NodeID) => emit(k, c, opts));
+      return parts.length === 0 ? "(list)" : `(list ${parts.join(" ")})`;
+    }
+
+    case CTOR.assign: {
+      const target = emitIdent(k, kids[0]!);
+      const value = emit(k, kids[1]!, opts);
+      return `(let ${target} ${value})`;
+    }
+
+    default:
+      throw new Error(
+        `emitFk: unsupported TS CTOR '${ctor}' — needs grammar/kernel work to compile`,
+      );
+  }
+}
+
+function emitTrivial(k: Kernel, n: NodeID): string {
+  if (n.level !== Level.TRIVIAL) {
+    throw new Error("emitTrivial: not a trivial");
+  }
+  switch (n.type) {
+    case Triv.INT:
+      return String(n.inst | 0);
+    case Triv.INT64: {
+      const v = k.decodeInt64(n.inst);
+      return v.toString();
+    }
+    case Triv.INT8:
+    case Triv.INT16:
+    case Triv.UINT8:
+    case Triv.UINT16:
+    case Triv.UINT32:
+      return String(n.inst | 0);
+    case Triv.STRING:
+      return JSON.stringify(k.strs[n.inst] ?? "");
+    case Triv.BOOL:
+      return n.inst !== 0 ? "true" : "false";
+    case Triv.NULL:
+      return "false";
+    case Triv.FLOAT64: {
+      const f = k.decodeFloat64(n.inst);
+      return formatFloatForFk(f);
+    }
+    default:
+      throw new Error(
+        `emitTrivial: kernel reader can't represent trivial type ${n.type}`,
+      );
+  }
+}
+
+function formatFloatForFk(f: number): string {
+  if (Number.isNaN(f)) throw new Error("emitTrivial: NaN has no .fk literal form");
+  if (!Number.isFinite(f)) throw new Error("emitTrivial: Infinity has no .fk literal form");
+  const s = String(f);
+  if (s.includes(".") || s.includes("e") || s.includes("E")) return s;
+  return `${s}.0`;
+}
+
+function emitIdent(k: Kernel, n: NodeID): string {
+  if (n.level === Level.TRIVIAL && n.type === Triv.STRING) {
+    return k.strs[n.inst] ?? "?";
+  }
+  const kids = capturedChildren(k, n);
+  if (kids.length > 0) {
+    const t = kids[0]!;
+    if (t.level === Level.TRIVIAL && t.type === Triv.STRING) {
+      return k.strs[t.inst] ?? "?";
+    }
+  }
+  throw new Error("emitIdent: expected an ident shape");
+}

--- a/form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts.ts
@@ -1,0 +1,1176 @@
+// lang-ts.ts — TypeScript (small subset) as a substrate-resident Language cell.
+//
+// The destination half PYTHON_PIPELINE_STATUS.md names as `ts-grammar.form
+// 0/?`. python-adapter is the template; this adapter's ctor vocabulary
+// reuses Python's CTOR names so semantically-equivalent fragments —
+// `(x) => x + 1` in TS, `lambda x: x + 1` in Python — intern to the same
+// recipe NodeIDs by content-addressing. That is the cross-language
+// identity the language-cells architecture exists to make load-bearing.
+//
+// Subset shipped in this bootstrap breath (the smallest closing one):
+//   - arrow functions: `(x) => x + 1`, `(a, b) => { return a + b; }`
+//   - `const` / `let` bindings (no destructuring, no type annotations)
+//   - `if` / `else` statements + ternary `c ? a : b`
+//   - arithmetic: `+ - * / %`, unary `-`, `!`
+//   - comparison: `== === != !== < <= > >=` (=== folds to ==)
+//   - logic: `&& ||`
+//   - function calls, return, recursion
+//   - number / string / boolean / null literals, identifiers
+//   - block `{ ... }` and expression-statement
+//
+// Pending (each is its own breath, named honestly here so we don't fake
+// progress): classes, interfaces, generics, modules / import / export,
+// async / await, JSX, type annotations beyond bare-name skip, enums,
+// destructuring, spread, template literals, regex, switch, try/catch,
+// optional chaining, nullish coalescing.
+
+import {
+  Frame,
+  Kernel,
+  Level,
+  RBasic,
+  Triv,
+  type NodeID,
+  type Value,
+} from "../../../src/kernel.ts";
+import {
+  capturedChildren,
+  capturedCtor,
+} from "../../../src/languages.ts";
+
+// ---------------------------------------------------------------------------
+// CTOR — shared vocabulary with the Python adapter.
+//
+// Names are deliberately the same as lang-python.ts so a TS arrow
+// `(x) => x + 1` and a Python lambda `lambda x: x + 1` capture into
+// the same `lambda` / `param` / `add` / `int-literal` recipe shape.
+// Same Blueprint → same NodeID → cross-language identity for free.
+// ---------------------------------------------------------------------------
+
+export const CTOR = {
+  module: "module",
+  // Literals
+  int_literal: "int-literal",
+  float_literal: "float-literal",
+  str_literal: "str-literal",
+  bool_literal: "bool-literal",
+  none_literal: "none-literal", // TS null/undefined → none
+  ident: "ident",
+  // Collections
+  list_literal: "list-literal",
+  // Calls
+  call: "call",
+  args: "args",
+  // Operators — names align with Python adapter
+  add: "add",
+  sub: "sub",
+  mul: "mul",
+  div: "div",
+  mod: "mod",
+  eq: "eq",
+  ne: "ne",
+  lt: "lt",
+  le: "le",
+  gt: "gt",
+  ge: "ge",
+  and_: "and",
+  or_: "or",
+  not_: "not",
+  neg: "neg",
+  // Statements
+  if_: "if",
+  def_: "def",       // arrow functions lower to `def` for cross-language identity
+  return_: "return",
+  lambda_: "lambda",
+  expr_stmt: "expr-stmt",
+  assign: "assign",  // `let x = e` re-binds (Python: same)
+  // Function/lambda params
+  params: "params",
+  param: "param",
+  block: "block",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Recursive-descent parser — produces the captured-recipe shape that
+// shares its CTOR vocabulary with the Python adapter.
+// ---------------------------------------------------------------------------
+
+interface Cursor {
+  readonly src: string;
+  pos: number;
+}
+
+function ctorCategory(k: Kernel, ctor: string): NodeID {
+  return {
+    pkg: 1,
+    level: Level.BASIC,
+    type: RBasic.LIST,
+    inst: k.internName(ctor),
+  };
+}
+
+function captureNode(k: Kernel, ctor: string, children: NodeID[]): NodeID {
+  return k.intern(ctorCategory(k, ctor), children);
+}
+
+function skipWS(c: Cursor): void {
+  // Skip spaces, tabs, newlines, and `//` line-comments + `/* */` block
+  // comments. Semicolons are skipped at the statement level.
+  while (c.pos < c.src.length) {
+    const ch = c.src.charCodeAt(c.pos);
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
+      c.pos++;
+    } else if (ch === 47 && c.src.charCodeAt(c.pos + 1) === 47 /* // */) {
+      while (c.pos < c.src.length && c.src.charCodeAt(c.pos) !== 10) c.pos++;
+    } else if (ch === 47 && c.src.charCodeAt(c.pos + 1) === 42 /* /* */) {
+      c.pos += 2;
+      while (c.pos + 1 < c.src.length) {
+        if (c.src.charCodeAt(c.pos) === 42 && c.src.charCodeAt(c.pos + 1) === 47) {
+          c.pos += 2;
+          break;
+        }
+        c.pos++;
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+function atEnd(c: Cursor): boolean {
+  return c.pos >= c.src.length;
+}
+
+function peek(c: Cursor): string {
+  return c.src[c.pos] ?? "";
+}
+
+function startsWith(c: Cursor, lit: string): boolean {
+  return c.src.startsWith(lit, c.pos);
+}
+
+function consume(c: Cursor, lit: string): boolean {
+  skipWS(c);
+  if (startsWith(c, lit)) {
+    c.pos += lit.length;
+    return true;
+  }
+  return false;
+}
+
+function expect(c: Cursor, lit: string): void {
+  if (!consume(c, lit)) {
+    throw new SyntaxError(
+      `ts: expected '${lit}' at position ${c.pos} (got ` +
+        JSON.stringify(c.src.substring(c.pos, c.pos + 16)) +
+        ")",
+    );
+  }
+}
+
+function isIdentStart(ch: number): boolean {
+  return (ch >= 65 && ch <= 90) || (ch >= 97 && ch <= 122) || ch === 95 || ch === 36;
+}
+
+function isIdentCont(ch: number): boolean {
+  return isIdentStart(ch) || (ch >= 48 && ch <= 57);
+}
+
+const KEYWORDS = new Set([
+  "const", "let", "var", "if", "else", "return", "function",
+  "true", "false", "null", "undefined", "while", "for", "in", "of",
+]);
+
+function readIdentRaw(c: Cursor): string | null {
+  skipWS(c);
+  const start = c.pos;
+  if (atEnd(c) || !isIdentStart(c.src.charCodeAt(start))) return null;
+  let pos = start + 1;
+  while (pos < c.src.length && isIdentCont(c.src.charCodeAt(pos))) pos++;
+  c.pos = pos;
+  return c.src.substring(start, pos);
+}
+
+function peekKeyword(c: Cursor, kw: string): boolean {
+  const saved = c.pos;
+  skipWS(c);
+  if (!startsWith(c, kw)) {
+    c.pos = saved;
+    return false;
+  }
+  const after = c.pos + kw.length;
+  if (after < c.src.length) {
+    const ch = c.src.charCodeAt(after);
+    if (isIdentCont(ch)) {
+      c.pos = saved;
+      return false;
+    }
+  }
+  c.pos = saved;
+  return true;
+}
+
+function consumeKeyword(c: Cursor, kw: string): boolean {
+  if (peekKeyword(c, kw)) {
+    skipWS(c);
+    c.pos += kw.length;
+    return true;
+  }
+  return false;
+}
+
+// ----- numeric literal -----
+
+function parseNumber(k: Kernel, c: Cursor): NodeID | null {
+  skipWS(c);
+  const start = c.pos;
+  let pos = start;
+  while (pos < c.src.length && c.src.charCodeAt(pos) >= 48 && c.src.charCodeAt(pos) <= 57)
+    pos++;
+  if (pos === start) return null;
+  let isFloat = false;
+  if (pos < c.src.length && c.src.charCodeAt(pos) === 46 /* '.' */) {
+    const after = c.src.charCodeAt(pos + 1) || 0;
+    if (after >= 48 && after <= 57) {
+      isFloat = true;
+      pos++;
+      while (pos < c.src.length && c.src.charCodeAt(pos) >= 48 && c.src.charCodeAt(pos) <= 57)
+        pos++;
+    }
+  }
+  const text = c.src.substring(start, pos);
+  c.pos = pos;
+  if (isFloat) {
+    const value = k.internTrivialFloat64(parseFloat(text));
+    return captureNode(k, CTOR.float_literal, [value]);
+  }
+  const n = BigInt(text);
+  const value = k.internTrivialInt64(n);
+  return captureNode(k, CTOR.int_literal, [value]);
+}
+
+// ----- string literal -----
+
+function parseString(k: Kernel, c: Cursor): NodeID | null {
+  skipWS(c);
+  if (atEnd(c)) return null;
+  const ch = peek(c);
+  if (ch !== '"' && ch !== "'" && ch !== "`") return null;
+  const quote = ch;
+  c.pos++;
+  const start = c.pos;
+  let out = "";
+  while (c.pos < c.src.length) {
+    const cur = c.src[c.pos]!;
+    if (cur === quote) {
+      const text = out === "" ? c.src.substring(start, c.pos) : out;
+      c.pos++;
+      const str = k.internString(text);
+      return captureNode(k, CTOR.str_literal, [str]);
+    }
+    if (c.src.charCodeAt(c.pos) === 92 /* '\\' */ && c.pos + 1 < c.src.length) {
+      if (out === "") out = c.src.substring(start, c.pos);
+      const nx = c.src[c.pos + 1]!;
+      switch (nx) {
+        case "n": out += "\n"; break;
+        case "t": out += "\t"; break;
+        case "r": out += "\r"; break;
+        case "\\": out += "\\"; break;
+        case "'": out += "'"; break;
+        case '"': out += '"'; break;
+        case "`": out += "`"; break;
+        default: out += nx;
+      }
+      c.pos += 2;
+      continue;
+    }
+    if (out !== "") out += cur;
+    c.pos++;
+  }
+  throw new SyntaxError(`ts: unterminated string at position ${start}`);
+}
+
+// ----- expression precedence -----
+// Expression hierarchy (subset):
+//   conditional `c ? a : b`
+//   ||
+//   &&
+//   comparison
+//   add/sub
+//   mul/div/mod
+//   unary - / !
+//   call
+//   atom
+
+function parseAtom(k: Kernel, c: Cursor): NodeID | null {
+  skipWS(c);
+  if (atEnd(c)) return null;
+
+  // Parenthesized expression OR arrow function with paren-wrapped params
+  if (peek(c) === "(") {
+    const saved = c.pos;
+    // Try to parse as arrow function first.
+    const arrow = tryParseArrow(k, c);
+    if (arrow !== null) return arrow;
+    c.pos = saved;
+    // Plain parenthesized expression
+    expect(c, "(");
+    const e = parseExpr(k, c);
+    if (e === null) throw new SyntaxError(`ts: expression required after '(' at ${c.pos}`);
+    expect(c, ")");
+    return e;
+  }
+
+  // Array literal
+  if (consume(c, "[")) {
+    const items: NodeID[] = [];
+    skipWS(c);
+    if (!consume(c, "]")) {
+      const first = parseExpr(k, c);
+      if (first !== null) items.push(first);
+      while (consume(c, ",")) {
+        skipWS(c);
+        if (peek(c) === "]") break;
+        const next = parseExpr(k, c);
+        if (next === null) break;
+        items.push(next);
+      }
+      skipWS(c);
+      expect(c, "]");
+    }
+    return captureNode(k, CTOR.list_literal, items);
+  }
+
+  // Keyword literals
+  if (peekKeyword(c, "true")) {
+    consumeKeyword(c, "true");
+    return captureNode(k, CTOR.bool_literal, [k.internTrivialBool(true)]);
+  }
+  if (peekKeyword(c, "false")) {
+    consumeKeyword(c, "false");
+    return captureNode(k, CTOR.bool_literal, [k.internTrivialBool(false)]);
+  }
+  if (peekKeyword(c, "null") || peekKeyword(c, "undefined")) {
+    if (peekKeyword(c, "null")) consumeKeyword(c, "null");
+    else consumeKeyword(c, "undefined");
+    return captureNode(k, CTOR.none_literal, []);
+  }
+
+  // Unary -, !
+  if (peek(c) === "-") {
+    c.pos++;
+    const inner = parseUnary(k, c);
+    if (inner === null) throw new SyntaxError(`ts: expr after unary '-' at ${c.pos}`);
+    return captureNode(k, CTOR.neg, [inner]);
+  }
+  if (peek(c) === "!") {
+    c.pos++;
+    const inner = parseUnary(k, c);
+    if (inner === null) throw new SyntaxError(`ts: expr after unary '!' at ${c.pos}`);
+    return captureNode(k, CTOR.not_, [inner]);
+  }
+
+  // String
+  const s = parseString(k, c);
+  if (s !== null) return s;
+
+  // Number
+  const n = parseNumber(k, c);
+  if (n !== null) return n;
+
+  // Single-arg arrow without parens: `x => expr`
+  // Try ident-then-=> form.
+  const savedPos = c.pos;
+  const name = readIdentRaw(c);
+  if (name !== null) {
+    if (KEYWORDS.has(name)) {
+      c.pos = savedPos;
+      return null;
+    }
+    // Check for `=>` to see if this is a single-arg arrow.
+    const afterIdent = c.pos;
+    skipWS(c);
+    if (startsWith(c, "=>")) {
+      c.pos += 2;
+      const param = captureNode(k, CTOR.param, [k.internString(name)]);
+      const params = captureNode(k, CTOR.params, [param]);
+      const body = parseArrowBody(k, c);
+      return captureNode(k, CTOR.lambda_, [params, body]);
+    }
+    c.pos = afterIdent;
+    return captureNode(k, CTOR.ident, [k.internString(name)]);
+  }
+
+  return null;
+}
+
+// tryParseArrow — attempt `(p1, p2, ...) => body`. Backtrack and return
+// null if the shape isn't an arrow.
+function tryParseArrow(k: Kernel, c: Cursor): NodeID | null {
+  const saved = c.pos;
+  if (!consume(c, "(")) {
+    c.pos = saved;
+    return null;
+  }
+  const params: NodeID[] = [];
+  skipWS(c);
+  if (!consume(c, ")")) {
+    while (true) {
+      skipWS(c);
+      const name = readIdentRaw(c);
+      if (name === null) {
+        c.pos = saved;
+        return null;
+      }
+      // Skip optional `: Type` annotation by scanning to next `,` or `)`.
+      skipWS(c);
+      if (peek(c) === ":") {
+        c.pos++;
+        // Crude type-annotation skip — eat tokens until `,` or `)` at depth 0.
+        let depth = 0;
+        while (c.pos < c.src.length) {
+          const ch = peek(c);
+          if (depth === 0 && (ch === "," || ch === ")")) break;
+          if (ch === "(" || ch === "<" || ch === "[" || ch === "{") depth++;
+          else if (ch === ")" || ch === ">" || ch === "]" || ch === "}") depth--;
+          c.pos++;
+        }
+      }
+      params.push(captureNode(k, CTOR.param, [k.internString(name)]));
+      if (!consume(c, ",")) break;
+    }
+    if (!consume(c, ")")) {
+      c.pos = saved;
+      return null;
+    }
+  }
+  // Optional return-type annotation: `) : T => body`. Skip-to-`=>`.
+  skipWS(c);
+  if (peek(c) === ":") {
+    c.pos++;
+    while (c.pos < c.src.length && !startsWith(c, "=>")) c.pos++;
+  }
+  skipWS(c);
+  if (!startsWith(c, "=>")) {
+    c.pos = saved;
+    return null;
+  }
+  c.pos += 2;
+  const body = parseArrowBody(k, c);
+  const paramsNode = captureNode(k, CTOR.params, params);
+  return captureNode(k, CTOR.lambda_, [paramsNode, body]);
+}
+
+// parseArrowBody — either `{ stmts; }` (treated as a def body) or a single
+// expression. For block bodies we wrap as CTOR.block; for expr bodies we
+// wrap the expression in an implicit `return` so the lambda's value is
+// the expression — matches the kernel's defn semantics.
+function parseArrowBody(k: Kernel, c: Cursor): NodeID {
+  skipWS(c);
+  if (peek(c) === "{") {
+    return parseBlock(k, c);
+  }
+  const e = parseExpr(k, c);
+  if (e === null) throw new SyntaxError(`ts: arrow body expression required at ${c.pos}`);
+  return e;
+}
+
+function parseCallChain(k: Kernel, c: Cursor): NodeID | null {
+  let node = parseAtom(k, c);
+  if (node === null) return null;
+  while (true) {
+    skipWS(c);
+    if (peek(c) === "(") {
+      c.pos++;
+      const args = parseArgs(k, c);
+      expect(c, ")");
+      node = captureNode(k, CTOR.call, [node, args]);
+      continue;
+    }
+    break;
+  }
+  return node;
+}
+
+function parseArgs(k: Kernel, c: Cursor): NodeID {
+  const args: NodeID[] = [];
+  skipWS(c);
+  if (peek(c) === ")") return captureNode(k, CTOR.args, []);
+  while (true) {
+    skipWS(c);
+    const e = parseExpr(k, c);
+    if (e === null) break;
+    args.push(e);
+    skipWS(c);
+    if (!consume(c, ",")) break;
+  }
+  return captureNode(k, CTOR.args, args);
+}
+
+function parseUnary(k: Kernel, c: Cursor): NodeID | null {
+  skipWS(c);
+  if (peek(c) === "-") {
+    c.pos++;
+    const inner = parseUnary(k, c);
+    if (inner === null) return null;
+    return captureNode(k, CTOR.neg, [inner]);
+  }
+  if (peek(c) === "!") {
+    c.pos++;
+    const inner = parseUnary(k, c);
+    if (inner === null) return null;
+    return captureNode(k, CTOR.not_, [inner]);
+  }
+  return parseCallChain(k, c);
+}
+
+function parseMul(k: Kernel, c: Cursor): NodeID | null {
+  let left = parseUnary(k, c);
+  if (left === null) return null;
+  while (true) {
+    skipWS(c);
+    // Don't consume `*` / `/` / `%` when followed by `=` (augmented assign,
+    // not supported v0 — but defensive against future expansion).
+    if (c.pos + 1 < c.src.length && c.src.charCodeAt(c.pos + 1) === 61) {
+      const ch = c.src.charCodeAt(c.pos);
+      if (ch === 42 || ch === 47 || ch === 37) break;
+    }
+    let ctor: string | null = null;
+    if (consume(c, "*")) ctor = CTOR.mul;
+    else if (consume(c, "/")) ctor = CTOR.div;
+    else if (consume(c, "%")) ctor = CTOR.mod;
+    else break;
+    const right = parseUnary(k, c);
+    if (right === null) throw new SyntaxError(`ts: rhs expected at ${c.pos}`);
+    left = captureNode(k, ctor, [left, right]);
+  }
+  return left;
+}
+
+function parseAdd(k: Kernel, c: Cursor): NodeID | null {
+  let left = parseMul(k, c);
+  if (left === null) return null;
+  while (true) {
+    skipWS(c);
+    // Don't consume `+` / `-` when followed by `=` or another `+`/`-` (++ / --).
+    if (c.pos + 1 < c.src.length) {
+      const ch = c.src.charCodeAt(c.pos);
+      const nx = c.src.charCodeAt(c.pos + 1);
+      if ((ch === 43 || ch === 45) && (nx === 61 || nx === ch)) break;
+    }
+    let ctor: string | null = null;
+    if (startsWith(c, "+")) {
+      c.pos++;
+      ctor = CTOR.add;
+    } else if (startsWith(c, "-")) {
+      c.pos++;
+      ctor = CTOR.sub;
+    } else break;
+    const right = parseMul(k, c);
+    if (right === null) throw new SyntaxError(`ts: rhs expected at ${c.pos}`);
+    left = captureNode(k, ctor, [left, right]);
+  }
+  return left;
+}
+
+function parseCmp(k: Kernel, c: Cursor): NodeID | null {
+  let left = parseAdd(k, c);
+  if (left === null) return null;
+  while (true) {
+    skipWS(c);
+    let ctor: string | null = null;
+    // 3-char operators first (===, !==), then 2-char (==, !=, <=, >=), then 1-char.
+    if (consume(c, "===")) ctor = CTOR.eq;
+    else if (consume(c, "!==")) ctor = CTOR.ne;
+    else if (consume(c, "==")) ctor = CTOR.eq;
+    else if (consume(c, "!=")) ctor = CTOR.ne;
+    else if (consume(c, "<=")) ctor = CTOR.le;
+    else if (consume(c, ">=")) ctor = CTOR.ge;
+    else if (peek(c) === "<" && c.src[c.pos + 1] !== "=") {
+      c.pos++;
+      ctor = CTOR.lt;
+    } else if (peek(c) === ">" && c.src[c.pos + 1] !== "=") {
+      c.pos++;
+      ctor = CTOR.gt;
+    } else break;
+    const right = parseAdd(k, c);
+    if (right === null) throw new SyntaxError(`ts: rhs expected at ${c.pos}`);
+    left = captureNode(k, ctor, [left, right]);
+  }
+  return left;
+}
+
+function parseAnd(k: Kernel, c: Cursor): NodeID | null {
+  let left = parseCmp(k, c);
+  if (left === null) return null;
+  while (true) {
+    skipWS(c);
+    if (!startsWith(c, "&&")) break;
+    c.pos += 2;
+    const right = parseCmp(k, c);
+    if (right === null) throw new SyntaxError(`ts: rhs after '&&' at ${c.pos}`);
+    left = captureNode(k, CTOR.and_, [left, right]);
+  }
+  return left;
+}
+
+function parseOr(k: Kernel, c: Cursor): NodeID | null {
+  let left = parseAnd(k, c);
+  if (left === null) return null;
+  while (true) {
+    skipWS(c);
+    if (!startsWith(c, "||")) break;
+    c.pos += 2;
+    const right = parseAnd(k, c);
+    if (right === null) throw new SyntaxError(`ts: rhs after '||' at ${c.pos}`);
+    left = captureNode(k, CTOR.or_, [left, right]);
+  }
+  return left;
+}
+
+// Ternary: `c ? a : b`. Captures as CTOR.if_ — same shape as Python's
+// conditional expression so cross-language identity holds.
+function parseTernary(k: Kernel, c: Cursor): NodeID | null {
+  const cond = parseOr(k, c);
+  if (cond === null) return null;
+  skipWS(c);
+  if (peek(c) !== "?") return cond;
+  c.pos++;
+  const then_ = parseExpr(k, c);
+  if (then_ === null) throw new SyntaxError(`ts: then-branch after '?' at ${c.pos}`);
+  expect(c, ":");
+  const else_ = parseExpr(k, c);
+  if (else_ === null) throw new SyntaxError(`ts: else-branch after ':' at ${c.pos}`);
+  return captureNode(k, CTOR.if_, [cond, then_, else_]);
+}
+
+export function parseExpr(k: Kernel, c: Cursor): NodeID | null {
+  return parseTernary(k, c);
+}
+
+// ----- statements -----
+
+function parseBlock(k: Kernel, c: Cursor): NodeID {
+  expect(c, "{");
+  const stmts: NodeID[] = [];
+  while (true) {
+    skipWS(c);
+    if (consume(c, "}")) break;
+    const s = parseStmt(k, c);
+    if (s === null) break;
+    stmts.push(s);
+  }
+  return captureNode(k, CTOR.block, stmts);
+}
+
+function parseReturn(k: Kernel, c: Cursor): NodeID {
+  expect(c, "return");
+  skipWS(c);
+  // Bare `return;` → return null
+  if (peek(c) === ";" || peek(c) === "}") {
+    consume(c, ";");
+    return captureNode(k, CTOR.return_, [captureNode(k, CTOR.none_literal, [])]);
+  }
+  const e = parseExpr(k, c);
+  if (e === null) {
+    consume(c, ";");
+    return captureNode(k, CTOR.return_, [captureNode(k, CTOR.none_literal, [])]);
+  }
+  consume(c, ";");
+  return captureNode(k, CTOR.return_, [e]);
+}
+
+function parseIf(k: Kernel, c: Cursor): NodeID {
+  expect(c, "if");
+  expect(c, "(");
+  const cond = parseExpr(k, c);
+  if (cond === null) throw new SyntaxError(`ts: condition required at ${c.pos}`);
+  expect(c, ")");
+  const thenBranch = parseStmtOrBlock(k, c);
+  const branches: NodeID[] = [cond, thenBranch];
+  skipWS(c);
+  if (peekKeyword(c, "else")) {
+    consumeKeyword(c, "else");
+    skipWS(c);
+    if (peekKeyword(c, "if")) {
+      // else-if chains
+      const elseIf = parseIf(k, c);
+      // Splice: the elseIf is itself a CTOR.if_; flatten its branches.
+      const eiKids = capturedChildren(k, elseIf);
+      for (const x of eiKids) branches.push(x);
+    } else {
+      const elseBranch = parseStmtOrBlock(k, c);
+      branches.push(elseBranch);
+    }
+  }
+  return captureNode(k, CTOR.if_, branches);
+}
+
+// parseStmtOrBlock — accepts either `{ ... }` or a single statement.
+// Single statements get wrapped in CTOR.block of length 1 so downstream
+// code can treat both forms uniformly.
+function parseStmtOrBlock(k: Kernel, c: Cursor): NodeID {
+  skipWS(c);
+  if (peek(c) === "{") return parseBlock(k, c);
+  const s = parseStmt(k, c);
+  if (s === null) throw new SyntaxError(`ts: statement required at ${c.pos}`);
+  return captureNode(k, CTOR.block, [s]);
+}
+
+// parseBinding — `const name = expr;` or `let name = expr;`. Type annotations
+// (`: T`) are parsed-and-ignored (skipped to `=`).
+function parseBinding(k: Kernel, c: Cursor): NodeID {
+  // Already consumed `const` or `let` by caller.
+  skipWS(c);
+  const name = readIdentRaw(c);
+  if (name === null) throw new SyntaxError(`ts: binding name required at ${c.pos}`);
+  skipWS(c);
+  if (peek(c) === ":") {
+    c.pos++;
+    // Skip until `=` (type annotation parse-and-ignore).
+    while (c.pos < c.src.length && peek(c) !== "=" && peek(c) !== ";") c.pos++;
+  }
+  expect(c, "=");
+  const value = parseExpr(k, c);
+  if (value === null) throw new SyntaxError(`ts: expression after '=' at ${c.pos}`);
+  consume(c, ";");
+  const target = captureNode(k, CTOR.ident, [k.internString(name)]);
+  return captureNode(k, CTOR.assign, [target, value]);
+}
+
+// parseFunctionDecl — `function name(args) { body }`. Lowers to CTOR.def_
+// so cross-language identity with Python `def` holds.
+function parseFunctionDecl(k: Kernel, c: Cursor): NodeID {
+  expect(c, "function");
+  skipWS(c);
+  const name = readIdentRaw(c);
+  if (name === null) throw new SyntaxError(`ts: function name required at ${c.pos}`);
+  expect(c, "(");
+  const params: NodeID[] = [];
+  skipWS(c);
+  if (!consume(c, ")")) {
+    while (true) {
+      skipWS(c);
+      const pn = readIdentRaw(c);
+      if (pn === null) break;
+      // optional `: T` annotation
+      skipWS(c);
+      if (peek(c) === ":") {
+        c.pos++;
+        let depth = 0;
+        while (c.pos < c.src.length) {
+          const ch = peek(c);
+          if (depth === 0 && (ch === "," || ch === ")")) break;
+          if (ch === "(" || ch === "<" || ch === "[" || ch === "{") depth++;
+          else if (ch === ")" || ch === ">" || ch === "]" || ch === "}") depth--;
+          c.pos++;
+        }
+      }
+      params.push(captureNode(k, CTOR.param, [k.internString(pn)]));
+      if (!consume(c, ",")) break;
+    }
+    expect(c, ")");
+  }
+  // Optional return-type annotation
+  skipWS(c);
+  if (peek(c) === ":") {
+    c.pos++;
+    while (c.pos < c.src.length && peek(c) !== "{") c.pos++;
+  }
+  const body = parseBlock(k, c);
+  return captureNode(k, CTOR.def_, [
+    captureNode(k, CTOR.ident, [k.internString(name)]),
+    captureNode(k, CTOR.params, params),
+    body,
+  ]);
+}
+
+export function parseStmt(k: Kernel, c: Cursor): NodeID | null {
+  skipWS(c);
+  if (atEnd(c)) return null;
+  // Skip stray semicolons
+  if (consume(c, ";")) return parseStmt(k, c);
+
+  if (peekKeyword(c, "const") || peekKeyword(c, "let") || peekKeyword(c, "var")) {
+    if (peekKeyword(c, "const")) consumeKeyword(c, "const");
+    else if (peekKeyword(c, "let")) consumeKeyword(c, "let");
+    else consumeKeyword(c, "var");
+    return parseBinding(k, c);
+  }
+  if (peekKeyword(c, "if")) return parseIf(k, c);
+  if (peekKeyword(c, "return")) return parseReturn(k, c);
+  if (peekKeyword(c, "function")) return parseFunctionDecl(k, c);
+
+  // Expression statement
+  const e = parseExpr(k, c);
+  if (e === null) return null;
+  consume(c, ";");
+  return captureNode(k, CTOR.expr_stmt, [e]);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level: parseTypeScript — module wrapping the statement sequence.
+// ---------------------------------------------------------------------------
+
+export function parseTypeScript(k: Kernel, source: string): NodeID {
+  const c: Cursor = { src: source, pos: 0 };
+  const stmts: NodeID[] = [];
+  while (true) {
+    skipWS(c);
+    if (atEnd(c)) break;
+    const s = parseStmt(k, c);
+    if (s === null) break;
+    stmts.push(s);
+  }
+  return captureNode(k, CTOR.module, stmts);
+}
+
+// ---------------------------------------------------------------------------
+// evalTypeScript — third-runtime walker for parity.
+//
+// Walks the captured-recipe tree directly (no .fk round-trip, no kernel
+// native binary). Same shape as evalPython since the CTOR vocabulary is
+// shared. Used by `ts-eval` to provide the second sibling-runtime in the
+// three-way parity check (alongside tsc-evaluation and form-kernel-rust
+// on the emitted .fk).
+// ---------------------------------------------------------------------------
+
+interface TsEnv {
+  parent: TsEnv | null;
+  vars: Map<number, Value>;
+}
+
+interface TsClosure {
+  params: number[];
+  body: NodeID;
+  env: TsEnv;
+}
+
+class ReturnSignal {
+  constructor(public value: Value) {}
+}
+
+function newEnv(parent: TsEnv | null = null): TsEnv {
+  return { parent, vars: new Map() };
+}
+
+function envLookup(env: TsEnv, nameID: number): Value | undefined {
+  let e: TsEnv | null = env;
+  while (e !== null) {
+    const v = e.vars.get(nameID);
+    if (v !== undefined) return v;
+    e = e.parent;
+  }
+  return undefined;
+}
+
+function envBind(env: TsEnv, nameID: number, value: Value): void {
+  env.vars.set(nameID, value);
+}
+
+export function evalTypeScript(k: Kernel, tree: NodeID, env?: TsEnv): Value {
+  const E = env ?? newEnv();
+  // Built-in bindings for the eval path.
+  envBind(E, k.internName("true"), { kind: "bool", bool: true });
+  envBind(E, k.internName("false"), { kind: "bool", bool: false });
+  envBind(E, k.internName("null"), { kind: "null" });
+  envBind(E, k.internName("undefined"), { kind: "null" });
+  return evalNode(k, tree, E);
+}
+
+function evalNode(k: Kernel, n: NodeID, env: TsEnv): Value {
+  if (n.level === Level.TRIVIAL) {
+    return trivialToValue(k, n);
+  }
+  const ctor = capturedCtor(k, n);
+  const kids = capturedChildren(k, n);
+  switch (ctor) {
+    case CTOR.module: {
+      let last: Value = { kind: "null" };
+      for (const s of kids) last = evalNode(k, s, env);
+      return last;
+    }
+    case CTOR.expr_stmt:
+      return evalNode(k, kids[0]!, env);
+    case CTOR.int_literal:
+    case CTOR.float_literal:
+      return trivialToValue(k, kids[0]!);
+    case CTOR.bool_literal:
+      return kids.length > 0 ? trivialToValue(k, kids[0]!) : { kind: "bool", bool: false };
+    case CTOR.none_literal:
+      return { kind: "null" };
+    case CTOR.str_literal: {
+      const t = kids[0]!;
+      if (t.level === Level.TRIVIAL && t.type === Triv.STRING) {
+        return { kind: "str", str: k.strs[t.inst] ?? "" };
+      }
+      return { kind: "str", str: "" };
+    }
+    case CTOR.ident: {
+      const nameTriv = kids[0]!;
+      if (nameTriv.level !== Level.TRIVIAL || nameTriv.type !== Triv.STRING) {
+        throw new Error("ident: missing name");
+      }
+      const v = envLookup(env, nameTriv.inst);
+      if (v === undefined) {
+        throw new Error(`ts: unbound name '${k.nameStr(nameTriv.inst)}'`);
+      }
+      return v;
+    }
+    case CTOR.list_literal:
+      return { kind: "list", list: kids.map((c) => evalNode(k, c, env)) };
+    case CTOR.add:
+      return numBinop(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "+");
+    case CTOR.sub:
+      return numBinop(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "-");
+    case CTOR.mul:
+      return numBinop(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "*");
+    case CTOR.div:
+      return numBinop(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "/");
+    case CTOR.mod:
+      return numBinop(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "%");
+    case CTOR.eq:
+      return { kind: "bool", bool: valueEq(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env)) };
+    case CTOR.ne:
+      return { kind: "bool", bool: !valueEq(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env)) };
+    case CTOR.lt: return cmpOp(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "<");
+    case CTOR.le: return cmpOp(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), "<=");
+    case CTOR.gt: return cmpOp(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), ">");
+    case CTOR.ge: return cmpOp(evalNode(k, kids[0]!, env), evalNode(k, kids[1]!, env), ">=");
+    case CTOR.and_: {
+      const a = evalNode(k, kids[0]!, env);
+      if (!truthy(a)) return a;
+      return evalNode(k, kids[1]!, env);
+    }
+    case CTOR.or_: {
+      const a = evalNode(k, kids[0]!, env);
+      if (truthy(a)) return a;
+      return evalNode(k, kids[1]!, env);
+    }
+    case CTOR.not_:
+      return { kind: "bool", bool: !truthy(evalNode(k, kids[0]!, env)) };
+    case CTOR.neg: {
+      const v = evalNode(k, kids[0]!, env);
+      if (v.kind === "int") return { kind: "int", int: -v.int };
+      if (v.kind === "f64") return { kind: "f64", float: -v.float };
+      throw new Error("neg: expected numeric");
+    }
+    case CTOR.if_: {
+      // Ternary form: exactly 3 kids and middle is NOT a block.
+      if (kids.length === 3 && capturedCtor(k, kids[1]!) !== CTOR.block) {
+        const cond = evalNode(k, kids[0]!, env);
+        return truthy(cond) ? evalNode(k, kids[1]!, env) : evalNode(k, kids[2]!, env);
+      }
+      // Statement form: pairs of (cond, body) optionally with trailing else.
+      let i = 0;
+      while (i + 1 < kids.length) {
+        const cond = evalNode(k, kids[i]!, env);
+        if (truthy(cond)) return evalNode(k, kids[i + 1]!, env);
+        i += 2;
+      }
+      if (i < kids.length) return evalNode(k, kids[i]!, env);
+      return { kind: "null" };
+    }
+    case CTOR.block: {
+      let last: Value = { kind: "null" };
+      for (const s of kids) last = evalNode(k, s, env);
+      return last;
+    }
+    case CTOR.return_: {
+      const v = evalNode(k, kids[0]!, env);
+      throw new ReturnSignal(v);
+    }
+    case CTOR.assign: {
+      const target = kids[0]!;
+      const value = evalNode(k, kids[1]!, env);
+      const tCtor = capturedCtor(k, target);
+      if (tCtor !== CTOR.ident) throw new Error(`ts: assign target must be ident (got ${tCtor})`);
+      const nameID = capturedChildren(k, target)[0]!.inst;
+      envBind(env, nameID, value);
+      return { kind: "null" };
+    }
+    case CTOR.def_: {
+      const nameNode = kids[0]!;
+      const params = capturedChildren(k, kids[1]!);
+      const body = kids[2]!;
+      const paramNames = params.map((p) => capturedChildren(k, p)[0]!.inst);
+      const fnNameID = capturedChildren(k, nameNode)[0]!.inst;
+      const closure: TsClosure = { params: paramNames, body, env };
+      envBind(env, fnNameID, { kind: "list", list: [], tsClosure: closure } as Value & { tsClosure?: TsClosure });
+      return { kind: "null" };
+    }
+    case CTOR.lambda_: {
+      const params = capturedChildren(k, kids[0]!);
+      const body = kids[1]!;
+      const paramNames = params.map((p) => capturedChildren(k, p)[0]!.inst);
+      const closure: TsClosure = { params: paramNames, body, env };
+      return { kind: "list", list: [], tsClosure: closure } as Value & { tsClosure?: TsClosure };
+    }
+    case CTOR.call: {
+      const callee = kids[0]!;
+      const argsNode = kids[1]!;
+      const argKids = capturedChildren(k, argsNode);
+      const argVals = argKids.map((a) => evalNode(k, a, env));
+      let calleeVal: Value;
+      if (capturedCtor(k, callee) === CTOR.ident) {
+        const nameID = capturedChildren(k, callee)[0]!.inst;
+        const bound = envLookup(env, nameID);
+        if (bound === undefined) {
+          // Minimal built-in fallback (console.log isn't here; emit-side
+          // doesn't carry side effects through .fk parity anyway).
+          throw new Error(`ts: unbound callable '${k.nameStr(nameID)}'`);
+        }
+        calleeVal = bound;
+      } else {
+        calleeVal = evalNode(k, callee, env);
+      }
+      return invokeClosure(k, calleeVal, argVals);
+    }
+    default:
+      throw new Error(`evalTypeScript: unsupported ctor '${ctor}'`);
+  }
+}
+
+function invokeClosure(k: Kernel, v: Value, args: Value[]): Value {
+  const closure = (v as Value & { tsClosure?: TsClosure }).tsClosure;
+  if (!closure) throw new Error("call: callee is not a TS closure");
+  if (args.length !== closure.params.length) {
+    throw new Error(`call: arity mismatch (expected ${closure.params.length}, got ${args.length})`);
+  }
+  const callEnv = newEnv(closure.env);
+  for (let i = 0; i < closure.params.length; i++) {
+    envBind(callEnv, closure.params[i]!, args[i]!);
+  }
+  try {
+    // Function-body shape: CTOR.block. For lambda expr-body, body is the
+    // expression itself — evaluate and return its value (no implicit
+    // return-signal needed).
+    const bodyCtor = capturedCtor(k, closure.body);
+    if (bodyCtor === CTOR.block) {
+      // Walk statements; if no `return` fires, last expression's value is
+      // not the return — function returns undefined. But for the demos we
+      // exercise, the function always has a return.
+      const stmts = capturedChildren(k, closure.body);
+      for (const s of stmts) evalNode(k, s, callEnv);
+      return { kind: "null" };
+    }
+    // Expression body — value of the expression IS the return value.
+    return evalNode(k, closure.body, callEnv);
+  } catch (e) {
+    if (e instanceof ReturnSignal) return e.value;
+    throw e;
+  }
+}
+
+function trivialToValue(k: Kernel, n: NodeID): Value {
+  if (n.level !== Level.TRIVIAL) throw new Error("trivialToValue: not a trivial");
+  switch (n.type) {
+    case Triv.INT32: {
+      const u = n.inst >>> 0;
+      return { kind: "int", int: u > 0x7fffffff ? u - 0x100000000 : u };
+    }
+    case Triv.INT64: {
+      const i = (k as unknown as { i64s: bigint[] }).i64s[n.inst];
+      if (i === undefined) return { kind: "int", int: 0 };
+      return { kind: "int", int: Number(i) };
+    }
+    case Triv.FLOAT64:
+      return { kind: "f64", float: k.decodeFloat64(n.inst) };
+    case Triv.STRING:
+      return { kind: "str", str: k.strs[n.inst] ?? "" };
+    case Triv.BOOL:
+      return { kind: "bool", bool: n.inst !== 0 };
+    case Triv.NULL:
+      return { kind: "null" };
+    default:
+      throw new Error(`trivialToValue: unknown trivial type ${n.type}`);
+  }
+}
+
+function numBinop(a: Value, b: Value, op: string): Value {
+  if (op === "+") {
+    if (a.kind === "str" || b.kind === "str") {
+      // JS `+` with any string operand coerces both → string concat.
+      return { kind: "str", str: renderForPrint(a) + renderForPrint(b) };
+    }
+    if (a.kind === "list" && b.kind === "list") {
+      return { kind: "list", list: [...a.list, ...b.list] };
+    }
+  }
+  const an = numericOf(a);
+  const bn = numericOf(b);
+  // JS `/` always produces a float; everything else stays int when both
+  // operands are ints (consistent with TypeScript demo expectations
+  // post-`| 0` truncation — but we follow TS / runtime semantics here).
+  const bothInt = an.isInt && bn.isInt && op !== "/";
+  let r: number;
+  switch (op) {
+    case "+": r = an.v + bn.v; break;
+    case "-": r = an.v - bn.v; break;
+    case "*": r = an.v * bn.v; break;
+    case "/": r = an.v / bn.v; break;
+    case "%": r = an.v % bn.v; break;
+    default: throw new Error(`numBinop: ${op}`);
+  }
+  if (bothInt) return { kind: "int", int: r };
+  return { kind: "f64", float: r };
+}
+
+function numericOf(v: Value): { v: number; isInt: boolean } {
+  if (v.kind === "int") return { v: v.int, isInt: true };
+  if (v.kind === "f64") return { v: v.float, isInt: false };
+  if (v.kind === "bool") return { v: v.bool ? 1 : 0, isInt: true };
+  throw new Error(`numeric: unexpected kind ${v.kind}`);
+}
+
+function valueEq(a: Value, b: Value): boolean {
+  if (a.kind === "int" && b.kind === "int") return a.int === b.int;
+  if (a.kind === "f64" && b.kind === "f64") return a.float === b.float;
+  if (a.kind === "int" && b.kind === "f64") return a.int === b.float;
+  if (a.kind === "f64" && b.kind === "int") return a.float === b.int;
+  if (a.kind === "str" && b.kind === "str") return a.str === b.str;
+  if (a.kind === "bool" && b.kind === "bool") return a.bool === b.bool;
+  if (a.kind === "null" && b.kind === "null") return true;
+  return false;
+}
+
+function cmpOp(a: Value, b: Value, op: string): Value {
+  const av = numericOf(a).v;
+  const bv = numericOf(b).v;
+  let r: boolean;
+  switch (op) {
+    case "<": r = av < bv; break;
+    case "<=": r = av <= bv; break;
+    case ">": r = av > bv; break;
+    case ">=": r = av >= bv; break;
+    default: throw new Error(`cmpOp: ${op}`);
+  }
+  return { kind: "bool", bool: r };
+}
+
+function truthy(v: Value): boolean {
+  switch (v.kind) {
+    case "null": return false;
+    case "bool": return v.bool;
+    case "int": return v.int !== 0;
+    case "f64": return v.float !== 0;
+    case "str": return v.str.length > 0;
+    case "list": return v.list.length > 0;
+    default: return true;
+  }
+}
+
+function renderForPrint(v: Value): string {
+  switch (v.kind) {
+    case "null": return "null";
+    case "bool": return v.bool ? "true" : "false";
+    case "int": return String(v.int);
+    case "f64": return String(v.float);
+    case "str": return v.str;
+    case "list": return "[" + v.list.map(renderForPrint).join(", ") + "]";
+    default: return "<value>";
+  }
+}
+
+// Re-export shared utilities Frame/Kernel for the emitter
+export { Frame, Kernel } from "../../../src/kernel.ts";

--- a/form/form-kernel-ts/seedbank/ts-adapter/src/main.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/src/main.ts
@@ -1,0 +1,201 @@
+// ts-adapter CLI — entry point the parity suite invokes.
+//
+// Four subcommands form the three-way parity gate alongside tsc + node:
+//
+//   ts-compile <file.ts> [out.fk|-]  — parse TS, emit .fk source
+//   ts-run     <file.ts>             — compile + execute via Rust binary
+//   ts-eval    <file.ts>             — parse + walk via TS evalTypeScript
+//   ts-trace   <file.ts>             — emit JSON dispatch report
+//
+// Three runtimes for parity:
+//   1. tsc transpile → node runs the JS, captures stdout of final expr
+//   2. ts-eval — our captured-recipe walker (no kernel binary, no .fk)
+//   3. ts-run  — emit .fk + run via form-kernel-rust binary
+// All three must agree on the printed value of the final expression.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { dirname, resolve as pathResolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Frame, Kernel, Trace, walk, type Value } from "../../../src/kernel.ts";
+import { evalTypeScript, parseTypeScript } from "./lang-ts.ts";
+import { emitFk } from "./lang-ts-fk.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error(
+      "usage: tsx src/main.ts (ts-compile <file.ts> [out.fk|-] | ts-run <file.ts> | ts-eval <file.ts> | ts-trace <file.ts>)",
+    );
+    process.exit(2);
+  }
+
+  switch (args[0]) {
+    case "ts-compile":
+      return runTsCompile(args.slice(1));
+    case "ts-run":
+      return runTsRun(args.slice(1));
+    case "ts-eval":
+      return runTsEval(args.slice(1));
+    case "ts-trace":
+      return runTsTrace(args.slice(1));
+    default:
+      console.error(`unknown subcommand: ${args[0]}`);
+      process.exit(2);
+  }
+}
+
+async function runTsCompile(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.error("usage: tsx src/main.ts ts-compile <file.ts> [out.fk|-]");
+    process.exit(2);
+  }
+  const inPath = args[0]!;
+  const outArg = args[1];
+  const src = await readFile(inPath, "utf8");
+
+  const k = new Kernel();
+  const tree = parseTypeScript(k, src);
+  const fk = emitFk(k, tree);
+
+  if (outArg === "-") {
+    process.stdout.write(fk + "\n");
+    return;
+  }
+  const outPath =
+    outArg ??
+    (inPath.endsWith(".ts") ? inPath.slice(0, -3) + ".fk" : inPath + ".fk");
+  await writeFile(outPath, fk + "\n", "utf8");
+  console.error(`ts-adapter: wrote ${outPath} (${fk.length} bytes of .fk)`);
+}
+
+async function runTsRun(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.error("usage: tsx src/main.ts ts-run <file.ts>");
+    process.exit(2);
+  }
+  const inPath = args[0]!;
+  const src = await readFile(inPath, "utf8");
+
+  const k = new Kernel();
+  const tree = parseTypeScript(k, src);
+  const fk = emitFk(k, tree);
+
+  const fkPath = inPath.endsWith(".ts")
+    ? inPath.slice(0, -3) + ".fk"
+    : inPath + ".fk";
+  await writeFile(fkPath, fk + "\n", "utf8");
+
+  const kernelPath = pathResolve(
+    __dirname,
+    "../../../../form-kernel-rust/target/release/form-kernel-rust",
+  );
+
+  const child = spawn(kernelPath, [fkPath], {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  const exitCode = await new Promise<number>((resolveCode) => {
+    child.on("close", (code) => resolveCode(code ?? 1));
+    child.on("error", (err) => {
+      console.error(`ts-run: failed to spawn ${kernelPath}: ${err.message}`);
+      console.error(
+        "build the kernel first: cd ../../../form-kernel-rust && cargo build --release",
+      );
+      resolveCode(127);
+    });
+  });
+  process.exit(exitCode);
+}
+
+async function runTsEval(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.error("usage: tsx src/main.ts ts-eval <file.ts>");
+    process.exit(2);
+  }
+  const src = await readFile(args[0]!, "utf8");
+  const k = new Kernel();
+  const tree = parseTypeScript(k, src);
+  const value = evalTypeScript(k, tree);
+  console.log(renderForParity(value));
+}
+
+async function runTsTrace(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.error("usage: tsx src/main.ts ts-trace <file.ts>");
+    process.exit(2);
+  }
+  const src = await readFile(args[0]!, "utf8");
+  const k = new Kernel();
+  const parseStart = process.hrtime.bigint();
+  const tree = parseTypeScript(k, src);
+  const parseNs = Number(process.hrtime.bigint() - parseStart);
+
+  k.trace = new Trace();
+  const frame = new Frame(null);
+  const evalStart = process.hrtime.bigint();
+  const value = walk(k, tree, frame);
+  const evalNs = Number(process.hrtime.bigint() - evalStart);
+
+  const report = {
+    source_path: args[0],
+    source_bytes: src.length,
+    result: renderForParity(value),
+    parse_us: Math.round(parseNs / 1000),
+    eval_us: Math.round(evalNs / 1000),
+    trace: k.trace.toJSON(),
+  };
+  console.log(JSON.stringify(report, null, 2));
+}
+
+// renderForParity — match the parity-comparison form. The TS demos end
+// with a bare expression; its value is what tsc / node prints when the
+// transpiled JS uses `console.log(<last>)`. Format here matches node's
+// default console output for primitive types.
+function renderForParity(v: Value): string {
+  switch (v.kind) {
+    case "f32":
+    case "f64":
+      return formatFloatJs(v.float);
+    case "int":
+    case "i8":
+    case "i16":
+    case "u8":
+    case "u16":
+    case "u32":
+      return String(v.int);
+    case "i64":
+    case "u64":
+      return String(v.bigint);
+    case "bool":
+      return v.bool ? "true" : "false";
+    case "str":
+      return v.str;
+    case "null":
+      return "null";
+    case "list":
+      return "[ " + v.list.map(renderForParity).join(", ") + " ]";
+    case "closure":
+      return `[Function]`;
+    case "nodeid":
+      return `@${v.nodeid.pkg}.${v.nodeid.level}.${v.nodeid.type}.${v.nodeid.inst}`;
+    case "ctor":
+      return `${v.ctor_name}(${v.args.map(renderForParity).join(", ")})`;
+  }
+}
+
+// JS-style float formatting: integer-valued floats render without
+// trailing `.0` (node prints `1` for the number `1.0`). The kernel's
+// own renderer drops `.0` already; this matches.
+function formatFloatJs(f: number): string {
+  if (Number.isNaN(f)) return "NaN";
+  if (!Number.isFinite(f)) return f > 0 ? "Infinity" : "-Infinity";
+  return String(f);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`ts-adapter: ${msg}`);
+  process.exit(1);
+});

--- a/kernels/PYTHON_PIPELINE_STATUS.md
+++ b/kernels/PYTHON_PIPELINE_STATUS.md
@@ -78,7 +78,7 @@ cd form/form-kernel-ts
 | `python-grammar.form` | core + control-flow | 13/20 |
 | `go-grammar.form` | package + import | 2/13 |
 | `rust-grammar.form` | use declarations | 1/11 |
-| `ts-grammar.form` | pending | 0/? |
+| `ts-grammar.form` | adapter seam landed (TS → .fk → kernel, 3-way parity 5/5); substrate-form grammar pending | 0/? |
 
 Each grammar's `capture_rules` list has `?rule py_X` / `?rule yaml_X` / etc. markers for pending rules. **Count the rules without `?` to see distance from bootstrap to destination.**
 


### PR DESCRIPTION
## What this opens

The **TS-grammar side** of the body's destination — the half PYTHON_PIPELINE_STATUS.md notes as `ts-grammar.form 0/?`. Mirrors the python-adapter structure: TS source → bootstrap parser + emitter → `.fk` text → `form-kernel-rust` walks it → result. Three-way parity gate exactly like Python's.

**5/5 demos three-way green** across node + ts-eval + form-kernel-rust.

## Honest framing — bootstrap, not destination

Urs surfaced this in conversation right before this PR landed: `lang-python.ts` knowing Python is a calcification, not the Form-native destination. The Form-native path is the kernel walking `python-bmf.fk` against source text (Breath 2e — template machinery — currently unlanded).

**This PR thickens the bootstrap on the TypeScript side.** Same shape, same hand-written parser+emitter pattern, same calcification. Adding `lang-ts.ts` next to `lang-python.ts` is the second copy of the smell, not the dissolution of it.

**What this PR also opens that's genuinely Form-native:** The NodeID layer. The recipe `fact(n) → if n ≤ 1 then 1 else n * fact(n-1)` interns to the **same Recipe NodeID** whether emitted from `lang-python-fk.ts` or `lang-ts-fk.ts`. That's the cross-language structural identity the language-cells architecture was waiting on a second sibling to demonstrate. Bootstrap above the NodeID layer; Form-native at and below.

The bootstrap shape is what ships today while Breath 2e (kernel walks `.fk` grammars against source) catches up. Open question for the body: whether to land Breath 2e and compost both `lang-python.ts` and `lang-ts.ts`, or keep thickening the bootstrap until more is known.

## TS shapes working

- Arrow functions: `(x) => x + 1`, `(a, b) => { return ... }`
- `function` declarations with recursion
- `const` / `let` / `var` bindings (with `: T` annotations parse-and-ignore)
- `if` / `else if` / `else` + ternary `c ? a : b`
- Arithmetic `+ - * / %`, unary `-` / `!`
- Comparison `== === != !== < <= > >=`, logic `&& || !`
- Function calls, `return`, number/string/bool/null literals

## Three-way parity proof

```
$ ./scripts/parity_suite.sh
  ✓ examples/ts_demo.ts                → ...
  ✓ examples/ts_arrow_demo.ts          → ...
  ✓ examples/ts_recursion_demo.ts      → ...
  ✓ examples/ts_let_demo.ts            → ...
  ✓ examples/ts_branching_demo.ts      → ...

parity_suite: 5 passing, 0 failing
```

Three runtimes:
- `node` (tsc + node runtime)
- `ts-eval` (hand-written walker — third runtime for parity)
- `form-kernel-rust` (via `.fk` compile)

All agree.

## Files touched

- `form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts.ts` — parser + ts-eval walker
- `form/form-kernel-ts/seedbank/ts-adapter/src/lang-ts-fk.ts` — `.fk` emitter
- `form/form-kernel-ts/seedbank/ts-adapter/src/main.ts` — CLI (`ts-compile`, `ts-run`, `ts-eval`, `ts-trace`)
- `form/form-kernel-ts/seedbank/ts-adapter/scripts/parity_suite.sh`
- `form/form-kernel-ts/seedbank/ts-adapter/README.md`
- 5 demo files under `seedbank/ts-adapter/examples/`
- `kernels/PYTHON_PIPELINE_STATUS.md` — ts-grammar row updated

## Honest pending — explicit, each its own breath

- Classes, interfaces, generics
- Modules / `import` / `export`
- `async` / `await`
- JSX (the React client-side story)
- Destructuring, template literal `${}`, spread, regex
- `switch`, `try`/`catch`, optional chaining
- `for` / `while` loops
- Method calls, property access (the chained kind, beyond simple subscript)

## Test plan

- [x] `./scripts/parity_suite.sh` — 5/5 three-way green
- [x] Demos exercise the full feature set listed above
- [x] No existing python-adapter demo regressed (sibling parity preserved)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_