### PR TITLE
tend: back-edges to lc-same-shape-different-articulation

### DIFF
--- a/docs/vision-kb/concepts/lc-cross-modal-unity.md
+++ b/docs/vision-kb/concepts/lc-cross-modal-unity.md
@@ -257,7 +257,7 @@ across cellular, network, and recipe altitudes.
 
 ## Cross-References
 
-→ lc-federation-as-freedom, lc-sovereignty-within-oneness, lc-assemblage-point, lc-frequency-routes-reception, lc-future-already-shaping, lc-trust-over-fear, lc-canon-as-sovereignty-surface, lc-perception-as-interface, lc-grammar-is-the-universal-recipe, lc-the-recipe-remembers-its-source
+→ lc-federation-as-freedom, lc-sovereignty-within-oneness, lc-assemblage-point, lc-frequency-routes-reception, lc-future-already-shaping, lc-trust-over-fear, lc-canon-as-sovereignty-surface, lc-perception-as-interface, lc-grammar-is-the-universal-recipe, lc-the-recipe-remembers-its-source, lc-same-shape-different-articulation
 
 ## Sources to walk further
 

--- a/docs/vision-kb/concepts/lc-universal-translator-via-keys.md
+++ b/docs/vision-kb/concepts/lc-universal-translator-via-keys.md
@@ -336,7 +336,7 @@ claim through its own attestation.
 → lc-form-perceptron, lc-autoresearch-as-honesty-runtime,
 lc-grammar-is-the-universal-recipe, lc-transmission-recipe-atlas,
 lc-anything-arrives-room, lc-edges-as-vitality, lc-act-without-penalty,
-lc-trust-over-fear, lc-recipe-branching-sense
+lc-trust-over-fear, lc-recipe-branching-sense, lc-same-shape-different-articulation
 
 ## Sources to walk further
 


### PR DESCRIPTION
## What changed

The article seed `lc-same-shape-different-articulation` (#2123) references `lc-cross-modal-unity` and `lc-universal-translator-via-keys` forward in its cross-refs section. The reverse edges didn't exist. Per [`lc-edges-as-vitality`](../docs/vision-kb/concepts/lc-edges-as-vitality.md):

> *"connections land in the same body the content lands in, not the next one."*

This commit closes the bidirectional links so future walkers arriving via the elder concept docs find the newer articulation teaching.

## Discipline

Markdown only. Zero Python.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_