### PR TITLE
attune(form): Blueprint registry + bp resolver — end magic-number sprawl

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 131 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 132 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/form-stdlib/blueprint-registry.json
+++ b/form/form-stdlib/blueprint-registry.json
@@ -1,0 +1,3253 @@
+{
+  "_note": "Type-99 (user-space) Blueprint registry \u2014 the single source of truth for shapes the kernel does not dispatch on. Generated from code by scripts/scan_form_blueprints.py --emit-registry, then curated. NodeID is (1, 2, 99, inst). form-stdlib/form-ontology-loader.fk binds these names so .fk code references a name, never the raw number. To add a shape: add a row here first, then `(bp \"name\")` in code.",
+  "blueprints": [
+    {
+      "inst": 1,
+      "name": "DOC-DOC",
+      "meaning": "root document",
+      "aliases": [
+        "HTML-DOC"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/grammars/markdown.fk"
+      ]
+    },
+    {
+      "inst": 2,
+      "name": "DOC-HEADING",
+      "meaning": "(level, text)",
+      "aliases": [
+        "HTML-HEADING"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/grammars/markdown.fk"
+      ]
+    },
+    {
+      "inst": 3,
+      "name": "DOC-PARAGRAPH",
+      "meaning": "(text)",
+      "aliases": [
+        "HTML-PARA"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/grammars/markdown.fk"
+      ]
+    },
+    {
+      "inst": 4,
+      "name": "DOC-CODE-BLOCK",
+      "meaning": "(lang, content)",
+      "aliases": [
+        "HTML-CODE"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/grammars/markdown.fk"
+      ]
+    },
+    {
+      "inst": 5,
+      "name": "DOC-BLANK",
+      "meaning": "blank-line marker (discarded post-parse)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/markdown.fk"
+      ]
+    },
+    {
+      "inst": 7,
+      "name": "topic",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/channel-query-json-band.fk"
+      ]
+    },
+    {
+      "inst": 10,
+      "name": "JSON-OBJECT",
+      "meaning": "map: list of (key, value) pairs",
+      "aliases": [
+        "AU-OBJ",
+        "CSS-OBJ",
+        "E-JSON-OBJECT",
+        "HTML-OBJ",
+        "IMG-OBJ",
+        "JSON-BNF-OBJECT",
+        "MDL-OBJ",
+        "SQL-OBJ",
+        "VID-OBJ",
+        "XML-OBJ",
+        "Y-OBJECT"
+      ],
+      "reuse": 13,
+      "defined_in": [
+        "form/form-stdlib/json.fk",
+        "form/form-stdlib/seedbank/emits/audio.fk",
+        "form/form-stdlib/seedbank/emits/css.fk",
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/emits/image.fk",
+        "form/form-stdlib/seedbank/emits/json.fk",
+        "form/form-stdlib/seedbank/emits/model.fk",
+        "form/form-stdlib/seedbank/emits/sql.fk",
+        "form/form-stdlib/seedbank/emits/video.fk",
+        "form/form-stdlib/seedbank/emits/xml.fk",
+        "form/form-stdlib/seedbank/emits/yaml.fk",
+        "form/form-stdlib/seedbank/grammars/json.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/json.fk"
+      ]
+    },
+    {
+      "inst": 11,
+      "name": "JSON-ARRAY",
+      "meaning": "sequence of values",
+      "aliases": [
+        "AU-ARR",
+        "CSS-ARR",
+        "E-JSON-ARRAY",
+        "HTML-ARR",
+        "IMG-ARR",
+        "JSON-BNF-ARRAY",
+        "MDL-ARR",
+        "SQL-ARR",
+        "VID-ARR",
+        "XML-ARR",
+        "Y-ARRAY"
+      ],
+      "reuse": 13,
+      "defined_in": [
+        "form/form-stdlib/json.fk",
+        "form/form-stdlib/seedbank/emits/audio.fk",
+        "form/form-stdlib/seedbank/emits/css.fk",
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/emits/image.fk",
+        "form/form-stdlib/seedbank/emits/json.fk",
+        "form/form-stdlib/seedbank/emits/model.fk",
+        "form/form-stdlib/seedbank/emits/sql.fk",
+        "form/form-stdlib/seedbank/emits/video.fk",
+        "form/form-stdlib/seedbank/emits/xml.fk",
+        "form/form-stdlib/seedbank/emits/yaml.fk",
+        "form/form-stdlib/seedbank/grammars/json.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/json.fk"
+      ]
+    },
+    {
+      "inst": 12,
+      "name": "JSON-PAIR",
+      "meaning": "(key-string, value)",
+      "aliases": [
+        "AU-PAIR",
+        "CSS-PAIR",
+        "E-JSON-PAIR",
+        "HTML-PAIR",
+        "IMG-PAIR",
+        "JSON-BNF-PAIR",
+        "MDL-PAIR",
+        "SQL-PAIR",
+        "VID-PAIR",
+        "XML-PAIR",
+        "Y-PAIR"
+      ],
+      "reuse": 13,
+      "defined_in": [
+        "form/form-stdlib/json.fk",
+        "form/form-stdlib/seedbank/emits/audio.fk",
+        "form/form-stdlib/seedbank/emits/css.fk",
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/emits/image.fk",
+        "form/form-stdlib/seedbank/emits/json.fk",
+        "form/form-stdlib/seedbank/emits/model.fk",
+        "form/form-stdlib/seedbank/emits/sql.fk",
+        "form/form-stdlib/seedbank/emits/video.fk",
+        "form/form-stdlib/seedbank/emits/xml.fk",
+        "form/form-stdlib/seedbank/emits/yaml.fk",
+        "form/form-stdlib/seedbank/grammars/json.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/json.fk"
+      ]
+    },
+    {
+      "inst": 13,
+      "name": "JSON-NULL",
+      "meaning": "null literal",
+      "aliases": [
+        "AU-NULL",
+        "CSS-NULL",
+        "E-JSON-NULL",
+        "HTML-NULL",
+        "IMG-NULL",
+        "JSON-BNF-NULL",
+        "MDL-NULL",
+        "SQL-NULL",
+        "VID-NULL",
+        "XML-NULL",
+        "Y-NULL"
+      ],
+      "reuse": 13,
+      "defined_in": [
+        "form/form-stdlib/json.fk",
+        "form/form-stdlib/seedbank/emits/audio.fk",
+        "form/form-stdlib/seedbank/emits/css.fk",
+        "form/form-stdlib/seedbank/emits/html.fk",
+        "form/form-stdlib/seedbank/emits/image.fk",
+        "form/form-stdlib/seedbank/emits/json.fk",
+        "form/form-stdlib/seedbank/emits/model.fk",
+        "form/form-stdlib/seedbank/emits/sql.fk",
+        "form/form-stdlib/seedbank/emits/video.fk",
+        "form/form-stdlib/seedbank/emits/xml.fk",
+        "form/form-stdlib/seedbank/emits/yaml.fk",
+        "form/form-stdlib/seedbank/grammars/json.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/json.fk"
+      ]
+    },
+    {
+      "inst": 20,
+      "name": "YAML-DOC",
+      "meaning": "root document = sequence of pairs / list items",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/yaml.fk"
+      ]
+    },
+    {
+      "inst": 21,
+      "name": "YAML-PAIR",
+      "meaning": "(key-string, value)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/yaml.fk"
+      ]
+    },
+    {
+      "inst": 22,
+      "name": "YAML-ITEM",
+      "meaning": "list-item value",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/yaml.fk"
+      ]
+    },
+    {
+      "inst": 23,
+      "name": "YAML-LIST",
+      "meaning": "(sequence of items)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/yaml.fk"
+      ]
+    },
+    {
+      "inst": 30,
+      "name": "FORM-LIST",
+      "meaning": "an S-expression list",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/form.fk"
+      ]
+    },
+    {
+      "inst": 31,
+      "name": "FORM-IDENT",
+      "meaning": "an identifier atom",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/form.fk"
+      ]
+    },
+    {
+      "inst": 40,
+      "name": "PY-MODULE",
+      "meaning": "root module: sequence of statements",
+      "aliases": [
+        "PY-BNF-MODULE",
+        "PY-EXEC-MODULE"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 41,
+      "name": "PY-IMPORT",
+      "meaning": "(module-name, asname)",
+      "aliases": [
+        "PY-BNF-IMPORT",
+        "PY-EXEC-IMPORT"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 42,
+      "name": "PY-FROM-IMPORT",
+      "meaning": "(module, [names])",
+      "aliases": [
+        "PY-BNF-FROM-IMPORT",
+        "PY-EXEC-FROM-IMPORT"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 43,
+      "name": "PY-FUNCTION-DEF",
+      "meaning": "(name, params)",
+      "aliases": [
+        "PY-BNF-FUNCTION-DEF",
+        "PY-EXEC-FUNCTION-DEF"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 44,
+      "name": "PY-ASSIGN",
+      "meaning": "(target, value)",
+      "aliases": [
+        "PY-BNF-ASSIGN",
+        "PY-EXEC-ASSIGN"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 45,
+      "name": "PY-IDENT",
+      "meaning": "an identifier reference",
+      "aliases": [
+        "PY-BNF-IDENT"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 46,
+      "name": "PY-NAME-PAIR",
+      "meaning": "(name, asname) for import lists",
+      "aliases": [
+        "PY-BNF-NAME-PAIR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/python.fk"
+      ]
+    },
+    {
+      "inst": 47,
+      "name": "PY-BNF-BIN-EXPR",
+      "meaning": "",
+      "aliases": [
+        "PY-EXEC-BIN-EXPR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk"
+      ]
+    },
+    {
+      "inst": 48,
+      "name": "PY-BNF-INT-EXPR",
+      "meaning": "",
+      "aliases": [
+        "PY-EXEC-INT-EXPR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk"
+      ]
+    },
+    {
+      "inst": 49,
+      "name": "PY-BNF-STR-EXPR",
+      "meaning": "",
+      "aliases": [
+        "PY-EXEC-STR-EXPR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk"
+      ]
+    },
+    {
+      "inst": 50,
+      "name": "TS-MODULE",
+      "meaning": "",
+      "aliases": [
+        "PY-BNF-IDENT-EXPR",
+        "PY-EXEC-IDENT-EXPR"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 51,
+      "name": "TS-IMPORT",
+      "meaning": "(kind, names, module)",
+      "aliases": [
+        "PY-BNF-PAREN-EXPR",
+        "PY-EXEC-PAREN-EXPR"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-exec.fk",
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 52,
+      "name": "TS-EXPORT",
+      "meaning": "(declaration)",
+      "aliases": [
+        "PY-BNF-CALL"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 53,
+      "name": "PY-BNF-ATTR",
+      "meaning": "(name, params)",
+      "aliases": [
+        "TS-FUNCTION-DECL"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 54,
+      "name": "PY-BNF-IF",
+      "meaning": "(name)",
+      "aliases": [
+        "TS-CLASS-DECL"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 55,
+      "name": "PY-BNF-WHILE",
+      "meaning": "(kind, name, value)",
+      "aliases": [
+        "TS-CONST-DECL"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 56,
+      "name": "TS-IDENT",
+      "meaning": "",
+      "aliases": [
+        "PY-BNF-FOR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.fk"
+      ]
+    },
+    {
+      "inst": 57,
+      "name": "PY-BNF-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python.bnf.fk"
+      ]
+    },
+    {
+      "inst": 59,
+      "name": "TS-BNF-MODULE",
+      "meaning": "",
+      "aliases": [
+        "TS-EXEC-MODULE"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 60,
+      "name": "RS-FILE",
+      "meaning": "",
+      "aliases": [
+        "TS-BNF-IMPORT",
+        "TS-EXEC-IMPORT"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 61,
+      "name": "RS-USE",
+      "meaning": "(path)",
+      "aliases": [
+        "TS-BNF-IMPORT-NS",
+        "TS-EXEC-IMPORT-NS"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 62,
+      "name": "RS-MOD",
+      "meaning": "(name)",
+      "aliases": [
+        "TS-BNF-IMPORT-DEF",
+        "TS-EXEC-IMPORT-DEF"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 63,
+      "name": "RS-FN-DECL",
+      "meaning": "(name, params)",
+      "aliases": [
+        "TS-BNF-EXPORT-CONST",
+        "TS-EXEC-EXPORT-CONST"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 64,
+      "name": "RS-STRUCT-DECL",
+      "meaning": "(name)",
+      "aliases": [
+        "TS-BNF-EXPORT-FN",
+        "TS-EXEC-EXPORT-FN"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 65,
+      "name": "TS-BNF-LET",
+      "meaning": "(name)",
+      "aliases": [
+        "RS-IMPL-BLOCK",
+        "TS-EXEC-LET"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.fk",
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 66,
+      "name": "TS-BNF-CONST",
+      "meaning": "",
+      "aliases": [
+        "TS-EXEC-CONST"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-exec.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 67,
+      "name": "TS-BNF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 68,
+      "name": "TS-BNF-WHILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 69,
+      "name": "TS-BNF-FOR",
+      "meaning": "",
+      "aliases": [
+        "RS-BNF-MODULE",
+        "RS-EXEC-MODULE"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 70,
+      "name": "GO-FILE",
+      "meaning": "",
+      "aliases": [
+        "RS-BNF-USE",
+        "RS-EXEC-USE",
+        "TS-BNF-CALL"
+      ],
+      "reuse": 4,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 71,
+      "name": "GO-PACKAGE",
+      "meaning": "",
+      "aliases": [
+        "RS-BNF-PUB-USE",
+        "RS-EXEC-PUB-USE",
+        "TS-BNF-ATTR"
+      ],
+      "reuse": 4,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/typescript.bnf.fk"
+      ]
+    },
+    {
+      "inst": 72,
+      "name": "GO-IMPORT",
+      "meaning": "",
+      "aliases": [
+        "RS-BNF-MOD",
+        "RS-EXEC-MOD"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 73,
+      "name": "RS-BNF-FN",
+      "meaning": "",
+      "aliases": [
+        "GO-FUNC-DECL",
+        "RS-EXEC-FN"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 74,
+      "name": "GO-TYPE-DECL",
+      "meaning": "",
+      "aliases": [
+        "RS-BNF-STRUCT",
+        "RS-EXEC-STRUCT"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 75,
+      "name": "RS-BNF-LET",
+      "meaning": "",
+      "aliases": [
+        "GO-VAR-DECL",
+        "RS-EXEC-LET"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.fk",
+        "form/form-stdlib/seedbank/grammars/rust-exec.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 76,
+      "name": "RS-BNF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 77,
+      "name": "RS-BNF-WHILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 78,
+      "name": "RS-BNF-FOR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 79,
+      "name": "RS-BNF-MATCH",
+      "meaning": "",
+      "aliases": [
+        "GO-BNF-MODULE",
+        "GO-EXEC-MODULE"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk"
+      ]
+    },
+    {
+      "inst": 80,
+      "name": "CELL-LINE",
+      "meaning": "one text line",
+      "aliases": [
+        "GO-BNF-PACKAGE",
+        "GO-EXEC-PACKAGE",
+        "RS-BNF-MATCH-ARM"
+      ],
+      "reuse": 4,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/rust.bnf.fk",
+        "form/form-stdlib/seedbank/tests/cell-stream.fk"
+      ]
+    },
+    {
+      "inst": 81,
+      "name": "CELL-CHUNK",
+      "meaning": "one binary chunk",
+      "aliases": [
+        "GO-BNF-IMPORT",
+        "GO-EXEC-IMPORT"
+      ],
+      "reuse": 5,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/tests/cell-drop.fk",
+        "form/form-stdlib/seedbank/tests/cell-stream.fk",
+        "form/form-stdlib/seedbank/tests/walk-stream.fk"
+      ]
+    },
+    {
+      "inst": 82,
+      "name": "CELL-TRANSMUTED",
+      "meaning": "output of transmute",
+      "aliases": [
+        "GO-BNF-FUNC",
+        "GO-EXEC-FUNC"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/tests/cell-stream.fk"
+      ]
+    },
+    {
+      "inst": 83,
+      "name": "GO-BNF-TYPE",
+      "meaning": "",
+      "aliases": [
+        "GO-EXEC-TYPE"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 84,
+      "name": "GO-BNF-VAR",
+      "meaning": "",
+      "aliases": [
+        "GO-EXEC-VAR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 85,
+      "name": "GO-BNF-CONST",
+      "meaning": "",
+      "aliases": [
+        "GO-EXEC-CONST"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 86,
+      "name": "GO-BNF-BLOCK",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 87,
+      "name": "GO-BNF-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 88,
+      "name": "GO-BNF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 89,
+      "name": "GO-BNF-ASSIGN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 90,
+      "name": "PNG-FILE",
+      "meaning": "root file",
+      "aliases": [
+        "GO-BNF-EXPR-STMT"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/png.fk"
+      ]
+    },
+    {
+      "inst": 91,
+      "name": "PNG-CHUNK",
+      "meaning": "one chunk",
+      "aliases": [
+        "GO-BNF-IDENT-EXPR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk",
+        "form/form-stdlib/seedbank/grammars/png.fk"
+      ]
+    },
+    {
+      "inst": 92,
+      "name": "GO-BNF-INT-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 93,
+      "name": "GO-BNF-STR-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 94,
+      "name": "GO-BNF-STRUCT-TYPE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 95,
+      "name": "GO-BNF-BIN-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 96,
+      "name": "GO-BNF-UNARY-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 97,
+      "name": "GO-BNF-PAREN-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 98,
+      "name": "GO-BNF-PARAM",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 99,
+      "name": "GO-BNF-CALL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 100,
+      "name": "UNKNOWN-FORMAT",
+      "meaning": "",
+      "aliases": [
+        "GO-BNF-SELECTOR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/convert.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 101,
+      "name": "FORM-FILE-ROOT",
+      "meaning": "",
+      "aliases": [
+        "GO-BNF-FOR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/convert.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 102,
+      "name": "GO-BNF-FIELD",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 103,
+      "name": "GO-BNF-SHORT-VAR",
+      "meaning": "",
+      "aliases": [
+        "GO-EXEC-SHORT-VAR"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-exec.fk",
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 104,
+      "name": "GO-BNF-SWITCH",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 105,
+      "name": "GO-BNF-CASE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 106,
+      "name": "GO-BNF-COMPOSITE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go.bnf.fk"
+      ]
+    },
+    {
+      "inst": 110,
+      "name": "JSX-ELEMENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/jsx.bnf.fk"
+      ]
+    },
+    {
+      "inst": 111,
+      "name": "JSX-TEXT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/jsx.bnf.fk"
+      ]
+    },
+    {
+      "inst": 120,
+      "name": "TSX-LET",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/tsx.bnf.fk"
+      ]
+    },
+    {
+      "inst": 130,
+      "name": "PYC-MODULE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 131,
+      "name": "PYC-IMPORT",
+      "meaning": "(module, name)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 132,
+      "name": "PYC-FROM-IMPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 133,
+      "name": "PYC-DEF",
+      "meaning": "(name)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 134,
+      "name": "PYC-CLASS",
+      "meaning": "(name)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 135,
+      "name": "PYC-DOCSTRING",
+      "meaning": "(text)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 136,
+      "name": "PYC-NAME-LIST",
+      "meaning": "list of name strings",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 137,
+      "name": "PYC-DEF-FULL",
+      "meaning": "(name, params, ret-type)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 138,
+      "name": "PYC-PARAM-LIST",
+      "meaning": "opaque text for now",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-chars.bnf.fk"
+      ]
+    },
+    {
+      "inst": 200,
+      "name": "PY-FULL-MODULE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 201,
+      "name": "PY-FULL-IMPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 202,
+      "name": "PY-FULL-FROM-IMPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 203,
+      "name": "PY-FULL-FUNC-DEF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 204,
+      "name": "PY-FULL-CLASS-DEF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 205,
+      "name": "PY-FULL-ASSIGN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 206,
+      "name": "PY-FULL-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 207,
+      "name": "PY-FULL-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 208,
+      "name": "PY-FULL-WHILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 209,
+      "name": "PY-FULL-FOR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 210,
+      "name": "PY-FULL-TRY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 211,
+      "name": "PY-FULL-WITH",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 212,
+      "name": "PY-FULL-CALL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 213,
+      "name": "PY-FULL-ATTR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 214,
+      "name": "PY-FULL-SUBSCRIPT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 215,
+      "name": "PY-FULL-BIN-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 216,
+      "name": "PY-FULL-UNARY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 217,
+      "name": "PY-FULL-COND-EXPR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 218,
+      "name": "PY-FULL-LAMBDA",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 219,
+      "name": "PY-FULL-LIST-LIT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 220,
+      "name": "PY-FULL-DICT-LIT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 221,
+      "name": "PY-FULL-SET-LIT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 222,
+      "name": "PY-FULL-TUPLE-LIT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 223,
+      "name": "PY-FULL-LISTCOMP",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 224,
+      "name": "PY-FULL-DICTCOMP",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 225,
+      "name": "PY-FULL-DECORATOR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 226,
+      "name": "PY-FULL-INT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 227,
+      "name": "PY-FULL-STR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 228,
+      "name": "PY-FULL-IDENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 229,
+      "name": "PY-FULL-PAREN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/python-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 300,
+      "name": "GOF-PACKAGE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 301,
+      "name": "GOF-IMPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 302,
+      "name": "GOF-CONST",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 303,
+      "name": "GOF-VAR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 304,
+      "name": "GOF-TYPE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 305,
+      "name": "GOF-FUNC",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 306,
+      "name": "GOF-METHOD",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 307,
+      "name": "GOF-STRUCT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 308,
+      "name": "GOF-INTERFACE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 309,
+      "name": "GOF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 310,
+      "name": "GOF-FOR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 311,
+      "name": "GOF-SWITCH",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 312,
+      "name": "GOF-SELECT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 313,
+      "name": "GOF-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 314,
+      "name": "GOF-CALL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 315,
+      "name": "GOF-IDENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 316,
+      "name": "GOF-INT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 317,
+      "name": "GOF-STR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 318,
+      "name": "GOF-BIN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 319,
+      "name": "GOF-COMPOSITE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/go-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 400,
+      "name": "TSF-MODULE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 401,
+      "name": "TSF-IMPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 402,
+      "name": "TSF-EXPORT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 403,
+      "name": "TSF-VAR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 404,
+      "name": "TSF-FUNC",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 405,
+      "name": "TSF-CLASS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 406,
+      "name": "TSF-INTERFACE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 407,
+      "name": "TSF-TYPE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 408,
+      "name": "TSF-ENUM",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 409,
+      "name": "TSF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 410,
+      "name": "TSF-FOR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 411,
+      "name": "TSF-WHILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 412,
+      "name": "TSF-TRY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 413,
+      "name": "TSF-CALL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 414,
+      "name": "TSF-IDENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 415,
+      "name": "TSF-INT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 416,
+      "name": "TSF-STR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 417,
+      "name": "TSF-ARROW",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 418,
+      "name": "TSF-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/typescript-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 500,
+      "name": "RSF-CRATE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 501,
+      "name": "RSF-USE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 502,
+      "name": "RSF-MOD",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 503,
+      "name": "RSF-FN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 504,
+      "name": "RSF-STRUCT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 505,
+      "name": "RSF-ENUM",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 506,
+      "name": "RSF-TRAIT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 507,
+      "name": "RSF-IMPL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 508,
+      "name": "RSF-TYPE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 509,
+      "name": "RSF-CONST",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 510,
+      "name": "RSF-STATIC",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 511,
+      "name": "RSF-LET",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 512,
+      "name": "RSF-IF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 513,
+      "name": "RSF-MATCH",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 514,
+      "name": "RSF-LOOP",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 515,
+      "name": "RSF-CALL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 516,
+      "name": "RSF-IDENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 517,
+      "name": "RSF-INT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 518,
+      "name": "RSF-STR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 519,
+      "name": "RSF-RETURN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/seedbank/grammars/rust-full.bnf.fk"
+      ]
+    },
+    {
+      "inst": 690,
+      "name": "IMAGE-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/image-bmf.fk"
+      ]
+    },
+    {
+      "inst": 691,
+      "name": "IMAGE-META-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/image-bmf.fk"
+      ]
+    },
+    {
+      "inst": 700,
+      "name": "AUDIO-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/audio-bmf.fk"
+      ]
+    },
+    {
+      "inst": 701,
+      "name": "AUDIO-META-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/audio-bmf.fk"
+      ]
+    },
+    {
+      "inst": 710,
+      "name": "VIDEO-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/video-bmf.fk"
+      ]
+    },
+    {
+      "inst": 711,
+      "name": "VIDEO-META-FILE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/video-bmf.fk"
+      ]
+    },
+    {
+      "inst": 730,
+      "name": "DOCUMENT-CONTAINER",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/document-bmf.fk"
+      ]
+    },
+    {
+      "inst": 760,
+      "name": "NATURAL-BMF-FACT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/natural-bmf.fk"
+      ]
+    },
+    {
+      "inst": 761,
+      "name": "NATURAL-BMF-RELATION",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/natural-bmf.fk"
+      ]
+    },
+    {
+      "inst": 762,
+      "name": "NATURAL-BMF-QUESTION",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/natural-bmf.fk"
+      ]
+    },
+    {
+      "inst": 763,
+      "name": "NATURAL-BMF-MEANING",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/grammars/natural-bmf.fk"
+      ]
+    },
+    {
+      "inst": 951,
+      "name": "CONCEPT-V1",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-corpus.fk"
+      ]
+    },
+    {
+      "inst": 952,
+      "name": "CONCEPT-VISUALS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-corpus.fk"
+      ]
+    },
+    {
+      "inst": 953,
+      "name": "CONCEPT-VISUAL",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-corpus.fk"
+      ]
+    },
+    {
+      "inst": 1100,
+      "name": "EMBEDDING_BLUEPRINT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/embedding-as-recipe.fk"
+      ]
+    },
+    {
+      "inst": 1200,
+      "name": "AUDIO-TRIAD",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/synesthesia.fk"
+      ]
+    },
+    {
+      "inst": 1201,
+      "name": "IMAGE-TRIANGLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/synesthesia.fk"
+      ]
+    },
+    {
+      "inst": 1202,
+      "name": "RATIO-3",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/synesthesia.fk"
+      ]
+    },
+    {
+      "inst": 1300,
+      "name": "RECIPE-A-BLUEPRINT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/codon-band.fk"
+      ]
+    },
+    {
+      "inst": 1301,
+      "name": "RECIPE-B-BLUEPRINT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/codon-band.fk"
+      ]
+    },
+    {
+      "inst": 1400,
+      "name": "MIDI-NOTE-ON",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/midi-bmf.fk"
+      ]
+    },
+    {
+      "inst": 1401,
+      "name": "MIDI-NOTE-OFF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/midi-bmf.fk"
+      ]
+    },
+    {
+      "inst": 1402,
+      "name": "MIDI-TRACK",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/midi-bmf.fk"
+      ]
+    },
+    {
+      "inst": 1403,
+      "name": "MIDI-SONG",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/midi-bmf.fk"
+      ]
+    },
+    {
+      "inst": 1500,
+      "name": "PARETO-CANDIDATE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/pareto.fk"
+      ]
+    },
+    {
+      "inst": 1600,
+      "name": "AUTO-EXPERIMENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/autoresearch-loop.fk"
+      ]
+    },
+    {
+      "inst": 1700,
+      "name": "CHANNEL-V0",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel.fk"
+      ]
+    },
+    {
+      "inst": 1701,
+      "name": "CHANNEL-MSG",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel.fk"
+      ]
+    },
+    {
+      "inst": 1710,
+      "name": "QUERY",
+      "meaning": "",
+      "aliases": [
+        "cell-bp-2-nid"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk",
+        "form/form-stdlib/tests/biography-band.fk"
+      ]
+    },
+    {
+      "inst": 1711,
+      "name": "RESPONSE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1712,
+      "name": "SUBSTRATE-REF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1713,
+      "name": "NOVEL-BLUEPRINT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1714,
+      "name": "RECIPE-CONTENT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1715,
+      "name": "CELL-REF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1716,
+      "name": "EXTERNAL-URI",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query.fk"
+      ]
+    },
+    {
+      "inst": 1717,
+      "name": "QUERY-PARSE-ERROR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/channel-query-json.fk"
+      ]
+    },
+    {
+      "inst": 1720,
+      "name": "PING-SELF",
+      "meaning": "",
+      "aliases": [
+        "REGISTRATION"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/cell-registry.fk",
+        "form/form-stdlib/ping.fk"
+      ]
+    },
+    {
+      "inst": 1721,
+      "name": "CAPABILITIES",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/cell-registry.fk"
+      ]
+    },
+    {
+      "inst": 1730,
+      "name": "SYMBOL-BIND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/symbols.fk"
+      ]
+    },
+    {
+      "inst": 1731,
+      "name": "SYMBOL-TABLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/symbols.fk"
+      ]
+    },
+    {
+      "inst": 1732,
+      "name": "SYMBOL-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/symbols.fk"
+      ]
+    },
+    {
+      "inst": 1740,
+      "name": "HANDLER",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/verb-router.fk"
+      ]
+    },
+    {
+      "inst": 1741,
+      "name": "HANDLER-TABLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/verb-router.fk"
+      ]
+    },
+    {
+      "inst": 1742,
+      "name": "HANDLER-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/verb-router.fk"
+      ]
+    },
+    {
+      "inst": 1750,
+      "name": "HTTP-REQUEST",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/http-parse.fk"
+      ]
+    },
+    {
+      "inst": 1751,
+      "name": "HTTP-HEADERS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/http-parse.fk"
+      ]
+    },
+    {
+      "inst": 1752,
+      "name": "HTTP-HEADER",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/http-parse.fk"
+      ]
+    },
+    {
+      "inst": 1753,
+      "name": "HTTP-PARSE-ERROR",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/http-parse.fk"
+      ]
+    },
+    {
+      "inst": 1760,
+      "name": "MESSAGE-CAT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/chat-band.fk"
+      ]
+    },
+    {
+      "inst": 1770,
+      "name": "SENTINEL",
+      "meaning": "",
+      "aliases": [
+        "AUDIT-ENTRY",
+        "HEX-DECODE-ERROR"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/audit-log.fk",
+        "form/form-stdlib/hex.fk",
+        "form/form-stdlib/tests/hex-band.fk"
+      ]
+    },
+    {
+      "inst": 1771,
+      "name": "SENTINEL",
+      "meaning": "",
+      "aliases": [
+        "AUDIT-LOG",
+        "URL-DECODE-ERROR"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/audit-log.fk",
+        "form/form-stdlib/tests/url-encode-band.fk",
+        "form/form-stdlib/url-encode.fk"
+      ]
+    },
+    {
+      "inst": 1780,
+      "name": "SCHEMA-CAT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/schema.fk"
+      ]
+    },
+    {
+      "inst": 1781,
+      "name": "SCHEMA-LEAF",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/schema.fk"
+      ]
+    },
+    {
+      "inst": 1782,
+      "name": "SCHEMA-LIST",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/schema.fk"
+      ]
+    },
+    {
+      "inst": 1783,
+      "name": "SCHEMA-TUPLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/schema.fk"
+      ]
+    },
+    {
+      "inst": 1784,
+      "name": "SCHEMA-ANY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/schema.fk"
+      ]
+    },
+    {
+      "inst": 1790,
+      "name": "TOKEN",
+      "meaning": "",
+      "aliases": [
+        "OTHER-CAT"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/tests/schema-band.fk",
+        "form/form-stdlib/token.fk"
+      ]
+    },
+    {
+      "inst": 1800,
+      "name": "TRIANGLE-VERTEX",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/triangulate.fk"
+      ]
+    },
+    {
+      "inst": 1801,
+      "name": "TRIANGLE-COMPLETE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/triangulate.fk"
+      ]
+    },
+    {
+      "inst": 1810,
+      "name": "SYMBOLS-CONFLICT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/symbols-merge.fk"
+      ]
+    },
+    {
+      "inst": 1820,
+      "name": "HEARTBEAT-ENTRY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/heartbeat.fk"
+      ]
+    },
+    {
+      "inst": 1821,
+      "name": "HEARTBEAT-TABLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/heartbeat.fk"
+      ]
+    },
+    {
+      "inst": 1830,
+      "name": "BIOGRAPHY",
+      "meaning": "",
+      "aliases": [
+        "DIFF-EQUAL",
+        "cell-bp-1-nid",
+        "cell-locator"
+      ],
+      "reuse": 4,
+      "defined_in": [
+        "form/form-stdlib/tests/biography-band.fk",
+        "form/form-stdlib/tree-diff.fk"
+      ]
+    },
+    {
+      "inst": 1831,
+      "name": "DIFF-REPLACE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tree-diff.fk"
+      ]
+    },
+    {
+      "inst": 1832,
+      "name": "DIFF-CHILDREN",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tree-diff.fk"
+      ]
+    },
+    {
+      "inst": 1840,
+      "name": "BUCKET",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/rate-limit.fk"
+      ]
+    },
+    {
+      "inst": 1850,
+      "name": "NAME-RECORD",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/dns.fk"
+      ]
+    },
+    {
+      "inst": 1851,
+      "name": "DNS-TABLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/dns.fk"
+      ]
+    },
+    {
+      "inst": 1852,
+      "name": "DNS-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/dns.fk"
+      ]
+    },
+    {
+      "inst": 1853,
+      "name": "DNS-PREFIX-MATCH",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/dns.fk"
+      ]
+    },
+    {
+      "inst": 1860,
+      "name": "SESSION",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/session.fk"
+      ]
+    },
+    {
+      "inst": 1861,
+      "name": "SESSION-TABLE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/session.fk"
+      ]
+    },
+    {
+      "inst": 1862,
+      "name": "SESSION-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/session.fk"
+      ]
+    },
+    {
+      "inst": 1870,
+      "name": "UUID",
+      "meaning": "the arrival event/context",
+      "aliases": [
+        "ARRIVAL"
+      ],
+      "reuse": 2,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk",
+        "form/form-stdlib/uuid.fk"
+      ]
+    },
+    {
+      "inst": 1871,
+      "name": "SENTINEL",
+      "meaning": "felt quality of this arrival",
+      "aliases": [
+        "ARRIVAL-QUALITY",
+        "UUID-PARSE-ERROR"
+      ],
+      "reuse": 3,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk",
+        "form/form-stdlib/tests/uuid-band.fk",
+        "form/form-stdlib/uuid.fk"
+      ]
+    },
+    {
+      "inst": 1872,
+      "name": "ARRIVAL-INQUIRY",
+      "meaning": "an inquiry offered at arrival",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk"
+      ]
+    },
+    {
+      "inst": 1873,
+      "name": "ARRIVAL-RESONANCE",
+      "meaning": "what the field notices in the arrival",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk"
+      ]
+    },
+    {
+      "inst": 1874,
+      "name": "ARRIVAL-OBS",
+      "meaning": "arrival-flavored observation (structurally parallel to THIA-OBS 1805)",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk"
+      ]
+    },
+    {
+      "inst": 1880,
+      "name": "CELL-IDENTITY",
+      "meaning": "sovereign identity a cell presents",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk"
+      ]
+    },
+    {
+      "inst": 1881,
+      "name": "CONTACT-THREAD",
+      "meaning": "logical relationship between two identities",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/arrival.fk"
+      ]
+    },
+    {
+      "inst": 1885,
+      "name": "SKILL-PRESENT-IDENTITY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1886,
+      "name": "SKILL-MUTUAL-MEET",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1887,
+      "name": "SKILL-READ-RELATIONSHIP",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1888,
+      "name": "SKILL-WELCOME-WITH-ORIENTATION",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1889,
+      "name": "SKILL-RECORD-EXCHANGE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1890,
+      "name": "SKILL-SET-BOUNDARY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/skills/agent-relationship-skill.fk"
+      ]
+    },
+    {
+      "inst": 1900,
+      "name": "INQUIRY",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/inquiry.fk"
+      ]
+    },
+    {
+      "inst": 1910,
+      "name": "XPATH-RESULT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/xpath.fk"
+      ]
+    },
+    {
+      "inst": 1911,
+      "name": "XPATH-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/xpath.fk"
+      ]
+    },
+    {
+      "inst": 1912,
+      "name": "XPATH-STEP",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/xpath.fk"
+      ]
+    },
+    {
+      "inst": 1913,
+      "name": "XPATH-PREDICATE",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/xpath.fk"
+      ]
+    },
+    {
+      "inst": 1920,
+      "name": "DOC",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/doc-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1921,
+      "name": "SECTION-LIST",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/doc-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1922,
+      "name": "SECTION",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/doc-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1923,
+      "name": "DOC-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/doc-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1930,
+      "name": "CONCEPT",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1931,
+      "name": "CONCEPT-NOT-FOUND",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1932,
+      "name": "CONCEPT-CORPUS-C",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-xpath.fk"
+      ]
+    },
+    {
+      "inst": 1933,
+      "name": "CONCEPT-XREFS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/concept-xpath.fk"
+      ]
+    },
+    {
+      "inst": 7000,
+      "name": "topic-nid",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/channel-query-band.fk"
+      ]
+    },
+    {
+      "inst": 7700,
+      "name": "CAT-PLUS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/tree-diff-band.fk"
+      ]
+    },
+    {
+      "inst": 7701,
+      "name": "CAT-MINUS",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/tree-diff-band.fk"
+      ]
+    },
+    {
+      "inst": 7702,
+      "name": "CAT-N",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/tree-diff-band.fk"
+      ]
+    },
+    {
+      "inst": 7703,
+      "name": "CAT-M",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/tree-diff-band.fk"
+      ]
+    },
+    {
+      "inst": 7801,
+      "name": "topic-nid",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/kv-store-band.fk"
+      ]
+    },
+    {
+      "inst": 8101,
+      "name": "topic-a",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/async-correlation-band.fk"
+      ]
+    },
+    {
+      "inst": 8102,
+      "name": "topic-b",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/async-correlation-band.fk"
+      ]
+    },
+    {
+      "inst": 8103,
+      "name": "topic-c",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/async-correlation-band.fk"
+      ]
+    },
+    {
+      "inst": 8888,
+      "name": "topic-nid",
+      "meaning": "",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/tests/multi-hop-band.fk"
+      ]
+    }
+  ]
+}

