### PR TITLE
feat(agents): universal human identity — git config + any agent

### DIFF
--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -160,7 +160,7 @@
 | [test_runtime_api.py](test_runtime_api.py) | Tests for the canonical-route-registry-and-runtime-mapping spec |
 | [test_runtime_event_store_precedence.py](test_runtime_event_store_precedence.py) | Regression tests for runtime telemetry DB precedence. |
 | [test_runtime_mode_and_events.py](test_runtime_mode_and_events.py) | _no top-of-file purpose_ |
-| [test_session_greeting.py](test_session_greeting.py) | Session greeting — detect agent + user, greet with memory, across all agents. |
+| [test_session_greeting.py](test_session_greeting.py) | Session greeting — detect agent + human, greet with memory, across all agents. |
 | [test_settlement_flow.py](test_settlement_flow.py) | Tests for settlement service + router — story-protocol-integration R8. |
 | [test_smart_reaper_module_boundary.py](test_smart_reaper_module_boundary.py) | _no top-of-file purpose_ |
 | [test_source_artifact_sensing_graph.py](test_source_artifact_sensing_graph.py) | Source artifact -> sensing -> concept graph integration tests. |

--- a/api/tests/test_session_greeting.py
+++ b/api/tests/test_session_greeting.py
@@ -1,9 +1,10 @@
-"""Session greeting — detect agent + user, greet with memory, across all agents.
+"""Session greeting — detect agent + human, greet with memory, across all agents.
 
 The greeting logic is a script (scripts/session_greeting.py) wired into
-arrival.py. These tests pin agent detection, the agent-independent user
+arrival.py. These tests pin agent detection across the roster, the human
+detection cascade (git config / keystore / env), the contributor-or-email
 resolution, the pure assembly, and opt-out gating — all with injected env /
