### PR TITLE
attune: CTOR_UNIFICATION_PLAN honest re-reading — three vocabularies, not two

### DIFF
--- a/kernels/CTOR_UNIFICATION_PLAN.md
+++ b/kernels/CTOR_UNIFICATION_PLAN.md
@@ -1,15 +1,29 @@
 # CTOR Vocabulary Unification — the universal translator's single-Blueprint promise
 
-## The finding (from `UNIVERSAL_TRANSLATOR_AUDIT.md` #4)
+## The finding (refined from `UNIVERSAL_TRANSLATOR_AUDIT.md` #4)
 
-The body holds **two parallel CTOR vocabularies** in production:
+The body holds **three parallel CTOR vocabularies** for arithmetic in
+production — not two, as the audit first named:
 
-- **`CTOR.add` (type=12)** — bootstrap path: `lang-python.ts` parses Python arithmetic and emits `CTOR.add` via the existing Math-primitive vocabulary
-- **`PY-BMF-BINOP` (type=99)** — Form-native path: `python-bmf.fk` rules produce `PY-BMF-BINOP` recipes (dialect type 99) carrying the operator as a string-trivial child
+- **Bootstrap** (`lang-python.ts`): emits `RBasic.LIST` (type=34) with the
+  operator-name `"add"` / `"sub"` etc. interned as the *inst* NameID.
+  See `ctorCategory` in `form-kernel-ts/seedbank/python-adapter/src/lang-python.ts:242`.
+  *(The audit's "Math-primitive type=12" framing for the bootstrap was
+  misattributed during honest reading — the bootstrap never reached MATH.)*
+- **Form-native PY-BMF** (`python-bmf.fk`): emits `PY-BMF-BINOP`
+  (type=99, inst=522 — dialect category, declared in
+  `form-stdlib/form-ontology.json:68`) with the operator as a
+  string-trivial child.
+- **True Form math** (`RBasic.MATH`): type=12, inst 1–4 for PLUS, MINUS,
+  MULTIPLY, DIVIDE. Used today only inside `form-stdlib/tests/emit-engine.fk`
+  and `seedbank/universal-emit.fk` — not by either Python parser.
 
-**Both encode `a + b`.** They walk to the same value when executed. But they have **different Blueprint NodeIDs**.
+**All three encode `a + b`** and walk to the same value. But they intern
+as three different Blueprint NodeIDs.
 
-The universal-translator's content-addressing promise — *"same shape in any source language → same Blueprint NodeID"* — rests on a **single Blueprint per shape**. Today we have two.
+The universal-translator's content-addressing promise — *"same shape in
+any source language → same Blueprint NodeID"* — rests on a **single
+Blueprint per shape**. Today the body holds three for arithmetic alone.
 
 ## Why this matters for Python-removal
 
@@ -30,11 +44,29 @@ The universal-translator's content-addressing promise — *"same shape in any so
 
 ### Shape B — Lift maps BINOP → MATH at recipe time
 
