### PR TITLE
feat(form): unify storage port — memory, segmented-file, and Postgres under one test

### DIFF
--- a/docs/coherence-substrate/ports-interface-and-structure.md
+++ b/docs/coherence-substrate/ports-interface-and-structure.md
@@ -181,14 +181,35 @@ predicted.
   there is no file-lattice-vs-SQL reconciliation to keep honest, because the
   contract is the single truth and a carrier is just where it lands today.
 
-## Status and next breath
+## Status — three carriers, one interface, one test (realized)
 
-This doc is the architecture (decision: architect-first). The next breath is the
-**storage-port prototype** as its first proof: the storage capability-contract
-with a **memory carrier** and the **file carrier** (`persistence.fk`) behind one
-Form interface, with the relational view (`db-schema.fk` + `emits/sql.fk`) as one
-interface over it. The prototype settles the binding-seam fork on evidence, and
-SQL/sqlite lands as the third carrier once the seam is proven on the leanest two.
+The architecture is built and proven end-to-end. The storage port
+(`storage-port.fk`) is one interface — `storage-open` / `storage-put` /
+`storage-get` / `storage-has?` — over a carrier record of four function-values.
+Three carriers now satisfy it, and the SAME carrier-agnostic test
+(`storage-test`) returns the IDENTICAL verdict through all three:
+
+| Carrier | Backend | File | Proof |
+|---|---|---|---|
+| **memory** | in-process assoc-list (pure) | `storage-port.fk` | three-way band, verdict 1111 |
+| **file** | the **segmented log store** (`cell-log-store.fk`) — real, scalable | `storage-port-file.fk` | three-way band, verdict 1111 |
+| **db** | **Postgres** via the `pg_*` natives | `storage-port-db.fk` | live-PG harness, verdict 1111 |
+
+`tests/storage-port-band.fk` (three-way, 11111) proves memory and the segmented
+file log return the identical verdict and the file store survives reopen
+(durability via replay). `integration/storage-port-all-carriers.fk` +
+`scripts/storage-port-carriers-test.sh` (Rust-only, self-provisions a throwaway
+Postgres) runs the **same test across all three** and asserts one verdict —
+**111111**: memory == file == Postgres. That identity is the substitutability
+claim made executable: the call site names no backend, so one logic path is
+proven over every storage backing.
+
+A new backend (IPFS, S3, a remote KV) is the same shape — four functions over a
+couple of effectful natives, no kernel change and no call-site change. IPFS is
+the cleanest fit: its CID is a content hash, the same identity the substrate
+already computes with `intern_node`. Testing is the payoff: unit tests run
+`carrier-memory` (instant, no I/O); integration tests swap in `carrier-file` or
+`carrier-db` over the *identical* logic.
 
 ## See also
 

--- a/form/form-stdlib/integration/storage-port-all-carriers.fk
+++ b/form/form-stdlib/integration/storage-port-all-carriers.fk
@@ -1,0 +1,41 @@
+; integration/storage-port-all-carriers.fk — ONE test, THREE backends, one verdict.
+;
+; preludes: form-stdlib/core.fk form-stdlib/cell-log-store.fk form-stdlib/storage-port.fk form-stdlib/storage-port-file.fk form-stdlib/storage-port-db.fk
+;
+; The executable substitutability proof across ALL carriers including live
+; Postgres. Run ONLY on the Rust kernel (the pg_* carrier floor), driven by
+; scripts/storage-port-carriers-test.sh which self-provisions a throwaway PG and
+; injects the DSN. The SAME storage-test runs through memory, the segmented file
+; log, AND Postgres; all three must return the identical verdict (1111). That
+; identity is the whole claim: the call site names no backend, so one logic path
+; is proven over every storage backing — the pattern any new backend (IPFS, S3,
+; a KV store) drops into unchanged.
+;
+; Verdict: 111111 when all three carriers pass AND agree.
+;   memory full pass        → 1
+;   file (log) full pass     → 10
+;   db (Postgres) full pass   → 100
+;   memory == file            → 1000
+;   file == db                 → 10000   (the cross-backend identity)
+;   db == memory                → 100000
+
+(do
+    (let DSN "PG_DSN_PLACEHOLDER")
+    (let dir "/tmp/storage-port-all.d")
+    (fs_rmdir dir)
+    ;; fresh kv table so the db verdict is from this run only.
+    (pg_exec (pg_connect DSN) "DROP TABLE IF EXISTS port_kv")
+
+    (let mem-v  (storage-test (carrier-memory) ""))
+    (let file-v (storage-test (carrier-file) dir))
+    (let db-v   (storage-test (carrier-db) DSN))
+
+    (let mem-ok  (if (eq mem-v 1111) 1 0))
+    (let file-ok (if (eq file-v 1111) 10 0))
+    (let db-ok   (if (eq db-v 1111) 100 0))
+    (let mf-ok   (if (eq mem-v file-v) 1000 0))
+    (let fd-ok   (if (eq file-v db-v) 10000 0))
+    (let dm-ok   (if (eq db-v mem-v) 100000 0))
+
+    (fs_rmdir dir)
+    (sum (list mem-ok file-ok db-ok mf-ok fd-ok dm-ok)))

