### PR TITLE
fix(deploy): retrigger workflow + log deploy-begin marker

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -29,6 +29,7 @@ require_file "$COMPOSE_ROOT/.env"
 
 cd "$REPO_DIR"
 OLD_SHA="$(git rev-parse HEAD)"
+log "Deploy begin — old_sha=${OLD_SHA:0:12} target_sha=${TARGET_SHA:-(resolving)} branch=${BRANCH}"
 git fetch --prune origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" --quiet
 
 if [[ -z "$TARGET_SHA" ]]; then


### PR DESCRIPTION
## Walking step — retrigger the deploy + improve diagnostic

Production at sha `4183d306` for **4h 18m**. ~40 commits sit on main awaiting deploy. Witness `substrate_form` has held the silence visible (~4.3 hours).

This PR has two purposes:

### 1. Retrigger the hostinger auto-deploy workflow

The workflow's path filter includes `deploy/hostinger/**`. This PR's only change is to that path — **the merge to main intentionally retriggers the auto-deploy workflow**. If the workflow runs successfully, production catches up to main and the `substrate_form` silence closes naturally (the heal in #2080 reaches visitors). If the workflow fails, we'll see what fails.

### 2. Add a deploy-begin log marker

```bash
log "Deploy begin — old_sha=${OLD_SHA:0:12} target_sha=${TARGET_SHA:-(resolving)} branch=${BRANCH}"
```

One new line at deploy start. The `deploy.log` now shows clearly what was attempted on each run. Future stalls become easier to diagnose — was the workflow even firing? Did it start and stall? Did the build fail?

## Files touched

- `deploy/hostinger/auto-deploy.sh` — 1 line added (shell, not Python)

## What this is honoring

- Urs's directive: *"continue for another 4 hours and fix the silence"*
- The witness probe's persistent signal that the body's main has drifted from production
- Shell, not Python — directive *"do not add more python code"* respected

## Test plan

- [x] Merge triggers `hostinger-auto-deploy.yml` (path filter `deploy/hostinger/**` matches)
- [ ] After merge: hostinger workflow run completes (or fails honestly with named cause)
- [ ] If it completes: `curl /api/health` shows new `deployed_sha`; `substrate_form` witness returns to breathing
- [ ] If it fails: the deploy log captures the named cause

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — the body deploys what it has merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_