### PR TITLE
attune(kernels): CTOR Shape B — Python arithmetic interns as MATH-12 at lift time

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -319,6 +319,26 @@
                 (node_value (head kids))
             (if (node_eq cat PY-BMF-IDENT)
                 (py-env-lookup env (node_value (head kids)))
+            (if (and (eq (node_pkg cat) 1)
+                     (and (eq (node_level cat) 2)
+                          (eq (node_type cat) 12)))
+                ;; CTOR Shape B: RBasic.MATH-12 arm. The Python lift now
+                ;; interns + - * / as MATH-12 nodes (positional children,
+                ;; no op-string-leaf) so a hand-built (intern_node MATH-PLUS
+                ;; (list 7 3)) and a Python-lifted "7 + 3" share one
+                ;; Blueprint NodeID. Dispatch on the cat's inst — 1=plus,
+                ;; 2=minus, 3=mul, 4=div — matching form-ontology.json.
+                (do
+                    (let lhs-val (py-eval (nth kids 0) env))
+                    (let rhs-val (py-eval (nth kids 1) env))
+                    (let math-inst (node_inst cat))
+                    (if (eq math-inst 1) (add lhs-val rhs-val)
+                    (if (eq math-inst 2) (sub lhs-val rhs-val)
+                    (if (eq math-inst 3) (mul lhs-val rhs-val)
+                    (if (eq math-inst 4) (div lhs-val rhs-val)
+                        (do
+                            (trace "py-eval MATH: unknown inst" math-inst)
+                            (head (empty))))))))
             (if (node_eq cat PY-BMF-BINOP)
                 (do
                     (let left  (py-eval (nth kids 0) env))
@@ -398,7 +418,7 @@
                     ;; category number so the next breath knows which
                     ;; arm to add.
                     (trace "py-eval: unimplemented category" cat)
-                    (head (empty))))))))))))))))))
+                    (head (empty)))))))))))))))))))
 
     ;; Surface for callers. py-run takes a module recipe and returns its
     ;; value. py-eval and py-eval-statement are exposed so band-tests

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -48,6 +48,21 @@
 ;                        grammars/python-bmf.fk, python-bmf-eval.fk
 
 (do
+    ;; ---- MATH-12 NodeIDs (CTOR Shape B) ----------------------------
+    ;;
+    ;; The canonical RBasic.MATH category — same NodeIDs the kernel's
+    ;; arithmetic primitives carry (see form-ontology.json `primitives`
+    ;; rows for add/sub/mul/div and tests/emit-engine.fk lines 30-33).
+    ;; lift-binop-loop interns `+ - * /` against these — picking up the
+    ;; one Blueprint per shape so a hand-built `(intern_node MATH-PLUS
+    ;; ...)` and a Python-lifted `7 + 3` content-address to the same
+    ;; cell. The other arithmetic ops (** // %) stay on PY-BMF-BINOP
+    ;; until MATH instances ship for them.
+    (let MATH-PLUS     (make_nodeid 1 2 12 1))
+    (let MATH-MINUS    (make_nodeid 1 2 12 2))
+    (let MATH-MULTIPLY (make_nodeid 1 2 12 3))
+    (let MATH-DIVIDE   (make_nodeid 1 2 12 4))
+
     ;; ---- token accessors -------------------------------------------
     ;;
     ;; Tokens are bare BMF objects from python-source-scan-*. Each carries
@@ -281,16 +296,31 @@
                         (lift-binop-loop (lift-recipe rhs-primary)
                                          (lift-rest rhs-primary)
                                          next-min))
+                    (let rhs-recipe (lift-recipe rhs-climb))
+                    ;; CTOR Shape B: + - * / intern as RBasic.MATH-12 nodes
+                    ;; (positional children only — the instance number IS the
+                    ;; operator, no op-string-leaf). Comparisons stay on
+                    ;; PY-BMF-COMPARE, and ** // % stay on PY-BMF-BINOP until
+                    ;; their MATH instances exist. The eval side has a
+                    ;; matching MATH-12 arm that dispatches on inst.
                     (let new-left
                         (if (op-is-compare? op)
                             (intern_node PY-BMF-COMPARE
                                 (list left
                                       (intern_trivial_string op)
-                                      (lift-recipe rhs-climb)))
+                                      rhs-recipe))
+                        (if (str_eq op "+")
+                            (intern_node MATH-PLUS     (list left rhs-recipe))
+                        (if (str_eq op "-")
+                            (intern_node MATH-MINUS    (list left rhs-recipe))
+                        (if (str_eq op "*")
+                            (intern_node MATH-MULTIPLY (list left rhs-recipe))
+                        (if (str_eq op "/")
+                            (intern_node MATH-DIVIDE   (list left rhs-recipe))
                             (intern_node PY-BMF-BINOP
                                 (list left
                                       (intern_trivial_string op)
-                                      (lift-recipe rhs-climb)))))
+                                      rhs-recipe))))))))
                     (lift-binop-loop new-left (lift-rest rhs-climb) min-prec)))))
 
     ;; --- conditional expression ------------------------------------

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -112,10 +112,39 @@ sign(5) + sign(0 - 3) + 5
 "))
     (let cell9-score (if (eq cell9-value 5) 9000 0))
 
