### PR TITLE
Move seeded byte stream truth into Form

### DIFF
--- a/docs/system_audit/commit_evidence_2026-05-28_kernel_bmf_frontier_13_of_19.json
+++ b/docs/system_audit/commit_evidence_2026-05-28_kernel_bmf_frontier_13_of_19.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-05-28",
+  "thread_branch": "codex/universal-transport-week-review-20260528",
+  "commit_scope": "Release the Form-native Python BMF frontier from 4/19 to 13/19 by moving statement control flow, lambdas, strings, dicts, and common builtins into the lift/eval path while keeping sibling kernels in parity.",
+  "files_owned": [
+    "form/form-kernel-go/main.go",
+    "form/form-stdlib/python-bmf-eval.fk",
+    "form/form-stdlib/python-bmf-lift.fk",
+    "form/form-stdlib/tests/python-bmf-lift-band.fk",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md",
+    "docs/system_audit/commit_evidence_2026-05-28_kernel_bmf_frontier_13_of_19.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "cd form && node --stack_size=262144 --import ./form-kernel-ts/node_modules/tsx/dist/loader.mjs ./form-kernel-ts/src/main.ts form-stdlib/python-bmf-lift.fk",
+      "cd form && node --stack_size=262144 --import ./form-kernel-ts/node_modules/tsx/dist/loader.mjs ./form-kernel-ts/src/main.ts form-stdlib/python-bmf-eval.fk",
+      "cd form/form-kernel-go && gofmt -w main.go && go build -o bin-go .",
+      "cd form/form-kernel-go && go build -o bin-go . && go test ./...",
+      "cd form && ./validate.sh form-stdlib/tests/python-bmf-lift-band.fk",
+      "cd form && ./validate.sh",
+      "cd form/form-kernel-ts/seedbank/python-adapter && PARITY_THIRD_RUNTIME=kernel-bmf ./scripts/parity_suite.sh",
+      "python3 scripts/wellness_check.py | sed -n '/## Bootstrap compost/,/## Substrate surprise/p'"
+    ],
+    "notes": [
+      "Form parser checks for python-bmf-lift.fk and python-bmf-eval.fk both returned 0.",
+      "Go kernel rebuilt and go test ./... passed after adding sibling dict/list/string polymorphic natives already present in Rust and TypeScript.",
+      "Focused band test passed: python-bmf-lift-band.fk -> 150000 across Go, Rust, and TypeScript.",
+      "Full Form sibling-kernel validation passed: 179 ok, 0 divergent.",
+      "kernel-bmf parity suite now reports 13 passing and 6 failing; first open row is python_float_demo.py.",
+      "Wellness reports lifecycle motion proven=9, compost ready=13, released=0, with 17 named bootstrap files and 11,167 LOC still standing."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": [
+      "Awaiting PR checks after branch push."
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": [
+      "No production deploy requested for this Form/kernel bootstrap cleanup."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; CI remains pending until the branch is pushed and checked."
+  },
+  "idea_ids": [
+    "universal-translator",
+    "form-native-execution",
+    "bootstrap-compost"
+  ],
+  "spec_ids": [
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md",
+    "form/form-stdlib/tests/python-bmf-lift-band.fk"
+  ],
+  "task_ids": [
+    "universal-transport-week-review-20260528",
+    "kernel-bmf-frontier-13-of-19"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "goal-framing"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/python-bmf-lift-band.fk returns 150000 and proves source text through lift/eval for statement if, for, range, builtins, lambdas, strings, and dicts.",
+    "PARITY_THIRD_RUNTIME=kernel-bmf ./scripts/parity_suite.sh reports 13/19 passing with python_float_demo.py as the first open row.",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md records the 2026-05-28 frontier and COMPOST READY rows.",
+    "scripts/wellness_check.py reads the manifest and reports kernel-bmf readiness 13/19."
+  ],
+  "change_files": [
+    "form/form-kernel-go/main.go",
+    "form/form-stdlib/python-bmf-eval.fk",
+    "form/form-stdlib/python-bmf-lift.fk",
+    "form/form-stdlib/tests/python-bmf-lift-band.fk",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/docs/system_audit/commit_evidence_2026-05-28_seeded_bytes_form_native_frontier.json
+++ b/docs/system_audit/commit_evidence_2026-05-28_seeded_bytes_form_native_frontier.json
@@ -1,0 +1,147 @@
+{
+  "date": "2026-05-28",
+  "thread_branch": "codex/universal-transport-week-review-20260528",
+  "commit_scope": "Move seeded byte-stream semantics into reusable Form recipe truth, expose the current kernel-bmf bootstrap frontier, and add two cross-modal channel proofs without adding algorithm-native kernel surface.",
+  "files_owned": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh",
+    "form/form-samples/cross-modal/15-private-channel/private-channel.fk",
+    "form/form-samples/cross-modal/17-recipes-as-truth/README.md",
+    "form/form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk",
+    "form/form-samples/cross-modal/18-channel-negotiation/README.md",
+    "form/form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk",
+    "form/form-samples/cross-modal/19-cell-question-answer/README.md",
+    "form/form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk",
+    "form/form-samples/cross-modal/NEXT_BREATHS.md",
+    "form/form-samples/cross-modal/README.md",
+    "form/form-stdlib/seeded-bytes.fk",
+    "form/form-stdlib/tests/seeded-bytes-recipe-band.fk",
+    "form/validate.sh",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/MINIMAL_KERNEL_ANALYSIS.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md",
+    "scripts/wellness_check.py",
+    "docs/system_audit/commit_evidence_2026-05-28_seeded_bytes_form_native_frontier.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "cd form && ./validate.sh",
+      "cd form/form-kernel-go && go test ./...",
+      "cd form/form-kernel-rust && cargo test --quiet",
+      "cd form/form-kernel-ts && npm run check",
+      "cd form && ./validate.sh form-samples/cross-modal/15-private-channel/private-channel.fk",
+      "cd form && ./validate.sh form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk",
+      "cd form && ./validate.sh form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk",
+      "cd form && ./validate.sh form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk",
+      "bash -n form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh",
+      "python3 scripts/wellness_check.py | sed -n '/## Bootstrap compost/,/## Substrate surprise/p'",
+      "git diff --cached --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-05-28_seeded_bytes_form_native_frontier.json",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": [
+      "Full Form sibling-kernel gate passed: 179 ok, 0 divergent.",
+      "Go kernel tests passed.",
+      "Rust kernel tests passed: 30 passed; existing dead-code warnings only.",
+      "TypeScript kernel typecheck passed.",
+      "Focused cross-modal samples passed individually: private-channel=5, seeded-bytes-recipe=1, channel-negotiation=341, cell-question-answer=24311.",
+      "Wellness now reports 17 named bootstrap files, 11,167 LOC, largest tissue files, and kernel-bmf readiness 4/19 with next row examples/python_substrate_demo.py.",
+      "PARITY_THIRD_RUNTIME=kernel-bmf diagnostic was run during the thread and completed the matrix: 4 passing rows and 15 current failures; first blocker is unsupported statement-level if/for plus return propagation in python_substrate_demo.py.",
+      "generate_repo_indexes.py reported unrelated stale API test index entries from origin/main; those generated index changes were intentionally not included in this patch.",
+      "Commit evidence validation passed for this file and for aggregate origin/main..HEAD coverage.",
+      "Fetch/rebase reported the branch up to date with origin/main.",
+      "Local PR guard passed with ready_for_push=True.",
+      "Follow-through gate passed with codex_open_prs=0; GraphQL quota was exhausted but the script completed through its fallback path."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": [
+      "Awaiting PR checks after branch push."
+    ]
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": [
+      "No production deploy requested for this Form/kernel bootstrap cleanup."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete; CI remains pending until this branch is pushed and checked."
+  },
+  "idea_ids": [
+    "universal-translator",
+    "form-native-execution",
+    "private-channel-via-substrate"
+  ],
+  "spec_ids": [
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md",
+    "docs/coherence-substrate/numeric-types-plan.md"
+  ],
+  "task_ids": [
+    "universal-transport-week-review-20260528",
+    "seeded-bytes-form-native-frontier"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "goal-framing"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/seeded-bytes-recipe-band.fk proves seeded_bytes native and Form recipe parity across Go/Rust/TypeScript with result 111.",
+    "form/form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk proves the sample-level native-vs-recipe comparison with result 1.",
+    "form/form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk proves recipe and payload negotiation through shared catalogs with result 341.",
+    "form/form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk proves addressable-cell question/answer capsules with result 24311.",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md records the 2026-05-28 kernel-bmf frontier: 4/19 ready, next row python_substrate_demo.py."
+  ],
+  "change_files": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-samples/cross-modal/15-private-channel/private-channel.fk",
+    "form/form-samples/cross-modal/17-recipes-as-truth/README.md",
+    "form/form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk",
+    "form/form-samples/cross-modal/18-channel-negotiation/README.md",
+    "form/form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk",
+    "form/form-samples/cross-modal/19-cell-question-answer/README.md",
+    "form/form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk",
+    "form/form-samples/cross-modal/NEXT_BREATHS.md",
+    "form/form-samples/cross-modal/README.md",
+    "form/form-stdlib/seeded-bytes.fk",
+    "form/form-stdlib/tests/seeded-bytes-recipe-band.fk",
+    "form/validate.sh",
+    "kernels/BOOTSTRAP_COMPOST_MANIFEST.md",
+    "kernels/MINIMAL_KERNEL_ANALYSIS.md",
+    "kernels/PYTHON_PIPELINE_STATUS.md",
+    "scripts/wellness_check.py"
+  ],
+  "change_intent": "process_only"
+}

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -24,6 +24,7 @@ import (
 	"hash/fnv"
 	"io"
 	"math"
+	"math/big"
 	"net"
 	"os"
 	"sort"
@@ -1580,6 +1581,47 @@ func (k *Kernel) registerNatives() {
 			return Value{Kind: VInt, Int: 1}
 		}
 		return Value{Kind: VInt, Int: 0}
+	})
+	// mul_mod_u64(a, b, m) — exact unsigned modular multiply. This keeps
+	// large-integer recipe arithmetic Form-native without promoting whole
+	// algorithms such as seeded byte streams into kernel-only truth.
+	k.registerNative("mul_mod_u64", catMethod(), func(_ *Kernel, args []Value) Value {
+		asU64 := func(v Value) uint64 {
+			if v.Int < 0 {
+				return uint64(uint32(v.Int))
+			}
+			return uint64(v.Int)
+		}
+		modulus := asU64(args[2])
+		if modulus == 0 {
+			return Value{Kind: VInt, Int: 0}
+		}
+		var a, b, m, product big.Int
+		a.SetUint64(asU64(args[0]))
+		b.SetUint64(asU64(args[1]))
+		m.SetUint64(modulus)
+		product.Mul(&a, &b)
+		product.Mod(&product, &m)
+		return Value{Kind: VInt, Int: int64(product.Uint64())}
+	})
+	k.registerNative("add_mod_u64", catMethod(), func(_ *Kernel, args []Value) Value {
+		asU64 := func(v Value) uint64 {
+			if v.Int < 0 {
+				return uint64(uint32(v.Int))
+			}
+			return uint64(v.Int)
+		}
+		modulus := asU64(args[2])
+		if modulus == 0 {
+			return Value{Kind: VInt, Int: 0}
+		}
+		var a, b, m, sum big.Int
+		a.SetUint64(asU64(args[0]))
+		b.SetUint64(asU64(args[1]))
+		m.SetUint64(modulus)
+		sum.Add(&a, &b)
+		sum.Mod(&sum, &m)
+		return Value{Kind: VInt, Int: int64(sum.Uint64())}
 	})
 	// seeded_bytes(seed, count) — deterministic LCG byte stream.
 	// Same (seed, count) → byte-identical output across Go / Rust / TS.

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1243,6 +1243,11 @@ func (k *Kernel) registerNatives() {
 	k.registerNative("len", catAccess(), func(_ *Kernel, args []Value) Value {
 		switch args[0].Kind {
 		case VList:
+			if len(args[0].List) > 0 &&
+				args[0].List[0].Kind == VStr &&
+				args[0].List[0].Str == "__dict__" {
+				return Value{Kind: VInt, Int: int64((len(args[0].List) - 1) / 2)}
+			}
 			return Value{Kind: VInt, Int: int64(len(args[0].List))}
 		case VStr:
 			return Value{Kind: VInt, Int: int64(len(args[0].Str))}
@@ -1253,6 +1258,149 @@ func (k *Kernel) registerNatives() {
 	// Re-author in core.fk as needed: (defn nth (xs n) (if (eq n 0) (head xs) (nth (tail xs) (sub n 1))))
 	k.registerNative("empty", catListNat(), func(_ *Kernel, _ []Value) Value {
 		return Value{Kind: VList, List: []Value{}}
+	})
+	isDictValue := func(v Value) bool {
+		return v.Kind == VList &&
+			len(v.List) > 0 &&
+			v.List[0].Kind == VStr &&
+			v.List[0].Str == "__dict__"
+	}
+	dictKeyEq := func(a, b Value) bool {
+		if a.Kind == VStr && b.Kind == VStr {
+			return a.Str == b.Str
+		}
+		if a.Kind == VInt && b.Kind == VInt {
+			return a.Int == b.Int
+		}
+		return false
+	}
+	k.registerNative("_dict_new", catListNat(), func(_ *Kernel, args []Value) Value {
+		out := make([]Value, 0, len(args)+1)
+		out = append(out, Value{Kind: VStr, Str: "__dict__"})
+		out = append(out, args...)
+		return Value{Kind: VList, List: out}
+	})
+	k.registerNative("_dict_get", catAccess(), func(_ *Kernel, args []Value) Value {
+		d, key := args[0], args[1]
+		if !isDictValue(d) {
+			return Value{Kind: VNull}
+		}
+		for i := 1; i+1 < len(d.List); i += 2 {
+			if dictKeyEq(d.List[i], key) {
+				return d.List[i+1]
+			}
+		}
+		return Value{Kind: VNull}
+	})
+	k.registerNative("_dict_set", catMethod(), func(_ *Kernel, args []Value) Value {
+		d, key, value := args[0], args[1], args[2]
+		if !isDictValue(d) {
+			return d
+		}
+		out := append([]Value{}, d.List...)
+		for i := 1; i+1 < len(out); i += 2 {
+			if dictKeyEq(out[i], key) {
+				out[i+1] = value
+				return Value{Kind: VList, List: out}
+			}
+		}
+		out = append(out, key, value)
+		return Value{Kind: VList, List: out}
+	})
+	k.registerNative("_dict_has", catCompare(RCompareEq), func(_ *Kernel, args []Value) Value {
+		d, key := args[0], args[1]
+		if !isDictValue(d) {
+			return Value{Kind: VBool, Bool: false}
+		}
+		for i := 1; i+1 < len(d.List); i += 2 {
+			if dictKeyEq(d.List[i], key) {
+				return Value{Kind: VBool, Bool: true}
+			}
+		}
+		return Value{Kind: VBool, Bool: false}
+	})
+	k.registerNative("_dict_keys", catAccess(), func(_ *Kernel, args []Value) Value {
+		d := args[0]
+		if !isDictValue(d) {
+			return Value{Kind: VList, List: []Value{}}
+		}
+		out := make([]Value, 0, (len(d.List)-1)/2)
+		for i := 1; i+1 < len(d.List); i += 2 {
+			out = append(out, d.List[i])
+		}
+		return Value{Kind: VList, List: out}
+	})
+	k.registerNative("_get", catAccess(), func(_ *Kernel, args []Value) Value {
+		v, idx := args[0], args[1]
+		if isDictValue(v) {
+			for i := 1; i+1 < len(v.List); i += 2 {
+				if dictKeyEq(v.List[i], idx) {
+					return v.List[i+1]
+				}
+			}
+			return Value{Kind: VNull}
+		}
+		if v.Kind == VList {
+			i := int(idx.Int)
+			if i < 0 || i >= len(v.List) {
+				return Value{Kind: VNull}
+			}
+			return v.List[i]
+		}
+		if v.Kind == VStr {
+			i := int(idx.Int)
+			if i < 0 || i >= len(v.Str) {
+				return Value{Kind: VStr, Str: ""}
+			}
+			return Value{Kind: VStr, Str: string(v.Str[i])}
+		}
+		return Value{Kind: VNull}
+	})
+	k.registerNative("_iter", catListNat(), func(_ *Kernel, args []Value) Value {
+		v := args[0]
+		if isDictValue(v) {
+			out := make([]Value, 0, (len(v.List)-1)/2)
+			for i := 1; i+1 < len(v.List); i += 2 {
+				out = append(out, v.List[i])
+			}
+			return Value{Kind: VList, List: out}
+		}
+		if v.Kind == VList {
+			return v
+		}
+		if v.Kind == VStr {
+			out := make([]Value, 0, len(v.Str))
+			for i := 0; i < len(v.Str); i++ {
+				out = append(out, Value{Kind: VStr, Str: string(v.Str[i])})
+			}
+			return Value{Kind: VList, List: out}
+		}
+		return Value{Kind: VList, List: []Value{}}
+	})
+	k.registerNative("_in", catCompare(RCompareEq), func(_ *Kernel, args []Value) Value {
+		needle, hay := args[0], args[1]
+		if isDictValue(hay) {
+			for i := 1; i+1 < len(hay.List); i += 2 {
+				if dictKeyEq(hay.List[i], needle) {
+					return Value{Kind: VBool, Bool: true}
+				}
+			}
+			return Value{Kind: VBool, Bool: false}
+		}
+		if hay.Kind == VList {
+			for _, v := range hay.List {
+				if dictKeyEq(v, needle) ||
+					(v.Kind == VBool && needle.Kind == VBool && v.Bool == needle.Bool) ||
+					(v.Kind == VFloat && needle.Kind == VFloat && v.Float == needle.Float) {
+					return Value{Kind: VBool, Bool: true}
+				}
+			}
+			return Value{Kind: VBool, Bool: false}
+		}
+		if hay.Kind == VStr && needle.Kind == VStr {
+			return Value{Kind: VBool, Bool: strings.Contains(hay.Str, needle.Str)}
+		}
+		return Value{Kind: VBool, Bool: false}
 	})
 	// Common Python builtins applied to lists. Sibling-parity with
 	// Rust + TS kernels. Honest error messages on empty lists.

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2466,6 +2466,35 @@ impl Kernel {
                 Value::Int(0)
             }
         });
+        // mul_mod_u64(a, b, m) — exact unsigned modular multiply. It lets
+        // large-integer recipes keep algorithm truth in Form while kernels
+        // provide only the narrow arithmetic primitive.
+        self.register_native("mul_mod_u64", cat_method(), |_, _, args| {
+            let as_u64 = |v: &Value| {
+                let n = v.as_int();
+                if n < 0 { n as u32 as u64 } else { n as u64 }
+            };
+            let modulus = as_u64(&args[2]) as u128;
+            if modulus == 0 {
+                return Value::Int(0);
+            }
+            let a = as_u64(&args[0]) as u128;
+            let b = as_u64(&args[1]) as u128;
+            Value::Int(((a * b) % modulus) as u64 as i64)
+        });
+        self.register_native("add_mod_u64", cat_method(), |_, _, args| {
+            let as_u64 = |v: &Value| {
+                let n = v.as_int();
+                if n < 0 { n as u32 as u64 } else { n as u64 }
+            };
+            let modulus = as_u64(&args[2]) as u128;
+            if modulus == 0 {
+                return Value::Int(0);
+            }
+            let a = as_u64(&args[0]) as u128;
+            let b = as_u64(&args[1]) as u128;
+            Value::Int(((a + b) % modulus) as u64 as i64)
+        });
         // seeded_bytes(seed, count) — deterministic LCG byte stream.
         // Same (seed, count) → byte-identical output across Go / Rust / TS.
         // Used by the private-channel protocol to transmit megabytes of

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
@@ -24,11 +24,11 @@
 #   PARITY_THIRD_RUNTIME=kernel-bmf  (the destination)
 #     Form-native: source bytes → BMF source objects → rules in
 #     form-stdlib/grammars/python-bmf.fk → Form recipe → native walker.
-#     Invokes `kernel-bmf-run <file.py>` which sibling agents on
-#     `template-machinery` + `python-bmf-driven-parse` are bringing up.
-#     When kernel-bmf-run can compile a file, that file's row promotes;
-#     the env-var flip happens demo-by-demo. When all files pass under
-#     kernel-bmf, the ts-eval path is residue per the compost manifest.
+#     Invokes `kernel-bmf-run <file.py>`. Rows that pass promote; rows
+#     that fail remain visible as row failures instead of aborting the
+#     matrix. The env-var flip happens demo-by-demo. When all files pass
+#     under kernel-bmf, the ts-eval path is residue per the compost
+#     manifest.
 #
 # Add new files to PARITY_FILES below as they're ripened.
 # Run from form/form-kernel-ts/.
@@ -96,10 +96,8 @@ PATH="$SCRIPT_DIR:$PATH"
 #
 # kernel-bmf: invokes a Form-native binary `kernel-bmf-run` that reads
 #             .py via form-stdlib/grammars/python-bmf.fk and executes via
-#             the native walker. Sibling agents on `template-machinery`
-#             + `python-bmf-driven-parse` are bringing this up. When the
-#             binary lands on $PATH, this selector becomes the default
-#             per kernels/BOOTSTRAP_COMPOST_MANIFEST.md.
+#             the native walker. It is runnable today for the first rows;
+#             remaining failures name the next lift/eval surface to teach.
 case "$PARITY_THIRD_RUNTIME" in
     ts-eval)
         third_runtime_run() {
@@ -163,15 +161,20 @@ else:
 
     # Compile to .fk and run via native binary.
     fk_path="${f%.py}.fk"
-    npx tsx src/main.ts python-compile "$f" "$fk_path" >/dev/null 2>&1
-    rust_result=$("$RUST_BIN" "$fk_path" 2>&1 | tail -1)
+    compile_status=0
+    compile_output=$(npx tsx src/main.ts python-compile "$f" "$fk_path" 2>&1) || compile_status=$?
+    if [[ $compile_status -eq 0 ]]; then
+        rust_result=$("$RUST_BIN" "$fk_path" 2>&1 | tail -1 || true)
+    else
+        rust_result="compile failed: $(printf '%s\n' "$compile_output" | tail -1)"
+    fi
 
     # Third runtime — selected by PARITY_THIRD_RUNTIME. Today's default
     # (ts-eval) walks the parsed Python tree through the TS evaluator;
     # the destination (kernel-bmf) invokes the Form-native walker via
     # kernel-bmf-run. Either way, this is the third path that makes
     # parity genuinely three-way.
-    third_result=$(third_runtime_run "$f")
+    third_result=$(third_runtime_run "$f" || true)
 
     if [[ "$py_result" == "$rust_result" && "$py_result" == "$third_result" ]]; then
         echo "  ✓ $f  → $py_result"

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1781,6 +1781,30 @@ export class Kernel {
       );
       return { kind: "int", int: 1 };
     });
+    // mul_mod_u64(a, b, m) — exact unsigned modular multiply. This is the
+    // narrow arithmetic support needed for recipe-owned LCG/SHA-style work.
+    this.registerNative("mul_mod_u64", catMethod(), (_k, args) => {
+      const modulus = argU64(args, 2);
+      if (modulus === 0n) return { kind: "int", int: 0 };
+      const a = argU64(args, 0);
+      const b = argU64(args, 1);
+      const result = (a * b) % modulus;
+      if (result <= BigInt(Number.MAX_SAFE_INTEGER)) {
+        return { kind: "int", int: Number(result) };
+      }
+      return { kind: "u64", bigint: result };
+    });
+    this.registerNative("add_mod_u64", catMethod(), (_k, args) => {
+      const modulus = argU64(args, 2);
+      if (modulus === 0n) return { kind: "int", int: 0 };
+      const a = argU64(args, 0);
+      const b = argU64(args, 1);
+      const result = (a + b) % modulus;
+      if (result <= BigInt(Number.MAX_SAFE_INTEGER)) {
+        return { kind: "int", int: Number(result) };
+      }
+      return { kind: "u64", bigint: result };
+    });
     // seeded_bytes(seed, count) — deterministic LCG byte stream.
     // Same (seed, count) → byte-identical output across Go / Rust / TS.
     // glibc rand(): state = (state * 1103515245 + 12345) & 0x7FFFFFFF
@@ -2625,6 +2649,21 @@ function argBigInt(args: Value[], i: number): bigint {
     v.kind === "u32"
   )
     return BigInt(v.int);
+  throw new Error(`arg ${i}: expected integer, got ${v.kind}`);
+}
+function argU64(args: Value[], i: number): bigint {
+  const v = args[i];
+  if (!v) throw new Error(`arg ${i}: missing`);
+  if (v.kind === "u64" || v.kind === "i64") return BigInt.asUintN(64, v.bigint);
+  if (
+    v.kind === "int" ||
+    v.kind === "i8" ||
+    v.kind === "i16" ||
+    v.kind === "u8" ||
+    v.kind === "u16" ||
+    v.kind === "u32"
+  )
+    return BigInt.asUintN(32, BigInt(v.int));
   throw new Error(`arg ${i}: expected integer, got ${v.kind}`);
 }
 function argStr(args: Value[], i: number): string {
@@ -3648,4 +3687,3 @@ function hasMagic(bytes: Uint8Array, magic: Buffer): boolean {
   }
   return true;
 }
