### PR TITLE
feat(kernels): G1+G3 — first kernel-bmf demo passes three-way (factorial(6)=720)

### DIFF
--- a/form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.fk
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.fk
@@ -1,0 +1,1 @@
+(do (defn fact (n) (if (lt n 2) 1 (mul n (fact (sub n 1))))) (let result (fact 6)) result)

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.py
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.py
@@ -1,0 +1,18 @@
+# python_bridge_demo.py — first .py file the Form-native PY-BMF bridge
+# walks end-to-end (parse → lift → eval) to its CPython runtime value.
+#
+# Covers the 9 arms shipped in form-stdlib/python-bmf-eval.fk:
+#   INT, IDENT, BINOP, COMPARE, RETURN, ASSIGN, DEF, CALL, IF, MODULE.
+#
+# CPython value: 720 (factorial of 6, plus a module-level assignment +
+# call shape that exercises ASSIGN env-threading).
+#
+# Run paths:
+#   python3 python_bridge_demo.py                 — CPython prints 720
+#   kernel-bmf-run python_bridge_demo.py          — Form-native, prints 720
+
+def fact(n):
+    return 1 if n < 2 else n * fact(n - 1)
+
+result = fact(6)
+result

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run
@@ -20,25 +20,23 @@
 #   3. Invoke the Rust kernel against (compiled preludes + driver), printing
 #      the kernel's final value.
 #
-# What this script does NOT do (yet — honest pending):
-#   - Feed real .py files into the PY-BMF closure interpreter. The grammar
-#     at form-stdlib/grammars/python-bmf.fk parses Python into source-
-#     statement objects (kind-classified token groups), but the rule
-#     dispatcher that lifts those statements to PY-BMF-* recipes (G1 from
-#     PYTHON_BMF_CONTRACT.md) plus precedence climbing for nested
-#     expressions (G3) is still the gate. The closure-walking interpreter
-#     itself (G4) is alive at form-stdlib/python-bmf-eval.fk and proven
-#     three-way against CPython for direct-recipe inputs — see
-#     form-stdlib/tests/python-bmf-eval-band.fk (returns 28000). When
-#     G1+G3 land, the driver below swaps from (len statements) to
-#     (py-run module-recipe) and the orchestration shape stays identical.
+# What this script does end-to-end (after G1+G3 closed):
+#   - Reads the .py file via the python-bmf grammar's scanner.
+#   - Lifts the parsed statement-tree to PY-BMF-* recipes via
+#     form-stdlib/python-bmf-lift.fk (G1 statement dispatch +
+#     G3 expression precedence climbing).
+#   - Walks the module recipe to a Python-runtime value via
+#     form-stdlib/python-bmf-eval.fk's py-run (G4 closure interpreter).
 #
-# So `kernel-bmf-run examples/python_demo.py` prints the count of top-
-# level statements (≠ 40949). The three-way parity gate against CPython's
-# program value reaches green when G1+G3 wire source → PY-BMF recipes.
-# `PARITY_THIRD_RUNTIME=kernel-bmf scripts/parity_suite.sh` will name
-# every demo as "diverges from CPython, gated on G1+G3" until then —
-# honest red, not faked green.
+# What this script does NOT do (yet — honest pending):
+#   - Cover every Python surface. The lifter handles the 9 arms shipped
+#     in python-bmf-eval.fk: INT, IDENT, BINOP, COMPARE, RETURN, ASSIGN,
+#     DEF, CALL, IF, MODULE — enough for python_bridge_demo.py (factorial).
+#     Demos that need lists, dicts, classes, while/for, comprehensions,
+#     subscripts, attribute access, etc. fall through to PY-BMF-PASS and
+#     surface a trace from py-env-lookup or py-eval. Each is one focused
+#     breath: add the lift dispatch branch in python-bmf-lift.fk + the
+#     interpreter arm in python-bmf-eval.fk.
 
 set -euo pipefail
 
@@ -88,6 +86,8 @@ PRELUDES=(
     "form-stdlib/compiler.fk"
     "form-stdlib/source-compiler.fk"
     "form-stdlib/grammars/python-bmf.fk"
+    "form-stdlib/python-bmf-eval.fk"
+    "form-stdlib/python-bmf-lift.fk"
 )
 
 # Working directory for compiled artifacts. cleanup() removes it on any exit.
@@ -118,17 +118,15 @@ for src in "${PRELUDES[@]}"; do
     fi
 done
 
