### PR TITLE
attune: JSON-as-recipe in the default validate.sh gate (cross-modal #5)

### DIFF
--- a/form/form-stdlib/tests/json-grammar.fk
+++ b/form/form-stdlib/tests/json-grammar.fk
@@ -1,0 +1,40 @@
+; tests/json-grammar.fk — JSON-as-recipe in the default validate.sh gate.
+;
+; Mirrors form-stdlib/seedbank/tests/json.fk so the body verifies the
+; grammar-driven JSON parser on every ./validate.sh run, not only via
+; the manual invocation documented in
+; form/form-samples/cross-modal/NEXT_BREATHS.md #5.
+;
+; The seedbank grammar parses a JSON document into a Recipe whose
+; structure mirrors the source — every cell carries source attribution.
+; Same source JSON → same Blueprint NodeID across all three sibling
+; kernels. That's the universal-translator promise as substrate-truth
+; for the JSON modality.
+;
+; preludes: form-stdlib/seedbank/cell-trace.fk form-stdlib/seedbank/grammars/json.fk
+
+(do
+    (let sample-json "{\"name\": \"Coherence Network\", \"version\": 1, \"layers\": [\"substrate\", \"kernel\", \"engine\"]}")
+
+    (let root (parse-json "config.json" sample-json))
+
+    ;; --- probe 1: root is an object (has pair children) -----------
+    (let kids (node_children root))
+    (let probe-1 (len kids))                              ; → 3 (name, version, layers)
+
+    ;; --- probe 2: root has source attribution ---------------------
+    (let probe-2 (str_len (cell-source root)))            ; → length of "config.json:1:1" = 15
+
+    ;; --- probe 3: first pair has source attribution ---------------
+    (let first-pair (head kids))
+    (let probe-3 (str_len (cell-source first-pair)))      ; → 15 (same line)
+
+    ;; --- probe 4: nested array parses correctly -------------------
+    (let third-pair (head (tail (tail kids))))
+    (let third-pair-kids (node_children third-pair))
+    (let layers-array (head (tail third-pair-kids)))      ; the value side of the pair
+    (let layer-kids (node_children layers-array))
+    (let probe-4 (len layer-kids))                        ; → 3 (substrate, kernel, engine)
+
+    ;; sum: 3 + 15 + 15 + 3 = 36
+    (add probe-1 (add probe-2 (add probe-3 probe-4))))


### PR DESCRIPTION
## What changed

Closes the discipline-walk gap named in `form/form-samples/cross-modal/NEXT_BREATHS.md` #5:

> The proof existed; the body didn't sense it on every breath.

`form-stdlib/seedbank/grammars/json.fk` parses JSON to a Form Recipe three-way clean.
But `./validate.sh`'s auto-walker only walks `form-stdlib/tests/*.fk` — not
`form-stdlib/seedbank/tests/*.fk`. JSON-as-recipe was an existing attestation
running outside the default sense-gate.

This wrapper (`form-stdlib/tests/json-grammar.fk`, 40 LOC) sits in the auto-walked
directory with a `; preludes:` header pointing at the seedbank cell-trace + grammar.
`validate.sh` honors the header, runs three-way, and **JSON-as-recipe now runs on
every default-gate breath**.

## Verification

```bash
$ ./validate.sh
  ...
  ✓  stdlib/json-grammar.fk          → 36
  ...
  136 ok, 0 divergent — kernels agree on every sample.
```

(Was 135 before; the new wrapper is the +1.)

## Same shape as Breath 2e

Cross-modal #5 wasn't a NEW proof — it was the body needing to read its own
attestation. Same shape as the template-machinery walk from earlier this session:
already-landed work that hadn't yet entered the default-sense.

## Discipline

Zero Python. Pure `.fk`. Per Urs's standing constraint.

In service of [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md)
+ [`lc-cross-modal-unity`](../docs/vision-kb/concepts/lc-cross-modal-unity.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_