### PR TITLE
feat(substrate): static name + blueprint resolution checker for Form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,9 +176,10 @@ A content-addressed numeric lattice that grounds structural reasoning. Every mem
 | View-as | — | `GET /api/substrate/view/{cd}/{cn}?bp_*=...` | `view_cell_through_blueprint(session, cell, view_blueprint)` |
 | Vocabulary histogram | — | `GET /api/substrate/histogram/{domain}` | — |
 | Form expression eval | `coh_substrate.py form "<expr>"` | — | `form_evaluate_text(session, expr)` |
+| Resolve / type-check (no execution) | `coh_substrate.py check "<expr>"` / `--file` | — | `form_check_text(session, expr)` → `[Diagnostic]` |
 | Ingest (write) | `coh_substrate.py ingest <path>` / `--all` / `--memories` | — (read-only by design) | `ingest_memory_file`, `ingest_concept_file`, `ingest_idea_file`, `ingest_spec_file`, `ingest_presence_file` |
 
-**Form notation** is a Lisp-shaped DSL for substrate queries — `?equivalent @spec(agent-pipeline)`, `@memory(presences_of_the_field) |> @presence`, etc. See [`docs/coherence-substrate/form-language.md`](docs/coherence-substrate/form-language.md).
+**Form notation** is a Lisp-shaped DSL for substrate queries — `?equivalent @spec(agent-pipeline)`, `@memory(presences_of_the_field) |> @presence`, etc. See [`docs/coherence-substrate/form-language.md`](docs/coherence-substrate/form-language.md). Before a refactor, `coh substrate check` statically resolves every name, blueprint, and global cell so a rename's breakage is legible in one pass — the resolution walk is the third peer of the recipe-walk and value-walk; its shape is named in [`docs/coherence-substrate/name-resolution-as-recipe.form`](docs/coherence-substrate/name-resolution-as-recipe.form).
 
 **Auto-ingest on merge:** `scripts/substrate_post_merge_hook.sh` runs after merges to main so the lattice stays in sync with the body without a manual ingest step.
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 135 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 239 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 224 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 225 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |

--- a/api/app/services/substrate/__init__.py
+++ b/api/app/services/substrate/__init__.py
@@ -58,6 +58,11 @@ from app.services.substrate.form_runtime import (
     execute as form_execute,
     form_execute_text,
 )
