### PR TITLE
attune(substrate): project the whole numeric vocabulary into the DB — and into prod

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,11 +34,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 135 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 239 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 225 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 226 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 134 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 135 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 225
+**Total files**: 226
 
 | File | Purpose |
 |---|---|

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 134
+**Total files**: 135
 
 | File | Purpose |
 |---|---|
@@ -123,6 +123,7 @@
 | [sync_presence_slugs.py](sync_presence_slugs.py) | Sync `/people/{slug}` presence pages back onto contributor nodes. |
 | [sync_presences_from_render.py](sync_presences_from_render.py) | Sync writing-surface presence .md files from the rendering-surface JSON. |
 | [sync_presences_to_db.py](sync_presences_to_db.py) | Sync presence markdown files -> Graph DB via API. |
+| [sync_substrate_vocabulary.py](sync_substrate_vocabulary.py) | Sync the substrate's own numeric vocabulary -> DB as NamedCells. |
 | [teaching_recipe_proof.py](teaching_recipe_proof.py) | teaching_recipe_proof.py — teachings compose into Recipes whose |
 | [trim_view_events.py](trim_view_events.py) | Trim the witness-trace table when it grows past comfortable. |
 | [upgrade_specs_to_form_predicates.py](upgrade_specs_to_form_predicates.py) | Augment every spec's done_when with Form predicates derived from its |

--- a/scripts/substrate_post_merge_hook.sh
+++ b/scripts/substrate_post_merge_hook.sh
@@ -59,6 +59,16 @@ if [ -n "$CHANGED_BP" ]; then
     python3 scripts/sync_blueprints_to_substrate.py
 fi
 
+# Substrate vocabulary (category.py enums) → substrate NamedCells. When the
+# type/domain/recipe alphabet shifts, re-project so the DB stays self-describing
+# ("what is type 12" → RBasic.MATH). Code-sourced — no external files needed.
+CHANGED_VOCAB=$(git diff --name-only --diff-filter=AM "$RANGE" -- \
+    'api/app/services/substrate/category.py' 2>/dev/null || true)
+if [ -n "$CHANGED_VOCAB" ]; then
+    echo "[substrate] category vocabulary changed — projecting enum names into NamedCells:"
+    python3 scripts/sync_substrate_vocabulary.py
+fi
+
 CHANGED=$(printf "%s\n%s" "$CHANGED_MD" "$CHANGED_CODE" | sed '/^$/d')
 
 if [ -z "$CHANGED" ]; then

--- a/scripts/sync_blueprints_to_substrate.py
+++ b/scripts/sync_blueprints_to_substrate.py
@@ -33,7 +33,10 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(ROOT / "api"))
+# Make `app` importable in both layouts: dev (package at <repo>/api/app) and
+# the prod api container (package at /app/app, with this script at /app/scripts).
+for _p in (ROOT, ROOT / "api"):
+    sys.path.insert(0, str(_p))
 
 ONTOLOGY = ROOT / "form" / "form-stdlib" / "form-ontology.json"
 REGISTRY = ROOT / "form" / "form-stdlib" / "blueprint-registry.json"

