### PR TITLE
feat(form): compiler gap — for-loop over a list lifts to PY-BMF-FOR

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -255,6 +255,19 @@
                 body-stmts
                 (py-eval-body-loop body-stmts env))))
 
+    ;; py-for-loop — iterate `items` (a Form list), binding `var` to each
+    ;; element and threading env through the body each pass. Mirrors
+    ;; py-while-loop's env-threading so a for-body can mutate via
+    ;; ASSIGN / AUG-ASSIGN and the mutations persist across iterations.
+    (defn py-for-loop (var items body-stmts env)
+        (if (nil? items) env
+            (py-for-loop
+                var
+                (tail items)
+                body-stmts
+                (py-eval-body-loop body-stmts
+                    (py-env-extend env var (head items))))))
+
     (defn py-eval-statement (recipe env)
         (do
             (let cat (node_category recipe))
@@ -286,6 +299,19 @@
                     (let body-stmts (tail kids))
                     (let final-env (py-while-loop cond-recipe body-stmts env))
                     (py-stmt-result 0 final-env))
+            (if (node_eq cat PY-BMF-FOR)
+                (do
+                    ;; FOR children: var-name-leaf, iterable-recipe,
+                    ;; body-stmt-recipes... Evaluate the iterable to a Form
+                    ;; list, bind var to each element, thread env through the
+                    ;; body. Returns 0 (Python None). Iterables today are
+                    ;; lists (PY-BMF-LIST / range-as-list); dict/string
+                    ;; iteration is a later breath.
+                    (let var (node_value (head kids)))
+                    (let items (py-eval (head (tail kids)) env))
+                    (let body-stmts (tail (tail kids)))
+                    (let final-env (py-for-loop var items body-stmts env))
+                    (py-stmt-result 0 final-env))
             (if (node_eq cat PY-BMF-DEF)
                 (do
                     ;; DEF children: name-leaf, param-leaves..., body-recipe.
@@ -297,7 +323,7 @@
                     (let closure (py-closure name pms body env))
                     (py-stmt-result closure (py-env-extend env name closure)))
                 ;; Default: expression statement — eval, env unchanged.
-                (py-stmt-result (py-eval recipe env) env)))))))
+                (py-stmt-result (py-eval recipe env) env))))))))
 
     (defn py-eval-module-loop (statements env last-value)
         (if (nil? statements) last-value

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -559,6 +559,28 @@
             (let body-recipes (lift-statements children))
             (intern_node PY-BMF-WHILE (cons cond body-recipes))))
 
+    ;; for-statement: tokens look like `for NAME in <iterable-tokens> :`.
+    ;; The iterable expression sits between the `in` keyword and the
+    ;; trailing `:`. Body children lift the same way while's do. The
+    ;; PY-BMF-FOR recipe's children are (var-name-leaf, iterable-recipe,
+    ;; body-stmt-recipes...) — the eval arm reads child 0 as the loop var,
+    ;; child 1 as the iterable, the rest as the body. lift-while-strip-colon
+    ;; is reused to drop the trailing `:`.
+
+    (defn lift-for (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let children (python-statement-tree-children statement-tree))
+            ;; tokens: for NAME in EXPR... :  → var is token 1, the
+            ;; iterable is everything after `in` (token 2), minus `:`.
+            (let var-name (tok-value (head (tail tokens))))
+            (let iter-tokens (lift-while-strip-colon (drop 3 tokens) (empty)))
+            (let iterable (lift-recipe (lift-expr iter-tokens)))
+            (let body-recipes (lift-statements children))
+            (intern_node PY-BMF-FOR
+                (cons (intern_trivial_string var-name)
+                      (cons iterable body-recipes)))))
+
     ;; augmented-assignment statement: `NAME <op>= EXPR...`. The scanner
     ;; classifies these as kind "expr" / rule "star_expressions" (the
     ;; `+=` token is a single py-op), so the dispatcher must catch them
@@ -613,12 +635,13 @@
             (if (str_eq kind "def")              (lift-def statement-tree)
             (if (str_eq kind "return")           (lift-return statement-tree)
             (if (str_eq kind "while")            (lift-while statement-tree)
+            (if (str_eq kind "for")              (lift-for statement-tree)
             (if (str_eq rule "assignment")       (lift-assign statement-tree)
             (if (eq (stmt-aug-op? statement-tree) 1) (lift-aug-assign statement-tree)
             (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
                 (do
                     (trace "lift-statement: unsupported kind/rule" (list kind rule))
-                    (intern_node PY-BMF-PASS (empty)))))))))))
+                    (intern_node PY-BMF-PASS (empty))))))))))))
 
     ;; ---- module lifter (the public surface) ------------------------
     ;;

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -205,14 +205,28 @@ d[1] + d[3]
 "))
     (let cell14-score (if (eq cell14-value 40) 10000 0))
 
+    ;; ---- cell 15: for-loop over a list — CPython:
+    ;;   total = 0
+    ;;   for i in [10, 20, 30, 40]:
+    ;;       total = total + i
+    ;;   total  → 100 ----------------------------------------------------
+
+    (let cell15-value (py-bmf-run-text "total = 0
+for i in [10, 20, 30, 40]:
+    total = total + i
+total
+"))
+    (let cell15-score (if (eq cell15-value 100) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
     ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
-    ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict) = 95000
+    ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict)
+    ;;   + 10000 (cell 15 for-loop) = 105000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
-               cell13-score cell14-score)))
+               cell13-score cell14-score cell15-score)))


### PR DESCRIPTION
Third Python→Form compiler-coverage breath ([queue](../blob/main/kernels/COMPILER_GAP_QUEUE.md) Batch 1). Follows #2168 (aug-assign), #2174 (dict).

## What
`PY-BMF-FOR` existed in the ontology (inst 511) but had **neither lift nor eval**, so `for i in xs:` fell through to `PY-BMF-PASS`.
- **lift** (`python-bmf-lift.fk`): `lift-for` — `for NAME in EXPR... :` → var = token 1, iterable = post-`in` tokens minus trailing `:` (reuses `lift-while-strip-colon`), body children lift like while's. Emits `PY-BMF-FOR(var, iterable, body...)`.
- **eval** (`python-bmf-eval.fk`): `py-for-loop` folds the body over the iterable's elements, binding var + threading env each pass (mirrors `py-while-loop` — for-bodies mutate via ASSIGN/AUG-ASSIGN and persist).
- **test**: cell 15 — `for i in [10,20,30,40]: total=total+i` → 100. Aggregate **95000 → 105000**.

## Scope (honest)
Iterables are **lists** today (list literals + nested for verified locally). `for i in range(n)` still returns unimplemented — `range()` doesn't yet produce an iterable in eval; that's its own breath.

## Proof
```
GO=105000 RUST=105000   (prepared-source chain, local)
```
CI's `validate-thread-process` runs the full three-way incl. TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)