--- a/form/form-stdlib/storage-port-db.fk
+++ b/form/form-stdlib/storage-port-db.fk
@@ -1,0 +1,70 @@
+; storage-port-db.fk — the Postgres carrier of the storage port.
+;
+; Binds the pg_* natives (the DB carrier floor) to the storage-port interface —
+; the PRODUCTION backend. Same four functions as memory and file; the call site
+; never changes. Rust-only (pg_* lives in the Rust kernel), so programs using
+; this carrier run on form-kernel-rust, exactly like the socket shim is TS-only.
+;
+; The store handle is a connection handle (an int from pg_connect). The key/value
+; table is a minimal kv table the carrier ensures on open:
+;   CREATE TABLE IF NOT EXISTS port_kv (k TEXT PRIMARY KEY, v TEXT)
+; put is an UPSERT (INSERT ... ON CONFLICT (k) DO UPDATE) — last-write-wins, the
+; same content-addressed get-or-insert gate the substrate's intern_node uses.
+; get is a SELECT; has is a COUNT. Reads use pg_query's tab/newline encoding.
+;
+; preludes: form-stdlib/core.fk form-stdlib/storage-port.fk
+;
+(do
+    ;; ---- SQL string-escaping (single-quote doubling) ----------------------
+    ;; A value may contain a quote; double it so the literal is safe. Keys here
+    ;; are substrate slugs (no quotes), but escape both for honesty.
+    (defn db-esc-loop (s i n acc)
+        (if (ge i n) acc
+            (do
+                (let c (substring s i (add i 1)))
+                (db-esc-loop s (add i 1) n
+                    (str_concat acc (if (str_eq c "'") "''" c))))))
+    (defn db-esc (s) (db-esc-loop s 0 (str_len s) ""))
+    (defn db-quote (s) (str_concat "'" (str_concat (db-esc s) "'")))
+
+    ;; ---- open: connect, ensure the kv table, return the connection handle --
+    (defn db-init (config)            ; config = a libpq DSN string
+        (do
+            (let conn (pg_connect config))
+            (pg_exec conn "CREATE TABLE IF NOT EXISTS port_kv (k TEXT PRIMARY KEY, v TEXT)")
+            conn))
+
+    ;; ---- put: UPSERT (last-write-wins) ------------------------------------
+    (defn db-put (conn key value)
+        (do
+            (pg_exec conn
+                (str_concat "INSERT INTO port_kv (k,v) VALUES ("
+                    (str_concat (db-quote key)
+                        (str_concat ", "
+                            (str_concat (db-quote value)
+                                (str_concat ") ON CONFLICT (k) DO UPDATE SET v = "
+                                    (str_concat (db-quote value) "")))))))
+            conn))
+
+    ;; ---- get: SELECT → 0-or-1 optional ------------------------------------
+    ;; pg_query returns the value string for a hit, "" for no rows. We can't
+    ;; distinguish "" (no row) from a genuinely empty stored value by the result
+    ;; alone, so get checks existence via has first.
+    (defn db-get (conn key)
+        (if (eq (db-has conn key) 1)
+            (list (pg_query conn
+                (str_concat "SELECT v FROM port_kv WHERE k = "
+                    (str_concat (db-quote key) ""))))
+            (empty)))
+
+    ;; ---- has?: COUNT ------------------------------------------------------
+    (defn db-has (conn key)
+        (if (str_eq (pg_query conn
+                      (str_concat "SELECT count(*) FROM port_kv WHERE k = "
+                          (str_concat (db-quote key) ""))) "1")
+            1 0))
+
+    (defn carrier-db ()
+        (mk-carrier "postgres" db-init db-put db-get db-has))
+
+    0)

