### PR TITLE
fix(deploy): align api docker runtime requirements

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -12,3 +12,5 @@ psycopg2-binary>=2.9.0
 neo4j>=5.0.0
 eth-account>=0.13.0
 cryptography>=41.0.0
+PyNaCl>=1.5.0
+pywebpush>=2.0

--- a/api/tests/test_api_dockerfile_contract.py
+++ b/api/tests/test_api_dockerfile_contract.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+import tomllib
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _dependency_name(value: str) -> str:
+    match = re.match(r"([A-Za-z0-9_.-]+)", value.strip())
+    assert match is not None
+    return match.group(1).lower().replace("_", "-")
 
 
 def test_api_kernel_builder_rust_toolchain_supports_locked_edition2024_crates() -> None:
@@ -25,3 +32,18 @@ def test_api_kernel_builder_rust_toolchain_supports_locked_edition2024_crates() 
 
     toolchain = (int(match.group("major")), int(match.group("minor")))
     assert toolchain >= (1, 86)
+
+
+def test_api_docker_requirements_cover_pyproject_runtime_dependencies() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "api" / "pyproject.toml").read_text(encoding="utf-8"))
+    project_dependencies = {
+        _dependency_name(value)
+        for value in pyproject["project"]["dependencies"]
+    }
+    docker_requirements = {
+        _dependency_name(line)
+        for line in (REPO_ROOT / "api" / "requirements.txt").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert sorted(project_dependencies - docker_requirements) == []

--- a/docs/system_audit/commit_evidence_2026-05-28_api_docker_requirements_parity.json
+++ b/docs/system_audit/commit_evidence_2026-05-28_api_docker_requirements_parity.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-05-28",
+  "thread_branch": "codex/api-docker-requirements-parity-20260528",
+  "commit_scope": "Restore the API image runtime dependency set by aligning api/requirements.txt with api/pyproject.toml for imports used at app startup.",
+  "files_owned": [
+    "api/requirements.txt",
+    "api/tests/test_api_dockerfile_contract.py",
+    "docs/system_audit/commit_evidence_2026-05-28_api_docker_requirements_parity.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_api_dockerfile_contract.py -q",
+      "/opt/homebrew/bin/ruff check api/tests/test_api_dockerfile_contract.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-28_api_docker_requirements_parity.json",
+      "git diff --check"
+    ],
+    "notes": [
+      "The API Docker image installs api/requirements.txt, while CI installs api/pyproject.toml. The Docker requirements were missing PyNaCl and pywebpush even though app.main imports runtime and push services that depend on them.",
+      "Focused requirements parity test passed.",
+      "Ruff passed on the Dockerfile contract test.",
+      "Local Docker daemon is not available in this desktop session, so image-start proof is deferred to Hostinger Auto Deploy."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": [
+      "Awaiting PR checks after branch push."
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": [
+      "Hostinger Auto Deploy run 26582186279 rebuilt the API image successfully with rust:1.86-slim-bookworm, then the API container did not pass public health; the image dependency set is the next likely startup blocker.",
+      "The next deploy must start the API image, expose /api/health, and clear POST /api/substrate/form for @concept(lc-pulse).blueprint."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local dependency parity is proved; CI and live deploy proof remain pending."
+  },
+  "idea_ids": [
+    "coherence-substrate"
+  ],
+  "spec_ids": [
+    "docs/coherence-substrate/form-language.md"
+  ],
+  "task_ids": [
+    "api-docker-requirements-parity-20260528",
+    "substrate-form-access-fallback-20260528"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "production-signal"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/main.py imports app.services.runtime_service at startup, and runtime_service imports nacl.",
+    "api/app/routers/push.py imports push_subscription_service at startup, and push_subscription_service imports pywebpush.",
+    "api/pyproject.toml already listed PyNaCl>=1.5.0 and pywebpush>=2.0, but api/requirements.txt did not."
+  ],
+  "change_files": [
+    "api/requirements.txt",
+    "api/tests/test_api_dockerfile_contract.py"
+  ],
+  "change_intent": "process_only"
+}


### PR DESCRIPTION
## Summary
- add the missing Docker runtime dependencies PyNaCl and pywebpush to api/requirements.txt
- extend the API Docker contract test so api/requirements.txt must cover every runtime dependency in api/pyproject.toml

## Why
The API Docker image installs api/requirements.txt, while CI/local dev install api/pyproject.toml. app.main imports runtime_service and push_subscription_service at startup; those need nacl and pywebpush. The rebuilt production image can fail to start if Docker requirements drift from pyproject.

## Proof
- make prompt-guide
- cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest tests/test_api_dockerfile_contract.py -q
- /opt/homebrew/bin/ruff check api/tests/test_api_dockerfile_contract.py
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main

Local Docker daemon is not available in this desktop session; Hostinger Auto Deploy is the real image-start proof.