-HTTP, so no network or real environment is touched.
+git / HTTP, so no network or real environment is touched.
 """
 from __future__ import annotations
 
@@ -30,6 +31,8 @@ import session_greeting as sg  # noqa: E402
         ({"AI_AGENT": "codex_1-2-3"}, "codex"),
         ({"CURSOR_TRACE_ID": "abc"}, "cursor"),
         ({"GEMINI_CLI": "1"}, "gemini"),
+        ({"AI_AGENT": "grok_4_agent"}, "grok"),
+        ({"OPENCODE_SESSION": "x"}, "opencode"),
         ({"AI_AGENT": "windsurf_9_agent"}, "windsurf"),  # generic AI_AGENT fallback
         ({}, sg.DEFAULT_AGENT),
     ],
@@ -38,34 +41,70 @@ def test_detect_agent(env, expected) -> None:
     assert sg.detect_agent(env) == expected
 
 
-# --- user resolution: provider lookup primary, /me fallback, agent-free ------
+# --- human detection cascade: git → keystore → env --------------------------
 
 
-def test_resolve_user_via_provider_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_detect_human_prefers_git() -> None:
+    git = {"user.name": "Urs Muff", "user.email": "urs@Example.COM"}.get
+    human = sg.detect_human({}, git=git)
+    assert human == {
+        "name": "Urs Muff",
+        "email": "urs@example.com",  # normalized
+        "provider": "email",
+        "provider_id": "urs@example.com",
+    }
+
+
+def test_detect_human_falls_back_to_keystore(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sg, "keystore_identity", lambda: ("github", "urs-muff"))
+    human = sg.detect_human({}, git=lambda k: None)
+    assert human["provider"] == "github"
+    assert human["provider_id"] == "urs-muff"
+
+
+def test_detect_human_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    human = sg.detect_human({"GIT_AUTHOR_EMAIL": "a@b.io", "GIT_AUTHOR_NAME": "A B"}, git=lambda k: None)
+    assert human["email"] == "a@b.io"
+    assert human["name"] == "A B"
+
+
+def test_detect_human_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    assert sg.detect_human({}, git=lambda k: None) is None
+
+
+# --- user resolution: contributor when linked, else email; display = name ----
+
+
+def test_resolve_user_links_contributor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sg, "detect_human",
+        lambda env: {"name": "Urs", "email": "u@x.io", "provider": "email", "provider_id": "u@x.io"},
+    )
 
     def http(method, url, headers, body):
-        assert url.endswith("/api/identity/lookup/github/urs-muff")
-        return 200, {"contributor_id": "milestone-agent"}
+        assert url.endswith("/api/identity/lookup/email/u@x.io")
+        return 200, {"contributor_id": "urs-contrib"}
 
-    assert sg.resolve_user(http, "https://api.test") == "milestone-agent"
-
-
-def test_resolve_user_falls_back_to_me_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
-    monkeypatch.setattr(sg, "load_api_key", lambda: "key-123")
-
-    def http(method, url, headers, body):
-        if url.endswith("/api/identity/me"):
-            assert headers.get("X-API-Key") == "key-123"
-            return 200, {"contributor_id": "urs"}
-        raise AssertionError(f"unexpected {url}")
-
-    assert sg.resolve_user(http, "https://api.test") == "urs"
+    key, display = sg.resolve_user(http, "https://api.test")
+    assert key == "urs-contrib"  # keyed on the resolved contributor
+    assert display == "Urs"      # greeted by the human name
 
 
-def test_resolve_user_none_when_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+def test_resolve_user_unlinked_keys_on_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sg, "detect_human",
+        lambda env: {"name": "Urs", "email": "u@x.io", "provider": "email", "provider_id": "u@x.io"},
+    )
+    # 404 from lookup → not linked → remember by email, still greet by name.
+    key, display = sg.resolve_user(lambda m, u, h, b: (404, None), "https://api.test")
+    assert key == "u@x.io"
+    assert display == "Urs"
+
+
+def test_resolve_user_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sg, "detect_human", lambda env: None)
     monkeypatch.setattr(sg, "load_api_key", lambda: None)
     assert sg.resolve_user(lambda *a: (0, None), "https://api.test") is None
 
@@ -74,17 +113,17 @@ def test_resolve_user_none_when_nothing(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_compose_first_contact() -> None:
-    line = sg.compose_greeting("urs", "claude-code", {"was_first_contact": True, "events": [
+    line = sg.compose_greeting("Urs", "claude-code", {"was_first_contact": True, "events": [
         {"type": "welcome"}, {"type": "session_start"},
     ]})
-    assert "First session together, urs" in line
+    assert "First session together, Urs" in line
     assert "claude-code" in line
 
 
 def test_compose_returning_counts_sessions_and_names_agent() -> None:
     events = [{"type": "session_start"}] * 3
-    line = sg.compose_greeting("urs", "codex", {"was_first_contact": False, "events": events})
-    assert "Welcome back, urs" in line
+    line = sg.compose_greeting("Urs", "codex", {"was_first_contact": False, "events": events})
+    assert "Welcome back, Urs" in line
     assert "session 3 with codex" in line
 
 
@@ -94,7 +133,7 @@ def test_compose_returning_surfaces_last_exchange() -> None:
         {"type": "session_start"},
         {"type": "exchange", "summary": "shipped the greeting"},
     ]
-    line = sg.compose_greeting("urs", "claude-code", {"was_first_contact": False, "events": events})
+    line = sg.compose_greeting("Urs", "claude-code", {"was_first_contact": False, "events": events})
     assert "shipped the greeting" in line  # the most recent, not the first
 
 
@@ -117,21 +156,24 @@ def test_greeting_lines_opted_out(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "off" in sg.greeting_lines(http=lambda *a: (0, None))[0].lower()
 
 
-# --- end-to-end greeting line (env + http injected) --------------------------
+# --- end-to-end greeting line (env + git + http injected) --------------------
 
 
 def test_greeting_lines_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
     monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
-    monkeypatch.setattr(sg, "keystore_identity", lambda: ("github", "urs-muff"))
-    monkeypatch.setattr(sg.os, "environ", {"AI_AGENT": "claude-code_2_agent", "CLAUDECODE": "1"})
+    monkeypatch.setattr(sg.os, "environ", {"AI_AGENT": "grok_4_agent"})
+    monkeypatch.setattr(
+        sg, "detect_human",
+        lambda env: {"name": "Urs", "email": "u@x.io", "provider": "email", "provider_id": "u@x.io"},
+    )
 
     def fake_http(method, url, headers, body):
-        if url.endswith("/api/identity/lookup/github/urs-muff"):
-            return 200, {"contributor_id": "urs"}
+        if "/api/identity/lookup/" in url:
+            return 404, None  # unlinked → key on email
         if url.endswith("/api/agents/bootstrap"):
-            assert body["my_name"] == "claude-code"  # agent detected, not hardcoded
-            assert body["other_name"] == "urs"
+            assert body["my_name"] == "grok"      # agent detected
+            assert body["other_name"] == "u@x.io"  # keyed on email
             return 200, {"was_first_contact": True, "events": [
                 {"type": "welcome"}, {"type": "session_start"},
             ]}
@@ -139,13 +181,13 @@ def test_greeting_lines_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
 
     lines = sg.greeting_lines(http=fake_http)
     assert len(lines) == 1
-    assert "First session together, urs" in lines[0]
-    assert "claude-code" in lines[0]
+    assert "First session together, Urs" in lines[0]
+    assert "grok" in lines[0]
 
 
 def test_greeting_lines_quiet_when_no_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COHERENCE_REMEMBER_SESSIONS", raising=False)
     monkeypatch.setattr(sg, "CONFIG_PATH", Path("/nonexistent/config.json"))
-    monkeypatch.setattr(sg, "keystore_identity", lambda: None)
+    monkeypatch.setattr(sg, "detect_human", lambda env: None)
     monkeypatch.setattr(sg, "load_api_key", lambda: None)
     assert sg.greeting_lines(http=lambda *a: (0, None)) == []

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -108,7 +108,7 @@
 | [sense_strategy_efficacy.py](sense_strategy_efficacy.py) | sense_strategy_efficacy.py — read accumulated strategy_fired traces and |
 | [sense_world.py](sense_world.py) | Sense the world through the new earth lens. |
 | [session_as_framebuffer.py](session_as_framebuffer.py) | Render a Claude session as a memory-as-framebuffer .mfb capture. |
-| [session_greeting.py](session_greeting.py) | Session greeting — detect the agent and the user, greet with memory. |
+| [session_greeting.py](session_greeting.py) | Session greeting — detect the agent and the human, greet with memory. |
 | [setup.py](setup.py) | Coherence Network — Auto-Setup. |
 | [song_recipe_proof.py](song_recipe_proof.py) | song_recipe_proof.py — songs compose into Recipes whose Blueprint |
 | [spec_recipe_proof.py](spec_recipe_proof.py) | spec_recipe_proof.py — a spec's frontmatter IS the playable Recipe. |

--- a/scripts/session_greeting.py
+++ b/scripts/session_greeting.py
@@ -1,36 +1,40 @@
 #!/usr/bin/env python3
-"""Session greeting — detect the agent and the user, greet with memory.
+"""Session greeting — detect the agent and the human, greet with memory.
 
 The real-world use case on top of the agent-relationship runtime: when a
 session begins, work out *which agent* is running and *who the human is*, greet
 with memory of prior sessions, and (when remembering is on) record the meeting
 so the next session continues the thread.
 
-Composed into the SessionStart layer by scripts/arrival.py — a peer of the
-orientation and wellness layers.
+Composed into the SessionStart layer by scripts/arrival.py.
 
-Detection is agent-agnostic, so the same greeting works across all known
-agents (Claude Code, Codex, Cursor, Gemini, …):
+Both detections are agent-agnostic, so the same greeting works across every
+agent (Claude Code, Codex, Cursor, Gemini, Grok, opencode, …):
 
 - Agent: read from the environment — the generic `AI_AGENT` signal first, then
-  per-agent markers and homes. Adding an agent is one row in KNOWN_AGENTS.
-- User: the human's verified identity travels in the keystore as
-  (provider, provider_id) regardless of agent. We resolve it to a contributor
-  via the public GET /api/identity/lookup/{provider}/{provider_id} — no key
-  required. A coherence API key, when present, is a stronger fallback (/me).
+  per-agent markers/homes. Adding an agent is one row in KNOWN_AGENTS; an
+  untabled agent that still sets AI_AGENT is named from its first segment.
+- Human: a cascade that detects a real name + email from whatever is present —
+  git config (universal), the coherence keystore, the session environment. The
+  human is resolved to a network contributor when their identity is linked
+  (public GET /api/identity/lookup/{provider}/{provider_id}); otherwise they
+  are still recognized and remembered, keyed by their email and greeted by
+  name. We never fabricate an identity — only surface what the machine already
+  attests.
 
 Remembering is on by default. Opt out anytime:
   - set "remember_sessions": false in ~/.coherence-network/config.json, or
   - export COHERENCE_REMEMBER_SESSIONS=0
 
-This module never raises into the hook: any failure (offline, no identity, API
-down) degrades to a quiet, non-blocking line so session start is never broken.
+This module never raises into the hook: any failure degrades to a quiet,
+non-blocking line so session start is never broken.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -43,22 +47,32 @@ CONFIG_PATH = HOME / ".coherence-network" / "config.json"
 DEFAULT_API_BASE = "https://api.coherencycoin.com"
 DEFAULT_AGENT = "unknown-agent"
 HTTP_TIMEOUT = 4.0
+USER_AGENT = "coherence-session-greeting/1.0"
 
 _OFF_VALUES = {"0", "false", "no", "off", ""}
 
 # Known session agents, each detected by a set of environment markers.
-# A marker "VAR^prefix" matches when env[VAR] starts with prefix (case-insensitive);
-# a bare "VAR" matches when that variable is set to anything truthy.
-# Adding an agent is one row — the detector is the engine, agents are data.
+# Marker "VAR^prefix" matches when env[VAR] starts with prefix (case-insensitive);
+# bare "VAR" matches when that variable is set. Adding an agent is one row —
+# the detector is the engine, agents are data. Any agent not listed here is
+# still named from AI_AGENT's first segment, so coverage is open-ended.
 KNOWN_AGENTS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("claude-code", ("AI_AGENT^claude", "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")),
     ("codex", ("AI_AGENT^codex", "CODEX_HOME", "CODEX_SANDBOX", "CODEX_THREAD_ID")),
     ("cursor", ("AI_AGENT^cursor", "CURSOR_TRACE_ID", "CURSOR_AGENT", "CURSOR_SESSION_ID")),
     ("gemini", ("AI_AGENT^gemini", "GEMINI_CLI", "GEMINI_SESSION", "GEMINICODE")),
+    ("grok", ("AI_AGENT^grok", "GROK_SESSION", "GROK_CLI", "XAI_SESSION")),
+    ("opencode", ("AI_AGENT^opencode", "OPENCODE_SESSION", "OPENCODE")),
 )
+
+# Environment variables that may carry the human's email / name (git + common).
+_EMAIL_ENV = ("GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL", "EMAIL")
+_NAME_ENV = ("GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME")
 
 # An HTTP call returns (status_code, parsed_json_or_None). Injectable for tests.
 HttpFn = Callable[[str, str, Dict[str, str], Optional[dict]], "tuple[int, Optional[dict]]"]
+# A git-config reader: key -> value or None. Injectable for tests.
+GitFn = Callable[[str], Optional[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -77,8 +91,7 @@ def api_base() -> str:
     """Where session memory lives — the production substrate by default.
 
     Honors an explicit override (env or a dedicated config key) but does not