--- a/form/form-stdlib/storage-port-file.fk
+++ b/form/form-stdlib/storage-port-file.fk
@@ -1,62 +1,36 @@
 ; storage-port-file.fk — the file carrier of the storage port.
 ;
-; Binds persistence.fk's .fkb cell store to the storage-port interface. Loaded
-; only when the file carrier is selected, so the memory-only path stays free of
-; channel/persistence dependencies. Same four-function carrier record as memory;
-; the call site in storage-port.fk never changes.
+; Binds the SEGMENTED log store (cell-log-store.fk) to the storage-port
+; interface — the real, scalable filesystem backend (bounded segment files, an
+; in-memory keydir, O(1) ops), not the old flat .fkb. Loaded only when the file
+; carrier is selected, so the memory-only path stays dependency-free.
 ;
-; The store value here is a path string (where the .fkb lives). put writes a
-; CELL in the "kv" domain (key = name, value = trivial-string CTOR); get reads
-; it back via lookup-cell, unwrapping the CTOR to the stored string. The effect
-; lands at the catCall floor (channel append/read) — this proves the port
-; interface is honest over an EFFECTFUL backend, not only the pure memory one.
+; The mapping is direct because the log store already speaks the port's shape:
+;   open  config(=dir) → (cls-open dir)            ; a store handle
+;   put   store k v     → (cls-put store k v)        ; returns the new handle
+;   get   store k       → (cls-get store k)          ; 0-or-1 optional
+;   has?  store k        → 1 if cls-get found, else 0
+; The effect lands at the catCall floor (file_append_bytes / read_file_slice) —
+; the port interface is honest over a real, segmented, durable backend.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/persistence.fk form-stdlib/storage-port.fk
+; preludes: form-stdlib/core.fk form-stdlib/cell-log-store.fk form-stdlib/storage-port.fk
 ;
 (do
-    (defn file-kv-domain () "kv")
+    ;; open: config is the store DIRECTORY. cls-open replays existing segments
+    ;; and returns the store handle.
+    (defn file-init (config) (cls-open config))
 
-    ;; init takes a path and returns it as the store handle. (The port's
-    ;; storage-open calls init with no args, so the file carrier is opened with
-    ;; a path baked into a closure-free wrapper: see file-carrier-at below.)
-    ;; the kv blueprint is a real structural NodeID (a slug as blueprint child
-    ;; breaks the channel write — persistence.fk wants a NodeID ref, not a
-    ;; trivial-string, in child 2).
-    (defn file-kv-blueprint () (make_nodeid 1 8 99 9600))
+    ;; put returns the (possibly segment-advanced) handle — exactly the port's
+    ;; put contract (store → store').
+    (defn file-put (store key value) (cls-put store key value))
 
-    (defn file-put (store key value)
-        (do
-            ;; value is a string; intern it as the CTOR (a trivial-string leaf,
-            ;; read back with node_value).
-            (cell-put store key (file-kv-domain)
-                      (file-kv-blueprint)
-                      (intern_trivial_string value))
-            store))
-
-    (defn file-get (store key)
-        (do
-            (let r (lookup-cell store (file-kv-domain) key))
-            (if (eq (cell-found? r) 1)
-                (list (node_value (cell-ctor (cell-of r))))
-                (empty))))
+    ;; get is already the 0-or-1 optional the port expects.
+    (defn file-get (store key) (cls-get store key))
 
     (defn file-has (store key)
-        (cell-found? (lookup-cell store (file-kv-domain) key)))
+        (if (eq (cls-found? (cls-get store key)) 1) 1 0))
 
-    ;; file-carrier-at path — a carrier whose init creates a fresh store at the
-    ;; given path. Because Form has no closures-over-let in carrier records, we
-    ;; expose the path through a nullary init by pairing the carrier with its
-    ;; path at the call site: storage-open-at handles that below.
-    (defn file-init-noop () "")   ; placeholder; real open uses storage-open-at
     (defn carrier-file ()
-        (mk-carrier "file" file-init-noop file-put file-get file-has))
-
-    ;; storage-open-at carrier path — open a file-backed store at path. For the
-    ;; file carrier this creates the .fkb and returns the path as the handle;
-    ;; for any non-file carrier it ignores the path and uses the normal init.
-    (defn storage-open-at (carrier path)
-        (if (str_eq (carrier-name carrier) "file")
-            (do (cell-store-create path) path)
-            (storage-open carrier)))
+        (mk-carrier "file" file-init file-put file-get file-has))
 
     0)

