### PR TITLE
feat(form): compiler gap — boolean and/or via short-circuit desugaring

### DIFF
--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -335,7 +335,10 @@
         (if (str_eq s "<=") 20
         (if (str_eq s ">")  20
         (if (str_eq s ">=") 20
-            (sub 0 1)))))))))))))))
+        ;; Boolean ops bind looser than comparison (Python: or < and < cmp).
+        (if (str_eq s "and") 15
+        (if (str_eq s "or")  10
+            (sub 0 1)))))))))))))))))
 
     (defn op-is-compare? (s)
         (or (str_eq s "==")
@@ -349,9 +352,16 @@
         (if (nil? tokens) (sub 0 1)
             (do
                 (let t (head tokens))
+                ;; Binary operators are py-op tokens; the boolean operators
+                ;; `and`/`or` arrive as py-keyword tokens but climb in the
+                ;; same loop, so grant them precedence here too.
                 (if (str_eq (tok-kind t) "py-op")
                     (op-prec (tok-value t))
-                    (sub 0 1)))))
+                (if (and (str_eq (tok-kind t) "py-keyword")
+                         (or (str_eq (tok-value t) "and")
+                             (str_eq (tok-value t) "or")))
+                    (op-prec (tok-value t))
+                    (sub 0 1))))))
 
     ;; --- binop climbing ---------------------------------------------
     ;;
@@ -385,6 +395,15 @@
                     ;; has matching MATH-12 and COMPARE-13 arms that dispatch
                     ;; on inst.
                     (let new-left
+                        ;; Boolean ops short-circuit, so they desugar to
+                        ;; PY-BMF-IF (the IF eval arm only walks the taken
+                        ;; branch) — no new eval arm needed:
+                        ;;   a and b → IF(a, b, a)   (a falsy → a, else b)
+                        ;;   a or  b → IF(a, a, b)   (a truthy → a, else b)
+                        (if (str_eq op "and")
+                            (intern_node PY-BMF-IF (list left rhs-recipe left))
+                        (if (str_eq op "or")
+                            (intern_node PY-BMF-IF (list left left rhs-recipe))
                         (if (str_eq op "==")
                             (intern_node COMPARE-EQ    (list left rhs-recipe))
                         (if (str_eq op "!=")
@@ -415,7 +434,7 @@
                             (intern_node PY-BMF-BINOP
                                 (list left
                                       (intern_trivial_string op)
-                                      rhs-recipe)))))))))))))))
+                                      rhs-recipe)))))))))))))))))
                     (lift-binop-loop new-left (lift-rest rhs-climb) min-prec)))))
 
     ;; --- conditional expression ------------------------------------

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -233,16 +233,34 @@ y + 8 + z + w
 "))
     (let cell16-score (if (eq cell16-value 4) 10000 0))
 
+    ;; ---- cell 17: boolean and/or — CPython value semantics + precedence:
+    ;;   1 and 7            → 7   (and returns the second when first truthy)
+    ;;   0 or 5             → 5   (or returns second when first falsy)
+    ;;   0 and 9            → 0   (short-circuit: returns first, 9 not eval'd)
+    ;;   2 or 9             → 2   (short-circuit: returns first)
+    ;;   precedence: 1 or 0 and 0  → 1 (and binds tighter: 1 or (0 and 0))
+    ;;   sum: 7 + 5 + 0 + 2 + 1 = 15 ------------------------------------
+
+    (let cell17-value (py-bmf-run-text "a = 1 and 7
+b = 0 or 5
+c = 0 and 9
+d = 2 or 9
+e = 1 or 0 and 0
+a + b + c + d + e
+"))
+    (let cell17-score (if (eq cell17-value 15) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
     ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
     ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict)
-    ;;   + 10000 (cell 15 for-loop) + 10000 (cell 16 unary) = 115000
+    ;;   + 10000 (cell 15 for-loop) + 10000 (cell 16 unary)
+    ;;   + 10000 (cell 17 bool-ops) = 125000
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
                cell13-score cell14-score cell15-score
-               cell16-score)))
+               cell16-score cell17-score)))


### PR DESCRIPTION
Fifth Python→Form compiler-coverage breath ([queue](../blob/main/kernels/COMPILER_GAP_QUEUE.md) Batch 1 — completes the cheap tier). Follows #2168, #2174, #2175, #2178.

## What
**Pure lift — no new eval arm.** Boolean ops short-circuit, so they desugar to `PY-BMF-IF` (whose eval arm only walks the taken branch):
- `a and b` → `IF(a, b, a)`
- `a or b` → `IF(a, a, b)`

- **op-prec**: `and`=15, `or`=10 (Python: `or` < `and` < comparison).
- **tok-binop-prec**: grants precedence to `and`/`or`, which arrive as `py-keyword` (not `py-op`) tokens but climb in the same loop.
- **lift-binop-loop**: `and`/`or` branch to `PY-BMF-IF`, left-associative.

cell 17 covers value semantics (`1 and 7`→7, `0 or 5`→5), short-circuit (`0 and 9`→0, `2 or 9`→2), and precedence (`1 or 0 and 0`→1). Aggregate **115000 → 125000**.

## Proof
`./validate.sh` full suite: `stdlib/python-bmf-lift-band.fk → 125000`, 0 divergent across Go/Rust/TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)