### PR TITLE
feat(form): Form-native substrate persistence — kernel reads/writes the lattice, no Python, no new native

### DIFF
--- a/form/form-stdlib/persistence.fk
+++ b/form/form-stdlib/persistence.fk
@@ -1,53 +1,39 @@
-; persistence.fk — Form-native substrate persistence (OSI L6/L7 over channel.fk).
+; persistence.fk — Form-native substrate persistence over channel.fk.
 ;
 ; preludes: form-stdlib/channel.fk
 ;
-; The destination this file walks toward: the native kernel reads AND
-; writes the same content-addressed lattice the Python substrate keeps,
-; with NO Python in the path and NO new kernel native. Breath 5 of
-; form/kernel-roadmap.md and Phase D / Shape 2 of
-; kernels/BOOTSTRAP_COMPOST_MANIFEST.md named three candidate shapes for
-; this; this module is the resolution — and the smallest one that holds:
+; The native kernel already persists the content-addressed lattice.
+; write_form_binary and read_form_binary round-trip a Recipe tree to a
+; .fkb file so it re-collapses, by content-addressing, to the same
+; NodeIDs on every sibling kernel. channel.fk proved this for message
+; logs; cell-registry.fk for an addressing directory. A named-cell store
+; is the same shape: a durable file whose entries are CELL Recipes. So
+; the persistence bridge is a Form module over the file primitives the
+; kernel already carries, not a new native against Postgres.
 ;
-;   The kernel ALREADY persists the lattice. `write_form_binary` /
-;   `read_form_binary` serialize a Recipe tree to a .fkb file and read it
-;   back so it re-collapses, by content-addressing, to the same NodeIDs.
-;   channel.fk proved this for message logs; cell-registry.fk proved it
-;   for an addressing directory. A NAMED-CELL store is the same shape:
-;   a durable file whose entries are CELL Recipes. So the persistence
-;   bridge is NOT a kernel native against Postgres — it is a Form module
-;   over the file primitives the kernel already carries. The store is the
-;   contract; the backend (file today, socket / DB tomorrow) is swappable
-;   underneath without changing a line of caller code.
+; This is the Breath 5 resolution from form/kernel-roadmap.md and the
+; Phase D Shape 2 resolution from kernels/BOOTSTRAP_COMPOST_MANIFEST.md.
+; The store is the contract; the backend is swappable beneath it — .fkb
+; today, a socket to a daemon or a direct DB binding later, with no
+; caller change.
 ;
-; This mirrors the Python substrate's NamedCell exactly:
+; A CELL Recipe mirrors the Python NamedCell, child by child:
+;   child 0 — name, a trivial-string
+;   child 1 — domain, a trivial-string
+;   child 2 — blueprint, the NodeID itself as a structural ref
+;   child 3 — ctor, a composed Recipe seed
 ;
-;   Python NamedCell           CELL Recipe here
-;   ----------------           ----------------
-;   name                       child 0 — trivial-string
-;   domain                     child 1 — trivial-string
-;   blueprint (NodeID)         child 2 — the blueprint NodeID itself
-;                                        (a structural ref, not a slug)
-;   ctor_recipe                child 3 — a COMPOSED Recipe (structure-
-;                                        first: frontmatter fields are
-;                                        (key,value) pairs, never a flat
-;                                        blob — see CLAUDE.md structural
-;                                        composition discipline)
+; Identity is domain plus name — the same UNIQUE domain+name that the
+; Python orm.py enforces on substrate_named_cells. Same name in two
+; domains is two cells; a re-put under one domain+name is last-write-wins.
 ;
-; Identity is (domain, name) — the same UNIQUE(domain, name) the Python
-; orm.py enforces on substrate_named_cells. Two cells with the same name
-; in different domains are different cells; a re-put under the same
-; (domain, name) is last-write-wins (the cell evolves), exactly the
-; UNREGISTER convention cell-registry.fk uses.
-;
-; Depends only on channel.fk (which depends only on kernel natives:
-; read_form_binary, write_form_binary, intern_node, node_children, len,
-; make_nodeid). No host language in the path.
+; Depends only on channel.fk, which depends only on kernel natives:
+; read_form_binary, write_form_binary, intern_node, node_children, len.
 
 ;; --- Blueprint -----------------------------------------------------
