### PR TITLE
attune(kernels): CTOR Shape B for comparisons — == != < <= > >= intern as COMPARE-13

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -339,6 +339,32 @@
                         (do
                             (trace "py-eval MATH: unknown inst" math-inst)
                             (head (empty))))))))
+            (if (and (eq (node_pkg cat) 1)
+                     (and (eq (node_level cat) 2)
+                          (eq (node_type cat) 13)))
+                ;; CTOR Shape B: RBasic.COMPARE-13 arm. The Python lift now
+                ;; interns == != < <= > >= as COMPARE-13 nodes (positional
+                ;; children, no op-string-leaf) so a hand-built
+                ;; (intern_node COMPARE-LT (list 5 7)) and a Python-lifted
+                ;; "5 < 7" share one Blueprint NodeID. Dispatch on the cat's
+                ;; inst — 1=eq, 2=ne, 3=lt, 4=le, 5=gt, 6=ge — matching
+                ;; form-ontology.json. Python convention: 1 for true, 0 for
+                ;; false (mirroring py-compare-apply, which is the OLD
+                ;; PY-BMF-COMPARE arm and still serves any unrecognised
+                ;; compare op the lift falls back to).
+                (do
+                    (let lhs-val (py-eval (nth kids 0) env))
+                    (let rhs-val (py-eval (nth kids 1) env))
+                    (let cmp-inst (node_inst cat))
+                    (if (eq cmp-inst 1) (if (eq lhs-val rhs-val) 1 0)
+                    (if (eq cmp-inst 2) (if (eq lhs-val rhs-val) 0 1)
+                    (if (eq cmp-inst 3) (if (lt lhs-val rhs-val) 1 0)
+                    (if (eq cmp-inst 4) (if (le lhs-val rhs-val) 1 0)
+                    (if (eq cmp-inst 5) (if (gt lhs-val rhs-val) 1 0)
+                    (if (eq cmp-inst 6) (if (ge lhs-val rhs-val) 1 0)
+                        (do
+                            (trace "py-eval COMPARE: unknown inst" cmp-inst)
+                            (head (empty))))))))))
             (if (node_eq cat PY-BMF-BINOP)
                 (do
                     (let left  (py-eval (nth kids 0) env))
@@ -418,7 +444,7 @@
                     ;; category number so the next breath knows which
                     ;; arm to add.
                     (trace "py-eval: unimplemented category" cat)
-                    (head (empty)))))))))))))))))))
+                    (head (empty))))))))))))))))))))
 
     ;; Surface for callers. py-run takes a module recipe and returns its
     ;; value. py-eval and py-eval-statement are exposed so band-tests

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -63,6 +63,22 @@
     (let MATH-MULTIPLY (make_nodeid 1 2 12 3))
     (let MATH-DIVIDE   (make_nodeid 1 2 12 4))
 
+    ;; ---- COMPARE-13 NodeIDs (CTOR Shape B for comparisons) ---------
+    ;;
+    ;; The canonical RBasic.COMPARE category — same NodeIDs the kernel's
+    ;; comparison primitives carry (see form-ontology.json `primitives`
+    ;; rows for eq/ne/lt/le/gt/ge at type=13). lift-binop-loop interns
+    ;; `== != < <= > >=` against these — picking up the one Blueprint
+    ;; per shape so a hand-built `(intern_node COMPARE-LT ...)` and a
+    ;; Python-lifted `5 < 7` content-address to the same cell. Unknown
+    ;; compare ops (none today, but defensive) fall back to PY-BMF-COMPARE.
+    (let COMPARE-EQ (make_nodeid 1 2 13 1))
+    (let COMPARE-NE (make_nodeid 1 2 13 2))
+    (let COMPARE-LT (make_nodeid 1 2 13 3))
+    (let COMPARE-LE (make_nodeid 1 2 13 4))
+    (let COMPARE-GT (make_nodeid 1 2 13 5))
+    (let COMPARE-GE (make_nodeid 1 2 13 6))
+
     ;; ---- token accessors -------------------------------------------
     ;;
     ;; Tokens are bare BMF objects from python-source-scan-*. Each carries
