### PR TITLE
feat(form): compiler gap — dict literal {k: v} lifts to PY-BMF-DICT (+ int-key lookup)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -171,14 +171,15 @@
 
     (defn py-dict-pairs (d) (tail d))
 
-    ;; Dict keys arrive as strings in today's surface; the lookup walks
-    ;; pairs with str_eq. Integer-keyed dicts are a later breath.
+    ;; Dict lookup walks pairs with value_eq — polymorphic equality across
+    ;; Value kinds, so integer-keyed and string-keyed dicts both resolve
+    ;; (value_eq is the same native py-dict? already relies on).
     (defn py-dict-lookup-str-loop (pairs key)
         (if (nil? pairs)
             (do
                 (trace "py-dict-lookup: missing key" key)
                 (head (empty)))
-            (if (str_eq (head (head pairs)) key)
+            (if (value_eq (head (head pairs)) key)
                 (head (tail (head pairs)))
                 (py-dict-lookup-str-loop (tail pairs) key))))
 

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -146,6 +146,41 @@
 
     (defn lift-list-elements (tokens) (lift-list-elements-loop tokens (empty)))
 
+    ;; --- dict literal: consume `{ k1: v1, k2: v2 }` ----------------
+    ;;
+    ;; Caller has already consumed the open `{`. Reads `key : value`
+    ;; pairs separated by `,` until `}`. Returns (flat-kv-list . rest),
+    ;; where flat-kv-list is (k1 v1 k2 v2 ...) — the exact 2N-children
+    ;; shape PY-BMF-DICT's eval arm reads (even=key, odd=value). Mirrors
+    ;; lift-list-elements but with a `:` between key and value and `}`
+    ;; as the closer.
+
+    (defn lift-dict-pairs-loop (tokens acc)
+        (if (nil? tokens)
+            (lift-result (reverse acc) tokens)
+            (if (tok-op? (head tokens) "}")
+                (lift-result (reverse acc) (tail tokens))
+                (do
+                    (let key-result (lift-expr tokens))
+                    (let after-key (lift-rest key-result))
+                    ;; require `:` between key and value
+                    (let after-colon
+                        (if (and (not (nil? after-key))
+                                 (tok-op? (head after-key) ":"))
+                            (tail after-key)
+                            after-key))
+                    (let val-result (lift-expr after-colon))
+                    (let next (lift-rest val-result))
+                    ;; push value then key so reverse yields k,v order
+                    (let acc2 (cons (lift-recipe val-result)
+                                    (cons (lift-recipe key-result) acc)))
+                    (if (and (not (nil? next))
+                             (tok-op? (head next) ","))
+                        (lift-dict-pairs-loop (tail next) acc2)
+                        (lift-dict-pairs-loop next acc2))))))
+
+    (defn lift-dict-pairs (tokens) (lift-dict-pairs-loop tokens (empty)))
+
     ;; --- subscript postfix: fold `[ idx ]` trailers onto a primary -
     ;;
     ;; After lift-primary parses a base recipe, peek for `[`. If present,
@@ -229,6 +264,17 @@
                     (lift-subscript-tail
                         (intern_node PY-BMF-LIST (lift-recipe elems-result))
                         (lift-rest elems-result)))
+            (if (tok-op? t "{")
+                ;; dict literal: collect `key: value` pairs separated by
+                ;; `,` until `}`. Empty dict `{}` lifts to PY-BMF-DICT with
+                ;; no children — the interpreter walks that to an empty
+                ;; sentinel-tagged alist. (Set literals `{a, b}` are a
+                ;; later breath; today `{` always means dict.)
+                (do
+                    (let pairs-result (lift-dict-pairs rest))
+                    (lift-subscript-tail
+                        (intern_node PY-BMF-DICT (lift-recipe pairs-result))
+                        (lift-rest pairs-result)))
             (if (tok-op? t "(")
                 ;; parenthesised expression: parse inner, consume ")"
                 (do
@@ -243,7 +289,7 @@
                            (list (tok-kind t) (tok-value t)))
                     (lift-result
                         (intern_node PY-BMF-PASS (empty))
-                        rest))))))))))))
+                        rest)))))))))))))
 
     ;; --- operator precedence ---------------------------------------
     ;;

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -197,14 +197,22 @@ x
 "))
     (let cell13-score (if (eq cell13-value 39) 10000 0))
 
+    ;; ---- cell 14: dict literal + subscript — CPython:
+    ;;   d = {1: 10, 2: 20, 3: 30}; d[1] + d[3]  → 40 -------------------
+
+    (let cell14-value (py-bmf-run-text "d = {1: 10, 2: 20, 3: 30}
+d[1] + d[3]
+"))
+    (let cell14-score (if (eq cell14-value 40) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
     ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
-    ;;   + 10000 (cell 13 aug-assign) = 85000
+    ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict) = 95000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
-               cell13-score)))
+               cell13-score cell14-score)))


### PR DESCRIPTION
Second Python→Form compiler-coverage breath ([queue](../blob/main/kernels/COMPILER_GAP_QUEUE.md) Batch 1). Companion to #2168.

## What
- **lift** (`python-bmf-lift.fk`): `lift-dict-pairs` + a `{` branch in `lift-primary`. The `PY-BMF-DICT` **eval arm already shipped**; only lift was missing, so `{1: 10}` fell through to `PY-BMF-PASS`.
- **eval fix** (`python-bmf-eval.fk`): dict lookup now uses `value_eq` (polymorphic, the native `py-dict?` already relies on) instead of `str_eq` — so **integer-keyed and string-keyed dicts both resolve**. Previously only string keys were intended; int keys silently returned the first value. (`value_eq` returns a bool — used directly, not wrapped in `eq..1`, which diverged Go from Rust mid-debug.)
- **test**: cell 14 — `d = {1:10,2:20,3:30}; d[1]+d[3]` → 40. Aggregate **85000 → 95000**.

## Proof
```
GO=95000 RUST=95000   (prepared-source chain, local)
```
CI's `validate-thread-process` runs the full three-way incl. TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)