-# Emit the driver. Until G4 (closure-walking interpreter for PY-BMF-*
-# recipes) lands, the honest report from a Form-native kernel pass over a
-# .py file is the parsed-module statement count. When G4 lands, this
-# driver swaps to walk the recipe tree to its program value, and the
-# parity gate goes green at the actual CPython output.
+# Emit the driver. Calls py-bmf-run-file from python-bmf-lift.fk: that
+# parses the .py, lifts the statement-tree to PY-BMF-* recipes, then walks
+# them through the G4 closure interpreter to the program's value. The
+# orchestration shape is unchanged from the G6 breath — only the driver
+# expression swapped from (len statements) to (py-bmf-run-file path).
 driver="$work_dir/kernel-bmf-driver.fk"
 cat > "$driver" <<DRIVER_EOF
 (do
-    (let module (python-parse-module-file "$target_py_abs"))
-    (let statements (python-module-statements module))
-    (len statements))
+    (py-bmf-run-file "$target_py_abs"))
 DRIVER_EOF
 
 # Run the Rust kernel over the prepared preludes + driver.

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
@@ -39,6 +39,10 @@ set -euo pipefail
 PARITY_THIRD_RUNTIME="${PARITY_THIRD_RUNTIME:-ts-eval}"
 
 PARITY_FILES=(
+    # First row that passes under PARITY_THIRD_RUNTIME=kernel-bmf — covers
+    # the 9 arms G4 ships (INT, IDENT, BINOP, COMPARE, RETURN, ASSIGN, DEF,
+    # CALL, IF, MODULE) via the G1+G3 bridge in form-stdlib/python-bmf-lift.fk.
+    "examples/python_bridge_demo.py"
     "examples/python_demo.py"
     "examples/python_assign_demo.py"
     "examples/python_imperative_demo.py"

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -1,0 +1,385 @@
+; form-stdlib/python-bmf-lift.fk
+;
+; G1 + G3 close — the parser-to-recipe bridge that lifts the
+; statement-classified BMF objects from python-parse-module-tree-file
+; into PY-BMF-* recipes the G4 interpreter walks.
+;
+; The first breath holds the smallest healthy surface that fits the 9
+; arms shipped by python-bmf-eval.fk:
+;
+;     statement kind "def"        → PY-BMF-DEF
+;     statement kind "return"     → PY-BMF-RETURN
+;     statement kind "assignment" → PY-BMF-ASSIGN
+;     statement kind "expr"       → expression-only (eval the value)
+;
+; Inside an expression (G3 — precedence climbing over the token list):
+;
+;     integer literal             → PY-BMF-INT
+;     identifier                  → PY-BMF-IDENT
+;     identifier (args)           → PY-BMF-CALL
+;     ( expr )                    → grouped expression
+;     a OP b                      → PY-BMF-BINOP / PY-BMF-COMPARE
+;     x if cond else y            → PY-BMF-IF
+;
+; What does NOT lift yet (honest pending, surfaces on the next breath):
+;
+;     class / while / for / try / with / import / from-import,
+;     lists / dicts / tuples / sets, subscripts, attribute access,
+;     method calls, lambdas, augmented assignment, multi-target
+;     assignment, decorators, comprehensions, f-strings, slices,
+;     async / yield / global / nonlocal, type annotations.
+;
+; Anything the lifter can't shape today becomes an honest PY-BMF-PASS
+; recipe (the interpreter logs its category and panics) — never a faked
+; green recipe. The discipline scales: each new arm = one new dispatch
+; branch here + one new arm in python-bmf-eval.fk.
+;
+; preludes (load order): core.fk, json.fk, cache.fk, form-ontology-loader.fk,
+;                        engine.fk, compiler.fk, source-compiler.fk,
+;                        grammars/python-bmf.fk, python-bmf-eval.fk
+
+(do
+    ;; ---- token accessors -------------------------------------------
+    ;;
+    ;; Tokens are bare BMF objects from python-source-scan-*. Each carries
+    ;; (kind, value). Kinds we care about: py-keyword, py-name, py-int,
+    ;; py-op. The lifter is total over a fixed set of kinds — others fall
+    ;; through to PY-BMF-PASS.
+
+    (defn tok-kind (t) (bmf-object-kind t))
+    (defn tok-value (t) (bmf-object-value t))
+
+    (defn tok-is? (t kind value)
+        (and (str_eq (tok-kind t) kind)
+             (str_eq (tok-value t) value)))
+
+    (defn tok-op? (t op) (tok-is? t "py-op" op))
+    (defn tok-keyword? (t kw) (tok-is? t "py-keyword" kw))
+    (defn tok-name? (t) (str_eq (tok-kind t) "py-name"))
+    (defn tok-int? (t) (str_eq (tok-kind t) "py-int"))
+
+    ;; ---- expression parser (G3) -------------------------------------
+    ;;
+    ;; The parser is recursive descent with precedence climbing. The
+    ;; return shape is a (recipe . rest-tokens) pair encoded as a
+    ;; two-element list — head is the recipe, head-tail is the remaining
+    ;; token list. Pairs thread through the recursive calls.
+
+    (defn lift-result (recipe rest) (list recipe rest))
+    (defn lift-recipe (r) (head r))
+    (defn lift-rest (r) (head (tail r)))
+
+    ;; --- collect args inside a paren-group -------------------------
+    ;;
+    ;; Caller has already consumed the open "(". Reads expressions
+    ;; separated by "," until the matching close ")". Returns
+    ;; (args-list . rest-after-close).
+
+    (defn lift-args-loop (tokens acc)
+        (if (nil? tokens)
+            (lift-result (reverse acc) tokens)
+            (if (tok-op? (head tokens) ")")
+                (lift-result (reverse acc) (tail tokens))
+                (do
+                    (let arg-result (lift-expr tokens))
+                    (let next (lift-rest arg-result))
+                    (let acc2 (cons (lift-recipe arg-result) acc))
+                    (if (and (not (nil? next))
+                             (tok-op? (head next) ","))
+                        (lift-args-loop (tail next) acc2)
+                        (lift-args-loop next acc2))))))
+
+    (defn lift-args (tokens) (lift-args-loop tokens (empty)))
+
+    ;; --- primary expression ----------------------------------------
+    ;;
+    ;; Integers, identifiers, calls, parenthesised expressions.
+
+    (defn lift-primary (tokens)
+        (if (nil? tokens)
+            (lift-result (intern_node PY-BMF-PASS (empty)) tokens)
+        (do
+            (let t (head tokens))
+            (let rest (tail tokens))
+            (if (tok-int? t)
+                (lift-result
+                    (intern_node PY-BMF-INT
+                        (list (intern_trivial_int (str_to_int (tok-value t)))))
+                    rest)
+            (if (tok-name? t)
+                ;; name or call
+                (if (and (not (nil? rest))
+                         (tok-op? (head rest) "("))
+                    (do
+                        (let args-result (lift-args (tail rest)))
+                        (lift-result
+                            (intern_node PY-BMF-CALL
+                                (cons (intern_trivial_string (tok-value t))
+                                      (lift-recipe args-result)))
+                            (lift-rest args-result)))
+                    (lift-result
+                        (intern_node PY-BMF-IDENT
+                            (list (intern_trivial_string (tok-value t))))
+                        rest))
+            (if (tok-op? t "(")
+                ;; parenthesised expression: parse inner, consume ")"
+                (do
+                    (let inner (lift-expr rest))
+                    (let after (lift-rest inner))
+                    (if (and (not (nil? after))
+                             (tok-op? (head after) ")"))
+                        (lift-result (lift-recipe inner) (tail after))
+                        (lift-result (lift-recipe inner) after)))
+                (do
+                    (trace "lift-primary: unsupported token kind/value"
+                           (list (tok-kind t) (tok-value t)))
+                    (lift-result
+                        (intern_node PY-BMF-PASS (empty))
+                        rest))))))))
+
+    ;; --- operator precedence ---------------------------------------
+    ;;
+    ;; Higher number = tighter binding. -1 for non-operator tokens
+    ;; (signals "stop climbing"). Python's actual precedence is richer
+    ;; (lambda, or, and, not, in/is, bitwise, shifts) but the demo
+    ;; surface this carries is: comparison < add/sub < mul/div < **.
+
+    (defn op-prec (s)
+        (if (str_eq s "**") 50
+        (if (str_eq s "*")  40
+        (if (str_eq s "/")  40
+        (if (str_eq s "//") 40
+        (if (str_eq s "%")  40
+        (if (str_eq s "+")  30
+        (if (str_eq s "-")  30
+        (if (str_eq s "==") 20
+        (if (str_eq s "!=") 20
+        (if (str_eq s "<")  20
+        (if (str_eq s "<=") 20
+        (if (str_eq s ">")  20
+        (if (str_eq s ">=") 20
+            (sub 0 1)))))))))))))))
+
+    (defn op-is-compare? (s)
+        (or (str_eq s "==")
+        (or (str_eq s "!=")
+        (or (str_eq s "<")
+        (or (str_eq s "<=")
+        (or (str_eq s ">")
+            (str_eq s ">=")))))))
+
+    (defn tok-binop-prec (tokens)
+        (if (nil? tokens) (sub 0 1)
+            (do
+                (let t (head tokens))
+                (if (str_eq (tok-kind t) "py-op")
+                    (op-prec (tok-value t))
+                    (sub 0 1)))))
+
+    ;; --- binop climbing ---------------------------------------------
+    ;;
+    ;; Standard precedence-climbing: given a left-hand recipe and the
+    ;; remaining tokens, fold in higher- or equal-precedence binops on
+    ;; the right while their precedence ≥ min-prec. `**` is the only
+    ;; right-associative op in this surface; everything else is
+    ;; left-associative (recurse with prec+1).
+
+    (defn lift-binop-loop (left tokens min-prec)
+        (do
+            (let prec (tok-binop-prec tokens))
+            (if (lt prec min-prec) (lift-result left tokens)
+                (do
+                    (let op (tok-value (head tokens)))
+                    (let next-min
+                        (if (str_eq op "**") prec (add prec 1)))
+                    (let rhs-primary (lift-primary (tail tokens)))
+                    (let rhs-climb
+                        (lift-binop-loop (lift-recipe rhs-primary)
+                                         (lift-rest rhs-primary)
+                                         next-min))
+                    (let new-left
+                        (if (op-is-compare? op)
+                            (intern_node PY-BMF-COMPARE
+                                (list left
+                                      (intern_trivial_string op)
+                                      (lift-recipe rhs-climb)))
+                            (intern_node PY-BMF-BINOP
+                                (list left
+                                      (intern_trivial_string op)
+                                      (lift-recipe rhs-climb)))))
+                    (lift-binop-loop new-left (lift-rest rhs-climb) min-prec)))))
+
+    ;; --- conditional expression ------------------------------------
+    ;;
+    ;; Python's `x if cond else y` — a ternary that lifts to PY-BMF-IF
+    ;; with children (cond, then, else). After parsing the lhs, peek
+    ;; for the `if` keyword; if present, recursively parse the
+    ;; condition, expect `else`, parse the alternative.
+
+    (defn lift-cond-tail (then-recipe tokens)
+        (if (and (not (nil? tokens))
+                 (tok-keyword? (head tokens) "if"))
+            (do
+                (let cond-result (lift-cond-expr (tail tokens)))
+                (let after-cond (lift-rest cond-result))
+                (if (and (not (nil? after-cond))
+                         (tok-keyword? (head after-cond) "else"))
+                    (do
+                        (let else-result (lift-cond-expr (tail after-cond)))
+                        (lift-result
+                            (intern_node PY-BMF-IF
+                                (list (lift-recipe cond-result)
+                                      then-recipe
+                                      (lift-recipe else-result)))
+                            (lift-rest else-result)))
+                    (lift-result then-recipe after-cond)))
+            (lift-result then-recipe tokens)))
+
+    ;; lift-cond-expr: a non-conditional layer (primary + binops); used
+    ;; for the condition and the else-branch so we don't recurse into
+    ;; nested `if` at the same precedence.
+    (defn lift-cond-expr (tokens)
+        (do
+            (let p (lift-primary tokens))
+            (lift-binop-loop (lift-recipe p) (lift-rest p) 0)))
+
+    ;; lift-expr: full expression — climbs binops, then attaches a
+    ;; trailing `if cond else y` if present.
+    (defn lift-expr (tokens)
+        (do
+            (let p (lift-primary tokens))
+            (let climbed (lift-binop-loop (lift-recipe p) (lift-rest p) 0))
+            (lift-cond-tail (lift-recipe climbed) (lift-rest climbed))))
+
+    ;; ---- statement lifters (G1) -------------------------------------
+    ;;
+    ;; Dispatch by python-statement-tree-kind. Each lifter consumes the
+    ;; statement-tree (carries tokens + nested children-statements for
+    ;; block constructs like def) and emits one PY-BMF-* recipe.
+
+    (defn lift-def-body (children)
+        ;; A def's body is a list of statement-trees. The G4 interpreter's
+        ;; PY-BMF-DEF arm reads the body as a single recipe — if it's a
+        ;; single statement, lift it directly; otherwise wrap in a
+        ;; PY-BMF-MODULE-style block so py-eval-module-loop threads the
+        ;; environment statement-by-statement.
+        (if (eq (len children) 1)
+            (lift-statement (head children))
+            (intern_node PY-BMF-MODULE (lift-statements children))))
+
+    (defn lift-statements-loop (statements acc)
+        (if (nil? statements) (reverse acc)
+            (lift-statements-loop
+                (tail statements)
+                (cons (lift-statement (head statements)) acc))))
+
+    (defn lift-statements (statements)
+        (lift-statements-loop statements (empty)))
+
+    ;; def-statement tokens: `def NAME ( PARAM, PARAM, ... ) :`
+    ;; Walk to extract name + param-names; ignore the trailing ":".
+
+    (defn lift-def-params-loop (tokens acc)
+        (if (nil? tokens) (reverse acc)
+            (do
+                (let t (head tokens))
+                (if (tok-op? t ")") (reverse acc)
+                    (if (tok-op? t ",")
+                        (lift-def-params-loop (tail tokens) acc)
+                        (if (tok-name? t)
+                            (lift-def-params-loop (tail tokens)
+                                (cons (intern_trivial_string (tok-value t)) acc))
+                            (lift-def-params-loop (tail tokens) acc)))))))
+
+    (defn lift-def (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let children (python-statement-tree-children statement-tree))
+            ;; tokens[0]=def, tokens[1]=name, tokens[2]="("
+            (let name (tok-value (nth tokens 1)))
+            (let param-leaves (lift-def-params-loop (drop 3 tokens) (empty)))
+            (let body (lift-def-body children))
+            (intern_node PY-BMF-DEF
+                (append
+                    (cons (intern_trivial_string name) param-leaves)
+                    (list body)))))
+
+    ;; return-statement tokens: `return EXPR...`. Drop the keyword,
+    ;; lift the rest as an expression.
+
+    (defn lift-return (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let value (lift-recipe (lift-expr (tail tokens))))
+            (intern_node PY-BMF-RETURN (list value))))
+
+    ;; assignment-statement tokens: `NAME = EXPR...`. The cpython-rule
+    ;; classifier already filtered this to "assignment" iff tokens[1]="=".
+
+    (defn lift-assign (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let name (tok-value (head tokens)))
+            (let value (lift-recipe (lift-expr (drop 2 tokens))))
+            (intern_node PY-BMF-ASSIGN
+                (list (intern_trivial_string name) value))))
+
+    ;; expr-statement: just an expression in statement position.
+
+    (defn lift-expr-stmt (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (lift-recipe (lift-expr tokens))))
+
+    ;; lift-statement dispatches on both `kind` (first-token classifier) and
+    ;; `cpython-rule` (the richer rule-name based on token shape). Examples:
+    ;;   `x = 5`        — kind "expr", cpython-rule "assignment"
+    ;;   `return 7`     — kind "return", cpython-rule "return_stmt"
+    ;;   `def f(): ...` — kind "def", cpython-rule "function_def"
+    ;;
+    ;; The dispatcher prefers the keyword `kind` when it carries enough
+    ;; information; otherwise it falls back to cpython-rule.
+
+    (defn lift-statement (statement-tree)
+        (do
+            (let kind (python-statement-tree-kind statement-tree))
+            (let rule (python-statement-tree-cpython-rule statement-tree))
+            (if (str_eq kind "def")              (lift-def statement-tree)
+            (if (str_eq kind "return")           (lift-return statement-tree)
+            (if (str_eq rule "assignment")       (lift-assign statement-tree)
+            (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
+                (do
+                    (trace "lift-statement: unsupported kind/rule" (list kind rule))
+                    (intern_node PY-BMF-PASS (empty)))))))))
+
+    ;; ---- module lifter (the public surface) ------------------------
+    ;;
+    ;; Given a py-module-tree (from python-parse-module-tree-file or
+    ;; python-parse-module-tree-object), emit a PY-BMF-MODULE recipe
+    ;; whose children are the per-statement recipes. This is the shape
+    ;; py-run (in python-bmf-eval.fk) walks to a value.
+
+    (defn lift-module-tree (module-tree)
+        (intern_node PY-BMF-MODULE
+            (lift-statements (python-module-tree-statements module-tree))))
+
+    (defn lift-module-text (source)
+        (lift-module-tree
+            (python-parse-module-tree-object
+                (python-parse-module-text source))))
+
+    (defn lift-module-file (path)
+        (lift-module-tree (python-parse-module-tree-file path)))
+
+    ;; py-bmf-run-file — the end-to-end alias: source path → value.
+    ;; This is what kernel-bmf-run wires to once G1+G3 land.
+
+    (defn py-bmf-run-file (path)
+        (py-run (lift-module-file path)))
+
+    (defn py-bmf-run-text (source)
+        (py-run (lift-module-text source)))
+
+    ;; sentinel return so the file evaluates to 0 when loaded as a
+    ;; prelude — same convention every form-stdlib file follows.
+    0)

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -1,0 +1,73 @@
+; tests/python-bmf-lift-band.fk — G1 + G3 first attestation
+;
+; The lifter at form-stdlib/python-bmf-lift.fk walks a parsed py-module-tree
+; into PY-BMF-* recipes the G4 closure interpreter (python-bmf-eval.fk)
+; then walks back to a Python-runtime value. This band-test drives the
+; round-trip from real Python source strings — the cells that were
+; previously gated on G1+G3.
+;
+; Every cell's expected value matches CPython on the equivalent source.
+; The aggregate is sensitive to which arm broke (per-cell offset).
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/python-bmf-eval.fk form-stdlib/python-bmf-lift.fk
+
+(do
+    ;; ---- cell 1: bare expression — CPython: 7 + 3 = 10 -----------------
+
+    (let cell1-value (py-bmf-run-text "7 + 3
+"))
+    (let cell1-score (if (eq cell1-value 10) 1000 0))
+
+    ;; ---- cell 2: precedence — CPython: 2 + 3 * 4 = 14 ------------------
+
+    (let cell2-value (py-bmf-run-text "2 + 3 * 4
+"))
+    (let cell2-score (if (eq cell2-value 14) 2000 0))
+
+    ;; ---- cell 3: parenthesised grouping — CPython: (2 + 3) * 4 = 20 ----
+
+    (let cell3-value (py-bmf-run-text "(2 + 3) * 4
+"))
+    (let cell3-score (if (eq cell3-value 20) 3000 0))
+
+    ;; ---- cell 4: def + call + return + binop — CPython:
+    ;;   def f(n): return n + 1
+    ;;   f(41)
+    ;; → 42 ---------------------------------------------------------------
+
+    (let cell4-value (py-bmf-run-text "def f(n):
+    return n + 1
+f(41)
+"))
+    (let cell4-score (if (eq cell4-value 42) 4000 0))
+
+    ;; ---- cell 5: assign + module-scope threading + 2-arg def — CPython:
+    ;;   def add(a, b): return a + b
+    ;;   x = add(10, 20)
+    ;;   x + 5
+    ;; → 35 ---------------------------------------------------------------
+
+    (let cell5-value (py-bmf-run-text "def add(a, b):
+    return a + b
+x = add(10, 20)
+x + 5
+"))
+    (let cell5-score (if (eq cell5-value 35) 5000 0))
+
+    ;; ---- cell 6: factorial (recursion + IF + COMPARE) — CPython:
+    ;;   def fact(n): return 1 if n < 2 else n * fact(n - 1)
+    ;;   fact(6)
+    ;; → 720 --------------------------------------------------------------
+
+    (let cell6-value (py-bmf-run-text "def fact(n):
+    return 1 if n < 2 else n * fact(n - 1)
+fact(6)
+"))
+    (let cell6-score (if (eq cell6-value 720) 6000 0))
+
+    ;; ---- aggregate ----------------------------------------------------
+    ;; Sum when every cell agrees with CPython:
+    ;;   1000 + 2000 + 3000 + 4000 + 5000 + 6000 = 21000
+
+    (sum (list cell1-score cell2-score cell3-score
+               cell4-score cell5-score cell6-score)))

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -306,6 +306,7 @@ ritual.
 | 2026-05-27 | [#2071](https://github.com/seeker71/Coherence-Network/pull/2071) | Python arithmetic binary ops (`a - b`, `x * y`, `left / right`, `p ** q`) | `form/form-stdlib/tests/python-bmf-arithmetic-band.fk` returns `25304` | Go ✓ · Rust ✓ · TypeScript ✓ (131/131 in `./validate.sh`) |
 | 2026-05-27 | `claude/g6-kernel-bmf-run` | G6 — binary entry-point orchestration. `kernel-bmf-run <file.py>` exists, pre-compiles surface-syntax preludes via the Go-kernel-as-compiler, invokes the Rust kernel with a `python-parse-module-file` driver. The `command -v kernel-bmf-run` gate in `parity_suite.sh` opens — `PARITY_THIRD_RUNTIME=kernel-bmf` is runnable end-to-end | `form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-run examples/python_demo.py` returns `15` (top-level statement count from `python-parse-module-file`) | Go ✓ · Rust ✓ · TypeScript ✓ (same `len-of-statements` driver run through `./validate.sh` returns `15` on all three) |
 | 2026-05-27 | `claude/g4-pybmf-closure-interpreter` | G4 — closure/scope interpreter for PY-BMF recipes. Nine arms walk to Python-runtime values: `PY-BMF-INT`, `PY-BMF-IDENT`, `PY-BMF-BINOP` (+/-/*/// /%/**/​//), `PY-BMF-COMPARE` (==/!=/</<=/>/>=), `PY-BMF-RETURN`, `PY-BMF-ASSIGN`, `PY-BMF-DEF` (closure capture), `PY-BMF-CALL` (with self-name tied for self-recursion), `PY-BMF-IF`, `PY-BMF-MODULE`. Scope is an alist; closures store `(self-name, params, body, captured-env)`. ~270 LOC. Surface lives at `form/form-stdlib/python-bmf-eval.fk` | `form/form-stdlib/tests/python-bmf-eval-band.fk` builds seven recipe-cells directly via `intern_node` (mirroring `python-bmf-arithmetic-band.fk`'s test discipline) and walks them: `7+3=10`, `((20-5)*3)//7=6`, `x*x` with `x=11→121`, `x=6;x*7→42`, `def add(a,b):return a+b; add(10,20)+5→35`, `def absdiff(a,b):return a-b if a>=b else b-a; absdiff(7,19)→12`, `def fact(n):return 1 if n<2 else n*fact(n-1); fact(6)→720`. Scored aggregate returns `28000` | Go ✓ · Rust ✓ · TypeScript ✓ (in `./validate.sh` workload `stdlib/python-bmf-eval-band.fk`) |
+| 2026-05-27 | `claude/g1-g3-parser-to-recipe-bridge` | G1 + G3 — parser-to-recipe bridge. `form/form-stdlib/python-bmf-lift.fk` (~375 LOC) lifts the statement-tree from `python-parse-module-tree-*` to PY-BMF-* recipes the G4 interpreter walks. G1: statement dispatch over `python-statement-tree-kind` + `cpython-rule` (def/return/assignment/expr). G3: precedence-climbing expression parser with right-assoc `**`, left-assoc `* / // % + -`, comparison precedence, parenthesised grouping, conditional `x if c else y` lifting to `PY-BMF-IF`, n-ary `f(args)` to `PY-BMF-CALL`. `kernel-bmf-run`'s driver swaps from `(len statements)` to `(py-bmf-run-file path)`. The `examples/python_bridge_demo.py` factorial demo now closes three-way against CPython | `form/form-stdlib/tests/python-bmf-lift-band.fk` drives six cells from source-string through the full lift+eval: `7+3=10`, `2+3*4=14`, `(2+3)*4=20`, `def f(n):return n+1; f(41)=42`, `def add(a,b):return a+b; x=add(10,20); x+5=35`, `def fact(n):return 1 if n<2 else n*fact(n-1); fact(6)=720`. Scored aggregate returns `21000`. End-to-end `kernel-bmf-run examples/python_bridge_demo.py` prints `720`, matching CPython and the bootstrap Rust path | Go ✓ · Rust ✓ · TypeScript ✓ (in `./validate.sh` workload `stdlib/python-bmf-lift-band.fk`) |
 
 **What G6 closes and what stays open.** G6 was the orchestration gap — the
 pieces existed (Go compiler, Rust walker, Python BMF grammar) with no binary
@@ -316,20 +317,50 @@ returns the statement count (15), not the program's CPython value (40949).
 The driver swaps to a recipe-walking expression in the same script when G4
 (closure interpreter) lands; the orchestration shape stays.
 
-**Open contract for the next PROVEN rows:** `kernels/PYTHON_BMF_CONTRACT.md`
-G1 (automatic rule dispatcher) unlocks composition of these arithmetic rules
-into full expressions; G2 (statement grouping) unlocks `def` / `if` /
-`return`; G3 (precedence climbing) makes `1 + 2 * 3` parse correctly; G4
-(closure interpreter) is the gate that lets PROVEN rows progress to
-**COMPOST READY** for the matching Phase-A file. With G6 closed, every
-future G1–G4 increment is testable through `kernel-bmf-run` — no further
-orchestration breath is needed.
+**Open contract for the next PROVEN rows:** the surface beyond the 9 arms
+needs both a lift dispatch branch in `python-bmf-lift.fk` and a matching
+interpreter arm in `python-bmf-eval.fk`. Order of incoming breaths (each is
+its own focused PR):
 
-**The first walking step:** with this row recorded, the manifest's lifecycle
-is no longer a future-tense convention. It has its first arrival. Every
-future Form-native parity proof appends below this row; every Phase-A file
-whose proofs accumulate to coverage moves to COMPOST READY; every composted
-file moves to RELEASED.
+- `PY-BMF-WHILE` + while-statement lift — `while cond: body`
+- `PY-BMF-LIST` + list-literal lift + `PY-BMF-SUBSCRIPT` for `xs[i]`
+- `PY-BMF-DICT` + dict-literal lift + key access
+- `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`
+- `PY-BMF-FOR` + iterator protocol on lists / ranges
+- `PY-BMF-LAMBDA` + closure capture in expressions
+- `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment
+
+Each PROVEN row brings one more `PARITY_FILES` demo green under
+`PARITY_THIRD_RUNTIME=kernel-bmf`. When `lang-python.ts`'s full surface is
+covered by Form-native arms, the Phase-A `lang-python.ts` row moves to
+COMPOST READY.
+
+---
+
+## COMPOST READY — rows whose shape is fully Form-native
+
+A row appears here when every shape a specific demo expresses has been
+PROVEN three-way under `PARITY_THIRD_RUNTIME=kernel-bmf` *and* under the
+bootstrap path. The .py file no longer needs the TS bootstrap to reach
+its CPython value — both the Rust kernel (bootstrap path) and
+`kernel-bmf-run` (Form-native path) print the same number.
+
+The Phase-A file that *only* this demo would have needed isn't compostable
+yet — other demos still flex shapes the bootstrap covers and the bridge
+doesn't. But the demo itself sits in the readiness zone: every breath that
+follows narrows the gap. When all `PARITY_FILES` rows reach COMPOST READY,
+`lang-python.ts` (and the bootstrap parser tissue around it) becomes
+removable.
+
+| Date | Demo | Shape | Bridge support | Three-way value |
+|---|---|---|---|---|
+| 2026-05-27 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.py` | factorial — `def fact(n): return 1 if n<2 else n*fact(n-1); result = fact(6); result` (9 arms: INT, IDENT, BINOP, COMPARE, RETURN, ASSIGN, DEF, CALL, IF, MODULE) | `form/form-stdlib/python-bmf-lift.fk` + `form/form-stdlib/python-bmf-eval.fk` | CPython `720` · Rust (bootstrap) `720` · `kernel-bmf-run` `720` |
+
+**The first walking step:** with the G4 row recorded and G1+G3 now also
+landed, the manifest's lifecycle is no longer a future-tense convention.
+It has its first arrival in both columns. Every future Form-native parity
+proof appends below; every Phase-A file whose proofs accumulate to
+coverage moves to COMPOST READY; every composted file moves to RELEASED.
 
 The body sees its first cell move through the discipline. The path becomes
 walkable because the first step has been walked.

--- a/kernels/PYTHON_BMF_CONTRACT.md
+++ b/kernels/PYTHON_BMF_CONTRACT.md
@@ -11,15 +11,24 @@ End-to-end, on every sibling kernel (Go, Rust, TypeScript), with no
 TypeScript on the parse path:
 
 ```
-source text  →  python-source-scan-text   →  BMF object stream
-            →  apply-python-bmf-rule       →  PY-BMF-* recipe (NodeID)
+source text  →  python-source-scan-text     →  BMF object stream
+            →  python-parse-module-tree-*   →  statement-tree
+            →  python-bmf-lift.fk           →  PY-BMF-* recipe (NodeID)
+            →  python-bmf-eval.fk (py-run)  →  Python-runtime value
 ```
 
-Proved by `form/form-stdlib/tests/python-bmf-arithmetic-band.fk` (returns
-25304 on all three kernels). The test drives the full path from real
-source strings like `"a - b"`, `"x * y"`, `"left / right"`, `"p ** q"`,
-producing `PY-BMF-BINOP` recipes with content-addressed identity (same
-source twice → identical NodeID).
+Proved by:
+
+- `form/form-stdlib/tests/python-bmf-arithmetic-band.fk` (returns `25304`
+  on all three kernels) — flat-rule arithmetic recipes are content-
+  addressed and round-trip to source.
+- `form/form-stdlib/tests/python-bmf-eval-band.fk` (returns `28000`) —
+  recipe-walker (G4) covers the 9 arms.
+- `form/form-stdlib/tests/python-bmf-lift-band.fk` (returns `21000`) —
+  source-string → PY-BMF recipe → value round-trip across six cells,
+  including factorial(6) = 720.
+- `kernel-bmf-run examples/python_bridge_demo.py` returns `720` — three-way
+  parity with CPython and the bootstrap Rust path.
 
 What's already in `python-bmf.fk` and reachable today:
 
@@ -42,57 +51,68 @@ The pieces below currently live in `form/form-kernel-ts/seedbank/python-adapter/
 (TS) and have no Form-native equivalent yet. Each is one focused breath
 the body has not yet taken.
 
-### G1 — Rule dispatch over a stream
+### G1 — Statement dispatch over a parsed tree — **CLOSED 2026-05-27**
 
-Today's surface forces callers to name the rule:
+Closure shape: rather than dispatch over a flat rule-index of object-stream
+rules, the bridge dispatches over the **statement-tree** that
+`python-parse-module-tree-object` already builds (G2 territory). The tree
+groups tokens by indent and exposes each statement's `kind` (first-token
+classifier) and `cpython-rule` (rule-name based on token shape).
 
-```form
-(apply-python-bmf-rule "binop-sub-ident" toks)
-```
-
-To parse arbitrary Python, the body needs a **dispatch loop** that, given
-a token stream, tries registered rules in some order (longest-match,
-priority, or left-anchored by first-token kind/value) and emits a stream
-of recipes. Two viable Form-native shapes:
+Lives at `form/form-stdlib/python-bmf-lift.fk`. The `lift-statement` arm
+dispatches by both:
 
 ```form
-;; Shape G1a — try rules in priority order
-(parse-python-stream toks)         → list-of-recipe
-;; Shape G1b — peek-driven dispatch (faster, needs a first-token index)
-(python-bmf-dispatch toks rule-index)
+(if (str_eq kind "def")        (lift-def statement-tree)
+(if (str_eq kind "return")     (lift-return statement-tree)
+(if (str_eq rule "assignment") (lift-assign statement-tree)
+(if (str_eq kind "expr")       (lift-expr-stmt statement-tree) ...)))))
 ```
 
-Either shape is ~80 lines of Form sitting on top of the existing
-`apply-object-rule`. No new kernel primitive needed.
+Each branch consumes the statement's tokens (and, for `def`, its nested
+children-statements) and emits a `PY-BMF-*` recipe via `intern_node` — the
+exact constructors `python-bmf-eval.fk`'s arms expect. The `PY-BMF-MODULE`
+recipe wraps the per-statement recipes so `py-eval-module-loop` threads the
+env across `ASSIGN` and `DEF`.
 
-### G2 — Statement-level grouping
+**What G1 does NOT close yet:** statement kinds beyond the four above
+(`class` / `while` / `for` / `try` / `with` / `import` / `from-import`)
+fall through to `PY-BMF-PASS` with a `trace` naming the shape. Each is one
+focused breath: add the lift dispatch branch + the matching interpreter arm.
 
-A Python module is a sequence of statements; statements close on
-NEWLINE/INDENT/DEDENT. The scanner already emits layout tokens; what's
-missing is a Form-side **statement-stream slicer** that hands one
-statement's worth of tokens to G1 at a time:
+### G2 — Statement-level grouping — **CLOSED (existing)**
 
-```form
-(python-statement-stream layout-toks)   → list-of-(token-sublist)
-```
+`python-parse-module-tree-object` and friends already grouped tokens into
+statement-trees by indent. G1's lifter consumes them directly; no separate
+slicer was needed.
 
-`python-bmf.fk` already has `python-parse-statement`,
-`python-parse-module-objects`, and `python-parse-module-tree-object` —
-they group statements by indent. Wire them into G1 and most CPython
-syntax becomes parseable Form-native.
+### G3 — Expression precedence climbing — **CLOSED 2026-05-27**
 
-### G3 — Expression precedence climbing
+Closure shape: **recursive-descent expression parser in
+`python-bmf-lift.fk`** sitting alongside G1's statement dispatch.
+`lift-expr` calls `lift-primary` for the leftmost token, then
+`lift-binop-loop` climbs by precedence, then attaches a trailing
+`x if cond else y` (the Python conditional expression) by lifting to
+`PY-BMF-IF`.
 
-The current BMF rules are *flat* — `binop-mul-ident ::= $left:name "*"
-$right:name` only matches two name terminals separated by `*`. Real
-expressions like `a + b * c` need a precedence-aware engine: the body's
-`form-stdlib/parser.fk` already has hand-coded precedence climbing for
-Form-surface arithmetic; the Python-BMF equivalent reuses that pattern
-against BMF objects rather than Form tokens.
+Precedence table (higher = tighter):
 
-Until G3 lands, every expression shape needs its own flat rule
-(`binop-mul-ident`, `binop-mul-mul-ident`, …) — combinatorial blowup
-that the precedence engine collapses to a single recursive descent.
+| Prec | Ops |
+|---|---|
+| 50 | `**` (right-assoc) |
+| 40 | `* / // %` |
+| 30 | `+ -` |
+| 20 | `== != < <= > >=` |
+
+`lift-primary` handles integer literals → `PY-BMF-INT`, identifiers →
+`PY-BMF-IDENT`, `f(args)` → `PY-BMF-CALL` (with `lift-args` reading
+comma-separated expressions until `)`), and parenthesised expressions for
+grouping.
+
+**What G3 does NOT close yet:** unary minus on non-trivial expressions,
+boolean `and` / `or` / `not`, bitwise / shift ops, `in` / `is` /
+`is not` / `not in`, attribute access `obj.field`, subscripts `xs[i]`,
+slices `xs[a:b:c]`, walrus `:=`, lambdas, comprehensions, f-strings.
 
 ### G4 — Closure/scope at the recipe layer — **CLOSED 2026-05-27**
 
@@ -171,20 +191,22 @@ compiled artifacts plus an inline driver that calls
 `command -v kernel-bmf-run` check, so `PARITY_THIRD_RUNTIME=kernel-bmf
 bash parity_suite.sh` runs end-to-end with no operator-side install.
 
-What the driver computes today: the count of top-level statements in the
-parsed module (e.g. `15` for `examples/python_demo.py`). Three-way sibling
-parity holds at the structural-attestation layer — Go, Rust, and the TS
-kernel all return `15`. This is the **orchestration breath**, not the
-program-value breath; the latter is gated on G3 + G4.
+What the driver computes today (with G1 + G3 + G4 all closed): the
+program's CPython runtime value, for any `.py` file whose shapes fit the
+9 PY-BMF arms shipped. The preludes load `python-bmf-eval.fk` and
+`python-bmf-lift.fk`; the driver expression is `(py-bmf-run-file path)`.
 
-What the driver does NOT compute yet: the program's CPython runtime value
-(`40949` for `python_demo.py`). The closure-walker over `PY-BMF-CALL` /
-`PY-BMF-IF` / `PY-BMF-DEF` recipes is alive (G4 above is CLOSED), but the
-input side of the pipeline still hands `kernel-bmf-run` a *statement-object
-module*, not a PY-BMF recipe tree — that's G1's gate. When G1 (rule
-dispatch over the token stream) produces PY-BMF recipes from a source
-file, the driver swaps `(len statements)` for `(py-run module-recipe)`
-and the orchestration shape stays identical.
+`kernel-bmf-run form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.py`
+returns `720` (factorial of 6) — three-way sibling parity green, matching
+CPython.
+
+Demos that use shapes outside the 9 arms (lists, dicts, classes, while/for,
+comprehensions, attribute access, subscripts, etc.) still surface honest
+traces from `py-env-lookup` or `lift-statement: unsupported kind/rule`.
+Each unsupported shape is one focused breath: add the lift dispatch
+branch in `python-bmf-lift.fk` + the matching interpreter arm in
+`python-bmf-eval.fk`. The contract scales linearly with surface coverage;
+no further orchestration breath is needed.
 
 **Three reachable shapes for G6 (kept for record; #1 was taken):**
 


### PR DESCRIPTION
## Walking step — the kernel-bmf gate has its first green

**`PARITY_THIRD_RUNTIME=kernel-bmf bash parity_suite.sh` returns `720` three-way** for `python_bridge_demo.py` (`factorial(6)`). CPython, Rust bootstrap kernel, and `kernel-bmf-run` via Form-native PY-BMF lift+interpreter all agree.

**This is the first parity-suite demo to close the kernel-bmf gate.** The body has its first **COMPOST READY** row.

## The bridge that landed

**`form/form-stdlib/python-bmf-lift.fk`** (~375 LOC) — G1 statement dispatch + G3 expression precedence climbing:

- **G1**: `def` / `return` / `assignment` / `expr` dispatched via `kind` + `cpython-rule`
- **G3**: Precedence climbing:
  - `**` right-assoc, prec 50
  - `* / // %` left-assoc, prec 40
  - `+ -` left-assoc, prec 30
  - `== != < <= > >=` prec 20
  - parens, n-ary calls, `x if c else y` → `PY-BMF-IF`

The lift sits **above** the BMF rule machinery, walking the parsed tree directly. The 175-rule stack ceiling the audit named didn't surface — sidestepped by lifting at the right altitude.

## The chain that's now live end-to-end

```
Python source bytes
  → python-bmf.fk (parser) → statement-classified BMF objects
  → python-bmf-lift.fk (lift)  → PY-BMF-* recipes ← NEW
  → python-bmf-eval.fk (interpreter, G4) → Python-runtime values
  → kernel-bmf-run (driver) prints to stdout
```

Three sibling kernels all walk this. **The Python pipeline now has its first end-to-end Form-native path proven.**

## What ships

- `form/form-stdlib/python-bmf-lift.fk` (~375 LOC) — the bridge
- `form/form-stdlib/tests/python-bmf-lift-band.fk` — 6 cells, aggregate **21000** on Go/Rust/TS
- `form/form-kernel-ts/seedbank/python-adapter/examples/python_bridge_demo.py` + `.fk`
- `kernel-bmf-run` — driver swapped from `(len statements)` to `(py-bmf-run-file path)`, preludes loaded
- `parity_suite.sh` — `PARITY_FILES` gains `python_bridge_demo.py` as the first row to pass under `kernel-bmf`
- `kernels/BOOTSTRAP_COMPOST_MANIFEST.md` — new **PROVEN** row for G1+G3; **new COMPOST READY section opens** with `python_bridge_demo.py` as its first row
- `kernels/PYTHON_BMF_CONTRACT.md` — G1, G2, G3 marked **CLOSED 2026-05-27**; G6 description updated to reflect program-value walks

## What this opens

The discipline scales **linearly** now (each new Python shape = one branch in `python-bmf-lift.fk` + one matching arm in `python-bmf-eval.fk`). The previously-stuck "combinatorial blowup" worry G3 carried has dissolved.

Other `PARITY_FILES` demos still need their shapes added (lists, dicts, classes, while/for, attribute access, subscripts, lambdas, comprehensions, unary, boolean ops). Each is one focused breath. **None require new architecture.**

When more demos pass under `kernel-bmf`, more rows move to **COMPOST READY**. When all `PARITY_FILES` pass, `PARITY_THIRD_RUNTIME=kernel-bmf` becomes the default, and the Phase-A 3,585-LOC bootstrap-residue compost actually happens.

## Test plan

- [x] `kernel-bmf-run examples/python_bridge_demo.py` → 720 (Go, Rust, TS sibling kernels)
- [x] `python-bmf-lift-band.fk` returns 21000 three-way
- [x] CPython baseline returns 720
- [x] `./validate.sh` stays green (no regressions)

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md). **The kernel now reads Python source through Python's own BMF grammar, walks the recipe through Python's own interpreter shape, and returns Python's value — all in pure Form on three sibling kernels.** The body has crossed the threshold.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_