### PR TITLE
feat(form): compiler gap — list comprehensions lift to PY-BMF-COMP (Batch 2)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -268,6 +268,18 @@
                 (py-eval-body-loop body-stmts
                     (py-env-extend env var (head items))))))
 
+    ;; py-comp-build — evaluate a list comprehension `[elem for var in iter]`.
+    ;; Maps elem-recipe over each item of the already-evaluated iter list,
+    ;; binding var in a child env per item (env is NOT mutated outward — a
+    ;; comprehension's loop var doesn't leak, matching Python 3). Returns a
+    ;; Form list of results in source order.
+    (defn py-comp-build (elem-recipe var items env acc)
+        (if (nil? items) (reverse acc)
+            (py-comp-build elem-recipe var (tail items) env
+                (cons (py-eval elem-recipe
+                          (py-env-extend env var (head items)))
+                      acc))))
+
     (defn py-eval-statement (recipe env)
         (do
             (let cat (node_category recipe))
@@ -456,6 +468,13 @@
                 ;; LIST children: element-recipes. Value is a Form list
                 ;; of evaluated elements, in source order.
                 (py-eval-args kids env)
+            (if (node_eq cat PY-BMF-COMP)
+                ;; COMP children: elem-recipe, var-name-leaf, iter-recipe.
+                ;; Evaluate iter to a list, map elem over it binding var.
+                (py-comp-build (nth kids 0)
+                               (node_value (nth kids 1))
+                               (py-eval (nth kids 2) env)
+                               env (empty))
             (if (node_eq cat PY-BMF-DICT)
                 ;; DICT children: (k1 v1 k2 v2 ...) — 2N recipes. Value
                 ;; is a sentinel-tagged alist so SUBSCRIPT can pick the
@@ -490,7 +509,7 @@
                     ;; category number so the next breath knows which
                     ;; arm to add.
                     (trace "py-eval: unimplemented category" cat)
-                    (head (empty))))))))))))))))))))
+                    (head (empty)))))))))))))))))))))
 
     ;; Surface for callers. py-run takes a module recipe and returns its
     ;; value. py-eval and py-eval-statement are exposed so band-tests

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -146,6 +146,49 @@
 
     (defn lift-list-elements (tokens) (lift-list-elements-loop tokens (empty)))
 
+    ;; --- list comprehension: `[ elem for var in iter ]` -------------
+    ;;
+    ;; Caller has consumed the open `[`. We lift the element expression
+    ;; first; if the next token is the `for` keyword, this is a
+    ;; comprehension (not a plain list). Token shape after `for`:
+    ;;   for VAR in ITER-tokens... ]
+    ;; VAR is a single py-name; ITER is everything between `in` and the
+    ;; closing `]`. Emits PY-BMF-COMP(elem-recipe, var-name-leaf,
+    ;; iter-recipe) — the eval arm maps elem over the evaluated iter,
+    ;; binding var each step (same env-threading as py-for-loop). Filter
+    ;; clauses (`if cond`) and nested fors are a later breath.
+    ;;
+    ;; lift-comp-iter-tokens — collect tokens from the start until the
+    ;; final `]`, returning (iter-tokens . rest-after-]). Single bracket
+    ;; depth only (the common case); nested `[` in the iterable would need
+    ;; depth tracking, deferred.
+    (defn lift-comp-iter-loop (tokens depth acc)
+        (if (nil? tokens) (lift-result (reverse acc) tokens)
+            (do
+                (let t (head tokens))
+                (if (and (eq depth 0) (tok-op? t "]"))
+                    (lift-result (reverse acc) (tail tokens))
+                    (do
+                        (let d2 (if (tok-op? t "[") (add depth 1)
+                                 (if (tok-op? t "]") (sub depth 1) depth)))
+                        (lift-comp-iter-loop (tail tokens) d2 (cons t acc)))))))
+
+    (defn lift-comprehension (elem-recipe after-elem)
+        ;; after-elem starts at the `for` keyword.
+        (do
+            (let after-for (tail after-elem))          ; drop `for`
+            (let var-name (tok-value (head after-for)))
+            (let after-var (tail after-for))           ; at `in`
+            (let after-in (tail after-var))            ; iter tokens start
+            (let iter-collected (lift-comp-iter-loop after-in 0 (empty)))
+            (let iter-recipe (lift-recipe (lift-expr (lift-recipe iter-collected))))
+            (lift-result
+                (intern_node PY-BMF-COMP
+                    (list elem-recipe
+                          (intern_trivial_string var-name)
+                          iter-recipe))
+                (lift-rest iter-collected))))
+
     ;; --- dict literal: consume `{ k1: v1, k2: v2 }` ----------------
     ;;
     ;; Caller has already consumed the open `{`. Reads `key : value`
