### PR TITLE
feat(form): compiler gap — range() builtin produces an iterable list

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -334,6 +334,19 @@
                     (py-stmt-env r)
                     (py-stmt-value r)))))
 
+    ;; range() builtin — produces a Form list so `for i in range(...)` (the
+    ;; most common substrate loop idiom) walks. Built as a plain Form list,
+    ;; the same shape PY-BMF-LIST eval returns, so the FOR arm iterates it
+    ;; with no special-casing. Supports range(stop) and range(start, stop);
+    ;; step is a later breath.
+    (defn py-range-build (i stop acc)
+        (if (ge i stop) (reverse acc)
+            (py-range-build (add i 1) stop (cons i acc))))
+    (defn py-range (args)
+        (if (eq (len args) 1)
+            (py-range-build 0 (head args) (empty))
+            (py-range-build (head args) (head (tail args)) (empty))))
+
     (defn py-eval (recipe env)
         (do
             (let cat (node_category recipe))
@@ -423,17 +436,22 @@
                     ;; the function itself. Mutual recursion is a later
                     ;; breath — this carries single-function self-ref.
                     (let callee-name (node_value (head kids)))
-                    (let closure (py-env-lookup env callee-name))
                     (let arg-values (py-eval-args (tail kids) env))
-                    (let captured-with-self
-                        (py-env-extend (py-closure-env closure)
-                                       (py-closure-name closure)
-                                       closure))
-                    (let call-env (py-bind-params
-                                    (py-closure-params closure)
-                                    arg-values
-                                    captured-with-self))
-                    (py-eval (py-closure-body closure) call-env))
+                    ;; range() is a builtin, not a closure — intercept before
+                    ;; the env lookup and return its Form list directly.
+                    (if (str_eq callee-name "range")
+                        (py-range arg-values)
+                        (do
+                            (let closure (py-env-lookup env callee-name))
+                            (let captured-with-self
+                                (py-env-extend (py-closure-env closure)
+                                               (py-closure-name closure)
+                                               closure))
+                            (let call-env (py-bind-params
+                                            (py-closure-params closure)
+                                            arg-values
+                                            captured-with-self))
+                            (py-eval (py-closure-body closure) call-env))))
             (if (node_eq cat PY-BMF-LIST)
                 ;; LIST children: element-recipes. Value is a Form list
                 ;; of evaluated elements, in source order.

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -250,6 +250,21 @@ a + b + c + d + e
 "))
     (let cell17-score (if (eq cell17-value 15) 10000 0))
 
+    ;; ---- cell 18: range() in for-loops — CPython:
+    ;;   total = 0
+    ;;   for i in range(5):        total += i   # 0+1+2+3+4 = 10
+    ;;   for j in range(2, 5):     total += j   # 2+3+4     = 9
+    ;;   total → 19 -----------------------------------------------------
+
+    (let cell18-value (py-bmf-run-text "total = 0
+for i in range(5):
+    total = total + i
+for j in range(2, 5):
+    total = total + j
+total
+"))
+    (let cell18-score (if (eq cell18-value 19) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
     ;; Sum when every cell agrees with CPython + Shape B converges for
     ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
@@ -263,4 +278,4 @@ a + b + c + d + e
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
                cell13-score cell14-score cell15-score
-               cell16-score cell17-score)))
+               cell16-score cell17-score cell18-score)))


### PR DESCRIPTION
Closes the `range()` follow-up surfaced by #2175: `for i in range(n)` — the most common substrate loop idiom — now walks. **Eval-side only** (no lift change; range is a normal CALL).

- `py-range` / `py-range-build` build a plain Form list `[start..stop-1]`, the same shape `PY-BMF-LIST` returns, so the FOR arm iterates it unchanged. CALL arm intercepts `callee-name=="range"` before closure lookup. Supports `range(stop)` and `range(start, stop)`; step is a later breath.
- cell 18: `range(5)` + `range(2,5)` summed in two for-loops → 19. Aggregate **125000 → 135000**.

Proof: `./validate.sh` full suite — 181 ok, 0 divergent (Go/Rust/TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)