### PR TITLE
feat(agents): auto-detect agent + user at session start, across all known agents

### DIFF
--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -160,7 +160,7 @@
 | [test_runtime_api.py](test_runtime_api.py) | Tests for the canonical-route-registry-and-runtime-mapping spec |
 | [test_runtime_event_store_precedence.py](test_runtime_event_store_precedence.py) | Regression tests for runtime telemetry DB precedence. |
 | [test_runtime_mode_and_events.py](test_runtime_mode_and_events.py) | _no top-of-file purpose_ |
-| [test_session_greeting.py](test_session_greeting.py) | Session greeting — the SessionStart recognition of user + agent with memory. |
+| [test_session_greeting.py](test_session_greeting.py) | Session greeting — detect agent + user, greet with memory, across all agents. |
 | [test_settlement_flow.py](test_settlement_flow.py) | Tests for settlement service + router — story-protocol-integration R8. |
 | [test_smart_reaper_module_boundary.py](test_smart_reaper_module_boundary.py) | _no top-of-file purpose_ |
 | [test_source_artifact_sensing_graph.py](test_source_artifact_sensing_graph.py) | Source artifact -> sensing -> concept graph integration tests. |

--- a/api/tests/test_session_greeting.py
+++ b/api/tests/test_session_greeting.py
@@ -1,8 +1,9 @@
-"""Session greeting — the SessionStart recognition of user + agent with memory.
+"""Session greeting — detect agent + user, greet with memory, across all agents.
 
 The greeting logic is a script (scripts/session_greeting.py) wired into
