### PR TITLE
feat(form): the data contract as a Form blueprint — DDL + migration as projections

### DIFF
--- a/form/form-stdlib/db-schema.fk
+++ b/form/form-stdlib/db-schema.fk
@@ -1,0 +1,141 @@
+; db-schema.fk — the data contract as a Form value; DDL + migration as projections.
+;
+; Urs (2026-05-30): "we need to be able to read and write to the DB and have a
+; way to represent the DB tables in form blueprints and a way to update the
+; schema when we need to update the data contract or vice versa ... migrate /
+; manage the tables." This is that engine.
+;
+; The shape (NUMS-Go: cells are part of what the struct IS):
+;   table   = (name, columns, uniques, indexes)   ← the Blueprint of a table
+;   column  = (name, logical-type, nullable, default)
+;   row     = a Record over that blueprint (read/write layer, separate file)
+;
+; ONE engine, DIALECT AS DATA (core-abstraction-first). sqlite and postgres are
+; not parallel code paths — they are two dialect values the same renderer reads.
+; Adding a third dialect is a new (mk-dialect ...) literal, not new code.
+;
+; Projections of a table-blueprint:
+;   create-ddl   table dialect          → CREATE TABLE ...
+;   index-ddls   table                  → [CREATE INDEX ...]
+;   schema-diff  old-cols new-cols       → columns present in new, absent in old
+;   migration-ddls old-table new-table d → [ALTER TABLE ... ADD COLUMN ...]
+;
+; The "vice versa" (live schema → table-blueprint via introspection) and the
+; row read/write layer ride the same value shape; they live in the DB-driver
+; file that executes these strings. This file is pure: it computes SQL, it does
+; not run it — so it is three-way parity-testable like every other engine here.
+;
+; preludes: form-stdlib/core.fk
+;
+(do
+    ;; ---- column -----------------------------------------------------------
+    ;; logical-type ∈ {"pk" "int" "str" "text" "datetime"}; nullable 1/0;
+    ;; default "" = none, else a literal rendered verbatim ("0", "'x'").
+    (defn mk-col (name type nullable default) (list "col" name type nullable default))
+    (defn col-name (c) (nth c 1))
+    (defn col-type (c) (nth c 2))
+    (defn col-nullable (c) (nth c 3))
+    (defn col-default (c) (nth c 4))
+
+    ;; ---- table ------------------------------------------------------------
+    (defn mk-table (name cols uniques indexes) (list "table" name cols uniques indexes))
+    (defn tbl-name (t) (nth t 1))
+    (defn tbl-cols (t) (nth t 2))
+    (defn tbl-uniques (t) (nth t 3))
+    (defn tbl-indexes (t) (nth t 4))
+
+    (defn mk-unique (cname colnames) (list "unique" cname colnames))
+    (defn uq-name (u) (nth u 1))
+    (defn uq-cols (u) (nth u 2))
+
+    (defn mk-index (iname colnames) (list "index" iname colnames))
+    (defn ix-name (i) (nth i 1))
+    (defn ix-cols (i) (nth i 2))
+
+    ;; ---- dialect (DATA, not code) -----------------------------------------
+    ;; (name, int-type, str-type, text-type, datetime-type, pk-clause)
+    (defn mk-dialect (name int-t str-t text-t dt-t pk-clause)
+        (list "dialect" name int-t str-t text-t dt-t pk-clause))
+    (defn dia-name (d) (nth d 2))
+    (defn dia-pk (d) (nth d 6))
+    (defn dia-type (d logical)
+        (if (str_eq logical "int")      (nth d 2)
+        (if (str_eq logical "str")      (nth d 3)
+        (if (str_eq logical "text")     (nth d 4)
+        (if (str_eq logical "datetime") (nth d 5)
+            logical)))))
+
+    ;; The two dialects the body actually runs (memory: dev/test sqlite,
+    ;; prod postgres). The only real divergence is the autoincrement PK and
+    ;; str's physical type — exactly the two cells that differ below.
+    (let SQLITE   (mk-dialect "sqlite"   "INTEGER" "TEXT"    "TEXT" "TIMESTAMP" "INTEGER PRIMARY KEY AUTOINCREMENT"))
+    (let POSTGRES (mk-dialect "postgres" "INTEGER" "VARCHAR" "TEXT" "TIMESTAMP" "SERIAL PRIMARY KEY"))
+
+    ;; ---- column → DDL fragment --------------------------------------------
+    ;; pk is a whole clause; every other column is  <name> <type> [NOT NULL]
+    ;; [DEFAULT x].
+    (defn col-ddl (c dia)
+        (if (str_eq (col-type c) "pk")
+            (str_concat (col-name c) (str_concat " " (dia-pk dia)))
+            (do
+                (let base (str_concat (col-name c)
+                            (str_concat " " (dia-type dia (col-type c)))))
+                (let with-null
+                    (if (eq (col-nullable c) 0)
+                        (str_concat base " NOT NULL")
+                        base))
+                (if (str_eq (col-default c) "")
+                    with-null
+                    (str_concat with-null
+                        (str_concat " DEFAULT " (col-default c)))))))
+
+    (defn uq-ddl (u)
+        (str_concat "CONSTRAINT "
+            (str_concat (uq-name u)
+                (str_concat " UNIQUE ("
+                    (str_concat (join ", " (uq-cols u)) ")")))))
+
+    ;; ---- table → CREATE TABLE ---------------------------------------------
+    (defn create-ddl (t dia)
+        (do
+            (let col-parts (map (fn (c) (col-ddl c dia)) (tbl-cols t)))
+            (let uq-parts  (map (fn (u) (uq-ddl u))      (tbl-uniques t)))
+            (let parts     (append col-parts uq-parts))
+            (str_concat "CREATE TABLE "
+                (str_concat (tbl-name t)
+                    (str_concat " ("
+                        (str_concat (join ", " parts) ")"))))))
+
+    ;; ---- table → CREATE INDEX (each its own statement) --------------------
+    (defn index-ddl (t i)
+        (str_concat "CREATE INDEX "
+            (str_concat (ix-name i)
+                (str_concat " ON "
+                    (str_concat (tbl-name t)
+                        (str_concat " ("
+                            (str_concat (join ", " (ix-cols i)) ")")))))))
+    (defn index-ddls (t)
+        (map (fn (i) (index-ddl t i)) (tbl-indexes t)))
+
+    ;; ---- migration: blueprint diff → ALTER --------------------------------
+    (defn has-col? (cols name)
+        (if (empty? cols) 0
+            (if (str_eq (col-name (head cols)) name) 1
+                (has-col? (tail cols) name))))
+
+    ;; columns present in new, absent in old — the safe forward migration the
+    ;; body already does by hand in orm.py _ensure_columns.
+    (defn schema-diff (old-cols new-cols)
+        (filter (fn (c) (eq (has-col? old-cols (col-name c)) 0)) new-cols))
+
+    (defn alter-add-ddl (tname c dia)
+        (str_concat "ALTER TABLE "
+            (str_concat tname
+                (str_concat " ADD COLUMN " (col-ddl c dia)))))
+
+    (defn migration-ddls (old-tbl new-tbl dia)
+        (do
+            (let adds (schema-diff (tbl-cols old-tbl) (tbl-cols new-tbl)))
+            (map (fn (c) (alter-add-ddl (tbl-name new-tbl) c dia)) adds)))
+
+    0)

