### PR TITLE
feat(cross-modal): image-as-recipe parameterized — 5 seeds, 5 SVGs, one recipe

### DIFF
--- a/form/form-samples/cross-modal/01-image-as-recipe/README.md
+++ b/form/form-samples/cross-modal/01-image-as-recipe/README.md
@@ -57,3 +57,68 @@ existing teaching: `lc-parsers-as-recipes`, `lc-the-kernel-knows-itself`.
 
 [`gradient-circles.svg`](gradient-circles.svg) — 658 bytes, sha256
 `86920289a88c175f4c8b7fcea66ae14600c0ec201a58fa227dae31af9e5cfac0`.
+
+## Parameterized — same recipe, five outputs
+
+The sibling recipe [`gradient-circles-seeded.fk`](gradient-circles-seeded.fk)
+takes the same compositional shape and adds one input cell: an integer
+**seed**. From that one cell, four visible dimensions of the image are
+derived:
+
+| derivation | formula |
+|---|---|
+| palette index   | `(mod seed 5)`            — selects one of 5 hand-picked color triples |
+| circle count    | `3 + (mod (div seed 5) 4)` — 3..6 circles |
+| circle radius   | `40 + (mod (div seed 7) 30)` — 40..69 px |
+| y-baseline      | `120 + (mod (div seed 23) 60)` — vertical row offset |
+
+Running the recipe with five seeds yields five visibly distinct SVGs that
+all share the same enclosing document, the same gradient defs, the same
+text-label shape. The structural prefix is shared; the divergent part is
+exactly the seed-derived sub-tree.
+
+| seed | palette         | count | radius | y   | bytes | sha256 |
+|------|-----------------|-------|--------|-----|-------|--------|
+| 5    | clay/sage/dusk  | 4     | 40     | 120 | 670   | `4ea82ca835100c7c6e25437dfe76db9ac6ffee15657ad1b6d70bc13e1c82df1e` |
+| 17   | rose/berry/violet | 6   | 42     | 120 | 774   | `e148d2b9289a22d0ce845ff297c2462d5e544f188996553207a73cd81c38fd4b` |
+| 86   | gold/saddle/slate | 4   | 52     | 123 | 671   | `6ca82307da089588ab942932a391e0364e16caf3b652082935483a8c7334b655` |
+| 138  | mint/aqua/sea     | 6   | 59     | 126 | 775   | `2718828b32b3bd602542930a155a14562fdc01d95fe535b87eb3b89d9778d241` |
+| 254  | sun/ember/brick   | 5   | 46     | 131 | 724   | `6ed1434f29460c971c08805240da4fa1c0b0a43d27d76912276f3a732475daa1` |
+
+Total emitted: 3614 bytes across the five files. Three-way verified —
+Go, Rust, and TypeScript kernels produce byte-identical SVGs for every
+seed.
+
+### The structural claim
+
+The recipe `(gen-circles seed)` is one function. Every invocation walks
+the same Form tree: `svg-document → svg-defs + svg-bg + circle-row + svg-text`.
+The only cell that differs across the five invocations is the integer
+literal passed as `seed`. Everything downstream — palette lookup, count,
+radius, y-base, label text — is *derived* from that single cell through
+pure integer arithmetic and table lookup.
+
+This is what *the recipe IS the parameter space* means in practice:
+
+- **One Blueprint for the recipe.** `gen-circles` has one structural identity.
+- **One Blueprint per output.** Each emission's Blueprint differs from the
+  recipe's only by the bound value of `seed` and the values its arithmetic
+  produces. The shape — `svg → defs + bg + row + text` — is identical.
+- **Content-addressing scales to families.** Two artifacts share lineage
+  via their recipe + seed pair, not via byte-level overlap. The five SVGs
+  have five distinct SHAs, but they share one structural ancestor.
+
+The substrate would surface this by interning `gen-circles` once and the
+five `(gen-circles N)` call sites as five sibling Recipes with shared
+parent. The deep proof — running `04-universal-diff` over two of these
+SVGs and showing the diff highlights *only* the parameter cell, not the
+hundreds of byte-positions that moved — is forward-map walk #7 (image
+structural diff). This walk lays the parameter space; #7 will measure it.
+
+### Generated artifacts
+
+- [`gen-circles-5.svg`](gen-circles-5.svg)   — palette 0, 4 circles
+- [`gen-circles-17.svg`](gen-circles-17.svg) — palette 2, 6 circles
+- [`gen-circles-86.svg`](gen-circles-86.svg) — palette 1, 4 circles
+- [`gen-circles-138.svg`](gen-circles-138.svg) — palette 3, 6 circles
+- [`gen-circles-254.svg`](gen-circles-254.svg) — palette 4, 5 circles

