### PR TITLE
feat(kernels): real TCP on all three kernels — TS socket shim closes the gap

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1940,6 +1940,21 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VInt, Int: socketRegister(ln)}
 	})
+	// (socket_port listener-handle) → bound TCP port | -1. Lets a listener
+	// opened on port 0 (ephemeral) report the OS-assigned port — the basis
+	// of single-process loopback (listen 0 → port → connect → accept).
+	k.registerNative("socket_port", catCall(), func(_ *Kernel, args []Value) Value {
+		v := socketLookup(args[0].Int)
+		ln, ok := v.(net.Listener)
+		if !ok {
+			return Value{Kind: VInt, Int: -1}
+		}
+		ta, ok := ln.Addr().(*net.TCPAddr)
+		if !ok {
+			return Value{Kind: VInt, Int: -1}
+		}
+		return Value{Kind: VInt, Int: int64(ta.Port)}
+	})
 	k.registerNative("socket_accept", catCall(), func(_ *Kernel, args []Value) Value {
 		v := socketLookup(args[0].Int)
 		ln, ok := v.(net.Listener)

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2870,6 +2870,23 @@ impl Kernel {
                 Err(_) => Value::Int(-1),
             }
         });
+        // (socket_port listener-handle) → bound TCP port | -1. Reports the
+        // OS-assigned port of an ephemeral (port 0) listener — the basis of
+        // single-process loopback.
+        self.register_native("socket_port", cat_call(), |_, _, args| {
+            let h = args[0].as_int();
+            let s = match socket_lookup(h) {
+                Some(s) => s,
+                None => return Value::Int(-1),
+            };
+            match &*s {
+                SocketKind::Listener(ln) => match ln.local_addr() {
+                    Ok(addr) => Value::Int(addr.port() as i64),
+                    Err(_) => Value::Int(-1),
+                },
+                _ => Value::Int(-1),
+            }
+        });
         self.register_native("socket_accept", cat_call(), |_, _, args| {
             let h = args[0].as_int();
             let s = match socket_lookup(h) {

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -27,6 +27,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { Worker } from "node:worker_threads";
 import { BP_TABLE } from "./bp_table";
 
 // ---------------------------------------------------------------------------
@@ -458,6 +459,88 @@ export function catCompareEq(): NodeID {
 }
 export function catUndefined(): NodeID {
   return { pkg: 1, level: Level.BASIC, type: RBasic.UNDEFINED, inst: 0 };
+}
+
+// --- Synchronous TCP shim — real sockets on the TS kernel ----------------
+// Node's event loop cannot do blocking accept/recv on the main thread. The
+// documented shim: a worker thread owns the sockets and does async net IO;
+// the main thread blocks on Atomics.wait against a SharedArrayBuffer until
+// the worker signals completion, then reads the result. This gives the TS
+// kernel the same synchronous (socket_listen/port/connect/accept/send/recv/
+// close) surface as Go/Rust — real loopback, sibling parity. The worker is
+// spawned lazily on first socket use, so non-socket programs never pay it.
+// Verified end-to-end under the real `tsx` runner before shipping.
+let _sockWorker: Worker | undefined;
+let _sockCtrl: Int32Array | undefined; // [0]=ready-flag, [1]=int result
+let _sockData: Buffer | undefined; // shared payload bytes for recv
+
+const SOCKET_WORKER_SRC = `
+import { parentPort, workerData } from "node:worker_threads";
+import net from "node:net";
+const ctrl = new Int32Array(workerData.ctrl);
+const dataBuf = Buffer.from(workerData.data);
+const handles = new Map(); let nextId = 1;
+function done(r){ Atomics.store(ctrl,1,r); Atomics.store(ctrl,0,1); Atomics.notify(ctrl,0); }
+parentPort.on("message", async (m) => { try {
+  if(m.op==="listen"){ const id=nextId++; const srv=net.createServer(); const rec={kind:"listener",obj:srv,backlog:[]};
+    srv.on("connection",s=>{s.pause();rec.backlog.push(s);});
+    await new Promise((res,rej)=>{srv.once("error",rej);srv.listen(m.port,"127.0.0.1",res);});
+    rec.port=srv.address().port; handles.set(id,rec); done(id);
+  } else if(m.op==="port"){ const r=handles.get(m.h); done(r&&r.kind==="listener"?r.port:-1);
+  } else if(m.op==="connect"){ const id=nextId++; const s=net.connect(m.port,m.host);
+    await new Promise((res,rej)=>{s.once("connect",res);s.once("error",rej);});
+    const rec={kind:"conn",obj:s,rbuf:Buffer.alloc(0),closed:false}; handles.set(id,rec);
+    s.on("data",d=>{rec.rbuf=Buffer.concat([rec.rbuf,d]);}); s.on("close",()=>{rec.closed=true;}); done(id);
+  } else if(m.op==="accept"){ const lr=handles.get(m.h); if(!lr||lr.kind!=="listener")return done(-1);
+    while(lr.backlog.length===0) await new Promise(r=>setTimeout(r,1));
+    const s=lr.backlog.shift(); const id=nextId++; const rec={kind:"conn",obj:s,rbuf:Buffer.alloc(0),closed:false};
+    handles.set(id,rec); s.on("data",d=>{rec.rbuf=Buffer.concat([rec.rbuf,d]);}); s.on("close",()=>{rec.closed=true;}); s.resume(); done(id);
+  } else if(m.op==="send"){ const r=handles.get(m.h); if(!r||r.kind!=="conn")return done(-1);
+    const b=Buffer.from(m.text,"utf8"); r.obj.write(b); done(b.length);
+  } else if(m.op==="recv"){ const r=handles.get(m.h); if(!r||r.kind!=="conn")return done(0);
+    while(r.rbuf.length===0&&!r.closed) await new Promise(res=>setTimeout(res,1));
+    const take=Math.min(m.max,r.rbuf.length); const out=r.rbuf.subarray(0,take); r.rbuf=r.rbuf.subarray(take);
+    out.copy(dataBuf,0); done(take);
+  } else if(m.op==="close"){ const r=handles.get(m.h); if(!r)return done(-1); try{r.obj.destroy();}catch{} handles.delete(m.h); done(0);
+  } else done(-1);
+} catch(e){ done(-1); } });
+`;
+
+function ensureSocketWorker(): void {
+  if (_sockWorker) return;
+  const ctrlSab = new SharedArrayBuffer(8);
+  const dataSab = new SharedArrayBuffer(65536);
+  _sockCtrl = new Int32Array(ctrlSab);
+  _sockData = Buffer.from(dataSab);
+  _sockWorker = new Worker(SOCKET_WORKER_SRC, {
+    eval: true,
+    workerData: { ctrl: ctrlSab, data: dataSab },
+  });
+  _sockWorker.unref(); // don't keep the process alive for the worker
+}
+
+// socketCall — post an op to the worker and block until it signals, returning
+// the worker's int result. recv payloads land in _sockData (read by caller).
+function socketCall(op: Record<string, unknown>): number {
+  ensureSocketWorker();
+  const ctrl = _sockCtrl!;
+  Atomics.store(ctrl, 0, 0);
+  _sockWorker!.postMessage(op);
+  Atomics.wait(ctrl, 0, 0);
+  return Atomics.load(ctrl, 1);
+}
+
+// shutdownSocketWorker — terminate the socket worker so the process can exit.
+// The worker holds net handles that keep Node's event loop alive even when
+// unref'd; the host (main.ts) calls this after execution completes. No-op if
+// the worker was never spawned (non-socket programs).
+export function shutdownSocketWorker(): void {
+  if (_sockWorker) {
+    void _sockWorker.terminate();
+    _sockWorker = undefined;
+    _sockCtrl = undefined;
+    _sockData = undefined;
+  }
 }
 
 export class Kernel {
@@ -2127,57 +2210,47 @@ export class Kernel {
     });
 
     // --- Socket natives — L1 physical layer for inter-cell IO ---------
-    // Sibling parity with form-kernel-go + form-kernel-rust at the API
-    // surface. TS scope limit: socket_listen / socket_accept / socket_recv
-    // are panic-stubs because Node's event-loop architecture cannot do
-    // blocking accept/read without a worker-thread + SharedArrayBuffer
-    // shim — that work is deferred to a later breath. socket_close is
-    // safe on -1 (sibling-parity no-op returning -1), so the band can
-    // witness API existence without crossing into the panic-stub region.
-    // TODO: implement TS sockets when we have a blocking shim
-    //       (Atomics.wait + worker_threads sync read).
-    this.registerNative("socket_listen", catCall(), (_k, _args) => {
-      throw new Error(
-        "socket_listen: TS kernel has no blocking-accept shim yet — " +
-          "sibling-loud-divergent panic-stub; use Go or Rust kernel for " +
-          "server-side socket work this breath.",
-      );
+    // Sibling parity with form-kernel-go + form-kernel-rust: REAL TCP. The
+    // synchronous worker-thread shim (see socketCall above) gives the TS
+    // kernel blocking listen/accept/connect/send/recv/close identical in
+    // surface and behavior to the Go (net.Listen/Dial) and Rust (std::net)
+    // kernels. Handle = int (≥0 success, -1 error); socket_recv returns the
+    // received string ("" on close/error). The worker spawns lazily on first
+    // socket use, so non-socket programs pay nothing.
+    this.registerNative("socket_listen", catCall(), (_k, args) => ({
+      kind: "int",
+      int: socketCall({ op: "listen", port: argInt(args, 0) }),
+    }));
+    // (socket_port listener-handle) → bound TCP port | -1 — sibling of the
+    // Go/Rust native; reports an ephemeral (port 0) listener's OS-assigned
+    // port for single-process loopback.
+    this.registerNative("socket_port", catCall(), (_k, args) => ({
+      kind: "int",
+      int: socketCall({ op: "port", h: argInt(args, 0) }),
+    }));
+    this.registerNative("socket_accept", catCall(), (_k, args) => ({
+      kind: "int",
+      int: socketCall({ op: "accept", h: argInt(args, 0) }),
+    }));
+    this.registerNative("socket_connect", catCall(), (_k, args) => ({
+      kind: "int",
+      int: socketCall({ op: "connect", host: argStr(args, 0), port: argInt(args, 1) }),
+    }));
+    this.registerNative("socket_send", catCall(), (_k, args) => ({
+      kind: "int",
+      int: socketCall({ op: "send", h: argInt(args, 0), text: argStr(args, 1) }),
+    }));
+    this.registerNative("socket_recv", catCall(), (_k, args) => {
+      const max = argInt(args, 1);
+      if (max <= 0) return { kind: "str", str: "" };
+      const n = socketCall({ op: "recv", h: argInt(args, 0), max });
+      if (n <= 0) return { kind: "str", str: "" };
+      return { kind: "str", str: _sockData!.subarray(0, n).toString("utf8") };
     });
-    this.registerNative("socket_accept", catCall(), (_k, _args) => {
-      throw new Error(
-        "socket_accept: TS kernel has no blocking-accept shim yet — " +
-          "sibling-loud-divergent panic-stub; use Go or Rust kernel.",
-      );
-    });
-    this.registerNative("socket_connect", catCall(), (_k, _args) => {
-      throw new Error(
-        "socket_connect: TS kernel has no blocking-IO shim yet — " +
-          "sibling-loud-divergent panic-stub; use Go or Rust kernel.",
-      );
-    });
-    this.registerNative("socket_send", catCall(), (_k, _args) => {
-      throw new Error(
-        "socket_send: TS kernel has no blocking-IO shim yet — " +
-          "sibling-loud-divergent panic-stub; use Go or Rust kernel.",
-      );
-    });
-    this.registerNative("socket_recv", catCall(), (_k, _args) => {
-      throw new Error(
-        "socket_recv: TS kernel has no blocking-IO shim yet — " +
-          "sibling-loud-divergent panic-stub; use Go or Rust kernel.",
-      );
-    });
-    // socket_close — the one socket native that has a sibling-safe
-    // sentinel branch on all three kernels: a -1 handle returns -1
-    // without touching the (nonexistent) TS connection table. Used by
-    // tests/socket-band.fk to witness that the API surface EXISTS on
-    // all three kernels even when the implementation diverges.
     this.registerNative("socket_close", catCall(), (_k, args) => {
       const h = argInt(args, 0);
       if (h < 0) return { kind: "int", int: -1 };
-      // No connection table in TS — handles > 0 are necessarily stale
-      // (we never returned one), so -1 is the honest response.
-      return { kind: "int", int: -1 };
+      return { kind: "int", int: socketCall({ op: "close", h }) };
     });
 
     // Substrate write surface — all attributed as WITNESS.

--- a/form/form-kernel-ts/src/main.ts
+++ b/form/form-kernel-ts/src/main.ts
@@ -8,7 +8,15 @@
 //   tsx src/main.ts path/to/file.fk
 
 import { readFile, writeFile } from "node:fs/promises";
-import { deserializeRecipeArtifact, Frame, Kernel, serializeRecipeArtifact, Trace, walk } from "./kernel.ts";
+import {
+  deserializeRecipeArtifact,
+  Frame,
+  Kernel,
+  serializeRecipeArtifact,
+  shutdownSocketWorker,
+  Trace,
+  walk,
+} from "./kernel.ts";
 import { readAll, readForm } from "./reader.ts";
 import { runBench } from "./bench.ts";
 import { compileNode } from "./compiler.ts";
@@ -156,8 +164,15 @@ async function runTrace(args: string[]): Promise<void> {
   console.log(JSON.stringify(report, null, 2));
 }
 
-main().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  console.error(`form-kernel-ts: ${msg}`);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Terminate the socket worker (if any) so the process exits promptly;
+    // its net handles otherwise keep Node's event loop alive.
+    shutdownSocketWorker();
+  })
+  .catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`form-kernel-ts: ${msg}`);
+    shutdownSocketWorker();
+    process.exit(1);
+  });