-arrival.py. These tests pin the pure assembly and the opt-in/auth gating with
-an injected HTTP function, so no network is touched.
+arrival.py. These tests pin agent detection, the agent-independent user
+resolution, the pure assembly, and opt-out gating — all with injected env /
+HTTP, so no network or real environment is touched.
 """
 from __future__ import annotations
 
@@ -17,6 +18,61 @@ sys.path.insert(0, str(SCRIPTS))
 import session_greeting as sg  # noqa: E402
 
 
+# --- agent detection: one row per known agent, plus generic + unknown --------
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"AI_AGENT": "claude-code_2-1-156_agent", "CLAUDECODE": "1"}, "claude-code"),
+        ({"CLAUDECODE": "1"}, "claude-code"),
+        ({"CODEX_HOME": "/x/codex"}, "codex"),
+        ({"AI_AGENT": "codex_1-2-3"}, "codex"),
+        ({"CURSOR_TRACE_ID": "abc"}, "cursor"),
+        ({"GEMINI_CLI": "1"}, "gemini"),
+        ({"AI_AGENT": "windsurf_9_agent"}, "windsurf"),  # generic AI_AGENT fallback
+        ({}, sg.DEFAULT_AGENT),
+    ],
+)
+def test_detect_agent(env, expected) -> None:
+    assert sg.detect_agent(env) == expected
+
+
+# --- user resolution: provider lookup primary, /me fallback, agent-free ------
+
+
+def test_resolve_user_via_provider_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "keystore_identity", lambda: ("github", "urs-muff"))
+
+    def http(method, url, headers, body):
+        assert url.endswith("/api/identity/lookup/github/urs-muff")
+        return 200, {"contributor_id": "milestone-agent"}
+
+    assert sg.resolve_user(http, "https://api.test") == "milestone-agent"
+
+
+def test_resolve_user_falls_back_to_me_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    monkeypatch.setattr(sg, "load_api_key", lambda: "key-123")
+
+    def http(method, url, headers, body):
+        if url.endswith("/api/identity/me"):
+            assert headers.get("X-API-Key") == "key-123"
+            return 200, {"contributor_id": "urs"}
+        raise AssertionError(f"unexpected {url}")
+
+    assert sg.resolve_user(http, "https://api.test") == "urs"
+
+
+def test_resolve_user_none_when_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    monkeypatch.setattr(sg, "load_api_key", lambda: None)
+    assert sg.resolve_user(lambda *a: (0, None), "https://api.test") is None
+
+
+# --- greeting assembly (pure) ------------------------------------------------
+
+
 def test_compose_first_contact() -> None:
     line = sg.compose_greeting("urs", "claude-code", {"was_first_contact": True, "events": [
         {"type": "welcome"}, {"type": "session_start"},
@@ -25,32 +81,28 @@ def test_compose_first_contact() -> None:
     assert "claude-code" in line
 
 
-def test_compose_returning_counts_sessions() -> None:
-    events = [
-        {"type": "welcome"},
-        {"type": "session_start"},
-        {"type": "session_start"},
-        {"type": "session_start"},
-    ]
-    line = sg.compose_greeting("urs", "claude-code", {"was_first_contact": False, "events": events})
+def test_compose_returning_counts_sessions_and_names_agent() -> None:
+    events = [{"type": "session_start"}] * 3
+    line = sg.compose_greeting("urs", "codex", {"was_first_contact": False, "events": events})
     assert "Welcome back, urs" in line
-    assert "session 3" in line
+    assert "session 3 with codex" in line
 
 
 def test_compose_returning_surfaces_last_exchange() -> None:
     events = [
-        {"type": "session_start"},
         {"type": "exchange", "summary": "first thing"},
         {"type": "session_start"},
         {"type": "exchange", "summary": "shipped the greeting"},
     ]
     line = sg.compose_greeting("urs", "claude-code", {"was_first_contact": False, "events": events})
-    assert "shipped the greeting" in line  # the most recent exchange, not the first
+    assert "shipped the greeting" in line  # the most recent, not the first
+
+
+# --- opt-out gating ----------------------------------------------------------
 
 
 def test_remembering_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
-    # No config file at the patched HOME → default True.
     monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
     assert sg.remembering_enabled() is True
 
@@ -62,30 +114,24 @@ def test_remembering_env_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_greeting_lines_opted_out(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("COHERENCE_REMEMBER_SESSIONS", "off")
-    lines = sg.greeting_lines(http=lambda *a: (0, None))
-    assert lines and "off" in lines[0].lower()
+    assert "off" in sg.greeting_lines(http=lambda *a: (0, None))[0].lower()
 
 
-def test_greeting_lines_no_api_key_is_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
-    monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
-    monkeypatch.setattr(sg, "load_api_key", lambda: None)
-    assert sg.greeting_lines(http=lambda *a: (0, None)) == []
+# --- end-to-end greeting line (env + http injected) --------------------------
 
 
 def test_greeting_lines_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
     monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
-    monkeypatch.setattr(sg, "load_api_key", lambda: "key-123")
-    monkeypatch.setattr(sg, "api_base", lambda: "https://api.test")
+    monkeypatch.setattr(sg, "keystore_identity", lambda: ("github", "urs-muff"))
+    monkeypatch.setattr(sg.os, "environ", {"AI_AGENT": "claude-code_2_agent", "CLAUDECODE": "1"})
 
     def fake_http(method, url, headers, body):
-        if url.endswith("/api/identity/me"):
-            assert headers.get("X-API-Key") == "key-123"
-            return 200, {"contributor_id": "urs", "source": "api_key"}
+        if url.endswith("/api/identity/lookup/github/urs-muff"):
+            return 200, {"contributor_id": "urs"}
         if url.endswith("/api/agents/bootstrap"):
+            assert body["my_name"] == "claude-code"  # agent detected, not hardcoded
             assert body["other_name"] == "urs"
-            assert body["my_name"] == sg.AGENT_NAME
             return 200, {"was_first_contact": True, "events": [
                 {"type": "welcome"}, {"type": "session_start"},
             ]}
@@ -94,15 +140,12 @@ def test_greeting_lines_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     lines = sg.greeting_lines(http=fake_http)
     assert len(lines) == 1
     assert "First session together, urs" in lines[0]
+    assert "claude-code" in lines[0]
 
 
-def test_greeting_lines_auth_fails_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_greeting_lines_quiet_when_no_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
     monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
-    monkeypatch.setattr(sg, "load_api_key", lambda: "bad-key")
-    monkeypatch.setattr(sg, "api_base", lambda: "https://api.test")
-    # Key present but 401 from /me → no fabrication, but say why and how to fix.
-    lines = sg.greeting_lines(http=lambda m, u, h, b: (401, None))
-    assert len(lines) == 1
-    assert "isn't recognized" in lines[0]
-    assert "coherence.api_key" in lines[0]
+    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    monkeypatch.setattr(sg, "load_api_key", lambda: None)
+    assert sg.greeting_lines(http=lambda *a: (0, None)) == []

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -108,7 +108,7 @@
 | [sense_strategy_efficacy.py](sense_strategy_efficacy.py) | sense_strategy_efficacy.py — read accumulated strategy_fired traces and |
 | [sense_world.py](sense_world.py) | Sense the world through the new earth lens. |
 | [session_as_framebuffer.py](session_as_framebuffer.py) | Render a Claude session as a memory-as-framebuffer .mfb capture. |
-| [session_greeting.py](session_greeting.py) | Session greeting — recognize the user and the agent at session start. |
+| [session_greeting.py](session_greeting.py) | Session greeting — detect the agent and the user, greet with memory. |
 | [setup.py](setup.py) | Coherence Network — Auto-Setup. |
 | [song_recipe_proof.py](song_recipe_proof.py) | song_recipe_proof.py — songs compose into Recipes whose Blueprint |
 | [spec_recipe_proof.py](spec_recipe_proof.py) | spec_recipe_proof.py — a spec's frontmatter IS the playable Recipe. |

--- a/scripts/session_greeting.py
+++ b/scripts/session_greeting.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
-"""Session greeting — recognize the user and the agent at session start.
+"""Session greeting — detect the agent and the user, greet with memory.
 
-The real-world use case for the agent-relationship runtime: when a session
-begins, identify the authenticated user and this agent, greet with memory of
-prior sessions, and (when remembering is on) record the meeting so the next
-session continues the thread.
+The real-world use case on top of the agent-relationship runtime: when a
+session begins, work out *which agent* is running and *who the human is*, greet
+with memory of prior sessions, and (when remembering is on) record the meeting
+so the next session continues the thread.
 
 Composed into the SessionStart layer by scripts/arrival.py — a peer of the
-orientation and wellness layers, not a replacement.
+orientation and wellness layers.
 
-Identity (explicit login/auth): the user is the contributor authenticated by
-the local API key (~/.coherence-network/keys.json), verified against
-GET /api/identity/me. No typed names, no guessing — if we cannot authenticate
-a user, we do not fabricate one.
+Detection is agent-agnostic, so the same greeting works across all known
+agents (Claude Code, Codex, Cursor, Gemini, …):
+
+- Agent: read from the environment — the generic `AI_AGENT` signal first, then
+  per-agent markers and homes. Adding an agent is one row in KNOWN_AGENTS.
+- User: the human's verified identity travels in the keystore as
+  (provider, provider_id) regardless of agent. We resolve it to a contributor
+  via the public GET /api/identity/lookup/{provider}/{provider_id} — no key
+  required. A coherence API key, when present, is a stronger fallback (/me).
 
 Remembering is on by default. Opt out anytime:
   - set "remember_sessions": false in ~/.coherence-network/config.json, or
   - export COHERENCE_REMEMBER_SESSIONS=0
 
-This module never raises into the hook: any failure (offline, no key, API
+This module never raises into the hook: any failure (offline, no identity, API
 down) degrades to a quiet, non-blocking line so session start is never broken.
 """
 
