### PR TITLE
feat(kernels): Record — mutable struct/object primitive (BML rung 2, Go/Rust/TS)

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -849,7 +849,43 @@ const (
 	// level via Math.fround, which the Rust+Go kernels don't do because
 	// host-language hardware always promotes to 64-bit in arithmetic.
 	VFloat
+	// VRecord — a mutable struct/object with identity (BML reference, rung 2).
+	// The first mutable Value the kernel carries; required for `self.x = v`.
+	// The Rec pointer gives shared mutable identity — two bindings to the same
+	// record see each other's mutations (object semantics, not value-copy).
+	VRecord
 )
+
+// Record — a mutable struct/object. Blueprint tags its type (class /
+// method-table NodeID); Fields is an ordered name→value map.
+type Record struct {
+	Blueprint NodeID
+	Fields    []recField
+}
+
+type recField struct {
+	name NameID
+	val  Value
+}
+
+func (r *Record) get(name NameID) (Value, bool) {
+	for i := len(r.Fields) - 1; i >= 0; i-- {
+		if r.Fields[i].name == name {
+			return r.Fields[i].val, true
+		}
+	}
+	return Value{Kind: VNull}, false
+}
+
+func (r *Record) set(name NameID, val Value) {
+	for i := range r.Fields {
+		if r.Fields[i].name == name {
+			r.Fields[i].val = val
+			return
+		}
+	}
+	r.Fields = append(r.Fields, recField{name: name, val: val})
+}
 
 // Value — runtime tagged union. List and Closure carry pointers; the rest
 // are inline. Kept as a flat struct so the walker's hot path is allocation-
@@ -863,6 +899,7 @@ type Value struct {
 	List  []Value
 	Cl    *Closure
 	Nid   NodeID
+	Rec   *Record
 }
 
 func (v Value) String() string {
@@ -891,6 +928,10 @@ func (v Value) String() string {
 	case VNodeID:
 		// Canonical substrate notation: @pkg.level.type.instance
 		return fmt.Sprintf("@%d.%d.%d.%d", v.Nid.Pkg, v.Nid.Level, v.Nid.Type, v.Nid.Inst)
+	case VRecord:
+		return fmt.Sprintf("<record @%d.%d.%d.%d #%dfields>",
+			v.Rec.Blueprint.Pkg, v.Rec.Blueprint.Level, v.Rec.Blueprint.Type,
+			v.Rec.Blueprint.Inst, len(v.Rec.Fields))
 	}
 	return "?"
 }
@@ -1075,6 +1116,45 @@ func (k *Kernel) registerNatives() {
 			result *= base
 		}
 		return Value{Kind: VInt, Int: result}
