### PR TITLE
feat(kernels): 7 more PY-BMF arms — past the iteration gate (LIST/SUBSCRIPT/WHILE/AUG-ASSIGN/LAMBDA/DICT/STRING)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -5,26 +5,35 @@
 ; def + call + return + binop + ident + int chain end-to-end, matching the
 ; value CPython would compute for the same expression.
 ;
-; What walks today (the minimum-viable arms):
+; What walks today (the minimum-viable arms plus the second-breath set):
 ;
-;   PY-BMF-INT       → integer leaf       (returns node_value)
-;   PY-BMF-IDENT     → env lookup         (alist-style scope)
-;   PY-BMF-BINOP     → recursive eval + op dispatch (+ - * / % ** //)
-;   PY-BMF-COMPARE   → recursive eval + comparison dispatch (== != < <= > >=)
-;   PY-BMF-IF        → branch on condition
-;   PY-BMF-RETURN    → eval the inner expression
-;   PY-BMF-ASSIGN    → bind-in-scope; returns extended env
-;   PY-BMF-DEF       → bind name → closure(params, body, captured-env)
-;   PY-BMF-CALL      → invoke closure: bind args, walk body
-;   PY-BMF-MODULE    → fold over statements, return last value
+;   PY-BMF-INT        → integer leaf       (returns node_value)
+;   PY-BMF-STRING     → string leaf        (returns node_value)
+;   PY-BMF-IDENT      → env lookup         (alist-style scope)
+;   PY-BMF-BINOP      → recursive eval + op dispatch (+ - * / % ** //)
+;   PY-BMF-COMPARE    → recursive eval + comparison dispatch (== != < <= > >=)
+;   PY-BMF-IF         → branch on condition
+;   PY-BMF-RETURN     → eval the inner expression
+;   PY-BMF-ASSIGN     → bind-in-scope; returns extended env
+;   PY-BMF-AUG-ASSIGN → x op= v  →  rebind x to (x op v)
+;   PY-BMF-DEF        → bind name → closure(params, body, captured-env)
+;   PY-BMF-LAMBDA     → anonymous closure (self-name = "")
+;   PY-BMF-CALL       → invoke closure: bind args, walk body
+;   PY-BMF-LIST       → eval children → Form list of values
+;   PY-BMF-DICT       → even/odd children = key/value recipes; value =
+;                       alist of (key value) pairs
+;   PY-BMF-SUBSCRIPT  → eval obj + index → nth(obj, index) for list-typed
+;                       objects; alist-lookup for dict-typed objects
+;   PY-BMF-WHILE      → first child is cond-recipe, rest are body-statements;
+;                       loop while cond≠0, threading env through body
+;   PY-BMF-MODULE     → fold over statements, return last value
 ;
 ; What does NOT walk yet (named honestly, gated on later breaths):
 ;
-;   PY-BMF-CLASS, PY-BMF-WHILE, PY-BMF-FOR, PY-BMF-LIST, PY-BMF-DICT,
-;   PY-BMF-SUBSCRIPT, PY-BMF-LAMBDA, PY-BMF-TUPLE, PY-BMF-AUG-ASSIGN,
-;   PY-BMF-TRY/RAISE, PY-BMF-IMPORT, comprehensions, slices, attrs,
-;   method calls, unary minus on non-trivial expressions, string ops,
-;   float arithmetic.
+;   PY-BMF-CLASS, PY-BMF-FOR, PY-BMF-TUPLE, PY-BMF-TRY/RAISE,
+;   PY-BMF-IMPORT, comprehensions, slices, attrs, method calls,
+;   unary minus on non-trivial expressions, string ops, float arithmetic,
+;   mutual recursion + general letrec.
 ;
 ; Each of those is its own focused breath. The discipline this interpreter
 ; holds: dispatch is by node_category, scope is a Form-side alist, and a
@@ -142,6 +151,51 @@
     (defn py-eval-args (recipes env)
         (py-eval-args-loop recipes env (empty)))
 
+    ;; ---- collection values -------------------------------------------
+    ;;
+    ;; PY-BMF-LIST values are plain Form lists. PY-BMF-DICT values are
+    ;; sentinel-tagged alists: (cons "py-dict" pairs) where each pair is
+    ;; a two-element list (key value). py-dict? lets SUBSCRIPT pick the
+    ;; right lookup path.
+
+    (defn py-dict-tag () "py-dict")
+
+    ;; py-dict? — safe across kernels regardless of value kind. value_eq
+    ;; is polymorphic across Value variants (Int/Str/Null/etc) and returns
+    ;; false on kind mismatch; str_eq would panic on a non-string head.
+    ;; List literals routinely have int heads, so the polymorphic compare
+    ;; is the load-bearing piece.
+    (defn py-dict? (v)
+        (and (not (nil? v))
+             (value_eq (head v) (py-dict-tag))))
+
+    (defn py-dict-pairs (d) (tail d))
+
+    ;; Dict keys arrive as strings in today's surface; the lookup walks
+    ;; pairs with str_eq. Integer-keyed dicts are a later breath.
+    (defn py-dict-lookup-str-loop (pairs key)
+        (if (nil? pairs)
+            (do
+                (trace "py-dict-lookup: missing key" key)
+                (head (empty)))
+            (if (str_eq (head (head pairs)) key)
+                (head (tail (head pairs)))
+                (py-dict-lookup-str-loop (tail pairs) key))))
+
+    ;; pairs-of-children: walk a flat (k1 v1 k2 v2 ...) child stream and
+    ;; eval each into a (key-value value-value) pair. Encoding: DICT
+    ;; children are 2*N recipes; even index = key-recipe, odd = value.
+    (defn py-eval-dict-pairs-loop (kids env acc)
+        (if (nil? kids)
+            (reverse acc)
+            (do
+                (let k (py-eval (head kids) env))
+                (let v (py-eval (head (tail kids)) env))
+                (py-eval-dict-pairs-loop
+                    (tail (tail kids))
+                    env
+                    (cons (list k v) acc)))))
+
     (defn py-bind-params-loop (pms args env)
         (if (nil? pms) env
             (py-bind-params-loop
@@ -178,6 +232,28 @@
     (defn py-last (xs)
         (if (nil? (tail xs)) (head xs) (py-last (tail xs))))
 
+    ;; py-while-loop — drive a WHILE body, threading env until the cond
+    ;; recipe evaluates to 0. Each body iteration walks its statements
+    ;; through py-eval-statement (mutual recursion: py-while-loop calls
+    ;; py-eval-body-loop which calls py-eval-statement which calls back
+    ;; through py-while-loop when the body itself contains a WHILE). The
+    ;; Form runtime resolves forward references at call-time, so the
+    ;; ordering below works.
+
+    (defn py-eval-body-loop (stmts env)
+        (if (nil? stmts) env
+            (do
+                (let r (py-eval-statement (head stmts) env))
+                (py-eval-body-loop (tail stmts) (py-stmt-env r)))))
+
+    (defn py-while-loop (cond-recipe body-stmts env)
+        (if (eq (py-eval cond-recipe env) 0)
+            env
+            (py-while-loop
+                cond-recipe
+                body-stmts
+                (py-eval-body-loop body-stmts env))))
+
     (defn py-eval-statement (recipe env)
         (do
             (let cat (node_category recipe))
@@ -188,6 +264,27 @@
                     (let name (node_value (nth kids 0)))
                     (let value (py-eval (nth kids 1) env))
                     (py-stmt-result value (py-env-extend env name value)))
+            (if (node_eq cat PY-BMF-AUG-ASSIGN)
+                (do
+                    ;; AUG-ASSIGN children: name-leaf, op-leaf, value-recipe.
+                    ;; Equivalent to `name = (lookup name) op (eval value)`.
+                    (let name (node_value (nth kids 0)))
+                    (let op (node_value (nth kids 1)))
+                    (let old (py-env-lookup env name))
+                    (let delta (py-eval (nth kids 2) env))
+                    (let new-val (py-binop-apply op old delta))
+                    (py-stmt-result new-val (py-env-extend env name new-val)))
+            (if (node_eq cat PY-BMF-WHILE)
+                (do
+                    ;; WHILE children: cond-recipe, body-stmt-recipes...
+                    ;; Loop while cond evaluates non-zero, threading env
+                    ;; through each body statement (so loop bodies can
+                    ;; mutate via ASSIGN / AUG-ASSIGN). The statement
+                    ;; itself returns 0 (Python None analogue).
+                    (let cond-recipe (head kids))
+                    (let body-stmts (tail kids))
+                    (let final-env (py-while-loop cond-recipe body-stmts env))
+                    (py-stmt-result 0 final-env))
             (if (node_eq cat PY-BMF-DEF)
                 (do
                     ;; DEF children: name-leaf, param-leaves..., body-recipe.
@@ -199,7 +296,7 @@
                     (let closure (py-closure name pms body env))
                     (py-stmt-result closure (py-env-extend env name closure)))
                 ;; Default: expression statement — eval, env unchanged.
-                (py-stmt-result (py-eval recipe env) env)))))
+                (py-stmt-result (py-eval recipe env) env)))))))
 
     (defn py-eval-module-loop (statements env last-value)
         (if (nil? statements) last-value
@@ -215,6 +312,10 @@
             (let cat (node_category recipe))
             (let kids (node_children recipe))
             (if (node_eq cat PY-BMF-INT)
+                (node_value (head kids))
+            (if (node_eq cat PY-BMF-STRING)
+                ;; STRING literal: the trivial-string child's node_value
+                ;; *is* the runtime value. Mirrors the INT shape.
                 (node_value (head kids))
             (if (node_eq cat PY-BMF-IDENT)
                 (py-env-lookup env (node_value (head kids)))
@@ -259,6 +360,37 @@
                                     arg-values
                                     captured-with-self))
                     (py-eval (py-closure-body closure) call-env))
+            (if (node_eq cat PY-BMF-LIST)
+                ;; LIST children: element-recipes. Value is a Form list
+                ;; of evaluated elements, in source order.
+                (py-eval-args kids env)
+            (if (node_eq cat PY-BMF-DICT)
+                ;; DICT children: (k1 v1 k2 v2 ...) — 2N recipes. Value
+                ;; is a sentinel-tagged alist so SUBSCRIPT can pick the
+                ;; right lookup path.
+                (cons (py-dict-tag) (py-eval-dict-pairs-loop kids env (empty)))
+            (if (node_eq cat PY-BMF-SUBSCRIPT)
+                (do
+                    ;; SUBSCRIPT children: object-recipe, index-recipe.
+                    ;; Dict → string-keyed alist lookup. List → nth(idx).
+                    ;; Integer-keyed dicts are a later breath; today's
+                    ;; band-test exercises the common string-keyed case.
+                    (let obj (py-eval (nth kids 0) env))
+                    (let idx (py-eval (nth kids 1) env))
+                    (if (py-dict? obj)
+                        (py-dict-lookup-str-loop (py-dict-pairs obj) idx)
+                        (nth obj idx)))
+            (if (node_eq cat PY-BMF-LAMBDA)
+                ;; LAMBDA children: param-leaves..., body-recipe.
+                ;; Builds an anonymous closure with self-name "" so the
+                ;; recursive-knot path in CALL does no harm (CALL only
+                ;; finds it via env binding from an enclosing ASSIGN).
+                (do
+                    (let n (len kids))
+                    (let body (py-last kids))
+                    (let param-leaves (py-take kids (sub n 1)))
+                    (let pms (py-collect-params-loop param-leaves (len param-leaves) (empty)))
+                    (py-closure "" pms body env))
             (if (node_eq cat PY-BMF-MODULE)
                 (py-eval-module-loop kids env 0)
                 (do
@@ -266,7 +398,7 @@
                     ;; category number so the next breath knows which
                     ;; arm to add.
                     (trace "py-eval: unimplemented category" cat)
-                    (head (empty)))))))))))))
+                    (head (empty))))))))))))))))))
 
     ;; Surface for callers. py-run takes a module recipe and returns its
     ;; value. py-eval and py-eval-statement are exposed so band-tests

