### PR TITLE
walk: natural language → Form recipe — universal translator's NL leg

### DIFF
--- a/form/form-samples/cross-modal/05-nl-to-recipe/README.md
+++ b/form/form-samples/cross-modal/05-nl-to-recipe/README.md
@@ -1,0 +1,89 @@
+# 05 — Natural Language to Recipe
+
+**Discovery**: a tiny English grammar emits Form recipes the kernel walks. The
+NL surface and the S-expression surface intern to the **same NodeID** when
+they describe the same shape. Two source tongues — one substrate identity.
+
+## Run
+
+```bash
+./form/validate.sh \
+    form/form-stdlib/core.fk \
+    form/form-stdlib/grammar-chars.fk \
+    form/form-samples/cross-modal/05-nl-to-recipe/nl-arithmetic-demo.fk
+```
+
+Output (Go / Rust / TypeScript all agree):
+
+```
+square=49 sum=10 twice=13 negate=-12 node_eq=1 value_eq=1
+```
+
+Aggregate is `62`. All three sibling kernels return `62`.
+
+## The four sentences
+
+| English | Recipe shape | Walks to |
+|---|---|---|
+| `the square of 7` | `(mul 7 7)` | `49` |
+| `the sum of 4 and 6` | `(add 4 6)` | `10` |
+| `twice 5 plus 3` | `(add (mul 2 5) 3)` | `13` |
+| `negate 12` | `(sub 0 12)` | `-12` |
+
+The grammar uses `grammar-chars.fk` directly — same `cm-parse` and
+`walk_recipe` plumbing that
+[`form-stdlib/tests/grammar-chars-demo.fk`](../../../form-stdlib/tests/grammar-chars-demo.fk)
+relies on for digit-arithmetic. The only addition is a number-word table
+(`one`..`twelve`) so spelled-out English numerals resolve to the same int
+domain as digit-runs.
+
+## The bonus — content-addressed convergence across modalities
+
+The demo also walks `(mul 7 7)` by hand and checks `node_eq` against the
+NL-built recipe for `the square of 7`. The kernel reports `node_eq=1` — they
+are **the same NodeID**, indistinguishable from each other.
+
+This is the universal-translator promise made concrete for natural language:
+the surface tongue varies; the substrate identity is one.
+
+## What's reachable today
+
+- **English sentence -> recipe NodeID** via `cm-parse` + a 4-rule grammar.
+- **Recipe NodeID -> int value** via `walk_recipe` against the kernel's
+  arithmetic arms (`RMathPlus=1`, `RMathMinus=2`, `RMathMultiply=3`).
+- **Cross-modality convergence**: NL `the square of 7` and S-expression
+  `(mul 7 7)` intern to the same NodeID, in every sibling kernel.
+- **Three-way kernel agreement**: Go, Rust, and TypeScript walk the same
+  recipes to the same values. No divergence, no mojibake (the output is
+  ASCII-clean by design).
+
+## What's not reachable yet
+
+- **Open vocabulary.** The grammar handles 4 sentence shapes and 12 number
+  words. Anything outside that lexicon falls through to a `-1` sentinel
+  rather than a structured parse error.
+- **Disambiguation.** `twice 5 plus 3` is `(2*5) + 3`, not `2 * (5+3)`,
+  because the rule reads left-to-right with no precedence shape. The
+  grammar is right-shape-by-design, not by user intent. Real NL parsing
+  needs more rule.
+- **Reverse direction (recipe -> NL).** This is the named-pending sibling
+  experiment. Walking a recipe back to readable English needs an NL
+  emitter the body doesn't carry yet at the arithmetic altitude — the
+  `nl-emit.fk` track is i18n surface bindings, not arithmetic generation.
+
+## The teaching
+
+A recipe is content-addressed; the kernel doesn't know or care which
+modality wrote it. Two writers — one typing `the square of 7` into prose,
+one typing `(mul 7 7)` into a `.fk` file — end up at the same node in
+the lattice. The convergence is bytewise, not fuzzy: either the
+serializations match or they don't.
+
+This is the same property
+[`02-cross-language-content-addressing`](../02-cross-language-content-addressing/)
+proved between Python-shape and TypeScript-shape recursive trees, extended
+down to the source-text altitude for NL specifically.
+
+Lineage: [`lc-parsers-as-recipes`](../../../../docs/vision-kb/concepts/lc-parsers-as-recipes.md),
+[`lc-one-kernel-many-tongues`](../../../../docs/vision-kb/concepts/lc-one-kernel-many-tongues.md),
+[`lc-the-kernel-knows-itself`](../../../../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

--- a/form/form-samples/cross-modal/05-nl-to-recipe/nl-arithmetic-demo.fk
+++ b/form/form-samples/cross-modal/05-nl-to-recipe/nl-arithmetic-demo.fk
@@ -1,0 +1,171 @@
+; nl-arithmetic-demo.fk — natural-language sentences become Form recipes.
+;
+; A small character-grammar walks 4 English sentences, emits arithmetic
+; recipes, and the kernel walks each recipe to a value. The companion
+; (mul 7 7) hand-built recipe lives in the same body — node_eq is the
+; content-addressed proof that NL and S-expression are two source
+; tongues pointing at one substrate identity.
+;
+; Sentences walked here:
+;   "the square of 7"           ->  (mul 7 7)         ->  49
+;   "the sum of 4 and 6"        ->  (add 4 6)         ->  10
+;   "twice 5 plus 3"            ->  (add (mul 2 5) 3) ->  13
+;   "negate 12"                 ->  (sub 0 12)        ->  -12
+;
+; The bonus claim — NL "the square of 7" interns to the SAME NodeID as
+; the hand-built (mul 7 7) — is what makes this a universal-translator
+; proof and not merely a parser demo. Two source modalities, one
+; content-addressed identity.
+;
+; preludes: form-stdlib/grammar-chars.fk
+
+(do
+    ;; --- Form math categories (kernel substrate numbering) -------------
+    ;; LEVEL_BASIC=2, RB_MATH=12, MUL=3, PLUS=1, MINUS=2.
+    (let math-mul   (make_nodeid 1 2 12 3))
+    (let math-plus  (make_nodeid 1 2 12 1))
+    (let math-minus (make_nodeid 1 2 12 2))
+
+    ;; --- Cap accessor (mirrors grammar-chars-demo.fk's caps-get) -------
+    (defn caps-get (caps name)
+        (if (nil? caps) (empty)
+            (if (str_eq (head (head caps)) name)
+                (head (tail (head caps)))
+                (caps-get (tail caps) name))))
+
+    ;; --- Number-word table: "one" -> 1, ..., "twelve" -> 12 ------------
+    ;; A spelled English numeral resolves to an int via this lookup.
+    ;; Digit runs ("7", "12") flow through str_to_int directly.
+    (defn word-to-int (w)
+        (if (str_eq w "one") 1
+        (if (str_eq w "two") 2
+        (if (str_eq w "three") 3
+        (if (str_eq w "four") 4
+        (if (str_eq w "five") 5
+        (if (str_eq w "six") 6
+        (if (str_eq w "seven") 7
+        (if (str_eq w "eight") 8
+        (if (str_eq w "nine") 9
+        (if (str_eq w "ten") 10
+        (if (str_eq w "eleven") 11
+        (if (str_eq w "twelve") 12
+            (sub 0 1)))))))))))))) ; -1 sentinel for an unmapped word
+
+    ;; A digit-run is parsed as int directly; a lowercase-word is looked
+    ;; up. The captured text-span doesn't tell us which path it came
+    ;; from, so we test the first byte: 48..57 is a digit.
+    (defn text-to-int (txt)
+        (do
+            (let cp (ord (char_at txt 0)))
+            (if (and (ge cp 48) (le cp 57))
+                (str_to_int txt)
+                (word-to-int txt))))
+
+    ;; --- Character patterns -------------------------------------------
+    (let digit       (list "char-range" 48 57))     ; '0'..'9'
+    (let lower       (list "char-range" 97 122))    ; 'a'..'z'
+    (let space-ch    (list "char" " "))
+
+    (let digits      (list "sequence" digit (list "star" digit)))
+    (let word        (list "sequence" lower (list "star" lower)))
+    (let number-tok  (list "choice" digits word))
+
+    ;; --- Rule actions: each builds a recipe NodeID --------------------
+
+    ;; square: caps has "n" -> "the square of N"
+    (defn square-action (caps)
+        (do
+            (let n (intern_trivial_int (text-to-int (caps-get caps "n"))))
+            (intern_node math-mul (list n n))))
+
+    ;; sum: caps has "lhs", "rhs" -> "the sum of L and R"
+    (defn sum-action (caps)
+        (do
+            (let lhs (intern_trivial_int (text-to-int (caps-get caps "lhs"))))
+            (let rhs (intern_trivial_int (text-to-int (caps-get caps "rhs"))))
+            (intern_node math-plus (list lhs rhs))))
+
+    ;; twice-plus: "twice N plus M" -> (add (mul 2 N) M)
+    (defn twice-action (caps)
+        (do
+            (let two (intern_trivial_int 2))
+            (let n (intern_trivial_int (text-to-int (caps-get caps "n"))))
+            (let m (intern_trivial_int (text-to-int (caps-get caps "m"))))
+            (let twice-n (intern_node math-mul (list two n)))
+            (intern_node math-plus (list twice-n m))))
+
+    ;; negate: "negate N" -> (sub 0 N)
+    (defn negate-action (caps)
+        (do
+            (let zero (intern_trivial_int 0))
+            (let n (intern_trivial_int (text-to-int (caps-get caps "n"))))
+            (intern_node math-minus (list zero n))))
+
+    ;; --- Grammar rules ------------------------------------------------
+    ;; One rule per sentence shape; each captures the number-tokens
+    ;; needed by its action.
+    (let rules
+        (list
+            (list "square"
+                  (list "sequence"
+                        (list "string" "the square of ")
+                        (list "capture" "n" number-tok))
+                  square-action)
+            (list "sum"
+                  (list "sequence"
+                        (list "string" "the sum of ")
+                        (list "capture" "lhs" number-tok)
+                        (list "string" " and ")
+                        (list "capture" "rhs" number-tok))
+                  sum-action)
+            (list "twice"
+                  (list "sequence"
+                        (list "string" "twice ")
+                        (list "capture" "n" number-tok)
+                        (list "string" " plus ")
+                        (list "capture" "m" number-tok))
+                  twice-action)
+            (list "negate"
+                  (list "sequence"
+                        (list "string" "negate ")
+                        (list "capture" "n" number-tok))
+                  negate-action)))
+
+    ;; --- Walk each NL sentence through grammar -> recipe -> value -----
+
+    (let r-square  (cm-parse "the square of 7"     rules "square"))
+    (let r-sum     (cm-parse "the sum of 4 and 6"  rules "sum"))
+    (let r-twice   (cm-parse "twice 5 plus 3"      rules "twice"))
+    (let r-negate  (cm-parse "negate 12"           rules "negate"))
+
+    (let v-square  (walk_recipe r-square))
+    (let v-sum     (walk_recipe r-sum))
+    (let v-twice   (walk_recipe r-twice))
+    (let v-negate  (walk_recipe r-negate))
+
+    ;; --- Hand-built S-expression recipe for the bonus claim -----------
+    ;; "the square of 7" should intern to the same NodeID as (mul 7 7)
+    ;; assembled directly. Same shape, same NodeID — content-addressed.
+    (let h7      (intern_trivial_int 7))
+    (let hand-square (intern_node math-mul (list h7 h7)))
+    (let same-node (if (node_eq r-square hand-square) 1 0))
+    (let same-value (if (eq v-square (walk_recipe hand-square)) 1 0))
+
+    ;; --- Print results (ASCII-clean so all three kernels agree) -------
+    (print "square=")
+    (print (int_to_str v-square))
+    (print " sum=")
+    (print (int_to_str v-sum))
+    (print " twice=")
+    (print (int_to_str v-twice))
+    (print " negate=")
+    (print (int_to_str v-negate))
+    (print " node_eq=")
+    (print (int_to_str same-node))
+    (print " value_eq=")
+    (print (int_to_str same-value))
+    (print "\n")
+
+    ;; Aggregate: 49 + 10 + 13 + (-12) + 1 + 1 = 62
+    ;; All three sibling kernels must produce 62.
+    (add v-square (add v-sum (add v-twice (add v-negate (add same-node same-value))))))

--- a/form/form-samples/cross-modal/README.md
+++ b/form/form-samples/cross-modal/README.md
@@ -1,11 +1,11 @@
 # Cross-Modal Recipe Experiments
 
-Four small demos exploring how Form recipes carry semantic content across
-modalities (text, structured data, image, code). Each subdirectory has its own
-runnable sample and a README documenting what's reachable today, what
-surprised, and what's not yet reachable. **The point isn't to ship a universal
-translator** — it's to feel the body's current surface area for cross-modality
-and name the honest discoveries.
+Five small demos exploring how Form recipes carry semantic content across
+modalities (text, structured data, image, code, natural language). Each
+subdirectory has its own runnable sample and a README documenting what's
+reachable today, what surprised, and what's not yet reachable. **The point
+isn't to ship a universal translator** — it's to feel the body's current
+surface area for cross-modality and name the honest discoveries.
 
 | # | Experiment | One-line finding |
 |---|---|---|
@@ -13,6 +13,7 @@ and name the honest discoveries.
 | 02 | [Cross-language content-addressing](02-cross-language-content-addressing/) | Two recursive trees built by different author-routes intern to the **same** NodeID; iterative shape interns to a different one. |
 | 03 | [Recipe as compression](03-recipe-as-compression/) | The substrate's "ice" (`.fkb`) is **4.17× larger** than the "water" (`.fk` text) at small payload sizes. Compression isn't automatic. |
 | 04 | [Universal diff](04-universal-diff/) | Structural diff of two algorithms surfaces "the predicate is the same; the accumulation strategy diverges" — text diff can't see this. |
+| 05 | [NL to recipe](05-nl-to-recipe/) | A 4-rule English grammar parses sentences into arithmetic recipes; NL `the square of 7` interns to the **same NodeID** as hand-built `(mul 7 7)`. |
 
 ## What every experiment shares
 
@@ -69,13 +70,11 @@ The deeper teachings the body holds about all of this:
 
 ## Not in this directory (yet)
 
-The other shapes from Urs's prompt that didn't ship in this breath:
+Shapes from Urs's prompt that still haven't shipped:
 
-- **Natural-language-to-recipe sketch** — a small `nl → recipe` walk via
-  `form/form-stdlib/grammars/natural-bmf.fk`. The grammar exists; wiring a
-  demo through it from a Form sample is the next breath.
 - **Reverse roundtrip** (recipe → NL description) — sketch-only territory;
-  needs an NL emitter the body doesn't carry yet.
+  needs an NL emitter the body doesn't carry yet at the arithmetic
+  altitude. The `nl-emit.fk` track is i18n surface bindings, a different
+  shape than generative arithmetic English.
 
-Naming them here so the absence is visible and the next breath has somewhere
-to land.
+Naming the absence so the next breath has somewhere to land.


### PR DESCRIPTION
## Walking step — natural language as cross-modal source

The cross-modal agent shipped the NL→recipe sketch named-pending in #2086. **Four English sentences walk through a Form-native NL grammar to Form recipes that walk to CPython-matching values.** Three sibling kernels (Go/Rust/TS) agree byte-for-byte.

## What walks today

| English | Recipe | Value |
|---|---|---|
| `the square of 7` | `(mul 7 7)` | 49 |
| `the sum of 4 and 6` | `(add 4 6)` | 10 |
| `twice 5 plus 3` | `(add (mul 2 5) 3)` | 13 |
| `negate 12` | `(sub 0 12)` | -12 |

**Aggregate 62** across Go, Rust, TypeScript kernels.

## The load-bearing claim — NodeID convergence

`node_eq=1` between NL "the square of 7" and hand-built `(mul 7 7)`. **Same NodeID in every sibling kernel.** Two writers — one typing English prose, one typing an S-expression — converge on the same numeric node in the lattice. The convergence is **bytewise, not fuzzy.**

This is the universal-translator's clearest small proof yet: the recipe is the substrate; the source language is a perspective. Two perspectives, one substrate.

## Files

- `form/form-samples/cross-modal/05-nl-to-recipe/nl-arithmetic-demo.fk`
- `form/form-samples/cross-modal/05-nl-to-recipe/README.md`
- `form/form-samples/cross-modal/README.md` — updated row + composted pending-note

## Honest pending

- **Recipe→NL reverse** stays honest-pending — needs an emitter that walks a recipe back to English. The body doesn't carry that at arithmetic altitude yet. Named in the umbrella README.
- The grammar covers four sentences; broadening (per `NEXT_BREATHS.md` #3 — conditionals + let-bindings) is the next walk.

## Run command

```bash
./form/validate.sh form/form-stdlib/core.fk \
  form/form-stdlib/grammar-chars.fk \
  form/form-samples/cross-modal/05-nl-to-recipe/nl-arithmetic-demo.fk
```

In service of [`lc-cross-modal-unity`](../docs/vision-kb/concepts/lc-cross-modal-unity.md) + [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md). The universal translator now has its **NL leg made concrete** — two source languages, one Form NodeID.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_