### PR TITLE
feat(form): Python class runs on the Form kernel (rung 2b-Python)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -97,6 +97,68 @@
     (defn py-closure-body   (c) (nth c 3))
     (defn py-closure-env    (c) (nth c 4))
 
+    ;; --- classes / objects (rung 2b-Python, BML/NUMS reference) ----------
+    ;; Runtime representation, built on the kernel's mutable Record value:
+    ;;   class value  = a record on CLASS-BP holding each method as a field
+    ;;                  (name → py-closure) plus "__name__".
+    ;;   instance     = a record on INSTANCE-BP holding data fields plus
+    ;;                  "__class__" → the class record.
+    ;; Methods are py-closures (the eval's own closure shape) whose first
+    ;; param is the receiver (Python `self`). Dispatch reads the instance's
+    ;; "__class__" and looks the method up by name on the class record.
+    (let CLASS-BP (make_nodeid 1 2 99 9500))
+    (let INSTANCE-BP (make_nodeid 1 2 99 9501))
+
+    ;; py-class-build — fold a list of method PY-BMF-DEF recipes into a class
+    ;; record. Each DEF becomes a (method-name → py-closure) field. The class
+    ;; record's blueprint is CLASS-BP. The captured env is the def-site env so
+    ;; methods close over module-level names.
+    (defn py-class-build-loop (defs env rec)
+        (if (nil? defs) rec
+            (do
+                (let d (head defs))
+                (let dk (node_children d))
+                (let n (len dk))
+                (let mname (node_value (head dk)))
+                (let body (py-last dk))
+                (let param-leaves (py-take (tail dk) (sub n 2)))
+                (let pms (py-collect-params-loop param-leaves (len param-leaves) (empty)))
+                (let cl (py-closure mname pms body env))
+                (record_set rec mname cl)
+                (py-class-build-loop (tail defs) env rec))))
+
+    (defn py-class-build (name defs env)
+        (do
+            (let rec (record_new CLASS-BP "__name__" name))
+            (py-class-build-loop defs env rec)))
+
+    (defn py-class? (v) (and (record? v) (node_eq (record_blueprint v) CLASS-BP)))
+    (defn py-instance? (v) (and (record? v) (node_eq (record_blueprint v) INSTANCE-BP)))
+
+    ;; py-instantiate — construct an instance of a class record: a fresh
+    ;; INSTANCE-BP record with "__class__" set, then run __init__ if present
+    ;; (binding self + the call args). Returns the instance.
+    (defn py-call-method (cls instance mname arg-values)
+        ;; Look up the method py-closure on the class, bind self=instance +
+        ;; args, walk the body. The closure's first param is the receiver.
+        (do
+            (let cl (record_get cls mname))
+            (let pms (py-closure-params cl))
+            (let body (py-closure-body cl))
+            ;; bind self (param 0) = instance, then the rest = arg-values
+            (let env0 (py-env-extend (py-closure-env cl) (head pms) instance))
+            (let call-env (py-bind-params (tail pms) arg-values env0))
+            (py-eval body call-env)))
+
+    (defn py-instantiate (cls arg-values)
+        (do
+            (let instance (record_new INSTANCE-BP "__class__" cls))
+            (if (record_has cls "__init__")
+                (do
+                    (py-call-method cls instance "__init__" arg-values)
+                    instance)
+                instance)))
+
     ;; ---- binop dispatch ----------------------------------------------
     ;;
     ;; PY-BMF-BINOP holds three children: left-recipe, op-string-leaf,
@@ -335,8 +397,24 @@
                     (let pms (py-collect-params-loop param-leaves (len param-leaves) (empty)))
                     (let closure (py-closure name pms body env))
                     (py-stmt-result closure (py-env-extend env name closure)))
