### PR TITLE
feat(form): compiler gap — unary operators (-x, not x) via desugaring

### DIFF
--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -215,6 +215,29 @@
         (do
             (let t (head tokens))
             (let rest (tail tokens))
+            ;; Unary operators desugar to existing binary recipes, so no new
+            ;; eval arm is needed — the MATH-12 / COMPARE-13 arms already walk
+            ;; them. `-operand` → MATH-MINUS(0, operand); `not operand` →
+            ;; COMPARE-EQ(operand, 0) (Python int-truthiness: not x is x == 0).
+            ;; The operand is parsed with lift-primary so chains (`not not x`,
+            ;; `-x[i]`) and tight binding work; precedence-climbing in
+            ;; lift-binop-loop then continues from the resulting recipe.
+            (if (tok-op? t "-")
+                (do
+                    (let operand (lift-primary rest))
+                    (lift-result
+                        (intern_node MATH-MINUS
+                            (list (intern_node PY-BMF-INT (list (intern_trivial_int 0)))
+                                  (lift-recipe operand)))
+                        (lift-rest operand)))
+            (if (tok-keyword? t "not")
+                (do
+                    (let operand (lift-primary rest))
+                    (lift-result
+                        (intern_node COMPARE-EQ
+                            (list (lift-recipe operand)
+                                  (intern_node PY-BMF-INT (list (intern_trivial_int 0)))))
+                        (lift-rest operand)))
             (if (tok-int? t)
                 (lift-subscript-tail
                     (intern_node PY-BMF-INT
@@ -289,7 +312,7 @@
                            (list (tok-kind t) (tok-value t)))
                     (lift-result
                         (intern_node PY-BMF-PASS (empty))
-                        rest)))))))))))))
+                        rest)))))))))))))))
 
     ;; --- operator precedence ---------------------------------------
     ;;

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -218,15 +218,31 @@ total
 "))
     (let cell15-score (if (eq cell15-value 100) 10000 0))
 
+    ;; ---- cell 16: unary operators — CPython:
+    ;;   x = 5
+    ;;   y = -x          # → -5   (MATH-MINUS(0, x))
+    ;;   z = not 0       # → 1    (COMPARE-EQ(0, 0))
+    ;;   w = not x       # → 0    (COMPARE-EQ(5, 0))
+    ;;   -x + 8 + z + w  # → -5 + 8 + 1 + 0 = 4 -------------------------
+
+    (let cell16-value (py-bmf-run-text "x = 5
+y = -x
+z = not 0
+w = not x
+y + 8 + z + w
+"))
+    (let cell16-score (if (eq cell16-value 4) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
     ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
     ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict)
-    ;;   + 10000 (cell 15 for-loop) = 105000
+    ;;   + 10000 (cell 15 for-loop) + 10000 (cell 16 unary) = 115000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
-               cell13-score cell14-score cell15-score)))
+               cell13-score cell14-score cell15-score
+               cell16-score)))


### PR DESCRIPTION
Fourth Python→Form compiler-coverage breath ([queue](../blob/main/kernels/COMPILER_GAP_QUEUE.md) Batch 1). Follows #2168, #2174, #2175.

## What
**Pure lift — no new eval arm.** Unary ops desugar to recipes the MATH-12 / COMPARE-13 arms already walk:
- `-operand` → `MATH-MINUS(0, operand)`
- `not operand` → `COMPARE-EQ(operand, 0)` (Python int-truthiness: `not x` ≡ `x == 0`)

`lift-primary` catches a leading `-` / `not` before the literal/name arms; the operand is parsed recursively so `not not x`, `-x[i]` chain and bind tightly. Binary `a - b` is untouched (handled in `lift-binop-loop`); only a *leading* minus reaches this branch.

cell 16: `x=5; y=-x; z=not 0; w=not x; y+8+z+w` → 4. Aggregate **105000 → 115000**.

## Proof
`./validate.sh` no-arg suite (Go/Rust/TS): `stdlib/python-bmf-lift-band.fk → 115000`, no divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)