--- a/form/form-stdlib/tests/socket-loopback-band.fk
+++ b/form/form-stdlib/tests/socket-loopback-band.fk
@@ -1,0 +1,53 @@
+; tests/socket-loopback-band.fk — REAL single-process TCP loopback, all 3 kernels.
+;
+; preludes: form-stdlib/core.fk
+;
+; Proves real networking on Go, Rust, AND TypeScript (whose sockets were
+; panic-stubs until the synchronous worker-thread shim). A single Form program
+; opens a listener on an ephemeral port, reads the OS-assigned port, connects to
+; it (the handshake backlogs), accepts the backlogged connection, sends bytes
+; client→server and server→client, and reads them back — all synchronous, over a
+; real TCP socket on 127.0.0.1. Identical behavior across the three kernels is
+; the proof the TS shim matches Go's net.Listen/Dial and Rust's std::net.
+;
+; The backlog trick makes single-process loopback work without threads in the
+; Form program: connect() completes the TCP handshake into the listener's
+; backlog and returns; accept() then returns that connection immediately rather
+; than blocking forever waiting for a peer.
+;
+; Band verdict: 111111 when every step agrees across all three kernels.
+;   listen on ephemeral port      → 1
+;   socket_port reports a port>0   → 10
+;   connect + accept succeed        → 100
+;   client→server PING round-trips  → 1000
+;   server→client PONG round-trips  → 10000
+;   clean close (0) on a live conn  → 100000
+
+(do
+    (let srv (socket_listen 0))                 ; ephemeral port
+    (let listen-ok (if (ge srv 0) 1 0))
+
+    (let port (socket_port srv))
+    (let port-ok (if (gt port 0) 10 0))
+
+    (let cli (socket_connect "127.0.0.1" port)) ; handshake → backlog
+    (let conn (socket_accept srv))              ; returns the backlogged conn
+    (let pair-ok
+        (if (ge cli 0) (if (ge conn 0) 100 0) 0))
+
+    ;; client → server
+    (let sent1 (socket_send cli "PING"))
+    (let got1 (socket_recv conn 4))
+    (let c2s-ok (if (str_eq got1 "PING") 1000 0))
+
+    ;; server → client
+    (let sent2 (socket_send conn "PONG"))
+    (let got2 (socket_recv cli 4))
+    (let s2c-ok (if (str_eq got2 "PONG") 10000 0))
+
+    ;; clean close of a live connection returns 0 (not the -1 sentinel)
+    (let close-ok (if (eq (socket_close conn) 0) 100000 0))
+    (socket_close cli)
+    (socket_close srv)
+
+    (sum (list listen-ok port-ok pair-ok c2s-ok s2c-ok close-ok)))