--- a/form/form-stdlib/storage-port.fk
+++ b/form/form-stdlib/storage-port.fk
@@ -1,33 +1,39 @@
-; storage-port.fk — the first Port: one storage interface, swappable carriers.
+; storage-port.fk — one storage interface, swappable carriers.
 ;
 ; The proof of docs/coherence-substrate/ports-interface-and-structure.md.
 ; A Port = a capability-contract (the operation shape) bound to a carrier (the
 ; host realization). Storage is the first port; its interface is the
 ; content-addressed get-or-insert the substrate already lives on:
 ;
-;   put    store key value   → store'         (insert by key, last-write-wins)
-;   get    store key         → (value) | ()   (0-or-1 list = the body's optional)
-;   has?   store key         → 1 | 0
+;   open   carrier config    → store          (config = path|dir|dsn; init it)
+;   put    carrier store k v  → store'         (insert by key, last-write-wins)
+;   get    carrier store k    → (value) | ()   (0-or-1 list = the body's optional)
+;   has?   carrier store k    → 1 | 0
 ;
-; A CARRIER is a record of named function-values — one per operation — plus its
-; initial state. Selecting a carrier is choosing which record; invoking pulls
-; the operation (a function value) and calls it with a STATIC head. The kernel
-; needs no port_bind native: first-class function values + the existing
-; effectful catCall natives are sufficient (settled by probe, see the doc).
+; A CARRIER is a record of named function-values — one per operation. Selecting a
+; carrier is choosing which record; invoking pulls the operation (a function
+; value) and calls it with a STATIC head. The kernel needs no port_bind native:
+; first-class function values + the existing effectful catCall natives suffice
+; (settled by probe — Form dispatches on a static head, so a backend must be a
+; value carried in data, not a branch at the call site).
 ;
-; Two carriers prove swap:
-;   - memory : a functional assoc-list threaded as the store value (no effect).
-;   - file   : persistence.fk over .fkb (the catCall floor) — same interface.
-;
-; The relational view (db-schema.fk + emits/sql.fk) is a THIRD carrier+interface
-; over this same port; it lands once the seam is proven on the leanest two.
+; THE CARRIERS (each in its own file, loaded only when used):
+;   - memory : a functional assoc-list (here). Pure, no effect, leanest — the
+;              unit-test backend.
+;   - file   : the segmented log store (storage-port-file.fk over
+;              cell-log-store.fk). Real filesystem, the dev/test durable backend.
+;   - db     : Postgres (storage-port-db.fk over the pg_* natives). The
+;              production backend. Rust-only (the pg_* carrier floor).
+; IPFS / S3 / any KV is the same shape: four functions over two effectful
+; natives, no kernel change and no call-site change.
 ;
 ; preludes: form-stdlib/core.fk
 ;
 (do
     ;; ---- the carrier record -----------------------------------------------
-    ;; (init-fn put-fn get-fn has-fn) — four function VALUES. The whole port is
-    ;; these four; a new backend is a new record, never a new call site.
+    ;; (name, init-fn, put-fn, get-fn, has-fn) — four function VALUES. The whole
+    ;; port is these four; a new backend is a new record, never a new call site.
+    ;; init-fn takes a CONFIG (path/dir/dsn; memory ignores it) → an open store.
     (defn mk-carrier (name init put get has) (list "carrier" name init put get has))
     (defn carrier-name (c) (nth c 1))
     (defn carrier-init (c) (nth c 2))
@@ -36,11 +42,11 @@
     (defn carrier-has  (c) (nth c 5))
 
     ;; ---- the PORT interface (carrier-agnostic) ----------------------------
-    ;; These three functions are the entire surface a caller sees. They pull the
-    ;; operation (a function value) from the carrier and call it static-head.
-    ;; The call site never names a backend.
-    (defn storage-open (carrier)
-        (do (let f (carrier-init carrier)) (f)))
+    ;; The entire surface a caller sees. Each pulls the operation (a function
+    ;; value) from the carrier and calls it static-head. The call site never
+    ;; names a backend.
+    (defn storage-open (carrier config)
+        (do (let f (carrier-init carrier)) (f config)))
     (defn storage-put (carrier store key value)
         (do (let f (carrier-put carrier)) (f store key value)))
     (defn storage-get (carrier store key)
@@ -52,12 +58,35 @@
     (defn storage-found? (result) (if (eq (len result) 1) 1 0))
     (defn storage-value  (result) (head result))
 
+    ;; ---- THE substitutability proof — one test, ANY carrier ---------------
+    ;; storage-test runs the port's whole contract through whatever carrier it is
+    ;; handed, returning a 4-bit verdict (1111 = full pass). Because it names no
+    ;; backend, the SAME logic runs over memory, file (log), and db — and the
+    ;; bands assert every carrier returns the identical verdict. That identity IS
+    ;; the pluggability claim, made executable: test the logic once against
+    ;; memory, swap the carrier to prove the backend, never change the code.
+    (defn storage-test (carrier config)
+        (do
+            (let s0 (storage-open carrier config))
+            (let s1 (storage-put carrier s0 "alpha" "one"))
+            (let s2 (storage-put carrier s1 "beta" "two"))
+            (let s3 (storage-put carrier s2 "alpha" "one-REVISED"))   ; overwrite
+            (let got-alpha   (storage-get carrier s3 "alpha"))
+            (let got-beta    (storage-get carrier s3 "beta"))
+            (let has-alpha   (storage-has? carrier s3 "alpha"))
+            (let has-missing (storage-has? carrier s3 "zeta"))
+            (let r1 (if (str_eq (storage-value got-alpha) "one-REVISED") 1 0))  ; LWW
+            (let r2 (if (str_eq (storage-value got-beta) "two") 10 0))
+            (let r3 (if (eq has-alpha 1) 100 0))
+            (let r4 (if (eq has-missing 0) 1000 0))                              ; honest absence
+            (sum (list r1 r2 r3 r4))))
+
     ;; ======================================================================
     ;; CARRIER 1 — memory: a functional assoc-list. Pure, no effect, leanest.
     ;; store = list of (key value) pairs; put conses a fresh pair (last-write
-    ;; -wins because get scans newest-first).
+    ;; -wins because get scans newest-first). init ignores its config.
     ;; ======================================================================
-    (defn mem-init () (empty))
+    (defn mem-init (config) (empty))
     (defn mem-pair (k v) (list k v))
     (defn mem-pair-key (p) (nth p 0))
     (defn mem-pair-val (p) (nth p 1))
@@ -72,23 +101,5 @@
 
     (defn carrier-memory ()
         (mk-carrier "memory" mem-init mem-put mem-get mem-has))
-
-    ;; ======================================================================
-    ;; CARRIER 2 — file: persistence.fk over .fkb. SAME interface; the store
-    ;; value is a path, the effect lands at the catCall floor (channel append /
-    ;; read). Requires persistence.fk in the prelude when this carrier is used.
-    ;;
-    ;; Mapping the generic (key value) onto the cell store: key = name in the
-    ;; "kv" domain; value = a trivial-string CTOR. lookup-cell returns 0-or-1,
-    ;; already the port's optional. This shows the port interface is honest over
-    ;; an effectful backend, not only the pure one.
-    ;;
-    ;; These functions reference persistence.fk symbols (cell-store-create,
-    ;; cell-put, lookup-cell, cell-found?, cell-of, cell-ctor) — bound when the
-    ;; file carrier is selected with persistence.fk loaded. The memory carrier
-    ;; needs none of them, so a caller using only memory loads only this file.
-    ;; ----------------------------------------------------------------------
-    ;; (file carrier constructor lives in storage-port-file.fk to keep this
-    ;; file dependency-free for the memory-only path; see that file.)
 
     0)

--- a/form/form-stdlib/tests/storage-port-band.fk
+++ b/form/form-stdlib/tests/storage-port-band.fk
@@ -1,63 +1,55 @@
-; tests/storage-port-band.fk — one interface, two carriers, identical behavior.
+; tests/storage-port-band.fk — one test, two carriers, identical verdict.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/persistence.fk form-stdlib/storage-port.fk form-stdlib/storage-port-file.fk
+; preludes: form-stdlib/core.fk form-stdlib/cell-log-store.fk form-stdlib/storage-port.fk form-stdlib/storage-port-file.fk
 ;
 ; Proves the Port abstraction (docs/coherence-substrate/ports-interface-and-
-; structure.md): the SAME sequence of storage-port calls, run through a pure
-; memory carrier AND an effectful .fkb file carrier, yields identical results.
-; The call site (the storage-put/get/has? interface) never names a backend —
-; selecting a carrier is choosing a record of function-values; the effect (or
-; lack of it) lands beneath the contract.
+; structure.md) the strongest possible way: the SAME carrier-agnostic test
+; (storage-test) is run through a pure MEMORY carrier and the real SEGMENTED-LOG
+; FILE carrier, and both return the IDENTICAL verdict. The test names no backend;
+; the carrier is injected as data. Identical-verdict-across-carriers IS the
+; substitutability claim, made executable.
 ;
-; Band verdict: 11111 when both carriers agree on every operation.
-;   mem last-write-wins    → 1
-;   mem optional + has?     → 10
-;   file last-write-wins    → 100   (effectful backend, same interface)
-;   file optional + has?    → 1000
-;   carriers AGREE          → 10000 (the swap is behavior-preserving)
+; (The Postgres carrier runs the same storage-test via scripts/storage-port-
+; carriers-test.sh against a live PG — it can't join this three-way band because
+; a live-DB effect isn't value-diffable and pg_* is Rust-only.)
+;
+; Band verdict: 11111 when both carriers fully pass AND agree.
+;   memory carrier full pass (storage-test = 1111)   → 1
+;   file (segmented log) carrier full pass            → 10
+;   the two verdicts are identical (substitutable)     → 100
+;   re-open the file store and the data survived        → 1000  (durability)
+;   memory is ephemeral, file is durable — both honest   → 10000
 
 (do
-    ;; --- memory carrier: a sequence of port calls ---
-    (let cm (carrier-memory))
-    (let m0 (storage-open cm))
-    (let m1 (storage-put cm m0 "alpha" "one"))
-    (let m2 (storage-put cm m1 "beta" "two"))
-    (let m3 (storage-put cm m2 "alpha" "ONE-UPDATED"))
-    (let mem-alpha (storage-value (storage-get cm m3 "alpha")))
-    (let mem-beta  (storage-value (storage-get cm m3 "beta")))
-    (let mem-has   (storage-has? cm m3 "alpha"))
-    (let mem-miss  (storage-has? cm m3 "zeta"))
+    (let dir "/tmp/storage-port-band.d")
+    (fs_rmdir dir)
 
-    ;; --- file carrier: the IDENTICAL sequence, effectful backend ---
+    ;; --- the SAME test, two carriers ---------------------------------------
+    (let mem-verdict  (storage-test (carrier-memory) ""))     ; config ignored
+    (let file-verdict (storage-test (carrier-file) dir))      ; config = dir
+
+    (let mem-ok   (if (eq mem-verdict 1111) 1 0))
+    (let file-ok  (if (eq file-verdict 1111) 10 0))
+    (let agree-ok (if (eq mem-verdict file-verdict) 100 0))   ; substitutable
+
+    ;; --- durability: re-open the file store; the last-write-wins value
+    ;; survived a fresh open (replay), which memory (ephemeral) cannot do. ---
     (let cf (carrier-file))
-    (let f0 (storage-open-at cf "/tmp/storage-port-band.fkb"))
-    (let f1 (storage-put cf f0 "alpha" "one"))
-    (let f2 (storage-put cf f1 "beta" "two"))
-    (let f3 (storage-put cf f2 "alpha" "ONE-UPDATED"))
-    (let file-alpha (storage-value (storage-get cf f3 "alpha")))
-    (let file-beta  (storage-value (storage-get cf f3 "beta")))
-    (let file-has   (storage-has? cf f3 "alpha"))
-    (let file-miss  (storage-has? cf f3 "zeta"))
+    (let reopened (storage-open cf dir))
+    (let durable-ok
+        (if (str_eq (storage-value (storage-get cf reopened "alpha")) "one-REVISED")
+            1000 0))
 
-    ;; --- the two carriers must agree, operation for operation ---
-    (let mem-ok
-        (if (str_eq mem-alpha "ONE-UPDATED")
-            (if (str_eq mem-beta "two")
-                (if (eq mem-has 1) (if (eq mem-miss 0) 1 0) 0) 0) 0))
-    (let mem-opt-ok
-        (if (eq (storage-found? (storage-get cm m3 "zeta")) 0)
-            (if (eq (storage-found? (storage-get cm m3 "alpha")) 1) 10 0) 0))
-    (let file-ok
-        (if (str_eq file-alpha "ONE-UPDATED")
-            (if (str_eq file-beta "two")
-                (if (eq file-has 1) (if (eq file-miss 0) 100 0) 0) 0) 0))
-    (let file-opt-ok
-        (if (eq (storage-found? (storage-get cf f3 "zeta")) 0)
-            (if (eq (storage-found? (storage-get cf f3 "alpha")) 1) 1000 0) 0))
-    (let agree
-        (if (str_eq mem-alpha file-alpha)
-            (if (str_eq mem-beta file-beta)
-                (if (eq mem-has file-has)
-                    (if (eq mem-miss file-miss) 10000 0) 0) 0) 0))
+    ;; --- both carriers are honest about their nature -----------------------
+    ;; a fresh memory store is empty; a fresh file store at a NEW dir is empty.
+    (let fresh-mem (storage-open (carrier-memory) ""))
+    (let fresh-dir "/tmp/storage-port-band-fresh.d")
+    (fs_rmdir fresh-dir)
+    (let fresh-file (storage-open cf fresh-dir))
+    (let honest-ok
+        (if (eq (storage-has? (carrier-memory) fresh-mem "alpha") 0)
+            (if (eq (storage-has? cf fresh-file "alpha") 0) 10000 0) 0))
 
-    (sum (list mem-ok mem-opt-ok file-ok file-opt-ok agree)))
+    (fs_rmdir dir)
+    (fs_rmdir fresh-dir)
+    (sum (list mem-ok file-ok agree-ok durable-ok honest-ok)))

--- a/form/scripts/storage-port-carriers-test.sh
+++ b/form/scripts/storage-port-carriers-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# storage-port-carriers-test.sh — prove ONE storage-port test passes identically
+# across ALL three carriers (memory, segmented file log, live Postgres).
+#
+# The executable substitutability proof: the same carrier-agnostic storage-test
+# runs over every backend and all return the identical verdict. Run on the Rust
+# kernel (the pg_* carrier floor). Self-provisions a throwaway Postgres unless
+# PG_DSN is supplied. See docs/coherence-substrate/ports-interface-and-structure.md.
+#
+# Usage:
+#   form/scripts/storage-port-carriers-test.sh                 # self-provision PG
+#   PG_DSN="host=... port=... user=... dbname=..." form/scripts/...   # existing PG
+#
+# Exit 0 on the expected verdict (111111), 1 otherwise.
+set -euo pipefail
+
+FORMDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$FORMDIR"
+
+RS_BIN="form-kernel-rust/target/release/form-kernel-rust"
+if [[ ! -x "$RS_BIN" ]]; then
+  echo "building rust kernel..." >&2
+  (cd form-kernel-rust && cargo build --release --quiet)
+fi
+
+PROVISIONED=0
+PGDIR=""
+SRCDIR=""
+cleanup() {
+  [[ -n "$SRCDIR" ]] && rm -rf "$SRCDIR"
+  if [[ "$PROVISIONED" -eq 1 && -n "$PGDIR" ]]; then
+    pg_ctl -D "$PGDIR/data" stop -m fast >/dev/null 2>&1 || true
+    rm -rf "$PGDIR"
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "${PG_DSN:-}" ]]; then
+  if ! command -v initdb >/dev/null 2>&1; then
+    echo "SKIP: no PG_DSN set and initdb not found — cannot self-provision." >&2
+    exit 0
+  fi
+  PGDIR="$(mktemp -d "${TMPDIR:-/tmp}/form-pg.XXXXXX")"
+  PROVISIONED=1
+  initdb -D "$PGDIR/data" -U postgres --auth=trust >/dev/null 2>&1
+  PGPORT=54402
+  pg_ctl -D "$PGDIR/data" -o "-p $PGPORT -k $PGDIR" -l "$PGDIR/log" start >/dev/null 2>&1
+  sleep 2
+  psql -h 127.0.0.1 -p "$PGPORT" -U postgres -c "CREATE DATABASE port_test;" >/dev/null 2>&1
+  PG_DSN="host=127.0.0.1 port=$PGPORT user=postgres dbname=port_test"
+fi
+
+SRCDIR="$(mktemp -d "${TMPDIR:-/tmp}/spcarriers.XXXXXX")"
+printf '(do (form-source-compile-file "form-stdlib/core.fk" "%s/core.fk"))\n' "$SRCDIR" > "$SRCDIR/drv.fk"
+form-kernel-go/bin-go form-stdlib/json.fk form-stdlib/cache.fk \
+  form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk "$SRCDIR/drv.fk" >/dev/null 2>&1
+
+TEST="$SRCDIR/all.fk"
+sed "s|PG_DSN_PLACEHOLDER|${PG_DSN}|" form-stdlib/integration/storage-port-all-carriers.fk > "$TEST"
+
+OUT="$("$RS_BIN" "$SRCDIR/core.fk" \
+  form-stdlib/cell-log-store.fk form-stdlib/storage-port.fk \
+  form-stdlib/storage-port-file.fk form-stdlib/storage-port-db.fk "$TEST" 2>&1 | tail -1)"
+echo "verdict: $OUT"
+if [[ "$OUT" == "111111" ]]; then
+  echo "storage port: PASS — one test, identical verdict across memory / file / Postgres."
+  exit 0
+else
+  echo "storage port: FAIL — expected 111111 (all three carriers pass + agree)." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes the three gaps I named when explaining the architecture's pluggability: the seam was designed and the engines existed, but SQL/log weren't *behind* the port and nothing *proved* substitutability end-to-end. Now they are, and it does.

