### PR TITLE
feat(form): real directory-backed substrate cell store — per-cell file CRUD

### DIFF
--- a/form/form-stdlib/cell-store-fs.fk
+++ b/form/form-stdlib/cell-store-fs.fk
@@ -1,0 +1,107 @@
+; cell-store-fs.fk — a REAL directory-backed substrate cell store.
+;
+; The production-shaped file backend: a store is an actual DIRECTORY TREE, one
+; real file per cell at  <root>/<domain>/<name>.fkb , with full per-cell CRUD.
+; This is the substrate store as a live filesystem — not a single flat append
+; log (persistence.fk's channel) but a directory the OS itself indexes:
+;
+;   <root>/
+;     idea/
+;       agent-pipeline.fkb        ← one cell, one file (a CELL Recipe)
+;     spec/
+;       agent-pipeline.fkb        ← same name, different domain, different file
+;     concept/
+;       lc-trust-over-fear.fkb
+;
+; Why this over the flat channel: real per-cell operations. cell-put writes ONE
+; file (no whole-store rewrite); cell-delete removes ONE file; list-domain reads
+; a real directory; cell-get reads a single file. Identity is (domain, name) —
+; the same UNIQUE(domain, name) the Python orm.py enforces — realized as a real
+; path. last-write-wins is the filesystem overwriting the file.
+;
+; Built on the fs_* CRUD natives (fs_mkdir/fs_list/fs_remove/fs_exists/fs_is_dir)
+; and the kernel's write_form_binary / read_form_binary. Same CELL Recipe shape
+; as persistence.fk (name, domain, blueprint, ctor) so cells round-trip between
+; the flat and directory backends — the store is the contract, the layout is the
+; carrier (docs/coherence-substrate/ports-interface-and-structure.md).
+;
+; preludes: form-stdlib/core.fk form-stdlib/persistence.fk
+;
+(do
+    ;; ---- path layout ------------------------------------------------------
+    ;; A cell lives at <root>/<domain>/<name>.fkb. Names are used verbatim as
+    ;; filenames; callers keep them filesystem-safe (the substrate's slugs
+    ;; already are: kebab-case, no slashes).
+    (defn cs-domain-dir (root domain) (str_concat root (str_concat "/" domain)))
+    (defn cs-cell-path (root domain name)
+        (str_concat (cs-domain-dir root domain)
+            (str_concat "/" (str_concat name ".fkb"))))
+
+    ;; strip the trailing ".fkb" from a listed filename → the cell name.
+    ;; (len ".fkb") = 4; substring [0, len-4).
+    (defn cs-strip-ext (filename)
+        (substring filename 0 (sub (str_len filename) 4)))
+
+    ;; ---- store create -----------------------------------------------------
+    ;; A store is just its root directory. Domain subdirs are made on demand.
+    (defn cell-store-fs-create (root) (fs_mkdir root))
+
+    ;; ---- write one cell ---------------------------------------------------
+    ;; Writes a single CELL Recipe to its own file. Makes the domain dir if
+    ;; absent. Overwrites = last-write-wins. Returns 0 on success, -1 on error.
+    (defn cell-fs-put (root name domain blueprint ctor)
+        (do
+            (fs_mkdir (cs-domain-dir root domain))
+            (write_form_binary
+                (cs-cell-path root domain name)
+                (make-cell-recipe name domain blueprint ctor))
+            0))
+
+    ;; ---- read one cell ----------------------------------------------------
+    ;; Returns a 0-or-1-element list (the body's optional). Honest absence when
+    ;; the file does not exist — no fabricated cell.
+    (defn cell-fs-get (root domain name)
+        (if (eq (fs_exists (cs-cell-path root domain name)) 1)
+            (list (read_form_binary (cs-cell-path root domain name)))
+            (empty)))
+
+    (defn cell-fs-found? (result) (if (eq (len result) 1) 1 0))
+    (defn cell-fs-of (result) (head result))
+
+    ;; ---- delete one cell --------------------------------------------------
+    ;; Real per-cell removal. Returns 0 on success, -1 if absent/error.
+    (defn cell-fs-delete (root domain name)
+        (fs_remove (cs-cell-path root domain name)))
+
+    ;; ---- enumerate a domain ----------------------------------------------
+    ;; list-domain root domain → list of cell NAMES in that domain (real
+    ;; directory read, name-sorted by fs_list). Empty list if the domain dir
+    ;; does not exist.
+    (defn cs-names-loop (filenames acc)
+        (if (nil? filenames) acc
+            (cs-names-loop (tail filenames)
+                (ps-append acc (list (cs-strip-ext (head filenames)))))))
+    (defn cell-fs-list-domain (root domain)
+        (do
+            (let dir (cs-domain-dir root domain))
+            (if (eq (fs_exists dir) 1)
+                (cs-names-loop (fs_list dir) (empty))
+                (empty))))
+
+    ;; ---- enumerate domains ------------------------------------------------
+    ;; list-domains root → the domain names present (the subdirectories).
+    (defn cell-fs-list-domains (root)
+        (if (eq (fs_exists root) 1)
+            (fs_list root)
+            (empty)))
+
+    ;; ---- read every cell in a domain (get-all) ---------------------------
+    ;; Threads list-domain through cell-fs-get, returning the CELL Recipes.
+    (defn cs-getall-loop (root domain names acc)
+        (if (nil? names) acc
+            (cs-getall-loop root domain (tail names)
+                (ps-append acc (cell-fs-get root domain (head names))))))
+    (defn cell-fs-domain-cells (root domain)
+        (cs-getall-loop root domain (cell-fs-list-domain root domain) (empty)))
+
+    0)

--- a/form/form-stdlib/tests/cell-store-fs-band.fk
+++ b/form/form-stdlib/tests/cell-store-fs-band.fk
@@ -1,0 +1,93 @@
+; tests/cell-store-fs-band.fk — the REAL directory-backed substrate store.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/persistence.fk form-stdlib/cell-store-fs.fk
+;
+; Proves the substrate cell store as a live filesystem TREE: each cell is its own
+; real file at <root>/<domain>/<name>.fkb, with per-cell CRUD and real directory
+; enumeration. Not a flat append log — actual files the OS indexes. Run identical
+; on Go/Rust/TS so the three kernels agree on real multi-file substrate I/O.
+;
+; The strange edge: two cells sharing a NAME across two DOMAINS (the UNIQUE
+; (domain, name) constraint, here realized as two real files in two real dirs),
+; plus a structure-first composed CTOR that must survive the per-file round-trip,
+; plus enumeration, last-write-wins overwrite, honest absence, and per-cell
+; delete that leaves siblings intact.
+;
+; Band verdict: 1111111 when every assertion holds across all three kernels.
+;   put two cells, two domains, found    → 1
+;   same name two domains = two files     → 10      (distinct cells)
+;   composed CTOR round-trips per-file     → 100
+;   list-domain enumerates real dir        → 1000
+;   last-write-wins overwrites one file    → 10000
+;   honest absence on missing cell          → 100000
+;   per-cell delete; sibling survives       → 1000000
+
+(do
+    (let root "/tmp/cell-store-fs-band")
+    (fs_rmdir root)                       ; clean slate
+    (cell-store-fs-create root)
+
+    ;; composed, structure-first CTOR (frontmatter as (key,value) fields).
+    (let FIELDS (make_nodeid 1 2 99 1741))
+    (let FIELD  (make_nodeid 1 2 99 1742))
+    (defn fld (k v)
+        (intern_node FIELD (list (intern_trivial_string k) (intern_trivial_string v))))
+    (let bp-idea (make_nodeid 1 8 4 1))
+    (let bp-spec (make_nodeid 1 8 4 2))
+    (defn ctor-idea ()
+        (intern_node FIELDS (list (fld "problem" "ideas need a pipeline")
+                                  (fld "status" "active"))))
+
+    ;; --- put two cells: same name, two domains → two real files -----------
+    (cell-fs-put root "agent-pipeline" "idea" bp-idea (ctor-idea))
+    (cell-fs-put root "agent-pipeline" "spec" bp-spec
+                 (intern_node FIELDS (list (fld "done_when" "tasks flow"))))
+    (let idea-hit (cell-fs-get root "idea" "agent-pipeline"))
+    (let spec-hit (cell-fs-get root "spec" "agent-pipeline"))
+    (let put-ok
+        (if (eq (cell-fs-found? idea-hit) 1)
+            (if (eq (cell-fs-found? spec-hit) 1) 1 0) 0))
+
+    ;; --- the two are DISTINCT cells (different files, different blueprints) -
+    (let distinct-ok
+        (if (node_eq (cell-fs-of idea-hit) (cell-fs-of spec-hit)) 0 10))
+
+    ;; --- the composed CTOR survived the per-file round-trip ---------------
+    (let ctor (cell-ctor (cell-fs-of idea-hit)))
+    (let first-field (head (node_children ctor)))
+    (let first-key (node_value (head (node_children first-field)))) ; "problem"
+    (let ctor-ok (if (str_eq first-key "problem") 100 0))
+
+    ;; --- list-domain reads the real directory -----------------------------
+    (cell-fs-put root "beta-idea" "idea" bp-idea (ctor-idea))
+    (let idea-names (cell-fs-list-domain root "idea"))
+    ;; two cells in idea/: "agent-pipeline" and "beta-idea", name-sorted.
+    (let list-ok
+        (if (eq (len idea-names) 2)
+            (if (str_eq (head idea-names) "agent-pipeline")
+                (if (str_eq (head (tail idea-names)) "beta-idea") 1000 0) 0) 0))
+
+    ;; --- last-write-wins: overwrite one file, read the new shape ----------
+    (cell-fs-put root "agent-pipeline" "idea" bp-idea
+                 (intern_node FIELDS (list (fld "problem" "REVISED problem"))))
+    (let revised (cell-fs-get root "idea" "agent-pipeline"))
+    (let rev-ctor (cell-ctor (cell-fs-of revised)))
+    (let rev-val (node_value (head (tail (node_children (head (node_children rev-ctor)))))))
+    (let overwrite-ok
+        (if (str_eq rev-val "REVISED problem") 10000 0))
+
+    ;; --- honest absence ----------------------------------------------------
+    (let miss (cell-fs-get root "idea" "no-such-idea"))
+    (let miss-ok (if (eq (cell-fs-found? miss) 0) 100000 0))
+
+    ;; --- per-cell delete; the sibling in the same domain survives ---------
+    (cell-fs-delete root "idea" "beta-idea")
+    (let after-del (cell-fs-list-domain root "idea"))
+    (let delete-ok
+        (if (eq (len after-del) 1)                          ; one cell left
+            (if (str_eq (head after-del) "agent-pipeline")  ; the right one
+                (if (eq (cell-fs-found? (cell-fs-get root "idea" "beta-idea")) 0)
+                    1000000 0) 0) 0))
+
+    (fs_rmdir root)                       ; teardown
+    (sum (list put-ok distinct-ok ctor-ok list-ok overwrite-ok miss-ok delete-ok)))


### PR DESCRIPTION
The substrate store as a **live filesystem tree**, built on the just-merged `fs_*` natives ([#2208](https://github.com/seeker71/Coherence-Network/pull/2208)). A store is a real directory; each cell is its own file at `<root>/<domain>/<name>.fkb` — real per-cell CRUD, not a flat append log.

## Surface (`cell-store-fs.fk`)
`cell-fs-put` (writes ONE file, no store rewrite) · `cell-fs-get` (one file, 0-or-1 optional) · `cell-fs-delete` (removes ONE file) · `cell-fs-list-domain` (enumerate a real dir, sorted) · `cell-fs-list-domains` · `cell-fs-domain-cells`.

Same CELL Recipe shape `(name, domain, blueprint, ctor)` as `persistence.fk`, so cells round-trip between the flat-channel and directory backends — **the store is the contract, the layout is the carrier**. Identity `(domain, name)` realized as a real path (the `UNIQUE(domain, name)` orm.py enforces); last-write-wins is the filesystem overwriting the file.

## Proof — `cell-store-fs-band.fk` → **1111111 three-way** against the REAL filesystem
Two cells sharing a name across two domains (two real files in two real dirs), a composed structure-first CTOR surviving the per-file round-trip, real directory enumeration, last-write-wins overwrite, honest absence, **per-cell delete that leaves the sibling intact**. Full suite **190 ok, 0 divergent**.

Real directory + file CRUD applied to the substrate itself. The **DB carrier** (production Postgres) and the **TS socket gap** follow on the same proven seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)