### PR TITLE
tend: PYTHON_BMF_CONTRACT — Shape B closed the NodeID-equality claim

### DIFF
--- a/kernels/PYTHON_BMF_CONTRACT.md
+++ b/kernels/PYTHON_BMF_CONTRACT.md
@@ -259,14 +259,28 @@ into `kernel-bmf-run`, then greening every `PARITY_FILES` row.
 - The bootstrap-compost-manifest sibling (`claude/bootstrap-compost-manifest`)
   is naming the deletion order; that branch is the source of truth for
   "what is safe to remove when."
-- Strict NodeID equality between bootstrap and BMF paths is **not**
-  achievable on the same source — bootstrap emits `CTOR.add/sub/mul`
-  (Math-primitive type=12), BMF emits `PY-BMF-BINOP` (dialect type=99,
-  with the operator as a string-trivial child). They are semantically
-  equivalent representations, structurally distinct by intent.
-  The honest parity gate is "BMF produces a recipe whose value walks to
-  the same Python-runtime result as bootstrap's recipe," not NodeID
-  equality. That gate sits behind G4.
+- **Inter-path NodeID equality landed for arithmetic 2026-05-27 (#2113).**
+  The first draft of this section claimed bootstrap emits `CTOR.add/sub/mul`
+  as "Math-primitive type=12." Honest re-reading of
+  `form-kernel-ts/seedbank/python-adapter/src/lang-python.ts:242` shows
+  the bootstrap actually emits `RBasic.LIST` (type=34) with the operator
+  name interned as a NameID inst. **Not MATH-12, ever, on the bootstrap
+  path.** See [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) for
+  the three-vocabulary reality (LIST-34 / PY-BMF-BINOP-99 / MATH-12) and
+  Shape B's landed closing.
+- After Shape B, the **Form-native PY-BMF path** interns `+ - * /` as
+  `RBasic.MATH` (`(1, 2, 12, 1..4)`) with positional children — the
+  *same* Blueprint a hand-built pure-Form arithmetic recipe interns to.
+  Cell 10 of `tests/python-bmf-lift-band.fk` is the proof: `node_eq` over
+  a hand-built `(intern_node MATH-PLUS …)` and a Python-lifted `"7 + 3"`
+  returns `1` across all three kernels.
+- The bootstrap path (LIST-34 with op-NameIDs) is structurally distinct
+  by intent and composts on Phase A's separate gate. The two living
+  paths agree on **value**; the Form-native path agrees on **NodeID**
+  with the rest of the substrate.
+- Pending arithmetic: `** // %` still ride `PY-BMF-BINOP` (no MATH
+  instances exist). Comparisons (`== != < <= > >=`) are the next breath
+  — same Shape B pattern, different category (COMPARE-13).
 
 ## How to run the proof
 


### PR DESCRIPTION
## What changed

`PYTHON_BMF_CONTRACT.md`'s *Parity discipline* section claimed:

> Strict NodeID equality between bootstrap and BMF paths is **not**
> achievable on the same source...

That was true before Shape B landed. Not the whole truth now.

Three refinements:

1. **Honest misattribution correction.** The audit repeatedly framed
   the bootstrap as emitting `CTOR.add/sub/mul` (Math-primitive type=12).
   Re-reading `lang-python.ts:242` shows the bootstrap actually emits
   `RBasic.LIST` (type=34) with operator NameIDs. Three vocabularies,
   not two — same finding as #2110.

2. **NodeID equality landed for the Form-native path.** After #2113,
   PY-BMF interns `+ - * /` as `RBasic.MATH` (NodeIDs `(1, 2, 12, 1..4)`)
   with positional children — the same Blueprint a hand-built pure-Form
   arithmetic recipe interns to. Cell 10 of `python-bmf-lift-band.fk` is
   the proof, three-way.

3. **Bootstrap path is now the residue, not the parity gate.** The two
   paths agree on **value**; the Form-native path also agrees on
   **NodeID** with the rest of the substrate. After Phase A composts,
   only the substrate-aligned path remains.

Pending arithmetic named: `** // %` still on `PY-BMF-BINOP`; comparisons
next breath via the same Shape B pattern.

## Why

Per CLAUDE.md: *"Memory carries the destination, not the journey to it."*
The "not achievable" shape composts into "landed for + - * /."

## Discipline

Markdown only. Zero Python.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_