+            (if (node_eq cat PY-BMF-CLASS)
+                (do
+                    ;; CLASS children: name-leaf, method-DEF-recipes... Build a
+                    ;; class record (methods as fields) and bind NAME in env.
+                    (let cname (node_value (head kids)))
+                    (let cls (py-class-build cname (tail kids) env))
+                    (py-stmt-result cls (py-env-extend env cname cls)))
+            (if (node_eq cat PY-BMF-ATTR-ASSIGN)
+                (do
+                    ;; ATTR-ASSIGN children: obj-recipe, attr-leaf, value-recipe.
+                    ;; obj.attr = value → record_set on the evaluated object.
+                    (let obj (py-eval (nth kids 0) env))
+                    (let attr (node_value (nth kids 1)))
+                    (let value (py-eval (nth kids 2) env))
+                    (record_set obj attr value)
+                    (py-stmt-result value env))
                 ;; Default: expression statement — eval, env unchanged.
-                (py-stmt-result (py-eval recipe env) env))))))))
+                (py-stmt-result (py-eval recipe env) env))))))))))
 
     (defn py-eval-module-loop (statements env last-value)
         (if (nil? statements) last-value
@@ -455,16 +533,38 @@
                     (if (str_eq callee-name "range")
                         (py-range arg-values)
                         (do
-                            (let closure (py-env-lookup env callee-name))
-                            (let captured-with-self
-                                (py-env-extend (py-closure-env closure)
-                                               (py-closure-name closure)
-                                               closure))
-                            (let call-env (py-bind-params
-                                            (py-closure-params closure)
-                                            arg-values
-                                            captured-with-self))
-                            (py-eval (py-closure-body closure) call-env))))
+                            (let callee (py-env-lookup env callee-name))
+                            ;; If the callee is a class, construct an instance
+                            ;; (record_new + __init__). Otherwise it's a normal
+                            ;; function closure — bind self-name for recursion.
+                            (if (py-class? callee)
+                                (py-instantiate callee arg-values)
+                                (do
+                                    (let captured-with-self
+                                        (py-env-extend (py-closure-env callee)
+                                                       (py-closure-name callee)
+                                                       callee))
+                                    (let call-env (py-bind-params
+                                                    (py-closure-params callee)
+                                                    arg-values
+                                                    captured-with-self))
+                                    (py-eval (py-closure-body callee) call-env))))))
+            (if (node_eq cat PY-BMF-ATTR)
+                (do
+                    ;; ATTR children: obj-recipe, attr-leaf. obj.attr →
+                    ;; record_get on the evaluated object (data field).
+                    (let obj (py-eval (nth kids 0) env))
+                    (record_get obj (node_value (nth kids 1))))
+            (if (node_eq cat PY-BMF-METHOD-CALL)
+                (do
+                    ;; METHOD-CALL children: obj-recipe, method-name-leaf,
+                    ;; arg-recipes... Resolve the method on the instance's
+                    ;; class and invoke with self=obj.
+                    (let obj (py-eval (nth kids 0) env))
+                    (let mname (node_value (nth kids 1)))
+                    (let arg-values (py-eval-args (tail (tail kids)) env))
+                    (let cls (record_get obj "__class__"))
+                    (py-call-method cls obj mname arg-values))
             (if (node_eq cat PY-BMF-LIST)
                 ;; LIST children: element-recipes. Value is a Form list
                 ;; of evaluated elements, in source order.
@@ -510,7 +610,7 @@
                     ;; category number so the next breath knows which
                     ;; arm to add.
                     (trace "py-eval: unimplemented category" cat)
-                    (head (empty)))))))))))))))))))))
+                    (head (empty)))))))))))))))))))))))
 
     ;; Surface for callers. py-run takes a module recipe and returns its
     ;; value. py-eval and py-eval-statement are exposed so band-tests

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -231,6 +231,13 @@
     ;; node, and loop (so `xs[i][j]` chains). This matches Python's
     ;; left-to-right subscript chaining.
 
+    ;; lift-subscript-tail — fold postfix trailers onto a base expression:
+    ;;   base [ idx ]         → PY-BMF-SUBSCRIPT(base, idx)
+    ;;   base . attr          → PY-BMF-ATTR(base, "attr")          (record_get)
+    ;;   base . method ( args ) → PY-BMF-METHOD-CALL(base, "method", args...)
+    ;; Chains left-to-right (a.b.c, xs[i].m(), obj.field[k]). The `.`
+    ;; trailer peeks one token past the name: `(` means a method call, else a
+    ;; plain attribute read.
     (defn lift-subscript-tail (base tokens)
         (if (and (not (nil? tokens))
                  (tok-op? (head tokens) "["))
@@ -244,7 +251,29 @@
                             (list base (lift-recipe idx-result)))
                         (tail after))
                     (lift-result base after)))
