### PR TITLE
tend: link CTOR_UNIFICATION_PLAN from audit §4 + kernels README

### DIFF
--- a/kernels/README.md
+++ b/kernels/README.md
@@ -126,3 +126,5 @@ The roadmap in [`form/kernel-roadmap.md`](../form/kernel-roadmap.md) names what 
 [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md) names every file that composts when Form-native parsing proves three-way parity per demo. The parity suite's `PARITY_THIRD_RUNTIME` selector flips the third runtime atomically; `make wellness` surfaces the remaining bootstrap weight each breath.
 
 [`UNIVERSAL_TRANSLATOR_AUDIT.md`](UNIVERSAL_TRANSLATOR_AUDIT.md) walks the body's current artifacts against the highest goal (universal translator across media, recipe orchestration in pure numeric space, less ice / more gas, minimize bootstrap surface). It names where the body is heavy in ice, heavy in bootstrap, heavy in dependencies, already light, and the top-ten concrete next breaths.
+
+[`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) names the closing shapes for the audit's finding #4 — *one Blueprint per shape across all source languages*. Three shapes (A: rules emit MATH directly; B: lift maps BINOP→MATH at recipe time; C: BINOP as Blueprint-view on MATH); Shape B is the smallest closing breath.

--- a/kernels/UNIVERSAL_TRANSLATOR_AUDIT.md
+++ b/kernels/UNIVERSAL_TRANSLATOR_AUDIT.md
@@ -292,6 +292,11 @@ which is the substrate property the universal-translator promise rests on.
 manifest); the rest of the operators follow the same pattern. Honest separate
 PRs let the parity-gate confirm the equivalence one rule-family at a time.
 
+**Closing shapes:** see [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md)
+— three shapes named (A: rules emit MATH directly; B: lift maps BINOP→MATH at
+recipe time; C: BINOP as Blueprint-view on MATH), with **Shape B** recommended
+as the smallest closing breath.
+
 ### 5. Author the missing modality grammars — *the universal-translator's actual coverage gap*
 
 **What:** Fill out the BMF grammars for image, audio, video, natural language


### PR DESCRIPTION
## What changed

Two small markdown edges. The CTOR unification plan (merged in #2104)
named three closing shapes for audit finding #4 but was disconnected
from the docs that index the body's planning artifacts:

- `kernels/UNIVERSAL_TRANSLATOR_AUDIT.md` §4 now points readers at
  `CTOR_UNIFICATION_PLAN.md` for the closing shapes
- `kernels/README.md`'s roadmap section names the plan alongside the
  audit and the bootstrap-compost manifest

## Why

Per [`lc-edges-as-vitality`](../docs/vision-kb/concepts/lc-edges-as-vitality.md):
*"connections land in the same body the content lands in, not the next one."*
The doc existed; readers arriving at the audit had no signal that the
closing shapes were already named. This commit closes that.

## Discipline

Markdown only. Zero Python. Per Urs's standing constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_