### PR TITLE
walk: fit deploy-lag probe — fetch before counting + graceful unknown

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1371,15 +1371,26 @@ def sense_deploy_lag() -> list[str]:
         )
         return lines
 
-    # How many commits between them?
+    # How many commits between them? The production sha may be ahead of
+    # local main when this runs from a worktree that hasn't fetched
+    # recently; ensure git knows both shas before counting. A fetch
+    # first guarantees `git rev-list deployed_sha..origin_sha` resolves
+    # both ends.
     try:
+        subprocess.run(
+            ["git", "fetch", "origin", "main", "--quiet"],
+            cwd=ROOT, capture_output=True, text=True, check=False, timeout=15,
+        )
         rev_list = subprocess.run(
             ["git", "rev-list", "--count", f"{deployed_sha}..{origin_sha}"],
             cwd=ROOT, capture_output=True, text=True, check=False, timeout=10,
         )
-        behind = rev_list.stdout.strip() if rev_list.returncode == 0 else "?"
-    except Exception:
-        behind = "?"
+        if rev_list.returncode == 0 and rev_list.stdout.strip().isdigit():
+            behind = rev_list.stdout.strip()
+        else:
+            behind = f"? (rev-list could not resolve {deployed_sha[:8]} locally — run `git fetch origin`)"
+    except Exception as exc:
+        behind = f"? ({exc})"
 
     lines.append(
         f"  deploy lagged — production at {deployed_sha[:8]} is {behind} commit(s) "


### PR DESCRIPTION
## Walking step — fit the deploy-lag probe to handle stale local refs

#2089 just landed `sense_deploy_lag()`, but the first wellness run after merge showed `? commit(s) behind` because the production sha `4183d306` wasn't in local git history (worktree hadn't fetched recently). The probe couldn't compute the count and gave a vague `?`.

This PR fits the probe:
- **Fetches `origin/main` quietly** before running `git rev-list`
- **Falls back gracefully** if the production sha *still* isn't resolvable, naming the recovery action: `? (rev-list could not resolve <sha> locally — run \`git fetch origin\`)`

The reader sees what to do instead of a bare `?`.

## Live output

```
deploy lagged — production at 4183d306 is 31 commit(s) behind origin/main (75041e1c), uptime 2h 58m 10s
unmerged work doesn't reach visitors until hostinger auto-deploy fires…
```

Wellness fits cleanly across all sections now.

## Files touched

- `scripts/wellness_check.py` — fetch before count + recovery-naming fallback (15 lines added, 4 removed)

## Test plan

- [x] Probe reports "31 commit(s) behind" honestly when production is lagged
- [x] Probe reports "deploy aligned" when shas match (verified by reading the if-branch)
- [x] No regression in other wellness sections

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_