@@ -29,17 +34,28 @@ import os
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
 HOME = Path(os.path.expanduser("~"))
 KEYS_PATH = HOME / ".coherence-network" / "keys.json"
 CONFIG_PATH = HOME / ".coherence-network" / "config.json"
 
 DEFAULT_API_BASE = "https://api.coherencycoin.com"
-AGENT_NAME = "claude-code"  # this Claude Code lineage, stable across sessions
+DEFAULT_AGENT = "unknown-agent"
 HTTP_TIMEOUT = 4.0
 
 _OFF_VALUES = {"0", "false", "no", "off", ""}
+
+# Known session agents, each detected by a set of environment markers.
+# A marker "VAR^prefix" matches when env[VAR] starts with prefix (case-insensitive);
+# a bare "VAR" matches when that variable is set to anything truthy.
+# Adding an agent is one row — the detector is the engine, agents are data.
+KNOWN_AGENTS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("claude-code", ("AI_AGENT^claude", "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")),
+    ("codex", ("AI_AGENT^codex", "CODEX_HOME", "CODEX_SANDBOX", "CODEX_THREAD_ID")),
+    ("cursor", ("AI_AGENT^cursor", "CURSOR_TRACE_ID", "CURSOR_AGENT", "CURSOR_SESSION_ID")),
+    ("gemini", ("AI_AGENT^gemini", "GEMINI_CLI", "GEMINI_SESSION", "GEMINICODE")),
+)
 
 # An HTTP call returns (status_code, parsed_json_or_None). Injectable for tests.
 HttpFn = Callable[[str, str, Dict[str, str], Optional[dict]], "tuple[int, Optional[dict]]"]
@@ -55,27 +71,6 @@ def _read_json(path: Path) -> Dict[str, Any]:
         return json.loads(path.read_text())
     except Exception:
         return {}
-
-
-def load_api_key() -> Optional[str]:
-    """The coherence contributor key that authenticates the user.
-
-    Order: env override, then the keystore's `coherence.api_key` (the
-    coherence-network contributor key), then a top-level `api_key` fallback.
-    """
-    env = os.environ.get("COHERENCE_API_KEY")
-    if env and env.strip():
-        return env.strip()
-    keys = _read_json(KEYS_PATH)
-    coherence = keys.get("coherence")
-    candidates = []
-    if isinstance(coherence, dict):
-        candidates.append(coherence.get("api_key"))
-    candidates.append(keys.get("api_key"))
-    for key in candidates:
-        if isinstance(key, str) and key.strip():
-            return key.strip()
-    return None
 
 
 def api_base() -> str:
