### PR TITLE
feat(kernels): real Postgres carrier — Form-native code reads/writes live PG

### DIFF
--- a/form/form-kernel-rust/Cargo.lock
+++ b/form/form-kernel-rust/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +30,39 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -31,6 +81,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,16 +154,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form-kernel-rust"
 version = "0.1.0"
 dependencies = [
  "libloading",
+ "postgres",
  "pyo3",
  "serde",
  "serde_json",
@@ -68,6 +199,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,14 +247,61 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -167,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +413,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +438,24 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -219,16 +474,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -246,10 +529,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -258,10 +593,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgres"
+version = "0.19.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -270,6 +673,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -354,6 +767,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,10 +806,10 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -407,6 +852,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -452,10 +909,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -464,10 +944,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "subtle"
@@ -514,10 +1015,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -571,6 +1173,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +1316,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +1341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -666,6 +1415,100 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/form/form-kernel-rust/Cargo.toml
+++ b/form/form-kernel-rust/Cargo.toml
@@ -30,6 +30,11 @@ serde_json = "1"
 # Tiny blocking HTTP client for the `fetch` subcommand (network resources).
 # Pure Rust, ~200 KB binary impact; zero-async.
 ureq = { version = "2", default-features = false, features = ["tls"] }
+# postgres — blocking PostgreSQL driver (pure Rust, no cgo). The DB carrier of
+# the storage port: Form-rendered SQL (db-schema.fk DDL + emits/sql.fk DML)
+# executed against a real Postgres. Effectful, per-kernel reference impl (a side
+# effect can't be value-diffed three ways) — same posture as sockets / fetch.
+postgres = "0.19"
 # libloading — dynamic load of cdylib .so plugins for the Form→Rust→host JIT
 # path. The kernel emits Rust source for a Form recipe, invokes `rustc
 # --crate-type=cdylib`, and loads the resulting plugin with libloading.

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -73,6 +73,86 @@ fn socket_drop(h: i64) -> bool {
     t.handles.remove(&h).is_some()
 }
 
+// --- Postgres natives — the DB carrier of the storage port --------------
+// Form-rendered SQL executed against a real Postgres. Handles are monotone
+// i64s; the kernel never reveals the postgres::Client to Form, only the
+// handle. -1 = error. Effectful, per-kernel reference impl — the SQL strings
+// are already three-way verified by db-schema.fk + emits/sql.fk; only
+// execution lives here. See docs/coherence-substrate/cell-store-architecture.md
+// (the DB is the production carrier; the FS log store is dev/test).
+struct PgTable {
+    handles: HashMap<i64, Arc<Mutex<postgres::Client>>>,
+    next: i64,
+}
+
+fn pg_table() -> &'static Mutex<PgTable> {
+    static T: OnceLock<Mutex<PgTable>> = OnceLock::new();
+    T.get_or_init(|| {
+        Mutex::new(PgTable {
+            handles: HashMap::new(),
+            next: 0,
+        })
+    })
+}
+
+fn pg_register(c: postgres::Client) -> i64 {
+    let mut t = pg_table().lock().unwrap();
+    t.next += 1;
+    let h = t.next;
+    t.handles.insert(h, Arc::new(Mutex::new(c)));
+    h
+}
+
+fn pg_lookup(h: i64) -> Option<Arc<Mutex<postgres::Client>>> {
+    let t = pg_table().lock().unwrap();
+    t.handles.get(&h).cloned()
+}
+
+fn pg_drop(h: i64) -> bool {
+    let mut t = pg_table().lock().unwrap();
+    t.handles.remove(&h).is_some()
+}
+
+// Render one column of a postgres row to a string, by its SQL type. Covers the
+// substrate's portable column set (text/varchar, the integer family, bool).
+// NULL → "". Unknown types → "?". try_get keeps a type mismatch from panicking.
+fn pg_cell_to_string(row: &postgres::Row, ci: usize) -> String {
+    let ty = row.columns()[ci].type_().name().to_string();
+    match ty.as_str() {
+        "text" | "varchar" | "bpchar" | "name" => {
+            row.try_get::<usize, Option<String>>(ci)
+                .ok()
+                .flatten()
+                .unwrap_or_default()
+        }
+        "int8" => row
+            .try_get::<usize, Option<i64>>(ci)
+            .ok()
+            .flatten()
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "int4" => row
+            .try_get::<usize, Option<i32>>(ci)
+            .ok()
+            .flatten()
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "int2" => row
+            .try_get::<usize, Option<i16>>(ci)
+            .ok()
+            .flatten()
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        "bool" => row
+            .try_get::<usize, Option<bool>>(ci)
+            .ok()
+            .flatten()
+            .map(|v| if v { "t".to_string() } else { "f".to_string() })
+            .unwrap_or_default(),
+        _ => "?".to_string(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Substrate — NodeID + Recipe + intern table
 // ---------------------------------------------------------------------------
@@ -2975,6 +3055,74 @@ impl Kernel {
                 return Value::Int(-1);
             }
             if socket_drop(h) {
+                Value::Int(0)
+            } else {
+                Value::Int(-1)
+            }
+        });
+
+        // --- Postgres natives — the DB carrier of the storage port ------
+        // (pg_connect dsn)        → handle | -1
+        // (pg_exec handle sql)    → rows-affected | -1   (DDL / INSERT / UPDATE)
+        // (pg_query handle sql)   → result-string | "ERR" (tab-separated cols,
+        //                            newline-separated rows; "" = zero rows)
+        // (pg_close handle)       → 0 | -1
+        // DSN is libpq form: "host=127.0.0.1 port=5432 user=u dbname=d ...".
+        self.register_native("pg_connect", cat_call(), |_, _, args| {
+            let dsn = args[0].as_str().to_string();
+            match postgres::Client::connect(&dsn, postgres::NoTls) {
+                Ok(c) => Value::Int(pg_register(c)),
+                Err(_) => Value::Int(-1),
+            }
+        });
+        self.register_native("pg_exec", cat_call(), |_, _, args| {
+            let h = args[0].as_int();
+            let sql = args[1].as_str().to_string();
+            let client = match pg_lookup(h) {
+                Some(c) => c,
+                None => return Value::Int(-1),
+            };
+            let mut g = client.lock().unwrap();
+            match g.execute(&sql, &[]) {
+                Ok(n) => Value::Int(n as i64),
+                Err(_) => Value::Int(-1),
+            }
+        });
+        self.register_native("pg_query", cat_call(), |_, _, args| {
+            let h = args[0].as_int();
+            let sql = args[1].as_str().to_string();
+            let client = match pg_lookup(h) {
+                Some(c) => c,
+                None => return Value::Str("ERR".to_string()),
+            };
+            let mut g = client.lock().unwrap();
+            let rows = match g.query(&sql, &[]) {
+                Ok(r) => r,
+                Err(_) => return Value::Str("ERR".to_string()),
+            };
+            // Encode rows as tab-separated columns, newline-separated rows.
+            // Columns are rendered to text via their SQL type (text/int8/bool
+            // cover the substrate's portable column set). NULL → empty string.
+            let mut out = String::new();
+            for (ri, row) in rows.iter().enumerate() {
+                if ri > 0 {
+                    out.push('\n');
+                }
+                for ci in 0..row.len() {
+                    if ci > 0 {
+                        out.push('\t');
+                    }
+                    out.push_str(&pg_cell_to_string(row, ci));
+                }
+            }
+            Value::Str(out)
+        });
+        self.register_native("pg_close", cat_call(), |_, _, args| {
+            let h = args[0].as_int();
+            if h < 0 {
+                return Value::Int(-1);
+            }
+            if pg_drop(h) {
                 Value::Int(0)
             } else {
                 Value::Int(-1)

--- a/form/form-stdlib/integration/pg-carrier-integration.fk
+++ b/form/form-stdlib/integration/pg-carrier-integration.fk
@@ -1,0 +1,73 @@
+; tests/pg-carrier-integration.fk — REAL Postgres carrier of the storage port.
+;
+; preludes: form-stdlib/core.fk form-stdlib/db-schema.fk
+;
+; NOT a three-way value band — it executes against a LIVE Postgres and is run
+; ONLY on the Rust kernel (the DB carrier's reference impl, like the socket shim
+; was for TS). Driven by scripts/pg-carrier-test.sh, which stands up a throwaway
+; Postgres, passes the DSN in via the PG_DSN trivial below (the harness rewrites
+; it), runs this on form-kernel-rust, and asserts the verdict.
+;
+; Proves the whole DB carrier end-to-end, not just raw SQL:
+;   - db-schema.fk renders the substrate table DDL for the postgres dialect
+;     (the STRUCTURE half — already three-way verified by db-schema-band);
+;   - pg_exec runs that DDL against the real DB (the CARRIER — Rust-only);
+;   - content-addressed get-or-insert (the intern_node pattern): a second
+;     "insert" of the same key does NOT duplicate — last-write-wins via the
+;     UNIQUE(domain,name) the schema declares;
+;   - pg_query reads the rows back.
+;
+; The DSN is injected by the harness replacing the PG_DSN string literal below.
+; Verdict: 111111 when every step holds against live Postgres.
+;   connect                       → 1
+;   render + run substrate DDL     → 10
+;   insert two distinct cells       → 100
+;   content-addressed: dup is no-op  → 1000   (UNIQUE(domain,name) holds)
+;   query reads both back            → 10000
+;   close                            → 100000
+
+(do
+    (let DSN "PG_DSN_PLACEHOLDER")
+
+    (let conn (pg_connect DSN))
+    (let connect-ok (if (ge conn 0) 1 0))
+
+    ;; --- render the substrate cells table via db-schema.fk, run it ---------
+    (let cells
+        (mk-table "substrate_cells"
+            (list
+                (mk-col "id"        "pk"   0 "")
+                (mk-col "name"      "str"  0 "")
+                (mk-col "domain"    "str"  0 "")
+                (mk-col "blueprint" "text" 0 "")
+                (mk-col "ctor"      "text" 1 ""))
+            (list (mk-unique "uq_cell_name_domain" (list "name" "domain")))
+            (list)))
+    (pg_exec conn "DROP TABLE IF EXISTS substrate_cells")
+    (let ddl (create-ddl cells (dialect-postgres)))
+    (let ddl-rc (pg_exec conn ddl))
+    ;; pg_exec returns 0 rows-affected for DDL (CREATE TABLE) — success is >= 0.
+    (let ddl-ok (if (ge ddl-rc 0) 10 0))
+
+    ;; --- insert two distinct cells -----------------------------------------
+    (pg_exec conn "INSERT INTO substrate_cells (name,domain,blueprint,ctor) VALUES ('agent-pipeline','idea','@1.8.4.1','problem')")
+    (pg_exec conn "INSERT INTO substrate_cells (name,domain,blueprint,ctor) VALUES ('agent-pipeline','spec','@1.8.4.2','done-when')")
+    (let after-two (pg_query conn "SELECT count(*) FROM substrate_cells"))
+    (let insert-ok (if (str_eq after-two "2") 100 0))
+
+    ;; --- content-addressed get-or-insert: a duplicate (domain,name) is a
+    ;; no-op via ON CONFLICT (the UNIQUE the schema declares). The intern_node
+    ;; gate, in SQL: insert only if the shape is new. ----------------------
+    (pg_exec conn "INSERT INTO substrate_cells (name,domain,blueprint,ctor) VALUES ('agent-pipeline','idea','@1.8.4.1','problem') ON CONFLICT (name,domain) DO NOTHING")
+    (let after-dup (pg_query conn "SELECT count(*) FROM substrate_cells"))
+    (let dedup-ok (if (str_eq after-dup "2") 1000 0))   ; still 2, not 3
+
+    ;; --- read both back -----------------------------------------------------
+    (let rows (pg_query conn "SELECT domain, name FROM substrate_cells ORDER BY domain"))
+    ;; "idea\tagent-pipeline\nspec\tagent-pipeline"
+    (let query-ok (if (str_eq rows "idea	agent-pipeline
+spec	agent-pipeline") 10000 0))
+
+    (let close-ok (if (eq (pg_close conn) 0) 100000 0))
+
+    (sum (list connect-ok ddl-ok insert-ok dedup-ok query-ok close-ok)))

--- a/form/scripts/pg-carrier-test.sh
+++ b/form/scripts/pg-carrier-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# pg-carrier-test.sh — integration test for the Form-native Postgres carrier.
+#
+# Stands up a throwaway local Postgres, renders + runs the substrate schema and a
+# content-addressed get-or-insert from a .fk program through the Rust kernel
+# (the DB carrier's reference impl), and asserts the verdict. This is the real
+# end-to-end proof that Form-native code reads/writes a real Postgres — the DB
+# carrier of the storage port (docs/coherence-substrate/cell-store-architecture.md).
+#
+# Not part of validate.sh's three-way suite: a live-DB side effect can't be
+# value-diffed three ways, and only the Rust kernel carries the pg_* natives
+# (same posture as the TS-only socket shim). CI runs this separately where a
+# Postgres is available; locally it self-provisions one if `initdb` exists.
+#
+# Usage:
+#   form/scripts/pg-carrier-test.sh                 # self-provision a throwaway PG
+#   PG_DSN="host=... port=... user=... dbname=..." \
+#     form/scripts/pg-carrier-test.sh               # use an existing PG
+#
+# Exit 0 on the expected verdict (111111), 1 otherwise.
+set -euo pipefail
+
+FORMDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$FORMDIR"
+
+RS_BIN="form-kernel-rust/target/release/form-kernel-rust"
+if [[ ! -x "$RS_BIN" ]]; then
+  echo "building rust kernel..." >&2
+  (cd form-kernel-rust && cargo build --release --quiet)
+fi
+
+# --- provision a Postgres (or use the caller's PG_DSN) ---------------------
+PROVISIONED=0
+PGDIR=""
+cleanup() {
+  if [[ "$PROVISIONED" -eq 1 && -n "$PGDIR" ]]; then
+    pg_ctl -D "$PGDIR/data" stop -m fast >/dev/null 2>&1 || true
+    rm -rf "$PGDIR"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${PG_DSN:-}" ]]; then
+  if ! command -v initdb >/dev/null 2>&1; then
+    echo "SKIP: no PG_DSN set and initdb not found — cannot self-provision." >&2
+    exit 0
+  fi
+  PGDIR="$(mktemp -d "${TMPDIR:-/tmp}/form-pg.XXXXXX")"
+  PROVISIONED=1
+  initdb -D "$PGDIR/data" -U postgres --auth=trust >/dev/null 2>&1
+  PGPORT=54399
+  pg_ctl -D "$PGDIR/data" -o "-p $PGPORT -k $PGDIR" -l "$PGDIR/log" start >/dev/null 2>&1
+  sleep 2
+  psql -h 127.0.0.1 -p "$PGPORT" -U postgres -c "CREATE DATABASE substrate_test;" >/dev/null 2>&1
+  PG_DSN="host=127.0.0.1 port=$PGPORT user=postgres dbname=substrate_test"
+fi
+
+# --- compile the core prelude (BML dialect → kernel-walkable) --------------
+SRCDIR="$(mktemp -d "${TMPDIR:-/tmp}/pgcarrier.XXXXXX")"
+trap 'rm -rf "$SRCDIR"; cleanup' EXIT
+printf '(do (form-source-compile-file "form-stdlib/core.fk" "%s/core.fk"))\n' "$SRCDIR" > "$SRCDIR/drv.fk"
+form-kernel-go/bin-go form-stdlib/json.fk form-stdlib/cache.fk \
+  form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk "$SRCDIR/drv.fk" >/dev/null 2>&1
+
+# --- inject the DSN into the test program ----------------------------------
+TEST="$SRCDIR/pg-test.fk"
+sed "s|PG_DSN_PLACEHOLDER|${PG_DSN}|" form-stdlib/integration/pg-carrier-integration.fk > "$TEST"
+
+# --- run on the Rust kernel ------------------------------------------------
+OUT="$("$RS_BIN" "$SRCDIR/core.fk" form-stdlib/db-schema.fk "$TEST" 2>&1 | tail -1)"
+echo "verdict: $OUT"
+if [[ "$OUT" == "111111" ]]; then
+  echo "PG carrier: PASS — Form-native code read/wrote real Postgres end-to-end."
+  exit 0
+else
+  echo "PG carrier: FAIL — expected 111111." >&2
+  exit 1
+fi


### PR DESCRIPTION
The **DB carrier of the storage port, connected and tested end-to-end.** Form-native code now executes real SQL against a real Postgres — the production backend, beside the dev/test FS log store.

## The carrier decision (deferred earlier, settled on evidence)
The PG driver lives in the **Rust kernel, not Go**. Effectful carriers are per-kernel reference impls — a live-DB side effect can't be value-diffed three ways — and the Rust kernel already carries network-I/O deps (`ureq` for `fetch`). So a `postgres` dependency there is precedent, not a new category. The Go kernel stays zero-dep.

## What
- `postgres` 0.19 (pure Rust, no cgo).
- `pg_connect` / `pg_exec` / `pg_query` / `pg_close` natives; connection handle table mirrors the socket table. `pg_cell_to_string` renders the substrate's portable column types (text/varchar/int family/bool); NULL → "".

## Proof — `scripts/pg-carrier-test.sh` → verdict **111111** against live Postgres
The harness **self-provisions a throwaway Postgres** (`initdb`), then a `.fk` program: connects, renders the `substrate_cells` DDL via `db-schema.fk` for the postgres dialect and **runs it against live PG**, inserts two cells, proves **content-addressed dedup** (a duplicate `(name,domain)` is a no-op via `ON CONFLICT` — the `intern_node` gate in SQL), queries both rows back, closes.

## Why the three-way suite stays green
The test lives under `integration/` (not `tests/`), so validate.sh doesn't glob it: a live-DB effect can't be value-diffed, and `pg_*` is Rust-only — same posture as the TS-only socket shim. The SQL strings themselves are already three-way verified (`db-schema.fk` DDL + `emits/sql.fk` DML); only execution lives in Rust.

The storage port now has all three carriers under one contract: **memory** (in-process), **file** (segmented log), **DB** (Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)