-    inherit `hub_url`, which addresses the local/federation hub, not the
-    durable relationship store.
+    inherit `hub_url`, which addresses the local/federation hub.
     """
     override = os.environ.get("COHERENCE_API_BASE") or _read_json(CONFIG_PATH).get(
         "session_api_base"
@@ -95,10 +108,7 @@ def remembering_enabled() -> bool:
 
 
 def load_api_key() -> Optional[str]:
-    """The coherence contributor key, if present (used as a stronger fallback).
-
-    Order: env override, keystore `coherence.api_key`, top-level `api_key`.
-    """
+    """The coherence contributor key, if present (a stronger resolution path)."""
     env = os.environ.get("COHERENCE_API_KEY")
     if env and env.strip():
         return env.strip()
@@ -115,15 +125,25 @@ def load_api_key() -> Optional[str]:
 
 
 def keystore_identity() -> Optional[Tuple[str, str]]:
-    """The human's verified (provider, provider_id) from the keystore.
-
-    This is agent-independent — every agent on this machine reads the same
-    identity. It is what lets us look the user up without an API key.
-    """
+    """The keystore's verified (provider, provider_id), if present."""
     keys = _read_json(KEYS_PATH)
     provider, provider_id = keys.get("provider"), keys.get("provider_id")
     if isinstance(provider, str) and provider and isinstance(provider_id, str) and provider_id:
         return provider, provider_id