## What
1. **`storage-port.fk`**: `storage-open` takes a **config** (path/dir/dsn; memory ignores it) so init is uniform. Adds **`storage-test`** — a carrier-**agnostic** test (put/get/overwrite=LWW/has?/honest-absence) that names no backend.
2. **`storage-port-file.fk`**: re-pointed from the old flat `persistence.fk` to the **segmented log store** (`cell-log-store.fk`) — the real, scalable filesystem backend.
3. **`storage-port-db.fk`** (new): the **Postgres carrier** over the `pg_*` natives. `put` = `INSERT ... ON CONFLICT DO UPDATE` (last-write-wins — the `intern_node` get-or-insert gate in SQL). Rust-only (pg_* floor), like the TS-only socket shim.

## Proof — one test, identical verdict across every backend
- `tests/storage-port-band.fk` → **11111 three-way**: memory AND the segmented file log return the identical `storage-test` verdict (1111); the file store survives reopen (durability via segment replay).
- `integration/storage-port-all-carriers.fk` + `scripts/storage-port-carriers-test.sh` (Rust-only, **self-provisions a throwaway Postgres**) → **111111**: the SAME `storage-test` passes through memory, file, AND live Postgres, and **all three verdicts are identical** (memory == file == db). That identity is the substitutability claim made executable. Full suite **192 ok, 0 divergent**.

## Why this answers "any SQL or IPFS"
A new backend is the same four-function shape over a couple of effectful natives — **no kernel change, no call-site change**. IPFS fits cleanest: its CID *is* the content hash the substrate already computes with `intern_node`. Testing payoff: unit tests run `carrier-memory` (instant, no I/O); integration tests swap `carrier-file` or `carrier-db` over the identical logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)