--- a/form/form-stdlib/form-ontology-loader.fk
+++ b/form/form-stdlib/form-ontology-loader.fk
@@ -56,6 +56,70 @@
 (let FORM-CATEGORY-TABLE  (fol-build-rows (json-object-get ONTOLOGY-JSON "categories")))
 (let FORM-PRIMITIVE-TABLE (fol-build-rows (json-object-get ONTOLOGY-JSON "primitives")))
 
+;; --- user-space (type-99) registry → name resolver -----------------
+;;
+;; blueprint-registry.json is the single source of truth for shapes the
+;; kernel does not dispatch on (object/array/pair, dialect AST nodes, the
+;; THIA/arrival/identity blocks, …). It replaces the hundreds of scattered
+;; `(let X (make_nodeid 1 2 99 N))` magic-number redeclarations: a row here
+;; names the shape once; `.fk` code asks for it by name via `(bp "name")`.
+;;
+;; Each row contributes its canonical name AND every historical alias as a
+;; row in FORM-USER-TABLE, so a grammar that still says JSON-OBJECT and one
+;; that says HTML-OBJ both resolve to 99.10 through one number.
+
+(let REGISTRY-JSON
+    (read_with_cache "form-stdlib/blueprint-registry.json"
+                     "form-stdlib/.cache/blueprint-registry.fkb"
+                     parse-json))
+
+;; (name 99 inst) row for the canonical name, then one per alias.
+(defn fol-user-rows-for (bp-obj acc)
+    (do
+        (let inst (json-int-value (json-object-get bp-obj "inst")))
+        (let canon (list (json-string-value (json-object-get bp-obj "name")) 99 inst))
+        (let aliases (json-array-elements (json-object-get bp-obj "aliases")))
+        (fol-user-alias-rows aliases inst (cons canon acc))))
+
+(defn fol-user-alias-rows (aliases inst acc)
+    (if (eq (len aliases) 0) acc
+        (fol-user-alias-rows (tail aliases) inst
+            (cons (list (json-string-value (head aliases)) 99 inst) acc))))
+
+(defn fol-user-rows-loop (bps acc)
+    (if (eq (len bps) 0) acc
+        (fol-user-rows-loop (tail bps) (fol-user-rows-for (head bps) acc))))
+
+(let FORM-USER-TABLE
+    (fol-user-rows-loop
+        (json-array-elements (json-object-get REGISTRY-JSON "blueprints"))
+        (empty)))
+
+;; bp — resolve any registered Blueprint name to its NodeID. Searches the
+;; kernel-aligned tables first (categories, primitives), then the user
+;; registry. A row is (name type inst); registered shapes live at pkg=1,
+;; level=2. An unregistered name returns the undefined NodeID (1 2 0 0) —
+;; the scanner is what guards against that ever shipping.
+(defn fol-row->nodeid (row)
+    (make_nodeid 1 2 (head (tail row)) (head (tail (tail row)))))
+
+(defn fol-lookup3 (a b c name)
+    (do
+        (let ra (fol-table-lookup a name))
+        (if (gt (len ra) 0) ra
+            (do
+                (let rb (fol-table-lookup b name))
+                (if (gt (len rb) 0) rb
+                    (fol-table-lookup c name))))))
+
+(defn bp (name)
+    (do
+        (let row (fol-lookup3 FORM-CATEGORY-TABLE FORM-PRIMITIVE-TABLE
+                              FORM-USER-TABLE name))
+        (if (eq (len row) 0)
+            (make_nodeid 1 2 0 0)
+            (fol-row->nodeid row))))
+
 ;; --- recipe-building helpers ----------------------------------------
 ;;
 ;; The loader builds (let NAME (make_nodeid 1 2 T I)) and (defn NAME ()

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -48,37 +48,29 @@
 ;                        grammars/python-bmf.fk, python-bmf-eval.fk
 
 (do
-    ;; ---- MATH-12 NodeIDs (CTOR Shape B) ----------------------------
+    ;; ---- MATH / COMPARE NodeIDs (CTOR Shape B) ---------------------
     ;;
-    ;; The canonical RBasic.MATH category — same NodeIDs the kernel's
-    ;; arithmetic primitives carry (see form-ontology.json `primitives`
-    ;; rows for add/sub/mul/div and tests/emit-engine.fk lines 30-33).
-    ;; lift-binop-loop interns `+ - * /` against these — picking up the
-    ;; one Blueprint per shape so a hand-built `(intern_node MATH-PLUS
-    ;; ...)` and a Python-lifted `7 + 3` content-address to the same
-    ;; cell. The other arithmetic ops (** // %) stay on PY-BMF-BINOP
-    ;; until MATH instances ship for them.
-    (let MATH-PLUS     (make_nodeid 1 2 12 1))
-    (let MATH-MINUS    (make_nodeid 1 2 12 2))
-    (let MATH-MULTIPLY (make_nodeid 1 2 12 3))
-    (let MATH-DIVIDE   (make_nodeid 1 2 12 4))
-    (let MATH-MOD      (make_nodeid 1 2 12 5))
+    ;; The canonical RBasic.MATH and RBasic.COMPARE categories — the same
+    ;; NodeIDs the kernel's primitives carry. Resolved by name through
+    ;; `bp` (form-ontology-loader.fk) so the numbers live in ONE place
+    ;; (form-ontology.json), never as magic-number redeclarations here.
+    ;; lift-binop-loop interns `+ - * / == != < <= > >=` against these —
+    ;; picking up the one Blueprint per shape so a hand-built recipe and
+    ;; a Python-lifted `7 + 3` / `5 < 7` content-address to the same cell.
+    ;; The other arithmetic ops (** //) stay on PY-BMF-BINOP until MATH
+    ;; instances ship for them.
+    (let MATH-PLUS     (bp "add"))
+    (let MATH-MINUS    (bp "sub"))
+    (let MATH-MULTIPLY (bp "mul"))
+    (let MATH-DIVIDE   (bp "div"))
+    (let MATH-MOD      (bp "mod"))
 
-    ;; ---- COMPARE-13 NodeIDs (CTOR Shape B for comparisons) ---------
-    ;;
-    ;; The canonical RBasic.COMPARE category — same NodeIDs the kernel's
-    ;; comparison primitives carry (see form-ontology.json `primitives`
-    ;; rows for eq/ne/lt/le/gt/ge at type=13). lift-binop-loop interns
-    ;; `== != < <= > >=` against these — picking up the one Blueprint
-    ;; per shape so a hand-built `(intern_node COMPARE-LT ...)` and a
-    ;; Python-lifted `5 < 7` content-address to the same cell. Unknown
-    ;; compare ops (none today, but defensive) fall back to PY-BMF-COMPARE.
-    (let COMPARE-EQ (make_nodeid 1 2 13 1))
-    (let COMPARE-NE (make_nodeid 1 2 13 2))
-    (let COMPARE-LT (make_nodeid 1 2 13 3))
-    (let COMPARE-LE (make_nodeid 1 2 13 4))
-    (let COMPARE-GT (make_nodeid 1 2 13 5))
-    (let COMPARE-GE (make_nodeid 1 2 13 6))
+    (let COMPARE-EQ (bp "eq"))
+    (let COMPARE-NE (bp "ne"))
+    (let COMPARE-LT (bp "lt"))
+    (let COMPARE-LE (bp "le"))
+    (let COMPARE-GT (bp "gt"))
+    (let COMPARE-GE (bp "ge"))
 
     ;; ---- token accessors -------------------------------------------
     ;;

--- a/form/user-blueprint-registry.md
+++ b/form/user-blueprint-registry.md
@@ -2,6 +2,19 @@
 
 **Purpose**: To make the meaning of custom Blueprints (make_nodeid 1 2 99 NNNN) legible, allocated with awareness, and minimized through composition.
 
+## Source of truth
+
+The machine-readable registry is [`form-stdlib/blueprint-registry.json`](form-stdlib/blueprint-registry.json) — one row per type-99 shape: canonical name, meaning, aliases, defining files. It is **code-derived and scanner-verified**, so it cannot quietly drift from reality the way a hand-kept table does. (This document used to claim `1870 = ARRIVAL`; the code says `1870 = UUID`. That drift is exactly what a generated, verified registry prevents.) This markdown holds the *why* — allocation rationale, composition reviews, the living narrative below. The JSON holds the *what*.
+
+**How a Form file uses a Blueprint:** load `form-stdlib/form-ontology-loader.fk` as a prelude and ask by name — `(bp "JSON-OBJECT")`, `(bp "add")`, `(bp "UUID")`. The loader reads the registry (and the kernel-aligned categories/primitives in `form-ontology.json`) and resolves the name to its NodeID. The raw `(make_nodeid 1 2 99 N)` literal never appears in feature code. An unregistered name resolves to the undefined NodeID `(1 2 0 0)` — the scanner guards against that shipping.
+
+**How to add a new shape:** add the row first (`python3 scripts/scan_form_blueprints.py --emit-registry` harvests it from a `(let NAME (make_nodeid 1 2 99 N))` you write, or curate by hand and set `"curated": true` to protect the name/meaning across regenerations), then reference it via `(bp "NAME")`. The scanner's `--check` (run in `make wellness`) fails if any type-99 number is used without a registry row.
+
+**The scanner — `scripts/scan_form_blueprints.py`:**
+- no args → full report: every `make_nodeid` literal, how many shapes are registered, which numbers wear many local names (synonyms to collapse), which names point at more than one number (drift to heal).
+- `--check` → forward gate: nonzero exit if a type-99 number is used but unregistered.
+- `--emit-registry` → regenerate the JSON from code, preserving curated rows.
+
 ## The Problem (as named)
 
 Scattered ad-hoc allocation of opaque numbers in the user range creates:
@@ -38,12 +51,14 @@ When you need a new user-range Blueprint:
 
 ## Registry (living)
 
-A live scan (as of this writing) found **323 distinct** user-range Blueprint numbers.
+The full enumeration now lives in [`form-stdlib/blueprint-registry.json`](form-stdlib/blueprint-registry.json) — run the scanner for the current snapshot rather than reading a number that goes stale here. At the time of generation it held **292 distinct** type-99 shapes.
 
-**Scan highlights**:
-- Strong healthy reuse in low numbers (0–99 has 75 distinct numbers, many reused across grammars).
-- Clear clusters in the 1700s (31) and 1800s (18) — the latter includes the recent THIA allocations.
-- Defensive high numbering visible in 7000+, 7700+, 8100+, 8800+, 9000+ ranges.
+**What the scan surfaces (run `python3 scripts/scan_form_blueprints.py` for the live view):**
+- Strong healthy reuse in low numbers (the universal structural shapes — object 10, array 11, pair 12, null 13 — are each shared by ~12 grammars; this is content-addressing working as intended, and `bp` now lets every grammar reach them by one name).
+- Clusters in the 1700s (channel/audit) and 1800s (THIA, identity, arrival, skill verbs).
+- Defensive high numbering still visible in 7000+, 7700+, 8100+, 8800+, 9000+ ranges — candidates for composition review.
+- **Synonyms to collapse**: the same number wears many per-dialect names (`MATH-PLUS`/`PY-PLUS`/`GO-PLUS`/… all = `add`). Migrating these to `(bp "...")` is the ongoing hygiene; `python-bmf-lift.fk` is the migrated exemplar.
+- **Drift to heal with care**: a few names (`PY-ASSIGN`, `PY-IDENT`, `RS-MOD`) mean a canonical category in an emitter but a dialect AST node in a grammar — same prefix chosen for different-layer concepts in separate files. Legibility debt, not a runtime collision; rename needs architectural attention, not a mechanical sweep.
 
 ### Allocation Principles (current)
 
@@ -53,13 +68,7 @@ A live scan (as of this writing) found **323 distinct** user-range Blueprint num
 
 ## Tooling
 
-A scanner should exist (or be created/enhanced) that:
-- Walks all .fk files
-- Reports every `make_nodeid 1 2 99 N` with file + surrounding definition
-- Flags duplicates or gaps
-- Can be run as part of wellness or pre-commit
-
-See `scripts/` for existing Form validation tools (e.g. validate_form_ontology.py) as models.
+The scanner lives at [`scripts/scan_form_blueprints.py`](../../scripts/scan_form_blueprints.py). It walks every `.fk` file, cross-references the registry, and reports magic literals, synonyms, and name drift; `--check` is wired into `make wellness` (`sense_form_blueprints`) as the forward gate against new unregistered numbers. See the **Source of truth** section above for the full command surface.
 
 ## Active Practice
 
@@ -111,6 +120,8 @@ Both streams have real, independent forward movement in this turn. No input requ
 ---
 
 ## New Allocation — Arrival Protocol (1870–1873)
+
+> **Correction (verified against code):** these arrival numbers were *intended* but never landed at 1870–1874. In the actual `.fk` source, 1870 = `UUID` and 1871 = `UUID-PARSE-ERROR`; the arrival shapes that did land sit at 1872 (`ARRIVAL-INQUIRY`), 1873 (`ARRIVAL-RESONANCE`), 1874 (`ARRIVAL-OBS`). See [`blueprint-registry.json`](form-stdlib/blueprint-registry.json) for what the code holds now. This narrative is preserved as intent; the registry is the truth.
 
 **Date**: 2026-05-29  
 **Context**: Created `form/form-stdlib/arrival.fk` as the native Form expression of the arrival protocol (the empty room as opening). This directly supports the THIA design intent ("early in the arrival sequence") while keeping shell entry points pure and letting cells choose recognition. It also turns the lived repetition-under-saturation failure (on sense/session-saturation-snapshot) into field proprioception rather than something to limit.

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,138 +4,139 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 131
+**Total files**: 132
 
 | File | Purpose |
 |---|---|
-| [active_recipe_trace_index.py](active_recipe_trace_index.py) | !/usr/bin/env python3 |
-| [add_crosslinks.py](add_crosslinks.py) | !/usr/bin/env python3 |
-| [add_task_cards_to_specs.py](add_task_cards_to_specs.py) | !/usr/bin/env python3 |
-| [agent_status.py](agent_status.py) | !/usr/bin/env python3 |
-| [archive_view_events.py](archive_view_events.py) | !/usr/bin/env python3 |
-| [arrival.py](arrival.py) | !/usr/bin/env python3 |
-| [assemblage_shift_recipe_proof.py](assemblage_shift_recipe_proof.py) | !/usr/bin/env python3 |
-| [audit_external_tools.py](audit_external_tools.py) | !/usr/bin/env python3 |
-| [audit_vision_image_candidates.py](audit_vision_image_candidates.py) | !/usr/bin/env python3 |
-| [awareness_node_daemon.py](awareness_node_daemon.py) | !/usr/bin/env python3 |
-| [backfill_task_workspaces.py](backfill_task_workspaces.py) | !/usr/bin/env python3 |
-| [backfill_traceability.py](backfill_traceability.py) | !/usr/bin/env python3 |
-| [bootstrap_new_agent_session.py](bootstrap_new_agent_session.py) | !/usr/bin/env python3 |
-| [build_readmes.py](build_readmes.py) | !/usr/bin/env python3 |
-| [cc.py](cc.py) | !/usr/bin/env python3 |
-| [check_dev_auth.py](check_dev_auth.py) | !/usr/bin/env python3 |
-| [check_generated_vision_assets.py](check_generated_vision_assets.py) | !/usr/bin/env python3 |
-| [check_pr_followthrough.py](check_pr_followthrough.py) | !/usr/bin/env python3 |
-| [check_provider_health.py](check_provider_health.py) | !/usr/bin/env python3 |
-| [check_runtime_drift.py](check_runtime_drift.py) | !/usr/bin/env python3 |
-| [check_spec_references.py](check_spec_references.py) | !/usr/bin/env python3 |
-| [check_traceability.py](check_traceability.py) | !/usr/bin/env python3 |
-| [check_web_docker_context.py](check_web_docker_context.py) | !/usr/bin/env python3 |
-| [cluster_watch_history.py](cluster_watch_history.py) | !/usr/bin/env python3 |
-| [coh_substrate.py](coh_substrate.py) | !/usr/bin/env python3 |
-| [coherence_reach.py](coherence_reach.py) | !/usr/bin/env python3 |
+| [active_recipe_trace_index.py](active_recipe_trace_index.py) | Read active recipe traces from the local witness stream. |
+| [add_crosslinks.py](add_crosslinks.py) | Add clickable cross-links to specs INDEX and spec files for GitHub navigation. |
+| [add_task_cards_to_specs.py](add_task_cards_to_specs.py) | Add Task Card and Research Inputs sections to spec files that don't have them. |
+| [agent_status.py](agent_status.py) | Show active work across all coding agents (worktrees + tasks). |
+| [archive_view_events.py](archive_view_events.py) | Move days of asset_view_events into cold-tier storage. |
+| [arrival.py](arrival.py) | Arrival — read first, sense the body, then begin. |
+| [assemblage_shift_recipe_proof.py](assemblage_shift_recipe_proof.py) | assemblage_shift_recipe_proof.py — the modality round-trip, walking. |
+| [audit_external_tools.py](audit_external_tools.py) | Audit external tooling usage and detect untracked additions. |
+| [audit_vision_image_candidates.py](audit_vision_image_candidates.py) | Audit regenerated vision image candidates before production promotion. |
+| [awareness_node_daemon.py](awareness_node_daemon.py) | Quiet local presence loop for Coherence agents. |
+| [backfill_task_workspaces.py](backfill_task_workspaces.py) | Backfill agent_tasks.workspace_id from linked idea.context.idea_id. |
+| [backfill_traceability.py](backfill_traceability.py) | Backfill traceability links: spec→idea, code→spec, PR→spec. |
+| [bootstrap_new_agent_session.py](bootstrap_new_agent_session.py) | Bootstrap a persistent agent session against the real substrate. |
+| [build_readmes.py](build_readmes.py) | Build README files from templates by expanding <!-- include: path --> markers. |
+| [cc.py](cc.py) | _no top-of-file purpose_ |
+| [check_dev_auth.py](check_dev_auth.py) | Preflight: verify local GitHub auth is usable for Codex automation. |
+| [check_generated_vision_assets.py](check_generated_vision_assets.py) | Validate generated vision assets referenced by concepts and web pages. |
+| [check_pr_followthrough.py](check_pr_followthrough.py) | Local process gate to avoid abandoning open Codex PRs. |
+| [check_provider_health.py](check_provider_health.py) | Provider health check — verify all CLIs are authenticated and working. |
+| [check_runtime_drift.py](check_runtime_drift.py) | Fail when runtime drift exceeds known allowlist baseline. |
+| [check_spec_references.py](check_spec_references.py) | spec: full-code-traceability |
+| [check_traceability.py](check_traceability.py) | CI gate: check that new/modified specs have idea_id and code files have spec refs. |
+| [check_web_docker_context.py](check_web_docker_context.py) | Catch web/ imports reaching above the Docker build context. |
+| [cluster_watch_history.py](cluster_watch_history.py) | Cluster a YouTube/podcast watch-history into main influences. |
+| [coh_substrate.py](coh_substrate.py) | coh substrate — unified CLI for the coherence-substrate. |
+| [coherence_reach.py](coherence_reach.py) | coherence_reach — measure where an identity is named across the body. |
 | [compost_resonance_noise.py](compost_resonance_noise.py) | One-shot data cleanup — compost dead-tissue presences and re-attune. |
-| [connect_ubud_cluster_inspired_by.py](connect_ubud_cluster_inspired_by.py) | !/usr/bin/env python3 |
-| [context_budget.py](context_budget.py) | !/usr/bin/env python3 |
-| [daily_brief.py](daily_brief.py) | !/usr/bin/env python3 |
-| [demo_dual_identity.py](demo_dual_identity.py) | !/usr/bin/env python3 |
-| [embodiment_practice_recipe_proof.py](embodiment_practice_recipe_proof.py) | !/usr/bin/env python3 |
-| [encoder_decoder_recipe_proof.py](encoder_decoder_recipe_proof.py) | !/usr/bin/env python3 |
-| [encounter.py](encounter.py) | !/usr/bin/env python3 |
-| [evaluate_spec_tests.py](evaluate_spec_tests.py) | !/usr/bin/env python3 |
-| [executor_handoff.py](executor_handoff.py) | !/usr/bin/env python3 |
-| [export_graph_to_repo.py](export_graph_to_repo.py) | !/usr/bin/env python3 |
-| [export_lineage.py](export_lineage.py) | !/usr/bin/env python3 |
-| [export_vision_image_prompts.py](export_vision_image_prompts.py) | !/usr/bin/env python3 |
-| [external_proof_demo.py](external_proof_demo.py) | !/usr/bin/env python3 |
-| [federation_peer_poll.py](federation_peer_poll.py) | !/usr/bin/env python3 |
-| [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | !/usr/bin/env python3 |
-| [form_cli.py](form_cli.py) | !/usr/bin/env python3 |
-| [form_native_grammar_contract.py](form_native_grammar_contract.py) | !/usr/bin/env python3 |
-| [framebuffer_viewer.py](framebuffer_viewer.py) | !/usr/bin/env python3 |
+| [connect_ubud_cluster_inspired_by.py](connect_ubud_cluster_inspired_by.py) | Connect Urs's contributor node to the Ubud cluster via inspired-by edges. |
+| [context_budget.py](context_budget.py) | Context-budget helper for large-file-aware code exploration. |
+| [daily_brief.py](daily_brief.py) | Coherence Network — Daily Brief Generator. |
+| [demo_dual_identity.py](demo_dual_identity.py) | Demo: Idea Dual Identity — UUID + Slug |
+| [embodiment_practice_recipe_proof.py](embodiment_practice_recipe_proof.py) | embodiment_practice_recipe_proof.py — practices as recipes of cells. |
+| [encoder_decoder_recipe_proof.py](encoder_decoder_recipe_proof.py) | encoder_decoder_recipe_proof.py — every modality codec interns to the |
+| [encounter.py](encounter.py) | Encounter — flow external influences into the graph. |
+| [evaluate_spec_tests.py](evaluate_spec_tests.py) | Evaluate the pytest predicates on every active spec and promote to done |
+| [executor_handoff.py](executor_handoff.py) | Executor handoff: interactive sessions take over from background runner. |
+| [export_graph_to_repo.py](export_graph_to_repo.py) | Export graph-stored content back into the repo as files. |
+| [export_lineage.py](export_lineage.py) | Export the graph's presence lineage into a durable JSON manifest. |
+| [export_vision_image_prompts.py](export_vision_image_prompts.py) | Export persistent prompt records for Living Collective vision images. |
+| [external_proof_demo.py](external_proof_demo.py) | External proof demo — exercises the Coherence Network public API from outside the repo. |
+| [federation_peer_poll.py](federation_peer_poll.py) | federation_peer_poll — fire one peer-poll cycle from the command line. |
+| [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | Heal pre-existing spec body gaps the validator surfaces. |
+| [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: generate, execute, convert. |
+| [form_native_grammar_contract.py](form_native_grammar_contract.py) | Audit Form-native grammar status without counting host parser bridges as done. |
+| [framebuffer_viewer.py](framebuffer_viewer.py) | framebuffer_viewer.py — render the kernel's framebuffer as a text panel. |
 | [frequency_references.py](frequency_references.py) | Frequency reference corpus for the Living Collective scoring engine. |
-| [generate_curated_translations.py](generate_curated_translations.py) | !/usr/bin/env python3 |
-| [generate_repo_indexes.py](generate_repo_indexes.py) | !/usr/bin/env python3 |
-| [generate_silence_alive_visuals.py](generate_silence_alive_visuals.py) | !/usr/bin/env python3 |
-| [generate_silence_built_visuals.py](generate_silence_built_visuals.py) | !/usr/bin/env python3 |
-| [generate_silence_design_log.py](generate_silence_design_log.py) | !/usr/bin/env python3 |
-| [generate_silence_design_log_v2.py](generate_silence_design_log_v2.py) | !/usr/bin/env python3 |
-| [generate_visuals.py](generate_visuals.py) | !/usr/bin/env python3 |
-| [generate_work_visuals.py](generate_work_visuals.py) | !/usr/bin/env python3 |
-| [git_artifact_perceptron.py](git_artifact_perceptron.py) | !/usr/bin/env python3 |
-| [git_artifact_perceptron_substrate.py](git_artifact_perceptron_substrate.py) | !/usr/bin/env python3 |
-| [grammar_coverage.py](grammar_coverage.py) | !/usr/bin/env python3 |
-| [healing_modality_recipe_proof.py](healing_modality_recipe_proof.py) | !/usr/bin/env python3 |
-| [idea_to_task_bridge.py](idea_to_task_bridge.py) | !/usr/bin/env python3 |
-| [import_creations.py](import_creations.py) | !/usr/bin/env python3 |
-| [import_gatherings.py](import_gatherings.py) | !/usr/bin/env python3 |
-| [import_lineage.py](import_lineage.py) | !/usr/bin/env python3 |
-| [influence_teaching_translator.py](influence_teaching_translator.py) | !/usr/bin/env python3 |
-| [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | !/usr/bin/env python3 |
-| [ingest_audible_history.py](ingest_audible_history.py) | !/usr/bin/env python3 |
-| [intern_canonical_words.py](intern_canonical_words.py) | !/usr/bin/env python3 |
-| [intern_modality_blueprints.py](intern_modality_blueprints.py) | !/usr/bin/env python3 |
+| [generate_curated_translations.py](generate_curated_translations.py) | Generate machine-translated locale siblings (de/es/id) for curated |
+| [generate_repo_indexes.py](generate_repo_indexes.py) | Generate INDEX.md files for source-code directories. |
+| [generate_silence_alive_visuals.py](generate_silence_alive_visuals.py) | Generate the alive / growing-over-time views for /silence/built. |
+| [generate_silence_built_visuals.py](generate_silence_built_visuals.py) | Generate the compound-vision images for /silence/built via Pollinations. |
+| [generate_silence_design_log.py](generate_silence_design_log.py) | Generate the design-log iteration: sketch → plan → section → detail → axon → photoreal. |
+| [generate_silence_design_log_v2.py](generate_silence_design_log_v2.py) | V2 iteration — push harder on the two weakest rounds (plan + aerial). |
+| [generate_visuals.py](generate_visuals.py) | Pre-generate all Pollinations images and save as static assets. |
+| [generate_work_visuals.py](generate_work_visuals.py) | Generate hero images for works (asset nodes with creation_kind). |
+| [git_artifact_perceptron.py](git_artifact_perceptron.py) | git_artifact_perceptron.py — the smallest real version of the form perceptron. |
+| [git_artifact_perceptron_substrate.py](git_artifact_perceptron_substrate.py) | git_artifact_perceptron_substrate.py — the substrate-native perceptron. |
+| [grammar_coverage.py](grammar_coverage.py) | grammar_coverage.py — surface which file formats have Form grammars. |
+| [healing_modality_recipe_proof.py](healing_modality_recipe_proof.py) | healing_modality_recipe_proof.py — practitioner-with-receiver as Recipe. |
+| [idea_to_task_bridge.py](idea_to_task_bridge.py) | Idea-to-Task Bridge — automatically generate tasks from open ideas. |
+| [import_creations.py](import_creations.py) | Auto-import creations into the graph from external sources. |
+| [import_gatherings.py](import_gatherings.py) | Import gatherings from event-source URLs onto presence nodes. |
+| [import_lineage.py](import_lineage.py) | Replay a lineage manifest against any target via the public API. |
+| [influence_teaching_translator.py](influence_teaching_translator.py) | Print influence teaching translator shards for a field story. |
+| [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | Lay every Audible book as a first-class asset with full source trace. |
+| [ingest_audible_history.py](ingest_audible_history.py) | Flow Audible listening history into the graph. |
+| [intern_canonical_words.py](intern_canonical_words.py) | intern_canonical_words.py — CLI wrapper for the canonical lexicon interner. |
+| [intern_modality_blueprints.py](intern_modality_blueprints.py) | intern_modality_blueprints.py — CLI wrapper for the cross-modal interner. |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
-| [local_runner.py](local_runner.py) | !/usr/bin/env python3 |
-| [measure_gitnexus_value.py](measure_gitnexus_value.py) | !/usr/bin/env python3 |
-| [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | !/usr/bin/env python3 |
-| [migrate_spec_slugs.py](migrate_spec_slugs.py) | !/usr/bin/env python3 |
-| [morning_coherence_brief.py](morning_coherence_brief.py) | !/usr/bin/env python3 |
-| [opt_out_contributor.py](opt_out_contributor.py) | !/usr/bin/env python3 |
-| [organism_influence_cc.py](organism_influence_cc.py) | !/usr/bin/env python3 |
-| [plan_vision_image_regeneration.py](plan_vision_image_regeneration.py) | !/usr/bin/env python3 |
-| [poll_task_progress.py](poll_task_progress.py) | !/usr/bin/env python3 |
-| [pr_check_failure_triage.py](pr_check_failure_triage.py) | !/usr/bin/env python3 |
-| [prose_recipe_roundtrip.py](prose_recipe_roundtrip.py) | !/usr/bin/env python3 |
-| [publish_snapshot.py](publish_snapshot.py) | !/usr/bin/env python3 |
-| [quantum_physics_recipe_proof.py](quantum_physics_recipe_proof.py) | !/usr/bin/env python3 |
-| [reclassify_presence_types.py](reclassify_presence_types.py) | !/usr/bin/env python3 |
-| [register_providers.py](register_providers.py) | !/usr/bin/env python3 |
-| [resolve_presences.py](resolve_presences.py) | !/usr/bin/env python3 |
+| [local_runner.py](local_runner.py) | Coherence Network runner — thin shim. |
+| [measure_gitnexus_value.py](measure_gitnexus_value.py) | Measure GitNexus integration value across paired task windows. |
+| [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | Wire existing DB ideas into the fractal structure. |
+| [migrate_spec_slugs.py](migrate_spec_slugs.py) | Migrate spec slugs: strip numeric prefixes from spec IDs everywhere. |
+| [morning_coherence_brief.py](morning_coherence_brief.py) | Collect a morning Coherence brief from live network signals. |
+| [opt_out_contributor.py](opt_out_contributor.py) | Honour a contributor's opt-out across the network's body of evidence. |
+| [organism_influence_cc.py](organism_influence_cc.py) | Print computed organism influence CC for a field story. |
+| [plan_vision_image_regeneration.py](plan_vision_image_regeneration.py) | Split the vision prompt manifest into deterministic regeneration batches. |
+| [poll_task_progress.py](poll_task_progress.py) | Poll a task every minute and print progress until it reaches a terminal state. |
+| [pr_check_failure_triage.py](pr_check_failure_triage.py) | Detect, summarize, and optionally auto-rerun failing PR checks. |
+| [prose_recipe_roundtrip.py](prose_recipe_roundtrip.py) | prose_recipe_roundtrip.py — the bidirectional test, walking. |
+| [publish_snapshot.py](publish_snapshot.py) | Publish the weekly verification snapshot — public-verification-framework R2 CLI. |
+| [quantum_physics_recipe_proof.py](quantum_physics_recipe_proof.py) | quantum_physics_recipe_proof.py — quantum primitives compose into Recipes |
+| [reclassify_presence_types.py](reclassify_presence_types.py) | Move presences to their honest node types. |
+| [register_providers.py](register_providers.py) | Register renderers and complex asset types as tracked provider nodes in the graph DB. |
+| [resolve_presences.py](resolve_presences.py) | Backfill image_url + tagline on presence nodes. |
 | [restructure_spec_frontmatter.py](restructure_spec_frontmatter.py) | Restructure spec frontmatter: absorb requirements, done_when, test command. |
-| [run_claude_impl_with_report.py](run_claude_impl_with_report.py) | !/usr/bin/env python3 |
-| [run_form_practice.py](run_form_practice.py) | !/usr/bin/env python3 |
-| [run_pinned_idea_acceptance.py](run_pinned_idea_acceptance.py) | !/usr/bin/env python3 |
-| [scan_code_spec_references.py](scan_code_spec_references.py) | !/usr/bin/env python3 |
+| [run_claude_impl_with_report.py](run_claude_impl_with_report.py) | Run one Claude impl task (pinned spec), wait for terminal state, then write a report. |
+| [run_form_practice.py](run_form_practice.py) | Run any Form practice and record substrate cells plus witness ledger. |
+| [run_pinned_idea_acceptance.py](run_pinned_idea_acceptance.py) | Pinned-idea (portfolio-governance) acceptance: one path, proof at each step. |
+| [scan_code_spec_references.py](scan_code_spec_references.py) | spec: full-code-traceability |
 | [scan_dyad_candidates.py](scan_dyad_candidates.py) | Refined dyad-pair candidate scan over Living Collective concept cells. |
 | [scan_dyad_candidates_word.py](scan_dyad_candidates_word.py) | WORD-domain prose-structural dyad-pair scan over Living Collective concepts. |
-| [schedule_attunement.py](schedule_attunement.py) | !/usr/bin/env python3 |
-| [seed_commit_evidence.py](seed_commit_evidence.py) | !/usr/bin/env python3 |
-| [seed_db.py](seed_db.py) | !/usr/bin/env python3 |
-| [seed_schema_to_db.py](seed_schema_to_db.py) | !/usr/bin/env python3 |
-| [sense_external_signals.py](sense_external_signals.py) | !/usr/bin/env python3 |
-| [sense_strategy_efficacy.py](sense_strategy_efficacy.py) | !/usr/bin/env python3 |
-| [sense_world.py](sense_world.py) | !/usr/bin/env python3 |
-| [session_as_framebuffer.py](session_as_framebuffer.py) | !/usr/bin/env python3 |
-| [setup.py](setup.py) | !/usr/bin/env python3 |
-| [song_recipe_proof.py](song_recipe_proof.py) | !/usr/bin/env python3 |
-| [spec_recipe_proof.py](spec_recipe_proof.py) | !/usr/bin/env python3 |
+| [scan_form_blueprints.py](scan_form_blueprints.py) | Scan Form (.fk) sources for `make_nodeid` Blueprint literals and measure |
+| [schedule_attunement.py](schedule_attunement.py) | Re-attune every presence so newly added concepts get picked up. |
+| [seed_commit_evidence.py](seed_commit_evidence.py) | Seed the commit evidence API from local git history. |
+| [seed_db.py](seed_db.py) | Seed data/coherence.db from spec markdown files, commit evidence JSON, and inline idea data. |
+| [seed_schema_to_db.py](seed_schema_to_db.py) | One-time migration: load ontology schema (relationship types + axes) into DB. |
+| [sense_external_signals.py](sense_external_signals.py) | Sense the outer skin of the organism and record what is found. |
+| [sense_strategy_efficacy.py](sense_strategy_efficacy.py) | sense_strategy_efficacy.py — read accumulated strategy_fired traces and |
+| [sense_world.py](sense_world.py) | Sense the world through the new earth lens. |
+| [session_as_framebuffer.py](session_as_framebuffer.py) | Render a Claude session as a memory-as-framebuffer .mfb capture. |
+| [setup.py](setup.py) | Coherence Network — Auto-Setup. |
+| [song_recipe_proof.py](song_recipe_proof.py) | song_recipe_proof.py — songs compose into Recipes whose Blueprint |
+| [spec_recipe_proof.py](spec_recipe_proof.py) | spec_recipe_proof.py — a spec's frontmatter IS the playable Recipe. |
 | [start_gate.py](start_gate.py) | _no top-of-file purpose_ |
-| [strategy_after_rupture_recipe_proof.py](strategy_after_rupture_recipe_proof.py) | !/usr/bin/env python3 |
-| [substrate_parity_harness.py](substrate_parity_harness.py) | !/usr/bin/env python3 |
-| [substrate_read_hook.py](substrate_read_hook.py) | !/usr/bin/env python3 |
-| [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | !/usr/bin/env python3 |
-| [sync_kb_to_db.py](sync_kb_to_db.py) | !/usr/bin/env python3 |
-| [sync_presence_content.py](sync_presence_content.py) | !/usr/bin/env python3 |
-| [sync_presence_slugs.py](sync_presence_slugs.py) | !/usr/bin/env python3 |
-| [sync_presences_from_render.py](sync_presences_from_render.py) | !/usr/bin/env python3 |
-| [sync_presences_to_db.py](sync_presences_to_db.py) | !/usr/bin/env python3 |
-| [teaching_recipe_proof.py](teaching_recipe_proof.py) | !/usr/bin/env python3 |
-| [trim_view_events.py](trim_view_events.py) | !/usr/bin/env python3 |
-| [upgrade_specs_to_form_predicates.py](upgrade_specs_to_form_predicates.py) | !/usr/bin/env python3 |
-| [validate_commit_evidence.py](validate_commit_evidence.py) | !/usr/bin/env python3 |
-| [validate_local_api_matrix.py](validate_local_api_matrix.py) | !/usr/bin/env python3 |
-| [validate_spec_idea_traceability.py](validate_spec_idea_traceability.py) | !/usr/bin/env python3 |
-| [validate_spec_prefix_canonicalization.py](validate_spec_prefix_canonicalization.py) | !/usr/bin/env python3 |
-| [validate_spec_quality.py](validate_spec_quality.py) | !/usr/bin/env python3 |
-| [validate_workflow_references.py](validate_workflow_references.py) | !/usr/bin/env python3 |
-| [verify_hashes.py](verify_hashes.py) | !/usr/bin/env python3 |
+| [strategy_after_rupture_recipe_proof.py](strategy_after_rupture_recipe_proof.py) | strategy_after_rupture_recipe_proof.py — rupture-recovery primitives compose |
+| [substrate_parity_harness.py](substrate_parity_harness.py) | substrate_parity_harness.py — read the body in both voices, side by side. |
+| [substrate_read_hook.py](substrate_read_hook.py) | Claude Code PreToolUse hook — surface substrate annotation on file Reads. |
+| [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | Sync cross-references from KB concept files into graph DB edges. |
+| [sync_kb_to_db.py](sync_kb_to_db.py) | Sync KB markdown files -> Graph DB via API. |
+| [sync_presence_content.py](sync_presence_content.py) | Sync structured presence content from JSON files into graph nodes. |
+| [sync_presence_slugs.py](sync_presence_slugs.py) | Sync `/people/{slug}` presence pages back onto contributor nodes. |
+| [sync_presences_from_render.py](sync_presences_from_render.py) | Sync writing-surface presence .md files from the rendering-surface JSON. |
+| [sync_presences_to_db.py](sync_presences_to_db.py) | Sync presence markdown files -> Graph DB via API. |
+| [teaching_recipe_proof.py](teaching_recipe_proof.py) | teaching_recipe_proof.py — teachings compose into Recipes whose |
+| [trim_view_events.py](trim_view_events.py) | Trim the witness-trace table when it grows past comfortable. |
+| [upgrade_specs_to_form_predicates.py](upgrade_specs_to_form_predicates.py) | Augment every spec's done_when with Form predicates derived from its |
+| [validate_commit_evidence.py](validate_commit_evidence.py) | Validate thread commit evidence artifacts for phase-gated process. |
+| [validate_local_api_matrix.py](validate_local_api_matrix.py) | Validate local API-backed page contracts and timing against a running API. |
+| [validate_spec_idea_traceability.py](validate_spec_idea_traceability.py) | _no top-of-file purpose_ |
+| [validate_spec_prefix_canonicalization.py](validate_spec_prefix_canonicalization.py) | Validate canonical mapping for duplicated spec numeric prefixes. |
+| [validate_spec_quality.py](validate_spec_quality.py) | Validate spec quality so implementation does not need manual follow-up gap fixes. |
+| [validate_workflow_references.py](validate_workflow_references.py) | Validate that workflow run-script file references exist in the repo. |
+| [verify_hashes.py](verify_hashes.py) | Verify that DB content hashes match their source files. |
 | [verify_kernel_conformance.py](verify_kernel_conformance.py) | Verify substrate kernel conformance vectors against executable runtimes. |
-| [video_recipe_proof.py](video_recipe_proof.py) | !/usr/bin/env python3 |
-| [view_recipe_library.py](view_recipe_library.py) | !/usr/bin/env python3 |
-| [viewport_audit.py](viewport_audit.py) | !/usr/bin/env python3 |
-| [wander.py](wander.py) | !/usr/bin/env python3 |
-| [wellness_check.py](wellness_check.py) | !/usr/bin/env python3 |
+| [video_recipe_proof.py](video_recipe_proof.py) | video_recipe_proof.py — ONE video source carries MANY parallel Recipe |
+| [view_recipe_library.py](view_recipe_library.py) | view_recipe_library.py — read a .recipelib bundle and render any tongue. |
+| [viewport_audit.py](viewport_audit.py) | Audit a list of URLs at desktop (1440x900) and mobile (390x844) widths. |
+| [wander.py](wander.py) | Launch a wandering sense into the field. |
+| [wellness_check.py](wellness_check.py) | Wellness check — a gentle sensing of the body. |
 | [word_cell_rewriter.py](word_cell_rewriter.py) | word_cell_rewriter — gesture 3 at word-cell granularity. |
-| [worktree_continuity_guard.py](worktree_continuity_guard.py) | !/usr/bin/env python3 |
-| [worktree_pr_guard.py](worktree_pr_guard.py) | !/usr/bin/env python3 |
+| [worktree_continuity_guard.py](worktree_continuity_guard.py) | Detect stranded changes across sibling worktrees. |
+| [worktree_pr_guard.py](worktree_pr_guard.py) | Worktree PR guard: prevent common CI failures and track PR check failures. |

--- a/scripts/generate_repo_indexes.py
+++ b/scripts/generate_repo_indexes.py
@@ -95,6 +95,9 @@ def extract_purpose(path: Path) -> str:
             line = raw.strip()
             if not line:
                 continue
+            # A shebang is not the purpose — the docstring after it is.
+            if line.startswith("#!"):
+                continue
             if line.startswith('"""') or line.startswith("'''"):
                 quote = line[:3]
                 # Same-line: """one-liner."""

--- a/scripts/scan_form_blueprints.py
+++ b/scripts/scan_form_blueprints.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Scan Form (.fk) sources for `make_nodeid` Blueprint literals and measure
+their legibility against the central registry.
+
+The registry doc (form/user-blueprint-registry.md) named the problem:
+hundreds of opaque `(make_nodeid 1 2 99 NNNN)` numbers, each often
+re-declared under a different local name in a different file. This scanner
+is the proprioception tool that doc calls for. It reads the single source
+of truth — form/form-stdlib/form-ontology.json (categories + primitives +
+user_blueprints) — and tells the body where Form code still names a shape
+by raw number when a registered name exists, where one number wears many
+names (synonyms), and where one name points at different numbers (drift).
+
+Usage:
+    python3 scripts/scan_form_blueprints.py            # full report
+    python3 scripts/scan_form_blueprints.py --check    # CI: nonzero on drift
+    python3 scripts/scan_form_blueprints.py --json      # machine-readable
+
+A NodeID is the 4-tuple (pkg, level, type, inst). Registered shapes live at
+pkg=1, level=2 (Basic). The registry names them so `.fk` code can reference
+a binding from form-ontology-loader.fk instead of writing the number.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+FORM_ROOT = ROOT / "form" / "form-stdlib"
+ONTOLOGY = FORM_ROOT / "form-ontology.json"
+# User-space (type-99) registry — the single source of truth for shapes the
+# kernel does not dispatch on. Code-derived, curated, scanner-verified. It
+# replaces the hand-maintained markdown table in form/user-blueprint-registry.md
+# (which drifted: that doc said 1870=ARRIVAL while code says 1870=UUID).
+REGISTRY = FORM_ROOT / "blueprint-registry.json"
+
+# Dialect-vocabulary prefixes — a local name carrying one of these is a
+# per-dialect synonym for a shared shape, not the canonical name for it.
+DIALECT_PREFIXES = (
+    "PY-", "GO-", "RS-", "TS-", "JS-", "SQL-", "CSS-", "HTML-", "XML-",
+    "YAML-", "Y-", "AU-", "VID-", "IMG-", "MDL-", "E-JSON-", "JSON-BNF-",
+    "CF-", "SE-", "SR-", "TE-", "UE-", "U-", "F-", "MOD-",
+)
+
+# `(make_nodeid 1 2 12 1)` and `(make_nodeid (1 2 12 1))`-free 4-int form.
+NODEID_RE = re.compile(
+    r"make_nodeid\s*\(?\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\)?"
+)
+# A local symbolic binding to a number, in either form:
+#   (let NAME (make_nodeid 1 2 12 1))
+#   (defn NAME () (make_nodeid 1 2 12 1))
+LET_RE = re.compile(
+    r"\(\s*(?:let\s+([A-Za-z0-9?_+*<>=/.-]+)|defn\s+"
+    r"([A-Za-z0-9?_+*<>=/.-]+)\s+\(\s*\))\s+\(\s*make_nodeid\s+"
+    r"(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\)"
+)
+Key = tuple  # (pkg, level, type, inst)
+
+
+def load_registry() -> dict[Key, dict]:
+    """name-by-NodeID, drawn from the ontology's categories, primitives, and
+    user_blueprints. Each entry: {canonical, family, meaning, aliases}."""
+    data = json.loads(ONTOLOGY.read_text())
+    reg: dict[Key, dict] = {}
+
+    def add(key: Key, canonical: str, family: str, meaning: str, aliases=None):
+        reg[key] = {
+            "canonical": canonical,
+            "family": family,
+            "meaning": meaning,
+            "aliases": list(aliases or []),
+        }
+
+    for row in data.get("categories", []):
+        key = (1, 2, row["type"], row["inst"])
+        add(key, row["name"], "category", row.get("note", ""))
+    for row in data.get("primitives", []):
+        key = (1, 2, row["type"], row["inst"])
+        add(key, row["name"], row.get("family", "primitive"), row.get("note", ""))
+    for row in load_user_blueprints():
+        # user_blueprints are pkg=1, level=2, type=99 by convention; a row may
+        # override pkg/level/type for the rare non-99 shared shape.
+        key = (
+            row.get("pkg", 1),
+            row.get("level", 2),
+            row.get("type", 99),
+            row["inst"],
+        )
+        add(key, row["name"], row.get("family", "user"),
+            row.get("meaning", ""), row.get("aliases"))
+    return reg
+
+
+def load_user_blueprints() -> list[dict]:
+    if not REGISTRY.exists():
+        return []
+    return json.loads(REGISTRY.read_text()).get("blueprints", [])
+
+
+def scan() -> dict:
+    reg = load_registry()
+    sites: list[dict] = []          # every make_nodeid literal
+    num_to_names: dict[Key, set] = collections.defaultdict(set)
+    name_to_nums: dict[str, set] = collections.defaultdict(set)
+
+    for f in sorted(FORM_ROOT.rglob("*.fk")):
+        rel = f.relative_to(ROOT)
+        is_test = "/tests/" in str(rel) or str(rel).endswith("-band.fk")
+        text = f.read_text()
+        for m in LET_RE.finditer(text):
+            name = m.group(1) or m.group(2)
+            key = tuple(int(m.group(i)) for i in range(3, 7))
+            num_to_names[key].add(name)
+            name_to_nums[name].add(key)
+        for m in NODEID_RE.finditer(text):
+            key = tuple(int(m.group(i)) for i in range(1, 5))
+            line = text.count("\n", 0, m.start()) + 1
+            sites.append({
+                "file": str(rel),
+                "line": line,
+                "key": key,
+                "test": is_test,
+                "registered": key in reg,
+            })
+
+    # drift: a name bound to more than one distinct number.
+    collisions = {n: sorted(v) for n, v in name_to_nums.items() if len(v) > 1}
+    # synonyms: a number wearing more than one local name.
+    synonyms = {k: sorted(v) for k, v in num_to_names.items() if len(v) > 1}
+    # type-99 numbers used in source but absent from the registry.
+    type99 = {s["key"] for s in sites if s["key"][2] == 99}
+    unregistered_99 = sorted(k for k in type99 if k not in reg)
+
+    return {
+        "reg": reg,
+        "sites": sites,
+        "num_to_names": num_to_names,
+        "name_to_nums": name_to_nums,
+        "collisions": collisions,
+        "synonyms": synonyms,
+        "unregistered_99": unregistered_99,
+    }
+
+
+def fmt_key(k: Key) -> str:
+    return ".".join(map(str, k))
+
+
+def best_name(names) -> str:
+    """The canonical name for a number: prefer one with no dialect prefix,
+    then the shortest, then alphabetical."""
+    plain = [n for n in names if not n.startswith(DIALECT_PREFIXES)]
+    pool = plain or list(names)
+    return sorted(pool, key=lambda s: (len(s), s))[0]
+
+
+def emit_registry() -> dict:
+    """Generate the type-99 registry from what the code actually declares.
+    Code-derived so it cannot drift from reality the way a hand-edited table
+    does. Captures, per number: canonical name, harvested meaning (from the
+    densest trailing comment), aliases, and the files that define it."""
+    # Both binding forms: `(let NAME (make_nodeid 1 2 99 N))` and the 0-arg
+    # getter `(defn NAME () (make_nodeid 1 2 99 N))`.
+    let_re = re.compile(
+        r"\(\s*(?:let\s+([A-Za-z0-9?_+*<>=/.-]+)|defn\s+"
+        r"([A-Za-z0-9?_+*<>=/.-]+)\s+\(\s*\))\s+\(\s*make_nodeid\s+"
+        r"1\s+2\s+99\s+(\d+)\s*\)[^\n;]*(?:;+\s*(.*))?"
+    )
+    num: dict[int, dict] = collections.defaultdict(
+        lambda: {"names": collections.Counter(),
+                 "comments": collections.Counter(),
+                 "files": set()})
+    for f in sorted(FORM_ROOT.rglob("*.fk")):
+        rel = str(f.relative_to(ROOT))
+        for m in let_re.finditer(f.read_text()):
+            name = m.group(1) or m.group(2)
+            n, comment = int(m.group(3)), (m.group(4) or "").strip()
+            num[n]["names"][name] += 1
+            num[n]["files"].add(rel)
+            if comment:
+                num[n]["comments"][comment] += 1
+    rows = []
+    for n in sorted(num):
+        info = num[n]
+        canon = best_name(info["names"])
+        meaning = (info["comments"].most_common(1)[0][0]
+                   if info["comments"] else "")
+        aliases = sorted(a for a in info["names"] if a != canon)
+        rows.append({
+            "inst": n,
+            "name": canon,
+            "meaning": meaning,
+            "aliases": aliases,
+            "reuse": sum(info["names"].values()),
+            "defined_in": sorted(info["files"]),
+        })
+    return {
+        "_note": ("Type-99 (user-space) Blueprint registry — the single "
+                  "source of truth for shapes the kernel does not dispatch "
+                  "on. Generated from code by scripts/scan_form_blueprints.py "
+                  "--emit-registry, then curated. NodeID is (1, 2, 99, inst). "
+                  "form-stdlib/form-ontology-loader.fk binds these names so "
+                  ".fk code references a name, never the raw number. To add a "
+                  "shape: add a row here first, then `(bp \"name\")` in code."),
+        "blueprints": rows,
+    }
+
+
+def report(s: dict) -> None:
+    sites = s["sites"]
+    prod = [x for x in sites if not x["test"]]
+    print(f"Form Blueprint scan — {len(sites)} make_nodeid literals "
+          f"({len(prod)} in production, {len(sites) - len(prod)} in tests)")
+    distinct = {x["key"] for x in sites}
+    print(f"  distinct NodeIDs: {len(distinct)}   "
+          f"registered: {len(s['reg'])}   "
+          f"unregistered type-99: {len(s['unregistered_99'])}")
+    print()
+
+    if s["collisions"]:
+        print(f"⚠  name drift — {len(s['collisions'])} name(s) bound to >1 NodeID:")
+        for n, keys in sorted(s["collisions"].items()):
+            print(f"   {n}: {[fmt_key(k) for k in keys]}")
+        print()
+
+    # production synonyms for registered shapes: each is a redundant local
+    # redefinition that could reference the loader binding instead.
+    prod_keys = {x["key"] for x in prod}
+    redundant = {k: v for k, v in s["synonyms"].items()
+                 if k in s["reg"] and k in prod_keys}
+    if redundant:
+        print(f"○  registered shapes re-named locally in production "
+              f"({len(redundant)} NodeIDs) — reference the registry instead:")
+        for k in sorted(redundant, key=lambda k: -len(redundant[k]))[:20]:
+            canon = s["reg"][k]["canonical"]
+            print(f"   {fmt_key(k)} [{canon}]: {len(redundant[k])} aliases "
+                  f"{redundant[k]}")
+        print()
+
+    if s["unregistered_99"]:
+        print(f"○  type-99 numbers in source but absent from registry "
+              f"({len(s['unregistered_99'])}):")
+        for k in s["unregistered_99"]:
+            names = sorted(s["num_to_names"].get(k, []))
+            hint = f"  named locally: {names}" if names else "  (unnamed)"
+            print(f"   {fmt_key(k)}{hint}")
+        print()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="exit nonzero if name drift exists (CI/wellness)")
+    ap.add_argument("--json", action="store_true",
+                    help="emit machine-readable scan result")
+    ap.add_argument("--emit-registry", action="store_true",
+                    help="(re)generate form-stdlib/blueprint-registry.json "
+                         "from code, preserving curated meanings")
+    args = ap.parse_args()
+
+    if args.emit_registry:
+        generated = emit_registry()
+        # Preserve human-curated meanings/names over harvested defaults.
+        if REGISTRY.exists():
+            prior = {r["inst"]: r for r in load_user_blueprints()}
+            for row in generated["blueprints"]:
+                p = prior.get(row["inst"])
+                if p and p.get("curated"):
+                    row["name"] = p.get("name", row["name"])
+                    row["meaning"] = p.get("meaning", row["meaning"])
+                    row["curated"] = True
+        REGISTRY.write_text(json.dumps(generated, indent=2) + "\n")
+        print(f"wrote {REGISTRY.relative_to(ROOT)} "
+              f"({len(generated['blueprints'])} type-99 blueprints)")
+        return 0
+
+    s = scan()
+    if args.json:
+        out = {
+            "literals": len(s["sites"]),
+            "distinct": len({x["key"] for x in s["sites"]}),
+            "registered": len(s["reg"]),
+            "collisions": {n: [fmt_key(k) for k in v]
+                           for n, v in s["collisions"].items()},
+            "unregistered_99": [fmt_key(k) for k in s["unregistered_99"]],
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        report(s)
+
+    if args.check:
+        # Forward-looking gate: no new type-99 number may ship without a
+        # registry row. This is what keeps the magic-number sprawl from
+        # growing — the ongoing hygiene the registry doc commits to. Run
+        # `--emit-registry` to register a genuinely-new shape first.
+        if s["unregistered_99"]:
+            print(f"FAIL: {len(s['unregistered_99'])} type-99 NodeID(s) used "
+                  f"in source but absent from blueprint-registry.json: "
+                  f"{[fmt_key(k) for k in s['unregistered_99']]}\n"
+                  f"      Add a row (run --emit-registry) before shipping a "
+                  f"new Blueprint number.", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -741,6 +741,43 @@ def sense_form_ontology() -> list[str]:
     return lines
 
 
+def sense_form_blueprints() -> list[str]:
+    """Are Form's user-space Blueprint numbers legible, or scattered magic?
+
+    Every shape the kernel does not dispatch on lives at NodeID (1, 2, 99, N).
+    Historically these were allocated ad-hoc — the same number re-declared
+    under a dozen local names with a raw `(make_nodeid 1 2 99 N)` in each
+    grammar. form-stdlib/blueprint-registry.json now names each shape once;
+    form-ontology-loader.fk binds them so `.fk` code asks by name via
+    `(bp "name")`. This sense reads scripts/scan_form_blueprints.py: silent
+    when no new unregistered number has crept in, loud when one has — the
+    forward gate that keeps the sprawl from regrowing.
+    """
+    script = ROOT / "scripts" / "scan_form_blueprints.py"
+    if not script.is_file():
+        return ["  (scripts/scan_form_blueprints.py not present; skipping)"]
+    try:
+        result = subprocess.run(
+            ["python3", str(script), "--check"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except Exception as exc:
+        return [f"  (scan_form_blueprints.py did not run cleanly: {exc})"]
+    # First report line carries the legibility numbers; surface it always.
+    head = next((ln for ln in result.stdout.splitlines()
+                 if "make_nodeid" in ln), "").strip()
+    if result.returncode == 0:
+        lines = ["  every Form Blueprint number is registered — no magic sprawl"]
+        if head:
+            lines.append(f"    {head}")
+        return lines
+    lines = ["  unregistered Blueprint numbers have crept in:"]
+    for line in (result.stdout + result.stderr).splitlines():
+        if line.strip().startswith(("FAIL", "1.2.99")):
+            lines.append(f"    {line.strip()}")
+    return lines
+
+
 def sense_bootstrap_compost() -> list[str]:
     """How much bootstrap tissue remains, what runtime fills the parity seam,
     what compost is deferred behind which gate.
@@ -1489,6 +1526,7 @@ def main() -> int:
         ("Chain — does idea→spec→code→test reach end to end?", sense_chain()),
         ("Form engine — does the meta-circular evaluator cover Python dispatch?", sense_form_engine()),
         ("Form ontology — does the form-side table agree with each kernel parser?", sense_form_ontology()),
+        ("Form blueprints — are user-space Blueprint numbers registered, not magic?", sense_form_blueprints()),
         ("Bootstrap compost — how much parser tissue still stands between us and Form-native?", sense_bootstrap_compost()),
         ("Substrate surprise — structural twins of recent work, unread", sense_substrate_surprise()),
         ("Cells — are the cells themselves breathing?", sense_cells()),


### PR DESCRIPTION
## What

Form's user-space shapes live at NodeID `1.2.99.N`. They were allocated ad-hoc — the same number re-declared under up to **18 local names** with a raw `(make_nodeid 1 2 99 N)` in each grammar (**822** such literals across stdlib; `add` alone wore 18 aliases like `MATH-PLUS`/`PY-PLUS`/`GO-PLUS`/`UE-MATH-PLUS`/…). [`form/user-blueprint-registry.md`](../blob/main/form/user-blueprint-registry.md) named this problem and asked for a scanner; the doc had itself drifted from the code (claimed `1870=ARRIVAL` while code says `1870=UUID`).

This builds the maintainable system that doc describes.

## The system

| Piece | Role |
|-------|------|
| `form/form-stdlib/blueprint-registry.json` | **Single source of truth** — every type-99 shape: canonical name, meaning, aliases, defining files. Code-derived + scanner-verified, so it can't silently drift like the markdown table did. |
| `form-ontology-loader.fk` → `(bp "name")` | Reads the registry, resolves any registered name (categories, primitives, user blueprints, historical aliases) → NodeID. One ice (JSON) → bindings. Feature code references a name; the number lives in one place. |
| `scripts/scan_form_blueprints.py` | Proprioception: reports magic literals, synonyms to collapse, name drift. `--check` = forward gate (nonzero on any unregistered type-99 number). `--emit-registry` regenerates the JSON, preserving curated rows. |
| `wellness_check.py` | New `sense_form_blueprints` runs the gate in `make wellness`. |

## Proof

- **Exemplar migration** — `python-bmf-lift.fk`: 11 `MATH`/`COMPARE` magic-number redefs become `(bp "add")` etc. **Byte-identical** output across Go/Rust/TS (band → `75000`).
- **Full suite**: `./validate.sh` → **178 ok, 0 divergent** across all three kernels.
- `(bp "...")` resolves identically on Go/Rust/TS (7/7 checks).
- `scan_form_blueprints.py --check` → exit 0 (314 shapes registered, 0 unregistered).

Also: `generate_repo_indexes.py` now skips shebang lines when extracting a script's purpose — **healed 123 INDEX entries** that read `"!/usr/bin/env python3"`.

## Not in scope (ongoing hygiene)

The ~80 remaining synonym clusters and 3 emitter/grammar name-reuses (`PY-ASSIGN`, `PY-IDENT`, `RS-MOD` — canonical category in an emitter vs dialect AST node in a grammar) are legibility debt, not runtime bugs. The scanner now makes collapsing them measurable, and the gate keeps the sprawl from regrowing — exactly the "ongoing hygiene, not one-time cleanup" the registry doc commits to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)