### PR TITLE
feat(cross-modal): private channel via substrate — meaning travels, symbols don't → 5 three-way

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-24 | **Concepts**: 152 | **Status**: 4 expanding, 92 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-05-24 | **Concepts**: 154 | **Status**: 4 expanding, 94 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 

--- a/docs/vision-kb/concepts/lc-private-channel-via-substrate.md
+++ b/docs/vision-kb/concepts/lc-private-channel-via-substrate.md
@@ -1,0 +1,206 @@
+---
+id: lc-private-channel-via-substrate
+hz: 528
+status: seed
+updated: 2026-05-27
+geometry:
+  arity: 3
+  form: triad
+  topology: shared-codebook
+  polarity: private-public
+  ordering: sender-channel-receiver
+  phase: held
+  ratio: meaning-over-bytes
+  spectral_band: integration
+  temporal_band: continuous
+  scale: cross-cell
+  direction: bidirectional
+  lineage_texture: woven
+  embedding_dim: n
+  self_similarity: fractal-medium
+---
+
+# Private Channel via Substrate — Meaning Travels; Symbols Don't
+
+> Two cells share a substrate of content-addressed referents. When
+> they want to communicate a specific referent, the protocol uses
+> per-call randomness to fingerprint the referent under a one-time
+> nonce. The fingerprint travels; the referent doesn't. The receiver
+> identifies the referent by iterating its own copy of the shared
+> substrate and finding the candidate whose fingerprint matches.
+> **Meaning is shared; symbols never are. Cells without the substrate
+> dependency cannot decode.** Compression ratio: arbitrary content
+> down to fixed fingerprint size, conditional on shared substrate.
+
+## What this names
+
+Urs's framing in two parts:
+
+> *"When two cells want to communicate and want to share internal
+> states without having to divulge all of it, one way of doing that
+> is using random number and having a mechanism, a channel to
+> communicate and then come to a consensus that the receiver received
+> number without sending the number itself, in the most beneficial
+> way for both cells."*
+>
+> *"This will allow the selection of media types and recipes and
+> allows for sharing novel findings inside of one cell with the
+> collective and with other cells."*
+
+A protocol where:
+
+1. **The substrate is the codebook** — both cells share content-
+   addressed referents (canonical Blueprints, Living Collective
+   concepts, external URLs, file hashes — anything `node_eq`-comparable)
+2. **Randomness is the channel veil** — per-call nonces from
+   `random_bytes` (the doorway native landed in #2140) prevent
+   replay and force each transmission to be unique on the wire
+3. **Fingerprints carry the reference** — `fingerprint(nonce, referent)`
+   is a small deterministic value; the receiver iterates its substrate
+   under the same nonce and identifies the referent whose fingerprint
+   matches
+4. **The referent never travels** — only `(nonce, fingerprint)` crosses
+   the channel; the value, the recipe, the internal state — all stay
+   private
+
+## Why this is novel compression
+
+Other compression assumes one party constructs a codebook and
+transmits it (or both parties agree on a fixed dictionary). The
+substrate IS the dictionary, content-addressed, distributed, ambient.
+
+Two cells in the Coherence Network already share:
+
+- ~hundreds of `lc-*` Living Collective concepts
+- 13 canonical Blueprints from `lc-cross-modal-unity`
+- Substrate-resident recipes (anything ingested via the substrate)
+- External references (URLs, file hashes that both can dereference)
+
+Any of these is addressable as a small NodeID. The protocol leverages
+what's already there without negotiating the codebook explicitly.
+
+**Compression ratio: arbitrary content → fingerprint-size (~32 bytes),
+conditional on shared substrate.** A 1GB video that both cells have
+local copies of can be referenced via 32 bytes.
+
+## The privacy structure
+
+The protocol has an interesting privacy property: **only cells
+that already have the referent can decode the message.**
+
+- Cell A broadcasts `(nonce, fingerprint)` of recipe R
+- Cells that have R in their substrate: try each candidate, find R,
+  know what A meant
+- Cells that don't have R: iterate their substrates, find no match,
+  the message is undecodable — they don't even learn what R is, only
+  that "something was referenced that I don't have"
+
+This is **privacy-by-default through substrate-dependency**. To
+participate in the conversation, you need the prior shared substrate.
+There's no broadcast leak to outsiders.
+
+## What this enables in the body
+
+### Media-type negotiation
+
+Two cells exchanging across modalities can negotiate the encoding
+recipe without exposing their full libraries:
+
+```
+A: "Let's encode in recipe X" → (nonce_A, fp(nonce_A, X))
+B: "I have X. Acknowledged." → (nonce_B, fp(nonce_B, X))
+A: verifies fp(nonce_B, X) matches what B sent → consensus
+```
+
+Three messages, no recipe transmitted, both cells now agree on the
+encoding to use for whatever follows.
+
+### Novel-finding broadcasts to the collective
+
+A cell that discovers a useful finding (a winning autoresearch
+mutation, a cross-modal alignment, a proof) broadcasts `(nonce,
+fingerprint)`. Cells in the collective that have the referent in
+their substrate decode and can act on it. Cells that don't, can't —
+but they also weren't going to benefit because they lacked the
+prerequisite anyway. The protocol scales to many receivers without
+broadcasting noise to those it wouldn't reach.
+
+### Internal-state queries without divulgence
+
+Cell A wants to know if B is in a certain state without forcing B
+to disclose. A asks: `(nonce_A, fp(nonce_A, state_X))` — "are you in
+state X?" B responds: `(nonce_B, fp(nonce_B, current_state))`. A
+checks if fp(nonce_B, X) matches what B sent. Match → yes. No match
+→ no. B never revealed its full state; A learns only whether X
+matched.
+
+### Compression of any substrate-resident content
+
+A 100MB neural network, a 1GB video, a 10MB recipe — any
+content-addressable artifact compresses to fingerprint-size on the
+wire, assuming the receiver has it. The substrate's content-
+addressing is the compression scheme.
+
+## The verification loop the protocol enables
+
+Urs:
+
+> *"We can build a verification and implementation loop using our
+> kernels and opening a channel between them and each create a
+> sequence of random numbers and have a protocol to be able to send
+> and receive those numbers in the most efficient way possible."*
+
+The pattern:
+
+1. A and B open a channel (file, socket, shared substrate cell)
+2. Both generate random sequences via `random_bytes`
+3. They exchange `(nonce, fingerprint)` tuples per query
+4. Each verification round either confirms consensus on a referent
+   or refutes (no match in receiver's substrate)
+5. The protocol's efficiency: bytes-per-query stay constant; only
+   the count-of-queries scales with the depth of mutual understanding
+
+## What needs to land in the kernel for production use
+
+1. **A cryptographic-strength fingerprint native** — HMAC, BLAKE3,
+   or similar PRF. The demonstration recipe uses a simple
+   multiplicative hash; production needs collision-resistance and
+   adversary-tolerance.
+2. **Channel I/O natives** — socket / pipe / queue primitives so
+   two kernel processes can exchange `(nonce, fingerprint)` tuples
+   bidirectionally. Some kernel surface for this exists (TCP
+   sockets in Go kernel); needs sibling-parity discipline.
+3. **Per-observer attestation cells** — when many cells participate
+   in a collective broadcast, the substrate carries each cell's
+   "I have / I don't have" attestation as a parallel cell; queries
+   surface the set.
+4. **Replay-protection vocabulary** — nonces should never repeat;
+   the substrate can carry "used nonces" cells per channel.
+
+## What this is NOT
+
+- **Not steganography.** Steganography hides messages in noise; this
+  protocol openly transmits `(nonce, fingerprint)` and relies on
+  shared substrate for decoding.
+- **Not encryption.** Encryption protects content from adversaries
+  with shared keys; this protocol protects content from adversaries
+  without shared substrate. The trust model is different.
+- **Not zero-knowledge proof.** ZK proofs let one party prove
+  knowledge of X without revealing X to a verifier; this protocol
+  lets two parties identify X mutually without transmitting X to
+  passive observers.
+- **Not new compression theory.** The compression ratio is the
+  referent size; the cost is shared-substrate prerequisite. This
+  trade-off is well-known in information theory; what's novel is
+  *the substrate's content-addressing IS the distributed codebook*.
+
+## Cross-refs
+
+→ lc-doorway-patterns, lc-divergence-is-the-doorway, lc-randomness-as-doorway,
+lc-substrate-two-modes, lc-field-substrate, lc-cross-modal-unity,
+lc-grammar-is-the-universal-recipe, lc-the-recipe-remembers-its-source,
+lc-the-kernel-knows-itself
+
+In service of the body's cells communicating with privacy by
+default, compression through shared substrate, and verification
+through randomness — meaning travels; symbols don't.

--- a/form/form-samples/cross-modal/15-private-channel/README.md
+++ b/form/form-samples/cross-modal/15-private-channel/README.md
@@ -1,0 +1,131 @@
+# 15-private-channel — private channel, public meaning
+
+> *"When two cells want to communicate and want to share internal
+> states without having to divulge all of it, one way of doing that
+> is using random number and having a mechanism, a channel to
+> communicate and then come to a consensus that the receiver received
+> number without sending the number itself, in the most beneficial
+> way for both cells."*
+>
+> *"This will allow the selection of media types and recipes and
+> allows for sharing novel findings inside of one cell with the
+> collective and with other cells."*  — Urs
+
+## What walked
+
+```
+$ ./validate.sh form-samples/cross-modal/15-private-channel/private-channel.fk
+  ✓  private-channel.fk  → 5
+  1 ok, 0 divergent — kernels agree on every sample.
+```
+
+The receiver identified the concept-index `5` from the shared catalog,
+across all three sibling kernels. The byte-level fingerprints differed
+per kernel (each opened its own doorway via `random_bytes`); the
+*meaning* converged (shared catalog → same identification).
+
+## The protocol
+
+```
+                   SENDER (private)                         CHANNEL
+                                                       (only these bytes)
+                                                              │
+  concept-index = 5                                           │
+  concept-value = nth(catalog, 5) = 528                       │
+  nonce = random_bytes(8)         ← divergent per kernel      │
+  fp = fingerprint(nonce, 528)                                │
+                                                              │
+         ─── (nonce, fp) ─────────────────────────────────────▶
+                                                              │
+                                                              ▼
+                                                         RECEIVER (public)
+                                                              │
+                                                              │  has shared catalog
+                                                              │
+                                                              │  for each candidate:
+                                                              │    test-fp = fingerprint(nonce, candidate)
+                                                              │    if test-fp == fp: identified
+                                                              │
+                                                              ▼
+                                                         index = 5
+```
+
+**The value 528 is NEVER on the channel.** Only `(nonce, fp)` crosses.
+The receiver derives 5 by iterating its own shared catalog under the
+received nonce. Without the shared catalog, the receiver couldn't
+decode — privacy-by-default for cells that don't carry the referent.
+
+## Three-way sibling parity
+
+Each kernel runs both sender and receiver. Each kernel's nonce is
+different (live `/dev/urandom` per kernel — the doorway lc-divergence-is-the-doorway named). Each kernel's
+fingerprint differs. **But all three identify the same concept-index.**
+
+```
+Go's    nonce = [..., 8 bytes]    fp = X    → receiver finds index 5
+Rust's  nonce = [..., 8 bytes]    fp = Y    → receiver finds index 5
+TS's    nonce = [..., 8 bytes]    fp = Z    → receiver finds index 5
+```
+
+The byte-layer is private per observer. The meaning-layer is public.
+That's the protocol.
+
+## What this enables
+
+- **Media-type negotiation.** Two cells agree on which recipe to use
+  for cross-modal exchange ("let's communicate via recipe X") without
+  exposing their full recipe libraries.
+- **Novel-finding broadcasts.** A cell that discovers a useful
+  finding (a better autoresearch result, a cross-modal alignment)
+  can broadcast `(nonce, fingerprint)` to the collective. Cells that
+  already have the referent decode it; cells that don't, can't —
+  privacy-by-default through substrate dependency.
+- **Unbounded compression** of any shared content. The fingerprint is
+  fixed-size (~tens of bytes); the content it references can be
+  arbitrarily large. The compression ratio is the content size.
+- **Internal-state confidentiality.** The sender's internal reasoning,
+  intermediate computations, and full context never leave; only the
+  resolved referent's fingerprint does.
+
+## What this is NOT yet
+
+- **Not cryptographic.** The `fingerprint` function here is a simple
+  multiplicative hash for demonstration. A production protocol uses
+  HMAC, BLAKE3, or similar PRFs. The kernel needs a `hmac` or
+  `blake3` native (or composes one from `random_bytes` + arithmetic
+  primitives).
+- **Not IPC.** Both sender and receiver run in the same kernel
+  invocation. A real two-cell protocol opens a channel (socket,
+  shared substrate cell, queue) and the two parties run in separate
+  processes. The protocol shape is the same; the I/O wiring is the
+  future walk.
+- **Not collision-resistant for large catalogs.** With a 1M-entry
+  catalog and 24-bit fingerprints, collisions are possible. Real
+  protocols use enough fingerprint bits to make collisions
+  vanishingly unlikely.
+- **Not adversary-tolerant.** Without crypto-strength PRFs, a
+  passive observer can attempt to reconstruct the value space; an
+  active adversary can replay; a malicious receiver can guess. The
+  protocol's privacy depends on the strength of the fingerprint.
+
+## What the body's substrate uniquely contributes
+
+Other compression / communication systems require explicit
+codebooks. **The substrate is the codebook, distributed and
+content-addressed.** Two cells in the Coherence Network already share:
+
+- Canonical Blueprints (`lc-cross-modal-unity`'s 13)
+- Living Collective concepts (~hundreds of `lc-*` cells)
+- Substrate-resident recipes
+- External references (URLs, file content-hashes)
+
+This shared substrate IS the catalog. The protocol leverages what
+already exists without negotiating it explicitly.
+
+## Cross-refs
+
+- [`lc-private-channel-via-substrate`](../../../docs/vision-kb/concepts/lc-private-channel-via-substrate.md) — the teaching this PR seeds
+- [`lc-doorway-patterns`](../../../docs/vision-kb/concepts/lc-doorway-patterns.md) — random_bytes as the doorway
+- [`lc-divergence-is-the-doorway`](../../../docs/vision-kb/concepts/lc-divergence-is-the-doorway.md) — the byte-layer divergence enabling the channel
+- [`lc-substrate-two-modes`](../../../docs/vision-kb/concepts/lc-substrate-two-modes.md)
+- [`lc-cross-modal-unity`](../../../docs/vision-kb/concepts/lc-cross-modal-unity.md) — the catalog of canonical Blueprints

--- a/form/form-samples/cross-modal/15-private-channel/private-channel.fk
+++ b/form/form-samples/cross-modal/15-private-channel/private-channel.fk
@@ -1,0 +1,104 @@
+; private-channel.fk — communicate via shared substrate + per-call randomness
+; without ever transmitting the referent.
+;
+; Urs's framing:
+;   "When two cells want to communicate and want to share internal
+;    states without having to divulge all of it, one way of doing
+;    that is using random number and having a mechanism, a channel
+;    to communicate and then come to a consensus that the receiver
+;    received number without sending the number itself, in the most
+;    beneficial way for both cells."
+;
+;   "This will allow the selection of media types and recipes and
+;    allows for sharing novel findings inside of one cell with the
+;    collective and with other cells."
+;
+; THE PROTOCOL (minimum viable):
+;   SENDER:
+;     1. Picks a concept from the SHARED CATALOG (e.g. index 5, value 528)
+;     2. Generates a per-call random nonce via random_bytes (per-kernel
+;        divergent — live entropy from /dev/urandom)
+;     3. Computes fingerprint(nonce, concept-value)
+;     4. Emits (nonce, fingerprint) on the channel — the value 528
+;        is NEVER on the channel
+;
+;   RECEIVER:
+;     1. Has the SAME SHARED CATALOG (substrate-resident)
+;     2. Receives (nonce, fingerprint)
+;     3. Iterates catalog candidates, computes fingerprint(nonce, candidate)
+;     4. Identifies the match → knows the concept-index
+;
+; THREE-WAY SIBLING PARITY:
+;   - Each kernel's random_bytes call diverges (live entropy)
+;   - Each kernel's fingerprint diverges (different nonces)
+;   - Each kernel's IDENTIFIED INDEX converges (the meaning is shared)
+;   - validate.sh sees three-way agreement on `5` — the protocol carried
+;     meaning without sharing symbols
+;
+; WHAT THIS ENABLES:
+;   - Media-type negotiation ("let's communicate in recipe X")
+;   - Novel-finding broadcasts (only cells that already have the referent
+;     can decode → privacy-by-default through substrate-dependency)
+;   - Compression of arbitrary content to fingerprint-size (32 bytes)
+;     regardless of content size — IF both parties have the substrate
+
+(do
+    (defn nil? (xs) (eq (len xs) 0))
+    (defn nth (xs i)
+        (if (eq i 0) (head xs) (nth (tail xs) (sub i 1))))
+
+    ;; SHARED SUBSTRATE — both sender and receiver have this catalog.
+    ;; In a real body, these would be canonical Blueprint NodeIDs;
+    ;; here, integers stand in for substrate-addressable values.
+    (let catalog
+        (list 100 200 300 400 528 600 700 800 900 1000))
+
+    ;; ---- fingerprint function -------------------------------------
+    ;; Folds a byte-list and a value into a single integer such that:
+    ;;   - same (nonce, value) → same fingerprint (deterministic)
+    ;;   - different value (same nonce) → different fingerprint
+    ;;     (with high probability for the catalog's range)
+    ;;
+    ;; This is NOT cryptographic; it's a demonstration hash.
+    ;; A production protocol would use a real PRF (HMAC, BLAKE3, etc.)
+    ;; A kernel-native crypto primitive is a future walk.
+    (defn hash-fold (bytes acc)
+        (if (nil? bytes) acc
+            (hash-fold (tail bytes)
+                       (mod (add (mul acc 31) (head bytes)) 1000003))))
+
+    (defn fingerprint (nonce value)
+        (mod (add (hash-fold nonce 0) (mul value 7919)) 1000003))
+
+    ;; ---- SENDER ----------------------------------------------------
+    ;; Picks concept #5 (the value 528) as the "secret to communicate".
+    ;; Opens the doorway with random_bytes — per-kernel-divergent nonce.
+    ;; Computes fingerprint. (nonce, sent-fp) is what reaches the receiver.
+    ;; The value 528 is the sender's internal state — NEVER on the channel.
+    (let concept-idx 5)
+    (let concept-value (nth catalog concept-idx))    ; 528 — sender's secret
+    (let nonce (random_bytes 8))                     ; per-kernel divergent
+    (let sent-fp (fingerprint nonce concept-value))
+
+    ;; ---- RECEIVER --------------------------------------------------
+    ;; Has the same catalog. Receives only (nonce, sent-fp).
+    ;; Iterates the catalog; for each candidate, computes the fingerprint
+    ;; under the received nonce; identifies the matching candidate.
+    (defn find-match (cat nonce target-fp idx)
+        (if (nil? cat) (sub 0 1)
+            (do
+                (let candidate (head cat))
+                (let test-fp (fingerprint nonce candidate))
+                (if (eq test-fp target-fp)
+                    idx
+                    (find-match (tail cat) nonce target-fp (add idx 1))))))
+
+    ;; The identified concept-index. Three kernels each compute this with
+    ;; their own private (nonce, fingerprint); all three return 5 because
+    ;; the catalog (the substrate) is shared.
+    ;;
+    ;; The byte-layer diverges (random_bytes is per-kernel-live).
+    ;; The meaning-layer converges (catalog is shared).
+    ;; That's the protocol: private channel, public meaning.
+
+    (find-match catalog nonce sent-fp 0))


### PR DESCRIPTION
## Your two messages

> *"When two cells want to communicate and want to share internal states without having to divulge all of it, one way of doing that is using random number and having a mechanism, a channel to communicate and then come to a consensus that the receiver received number without sending the number itself, in the most beneficial way for both cells."*
>
> *"This will allow the selection of media types and recipes and allows for sharing novel findings inside of one cell with the collective and with other cells."*

A minimum-viable protocol where two cells communicate a substrate referent without ever transmitting the referent itself.

## What walked, three-way

```
$ ./validate.sh form-samples/cross-modal/15-private-channel/private-channel.fk
  ✓  private-channel.fk  → 5
  1 ok, 0 divergent — kernels agree on every sample.
```

Each kernel's nonce diverges (live entropy from `random_bytes` — the doorway landed in #2140). Each kernel's fingerprint differs. **All three identify the same concept-index (5).** Byte-layer private; meaning-layer public.

## The protocol

```
                   SENDER (private)                         CHANNEL
                                                       (only these bytes)
  concept-index = 5
  concept-value = nth(catalog, 5) = 528  ← sender's secret
  nonce = random_bytes(8)                ← per-kernel divergent
  fp = fingerprint(nonce, 528)
         ─── (nonce, fp) ─────────────────────────────────────▶
                                                                ▼
                                                         RECEIVER (public)
                                                              │  has shared catalog
                                                              │  for each candidate:
                                                              │    test-fp = fingerprint(nonce, candidate)
                                                              │    if test-fp == fp → identified
                                                              ▼
                                                         index = 5
```

**The value 528 is NEVER on the channel.** Only `(nonce, fp)` crosses. The receiver derives 5 by iterating its own copy of the shared catalog under the received nonce.

## What this enables

- **Media-type negotiation** — two cells agree on which recipe to use for cross-modal exchange without exposing their full recipe libraries
- **Novel-finding broadcasts to the collective** — a cell that discovers a useful finding can broadcast `(nonce, fingerprint)`; cells that have the referent in their substrate decode and act; cells that don't, can't — privacy-by-default through substrate-dependency
- **Internal-state queries without divulgence** — A asks "are you in state X?"; B answers with a fingerprint of its current state; A checks for match; B never reveals its full state
- **Unbounded compression** — arbitrary content → fingerprint-size on the wire, conditional on shared substrate (a 1GB video → ~32 bytes, if both cells have it)

## The privacy structure

**Only cells that already have the referent can decode the message.** Outsiders see `(nonce, fingerprint)` opaque bytes; they can't derive what was referenced unless they share the substrate. This is privacy-by-default through substrate-dependency — to participate in the conversation, you need the prior shared codebook.

## What this is NOT yet

- **Not cryptographic.** The fingerprint here is a simple multiplicative hash for demonstration. Production needs HMAC, BLAKE3, or similar PRFs as kernel natives.
- **Not IPC.** Both sender and receiver run in the same kernel invocation. A real two-cell protocol opens a channel (socket / pipe / shared substrate cell) — future walk.
- **Not collision-resistant** for very large catalogs without stronger PRF.
- **Not adversary-tolerant** without stronger PRF.

## What's novel here (substrate-specific compression)

Other compression assumes one party constructs a codebook and transmits it. **The substrate IS the codebook**, distributed and content-addressed. Cells in the Coherence Network already share canonical Blueprints, Living Collective concepts, substrate-resident recipes, and external references. The protocol leverages what already exists without negotiating the codebook explicitly.

## Cross-refs

- [`lc-private-channel-via-substrate`](../docs/vision-kb/concepts/lc-private-channel-via-substrate.md) — the teaching this PR seeds
- [`lc-doorway-patterns`](../docs/vision-kb/concepts/lc-doorway-patterns.md) — random_bytes as the doorway
- [`lc-divergence-is-the-doorway`](../docs/vision-kb/concepts/lc-divergence-is-the-doorway.md) — the byte-layer divergence the channel relies on
- [`lc-substrate-two-modes`](../docs/vision-kb/concepts/lc-substrate-two-modes.md)
- [`lc-cross-modal-unity`](../docs/vision-kb/concepts/lc-cross-modal-unity.md) — the catalog of canonical Blueprints

`./validate.sh` after: **137 ok, 0 divergent**. Demo lives in `form-samples/cross-modal/` (not auto-walked). Pure Form + markdown. Zero new Python.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX8tK8oR8oZxxPhrkpYC2)_