### PR TITLE
walk: G6 orchestration closed + fixes 2 main-blocking regressions

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -1554,6 +1554,7 @@ impl Kernel {
                 a.bind(frame, *p, call_args[i].clone());
             }
             walk(k, a, cl.body, frame)
+        });
         // --- Dict natives ---------------------------------------------------
         // Dicts are first-class but ride on Value::List with a "__dict__"
         // tag in slot 0, followed by alternating key/value pairs:
@@ -1880,6 +1881,9 @@ impl Kernel {
                     }
                 }
                 i += 2;
+            }
+            Value::List(out)
+        });
         // --- Substrate read primitives — kernel reaches the REST surface ----
         // The body's substrate lives behind /api/substrate/*. Until now the
         // kernel could compute over data it was handed but could not pull

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# kernel-bmf-run — Form-native Python entry point.
+#
+# Closes G6 of kernels/PYTHON_BMF_CONTRACT.md: the orchestration breath
+# between surface-syntax preludes (python-bmf.fk and friends) and the
+# standalone kernel binary that reads S-expression artifacts.
+#
+# Interface (per parity_suite.sh):
+#   kernel-bmf-run <file.py>  → prints the final expression's value to stdout
+#
+# What this script does:
+#   1. Pre-compile the surface-syntax preludes (json.fk, cache.fk,
+#      form-ontology-loader.fk, engine.fk, compiler.fk, source-compiler.fk,
+#      grammars/python-bmf.fk) using the Go kernel as a compiler. This is
+#      the same dance form/validate.sh's prepare_sources() runs — it
+#      detects `section [...]` syntax and lowers each file to a kernel-
+#      readable S-expression artifact via form-source-compile-file.
+#   2. Emit a driver .fk that calls (python-parse-module-file <path>) and
+#      reports a value derived from the parsed module.
+#   3. Invoke the Rust kernel against (compiled preludes + driver), printing
+#      the kernel's final value.
+#
+# What this script does NOT do (yet — honest pending):
+#   - Walk PY-BMF-* recipes back to Python runtime values. The grammar at
+#     form-stdlib/grammars/python-bmf.fk parses Python into PY-BMF-CALL /
+#     PY-BMF-IF / PY-BMF-ASSIGN / PY-BMF-DEF recipes, but the closure-
+#     scoping interpreter that walks those recipes to a value (G4 from
+#     PYTHON_BMF_CONTRACT.md) is the next breath. Until G4 lands, the
+#     value this script reports is the parsed-module statement count, NOT
+#     the program's CPython result.
+#
+# So `kernel-bmf-run examples/python_demo.py` prints the count of top-
+# level statements (≠ 40949). The three-way parity gate against CPython's
+# program value reaches green when G4 (and G3 precedence climbing) ship.
+# `PARITY_THIRD_RUNTIME=kernel-bmf scripts/parity_suite.sh` will name
+# every demo as "diverges from CPython, gated on G3+G4" until then —
+# honest red, not faked green.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: kernel-bmf-run <file.py>" >&2
+    exit 2
+fi
+
+target_py="$1"
+if [[ ! -f "$target_py" ]]; then
+    echo "kernel-bmf-run: file not found: $target_py" >&2
+    exit 2
+fi
+
+# Resolve target_py to an absolute path so the driver works regardless of
+# where the kernel runs from.
+target_py_abs="$(cd "$(dirname "$target_py")" && pwd)/$(basename "$target_py")"
+
+# Locate the form/ directory — siblings live as form/form-kernel-{go,rust}.
+# This script lives at form/form-kernel-ts/seedbank/python-adapter/scripts/.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FORM_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+GO_BIN="$FORM_DIR/form-kernel-go/bin-go"
+RS_BIN="$FORM_DIR/form-kernel-rust/target/release/form-kernel-rust"
+
+if [[ ! -x "$GO_BIN" ]]; then
+    echo "kernel-bmf-run: go kernel not built at $GO_BIN" >&2
+    echo "  build it: (cd $FORM_DIR/form-kernel-go && go build -o bin-go .)" >&2
+    exit 2
+fi
+if [[ ! -x "$RS_BIN" ]]; then
+    echo "kernel-bmf-run: rust kernel not built at $RS_BIN" >&2
+    echo "  build it: (cd $FORM_DIR/form-kernel-rust && cargo build --release)" >&2
+    exit 2
+fi
+
+# Preludes the parse path needs. Order matters: core, json, cache, ontology
+# loader, engine, compiler, source-compiler, then the python grammar. This
+# mirrors the workload in PYTHON_BMF_CONTRACT.md's "How to run the proof".
+PRELUDES=(
+    "form-stdlib/core.fk"
+    "form-stdlib/json.fk"
+    "form-stdlib/cache.fk"
+    "form-stdlib/form-ontology-loader.fk"
+    "form-stdlib/engine.fk"
+    "form-stdlib/compiler.fk"
+    "form-stdlib/source-compiler.fk"
+    "form-stdlib/grammars/python-bmf.fk"
+)
+
+# Working directory for compiled artifacts. cleanup() removes it on any exit.
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/kernel-bmf.XXXXXX")"
+cleanup() { rm -rf "$work_dir"; }
+trap cleanup EXIT
+
+# prepare_sources — mirrors form/validate.sh prepare_sources(). For any
+# prelude that uses surface syntax (lines starting with `section [`),
+# compile it through the Go kernel via form-source-compile-file. Files
+# that are already S-expression syntax pass through unchanged.
+cd "$FORM_DIR"
+prepared=()
+for src in "${PRELUDES[@]}"; do
+    if grep -Eq '^[[:space:]]*section \[' "$src" 2>/dev/null; then
+        safe="${src//\//__}"
+        out="$work_dir/$safe"
+        driver="$work_dir/compile-${safe}.fk"
+        printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
+        "$GO_BIN" \
+            "form-stdlib/json.fk" "form-stdlib/cache.fk" \
+            "form-stdlib/form-ontology-loader.fk" \
+            "form-stdlib/source-compiler.fk" \
+            "$driver" >/dev/null
+        prepared+=("$out")
+    else
+        prepared+=("$src")
+    fi
+done
+
+# Emit the driver. Until G4 (closure-walking interpreter for PY-BMF-*
+# recipes) lands, the honest report from a Form-native kernel pass over a
+# .py file is the parsed-module statement count. When G4 lands, this
+# driver swaps to walk the recipe tree to its program value, and the
+# parity gate goes green at the actual CPython output.
+driver="$work_dir/kernel-bmf-driver.fk"
+cat > "$driver" <<DRIVER_EOF
+(do
+    (let module (python-parse-module-file "$target_py_abs"))
+    (let statements (python-module-statements module))
+    (len statements))
+DRIVER_EOF
+
+# Run the Rust kernel over the prepared preludes + driver.
+"$RS_BIN" "${prepared[@]}" "$driver"

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
@@ -76,6 +76,13 @@ fi
 # `src/main.ts` path the README documents stays honest.
 cd "$ADAPTER_DIR"
 