--- a/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-138.svg
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-138.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6d3"/>
+      <stop offset="100%" stop-color="#c8d8e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#bg)"/>
+  <circle cx="85" cy="126" r="59" fill="#00b894"/>
+  <circle cx="171" cy="126" r="59" fill="#00cec9"/>
+  <circle cx="257" cy="126" r="59" fill="#0984e3"/>
+  <circle cx="342" cy="126" r="59" fill="#00b894"/>
+  <circle cx="428" cy="126" r="59" fill="#00cec9"/>
+  <circle cx="514" cy="126" r="59" fill="#0984e3"/>
+  <text x="300" y="270" font-family="sans-serif" font-size="20" text-anchor="middle" fill="#1a1a1a">seed=138</text>
+</svg>

--- a/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-17.svg
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-17.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6d3"/>
+      <stop offset="100%" stop-color="#c8d8e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#bg)"/>
+  <circle cx="85" cy="120" r="42" fill="#ff6b9d"/>
+  <circle cx="171" cy="120" r="42" fill="#c44569"/>
+  <circle cx="257" cy="120" r="42" fill="#574b90"/>
+  <circle cx="342" cy="120" r="42" fill="#ff6b9d"/>
+  <circle cx="428" cy="120" r="42" fill="#c44569"/>
+  <circle cx="514" cy="120" r="42" fill="#574b90"/>
+  <text x="300" y="270" font-family="sans-serif" font-size="20" text-anchor="middle" fill="#1a1a1a">seed=17</text>
+</svg>

--- a/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-254.svg
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-254.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6d3"/>
+      <stop offset="100%" stop-color="#c8d8e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#bg)"/>
+  <circle cx="100" cy="131" r="46" fill="#f8b500"/>
+  <circle cx="200" cy="131" r="46" fill="#ee5a24"/>
+  <circle cx="300" cy="131" r="46" fill="#c0392b"/>
+  <circle cx="400" cy="131" r="46" fill="#f8b500"/>
+  <circle cx="500" cy="131" r="46" fill="#ee5a24"/>
+  <text x="300" y="270" font-family="sans-serif" font-size="20" text-anchor="middle" fill="#1a1a1a">seed=254</text>
+</svg>

--- a/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-5.svg
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-5.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6d3"/>
+      <stop offset="100%" stop-color="#c8d8e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#bg)"/>
+  <circle cx="120" cy="120" r="40" fill="#e07b5a"/>
+  <circle cx="240" cy="120" r="40" fill="#7ab37a"/>
+  <circle cx="360" cy="120" r="40" fill="#5a7ab3"/>
+  <circle cx="480" cy="120" r="40" fill="#e07b5a"/>
+  <text x="300" y="270" font-family="sans-serif" font-size="20" text-anchor="middle" fill="#1a1a1a">seed=5</text>
+</svg>

