### PR TITLE
walk: wellness senses lifecycle motion, not just weight

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -826,6 +826,32 @@ def sense_bootstrap_compost() -> list[str]:
             f"    · Phase {phase} ({label}): {present} files, {loc} LOC{composted}"
         )
 
+    # Lifecycle motion — count rows that have walked from tissue → PROVEN →
+    # COMPOST READY → RELEASED. The body senses not just load but movement-
+    # through-load. A row appears under each heading when a sibling PR proves
+    # parity for a shape; the count grows as the discipline is practiced.
+    manifest_text = manifest.read_text(encoding="utf-8")
+    sections = {
+        "PROVEN": 0,
+        "COMPOST READY": 0,
+        "RELEASED": 0,
+    }
+    # Each section's data rows match `| YYYY-MM-DD |` at the start.
+    # The heading is `## PROVEN` (etc); we scan rows between headings.
+    current_section: str | None = None
+    for raw in manifest_text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("## "):
+            heading = stripped[3:].split(" — ", 1)[0].strip()
+            current_section = heading if heading in sections else None
+            continue
+        if current_section and re.match(r"^\|\s*\d{4}-\d{2}-\d{2}\s*\|", raw):
+            sections[current_section] += 1
+    lifecycle_summary = ", ".join(
+        f"{name.lower()}: {count}" for name, count in sections.items()
+    )
+    lines.append(f"  lifecycle motion — {lifecycle_summary}")
+
     # Third-runtime selector — read the default out of the parity script.
     # Today: ts-eval (bootstrap). Destination: kernel-bmf (Form-native).
     parity = ROOT / "form" / "form-kernel-ts" / "seedbank" / "python-adapter" / "scripts" / "parity_suite.sh"


### PR DESCRIPTION
## Walking step — wellness senses motion, not just weight

Today `sense_bootstrap_compost` surfaces **bootstrap weight** (11,156 LOC of tissue across 17 files). It doesn't yet surface **lifecycle motion** — how many rows have walked from `tissue → PROVEN → COMPOST READY → RELEASED`. This PR extends the probe so the body sees both: load AND movement-through-load.

Composes cleanly with **#2073** (which adds the first PROVEN row). Order of merge doesn't matter — different files, no conflict.

## Probe output before / after

**Before:**
```
  bootstrap weight — 17 files still tissue, 11156 LOC remaining
    · Phase A (parsers + emitters): 7 files, 7034 LOC
    · Phase B (CLIs + scripts): 5 files, 794 LOC
    · Phase C (Python bridge + runtime): 5 files, 3328 LOC
  third runtime default: ts-eval (TS bootstrap) — flip to kernel-bmf …
```

**After (today, on main):**
```
  bootstrap weight — 17 files still tissue, 11156 LOC remaining
    · Phase A (parsers + emitters): 7 files, 7034 LOC
    · Phase B (CLIs + scripts): 5 files, 794 LOC
    · Phase C (Python bridge + runtime): 5 files, 3328 LOC
  lifecycle motion — proven: 0, compost ready: 0, released: 0
  third runtime default: ts-eval (TS bootstrap) — flip to kernel-bmf …
```

**After (once #2073 also merges):**
```
  …
  lifecycle motion — proven: 1, compost ready: 0, released: 0
  …
```

The number rises as the discipline is practiced. When `proven` covers a whole Phase-A file's surface, its row moves to `compost ready`; when the file composts, it moves to `released` and the LOC weight drops. **The body's awareness now includes its own walking pace.**

## What the probe reads

Each section heading (`## PROVEN`, `## COMPOST READY`, `## RELEASED`) under `kernels/BOOTSTRAP_COMPOST_MANIFEST.md` carries data rows starting with `| YYYY-MM-DD |`. The probe counts those rows per section. No new conventions; just sensing what's already named.

## Files touched

- `scripts/wellness_check.py` — `sense_bootstrap_compost` extended with lifecycle-motion section

## Test plan

- [x] Probe runs cleanly with manifest in current state (`proven: 0` on main)
- [x] Probe runs cleanly with manifest containing #2073's first PROVEN row (`proven: 1`)
- [x] No existing wellness output regressed
- [ ] After #2073 + this PR merge: `python3 scripts/wellness_check.py` shows `lifecycle motion — proven: 1`

## In one sentence

The body now sees not just its load but its walking pace, named in the same units the discipline uses.

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_