@@ -297,13 +313,28 @@
                                          (lift-rest rhs-primary)
                                          next-min))
                     (let rhs-recipe (lift-recipe rhs-climb))
-                    ;; CTOR Shape B: + - * / intern as RBasic.MATH-12 nodes
+                    ;; CTOR Shape B: + - * / intern as RBasic.MATH-12 nodes,
+                    ;; and == != < <= > >= intern as RBasic.COMPARE-13 nodes
                     ;; (positional children only — the instance number IS the
-                    ;; operator, no op-string-leaf). Comparisons stay on
-                    ;; PY-BMF-COMPARE, and ** // % stay on PY-BMF-BINOP until
-                    ;; their MATH instances exist. The eval side has a
-                    ;; matching MATH-12 arm that dispatches on inst.
+                    ;; operator, no op-string-leaf). ** // % stay on
+                    ;; PY-BMF-BINOP until their MATH instances exist; any
+                    ;; unrecognised compare op (none today) falls back to
+                    ;; PY-BMF-COMPARE so the path stays total. The eval side
+                    ;; has matching MATH-12 and COMPARE-13 arms that dispatch
+                    ;; on inst.
                     (let new-left
+                        (if (str_eq op "==")
+                            (intern_node COMPARE-EQ    (list left rhs-recipe))
+                        (if (str_eq op "!=")
+                            (intern_node COMPARE-NE    (list left rhs-recipe))
+                        (if (str_eq op "<")
+                            (intern_node COMPARE-LT    (list left rhs-recipe))
+                        (if (str_eq op "<=")
+                            (intern_node COMPARE-LE    (list left rhs-recipe))
+                        (if (str_eq op ">")
+                            (intern_node COMPARE-GT    (list left rhs-recipe))
+                        (if (str_eq op ">=")
+                            (intern_node COMPARE-GE    (list left rhs-recipe))
                         (if (op-is-compare? op)
                             (intern_node PY-BMF-COMPARE
                                 (list left
@@ -320,7 +351,7 @@
                             (intern_node PY-BMF-BINOP
                                 (list left
                                       (intern_trivial_string op)
-                                      rhs-recipe))))))))
+                                      rhs-recipe))))))))))))))
                     (lift-binop-loop new-left (lift-rest rhs-climb) min-prec)))))
 
     ;; --- conditional expression ------------------------------------

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -140,11 +140,37 @@ sign(5) + sign(0 - 3) + 5
     (let lifted-plus (head (node_children lifted-module)))
     (let cell10-score (if (node_eq handbuilt-plus lifted-plus) 10000 0))
 
+    ;; ---- cell 11: CTOR Shape B Blueprint convergence for COMPARE -------
+    ;; Same substrate-truth claim as cell 10, walked one breath further:
+    ;; a hand-built COMPARE-LT recipe with PY-BMF-INT-wrapped int leaves
+    ;; AND a Python-lifted `5 < 7` must `node_eq` to 1 — both content-
+    ;; address to the canonical RBasic.COMPARE-13 inst=3 (lt) Blueprint.
+    ;; Before this breath the lifted recipe carried PY-BMF-COMPARE
+    ;; (type=99 inst=527 with an op-string-leaf child); after, it carries
+    ;; COMPARE-LT (type=13 inst=3, positional children only) — same
+    ;; Blueprint as the hand-built reference.
+    ;;
+    ;; Honest scope: this proves convergence at the COMPARE layer. The
+    ;; integer LEAVES are PY-BMF-INT(trivial_int) on both sides — same
+    ;; leaf-vocabulary residue as cell 10 — because both sides build leaves
+    ;; the same way, not because the substrate normalises bare ints.
+
+    (let COMPARE-LT-REF (make_nodeid 1 2 13 3))
+    (let handbuilt-lt
+        (intern_node COMPARE-LT-REF
+            (list (intern_node PY-BMF-INT (list (intern_trivial_int 5)))
+                  (intern_node PY-BMF-INT (list (intern_trivial_int 7))))))
+    (let lifted-cmp-module (lift-module-text "5 < 7
+"))
+    (let lifted-lt (head (node_children lifted-cmp-module)))
+    (let cell11-score (if (node_eq handbuilt-lt lifted-lt) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
-    ;; Sum when every cell agrees with CPython + Shape B converges:
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000 = 55000
+    ;; Sum when every cell agrees with CPython + Shape B converges for
+    ;; both arithmetic (cell 10) and comparison (cell 11):
+    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000 = 65000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
-               cell10-score)))
+               cell10-score cell11-score)))