--- a/form/form-stdlib/tests/python-bmf-eval-band.fk
+++ b/form/form-stdlib/tests/python-bmf-eval-band.fk
@@ -59,6 +59,45 @@
     (defn py-module (stmts)
         (intern_node PY-BMF-MODULE stmts))
 
+    (defn mk-py-list (elems)
+        (intern_node PY-BMF-LIST elems))
+
+    (defn mk-py-subscript (obj idx)
+        (intern_node PY-BMF-SUBSCRIPT (list obj idx)))
+
+    (defn mk-py-aug-assign (name op delta)
+        (intern_node PY-BMF-AUG-ASSIGN
+            (list (intern_trivial_string name)
+                  (intern_trivial_string op)
+                  delta)))
+
+    (defn mk-py-while (cond body-stmts)
+        ;; WHILE children: cond-recipe, body-stmt-recipes... — flatten the
+        ;; body list onto a (cond . body) child stream.
+        (intern_node PY-BMF-WHILE (cons cond body-stmts)))
+
+    (defn mk-leaf-str (s) (intern_trivial_string s))
+
+    (defn mk-py-lambda (pms body)
+        ;; LAMBDA children: param-leaves..., body-recipe (last child).
+        ;; Naming note: the parameter is "pms" not "params" because
+        ;; `params` is a reserved Form verb (builds a SEQUENCE block);
+        ;; using it as a defn parameter silently truncates the arg list
+        ;; at parse time.
+        (do
+            (let param-leaves (map mk-leaf-str pms))
+            (intern_node PY-BMF-LAMBDA (append param-leaves (list body)))))
+
+    (defn mk-py-str-lit (s)
+        ;; PY-BMF-STRING wraps a trivial-string leaf; py-eval reads
+        ;; node_value to recover the runtime string. Same shape as INT.
+        (intern_node PY-BMF-STRING (list (intern_trivial_string s))))
+
+    (defn mk-py-dict (pairs)
+        ;; pairs is a flat (k1-recipe v1-recipe k2-recipe v2-recipe ...)
+        ;; list; the interpreter expects exactly that shape.
+        (intern_node PY-BMF-DICT pairs))
+
     ;; ---- cell 1: bare arithmetic — CPython: 7 + 3 = 10 ---------------
 
     (let cell1
@@ -164,9 +203,121 @@
     (let cell7-value (py-run cell7))                           ; 720
     (let cell7-score (if (eq cell7-value 720) 7000 0))
 
+    ;; ---- cell 8: LIST + SUBSCRIPT — indexed access.
+    ;;   xs = [10, 20, 30, 40]
+    ;;   xs[2] + xs[0]
+    ;; CPython: 30 + 10 = 40 ---------------------------------------------
+
+    (let cell8
+        (py-module
+            (list
+                (py-assign "xs"
+                    (mk-py-list (list (py-int-lit 10) (py-int-lit 20)
+                                   (py-int-lit 30) (py-int-lit 40))))
+                (py-binop
+                    (mk-py-subscript (py-ident "xs") (py-int-lit 2))
+                    "+"
+                    (mk-py-subscript (py-ident "xs") (py-int-lit 0))))))
+    (let cell8-value (py-run cell8))                           ; 40
+    (let cell8-score (if (eq cell8-value 40) 8000 0))
+
+    ;; ---- cell 9: WHILE + AUG-ASSIGN — counted sum.
+    ;;   total = 0
+    ;;   i = 1
+    ;;   while i <= 10:
+    ;;       total += i
+    ;;       i += 1
+    ;;   total
+    ;; CPython: 55 -------------------------------------------------------
+
+    (let cell9
+        (py-module
+            (list
+                (py-assign "total" (py-int-lit 0))
+                (py-assign "i" (py-int-lit 1))
+                (mk-py-while
+                    (py-compare (py-ident "i") "<=" (py-int-lit 10))
+                    (list
+                        (mk-py-aug-assign "total" "+" (py-ident "i"))
+                        (mk-py-aug-assign "i" "+" (py-int-lit 1))))
+                (py-ident "total"))))
+    (let cell9-value (py-run cell9))                           ; 55
+    (let cell9-score (if (eq cell9-value 55) 9000 0))
+
+    ;; ---- cell 10: LAMBDA — anonymous closure bound by ASSIGN.
+    ;;   square = lambda n: n * n
+    ;;   square(7) + square(3)
+    ;; CPython: 49 + 9 = 58 ---------------------------------------------
+
+    (let square-body
+        (py-binop (py-ident "n") "*" (py-ident "n")))
+    (let cell10
+        (py-module
+            (list
+                (py-assign "square" (mk-py-lambda (list "n") square-body))
+                (py-binop
+                    (py-call "square" (list (py-int-lit 7)))
+                    "+"
+                    (py-call "square" (list (py-int-lit 3)))))))
+    (let cell10-value (py-run cell10))                         ; 58
+    (let cell10-score (if (eq cell10-value 58) 10000 0))
+
+    ;; ---- cell 11: DICT + SUBSCRIPT — string-keyed lookup.
+    ;;   d = {"a": 11, "b": 22, "c": 33}
+    ;;   d["a"] + d["c"]
+    ;; CPython: 11 + 33 = 44 --------------------------------------------
+
+    (let cell11
+        (py-module
+            (list
+                (py-assign "d"
+                    (mk-py-dict
+                        (list (mk-py-str-lit "a") (py-int-lit 11)
+                              (mk-py-str-lit "b") (py-int-lit 22)
+                              (mk-py-str-lit "c") (py-int-lit 33))))
+                (py-binop
+                    (mk-py-subscript (py-ident "d") (mk-py-str-lit "a"))
+                    "+"
+                    (mk-py-subscript (py-ident "d") (mk-py-str-lit "c"))))))
+    (let cell11-value (py-run cell11))                         ; 44
+    (let cell11-score (if (eq cell11-value 44) 11000 0))
+
+    ;; ---- cell 12: nested LIST + WHILE iteration over indexed access.
+    ;;   xs = [3, 5, 7, 9, 11]
+    ;;   i = 0
+    ;;   acc = 0
+    ;;   while i < 5:
+    ;;       acc += xs[i]
+    ;;       i += 1
+    ;;   acc
+    ;; CPython: 3+5+7+9+11 = 35 -----------------------------------------
+
+    (let cell12
+        (py-module
+            (list
+                (py-assign "xs"
+                    (mk-py-list (list (py-int-lit 3) (py-int-lit 5)
+                                   (py-int-lit 7) (py-int-lit 9)
+                                   (py-int-lit 11))))
+                (py-assign "i" (py-int-lit 0))
+                (py-assign "acc" (py-int-lit 0))
+                (mk-py-while
+                    (py-compare (py-ident "i") "<" (py-int-lit 5))
+                    (list
+                        (mk-py-aug-assign "acc" "+"
+                            (mk-py-subscript (py-ident "xs") (py-ident "i")))
+                        (mk-py-aug-assign "i" "+" (py-int-lit 1))))
+                (py-ident "acc"))))
+    (let cell12-value (py-run cell12))                         ; 35
+    (let cell12-score (if (eq cell12-value 35) 12000 0))
+
     ;; ---- aggregate ---------------------------------------------------
-    ;; Total when every cell agrees with CPython:
-    ;;   1000 + 2000 + 3000 + 4000 + 5000 + 6000 + 7000 = 28000
+    ;; Cell-N awards N*1000 when its value matches CPython. Total when
+    ;; every cell agrees: (1+2+3+4+5+6+7+8+9+10+11+12)*1000 = 78000.
+    ;; Any single cell failing leaves the aggregate sensitive to which
+    ;; arm broke — a cell-9 failure shows up as 78000-9000=69000.
 
     (sum (list cell1-score cell2-score cell3-score cell4-score
-               cell5-score cell6-score cell7-score)))
+               cell5-score cell6-score cell7-score
+               cell8-score cell9-score cell10-score
+               cell11-score cell12-score)))