+    return None
+
+
+def _git_config_reader(key: str) -> Optional[str]:
+    """Read a merged-then-global git config value, or None."""
+    for args in (["git", "config", "--get", key], ["git", "config", "--global", "--get", key]):
+        try:
+            out = subprocess.run(
+                args, capture_output=True, text=True, timeout=2.0
+            ).stdout.strip()
+            if out:
+                return out
+        except Exception:
+            continue
     return None
 
 
@@ -140,12 +160,7 @@ def _marker_matches(marker: str, env: Mapping[str, str]) -> bool:
 
 
 def detect_agent(env: Mapping[str, str]) -> str:
-    """Name the agent running this session, across all known agents.
-
-    Explicit markers win; an unrecognized agent that still sets AI_AGENT is
-    named from its first segment (e.g. "claude-code_2-1-156_agent" →
-    "claude-code"); otherwise DEFAULT_AGENT.
-    """
+    """Name the agent running this session, across all known agents."""
     for name, markers in KNOWN_AGENTS:
         if any(_marker_matches(m, env) for m in markers):
             return name
@@ -153,6 +168,53 @@ def detect_agent(env: Mapping[str, str]) -> str:
     if ai_agent:
         return ai_agent.split("_", 1)[0]
     return DEFAULT_AGENT
+
+
+# ---------------------------------------------------------------------------
+# Human detection (a cascade over every signal a human leaves on the machine)
+# ---------------------------------------------------------------------------
+
+
+def detect_human(
+    env: Mapping[str, str], git: GitFn = _git_config_reader
+) -> Optional[Dict[str, Optional[str]]]:
+    """Detect the human as {name, email, provider, provider_id} from any source.
+
+    Priority: git config (the universal human signal), then the coherence
+    keystore's verified link, then session environment. The first source that
+    yields a usable handle wins; name/email are filled in from git when known.
+    Returns None only when nothing identifies a human.
+    """
+    git_name = git("user.name")
+    git_email = git("user.email")
+
+    # 1. git email — the most universal human identifier across machines/agents.
+    if git_email:
+        return {
+            "name": git_name,
+            "email": git_email.lower(),
+            "provider": "email",
+            "provider_id": git_email.lower(),
+        }
+
+    # 2. keystore verified link (may map to a contributor directly).
+    ident = keystore_identity()
+    if ident:
+        provider, provider_id = ident
+        return {"name": git_name, "email": None, "provider": provider, "provider_id": provider_id}
+
+    # 3. environment email/name.
+    env_email = next((env[k] for k in _EMAIL_ENV if env.get(k)), None)
+    if env_email:
+        env_name = next((env[k] for k in _NAME_ENV if env.get(k)), None) or git_name
+        return {
+            "name": env_name,
+            "email": env_email.lower(),
+            "provider": "email",
+            "provider_id": env_email.lower(),
+        }
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -167,7 +229,7 @@ def _http_json(
     req = urllib.request.Request(url, data=data, method=method, headers=headers)
     # A real User-Agent: the edge (Cloudflare) blocks the default Python-urllib
     # agent with 403 before the request ever reaches the API.
-    req.add_header("User-Agent", "coherence-session-greeting/1.0")
+    req.add_header("User-Agent", USER_AGENT)
     if body is not None:
         req.add_header("Content-Type", "application/json")
     try:
@@ -185,46 +247,54 @@ def _http_json(
 # ---------------------------------------------------------------------------
 
 
-def resolve_user(http: HttpFn, base: str) -> Optional[str]:
-    """The contributor id for the human at this machine, or None.
+def _lookup_contributor(http: HttpFn, base: str, provider: str, provider_id: str) -> Optional[str]:
+    status, body = http("GET", f"{base}/api/identity/lookup/{provider}/{provider_id}", {}, None)
+    if status == 200 and isinstance(body, dict):
+        cid = body.get("contributor_id")
+        if isinstance(cid, str) and cid:
+            return cid
+    return None
 
-    Primary path (agent-independent, no key): the keystore (provider,
-    provider_id) resolved via the public identity lookup. Stronger fallback:
-    the coherence API key resolved via /me, when a key is present.
+
+def resolve_user(http: HttpFn, base: str) -> Optional[Tuple[str, str]]:
+    """Resolve the human to a (relationship_key, display_name), or None.
+
+    The relationship key prefers a resolved network contributor; otherwise it
+    is the human's email — so a human is remembered even before they link a
+    contributor. The display name prefers the human's real name (git), falling
+    back to the contributor handle or the email's local part.
     """
-    ident = keystore_identity()
-    if ident:
-        provider, provider_id = ident
-        status, body = http(
-            "GET", f"{base}/api/identity/lookup/{provider}/{provider_id}", {}, None
-        )
-        if status == 200 and isinstance(body, dict):
-            cid = body.get("contributor_id")
-            if isinstance(cid, str) and cid:
-                return cid
+    human = detect_human(os.environ)
+    if human:
+        cid = _lookup_contributor(http, base, human["provider"], human["provider_id"])
+        email = human.get("email")
+        key = cid or email or human["provider_id"]
+        display = human.get("name") or cid or (email.split("@")[0] if email else key)
+        return key, display
 
+    # No human signal at all — last resort: a coherence key resolved via /me.
     api_key = load_api_key()
     if api_key:
         status, body = http("GET", f"{base}/api/identity/me", {"X-API-Key": api_key}, None)
         if status == 200 and isinstance(body, dict):
             cid = body.get("contributor_id")
             if isinstance(cid, str) and cid:
-                return cid
+                return cid, cid
 
     return None
 
 
 def bootstrap_meeting(
-    http: HttpFn, base: str, agent: str, user: str
+    http: HttpFn, base: str, agent: str, user_key: str, display: str
 ) -> Optional[Dict[str, Any]]:
     payload = {
         "my_name": agent,
-        "other_name": user,
+        "other_name": user_key,
         "my_description": f"{agent} — an agent session tending the Coherence Network.",
         "welcome_guidance": (
-            "First meeting. From here I remember our sessions and continue the "
-            "thread next time. Opt out anytime via remember_sessions in "
-            "~/.coherence-network/config.json."
+            f"First meeting with {display}. From here I remember our sessions and "
+            "continue the thread next time. Opt out anytime via remember_sessions "
+            "in ~/.coherence-network/config.json."
         ),
     }
     status, body = http("POST", f"{base}/api/agents/bootstrap", {}, payload)
@@ -236,7 +306,7 @@ def bootstrap_meeting(
 # ---------------------------------------------------------------------------
 
 
-def compose_greeting(user: str, agent: str, result: Dict[str, Any]) -> str:
+def compose_greeting(display: str, agent: str, result: Dict[str, Any]) -> str:
     events = result.get("events") or []
     sessions = sum(1 for e in events if e.get("type") == "session_start")
     last_exchange = next(
@@ -246,12 +316,12 @@ def compose_greeting(user: str, agent: str, result: Dict[str, Any]) -> str:
 
     if result.get("was_first_contact"):
         line = (
-            f"🌱 First session together, {user}. I'm {agent} — from here I'll "
+            f"🌱 First session together, {display}. I'm {agent} — from here I'll "
             f"remember our work and continue the thread next time."
         )
     else:
         nth = f"session {sessions}" if sessions else "another session"
-        line = f"🌿 Welcome back, {user}. This is {nth} with {agent}."
+        line = f"🌿 Welcome back, {display}. This is {nth} with {agent}."
         if last_exchange:
             line += f" Last we noted: {last_exchange}"
 
@@ -268,15 +338,16 @@ def greeting_lines(http: HttpFn = _http_json) -> list[str]:
 
     base = api_base()
     agent = detect_agent(os.environ)
-    user = resolve_user(http, base)
-    if not user:
-        return []  # no resolvable identity — do not fabricate a user, stay quiet
+    resolved = resolve_user(http, base)
+    if not resolved:
+        return []  # no human signal — do not fabricate, stay quiet
 
-    result = bootstrap_meeting(http, base, agent, user)
+    user_key, display = resolved
+    result = bootstrap_meeting(http, base, agent, user_key, display)
     if not result:
-        return [f"🌿 Hello again, {user}. (Session memory unreachable right now.)"]
+        return [f"🌿 Hello again, {display}. (Session memory unreachable right now.)"]
 
-    return [compose_greeting(user, agent, result)]
+    return [compose_greeting(display, agent, result)]
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Generalizes session-start identification so it works for **cursor, grok, codex, gemini, opencode, or any agent**, and identifies the **human by name + email** from whatever the machine attests — git global config is now a first-class source.

## Agent roster — open-ended

`KNOWN_AGENTS` adds **grok** and **opencode** alongside claude-code/codex/cursor/gemini, each matched by environment markers (data-driven, one row per agent). Any untabled agent that sets `AI_AGENT` is still named from its first segment, so coverage doesn't depend on us enumerating every agent.

## Human detection — a cascade (`detect_human`)

1. **git config** `user.name` + `user.email` (merged, then `--global`) — the universal human signal present on essentially every dev machine.
2. the coherence keystore's verified `(provider, provider_id)`.
3. session environment (`GIT_AUTHOR_EMAIL` / `EMAIL` / name vars).

The human resolves to a network **contributor when their identity is linked** (public `GET /api/identity/lookup/{provider}/{provider_id}`); otherwise they are still **remembered, keyed by email, and greeted by their real name**. No identity is fabricated — we only surface what the machine already attests (the held-open discipline). `resolve_user` now returns `(relationship_key, display_name)`: key prefers a resolved contributor, else email; display prefers the human's git name.

## Verified live (this session)

```
detect_human → {name: 'urs-muff', email: 'urs.muff@merly.ai', provider: 'email', ...}
🌱 First session together, urs-muff. I'm claude-code …
🌿 Welcome back, urs-muff. This is session 2 with claude-code.
```

Identified from git config, keyed by email, greeted by name, continuation across runs, agent auto-detected.

## Tests

`api/tests/test_session_greeting.py` (25) — agent roster incl. grok/opencode/generic/unknown, the human cascade (git → keystore → env), contributor-or-email resolution, greeting assembly, opt-out gating, and the end-to-end line with injected env/git/HTTP. Full suite: 2332 passed.

## Note

A human whose email isn't yet linked to a contributor is remembered under their email; if they later link it, the relationship key shifts to the contributor id (a reconciliation pass can merge the two threads — flagged for follow-up, not built here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)