### PR TITLE
feat(form): py-call-export — host a module, call a named export (the API contract)

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -619,6 +619,47 @@
     (defn py-run (module-recipe)
         (py-eval module-recipe (py-env-empty)))
 
+    ;; --- module-as-library: host a module, then call an export -----------
+    ;; A substrate file like kernel.py is NOT a script — it defines functions
+    ;; (intern_node, lookup_cell, ...) the rest of the system calls. So the
+    ;; Form-native contract for API code is "load the module, then invoke an
+    ;; export with args", not "run and take the last value".
+    ;;
+    ;; py-module-env — evaluate a PY-BMF-MODULE's statements, threading env,
+    ;; and return the FINAL env (with all defs/classes bound) instead of the
+    ;; last value. The bridge FormNativeStore drives.
+    (defn py-module-env-loop (statements env)
+        (if (nil? statements) env
+            (do
+                (let r (py-eval-statement (head statements) env))
+                (py-module-env-loop (tail statements) (py-stmt-env r)))))
+
+    (defn py-module-env (module-recipe)
+        ;; module-recipe is PY-BMF-MODULE; its children are the statements.
+        (py-module-env-loop (node_children module-recipe) (py-env-empty)))
+
+    ;; py-call-export — load a module recipe, look up a top-level function by
+    ;; name in its env, and call it with arg-values (a Form list). Mirrors the
+    ;; PY-BMF-CALL closure path: bind the self-name for recursion, bind params,
+    ;; walk the body. This is "the API calls a substrate op" → "the kernel
+    ;; walks the compiled recipe".
+    (defn py-call-export (module-recipe fn-name arg-values)
+        (do
+            (let env (py-module-env module-recipe))
+            (let callee (py-env-lookup env fn-name))
+            (if (py-class? callee)
+                (py-instantiate callee arg-values)
+                (do
+                    (let captured-with-self
+                        (py-env-extend (py-closure-env callee)
+                                       (py-closure-name callee)
+                                       callee))
+                    (let call-env (py-bind-params
+                                    (py-closure-params callee)
+                                    arg-values
+                                    captured-with-self))
+                    (py-eval (py-closure-body callee) call-env)))))
+
     ;; sentinel return so the file evaluates to 0 when loaded as a
     ;; prelude — by convention every form-stdlib file lands on a small
     ;; integer to keep validate.sh's diff cheap.

--- a/form/form-stdlib/tests/python-export-band.fk
+++ b/form/form-stdlib/tests/python-export-band.fk
@@ -1,0 +1,36 @@
+; tests/python-export-band.fk — module-as-library: host a module, call exports.
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/python-bmf-eval.fk form-stdlib/python-bmf-lift.fk
+;
+; The contract for API code → Form-native: a substrate module like kernel.py
+; is NOT a script that yields a value — it DEFINES functions the rest of the
+; system imports and calls. py-call-export loads a PY-BMF-MODULE (functions
+; bound in its env) and invokes a named export with args. This is "the API
+; calls intern_node(args)" → "the kernel walks the compiled recipe".
+;
+; Band verdict: 562 when every call returns the right value across Go/Rust/TS.
+;   add3(2,3,4)=9 → 2 ; mul(6,7)=42 → 40 ; mul(2,5)=10 → 20 ; chained=500
+;   (the distinct mul results prove args bind per-call, not a cached value).
+
+(do
+    (let mod (lift-module-text "def add3(a, b, c):
+    return a + b + c
+def mul(a, b):
+    return a * b
+def poly(x):
+    return mul(x, x) + add3(x, x, x)
+0
+"))
+
+    (let r-add3 (py-call-export mod "add3" (list 2 3 4)))      ; 9
+    (let r-mul1 (py-call-export mod "mul" (list 6 7)))          ; 42
+    (let r-mul2 (py-call-export mod "mul" (list 2 5)))          ; 10
+    ;; poly(x) = x*x + 3x ; poly(20) = 400 + 60 = 460
+    (let r-poly (py-call-export mod "poly" (list 20)))          ; 460
+
+    (let add3-ok (if (eq r-add3 9) 2 0))
+    (let mul1-ok (if (eq r-mul1 42) 40 0))
+    (let mul2-ok (if (eq r-mul2 10) 20 0))
+    (let poly-ok (if (eq r-poly 460) 500 0))
+
+    (sum (list add3-ok mul1-ok mul2-ok poly-ok)))


### PR DESCRIPTION
Answers **'why are we running the file?'** — a substrate module like `kernel.py` is NOT a script that yields a value; it **defines functions** the system imports and calls. The Form-native contract for API code is **'load the module, invoke an export with args'**, not 'run and take the last value'.

## What
- `py-module-env` — run a PY-BMF-MODULE's statements, return the **final env** (all defs/classes bound).
- `py-call-export module "fn" args` — look up a top-level function/class by name and call it (mirrors the PY-BMF-CALL closure path; class callee → construct). This is **'the API calls intern_node(args)'** → **'the kernel walks the compiled recipe'**.

## Proof
`python-export-band.fk` → **562** three-way: `add3(2,3,4)=9`, `mul(6,7)=42`, `mul(2,5)=10` (distinct results prove per-call arg binding, not a cached value), `poly(20)=460` where poly calls mul+add3 (export-calls-export). Full suite **184 ok, 0 divergent**.

This is the surface **FormNativeStore** drives: the store's ops (`intern`, `lookup_cell`, …) are exports of a compiled substrate module, invoked by the live API.

(Debugging note: a stale local Go binary — missing the record natives `py-class?` needs — produced a confusing 'returns 9 for everything'; rebuilding fixed it. The Form code was correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)