+from app.services.substrate.form_check import (
+    Diagnostic as FormDiagnostic,
+    check_ast as form_check_ast,
+    check_text as form_check_text,
+)
 from app.services.substrate.grammar import (
     BID_grammar,
     FormRule,
@@ -297,6 +302,9 @@ __all__ = [
     "form_evaluate_text",
     "form_execute",
     "form_execute_text",
+    "form_check_text",
+    "form_check_ast",
+    "FormDiagnostic",
     "FormFrame",
     "form_parse",
     "form_serialize_cell",

--- a/api/app/services/substrate/form_check.py
+++ b/api/app/services/substrate/form_check.py
@@ -1,0 +1,723 @@
+# Static name-resolution + blueprint-type checker for the substrate Form dialect.
+#
+# Form text becomes recipes (`_to_recipe_node_id`) or values (`form_runtime.execute`)
+# through two AST walks that resolve names lazily — they raise on the FIRST
+# unresolved name, only when that node is reached, only at run time. That is
+# enough to run a known-good expression; it is NOT enough to refactor with
+# confidence. Rename a global cell, a function, or a blueprint and nothing
+# tells you what broke until you happen to execute the exact path that touches it.
+#
+# This module is a THIRD walk over the same AST — alongside the recipe walk and
+# the value walk, a *resolution* walk. It threads a lexical Scope (mirroring the
+# runtime Frame), resolves every name against the same namespaces the runtime
+# uses, infers a conservative blueprint for each expression, and COLLECTS every
+# problem instead of raising on the first. The output is the whole map of what a
+# refactor broke, in one pass, before anything runs.
+#
+# Three namespaces, the three the request named:
+#   • blueprints — `~Integer`/`~Memory` (TRIVIAL_REFS) and bare `@domain`
+#   • recipes    — named callables: `defn` closures (arity-checked) + built-ins
+#   • global cells — `@domain(name)` resolved against the live substrate
+#
+# Single source of truth: the checker draws its "known names" from the same live
+# registries the runtime reads (`_BUILTIN_FUNCTIONS`, `TRIVIAL_REFS`,
+# `lookup_eval_category`, `lookup_cell`), never a second hand-maintained copy.
+# When a built-in or operator is added, the checker learns it for free.
+#
+# Calibration — the checker must never cry wolf, or it stops being trusted:
+#   • Name/scope/operator resolution failures are unambiguous → ERROR.
+#   • Blueprint/type mismatches in a dynamically-typed substrate are best-effort
+#     → WARNING, and only raised when a value is *definitely* the wrong shape.
+#   • Anything the walk can't statically know (cell-field access, method
+#     dispatch, builtin results) infers as UNKNOWN and is never flagged.
+#
+# Dialect scope: this checks the substrate Form dialect that the Python
+# `form_runtime` executes — what `coh substrate form/run` and the MCP substrate
+# tools accept. It deliberately does NOT check the TS-kernel `.fk`/stdlib dialect
+# (a different runtime with a different, larger builtin vocabulary); pointing a
+# Python-vocabulary checker at those would be all false positives. Sibling-parity
+# for the TS kernel is a separate follow-up.
+#
+# Canonical shape (this checker in Form's own voice):
+# docs/coherence-substrate/name-resolution-as-recipe.form — the resolution walk
+# as the third peer of the recipe-walk and value-walk.
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.services.substrate import form as F
+from app.services.substrate.kernel import NodeID, lookup_cell
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+ERROR = "error"
+WARNING = "warning"
+
+
+@dataclass
+class Diagnostic:
+    """One thing the resolution walk found. `code` is a stable kebab-case
+    identifier so tooling can filter; `message` is the human sentence;
+    `snippet` is a compact Form rendering of the offending node so a reader
+    can grep the source for it."""
+
+    severity: str  # ERROR | WARNING
+    code: str
+    message: str
+    snippet: str = ""
+
+    def __str__(self) -> str:
+        loc = f"  in `{self.snippet}`" if self.snippet else ""
+        return f"[{self.severity}] {self.code}: {self.message}{loc}"
+
+
+# ---------------------------------------------------------------------------
+# Inferred blueprint types — a small conservative lattice
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FormType:
+    """A statically-inferred blueprint. `kind` is the coarse shape; `arity`
+    carries a closure's parameter count; `domain` carries a cell's domain.
+    UNKNOWN is the top — it unifies with everything and is never flagged."""
+
+    kind: str
+    arity: int = -1
+    domain: str = ""
+
+    def __str__(self) -> str:
+        if self.kind == "closure":
+            return f"closure/{self.arity}"
+        if self.kind == "cell":
+            return f"cell<{self.domain}>" if self.domain else "cell"
+        return self.kind
+
+
+UNKNOWN = FormType("unknown")
+NULL = FormType("null")
+INT = FormType("int")
+DECIMAL = FormType("decimal")
+BOOL = FormType("bool")
+STRING = FormType("string")
+SLUG = FormType("slug")
+NODEID = FormType("nodeid")
+BLUEPRINT = FormType("blueprint")
+LIST = FormType("list")
+DICT = FormType("dict")
+
+_NUMERIC = {"int", "decimal"}
+
+
+def _join(a: FormType, b: FormType) -> FormType:
+    """Least-committed common type of two branches. Equal → that type;
+    both numeric → numeric-ish; otherwise UNKNOWN. Used by if/match/choose
+    where the result is one branch or another."""
+    if a == b:
+        return a
+    if a.kind in _NUMERIC and b.kind in _NUMERIC:
+        return DECIMAL if "decimal" in (a.kind, b.kind) else INT
+    return UNKNOWN
+
+
+def _is_definitely(t: FormType, *kinds: str) -> bool:
+    """True only when the type is known to be one of `kinds`. UNKNOWN is
+    never 'definitely' anything — that is what keeps the type layer from
+    crying wolf."""
+    return t.kind in kinds
+
+
+# ---------------------------------------------------------------------------
+# Lexical scope — mirrors form_runtime.Frame, carrying types instead of values
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Scope:
+    vars: dict = field(default_factory=dict)  # name -> FormType
+    parent: Optional["Scope"] = None
+    has_subject: bool = False  # inside a `with` / catch / method body
+
+    def child(self, *, has_subject: bool = False) -> "Scope":
+        return Scope(parent=self, has_subject=has_subject)
+
+    def define(self, name: str, t: FormType) -> None:
+        self.vars[name] = t
+
+    def lookup(self, name: str) -> Optional[FormType]:
+        s: Optional[Scope] = self
+        while s is not None:
+            if name in s.vars:
+                return s.vars[name]
+            s = s.parent
+        return None
+
+    def in_with(self) -> bool:
+        s: Optional[Scope] = self
+        while s is not None:
+            if s.has_subject:
+                return True
+            s = s.parent
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Compact AST renderer — for the `snippet` field of diagnostics
+# ---------------------------------------------------------------------------
+
+
+def render(node: Any) -> str:
+    """Best-effort compact Form-ish rendering of a node, for diagnostics.
+    Not a faithful pretty-printer — enough that a reader recognizes the
+    offending construct and can grep for it."""
+    n = node
+    if isinstance(n, F.IntLit):
+        return str(n.value)
+    if isinstance(n, F.BoolLit):
+        return "true" if n.value else "false"
+    if isinstance(n, F.StringLit):
+        return f'"{n.value}"'
+    if isinstance(n, F.Identifier):
+        return n.name
+    if isinstance(n, F.TrivialRef):
+        return f"~{n.name}"
+    if isinstance(n, F.CellRef):
+        return f"@{n.domain}" if n.name is None else f"@{n.domain}({n.name})"
+    if isinstance(n, F.BinOp):
+        return f"{render(n.left)} {n.op} {render(n.right)}"
+    if isinstance(n, F.UnaryOp):
+        return f"{n.op}{render(n.operand)}"
+    if isinstance(n, F.FnCall):
+        return f"{n.name}({', '.join(render(a) for a in n.args)})"
+    if isinstance(n, F.SetExpr):
+        return f"set {n.name} = {render(n.value)}"
+    if isinstance(n, F.Let):
+        return f"let {n.name} = {render(n.value)}"
+    if isinstance(n, F.SelfRef):
+        return ".self"
+    if isinstance(n, F.Access):
+        return f"{render(n.target)}.{n.field}"
+    if isinstance(n, F.IndexExpr):
+        return f"{render(n.target)}[{render(n.index)}]"
+    if isinstance(n, list):
+        return f"[{', '.join(render(x) for x in n)}]"
+    return f"<{type(n).__name__}>"
+
+
+# ---------------------------------------------------------------------------
+# The checker
+# ---------------------------------------------------------------------------
+
+
+class Checker:
+    """One resolution walk. Construct with a substrate session (cell lookups
+    flow through it), call `check(ast)`, read `diagnostics`.
+
+    Design: the nodes that carry genuine scope / reference / type semantics
+    get explicit handlers (that knowledge lives nowhere else and is exactly
+    what a type system needs). Every other node — pure containers and future
+    additions — falls through to `_walk`, a generic recursion into all
+    AST-shaped fields. So adding a new container AST node needs no change
+    here: its sub-expressions are name-checked automatically."""
+
+    def __init__(self, session: Session):
+        self.session = session
+        self.diagnostics: List[Diagnostic] = []
+        # Pulled once from the live registries — single source of truth.
+        from app.services.substrate.form_runtime import (
+            _BUILTIN_FUNCTIONS,
+            _BUILTIN_IDENTIFIERS,
+        )
+
+        self._builtin_fns = set(_BUILTIN_FUNCTIONS)
+        self._builtin_idents = dict(_BUILTIN_IDENTIFIERS)
+        # Cell existence only means something against an ingested lattice. On an
+        # empty substrate every `@domain(name)` would flag as unresolved — pure
+        # noise — so sense once whether the lattice carries cells and skip cell
+        # existence (with a single honest note) when it doesn't. Domain validity
+        # (`@notadomain`) is static and stays on regardless.
+        self._lattice_populated = self._sense_lattice()
+        self._skip_note_emitted = False
+
+    def _sense_lattice(self) -> bool:
+        try:
+            from app.services.substrate.orm import SubstrateNamedCellORM
+
+            return self.session.query(SubstrateNamedCellORM).limit(1).count() > 0
+        except Exception:
+            # If we can't sense the lattice, don't claim cells are missing.
+            return False
+
+    # -- diagnostic helpers --------------------------------------------------
+
+    def _err(self, code: str, message: str, node: Any) -> None:
+        self.diagnostics.append(Diagnostic(ERROR, code, message, render(node)))
+
+    def _warn(self, code: str, message: str, node: Any) -> None:
+        self.diagnostics.append(Diagnostic(WARNING, code, message, render(node)))
+
+    # -- entry ---------------------------------------------------------------
+
+    def check(self, ast: Any, scope: Optional[Scope] = None) -> FormType:
+        if scope is None:
+            scope = Scope()
+        return self._dispatch(ast, scope)
+
+    # -- dispatch ------------------------------------------------------------
+
+    def _dispatch(self, node: Any, scope: Scope) -> FormType:
+        # Literals -----------------------------------------------------------
+        if isinstance(node, F.IntLit):
+            return INT
+        if isinstance(node, F.BoolLit):
+            return BOOL
+        if isinstance(node, F.StringLit):
+            return STRING
+        if isinstance(node, F.NodeIDLit):
+            return NODEID
+        if isinstance(node, list):
+            for item in node:
+                self._dispatch(item, scope)
+            return LIST
+
+        # Names --------------------------------------------------------------
+        if isinstance(node, F.Identifier):
+            return self._check_identifier(node, scope)
+        if isinstance(node, F.FnCall):
+            return self._check_fncall(node, scope)
+        if isinstance(node, F.SetExpr):
+            return self._check_set(node, scope)
+
+        # Blueprints + cells -------------------------------------------------
+        if isinstance(node, F.TrivialRef):
+            return self._check_trivial(node)
+        if isinstance(node, F.CellRef):
+            return self._check_cellref(node)
+
+        # Operators ----------------------------------------------------------
+        if isinstance(node, F.BinOp):
+            return self._check_binop(node, scope)
+        if isinstance(node, F.UnaryOp):
+            return self._check_unop(node, scope)
+
+        # Binding forms ------------------------------------------------------
+        if isinstance(node, F.Let):
+            t = self._dispatch(node.value, scope)
+            scope.define(node.name, t)
+            return t
+        if isinstance(node, F.FnDef):
+            return self._check_fndef(node, scope)
+        if isinstance(node, F.DoBlock):
+            return self._check_do(node, scope)
+
+        # Control flow -------------------------------------------------------
+        if isinstance(node, F.IfExpr):
+            self._dispatch(node.cond, scope)
+            t_then = self._dispatch(node.then_branch, scope)
+            if node.else_branch is None:
+                return UNKNOWN
+            return _join(t_then, self._dispatch(node.else_branch, scope))
+        if isinstance(node, F.TernaryExpr):
+            self._dispatch(node.cond, scope)
+            return _join(
+                self._dispatch(node.then_branch, scope),
+                self._dispatch(node.else_branch, scope),
+            )
+        if isinstance(node, F.MatchExpr):
+            return self._check_match(node, scope)
+        if isinstance(node, F.ChooseExpr):
+            t = UNKNOWN
+            for i, cand in enumerate(node.candidates):
+                ct = self._dispatch(cand, scope)
+                t = ct if i == 0 else _join(t, ct)
+            return t
+
+        # Scopes -------------------------------------------------------------
+        if isinstance(node, F.WithExpr):
+            self._dispatch(node.subject, scope)
+            return self._dispatch(node.body, scope.child(has_subject=True))
+        if isinstance(node, F.SelfRef):
+            if not scope.in_with():
+                self._err(
+                    "self-outside-with",
+                    "`.self` used outside a `with` block (no implicit subject in scope)",
+                    node,
+                )
+            return UNKNOWN
+        if isinstance(node, F.ForExpr):
+            self._dispatch(node.iter, scope)
+            sub = scope.child()
+            sub.define(node.var, UNKNOWN)
+            self._dispatch(node.body, sub)
+            return LIST
+        if isinstance(node, F.WhileExpr):
+            # Runtime runs the body in the caller's frame (so accumulation via
+            # `set` persists) — mirror that: no child scope.
+            self._dispatch(node.cond, scope)
+            self._dispatch(node.body, scope)
+            return UNKNOWN
+
+        # Containers with known result shape --------------------------------
+        if isinstance(node, F.DictExpr):
+            for _key, value in node.pairs:
+                self._dispatch(value, scope)
+            return DICT
+        if isinstance(node, F.IndexExpr):
+            target_t = self._dispatch(node.target, scope)
+            self._dispatch(node.index, scope)
+            if _is_definitely(target_t, "int", "decimal", "bool"):
+                self._warn(
+                    "not-indexable",
+                    f"indexing a value inferred as {target_t} — only lists, "
+                    "strings, and dicts are indexable",
+                    node,
+                )
+            return UNKNOWN
+
+        # Methods + cell-shared forms (dynamic dispatch — refs only) ---------
+        if isinstance(node, F.MethodDefExpr):
+            self._dispatch(node.target, scope)
+            body_scope = scope.child(has_subject=True)
+            for p in node.params:
+                body_scope.define(p, UNKNOWN)
+            self._dispatch(node.body, body_scope)
+            return UNKNOWN
+        if isinstance(node, F.TryCatchExpr):
+            self._dispatch(node.body, scope.child())
+            # The raised payload is the catch block's `.self`.
+            self._dispatch(node.handler, scope.child(has_subject=True))
+            return UNKNOWN
+
+        # Everything else: generic recursion into AST-shaped fields ----------
+        return self._walk(node, scope)
+
+    # -- generic fallback ----------------------------------------------------
+
+    def _walk(self, node: Any, scope: Scope) -> FormType:
+        """Recurse into every AST-shaped field of a node we don't model
+        explicitly. Sub-expressions still get name-checked; the node itself
+        infers as UNKNOWN. This is what lets new container nodes drop in as
+        data without touching the dispatch ladder."""
+        if not dataclasses.is_dataclass(node):
+            return UNKNOWN
+        for f in dataclasses.fields(node):
+            value = getattr(node, f.name)
+            self._recurse_value(value, scope)
+        return UNKNOWN
+
+    def _recurse_value(self, value: Any, scope: Scope) -> None:
+        if self._is_ast(value):
+            self._dispatch(value, scope)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                self._recurse_value(item, scope)
+
+    @staticmethod
+    def _is_ast(value: Any) -> bool:
+        # AST dataclasses live in the form module; NodeID is a value dataclass,
+        # not an AST node, so exclude it.
+        return (
+            dataclasses.is_dataclass(value)
+            and not isinstance(value, NodeID)
+            and type(value).__module__ == F.__name__
+        )
+
+    # -- name handlers -------------------------------------------------------
+
+    def _check_identifier(self, node: F.Identifier, scope: Scope) -> FormType:
+        name = node.name
+        if name in self._builtin_idents:
+            v = self._builtin_idents[name]
+            if v is True or v is False:
+                return BOOL
+            return NULL
+        t = scope.lookup(name)
+        if t is not None:
+            return t
+        # A bare name that's a known built-in function used without call is a
+        # callable value — legal (e.g. passed to map). Resolve it.
+        if name in self._builtin_fns:
+            return UNKNOWN
+        self._err(
+            "unresolved-name",
+            f"`{name}` is not bound in scope and is not a built-in",
+            node,
+        )
+        return UNKNOWN
+
+    def _check_fncall(self, node: F.FnCall, scope: Scope) -> FormType:
+        for a in node.args:
+            self._dispatch(a, scope)
+        name = node.name
+        bound = scope.lookup(name)
+        if bound is not None:
+            if bound.kind == "closure" and bound.arity >= 0:
+                if len(node.args) != bound.arity:
+                    self._err(
+                        "arity-mismatch",
+                        f"`{name}` takes {bound.arity} arg(s), called with "
+                        f"{len(node.args)}",
+                        node,
+                    )
+            elif bound.kind not in ("closure", "unknown"):
+                self._warn(
+                    "not-callable",
+                    f"`{name}` is bound as {bound} — calling a non-closure value",
+                    node,
+                )
+            return UNKNOWN
+        if name in self._builtin_fns:
+            return self._builtin_result_type(name)
+        self._err(
+            "unresolved-function",
+            f"`{name}` is not a defined function (no `defn`/binding in scope) "
+            "and not a built-in",
+            node,
+        )
+        return UNKNOWN
+
+    @staticmethod
+    def _builtin_result_type(name: str) -> FormType:
+        # Only the built-ins whose result shape is certain. The rest stay
+        # UNKNOWN so nothing downstream is wrongly flagged.
+        return {
+            "len": INT,
+            "int": INT,
+            "str": STRING,
+            "bool": BOOL,
+            "range": LIST,
+            "reverse": LIST,
+            "concat": LIST,
+            "map": LIST,
+            "filter": LIST,
+            "sum": INT,
+            "abs": INT,
+            "nchildren": INT,
+            "integer_value": INT,
+            "string_value": STRING,
+            "bool_value": BOOL,
+            "child": NODEID,
+            "category": NODEID,
+            "file_exists": BOOL,
+            "file_contains": BOOL,
+            "file_size": INT,
+            "symbol_in_file": BOOL,
+            "pytest_passes": BOOL,
+        }.get(name, UNKNOWN)
+
+    def _check_set(self, node: F.SetExpr, scope: Scope) -> FormType:
+        t = self._dispatch(node.value, scope)
+        if scope.lookup(node.name) is None:
+            self._err(
+                "set-unbound",
+                f"`set {node.name} = ...` but `{node.name}` has no binding in "
+                "scope — use `let` to introduce it",
+                node,
+            )
+        else:
+            scope.define(node.name, t)
+        return t
+
+    # -- blueprint + cell handlers ------------------------------------------
+
+    def _check_trivial(self, node: F.TrivialRef) -> FormType:
+        if node.name not in F.TRIVIAL_REFS:
+            self._err(
+                "unresolved-blueprint",
+                f"`~{node.name}` is not a known trivial blueprint",
+                node,
+            )
+        return BLUEPRINT
+
+    def _check_cellref(self, node: F.CellRef) -> FormType:
+        if node.name is None:
+            if node.domain not in F.DOMAIN_TO_REF:
+                self._err(
+                    "unknown-domain",
+                    f"`@{node.domain}` is not a known substrate domain",
+                    node,
+                )
+            return BLUEPRINT
+        # @domain(name) — resolve against the live substrate, but only when the
+        # lattice is actually ingested (else every ref is a false alarm).
+        if not self._lattice_populated:
+            if not self._skip_note_emitted:
+                self._skip_note_emitted = True
+                self._warn(
+                    "cell-resolution-skipped",
+                    "substrate lattice is empty — cell existence not checked "
+                    "(run `coh substrate ingest --all` to enable cell resolution)",
+                    node,
+                )
+            return FormType("cell", domain=node.domain)
+        try:
+            cell = lookup_cell(self.session, node.domain, node.name)
+        except Exception:
+            cell = None
+        if cell is None:
+            self._err(
+                "unresolved-cell",
+                f"global cell `@{node.domain}({node.name})` not found in the "
+                "substrate",
+                node,
+            )
+        return FormType("cell", domain=node.domain)
+
+    # -- operator handlers ---------------------------------------------------
+
+    def _check_binop(self, node: F.BinOp, scope: Scope) -> FormType:
+        lt = self._dispatch(node.left, scope)
+        rt = self._dispatch(node.right, scope)
+        from app.services.substrate.form_eval import lookup_eval_category
+
+        if lookup_eval_category(node.op, "binary") is None:
+            self._err(
+                "unknown-operator",
+                f"binary operator `{node.op}` has no evaluation mapping",
+                node,
+            )
+            return UNKNOWN
+        return self._binop_type(node, lt, rt)
+
+    def _binop_type(self, node: F.BinOp, lt: FormType, rt: FormType) -> FormType:
+        op = node.op
+        if op in ("==", "!=", "<", "<=", ">", ">="):
+            # Ordering comparisons on a definitely-bool / cell / blueprint
+            # operand are almost surely a mistake; equality accepts anything.
+            if op not in ("==", "!="):
+                for t in (lt, rt):
+                    if _is_definitely(t, "bool", "cell", "blueprint", "nodeid"):
+                        self._warn(
+                            "type-mismatch",
+                            f"`{op}` orders a value inferred as {t}",
+                            node,
+                        )
+                        break
+            return BOOL
+        if op in ("&&", "||"):
+            return _join(lt, rt)
+        # Arithmetic. `+` is overloaded (numeric add / string concat / list
+        # concat), so only flag the strictly-numeric operators.
+        if op == "+":
+            if _is_definitely(lt, "string") or _is_definitely(rt, "string"):
+                return STRING
+            if lt.kind in _NUMERIC and rt.kind in _NUMERIC:
+                return _join(lt, rt)
+            return UNKNOWN
+        if op in ("-", "*", "/", "%"):
+            for t in (lt, rt):
+                if _is_definitely(t, "string", "bool", "cell", "blueprint"):
+                    self._warn(
+                        "type-mismatch",
+                        f"arithmetic `{op}` on a value inferred as {t}",
+                        node,
+                    )
+                    break
+            if op == "/":
+                return DECIMAL if "decimal" in (lt.kind, rt.kind) else INT
+            return _join(lt, rt) if (lt.kind in _NUMERIC and rt.kind in _NUMERIC) else UNKNOWN
+        return UNKNOWN
+
+    def _check_unop(self, node: F.UnaryOp, scope: Scope) -> FormType:
+        t = self._dispatch(node.operand, scope)
+        from app.services.substrate.form_eval import lookup_eval_category
+
+        if lookup_eval_category(node.op, "unary") is None:
+            self._err(
+                "unknown-operator",
+                f"unary operator `{node.op}` has no evaluation mapping",
+                node,
+            )
+            return UNKNOWN
+        if node.op == "!":
+            return BOOL
+        if node.op == "-":
+            if _is_definitely(t, "string", "bool", "cell", "blueprint"):
+                self._warn(
+                    "type-mismatch", f"unary `-` on a value inferred as {t}", node
+                )
+            return t if t.kind in _NUMERIC else UNKNOWN
+        return UNKNOWN
+
+    # -- binding-form handlers ----------------------------------------------
+
+    def _check_fndef(self, node: F.FnDef, scope: Scope) -> FormType:
+        closure_t = FormType("closure", arity=len(node.params))
+        # Name visible to siblings AND inside its own body (recursion).
+        scope.define(node.name, closure_t)
+        body_scope = scope.child()
+        body_scope.define(node.name, closure_t)
+        for p in node.params:
+            body_scope.define(p, UNKNOWN)
+        self._dispatch(node.body, body_scope)
+        return closure_t
+
+    def _check_do(self, node: F.DoBlock, scope: Scope) -> FormType:
+        # One sub-scope for the whole block; `let`s accumulate so later
+        # statements see earlier bindings (matches the runtime's single
+        # sub-frame). Last statement's type is the block's type.
+        sub = scope.child()
+        t: FormType = NULL
+        for stmt in node.statements:
+            t = self._dispatch(stmt, sub)
+        return t
+
+    def _check_match(self, node: F.MatchExpr, scope: Scope) -> FormType:
+        self._dispatch(node.scrutinee, scope)
+        result: Optional[FormType] = None
+        for arm in node.arms:
+            # `_` wildcard is a pattern sentinel, not a name reference.
+            if not (isinstance(arm.pattern, F.Identifier) and arm.pattern.name == "_"):
+                self._dispatch(arm.pattern, scope)
+            bt = self._dispatch(arm.body, scope)
+            result = bt if result is None else _join(result, bt)
+        return result if result is not None else UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def check_ast(session: Session, ast: Any) -> List[Diagnostic]:
+    """Resolve names and infer blueprints across an already-parsed AST.
+    Returns every diagnostic found (empty list = clean)."""
+    checker = Checker(session)
+    checker.check(ast)
+    return checker.diagnostics
+
+
+def check_text(
+    session: Session, code: str, *, prefer_registered: bool = False
+) -> List[Diagnostic]:
+    """Parse and check a Form expression in one step. A parse failure surfaces
+    as a single `parse-error` diagnostic rather than an exception, so callers
+    that check a whole corpus get a uniform diagnostic stream."""
+    try:
+        ast = F.parse(code, prefer_registered=prefer_registered)
+    except SyntaxError as e:
+        return [Diagnostic(ERROR, "parse-error", str(e))]
+    return check_ast(session, ast)
+
+
+def has_errors(diagnostics: List[Diagnostic]) -> bool:
+    return any(d.severity == ERROR for d in diagnostics)
+
+
+def format_report(diagnostics: List[Diagnostic]) -> str:
+    """Render diagnostics as a block of lines, errors before warnings."""
+    if not diagnostics:
+        return "✓ no resolution or type problems found"
+    errs = [d for d in diagnostics if d.severity == ERROR]
+    warns = [d for d in diagnostics if d.severity == WARNING]
+    lines = [str(d) for d in errs] + [str(d) for d in warns]
+    tail = f"\n{len(errs)} error(s), {len(warns)} warning(s)"
+    return "\n".join(lines) + tail

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 224
+**Total files**: 225
 
 | File | Purpose |
 |---|---|
@@ -178,6 +178,7 @@
 | [test_substrate_form_bml_state.py](test_substrate_form_bml_state.py) | BML state-stack + exception-flow primitives in Form. |
 | [test_substrate_form_builders.py](test_substrate_form_builders.py) | Tests for substrate-resident builders (Build/CaptureRef/Const DSL). |
 | [test_substrate_form_builtins.py](test_substrate_form_builtins.py) | Built-in functions in Form runtime — list ops, type coercion, numerics. |
+| [test_substrate_form_check.py](test_substrate_form_check.py) | Static resolution + blueprint-type checking — the third walk over a Form AST. |
 | [test_substrate_form_decompile_round_trip.py](test_substrate_form_decompile_round_trip.py) | Source round-trip fidelity: text → Recipe → text' → Recipe' is identity. |
 | [test_substrate_form_dict_literals.py](test_substrate_form_dict_literals.py) | Dict literals + field access on dicts. |
 | [test_substrate_form_endpoint.py](test_substrate_form_endpoint.py) | Smoke tests for POST /api/substrate/form — the substrate-native query DSL |

--- a/api/tests/test_substrate_form_check.py
+++ b/api/tests/test_substrate_form_check.py
@@ -1,0 +1,167 @@
+"""Static resolution + blueprint-type checking — the third walk over a Form AST.
+
+`form_check` resolves names (bare names, function calls + arity, `set` targets),
+blueprints (`~Trivial`, `@domain`, `@domain(name)` cells), and operators, then
+infers a conservative blueprint for each expression — collecting EVERY problem in
+one pass instead of raising on the first. That is the unlock for refactoring with
+confidence: rename a cell or a function and the checker names every break at once.
+
+The load-bearing test is `test_clean_program_is_silent` — a checker that cries
+wolf on real code is a checker nobody trusts, so the bar is zero false positives
+on the full constructed language. The error tests pin each error CLASS the
+checker is responsible for, expressed as the simplest snippet that triggers it.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.substrate.category import BDomain, BType, BBasic, Level
+from app.services.substrate.form import TRIVIAL_REFS
+from app.services.substrate.form_check import (
+    ERROR,
+    WARNING,
+    check_text,
+    has_errors,
+)
+from app.services.substrate.kernel import NodeID, make_cell
+from app.services.substrate.orm import SubstrateNamedCellORM, SubstrateNodeORM
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SubstrateNodeORM.__table__.create(engine, checkfirst=True)
+    SubstrateNamedCellORM.__table__.create(engine, checkfirst=True)
+    from app.services.substrate.substrate_strings import SubstrateStringORM
+
+    SubstrateStringORM.__table__.create(engine, checkfirst=True)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session()
+    # Seed one global cell so cell-resolution has something real to resolve to.
+    make_cell(
+        s,
+        name="agent-pipeline",
+        domain="idea",
+        blueprint=NodeID(1, Level.BASIC, BBasic.DOMAIN, BDomain.IDEA),
+    )
+    s.flush()
+    try:
+        yield s
+        s.commit()
+    finally:
+        s.close()
+
+
+def codes(diags, severity=None):
+    return [d.code for d in diags if severity is None or d.severity == severity]
+
+
+# ---------------------------------------------------------------------------
+# The trust bar: a real program with every scoping construct stays silent
+# ---------------------------------------------------------------------------
+
+
+def test_clean_program_is_silent(session):
+    src = """
+    do {
+        defn add_pair(a, b) = a + b;
+        defn fib(n) = if n < 2 then n else fib(n - 1) + fib(n - 2);
+        let xs = range(0, 5);
+        let doubled = map(fib, xs);
+        let total = fold(add_pair, 0, doubled);
+        let greeting = "fib of five: " + str(total);
+        let subject = with @idea(agent-pipeline) { .self };
+        let squared = for x in doubled { x * 2 };
+        let m = match total { 0 => "zero", _ => greeting };
+        ~Integer;
+        @memory;
+        greeting
+    }
+    """
+    diags = check_text(session, src)
+    assert diags == [], f"clean program flagged: {[str(d) for d in diags]}"
+
+
+# ---------------------------------------------------------------------------
+# One snippet, one of each error class — the strange-minimal boundary sweep
+# ---------------------------------------------------------------------------
+
+
+def test_one_of_each_error_class(session):
+    # Each line below carries exactly one resolution fault; the do-block lets
+    # `goodfn` exist so the arity fault is about count, not existence.
+    src = """
+    do {
+        defn goodfn(a) = a;
+        goodfn(1, 2);
+        nope;
+        missing_fn(3);
+        set never = 9;
+        ~Nonesuch;
+        @idea(does-not-exist);
+        @notadomain;
+        .self
+    }
+    """
+    diags = check_text(session, src)
+    found = set(codes(diags, ERROR))
+    expected = {
+        "arity-mismatch",       # goodfn(1, 2) — defined with 1 param
+        "unresolved-name",      # nope
+        "unresolved-function",  # missing_fn(3)
+        "set-unbound",          # set never = 9
+        "unresolved-blueprint", # ~Nonesuch
+        "unresolved-cell",      # @idea(does-not-exist)
+        "unknown-domain",       # @notadomain
+        "self-outside-with",    # .self at top of do-block
+    }
+    assert expected <= found, f"missing {expected - found}; got {found}"
+
+
+# ---------------------------------------------------------------------------
+# Cell resolution — the refactoring case: rename a cell, every ref lights up
+# ---------------------------------------------------------------------------
+
+
+def test_known_cell_resolves(session):
+    assert check_text(session, "@idea(agent-pipeline)") == []
+
+
+def test_renamed_cell_is_caught(session):
+    diags = check_text(session, "@idea(agent-pipeline-renamed)")
+    assert codes(diags, ERROR) == ["unresolved-cell"]
+
+
+# ---------------------------------------------------------------------------
+# Conservative typing — flag the definitely-wrong, never the overloaded
+# ---------------------------------------------------------------------------
+
+
+def test_overloaded_plus_is_not_flagged(session):
+    # `+` is string concat / numeric add / list concat — never a type error.
+    assert check_text(session, '"a" + "b"') == []
+    assert check_text(session, "1 + 2") == []
+
+
+def test_arithmetic_on_string_warns_not_errors(session):
+    diags = check_text(session, '"x" - 1')
+    assert codes(diags, ERROR) == []
+    assert "type-mismatch" in codes(diags, WARNING)
+
+
+# ---------------------------------------------------------------------------
+# Failures stay diagnostics, not exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_is_a_diagnostic(session):
+    diags = check_text(session, "do {")
+    assert codes(diags, ERROR) == ["parse-error"]
+    assert has_errors(diags)

--- a/docs/coherence-substrate/name-resolution-as-recipe.form
+++ b/docs/coherence-substrate/name-resolution-as-recipe.form
@@ -1,0 +1,128 @@
+# ─────────────────────────────────────────────────────────────────────
+# name-resolution-as-recipe.form — the third walk, in Form's voice
+# ─────────────────────────────────────────────────────────────────────
+#
+# A Form expression is walked three ways. The recipe-walk turns it into a
+# content-addressed NodeID (`_to_recipe_node_id`). The value-walk runs it to a
+# value (`form_runtime.execute`). This file names the third walk: the
+# resolution-walk, which turns the same AST into a set of diagnostics — every
+# name that does not resolve, every blueprint that is not known, every call whose
+# arity does not match — gathered in one pass, before anything runs.
+#
+# The three walks are peers. Each is a projection of the same dispatch over the
+# same tree; they differ only in what they accumulate as they descend. The
+# recipe-walk accumulates NodeIDs. The value-walk accumulates values. The
+# resolution-walk accumulates diagnostics, and infers a blueprint for each node
+# so the next node up can be checked against it.
+#
+# Why a third walk earns its place: the first two resolve names lazily — they
+# raise on the first unresolved name, only when that node is reached, only at
+# run time. That is enough to run a known-good expression. It is not enough to
+# rename a cell and see, in one read, everything the rename broke. The
+# resolution-walk is what makes a refactor legible before it runs.
+#
+# Bootstrap: api/app/services/substrate/form_check.py (Python). Canonical shape:
+# this file — same relationship kernel.py holds to substrate-kernel.form.
+#
+# Companion teaching: lc-edges-as-vitality (a rename is an edge moving; the
+# checker is the body sensing which edges still land), form-engine.form (the
+# meta-circular walk this is a sibling of).
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 1 — three namespaces, the three a refactor moves through
+# ─────────────────────────────────────────────────────────────────────
+#
+# A name in Form resolves through exactly one of three namespaces. The walk
+# asks each in turn; an unresolved name belongs to none of them.
+
+# BLUEPRINTS — `~Integer`, `~Memory` (the trivial table) and bare `@memory`
+# (a domain's blueprint). A blueprint reference resolves iff its name is a key
+# of the known-blueprint table. The table is the body's type vocabulary; a
+# name outside it is a type that does not exist.
+defn blueprint_known(name) = trivial_ref_exists(name);            # GAP-B1: trivial-table membership predicate
+
+# RECIPES — named callables. A `defn` binds a closure into the lexical scope;
+# the built-ins close the rest. A call resolves iff the name is bound in scope
+# OR is a built-in; and if it is a bound closure of known arity, the call's
+# argument count must match.
+defn recipe_known(scope, name) = or(scope_has(scope, name), builtin_fn_exists(name));
+
+# GLOBAL CELLS — `@domain(name)`. A cell reference resolves iff the substrate
+# carries a NamedCell at that (domain, name). This is the one namespace that
+# lives in the lattice, not in a static table — so it resolves against the
+# ingested body, and is honestly skipped when the lattice is empty.
+defn cell_known(domain, name) = is_some(lookup_cell(domain, name));   # GAP-B2: lookup_cell as a Form host-intrinsic
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 2 — the walk, as a fold over the AST that carries a scope
+# ─────────────────────────────────────────────────────────────────────
+#
+# The scope is the same lexical frame the value-walk threads — `let`, `defn`
+# params, `for` var, the `with` subject — but it carries inferred blueprints
+# where the runtime frame carries values. A node resolves its own references
+# against the scope it is handed, then hands its children the scope they see.
+
+# An identifier resolves against scope, then built-ins. Neither → a diagnostic.
+defn check_identifier(scope, name) =
+    if scope_has(scope, name) then ok
+    else if builtin_ident_exists(name) then ok
+    else diagnostic("unresolved-name", name);
+
+# A call resolves the callable, then checks arity when the arity is known.
+defn check_call(scope, name, argc) =
+    match scope_arity(scope, name) {
+        -1 => if builtin_fn_exists(name) then ok else diagnostic("unresolved-function", name),
+        _  => if scope_arity(scope, name) == argc then ok
+              else diagnostic("arity-mismatch", name)
+    };
+
+# A `set` is a reference, not a binder — its target must already be bound.
+defn check_set(scope, name) =
+    if scope_has(scope, name) then ok else diagnostic("set-unbound", name);
+
+# `.self` is bound only inside a `with` (or a catch / method body). The scope
+# carries that as a flag the walk reads — structure, not a name.
+defn check_self(scope) =
+    if scope_in_with(scope) then ok else diagnostic("self-outside-with", ".self");
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 3 — the calibration that keeps the walk trusted
+# ─────────────────────────────────────────────────────────────────────
+#
+# A checker that cries wolf is a checker nobody runs. So the severities split
+# by certainty:
+#
+#   • Name / scope / operator / cell resolution → ERROR. These are exact: a
+#     name either resolves or it does not.
+#   • Blueprint / type mismatch → WARNING, and only when a value is DEFINITELY
+#     the wrong shape. In a dynamically-typed substrate most expressions infer
+#     to `unknown`, which unifies with everything and is never flagged.
+#
+# The overloaded operators are the sharpest test of this discipline. `+` is
+# numeric add, string concat, AND list concat — so `+` is never a type error.
+# Only the strictly-numeric operators (`- * / %`) can mismatch, and only when
+# an operand is definitely a string / bool / cell.
+defn plus_is_overloaded() = true;        # the body refuses to flag `"a" + "b"`
+
+# `unknown` is the top of the lattice — the honest answer when the walk cannot
+# know. A cell-field access, a method dispatch, a built-in whose result shape
+# is not certain: all infer `unknown`, and nothing downstream is wrongly flagged.
+defn infer_unknown_is_safe() = true;
+
+# ─────────────────────────────────────────────────────────────────────
+# Part 4 — the surface
+# ─────────────────────────────────────────────────────────────────────
+#
+#   coh substrate check "<expression>"      — resolve an expression, exit 1 on error
+#   coh substrate check --file <path>        — resolve a single-form source
+#
+# The diagnostics carry a stable kebab-case `code` so tooling can filter, the
+# human sentence, and a compact rendering of the offending node so a reader can
+# grep the source for it. The exit code composes into CI and pre-commit gates:
+# a green check means every name in the expression lands somewhere real.
+#
+# The GAP-BN markers above name the host-intrinsic predicates the Python
+# bootstrap already provides (`form_check.py`) and that a Form-native checker
+# would reach for once the lattice exposes them as Form surfaces. Asymmetry is
+# signal, not failure — each gap is one surface away from the walk being
+# expressible end-to-end in the tongue it describes.

--- a/scripts/coh_substrate.py
+++ b/scripts/coh_substrate.py
@@ -13,6 +13,7 @@ Usage:
     coh_substrate.py annotate <path>                    # substrate context for a file
     coh_substrate.py form "<expression>"                # evaluate (intern as recipe / return substrate answer)
     coh_substrate.py run "<expression>"                 # execute (run the recipe, return its value)
+    coh_substrate.py check "<expression>"               # static name + blueprint resolution (no execution); --file <path>
 
 For detail on Form syntax see docs/coherence-substrate/form-language.md.
 For agent grounding patterns see docs/coherence-substrate/agents-using-substrate.md.
@@ -925,6 +926,61 @@ def cmd_form(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_check(args: argparse.Namespace) -> int:
+    """Statically resolve names + blueprints across a Form expression or
+    `.form` file — the refactor-with-confidence surface.
+
+    Unlike `form`/`run`, this never executes: it walks the parsed AST,
+    resolves every name against the live substrate (global cells), the
+    blueprint table (`~Trivial`, `@domain`), and the runtime's built-in and
+    operator registries, then reports EVERY unresolved name / arity mismatch /
+    blueprint problem in one pass. Exit 1 when any error-severity diagnostic is
+    found, so it composes into CI and pre-commit gates.
+    """
+    from app.services.substrate.form_check import (
+        ERROR,
+        check_text,
+        format_report,
+        has_errors,
+    )
+
+    if args.file:
+        path = Path(args.file)
+        if not path.exists() or path.is_dir():
+            print(f"check: not a file: {path}", file=sys.stderr)
+            return 2
+        code = path.read_text()
+        label = str(path)
+    elif args.expression:
+        code = args.expression
+        label = "<expression>"
+    else:
+        print("check: pass an expression or --file <path>", file=sys.stderr)
+        return 2
+
+    with session_scope() as session:
+        diags = check_text(session, code)
+
+    if args.json:
+        print(json.dumps({
+            "target": label,
+            "diagnostics": [
+                {
+                    "severity": d.severity,
+                    "code": d.code,
+                    "message": d.message,
+                    "snippet": d.snippet,
+                }
+                for d in diags
+            ],
+            "errors": sum(1 for d in diags if d.severity == ERROR),
+        }, indent=2))
+    else:
+        print(f"check: {label}")
+        print(format_report(diags))
+    return 1 if has_errors(diags) else 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
@@ -990,6 +1046,25 @@ def main(argv: list[str] | None = None) -> int:
         help="Execute a Form expression — run the recipe, return its value",
     )
     p_run.add_argument("expression")
+
+    p_check = sub.add_parser(
+        "check",
+        help=(
+            "Statically resolve names + blueprints (no execution): report every "
+            "unresolved name, cell, blueprint, operator, and arity mismatch in "
+            "one pass. Exit 1 on errors. Refactor with confidence."
+        ),
+    )
+    p_check.add_argument(
+        "expression",
+        nargs="?",
+        help="A Form expression to check (or use --file).",
+    )
+    p_check.add_argument(
+        "--file",
+        default=None,
+        help="Path to a single-form .form/.fk source to check instead of an inline expression.",
+    )
 
     p_exec = sub.add_parser(
         "execute",
@@ -1141,6 +1216,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_form(args)
     if args.cmd == "run":
         return cmd_run(args)
+    if args.cmd == "check":
+        return cmd_check(args)
     if args.cmd == "execute":
         return cmd_execute_dispatch(args)
     if args.cmd == "discover":


### PR DESCRIPTION
## What

A **third walk** over the Form AST — peer to the recipe-walk (`_to_recipe_node_id`) and the value-walk (`form_runtime.execute`). Where those resolve names lazily and raise on the first failure at run time, the **resolution-walk** turns an expression into a set of diagnostics: every name that doesn't resolve, every blueprint that isn't known, every call whose arity doesn't match — gathered in one pass, before anything runs. This is what makes a refactor legible: rename a cell and the checker names every break.

Resolves the three namespaces a refactor moves through:
- **blueprints** — `~Integer`/`~Memory` (trivial table) and bare `@domain`
- **recipes** — named callables: `defn` closures (arity-checked) + built-ins
- **global cells** — `@domain(name)` resolved against the live substrate lattice

## How

- **`api/app/services/substrate/form_check.py`** — scope-aware walk with explicit handlers for the scope/reference/type-bearing nodes and a generic `dataclasses.fields()` recursion for everything else, so new AST nodes get name-checked for free. Known names are drawn from the **live runtime registries** (`_BUILTIN_FUNCTIONS`, `TRIVIAL_REFS`, `lookup_eval_category`, `lookup_cell`) — single source of truth, can't drift from what the runtime accepts.
- **Calibrated to never cry wolf:** name/scope/operator/cell faults are `ERROR` (exact); blueprint/type mismatches are `WARNING` and only when a value is *definitely* the wrong shape (`+` stays overloaded — never flagged). An empty lattice skips cell-existence with one honest note instead of flagging every ref.
- **`coh substrate check "<expr>"` / `--file`** — exit 1 on errors; composes into CI / pre-commit.
- **`docs/coherence-substrate/name-resolution-as-recipe.form`** — the canonical shape in Form's own voice (Python is bootstrap).
- Edges landed in the same breath: `__init__` export (`form_check_text`), CLAUDE.md substrate-surfaces row, INDEX/MANIFEST regen.

## Proof

- 7 strange-minimal tests incl. the **zero-false-positive trust bar** (a real program using every scoping construct stays silent). All **626** form tests green.
- End-to-end against the ingested lattice: `@idea(agent-pipeline)` → exit 0; `@idea(agent-pipeline-renamed)` → `unresolved-cell`, exit 1.

## Scope

Checks the substrate Form dialect that the Python `form_runtime` executes (what `coh substrate form/run` and the MCP substrate tools accept). Deliberately does **not** check the TS-kernel `.fk`/stdlib dialect — a different runtime with a larger builtin vocabulary; pointing a Python-vocabulary checker there would be all false positives. TS sibling-parity is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)