### PR DESCRIPTION
Networking made **real** (not panic-stubs). The TS kernel's sockets were loud-divergent panic-stubs ('use Go or Rust'); now **all three kernels do real blocking TCP at parity**, proven by single-process loopback.

## What
- **TS synchronous worker shim**: a worker thread owns the sockets and does async net IO; the main thread blocks on `Atomics.wait` against a `SharedArrayBuffer` until the worker signals, then reads the result. Gives blocking `listen/accept/connect/send/recv/close`. Spawned **lazily** on first socket use (non-socket programs pay nothing), **terminated** after execution so the process exits promptly. Prototyped standalone under the real `tsx` runner before kernel wiring.
- **`socket_port` (all three kernels)**: reads an ephemeral (port 0) listener's OS-assigned port — the missing piece for single-process loopback. Go `Addr().(*net.TCPAddr).Port`, Rust `local_addr().port()`, TS worker.

## Proof — `socket-loopback-band.fk` → **111111 three-way**
One Form program: listen on ephemeral port → read port → connect (handshake backlogs) → accept → round-trip **PING client→server AND PONG server→client over real 127.0.0.1 TCP** → clean-close (0, not the -1 sentinel). Identical Go/Rust/TS. Full suite **191 ok, 0 divergent**.

## Two bugs found via debug-first bisection
1. The TS client socket was left **paused** after connect, so the second-roundtrip `recv` busy-waited forever — removed the pause so data flows.
2. The worker kept Node's event loop alive after execution — `terminate` it in `main()` so validate.sh doesn't hang.

Real networking, end-to-end, three kernels. The **production DB substrate store** follows as its own focused build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)