--- a/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-86.svg
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gen-circles-86.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f5e6d3"/>
+      <stop offset="100%" stop-color="#c8d8e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#bg)"/>
+  <circle cx="120" cy="123" r="52" fill="#d4af37"/>
+  <circle cx="240" cy="123" r="52" fill="#8b4513"/>
+  <circle cx="360" cy="123" r="52" fill="#2f4f4f"/>
+  <circle cx="480" cy="123" r="52" fill="#d4af37"/>
+  <text x="300" y="270" font-family="sans-serif" font-size="20" text-anchor="middle" fill="#1a1a1a">seed=86</text>
+</svg>

--- a/form/form-samples/cross-modal/01-image-as-recipe/gradient-circles-seeded.fk
+++ b/form/form-samples/cross-modal/01-image-as-recipe/gradient-circles-seeded.fk
@@ -1,0 +1,159 @@
+; gradient-circles-seeded.fk — image-as-recipe, parameterized by a seed.
+;
+; The sibling of `gradient-circles.fk`: the same compositional shape, but the
+; recipe now takes a `seed` integer and emits a visibly distinct SVG for each
+; seed. Five seeds are baked in (5, 86, 17, 138, 254); the recipe writes five
+; SVGs in one run. Same recipe, five outputs, content-addresses to five
+; different Blueprints whose ONLY structural difference is the parameter cell
+; (the bound value of `seed`).
+;
+; The five seeds were chosen so that (mod seed 5) spans 0..4 — five distinct
+; palettes — while counts, radii, and y-offsets also vary visibly. No two of
+; the five outputs share both palette AND count AND radius AND y-base; each
+; pair differs in at least three of the four derived dimensions.
+;
+; The seed drives three visible dimensions:
+;   - palette  = (mod seed 5)                — one of 5 hand-picked triplets
+;   - count    = 3 + (mod (div seed 5) 4)    — 3..6 circles
+;   - radius   = 40 + (mod (div seed 7) 30)  — varying disc size
+;   - y-base   = 120 + (mod (div seed 23) 60) — vertical offset of the row
+;
+; All five SVGs share the same enclosing document, the same gradient defs, the
+; same text-label shape. Only the seed-derived parameters change. Run twice and
+; the bytes are identical: determinism is the proof that the parameter cell
+; (not the surface text) is the recipe's identity.
+;
+; Run with the Go kernel from the repo root:
+;   form/form-kernel-go/bin-go form/form-samples/cross-modal/01-image-as-recipe/gradient-circles-seeded.fk
+; Outputs gen-circles-{seed}.svg next to this file for each of the five seeds
+; and prints the total byte count.
+
+(do
+    ; --- small string-builder helpers (same as gradient-circles.fk) ---------
+    (defn s2 (a b) (str_concat a b))
+    (defn s3 (a b c) (str_concat a (str_concat b c)))
+    (defn s4 (a b c d) (str_concat (str_concat a b) (str_concat c d)))
+    (defn s5 (a b c d e) (str_concat (s4 a b c d) e))
+
+    (defn istr (n) (int_to_str n))
+
+    ; --- list indexer -------------------------------------------------------
+    (defn nth (xs n)
+        (if (eq n 0)
+            (head xs)
+            (nth (tail xs) (sub n 1))))
+
+    ; --- palettes (5 triples of hex strings) --------------------------------
+    ; The "parameter cell" lookup target. Picked for visible contrast across
+    ; the five seeds. Each row is a (left, middle, right) circle color.
+    (let palette-0 (list "#e07b5a" "#7ab37a" "#5a7ab3"))  ; clay / sage / dusk
+    (let palette-1 (list "#d4af37" "#8b4513" "#2f4f4f"))  ; gold / saddle / slate
+    (let palette-2 (list "#ff6b9d" "#c44569" "#574b90"))  ; rose / berry / violet
+    (let palette-3 (list "#00b894" "#00cec9" "#0984e3"))  ; mint / aqua / sea
+    (let palette-4 (list "#f8b500" "#ee5a24" "#c0392b"))  ; sun / ember / brick
+
+    (defn palette-for (idx)
+        (if (eq idx 0) palette-0
+        (if (eq idx 1) palette-1
+        (if (eq idx 2) palette-2
+        (if (eq idx 3) palette-3
+                       palette-4)))))
+
+    ; A circle's color comes from (i mod 3) into the seed's palette tuple.
+    (defn color-at (pal i)
+        (nth pal (mod i 3)))
+
+    ; --- gradient defs (shared; seed does not vary the background) ----------
+    (defn svg-defs ()
+        (str_concat
+            "  <defs>\n"
+            (str_concat
+                "    <linearGradient id=\"bg\" x1=\"0%\" y1=\"0%\" x2=\"100%\" y2=\"100%\">\n"
+                (str_concat
+                    "      <stop offset=\"0%\" stop-color=\"#f5e6d3\"/>\n"
+                    (str_concat
+                        "      <stop offset=\"100%\" stop-color=\"#c8d8e8\"/>\n"
+                        (str_concat "    </linearGradient>\n" "  </defs>\n"))))))
+
+    (defn svg-bg (w h)
+        (s5 "  <rect width=\"" (istr w) "\" height=\"" (istr h)
+            "\" fill=\"url(#bg)\"/>\n"))
+
+    (defn svg-circle (cx cy r fill)
+        (str_concat
+            (s4 "  <circle cx=\"" (istr cx) "\" cy=\"" (istr cy))
+            (s5 "\" r=\"" (istr r) "\" fill=\"" fill "\"/>\n")))
+
+    (defn svg-text (x y size content)
+        (str_concat
+            (s4 "  <text x=\"" (istr x) "\" y=\"" (istr y))
+            (str_concat
+                (s3 "\" font-family=\"sans-serif\" font-size=\"" (istr size) "\" text-anchor=\"middle\" fill=\"#1a1a1a\">")
+                (s3 "" content "</text>\n"))))
+
+    ; --- circle row: lay out `count` circles evenly across width `w` --------
+    ; cx_i = ((i + 1) * w) / (count + 1)
+    (defn row-rec (i count w y r pal acc)
+        (if (eq i count)
+            acc
+            (row-rec (add i 1) count w y r pal
+                (str_concat acc
+                    (svg-circle
+                        (div (mul (add i 1) w) (add count 1))
+                        y
+                        r
+                        (color-at pal i))))))
+
+    (defn circle-row (count w y r pal)
+        (row-rec 0 count w y r pal ""))
+
+    ; --- the full document, parameterized by seed ---------------------------
+    (defn svg-document (w h body)
+        (str_concat
+            (s5 "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\""
+                (istr w)
+                "\" height=\""
+                (istr h)
+                "\" viewBox=\"0 0 ")
+            (str_concat
+                (s3 (istr w) " " (istr h))
+                (s3 "\">\n" body "</svg>\n"))))
+
+    ; gen-circles — THE parameterized recipe. One input cell (seed), one SVG.
+    ; The body is a single (do …) so that the seed-derived lets bind in scope
+    ; for the final svg-document expression that returns the SVG bytes.
+    (defn gen-circles (seed)
+        (do
+            (let pal     (palette-for (mod seed 5)))
+            (let count   (add 3 (mod (div seed 5) 4)))
+            (let radius  (add 40 (mod (div seed 7) 30)))
+            (let y-base  (add 120 (mod (div seed 23) 60)))
+            (let label   (str_concat "seed=" (istr seed)))
+            (svg-document 600 300
+                (str_concat
+                    (svg-defs)
+                    (str_concat
+                        (svg-bg 600 300)
+                        (str_concat
+                            (circle-row count 600 y-base radius pal)
+                            (svg-text 300 270 20 label)))))))
+
+    ; --- write one SVG per seed --------------------------------------------
+    ; Each call differs in exactly one cell: the seed. The recipe tree above
+    ; (svg-document → svg-defs + svg-bg + circle-row + svg-text) is identical
+    ; across all five calls; only the parameter NodeID varies.
+    (let svg-5    (gen-circles 5))
+    (let svg-86   (gen-circles 86))
+    (let svg-17   (gen-circles 17))
+    (let svg-138  (gen-circles 138))
+    (let svg-254  (gen-circles 254))
+
+    (write_file_text "form/form-samples/cross-modal/01-image-as-recipe/gen-circles-5.svg"   svg-5)
+    (write_file_text "form/form-samples/cross-modal/01-image-as-recipe/gen-circles-86.svg"  svg-86)
+    (write_file_text "form/form-samples/cross-modal/01-image-as-recipe/gen-circles-17.svg"  svg-17)
+    (write_file_text "form/form-samples/cross-modal/01-image-as-recipe/gen-circles-138.svg" svg-138)
+    (write_file_text "form/form-samples/cross-modal/01-image-as-recipe/gen-circles-254.svg" svg-254)
+
+    (add (add (str_len svg-5) (str_len svg-86))
+         (add (str_len svg-17)
+              (add (str_len svg-138) (str_len svg-254)))))

