### PR TITLE
feat(form): module visibility — names as a view over the lattice, enforced

### DIFF
--- a/form/form-stdlib/name-check.fk
+++ b/form/form-stdlib/name-check.fk
@@ -103,4 +103,66 @@
     ;; --- a yes/no gate over a program recipe ------------------------------
     (defn name-check-clean? (program known)
         (nc-empty? (name-check program known)))
+
+    ;; =====================================================================
+    ;; Module visibility — names as a view over the content-addressed lattice
+    ;; =====================================================================
+    ;;
+    ;; In Go/Python a module is an identity+container boundary. In Form identity
+    ;; is content-addressed — `(add a b)` is one NodeID for everyone — so a
+    ;; module can't contain identities; it is a *visibility view* over the shared
+    ;; lattice. You can hide a NAME, never a structure: a private recipe's NodeID
+    ;; still exists globally, reachable by anyone holding it. Encapsulation here
+    ;; protects coupling ("don't bind my internal names"), not secrecy.
+    ;;
+    ;; Policy (concrete, swappable): a name is PRIVATE iff it begins with `_`,
+    ;; matching the kernel's own `_dict_*` / `_plus` internal grain. Default is
+    ;; public — non-breaking for the existing all-public corpus. The Go-true
+    ;; alternative (private by default, export an explicit set) is the same
+    ;; enforcement below with `module-public-names` swapped for an export list;
+    ;; that flip wants a corpus migration, so it is staged as strict mode.
+
+    (defn nc-private? (name)
+        (str_eq (char_at name 0) "_"))
+
+    ;; --- partition a collected name-list by the visibility policy ---------
+    (defn nc-keep-public (names acc)
+        (if (nc-empty? names)
+            acc
+            (nc-keep-public (tail names)
+                (if (nc-private? (head names)) acc (cons (head names) acc)))))
+    (defn nc-keep-private (names acc)
+        (if (nc-empty? names)
+            acc
+            (nc-keep-private (tail names)
+                (if (nc-private? (head names)) (cons (head names) acc) acc))))
+
+    ;; A module's exported surface / its hidden internals, from its own recipe.
+    (defn module-public-names (module)
+        (nc-keep-public (nc-collect module (empty)) (empty)))
+    (defn module-private-names (module)
+        (nc-keep-private (nc-collect module (empty)) (empty)))
+
+    ;; --- set intersection / difference over string-name lists -------------
+    (defn nc-in-set (names set acc)
+        (if (nc-empty? names)
+            acc
+            (nc-in-set (tail names) set
+                (if (nc-member? (head names) set) (cons (head names) acc) acc))))
+    (defn nc-not-in-set (names set acc)
+        (if (nc-empty? names)
+            acc
+            (nc-not-in-set (tail names) set
+                (if (nc-member? (head names) set) acc (cons (head names) acc)))))
+
+    ;; --- the module-aware verdict -----------------------------------------
+    ;; `visible` = the referencing module's own names ∪ imported modules' PUBLIC
+    ;; names ∪ natives. `hidden` = imported modules' PRIVATE names. A reference
+    ;; outside `visible` that lands in `hidden` is a visibility violation — the
+    ;; name exists, but it's another module's internal; everything else outside
+    ;; `visible` is genuinely undefined.
+    (defn name-check-escapes (program visible hidden)
+        (nc-in-set (name-check program visible) hidden (empty)))
+    (defn name-check-unknowns (program visible hidden)
+        (nc-not-in-set (name-check program visible) hidden (empty)))
 )