@@ -278,15 +321,36 @@
                             (list (intern_trivial_string (tok-value t))))
                         rest))
             (if (tok-op? t "[")
-                ;; list literal: collect comma-separated expressions
-                ;; until `]`. Empty list `[]` lifts to PY-BMF-LIST with
-                ;; no children — the interpreter walks that to an empty
-                ;; Form list naturally.
-                (do
-                    (let elems-result (lift-list-elements rest))
+                ;; `[` opens either a list literal or a comprehension. Empty
+                ;; `[]` is a list. Otherwise lift the first expression and
+                ;; peek: a following `for` keyword means comprehension; a
+                ;; `,` or `]` means a plain list. For the list case we re-lift
+                ;; from `rest` via lift-list-elements (it re-reads the first
+                ;; element) — simpler than threading the already-lifted head,
+                ;; and lift is pure so the duplicate parse is harmless.
+                (if (and (not (nil? rest)) (tok-op? (head rest) "]"))
+                    ;; empty list []
                     (lift-subscript-tail
-                        (intern_node PY-BMF-LIST (lift-recipe elems-result))
-                        (lift-rest elems-result)))
+                        (intern_node PY-BMF-LIST (empty))
+                        (tail rest))
+                    (do
+                        (let first (lift-expr rest))
+                        (let after (lift-rest first))
+                        (if (and (not (nil? after))
+                                 (tok-keyword? (head after) "for"))
+                            ;; comprehension: lift-comprehension returns a
+                            ;; (recipe . rest) result; subscript-tail onto it.
+                            (do
+                                (let comp (lift-comprehension (lift-recipe first) after))
+                                (lift-subscript-tail
+                                    (lift-recipe comp)
+                                    (lift-rest comp)))
+                            ;; plain list literal — re-lift from rest
+                            (do
+                                (let elems-result (lift-list-elements rest))
+                                (lift-subscript-tail
+                                    (intern_node PY-BMF-LIST (lift-recipe elems-result))
+                                    (lift-rest elems-result))))))
             (if (tok-op? t "{")
                 ;; dict literal: collect `key: value` pairs separated by
                 ;; `,` until `}`. Empty dict `{}` lifts to PY-BMF-DICT with

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -265,17 +265,23 @@ total
 "))
     (let cell18-score (if (eq cell18-value 19) 10000 0))
 
+    ;; ---- cell 19: list comprehension — CPython:
+    ;;   xs = [i + 1 for i in [10, 20, 30]]   → [11, 21, 31]
+    ;;   xs[0] + xs[1] + xs[2]                → 63
+    ;; Exercises [elem for var in iter]: maps elem-expr (i+1) over the
+    ;; iterable list, binding the loop var per element, then subscripts.
+    (let cell19-value (py-bmf-run-text "xs = [i + 1 for i in [10, 20, 30]]
+xs[0] + xs[1] + xs[2]
+"))
+    (let cell19-score (if (eq cell19-value 63) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
-    ;; Sum when every cell agrees with CPython + Shape B converges for
-    ;; arithmetic (cell 10), comparison (cell 11), and mod (cell 12):
-    ;;   1000+2000+3000+4000+5000+6000+7000+8000+9000+10000+10000+10000
-    ;;   + 10000 (cell 13 aug-assign) + 10000 (cell 14 dict)
-    ;;   + 10000 (cell 15 for-loop) + 10000 (cell 16 unary)
-    ;;   + 10000 (cell 17 bool-ops) = 125000
+    ;; 18 cells through range = 135000; + 10000 (cell 19 comprehension) = 145000.
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
                cell7-score cell8-score cell9-score
                cell10-score cell11-score cell12-score
                cell13-score cell14-score cell15-score
-               cell16-score cell17-score cell18-score)))
+               cell16-score cell17-score cell18-score
+               cell19-score)))


### PR DESCRIPTION
Second **Batch 2** construct. (f-strings remain blocked on a separate grammar-layer statement-splitter bug — comprehension statements *survive* module-tree grouping, which I verified before starting, so this one is clean.)

## What
`[elem for var in iter]` now walks. The scanner hands a flat token stream `[ elem for var in iter ]` (the `for` sits inside the brackets):
- **lift** (`python-bmf-lift.fk`): the `[` branch lifts the first expression, then peeks — a `for` keyword ⇒ comprehension, else plain list (re-lifted via `lift-list-elements`; lift is pure). `lift-comprehension` consumes `for VAR in ITER…]` (bracket-depth tracking for the close) and emits `PY-BMF-COMP(elem, var, iter)`. Empty `[]` short-circuits to `PY-BMF-LIST`.
- **eval** (`python-bmf-eval.fk`): `PY-BMF-COMP` arm evaluates iter to a list, `py-comp-build` maps elem over it binding var in a per-item child env (loop var doesn't leak — Python 3 semantics).
- **test**: cell 19 — `xs = [i + 1 for i in [10,20,30]]; xs[0]+xs[1]+xs[2]` → 63. Aggregate **135000 → 145000**.

Edge-verified locally: comp over `range()` (`[i*i for i in range(4)]` → 14), plain list literal still works (12), empty `[]` (0). Filter clauses (`if cond`) and nested fors are a later breath.

## Proof
`./validate.sh` full suite — 181 ok, 0 divergent (Go/Rust/TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)