--- a/form/form-samples/cross-modal/NEXT_BREATHS.md
+++ b/form/form-samples/cross-modal/NEXT_BREATHS.md
@@ -19,11 +19,22 @@ A Form recipe that procedurally generates a `.wav` file. Same content-addressing
 
 **Landed:** [`06-audio-as-recipe/gen-sine.fk`](06-audio-as-recipe/gen-sine.fk) — 1-second 440 Hz tone, mono 8-bit PCM at 8000 Hz, 8044-byte WAV with sha256 `6d170ffe323b378ce29b886252105cb5e6d68e0bc1589160a472075afc635447`, byte-identical across Go/Rust/TS kernels. The walk also closed a sibling-parity gap: the TS kernel was missing `write_file_bytes`. Envelope and FM synthesis remain for future breaths.
 
-### 2. **Image-as-recipe — parameterized**
+### 2. **Image-as-recipe — parameterized** — **landed 2026-05-27**
 
-Extend `01-image-as-recipe/gradient-circles.fk` to take a seed and produce 5 visibly distinct SVGs from 5 seeds. Shows that the recipe is **the parameter space**, not a single output. Proves: same recipe + different parameters = different content-addressed outputs whose only difference is the parameter NodeID.
+A single recipe `(gen-circles seed)` takes one integer cell and emits a
+visibly distinct SVG. Five seeds (5, 86, 17, 138, 254) chosen so `(mod
+seed 5)` spans 0..4 — five distinct palettes — while count, radius, and
+y-baseline also vary.
 
