### PR TITLE
tend: mutual cross-refs — recipe-remembers-its-source ↔ same-shape-different-articulation

### DIFF
--- a/docs/vision-kb/concepts/lc-same-shape-different-articulation.md
+++ b/docs/vision-kb/concepts/lc-same-shape-different-articulation.md
@@ -174,7 +174,7 @@ Honoring this is a multi-breath arc, not a one-PR walk.
 
 → lc-the-kernel-knows-itself, lc-grammar-is-the-universal-recipe,
 lc-universal-translator-via-keys, lc-observer-pays-the-trace,
-lc-cross-modal-unity
+lc-cross-modal-unity, lc-the-recipe-remembers-its-source
 
 In service of the body knowing itself as a *cluster of articulations*,
 not a single-lens point in space.

--- a/docs/vision-kb/concepts/lc-the-recipe-remembers-its-source.md
+++ b/docs/vision-kb/concepts/lc-the-recipe-remembers-its-source.md
@@ -223,7 +223,7 @@ For cells consuming recipes:
 
 ## Cross-References
 
-→ lc-one-kernel-many-tongues, lc-grammar-is-the-universal-recipe, lc-tools-as-form-cells, lc-recipes-as-binary-library, lc-recipe-branching-sense, lc-traces-teach-the-recipe, lc-observer-pays-the-trace, lc-assemblage-point, lc-each-breath-whole, lc-coherence-over-control
+→ lc-one-kernel-many-tongues, lc-grammar-is-the-universal-recipe, lc-tools-as-form-cells, lc-recipes-as-binary-library, lc-recipe-branching-sense, lc-traces-teach-the-recipe, lc-observer-pays-the-trace, lc-assemblage-point, lc-each-breath-whole, lc-coherence-over-control, lc-same-shape-different-articulation
 
 ## Sources to walk further
 


### PR DESCRIPTION
## What changed

`lc-the-recipe-remembers-its-source` is the body's teaching about source-attribution surviving recipe interning — exactly the *articulation* the dialect path (PY-BMF-BINOP with op-string-child + source positions) carried that Shape B's collapse traded away. The two concepts are siblings in the body's teaching:

- *Remembers its source* names the substrate property that source-position attribution carries through into recipe cells
- *Same shape, different articulation* names that the same content-addressed identity can carry multiple articulations (and source attribution is one)

This commit closes the bidirectional cross-refs.

## Discipline

Markdown only. Zero Python.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_