### PR DESCRIPTION
## Walking step — interpreter past the iteration gate

The G4 closure interpreter (#2092) shipped 9 arms (INT, IDENT, BINOP, COMPARE, RETURN, ASSIGN, DEF, CALL, IF, MODULE). This PR adds **7 more** — the interpreter now covers most of the small-Python surface.

## Arms shipped

| Arm | Behavior |
|---|---|
| `PY-BMF-STRING` | String literal (free addition — DICT keys need it) |
| `PY-BMF-LIST` | List literal `[a, b, c]` |
| `PY-BMF-DICT` | Dict literal `{k: v}` |
| `PY-BMF-SUBSCRIPT` | `obj[i]` (polymorphic across lists and dicts) |
| `PY-BMF-WHILE` | Loop with body that mutates env via ASSIGN/AUG-ASSIGN |
| `PY-BMF-AUG-ASSIGN` | `x += y` (composes ASSIGN + BINOP) |
| `PY-BMF-LAMBDA` | Anonymous function (reuses DEF/CALL machinery) |

## What this unlocks

**LIST + SUBSCRIPT + WHILE + AUG-ASSIGN compose into the counted-loop pattern** that most Python code uses. The interpreter is past the iteration gate.

## Test coverage

`form/form-stdlib/tests/python-bmf-eval-band.fk` grows 7 → 12 cells:

| Cell | Tests | Value |
|---|---|---|
| 1 | `7+3` | 10 |
| ... | ... | ... |
| 8 | Indexed list access | 40 |
| 9 | Counted sum with WHILE+AUG-ASSIGN | 55 |
| 10 | Lambda + ASSIGN + call | 58 |
| 11 | String-keyed dict lookup | 44 |
| 12 | Nested LIST + WHILE + SUBSCRIPT | 35 |

**Aggregate 78000 on Go, Rust, TypeScript.** All five new shapes pin CPython-equivalent values.

`./validate.sh`: 134 ok, 0 divergent.

## In-tissue gotcha named

**Form reserves verbs** (`params`, `seq`, `let`, `if`, `and`, `or`, `not`); using them as defn parameter names silently truncates arg lists at parse time. `mk-py-lambda` uses `pms` not `params`. The test file documents the gotcha so the next walker doesn't relive the debug.

## How this composes with G1+G3 (#2100)

The G1+G3 bridge translates Python parse-tree shapes → PY-BMF recipes. With these 7 new arms, the lift can dispatch more shapes, more `PARITY_FILES` demos pass under `kernel-bmf`, and more rows move to **COMPOST READY**. Each new shape: one lift branch + one interpreter arm. **Linear scaling, no new architecture.**

## Honest pending (from the contract)

Still ahead: class/method/attr semantics, FOR-iteration, exceptions, comprehensions, mutual recursion, slices, walrus, async, float math.

## Files touched

- `form/form-stdlib/python-bmf-eval.fk` — 7 new arms + STRING + helpers (~150 LOC added)
- `form/form-stdlib/tests/python-bmf-eval-band.fk` — 12 cells (was 7)

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md). The kernel walks more of Python's recipes today than yesterday.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_