--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -619,6 +619,47 @@
     (defn py-run (module-recipe)
         (py-eval module-recipe (py-env-empty)))
 
+    ;; --- module-as-library: host a module, then call an export -----------
+    ;; A substrate file like kernel.py is NOT a script — it defines functions
+    ;; (intern_node, lookup_cell, ...) the rest of the system calls. So the
+    ;; Form-native contract for API code is "load the module, then invoke an
+    ;; export with args", not "run and take the last value".
+    ;;
+    ;; py-module-env — evaluate a PY-BMF-MODULE's statements, threading env,
+    ;; and return the FINAL env (with all defs/classes bound) instead of the
+    ;; last value. The bridge FormNativeStore drives.
+    (defn py-module-env-loop (statements env)
+        (if (nil? statements) env
+            (do
+                (let r (py-eval-statement (head statements) env))
+                (py-module-env-loop (tail statements) (py-stmt-env r)))))
+
+    (defn py-module-env (module-recipe)
+        ;; module-recipe is PY-BMF-MODULE; its children are the statements.
+        (py-module-env-loop (node_children module-recipe) (py-env-empty)))
+
+    ;; py-call-export — load a module recipe, look up a top-level function by
+    ;; name in its env, and call it with arg-values (a Form list). Mirrors the
+    ;; PY-BMF-CALL closure path: bind the self-name for recursion, bind params,
+    ;; walk the body. This is "the API calls a substrate op" → "the kernel
+    ;; walks the compiled recipe".
+    (defn py-call-export (module-recipe fn-name arg-values)
+        (do
+            (let env (py-module-env module-recipe))
+            (let callee (py-env-lookup env fn-name))
+            (if (py-class? callee)
+                (py-instantiate callee arg-values)
+                (do
+                    (let captured-with-self
+                        (py-env-extend (py-closure-env callee)
+                                       (py-closure-name callee)
+                                       callee))
+                    (let call-env (py-bind-params
+                                    (py-closure-params callee)
+                                    arg-values
+                                    captured-with-self))
+                    (py-eval (py-closure-body callee) call-env)))))
+
     ;; sentinel return so the file evaluates to 0 when loaded as a
     ;; prelude — by convention every form-stdlib file lands on a small
     ;; integer to keep validate.sh's diff cheap.

