### PR TITLE
feat(kernels): methods on the blueprint (BML/NUMS rung 2b, Go/Rust/TS)

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -405,6 +405,10 @@ type Kernel struct {
 	f64Idx map[uint64]uint32
 	natives    map[NameID]NativeEntry
 	envNatives map[NameID]EnvAwareNativeEntry
+	// methods — the blueprint method table (BML/NUMS reference: methods live
+	// on the blueprint/type, shared by all instances, name-dispatched). Keyed
+	// by (blueprint, method-name) → the method's Closure.
+	methods map[methodKey]*Closure
 	// jitAliases: Form-function-name → native-name redirect. When a
 	// function call's name is in this map, the walker substitutes the
 	// aliased name before native lookup. Lets a Form recipe DEFINE an
@@ -456,6 +460,7 @@ func NewKernel() *Kernel {
 		f64Idx:     make(map[uint64]uint32),
 		natives:       make(map[NameID]NativeEntry),
 		envNatives:    make(map[NameID]EnvAwareNativeEntry),
+		methods:       make(map[methodKey]*Closure),
 		jitAliases:    make(map[NameID]NameID),
 		jitCompiledGo: make(map[string]func([]int64) int64),
 	}
@@ -990,6 +995,12 @@ type Closure struct {
 	Env    *Frame
 }
 
+// methodKey — (blueprint, method-name) key for the blueprint method table.
+type methodKey struct {
+	blueprint NodeID
+	name      NameID
+}
+
 // ---------------------------------------------------------------------------
 // Frame — scope primitive
 // ---------------------------------------------------------------------------
@@ -1155,6 +1166,62 @@ func (k *Kernel) registerNatives() {
 	// record? — (record? v) → bool type predicate.
 	k.registerNative("record?", catAccess(), func(_ *Kernel, args []Value) Value {
 		return Value{Kind: VBool, Bool: args[0].Kind == VRecord}
+	})
+	// --- methods on the blueprint (BML/NUMS reference, rung 2b) ----------
+	// Methods live on the blueprint/type, shared by all records of that type,
+	// name-dispatched. The keystone that makes a Record a real object.
+	//
+	// method_define — (method_define blueprint "name" closure) → blueprint.
+	k.registerNative("method_define", catMethod(), func(k *Kernel, args []Value) Value {
+		if args[2].Kind != VClosure {
+			panic("method_define: third arg must be a closure")
+		}
+		k.methods[methodKey{args[0].Nid, k.internName(args[1].Str)}] = args[2].Cl
+		return args[0]
+	})
+	// method_has — (method_has record-or-blueprint "name") → bool.
+	k.registerNative("method_has", catAccess(), func(k *Kernel, args []Value) Value {
+		var bp NodeID
+		switch args[0].Kind {
+		case VRecord:
+			bp = args[0].Rec.Blueprint
+		case VNodeID:
+			bp = args[0].Nid
+		default:
+			return Value{Kind: VBool, Bool: false}
+		}
+		_, ok := k.methods[methodKey{bp, k.internName(args[1].Str)}]
+		return Value{Kind: VBool, Bool: ok}
+	})
+	// method_invoke — (method_invoke record "name" arg1 arg2 ...) → value.
+	// Dispatches by the record's blueprint; the method's FIRST param is the
+	// receiver (Python `self` convention), remaining params bind to call args.
+	k.registerNative("method_invoke", catMethod(), func(k *Kernel, args []Value) Value {
+		if args[0].Kind != VRecord {
+			panic("method_invoke: first arg must be a record")
+		}
+		rec := args[0].Rec
+		key := methodKey{rec.Blueprint, k.internName(args[1].Str)}
+		cl, ok := k.methods[key]
+		if !ok {
+			panic(fmt.Sprintf("method_invoke: no method '%s' on blueprint @%d.%d.%d.%d",
+				args[1].Str, rec.Blueprint.Pkg, rec.Blueprint.Level,
+				rec.Blueprint.Type, rec.Blueprint.Inst))
+		}
+		callArgs := args[2:]
+		if len(cl.Params) == 0 {
+			panic(fmt.Sprintf("method '%s' must declare a receiver param (self)", args[1].Str))
+		}
+		if len(callArgs) != len(cl.Params)-1 {
+			panic(fmt.Sprintf("method '%s' wants %d args, got %d",
+				args[1].Str, len(cl.Params)-1, len(callArgs)))
+		}
+		call := NewCallFrame(cl.Env, len(cl.Params))
+		call.Bind(cl.Params[0], args[0]) // receiver
+		for i, p := range cl.Params[1:] {
+			call.Bind(p, callArgs[i])
+		}
+		return k.walk(cl.Body, call)
 	})
 	// str_find — Go-level substring search starting at index `from`.
 	// Signature: (str_find s needle from) → int (index or -1). The whole

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -236,6 +236,12 @@ pub(crate) struct Kernel {
     next_inst: u32,
     natives: HashMap<NameID, NativeEntry>,
     env_natives: HashMap<NameID, EnvAwareNativeEntry>,
+    // methods — the blueprint method table (BML/NUMS reference: methods live
+    // on the blueprint/type, shared by all instances, name-dispatched). Keyed
+    // by (blueprint NodeID, method-name NameID) → the method's Closure. A
+    // record's blueprint tag selects its method set; method_invoke binds
+    // `self` to the receiver record.
+    methods: HashMap<(NodeID, NameID), Arc<Closure>>,
     // jit_aliases: Form-function-name → native-name redirect.
     // When a function call's name is in this map, the walker substitutes
     // the aliased name before native lookup. Lets a Form recipe DEFINE
@@ -533,6 +539,7 @@ impl Kernel {
             next_inst: 1,
             natives: HashMap::new(),
             env_natives: HashMap::new(),
+            methods: HashMap::new(),
             jit_aliases: HashMap::new(),
             jit_compiled: HashMap::new(),
             active_roots: Vec::new(),
@@ -887,6 +894,7 @@ impl Kernel {
             next_inst: self.next_inst,
             natives: self.natives.clone(),
             env_natives: self.env_natives.clone(),
+            methods: self.methods.clone(),
             jit_aliases: self.jit_aliases.clone(),
             // Arc clones — Library handles stay shared across the kernel and
             // its workers; the .so stays mapped for the duration.
@@ -1510,6 +1518,87 @@ impl Kernel {
         // record? — (record? v) → bool. Type predicate so Form code can branch.
         self.register_native("record?", cat_access(), |_, _, args| {
             Value::Bool(matches!(&args[0], Value::Record(_)))
+        });
+        // --- methods on the blueprint (BML/NUMS reference, rung 2b) ---------
+        // Methods live on the blueprint/type, not on instances — shared by all
+        // records of that type, name-dispatched. The keystone that makes a
+        // Record a real object: obj.m(args) works.
+        //
+        // method_define — (method_define blueprint "name" closure) → blueprint.
+        // Registers the closure under (blueprint, name) in the method table.
+        self.register_native("method_define", cat_method(), |k, _, args| {
+            let blueprint = args[0].as_nid();
+            let name = k.intern_string(args[1].as_str()).inst;
+            let cl = match &args[2] {
+                Value::Closure(c) => c.clone(),
+                _ => panic!("method_define: third arg must be a closure"),
+            };
+            k.methods.insert((blueprint, name), cl);
+            args[0].clone()
+        });
+        // method_has — (method_has record-or-blueprint "name") → bool. Accepts
+        // either a record (uses its blueprint) or a blueprint NodeID directly.
+        self.register_native("method_has", cat_access(), |k, _, args| {
+            let blueprint = match &args[0] {
+                Value::Record(r) => r.lock().unwrap().blueprint,
+                Value::Nid(n) => *n,
+                _ => return Value::Bool(false),
+            };
+            let name = k.intern_string(args[1].as_str()).inst;
+            Value::Bool(k.methods.contains_key(&(blueprint, name)))
+        });
+        // method_invoke — (method_invoke record "name" arg1 arg2 ...) → value.
+        // Dispatches by the record's blueprint, binds `self` = record (the
+        // structural+behavioral base; dual-base separation is rung 2d), binds
+        // the method's declared params to the remaining args, walks the body
+        // in a frame extending the method closure's captured env.
+        self.register_native("method_invoke", cat_method(), |k, a, args| {
+            let rec = match &args[0] {
+                Value::Record(r) => r.clone(),
+                _ => panic!("method_invoke: first arg must be a record"),
+            };
+            let blueprint = rec.lock().unwrap().blueprint;
+            let name_id = k.intern_string(args[1].as_str()).inst;
+            let cl = k
+                .methods
+                .get(&(blueprint, name_id))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "method_invoke: no method '{}' on blueprint @{}.{}.{}.{}",
+                        args[1].as_str(),
+                        blueprint.pkg,
+                        blueprint.level,
+                        blueprint.ty,
+                        blueprint.inst
+                    )
+                })
+                .clone();
+            // The method's FIRST param is the receiver (Python `self`
+            // convention); the remaining params bind to the call args
+            // (args[2..]). So a `def get(self)` method is invoked with zero
+            // call args, and the receiver fills param 0.
+            let call_args = &args[2..];
+            if cl.params.is_empty() {
+                panic!(
+                    "method '{}' must declare a receiver param (self)",
+                    args[1].as_str()
+                );
+            }
+            if call_args.len() != cl.params.len() - 1 {
+                panic!(
+                    "method '{}' wants {} args, got {}",
+                    args[1].as_str(),
+                    cl.params.len() - 1,
+                    call_args.len()
+                );
+            }
+            let call_frame = a.new_frame_with_capacity(Some(cl.env), cl.params.len());
+            // param 0 = receiver; params 1.. = the call args in order.
+            a.bind(call_frame, cl.params[0], Value::Record(rec.clone()));
+            for (i, p) in cl.params[1..].iter().enumerate() {
+                a.bind(call_frame, *p, call_args[i].clone());
+            }
+            walk(k, a, cl.body, call_frame)
         });
         // str_find — Rust-level substring search starting at index `from`.
         // (str_find s needle from) → int (index or -1). Whole search in

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -485,6 +485,10 @@ export class Kernel {
   // Form-shape a native expresses, alongside the FNCALL arm.
   natives = new Map<NameID, NativeEntry>();
   envNatives = new Map<NameID, EnvAwareNativeEntry>();
+  // methods — the blueprint method table (BML/NUMS reference: methods live on
+  // the blueprint/type, shared by all instances, name-dispatched). Keyed by
+  // `${nodeKey(blueprint)}:${nameID}` → the method's Closure.
+  methods = new Map<string, Closure>();
 
   // jitAliases — Form-function-name → native-name redirect. When a
   // function call's name is in this map, the walker substitutes the
@@ -1129,6 +1133,65 @@ export class Kernel {
       kind: "bool",
       bool: args[0]!.kind === "record",
     }));
+    // --- methods on the blueprint (BML/NUMS reference, rung 2b) ----------
+    // Methods live on the blueprint/type, shared by all records of that type,
+    // name-dispatched. The keystone that makes a Record a real object.
+    //
+    // method_define — (method_define blueprint "name" closure) → blueprint.
+    this.registerNative("method_define", catMethod(), (k, args) => {
+      const cl = args[2]!;
+      if (cl.kind !== "closure") {
+        throw new Error("method_define: third arg must be a closure");
+      }
+      const bp = argNodeID(args, 0);
+      const key = `${nodeKey(bp)}:${k.internName(argStr(args, 1))}`;
+      k.methods.set(key, cl.closure);
+      return args[0]!;
+    });
+    // method_has — (method_has record-or-blueprint "name") → bool.
+    this.registerNative("method_has", catAccess(), (k, args) => {
+      const a0 = args[0]!;
+      let bp: NodeID;
+      if (a0.kind === "record") bp = a0.record.blueprint;
+      else if (a0.kind === "nodeid") bp = a0.nodeid;
+      else return { kind: "bool", bool: false };
+      const key = `${nodeKey(bp)}:${k.internName(argStr(args, 1))}`;
+      return { kind: "bool", bool: k.methods.has(key) };
+    });
+    // method_invoke — (method_invoke record "name" arg1 ...) → value.
+    // Dispatches by the record's blueprint; the method's FIRST param is the
+    // receiver (Python `self`), remaining params bind to call args.
+    this.registerNative("method_invoke", catMethod(), (k, args) => {
+      const a0 = args[0]!;
+      if (a0.kind !== "record") {
+        throw new Error("method_invoke: first arg must be a record");
+      }
+      const bp = a0.record.blueprint;
+      const key = `${nodeKey(bp)}:${k.internName(argStr(args, 1))}`;
+      const cl = k.methods.get(key);
+      if (!cl) {
+        throw new Error(
+          `method_invoke: no method '${argStr(args, 1)}' on blueprint @${nodeKey(bp)}`,
+        );
+      }
+      const callArgs = args.slice(2);
+      if (cl.params.length === 0) {
+        throw new Error(
+          `method '${argStr(args, 1)}' must declare a receiver param (self)`,
+        );
+      }
+      if (callArgs.length !== cl.params.length - 1) {
+        throw new Error(
+          `method '${argStr(args, 1)}' wants ${cl.params.length - 1} args, got ${callArgs.length}`,
+        );
+      }
+      const callFrame = new Frame(cl.env);
+      callFrame.bind(cl.params[0]!, a0); // receiver
+      for (let i = 0; i < callArgs.length; i++) {
+        callFrame.bind(cl.params[i + 1]!, callArgs[i]!);
+      }
+      return walk(k, cl.body, callFrame);
+    });
     // str_find — JS-level substring search starting at index `from`.
     // (str_find s needle from) → int (index or -1). Whole search in this
     // JS String.indexOf call; no Form callback per byte, no Form recursion.

--- a/form/form-stdlib/tests/method-band.fk
+++ b/form/form-stdlib/tests/method-band.fk
@@ -1,0 +1,51 @@
+; tests/method-band.fk — methods on the blueprint (BML/NUMS reference, rung 2b).
+;
+; preludes: form-stdlib/core.fk
+;
+; Methods live on the blueprint/type (NUMS-Go: NamedRecipes on the Blueprint),
+; shared by all records of that type, name-dispatched. method_define registers
+; a closure under (blueprint, name); method_invoke dispatches by the record's
+; blueprint and binds the closure's first param as the receiver (Python `self`
+; convention). This is the keystone that turns a Record into a real object —
+; `obj.method(args)` works, every language's class compiles onto it.
+;
+; Band verdict: 116 when every assertion holds across Go, Rust, TypeScript.
+;   - method reads a field through `self` (get → 10)
+;   - method mutates `self` in place, persists (bump+5 → 15, stays 15)
+;   - method_has true for defined, false for absent
+;   - TWO instances share the blueprint's methods but keep SEPARATE state
+;     (c2 bumps to 101 while c stays 15) — proving methods-on-type + per-
+;     instance data, the core of the object model
+;   - final 15 + 101 = 116
+
+(do
+    (let Counter (make_nodeid 1 2 99 9100))
+
+    ;; method get(self) = self.n
+    (defn counter-get (self) (record_get self "n"))
+    ;; method bump(self, by) = self.n += by; return self.n
+    (defn counter-bump (self by)
+        (do
+            (record_set self "n" (add (record_get self "n") by))
+            (record_get self "n")))
+
+    (method_define Counter "get" counter-get)
+    (method_define Counter "bump" counter-bump)
+
+    ;; instance c starts at 10
+    (let c (record_new Counter "n" 10))
+    (let get-ok (eq (method_invoke c "get") 10))
+    (let bump-ok (eq (method_invoke c "bump" 5) 15))
+    (let persist-ok (eq (method_invoke c "get") 15))
+    (let has-ok (and (method_has c "get") (not (method_has c "nope"))))
+
+    ;; instance c2 shares methods, separate state
+    (let c2 (record_new Counter "n" 100))
+    (method_invoke c2 "bump" 1)
+    (let independence-ok
+        (and (eq (method_invoke c2 "get") 101)
+             (eq (method_invoke c "get") 15)))
+
+    (if (and get-ok (and bump-ok (and persist-ok (and has-ok independence-ok))))
+        (add (method_invoke c "get") (method_invoke c2 "get"))
+        0))


### PR DESCRIPTION
The keystone that makes a Record a real object: **`obj.method(args)` works.** Methods live on the blueprint/type — shared by all instances, name-dispatched — exactly as NUMS-Go puts NamedRecipes on the Blueprint and BML dispatches via the interface. Sibling-parity across all three kernels.

Rung 2b of [OBJECT_MODEL_BML_NUMS.md](../blob/main/kernels/OBJECT_MODEL_BML_NUMS.md).

## What
- Kernel gains a **method table** keyed `(blueprint NodeID, method NameID) → Closure` (Rust HashMap, Go map[methodKey], TS Map).
- Three natives per kernel:
  - `method_define(blueprint, "name", closure)` → registers the method.
  - `method_has(record-or-blueprint, "name")` → bool.
  - `method_invoke(record, "name", args...)` → dispatches by the record's blueprint, binds the closure's **first param as the receiver** (Python `self`), binds remaining params to call args, walks the body in the method closure's captured env.

## Proof
`form-stdlib/tests/method-band.fk` → **116** three-way. Proves `self` field read, in-place `self` mutation that persists, `method_has` true/false, and — the load-bearing cell — two instances **share the blueprint's methods but keep separate state** (c2→101 while c stays 15). Methods-on-type + per-instance data = the object model's core. Full suite **183 ok, 0 divergent** (Go/Rust/TS).

## Next
Wire Python `class` onto these natives (Form-side), then interface_id decoupling (2c) and dual-base dispatch + delegation (2d) where **multiple inheritance emerges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)