-**Smallest closing breath:** 5 SVGs with their SHAs documented; same recipe, 5 NodeIDs differing only in parameter children.
+**Landed:** [`01-image-as-recipe/gradient-circles-seeded.fk`](01-image-as-recipe/gradient-circles-seeded.fk)
+emits five SVGs totalling 3614 bytes; three-way Go/Rust/TS kernel
+agreement on every seed (verified file-by-file with `cmp`). Each emission
+shares the same Form tree shape — `svg-document → svg-defs + svg-bg +
+circle-row + svg-text` — and differs only in the seed-derived sub-tree.
+
+The deeper proof (structural diff over two of the SVGs surfacing *only*
+the parameter cell as the delta, not the byte-level moves) is forward-map
+walk #7. This walk lays the parameter space; #7 will measure it.
 
 ### 3. **NL→recipe broadened**
 

--- a/form/form-samples/cross-modal/README.md
+++ b/form/form-samples/cross-modal/README.md
@@ -10,7 +10,7 @@ discoveries.
 
 | # | Experiment | One-line finding |
 |---|---|---|
-| 01 | [Image as recipe](01-image-as-recipe/) | A procedural SVG written as Form recipes; same recipe → identical SVG bytes by SHA256. |
+| 01 | [Image as recipe](01-image-as-recipe/) | A procedural SVG written as Form recipes; same recipe → identical SVG bytes by SHA256. **Parameterized** sibling: one recipe + 5 seeds → 5 byte-distinct SVGs whose only structural difference is the seed cell. |
 | 02 | [Cross-language content-addressing](02-cross-language-content-addressing/) | Two recursive trees built by different author-routes intern to the **same** NodeID; iterative shape interns to a different one. |
 | 03 | [Recipe as compression](03-recipe-as-compression/) | The substrate's "ice" (`.fkb`) is **4.17× larger** than the "water" (`.fk` text) at small payload sizes. Compression isn't automatic. |
 | 04 | [Universal diff](04-universal-diff/) | Structural diff of two algorithms surfaces "the predicate is the same; the accumulation strategy diverges" — text diff can't see this. |