--- a/scripts/sync_substrate_vocabulary.py
+++ b/scripts/sync_substrate_vocabulary.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Sync the substrate's own numeric vocabulary -> DB as NamedCells.
+
+`api/app/services/substrate/category.py` is the authoritative registry for
+every magic number the substrate uses: Level (compositional depth), the
+Blueprint type axes (BType / BNumeric / BAtomic / BBasic / BContainer /
+BReference / BRecipe / BDomain) and the Recipe type axes (RType / RBasic and
+the per-category instance enums RMath / RCompare / RBlock / RJump / …). They
+are named constants in Python — but nothing in the DB knows that `type 12`
+is MATH or `domain 6` is MEMORY. So every node's coordinate reads as a bare
+number unless you grep the enums.
+
+This projects each enum member into substrate_named_cells (domain
+"substrate-vocabulary") at its real NodeID(1, level, type, instance), under a
+fully-qualified name (RBasic.MATH, RMath.PLUS, BDomain.MEMORY). After it runs
+the substrate is self-describing: lookup_cell("substrate-vocabulary",
+"RBasic.MATH") → 1.2.12.0, and a Blueprint number resolves to its meaning.
+
+Coordinate convention (faithful to category.py docstrings + how the substrate
+builds NodeIDs — see form_builders.py / kernel.py):
+  - A TYPE-axis enum (BType/BBasic level-1/2 blueprint, RType/RBasic recipe)
+    names the type field; its cell sits at instance 0 (the UNDEFINED slot at
+    level 2 — never a real shape — so the marker collides with nothing).
+  - An INSTANCE-axis enum (RMath, RBlock, BAtomic, …) names the instance field
+    under a fixed parent type, so RMath.PLUS → (1, 2, RBasic.MATH=12, 1) — a
+    real recipe shape.
+  - Level names the level field: (1, level, 0, 0).
+UNDEFINED=0 members are skipped (the null marker names nothing).
+
+Code-sourced — needs no external files — so it runs unchanged in the prod api
+container. Idempotent on (domain, name) via make_cell; re-running reconciles.
+
+Usage:
+    python scripts/sync_substrate_vocabulary.py            # project all
+    python scripts/sync_substrate_vocabulary.py --dry-run  # show, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+# Make `app` importable in both layouts: dev (package at <repo>/api/app) and
+# the prod api container (package at /app/app, with this script at /app/scripts).
+for _p in (ROOT, ROOT / "api"):
+    sys.path.insert(0, str(_p))
+
+DOMAIN = "substrate-vocabulary"
+
+
+def axis_spec():
+    """Per-enum placement: (enum, axis, level, parent_type).
+
+    axis "type"     → member value fills the TYPE field, instance = 0.
+    axis "instance" → member value fills the INSTANCE field under parent_type.
+    axis "level"    → member value fills the LEVEL field, type = instance = 0.
+    Parent types are read straight from category.py's structure (each R*
+    instance enum lives under the RBasic category of the same name; the B*
+    instance enums under their BType/BBasic parent)."""
+    from app.services.substrate import category as C
+
+    L1, L2 = C.Level.TRIVIAL, C.Level.BASIC
+    return [
+        # level axis
+        (C.Level, "level", None, None),
+        # blueprint type axes
+        (C.BType, "type", L1, None),
+        (C.BBasic, "type", L2, None),
+        # blueprint instance axes (under their parent type)
+        (C.BNumeric, "instance", L1, C.BType.NUMERIC),
+        (C.BAtomic, "instance", L1, C.BType.ATOMIC),
+        (C.BContainer, "instance", L2, C.BBasic.CONTAINER),
+        (C.BReference, "instance", L2, C.BBasic.REFERENCE),
+        (C.BRecipe, "instance", L2, C.BBasic.RECIPE),
+        (C.BDomain, "instance", L2, C.BBasic.DOMAIN),
+        # recipe type axes
+        (C.RType, "type", L1, None),
+        (C.RBasic, "type", L2, None),
+        (C.Triv, "type", L1, None),
+        # recipe instance axes (under their RBasic category)
+        (C.RTend, "instance", L2, C.RBasic.TEND),
+        (C.RCompose, "instance", L2, C.RBasic.COMPOSE),
+        (C.RTransmit, "instance", L2, C.RBasic.TRANSMIT),
+        (C.RRealize, "instance", L2, C.RBasic.REALIZE),
+        (C.RMath, "instance", L2, C.RBasic.MATH),
+        (C.RCompare, "instance", L2, C.RBasic.COMPARE),
+        (C.RLogic, "instance", L2, C.RBasic.LOGIC),
+        (C.RCond, "instance", L2, C.RBasic.COND),
+        (C.RMatch, "instance", L2, C.RBasic.MATCH),
+        (C.RBlock, "instance", L2, C.RBasic.BLOCK),
+        (C.RJump, "instance", L2, C.RBasic.JUMP),
+        (C.RResonance, "instance", L2, C.RBasic.RESONANCE),
+        (C.RChoice, "instance", L2, C.RBasic.CHOICE),
+        (C.RState, "instance", L2, C.RBasic.STATE),
+        (C.RException, "instance", L2, C.RBasic.EXCEPTION),
+        (C.RTry, "instance", L2, C.RBasic.TRY),
+        (C.RDelegate, "instance", L2, C.RBasic.DELEGATE),
+        (C.RReverse, "instance", L2, C.RBasic.REVERSE),
+        (C.RCommon, "instance", L2, C.RBasic.COMMON),
+        (C.RMethod, "instance", L2, C.RBasic.METHOD),
+        (C.RReactive, "instance", L2, C.RBasic.REACTIVE),
+        (C.RProjection, "instance", L2, C.RBasic.PROJECTION),
+    ]
+
+
+def rows():
+    """One (name, NodeID-tuple) per non-UNDEFINED enum member."""
+    from app.services.substrate import NodeID  # noqa: E402
+
+    out = []
+    for enum, axis, level, parent in axis_spec():
+        for member in enum:
+            if member.value == 0:  # UNDEFINED — names nothing
+                continue
+            if axis == "level":
+                node = NodeID(1, int(member.value), 0, 0)
+            elif axis == "type":
+                node = NodeID(1, int(level), int(member.value), 0)
+            else:  # instance
+                node = NodeID(1, int(level), int(parent), int(member.value))
+            out.append((f"{enum.__name__}.{member.name}", node))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be projected without writing")
+    args = ap.parse_args()
+
+    items = rows()
+    if args.dry_run:
+        print(f"would project {len(items)} substrate-vocabulary name(s) into "
+              f"substrate_named_cells (domain '{DOMAIN}'):")
+        for name, node in items[:16]:
+            print(f"  {node}  {name}")
+        if len(items) > 16:
+            print(f"  … and {len(items) - 16} more")
+        return 0
+
+    from app.services.substrate import make_cell, lookup_cell  # noqa: E402
+    from app.services.unified_db import session as session_scope  # noqa: E402
+
+    with session_scope() as session:
+        for name, node in items:
+            make_cell(session, name=name, domain=DOMAIN, blueprint=node,
+                      source_path="api/app/services/substrate/category.py")
+        session.commit()
+        probe = lookup_cell(session, DOMAIN, "RBasic.MATH")
+        probe2 = lookup_cell(session, DOMAIN, "BDomain.MEMORY")
+    print(f"projected {len(items)} substrate-vocabulary name(s) into "
+          f"substrate_named_cells (domain '{DOMAIN}')")
+    if probe:
+        print(f"  verify: RBasic.MATH → {probe.blueprint}")
+    if probe2:
+        print(f"  verify: BDomain.MEMORY → {probe2.blueprint}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Follow-up to [#2156](https://github.com/seeker71/Coherence-Network/pull/2156). Extends the Blueprint-name projection from the type-99 form shapes to the substrate's **entire numeric vocabulary**, and ships it to **production** — so no coordinate the substrate uses is a bare magic number in the DB.

`api/app/services/substrate/category.py` is the authoritative registry for every magic number: `Level`, the Blueprint axes (`BType/BNumeric/BAtomic/BBasic/BContainer/BReference/BRecipe/BDomain`) and the Recipe axes (`RType/RBasic` + per-category instance enums `RMath/RCompare/RBlock/RJump/…`). Named in Python, but the DB couldn't say "type 12 is MATH" or "domain 6 is MEMORY".

## Changes

- **`scripts/sync_substrate_vocabulary.py`** — introspects every `category.py` enum, projects each member into `substrate_named_cells` (domain `substrate-vocabulary`) at its real `NodeID(1, level, type, instance)`, fully-qualified (`RBasic.MATH`, `RMath.PLUS`, `BDomain.MEMORY`). Code-sourced — no external files — so it runs unchanged in the prod api container. **174 names.**
- **`substrate_post_merge_hook.sh`** — re-projects when `category.py` changes, alongside the form-registry projection.
- Both sync scripts now insert `ROOT` and `ROOT/api` on `sys.path` so `app` imports in both dev (`<repo>/api/app`) and the prod container (`/app/app`).

## Shipped to production (verified live)

Ran both projections against the prod substrate DB via the api container — **174 substrate-vocabulary + 314 form-blueprint names**. Confirmed through the read-only REST surface:

```
GET /api/substrate/cell/substrate-vocabulary/RBasic.MATH   → 1.2.12.0
GET /api/substrate/cell/substrate-vocabulary/RJump.RETURN  → 1.2.18.1
GET /api/substrate/cell/substrate-vocabulary/BDomain.MEMORY→ 1.2.4.6
GET /api/substrate/cell/form-blueprint/JSON-OBJECT         → 1.2.99.10
GET /api/substrate/cell/form-blueprint/UUID                → 1.2.99.1870
```

The category-layer numbers I flagged two turns ago as unnamed (`ACCESS=15`, `WRITE=16`, `JUMP=18`) now resolve both forward (name→node) and reverse (node→name).

## Coordinate convention

Faithful to how the substrate builds NodeIDs (`form_builders.py`/`kernel.py`): instance-axis enums → real `(1, level, parent_type, instance)` cells; type-axis category enums → the `instance 0` marker (the UNDEFINED slot at level 2, never a real shape); `Level` → `(1, level, 0, 0)`. `UNDEFINED=0` members skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)