### PR TITLE
walk: wellness probe sees the wider perimeter — closes the audit's 75% undercount

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -813,7 +813,7 @@ def sense_bootstrap_compost() -> list[str]:
     grand_files = sum(t[0] for t in totals.values())
     lines.append(
         f"  bootstrap weight — {grand_files} files still tissue, "
-        f"{grand_loc} LOC remaining"
+        f"{grand_loc} LOC remaining (named in manifest)"
     )
     for phase, (present, absent, loc) in totals.items():
         label = {
@@ -824,6 +824,37 @@ def sense_bootstrap_compost() -> list[str]:
         composted = f"; {absent} already composted" if absent else ""
         lines.append(
             f"    · Phase {phase} ({label}): {present} files, {loc} LOC{composted}"
+        )
+
+    # Wider perimeter — the substrate-Python directory carries more than
+    # the manifest's Phase C names. The audit at
+    # kernels/UNIVERSAL_TRANSLATOR_AUDIT.md found 16,309 LOC across 24
+    # modules in api/app/services/substrate/, of which the manifest names
+    # ~2,938 (form_runtime + self_host + form_rules + form_builders).
+    # Surfacing the gap so the body sees its TRUE bootstrap weight,
+    # not just the named subset. Each unnamed module is a future row
+    # in the manifest waiting for its firing-question walk.
+    substrate_dir = ROOT / "api" / "app" / "services" / "substrate"
+    if substrate_dir.is_dir():
+        substrate_files = sorted(substrate_dir.glob("*.py"))
+        substrate_loc = 0
+        for p in substrate_files:
+            try:
+                substrate_loc += sum(1 for _ in p.open("rb"))
+            except OSError:
+                pass
+        # Manifest Phase C subset already counted in totals['C']
+        named_c_loc = totals.get("C", (0, 0, 0))[2]
+        unnamed = substrate_loc - named_c_loc
+        unnamed_files = len(substrate_files) - totals.get("C", (0, 0, 0))[0]
+        lines.append(
+            f"  wider perimeter — api/app/services/substrate/ has "
+            f"{len(substrate_files)} modules, {substrate_loc} LOC total"
+        )
+        lines.append(
+            f"    · manifest names {totals.get('C', (0, 0, 0))[0]} files / "
+            f"{named_c_loc} LOC; the remaining {unnamed_files} files / "
+            f"{unnamed} LOC are unnamed bootstrap awaiting firing-questions"
         )
 
     # Lifecycle motion — count rows that have walked from tissue → PROVEN →


### PR DESCRIPTION
## Walking step — wellness probe sees the wider perimeter

The audit (#2083) found `api/app/services/substrate/` holds **16,309 LOC across 24 modules**; the manifest's Phase C names ~2,938. The wellness probe was undercounting the real bootstrap weight by ~75%.

This PR extends `sense_bootstrap_compost` to surface both numbers honestly.

## Live output (after this PR)

```
bootstrap weight — 17 files still tissue, 11156 LOC remaining (named in manifest)
  · Phase A (parsers + emitters): 7 files, 7034 LOC
  · Phase B (CLIs + scripts): 5 files, 794 LOC
  · Phase C (Python bridge + runtime): 5 files, 3328 LOC
wider perimeter — api/app/services/substrate/ has 30 modules, 16362 LOC total
  · manifest names 5 files / 3328 LOC; the remaining 25 files / 13034 LOC are unnamed bootstrap awaiting firing-questions
lifecycle motion — proven: 1, compost ready: 0, released: 0
```

The probe now tells the truth: 30 modules in the substrate-Python perimeter, 25 of which aren't in the manifest yet. Each is a firing-question waiting to be walked.

## What this opens

The body's awareness of its own bootstrap weight becomes honest. Future PRs that thicken `api/app/services/substrate/` will see the wider-perimeter number rise. The compost work has 25 more files to walk than the manifest currently shows; each walking step (one firing-question per file, per the `PHASE_A_FIRING_QUESTIONS.md` discipline) brings one row into the manifest.

## Files touched

- `scripts/wellness_check.py` — adds wider-perimeter measurement to `sense_bootstrap_compost`

## Test plan

- [x] `python3 scripts/wellness_check.py` shows both numbers cleanly
- [x] No regression in other wellness sections

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_