### PR TITLE
feat(form): compiler gap — power operator ** (Python-side, no kernel native)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -105,6 +105,14 @@
     ;; an honest unknown-op panic (head empty) for any op we haven't
     ;; reached yet.
 
+    ;; py-pow — integer exponentiation by repeated multiplication. No kernel
+    ;; `pow` native exists, so `**` computes in Form. Non-negative exponents
+    ;; only (Python's int**negative yields a float — a later breath when the
+    ;; interpreter grows floats on this path).
+    (defn py-pow (base exp acc)
+        (if (le exp 0) acc
+            (py-pow base (sub exp 1) (mul acc base))))
+
     (defn py-binop-apply (op left right)
         (if (str_eq op "+")  (add left right)
         (if (str_eq op "-")  (sub left right)
@@ -112,7 +120,8 @@
         (if (str_eq op "/")  (div left right)
         (if (str_eq op "%")  (mod left right)
         (if (str_eq op "//") (div left right)
-            (do (trace "py-binop: unsupported op" op) (head (empty))))))))))
+        (if (str_eq op "**") (py-pow left right 1)
+            (do (trace "py-binop: unsupported op" op) (head (empty)))))))))))
 
     (defn py-compare-apply (op left right)
         (if (str_eq op "==") (if (eq left right) 1 0)

--- a/form/form-stdlib/tests/python-bmf-lift-band.fk
+++ b/form/form-stdlib/tests/python-bmf-lift-band.fk
@@ -275,8 +275,20 @@ xs[0] + xs[1] + xs[2]
 "))
     (let cell19-score (if (eq cell19-value 63) 10000 0))
 
+    ;; ---- cell 20: power operator ** — CPython:
+    ;;   a = 2 ** 10       → 1024
+    ;;   b = 3 ** 0        → 1     (exp 0 → 1)
+    ;;   c = 2 ** 3 + 5 ** 2 → 8 + 25 = 33  (precedence: ** binds tightest)
+    ;;   a + b + c = 1024 + 1 + 33 = 1058
+    (let cell20-value (py-bmf-run-text "a = 2 ** 10
+b = 3 ** 0
+c = 2 ** 3 + 5 ** 2
+a + b + c
+"))
+    (let cell20-score (if (eq cell20-value 1058) 10000 0))
+
     ;; ---- aggregate ----------------------------------------------------
-    ;; 18 cells through range = 135000; + 10000 (cell 19 comprehension) = 145000.
+    ;; 19 cells through comprehension = 145000; + 10000 (cell 20 power) = 155000.
 
     (sum (list cell1-score cell2-score cell3-score
                cell4-score cell5-score cell6-score
@@ -284,4 +296,4 @@ xs[0] + xs[1] + xs[2]
                cell10-score cell11-score cell12-score
                cell13-score cell14-score cell15-score
                cell16-score cell17-score cell18-score
-               cell19-score)))
+               cell19-score cell20-score)))


### PR DESCRIPTION
`2 ** 10` now walks. The lift already routes `**` to PY-BMF-BINOP (no MATH instance for power); only the **eval** was missing the op. No kernel `pow` native exists, so `py-pow` computes integer exponentiation by repeated multiplication **in Form** — no 3-language kernel change.

- `py-pow` (recursive multiply, non-negative exp) + `**` case in `py-binop-apply`. (`//` already mapped to integer div; this fills the last common arithmetic op the eval lacked.)
- cell 20: `a=2**10; b=3**0; c=2**3+5**2; a+b+c` → 1058 — verifies value (1024), exp-0 (→1), precedence (`**` tighter than `+`: `2**3+5**2`=33). Aggregate **145000 → 155000**.

Negative exponents (Python's `int**-n` → float) are a later breath. Full suite 181 ok, 0 divergent (Go/Rust/TS).

> Note on the heavier Batch-2 items I probed this turn and did **not** ship: **try/except** is blocked — the interpreter has no raise/exception mechanism and a real error (`1/0`) is a hard kernel panic, not a catchable signal; a try that only ever runs the body would be dishonest. **class** needs an object/attribute/method-dispatch subsystem the interpreter lacks. Both are real subsystems, not desugar breaths. `**` was the clean unblocked win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)