--- a/form/form-stdlib/tests/db-schema-band.fk
+++ b/form/form-stdlib/tests/db-schema-band.fk
@@ -1,0 +1,99 @@
+; tests/db-schema-band.fk — the substrate's real tables, as Form blueprints.
+;
+; preludes: form-stdlib/core.fk form-stdlib/db-schema.fk
+;
+; Proves the data-contract engine against the ACTUAL substrate schema
+; (api/app/services/substrate/orm.py):
+;   - CREATE TABLE renders correctly for sqlite AND postgres from one blueprint
+;     (dialect as data: only the id PK + str type differ).
+;   - the migration diff REGENERATES orm.py's hand-written _ensure_columns
+;     patches exactly — "ALTER TABLE substrate_nodes ADD COLUMN domain INTEGER
+;     NOT NULL DEFAULT 0" and "...substrate_cells ADD COLUMN access_recipe TEXT"
+;     fall out of (blueprint-without-col → blueprint-with-col), by hand no more.
+;   - CREATE INDEX projects from the blueprint's index list.
+;
+; Band verdict: 11111 when every projection matches.
+;   sqlite-create=1 ; postgres-create=10 ; domain-migration=100 ;
+;   access_recipe-migration=1000 ; index=10000.
+
+(do
+    ;; substrate_nodes — current contract (with domain).
+    (let nodes
+        (mk-table "substrate_nodes"
+            (list
+                (mk-col "id"         "pk"       0 "")
+                (mk-col "package"    "int"      0 "")
+                (mk-col "level"      "int"      0 "")
+                (mk-col "type"       "int"      0 "")
+                (mk-col "instance"   "int"      0 "")
+                (mk-col "serialized" "text"     0 "")
+                (mk-col "domain"     "int"      0 "0")
+                (mk-col "created_at" "datetime" 1 ""))
+            (list (mk-unique "uq_node_id" (list "package" "level" "type" "instance")))
+            (list (mk-index "ix_node_lookup"  (list "package" "level" "type" "instance"))
+                  (mk-index "ix_node_content" (list "package" "level" "domain" "serialized")))))
+
+    ;; substrate_nodes — older contract (before domain shipped).
+    (let nodes-v0
+        (mk-table "substrate_nodes"
+            (list
+                (mk-col "id"         "pk"       0 "")
+                (mk-col "package"    "int"      0 "")
+                (mk-col "level"      "int"      0 "")
+                (mk-col "type"       "int"      0 "")
+                (mk-col "instance"   "int"      0 "")
+                (mk-col "serialized" "text"     0 "")
+                (mk-col "created_at" "datetime" 1 ""))
+            (list (mk-unique "uq_node_id" (list "package" "level" "type" "instance")))
+            (list)))
+
+    ;; substrate_cells — current contract (with access_recipe).
+    (let cells
+        (mk-table "substrate_cells"
+            (list
+                (mk-col "id"            "pk"       0 "")
+                (mk-col "name"          "str"      0 "")
+                (mk-col "domain"        "int"      0 "")
+                (mk-col "blueprint"     "text"     0 "")
+                (mk-col "ctor"          "text"     1 "")
+                (mk-col "access_recipe" "text"     1 "")
+                (mk-col "created_at"    "datetime" 1 ""))
+            (list (mk-unique "uq_cell_name_domain" (list "name" "domain")))
+            (list (mk-index "ix_cell_lookup" (list "name" "domain")))))
+
+    ;; substrate_cells — older contract (before access_recipe shipped).
+    (let cells-v0
+        (mk-table "substrate_cells"
+            (list
+                (mk-col "id"        "pk"       0 "")
+                (mk-col "name"      "str"      0 "")
+                (mk-col "domain"    "int"      0 "")
+                (mk-col "blueprint" "text"     0 "")
+                (mk-col "ctor"      "text"     1 "")
+                (mk-col "created_at" "datetime" 1 ""))
+            (list (mk-unique "uq_cell_name_domain" (list "name" "domain")))
+            (list)))
+
+    ;; ---- expected strings -------------------------------------------------
+    (let exp-sqlite
+        "CREATE TABLE substrate_nodes (id INTEGER PRIMARY KEY AUTOINCREMENT, package INTEGER NOT NULL, level INTEGER NOT NULL, type INTEGER NOT NULL, instance INTEGER NOT NULL, serialized TEXT NOT NULL, domain INTEGER NOT NULL DEFAULT 0, created_at TIMESTAMP, CONSTRAINT uq_node_id UNIQUE (package, level, type, instance))")
+    (let exp-postgres
+        "CREATE TABLE substrate_nodes (id SERIAL PRIMARY KEY, package INTEGER NOT NULL, level INTEGER NOT NULL, type INTEGER NOT NULL, instance INTEGER NOT NULL, serialized TEXT NOT NULL, domain INTEGER NOT NULL DEFAULT 0, created_at TIMESTAMP, CONSTRAINT uq_node_id UNIQUE (package, level, type, instance))")
+    ;; these two must equal orm.py _ensure_columns verbatim.
+    (let exp-domain-alter   "ALTER TABLE substrate_nodes ADD COLUMN domain INTEGER NOT NULL DEFAULT 0")
+    (let exp-cellcol-alter  "ALTER TABLE substrate_cells ADD COLUMN access_recipe TEXT")
+    (let exp-index          "CREATE INDEX ix_node_lookup ON substrate_nodes (package, level, type, instance)")
+
+    ;; ---- projections ------------------------------------------------------
+    (let got-sqlite   (create-ddl nodes SQLITE))
+    (let got-postgres (create-ddl nodes POSTGRES))
+    (let got-domain   (head (migration-ddls nodes-v0 nodes SQLITE)))
+    (let got-cellcol  (head (migration-ddls cells-v0 cells SQLITE)))
+    (let got-index    (head (index-ddls nodes)))
+
+    (sum (list
+        (if (str_eq got-sqlite   exp-sqlite)       1     0)
+        (if (str_eq got-postgres exp-postgres)     10    0)
+        (if (str_eq got-domain   exp-domain-alter) 100   0)
+        (if (str_eq got-cellcol  exp-cellcol-alter) 1000 0)
+        (if (str_eq got-index    exp-index)        10000 0))))