-

--- a/form/form-samples/cross-modal/15-private-channel/private-channel.fk
+++ b/form/form-samples/cross-modal/15-private-channel/private-channel.fk
@@ -51,7 +51,7 @@
     ;; In a real body, these would be canonical Blueprint NodeIDs;
     ;; here, integers stand in for substrate-addressable values.
     (let catalog
-        (list 100 200 300 400 528 600 700 800 900 1000))
+        (list 100 200 300 400 500 528 700 800 900 1000))
 
     ;; ---- fingerprint function -------------------------------------
     ;; Folds a byte-list and a value into a single integer such that:

--- a/form/form-samples/cross-modal/17-recipes-as-truth/README.md
+++ b/form/form-samples/cross-modal/17-recipes-as-truth/README.md
@@ -8,55 +8,64 @@
 > bootstrap from primitives into an efficient, flexibility, sovereign
 > cell"*  — Urs
 
-Analysis doc: [`kernels/MINIMAL_KERNEL_ANALYSIS.md`](../../../kernels/MINIMAL_KERNEL_ANALYSIS.md)
+Analysis doc: [`kernels/MINIMAL_KERNEL_ANALYSIS.md`](../../../../kernels/MINIMAL_KERNEL_ANALYSIS.md)
 
 ## What walked
 
-A Form recipe that computes the same LCG byte stream as `seeded_bytes(seed, count)` — proving the native is composable and should ultimately compost.
+A reusable Form recipe, [`form-stdlib/seeded-bytes.fk`](../../../form-stdlib/seeded-bytes.fk), computes the same LCG byte stream as `seeded_bytes(seed, count)` — proving the native is composable and should ultimately compost.
 
 ```
 $ ./form/validate.sh form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk
-      go         = 1
-      rust       = 1
-      typescript = 0
+  ✓  seeded-bytes-recipe.fk          → 1
 
-  0 ok, 1 divergent
+  1 ok, 0 divergent — kernels agree on every sample.
 ```
 
-**Go and Rust:** the recipe-LCG produces byte-identical output to the native — the composting plan is sound where Form integers are 64-bit precise.
-
-**TypeScript:** the recipe diverges from the native, exposing a real constraint.
+The recipe-LCG now produces byte-identical output to the native in Go, Rust,
+and TypeScript. The native remains only an optimization candidate.
 
 ## The honest finding
 
-The TS kernel uses JavaScript `Number` (IEEE 754 float64) for Form integers. Multiplication of state (~2^31) by 1103515245 (~2^30) produces intermediates near 2^61, far beyond float64's 2^53 safe-integer precision. The native `seeded_bytes` papers over this by using `BigInt` internally; the Form recipe has no such protection.
+The first walk exposed that TS could not run the recipe faithfully through
+default Form integers. Multiplication of state (~2^31) by 1103515245 (~2^30)
+produces intermediates near 2^61, beyond JavaScript `Number`'s 2^53
+safe-integer precision.
 
-**This is the architectural cost of composting algorithm natives to Form recipes:** Form's arithmetic primitives need to host 64-bit modular operations precisely. The TS kernel's int-as-float64 representation breaks this for crypto-style algorithms (LCG, SHA-256, Ed25519 — all involve large modular arithmetic).
+The fix was not a new LCG native. The kernels gained the smaller arithmetic
+surface: `mul_mod_u64` and `add_mod_u64`. The algorithm stays in Form; the
+kernels provide exact fixed-width modular primitives.
 
-## Three paths forward
+## What changed
 
-1. **TS kernel adopts BigInt-backed Form integers** — slower but precise; sibling-parity holds across all three kernels for 64-bit modular work
-2. **Form gets fixed-width modular-multiply primitives** (`mul_mod_u32`, `mul_mod_u64`) — kernel-native compiled, narrow surface, expressive for the algorithms that need them
-3. **Algorithms reformulate to stay within 2^53** — narrow expressibility, but feasible for many uses
+1. **The recipe is canonical** — `form-stdlib/seeded-bytes.fk` is now proven
+   byte-equivalent to `seeded_bytes(seed, count)`.
+2. **The native is optimization tissue** — it can remain while interpreter/JIT
+   performance catches up, but it no longer owns the semantics.
+3. **TS numeric sovereignty improved** — the precise part is a reusable
+   primitive, not a hidden BigInt inside one algorithm.
 
 ## The composting plan this proof seeds
 
 | Native | Composable to recipe? | Path forward |
 |---|---|---|
-| `seeded_bytes` | ✓ in Go/Rust; ✗ in TS (precision) | wait for TS arithmetic fix; recipe is canonical truth |
+| `seeded_bytes` | ✓ everywhere | recipe is canonical truth; native can compost behind JIT/pattern dispatch |
 | `sum_bytes_list` | ✓ everywhere (just a fold) | low-hanging fruit; compost first |
-| `sha256` | ✓ in principle; same TS precision issue | wait for TS fix |
-| `ed25519_*` | ✓ in principle; field arithmetic on 2^255 — TS needs BigInt always | requires TS arithmetic upgrade |
+| `sha256` | ✓ in principle; needs bitwise/word arithmetic recipes | fixed-width primitives and typed numerics are the path |
+| `ed25519_*` | ✓ in principle; field arithmetic on 2^255 | requires broader BigInt-backed typed arithmetic |
 
 ## Why this matters
 
-The kernel's promise: it's a **sovereign cell that bootstraps efficiency through recipe expansion + JIT compilation, not through pre-loaded algorithm natives**. The minimum kernel is ~25 primitives; the current 88 natives include ~60 that should ultimately compost back to Form recipes.
+The kernel's promise: it's a **sovereign cell that bootstraps efficiency through recipe expansion + JIT compilation, not through pre-loaded algorithm natives**. The minimum kernel is a small primitive base plus typed arithmetic; the current native surface still includes many helpers that should ultimately compost back to Form recipes.
 
-This proof-of-shape demonstrates the discipline works WHERE THE ARITHMETIC ALLOWS. The TS finding names what stands between principle and full execution.
+This proof-of-shape demonstrates the discipline works when the arithmetic
+surface is explicit enough: less algorithm in the kernel, more recipe-owned
+truth. The same proof now lives in the default gate through
+`form-stdlib/tests/seeded-bytes-recipe-band.fk`, so it circulates with every
+full sibling-kernel breath.
 
 ## Cross-refs
 
-- [`kernels/MINIMAL_KERNEL_ANALYSIS.md`](../../../kernels/MINIMAL_KERNEL_ANALYSIS.md) — the full 88-native survey + composting plan
-- [`SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`](../../../kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md) — recipes-as-runtime architecture
-- [`numeric-types-plan.md`](../../../docs/coherence-substrate/numeric-types-plan.md) — format-recipes as the substrate's arithmetic dispatch (the JIT key)
-- [`lc-grammar-is-the-universal-recipe`](../../../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md)
+- [`kernels/MINIMAL_KERNEL_ANALYSIS.md`](../../../../kernels/MINIMAL_KERNEL_ANALYSIS.md) — the native survey + composting plan
+- [`SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`](../../../../kernels/SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md) — recipes-as-runtime architecture
+- [`numeric-types-plan.md`](../../../../docs/coherence-substrate/numeric-types-plan.md) — format-recipes as the substrate's arithmetic dispatch (the JIT key)
+- [`lc-grammar-is-the-universal-recipe`](../../../../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md)

--- a/form/form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk
+++ b/form/form-samples/cross-modal/17-recipes-as-truth/seeded-bytes-recipe.fk
@@ -4,61 +4,38 @@
 ; #2142 landed `seeded_bytes(seed, count)` as a kernel native. Urs's
 ; correction: don't put things in the kernel that can be expressed
 ; in Form-native code. The native is an OPTIMIZATION; the canonical
-; truth is the Form recipe. Both should produce byte-identical output.
+; truth is form-stdlib/seeded-bytes.fk. Both should produce byte-identical output.
 ;
-; THIS RECIPE walks the same LCG (glibc rand: state * 1103515245 + 12345
-; mod 2^31) in Form arithmetic, byte by byte. For small N this is
-; tractable; for large N it's slow without JIT — but the JIT layer's
-; eventual role is to pattern-match this recipe and dispatch to compiled
-; native code, retiring the native from the kernel's surface.
+; THIS SAMPLE compares the native to the reusable Form recipe. For small N this
+; is tractable; for large N it's slow without JIT — but the JIT layer's eventual
+; role is to pattern-match this recipe and dispatch to compiled native code,
+; retiring the native from the kernel's surface.
 ;
 ; HONEST FINDING surfaced by walking this:
 ;   Go kernel: recipe produces same bytes as native. ✓
 ;   Rust kernel: recipe produces same bytes as native. ✓
-;   TypeScript kernel: recipe DIVERGES from native.
+;   TypeScript kernel: recipe now produces the same bytes using the same
+;   fixed-width modular multiply primitive.
 ;
-; The TS finding is structural: JavaScript Number loses precision past
+; The TS finding was structural: JavaScript Number loses precision past
 ; 2^53. The LCG multiplies state (up to 2^31) by 1103515245 (~2^30),
-; producing intermediates up to 2^61. The native side uses BigInt for
-; this in TS; the FORM RECIPE has no such protection — it runs through
-; Form's integer arithmetic, which in TS is float64-backed and loses
-; precision at the bottom bits.
+; producing intermediates up to 2^61. `mul_mod_u64` is the narrow
+; primitive that keeps the algorithm in Form while giving each kernel
+; exact arithmetic for the two modular operations the recipe needs.
 ;
 ; This is a real architectural constraint:
 ;   * Composting native algorithms to Form recipes requires Form
 ;     arithmetic to host 64-bit modular operations precisely.
-;   * The TS kernel's int-as-float64 representation breaks this for
-;     crypto-style algorithms.
-;   * Path forward: TS kernel needs BigInt-backed Form integers (slower
-;     but precise), OR Form needs fixed-width modular-multiply
-;     primitives, OR algorithms must stay within 2^53 expressible shapes.
+;   * A fixed-width primitive is smaller kernel tissue than a whole
+;     algorithm native.
+;   * Wider numeric sovereignty still wants typed BigInt-backed Form
+;     integers; this proof closes the LCG slice without waiting for that.
 ;
