### PR TITLE
feat(agents): wire Grok session hook + Gemini instruction-tier

### DIFF
--- a/.grok/hooks/hooks.json
+++ b/.grok/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "COHERENCE_AGENT=grok python3 \"$(git rev-parse --show-toplevel)/scripts/session_greeting.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,20 @@
+# Gemini — Coherence Network
+
+Full agent orientation lives in [`AGENTS.md`](AGENTS.md) (provider-neutral) and
+[`CLAUDE.md`](CLAUDE.md). Read `AGENTS.md` first — it carries how this body is
+tended.
+
+## Session start
+
+Gemini CLI has no session-start command hook, so this is the one instruction
+that can't be automated: at the start of a session, run the greeting so this
+agent and the human are recognized and remembered (same as the Claude/Codex/
+Grok hooks do automatically):
+
+```bash
+python3 "$(git rev-parse --show-toplevel)/scripts/session_greeting.py"
+```
+
+It detects the agent and the human (git config / project identity), records the
+meeting on the substrate, and greets with memory of prior sessions. It is
+read-only-safe, never blocks, and honors `remember_sessions` opt-out.

--- a/api/tests/test_session_greeting.py
+++ b/api/tests/test_session_greeting.py
@@ -41,6 +41,12 @@ def test_detect_agent(env, expected) -> None:
     assert sg.detect_agent(env) == expected
 
 
+def test_detect_agent_explicit_override_wins() -> None:
+    # An agent's own hook (e.g. .grok/hooks/) can declare itself when it leaves
+    # no recognizable env marker. The override beats marker detection.
+    assert sg.detect_agent({"COHERENCE_AGENT": "grok", "CLAUDECODE": "1"}) == "grok"
+
+
 # --- human detection cascade: git → keystore → env --------------------------
 
 

--- a/scripts/session_greeting.py
+++ b/scripts/session_greeting.py
@@ -164,7 +164,15 @@ def _marker_matches(marker: str, env: Mapping[str, str]) -> bool:
 
 
 def detect_agent(env: Mapping[str, str]) -> str:
-    """Name the agent running this session, across all known agents."""
+    """Name the agent running this session, across all known agents.
+
+    An explicit COHERENCE_AGENT override wins — an agent's own hook lives in an
+    agent-specific location (e.g. .grok/hooks/), so it can declare which agent
+    it is when that agent leaves no recognizable environment marker.
+    """
+    override = env.get("COHERENCE_AGENT", "").strip()
+    if override:
+        return override
     for name, markers in KNOWN_AGENTS:
         if any(_marker_matches(m, env) for m in markers):
             return name


### PR DESCRIPTION
## What

Looked at `~/.grok` and `~/.gemini` for their session-start mechanisms and wired what each supports.

- **Grok** — has project-scoped lifecycle hooks (`.grok/hooks/`) and consumes the Claude `hooks.json` format. Added **`.grok/hooks/hooks.json`** with a `SessionStart` command running the universal `scripts/session_greeting.py`. Verified live (simulating the exact hook command): greets `I'm grok`, identifies the human, opens its own `grok ↔ contributor` thread. ⚠️ Grok requires a one-time **`/hooks-trust`** per project before hooks execute.
- **Gemini** — Gemini CLI has **no** session-start command hook (settings.json is config-only; no extensions/hooks surface). Added a repo **`GEMINI.md`** that points at `AGENTS.md` for orientation and instructs running the greeting at session start. This is **instruction-tier** (the model runs it), not an automatic command hook — the honest ceiling for Gemini.
- **Agent override** — `detect_agent` now honors a `COHERENCE_AGENT` env override, so an agent whose hook lives in an agent-specific location (`.grok/hooks/`) can declare itself when it leaves no recognizable env marker. Not identity hardcoding — the hook is agent-specific by location.

## Coverage now

| Agent | Trigger | Auto-fires |
|---|---|---|
| Claude Code | `.claude/settings.json` | ✅ |
| Codex | `.codex/hooks.json` | ✅ |
| Cursor | `.cursor/hooks.json` | ✅ (binds; no display) |
| Grok | `.grok/hooks/hooks.json` | ✅ after one-time `/hooks-trust` |
| Gemini | `GEMINI.md` instruction | instruction-tier (no command hook exists) |
| any other | generic `AI_AGENT` detection / `COHERENCE_AGENT` | one hook-line away |

## Tests

`api/tests/test_session_greeting.py` (26) — adds the `COHERENCE_AGENT` override case. Full suite: 2340 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)