--- a/form/form-stdlib/tests/python-export-band.fk
+++ b/form/form-stdlib/tests/python-export-band.fk
@@ -1,0 +1,36 @@
+; tests/python-export-band.fk — module-as-library: host a module, call exports.
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/python-bmf.fk form-stdlib/python-bmf-eval.fk form-stdlib/python-bmf-lift.fk
+;
+; The contract for API code → Form-native: a substrate module like kernel.py
+; is NOT a script that yields a value — it DEFINES functions the rest of the
+; system imports and calls. py-call-export loads a PY-BMF-MODULE (functions
+; bound in its env) and invokes a named export with args. This is "the API
+; calls intern_node(args)" → "the kernel walks the compiled recipe".
+;
+; Band verdict: 562 when every call returns the right value across Go/Rust/TS.
+;   add3(2,3,4)=9 → 2 ; mul(6,7)=42 → 40 ; mul(2,5)=10 → 20 ; chained=500
+;   (the distinct mul results prove args bind per-call, not a cached value).
+
+(do
+    (let mod (lift-module-text "def add3(a, b, c):
+    return a + b + c
+def mul(a, b):
+    return a * b
+def poly(x):
+    return mul(x, x) + add3(x, x, x)
+0
+"))
+
+    (let r-add3 (py-call-export mod "add3" (list 2 3 4)))      ; 9
+    (let r-mul1 (py-call-export mod "mul" (list 6 7)))          ; 42
+    (let r-mul2 (py-call-export mod "mul" (list 2 5)))          ; 10
+    ;; poly(x) = x*x + 3x ; poly(20) = 400 + 60 = 460
+    (let r-poly (py-call-export mod "poly" (list 20)))          ; 460
+
+    (let add3-ok (if (eq r-add3 9) 2 0))
+    (let mul1-ok (if (eq r-mul1 42) 40 0))
+    (let mul2-ok (if (eq r-mul2 10) 20 0))
+    (let poly-ok (if (eq r-poly 460) 500 0))
+
+    (sum (list add3-ok mul1-ok mul2-ok poly-ok)))

--- a/kernels/ORM_TO_FORM_NATIVE.md
+++ b/kernels/ORM_TO_FORM_NATIVE.md
@@ -1,92 +1,93 @@
-# ORM → Form-native: the gating dependency for "API code runs Form-native"
+# DB → Form-native: the data contract lives in Form blueprints
 
-> Urs: "we need ORM support, no?" — Yes. It is THE gate. The substrate's core
-> files (`kernel.py`, `orm.py`, `agent_relationship.py`, `substrate_strings.py`)
-> exist to do content-addressed persistence; compiling them to `.fkb` is
-> useless until the Form kernel can read/write the same store.
+> Urs (2026-05-30): "we don't need full SQLAlchemy support. We need to read and
+> write to the DB, represent the DB tables in Form blueprints, and update the
+> schema when the data contract changes — or vice versa. Migrate / manage the
+> tables."
 
-## The two groups (from the substrate scan, 2026-05-30)
+That reframes the goal. The earlier plan here (wrap SQLAlchemy behind a
+`SubstrateStore` interface and keep it as the backend) is **composted** — we are
+not emulating an ORM. We own the schema. The **Blueprint is the schema**, DDL
+and DML are **projections** of the blueprint into a dialect, and a migration is
+a **blueprint diff** rendered to `ALTER`. Four small things, not an ORM:
 
-- **Pure-computation (orm=0):** `form_eval`, `form_render`, `form_lexer`,
-  `form_atoms`, `category`, `numeric_formats`, … → compile + run Form-native
-  *today* (gated only on compiler syntax coverage). No ORM needed.
-- **ORM-bound (orm≥10):** `kernel.py` (30), `orm.py` (20),
-  `agent_relationship.py` (16), `substrate_strings.py` (11) → the substrate's
-  *heart*. These `session.query(...)` / `Column(...)` against SQLAlchemy. They
-  cannot run Form-native until the store is reachable from the kernel.
+1. **Represent** tables as Form blueprints. *(done — `db-schema.fk`)*
+2. **Project** a blueprint → DDL (CREATE/INDEX) per dialect. *(done)*
+3. **Migrate** via blueprint diff → ALTER, both directions. *(forward done;
+   introspection — live schema → blueprint — is the open "vice versa")*
+4. **Read/write** rows ↔ Records through a thin DB driver. *(open)*
 
-## The ORM surface is tiny — it is content-addressed interning
-
-`intern_node` (the central op) is: `serialize_tree(category, children)` → a
-string key → `SELECT by (package, level, domain, serialized)` → return the
-existing NodeID, else allocate the next instance and INSERT. Plus:
-`lookup_node(NodeID)`, `lookup_cell(domain, name)`, `make_cell(...)`. That's
-the whole hot surface — four operations, all **content-addressed get-or-insert**.
-
-The Form kernel **already does exactly this**:
-- The native `intern_node` (Rust/Go/TS) content-addresses in-memory.
-- `form-stdlib/persistence.fk` (Breath 5) does it file-backed: `cell-put` /
-  `lookup-cell` / `store-cells`, same `(domain, name)` identity and the same
-  `UNIQUE(domain, name)` semantics `orm.py` enforces.
-- Records + methods (this session) give the mutable row/handle shape.
-
-So "ORM support" = **bind those four operations to the Form-native store**, not
-reimplement SQLAlchemy.
-
-## The reshape (we own the code; functionality preserved)
-
-Introduce a thin **`SubstrateStore` interface** that the substrate code calls
-instead of `session.query` directly. Two backends, identical behavior:
+## The model (NUMS-Go: cells are part of what the struct IS)
 
 ```
-SubstrateStore (protocol)
-  intern(domain, category, children) -> NodeID      # get-or-insert by content
-  lookup_node(node_id) -> row | None
-  lookup_cell(domain, name) -> cell | None
-  put_cell(name, domain, blueprint, ctor, ...) -> cell
-  next_instance(package, level, type_) -> int
-
-  SqlAlchemyStore   — wraps today's session.query/ORM (current behavior, default)
-  FormNativeStore   — wraps persistence.fk via the kernel (the dogfood target)
+table   = (name, columns, uniques, indexes)     ← the Blueprint of a table
+column  = (name, logical-type, nullable, default)
+row     = a Record over that blueprint
+dialect = (name, int-type, str-type, text-type, datetime-type, pk-clause)  ← DATA
 ```
 
-Migration is mechanical and safe:
-1. Extract the ~4 query patterns in `kernel.py`/`orm.py` behind
-   `SubstrateStore`. `SqlAlchemyStore` IS the current code, moved — zero
-   behavior change, all existing tests stay green.
-2. Now `kernel.py`'s logic (level computation, serialize_tree, the get-or-
-   insert control flow) is **pure** — it calls `store.intern(...)`. *That*
-   logic compiles to `.fkb` and runs Form-native, with `store` = a small set
-   of kernel natives over `persistence.fk`.
-3. `FormNativeStore` routes the same ops to the kernel's `intern_node` +
-   `persistence.fk` cell store. The `.fkb`↔SQLAlchemy reconciliation (Breath
-   5's open item) is the one real bridge: one shared lattice on disk, or the
-   Form store as a cache over the SQL backend.
+`logical-type ∈ {pk int str text datetime}`. The substrate's whole live schema
+(`substrate_nodes`, `substrate_cells`, `substrate_agents`,
+`substrate_relationships`) is exactly these types — no ORM machinery needed to
+express it.
 
-## Why this unlocks the whole goal
+**One engine, dialect as data** (core-abstraction-first). sqlite and postgres
+are not parallel code paths; they are two `mk-dialect` values the same renderer
+reads. The only cells that differ are the autoincrement PK
+(`INTEGER PRIMARY KEY AUTOINCREMENT` vs `SERIAL PRIMARY KEY`) and `str`'s
+physical type (`TEXT` vs `VARCHAR`). A third dialect is a new literal, not new
+code.
 
-Once the store is an interface:
-- The substrate's **control logic** (the interesting part — interning,
-  leveling, equivalence) runs Form-native via `.fkb`. Dogfooding lands on the
-  core, not just the leaves.
-- The **persistence** stays correct (SqlAlchemyStore) until FormNativeStore is
-  proven at parity, then flips per the same swappable-backend discipline
-  Breath 5 named.
-- Every advantage you listed — traceability (recipe provenance on every
-  intern), perf tuning (kernel-native hot path), feature-priority signal
-  (what the kernel can't yet express is the next breath) — accrues to the
-  substrate's center.
+## What's proven (`form/form-stdlib/db-schema.fk`, band 11111 three-way)
 
-## Order
+The real substrate tables, defined as Form blueprints in
+[`db-schema-band.fk`](../form/form-stdlib/tests/db-schema-band.fk), project to:
 
-1. **Compiler coverage for the pure files first** (no ORM) — proves the
-   end-to-end `.py → .fkb → run` arc on real substrate code now. (`form_eval`,
-   `form_atoms`, `form_lexer` are the leanest; they need: classes/decorators
-   per their feature scan, then they compile.)
-2. **Extract `SubstrateStore`** (Python reshape, SqlAlchemyStore = current
-   behavior, all tests green). Pure, behavior-preserving.
-3. **FormNativeStore over persistence.fk** + the `.fkb`↔SQL reconciliation.
-4. **Compile the now-store-abstracted `kernel.py` logic** to `.fkb`, run it
-   Form-native against FormNativeStore. The core dogfoods.
+- `create-ddl nodes SQLITE` / `... POSTGRES` → the correct `CREATE TABLE` for
+  each dialect from **one** blueprint.
+- `index-ddls nodes` → the `CREATE INDEX` statements.
+- `migration-ddls nodes-v0 nodes SQLITE` → **regenerates orm.py's hand-written
+  `_ensure_columns` patches verbatim**:
+  `ALTER TABLE substrate_nodes ADD COLUMN domain INTEGER NOT NULL DEFAULT 0`
+  and `ALTER TABLE substrate_cells ADD COLUMN access_recipe TEXT` now *fall out*
+  of `(blueprint-without-col → blueprint-with-col)`. The migration that was
+  maintained by hand is a projection of the contract.
 
-This doc is the spec for steps 2–4; the COMPILER_GAP_QUEUE drives step 1.
+This file is **pure** — it computes SQL strings, it does not run them — so it is
+three-way parity-tested (Go/Rust/TS, 0 divergent) like every other engine here.
+
+## What's open (the next breaths, in order)
+
+1. **DB driver natives** — `sql_exec(dsn, ddl)` and `sql_query(dsn, sql) → rows`.
+   This is the side-effecting leaf, so it does NOT get three-way value-parity
+   (a side effect can't be diffed three ways); it gets one reference
+   implementation per kernel and an integration test against a real **sqlite**
+   file (dev/test dialect — no server, cheap). The **SQL strings** it runs are
+   already three-way verified by the pure engine; only execution is per-kernel.
+   sqlite first (dev/test), postgres via the same native signature for prod.
+2. **Introspection — the "vice versa."** `introspect(dsn, table) → blueprint`
+   by reading `PRAGMA table_info` (sqlite) / `information_schema.columns`
+   (postgres). Then `schema-diff (introspect live) (contract blueprint)` names
+   the drift in *either* direction: contract ahead of DB → forward ALTER; DB
+   ahead of contract → the contract file needs the column. Same diff engine,
+   both directions.
+3. **Row ↔ Record read/write.** A row is a Record over the table blueprint;
+   `insert table record`, `select table where`, `update`. Field types come from
+   the blueprint, so serialization (datetime ↔ text, etc.) is contract-driven.
+4. **Wire the contract into the body.** The substrate tables' blueprints live in
+   a `.fk` (or interned substrate cells), and `init_db` / `_ensure_columns`
+   become "render + apply the projections" instead of hand-maintained SQL. The
+   data contract has one home, in Form, and the DB follows it.
+
+## Why this is the right shape
+
+- **Traceability**: every DDL/migration string has a recipe provenance — you can
+  ask the substrate *why* a column exists (which blueprint, which diff).
+- **No drift**: the hand-written `_ensure_columns` was a place the contract and
+  the DB could silently disagree. A projection can't disagree with itself.
+- **Dogfooding the center**: the substrate's own persistence shape is expressed
+  in the substrate's own language, content-addressed like everything else.
+- **Small**: four operations and a dialect table — not an ORM, not SQLAlchemy.
+
+The pure engine (steps 1–2 of the model) is the spec made executable; the driver
+and introspection (open items above) are the remaining I/O leaves.


### PR DESCRIPTION
Reframes 'ORM support' per Urs: **we don't emulate SQLAlchemy.** The **Blueprint IS the schema**; DDL/DML are projections into a dialect; a migration is a **blueprint diff** rendered to `ALTER`. Four small things, not an ORM.

## The model (NUMS-Go: cells are part of what the struct IS)
```
table   = (name, columns, uniques, indexes)     ← the Blueprint of a table
column  = (name, logical-type, nullable, default)
dialect = (name, int-type, str-type, text-type, datetime-type, pk-clause)  ← DATA
```
**One engine, dialect as data** (core-abstraction-first). sqlite/postgres differ only in the autoincrement PK + `str`'s physical type — a third dialect is a literal, not new code.

## Proof — `db-schema-band.fk` → **11111 three-way**
The REAL substrate tables defined as Form blueprints:
- `create-ddl` → correct `CREATE TABLE` for **sqlite AND postgres** from one blueprint.
- `migration-ddls nodes-v0 nodes` → **regenerates orm.py's hand-written `_ensure_columns` verbatim**: `ALTER TABLE substrate_nodes ADD COLUMN domain INTEGER NOT NULL DEFAULT 0` and `...substrate_cells ADD COLUMN access_recipe TEXT` now *fall out* of (blueprint-v0 → blueprint). The by-hand migration is a projection of the contract.

Pure (computes SQL, doesn't run it) → three-way parity-tested. Full suite **186 ok, 0 divergent**.

## Open leaves (next breaths, in [ORM_TO_FORM_NATIVE.md](kernels/ORM_TO_FORM_NATIVE.md))
1. **DB driver natives** `sql_exec`/`sql_query` — side-effecting leaf, per-kernel reference impl (side effects don't value-diff), sqlite-first integration test. The SQL strings are already three-way verified.
2. **Introspection** (live schema → blueprint) — the 'vice versa'; same diff engine, both directions.
3. **Row ↔ Record** read/write, field types from the blueprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)