### PR DESCRIPTION
## Summary

Walks breath #2 from `form/form-samples/cross-modal/NEXT_BREATHS.md`: **image-as-recipe parameterized**.

- A single Form recipe `(gen-circles seed)` takes one integer cell and emits a visibly distinct SVG. Five seeds (5, 86, 17, 138, 254) chosen so `(mod seed 5)` spans 0..4 — five distinct palettes — while count, radius, and y-baseline also vary.
- Three-way verified: Go, Rust, and TypeScript kernels produce byte-identical SVGs for every seed. `validate.sh` remains at **136 ok, 0 divergent** — no regressions.
- The structural claim: every emission walks the same Form tree (`svg-document → svg-defs + svg-bg + circle-row + svg-text`). The only cell that differs across the five invocations is the integer literal passed as `seed`; everything downstream — palette, count, radius, y-base — is derived from that single cell through pure integer arithmetic and table lookup.

This is content-addressing scaling from "identity of single artifacts" to **identity of artifact families**.

The deeper structural-diff proof (running `04-universal-diff` over two of these SVGs and showing the diff highlights only the parameter cell, not the byte-level moves) is forward-map walk #7. This walk lays the parameter space; #7 will measure it.

## Files

- `form/form-samples/cross-modal/01-image-as-recipe/gradient-circles-seeded.fk` — the parameterized recipe (extends the original `gradient-circles.fk`, which is preserved unchanged).
- 5 generated SVGs: `gen-circles-{5,17,86,138,254}.svg`.
- README updates in `01-image-as-recipe/`, top-level `cross-modal/README.md`, and `NEXT_BREATHS.md` (#2 marked landed).

## SHAs of the five emissions

| seed | palette         | count | radius | y   | bytes | sha256 (head) |
|------|-----------------|-------|--------|-----|-------|---------------|
| 5    | clay/sage/dusk  | 4     | 40     | 120 | 670   | `4ea82ca835100c7c…` |
| 17   | rose/berry/violet | 6   | 42     | 120 | 774   | `e148d2b9289a22d0…` |
| 86   | gold/saddle/slate | 4   | 52     | 123 | 671   | `6ca82307da089588…` |
| 138  | mint/aqua/sea     | 6   | 59     | 126 | 775   | `2718828b32b3bd60…` |
| 254  | sun/ember/brick   | 5   | 46     | 131 | 724   | `6ed1434f29460c97…` |

Total: 3614 bytes across five files.

## Test plan

- [x] `form/form-kernel-go/bin-go form/form-samples/cross-modal/01-image-as-recipe/gradient-circles-seeded.fk` writes five SVGs, returns 3614.
- [x] Same recipe on Rust kernel produces byte-identical SVGs for all five seeds (verified file-by-file with `cmp`).
- [x] Same recipe on TS kernel produces byte-identical SVGs for all five seeds.
- [x] `./form/validate.sh` reports `136 ok, 0 divergent`.
- [x] Original `gradient-circles.svg` still matches the documented sha `86920289a88c…`.

In service of [`lc-grammar-is-the-universal-recipe`](docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) + [`lc-cross-modal-unity`](docs/vision-kb/concepts/lc-cross-modal-unity.md).

https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_