-            (lift-result base tokens)))
+        (if (and (not (nil? tokens))
+                 (tok-op? (head tokens) "."))
+            (do
+                (let after-dot (tail tokens))
+                (let attr-name (tok-value (head after-dot)))
+                (let after-name (tail after-dot))
+                (if (and (not (nil? after-name))
+                         (tok-op? (head after-name) "("))
+                    ;; method call: obj.method(args)
+                    (do
+                        (let args-result (lift-args (tail after-name)))
+                        (lift-subscript-tail
+                            (intern_node PY-BMF-METHOD-CALL
+                                (cons base
+                                      (cons (intern_trivial_string attr-name)
+                                            (lift-recipe args-result))))
+                            (lift-rest args-result)))
+                    ;; attribute read: obj.attr
+                    (lift-subscript-tail
+                        (intern_node PY-BMF-ATTR
+                            (list base (intern_trivial_string attr-name)))
+                        after-name)))
+            (lift-result base tokens))))
 
     ;; --- primary expression ----------------------------------------
     ;;
@@ -617,6 +646,12 @@
 
     ;; assignment-statement tokens: `NAME = EXPR...`. The cpython-rule
     ;; classifier already filtered this to "assignment" iff tokens[1]="=".
+    ;;
+    ;; Attribute assignment `obj.attr = expr` (e.g. `self.n = n`) also
+    ;; classifies as kind "expr" / rule "star_expressions" — the lifter
+    ;; catches it (stmt-attr-assign? / lift-attr-assign) before the bare-expr
+    ;; arm and emits PY-BMF-ATTR-ASSIGN(obj-recipe, "attr", value-recipe),
+    ;; which the eval routes to record_set.
 
     (defn lift-assign (statement-tree)
         (do
@@ -625,6 +660,44 @@
             (let value (lift-recipe (lift-expr (drop 2 tokens))))
             (intern_node PY-BMF-ASSIGN
                 (list (intern_trivial_string name) value))))
+
+    ;; stmt-attr-assign? — 1 iff tokens are `NAME . NAME = EXPR...` (object
+    ;; attribute assignment). Distinct from plain `NAME = EXPR` and from a
+    ;; bare expression. We require: name, ".", name, "=" in the first four
+    ;; tokens. (Chained `a.b.c = v` is a later breath; v1 handles one dot.)
+    (defn stmt-attr-assign? (statement-tree)
+        (do
+            (let t (python-statement-tree-tokens statement-tree))
+            (if (lt (len t) 5) 0
+                (if (and (tok-name? (nth t 0))
+                         (and (tok-op? (nth t 1) ".")
+                              (and (tok-name? (nth t 2))
+                                   (tok-op? (nth t 3) "="))))
+                    1 0))))
+
+    (defn lift-attr-assign (statement-tree)
+        (do
+            (let t (python-statement-tree-tokens statement-tree))
+            ;; obj is token 0 (an identifier); attr is token 2; value is drop 4.
+            (let obj (lift-recipe (lift-primary (list (nth t 0)))))
+            (let attr (tok-value (nth t 2)))
+            (let value (lift-recipe (lift-expr (drop 4 t))))
+            (intern_node PY-BMF-ATTR-ASSIGN
+                (list obj (intern_trivial_string attr) value))))
+
+    ;; class-statement: `class NAME :` with method `def`s as children. Lifts
+    ;; to PY-BMF-CLASS(name-leaf, method-def-recipes...). The eval arm builds
+    ;; a class value (methods keyed by name) and binds NAME in the env; calling
+    ;; NAME(args) constructs an instance record and runs __init__.
+    (defn lift-class (statement-tree)
+        (do
+            (let tokens (python-statement-tree-tokens statement-tree))
+            (let children (python-statement-tree-children statement-tree))
+            ;; tokens[0]=class, tokens[1]=name
+            (let name (tok-value (nth tokens 1)))
+            (let method-recipes (lift-statements children))
+            (intern_node PY-BMF-CLASS
+                (cons (intern_trivial_string name) method-recipes))))
 
     ;; expr-statement: just an expression in statement position.
 
@@ -742,12 +815,14 @@
             (if (str_eq kind "return")           (lift-return statement-tree)
             (if (str_eq kind "while")            (lift-while statement-tree)
             (if (str_eq kind "for")              (lift-for statement-tree)
+            (if (str_eq kind "class")            (lift-class statement-tree)
             (if (str_eq rule "assignment")       (lift-assign statement-tree)
+            (if (eq (stmt-attr-assign? statement-tree) 1) (lift-attr-assign statement-tree)
             (if (eq (stmt-aug-op? statement-tree) 1) (lift-aug-assign statement-tree)
             (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
                 (do
                     (trace "lift-statement: unsupported kind/rule" (list kind rule))
-                    (intern_node PY-BMF-PASS (empty))))))))))))
+                    (intern_node PY-BMF-PASS (empty))))))))))))))
 
     ;; ---- module lifter (the public surface) ------------------------
     ;;

