### PR TITLE
feat(form): compiler gap — augmented assignment (x += y) lifts to PY-BMF-AUG-ASSIGN

### DIFF
--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -513,6 +513,44 @@
             (let body-recipes (lift-statements children))
             (intern_node PY-BMF-WHILE (cons cond body-recipes))))
 
+    ;; augmented-assignment statement: `NAME <op>= EXPR...`. The scanner
+    ;; classifies these as kind "expr" / rule "star_expressions" (the
+    ;; `+=` token is a single py-op), so the dispatcher must catch them
+    ;; before the bare-expr arm. aug-base-op maps the compound operator
+    ;; to its base op — the same op string py-binop-apply (and the eval
+    ;; AUG-ASSIGN arm) already dispatch on. "" means "not an aug-op".
+
+    (defn aug-base-op (opstr)
+        (if (str_eq opstr "+=")  "+"
+        (if (str_eq opstr "-=")  "-"
+        (if (str_eq opstr "*=")  "*"
+        (if (str_eq opstr "/=")  "/"
+        (if (str_eq opstr "%=")  "%"
+        (if (str_eq opstr "//=") "//"
+            "")))))))
+
+    ;; stmt-aug-op? — 1 iff the statement is `NAME <augop> EXPR`: at least
+    ;; three tokens, first a name, second an aug-assign operator.
+    (defn stmt-aug-op? (statement-tree)
+        (do
+            (let toks (python-statement-tree-tokens statement-tree))
+            (if (lt (len toks) 3) 0
+                (if (tok-name? (head toks))
+                    (if (str_eq (aug-base-op (tok-value (head (tail toks)))) "")
+                        0 1)
+                    0))))
+
+    (defn lift-aug-assign (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let name (tok-value (head tokens)))
+            (let base-op (aug-base-op (tok-value (head (tail tokens)))))
+            (let value (lift-recipe (lift-expr (drop 2 tokens))))
+            (intern_node PY-BMF-AUG-ASSIGN
+                (list (intern_trivial_string name)
+                      (intern_trivial_string base-op)
+                      value))))
+
     ;; lift-statement dispatches on both `kind` (first-token classifier) and
     ;; `cpython-rule` (the richer rule-name based on token shape). Examples:
     ;;   `x = 5`        — kind "expr", cpython-rule "assignment"
@@ -530,10 +568,11 @@
             (if (str_eq kind "return")           (lift-return statement-tree)
             (if (str_eq kind "while")            (lift-while statement-tree)
             (if (str_eq rule "assignment")       (lift-assign statement-tree)
+            (if (eq (stmt-aug-op? statement-tree) 1) (lift-aug-assign statement-tree)
             (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
                 (do
                     (trace "lift-statement: unsupported kind/rule" (list kind rule))
-                    (intern_node PY-BMF-PASS (empty))))))))))
+                    (intern_node PY-BMF-PASS (empty)))))))))))
 
     ;; ---- module lifter (the public surface) ------------------------
     ;;

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -186,12 +186,25 @@ sign(5) + sign(0 - 3) + 5
     (let lifted-mod (head (node_children lifted-mod-module)))
     (let cell12-score (if (node_eq handbuilt-mod lifted-mod) 10000 0))
 
+    ;; ---- cell 13: augmented assignment — CPython:
+    ;;   x = 10; x += 5; x -= 2; x *= 3; x  → 39 -------------------------
+
+    (let cell13-value (py-bmf-run-text "x = 10
+x += 5
+x -= 2
+x *= 3
+x
+"))
+    (let cell13-score (if (eq cell13-value 39) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000 = 75000
+    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
+    ;;   + 10000 (cell 13 aug-assign) = 85000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
-               cell10-score cell11-score cell12-score)))
+               cell10-score cell11-score cell12-score
+               cell13-score)))


### PR DESCRIPTION
## Why

First breath of the Python→Form **compiler coverage** arc — the load-bearing blocker for compiling `api/app/services/substrate/*.py` to `.fkb` (your "compile, don't rewrite" strategy) instead of hand-porting to Form. Each construct the compiler can't lift is a file it can't compile; we've been pushing this back for weeks.

## What

Augmented assignment (`x += y`). The **eval** arm for `PY-BMF-AUG-ASSIGN` already shipped (`python-bmf-eval.fk:267`); only the **lift** side was missing, so `x += 5` fell through to `lift-expr-stmt` and silently mis-compiled.

- `python-bmf-lift.fk`:
  - `aug-base-op` — maps `+= -= *= /= %= //=` to the base op string the eval arm + `py-binop-apply` already dispatch on.
  - `stmt-aug-op?` — detects `NAME <augop> EXPR`. The scanner classifies these as `kind "expr"` / `rule "star_expressions"` (the `+=` is a single `py-op` token), so the dispatcher must catch them *before* the bare-expr arm.
  - `lift-aug-assign` — emits `AUG-ASSIGN(name, base-op, value-recipe)`, the exact shape the interpreter expects.
- `python-bmf-lift-band.fk`: cell 13 — `x=10; x+=5; x-=2; x*=3; x` → **39**. Aggregate **75000 → 85000**.

## Proof

```
GO=85000 RUST=85000   (prepared-source chain, local)
```

CI's no-arg `validate-thread-process` suite reads the band's `; preludes:` header and runs the full three-way (Go / Rust / TypeScript) — authoritative for sibling parity.

## Next

This is template-proven now. Remaining cheap lift-only gaps (dict-literal lift, `for`, unary ops, `and`/`or`) then the substrate-critical heavy ones (f-strings, try/except, comprehensions, classes-with-dataclass, decorators) follow the same shape. Tracking doc + parallel workflow next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)