### PR TITLE
feat(agents): auto-fire the session greeting in Codex and Cursor too

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/session_greeting.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": ".cursor/hooks/coherence-session.sh"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/coherence-session.sh
+++ b/.cursor/hooks/coherence-session.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Cursor sessionStart hook — bind this agent + the human into session memory.
+#
+# Cursor command hooks exchange JSON over stdin/stdout, and sessionStart has no
+# context-injection output field, so we run the binding for its effect (the
+# bootstrap call inside session_greeting records this agent<->user meeting on
+# the substrate) and return valid empty JSON. The greeting text itself surfaces
+# in agents whose session-start renders hook stdout (Claude Code, Codex).
+#
+# Never blocks the session: any failure is swallowed.
+cat >/dev/null 2>&1 || true   # consume the stdin JSON cursor sends
+root="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -n "$root" ]; then
+  python3 "$root/scripts/session_greeting.py" >/dev/null 2>&1 || true
+fi
+echo '{}'


### PR DESCRIPTION
## What

The identity-binding logic ([#2159](https://github.com/seeker71/Coherence-Network/pull/2159), [#2162](https://github.com/seeker71/Coherence-Network/pull/2162)) was already agent-agnostic and unhardcoded — but only **Claude Code**'s `SessionStart` hook actually invoked it. This wires the other agents that run here, each via its **own repo-scoped, version-controlled hook** pointing at the same universal `scripts/session_greeting.py`:

- **`.codex/hooks.json`** — Codex `SessionStart` command hook. Codex hooks mirror Claude's stdout-as-context, so the greeting both **binds and displays**.
- **`.cursor/hooks.json` + `.cursor/hooks/coherence-session.sh`** — Cursor `sessionStart`. Cursor command hooks speak JSON over stdin/stdout and `sessionStart` has no context-injection output, so the wrapper runs the binding for its **effect** (records the agent↔user meeting) and returns valid empty JSON. The greeting text surfaces in agents whose session-start renders hook stdout (Claude, Codex).

No hardcoding anywhere: each hook just runs the detector, which names the agent from the environment and the human from the identity cascade.

## Verified live

Simulated each agent's session — all three now have their own durable thread with the resolved contributor (`seeker71`), no name hardcoded:

```
codex  → 🌱 First session together, Urs. I'm codex …
claude-code ↔ seeker71 : ['welcome','session_start','session_start']
codex       ↔ seeker71 : ['welcome','session_start']
cursor      ↔ seeker71 : ['welcome','session_start']
```

## Coverage now

| Agent | Trigger | Binds | Displays greeting |
|---|---|---|---|
| Claude Code | `.claude/settings.json` | ✅ | ✅ |
| Codex | `.codex/hooks.json` | ✅ | ✅ |
| Cursor | `.cursor/hooks.json` | ✅ | (sessionStart has no display output) |
| Gemini / opencode / Grok / any | generic `AI_AGENT` detection | when a start hook invokes the script | — |

Gemini/opencode/Grok aren't wired here (their session-start hook mechanisms aren't confirmed on this machine, and wiring would touch global configs); the detector already names them, so each is one hook-line away. Hooks never block session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)