### PR TITLE
feat(kernels): real filesystem CRUD natives — directories + files, Go/Rust/TS parity

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1852,6 +1852,77 @@ func (k *Kernel) registerNatives() {
 		return Value{Kind: VStr, Str: string(buf[:n])}
 	})
 
+	// --- Filesystem CRUD natives — real directories + files ------------
+	// Sibling parity across Go/Rust/TS. Paths are strings. Convention:
+	// predicates return 1/0; mutations return 0 on success, -1 on error;
+	// fs_list returns a VList of name-strings (entries of a directory),
+	// or VNull on error. These compose into a real directory tree with
+	// file CRUD, the foundation under the file carrier and the substrate
+	// file store.
+	// (fs_exists path)        → 1 | 0
+	// (fs_is_dir path)        → 1 | 0
+	// (fs_mkdir path)         → 0 | -1   (mkdir -p; existing dir is success)
+	// (fs_rmdir path)         → 0 | -1   (recursive remove of a directory)
+	// (fs_remove path)        → 0 | -1   (remove a single file)
+	// (fs_rename old new)     → 0 | -1
+	// (fs_list path)          → VList of entry-name strings | VNull
+	k.registerNative("fs_exists", catCall(), func(_ *Kernel, args []Value) Value {
+		if _, err := os.Stat(args[0].Str); err != nil {
+			return Value{Kind: VInt, Int: 0}
+		}
+		return Value{Kind: VInt, Int: 1}
+	})
+	k.registerNative("fs_is_dir", catCall(), func(_ *Kernel, args []Value) Value {
+		info, err := os.Stat(args[0].Str)
+		if err != nil || !info.IsDir() {
+			return Value{Kind: VInt, Int: 0}
+		}
+		return Value{Kind: VInt, Int: 1}
+	})
+	k.registerNative("fs_mkdir", catCall(), func(_ *Kernel, args []Value) Value {
+		if err := os.MkdirAll(args[0].Str, 0755); err != nil {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: 0}
+	})
+	k.registerNative("fs_rmdir", catCall(), func(_ *Kernel, args []Value) Value {
+		info, err := os.Stat(args[0].Str)
+		if err != nil || !info.IsDir() {
+			return Value{Kind: VInt, Int: -1}
+		}
+		if err := os.RemoveAll(args[0].Str); err != nil {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: 0}
+	})
+	k.registerNative("fs_remove", catCall(), func(_ *Kernel, args []Value) Value {
+		info, err := os.Stat(args[0].Str)
+		if err != nil || info.IsDir() {
+			return Value{Kind: VInt, Int: -1}
+		}
+		if err := os.Remove(args[0].Str); err != nil {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: 0}
+	})
+	k.registerNative("fs_rename", catCall(), func(_ *Kernel, args []Value) Value {
+		if err := os.Rename(args[0].Str, args[1].Str); err != nil {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: 0}
+	})
+	k.registerNative("fs_list", catCall(), func(_ *Kernel, args []Value) Value {
+		entries, err := os.ReadDir(args[0].Str)
+		if err != nil {
+			return Value{Kind: VNull}
+		}
+		out := make([]Value, len(entries))
+		for i, e := range entries {
+			out[i] = Value{Kind: VStr, Str: e.Name()}
+		}
+		return Value{Kind: VList, List: out}
+	})
+
 	// --- Socket natives — L1 physical layer for inter-cell IO ----------
 	// Sibling parity across Go/Rust/TS. Handle = int (≥ 0 success, -1
 	// error). The connection table is package-level (socketHandles).

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2791,6 +2791,69 @@ impl Kernel {
             }
         });
 
