### PR TITLE
attune(substrate): project Form Blueprint names into the substrate DB

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 133 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 134 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/user-blueprint-registry.md
+++ b/form/user-blueprint-registry.md
@@ -10,6 +10,8 @@ The machine-readable registry is [`form-stdlib/blueprint-registry.json`](form-st
 
 **How to add a new shape:** add the row first (`python3 scripts/scan_form_blueprints.py --emit-registry` harvests it from a `(let NAME (make_nodeid 1 2 99 N))` you write, or curate by hand and set `"curated": true` to protect the name/meaning across regenerations), then reference it via `(bp "NAME")`. The scanner's `--check` (run in `make wellness`) fails if any type-99 number is used without a registry row.
 
+**Why the file *and* the substrate:** the Form kernels (Go/Rust/TS) are standalone offline engines with no DB access, so the authored source of truth must be a file `(bp ...)` can read at load time. The substrate is the body's *query* surface — `substrate_named_cells(name, domain, blueprint_node_id)` is exactly a Blueprint-registry row. So this follows the same two-layer pattern as the KB: author in the file, **project into the DB** via `python3 scripts/sync_blueprints_to_substrate.py` (domain `form-blueprint`; wired into `substrate_post_merge_hook.sh`). After the sync, `lookup_cell(session, "form-blueprint", "JSON-OBJECT")` → `1.2.99.10`, and a Blueprint name can surface alongside the cells that share its shape. The file stays authoritative; the DB is the reflection, not a second place to author.
+
 **The scanner — `scripts/scan_form_blueprints.py`:**
 - no args → full report: every `make_nodeid` literal, how many shapes are registered, which numbers wear many local names (synonyms to collapse), which names point at more than one number (drift to heal).
 - `--check` → forward gate: nonzero exit if a type-99 number is used but unregistered.

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 133
+**Total files**: 134
 
 | File | Purpose |
 |---|---|
@@ -116,6 +116,7 @@
 | [strategy_after_rupture_recipe_proof.py](strategy_after_rupture_recipe_proof.py) | strategy_after_rupture_recipe_proof.py — rupture-recovery primitives compose |
 | [substrate_parity_harness.py](substrate_parity_harness.py) | substrate_parity_harness.py — read the body in both voices, side by side. |
 | [substrate_read_hook.py](substrate_read_hook.py) | Claude Code PreToolUse hook — surface substrate annotation on file Reads. |
+| [sync_blueprints_to_substrate.py](sync_blueprints_to_substrate.py) | Sync Form Blueprint names -> substrate DB as NamedCells. |
 | [sync_crossrefs_to_db.py](sync_crossrefs_to_db.py) | Sync cross-references from KB concept files into graph DB edges. |
 | [sync_kb_to_db.py](sync_kb_to_db.py) | Sync KB markdown files -> Graph DB via API. |
 | [sync_presence_content.py](sync_presence_content.py) | Sync structured presence content from JSON files into graph nodes. |

--- a/scripts/substrate_post_merge_hook.sh
+++ b/scripts/substrate_post_merge_hook.sh
@@ -47,6 +47,18 @@ CHANGED_CODE=$(git diff --name-only --diff-filter=AM "$RANGE" -- \
     'docs/coherence-substrate/*.form' \
     'experiments/form-stdlib/**/*.fk' 2>/dev/null || true)
 
+# Form Blueprint registry → substrate NamedCells. The offline kernels read the
+# JSON files; the substrate needs the names projected in so it can answer
+# "what is 1.2.99.10 called". Runs whenever either authored file changed —
+# independent of the markdown/code ingestion below.
+CHANGED_BP=$(git diff --name-only --diff-filter=AM "$RANGE" -- \
+    'form/form-stdlib/form-ontology.json' \
+    'form/form-stdlib/blueprint-registry.json' 2>/dev/null || true)
+if [ -n "$CHANGED_BP" ]; then
+    echo "[substrate] Blueprint registry changed — projecting names into NamedCells:"
+    python3 scripts/sync_blueprints_to_substrate.py
+fi
+
 CHANGED=$(printf "%s\n%s" "$CHANGED_MD" "$CHANGED_CODE" | sed '/^$/d')
 
 if [ -z "$CHANGED" ]; then

--- a/scripts/sync_blueprints_to_substrate.py
+++ b/scripts/sync_blueprints_to_substrate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Sync Form Blueprint names -> substrate DB as NamedCells.
+
+The Form runtime (Go/Rust/TS kernels) is a standalone offline engine — it
+cannot query the substrate DB at load time, so the authored source of truth
+for Blueprint names must be a file the kernel can read:
+form-stdlib/form-ontology.json (kernel-aligned categories + primitives) and
+form-stdlib/blueprint-registry.json (type-99 user-space shapes). `(bp "name")`
+in form-ontology-loader.fk resolves against those files.
+
+But the substrate is the body's query surface, and `substrate_named_cells`
+(name, domain, blueprint_node_id) is exactly a Blueprint-registry row. Without
+this sync the substrate is blind to the legibility layer — it cannot answer
+"what is 1.2.99.10 called", "what shape does JSON-OBJECT carry", or surface a
+Blueprint name alongside the cells that share its shape. This is the same
+two-layer pattern the KB uses (sync_kb_to_db.py): author in files the offline
+tools read, project into the DB for querying. The file stays authoritative;
+the DB is the reflection.
+
+Each shape becomes one NamedCell in domain "form-blueprint": its canonical
+name, the NodeID it carries, and the file that defines it. make_cell is
+idempotent on (domain, name), so re-running reconciles rather than duplicates.
+
+Usage:
+    python scripts/sync_blueprints_to_substrate.py            # project all
+    python scripts/sync_blueprints_to_substrate.py --dry-run  # show, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "api"))
+
+ONTOLOGY = ROOT / "form" / "form-stdlib" / "form-ontology.json"
+REGISTRY = ROOT / "form" / "form-stdlib" / "blueprint-registry.json"
+DOMAIN = "form-blueprint"
+
+
+def rows() -> list[dict]:
+    """Every named Blueprint shape: (name, pkg, level, type, inst, meaning, src).
+
+    Kernel-aligned categories/primitives live at pkg=1 level=2; type-99 user
+    shapes carry their inst from the registry. One row per canonical name —
+    aliases stay in the files and resolve through `(bp ...)`; the substrate
+    holds one name per shape, its native individuation."""
+    out: list[dict] = []
+    onto = json.loads(ONTOLOGY.read_text())
+    for fam, items in (("category", onto.get("categories", [])),
+                       ("primitive", onto.get("primitives", []))):
+        for r in items:
+            out.append({"name": r["name"], "pkg": 1, "level": 2,
+                        "type": r["type"], "inst": r["inst"],
+                        "meaning": r.get("note", ""), "src": ONTOLOGY.name,
+                        "family": r.get("family", fam)})
+    if REGISTRY.exists():
+        for r in json.loads(REGISTRY.read_text()).get("blueprints", []):
+            defined = r.get("defined_in") or []
+            out.append({"name": r["name"], "pkg": r.get("pkg", 1),
+                        "level": r.get("level", 2), "type": r.get("type", 99),
+                        "inst": r["inst"], "meaning": r.get("meaning", ""),
+                        "src": defined[0] if defined else REGISTRY.name,
+                        "family": r.get("family", "user")})
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be projected without writing")
+    args = ap.parse_args()
+
+    blueprints = rows()
+    if args.dry_run:
+        print(f"would project {len(blueprints)} Blueprint name(s) into "
+              f"substrate_named_cells (domain '{DOMAIN}'):")
+        for r in blueprints[:12]:
+            print(f"  {r['pkg']}.{r['level']}.{r['type']}.{r['inst']:<5} "
+                  f"{r['name']:<24} ← {r['src']}")
+        if len(blueprints) > 12:
+            print(f"  … and {len(blueprints) - 12} more")
+        return 0
+
+    from app.services.substrate import NodeID, make_cell, lookup_cell  # noqa: E402
+    from app.services.unified_db import session as session_scope  # noqa: E402
+
+    written = 0
+    with session_scope() as session:
+        for r in blueprints:
+            node = NodeID(r["pkg"], r["level"], r["type"], r["inst"])
+            make_cell(session, name=r["name"], domain=DOMAIN,
+                      blueprint=node, source_path=r["src"])
+            written += 1
+        session.commit()
+        # Attest the round-trip on a known shape.
+        probe = lookup_cell(session, DOMAIN, "JSON-OBJECT")
+    print(f"projected {written} Blueprint name(s) into substrate_named_cells "
+          f"(domain '{DOMAIN}')")
+    if probe is not None:
+        print(f"  verify: JSON-OBJECT → {probe.blueprint}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Follow-up to [#2154](https://github.com/seeker71/Coherence-Network/pull/2154) (the Blueprint registry + `bp` resolver), answering: *shouldn't this be in the substrate DB?*

**Yes — as a projection, not a second authored source.** The substrate is the body's query surface, and `substrate_named_cells(name, domain, blueprint_node_id)` *is* a Blueprint-registry row. Without this projection the substrate was blind to the legibility layer the registry built — it couldn't answer "what is `1.2.99.10` called" or surface a Blueprint name next to the cells that share its shape.

The **file stays authoritative** because the Form kernels (Go/Rust/TS) are standalone offline engines with no DB access — `(bp ...)` must read a file at load time (same reason `form-ontology.json` is a file). So this is the KB's two-layer pattern: author in the file, project into the DB.

## Changes

- **`scripts/sync_blueprints_to_substrate.py`** — reads `form-ontology.json` (categories + primitives) and `blueprint-registry.json`, projects each shape into `substrate_named_cells` (domain `form-blueprint`) via the idempotent `make_cell`. One name per shape; aliases stay in the files and resolve through `(bp ...)`.
- **`substrate_post_merge_hook.sh`** — runs the sync whenever either authored file changes, so the DB stays current.
- **`user-blueprint-registry.md`** — documents the file↔DB two-layer relationship.

## Verified

```
projected 314 Blueprint name(s) into substrate_named_cells (domain 'form-blueprint')
  verify: JSON-OBJECT → 1.2.99.10
lookups: add→1.2.12.1  lt→1.2.13.3  UUID→1.2.99.1870  JSON-PAIR→1.2.99.12
```

## Honest signals it surfaces

- **314 names → 310 cells**: a few canonical names (`SENTINEL`, `topic-nid`) collide on different numbers — the name-drift the scanner flagged, now concrete in the DB.
- **`jump`/`ACCESS`/`WRITE` absent**: the type-15/16/18 category-layer shapes aren't projected because they're not in any registry yet — the next hygiene step named in the prior turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)