### PR TITLE
tend(deploy): widen auto-deploy filter to paths baked into the image

### DIFF
--- a/.github/workflows/hostinger-auto-deploy.yml
+++ b/.github/workflows/hostinger-auto-deploy.yml
@@ -12,6 +12,9 @@ on:
       - 'scripts/verify_web_api_deploy.sh'
       - 'scripts/.gitnexus-pin'
       - '.github/workflows/hostinger-auto-deploy.yml'
+      - 'Dockerfile*'
+      - 'form/form-kernel-rust/**'
+      - 'kernels/python_bmf/**'
   workflow_dispatch:
     inputs:
       sha:


### PR DESCRIPTION
## Summary

The Hostinger auto-deploy `paths:` filter doesn't include the paths that are actually baked into the API container:

- `Dockerfile.api` stage 1 builds **`form/form-kernel-rust/`** into the image
- The PyO3 bridge imports **`kernels/python_bmf/`** at runtime

Both are part of what ships. The filter was missing them, so the 8+ commits since `d5b40d51` (last deploy.sh edit) landed on main without rolling the VPS forward.

## Fix

Add three patterns:
- `Dockerfile*` — image recipe changes redeploy
- `form/form-kernel-rust/**` — kernel source changes redeploy
- `kernels/python_bmf/**` — Python kernel package changes redeploy

## Side effect (the point of this PR right now)

This commit itself touches the workflow file, so merging it triggers the deploy that propagates the current backlog forward.

## Test plan
- [x] YAML still parses (only path additions)
- [ ] Merge fires `Hostinger Auto Deploy` — confirm via workflow run
- [ ] After rollout: `/api/health.kernel_runtime` reports `inline` (PyO3) or `subprocess` (binary) — `python-fallback` would mean the image build missed the kernel

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8BrckUnDcqWTo16p1s382)_