### PR TITLE
walk: PYTHON_PIPELINE_STATUS reflects current breath — bullet-by-bullet + motion

### DIFF
--- a/kernels/PYTHON_PIPELINE_STATUS.md
+++ b/kernels/PYTHON_PIPELINE_STATUS.md
@@ -8,6 +8,28 @@
 
 This document is the honest map of distance covered and distance remaining. Updated each ripening breath.
 
+## Where each bullet stands today (2026-05-27)
+
+A bullet-by-bullet read of the four-bullet destination, with the live artifact each one points at:
+
+1. **ALL Python talking to substrate → native Form.** *In motion.* Three FastAPI utility endpoints (`/api/utils/coherence_weight`, `nodeid_distance`, `weighted_average`) carry their bodies as Form recipes via `serve_via_kernel`; the first substrate-touching endpoint (`/api/substrate/lattice/stats`) reads through kernel-native `http_get` + `_json_to_dict`. The kernel even serves HTTP directly (proof-of-shape `form-kernel-rust serve`). PyO3 inline removes the subprocess seam — kernel calls run sub-millisecond in the API process address space. Substrate-write transmutation is the next major arc.
+
+2. **ALL file types parseable via Form-native BMF grammars.** *First cell sprouted.* Python arithmetic shapes (`a-b`, `x*y`, `l/r`, `p**q`) parse through `form-stdlib/grammars/python-bmf.fk` driven by the kernel — sibling-validated on Go, Rust, TypeScript (131/131 in `./validate.sh`). The remaining gap is named in [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — G1 (rule dispatcher), G2 (statement grouping), G3 (precedence), G4 (closure interpreter), G5 (template-machinery overlap).
+
+3. **Compile any file → Form-recipe binary the kernel CLI runs standalone.** *Routine for the demo set.* Every demo in `parity_suite.sh` (16 entries) compiles to `.fk` and runs through `form-kernel-rust` standalone. The bootstrap emit path (`lang-python-fk.ts`) is named for compost in [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md); the Form-native emitter is the second half of bullet 2.
+
+4. **Framebuffer-driven optimization → same OOM as Python.** *Met and exceeded.* `form-kernel-rust` is 1.8× faster than CPython on the recursion workload (24.08ms vs 41.79ms per iter). Width-tagged trace dispatch is named as a separate breath.
+
+## Lifecycle in motion
+
+The body's bootstrap-vs-Form-native migration is no longer a future-tense convention. The discipline lives:
+
+- **Bootstrap weight** is measured on every wellness check: today 17 files of tissue, 11,156 LOC remaining. [`sense_bootstrap_compost`](../scripts/wellness_check.py) reads the manifest's file list.
+- **Lifecycle motion** is counted on every wellness check: rows that have walked from `tissue → PROVEN → COMPOST READY → RELEASED`. The first PROVEN row landed via #2073; the probe's lifecycle-motion line was added in #2074. Future Form-native parity proofs append rows; when a Phase-A file's surface is fully covered, its row moves to COMPOST READY; when the file composts, its LOC drops out of the weight measurement.
+- **Parity-gate seam** lives in `seedbank/python-adapter/scripts/parity_suite.sh` — `PARITY_THIRD_RUNTIME=kernel-bmf` flips the third runtime from the TS bootstrap to the Form-native walker, one demo at a time. No flag day; the migration is the verification.
+
+The body senses both **what it's carrying** and **how much it has walked**. In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).
+
 ## The pipeline that runs today (verified)
 
 ```


### PR DESCRIPTION
## Walking step — status doc reflects current breath

The four-bullet destination map (Urs 2026-05-21) was honest at the top of `kernels/PYTHON_PIPELINE_STATUS.md` but the doc didn't synthesize **where each bullet stands today**. It described the bootstrap pipeline as if that were "the pipeline that runs," when the Form-native pipeline is also live for one shape and the bootstrap is named for compost.

A fresh visitor (next session, next contributor, next agent) should land on a truthful map of where we are — not a bootstrap-shaped map three days behind the body.

## What this adds

Two new sections near the top of the status doc:

### 1. "Where each bullet stands today (2026-05-27)"

Bullet-by-bullet read with live artifact for each:

- **Bullet 1** (Python → native Form): *in motion* — three utility endpoints + one substrate-touching endpoint transmuted, kernel serves HTTP directly, PyO3 inline removes subprocess seam
- **Bullet 2** (Form-native BMF grammars): *first cell sprouted* — Python arithmetic shapes parse through `python-bmf.fk` on three sibling kernels; G1-G5 gaps named in [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md)
- **Bullet 3** (compile-any-file → kernel binary): *routine for the demo set* — 16 demos compile and run standalone; bootstrap emit path named for compost
- **Bullet 4** (framebuffer-driven optimization): *met and exceeded* — 1.8× faster than CPython on recursion

### 2. "Lifecycle in motion"

Names the manifest, the wellness probe's load + motion senses, the parity-gate seam:

- **Bootstrap weight** measured on every wellness check — 17 files / 11,156 LOC today
- **Lifecycle motion** counted on every wellness check — first PROVEN row landed via #2073, probe line added in #2074
- **Parity-gate seam** — `PARITY_THIRD_RUNTIME=kernel-bmf` flips one demo at a time

A reader walks from destination to discipline-in-motion in one read.

## Files touched

- `kernels/PYTHON_PIPELINE_STATUS.md` — two new sections near the top (~22 lines)

## Test plan

- [x] Markdown renders cleanly
- [x] Every cross-reference target exists (`PYTHON_BMF_CONTRACT.md`, `BOOTSTRAP_COMPOST_MANIFEST.md`, `sense_bootstrap_compost`, `lc-the-kernel-knows-itself`, the parity script)
- [x] Doesn't conflict with existing prose; the four-bullet destination at the top stays unchanged

## In one sentence

The status doc now reflects the body's current breath — bullet-by-bullet, in motion, with discipline visible at every wellness check.

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_