### PR TITLE
fix(deploy): use RUNNING_SHA, not OLD_SHA, as change-detection base

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -273,15 +273,31 @@ services_to_rebuild() {
   echo "${out[*]}"
 }
 
-if is_static_only_change "$OLD_SHA" "$TARGET_SHA"; then
-  log "Static-only change detected ($OLD_SHA -> $TARGET_SHA); skipping rebuild"
-  sync_web_public "$OLD_SHA" "$TARGET_SHA"
+# Pick the comparison base: prefer what's ACTUALLY RUNNING in the api
+# container over what the repo claims is its HEAD. The repo's OLD_SHA
+# gets advanced by `git reset --hard` on every deploy, but if a prior
+# rebuild stalled silently the container is still at an older SHA.
+# Detecting changes from OLD_SHA in that case sees an empty/static-only
+# diff and skips rebuild — pinning the container at the old SHA forever.
+# Using RUNNING_SHA as the comparison base means: change-detection asks
+# what the CONTAINER is missing, not what the filesystem is missing.
+DIFF_BASE="$OLD_SHA"
+if [[ -n "$RUNNING_SHA" ]] && git cat-file -e "${RUNNING_SHA}^{commit}" 2>/dev/null; then
+  if [[ "$RUNNING_SHA" != "$OLD_SHA" ]]; then
+    log "Diff base: using RUNNING_SHA=${RUNNING_SHA:0:12} (container) instead of OLD_SHA=${OLD_SHA:0:12} (repo) — the repo may have advanced past a stalled rebuild"
+  fi
+  DIFF_BASE="$RUNNING_SHA"
+fi
+
+if [[ "$DIFF_BASE" != "$TARGET_SHA" ]] && is_static_only_change "$DIFF_BASE" "$TARGET_SHA"; then
+  log "Static-only change detected ($DIFF_BASE -> $TARGET_SHA); skipping rebuild"
+  sync_web_public "$DIFF_BASE" "$TARGET_SHA"
   # The subsequent sync_field_docs / sync_repo_docs / etc. functions
   # below will pick up the api-side static syncs as they would in a
   # rebuild flow. No `docker compose build` needed.
 else
-  REBUILD_SERVICES="$(services_to_rebuild "$OLD_SHA" "$TARGET_SHA")"
-  log "Rebuild scope: ${REBUILD_SERVICES} (changed paths -> services)"
+  REBUILD_SERVICES="$(services_to_rebuild "$DIFF_BASE" "$TARGET_SHA")"
+  log "Rebuild scope: ${REBUILD_SERVICES} (changed paths -> services, diff_base=${DIFF_BASE:0:12})"
 
   build_started="$(date +%s)"
   log "docker compose build ${REBUILD_SERVICES}"
@@ -512,7 +528,11 @@ else
 fi
 
 sync_substrate_content
-run_substrate_ingest "$OLD_SHA" "$TARGET_SHA"
+# Use DIFF_BASE (RUNNING_SHA when known) so substrate ingest catches any
+# content the container is missing, not just what the repo's HEAD claims
+# is new. Same reasoning as the rebuild gate above: the repo advances on
+# git reset even when the container didn't see the change.
+run_substrate_ingest "$DIFF_BASE" "$TARGET_SHA"
 
 log "Deploy complete (${TARGET_SHA:0:12}) — public health check runs next in CI"
 


### PR DESCRIPTION
Closes #2111.

## Root cause

The deploy script's change-detection reads `OLD_SHA → TARGET_SHA` from the VPS repo. But `git reset --hard` advances `OLD_SHA` on every deploy, **even when the subsequent rebuild stalled silently**. Once one rebuild fails:

1. Next deploy sees `OLD_SHA` = recent commit (post-stall reset)
2. `TARGET_SHA` = main HEAD
3. Diff is only the `*.md` / `form/` / `kernels/` commits since the stall
4. `is_static_only_change` returns TRUE (everything matches `*.md`, `form/*`, etc.)
5. Script skips rebuild entirely
6. API container stays at the pre-stall SHA forever — `deployed_sha: 4183d306` for 5h43m

The witness silence on `substrate_form` is the downstream symptom: PR #2080's heal is in the repo since ~09:02Z but the container has never restarted to load it.

## Fix

Prefer `RUNNING_SHA` (queried from `/api/health` inside the live container) over `OLD_SHA` as the comparison base whenever the running SHA is known and present in the repo's history.

- `RUNNING_SHA` = what the container **actually has loaded**
- `OLD_SHA` = what the filesystem claims (can drift ahead)

Falls back to `OLD_SHA` when `RUNNING_SHA` is empty (curl failed) or unknown to the repo (very old or external SHA) — never less safe than before.

## Triggering this PR's deploy

This commit touches `deploy/hostinger/**` which is in the auto-deploy filter, so merging it will:
1. Sync the updated `auto-deploy.sh` to the VPS (per workflow line 72)
2. Trigger the deploy itself with the new logic
3. Detect `RUNNING_SHA=4183d306` ≠ `TARGET_SHA=<this PR's merge SHA>`
4. Diff base = `4183d306` → 28 commits worth of changes including `api/app/services/substrate/form.py` (#2080's heal)
5. NOT static-only → full rebuild of `api` (and others)
6. `docker compose up -d --wait` recreates the api container
7. `substrate_form` witness flips to breathing

## Test plan

- [ ] Merge fires Hostinger Auto Deploy
- [ ] Workflow `Roll forward VPS` step logs `Diff base: using RUNNING_SHA=4183d30655de` instead of OLD_SHA
- [ ] Workflow logs `Rebuild scope: api ...` (not "skipping rebuild")
- [ ] After rollout: `curl https://api.coherencycoin.com/api/health | jq .deployed_sha` shows this PR's merge SHA
- [ ] `substrate_form` witness organ flips to breathing

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8BrckUnDcqWTo16p1s382)_