+	})
+	// --- struct/object primitive (BML reference, rung 2) -------------------
+	// A Record is the kernel's first MUTABLE value: a struct/object with
+	// identity. Every language's class/struct compiles onto these natives.
+	// Blueprint NodeID tags the type; fields are a name→value map.
+	//
+	// record_new — (record_new blueprint k1 v1 k2 v2 ...) → Record.
+	k.registerNative("record_new", catMethod(), func(k *Kernel, args []Value) Value {
+		rec := &Record{Blueprint: args[0].Nid}
+		i := 1
+		for i+1 < len(args) {
+			rec.set(k.internName(args[i].Str), args[i+1])
+			i += 2
+		}
+		return Value{Kind: VRecord, Rec: rec}
+	})
+	// record_get — (record_get rec "field") → value, or null if absent.
+	k.registerNative("record_get", catAccess(), func(k *Kernel, args []Value) Value {
+		v, _ := args[0].Rec.get(k.internName(args[1].Str))
+		return v
+	})
+	// record_set — (record_set rec "field" value) → the record (mutated in
+	// place; shared identity means all holders see it). BML's `self.x = v`.
+	k.registerNative("record_set", catMethod(), func(k *Kernel, args []Value) Value {
+		args[0].Rec.set(k.internName(args[1].Str), args[2])
+		return args[0]
+	})
+	// record_has — (record_has rec "field") → bool.
+	k.registerNative("record_has", catAccess(), func(k *Kernel, args []Value) Value {
+		_, ok := args[0].Rec.get(k.internName(args[1].Str))
+		return Value{Kind: VBool, Bool: ok}
+	})
+	// record_blueprint — (record_blueprint rec) → the blueprint NodeID.
+	k.registerNative("record_blueprint", catAccess(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VNodeID, Nid: args[0].Rec.Blueprint}
+	})
+	// record? — (record? v) → bool type predicate.
+	k.registerNative("record?", catAccess(), func(_ *Kernel, args []Value) Value {
+		return Value{Kind: VBool, Bool: args[0].Kind == VRecord}
 	})
 	// str_find — Go-level substring search starting at index `from`.
 	// Signature: (str_find s needle from) → int (index or -1). The whole

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -970,6 +970,33 @@ pub(crate) enum Value {
     List(Vec<Value>),
     Closure(Arc<Closure>),
     Nid(NodeID),
+    // Record — a mutable struct/object with identity. The first mutable Value
+    // the kernel carries; BML requires it for `self.x = v`. `blueprint` tags
+    // the record's type (its method-table / class NodeID); `fields` is an
+    // ordered name→value map. Arc<Mutex> gives shared mutable identity that is
+    // also Send (Value crosses thread boundaries in the parallel arms), so two
+    // bindings to the same record see each other's mutations — object
+    // semantics, not value-copy semantics.
+    Record(Arc<Mutex<Record>>),
+}
+
+#[derive(Debug)]
+pub(crate) struct Record {
+    blueprint: NodeID,
+    fields: Vec<(NameID, Value)>,
+}
+
+impl Record {
+    fn get(&self, name: NameID) -> Option<Value> {
+        self.fields.iter().rev().find(|(n, _)| *n == name).map(|(_, v)| v.clone())
+    }
+    fn set(&mut self, name: NameID, value: Value) {
+        if let Some(slot) = self.fields.iter_mut().find(|(n, _)| *n == name) {
+            slot.1 = value;
+        } else {
+            self.fields.push((name, value));
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -1067,6 +1094,17 @@ impl Value {
             }
             Value::Closure(c) => format!("<closure #{}>", c.name),
             Value::Nid(n) => format!("@{}.{}.{}.{}", n.pkg, n.level, n.ty, n.inst),
+            Value::Record(r) => {
+                let rec = r.lock().unwrap();
+                format!(
+                    "<record @{}.{}.{}.{} #{}fields>",
+                    rec.blueprint.pkg,
+                    rec.blueprint.level,
+                    rec.blueprint.ty,
+                    rec.blueprint.inst,
+                    rec.fields.len()
+                )
+            }
         }
     }
 
@@ -1411,6 +1449,67 @@ impl Kernel {
             } else {
                 Value::Int(base.pow(exp as u32))
             }
+        });
+        // --- struct/object primitive (BML reference, rung 2) ----------------
+        // A Record is the kernel's first MUTABLE value: a struct/object with
+        // identity. Every language's class/struct compiles onto these four
+        // natives. The blueprint NodeID tags the record's type (its class /
+        // method-table); fields are a name→value map.
+        //
+        // record_new — (record_new blueprint k1 v1 k2 v2 ...) → Record.
+        // The first arg is the blueprint NodeID; the rest are alternating
+        // field-name (string) and value pairs. Field names intern to NameIDs.
+        self.register_native("record_new", cat_method(), |k, _, args| {
+            let blueprint = args[0].as_nid();
+            let mut fields: Vec<(NameID, Value)> = Vec::new();
+            let mut i = 1;
+            while i + 1 < args.len() {
+                let name = k.intern_string(args[i].as_str()).inst;
+                fields.push((name, args[i + 1].clone()));
+                i += 2;
+            }
+            Value::Record(Arc::new(Mutex::new(Record { blueprint, fields })))
+        });
+        // record_get — (record_get rec "field") → value, or null if absent.
+        self.register_native("record_get", cat_access(), |k, _, args| {
+            let name = k.intern_string(args[1].as_str()).inst;
+            match &args[0] {
+                Value::Record(r) => r.lock().unwrap().get(name).unwrap_or(Value::Null),
+                _ => panic!("record_get: not a record: {:?}", args[0]),
+            }
+        });
+        // record_set — (record_set rec "field" value) → the record (mutated
+        // in place; shared identity means all holders see the change). This is
+        // the kernel's first in-place mutation — BML's `self.x = v`.
+        self.register_native("record_set", cat_method(), |k, _, args| {
+            let name = k.intern_string(args[1].as_str()).inst;
+            match &args[0] {
+                Value::Record(r) => {
+                    r.lock().unwrap().set(name, args[2].clone());
+                    args[0].clone()
+                }
+                _ => panic!("record_set: not a record: {:?}", args[0]),
+            }
+        });
+        // record_has — (record_has rec "field") → bool.
+        self.register_native("record_has", cat_access(), |k, _, args| {
+            let name = k.intern_string(args[1].as_str()).inst;
+            match &args[0] {
+                Value::Record(r) => Value::Bool(r.lock().unwrap().get(name).is_some()),
+                _ => Value::Bool(false),
+            }
+        });
+        // record_blueprint — (record_blueprint rec) → the blueprint NodeID
+        // (the record's class/type tag, for method dispatch by the lifter).
+        self.register_native("record_blueprint", cat_access(), |_, _, args| {
+            match &args[0] {
+                Value::Record(r) => Value::Nid(r.lock().unwrap().blueprint),
+                _ => panic!("record_blueprint: not a record: {:?}", args[0]),
+            }
+        });
+        // record? — (record? v) → bool. Type predicate so Form code can branch.
+        self.register_native("record?", cat_access(), |_, _, args| {
+            Value::Bool(matches!(&args[0], Value::Record(_)))
         });
         // str_find — Rust-level substring search starting at index `from`.
         // (str_find s needle from) → int (index or -1). Whole search in

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1004,6 +1004,8 @@ export class Kernel {
         return `@${nodeKey(v.nodeid)}`;
       case "ctor":
         return `${v.ctor_name}(${v.args.map((a) => this.render(a)).join(", ")})`;
+      case "record":
+        return `<record @${nodeKey(v.record.blueprint)} #${v.record.fields.length}fields>`;
     }
   }
 