+    ;; ---- cell 10: CTOR Shape B Blueprint convergence -------------------
+    ;; The substrate-truth claim of CTOR Shape B (kernels/CTOR_UNIFICATION_PLAN.md):
+    ;; same shape → same Blueprint NodeID. A hand-built MATH-PLUS recipe
+    ;; with PY-BMF-INT-wrapped int leaves AND a Python-lifted `7 + 3`
+    ;; must `node_eq` to 1 — both content-address to the canonical
+    ;; RBasic.MATH-12 inst=1 (plus) Blueprint. Before Shape B the lifted
+    ;; recipe carried PY-BMF-BINOP (type=99 inst=522); after, it carries
+    ;; MATH-PLUS (type=12 inst=1) — same as the hand-built reference.
+    ;;
+    ;; Honest scope: this proves convergence at the BINOP layer. The
+    ;; integer LEAVES are PY-BMF-INT(trivial_int) on both sides — that
+    ;; vocabulary is shared because both sides use the same leaf shape,
+    ;; not because the substrate normalises bare ints into PY-BMF-INT.
+
+    (let MATH-PLUS-REF (make_nodeid 1 2 12 1))
+    (let handbuilt-plus
+        (intern_node MATH-PLUS-REF
+            (list (intern_node PY-BMF-INT (list (intern_trivial_int 7)))
+                  (intern_node PY-BMF-INT (list (intern_trivial_int 3))))))
+    ;; Lift "7 + 3" via the same lift-module-text path the other cells use,
+    ;; then walk into the PY-BMF-MODULE's first (and only) statement —
+    ;; an expression-statement that IS the BINOP recipe. node_children of
+    ;; the module gives the statement list; head of that is the binop.
+    (let lifted-module (lift-module-text "7 + 3
+"))
+    (let lifted-plus (head (node_children lifted-module)))
+    (let cell10-score (if (node_eq handbuilt-plus lifted-plus) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
-    ;; Sum when every cell agrees with CPython:
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000 = 45000
+    ;; Sum when every cell agrees with CPython + Shape B converges:
+    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000 = 55000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
-               cell7-score cell8-score cell9-score)))
+               cell7-score cell8-score cell9-score
+               cell10-score)))


### PR DESCRIPTION
## Summary

Closes Shape B from `kernels/CTOR_UNIFICATION_PLAN.md` — the
Python-source arithmetic CTOR vocabulary now unifies with `RBasic.MATH` at
lift time. Two changes in pure Form (.fk), zero new Python:

- **`form/form-stdlib/python-bmf-lift.fk`** — `lift-binop-loop` now switches on the operator: `+ - * /` intern as `MATH-PLUS/MINUS/MULTIPLY/DIVIDE` (NodeIDs `(make_nodeid 1 2 12 1..4)`, positional children, no op-string-leaf). `** // %` stay on `PY-BMF-BINOP` until MATH instances exist for them. Comparisons stay on `PY-BMF-COMPARE`.
- **`form/form-stdlib/python-bmf-eval.fk`** — new MATH-12 arm in `py-eval`, dispatched by `(eq (node_pkg cat) 1)` + `(eq (node_level cat) 2)` + `(eq (node_type cat) 12)`, then `node_inst` selects `add`/`sub`/`mul`/`div`.

The substrate-truth claim of Shape B becomes attestable: same shape → same Blueprint NodeID. Before this change, two encodings of `a + b` carried different NodeIDs (`type=12 inst=1` for kernel-native MATH; `type=99 inst=522` for `PY-BMF-BINOP`). After, the Python-source path interns into the same canonical MATH-12 Blueprint that NL/S-expression paths use — content-addressing holds end-to-end at the math-primitive layer.

## Verification

- All 136 `validate.sh` samples green across go/rust/typescript kernels (was 136 after #2108; same after this change — no regressions, no new test gates).
- **New cell 10 of `python-bmf-lift-band.fk`** proves Blueprint convergence directly: a hand-built `(intern_node MATH-PLUS (list (intern_node PY-BMF-INT ...) (intern_node PY-BMF-INT ...)))` and a Python-lifted `"7 + 3"` `node_eq` to true across all three kernels. Aggregate rose 45000 → 55000.
- The four kernel-bmf parity demos return their canonical CPython values: `python_bridge_demo.py → 720`, `python_assign_demo.py → 45`, `python_imperative_demo.py → 45370`, `python_demo.py → 40949`.

## Honest scope (what Shape B unifies, what it leaves alone)

- **Unifies at the BINOP layer** for `+ - * /`. The integer **leaves** are `PY-BMF-INT(trivial_int)` on both the hand-built reference and the lifted recipe — the convergence test makes this explicit by building both sides with the same leaf shape. Bare-int vs `PY-BMF-INT(...)` leaves still differ in vocabulary — that's a future breath, called out in the test cell's comment.
- `** // %` are not yet unified — they continue interning as `PY-BMF-BINOP` and the original `py-binop-apply` arm in the evaluator still services them.

## Test plan

- [x] `./form/validate.sh` green — 136 ok, 0 divergent
- [x] `python-bmf-lift-band.fk` aggregate 55000 (was 45000 — cell 10 added, all prior cells unchanged)
- [x] `kernel-bmf-run python_bridge_demo.py` → 720
- [x] `kernel-bmf-run python_assign_demo.py` → 45
- [x] `kernel-bmf-run python_imperative_demo.py` → 45370
- [x] `kernel-bmf-run python_demo.py` → 40949

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md), [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md), and [`lc-universal-translator-via-keys`](../docs/vision-kb/concepts/lc-universal-translator-via-keys.md).

https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_