### PR TITLE
feat(kernels): pow native (Go/Rust/TS) — ** in the kernel, not Form recursion

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1061,6 +1061,21 @@ func (k *Kernel) registerNatives() {
 	k.registerNative("str_concat", catMethod(), func(_ *Kernel, args []Value) Value {
 		return Value{Kind: VStr, Str: args[0].Str + args[1].Str}
 	})
+	// pow — integer exponentiation in native code (no Form recursion).
+	// (pow base exp) → base**exp. Negative exponents return 0 (Python's
+	// int**-n is a float; floats on this path are a later breath).
+	k.registerNative("pow", catMethod(), func(_ *Kernel, args []Value) Value {
+		base := args[0].Int
+		exp := args[1].Int
+		if exp < 0 {
+			return Value{Kind: VInt, Int: 0}
+		}
+		result := int64(1)
+		for i := int64(0); i < exp; i++ {
+			result *= base
+		}
+		return Value{Kind: VInt, Int: result}
+	})
 	// str_find — Go-level substring search starting at index `from`.
 	// Signature: (str_find s needle from) → int (index or -1). The whole
 	// search runs in this Go loop (uses strings.Index after slicing); no

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -1400,6 +1400,18 @@ impl Kernel {
             s.push_str(args[1].as_str());
             Value::Str(s)
         });
+        // pow — integer exponentiation in native code (no Form recursion).
+        // (pow base exp) → base**exp. Negative exponents return 0 (Python's
+        // int**-n is a float; floats on this path are a later breath).
+        self.register_native("pow", cat_method(), |_, _, args| {
+            let base = args[0].as_int();
+            let exp = args[1].as_int();
+            if exp < 0 {
+                Value::Int(0)
+            } else {
+                Value::Int(base.pow(exp as u32))
+            }
+        });
         // str_find — Rust-level substring search starting at index `from`.
         // (str_find s needle from) → int (index or -1). Whole search in
         // this Rust loop; no Form callback per byte, no Form recursion.

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1068,6 +1068,17 @@ export class Kernel {
       kind: "str",
       str: argStr(args, 0) + argStr(args, 1),
     }));
+    // pow — integer exponentiation in native code (no Form recursion).
+    // (pow base exp) → base**exp. Negative exponents return 0 (Python's
+    // int**-n is a float; floats on this path are a later breath).
+    this.registerNative("pow", catMethod(), (_k, args) => {
+      const base = argInt(args, 0);
+      const exp = argInt(args, 1);
+      if (exp < 0) return { kind: "int", int: 0 };
+      let result = 1;
+      for (let i = 0; i < exp; i++) result *= base;
+      return { kind: "int", int: result };
+    });
     // str_find — JS-level substring search starting at index `from`.
     // (str_find s needle from) → int (index or -1). Whole search in this
     // JS String.indexOf call; no Form callback per byte, no Form recursion.

--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -105,14 +105,6 @@
     ;; an honest unknown-op panic (head empty) for any op we haven't
     ;; reached yet.
 
-    ;; py-pow — integer exponentiation by repeated multiplication. No kernel
-    ;; `pow` native exists, so `**` computes in Form. Non-negative exponents
-    ;; only (Python's int**negative yields a float — a later breath when the
-    ;; interpreter grows floats on this path).
-    (defn py-pow (base exp acc)
-        (if (le exp 0) acc
-            (py-pow base (sub exp 1) (mul acc base))))
-
     (defn py-binop-apply (op left right)
         (if (str_eq op "+")  (add left right)
         (if (str_eq op "-")  (sub left right)
@@ -120,7 +112,7 @@
         (if (str_eq op "/")  (div left right)
         (if (str_eq op "%")  (mod left right)
         (if (str_eq op "//") (div left right)
-        (if (str_eq op "**") (py-pow left right 1)
+        (if (str_eq op "**") (pow left right)
             (do (trace "py-binop: unsupported op" op) (head (empty)))))))))))
 
     (defn py-compare-apply (op left right)


### PR DESCRIPTION
Per Urs: `**` must compute in the kernel, not via recursive Form. Adds a `pow` native to all three sibling kernels and rewires the python-bmf interpreter's `**` to call it, deleting the recursive `py-pow` from #2188.

- **rust** `i64::pow`, **go** + **ts** native loops. `(pow base exp)` → `base**exp`; negative exp → 0 (Python `int**-n` is a float — later breath).
- `python-bmf-eval.fk`: `py-binop-apply` `**` case → `(pow l r)`; `py-pow` removed.

Band stays 155000 (cell 20 unchanged), now computed natively. Full suite 181 ok, 0 divergent (Go/Rust/TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)