@@ -1079,6 +1081,54 @@ export class Kernel {
       for (let i = 0; i < exp; i++) result *= base;
       return { kind: "int", int: result };
     });
+    // --- struct/object primitive (BML reference, rung 2) ----------------
+    // A Record is the kernel's first MUTABLE value: a struct/object with
+    // identity. Every language's class/struct compiles onto these natives.
+    // Blueprint NodeID tags the type; fields are a name→value map.
+    //
+    // record_new — (record_new blueprint k1 v1 k2 v2 ...) → record.
+    this.registerNative("record_new", catMethod(), (k, args) => {
+      const rec: Record = { blueprint: argNodeID(args, 0), fields: [] };
+      let i = 1;
+      while (i + 1 < args.length) {
+        recordSet(rec, k.internName(argStr(args, i)), args[i + 1]!);
+        i += 2;
+      }
+      return { kind: "record", record: rec };
+    });
+    // record_get — (record_get rec "field") → value, or null if absent.
+    this.registerNative("record_get", catAccess(), (k, args) => {
+      const r = args[0]!;
+      if (r.kind !== "record") throw new Error("record_get: not a record");
+      const v = recordGet(r.record, k.internName(argStr(args, 1)));
+      return v ?? { kind: "null" };
+    });
+    // record_set — (record_set rec "field" value) → the record (mutated in
+    // place; shared identity means all holders see it). BML's `self.x = v`.
+    this.registerNative("record_set", catMethod(), (k, args) => {
+      const r = args[0]!;
+      if (r.kind !== "record") throw new Error("record_set: not a record");
+      recordSet(r.record, k.internName(argStr(args, 1)), args[2]!);
+      return r;
+    });
+    // record_has — (record_has rec "field") → bool.
+    this.registerNative("record_has", catAccess(), (k, args) => {
+      const r = args[0]!;
+      if (r.kind !== "record") return { kind: "bool", bool: false };
+      const v = recordGet(r.record, k.internName(argStr(args, 1)));
+      return { kind: "bool", bool: v !== undefined };
+    });
+    // record_blueprint — (record_blueprint rec) → the blueprint NodeID.
+    this.registerNative("record_blueprint", catAccess(), (_k, args) => {
+      const r = args[0]!;
+      if (r.kind !== "record") throw new Error("record_blueprint: not a record");
+      return { kind: "nodeid", nodeid: r.record.blueprint };
+    });
+    // record? — (record? v) → bool type predicate.
+    this.registerNative("record?", catAccess(), (_k, args) => ({
+      kind: "bool",
+      bool: args[0]!.kind === "record",
+    }));
     // str_find — JS-level substring search starting at index `from`.
     // (str_find s needle from) → int (index or -1). Whole search in this
     // JS String.indexOf call; no Form callback per byte, no Form recursion.
@@ -2596,6 +2646,8 @@ export class Kernel {
         return `@${nodeKey(v.nodeid)}`;
       case "ctor":
         return `${v.ctor_name}(${v.args.map((a) => this.render(a)).join(", ")})`;
+      case "record":
+        return `<record @${nodeKey(v.record.blueprint)} #${v.record.fields.length}fields>`;
     }
   }
 }
@@ -2684,6 +2736,7 @@ export type Value =
   | { kind: "list"; list: Value[] }
   | { kind: "closure"; closure: Closure }
   | { kind: "nodeid"; nodeid: NodeID }
+  | { kind: "record"; record: Record } // mutable struct/object (BML rung 2)
   | { // #21 — INDUCTIVE-typed value (constructor application result)
       kind: "ctor";
       inductive: NodeID;
@@ -2691,6 +2744,34 @@ export type Value =
       ctor_index: number;
       args: Value[];
     };
