### PR TITLE
walk: JSON-as-recipe is already alive — body hadn't read its attestation

### DIFF
--- a/form/form-samples/cross-modal/NEXT_BREATHS.md
+++ b/form/form-samples/cross-modal/NEXT_BREATHS.md
@@ -33,9 +33,32 @@ Once `cross-modal-nl-to-recipe` lands, extend the NL grammar with one or two mor
 
 Walk a recipe NodeID and emit an English description. The reverse of #3. Together with #3, demonstrates **round-trip across the NL/recipe boundary** — the substrate-of-meaning is preserved through both translations.
 
-### 5. **JSON-as-recipe** (data, not code)
+### 5. **JSON-as-recipe** — *already alive, not in the auto-gate yet*
 
-`form/form-stdlib/grammars/json-grammar.form` already exists (per PYTHON_PIPELINE_STATUS grammar-coverage). Wire a small JSON file through it; produce a recipe; walk the recipe back to JSON. **Data grammar separate from code grammar.** Per Urs's directive: "for data use a data grammar and keep data and code separate when you can."
+**Finding (2026-05-27):** `form/form-stdlib/seedbank/grammars/json.fk` exists
+and `form/form-stdlib/seedbank/tests/json.fk` runs three-way clean:
+
+```
+$ cd form && ./validate.sh form-stdlib/core.fk \
+                            form-stdlib/seedbank/cell-trace.fk \
+                            form-stdlib/seedbank/grammars/json.fk \
+                            form-stdlib/seedbank/tests/json.fk
+  ✓  core.fk+cell-trace.fk+json.fk+json.fk  → 36
+  1 ok, 0 divergent — kernels agree on every sample.
+```
+
+Same source JSON, same NodeID across Go/Rust/TS. **JSON-as-recipe is real today.**
+
+**Remaining honest gap:** `validate.sh` auto-walks `form-stdlib/tests/*.fk`
+but NOT `form-stdlib/seedbank/tests/*.fk`. The JSON proof exists but isn't
+in the default gate. The walk that closes this: move (or symlink, or add
+a band-shaped wrapper to) the seedbank JSON test into the regular tests/
+directory so the body verifies JSON-as-recipe on every `./validate.sh`
+run.
+
+Same pattern as Breath 2e (already-landed, the body hadn't read its own
+attestation). The forward-map's #5 isn't a future walk; it's a discipline
+walk: bring the existing proof into the default sense-gate.
 
 ### 6. **CSV→Form-table→NL summary**
 


### PR DESCRIPTION
## Walking step — JSON-as-recipe is already alive

Another already-landed finding, same pattern as Breath 2e (the body hadn't read its own attestation).

## The finding

```bash
$ cd form && ./validate.sh \
    form-stdlib/core.fk \
    form-stdlib/seedbank/cell-trace.fk \
    form-stdlib/seedbank/grammars/json.fk \
    form-stdlib/seedbank/tests/json.fk

  ✓  core.fk+cell-trace.fk+json.fk+json.fk  → 36
  1 ok, 0 divergent — kernels agree on every sample.
```

**JSON-as-recipe is real today.** A JSON file walks through `seedbank/grammars/json.fk`, produces a recipe NodeID, walks to a deterministic value (36) — same on Go, Rust, TypeScript sibling kernels.

The grammar maps cleanly:
- object → B_Dictionary recipe with (key, value) children
- array → B_List recipe with element children
- string → trivial string
- number → trivial int
- bool → trivial bool
- null → trivial null

## The honest remaining gap

`validate.sh` auto-walks `form-stdlib/tests/*.fk` but NOT `form-stdlib/seedbank/tests/*.fk`. The proof exists but lives outside the default sense-gate. The walk that closes #5 from `NEXT_BREATHS.md` is bringing the existing proof into the default gate (move, symlink, or wrap as a band test in `tests/`).

## Updates the forward-map

`form/form-samples/cross-modal/NEXT_BREATHS.md` #5 reframed from "future walk" to "already-alive, discipline walk to bring it into the gate." Same shape as Breath 2e — the body's destination doc had to catch up to the body's present.

## Files touched

- `form/form-samples/cross-modal/NEXT_BREATHS.md` — #5 reframed with the live attestation + remaining discipline gap

In service of [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) — *"for data use a data grammar and keep data and code separate"*. Data has its grammar, walked by the same kernel that walks code.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_