--- a/form/form-stdlib/tests/python-class-band.fk
+++ b/form/form-stdlib/tests/python-class-band.fk
@@ -1,0 +1,68 @@
+; tests/python-class-band.fk — Python `class` running on the Form kernel.
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/python-bmf-eval.fk form-stdlib/python-bmf-lift.fk
+;
+; Real Python classes compile to kernel records + methods (rung 2b-Python).
+; class → PY-BMF-CLASS (methods built as py-closures keyed on a class record);
+; Counter(10) → construct instance record + run __init__; self.n → record_get;
+; self.n = v → record_set (PY-BMF-ATTR-ASSIGN); c.bump(5) → PY-BMF-METHOD-CALL
+; dispatched through the instance's __class__. No Python runtime — the whole
+; pipeline (scan → lift → eval) walks on the native kernel.
+;
+; Band verdict: 30100 when every cell agrees with CPython across Go, Rust, TS.
+;   cell 1: __init__ + method that reads+mutates self, returns value (→ 15)
+;   cell 2: two instances keep separate state (→ 85)
+;   cell 3: method calling another method on self (→ 30000)
+
+(do
+    ;; ---- cell 1: construct, mutate self, read back — CPython:
+    ;;   c = Counter(10); c.bump(5); c.get()  → 15 ----------------------
+    (let cell1 (py-bmf-run-text "class Counter:
+    def __init__(self, n):
+        self.n = n
+    def bump(self, by):
+        self.n = self.n + by
+        return self.n
+    def get(self):
+        return self.n
+c = Counter(10)
+c.bump(5)
+c.get()
+"))
+    (let cell1-score (if (eq cell1 15) 100 0))
+
+    ;; ---- cell 2: two instances, separate state — CPython:
+    ;;   a = Counter(3); b = Counter(40); a.bump(2); b.bump(40);
+    ;;   a.get() + b.get() = 5 + 80 = 85 -------------------------------
+    (let cell2 (py-bmf-run-text "class Counter:
+    def __init__(self, n):
+        self.n = n
+    def bump(self, by):
+        self.n = self.n + by
+        return self.n
+    def get(self):
+        return self.n
+a = Counter(3)
+b = Counter(40)
+a.bump(2)
+b.bump(40)
+a.get() + b.get()
+"))
+    (let cell2-score (if (eq cell2 85) 1000 0))
+
+    ;; ---- cell 3: a method calling another method on self — CPython:
+    ;;   class Box: __init__ sets v; double(self) returns self.get()*2;
+    ;;   get(self) returns self.v.  Box(15000).double() = 30000 --------
+    (let cell3 (py-bmf-run-text "class Box:
+    def __init__(self, v):
+        self.v = v
+    def get(self):
+        return self.v
+    def double(self):
+        return self.get() + self.get()
+b = Box(15000)
+b.double()
+"))
+    (let cell3-score (if (eq cell3 30000) 30000 0))
+
+    (sum (list cell1-score cell2-score cell3-score)))


### PR DESCRIPTION
**Real Python classes run on the Form kernel** — no Python runtime, the whole scan→lift→eval pipeline walks on the native kernels (Go/Rust/TS). Built on the Record (#2195) + method primitives (#2198); Form-side only this breath.

## What
**lift** (`python-bmf-lift.fk`):
- `lift-subscript-tail` extended to fold `.attr` and `.method(args)` postfix trailers → `PY-BMF-ATTR` / `PY-BMF-METHOD-CALL` (chains: `a.b.c`, `xs[i].m()`).
- `lift-class` → `PY-BMF-CLASS(name, method-DEFs...)`.
- `self.x = v` (kind "expr"/rule "star_expressions") caught before the bare-expr arm → `PY-BMF-ATTR-ASSIGN`.

**eval** (`python-bmf-eval.fk`): class value = a record holding methods by name; instance = a record with data + `__class__`. CALL arm constructs (record_new + `__init__`) when the callee is a class; ATTR→record_get, ATTR-ASSIGN→record_set, METHOD-CALL resolves via the instance's `__class__` and binds `self`.

## Proof
`python-class-band.fk` → **31100** three-way: `__init__` + self read/mutate (15), two instances with separate state (85), and a method calling another method on self (30000). Full suite **184 ok, 0 divergent** (Go/Rust/TS).

(Also fixed a paren over-close in `lift-statement` found via depth analysis — it had dropped later defns out of the outer scope.)

## Next
Inheritance/dunders (richer class surface), then the deeper BML rungs: interface_id decoupling (2c) and dual-base dispatch + delegation (2d) where multiple inheritance emerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)