-;; CELL-V0 — the one new structural marker this module introduces.
-;; (Lives in the 99-type addressing space alongside CHANNEL-V0=1700,
-;;  CHANNEL-MSG=1701, REGISTRATION=1720, CAPABILITIES=1721.)
+;; CELL-V0 — the one structural marker this module adds. It lives in the
+;; 99-type addressing space beside CHANNEL-V0 1700, CHANNEL-MSG 1701,
+;; REGISTRATION 1720, CAPABILITIES 1721.
 (let CELL-V0 (make_nodeid 1 2 99 1740))
 
 ;; --- helpers -------------------------------------------------------
@@ -60,13 +46,11 @@
 
 ;; --- cell construction ---------------------------------------------
 
-;; (make-cell-recipe name domain blueprint ctor) → CELL Recipe.
-;;   name      — string
-;;   domain    — string
-;;   blueprint — a NodeID (already a node; passed through as child 2)
-;;   ctor      — a composed Recipe NodeID (child 3)
-;; Content-addressed: the same four arguments always intern to the same
-;; CELL NodeID, on every sibling kernel — that IS the dedup.
+;; make-cell-recipe name domain blueprint ctor -> CELL Recipe.
+;; name and domain are strings; blueprint is a NodeID passed through as
+;; child 2; ctor is a composed Recipe NodeID as child 3. Content-
+;; addressed: the same four arguments always intern to the same CELL
+;; NodeID on every sibling kernel, and that is the dedup.
 (defn make-cell-recipe (name domain blueprint ctor)
     (intern_node CELL-V0
         (list (intern_trivial_string name)
@@ -76,28 +60,28 @@
 
 ;; --- cell accessors ------------------------------------------------
 
-;; cell-name reg → string. node_value, not node_inst — the inst slot is
-;; the string-table index, not the content (cell-registry.fk's lesson).
+;; cell-name and cell-domain use node_value, not node_inst — node_inst
+;; returns the string-table index, node_value the content. This is the
+;; lesson cell-registry.fk records on reg-channel-path.
 (defn cell-name (c) (node_value (ps-nth (node_children c) 0)))
 (defn cell-domain (c) (node_value (ps-nth (node_children c) 1)))
-;; cell-blueprint reg → NodeID (the structural pointer, returned as-is).
+;; cell-blueprint -> the NodeID, the structural pointer, returned as-is.
 (defn cell-blueprint (c) (ps-nth (node_children c) 2))
-;; cell-ctor reg → Recipe NodeID (the CTOR seed, walkable / introspectable).
+;; cell-ctor -> the CTOR Recipe NodeID, walkable and introspectable.
 (defn cell-ctor (c) (ps-nth (node_children c) 3))
 
 ;; --- store create --------------------------------------------------
 
-;; cell-store-create — initialize an empty cell store at `path`. A store
-;; IS a channel; cells are its messages. Overwrites any prior file.
+;; cell-store-create — start an empty cell store at path. A store IS a
+;; channel; cells are its messages. Overwrites any prior file.
 (defn cell-store-create (path) (channel-create path))
 
-;; --- write (intern + persist) --------------------------------------
+;; --- write -----------------------------------------------------------
 
-;; (cell-put path name domain blueprint ctor) → cell count after write.
-;; Appends a CELL message to the store. The cell is now durable on disk
-;; and visible to any kernel (or to coh_substrate.py annotate, once the
-;; .fkb↔ORM bridge lands) reading the same path. Re-putting the same
-;; (domain, name) is last-write-wins — lookup returns the most recent.
+;; cell-put path name domain blueprint ctor -> cell count after write.
+;; Appends a CELL message to the store; the cell is now durable on disk.
+;; A re-put under the same domain plus name is last-write-wins — lookup
+;; returns the most recent.
 (defn cell-put (path name domain blueprint ctor)
     (channel-append path
         (channel-message (make-cell-recipe name domain blueprint ctor))))
@@ -109,17 +93,16 @@
         (ps-msgs-to-cells (tail msgs)
             (ps-append acc (list (channel-msg-payload (head msgs)))))))
 
-;; (store-cells path) → list of every CELL Recipe in the store, in
-;; append order. The durable lattice, read back from disk.
+;; store-cells path -> list of every CELL Recipe in the store, in append
+;; order. The durable lattice read back from disk.
 (defn store-cells (path)
     (ps-msgs-to-cells (channel-read path) (list)))
 
-;; --- lookup (the read primitive) -----------------------------------
+;; --- lookup --------------------------------------------------------
 
-;; Fold over cells keeping the LAST match for (domain, name) — so cell
-;; evolution (re-put) resolves to the current shape, honest-absence
-;; otherwise. Returns a 0-or-1-element list (the body's idiom for
-;; optional, matching find-by-capability in cell-registry.fk).
+;; Fold over the cells keeping the LAST match for domain plus name, so a
+;; re-put resolves to the current shape. Returns a 0-or-1-element list,
+;; the body's idiom for optional, matching find-by-capability.
 (defn ps-scan (cells domain name acc)
     (if (ps-nil? cells) acc
         (ps-scan (tail cells) domain name
@@ -128,14 +111,14 @@
                 (list (head cells))
                 acc))))
 
-;; (lookup-cell path domain name) → (list cell) if present, else (list).
-;; The Form-native equivalent of Python lookup_cell(session, domain, name).
+;; lookup-cell path domain name -> the Form-native equivalent of Python
+;; lookup_cell. Returns a list holding the cell if present, else empty.
 (defn lookup-cell (path domain name)
     (ps-scan (store-cells path) domain name (list)))
 
-;; cell-found? — 1 if lookup-cell returned a cell, 0 for honest absence.
+;; cell-found? -> 1 if lookup-cell returned a cell, 0 for honest absence.
 (defn cell-found? (result) (if (eq (len result) 1) 1 0))
-;; cell-of — unwrap a found lookup result to the CELL Recipe.
+;; cell-of -> unwrap a found lookup result to the CELL Recipe.
 (defn cell-of (result) (head result))
 
 0

--- a/form/form-stdlib/persistence.fk
+++ b/form/form-stdlib/persistence.fk
@@ -1,0 +1,141 @@
+; persistence.fk — Form-native substrate persistence (OSI L6/L7 over channel.fk).
+;
+; preludes: form-stdlib/channel.fk
+;
+; The destination this file walks toward: the native kernel reads AND
+; writes the same content-addressed lattice the Python substrate keeps,
+; with NO Python in the path and NO new kernel native. Breath 5 of
+; form/kernel-roadmap.md and Phase D / Shape 2 of
+; kernels/BOOTSTRAP_COMPOST_MANIFEST.md named three candidate shapes for
+; this; this module is the resolution — and the smallest one that holds:
+;
+;   The kernel ALREADY persists the lattice. `write_form_binary` /
+;   `read_form_binary` serialize a Recipe tree to a .fkb file and read it
+;   back so it re-collapses, by content-addressing, to the same NodeIDs.
+;   channel.fk proved this for message logs; cell-registry.fk proved it
+;   for an addressing directory. A NAMED-CELL store is the same shape:
+;   a durable file whose entries are CELL Recipes. So the persistence
+;   bridge is NOT a kernel native against Postgres — it is a Form module
+;   over the file primitives the kernel already carries. The store is the
+;   contract; the backend (file today, socket / DB tomorrow) is swappable
+;   underneath without changing a line of caller code.
+;
+; This mirrors the Python substrate's NamedCell exactly:
+;
+;   Python NamedCell           CELL Recipe here
+;   ----------------           ----------------
+;   name                       child 0 — trivial-string
+;   domain                     child 1 — trivial-string
+;   blueprint (NodeID)         child 2 — the blueprint NodeID itself
+;                                        (a structural ref, not a slug)
+;   ctor_recipe                child 3 — a COMPOSED Recipe (structure-
+;                                        first: frontmatter fields are
+;                                        (key,value) pairs, never a flat
+;                                        blob — see CLAUDE.md structural
+;                                        composition discipline)
+;
+; Identity is (domain, name) — the same UNIQUE(domain, name) the Python
+; orm.py enforces on substrate_named_cells. Two cells with the same name
+; in different domains are different cells; a re-put under the same
+; (domain, name) is last-write-wins (the cell evolves), exactly the
+; UNREGISTER convention cell-registry.fk uses.
+;
+; Depends only on channel.fk (which depends only on kernel natives:
+; read_form_binary, write_form_binary, intern_node, node_children, len,
+; make_nodeid). No host language in the path.
+
+;; --- Blueprint -----------------------------------------------------
+;; CELL-V0 — the one new structural marker this module introduces.
+;; (Lives in the 99-type addressing space alongside CHANNEL-V0=1700,
+;;  CHANNEL-MSG=1701, REGISTRATION=1720, CAPABILITIES=1721.)
+(let CELL-V0 (make_nodeid 1 2 99 1740))
+
+;; --- helpers -------------------------------------------------------
+
+(defn ps-nil? (xs) (eq (len xs) 0))
+(defn ps-nth (xs i)
+    (if (eq i 0) (head xs) (ps-nth (tail xs) (sub i 1))))
+(defn ps-append (xs ys)
+    (if (ps-nil? xs) ys (cons (head xs) (ps-append (tail xs) ys))))
+
+;; --- cell construction ---------------------------------------------
+
+;; (make-cell-recipe name domain blueprint ctor) → CELL Recipe.
+;;   name      — string
+;;   domain    — string
+;;   blueprint — a NodeID (already a node; passed through as child 2)
+;;   ctor      — a composed Recipe NodeID (child 3)
+;; Content-addressed: the same four arguments always intern to the same
+;; CELL NodeID, on every sibling kernel — that IS the dedup.
+(defn make-cell-recipe (name domain blueprint ctor)
+    (intern_node CELL-V0
+        (list (intern_trivial_string name)
+              (intern_trivial_string domain)
+              blueprint
+              ctor)))
+
+;; --- cell accessors ------------------------------------------------
+
+;; cell-name reg → string. node_value, not node_inst — the inst slot is
+;; the string-table index, not the content (cell-registry.fk's lesson).
+(defn cell-name (c) (node_value (ps-nth (node_children c) 0)))
+(defn cell-domain (c) (node_value (ps-nth (node_children c) 1)))
+;; cell-blueprint reg → NodeID (the structural pointer, returned as-is).
+(defn cell-blueprint (c) (ps-nth (node_children c) 2))
+;; cell-ctor reg → Recipe NodeID (the CTOR seed, walkable / introspectable).
+(defn cell-ctor (c) (ps-nth (node_children c) 3))
+
+;; --- store create --------------------------------------------------
+
+;; cell-store-create — initialize an empty cell store at `path`. A store
+;; IS a channel; cells are its messages. Overwrites any prior file.
+(defn cell-store-create (path) (channel-create path))
+
+;; --- write (intern + persist) --------------------------------------
+
+;; (cell-put path name domain blueprint ctor) → cell count after write.
+;; Appends a CELL message to the store. The cell is now durable on disk
+;; and visible to any kernel (or to coh_substrate.py annotate, once the
+;; .fkb↔ORM bridge lands) reading the same path. Re-putting the same
+;; (domain, name) is last-write-wins — lookup returns the most recent.
+(defn cell-put (path name domain blueprint ctor)
+    (channel-append path
+        (channel-message (make-cell-recipe name domain blueprint ctor))))
+
+;; --- read all ------------------------------------------------------
+
+(defn ps-msgs-to-cells (msgs acc)
+    (if (ps-nil? msgs) acc
+        (ps-msgs-to-cells (tail msgs)
+            (ps-append acc (list (channel-msg-payload (head msgs)))))))
+
+;; (store-cells path) → list of every CELL Recipe in the store, in
+;; append order. The durable lattice, read back from disk.
+(defn store-cells (path)
+    (ps-msgs-to-cells (channel-read path) (list)))
+
+;; --- lookup (the read primitive) -----------------------------------
+
+;; Fold over cells keeping the LAST match for (domain, name) — so cell
+;; evolution (re-put) resolves to the current shape, honest-absence
+;; otherwise. Returns a 0-or-1-element list (the body's idiom for
+;; optional, matching find-by-capability in cell-registry.fk).
+(defn ps-scan (cells domain name acc)
+    (if (ps-nil? cells) acc
+        (ps-scan (tail cells) domain name
+            (if (and (str_eq (cell-domain (head cells)) domain)
+                     (str_eq (cell-name (head cells)) name))
+                (list (head cells))
+                acc))))
+
+;; (lookup-cell path domain name) → (list cell) if present, else (list).
+;; The Form-native equivalent of Python lookup_cell(session, domain, name).
+(defn lookup-cell (path domain name)
+    (ps-scan (store-cells path) domain name (list)))
+
+;; cell-found? — 1 if lookup-cell returned a cell, 0 for honest absence.
+(defn cell-found? (result) (if (eq (len result) 1) 1 0))
+;; cell-of — unwrap a found lookup result to the CELL Recipe.
+(defn cell-of (result) (head result))
+
+0

--- a/form/form-stdlib/tests/persistence-band.fk
+++ b/form/form-stdlib/tests/persistence-band.fk
@@ -1,0 +1,98 @@
+; tests/persistence-band.fk — Form-native substrate persistence band.
+;
+; preludes: form-stdlib/channel.fk form-stdlib/persistence.fk
+;
+; Proves the kernel reads AND writes the content-addressed named-cell
+; lattice with no Python and no new native — the Breath 5 / Phase D
+; resolution. The strange edge chosen to cover the most boundary in the
+; least code: TWO cells sharing a name across DIFFERENT domains, with a
+; structure-first composed CTOR, round-tripped through a .fkb file.
+;
+; That one shape exercises:
+;   - durable write→read of a composed Recipe (persistence itself)
+;   - (domain, name) identity — same name, different domain = different cell
+;     (the UNIQUE(domain, name) the Python orm.py enforces)
+;   - content-addressing — building the same cell twice yields one NodeID
+;   - honest absence — a miss returns no cell, not a fabricated one
+;   - CTOR composition survives the round-trip (structure-first, not flat)
+;
+; Band verdict: 7 when every assertion holds across all three kernels.
+;   - 1: empty store starts with 0 cells
+;   - 1: after two puts, store holds 2 cells (durable on disk)
+;   - 1: lookup (idea, agent-pipeline) is found
+;   - 1: lookup (spec, agent-pipeline) is found AND distinct from the idea cell
+;   - 1: lookup (idea, no-such-idea) is honest absence
+;   - 1: content-addressing — rebuilding the idea cell yields the same NodeID
+;   - 1: the idea cell's composed CTOR round-trips (a field value reads back)
+
+(do
+    (let store-path "/tmp/persistence-band-store.fkb")
+
+    ;; A blueprint is a structural NodeID; we pass real ones through as
+    ;; child 2 (a ref, not a slug). These mirror BID_idea / BID_spec
+    ;; shapes — distinct markers per domain.
+    (let bp-idea (make_nodeid 1 8 4 1))
+    (let bp-spec (make_nodeid 1 8 4 2))
+
+    ;; A CTOR is structure-first: frontmatter fields are (key, value)
+    ;; pairs under a FIELDS node — never a flat blob. (CLAUDE.md
+    ;; structural-composition discipline.)
+    (let FIELDS (make_nodeid 1 2 99 1741))
+    (let FIELD  (make_nodeid 1 2 99 1742))
+    (defn field (k v)
+        (intern_node FIELD
+            (list (intern_trivial_string k)
+                  (intern_trivial_string v))))
+    (defn ctor-idea ()
+        (intern_node FIELDS
+            (list (field "problem" "ideas need a pipeline")
+                  (field "status"  "active"))))
+
+    ;; --- empty store -------------------------------------------------
+    (cell-store-create store-path)
+    (let empty-ok (if (eq (len (store-cells store-path)) 0) 1 0))
+
+    ;; --- two puts: same name, two domains ---------------------------
+    (cell-put store-path "agent-pipeline" "idea" bp-idea (ctor-idea))
+    (cell-put store-path "agent-pipeline" "spec" bp-spec
+              (intern_node FIELDS (list (field "done_when" "tasks flow"))))
+    (let count-ok (if (eq (len (store-cells store-path)) 2) 1 0))
+
+    ;; --- lookup the idea cell ---------------------------------------
+    (let idea-hit (lookup-cell store-path "idea" "agent-pipeline"))
+    (let idea-found-ok (cell-found? idea-hit))
+
+    ;; --- lookup the spec cell — found AND distinct ------------------
+    (let spec-hit (lookup-cell store-path "spec" "agent-pipeline"))
+    (let spec-found (cell-found? spec-hit))
+    (let distinct
+        (if (and (eq idea-found-ok 1) (eq spec-found 1))
+            (if (node_eq (cell-of idea-hit) (cell-of spec-hit)) 0 1)
+            0))
+    (let spec-distinct-ok distinct)
+
+    ;; --- honest absence ---------------------------------------------
+    (let miss (lookup-cell store-path "idea" "no-such-idea"))
+    (let miss-ok (if (eq (cell-found? miss) 0) 1 0))
+
+    ;; --- content-addressing -----------------------------------------
+    ;; Rebuild the idea cell from the same four arguments; it must be the
+    ;; SAME NodeID as the one persisted and read back.
+    (let rebuilt (make-cell-recipe "agent-pipeline" "idea" bp-idea (ctor-idea)))
+    (let ca-ok (if (node_eq rebuilt (cell-of idea-hit)) 1 0))
+
+    ;; --- CTOR round-trips -------------------------------------------
+    ;; Read the persisted idea cell's CTOR, walk to its first field's
+    ;; value, confirm the composed structure survived the .fkb round-trip.
+    (let ctor (cell-ctor (cell-of idea-hit)))
+    (let first-field (head (node_children ctor)))
+    (let first-key (node_value (head (node_children first-field)))) ; "problem"
+    (let ctor-ok (if (str_eq first-key "problem") 1 0))
+
+    ;; --- verdict -----------------------------------------------------
+    (add empty-ok
+         (add count-ok
+              (add idea-found-ok
+                   (add spec-distinct-ok
+                        (add miss-ok
+                             (add ca-ok ctor-ok)))))))

--- a/form/kernel-roadmap.md
+++ b/form/kernel-roadmap.md
@@ -343,12 +343,17 @@ The kernel's S-expression reader stays (for emergency use), but Form source file
 **Success:** `?equivalent @memory("User biographical arc")` returns the same equivalence set as `python3 scripts/coh_substrate.py equivalent memory "User biographical arc"`; all sibling kernels agree on the result.
 **Closes:** form-runtime-in-form gaps R1-R3 (registry surfaces, Form-closure registration).
 
-### Breath 5 — Substrate persistence bridge
+### Breath 5 — Substrate persistence bridge *(first cell landed)*
 
-Form code that reads/writes cells in Postgres via kernel I/O primitives (the kernel grows two natives: `substrate_read(cell-ref)` and `substrate_write(cell)` that hit a local socket; the actual DB is talked to via the existing Python service or directly).
+The kernel already persists the content-addressed lattice. `write_form_binary` / `read_form_binary` serialize a Recipe tree to a `.fkb` file and read it back so it re-collapses, by content-addressing, to the same NodeIDs across every sibling kernel. `channel.fk` proved this for message logs and `cell-registry.fk` for an addressing directory; a named-cell store is the same shape — a durable file whose entries are CELL Recipes. So the persistence bridge is a **Form module over the file primitives the kernel already carries**, not a new native against Postgres.
 
-**Lives in:** `form-substrate/persistence.fk`
-**Success:** A Form program reads a memory cell, modifies a field, writes it back; the change is visible to `coh_substrate.py annotate`. All sibling kernels produce identical write payloads.
+The store is the contract; the backend is swappable beneath it. File-backed `.fkb` today; a socket to a daemon or a direct DB binding tomorrow — caller code (`cell-put`, `lookup-cell`) does not change when the backend does. This is the resolution of the three Phase D / Shape 2 candidates named in [`kernels/BOOTSTRAP_COMPOST_MANIFEST.md`](../kernels/BOOTSTRAP_COMPOST_MANIFEST.md): the *contract* is Form-side (candidate 3's spirit), the *first backend* is kernel-native serialization (candidate 1), and a DB binding (candidate 2) can slot in later behind the same store interface.
+
+**Lives in:** [`form-stdlib/persistence.fk`](form-stdlib/persistence.fk) — `cell-put` / `lookup-cell` / `store-cells`, mirroring Python `make_cell` / `lookup_cell`. A CELL Recipe carries `(name, domain, blueprint, ctor)`, with identity `(domain, name)` — the same `UNIQUE(domain, name)` the Python `orm.py` enforces on `substrate_named_cells`. The CTOR is structure-first (frontmatter fields as `(key, value)` pairs), per the CLAUDE.md composition discipline.
+
+**Proven:** [`form-stdlib/tests/persistence-band.fk`](form-stdlib/tests/persistence-band.fk) returns `7` three-way (Go, Rust, TypeScript) via `./validate.sh form-stdlib/tests/persistence-band.fk` — 1 workload, 0 divergent. The band round-trips two cells sharing a name across different domains through a `.fkb` file, proving durable write→read, `(domain, name)` identity, content-addressing, honest absence, and CTOR composition survival in one strange edge.
+
+**Still ahead in this breath:** the `.fkb`↔ORM reconciliation so a Form-written cell is visible to `coh_substrate.py annotate` and vice-versa (one ingest pass each way over the shared store, or the daemon/DB backend behind the same `cell-put`/`lookup-cell` contract). Until then the Form store and the Python store are two backends of one interface, not yet a single shared lattice on disk. That bridge is the gate on composting `orm.py` and the rest of `api/app/services/substrate/*.py`.
 
 ### Breath 6 — Embed in `api/`
 

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -175,15 +175,28 @@ Phase A/B/C.
 **Gate per file:** the body has a **Form-native persistence story** — a
 durable store that the kernel writes/reads with the same atomicity guarantee
 `orm.py`'s UNIQUE constraint provides, with sibling-kernel portability
-(Go/Rust/TS can all read/write the same store). Possible shapes:
+(Go/Rust/TS can all read/write the same store).
 
-1. Kernel-native serialization to `.fkb` Form-binary artifacts as the
-   canonical store (closest to the audit's #10 single-binary-distribution
-   breath)
-2. Kernel-native binding to PG/SQLite directly (replaces SQLAlchemy without
-   changing the backend)
-3. A hybrid — kernel-native primitives walk an underlying SQLAlchemy /
-   PG / SQLite layer, but the *contract* is Form-side
+**The story's first cell has landed** (`form-stdlib/persistence.fk`, proven
+three-way 2026-05-29 — see the PROVEN row below). The resolution unifies the
+three shapes that were once a fork: the persistence *contract* is a Form
+module (`cell-put` / `lookup-cell`), and the *backend* is swappable beneath
+it. The kernel already persists the content-addressed lattice via
+`write_form_binary` / `read_form_binary` — no new native against a DB was
+needed. The three shapes become one layered answer, not a choice:
+
+1. **Backend (shipped today):** kernel-native serialization to `.fkb`
+   Form-binary artifacts — the canonical store, closest to the audit's #10
+   single-binary-distribution breath.
+2. **Backend (later, behind the same contract):** binding to PG/SQLite
+   directly, slotting under `cell-put`/`lookup-cell` without changing callers.
+3. **The unifier:** the *contract* is Form-side — which was always shape 3's
+   spirit. Shapes 1 and 2 are two backends of it.
+
+What still gates `orm.py`'s compost: the `.fkb`↔ORM reconciliation so the
+Form store and the Python `substrate_named_cells` are one shared lattice on
+disk (a Form-written cell visible to `coh_substrate.py annotate`), not two
+backends of one interface. That bridge is the rest of Breath 5.
 
 This is a **much bigger arc** than Phase A's parity flip. The audit names it
 as the #10 next breath. The manifest carries the named shape so future
@@ -311,6 +324,7 @@ ritual.
 | 2026-05-27 | [#2113](https://github.com/seeker71/Coherence-Network/pull/2113) | CTOR Shape B for `+ - * /`. The PY-BMF lift now interns `+ - * /` as `RBasic.MATH-12` (NodeIDs `(1, 2, 12, 1..4)`) with positional children — the *same* Blueprint a hand-built `(intern_node MATH-PLUS …)` interns to. **Cross-modal NodeID equality at the math-primitive layer becomes substrate-truth for arithmetic.** New MATH-12 arm in `python-bmf-eval.fk` walks the unified shape; old `PY-BMF-BINOP` arm still services `** // %` (no MATH instances exist for those today). | Cell 10 of `python-bmf-lift-band.fk` builds a hand-built `MATH-PLUS(7, 3)` and a Python-lifted `"7 + 3"`; `node_eq` returns 1 across all three kernels. Aggregate moves 45000 → 55000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
 | 2026-05-27 | [#2119](https://github.com/seeker71/Coherence-Network/pull/2119) | CTOR Shape B extends to comparisons — `== != < <= > >=`. The PY-BMF lift now interns comparisons as `RBasic.COMPARE-13` (NodeIDs `(1, 2, 13, 1..6)`) with positional children. New COMPARE-13 arm in `py-eval` dispatches on `node_inst` to `eq`/`lt`/`le`/`gt`/`ge` natives (Python's 1/0 integer convention preserved). Old `PY-BMF-COMPARE` arm stays for unrecognised ops (defensive) | Cell 11 of `python-bmf-lift-band.fk` proves convergence: hand-built `COMPARE-LT(5, 7)` and Python-lifted `"5 < 7"` `node_eq` to 1 across all three kernels. Aggregate moves 55000 → 65000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
 | 2026-05-27 | [#2122](https://github.com/seeker71/Coherence-Network/pull/2122) | CTOR Shape B extends to `%` (mod) — closes the last arithmetic operator MATH-12 carries today (`inst=5`). Lift dispatcher gains the `%` case before falling back to `PY-BMF-BINOP`; eval MATH-12 arm gains the `(if (eq math-inst 5) (mod lhs rhs))` branch. What's still on `PY-BMF-BINOP` for arithmetic: `**` (power) and `//` (floor-div) — no MATH instances exist for those today; closing them is a separate breath that adds inst=6,7 to `form-ontology.json` + native registration in three kernels | Cell 12 of `python-bmf-lift-band.fk` proves: hand-built `MATH-MOD(10, 3)` and Python-lifted `"10 % 3"` `node_eq` to 1 across all three kernels. Aggregate moves 65000 → 75000 | Go ✓ · Rust ✓ · TypeScript ✓ (136/136 in `./validate.sh`) |
+| 2026-05-29 | `claude/form-native-substrate-persistence` | **Phase D — Breath 5 first cell.** Form-native substrate persistence: the kernel reads AND writes the content-addressed named-cell lattice with no Python and no new native. `form-stdlib/persistence.fk` adds `cell-put` / `lookup-cell` / `store-cells` over `channel.fk`'s `.fkb` file primitives; a CELL Recipe carries `(name, domain, blueprint, ctor)` with `(domain, name)` identity (the same `UNIQUE(domain, name)` Python `orm.py` enforces). Resolves the Phase D three-shape fork: contract is Form-side, backend swappable (`.fkb` today, DB later). What stays open: `.fkb`↔ORM reconciliation so the two stores become one shared lattice on disk | `form-stdlib/tests/persistence-band.fk` returns `7` — round-trips two cells sharing a name across different domains through a `.fkb` file, proving durable write→read, `(domain, name)` identity, content-addressing, honest absence, and composed-CTOR survival in one strange edge | Go ✓ · Rust ✓ · TypeScript ✓ (`./validate.sh form-stdlib/tests/persistence-band.fk`, 1 workload 0 divergent) |
 
 **What G6 closes and what stays open.** G6 was the orchestration gap — the
 pieces existed (Go compiler, Rust walker, Python BMF grammar) with no binary


### PR DESCRIPTION
## What this walks

Your ask: *have the Form native kernel talk to the substrate directly, so we can replace `api/app/services/substrate/*.py` with Form code.*

The walk found the destination was nearer than the roadmap predicted. **The native kernel already persists the content-addressed lattice** — `write_form_binary` / `read_form_binary` round-trip a Recipe tree to a `.fkb` file so it re-collapses, by content-addressing, to the same NodeIDs on every sibling kernel. `channel.fk` proved this for message logs; `cell-registry.fk` for an addressing directory. A named-cell store is the same shape.

So the persistence bridge is a **Form module over file primitives the kernel already carries** — not a new native against Postgres. No kernel change. No DB native. No Python in the path.

## The resolution

This closes the open fork named in `form/kernel-roadmap.md` Breath 5 and `kernels/BOOTSTRAP_COMPOST_MANIFEST.md` Phase D / Shape 2 — which listed three candidate persistence shapes and deferred the choice. They unify into one layered answer:

- **Contract** is Form-side (`cell-put` / `lookup-cell`) — this was shape 3's spirit.
- **Backend** is swappable beneath it: `.fkb` serialization today (shape 1); a PG/SQLite binding later (shape 2), behind the same caller interface.

## What landed

- **`form-stdlib/persistence.fk`** — `cell-put` / `lookup-cell` / `store-cells`, mirroring Python `make_cell` / `lookup_cell`. A CELL Recipe carries `(name, domain, blueprint, ctor)` with identity `(domain, name)` — the same `UNIQUE(domain, name)` `orm.py` enforces on `substrate_named_cells`. The CTOR is structure-first (frontmatter fields as `(key,value)` pairs), per the CLAUDE.md composition discipline.
- **`form-stdlib/tests/persistence-band.fk`** → **`7` three-way** (Go, Rust, TypeScript). One strange edge — two cells sharing a name across different domains, round-tripped through a `.fkb` — covers durable write→read, `(domain,name)` identity, content-addressing, honest absence, and composed-CTOR survival.

```
$ ./validate.sh form-stdlib/tests/persistence-band.fk
  ✓  stdlib/persistence-band.fk     → 7
  validated 1 workload, 0 divergent
```

## What's still ahead (the rest of Breath 5)

The `.fkb`↔ORM reconciliation, so the Form store and the Python `substrate_named_cells` table become **one shared lattice on disk** — a Form-written cell visible to `coh_substrate.py annotate` and vice-versa. Until that bridge, the Form store and the Python store are two backends of one interface, not yet a single shared store. That is the gate on actually composting `orm.py` and the rest of `api/app/services/substrate/*.py` — this PR lays the contract the compost walks down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)