### PR TITLE
fix(playground): Evaluate sends mode `ast`, not the rejected `evaluate`

### DIFF
--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -1207,10 +1207,16 @@ export function FormPlayground() {
     setError(null);
     setResult(null);
     try {
+      // The API contract for `mode` is `ast | streaming | run`. The UI's
+      // "Intern" mode (internally "evaluate") interns the expression to a
+      // Recipe NodeID — that is the API's `ast`. Translate at the wire boundary
+      // so the two vocabularies can't silently drift into a 422 again (they had:
+      // the button posted "evaluate", which the API rejects).
+      const apiMode = mode === "run" ? "run" : "ast";
       const res = await fetch("/api/substrate/form", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ expression, mode }),
+        body: JSON.stringify({ expression, mode: apiMode }),
       });
       const data = await res.json();
       if (!res.ok) {

--- a/web/app/substrate/form/_components/FormPlayground.tsx
+++ b/web/app/substrate/form/_components/FormPlayground.tsx
@@ -1155,6 +1155,32 @@ function starterFromCell(cellRef: string | null): {
   };
 }
 
+// FastAPI error bodies are heterogeneous: `detail` is a plain string for an
+// HTTPException, but an array of `{type, loc, msg, input, ctx}` objects for a
+// 422 validation error. Coerce any shape to a readable string so the error
+// banner never receives a non-primitive React child (React #31).
+function detailToMessage(detail: unknown, status: number): string {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    const msg = detail
+      .map((d) => {
+        if (d && typeof d === "object") {
+          const item = d as { loc?: unknown[]; msg?: string };
+          const loc = Array.isArray(item.loc) ? item.loc.join(".") : "";
+          const m = typeof item.msg === "string" ? item.msg : JSON.stringify(d);
+          return loc ? `${loc}: ${m}` : m;
+        }
+        return String(d);
+      })
+      .filter(Boolean)
+      .join("; ");
+    if (msg) return msg;
+  } else if (detail && typeof detail === "object") {
+    return JSON.stringify(detail);
+  }
+  return `Evaluation failed (${status})`;
+}
+
 export function FormPlayground() {
   const searchParams = useSearchParams();
   const cellParam = searchParams.get("cell");
@@ -1220,7 +1246,11 @@ export function FormPlayground() {
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.detail || `Evaluation failed (${res.status})`);
+        // FastAPI's `detail` is a string for HTTPException but an ARRAY of
+        // `{type, loc, msg, ...}` objects for validation (422). Setting that
+        // array as `error` and rendering it crashed the page with React #31
+        // (objects are not valid as a React child). Always coerce to a string.
+        setError(detailToMessage(data.detail, res.status));
         return;
       }
       setResult(data);


### PR DESCRIPTION
## The break

Clicking **Evaluate** (Intern mode) on `/substrate/form` failed — every Intern evaluation returned **HTTP 422**. The button posts `{ expression, mode: "evaluate" }` to `/api/substrate/form`, but the API's `mode` contract is `^(ast|streaming|run)$`. The web and API vocabularies drifted: "Run" mode (`run`) still matched, so only the default Intern lane was broken.

Confirmed against production:
```
POST /api/substrate/form {"mode":"evaluate"} → 422 string_pattern_mismatch
POST /api/substrate/form {"mode":"ast"}      → 200 {"kind":"node_id","node_id":{…}}
```
`200` returns exactly the `node_id` shape `FormPlayground` already renders.

## The fix

Translate the UI's internal mode to the API contract **at the wire boundary** — Intern → `ast`, Run → `run` — with a comment so the two can't silently drift into a 422 again. The internal `EvalMode` and all UI state are untouched; one mapping line at the `fetch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)