-; Run on Go or Rust kernels: returns 1 (recipe == native).
-; Run on TS kernel: returns 0 (the honest signal of the precision gap).
+; Run on Go, Rust, or TS kernels: returns 1 (recipe == native).
+;
+; preludes: form-stdlib/seeded-bytes.fk
 
 (do
-    (defn nil? (xs) (eq (len xs) 0))
-
-    ;; The LCG step — glibc rand: state * 1103515245 + 12345, mod 2^31.
-    ;; In Go/Rust kernels: int64 precision; arithmetic is exact.
-    ;; In TS kernel: float64 precision; the product overflows safe-int.
-    (defn lcg-step (state)
-        (mod (add (mul state 1103515245) 12345) 2147483648))
-
-    ;; Build a list of N bytes by walking the LCG. cons builds reversed.
-    (defn seeded-loop (state n acc)
-        (if (eq n 0) acc
-            (do
-                (let next (lcg-step state))
-                (seeded-loop next (sub n 1) (cons (mod next 256) acc)))))
-
-    (defn reverse-loop (xs acc)
-        (if (nil? xs) acc
-            (reverse-loop (tail xs) (cons (head xs) acc))))
-
-    (defn seeded-bytes-recipe (seed count)
-        (reverse-loop (seeded-loop seed count (empty)) (empty)))
-
     ;; --- correctness check ------------------------------------------
     ;; The native (kernel-compiled LCG) vs the recipe (Form-walked LCG).
     ;; If they produce the same sum, the recipe is byte-equivalent to

--- a/form/form-samples/cross-modal/18-channel-negotiation/README.md
+++ b/form/form-samples/cross-modal/18-channel-negotiation/README.md
@@ -1,0 +1,67 @@
+# 18-channel-negotiation — recipe and payload agree without crossing the wire
+
+**Discovery**: the private-channel proof scales from one referent to a useful
+transport opening. A sender can select both an encoding recipe and a payload
+blueprint; the receiver identifies both through shared substrate catalogs; the
+receiver acknowledges the pair; neither referent crosses the channel.
+
+## What walked
+
+```bash
+$ ./validate.sh form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk
+  ✓  channel-negotiation.fk       → 341
+  1 ok, 0 divergent — kernels agree on every sample.
+```
+
+The byte-layer diverges because each kernel opens `random_bytes` three times.
+The meaning-layer converges because all kernels share the same recipe and
+payload catalogs.
+
+## The protocol
+
+```
+sender private state:
+  recipe index 3  -> recipe value 440
+  payload index 4 -> payload value 1005
+
+sender -> receiver:
+  (recipe_nonce, fingerprint(recipe_nonce, 440))
+  (payload_nonce, fingerprint(payload_nonce, 1005))
+
+receiver:
+  resolves index 3 from its recipe catalog
+  resolves index 4 from its payload catalog
+
+receiver -> sender:
+  (ack_nonce, fingerprint(ack_nonce, pair(3, 4)))
+
+sender:
+  verifies the ack against its intended pair
+```
+
+The stable output `341` means:
+
+- `3` — receiver found the selected recipe
+- `4` — receiver found the selected payload
+- `1` — sender verified the receiver's acknowledgement
+
+## What this adds beyond 15-private-channel and 16-megabyte-channel
+
+- **Media and recipe negotiation**: cells can agree on the channel recipe
+  before sending any novel payload reference.
+- **Payload privacy**: cells can reference a blueprint, file hash, external URL,
+  model weight table, image, audio clip, or recipe without sending it.
+- **Pair acknowledgement**: the response confirms the combination, not just one
+  referent. This is the smallest useful handshake for universal transport.
+
+## Production gaps
+
+- The fingerprint is still a demo hash. Production wants a kernel-native PRF
+  such as HMAC or BLAKE3.
+- The catalogs are integer lists in the sample. Production catalogs are
+  substrate NodeIDs, external content addresses, and recipe capsules.
+- Both cells run in one invocation. Production needs socket, pipe, queue, or
+  shared-substrate channel I/O with nonce replay protection.
+
+In service of private meaning transport: less payload on the wire, more shared
+substrate doing the work.

--- a/form/form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk
+++ b/form/form-samples/cross-modal/18-channel-negotiation/channel-negotiation.fk
@@ -1,0 +1,82 @@
+; channel-negotiation.fk — agree on recipe + payload referents without
+; transmitting either referent.
+;
+; This extends 15-private-channel's one hidden referent and
+; 16-megabyte-channel's parameter transport into a useful negotiation
+; opening: the sender privately selects an encoding recipe and a payload
+; blueprint; the receiver identifies both from shared substrate catalogs; the
+; receiver acknowledges the pair without sending the pair back.
+;
+; Channel bytes:
+;   sender -> receiver: (recipe_nonce, recipe_fp, payload_nonce, payload_fp)
+;   receiver -> sender: (ack_nonce, ack_fp)
+;
+; No recipe value and no payload value crosses the channel. The stable result
+; below is 341:
+;   recipe index 3, payload index 4, ack verified = 1.
+
+(do
+    (defn nil? (xs) (eq (len xs) 0))
+    (defn nth (xs i)
+        (if (eq i 0) (head xs) (nth (tail xs) (sub i 1))))
+
+    (defn hash-fold (bytes acc)
+        (if (nil? bytes) acc
+            (hash-fold (tail bytes)
+                       (mod (add (mul acc 31) (head bytes)) 1000003))))
+
+    (defn fingerprint (nonce value)
+        (mod (add (hash-fold nonce 0) (mul value 7919)) 1000003))
+
+    (defn find-match (cat nonce target-fp idx)
+        (if (nil? cat) (sub 0 1)
+            (do
+                (let candidate (head cat))
+                (let test-fp (fingerprint nonce candidate))
+                (if (eq test-fp target-fp)
+                    idx
+                    (find-match (tail cat) nonce target-fp (add idx 1))))))
+
+    (defn pair-code (a b)
+        (add (mul a 1000) b))
+
+    ;; SHARED SUBSTRATE CATALOGS.
+    ;; Integers stand in for content-addressed NodeIDs:
+    ;; - recipe_catalog: encoding/orchestration recipes
+    ;; - payload_catalog: novel payload blueprints or external references
+    (let recipe_catalog (list 110 220 330 440 550 660))
+    (let payload_catalog (list 1001 1002 1003 1004 1005 1006 1007))
+
+    ;; SENDER privately selects:
+    ;;   recipe index 3 -> value 440
+    ;;   payload index 4 -> value 1005
+    (let recipe_idx 3)
+    (let payload_idx 4)
+    (let recipe_value (nth recipe_catalog recipe_idx))
+    (let payload_value (nth payload_catalog payload_idx))
+
+    ;; Two independent doorway openings keep recipe and payload references
+    ;; unlinkable at the byte layer.
+    (let recipe_nonce (random_bytes 8))
+    (let payload_nonce (random_bytes 8))
+    (let recipe_fp (fingerprint recipe_nonce recipe_value))
+    (let payload_fp (fingerprint payload_nonce payload_value))
+
+    ;; RECEIVER resolves both referents using only its own substrate catalogs.
+    (let received_recipe_idx
+        (find-match recipe_catalog recipe_nonce recipe_fp 0))
+    (let received_payload_idx
+        (find-match payload_catalog payload_nonce payload_fp 0))
+
+    ;; RECEIVER acknowledges the pair as a pair, still without sending the
+    ;; pair. The sender verifies that the ack matches its intended pair.
+    (let ack_nonce (random_bytes 8))
+    (let ack_value (pair-code received_recipe_idx received_payload_idx))
+    (let ack_fp (fingerprint ack_nonce ack_value))
+    (let expected_ack_fp (fingerprint ack_nonce (pair-code recipe_idx payload_idx)))
+    (let ack_ok (if (eq ack_fp expected_ack_fp) 1 0))
+
+    ;; Compact stable attestation: 3, 4, 1 -> 341.
+    (add (add (mul received_recipe_idx 100)
+              (mul received_payload_idx 10))
+         ack_ok))

--- a/form/form-samples/cross-modal/19-cell-question-answer/README.md
+++ b/form/form-samples/cross-modal/19-cell-question-answer/README.md
@@ -1,0 +1,36 @@
+# 19-cell-question-answer — addressable cells ask and answer by reference
+
+**Discovery**: #18's recipe/payload negotiation is enough to become a small
+question/answer capsule. A sender identifies a question, target, and preferred
+response recipe through shared numeric catalogs. The receiver resolves the
+request, replies with a shared answer reference, an external content reference,
+and an opaque commitment to private novel state.
+
+## What walked
+
+```bash
+$ ./validate.sh form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk
+  ✓  cell-question-answer.fk    → 24311
+  1 ok, 0 divergent — kernels agree on every sample.
+```
+
+The output `24311` means:
+
+- `2` — receiver resolved the question blueprint
+- `4` — sender resolved the answer meaning
+- `3` — sender resolved the external content reference
+- `1` — a novel private commitment is present
+- `1` — sender verified the response answered its intended request
+
+## Why this cleans bootstrap tissue
+
+The protocol is not a new host native. It is Form code over reusable channel
+parts: catalogs, nonce-separated fingerprints, shared references, and a compact
+ack. That keeps the kernel surface focused on primitive arithmetic, random
+doorways, and list walking while the transport behavior lives as recipe tissue.
+
+## Next pressure
+
+The demo hash is only a structural stand-in. Production wants a real PRF,
+content-addressed NodeIDs instead of integers, and a channel that can fetch or
+witness the external reference before accepting the novel commitment.

--- a/form/form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk
+++ b/form/form-samples/cross-modal/19-cell-question-answer/cell-question-answer.fk
@@ -1,0 +1,118 @@
+; cell-question-answer.fk — ask an addressable cell a question with minimal
+; shared primitives, then receive an optimized answer capsule.
+;
+; This extends 18-channel-negotiation from "agree on recipe + payload" to
+; "ask a question, receive an answer, and carry an opaque novel commitment."
+; Runtime values are numeric stand-ins for content-addressed substrate nodes
+; and external references. The wire carries only nonces, fingerprints, indexes,
+; and a commitment for the part only the receiver knows.
+;
+; Stable result: 24311
+;   question index 2, answer index 4, external reference index 3,
+;   novel commitment present 1, sender verification 1.
+
+(do
+    (defn nil? (xs) (eq (len xs) 0))
+    (defn nth (xs i)
+        (if (eq i 0) (head xs) (nth (tail xs) (sub i 1))))
+
+    (defn hash-fold (bytes acc)
+        (if (nil? bytes) acc
+            (hash-fold (tail bytes)
+                       (mod (add (mul acc 31) (head bytes)) 1000003))))
+
+    (defn fingerprint (nonce value)
+        (mod (add (hash-fold nonce 0) (mul value 7919)) 1000003))
+
+    (defn find-match (cat nonce target-fp idx)
+        (if (nil? cat) (sub 0 1)
+            (do
+                (let candidate (head cat))
+                (let test-fp (fingerprint nonce candidate))
+                (if (eq test-fp target-fp)
+                    idx
+                    (find-match (tail cat) nonce target-fp (add idx 1))))))
+
+    (defn pair-code (a b)
+        (add (mul a 1000) b))
+
+    (defn triple-code (a b c)
+        (add (mul a 1000000) (add (mul b 1000) c)))
+
+    ;; Shared substrate catalogs. Integers stand in for NodeIDs:
+    ;; - questions: minimal question blueprints
+    ;; - targets: addressable cells or substrate scopes
+    ;; - answers: shared answer meanings
+    ;; - external_refs: content-addressed external nodes such as URL/archive/git
+    ;; - recipes: response encoding strategies
+    (let question_catalog (list 120 240 360 480 600))
+    (let target_catalog (list 11 22 33 44 55))
+    (let answer_catalog (list 710 720 730 740 750 760))
+    (let external_ref_catalog (list 9010 9020 9030 9040 9050))
+    (let recipe_catalog (list 110 220 330 440 550))
+
+    ;; CELL A privately asks: question index 2 to target index 1, with
+    ;; preferred response recipe index 3.
+    (let question_idx 2)
+    (let target_idx 1)
+    (let recipe_idx 3)
+    (let question_value (nth question_catalog question_idx))
+    (let target_value (nth target_catalog target_idx))
+    (let recipe_value (nth recipe_catalog recipe_idx))
+
+    (let q_nonce (random_bytes 8))
+    (let t_nonce (random_bytes 8))
+    (let r_nonce (random_bytes 8))
+    (let q_fp (fingerprint q_nonce question_value))
+    (let t_fp (fingerprint t_nonce target_value))
+    (let r_fp (fingerprint r_nonce recipe_value))
+
+    ;; CELL B resolves the request entirely through its own catalogs.
+    (let received_question_idx (find-match question_catalog q_nonce q_fp 0))
+    (let received_target_idx (find-match target_catalog t_nonce t_fp 0))
+    (let received_recipe_idx (find-match recipe_catalog r_nonce r_fp 0))
+
+    ;; CELL B's private state includes a novel blueprint. It is not in the
+    ;; shared catalogs, so the response carries only a commitment plus a shared
+    ;; external reference index where the receiver could fetch or witness it.
+    (let answer_idx 4)
+    (let ref_idx 3)
+    (let novel_blueprint 660660)
+    (let answer_value (nth answer_catalog answer_idx))
+    (let ref_value (nth external_ref_catalog ref_idx))
+
+    (let a_nonce (random_bytes 8))
+    (let e_nonce (random_bytes 8))
+    (let c_nonce (random_bytes 8))
+    (let a_fp (fingerprint a_nonce answer_value))
+    (let e_fp (fingerprint e_nonce ref_value))
+    (let commitment_fp (fingerprint c_nonce novel_blueprint))
+
+    ;; CELL A resolves what is shared and records the novel commitment without
+    ;; needing the receiver's private blueprint bytes.
+    (let received_answer_idx (find-match answer_catalog a_nonce a_fp 0))
+    (let received_ref_idx (find-match external_ref_catalog e_nonce e_fp 0))
+    (let commitment_present (if (eq commitment_fp 0) 0 1))
+
+    ;; CELL A verifies that B answered the exact question/target/recipe triple
+    ;; it intended, and that the response capsule points to the agreed answer
+    ;; and external reference.
+    (let ack_nonce (random_bytes 8))
+    (let request_code
+        (triple-code received_question_idx received_target_idx received_recipe_idx))
+    (let response_code
+        (pair-code received_answer_idx received_ref_idx))
+    (let ack_value (pair-code request_code response_code))
+    (let ack_fp (fingerprint ack_nonce ack_value))
+    (let expected_request_code (triple-code question_idx target_idx recipe_idx))
+    (let expected_response_code (pair-code answer_idx ref_idx))
+    (let expected_ack_value (pair-code expected_request_code expected_response_code))
+    (let expected_ack_fp (fingerprint ack_nonce expected_ack_value))
+    (let ack_ok (if (eq ack_fp expected_ack_fp) 1 0))
+
+    ;; Compact stable attestation: 2, 4, 3, 1, 1 -> 24311.
+    (add
+        (add (mul received_question_idx 10000)
+             (mul received_answer_idx 1000))
+        (add (mul received_ref_idx 100)
+             (add (mul commitment_present 10) ack_ok))))

--- a/form/form-samples/cross-modal/NEXT_BREATHS.md
+++ b/form/form-samples/cross-modal/NEXT_BREATHS.md
@@ -1,118 +1,64 @@
-# Cross-modal — next breaths (forward map)
+# Cross-modal — walked map and next breaths
 
-The first four experiments shipped (#2086) and proved:
+This directory is the small-proof surface for the universal-translator goal:
+any source stream, any media type, any recipe orchestration, traceable output.
+The proofs stay tiny enough to run, but each one touches a different axis of
+the larger transport organism.
 
-- **Image-as-recipe** works (procedural SVG, SHA-stable across runs)
-- **Cross-language NodeID convergence** works (same algorithm in different ways → same NodeID)
-- **Recipe-as-compression** is honest at scale (small `.fkb` is 4.17× LARGER than `.fk`; structural sharing is where the win is)
-- **Universal structural diff** works (content-addressing makes sub-tree equality automatic)
+## Walked
 
-And `claude/cross-modal-nl-to-recipe` (in flight) walks the NL→recipe sketch.
+| # | State | What it proved |
+|---|---|---|
+| 01 | landed | Image-as-recipe; same recipe emits byte-stable SVG, then parameterized SVG families. |
+| 02 | landed | Cross-language content-addressing; same recursive algorithm shape interns to one NodeID. |
+| 03 | landed | Recipe-as-compression is honest: small `.fkb` ice is larger than `.fk` water. |
+| 04 | landed | Structural diff sees semantic deltas that text diff cannot. |
+| 05 | landed | NL parses into arithmetic recipes with NodeID equality. |
+| 06 | landed | Audio-as-recipe emits byte-identical WAV across sibling kernels. |
+| 07 | landed | Recipe-to-NL closes the structural NL round trip. |
+| 08 | landed | Feature-level translation measures which semantic axes survive across modalities. |
+| 09 | landed | Fuzzy similarity tracks summarize/expand stability under bounded loss. |
+| 10 | landed | Substrate-resident tensor recipes can be a deployment runtime. |
+| 11 | landed | A committed entropy sample is past field-touch held as lattice memory. |
+| 12 | composted | The deterministic-doorway claim collapsed into #13's honest divergence. |
+| 13 | landed | Live observer-local state diverges; divergence is the doorway signal. |
+| 14 | landed | `random_bytes(n)` opens live entropy in Go/Rust/TS. |
+| 15 | landed | Private channel identifies one shared referent without sending it. |
+| 16 | landed | Megabyte channel proves 1 MB can travel through a 15-byte recipe/parameter channel. |
+| 17 | landed | Recipes-as-truth moves `seeded_bytes` semantics into `form-stdlib/seeded-bytes.fk`; the native is optimization tissue. |
+| 18 | landed | Channel negotiation agrees on recipe + payload referents and acknowledges the pair. |
+| 19 | landed | Addressable-cell Q/A returns an answer/reference capsule plus a novel private commitment. |
 
-This doc names the next 10 walks toward the universal translator's destination. Each is a small, shippable breath that extends a specific dimension of cross-modality.
+## Top 10 next combinations
 
-## The 10 next walks
+1. **CSV → Form-table → NL summary**: data grammar stays separate from code;
+   the output is a summary recipe, not a string-only artifact.
+2. **Parameterized image structural diff**: compare two #01 seeded SVGs and
+   prove the delta is the seed cell, not the byte churn.
+3. **Audio → melody recipe → re-synthesis**: extract pitch/rhythm from WAV,
+   re-emit with different timbre, score fidelity under a compute budget.
+4. **Image → NL → image loop**: describe a generated image, regenerate a new
+   image, and fuzzy-score feature survival.
+5. **One recipe → Python/Go/Rust/TypeScript**: emit native idiom in four target
+   languages from one Form source and run each target.
+6. **Multi-round cell dialogue**: chain #19 question capsules so cells can ask
+   clarifying questions before revealing any novel blueprint bytes.
+7. **External-resource fetch verification**: transmit URL/hash/recipe capsule
+   pointers for GitHub, archive.org, YouTube, or paste-like content; fetch only
+   when the receiver lacks the referent, then verify against the commitment.
+8. **Learned feature quantizer**: LLM or perceptron extracts a compact
+   feature-recipe from raw media; the kernel verifies the recipe, not the model.
+9. **Budgeted recipe search**: orchestrator chooses among codecs, emitters,
+   summarizers, and fuzzy validators on a Pareto frontier of fidelity/compute.
+10. **Framebuffer transport**: runtime memory frames become visual frames,
+    then recipes, then code again; state travels through a media surface.
 
-### 1. **Audio-as-recipe** (synthesis path) — **landed 2026-05-27**
+## Discipline
 
-A Form recipe that procedurally generates a `.wav` file. Same content-addressing claim as image-as-recipe: same recipe → same audio. Walks the "audio is a procedural artifact" frame.
+- Keep source data and executable recipes separate where the target language or
+  medium gives a natural data grammar.
+- Make every artifact parsable, compressible into Form objects, and emittable.
+- Minimize ice: prefer one recipe plus parameters over many frozen outputs.
+- Run `./validate.sh <sample>` for every kernel-walked `.fk` proof.
 
-**Landed:** [`06-audio-as-recipe/gen-sine.fk`](06-audio-as-recipe/gen-sine.fk) — 1-second 440 Hz tone, mono 8-bit PCM at 8000 Hz, 8044-byte WAV with sha256 `6d170ffe323b378ce29b886252105cb5e6d68e0bc1589160a472075afc635447`, byte-identical across Go/Rust/TS kernels. The walk also closed a sibling-parity gap: the TS kernel was missing `write_file_bytes`. Envelope and FM synthesis remain for future breaths.
-
-### 2. **Image-as-recipe — parameterized** — **landed 2026-05-27**
-
-A single recipe `(gen-circles seed)` takes one integer cell and emits a
-visibly distinct SVG. Five seeds (5, 86, 17, 138, 254) chosen so `(mod
-seed 5)` spans 0..4 — five distinct palettes — while count, radius, and
-y-baseline also vary.
-
-**Landed:** [`01-image-as-recipe/gradient-circles-seeded.fk`](01-image-as-recipe/gradient-circles-seeded.fk)
-emits five SVGs totalling 3614 bytes; three-way Go/Rust/TS kernel
-agreement on every seed (verified file-by-file with `cmp`). Each emission
-shares the same Form tree shape — `svg-document → svg-defs + svg-bg +
-circle-row + svg-text` — and differs only in the seed-derived sub-tree.
-
-The deeper proof (structural diff over two of the SVGs surfacing *only*
-the parameter cell as the delta, not the byte-level moves) is forward-map
-walk #7. This walk lays the parameter space; #7 will measure it.
-
-### 3. **NL→recipe broadened**
-
-Once `cross-modal-nl-to-recipe` lands, extend the NL grammar with one or two more operations: conditionals ("if X is greater than Y, …"), let-bindings ("let x equal 5; the square of x"). Shows the grammar can grow without changing its driver — the universal-translator scaling pattern.
-
-### 4. **Recipe→NL reverse** — **landed 2026-05-27**
-
-Walk a recipe NodeID and emit an English description. The reverse of #3. Together with #3, demonstrates **round-trip across the NL/recipe boundary** — the substrate-of-meaning is preserved through both translations.
-
-**Landed:** [`07-recipe-to-nl/recipe-to-nl.fk`](07-recipe-to-nl/recipe-to-nl.fk) — a 7-rule walker dispatching on `node_category` / `node_children` / `node_value` emits English for `(mul 7 7)` → `the square of seven`, `(add 4 6)` → `the sum of four and six`, nested `(mul (add 2 3) 4)` → `the product of the sum of two and three and four`, `(sub 0 12)` → `negative twelve`, `(mul 5 6)` → `the product of five and six`. Output written to `recipe-to-nl.txt`, byte-identical across Go/Rust/TS (sha256 `94555ee6a6fd8764838bcd934d2910d0e01b944a7654b3015b3ee35862aa5d7e`).
-
-**Round-trip claim attested.** The `(mul 5 6)` emission ("the product of five and six") parses back through `cm-parse` to the original NodeID — `node_eq=1` across all three kernels. **Structural round-trip across the NL/recipe boundary closes; the recipe NodeID is preserved exactly through walk → emit → parse → walk.**
-
-The honest gap: `(mul 7 7)` emits as `the square of seven`, not `the product of seven and seven`. The grammar at this altitude recognizes only `the product of … and …`, so `nl-square`'s round-trip is a *paraphrase* (substrate identity preserved, surface English differs). One breath of additive rule-mapping would close the lexical gap; the structural claim is already attested.
-
-### 5. **JSON-as-recipe** — *landed in default gate 2026-05-27 (#2105)*
-
-`form/form-stdlib/seedbank/grammars/json.fk` parses JSON to a Form Recipe
-three-way clean. Closure walk in #2105 added
-`form/form-stdlib/tests/json-grammar.fk` — a thin wrapper that names the
-seedbank grammar via a `; preludes:` header. The validate.sh auto-walker
-honors the header, runs three-way, and **JSON-as-recipe now runs on every
-default-gate breath**.
-
-```
-$ ./validate.sh
-  ...
-  ✓  stdlib/json-grammar.fk          → 36
-  ...
-  136 ok, 0 divergent — kernels agree on every sample.
-```
-
-Same shape as Breath 2e (already-landed, the body hadn't read its own
-attestation). The forward-map's #5 was a discipline walk, not a new proof:
-bring the existing attestation into the default sense-gate so the body
-knows itself on every breath.
-
-### 6. **CSV→Form-table→NL summary**
-
-CSV file → parsed via CSV grammar → recipe NodeID → walk via summary-generating recipe → English summary. **Cross-modal chain across three formats.** Shows that orchestration composes — each step is a recipe, the chain itself is a recipe.
-
-### 7. **Image structural diff**
-
-Take two procedural SVG recipes from #2's parameter space. Run the `04-universal-diff` over them. Show the diff highlights the parameter-level delta (which RNG seed changed), not the byte-level delta (every pixel that moved). **Structural diff IS semantic diff at the recipe altitude.**
-
-### 8. **Audio→melody recipe**
-
-Read a `.wav` file via an audio grammar; extract pitch+rhythm into a recipe; walk the recipe through a re-synthesis to produce a (different timbre, same melody) `.wav`. **Source-modality content extracted at semantic altitude, re-emitted in same modality.** Proves the "any source → recipe → any target" frame works within one modality (audio → audio).
-
-### 9. **Image→NL description→Image**
-
-The triangle of the universal translator made literal:
-1. Generate procedural SVG (recipe known)
-2. Walk a "describe this image" recipe over its content → NL description
-3. Walk an "image from description" recipe → new SVG
-4. Compare original and recreated — they won't byte-match, but they SHOULD content-address to similar Blueprint NodeIDs at the recipe-altitude (because both are circles-on-a-gradient).
-
-The honest finding will be: how close is the structural similarity? That's the **fidelity-for-compute-budget** test Urs named.
-
-### 10. **One recipe, three target languages**
-
-Take the factorial recipe (already proven Form-native and emitted to native Python in #2082). Add native-idiom emitters for: Go, Rust, TypeScript. **Same recipe, four target languages, one Form.** This is the universal-translator's clearest small proof: the recipe is the substrate; the target is a perspective.
-
-## What this enables
-
-When 5+ of these walks land, the body's cross-modal surface is genuinely *exercised*:
-- Three or more modalities (image, audio, text, data, code) all flow through Form recipes
-- Round-trips work in both directions for at least one modality pair
-- Structural diff distinguishes parameter changes from byte changes
-- One recipe, multiple emitters becomes a habit
-
-The destination — **any source → recipe orchestration → any target** — moves from "named" to "walked."
-
-## Discipline reminders
-
-- Each walk ships as its own PR with its own honest finding (success OR named gap)
-- Each adds a section to `form/form-samples/cross-modal/README.md`
-- Each runs through `./validate.sh` if it touches kernel-walked recipes
-- "Most surprising" lessons are as valuable as wins — the audit's #4 finding (CTOR vocabulary duplication) and the cross-modal agent's #3 finding (ice is 4.17× larger than water at small scale) both came from honest experiments that didn't go where intuition expected
-
-In service of [`lc-grammar-is-the-universal-recipe`](../../../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) + [`lc-cross-modal-unity`](../../../docs/vision-kb/concepts/lc-cross-modal-unity.md) + [`lc-the-kernel-knows-itself`](../../../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md).
+In service of [`lc-grammar-is-the-universal-recipe`](../../../docs/vision-kb/concepts/lc-grammar-is-the-universal-recipe.md) + [`lc-cross-modal-unity`](../../../docs/vision-kb/concepts/lc-cross-modal-unity.md) + [`lc-private-channel-via-substrate`](../../../docs/vision-kb/concepts/lc-private-channel-via-substrate.md).

--- a/form/form-samples/cross-modal/README.md
+++ b/form/form-samples/cross-modal/README.md
@@ -1,12 +1,12 @@
 # Cross-Modal Recipe Experiments
 
-Seven small demos exploring how Form recipes carry semantic content across
-modalities (text, structured data, image, audio, code, natural language).
-Each subdirectory has its own runnable sample and a README documenting
-what's reachable today, what surprised, and what's not yet reachable.
-**The point isn't to ship a universal translator** — it's to feel the
-body's current surface area for cross-modality and name the honest
-discoveries.
+Eighteen runnable demos exploring how Form recipes carry semantic content across
+modalities (text, structured data, image, audio, code, natural language,
+randomness, neural recipes, and private channels). Each subdirectory has its
+own runnable sample and a README documenting what's reachable today, what
+surprised, and what's not yet reachable. Number 12 is intentionally absent:
+the deterministic-doorway claim was composted by #13. The point is to keep the
+universal-translator goal walked by small proofs.
 
 | # | Experiment | One-line finding |
 |---|---|---|
@@ -17,6 +17,17 @@ discoveries.
 | 05 | [NL to recipe](05-nl-to-recipe/) | A 4-rule English grammar parses sentences into arithmetic recipes; NL `the square of 7` interns to the **same NodeID** as hand-built `(mul 7 7)`. |
 | 06 | [Audio as recipe](06-audio-as-recipe/) | A 1-second 440 Hz sine `.wav` composes from a 200-entry table + integer math; same recipe → byte-identical 8044-byte WAV across Go/Rust/TS kernels. Surfaced a sibling-parity gap: TS was missing `write_file_bytes`. |
 | 07 | [Recipe to NL](07-recipe-to-nl/) | A 7-rule walker emits English from arithmetic recipe NodeIDs (`(mul 5 6)` → `the product of five and six`). Round-trip with #05 closes structurally — `node_eq` proves the parsed-back NodeID matches the original; the surface English paraphrases (`square` ↔ `product of N and N`). |
+| 08 | [Feature-level translation](08-feature-level-translation/) | Prose → feature recipe → melody/SVG/tercet → re-extracted feature recipes; `323110` position-encodes which semantic axes survived across targets. |
+| 09 | [Fuzzy similarity cycles](09-fuzzy-similarity-cycles/) | Summarize/expand cycles use fuzzy membership math, not exact token equality, to measure perceived-value stability; three-way result `58879`. |
+| 10 | [Substrate as runtime](10-substrate-as-runtime/) | A one-layer tensor recipe walks as the translator runtime itself; weights and ops are substrate-resident recipes. |
+| 11 | [Randomness doorway](11-randomness-doorway/) | A committed entropy sample is a past field-touch held as lattice memory; deterministic replay selects a shared Blueprint. |
+| 13 | [Divergence as doorway](13-divergence-as-doorway/) | Live observer-local state must diverge across sibling kernels; divergence is the signal that the doorway is actually open. |
+| 14 | [Live entropy](14-live-entropy/) | `random_bytes(n)` reads `/dev/urandom` in Go/Rust/TS; validate divergence is success, not failure. |
+| 15 | [Private channel](15-private-channel/) | `(nonce, fingerprint)` lets a receiver identify a shared referent without the referent crossing the channel. |
+| 16 | [Megabyte channel](16-megabyte-channel/) | Two cells converge on a 1 MB payload through a 15-byte channel by sharing a seeded-bytes recipe and parameters. |
+| 17 | [Recipes as truth](17-recipes-as-truth/) | `seeded_bytes` semantics move into `form-stdlib/seeded-bytes.fk`; the native becomes optimization tissue backed by a default-gate parity proof. |
+| 18 | [Channel negotiation](18-channel-negotiation/) | Sender and receiver agree on both recipe and payload referents, acknowledge the pair, and still transmit neither referent. |
+| 19 | [Cell question answer](19-cell-question-answer/) | An addressable cell question resolves through shared catalogs, returns an answer/reference capsule, and carries an opaque novel commitment. |
 
 ## What every experiment shares
 
@@ -39,7 +50,7 @@ for d in form/form-samples/cross-modal/*/; do
 done
 ```
 
-## What the seven together teach
+## What the current set teaches
 
 The body's surface area for cross-modality is **smaller than the marketing
 slogan and larger than the engineering reflex**.
@@ -56,6 +67,10 @@ slogan and larger than the engineering reflex**.
   Experiments 02 and 04 show it directly. The same property extends to any
   surface tongue whose grammar lands as a Form recipe. The substrate is the
   universal translator; the tongues are dictionaries pointing at it.
+- **Newer**: exact equality is one altitude. Feature recipes (#08), fuzzy
+  stability (#09), live randomness (#13/#14), and private-channel consensus
+  (#15/#16/#18/#19) show how translation can preserve meaning under bounded loss,
+  observer-local entropy, and wire-minimized negotiation.
 
 The honest gap: at small scale, the ice is bigger than the water (experiment
 03). The compression intuition only pays off at scale, and only when many
@@ -71,24 +86,10 @@ The deeper teachings the body holds about all of this:
 - [`lc-form-kernel-runtime-visualizer`](../../../docs/vision-kb/concepts/lc-form-kernel-runtime-visualizer.md) — what falls out when the cross-modality reaches the runtime.
 - [`lc-one-kernel-many-tongues`](../../../docs/vision-kb/concepts/lc-one-kernel-many-tongues.md) — the multi-language sibling-kernel discipline.
 
-## Not in this directory (yet)
+## Not in this directory yet
 
-The reverse roundtrip — recipe → NL description — **landed in #07**.
-The remaining gap is *lexical* round-trip: the substrate identity
-preserves cleanly (`node_eq=1`) but `(mul 7 7)` emits as `the square
-of seven` and the symmetric grammar recognizes only `the product of N
-and N`. One breath of additive rule-mapping closes it.
-
-Remaining shapes from the cross-modal arc:
-
-- **CSV → Form-table → NL summary** (#6 in NEXT_BREATHS) — three-modality
-  chain.
-- **Image structural diff** (#7) — show structural diff highlights
-  parameter-level deltas, not pixel-level deltas.
-- **Audio → melody recipe → re-synthesis** (#8) — same-modality
-  round-trip with content extraction.
-- **Image → NL description → Image** (#9) — the triangle made literal.
-- **One recipe, four target languages** (#10) — universal-translator's
-  cleanest small proof.
-
-Naming what remains so the next breath has somewhere to land.
+The next gaps are named in [`NEXT_BREATHS.md`](NEXT_BREATHS.md): data grammar
+chains, structural media diff, audio semantic extraction, image/NL/image loops,
+multi-language native emission, external-resource fetch verification, and
+budgeted recipe orchestration. Naming what remains keeps the next breath
+parsable.

--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -106,7 +106,7 @@
     ;; reached yet.
 
     (defn py-binop-apply (op left right)
-        (if (str_eq op "+")  (add left right)
+        (if (str_eq op "+")  (_plus left right)
         (if (str_eq op "-")  (sub left right)
         (if (str_eq op "*")  (mul left right)
         (if (str_eq op "/")  (div left right)
@@ -121,24 +121,27 @@
         (if (str_eq op "<=") (if (le left right) 1 0)
         (if (str_eq op ">")  (if (gt left right) 1 0)
         (if (str_eq op ">=") (if (ge left right) 1 0)
-            (do (trace "py-compare: unsupported op" op) (head (empty))))))))))
+        (if (str_eq op "in") (py-container-contains left right)
+            (do (trace "py-compare: unsupported op" op) (head (empty)))))))))))
 
     ;; ---- the interpreter --------------------------------------------
     ;;
     ;; py-eval — walk a PY-BMF recipe to a value in env. Dispatch is by
     ;; node_category; each arm names its expected children shape.
     ;;
-    ;; py-eval-statement — variant that returns a (value . env) pair so
-    ;; ASSIGN and DEF can thread a new scope into the next statement.
-    ;; Expression statements return the unchanged env; ASSIGN and DEF
-    ;; extend it.
+    ;; py-eval-statement — variant that returns (value, env, return-flag)
+    ;; so ASSIGN and DEF can thread scope, while RETURN can escape nested
+    ;; IF/FOR/WHILE bodies instead of becoming an ordinary expression value.
     ;;
-    ;; The pair is encoded as (list value env) — head is value, head-tail
-    ;; is env. py-stmt-value and py-stmt-env read the two slots.
+    ;; The triple is encoded as (list value env return-flag). Flag 1 means a
+    ;; Python `return` has been observed and must propagate outward until the
+    ;; function/module boundary turns it into the function's value.
 
-    (defn py-stmt-result (value env) (list value env))
+    (defn py-stmt-result (value env) (list value env 0))
+    (defn py-stmt-return (value env) (list value env 1))
     (defn py-stmt-value (r) (head r))
     (defn py-stmt-env (r) (head (tail r)))
+    (defn py-stmt-return? (r) (nth r 2))
 
     (defn py-eval-args-loop (recipes env acc)
         (if (nil? recipes)
@@ -151,40 +154,56 @@
     (defn py-eval-args (recipes env)
         (py-eval-args-loop recipes env (empty)))
 
+    ;; ---- tiny builtins -----------------------------------------------
+    ;;
+    ;; These are Python-runtime library semantics, not kernel natives.
+    ;; They live in the Form interpreter so kernel-bmf rows can compost the
+    ;; TS bootstrap without expanding the kernel surface.
+
+    (defn py-range-loop (i end acc)
+        (if (ge i end) (reverse acc)
+            (py-range-loop (add i 1) end (cons i acc))))
+
+    (defn py-range (args)
+        (if (eq (len args) 1)
+            (py-range-loop 0 (head args) (empty))
+            (if (eq (len args) 2)
+                (py-range-loop (nth args 0) (nth args 1) (empty))
+                (do
+                    (trace "py-range: unsupported arity" (len args))
+                    (head (empty))))))
+
+    (defn py-sum-loop (xs acc)
+        (if (nil? xs) acc
+            (py-sum-loop (tail xs) (_plus acc (head xs)))))
+
+    (defn py-min-loop (xs best)
+        (if (nil? xs) best
+            (py-min-loop (tail xs)
+                (if (lt (head xs) best) (head xs) best))))
+
+    (defn py-max-loop (xs best)
+        (if (nil? xs) best
+            (py-max-loop (tail xs)
+                (if (gt (head xs) best) (head xs) best))))
+
+    (defn py-abs (x)
+        (if (lt x 0) (sub 0 x) x))
+
     ;; ---- collection values -------------------------------------------
     ;;
-    ;; PY-BMF-LIST values are plain Form lists. PY-BMF-DICT values are
-    ;; sentinel-tagged alists: (cons "py-dict" pairs) where each pair is
-    ;; a two-element list (key value). py-dict? lets SUBSCRIPT pick the
-    ;; right lookup path.
+    ;; PY-BMF-LIST values are plain Form lists. PY-BMF-DICT values use the
+    ;; same kernel-native dict encoding the bootstrap emitter uses:
+    ;; "__dict__", k1, v1, k2, v2, ...
 
-    (defn py-dict-tag () "py-dict")
+    (defn py-dict-tag () "__dict__")
 
-    ;; py-dict? — safe across kernels regardless of value kind. value_eq
-    ;; is polymorphic across Value variants (Int/Str/Null/etc) and returns
-    ;; false on kind mismatch; str_eq would panic on a non-string head.
-    ;; List literals routinely have int heads, so the polymorphic compare
-    ;; is the load-bearing piece.
-    (defn py-dict? (v)
-        (and (not (nil? v))
-             (value_eq (head v) (py-dict-tag))))
-
-    (defn py-dict-pairs (d) (tail d))
-
-    ;; Dict keys arrive as strings in today's surface; the lookup walks
-    ;; pairs with str_eq. Integer-keyed dicts are a later breath.
-    (defn py-dict-lookup-str-loop (pairs key)
-        (if (nil? pairs)
-            (do
-                (trace "py-dict-lookup: missing key" key)
-                (head (empty)))
-            (if (str_eq (head (head pairs)) key)
-                (head (tail (head pairs)))
-                (py-dict-lookup-str-loop (tail pairs) key))))
+    (defn py-container-contains (needle container)
+        (if (_in needle container) 1 0))
 
     ;; pairs-of-children: walk a flat (k1 v1 k2 v2 ...) child stream and
-    ;; eval each into a (key-value value-value) pair. Encoding: DICT
-    ;; children are 2*N recipes; even index = key-recipe, odd = value.
+    ;; eval each into the kernel-native flat dict shape:
+    ;;   "__dict__", k1, v1, k2, v2, ...
     (defn py-eval-dict-pairs-loop (kids env acc)
         (if (nil? kids)
             (reverse acc)
@@ -194,7 +213,7 @@
                 (py-eval-dict-pairs-loop
                     (tail (tail kids))
                     env
-                    (cons (list k v) acc)))))
+                    (cons v (cons k acc))))))
 
     (defn py-bind-params-loop (pms args env)
         (if (nil? pms) env
@@ -232,38 +251,69 @@
     (defn py-last (xs)
         (if (nil? (tail xs)) (head xs) (py-last (tail xs))))
 
-    ;; py-while-loop — drive a WHILE body, threading env until the cond
-    ;; recipe evaluates to 0. Each body iteration walks its statements
-    ;; through py-eval-statement (mutual recursion: py-while-loop calls
-    ;; py-eval-body-loop which calls py-eval-statement which calls back
-    ;; through py-while-loop when the body itself contains a WHILE). The
-    ;; Form runtime resolves forward references at call-time, so the
-    ;; ordering below works.
+    ;; Body drivers return the same statement triple. This lets `return`
+    ;; propagate through nested IF/FOR/WHILE bodies without losing the latest
+    ;; environment for non-returning bodies.
 
     (defn py-eval-body-loop (stmts env)
-        (if (nil? stmts) env
+        (if (nil? stmts) (py-stmt-result 0 env)
             (do
                 (let r (py-eval-statement (head stmts) env))
-                (py-eval-body-loop (tail stmts) (py-stmt-env r)))))
+                (if (eq (py-stmt-return? r) 1)
+                    r
+                    (py-eval-body-loop (tail stmts) (py-stmt-env r))))))
 
     (defn py-while-loop (cond-recipe body-stmts env)
         (if (eq (py-eval cond-recipe env) 0)
-            env
-            (py-while-loop
-                cond-recipe
-                body-stmts
-                (py-eval-body-loop body-stmts env))))
+            (py-stmt-result 0 env)
+            (do
+                (let body-result (py-eval-body-loop body-stmts env))
+                (if (eq (py-stmt-return? body-result) 1)
+                    body-result
+                    (py-while-loop
+                        cond-recipe
+                        body-stmts
+                        (py-stmt-env body-result))))))
+
+    (defn py-for-loop (items target-name body-stmts env)
+        (if (nil? items)
+            (py-stmt-result 0 env)
+            (do
+                (let item-env (py-env-extend env target-name (head items)))
+                (let body-result (py-eval-body-loop body-stmts item-env))
+                (if (eq (py-stmt-return? body-result) 1)
+                    body-result
+                    (py-for-loop
+                        (tail items)
+                        target-name
+                        body-stmts
+                        (py-stmt-env body-result))))))
 
     (defn py-eval-statement (recipe env)
         (do
             (let cat (node_category recipe))
             (let kids (node_children recipe))
+            (if (node_eq cat PY-BMF-RETURN)
+                (py-stmt-return (py-eval (head kids) env) env)
             (if (node_eq cat PY-BMF-ASSIGN)
                 (do
                     ;; ASSIGN children: name-leaf, value-recipe
                     (let name (node_value (nth kids 0)))
                     (let value (py-eval (nth kids 1) env))
                     (py-stmt-result value (py-env-extend env name value)))
+            (if (node_eq cat PY-BMF-SUB-ASSIGN)
+                (do
+                    ;; SUB-ASSIGN children: object-name-leaf, index-recipe,
+                    ;; value-recipe. Dict updates are persistent: rebind the
+                    ;; outer object name to an alist with one pair changed or
+                    ;; appended.
+                    (let object-name (node_value (nth kids 0)))
+                    (let old-object (py-env-lookup env object-name))
+                    (let idx (py-eval (nth kids 1) env))
+                    (let value (py-eval (nth kids 2) env))
+                    (let new-object (_dict_set old-object idx value))
+                    (py-stmt-result value
+                        (py-env-extend env object-name new-object)))
             (if (node_eq cat PY-BMF-AUG-ASSIGN)
                 (do
                     ;; AUG-ASSIGN children: name-leaf, op-leaf, value-recipe.
@@ -283,8 +333,26 @@
                     ;; itself returns 0 (Python None analogue).
                     (let cond-recipe (head kids))
                     (let body-stmts (tail kids))
-                    (let final-env (py-while-loop cond-recipe body-stmts env))
-                    (py-stmt-result 0 final-env))
+                    (py-while-loop cond-recipe body-stmts env))
+            (if (and (node_eq cat PY-BMF-IF)
+                     (node_eq (node_category (nth kids 1)) PY-BMF-MODULE))
+                (do
+                    ;; Statement-form IF uses PY-BMF-IF with module children:
+                    ;; cond, then-module, else-module. Expression-form IF is
+                    ;; handled by py-eval below.
+                    (let cond (py-eval (nth kids 0) env))
+                    (if (eq cond 0)
+                        (py-eval-body-loop (node_children (nth kids 2)) env)
+                        (py-eval-body-loop (node_children (nth kids 1)) env)))
+            (if (node_eq cat PY-BMF-FOR)
+                (do
+                    ;; FOR children: target-name-leaf, iter-recipe,
+                    ;; body-stmt-recipes... . List values iterate items;
+                    ;; dict values iterate insertion-ordered keys.
+                    (let target-name (node_value (nth kids 0)))
+                    (let iter-value (py-eval (nth kids 1) env))
+                    (let body-stmts (drop 2 kids))
+                    (py-for-loop (_iter iter-value) target-name body-stmts env))
             (if (node_eq cat PY-BMF-DEF)
                 (do
                     ;; DEF children: name-leaf, param-leaves..., body-recipe.
@@ -296,16 +364,18 @@
                     (let closure (py-closure name pms body env))
                     (py-stmt-result closure (py-env-extend env name closure)))
                 ;; Default: expression statement — eval, env unchanged.
-                (py-stmt-result (py-eval recipe env) env)))))))
+                (py-stmt-result (py-eval recipe env) env)))))))))))
 
     (defn py-eval-module-loop (statements env last-value)
         (if (nil? statements) last-value
             (do
                 (let r (py-eval-statement (head statements) env))
-                (py-eval-module-loop
-                    (tail statements)
-                    (py-stmt-env r)
-                    (py-stmt-value r)))))
+                (if (eq (py-stmt-return? r) 1)
+                    (py-stmt-value r)
+                    (py-eval-module-loop
+                        (tail statements)
+                        (py-stmt-env r)
+                        (py-stmt-value r))))))
 
     (defn py-eval (recipe env)
         (do
@@ -332,7 +402,7 @@
                     (let lhs-val (py-eval (nth kids 0) env))
                     (let rhs-val (py-eval (nth kids 1) env))
                     (let math-inst (node_inst cat))
-                    (if (eq math-inst 1) (add lhs-val rhs-val)
+                    (if (eq math-inst 1) (_plus lhs-val rhs-val)
                     (if (eq math-inst 2) (sub lhs-val rhs-val)
                     (if (eq math-inst 3) (mul lhs-val rhs-val)
                     (if (eq math-inst 4) (div lhs-val rhs-val)
@@ -396,17 +466,30 @@
                     ;; the function itself. Mutual recursion is a later
                     ;; breath — this carries single-function self-ref.
                     (let callee-name (node_value (head kids)))
-                    (let closure (py-env-lookup env callee-name))
                     (let arg-values (py-eval-args (tail kids) env))
-                    (let captured-with-self
-                        (py-env-extend (py-closure-env closure)
-                                       (py-closure-name closure)
-                                       closure))
-                    (let call-env (py-bind-params
-                                    (py-closure-params closure)
-                                    arg-values
-                                    captured-with-self))
-                    (py-eval (py-closure-body closure) call-env))
+                    (if (str_eq callee-name "range")
+                        (py-range arg-values)
+                    (if (str_eq callee-name "sum")
+                        (py-sum-loop (head arg-values) 0)
+                    (if (str_eq callee-name "min")
+                        (py-min-loop (tail (head arg-values)) (head (head arg-values)))
+                    (if (str_eq callee-name "max")
+                        (py-max-loop (tail (head arg-values)) (head (head arg-values)))
+                    (if (str_eq callee-name "abs")
+                        (py-abs (head arg-values))
+                    (if (str_eq callee-name "len")
+                        (len (head arg-values))
+                        (do
+                            (let closure (py-env-lookup env callee-name))
+                            (let captured-with-self
+                                (py-env-extend (py-closure-env closure)
+                                               (py-closure-name closure)
+                                               closure))
+                            (let call-env (py-bind-params
+                                            (py-closure-params closure)
+                                            arg-values
+                                            captured-with-self))
+                            (py-eval (py-closure-body closure) call-env)))))))))
             (if (node_eq cat PY-BMF-LIST)
                 ;; LIST children: element-recipes. Value is a Form list
                 ;; of evaluated elements, in source order.
@@ -424,9 +507,7 @@
                     ;; band-test exercises the common string-keyed case.
                     (let obj (py-eval (nth kids 0) env))
                     (let idx (py-eval (nth kids 1) env))
-                    (if (py-dict? obj)
-                        (py-dict-lookup-str-loop (py-dict-pairs obj) idx)
-                        (nth obj idx)))
+                    (_get obj idx))
             (if (node_eq cat PY-BMF-LAMBDA)
                 ;; LAMBDA children: param-leaves..., body-recipe.
                 ;; Builds an anonymous closure with self-name "" so the

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -15,6 +15,7 @@
 ; Inside an expression (G3 — precedence climbing over the token list):
 ;
 ;     integer literal             → PY-BMF-INT
+;     string literal              → PY-BMF-STRING
 ;     identifier                  → PY-BMF-IDENT
 ;     identifier (args)           → PY-BMF-CALL
 ;     ( expr )                    → grouped expression
@@ -27,14 +28,16 @@
 ;                                    (1 / 0 / 0 — matches the interpreter's
 ;                                    int-as-bool convention).
 ;     [ a, b, c ]                 → PY-BMF-LIST (interpreter arm exists).
+;     { k: v }                    → PY-BMF-DICT (interpreter arm exists).
 ;     expr [ idx ]                → PY-BMF-SUBSCRIPT (interpreter arm exists).
+;     lambda args: expr           → PY-BMF-LAMBDA (interpreter arm exists).
 ;     while-statement             → PY-BMF-WHILE (interpreter arm exists).
 ;
 ; What does NOT lift yet (honest pending, surfaces on the next breath):
 ;
 ;     class / for / try / with / import / from-import,
-;     dicts / tuples / sets, attribute access,
-;     method calls, lambdas, augmented assignment, multi-target
+;     tuples / sets, attribute access,
+;     method calls, multi-target
 ;     assignment, decorators, comprehensions, f-strings, slices,
 ;     async / yield / global / nonlocal, type annotations.
 ;
@@ -98,6 +101,7 @@
     (defn tok-keyword? (t kw) (tok-is? t "py-keyword" kw))
     (defn tok-name? (t) (str_eq (tok-kind t) "py-name"))
     (defn tok-int? (t) (str_eq (tok-kind t) "py-int"))
+    (defn tok-string? (t) (str_eq (tok-kind t) "py-string"))
 
     ;; ---- expression parser (G3) -------------------------------------
     ;;
@@ -154,6 +158,56 @@
 
     (defn lift-list-elements (tokens) (lift-list-elements-loop tokens (empty)))
 
+    ;; --- dict literal: consume `{ key: value, ... }` ----------------
+    ;;
+    ;; Children are flat key/value recipes: k1 v1 k2 v2 ... . The eval
+    ;; side tags the resulting alist so SUBSCRIPT, FOR, len, and `in`
+    ;; can choose dict semantics without changing the kernel.
+
+    (defn lift-dict-pairs-loop (tokens acc)
+        (if (nil? tokens)
+            (lift-result (reverse acc) tokens)
+            (if (tok-op? (head tokens) "}")
+                (lift-result (reverse acc) (tail tokens))
+                (do
+                    (let key-result (lift-expr tokens))
+                    (let after-key (lift-rest key-result))
+                    (if (and (not (nil? after-key))
+                             (tok-op? (head after-key) ":"))
+                        (do
+                            (let value-result (lift-expr (tail after-key)))
+                            (let next (lift-rest value-result))
+                            (let acc2
+                                (cons (lift-recipe value-result)
+                                      (cons (lift-recipe key-result) acc)))
+                            (if (and (not (nil? next))
+                                     (tok-op? (head next) ","))
+                                (lift-dict-pairs-loop (tail next) acc2)
+                                (lift-dict-pairs-loop next acc2)))
+                        (lift-result (reverse acc) after-key))))))
+
+    (defn lift-dict-pairs (tokens) (lift-dict-pairs-loop tokens (empty)))
+
+    ;; --- lambda expression: consume `lambda a, b: expr` -------------
+
+    (defn lift-lambda-params-loop (tokens acc)
+        (if (nil? tokens)
+            (lift-result (reverse acc) tokens)
+            (do
+                (let t (head tokens))
+                (if (tok-op? t ":")
+                    (lift-result (reverse acc) (tail tokens))
+                    (if (tok-op? t ",")
+                        (lift-lambda-params-loop (tail tokens) acc)
+                        (if (tok-name? t)
+                            (lift-lambda-params-loop
+                                (tail tokens)
+                                (cons (intern_trivial_string (tok-value t)) acc))
+                            (lift-lambda-params-loop (tail tokens) acc)))))))
+
+    (defn lift-lambda-params (tokens)
+        (lift-lambda-params-loop tokens (empty)))
+
     ;; --- subscript postfix: fold `[ idx ]` trailers onto a primary -
     ;;
     ;; After lift-primary parses a base recipe, peek for `[`. If present,
@@ -192,6 +246,11 @@
                 (lift-subscript-tail
                     (intern_node PY-BMF-INT
                         (list (intern_trivial_int (str_to_int (tok-value t)))))
+                    rest)
+            (if (tok-string? t)
+                (lift-subscript-tail
+                    (intern_node PY-BMF-STRING
+                        (list (intern_trivial_string (tok-value t))))
                     rest)
             (if (tok-keyword? t "True")
                 ;; True → PY-BMF-INT(1). Matches the interpreter's
@@ -237,6 +296,21 @@
                     (lift-subscript-tail
                         (intern_node PY-BMF-LIST (lift-recipe elems-result))
                         (lift-rest elems-result)))
+            (if (tok-op? t "{")
+                (do
+                    (let pairs-result (lift-dict-pairs rest))
+                    (lift-subscript-tail
+                        (intern_node PY-BMF-DICT (lift-recipe pairs-result))
+                        (lift-rest pairs-result)))
+            (if (tok-keyword? t "lambda")
+                (do
+                    (let params-result (lift-lambda-params rest))
+                    (let body-result (lift-expr (lift-rest params-result)))
+                    (lift-subscript-tail
+                        (intern_node PY-BMF-LAMBDA
+                            (append (lift-recipe params-result)
+                                    (list (lift-recipe body-result))))
+                        (lift-rest body-result)))
             (if (tok-op? t "(")
                 ;; parenthesised expression: parse inner, consume ")"
                 (do
@@ -251,7 +325,7 @@
                            (list (tok-kind t) (tok-value t)))
                     (lift-result
                         (intern_node PY-BMF-PASS (empty))
-                        rest))))))))))))
+                        rest)))))))))))))))
 
     ;; --- operator precedence ---------------------------------------
     ;;
@@ -274,7 +348,8 @@
         (if (str_eq s "<=") 20
         (if (str_eq s ">")  20
         (if (str_eq s ">=") 20
-            (sub 0 1)))))))))))))))
+        (if (str_eq s "in") 20
+            (sub 0 1))))))))))))))))
 
     (defn op-is-compare? (s)
         (or (str_eq s "==")
@@ -282,13 +357,15 @@
         (or (str_eq s "<")
         (or (str_eq s "<=")
         (or (str_eq s ">")
-            (str_eq s ">=")))))))
+        (or (str_eq s ">=")
+            (str_eq s "in"))))))))
 
     (defn tok-binop-prec (tokens)
         (if (nil? tokens) (sub 0 1)
             (do
                 (let t (head tokens))
-                (if (str_eq (tok-kind t) "py-op")
+                (if (or (str_eq (tok-kind t) "py-op")
+                        (str_eq (tok-kind t) "py-keyword"))
                     (op-prec (tok-value t))
                     (sub 0 1)))))
 
@@ -482,6 +559,84 @@
             (intern_node PY-BMF-ASSIGN
                 (list (intern_trivial_string name) value))))
 
+    ;; subscript assignment: `NAME[IDX] = EXPR`.
+
+    (defn lift-sub-assign? (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (and (gt (len tokens) 5)
+                 (and (tok-name? (head tokens))
+                      (and (tok-op? (nth tokens 1) "[")
+                           (do
+                               (let idx-result (lift-expr (drop 2 tokens)))
+                               (let after-idx (lift-rest idx-result))
+                               (let after-close
+                                   (if (and (not (nil? after-idx))
+                                            (tok-op? (head after-idx) "]"))
+                                       (tail after-idx)
+                                       after-idx))
+                               (and (not (nil? after-close))
+                                    (tok-op? (head after-close) "="))))))))
+
+    (defn lift-sub-assign (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let object-name (tok-value (head tokens)))
+            (let idx-result (lift-expr (drop 2 tokens)))
+            (let after-idx (lift-rest idx-result))
+            (let after-close
+                (if (and (not (nil? after-idx))
+                         (tok-op? (head after-idx) "]"))
+                    (tail after-idx)
+                    after-idx))
+            (let value-tokens
+                (if (and (not (nil? after-close))
+                         (tok-op? (head after-close) "="))
+                    (tail after-close)
+                    after-close))
+            (let value (lift-recipe (lift-expr value-tokens)))
+            (intern_node PY-BMF-SUB-ASSIGN
+                (list (intern_trivial_string object-name)
+                      (lift-recipe idx-result)
+                      value))))
+
+    ;; augmented assignment: `NAME += EXPR` / `NAME -= EXPR` / ...
+    ;; Emits the already-walked PY-BMF-AUG-ASSIGN shape with the base op
+    ;; string (`+`, `-`, `*`, `/`, `%`) as the middle child.
+
+    (defn lift-aug-op? (op)
+        (or (str_eq op "+=")
+        (or (str_eq op "-=")
+        (or (str_eq op "*=")
+        (or (str_eq op "/=")
+            (str_eq op "%="))))))
+
+    (defn lift-aug-base-op (op)
+        (if (str_eq op "+=") "+"
+        (if (str_eq op "-=") "-"
+        (if (str_eq op "*=") "*"
+        (if (str_eq op "/=") "/"
+        (if (str_eq op "%=") "%"
+            op))))))
+
+    (defn lift-aug-assign? (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (and (gt (len tokens) 2)
+                 (and (tok-name? (head tokens))
+                      (lift-aug-op? (tok-value (nth tokens 1)))))))
+
+    (defn lift-aug-assign (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let name (tok-value (head tokens)))
+            (let op (lift-aug-base-op (tok-value (nth tokens 1))))
+            (let value (lift-recipe (lift-expr (drop 2 tokens))))
+            (intern_node PY-BMF-AUG-ASSIGN
+                (list (intern_trivial_string name)
+                      (intern_trivial_string op)
+                      value))))
+
     ;; expr-statement: just an expression in statement position.
 
     (defn lift-expr-stmt (statement-tree)
@@ -521,6 +676,43 @@
             (let body-recipes (lift-statements children))
             (intern_node PY-BMF-WHILE (cons cond body-recipes))))
 
+    ;; if-statement: tokens look like `if <cond-tokens> :`. The body is
+    ;; represented as a PY-BMF-MODULE child so the evaluator can distinguish
+    ;; statement-form IF from expression-form ternary IF.
+
+    (defn lift-if-cond-tokens (tokens)
+        (lift-while-strip-colon (tail tokens) (empty)))
+
+    (defn lift-if (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let children (python-statement-tree-children statement-tree))
+            (let cond-tokens (lift-if-cond-tokens tokens))
+            (let cond (lift-recipe (lift-expr cond-tokens)))
+            (let then-body (intern_node PY-BMF-MODULE (lift-statements children)))
+            (let else-body (intern_node PY-BMF-MODULE (empty)))
+            (intern_node PY-BMF-IF (list cond then-body else-body))))
+
+    ;; for-statement: tokens look like `for NAME in <iter-expr> :`. This first
+    ;; Form-native breath supports list-valued iterables; range/builtin
+    ;; iterators are a later row.
+
+    (defn lift-for-iter-tokens (tokens)
+        (lift-while-strip-colon (drop 3 tokens) (empty)))
+
+    (defn lift-for (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let children (python-statement-tree-children statement-tree))
+            (let target (tok-value (nth tokens 1)))
+            (let iter-tokens (lift-for-iter-tokens tokens))
+            (let iter-recipe (lift-recipe (lift-expr iter-tokens)))
+            (let body-recipes (lift-statements children))
+            (intern_node PY-BMF-FOR
+                (append
+                    (list (intern_trivial_string target) iter-recipe)
+                    body-recipes))))
+
     ;; lift-statement dispatches on both `kind` (first-token classifier) and
     ;; `cpython-rule` (the richer rule-name based on token shape). Examples:
     ;;   `x = 5`        — kind "expr", cpython-rule "assignment"
@@ -536,12 +728,16 @@
             (let rule (python-statement-tree-cpython-rule statement-tree))
             (if (str_eq kind "def")              (lift-def statement-tree)
             (if (str_eq kind "return")           (lift-return statement-tree)
+            (if (str_eq kind "if")               (lift-if statement-tree)
             (if (str_eq kind "while")            (lift-while statement-tree)
+            (if (str_eq kind "for")              (lift-for statement-tree)
+            (if (lift-sub-assign? statement-tree) (lift-sub-assign statement-tree)
+            (if (lift-aug-assign? statement-tree) (lift-aug-assign statement-tree)
             (if (str_eq rule "assignment")       (lift-assign statement-tree)
             (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
                 (do
                     (trace "lift-statement: unsupported kind/rule" (list kind rule))
-                    (intern_node PY-BMF-PASS (empty))))))))))
+                    (intern_node PY-BMF-PASS (empty))))))))))))))
 
     ;; ---- module lifter (the public surface) ------------------------
     ;;

--- a/form/form-stdlib/seeded-bytes.fk
+++ b/form/form-stdlib/seeded-bytes.fk
@@ -1,0 +1,31 @@
+; seeded-bytes.fk — canonical Form recipe for deterministic byte streams.
+;
+; The native `seeded_bytes(seed, count)` remains optimization tissue while
+; interpreter/JIT speed catches up. This recipe owns the semantics: glibc-style
+; LCG, state = state * 1103515245 + 12345 mod 2^31, emitting low bytes.
+
+(defn seeded-bytes-empty? (xs)
+    (eq (len xs) 0))
+
+(defn seeded-bytes-lcg-step (state)
+    (add_mod_u64
+        (mul_mod_u64 state 1103515245 2147483648)
+        12345
+        2147483648))
+
+(defn seeded-bytes-loop (state n acc)
+    (if (eq n 0) acc
+        (do
+            (let next (seeded-bytes-lcg-step state))
+            (seeded-bytes-loop next (sub n 1) (cons (mod next 256) acc)))))
+
+(defn seeded-bytes-reverse-loop (xs acc)
+    (if (seeded-bytes-empty? xs) acc
+        (seeded-bytes-reverse-loop (tail xs) (cons (head xs) acc))))
+
+(defn seeded-bytes-recipe (seed count)
+    (seeded-bytes-reverse-loop
+        (seeded-bytes-loop seed count (empty))
+        (empty)))
+
+0

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -186,12 +186,102 @@ sign(5) + sign(0 - 3) + 5
     (let lifted-mod (head (node_children lifted-mod-module)))
     (let cell12-score (if (node_eq handbuilt-mod lifted-mod) 10000 0))
 
+    ;; ---- cell 13: statement IF + early RETURN propagation -----------
+    ;; CPython:
+    ;;   pick(0) + pick(1) + pick(2) = 100 + 50 + 7 = 157
+    ;; This proves statement-form IF bodies return through nested module
+    ;; walks instead of becoming ordinary expression values.
+
+    (let cell13-value (py-bmf-run-text "def pick(n):
+    if n == 0:
+        return 100
+    if n == 1:
+        return 50
+    return 7
+pick(0) + pick(1) + pick(2)
+"))
+    (let cell13-score (if (eq cell13-value 157) 13000 0))
+
+    ;; ---- cell 14: FOR + range + augmented assignment + builtins -----
+    ;; Mirrors python_builtins_demo.py:
+    ;;   sum(xs)=69, min=3, max=22, distance-to-10=37 => 131.
+
+    (let cell14-value (py-bmf-run-text "def dist(xs, target):
+    d = 0
+    for v in xs:
+        d += abs(v - target)
+    return d
+xs = [3, 17, 8, 22, 5, 14]
+sum(xs) + min(xs) + max(xs) + dist(xs, 10)
+"))
+    (let cell14-score (if (eq cell14-value 131) 14000 0))
+
+    ;; ---- cell 15: lambda values in vars/lists + higher-order call ---
+    ;; Mirrors python_lambda_demo.py. Lambdas are runtime closures; list
+    ;; iteration carries them through the same value channel as ints.
+
+    (let cell15-value (py-bmf-run-text "double = lambda x: x * 2
+add = lambda a, b: a + b
+sq = lambda n: n * n
+result = add(double(5), sq(6))
+fns = [double, sq, lambda x: x + 100]
+out = 0
+for f in fns:
+    out += f(7)
+result + out
+"))
+    (let cell15-score (if (eq cell15-value 216) 15000 0))
+
+    ;; ---- cell 16: string literal + polymorphic plus + len -----------
+    ;; Mirrors python_string_demo.py. `+` routes through the kernel's
+    ;; polymorphic `_plus` while Form-native CALL handles Python `len`.
+
+    (let cell16-value (py-bmf-run-text "def greet(name):
+    return \"hello, \" + name
+def banner_length(name, decoration):
+    msg = greet(name) + decoration
+    return len(msg)
+a = banner_length(\"world\", \"!\")
+b = banner_length(\"substrate\", \"!!!\")
+c = banner_length(\"kernel\", \"\")
+a + b + c
+"))
+    (let cell16-score (if (eq cell16-value 45) 16000 0))
+
+    ;; ---- cell 17: dict literal/read/write/in/iteration --------------
+    ;; Mirrors python_dict_demo.py's scalar proof:
+    ;;   7 + 11 + 43 + 1 + 0 + 22 + 4 = 88.
+
+    (let cell17-value (py-bmf-run-text "def score_response(payload):
+    out = {\"signal\": payload[\"signal\"], \"vitality\": payload[\"vitality\"]}
+    out[\"weighted\"] = out[\"signal\"] * 3 + out[\"vitality\"] * 2
+    return out
+req = {\"signal\": 7, \"vitality\": 11}
+resp = score_response(req)
+s = resp[\"signal\"]
+v = resp[\"vitality\"]
+w = resp[\"weighted\"]
+has_w = \"weighted\" in resp
+has_x = \"missing\" in resp
+key_chars = 0
+for k in resp:
+    key_chars = key_chars + len(k)
+resp[\"scope\"] = 4
+n_keys = len(resp)
+s + v + w + (1 if has_w else 0) + (1 if has_x else 0) + key_chars + n_keys
+"))
+    (let cell17-score (if (eq cell17-value 88) 17000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
-    ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000 = 75000
+    ;; arithmetic (cell 10), comparison (cell 11), mod (cell 12), and
+    ;; the Form-native Python runtime rows through dict/lambda/string
+    ;; semantics (cells 13-17):
+    ;;   previous 75000 + 13000+14000+15000+16000+17000 = 150000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
-               cell10-score cell11-score cell12-score)))
+               cell10-score cell11-score cell12-score
+               cell13-score cell14-score cell15-score
+               cell16-score cell17-score)))

--- a/form/form-stdlib/tests/seeded-bytes-recipe-band.fk
+++ b/form/form-stdlib/tests/seeded-bytes-recipe-band.fk
@@ -1,0 +1,23 @@
+; seeded-bytes-recipe-band.fk — seeded_bytes native is optimization tissue.
+;
+; The Form recipe in form-stdlib/seeded-bytes.fk must remain byte-equivalent
+; to the native across sibling kernels. The native can then compost behind JIT
+; or pattern dispatch without changing meaning.
+;
+; preludes: form-stdlib/seeded-bytes.fk
+
+(do
+    (let native-sum-42 (sum_bytes_list (seeded_bytes 42 100)))
+    (let recipe-sum-42 (sum_bytes_list (seeded-bytes-recipe 42 100)))
+    (let score-42
+        (if (eq native-sum-42 recipe-sum-42) 100 0))
+
+    (let native-sum-7 (sum_bytes_list (seeded_bytes 7 17)))
+    (let recipe-sum-7 (sum_bytes_list (seeded-bytes-recipe 7 17)))
+    (let score-7
+        (if (eq native-sum-7 recipe-sum-7) 10 0))
+
+    (let zero-len-score
+        (if (eq (len (seeded-bytes-recipe 99 0)) 0) 1 0))
+
+    (add (add score-42 score-7) zero-len-score))

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -148,6 +148,10 @@ run_workload() {
     fi
 }
 
+declared_preludes() {
+    grep -E '^; preludes:' "$1" 2>/dev/null | head -1 | sed 's/^; preludes://' || true
+}
+
 ok=0
 fail=0
 
@@ -162,7 +166,17 @@ if [[ $# -gt 0 ]]; then
             label="$label+$base"
         fi
     done
-    run_workload "$label" "$@"
+    if [[ $# -eq 1 ]]; then
+        preludes=$(declared_preludes "$1")
+        if [[ -n "$preludes" ]]; then
+            # shellcheck disable=SC2086
+            run_workload "$label" "form-stdlib/core.fk" $preludes "$1"
+        else
+            run_workload "$label" "$@"
+        fi
+    else
+        run_workload "$label" "$@"
+    fi
 else
     # --- form-samples/*.fk: self-contained files ------------------------
     for f in form-samples/*.fk; do
@@ -185,7 +199,7 @@ else
             # When present, those modules load between core.fk and the test
             # (in the order declared). The same-name convention still works
             # — modules referenced by the header replace the auto-prepend.
-            preludes=$(grep -E '^; preludes:' "$f" 2>/dev/null | head -1 | sed 's/^; preludes://' || true)
+            preludes=$(declared_preludes "$f")
             if [[ -n "$preludes" ]]; then
                 # shellcheck disable=SC2086
                 run_workload "stdlib/$(basename "$f")" "form-stdlib/core.fk" $preludes "$f"

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -233,9 +233,9 @@ confirm Shape 2 classification + LOC count.
   every existing gate runs unchanged.
 - `kernel-bmf` (the destination) — invokes `kernel-bmf-run <source.py>`,
   expecting the binary to read `.py` via `form-stdlib/grammars/python-bmf.fk`
-  and execute via Form-native walker. **The binary doesn't exist yet.** The
-  parity script prints a clear "deferred" message naming the file the
-  Form-native path must learn to compile.
+  and execute via Form-native walker. The binary exists and is now part of the
+  diagnostic matrix; rows that fail under `kernel-bmf` remain row failures
+  instead of aborting the suite.
 
 Switching the default from `ts-eval` to `kernel-bmf` is the single env-var
 change that flips the third runtime. Each demo gets promoted individually
@@ -245,6 +245,30 @@ are residue.
 
 The same selector shape can extend to the TS adapter parity gate
 (`PARITY_THIRD_RUNTIME` over `ts-eval` vs `kernel-bmf-ts`).
+
+---
+
+## Current kernel-bmf frontier — 2026-05-28
+
+`PARITY_THIRD_RUNTIME=kernel-bmf ./scripts/parity_suite.sh` now completes the
+full Python matrix and reports the frontier instead of stopping at the first
+nonzero row.
+
+- Ready: 4/19 demos are COMPOST READY under `kernel-bmf`:
+  `python_bridge_demo.py`, `python_demo.py`, `python_assign_demo.py`,
+  `python_imperative_demo.py`.
+- First open row: `examples/python_substrate_demo.py`.
+- Observed trace: three `if_stmt` lifts are unsupported, two `for_stmt` lifts
+  are unsupported, and the evaluator then reaches an unimplemented recipe
+  category before returning `0`.
+- Required next arm bundle: statement-level `if` lift/eval, `for` lift/eval
+  over lists/ranges, and return propagation through nested statement bodies so
+  early-return Python helpers keep CPython semantics.
+
+This is the biggest named tightness because it attacks
+`form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts` directly: each
+green row removes surface from the hand-coded Python adapter rather than adding
+another algorithm native.
 
 ---
 
@@ -321,18 +345,18 @@ returns the statement count (15), not the program's CPython value (40949).
 The driver swaps to a recipe-walking expression in the same script when G4
 (closure interpreter) lands; the orchestration shape stays.
 
-**Open contract for the next PROVEN rows:** the surface beyond the 9 arms
-needs both a lift dispatch branch in `python-bmf-lift.fk` and a matching
-interpreter arm in `python-bmf-eval.fk`. Order of incoming breaths (each is
-its own focused PR):
+**Open contract for the next PROVEN rows:** the surface beyond the four
+COMPOST READY demos needs both a lift dispatch branch in
+`python-bmf-lift.fk` and a matching interpreter arm in
+`python-bmf-eval.fk`. Order of incoming breaths (each is its own focused PR):
 
-- `PY-BMF-WHILE` + while-statement lift — `while cond: body`
-- `PY-BMF-LIST` + list-literal lift + `PY-BMF-SUBSCRIPT` for `xs[i]`
-- `PY-BMF-DICT` + dict-literal lift + key access
-- `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`
-- `PY-BMF-FOR` + iterator protocol on lists / ranges
-- `PY-BMF-LAMBDA` + closure capture in expressions
-- `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment
+- Statement-level `if` + return propagation through nested bodies — first
+  blocker for `python_substrate_demo.py`.
+- `PY-BMF-FOR` + iterator protocol on lists / ranges — same first blocker.
+- `PY-BMF-DICT` + dict-literal lift + key access.
+- `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`.
+- `PY-BMF-LAMBDA` + closure capture in expressions.
+- `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment.
 
 Each PROVEN row brings one more `PARITY_FILES` demo green under
 `PARITY_THIRD_RUNTIME=kernel-bmf`. When `lang-python.ts`'s full surface is

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -254,21 +254,22 @@ The same selector shape can extend to the TS adapter parity gate
 full Python matrix and reports the frontier instead of stopping at the first
 nonzero row.
 
-- Ready: 4/19 demos are COMPOST READY under `kernel-bmf`:
-  `python_bridge_demo.py`, `python_demo.py`, `python_assign_demo.py`,
-  `python_imperative_demo.py`.
-- First open row: `examples/python_substrate_demo.py`.
-- Observed trace: three `if_stmt` lifts are unsupported, two `for_stmt` lifts
-  are unsupported, and the evaluator then reaches an unimplemented recipe
-  category before returning `0`.
-- Required next arm bundle: statement-level `if` lift/eval, `for` lift/eval
-  over lists/ranges, and return propagation through nested statement bodies so
-  early-return Python helpers keep CPython semantics.
+- Ready: **13/19 demos are COMPOST READY** under `kernel-bmf`.
+- First open row: `examples/python_float_demo.py`.
+- Newly released shape bundle: statement-level `if`, `for`, return
+  propagation, `range`, `sum`/`min`/`max`/`abs`, augmented assignment,
+  lambda closures, string literals/concat/`len`, dict literal/read/write,
+  `in` membership, dict-key iteration, and the lattice-stats endpoint shape.
+- Required next arm bundle: float source scanning + Form-native float literal
+  values, then import/attribute access for `math`, followed by class,
+  inheritance, and typing-composition surfaces.
 
 This is the biggest named tightness because it attacks
 `form/form-kernel-ts/seedbank/python-adapter/src/lang-python.ts` directly: each
 green row removes surface from the hand-coded Python adapter rather than adding
-another algorithm native.
+another algorithm native. The only kernel-side edit in the 13/19 breath is
+Go sibling parity for dict/list/string polymorphic natives already present in
+Rust and TypeScript (`_get`, `_iter`, `_in`, `_dict_*`).
 
 ---
 
@@ -335,6 +336,7 @@ ritual.
 | 2026-05-27 | [#2113](https://github.com/seeker71/Coherence-Network/pull/2113) | CTOR Shape B for `+ - * /`. The PY-BMF lift now interns `+ - * /` as `RBasic.MATH-12` (NodeIDs `(1, 2, 12, 1..4)`) with positional children — the *same* Blueprint a hand-built `(intern_node MATH-PLUS …)` interns to. **Cross-modal NodeID equality at the math-primitive layer becomes substrate-truth for arithmetic.** New MATH-12 arm in `python-bmf-eval.fk` walks the unified shape; old `PY-BMF-BINOP` arm still services `** // %` (no MATH instances exist for those today). | Cell 10 of `python-bmf-lift-band.fk` builds a hand-built `MATH-PLUS(7, 3)` and a Python-lifted `"7 + 3"`; `node_eq` returns 1 across all three kernels. Aggregate moves 45000 → 55000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
 | 2026-05-27 | [#2119](https://github.com/seeker71/Coherence-Network/pull/2119) | CTOR Shape B extends to comparisons — `== != < <= > >=`. The PY-BMF lift now interns comparisons as `RBasic.COMPARE-13` (NodeIDs `(1, 2, 13, 1..6)`) with positional children. New COMPARE-13 arm in `py-eval` dispatches on `node_inst` to `eq`/`lt`/`le`/`gt`/`ge` natives (Python's 1/0 integer convention preserved). Old `PY-BMF-COMPARE` arm stays for unrecognised ops (defensive) | Cell 11 of `python-bmf-lift-band.fk` proves convergence: hand-built `COMPARE-LT(5, 7)` and Python-lifted `"5 < 7"` `node_eq` to 1 across all three kernels. Aggregate moves 55000 → 65000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
 | 2026-05-27 | [#2122](https://github.com/seeker71/Coherence-Network/pull/2122) | CTOR Shape B extends to `%` (mod) — closes the last arithmetic operator MATH-12 carries today (`inst=5`). Lift dispatcher gains the `%` case before falling back to `PY-BMF-BINOP`; eval MATH-12 arm gains the `(if (eq math-inst 5) (mod lhs rhs))` branch. What's still on `PY-BMF-BINOP` for arithmetic: `**` (power) and `//` (floor-div) — no MATH instances exist for those today; closing them is a separate breath that adds inst=6,7 to `form-ontology.json` + native registration in three kernels | Cell 12 of `python-bmf-lift-band.fk` proves: hand-built `MATH-MOD(10, 3)` and Python-lifted `"10 % 3"` `node_eq` to 1 across all three kernels. Aggregate moves 65000 → 75000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
+| 2026-05-28 | `codex/universal-transport-week-review-20260528` | Form-native Python runtime widens from 4/19 to 13/19. Lift/eval now covers statement `if`, `for`, return propagation, augmented assignment, lambdas, strings, dict literals, subscript assignment, `in`, dict-key iteration, and Python builtins `range`, `sum`, `min`, `max`, `abs`, `len`. Go gains the dict/list/string polymorphic natives already present in Rust/TypeScript so sibling kernels agree on the same Form-native dict surface. | `form/form-stdlib/tests/python-bmf-lift-band.fk` extends to 17 cells and returns `150000`. End-to-end `kernel-bmf-run` now matches CPython/bootstrap for `python_substrate_demo.py=17680`, `python_range_demo.py=41650`, `python_builtins_demo.py=131`, `python_lambda_demo.py=216`, `python_string_demo.py=45`, `python_dict_demo.py=88`, `endpoint_coherence_weight_demo.py=16185`, and `endpoint_lattice_stats_demo.py=1089`. | Go ✓ · Rust ✓ · TypeScript ✓ for the band; parity matrix: 13 passing / 6 open under `PARITY_THIRD_RUNTIME=kernel-bmf` |
 
 **What G6 closes and what stays open.** G6 was the orchestration gap — the
 pieces existed (Go compiler, Rust walker, Python BMF grammar) with no binary
@@ -345,18 +347,18 @@ returns the statement count (15), not the program's CPython value (40949).
 The driver swaps to a recipe-walking expression in the same script when G4
 (closure interpreter) lands; the orchestration shape stays.
 
-**Open contract for the next PROVEN rows:** the surface beyond the four
+**Open contract for the next PROVEN rows:** the surface beyond the thirteen
 COMPOST READY demos needs both a lift dispatch branch in
 `python-bmf-lift.fk` and a matching interpreter arm in
 `python-bmf-eval.fk`. Order of incoming breaths (each is its own focused PR):
 
-- Statement-level `if` + return propagation through nested bodies — first
-  blocker for `python_substrate_demo.py`.
-- `PY-BMF-FOR` + iterator protocol on lists / ranges — same first blocker.
-- `PY-BMF-DICT` + dict-literal lift + key access.
+- Float scanner + runtime value path for `python_float_demo.py` and
+  `endpoint_weighted_average_demo.py`.
+- Import no-op/binding + attribute access/calls for `python_import_demo.py`.
 - `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`.
-- `PY-BMF-LAMBDA` + closure capture in expressions.
-- `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment.
+- Inheritance/super dispatch for `python_inheritance_demo.py`.
+- Typing annotations/imports that compose with class surfaces for
+  `python_typing_compose_demo.py`.
 
 Each PROVEN row brings one more `PARITY_FILES` demo green under
 `PARITY_THIRD_RUNTIME=kernel-bmf`. When `lang-python.ts`'s full surface is
@@ -386,6 +388,15 @@ removable.
 | 2026-05-27 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_demo.py` | mixed recursion — fact, fib, ackermann, is_prime + is_prime_helper, count_primes + count_primes_helper. Exercises `True`/`False` keyword lift, multi-level right-associative ternary chains (`a if p else b if q else c`), pure-recursive function composition `count_primes(30) + fact(8) + fib(15) + ackermann(2, 3)` | `python-bmf-lift.fk` (True/False keyword arms + lift-cond-tail right-assoc fix) | CPython `40949` · Rust (bootstrap) `40949` · `kernel-bmf-run` `40949` |
 | 2026-05-27 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_assign_demo.py` | assignment + list literal + subscript — `def add(a, b): return a+b; result = add(10, 20); xs = [1,2,3,4,5]; total = xs[0]+xs[1]+xs[2]+xs[3]+xs[4]; result + total` | `python-bmf-lift.fk` (PY-BMF-LIST list-literal arm + PY-BMF-SUBSCRIPT postfix arm) | CPython `45` · Rust (bootstrap) `45` · `kernel-bmf-run` `45` |
 | 2026-05-27 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_imperative_demo.py` | while-loop accumulators — `def sum_to(n): total=0; i=1; while i<=n: total=total+i; i=i+1; return total` and a parallel `fact_loop`; result `sum_to(100) + fact_loop(8)`. Drives the WHILE statement-lift, multi-statement def-body wrapping, env threading through loop-body assignments | `python-bmf-lift.fk` (lift-while statement arm + always-wrap-MODULE def-body) | CPython `45370` · Rust (bootstrap) `45370` · `kernel-bmf-run` `45370` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_substrate_demo.py` | substrate-style helper composition — `for` loops, statement `if`, early returns through nested bodies, and list/range helpers | `python-bmf-lift.fk` + `python-bmf-eval.fk` statement `if`/`for`/return propagation | CPython `17680` · Rust (bootstrap) `17680` · `kernel-bmf-run` `17680` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_range_demo.py` | `range()` as an eager Form list plus recursive square/sum composition | Form-side `py-range` builtin + `PY-BMF-FOR` iteration | CPython `41650` · Rust (bootstrap) `41650` · `kernel-bmf-run` `41650` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_builtins_demo.py` | builtins + augmented assignment — `sum`, `min`, `max`, `abs`, `+=` | Form-side builtin dispatch + `PY-BMF-AUG-ASSIGN` | CPython `131` · Rust (bootstrap) `131` · `kernel-bmf-run` `131` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_lambda_demo.py` | lambda closures stored in variables/lists and called through `for f in fns` | `PY-BMF-LAMBDA` lift/eval + closure values in list iteration | CPython `216` · Rust (bootstrap) `216` · `kernel-bmf-run` `216` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_string_demo.py` | string literals, concat, and `len(s)` | `PY-BMF-STRING` lift/eval + polymorphic `_plus` + `len` builtin | CPython `45` · Rust (bootstrap) `45` · `kernel-bmf-run` `45` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_coherence_weight_demo.py` | utility endpoint arithmetic shape with early-return/helper semantics | Same statement/control-flow bundle as substrate demo | CPython `16185` · Rust (bootstrap) `16185` · `kernel-bmf-run` `16185` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/python_dict_demo.py` | dict literal, subscript read, subscript assignment, membership, key iteration, `len(d)` | `PY-BMF-DICT`, `PY-BMF-SUB-ASSIGN`, `_get`, `_dict_set`, `_in`, `_iter` | CPython `88` · Rust (bootstrap) `88` · `kernel-bmf-run` `88` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_distance_demo.py` | NodeID distance utility endpoint shape already inside integer/list arithmetic reach | Existing Shape-B math/list/subscript surface | CPython `7` · Rust (bootstrap) `7` · `kernel-bmf-run` `7` |
+| 2026-05-28 | `form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_lattice_stats_demo.py` | substrate lattice stats shape — dict over three integer counts, subscript reads, final sum | Dict native surface + Shape-B math | CPython `1089` · Rust (bootstrap) `1089` · `kernel-bmf-run` `1089` |
 
 **The first walking step:** with the G4 row recorded and G1+G3 now also
 landed, the manifest's lifecycle is no longer a future-tense convention.

--- a/kernels/MINIMAL_KERNEL_ANALYSIS.md
+++ b/kernels/MINIMAL_KERNEL_ANALYSIS.md
@@ -27,7 +27,8 @@ growing list of pre-compiled algorithms.
 PRs #2140, #2142, and the in-progress #2143 added:
 
 - `random_bytes(n)` — primitive ✓ (entropy at OS boundary)
-- `seeded_bytes(seed, count)` — **composable** (LCG: state = state * A + C mod M, expressible from `mul`/`add`/`mod`)
+- `mul_mod_u64(a, b, m)` / `add_mod_u64(a, b, m)` — primitive enough to keep fixed-width modular arithmetic exact across sibling kernels
+- `seeded_bytes(seed, count)` — **composable** (LCG: state = state * A + C mod M, now lives in `form-stdlib/seeded-bytes.fk` with exact u64 modular primitives)
 - `sum_bytes_list(list)` — **composable** (reduce-via-fold)
 - `sha256(byte-list)` — **composable** (SHA-256 is bit-ops + arithmetic; implementable in Form, just slow without JIT)
 - `ed25519_*` — **composable** (Ed25519 is field arithmetic on curve25519; implementable in Form, just slow without JIT)
@@ -39,7 +40,7 @@ kernel's walker faster (JIT) so Form recipes can carry them.
 
 ## Current native surface (Go kernel — counted)
 
-**88 natives** registered. Breakdown:
+**90 natives** registered. Breakdown:
 
 ### Truly primitive (~25)
 
@@ -55,6 +56,7 @@ kernel's walker faster (JIT) so Form recipes can carry them.
 | `read_form_binary`, `write_form_binary` | Substrate serialization to/from disk |
 | `file_byte_at`, `file_mtime`, `file_size` | File metadata at OS boundary |
 | `random_bytes` | Entropy at OS boundary (the doorway) |
+| `mul_mod_u64`, `add_mod_u64` | Fixed-width arithmetic boundary; smaller than carrying whole algorithm natives |
 | `socket_*` (6 natives) | Network I/O at OS boundary |
 | `walk_recipe` | The kernel's own recursive entry point |
 
@@ -75,7 +77,7 @@ kernel's walker faster (JIT) so Form recipes can carry them.
 
 | Native | Algorithm | Status |
 |---|---|---|
-| `seeded_bytes` | LCG (multiply-add-mod loop) | **Added in #2142 — should be Form recipe** |
+| `seeded_bytes` | LCG (multiply-add-mod loop) | **Form recipe in `form-stdlib/seeded-bytes.fk` passes Go/Rust/TS; native is optimization tissue** |
 | `sum_bytes_list` | Reduce(+) | **Added in #2142 — should be Form recipe** |
 | `sha256` | SHA-256 (RFC 6234) | **Added in this branch — should be Form recipe** |
 | `ed25519_keypair_from_seed` | Ed25519 keygen (RFC 8032) | **Added in this branch — should be Form recipe** |
@@ -110,7 +112,7 @@ edge of "kernel internal" vs "composable."
 | Algorithmic-should-compost | ~7 | composting candidates NOW |
 | Walker/runtime/framebuffer | ~12 | likely stays kernel-internal |
 
-**Minimum kernel target: ~25 primitives.** Currently 88. The body could
+**Minimum kernel target: ~25-27 primitives.** Currently 90. The body could
 shed ~60 natives onto Form recipes once the JIT layer makes recipe
 execution fast enough for hot paths.
 
@@ -152,8 +154,10 @@ execution fast enough for hot paths.
 This concept seeds the discipline. Concrete walks that follow:
 
 1. **Walk a Form recipe for seeded_bytes** (LCG in Form arithmetic) —
-   demonstrate it produces identical bytes to the native; name the
-   slowness; preserve as the canonical reference.
+   done in `form-stdlib/seeded-bytes.fk` and witnessed by
+   `form-samples/cross-modal/17-recipes-as-truth/`; it produces identical
+   bytes to the native across Go/Rust/TS. Preserve it as the canonical
+   reference and measure slowness honestly.
 2. **Walk a JIT recognizer** that pattern-matches the LCG recipe and
    dispatches to compiled native code. The kernel's native registry
    loses one entry; the JIT gains a pattern.

--- a/kernels/PYTHON_PIPELINE_STATUS.md
+++ b/kernels/PYTHON_PIPELINE_STATUS.md
@@ -14,9 +14,9 @@ A bullet-by-bullet read of the four-bullet destination, with the live artifact e
 
 1. **ALL Python talking to substrate → native Form.** *In motion.* Three FastAPI utility endpoints (`/api/utils/coherence_weight`, `nodeid_distance`, `weighted_average`) carry their bodies as Form recipes via `serve_via_kernel`; the first substrate-touching endpoint (`/api/substrate/lattice/stats`) reads through kernel-native `http_get` + `_json_to_dict`. The kernel even serves HTTP directly (proof-of-shape `form-kernel-rust serve`). PyO3 inline removes the subprocess seam — kernel calls run sub-millisecond in the API process address space. Substrate-write transmutation is the next major arc.
 
-2. **ALL file types parseable via Form-native BMF grammars.** *First cell sprouted.* Python arithmetic shapes (`a-b`, `x*y`, `l/r`, `p**q`) parse through `form-stdlib/grammars/python-bmf.fk` driven by the kernel — sibling-validated on Go, Rust, TypeScript (179/179 in `./validate.sh` in this worktree). All five gates from [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — G1 (rule dispatcher), G2 (statement grouping), G3 (precedence), G4 (closure interpreter), G5 (template-machinery overlap), G6 (binary entry-point orchestration) — are closed (PRs #2087, #2092, #2100, #2101). **CTOR Shape B** (PRs #2113, #2119, #2122) lands inter-path NodeID equality at the math-primitive layer: Python-source `+ - * / %` interns as `RBasic.MATH-12` and `== != < <= > >=` as `RBasic.COMPARE-13`, with the same Blueprint a hand-built pure-Form recipe interns to. See [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) for the full closing-shape map and the future Shape C walk that preserves dialect *articulations* over the shared identity.
+2. **ALL file types parseable via Form-native BMF grammars.** *First cell sprouted and branching.* Python arithmetic, control flow, lambdas, strings, dicts, and common builtins now parse through `form-stdlib/grammars/python-bmf.fk` driven by the kernel — sibling-validated on Go, Rust, TypeScript by `python-bmf-lift-band.fk` returning `150000`. All five gates from [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — G1 (rule dispatcher), G2 (statement grouping), G3 (precedence), G4 (closure interpreter), G5 (template-machinery overlap), G6 (binary entry-point orchestration) — are closed (PRs #2087, #2092, #2100, #2101). **CTOR Shape B** (PRs #2113, #2119, #2122) lands inter-path NodeID equality at the math-primitive layer: Python-source `+ - * / %` interns as `RBasic.MATH-12` and `== != < <= > >=` as `RBasic.COMPARE-13`, with the same Blueprint a hand-built pure-Form recipe interns to. See [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) for the full closing-shape map and the future Shape C walk that preserves dialect *articulations* over the shared identity.
 
-3. **Compile any file → Form-recipe binary the kernel CLI runs standalone.** *Routine for the bootstrap demo set; partial for Form-native BMF.* Every demo in `parity_suite.sh` (19 entries) compiles to `.fk` through the bootstrap emitter and runs through `form-kernel-rust` standalone. The Form-native `kernel-bmf` selector is now runnable across the whole matrix: 4/19 demos are COMPOST READY, and the first open row is `python_substrate_demo.py`. The bootstrap emit path (`lang-python-fk.ts`) is named for compost in [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md); the next removal comes from teaching the Form-native lift/eval path statement-level `if`, `for`, and return propagation.
+3. **Compile any file → Form-recipe binary the kernel CLI runs standalone.** *Routine for the bootstrap demo set; widening for Form-native BMF.* Every demo in `parity_suite.sh` (19 entries) compiles to `.fk` through the bootstrap emitter and runs through `form-kernel-rust` standalone. The Form-native `kernel-bmf` selector is now runnable across the whole matrix: **13/19 demos are COMPOST READY**, and the first open row is `python_float_demo.py`. The bootstrap emit path (`lang-python-fk.ts`) is named for compost in [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md); the next removal comes from teaching the Form-native scanner/eval path float literals, then import/math attributes.
 
 4. **Framebuffer-driven optimization → same OOM as Python.** *Met and exceeded.* `form-kernel-rust` is 1.8× faster than CPython on the recursion workload (24.08ms vs 41.79ms per iter). Width-tagged trace dispatch is named as a separate breath.
 
@@ -53,12 +53,15 @@ result
 - TS evalPython (the bootstrap evaluator)
 - form-kernel-rust native binary
 
-**Form-native `kernel-bmf` frontier:** 4/19 rows already produce the same
+**Form-native `kernel-bmf` frontier:** 13/19 rows already produce the same
 CPython value without the TS evaluator:
-`python_bridge_demo.py`, `python_demo.py`, `python_assign_demo.py`, and
-`python_imperative_demo.py`. The first failing row,
-`python_substrate_demo.py`, traces to unsupported statement-level `if` and
-`for` lift/eval plus early-return propagation inside nested bodies.
+`python_bridge_demo.py`, `python_demo.py`, `python_assign_demo.py`,
+`python_imperative_demo.py`, `python_substrate_demo.py`, `python_range_demo.py`,
+`python_builtins_demo.py`, `python_lambda_demo.py`, `python_string_demo.py`,
+`endpoint_coherence_weight_demo.py`, `python_dict_demo.py`,
+`endpoint_nodeid_distance_demo.py`, and `endpoint_lattice_stats_demo.py`.
+The first failing row is `python_float_demo.py`, which now isolates the next
+gap to Form-native float source scanning/value construction.
 
 ## Parity suite — `scripts/parity_suite.sh`
 

--- a/kernels/PYTHON_PIPELINE_STATUS.md
+++ b/kernels/PYTHON_PIPELINE_STATUS.md
@@ -8,15 +8,15 @@
 
 This document is the honest map of distance covered and distance remaining. Updated each ripening breath.
 
-## Where each bullet stands today (2026-05-27)
+## Where each bullet stands today (2026-05-28)
 
 A bullet-by-bullet read of the four-bullet destination, with the live artifact each one points at:
 
 1. **ALL Python talking to substrate → native Form.** *In motion.* Three FastAPI utility endpoints (`/api/utils/coherence_weight`, `nodeid_distance`, `weighted_average`) carry their bodies as Form recipes via `serve_via_kernel`; the first substrate-touching endpoint (`/api/substrate/lattice/stats`) reads through kernel-native `http_get` + `_json_to_dict`. The kernel even serves HTTP directly (proof-of-shape `form-kernel-rust serve`). PyO3 inline removes the subprocess seam — kernel calls run sub-millisecond in the API process address space. Substrate-write transmutation is the next major arc.
 
-2. **ALL file types parseable via Form-native BMF grammars.** *First cell sprouted.* Python arithmetic shapes (`a-b`, `x*y`, `l/r`, `p**q`) parse through `form-stdlib/grammars/python-bmf.fk` driven by the kernel — sibling-validated on Go, Rust, TypeScript (136/136 in `./validate.sh`). All five gates from [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — G1 (rule dispatcher), G2 (statement grouping), G3 (precedence), G4 (closure interpreter), G5 (template-machinery overlap), G6 (binary entry-point orchestration) — are closed (PRs #2087, #2092, #2100, #2101). **CTOR Shape B** (PRs #2113, #2119, #2122) lands inter-path NodeID equality at the math-primitive layer: Python-source `+ - * / %` interns as `RBasic.MATH-12` and `== != < <= > >=` as `RBasic.COMPARE-13`, with the same Blueprint a hand-built pure-Form recipe interns to. See [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) for the full closing-shape map and the future Shape C walk that preserves dialect *articulations* over the shared identity.
+2. **ALL file types parseable via Form-native BMF grammars.** *First cell sprouted.* Python arithmetic shapes (`a-b`, `x*y`, `l/r`, `p**q`) parse through `form-stdlib/grammars/python-bmf.fk` driven by the kernel — sibling-validated on Go, Rust, TypeScript (179/179 in `./validate.sh` in this worktree). All five gates from [`PYTHON_BMF_CONTRACT.md`](PYTHON_BMF_CONTRACT.md) — G1 (rule dispatcher), G2 (statement grouping), G3 (precedence), G4 (closure interpreter), G5 (template-machinery overlap), G6 (binary entry-point orchestration) — are closed (PRs #2087, #2092, #2100, #2101). **CTOR Shape B** (PRs #2113, #2119, #2122) lands inter-path NodeID equality at the math-primitive layer: Python-source `+ - * / %` interns as `RBasic.MATH-12` and `== != < <= > >=` as `RBasic.COMPARE-13`, with the same Blueprint a hand-built pure-Form recipe interns to. See [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) for the full closing-shape map and the future Shape C walk that preserves dialect *articulations* over the shared identity.
 
-3. **Compile any file → Form-recipe binary the kernel CLI runs standalone.** *Routine for the demo set.* Every demo in `parity_suite.sh` (16 entries) compiles to `.fk` and runs through `form-kernel-rust` standalone. The bootstrap emit path (`lang-python-fk.ts`) is named for compost in [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md); the Form-native emitter is the second half of bullet 2.
+3. **Compile any file → Form-recipe binary the kernel CLI runs standalone.** *Routine for the bootstrap demo set; partial for Form-native BMF.* Every demo in `parity_suite.sh` (19 entries) compiles to `.fk` through the bootstrap emitter and runs through `form-kernel-rust` standalone. The Form-native `kernel-bmf` selector is now runnable across the whole matrix: 4/19 demos are COMPOST READY, and the first open row is `python_substrate_demo.py`. The bootstrap emit path (`lang-python-fk.ts`) is named for compost in [`BOOTSTRAP_COMPOST_MANIFEST.md`](BOOTSTRAP_COMPOST_MANIFEST.md); the next removal comes from teaching the Form-native lift/eval path statement-level `if`, `for`, and return propagation.
 
 4. **Framebuffer-driven optimization → same OOM as Python.** *Met and exceeded.* `form-kernel-rust` is 1.8× faster than CPython on the recursion workload (24.08ms vs 41.79ms per iter). Width-tagged trace dispatch is named as a separate breath.
 
@@ -24,7 +24,7 @@ A bullet-by-bullet read of the four-bullet destination, with the live artifact e
 
 The body's bootstrap-vs-Form-native migration is no longer a future-tense convention. The discipline lives:
 
-- **Bootstrap weight** is measured on every wellness check: today 17 files of tissue, 11,156 LOC remaining. [`sense_bootstrap_compost`](../scripts/wellness_check.py) reads the manifest's file list.
+- **Bootstrap weight** is measured on every wellness check: today 17 files of tissue, 11,167 LOC remaining. [`sense_bootstrap_compost`](../scripts/wellness_check.py) reads the manifest's file list and now names the three largest files plus the first unready parity row.
 - **Lifecycle motion** is counted on every wellness check: rows that have walked from `tissue → PROVEN → COMPOST READY → RELEASED`. The first PROVEN row landed via #2073; the probe's lifecycle-motion line was added in #2074. Future Form-native parity proofs append rows; when a Phase-A file's surface is fully covered, its row moves to COMPOST READY; when the file composts, its LOC drops out of the weight measurement.
 - **Parity-gate seam** lives in `seedbank/python-adapter/scripts/parity_suite.sh` — `PARITY_THIRD_RUNTIME=kernel-bmf` flips the third runtime from the TS bootstrap to the Form-native walker, one demo at a time. No flag day; the migration is the verification.
 
@@ -52,6 +52,13 @@ result
 - CPython
 - TS evalPython (the bootstrap evaluator)
 - form-kernel-rust native binary
+
+**Form-native `kernel-bmf` frontier:** 4/19 rows already produce the same
+CPython value without the TS evaluator:
+`python_bridge_demo.py`, `python_demo.py`, `python_assign_demo.py`, and
+`python_imperative_demo.py`. The first failing row,
+`python_substrate_demo.py`, traces to unsupported statement-level `if` and
+`for` lift/eval plus early-return propagation inside nested bodies.
 
 ## Parity suite — `scripts/parity_suite.sh`
 

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -793,6 +793,7 @@ def sense_bootstrap_compost() -> list[str]:
 
     lines: list[str] = []
     totals: dict[str, tuple[int, int, int]] = {}
+    named_tissue: list[tuple[str, str, int]] = []
     for phase, paths in phase_files.items():
         present = 0
         loc = 0
@@ -801,7 +802,9 @@ def sense_bootstrap_compost() -> list[str]:
             p = ROOT / rel
             if p.is_file():
                 try:
-                    loc += sum(1 for _ in p.open("rb"))
+                    file_loc = sum(1 for _ in p.open("rb"))
+                    loc += file_loc
+                    named_tissue.append((phase, rel, file_loc))
                     present += 1
                 except OSError:
                     pass
@@ -825,6 +828,12 @@ def sense_bootstrap_compost() -> list[str]:
         lines.append(
             f"    · Phase {phase} ({label}): {present} files, {loc} LOC{composted}"
         )
+    if named_tissue:
+        lines.append("  largest named tissue:")
+        for phase, rel, loc in sorted(
+            named_tissue, key=lambda row: row[2], reverse=True
+        )[:3]:
+            lines.append(f"    · Phase {phase}: {rel} — {loc} LOC")
 
     # Wider perimeter — the substrate-Python directory carries more than
     # the manifest's Phase C names. The audit at
@@ -888,12 +897,36 @@ def sense_bootstrap_compost() -> list[str]:
     parity = ROOT / "form" / "form-kernel-ts" / "seedbank" / "python-adapter" / "scripts" / "parity_suite.sh"
     third = "unknown"
     if parity.is_file():
+        parity_text = parity.read_text()
         m = re.search(
             r'PARITY_THIRD_RUNTIME="?\$\{PARITY_THIRD_RUNTIME:-([a-z0-9-]+)\}',
-            parity.read_text(),
+            parity_text,
         )
         if m:
             third = m.group(1)
+        parity_block = re.search(r"PARITY_FILES=\(\n(.*?)\n\)", parity_text, re.DOTALL)
+        if parity_block:
+            parity_files = re.findall(r'"([^"]+\.py)"', parity_block.group(1))
+            ready_block = re.search(
+                r"## COMPOST READY\b(.*?)(?:\n## |\Z)",
+                manifest_text,
+                re.DOTALL,
+            )
+            ready_files: set[str] = set()
+            if ready_block:
+                ready_files = set(
+                    re.findall(
+                        r"`form/form-kernel-ts/seedbank/python-adapter/(examples/[^`]+\.py)`",
+                        ready_block.group(1),
+                    )
+                )
+            if parity_files:
+                first_unready = next((p for p in parity_files if p not in ready_files), None)
+                suffix = f"; next row: {first_unready}" if first_unready else ""
+                lines.append(
+                    f"  kernel-bmf readiness — {len(ready_files)}/{len(parity_files)} "
+                    f"parity demos marked COMPOST READY{suffix}"
+                )
     if third == "ts-eval":
         lines.append(
             "  third runtime default: ts-eval (TS bootstrap) — flip to "


### PR DESCRIPTION
## Summary
- move seeded byte stream semantics into `form/form-stdlib/seeded-bytes.fk` and make the existing native an optimization witness
- add exact `mul_mod_u64` / `add_mod_u64` primitives across Go/Rust/TS so the Form recipe stays byte-equivalent across sibling kernels
- make the kernel-bmf frontier visible: wellness now reports largest bootstrap tissue and 4/19 readiness, and the parity suite completes the matrix instead of aborting on first failure
- add cross-modal proofs for channel negotiation and addressable-cell question/answer capsules

## Proof
- `cd form && ./validate.sh` -> 179 ok, 0 divergent
- `cd form/form-kernel-go && go test ./...`
- `cd form/form-kernel-rust && cargo test --quiet`
- `cd form/form-kernel-ts && npm run check`
- focused cross-modal validates: private-channel=5, seeded-bytes-recipe=1, channel-negotiation=341, cell-question-answer=24311
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main` -> ready_for_push=True
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict` -> codex_open_prs=0

## Current Frontier
- `PARITY_THIRD_RUNTIME=kernel-bmf` diagnostic completes all 19 rows: 4 ready, 15 current failures
- first open row: `examples/python_substrate_demo.py`
- next implementation bundle: statement-level `if`, `for` over lists/ranges, and nested return propagation in `python-bmf-lift.fk` / `python-bmf-eval.fk`