+        // --- Filesystem CRUD natives — real directories + files --------
+        // Sibling parity across Go/Rust/TS. Predicates return 1/0;
+        // mutations return 0 on success, -1 on error; fs_list returns a
+        // List of name-strings or Null on error.
+        self.register_native("fs_exists", cat_call(), |_, _, args| {
+            if fs::metadata(args[0].as_str()).is_ok() {
+                Value::Int(1)
+            } else {
+                Value::Int(0)
+            }
+        });
+        self.register_native("fs_is_dir", cat_call(), |_, _, args| {
+            match fs::metadata(args[0].as_str()) {
+                Ok(meta) if meta.is_dir() => Value::Int(1),
+                _ => Value::Int(0),
+            }
+        });
+        self.register_native("fs_mkdir", cat_call(), |_, _, args| {
+            match fs::create_dir_all(args[0].as_str()) {
+                Ok(_) => Value::Int(0),
+                Err(_) => Value::Int(-1),
+            }
+        });
+        self.register_native("fs_rmdir", cat_call(), |_, _, args| {
+            match fs::metadata(args[0].as_str()) {
+                Ok(meta) if meta.is_dir() => match fs::remove_dir_all(args[0].as_str()) {
+                    Ok(_) => Value::Int(0),
+                    Err(_) => Value::Int(-1),
+                },
+                _ => Value::Int(-1),
+            }
+        });
+        self.register_native("fs_remove", cat_call(), |_, _, args| {
+            match fs::metadata(args[0].as_str()) {
+                Ok(meta) if !meta.is_dir() => match fs::remove_file(args[0].as_str()) {
+                    Ok(_) => Value::Int(0),
+                    Err(_) => Value::Int(-1),
+                },
+                _ => Value::Int(-1),
+            }
+        });
+        self.register_native("fs_rename", cat_call(), |_, _, args| {
+            match fs::rename(args[0].as_str(), args[1].as_str()) {
+                Ok(_) => Value::Int(0),
+                Err(_) => Value::Int(-1),
+            }
+        });
+        self.register_native("fs_list", cat_call(), |_, _, args| {
+            match fs::read_dir(args[0].as_str()) {
+                Ok(rd) => {
+                    // sort by name for cross-kernel parity (Go's os.ReadDir
+                    // is name-sorted; Rust/Node are OS-arbitrary).
+                    let mut names: Vec<String> = rd
+                        .flatten()
+                        .map(|e| e.file_name().to_string_lossy().to_string())
+                        .collect();
+                    names.sort();
+                    Value::List(names.into_iter().map(Value::Str).collect())
+                }
+                Err(_) => Value::Null,
+            }
+        });
+
         // --- Socket natives — L1 physical layer for inter-cell IO ------
         // Sibling parity across Go/Rust/TS. Handle = int (≥ 0 success,
         // -1 error). Connection table is a module-level OnceLock<Mutex>.

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -13,7 +13,19 @@
 // Aligned with api/app/services/substrate/category.py and the Go/Rust
 // kernels. Cross-kernel NodeID agreement is the conformance contract.
 
-import { closeSync, openSync, readFileSync, readSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { execFileSync } from "node:child_process";
 import { BP_TABLE } from "./bp_table";
 
@@ -2020,6 +2032,71 @@ export class Kernel {
         if (fd !== undefined) closeSync(fd);
       }
     });
