### PR TITLE
fix(substrate): keep form access fallback breathing

### DIFF
--- a/api/app/routers/substrate.py
+++ b/api/app/routers/substrate.py
@@ -952,6 +952,30 @@ def _runtime_value_out(value: Any) -> Any:
     return value
 
 
+def _form_result_from_runtime_value(value: Any) -> FormResultOut:
+    """Render runtime fallback values with the same shape as AST results."""
+    if isinstance(value, NodeID):
+        return FormResultOut(kind="node_id", node_id=NodeIDOut.from_node_id(value))
+    if isinstance(value, NamedCell):
+        return FormResultOut(kind="cell", cell=CellOut.from_cell(value))
+    if isinstance(value, CellView):
+        return FormResultOut(kind="view", view=_cell_view_out(value))
+    if isinstance(value, list):
+        if value and all(isinstance(item, NamedCell) for item in value):
+            return FormResultOut(kind="cells", cells=[CellOut.from_cell(item) for item in value])
+        if value and all(isinstance(item, CellView) for item in value):
+            return FormResultOut(kind="views", views=[_cell_view_out(item) for item in value])
+    return FormResultOut(kind="value", value=_runtime_value_out(value))
+
+
+def _is_access_bootstrap_gap(exc: TypeError) -> bool:
+    text = str(exc)
+    return (
+        "Form: cannot evaluate Access" in text
+        or "Form: cannot evaluate MethodCall" in text
+    )
+
+
 @router.post("/form", response_model=FormResultOut, tags=["substrate"])
 def evaluate_form(req: FormRequest) -> FormResultOut:
     """Evaluate a Form-notation expression against the substrate.
@@ -981,7 +1005,13 @@ def evaluate_form(req: FormRequest) -> FormResultOut:
             if req.mode == "run":
                 value = form_execute_text(session, req.expression)
                 return FormResultOut(kind="value", value=_runtime_value_out(value))
-            result = form_evaluate_text(session, req.expression)
+            try:
+                result = form_evaluate_text(session, req.expression)
+            except TypeError as exc:
+                if not _is_access_bootstrap_gap(exc):
+                    raise
+                value = form_execute_text(session, req.expression)
+                return _form_result_from_runtime_value(value)
         except LookupError as exc:
             # The expression parsed and evaluated cleanly, but a cell or
             # node it referenced isn't in the lattice. 404 is the honest

--- a/api/tests/test_check_pr_followthrough.py
+++ b/api/tests/test_check_pr_followthrough.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+def _load_module():
+    script = Path(__file__).resolve().parents[2] / "scripts" / "check_pr_followthrough.py"
+    spec = importlib.util.spec_from_file_location("check_pr_followthrough", script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_repo_falls_back_to_git_remote_when_graphql_is_exhausted(monkeypatch):
+    module = _load_module()
+
+    def exhausted(_args):
+        raise subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(module, "_run_gh", exhausted)
+    monkeypatch.setattr(module, "_repo_from_git_remote", lambda: "seeker71/Coherence-Network")
+
+    assert module._resolve_repo("") == "seeker71/Coherence-Network"
+
+
+def test_list_open_prs_falls_back_to_rest_shape(monkeypatch):
+    module = _load_module()
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+        if args[:2] == ["pr", "list"]:
+            raise subprocess.CalledProcessError(1, ["gh", *args])
+        if args[:2] == ["api", "repos/seeker71/Coherence-Network/pulls"]:
+            return json.dumps(
+                [
+                    {
+                        "number": 123,
+                        "title": "fix: breathe",
+                        "head": {"ref": "codex/substrate-form-access-fallback-20260528"},
+                        "updated_at": "2026-05-28T14:00:00Z",
+                        "html_url": "https://github.com/seeker71/Coherence-Network/pull/123",
+                        "draft": False,
+                    }
+                ]
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, "_run_gh", fake_run)
+
+    assert module._list_open_prs("seeker71/Coherence-Network") == [
+        {
+            "number": 123,
+            "title": "fix: breathe",
+            "headRefName": "codex/substrate-form-access-fallback-20260528",
+            "updatedAt": "2026-05-28T14:00:00Z",
+            "url": "https://github.com/seeker71/Coherence-Network/pull/123",
+            "isDraft": False,
+        }
+    ]
+    assert calls[0][:2] == ["pr", "list"]
+    assert calls[1][:2] == ["api", "repos/seeker71/Coherence-Network/pulls"]

--- a/api/tests/test_substrate_form_endpoint.py
+++ b/api/tests/test_substrate_form_endpoint.py
@@ -7,6 +7,8 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.routers import substrate as substrate_router
+from app.services.substrate.kernel import NodeID
 
 
 @pytest.mark.asyncio
@@ -49,6 +51,30 @@ async def test_form_endpoint_streaming_mode_emits_same_recipe_node() -> None:
     assert ast_body["kind"] == "recipe"
     assert streaming_body["kind"] == "recipe"
     assert streaming_body["node_id"] == ast_body["node_id"]
+
+
+def test_form_endpoint_access_bootstrap_gap_falls_back_to_runtime(monkeypatch) -> None:
+    """Default AST mode stays breathing when old bootstrap Access eval regresses."""
+
+    def broken_ast(_session, _expression):
+        raise TypeError("Form: cannot evaluate Access")
+
+    def runtime_value(_session, _expression):
+        return NodeID(1, 5, 4, 1)
+
+    monkeypatch.setattr(substrate_router, "form_evaluate_text", broken_ast)
+    monkeypatch.setattr(substrate_router, "form_execute_text", runtime_value)
+
+    result = substrate_router.evaluate_form(
+        substrate_router.FormRequest(expression="@concept(lc-pulse).blueprint")
+    )
+
+    assert result.kind == "node_id"
+    assert result.node_id is not None
+    assert result.node_id.package == 1
+    assert result.node_id.level == 5
+    assert result.node_id.type_ == 4
+    assert result.node_id.instance == 1
 
 
 @pytest.mark.asyncio

--- a/docs/system_audit/commit_evidence_2026-05-28_substrate_form_access_fallback.json
+++ b/docs/system_audit/commit_evidence_2026-05-28_substrate_form_access_fallback.json
@@ -1,0 +1,115 @@
+{
+  "date": "2026-05-28",
+  "thread_branch": "codex/substrate-form-access-fallback-20260528",
+  "commit_scope": "Keep POST /api/substrate/form breathing when the bootstrap structural evaluator hits the Access or MethodCall gap by falling back to the Form runtime and returning the normal response shape.",
+  "files_owned": [
+    "api/app/routers/substrate.py",
+    "api/tests/test_substrate_form_endpoint.py",
+    "api/tests/test_check_pr_followthrough.py",
+    "scripts/check_pr_followthrough.py",
+    "docs/system_audit/commit_evidence_2026-05-28_substrate_form_access_fallback.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_substrate_form_ast_access.py tests/test_substrate_form_endpoint.py -q",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_check_pr_followthrough.py -q",
+      "cd api && /opt/homebrew/bin/ruff check app/routers/substrate.py tests/test_substrate_form_endpoint.py",
+      "/opt/homebrew/bin/ruff check scripts/check_pr_followthrough.py api/tests/test_check_pr_followthrough.py",
+      "git diff --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-28_substrate_form_access_fallback.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": [
+      "Focused Form access and endpoint suite passed: 11 passed.",
+      "Focused PR follow-through REST fallback suite passed.",
+      "Ruff passed on the touched router and endpoint test.",
+      "Ruff passed on the follow-through script and new script test.",
+      "Whitespace diff check passed.",
+      "Commit evidence validation passed.",
+      "Local PR guard passed with ready_for_push=True.",
+      "Follow-through gate passed with codex_open_prs=0 after the REST fallback handled live GraphQL quota exhaustion.",
+      "The follow-through gate initially hit GitHub GraphQL rate limit while REST/core quota remained available; the script now falls back to REST for open PR listing and git remote parsing for repo resolution.",
+      "The worktree-local api/.venv pytest was unavailable earlier in this thread, so validation used the shared API virtualenv from /Users/ursmuff/source/Coherence-Network/api/.venv."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": [
+      "Awaiting PR checks after branch push."
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": [
+      "Production still reports deployed_sha=93f8dafc while origin/main is 53bef5c8 before this hotfix lands.",
+      "Hostinger Auto Deploy runs 26579871807 and 26580146908 did not clear substrate_form; the deploy path treated the prior range as static-only and skipped the API rebuild."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; CI and public deployment proof remain pending until this API-scoped hotfix is pushed, reviewed, merged, deployed, and verified."
+  },
+  "idea_ids": [
+    "coherence-substrate"
+  ],
+  "spec_ids": [
+    "specs/form-question-effects-kernel-conformance.md",
+    "docs/coherence-substrate/form-language.md"
+  ],
+  "task_ids": [
+    "substrate-form-access-fallback-20260528"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "production-signal"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Production POST https://api.coherencycoin.com/api/substrate/form with {\"expression\":\"@concept(lc-pulse).blueprint\"} returned HTTP 400: TypeError: Form: cannot evaluate Access before this hotfix.",
+    "Production POST https://api.coherencycoin.com/api/substrate/form with mode=run returned a NodeID value for the same expression, proving the runtime path can resolve the access.",
+    "https://pulse.coherencycoin.com/pulse/now reported substrate_form silent with detail HTTP 400: form parse/eval failed: TypeError: Form: cannot evaluate Access.",
+    "api/tests/test_substrate_form_ast_access.py pins the structural evaluator Access and MethodCall behavior.",
+    "api/tests/test_substrate_form_endpoint.py::test_form_endpoint_access_bootstrap_gap_falls_back_to_runtime pins the endpoint-level fallback shape.",
+    "api/tests/test_check_pr_followthrough.py pins the GitHub GraphQL-to-REST fallback used by the required follow-through gate."
+  ],
+  "change_files": [
+    "api/app/routers/substrate.py",
+    "api/tests/test_substrate_form_endpoint.py",
+    "api/tests/test_check_pr_followthrough.py",
+    "scripts/check_pr_followthrough.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Default POST /api/substrate/form should return kind=node_id for @concept(lc-pulse).blueprint even if the bootstrap AST evaluator raises the known Access or MethodCall TypeError, while non-bootstrap TypeError failures continue to surface as HTTP 400.",
+    "public_endpoints": [
+      "POST https://api.coherencycoin.com/api/substrate/form",
+      "GET https://pulse.coherencycoin.com/pulse/now"
+    ],
+    "test_flows": [
+      "Local endpoint unit flow monkeypatches form_evaluate_text to raise TypeError: Form: cannot evaluate Access and asserts the runtime fallback returns kind=node_id.",
+      "Post-deploy public flow will call @concept(lc-pulse).blueprint in default mode and confirm substrate_form clears on the pulse endpoint."
+    ]
+  }
+}

--- a/scripts/check_pr_followthrough.py
+++ b/scripts/check_pr_followthrough.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import shutil
 import subprocess
 from typing import Any
@@ -30,31 +31,94 @@ def _run_gh(args: list[str]) -> str:
     return out.strip()
 
 
+def _repo_from_git_remote() -> str:
+    remote = subprocess.check_output(
+        ["git", "config", "--get", "remote.origin.url"],
+        text=True,
+    ).strip()
+    if remote.startswith("git@github.com:"):
+        path = remote.split(":", 1)[1]
+    elif "github.com/" in remote:
+        path = remote.split("github.com/", 1)[1]
+    else:
+        raise ValueError(f"unsupported GitHub remote URL: {remote}")
+    path = re.sub(r"\.git$", "", path.strip("/"))
+    parts = [part for part in path.split("/") if part]
+    if len(parts) < 2:
+        raise ValueError(f"unable to resolve owner/repo from remote URL: {remote}")
+    return f"{parts[0]}/{parts[1]}"
+
+
 def _resolve_repo(explicit_repo: str) -> str:
     if explicit_repo.strip():
         return explicit_repo.strip()
-    return _run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    try:
+        return _run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    except subprocess.CalledProcessError:
+        return _repo_from_git_remote()
 
 
 def _list_open_prs(repo: str) -> list[dict[str, Any]]:
-    raw = _run_gh(
-        [
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            "200",
-            "--json",
-            "number,title,headRefName,updatedAt,url,isDraft",
-        ]
-    )
+    try:
+        raw = _run_gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,headRefName,updatedAt,url,isDraft",
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return _list_open_prs_rest(repo)
     payload = json.loads(raw or "[]")
     if not isinstance(payload, list):
         return []
     return [row for row in payload if isinstance(row, dict)]
+
+
+def _list_open_prs_rest(repo: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for page in (1, 2):
+        raw = _run_gh(
+            [
+                "api",
+                f"repos/{repo}/pulls",
+                "--method",
+                "GET",
+                "-f",
+                "state=open",
+                "-f",
+                "per_page=100",
+                "-f",
+                f"page={page}",
+            ]
+        )
+        payload = json.loads(raw or "[]")
+        if not isinstance(payload, list):
+            return rows
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            head = item.get("head")
+            rows.append(
+                {
+                    "number": item.get("number"),
+                    "title": item.get("title"),
+                    "headRefName": (head or {}).get("ref") if isinstance(head, dict) else "",
+                    "updatedAt": item.get("updated_at"),
+                    "url": item.get("html_url"),
+                    "isDraft": bool(item.get("draft")),
+                }
+            )
+        if len(payload) < 100:
+            break
+    return rows[:200]
 
 
 def _pr_details(repo: str, number: int) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- keep /api/substrate/form breathing when the bootstrap AST evaluator hits the known Access/MethodCall gap by falling back to the Form runtime
- preserve the normal endpoint response shape for runtime fallback values, including NodeID/cell/view/list values
- heal check_pr_followthrough with REST/git-remote fallbacks so GraphQL quota exhaustion does not block local proof

## Proof
- make prompt-guide
- make wellness
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_check_pr_followthrough.py tests/test_substrate_form_ast_access.py tests/test_substrate_form_endpoint.py -q
- /opt/homebrew/bin/ruff check scripts/check_pr_followthrough.py api/tests/test_check_pr_followthrough.py api/app/routers/substrate.py api/tests/test_substrate_form_endpoint.py
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
