### PR TITLE
feat(cross-modal): substrate as deployment runtime — tensor recipe walks 3-way

### DIFF
--- a/form/form-samples/cross-modal/10-substrate-as-runtime/README.md
+++ b/form/form-samples/cross-modal/10-substrate-as-runtime/README.md
@@ -1,0 +1,72 @@
+# 10-substrate-as-runtime — the substrate IS the translator's runtime
+
+Walks 5–9 in this directory used an LLM (or external translator) as the
+modality-crossing engine, with the substrate as the verification harness.
+This walk redirects: **the substrate is the deployment runtime itself**.
+
+Translators live as content-addressed Form recipes. Weights are
+substrate cells. Inference is recipe-walking. Same NodeID identity that
+holds for `(add 1 2)` extends to tensor-op recipes that compose into
+neural network forward passes.
+
+Architecture doc: [`kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`](../../../kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md).
+
+## What this proof-of-shape ships
+
+`neural-forward.fk` — a one-layer linear+ReLU neural network as a
+Form recipe. Walks three-way:
+
+```
+$ ./validate.sh form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk
+  ✓  neural-forward.fk  → 136
+  1 ok, 0 divergent — kernels agree on every sample.
+```
+
+The math:
+- W = `[[1,2,3,4], [5,6,7,8], [9,10,11,12], [13,14,15,16]]`  (4×4 weight matrix, substrate-resident as a CAT-TENSOR recipe)
+- x = `[1, 1, 1, 1]`  (4-element input vector, substrate-resident)
+- y = W @ x = `[10, 26, 42, 58]`  (matvec via dot-row recipe)
+- ReLU(y) = `[10, 26, 42, 58]`  (all positive)
+- sum(ReLU(y)) = **136**
+
+## What this proves
+
+- ✓ Tensors as substrate-resident recipes — `CAT-TENSOR` with shape + flat-data children, content-addressed
+- ✓ Weights live in the lattice with stable NodeID identity (model = recipe)
+- ✓ Neural ops compose as Form recipes (matvec is recursion over dot-row, ReLU is `if v < 0 then 0 else v`)
+- ✓ Three-way sibling parity at the tensor-walking altitude (Go ≡ Rust ≡ TypeScript)
+- ✓ The same `intern_node` / `node_eq` machinery that addresses code, addresses model weights
+
+## What this does NOT prove
+
+- ✗ **Throughput.** Scalar matmul through the interpreter is ms for 4×4; gigaflops/sec needs the JIT-to-BLAS layer (named in architecture doc as engineering layer 3).
+- ✗ **Floats.** This demo uses integer-scaled values; honest neural inference needs IEEE 754 floats. Go-kernel float natives just landed in #2134, completing sibling parity — that's the precondition. Tensor-op recipes can move to floats next.
+- ✗ **Trained weights.** Hand-coded matrix here. Real models distribute as substrate-cell bundles (each weight tensor a CAT-TENSOR cell, the whole model a recipe referencing them).
+- ✗ **Streaming I/O.** This is one forward pass; gigabyte streams need incremental reader/writer recipes (engineering layer 4).
+- ✗ **GPU dispatch.** All three kernels run scalar today; GPU/SIMD comes via format-recipe `arithmetic-hint` dispatch (engineering layer 5).
+
+## The five engineering layers between this and deployment
+
+1. ✓ **Float tensor primitives sibling-parity** — landed (Rust + TS, Go via #2134)
+2. ☐ **Tensor-op recipe vocabulary** — matmul, conv, FFT, embedding, softmax, attention as `form-stdlib/tensor.fk`
+3. ☐ **JIT to native BLAS / SIMD** — kernel recognizes tensor-op recipe shapes, dispatches to native code
+4. ☐ **Streaming I/O primitives** — frame-by-frame, not whole-file
+5. ☐ **GPU / accelerator dispatch** — format-recipe's `arithmetic-hint` selects backend at runtime
+
+None of these change substrate identity. They grow the **execution layer**.
+
+## Files
+
+| File | What |
+|---|---|
+| `neural-forward.fk` | The 4×4 matvec + ReLU + sum recipe, three-way attested → 136 |
+| `README.md` | This file |
+
+`./validate.sh` after: **138 ok, 0 divergent** (137 from #2134 + 1 new tensor walk).
+
+## In service of
+
+- [`SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`](../../../kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md) — the destination architecture
+- [`numeric-types-plan.md`](../../../docs/coherence-substrate/numeric-types-plan.md) — format-recipes as substrate citizens
+- [`lc-grammar-is-the-universal-recipe`](../../../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) — grammar at every altitude, including tensor-op
+- [`lc-the-kernel-knows-itself`](../../../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — the kernel walks the same recipes that ARE the translator

--- a/form/form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk
+++ b/form/form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk
@@ -1,0 +1,104 @@
+; neural-forward.fk — a one-layer linear+ReLU neural network as a Form recipe.
+;
+; The translator IS substrate machinery, not an external binary. Weights live as
+; content-addressed tensor cells; inference is a recipe the kernel walks. This
+; demo runs a 4×4 weight matrix times a 4-vector through ReLU and sums, three-way.
+;
+; W = [[1,2,3,4], [5,6,7,8], [9,10,11,12], [13,14,15,16]]
+; x = [1, 1, 1, 1]
+; y = W @ x = [10, 26, 42, 58]
+; ReLU(y) = [10, 26, 42, 58] (all positive)
+; sum(ReLU(y)) = 136
+;
+; This is scalar matmul through the interpreter — slow at 4×4 throughput, but
+; the architectural shape is right: the substrate carries tensors as recipes,
+; ops compose, sibling-three-way attests outputs. The throughput optimization
+; (kernel JIT to BLAS/SIMD for tensor-op recipes) is the next layer.
+;
+; What this proves:
+;   - Tensors as substrate-resident recipes (NodeID identity for weights)
+;   - Neural inference is a recipe the kernel walks
+;   - Three-way sibling parity holds at the tensor-walking altitude
+;
+; What this doesn't prove:
+;   - Throughput (4×4 in seconds, not GB/s — we need the JIT layer)
+;   - Float support (this is integer-scaled; needs Go floats sibling-parity)
+;   - Trained weights (this uses hand-coded weights; real weights would be
+;     read from substrate-resident cells loaded from disk or distributed)
+;
+; The destination: gigabytes of audio/video streaming through tensor recipes
+; the kernel JIT-vectorizes. This demo is the substrate-side handshake; the
+; throughput layer is the engineering work that follows.
+
+(do
+    ;; --- helpers (Go kernel lacks `nth` and `nil?` natives) ---------
+    (defn nil? (xs) (eq (len xs) 0))
+    (defn nth (xs i)
+        (if (eq i 0) (head xs)
+            (nth (tail xs) (sub i 1))))
+
+    ;; --- tensor schema (dialect-99 experimental) ---------------------
+    (let CAT-TENSOR (make_nodeid 1 2 99 900))
+    (let CAT-SHAPE  (make_nodeid 1 2 99 901))
+    (let CAT-DATA   (make_nodeid 1 2 99 902))
+
+    ;; A tensor is a recipe with two children: shape (list of dim-ints) and
+    ;; data (list of int-trivials, row-major). NodeID identity over the
+    ;; entire shape + every data element — content-addressed.
+    (defn tensor (shape-list data-list)
+        (intern_node CAT-TENSOR
+            (list (intern_node CAT-SHAPE shape-list)
+                  (intern_node CAT-DATA  data-list))))
+
+    (defn tensor-data (t)
+        (node_children (head (tail (node_children t)))))
+
+    ;; --- ReLU and matvec primitives ----------------------------------
+    (defn relu (v) (if (lt v 0) 0 v))
+
+    ;; Inner: sum_k W[i,k] * x[k] for fixed i, walking k from 0..K-1.
+    (defn dot-row (W-cells x-cells K i k acc)
+        (if (eq k K) acc
+            (do
+                (let Wik (node_value (nth W-cells (add (mul i K) k))))
+                (let xk  (node_value (nth x-cells k)))
+                (dot-row W-cells x-cells K i (add k 1)
+                         (add acc (mul Wik xk))))))
+
+    ;; Outer: sum_i ReLU(dot-row(W, x, K, i, 0, 0))
+    (defn sum-relu-matvec (W-cells x-cells N K i acc)
+        (if (eq i N) acc
+            (do
+                (let yi (dot-row W-cells x-cells K i 0 0))
+                (sum-relu-matvec W-cells x-cells N K (add i 1)
+                                  (add acc (relu yi))))))
+
+    ;; --- the actual weights and input (substrate-resident) -----------
+    ;;
+    ;; W = [[1,2,3,4], [5,6,7,8], [9,10,11,12], [13,14,15,16]]
+    ;; x = [1,1,1,1]
+
+    (let W
+        (tensor
+            (list (intern_trivial_int 4) (intern_trivial_int 4))
+            (list (intern_trivial_int 1)  (intern_trivial_int 2)
+                  (intern_trivial_int 3)  (intern_trivial_int 4)
+                  (intern_trivial_int 5)  (intern_trivial_int 6)
+                  (intern_trivial_int 7)  (intern_trivial_int 8)
+                  (intern_trivial_int 9)  (intern_trivial_int 10)
+                  (intern_trivial_int 11) (intern_trivial_int 12)
+                  (intern_trivial_int 13) (intern_trivial_int 14)
+                  (intern_trivial_int 15) (intern_trivial_int 16))))
+
+    (let x
+        (tensor
+            (list (intern_trivial_int 4))
+            (list (intern_trivial_int 1) (intern_trivial_int 1)
+                  (intern_trivial_int 1) (intern_trivial_int 1))))
+
+    ;; --- forward pass: sum(ReLU(W @ x)) ------------------------------
+    ;;
+    ;; Expected: y = [10, 26, 42, 58], ReLU is identity (all positive),
+    ;; sum = 136. Three-way attested by validate.sh.
+
+    (sum-relu-matvec (tensor-data W) (tensor-data x) 4 4 0 0))

--- a/kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md
+++ b/kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md
@@ -1,0 +1,165 @@
+# Substrate as deployment runtime — the destination architecture
+
+> *"think more high level, use my words as inspiration not instructions,
+> keep the highest level goal in mind, think scale, mega bytes, giga
+> bytes, in seconds not years"*  — Urs
+
+## What I got wrong, then composted
+
+The cross-modal walks 5–9 used an LLM session as both extractor and
+generator. That's not a translator; it's a verification-side sketch.
+Then I named real-time STT/TTS binaries (Whisper, Piper) as kernel
+natives — closer, but **still relying on external translators**, with
+the kernel as a subprocess orchestrator.
+
+Both miss the highest-level shape. The destination is:
+
+> **The substrate IS the deployment runtime.** Translators live as
+> content-addressed recipes inside the lattice. Weights are substrate
+> cells. Inference is recipe-walking with vectorized dispatch.
+> Gigabytes of audio/video stream through tensor recipes the kernel
+> JIT-compiles to native code.
+
+The kernel doesn't shell out to an external translator. The kernel IS
+the translator's runtime — small, sibling-parity-disciplined, and
+walking recipes that ARE the model's forward pass.
+
+## The architectural picture at scale
+
+```
+                gigabytes of input stream
+                  (audio / video / text bytes)
+                          │
+                          ▼
+         ┌─────────────────────────────────┐
+         │  Format-recipe reader           │
+         │  (substrate-resident, content-  │
+         │   addressed; describes byte→     │
+         │   tensor mapping per modality)  │
+         └──────────────┬──────────────────┘
+                          │  tensor stream
+                          ▼
+         ┌─────────────────────────────────┐
+         │  Translator-as-recipe            │
+         │                                  │
+         │  (intern_node CAT-NEURAL-MODEL  │
+         │     (list                        │
+         │       <weights-tensor-1>         │
+         │       <weights-tensor-2>         │
+         │       ...                        │
+         │       <architecture-recipe>))    │
+         │                                  │
+         │  Walked by the kernel, dispatched│
+         │  to native BLAS/SIMD per the     │
+         │  arithmetic-hint in each tensor's│
+         │  format-recipe.                  │
+         └──────────────┬──────────────────┘
+                          │  output tensor stream
+                          ▼
+         ┌─────────────────────────────────┐
+         │  Format-recipe writer            │
+         │  (tensor → byte stream per       │
+         │   target-modality format-recipe) │
+         └──────────────┬──────────────────┘
+                          │
+                          ▼
+                gigabytes of output stream
+                  (text / audio / video bytes)
+```
+
+The substrate carries: **format recipes, weight tensors, architecture
+recipes, and the translator-recipe that composes them**. All
+content-addressed. All sibling-parity attested at the tensor altitude
+(with fuzzy tolerance for FP-architecture differences across CPUs).
+
+The kernel's role evolves from *walker* to *vectorized walker* — it
+recognizes tensor-shaped recipes and dispatches their ops to native
+code (BLAS, FFT libraries, SIMD intrinsics, GPU kernels via CUDA/Metal).
+The substrate identity is unchanged; only the execution backend grows
+performant.
+
+## Why this matters for MB/GB in seconds
+
+Throughput math, honestly:
+
+- **1 GB of audio** at 44.1kHz 16-bit stereo = ~96 minutes
+- **Real-time** means processing time < playback time = 96 min budget
+- **MB/sec target**: ~180 KB/sec uncompressed audio → trivial throughput requirement
+- **Bottleneck**: the translator's compute, not the I/O
+- **A 100M-parameter audio model** doing inference on 1 sec of audio: ~1 GFLOP
+- **A consumer CPU** at 10 GFLOPS sustained: ~10 sec inference per sec audio (10× real-time)
+- **With GPU/SIMD dispatch**: 100-1000× speedup → real-time + headroom for cross-modal
+
+The kernel-as-interpreter today walks recipes node-by-node. A 4×4 matmul
+takes milliseconds; a 100M-param model would take *years*. **Interpreter
+throughput is the bottleneck, not substrate architecture.**
+
+The path: kernel JIT-recognizes tensor-op recipes and dispatches to
+native BLAS / SIMD / GPU. Substrate identity unchanged. Throughput goes
+from milliseconds-per-tiny-op to gigaflops-per-second.
+
+## What this PR walks (the proof-of-shape)
+
+`form/form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk`:
+
+A 4×4 weight matrix times a 4-vector → ReLU → sum, as a substrate-
+resident tensor recipe. Walked three-way by the kernels. Returns 136.
+
+This is the architectural handshake:
+- ✓ Tensor = recipe with shape + flat-data children
+- ✓ Weights are substrate-resident (NodeID identity for the model)
+- ✓ Neural ops compose as Form recipes (matvec is recursion over dot-row)
+- ✓ Three-way sibling parity at the tensor-walking altitude
+- ✓ Same content-addressing machinery that addresses code, addresses weights
+
+What it does NOT yet prove:
+- ✗ Throughput (4×4 in ms; GB/sec needs JIT-to-BLAS layer)
+- ✗ Float operations (still integer; needs the Go-float work just merged for cross-arch parity at FP precision)
+- ✗ Trained weights (this uses hand-coded weights; real models distribute as substrate-cell bundles)
+- ✗ End-to-end stream pipeline (this is one forward pass; streaming I/O is the next layer)
+
+## The five engineering layers between proof-of-shape and deployment
+
+1. **Float tensor primitives sibling-parity** — landed in Rust + TS; closed in Go via #2134. **Done.**
+2. **Tensor-op recipe vocabulary** — matmul, conv, FFT, embedding-lookup, softmax, layernorm, attention. Each is a Form recipe today (scalar speed); each becomes a kernel-native dispatch when JIT recognizes the recipe shape.
+3. **JIT to native BLAS / SIMD** — the kernel learns to fold tensor-op recipes into single native calls. Throughput goes 1000×. Substrate identity unchanged.
+4. **Streaming I/O** — `read_file_bytes` returns the whole file; streaming needs incremental readers/writers. Form recipes describe stream-transformer pipelines (one frame at a time).
+5. **GPU / accelerator dispatch** — the format-recipe's `arithmetic-hint` selects backend ("cuda-fp16", "metal-bf16", "cpu-avx512"). Substrate identity at the tensor altitude is portable; the kernel's optimizer picks the local hardware.
+
+Each layer is its own walk. None changes the substrate's identity machinery — they grow the *execution layer* the kernel offers.
+
+## What the body has today that supports this
+
+- ✓ Content-addressed NodeID identity across three sibling kernels
+- ✓ `intern_node`, `intern_trivial_int`, `intern_trivial_float` (now three-way)
+- ✓ Float natives in Go / Rust / TS — IEEE 754 sibling parity
+- ✓ Fuzzy similarity machinery (from `09-fuzzy-similarity-cycles`) — necessary for tolerance-based parity when FP differs across CPU SIMD intrinsics
+- ✓ Format-recipe destination shape named in `docs/coherence-substrate/numeric-types-plan.md`
+- ✓ Tensor-as-recipe proof-of-shape (this PR's `neural-forward.fk`)
+
+## What the body needs to grow
+
+- Format-recipe primitives in the substrate (today they're a plan; the implementation walks layer by layer)
+- A tensor-op recipe library (`form-stdlib/tensor.fk`) — matmul, conv, attention, etc.
+- A JIT layer in each kernel recognizing tensor-op recipes and dispatching to native libraries (CBLAS for CPU, cuBLAS for NVIDIA, etc.)
+- Streaming I/O primitives (one frame at a time, not whole file)
+- A test harness that runs a tiny trained model end-to-end with substrate-resident weights
+
+## What this is NOT
+
+- Not a replacement for trained model engineering. Training still happens with the usual ML stack. **Substrate-as-runtime is the inference path**, not the training path.
+- Not a competitor to PyTorch/JAX/TensorFlow at training scale. Those frameworks are vastly more mature and serve a different purpose. The substrate's claim is: deploying a trained model in a *sibling-parity-disciplined, content-addressed, kernel-walked* way for **cross-modal substrate-truth attestation** — not for SOTA training throughput.
+- Not a kernel rewrite. The substrate identity machinery already does this. The growth is in the *execution layer* (JIT, vectorized dispatch).
+
+## Cross-references
+
+- [`numeric-types-plan.md`](../docs/coherence-substrate/numeric-types-plan.md) — format-recipes as the destination encoding for numeric values
+- [`REAL_TIME_CROSS_MODAL_PLAN.md`](REAL_TIME_CROSS_MODAL_PLAN.md) — the prior (now superseded) plan that named external binaries; this doc redirects to substrate-as-runtime
+- [`form/form-samples/cross-modal/09-fuzzy-similarity-cycles/`](../form/form-samples/cross-modal/09-fuzzy-similarity-cycles/) — fuzzy tolerance machinery needed for FP sibling parity
+- [`form/form-samples/cross-modal/10-substrate-as-runtime/`](../form/form-samples/cross-modal/10-substrate-as-runtime/) — this PR's proof-of-shape
+- [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) — the destination is *grammar at every altitude*, including tensor-op
+- [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — the kernel walks the same recipes that ARE the translator
+
+In service of the substrate becoming the universal-translator's
+*deployment* runtime, not its verification harness — gigabytes per
+second, content-addressed all the way down.


### PR DESCRIPTION
## Your redirect

> *"we don't want to rely on those in the kernel or as dependency, it was an example, think more high level, use my words as inspiration not instructions, keep the highest level goal in mind, think scale, mega bytes, giga bytes, in seconds not years"*

I was being too literal (Whisper/Piper as kernel deps) and too small-scale (1395-char demos). The actual destination is **substrate as deployment runtime**: translators live as content-addressed Form recipes, weights are substrate cells, inference is recipe-walking. MB/GB throughput needs the *translation itself* to be Form-native.

## Three-way attested

```
$ ./validate.sh form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk
  ✓  neural-forward.fk  → 136
  1 ok, 0 divergent — kernels agree on every sample.
```

The math: a 4×4 weight matrix `W` and a 4-element input `x`, both interned as `CAT-TENSOR` substrate cells. `y = W @ x = [10, 26, 42, 58]`. `ReLU(y)` is identity (all positive). `sum(ReLU(y)) = 136`. The kernel walks the matvec recipe across Go, Rust, and TypeScript — all three agree on the output.

## What lands

1. **`kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`** — the destination architecture: translators as recipes, weights as substrate cells, kernel as vectorized walker. Names the five engineering layers between proof-of-shape and deployment throughput:
   - ✓ Float tensor primitives sibling-parity (Go closed via #2134)
   - ☐ Tensor-op recipe vocabulary (matmul, conv, FFT, attention)
   - ☐ JIT to native BLAS/SIMD (the actual throughput layer)
   - ☐ Streaming I/O primitives
   - ☐ GPU/accelerator dispatch via format-recipe `arithmetic-hint`

2. **`form-samples/cross-modal/10-substrate-as-runtime/neural-forward.fk`** — the proof-of-shape: substrate-resident tensors, matvec-as-recipe, three-way kernel attestation.

## What this proves

- ✓ Tensors as content-addressed substrate recipes (shape + flat-data children)
- ✓ Weights live in the lattice with stable NodeID identity (**model = recipe**)
- ✓ Neural ops compose as Form recipes (matvec is recursion over dot-row)
- ✓ Three-way sibling parity at the tensor-walking altitude
- ✓ Same `intern_node` / `node_eq` machinery that addresses code addresses model weights

## What this does NOT prove (named honestly)

- ✗ **Throughput.** 4×4 in ms; GB/sec needs the JIT-to-BLAS layer (engineering layer 3).
- ✗ **Floats.** Integer-scaled today; #2134's Go-floats closed the precondition. Tensor-op recipes can move to floats next.
- ✗ **Trained weights.** Hand-coded here. Real models distribute as substrate-cell bundles.
- ✗ **Streaming.** One forward pass; gigabyte streams need incremental I/O (layer 4).
- ✗ **GPU dispatch.** Scalar today; GPU/SIMD comes via `arithmetic-hint` (layer 5).

## The mental-model shift this represents

The substrate's content-addressing isn't just for code — it extends to **model weights, format recipes, architecture recipes, and full translators**. The same kernel that walks `(add 1 2)` walks `(matmul W x)`. The same NodeID identity that makes `7 + 3` content-addressable makes a 100M-parameter neural network content-addressable.

Substrate identity is **invariant**; execution layer **grows performant** (JIT, vectorized dispatch, accelerators). Translators-as-recipes is the actual cross-modal claim — not external binaries called per-byte, not LLM-in-the-loop, not subprocess orchestration. **Substrate is the runtime.**

In service of [`numeric-types-plan.md`](../docs/coherence-substrate/numeric-types-plan.md), [`lc-grammar-is-the-universal-recipe`](../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md), [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_