+
+    // --- Filesystem CRUD natives — real directories + files ----------
+    // Sibling parity across Go/Rust/TS. Predicates return 1/0; mutations
+    // return 0 on success, -1 on error; fs_list returns a name-string list
+    // (sorted for cross-kernel parity) or null on error.
+    this.registerNative("fs_exists", catCall(), (_k, args) => {
+      try {
+        statSync(argStr(args, 0));
+        return { kind: "int", int: 1 };
+      } catch {
+        return { kind: "int", int: 0 };
+      }
+    });
+    this.registerNative("fs_is_dir", catCall(), (_k, args) => {
+      try {
+        return { kind: "int", int: statSync(argStr(args, 0)).isDirectory() ? 1 : 0 };
+      } catch {
+        return { kind: "int", int: 0 };
+      }
+    });
+    this.registerNative("fs_mkdir", catCall(), (_k, args) => {
+      try {
+        mkdirSync(argStr(args, 0), { recursive: true });
+        return { kind: "int", int: 0 };
+      } catch {
+        return { kind: "int", int: -1 };
+      }
+    });
+    this.registerNative("fs_rmdir", catCall(), (_k, args) => {
+      try {
+        if (!statSync(argStr(args, 0)).isDirectory()) return { kind: "int", int: -1 };
+        rmSync(argStr(args, 0), { recursive: true, force: true });
+        return { kind: "int", int: 0 };
+      } catch {
+        return { kind: "int", int: -1 };
+      }
+    });
+    this.registerNative("fs_remove", catCall(), (_k, args) => {
+      try {
+        if (statSync(argStr(args, 0)).isDirectory()) return { kind: "int", int: -1 };
+        unlinkSync(argStr(args, 0));
+        return { kind: "int", int: 0 };
+      } catch {
+        return { kind: "int", int: -1 };
+      }
+    });
+    this.registerNative("fs_rename", catCall(), (_k, args) => {
+      try {
+        renameSync(argStr(args, 0), argStr(args, 1));
+        return { kind: "int", int: 0 };
+      } catch {
+        return { kind: "int", int: -1 };
+      }
+    });
+    this.registerNative("fs_list", catCall(), (_k, args) => {
+      try {
+        // sort by name for cross-kernel parity (Go's os.ReadDir is
+        // name-sorted; Rust/Node are OS-arbitrary).
+        const names = readdirSync(argStr(args, 0)).sort();
+        return { kind: "list", list: names.map((n) => ({ kind: "str", str: n }) as Value) };
+      } catch {
+        return { kind: "null" };
+      }
+    });
+
     // write_file_bytes — sibling of read_file_bytes; writes a byte list.
     // Sibling-parity with form-kernel-go + form-kernel-rust. Values out of
     // 0..255 truncate per Go's `byte(v.Int)` and Rust's `as u8`.