@@ -99,6 +94,67 @@ def remembering_enabled() -> bool:
     return bool(_read_json(CONFIG_PATH).get("remember_sessions", True))
 
 
+def load_api_key() -> Optional[str]:
+    """The coherence contributor key, if present (used as a stronger fallback).
+
+    Order: env override, keystore `coherence.api_key`, top-level `api_key`.
+    """
+    env = os.environ.get("COHERENCE_API_KEY")
+    if env and env.strip():
+        return env.strip()
+    keys = _read_json(KEYS_PATH)
+    coherence = keys.get("coherence")
+    candidates = []
+    if isinstance(coherence, dict):
+        candidates.append(coherence.get("api_key"))
+    candidates.append(keys.get("api_key"))
+    for key in candidates:
+        if isinstance(key, str) and key.strip():
+            return key.strip()
+    return None
+
+
+def keystore_identity() -> Optional[Tuple[str, str]]:
+    """The human's verified (provider, provider_id) from the keystore.
+
+    This is agent-independent — every agent on this machine reads the same
+    identity. It is what lets us look the user up without an API key.
+    """
+    keys = _read_json(KEYS_PATH)
+    provider, provider_id = keys.get("provider"), keys.get("provider_id")
+    if isinstance(provider, str) and provider and isinstance(provider_id, str) and provider_id:
+        return provider, provider_id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Agent detection (pure — unit tested)
+# ---------------------------------------------------------------------------
+
+
+def _marker_matches(marker: str, env: Mapping[str, str]) -> bool:
+    if "^" in marker:
+        var, prefix = marker.split("^", 1)
+        return env.get(var, "").lower().startswith(prefix.lower())
+    return bool(env.get(marker))
+
+
+def detect_agent(env: Mapping[str, str]) -> str:
+    """Name the agent running this session, across all known agents.
+
+    Explicit markers win; an unrecognized agent that still sets AI_AGENT is
+    named from its first segment (e.g. "claude-code_2-1-156_agent" →
+    "claude-code"); otherwise DEFAULT_AGENT.
+    """
+    for name, markers in KNOWN_AGENTS:
+        if any(_marker_matches(m, env) for m in markers):
+            return name
+    ai_agent = env.get("AI_AGENT", "").strip()
+    if ai_agent:
+        return ai_agent.split("_", 1)[0]
+    return DEFAULT_AGENT
+
+
 # ---------------------------------------------------------------------------
 # HTTP (stdlib, short timeout, never raises out)
 # ---------------------------------------------------------------------------
@@ -109,6 +165,9 @@ def _http_json(
 ) -> "tuple[int, Optional[dict]]":
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    # A real User-Agent: the edge (Cloudflare) blocks the default Python-urllib
+    # agent with 403 before the request ever reaches the API.
+    req.add_header("User-Agent", "coherence-session-greeting/1.0")
     if body is not None:
         req.add_header("Content-Type", "application/json")
     try:
