### PR TITLE
walk: weave cross-modal companions into the status doc

### DIFF
--- a/kernels/PYTHON_PIPELINE_STATUS.md
+++ b/kernels/PYTHON_PIPELINE_STATUS.md
@@ -223,12 +223,27 @@ We are not there yet. We are demonstrably walking toward it, one breath at a tim
 
 ## Companion docs
 
-- [`lc-parser-as-form-recipe.md`](../docs/vision-kb/concepts/lc-parser-as-form-recipe.md) — the parser-self-hosting arc
-- [`lc-form-kernel-runtime-visualizer.md`](../docs/vision-kb/concepts/lc-form-kernel-runtime-visualizer.md) — the Python → kernel → framebuffer synthesis
-- [`lc-the-kernel-knows-itself.md`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — grammar as self-mirror
-- [`lc-native-kernel-binary.md`](../docs/vision-kb/concepts/lc-native-kernel-binary.md) — the kernel as a distributable Mach-O binary
-- [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md) — every bootstrap file named with its compost gate; parity_suite's runtime selector + wellness sensor read it
-- [`README.md`](README.md) — the public profile
+The Python→Form→native-kernel arc is one organ of a larger body. The body's
+highest goal — *universal translator across any media type, recipe
+orchestration in pure numeric space, content-addressing carrying meaning
+across modalities* — lives in these teachings:
+
+- [`lc-grammar-is-the-universal-recipe.md`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) — every structured input is a (parse, emit) pair in the substrate. Code, data, prose, audio, image, video — same bridge.
+- [`lc-cross-modal-unity.md`](../docs/vision-kb/concepts/lc-cross-modal-unity.md) — one shape speaks in many tongues; cross-modal content-addressing via Form NodeIDs. Same semantic shape in text, image, audio → same NodeID.
+- [`lc-the-kernel-knows-itself.md`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — grammar as self-mirror. Each kernel implementation reads itself through its own host-language BMF grammar.
+- [`lc-parser-as-form-recipe.md`](../docs/vision-kb/concepts/lc-parser-as-form-recipe.md) — the parser-self-hosting arc.
+- [`lc-form-kernel-runtime-visualizer.md`](../docs/vision-kb/concepts/lc-form-kernel-runtime-visualizer.md) — the Python → kernel → framebuffer synthesis.
+- [`lc-native-kernel-binary.md`](../docs/vision-kb/concepts/lc-native-kernel-binary.md) — the kernel as a distributable Mach-O binary.
+
+The first three carry the destination most directly. The Python pipeline this
+doc tracks is one instance of the universal pattern they name.
+
+Discipline docs that practice these teachings:
+
+- [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md) — every bootstrap file named with its compost gate; parity_suite's runtime selector + wellness sensor read it.
+- [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — the G1–G6 gaps between today's reach and full Form-native Python.
+- [`PHASE_A_FIRING_QUESTIONS.md`](PHASE_A_FIRING_QUESTIONS.md) — per-file honest reads of what each bootstrap file carries vs. what's already replaced.
+- [`README.md`](README.md) — the public profile.
 
 ## kernels/python_bmf — the Form→native-Python emitter arc
 


### PR DESCRIPTION
## Walking step — discipline-ops + teaching layers weave

The body already carries the three teachings that name the new highest goal — `lc-grammar-is-the-universal-recipe` (2026-05-21) and `lc-cross-modal-unity` (2026-05-24) both predate this session by days. But the discipline-ops chain (`PYTHON_PIPELINE_STATUS` → `BOOTSTRAP_COMPOST_MANIFEST` → `PYTHON_BMF_CONTRACT` → `PHASE_A_FIRING_QUESTIONS`) only referenced `lc-the-kernel-knows-itself`.

Future sessions reading the discipline-ops would land on the code-teaching but miss the cross-modal extension. This PR weaves the bridge.

## What this carries

`kernels/PYTHON_PIPELINE_STATUS.md` Companion docs section now:

1. **Leads with the three teachings that carry the destination** (universal recipe, cross-modal unity, kernel-knows-itself), in order of breadth
2. **Names the Python pipeline as one instance** of the universal pattern those teachings carry
3. **Separates discipline docs** (manifest, contract, firing questions) from teaching concepts — both are real, both visible, neither confused for the other

## In one sentence

The body's teaching layer + discipline-ops layer + code now share one visible bridge. Future sessions read the destination, not just the pipeline tracking it.

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) + [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) + [`lc-cross-modal-unity`](../docs/vision-kb/concepts/lc-cross-modal-unity.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_