--- a/form/form-stdlib/tests/fs-crud-band.fk
+++ b/form/form-stdlib/tests/fs-crud-band.fk
@@ -1,0 +1,92 @@
+; tests/fs-crud-band.fk — REAL filesystem CRUD against the live OS.
+;
+; preludes: form-stdlib/core.fk
+;
+; Not a value-toy: this band creates a real directory TREE on disk, writes real
+; files into it, lists the directory, reads contents back, renames a file,
+; removes a file, removes the tree, and asserts each step against the actual
+; filesystem via fs_exists / fs_is_dir / fs_list. Run identically on Go/Rust/TS,
+; so the three kernels' real os.MkdirAll / fs::create_dir_all / mkdirSync (and
+; the read/write/remove/rename siblings) are proven to agree on real I/O.
+;
+; The strange edge chosen to cover the most boundary in the least code: a nested
+; dir with two files, where one is renamed and one removed, then the whole tree
+; torn down — touching mkdir(-p), exists, is_dir, write, read, list (sorted),
+; rename, remove(file), and rmdir(recursive) in one arc, with honest-failure
+; checks (remove a dir as if a file, list a missing dir) folded in.
+;
+; Band verdict: 11111111 when every assertion holds across all three kernels.
+;   mkdir tree + is_dir          → 1
+;   write two files + exists      → 10
+;   read content back             → 100
+;   list returns both, sorted     → 1000
+;   rename moves the file          → 10000
+;   remove(file) deletes one       → 100000
+;   honest failure (wrong-kind ops)→ 1000000
+;   rmdir tears the tree down      → 10000000
+
+(do
+    (let root "/tmp/fs-crud-band")
+    ;; clean slate (ignore result — may not exist yet)
+    (fs_rmdir root)
+
+    ;; --- mkdir -p a nested tree, confirm it IS a directory -----------------
+    (let nested (str_concat root "/a/b"))
+    (fs_mkdir nested)
+    (let mkdir-ok
+        (if (eq (fs_exists nested) 1)
+            (if (eq (fs_is_dir nested) 1) 1 0) 0))
+
+    ;; --- write two real files into the tree -------------------------------
+    (let f-one (str_concat nested "/one.txt"))
+    (let f-two (str_concat nested "/two.txt"))
+    (write_file_text f-one "ONE")
+    (write_file_text f-two "TWO")
+    (let write-ok
+        (if (eq (fs_exists f-one) 1)
+            (if (eq (fs_is_dir f-one) 0)        ; a file is not a dir
+                (if (eq (fs_exists f-two) 1) 10 0) 0) 0))
+
+    ;; --- read content back from disk --------------------------------------
+    (let read-ok
+        (if (str_eq (read_file f-one) "ONE")
+            (if (str_eq (read_file f-two) "TWO") 100 0) 0))
+
+    ;; --- list the directory: both entries, name-sorted --------------------
+    (let entries (fs_list nested))
+    (let list-ok
+        (if (eq (len entries) 2)
+            (if (str_eq (head entries) "one.txt")        ; sorted: one < two
+                (if (str_eq (head (tail entries)) "two.txt") 1000 0) 0) 0))
+
+    ;; --- rename a file ----------------------------------------------------
+    (let f-renamed (str_concat nested "/renamed.txt"))
+    (fs_rename f-one f-renamed)
+    (let rename-ok
+        (if (eq (fs_exists f-one) 0)                     ; old path gone
+            (if (eq (fs_exists f-renamed) 1)             ; new path present
+                (if (str_eq (read_file f-renamed) "ONE") 10000 0) 0) 0))
+
+    ;; --- remove a single file ---------------------------------------------
+    (fs_remove f-two)
+    (let remove-ok
+        (if (eq (fs_exists f-two) 0)                     ; file gone
+            (if (eq (len (fs_list nested)) 1) 100000 0) 0))  ; only renamed left
+
+    ;; --- honest failure: wrong-kind operations return -1 / null -----------
+    ;; fs_remove on a directory fails; fs_rmdir on a file fails; fs_list on a
+    ;; missing path is null. The kernel refuses the category error.
+    (let bad-remove-dir (fs_remove nested))             ; -1: nested is a dir
+    (let bad-rmdir-file (fs_rmdir f-renamed))           ; -1: renamed is a file
+    (let missing-list (fs_list (str_concat root "/nope")))
+    (let fail-ok
+        (if (eq bad-remove-dir -1)
+            (if (eq bad-rmdir-file -1)
+                (if (eq (len missing-list) 0) 1000000 0) 0) 0))
+
+    ;; --- tear the whole tree down -----------------------------------------
+    (fs_rmdir root)
+    (let teardown-ok
+        (if (eq (fs_exists root) 0) 10000000 0))
+
+    (sum (list mkdir-ok write-ok read-ok list-ok rename-ok remove-ok fail-ok teardown-ok)))


### PR DESCRIPTION
First layer of **real** (not toy) host integration: actual directory + file CRUD against the **live OS**, three-way parity.

## Seven natives per kernel (catCall)
`fs_exists` · `fs_is_dir` · `fs_mkdir` (mkdir -p) · `fs_rmdir` (recursive, refuses non-dir) · `fs_remove` (file, refuses dir) · `fs_rename` · `fs_list` (name-**sorted** entry list | null)

Go (`os.MkdirAll/RemoveAll/Remove/Rename/ReadDir`), Rust (`fs::create_dir_all/remove_dir_all/remove_file/rename/read_dir`), TS (`mkdirSync/rmSync/unlinkSync/renameSync/readdirSync`).

**Parity trap fixed:** Go's `os.ReadDir` is name-sorted but Rust `read_dir` / Node `readdirSync` are OS-arbitrary — all three now sort explicitly so `fs_list` agrees.

## Proof — `fs-crud-band.fk` → **11111111 three-way** against the REAL filesystem
Makes a nested tree (`/tmp/fs-crud-band/a/b`), writes two files, reads them back, lists sorted, renames one, removes one, folds in **honest wrong-kind refusals** (remove-a-dir, rmdir-a-file, list-a-missing-path → -1/null), tears the tree down, confirms it's gone. Real I/O asserted against actual OS state, identical on Go/Rust/TS. Full suite **189 ok, 0 divergent**.

This is the foundation under the file carrier and the substrate file store. The **DB carrier** (production Postgres) and the **TS socket gap** (currently panic-stubs) follow on this proven seam — tracked as the next breaths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)