--- a/form/form-stdlib/tests/name-check-visibility-band.fk
+++ b/form/form-stdlib/tests/name-check-visibility-band.fk
@@ -1,0 +1,49 @@
+; name-check-visibility-band.fk — module visibility enforced by the resolver.
+;
+; preludes: form-stdlib/name-check.fk
+;
+; Two modules, built with intern_node:
+;   module N exports `n-pub` and hides `_n-priv` (leading `_` = private).
+;   module M references `n-pub` (allowed), `_n-priv` (N's internal — a
+;     visibility violation), and `bogus` (defined nowhere).
+;
+; The resolver, given N's public surface as `visible` and N's privates as
+; `hidden`, must split M's dangling references into exactly one escape
+; (`_n-priv`) and one genuine unknown (`bogus`). The `n-pub` reference resolves
+; and is reported by neither. Deterministic, so the three kernels must agree.
+
+(do
+    (let fncall-cat (make_nodeid 1 2 32 1))
+    (let fndef-cat  (make_nodeid 1 2 31 1))
+    (let seq-cat    (make_nodeid 1 2 9 2))
+    (let do-cat     (make_nodeid 1 2 9 1))
+
+    (defn nv-defn (nm)
+        (intern_node fndef-cat
+            (list (intern_trivial_string nm)
+                  (intern_node seq-cat (empty))
+                  (intern_trivial_int 0))))
+    (defn nv-call (nm)
+        (intern_node fncall-cat (list (intern_trivial_string nm))))
+
+    ;; module N — one public export, one private internal
+    (let module-n (intern_node do-cat
+                      (list (nv-defn "n-pub") (nv-defn "_n-priv"))))
+    ;; module M — references across the boundary
+    (let module-m (intern_node do-cat
+                      (list (nv-call "n-pub") (nv-call "_n-priv") (nv-call "bogus"))))
+
+    (let visible (module-public-names module-n))   ; ⇒ (n-pub)
+    (let hidden  (module-private-names module-n))   ; ⇒ (_n-priv)
+
+    (let escapes  (name-check-escapes  module-m visible hidden))  ; ⇒ (_n-priv)
+    (let unknowns (name-check-unknowns module-m visible hidden))  ; ⇒ (bogus)
+
+    (let pass
+        (and (eq (len visible) 1)
+        (and (eq (len hidden) 1)
+        (and (eq (len escapes) 1)
+             (eq (len unknowns) 1)))))
+
+    (print (if pass "name-check-visibility-band: PASS" "name-check-visibility-band: FAIL"))
+)


### PR DESCRIPTION
## What

The module / visibility layer the [name resolver](https://github.com/seeker71/Coherence-Network/pull/2165) was built to enforce.

**The Form-specific idea.** In Go/Python a module is an *identity + container* boundary — `pkg.Foo` ≠ `other.Foo`, and the package owns its symbols. In Form **identity is content-addressed**: `(add a b)` is one NodeID for everyone, the lattice holds every recipe globally by structure. So a Form module can't contain identities — it is a **visibility view over the shared lattice**. The honest consequence: *you can hide a name, never a structure.* A private recipe's NodeID still exists globally and is reachable by anyone holding it; encapsulation here protects **coupling** ("don't bind my internal names"), not secrecy.

**Visibility policy** (adapting Go's intrinsic-in-name rule to kebab-case Lisp): a name is **private iff it begins with `_`**, matching the kernel's own `_dict_*`/`_plus` internal grain — no export list, the name itself carries it. Default is **public** (non-breaking for the ~4,400 all-public defns). Go-true **default-private** is the *same enforcement* with `module-public-names` swapped for an explicit export set — that flip needs a corpus migration, so it's staged as **strict mode**, not silently assumed.

## How (a small reuse, not a new engine)

`name-check` already returns the unresolved set, so visibility is just **classifying that set** against the imported modules' private names:

- `name-check-escapes`  = unresolved ∩ imported-private → **a name that exists but is another module's internal** (a visibility violation, sharper than "undefined")
- `name-check-unknowns` = unresolved \ imported-private → genuinely defined nowhere

No new walk — set ops + the `_` policy + module-surface partitioning (`module-public-names` / `module-private-names`).

## Proof

`name-check-visibility-band.fk` builds two modules with `intern_node`: N exports `n-pub`, hides `_n-priv`; M references `n-pub` (allowed), `_n-priv` (escape), `bogus` (unknown). The resolver splits M's dangling refs into **exactly one escape and one unknown**, allowing the public one. Auto-swept by `validate.sh`; **byte-identical across Go, Rust, and TypeScript** (`0 divergent`).

## Staged next

- **Strict mode** (Go-true default-private): swap the public-surface policy from "not `_`-prefixed" to an explicit export set; migrate per module.
- **Module declarations**: promote the de-facto prefix-namespaces (`fsc-`, `pn-`, `bmf-`, …) and `; preludes:` into real `(module …)` / `(requires …)` forms, so the checker reads the import graph instead of being handed `visible`/`hidden` by the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)