+
+// Record — a mutable struct/object with identity (BML reference, rung 2).
+// The first mutable Value the kernel carries; required for `self.x = v`. A
+// JS object reference gives shared mutable identity — two bindings to the same
+// record see each other's mutations (object semantics, not value-copy).
+// blueprint tags the record's type (class / method-table NodeID); fields is
+// an ordered name→value map.
+export interface Record {
+  blueprint: NodeID;
+  fields: { name: NameID; val: Value }[];
+}
+
+export function recordGet(r: Record, name: NameID): Value | undefined {
+  for (let i = r.fields.length - 1; i >= 0; i--) {
+    if (r.fields[i]!.name === name) return r.fields[i]!.val;
+  }
+  return undefined;
+}
+
+export function recordSet(r: Record, name: NameID, val: Value): void {
+  for (const f of r.fields) {
+    if (f.name === name) {
+      f.val = val;
+      return;
+    }
+  }
+  r.fields.push({ name, val });
+}
 
 export interface Closure {
   readonly name: NameID;

--- a/form/form-stdlib/tests/record-band.fk
+++ b/form/form-stdlib/tests/record-band.fk
@@ -1,0 +1,54 @@
+; tests/record-band.fk — struct/object kernel primitive (BML reference, rung 2).
+;
+; preludes: form-stdlib/core.fk
+;
+; Records are the kernel's first MUTABLE value — a struct/object with identity.
+; Every language's class/struct compiles onto record_new / record_get /
+; record_set / record_has / record_blueprint / record? (kernel natives, present
+; in all three sibling kernels). The blueprint NodeID tags the record's type.
+;
+; Band verdict: 176 when every assertion holds across Go, Rust, TypeScript.
+;   - field read after construct (10 + 20)
+;   - field update in place (x: 10 → 99)
+;   - shared mutable identity: r2 = r; set via r2 visible via r (y → 77)
+;   - final sum 99 + 77 = 176
+;
+; The strange-minimal edge that covers the most: aliasing + mutation. If
+; records were value-copied (not reference identity), the r2 mutation would
+; not show through r and the sum would be 119, not 176 — so this one cell
+; proves object semantics, not just a field map.
+;
+; Note: and/or take bool operands (the TS kernel enforces this strictly), so
+; every flag below is a comparison/predicate result, combined with and, and
+; only collapsed to the int sum at the very end.
+
+(do
+    (let bp (make_nodeid 1 2 99 9001))
+    (let r (record_new bp "x" 10 "y" 20))
+
+    ;; basic read + has (record_has returns bool; eq returns bool)
+    (let read-ok
+        (and (eq (record_get r "x") 10)
+             (and (eq (record_get r "y") 20)
+                  (and (record_has r "x")
+                       (not (record_has r "z"))))))
+
+    ;; in-place update
+    (record_set r "x" 99)
+    (let update-ok (eq (record_get r "x") 99))
+
+    ;; type predicate
+    (let type-ok (and (record? r) (not (record? 5))))
+
+    ;; shared mutable identity — the load-bearing assertion
+    (let r2 r)
+    (record_set r2 "y" 77)
+    (let identity-ok (eq (record_get r "y") 77))
+
+    ;; blueprint round-trips
+    (let bp-ok (node_eq (record_blueprint r) bp))
+
+    ;; value carry: 99 + 77 = 176 only when all of the above held
+    (if (and read-ok (and update-ok (and type-ok (and identity-ok bp-ok))))
+        (add (record_get r "x") (record_get r "y"))
+        0))


### PR DESCRIPTION
The kernel's **first mutable value**: a struct/object with identity. BML requires it for `self.x = v`; every language's class/struct compiles onto it. Sibling-parity across all three kernels.

Rung 2 of the [struct/exceptions plan](../blob/main/kernels/KERNEL_PRIMITIVES_STRUCT_AND_EXCEPTIONS.md).

## What
- **Value gains a Record variant**: `{ blueprint: NodeID, fields: name→value }`. Rust `Arc<Mutex>` (Send — the parallel arms cross threads), Go `*Record`, TS object ref. All three give **shared mutable identity** — object semantics, not value-copy. The blueprint NodeID tags the type for method dispatch.
- **Six natives per kernel**: `record_new`, `record_get`, `record_set` (the kernel's first in-place mutation), `record_has`, `record_blueprint`, `record?`.
- display/render arms for the new variant in all three.

## Proof
`form-stdlib/tests/record-band.fk` → **176** three-way. The load-bearing cell: `r2 = r; record_set r2 "y" 77` shows through `r` — proving reference identity, not a copied field map (value-copy would give 119). Full suite **182 ok, 0 divergent** (Go/Rust/TS).

## Scope
No new walk arm yet — these are natives via FNCALL, the minimal core. Executable METHOD/ACCESS arms + Python `class` lifting are the next rungs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)