@@ -122,16 +181,36 @@ def _http_json(
 
 
 # ---------------------------------------------------------------------------
-# Identity + relationship
+# User resolution + relationship
 # ---------------------------------------------------------------------------
 
 
-def resolve_user(http: HttpFn, base: str, api_key: str) -> Optional[str]:
-    """The authenticated contributor id, or None if auth does not resolve."""
-    status, body = http("GET", f"{base}/api/identity/me", {"X-API-Key": api_key}, None)
-    if status == 200 and isinstance(body, dict):
-        cid = body.get("contributor_id")
-        return cid if isinstance(cid, str) and cid else None
+def resolve_user(http: HttpFn, base: str) -> Optional[str]:
+    """The contributor id for the human at this machine, or None.
+
+    Primary path (agent-independent, no key): the keystore (provider,
+    provider_id) resolved via the public identity lookup. Stronger fallback:
+    the coherence API key resolved via /me, when a key is present.
+    """
+    ident = keystore_identity()
+    if ident:
+        provider, provider_id = ident
+        status, body = http(
+            "GET", f"{base}/api/identity/lookup/{provider}/{provider_id}", {}, None
+        )
+        if status == 200 and isinstance(body, dict):
+            cid = body.get("contributor_id")
+            if isinstance(cid, str) and cid:
+                return cid
+
+    api_key = load_api_key()
+    if api_key:
+        status, body = http("GET", f"{base}/api/identity/me", {"X-API-Key": api_key}, None)
+        if status == 200 and isinstance(body, dict):
+            cid = body.get("contributor_id")
+            if isinstance(cid, str) and cid:
+                return cid
+
     return None
 
 
@@ -141,7 +220,7 @@ def bootstrap_meeting(
     payload = {
         "my_name": agent,
         "other_name": user,
-        "my_description": "Claude Code — a Claude lineage tending the Coherence Network.",
+        "my_description": f"{agent} — an agent session tending the Coherence Network.",
         "welcome_guidance": (
             "First meeting. From here I remember our sessions and continue the "
             "thread next time. Opt out anytime via remember_sessions in "
@@ -172,7 +251,7 @@ def compose_greeting(user: str, agent: str, result: Dict[str, Any]) -> str:
         )
     else:
         nth = f"session {sessions}" if sessions else "another session"
-        line = f"🌿 Welcome back, {user}. This is {nth} together."
+        line = f"🌿 Welcome back, {user}. This is {nth} with {agent}."
         if last_exchange:
             line += f" Last we noted: {last_exchange}"
 
@@ -187,26 +266,17 @@ def greeting_lines(http: HttpFn = _http_json) -> list[str]:
             "Re-enable in ~/.coherence-network/config.json."
         ]
 
-    api_key = load_api_key()
-    if not api_key:
-        return []  # no key at all — no user to authenticate, stay quiet
-
     base = api_base()
-    user = resolve_user(http, base, api_key)
+    agent = detect_agent(os.environ)
+    user = resolve_user(http, base)
     if not user:
-        # A key is present but the network did not recognize it. Don't fabricate
-        # a user — say why, so memory can be switched on with one provisioning step.
-        return [
-            f"🔑 Session memory is ready, but your key isn't recognized at {base}. "
-            "Generate a contributor key (POST /api/auth/keys) and store it as "
-            "coherence.api_key in ~/.coherence-network/keys.json to be greeted by name."
-        ]
+        return []  # no resolvable identity — do not fabricate a user, stay quiet
 
-    result = bootstrap_meeting(http, base, AGENT_NAME, user)
+    result = bootstrap_meeting(http, base, agent, user)
     if not result:
         return [f"🌿 Hello again, {user}. (Session memory unreachable right now.)"]
 
-    return [compose_greeting(user, AGENT_NAME, result)]
+    return [compose_greeting(user, agent, result)]
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Answers *"can we detect and automatically look up the user from the agent session, supporting all known agents?"* — yes. The session-start greeting ([#2153](https://github.com/seeker71/Coherence-Network/pull/2153)) no longer hardcodes the agent (`claude-code`) or depends on a registered API key.

## How

**Agent detection — data-driven, one row per agent.** `KNOWN_AGENTS` maps each agent (claude-code, codex, cursor, gemini) to environment markers — the generic `AI_AGENT` signal first, then per-agent env/home (`CLAUDECODE`, `CODEX_HOME`, `CURSOR_TRACE_ID`, `GEMINI_CLI`, …). An untabled agent that still sets `AI_AGENT` is named from its first segment (`windsurf_9_agent` → `windsurf`). Adding an agent is one row — the detector is the engine, agents are data.

**User resolution — agent-independent and keyless.** The human's verified `(provider, provider_id)` lives in the keystore regardless of which agent runs. We resolve it to a contributor via the **public** `GET /api/identity/lookup/{provider}/{provider_id}` — no key required. A coherence API key, when present, is a stronger `/me` fallback. This sidesteps the registered-key problem that kept the greeting silent in #2153.

**Edge fix.** Outbound calls now send a real `User-Agent` — Cloudflare returns `403` to the default `Python-urllib` agent before requests reach the API. That 403 (not an invalid key) is what had silenced the greeting.

Each (agent, user) pair gets its own durable relationship thread, so the same human is remembered separately per agent — exactly "support all known agents."

## Verified live (real Claude Code session)

```
🌱 First session together, milestone-agent. I'm claude-code …
🌿 Welcome back, milestone-agent. This is session 2 with claude-code.
🌿 Welcome back, milestone-agent. This is session 3 with claude-code.
```

Agent detected (`claude-code`), user resolved from `github/urs-muff` → contributor with no key, memory accumulating across runs.

## Tests

`api/tests/test_session_greeting.py` (19) — agent detection across the roster + generic/unknown, provider-lookup + `/me` resolution, greeting assembly, opt-out gating, and the end-to-end line with injected env/HTTP. Full suite: 2326 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)