### PR DESCRIPTION
## Summary

The next breath after #2113. Shape B's same-shape-same-Blueprint claim walks one vocabulary further: Python-source `== != < <= > >=` now intern as `RBasic.COMPARE-13` nodes (insts 1/2/3/4/5/6) instead of the dialect-99 `PY-BMF-COMPARE` shape with an op-string-leaf child. A matching `COMPARE-13` arm in `python-bmf-eval.fk` dispatches on `node_inst` to the eq/lt/le/gt/ge natives that already carry these Blueprint NodeIDs in `form-ontology.json`.

- `form/form-stdlib/python-bmf-lift.fk` — six `COMPARE-*` NodeID `let` bindings + dispatch in `lift-binop-loop` (compares are checked before the old `op-is-compare?` fallback, which now only fires for ops outside `== != < <= > >=` — none exist today, but the path stays total).
- `form/form-stdlib/python-bmf-eval.fk` — new `COMPARE-13` arm adjacent to the `MATH-12` arm, dispatching on inst (1=eq, 2=ne, 3=lt, 4=le, 5=gt, 6=ge). Returns `1`/`0` integers — same convention as the OLD `py-compare-apply` arm, which stays untouched.
- `form/form-stdlib/tests/python-bmf-lift-band.fk` — new cell 11 proves convergence: hand-built `COMPARE-LT(PY-BMF-INT(5), PY-BMF-INT(7))` and Python-lifted `"5 < 7"` `node_eq` to 1.

## Honest findings

- **Comparison-result residue (same shape as cell 10's integer-leaf residue):** the new COMPARE-13 arm returns `1`/`0` integers matching the OLD `py-compare-apply` convention. Python's `True`/`False` don't materialise as a distinct vocabulary here; both arms speak ints. This is a deliberate mirror of the existing arm's choice — when boolean-as-vocabulary becomes its own breath, both arms will move together.
- **What still rides PY-BMF-COMPARE:** only unrecognised comparison ops the lift falls back to defensively (none in today's op-prec surface). The OLD arm in `python-bmf-eval.fk` remains untouched and still serves the hand-built `PY-BMF-COMPARE` nodes that `python-bmf-eval-band.fk` constructs through `py-compare` directly.
- **The `lt` / `le` / `gt` / `ge` natives exist** on the Form surface — used by the existing `py-compare-apply`. No gap to compose around.

## Test plan

- [x] `./form/validate.sh` — 136 ok, 0 divergent (matches baseline).
- [x] `stdlib/python-bmf-lift-band.fk` aggregate: 55000 → **65000** (+10000 for cell 11 — Blueprint convergence).
- [x] `stdlib/python-bmf-eval-band.fk` aggregate: **78000** (unchanged — hand-built `PY-BMF-COMPARE` still routes through the OLD arm).
- [x] `stdlib/python-bmf-arithmetic-band.fk`: **25304** (unchanged).
- [x] Cells 6 (factorial with `<`), 8 (while with `<=`), 9 (right-assoc ternary with `>` and `<`) in `python-bmf-lift-band.fk` all still pass — comparison-using Python source flows correctly through the new COMPARE-13 arm.
- [x] kernel-bmf parity demos (bridge=720, assign=45, imperative=45370, demo=40949) compile through the TS adapter's `python-compile` path — unchanged — so their CPython-canonical values are preserved.

In service of [`lc-the-kernel-knows-itself`](https://github.com/seeker71/Coherence-Network/blob/main/docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) + [`lc-grammar-is-the-universal-recipe`](https://github.com/seeker71/Coherence-Network/blob/main/docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) + [`lc-universal-translator-via-keys`](https://github.com/seeker71/Coherence-Network/blob/main/docs/vision-kb/concepts/lc-universal-translator-via-keys.md).

https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_