### PR TITLE
attune(kernels): CTOR Shape B extends to `%` (mod) — MATH-12 inst=5

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -323,11 +323,11 @@
                      (and (eq (node_level cat) 2)
                           (eq (node_type cat) 12)))
                 ;; CTOR Shape B: RBasic.MATH-12 arm. The Python lift now
-                ;; interns + - * / as MATH-12 nodes (positional children,
+                ;; interns + - * / % as MATH-12 nodes (positional children,
                 ;; no op-string-leaf) so a hand-built (intern_node MATH-PLUS
                 ;; (list 7 3)) and a Python-lifted "7 + 3" share one
                 ;; Blueprint NodeID. Dispatch on the cat's inst — 1=plus,
-                ;; 2=minus, 3=mul, 4=div — matching form-ontology.json.
+                ;; 2=minus, 3=mul, 4=div, 5=mod — matching form-ontology.json.
                 (do
                     (let lhs-val (py-eval (nth kids 0) env))
                     (let rhs-val (py-eval (nth kids 1) env))
@@ -336,9 +336,10 @@
                     (if (eq math-inst 2) (sub lhs-val rhs-val)
                     (if (eq math-inst 3) (mul lhs-val rhs-val)
                     (if (eq math-inst 4) (div lhs-val rhs-val)
+                    (if (eq math-inst 5) (mod lhs-val rhs-val)
                         (do
                             (trace "py-eval MATH: unknown inst" math-inst)
-                            (head (empty))))))))
+                            (head (empty)))))))))
             (if (and (eq (node_pkg cat) 1)
                      (and (eq (node_level cat) 2)
                           (eq (node_type cat) 13)))

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -62,6 +62,7 @@
     (let MATH-MINUS    (make_nodeid 1 2 12 2))
     (let MATH-MULTIPLY (make_nodeid 1 2 12 3))
     (let MATH-DIVIDE   (make_nodeid 1 2 12 4))
+    (let MATH-MOD      (make_nodeid 1 2 12 5))
 
     ;; ---- COMPARE-13 NodeIDs (CTOR Shape B for comparisons) ---------
     ;;
@@ -348,10 +349,12 @@
                             (intern_node MATH-MULTIPLY (list left rhs-recipe))
                         (if (str_eq op "/")
                             (intern_node MATH-DIVIDE   (list left rhs-recipe))
+                        (if (str_eq op "%")
+                            (intern_node MATH-MOD      (list left rhs-recipe))
                             (intern_node PY-BMF-BINOP
                                 (list left
                                       (intern_trivial_string op)
-                                      rhs-recipe))))))))))))))
+                                      rhs-recipe)))))))))))))))
                     (lift-binop-loop new-left (lift-rest rhs-climb) min-prec)))))
 
     ;; --- conditional expression ------------------------------------

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -165,12 +165,33 @@ sign(5) + sign(0 - 3) + 5
     (let lifted-lt (head (node_children lifted-cmp-module)))
     (let cell11-score (if (node_eq handbuilt-lt lifted-lt) 10000 0))
 
+    ;; ---- cell 12: CTOR Shape B convergence for `mod` (%) -------------
+    ;; Closes the last arithmetic operator MATH-12 carries today:
+    ;; mod (inst=5). Same shape as cells 10 and 11 — a hand-built
+    ;; MATH-MOD recipe with PY-BMF-INT leaves AND a Python-lifted
+    ;; `10 % 3` must node_eq to 1. Before this breath `%` rode the
+    ;; PY-BMF-BINOP fallback (type=99 inst=522 with op-string-leaf);
+    ;; after, it carries MATH-MOD (type=12 inst=5, positional only).
+    ;;
+    ;; The arithmetic surface that's still on PY-BMF-BINOP after this:
+    ;; ** and // (no MATH instances exist for power or floor-div today).
+
+    (let MATH-MOD-REF (make_nodeid 1 2 12 5))
+    (let handbuilt-mod
+        (intern_node MATH-MOD-REF
+            (list (intern_node PY-BMF-INT (list (intern_trivial_int 10)))
+                  (intern_node PY-BMF-INT (list (intern_trivial_int 3))))))
+    (let lifted-mod-module (lift-module-text "10 % 3
+"))
+    (let lifted-mod (head (node_children lifted-mod-module)))
+    (let cell12-score (if (node_eq handbuilt-mod lifted-mod) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
-    ;; both arithmetic (cell 10) and comparison (cell 11):
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000 = 65000
+    ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
+    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000 = 75000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
-               cell10-score cell11-score)))
+               cell10-score cell11-score cell12-score)))


### PR DESCRIPTION
## What changed

The next small breath after #2113 (`+ - * /`) and #2119 (`== != < <= > >=`).
Python's `%` (mod) now interns as `RBasic.MATH-12 inst=5` — the same
Blueprint a hand-built `(intern_node MATH-MOD ...)` interns to.

Three small changes:
- `python-bmf-lift.fk` — `MATH-MOD` let binding + `(if (str_eq op "%") …)` in `lift-binop-loop`
- `python-bmf-eval.fk` — `(if (eq math-inst 5) (mod lhs rhs))` added before the unknown-inst fallback
- `python-bmf-lift-band.fk` — **cell 12** proves convergence: lifted `"10 % 3"` `node_eq` hand-built `MATH-MOD(10, 3)` → 1 three-way

## Verification

- `./form/validate.sh` → **136 ok, 0 divergent**
- `python-bmf-lift-band.fk` aggregate: **65000 → 75000** (+10000 for cell 12)

## What's still on PY-BMF-BINOP

Just `**` (power) and `//` (floor-div). No MATH instances exist for those today; future breath adds MATH inst=6 for power and inst=7 for floor-div, with kernel native registration.

## Discipline

Zero new Python. Pure Form. Per Urs's standing constraint.

In service of [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md), [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md), [`lc-universal-translator-via-keys`](../docs/vision-kb/concepts/lc-universal-translator-via-keys.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_