-`python-bmf-lift.fk` (already exists from #2100) translates statement-tree → PY-BMF recipes. Extend it: when it sees a BINOP shape, intern as `RBasic.MATH.PLUS` (etc.) instead of `PY-BMF-BINOP`.
+`python-bmf-lift.fk` (already exists from #2100) translates statement-tree → PY-BMF recipes. Extend it: when it sees a BINOP shape with `+ - * /`, intern as `RBasic.MATH` (1, 2, 12, 1–4) instead of `PY-BMF-BINOP`.
 
-**Cost:** minimal — one branch addition in `python-bmf-lift.fk`. Doesn't touch the parser.
+**Cost (refined honestly):** *not* the one-branch change the first draft claimed.
+The honest closing breath is **two changes**:
+1. `python-bmf-lift.fk:206` — in `lift-binop-loop`, switch on `op` and intern
+   under `MATH-PLUS/MINUS/MULTIPLY/DIVIDE` for `+ - * /`; keep
+   `PY-BMF-BINOP` for `** // %` (no MATH instances exist for those today).
+2. `python-bmf-eval.fk:322` — add a MATH-12 arm that dispatches on the
+   instance (1=add, 2=sub, 3=mul, 4=div) and walks the two children.
+   The existing `PY-BMF-BINOP` arm stays for `** // %` until those land
+   in MATH too.
 
-**Win:** unification happens at the lift layer. Parser stays simple. NodeIDs converge at the recipe level.
+**Why the refinement:** the audit's first framing implied the interpreter
+already had a MATH arm (because bootstrap supposedly emitted MATH). It
+doesn't — bootstrap emits LIST-34 with operator NameIDs (see top of doc).
+Adding the MATH arm is part of the breath.
+
+**Win:** unification happens at the lift layer. Parser stays simple.
+Form-native Python arithmetic interns as `@1.2.12.{1..4}` — the same
+Blueprint NodeID the (pure-Form) `(intern_node CAT-PLUS …)` interns to.
+**Cross-modal at the math-primitive layer becomes substrate-truth for
+arithmetic.** The bootstrap path (LIST-34) remains separate until Phase A
+composts — but that compost is named and walking.
 
 ### Shape C — Both stay; rename dialect-99 to be a *view* on MATH
 
@@ -48,18 +80,41 @@ Keep both encodings but make `PY-BMF-BINOP` a structural alias / view of `RBasic
 
 ## Concrete next breath
 
-In `form/form-stdlib/python-bmf-lift.fk`:
+In `form/form-stdlib/python-bmf-lift.fk:206` (the `lift-binop-loop` intern site
+that emits `PY-BMF-BINOP` for every `op`):
 
 ```form
-;; Where BINOP is lifted today (probably around lift-binary-op):
-;; (intern_node @PY-BMF-BINOP (list operator left right))
+;; Today:
+;; (intern_node PY-BMF-BINOP (list left (intern_trivial_string op) rhs))
 
-;; Change to:
-;; (let math-arm (case operator
-;;     "+" @RBasic.MATH.PLUS
-;;     "-" @RBasic.MATH.MINUS
-;;     ...))
-;; (intern_node math-arm (list left right))
+;; Replace with a math-or-binop choice. Numeric NodeIDs for MATH (type=12):
+;; (let MATH-PLUS     (make_nodeid 1 2 12 1))
+;; (let MATH-MINUS    (make_nodeid 1 2 12 2))
+;; (let MATH-MULTIPLY (make_nodeid 1 2 12 3))
+;; (let MATH-DIVIDE   (make_nodeid 1 2 12 4))
+;;
+;; (let new-left
+;;     (if (str_eq op "+")  (intern_node MATH-PLUS     (list left rhs))
+;;     (if (str_eq op "-")  (intern_node MATH-MINUS    (list left rhs))
+;;     (if (str_eq op "*")  (intern_node MATH-MULTIPLY (list left rhs))
+;;     (if (str_eq op "/")  (intern_node MATH-DIVIDE   (list left rhs))
+;;     ;; ** // % stay on PY-BMF-BINOP until MATH gets those slots
+;;     (intern_node PY-BMF-BINOP
+;;         (list left (intern_trivial_string op) rhs)))))))
+
+;; Then in form/form-stdlib/python-bmf-eval.fk:322, add a MATH arm before
+;; the existing PY-BMF-BINOP arm:
+;;
+;; (if (and (eq (node_type cat) 12)
+;;          (eq (node_pkg cat) 1)
+;;          (eq (node_level cat) 2))
+;;     (let lhs-val (py-eval (nth (node_children r) 0) env))
+;;     (let rhs-val (py-eval (nth (node_children r) 1) env))
+;;     (let inst (node_inst cat))
+;;     (if (eq inst 1) (add lhs-val rhs-val)
+;;     (if (eq inst 2) (sub lhs-val rhs-val)
+;;     (if (eq inst 3) (mul lhs-val rhs-val)
+;;     (if (eq inst 4) (div lhs-val rhs-val) (head (empty)))))))
 ```
 
 The `python-bmf-eval.fk` interpreter's BINOP arm composts; the existing MATH arm picks up the work.


### PR DESCRIPTION
## What changed

Re-read `lang-python.ts:242` and `form-stdlib/form-ontology.json` to confirm
the actual CTOR shapes the body interns today. The first draft of
`CTOR_UNIFICATION_PLAN.md` (#2104) repeated the audit's framing that the
bootstrap emits `CTOR.add (Math-primitive type=12)`. **The bootstrap actually
emits `RBasic.LIST` (type=34) with the operator-name as a NameID inst.** No
MATH-12 anywhere in the Python-source path.

So the body holds **three** parallel arithmetic vocabularies, not two:

| Path | Category | NodeID shape |
|---|---|---|
| Bootstrap (lang-python.ts) | `RBasic.LIST` | `(1, 2, 34, NameID("add"))` |
| Form-native PY-BMF | `PY-BMF-BINOP` | `(1, 2, 99, 522)` + op-string child |
| Pure Form math | `RBasic.MATH` | `(1, 2, 12, {1,2,3,4})` for `+ - * /` |

Pure-Form math is used today only by `form-stdlib/tests/emit-engine.fk`
and `seedbank/universal-emit.fk` — not by either Python parser.

## The plan refinement

Shape B's "minimal — one branch addition" claim was over-confident. The
honest closing breath is **two changes**:

1. `python-bmf-lift.fk:206` — switch on `op`, intern under MATH-{PLUS,
   MINUS, MULTIPLY, DIVIDE} for `+ - * /`; keep `PY-BMF-BINOP` for `** // %`
2. `python-bmf-eval.fk:322` — add a MATH-12 arm before the existing
   `PY-BMF-BINOP` arm

The audit's framing implied the interpreter already had a MATH arm
(because bootstrap supposedly emitted MATH). It doesn't — that arm is
part of the breath.

The "Concrete next breath" code block now matches what the lift + eval
actually look like in code, not what the audit's framing implied.

## Why this matters

The misattribution would have led the next walker into a "one-line change"
they couldn't complete, then doubt the closing shape. Naming the shape
honestly — *two changes, here are the file:line anchors, here's the code* —
keeps the walk tractable.

Per CLAUDE.md: *"Memory carries the destination, not the journey to it."*
The original draft's single-branch claim composts here.

## Discipline

Markdown only. Zero Python. Per Urs's standing constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_