+# Put this script's own directory on PATH so `command -v kernel-bmf-run`
+# finds the sibling binary without operator-side installation. The
+# kernel-bmf-run script lives next to this one when G6 of
+# kernels/PYTHON_BMF_CONTRACT.md is closed.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATH="$SCRIPT_DIR:$PATH"
+
 # Resolve the third-runtime invoker. The interface is:
 #   third_runtime_run <file.py>  →  prints the final expression's value to stdout
 #

--- a/form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts
+++ b/form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts
@@ -1077,14 +1077,16 @@ function parseStmt(k: Kernel, c: Cursor, blockIndent: number): NodeID | null {
     c.src.charCodeAt(c.pos) === 61 /* = */ &&
     c.src.charCodeAt(c.pos + 1) !== 61 /* not == */
   ) {
-    // Confirm LHS is a target Python permits (IDENT or ATTR for v1).
+    // Confirm LHS is a target Python permits.
+    // CTOR.ident → plain `x = expr`. CTOR.attr → `obj.x = expr`.
+    // CTOR.subscript → `d[k] = v` (dict / list mutation; emitFk lowers via
+    // _dict_set so dicts are immutable-updated). Other targets remain pending.
     const lhsCtor = capturedCtor(k, e);
-    if (lhsCtor === CTOR.ident || lhsCtor === CTOR.attr) {
-    const lhsCtor = capturedCtor(k, e);
-    // CTOR.ident → plain `x = expr`. CTOR.subscript → `d[k] = v`
-    // (dict / list mutation; emitFk lowers via _dict_set so dicts are
-    // immutable-updated). Other targets remain pending.
-    if (lhsCtor === CTOR.ident || lhsCtor === CTOR.subscript) {
+    if (
+      lhsCtor === CTOR.ident ||
+      lhsCtor === CTOR.attr ||
+      lhsCtor === CTOR.subscript
+    ) {
       c.pos++; // skip `=`
       skipSpacesAndComments(c);
       const value = parseExpr(k, c);
@@ -1094,11 +1096,9 @@ function parseStmt(k: Kernel, c: Cursor, blockIndent: number): NodeID | null {
       consumeEndOfLine(c);
       return captureNode(k, CTOR.assign, [e, value]);
     }
-    // Subscript target — not yet supported as an assignment LHS.
+    // Unsupported assignment target.
     throw new SyntaxError(
-      `python: assignment target must be a name or attribute (v1) at ${savedPos}`,
-    throw new SyntaxError(
-      `python: assignment target must be a name or subscript (v1) at ${savedPos}`,
+      `python: assignment target must be a name, attribute, or subscript (v1) at ${savedPos}`,
     );
   }
   consumeEndOfLine(c);
@@ -2160,9 +2160,6 @@ function evalNode(k: Kernel, n: NodeID, env: PyEnv): Value {
         const field = k.nameStr(fieldID);
         recordPut(recv, field, value);
         return { kind: "null" };
-      }
-      throw new Error(
-        `python: assignment target must be a name or attribute (got ${targetCtor})`,
       }
       if (targetCtor === CTOR.subscript) {
         const subKids = capturedChildren(k, target);

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -254,13 +254,25 @@ ritual.
 | Date | PR | Shape proved | Selector | Sibling parity |
 |---|---|---|---|---|
 | 2026-05-27 | [#2071](https://github.com/seeker71/Coherence-Network/pull/2071) | Python arithmetic binary ops (`a - b`, `x * y`, `left / right`, `p ** q`) | `form/form-stdlib/tests/python-bmf-arithmetic-band.fk` returns `25304` | Go ✓ · Rust ✓ · TypeScript ✓ (131/131 in `./validate.sh`) |
+| 2026-05-27 | `claude/g6-kernel-bmf-run` | G6 — binary entry-point orchestration. `kernel-bmf-run <file.py>` exists, pre-compiles surface-syntax preludes via the Go-kernel-as-compiler, invokes the Rust kernel with a `python-parse-module-file` driver. The `command -v kernel-bmf-run` gate in `parity_suite.sh` opens — `PARITY_THIRD_RUNTIME=kernel-bmf` is runnable end-to-end | `form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run examples/python_demo.py` returns `15` (top-level statement count from `python-parse-module-file`) | Go ✓ · Rust ✓ · TypeScript ✓ (same `len-of-statements` driver run through `./validate.sh` returns `15` on all three) |
+
+**What G6 closes and what stays open.** G6 was the orchestration gap — the
+pieces existed (Go compiler, Rust walker, Python BMF grammar) with no binary
+on PATH to drive them together. That gap closes: `kernel-bmf-run` is the
+walking shape. What G6 does NOT close: the parsed PY-BMF-* recipes are not
+yet walked back to Python runtime values, so `kernel-bmf-run python_demo.py`
+returns the statement count (15), not the program's CPython value (40949).
+The driver swaps to a recipe-walking expression in the same script when G4
+(closure interpreter) lands; the orchestration shape stays.
 
 **Open contract for the next PROVEN rows:** `kernels/PYTHON_BMF_CONTRACT.md`
 G1 (automatic rule dispatcher) unlocks composition of these arithmetic rules
 into full expressions; G2 (statement grouping) unlocks `def` / `if` /
 `return`; G3 (precedence climbing) makes `1 + 2 * 3` parse correctly; G4
 (closure interpreter) is the gate that lets PROVEN rows progress to
-**COMPOST READY** for the matching Phase-A file.
+**COMPOST READY** for the matching Phase-A file. With G6 closed, every
+future G1–G4 increment is testable through `kernel-bmf-run` — no further
+orchestration breath is needed.
 
 **The first walking step:** with this row recorded, the manifest's lifecycle
 is no longer a future-tense convention. It has its first arrival. Every

--- a/kernels/PYTHON_BMF_CONTRACT.md
+++ b/kernels/PYTHON_BMF_CONTRACT.md
@@ -118,28 +118,39 @@ load-bearing proof in `form-stdlib/tests/grammar-chars-demo.fk` parses
 
 G1's dispatcher can now be written. G5 is no longer a blocker.
 
-### G6 — Binary entry-point orchestration — *next concrete gap*
+### G6 — Binary entry-point orchestration — **CLOSED 2026-05-27**
 
-Surfaced 2026-05-27 while trying to wire `PARITY_THIRD_RUNTIME=kernel-bmf`
-end-to-end via the existing pieces. The finding:
+Closure shape: **wrapper script** (the first of the three reachable shapes
+named below). Lives at
+`form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run`.
+The script pre-compiles each surface-syntax prelude through the Go kernel
+(`form-source-compile-file`), then invokes the Rust kernel with the
+compiled artifacts plus an inline driver that calls
+`python-parse-module-file` against the target `.py`.
 
-- `python-bmf.fk` uses surface syntax (`def`, `if`, `then`, `else`, ...)
-- The Rust + TS + Go kernel binaries read **S-expression syntax only**
-- `validate.sh` handles this via `prepare_sources()` — it detects surface
-  syntax (`section [...]`) and pre-compiles each file through the
-  Go-kernel-as-compiler invoking `form-source-compile-file`. The resulting
-  S-expression artifact is what the kernel binaries actually walk.
+`parity_suite.sh` puts its own `scripts/` directory on `PATH` before the
+`command -v kernel-bmf-run` check, so `PARITY_THIRD_RUNTIME=kernel-bmf
+bash parity_suite.sh` runs end-to-end with no operator-side install.
 
-`kernel-bmf-run` doesn't exist today because there's a compile-step gap
-between surface-syntax `.fk` files (like `python-bmf.fk`) and the
-standalone kernel binary. The pieces exist; they need orchestration.
+What the driver computes today: the count of top-level statements in the
+parsed module (e.g. `15` for `examples/python_demo.py`). Three-way sibling
+parity holds at the structural-attestation layer — Go, Rust, and the TS
+kernel all return `15`. This is the **orchestration breath**, not the
+program-value breath; the latter is gated on G3 + G4.
 
-**Three reachable shapes for closing G6:**
+What the driver does NOT compute yet: the program's CPython runtime value
+(`40949` for `python_demo.py`). The walker over `PY-BMF-CALL` /
+`PY-BMF-IF` / `PY-BMF-DEF` recipes back to a Python-shaped runtime is the
+next breath (see G4 above). When G4 lands, the driver inside
+`kernel-bmf-run` swaps from `(len statements)` to a recipe-walk call; the
+orchestration shape stays identical.
 
-1. **Wrapper script** — `kernel-bmf-run` is a bash script that runs the
-   same pre-compile dance `validate.sh` does (Go-kernel compiles the
-   source-syntax preludes → Rust kernel reads the compiled artifacts +
-   the target `.py`'s parse expression). Cheapest; most fragile under
+**Three reachable shapes for G6 (kept for record; #1 was taken):**
+
+1. **Wrapper script** *(taken)* — `kernel-bmf-run` is a bash script that
+   runs the same pre-compile dance `validate.sh` does (Go-kernel compiles
+   the source-syntax preludes → Rust kernel reads the compiled artifacts
+   + the target `.py`'s parse expression). Cheapest; most fragile under
    load-order drift.
 
 2. **Pre-shipped compiled artifacts** — `python-bmf.fk` + its prelude
@@ -152,23 +163,27 @@ standalone kernel binary. The pieces exist; they need orchestration.
    (embedding the same path `validate.sh` walks externally). Deepest;
    single-binary entry on PATH.
 
-**Repro of the finding:**
+**Repro of the closure:**
 
 ```bash
-# Standalone kernel can't read python-bmf.fk's surface syntax:
-form-kernel-rust form-stdlib/core.fk → parse error at line 23 col 43
+cd form
+form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run \
+    form-kernel-ts/seedbank/python-adapter/examples/python_demo.py
+# → 15  (top-level statement count, sibling-parity ✓)
 
-# validate.sh works green via the pre-compile dance:
-./validate.sh form-stdlib/core.fk form-stdlib/grammars/python-bmf.fk \
-              form-stdlib/tests/python-bmf-arithmetic-band.fk
-# → 25304 on go, rust, typescript
+# Same value through validate.sh, confirming three-kernel agreement:
+./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk \
+              form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk \
+              form-stdlib/compiler.fk form-stdlib/source-compiler.fk \
+              form-stdlib/grammars/python-bmf.fk /tmp/parse-demo.fk
+# → 15 on go, rust, typescript
 ```
 
-`PARITY_THIRD_RUNTIME=kernel-bmf` is reachable today only after G6 closes.
-The compost gate for Phase A's parser+emitter+test triple (~3,585 LOC,
-per `kernels/PHASE_A_FIRING_QUESTIONS.md`) sits behind this gap.
-
-This is the next concrete walking step toward the body's bootstrap shedding.
+`PARITY_THIRD_RUNTIME=kernel-bmf` is now runnable. The parity rows go
+honest-red against CPython at every demo until G3 + G4 ship — no faked
+green. The compost gate for Phase A's parser+emitter+test triple (~3,585
+LOC, per `kernels/PHASE_A_FIRING_QUESTIONS.md`) is downstream of G4
+greening every `PARITY_FILES` row, not G6.
 
 ## Parity discipline (do not compost yet)
 


### PR DESCRIPTION
## Walking step — G6 orchestration closed + main-blocking regressions fixed

The agent shipped what `kernels/PYTHON_BMF_CONTRACT.md` named as G6 (binary entry-point orchestration) — and discovered + fixed two regressions on main that were blocking it.

## G6 orchestration shipped

**`kernel-bmf-run`** wrapper script at `form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run`:
- Pre-compiles surface-syntax preludes through Go-kernel-as-compiler (mirrors `validate.sh prepare_sources()`)
- Invokes Rust kernel with compiled artifacts + driver calling `python-parse-module-file`
- `parity_suite.sh` resolves it via its own sibling-`scripts/` dir on PATH
- Closure shape #1 from the G6 contract — wrapper script — chosen as the cheapest closing breath

## Parity outcome — honest red, with reason

**`PARITY_THIRD_RUNTIME=kernel-bmf` parses today** for `examples/python_demo.py` → three-way agreement (Go, Rust, TS) on **`15`** (top-level statement count). The orchestration works.

**It fails three-way against CPython's actual program value** (`40949` vs `15`). The reason is named honestly: **G4 (closure interpreter, ~200 LOC of Form) does not yet exist.** PY-BMF-CALL / PY-BMF-IF / PY-BMF-DEF recipes parse but are inert until G4 walks them to Python-runtime values. When G4 lands, the driver swaps `(len statements)` for a recipe-walk call; the orchestration stays.

This is one of the "honest red" results CLAUDE.md asks for — the parity gate doesn't lie to make a green look easy.

## Critical regressions fixed en route

Two regressions on `main` were blocking everything downstream:

1. **`form/form-kernel-rust/src/main.rs`** — `_dispatch` and `_merge_record` lost their `});` closers in a recent merge. Rust kernel couldn't compile. Fixed; `validate.sh` 133/133 ok.

2. **`form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts`** — duplicated assignment-target handling rejected by esbuild. Consolidated; `python-compile` + `python-eval` work; existing ts-eval parity gate returns 40949 end-to-end.

**Without these fixes, this PR could not have been tested at all** — and earlier merges on main might already be broken in production. Naming this explicitly so review knows the load-bearing scope.

## Manifest row moved

One new **PROVEN** row appended to `kernels/BOOTSTRAP_COMPOST_MANIFEST.md`:
- G6 orchestration (three-way ✓ at 15) — `kernel-bmf-run` parses Python through `python-bmf.fk` driven by the kernel, sibling-validated

## Files touched

- `form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run` (new) — the wrapper
- `form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh` — resolves the wrapper on PATH
- `form/form-kernel-rust/src/main.rs` — regression fix
- `form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts` — regression fix
- `kernels/BOOTSTRAP_COMPOST_MANIFEST.md` — new PROVEN row
- `kernels/PYTHON_BMF_CONTRACT.md` — G6 status update

## What this opens

The orchestration gap from #2079 is closed. The next concrete walking step toward the first Phase-A compost is **G4 — closure/scope interpreter for PY-BMF recipes**. ~200 LOC of Form per the contract. When that lands, the driver swaps to a recipe-walk call; demos return real Python-runtime values; manifest rows move PROVEN → COMPOST READY.

## Test plan

- [x] `./validate.sh` — 133/133 sibling-kernel samples agree (was broken before the regression fixes)
- [x] `kernel-bmf-run examples/python_demo.py` returns 15 three-way
- [x] `python-compile` + `python-eval` work on the bootstrap path
- [x] No existing parity-suite demo regresses

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) + [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_