### PR TITLE
feat(api): /api/utils/nodeid_compatibility — a real route whose body runs Form-native

### DIFF
--- a/api/app/routers/utils.py
+++ b/api/app/routers/utils.py
@@ -228,6 +228,87 @@ async def nodeid_distance(
 
 
 # ---------------------------------------------------------------------------
+# Endpoint: /api/utils/nodeid_compatibility
+#
+# Pure computation: graded structural compatibility between two NodeIDs, 0..4
+# by how many of the four coordinates (package, level, type, instance) match.
+# Sibling of nodeid_distance — that measures L1 distance, this measures
+# coordinate agreement. It is the kernel of the substrate's view-through-
+# blueprint compatibility check: two NodeIDs sharing more coordinates are more
+# structurally interchangeable. Body transmuted to a Form recipe.
+# ---------------------------------------------------------------------------
+
+
+def nodeid_compatibility_py(
+    a_pkg: int, a_lvl: int, a_type: int, a_inst: int,
+    b_pkg: int, b_lvl: int, b_type: int, b_inst: int,
+) -> int:
+    """Python fallback — semantically identical to the Form recipe."""
+    return (
+        int(a_pkg == b_pkg)
+        + int(a_lvl == b_lvl)
+        + int(a_type == b_type)
+        + int(a_inst == b_inst)
+    )
+
+
+class NodeIdCompatibilityResponse(BaseModel):
+    """GET /api/utils/nodeid_compatibility response."""
+
+    model_config = ConfigDict(extra="forbid")
+    compatibility: Annotated[
+        int, Field(description="Coordinate-agreement score 0..4 between the two NodeIDs")
+    ]
+    a: Annotated[list[int], Field(description="NodeID a as [package, level, type, instance]")]
+    b: Annotated[list[int], Field(description="NodeID b as [package, level, type, instance]")]
+    runtime: Annotated[
+        str,
+        Field(description="Which runtime computed the answer — 'inline', 'subprocess', or 'python-fallback'"),
+    ]
+
+
+@router.get(
+    "/nodeid_compatibility",
+    response_model=NodeIdCompatibilityResponse,
+    summary="Structural compatibility (0..4 coordinate agreement) between two NodeIDs (body runs as Form recipe)",
+    description=(
+        "Pure-computation endpoint, body transmuted to a Form recipe. "
+        "Returns how many of the four NodeID coordinates (package, level, "
+        "type, instance) two cells share — the cheapest structural-"
+        "interchangeability signal. Kernel-or-fallback via serve_via_kernel; "
+        "three-way parity (CPython, TS, Rust) is the gate."
+    ),
+)
+async def nodeid_compatibility(
+    a_pkg: Annotated[int, Query(description="NodeID a — package")] = 1,
+    a_lvl: Annotated[int, Query(description="NodeID a — level")] = 5,
+    a_type: Annotated[int, Query(description="NodeID a — type_")] = 4,
+    a_inst: Annotated[int, Query(description="NodeID a — instance")] = 1,
+    b_pkg: Annotated[int, Query(description="NodeID b — package")] = 1,
+    b_lvl: Annotated[int, Query(description="NodeID b — level")] = 4,
+    b_type: Annotated[int, Query(description="NodeID b — type_")] = 4,
+    b_inst: Annotated[int, Query(description="NodeID b — instance")] = 7,
+) -> NodeIdCompatibilityResponse:
+    compatibility, runtime = serve_via_kernel(
+        "endpoint_nodeid_compatibility_demo.fk",
+        bindings={
+            "a_pkg": a_pkg, "a_lvl": a_lvl, "a_type": a_type, "a_inst": a_inst,
+            "b_pkg": b_pkg, "b_lvl": b_lvl, "b_type": b_type, "b_inst": b_inst,
+        },
+        fallback=lambda: nodeid_compatibility_py(
+            a_pkg, a_lvl, a_type, a_inst, b_pkg, b_lvl, b_type, b_inst,
+        ),
+        parse=int,
+    )
+    return NodeIdCompatibilityResponse(
+        compatibility=compatibility,
+        a=[a_pkg, a_lvl, a_type, a_inst],
+        b=[b_pkg, b_lvl, b_type, b_inst],
+        runtime=runtime,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Endpoint: /api/utils/weighted_average
 #
 # Pure computation: weighted average of a list of float scores against a

--- a/api/tests/test_utils_nodeid_compatibility.py
+++ b/api/tests/test_utils_nodeid_compatibility.py
@@ -1,0 +1,79 @@
+"""Tests for /api/utils/nodeid_compatibility — transmuted under the habit pattern.
+
+The body of this endpoint runs as a Form recipe through form-kernel-rust when
+available, with Python fallback when the binary is missing. Either runtime
+returns the same integer for the same inputs — the coordinate-agreement score
+0..4 between two NodeIDs (how many of package, level, type, instance match).
+
+Sibling of test_utils_nodeid_distance: distance measures L1 separation, this
+measures coordinate agreement. The test verifies the route is wired, the score
+is correct, the runtime field reports which path served, and the Python fallback
+agrees with the recipe.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.routers.utils import nodeid_compatibility_py
+
+BASE = "http://test"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=BASE) as c:
+        yield c
+
+
+class TestNodeIdCompatibilityEndpoint:
+    """Pure-computation endpoint, transmuted to a Form recipe."""
+
+    @pytest.mark.anyio
+    async def test_canonical_inputs_two_match(self, client: AsyncClient):
+        """Default query: NodeID(1,5,4,1) vs (1,4,4,7) — package and type match → 2."""
+        res = await client.get("/api/utils/nodeid_compatibility")
+        assert res.status_code == 200, res.text
+        data = res.json()
+        assert data["compatibility"] == 2
+        assert data["a"] == [1, 5, 4, 1]
+        assert data["b"] == [1, 4, 4, 7]
+        assert data["runtime"] in ("inline", "subprocess", "python-fallback")
+
+    @pytest.mark.anyio
+    async def test_python_fallback_agrees_with_recipe(self):
+        """The Python body (fallback) returns the same integer as the recipe."""
+        assert nodeid_compatibility_py(1, 5, 4, 1, 1, 4, 4, 7) == 2
+
+    @pytest.mark.anyio
+    async def test_all_coordinates_match(self, client: AsyncClient):
+        """Same NodeID twice → full compatibility 4."""
+        res = await client.get(
+            "/api/utils/nodeid_compatibility",
+            params={
+                "a_pkg": 1, "a_lvl": 3, "a_type": 2, "a_inst": 4,
+                "b_pkg": 1, "b_lvl": 3, "b_type": 2, "b_inst": 4,
+            },
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["compatibility"] == 4
+
+    @pytest.mark.anyio
+    async def test_no_coordinates_match(self, client: AsyncClient):
+        """Fully disjoint NodeIDs → compatibility 0."""
+        res = await client.get(
+            "/api/utils/nodeid_compatibility",
+            params={
+                "a_pkg": 1, "a_lvl": 2, "a_type": 3, "a_inst": 4,
+                "b_pkg": 5, "b_lvl": 6, "b_type": 7, "b_inst": 8,
+            },
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["compatibility"] == 0

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.fk
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.fk
@@ -1,0 +1,26 @@
+(do
+    ;; nodeid_compatibility — graded structural compatibility between two
+    ;; substrate NodeIDs, 0..4 by how many of the four coordinates match
+    ;; (package, level, type, instance). This is the kernel of the substrate's
+    ;; view-through-blueprint compatibility check: two NodeIDs sharing more
+    ;; coordinates are more structurally interchangeable. Sibling of
+    ;; nodeid_distance (which measures L1 distance); this measures coordinate
+    ;; agreement. Pure integer computation — three-way parity (CPython/TS/Rust)
+    ;; is the gate, served by serve_via_kernel with a Python fallback.
+    (defn match1 (x y) (if (eq x y) 1 0))
+    (defn compatibility (a_pkg a_lvl a_type a_inst b_pkg b_lvl b_type b_inst)
+        (add (match1 a_pkg b_pkg)
+            (add (match1 a_lvl b_lvl)
+                (add (match1 a_type b_type)
+                     (match1 a_inst b_inst)))))
+    ;; input bindings — serve_via_kernel rewrites these (let ...) forms with the
+    ;; request's query params; the trailing call is the result.
+    (let a_pkg 1)
+    (let a_lvl 5)
+    (let a_type 4)
+    (let a_inst 1)
+    (let b_pkg 1)
+    (let b_lvl 4)
+    (let b_type 4)
+    (let b_inst 7)
+    (compatibility a_pkg a_lvl a_type a_inst b_pkg b_lvl b_type b_inst))

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.py
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.py
@@ -1,0 +1,43 @@
+# endpoint_nodeid_compatibility_demo.py — the body of
+# /api/utils/nodeid_compatibility, captured as pure Python and compiled to a
+# Form recipe.
+#
+# Sibling of endpoint_nodeid_distance_demo: that measures L1 distance between
+# two NodeIDs; this measures coordinate AGREEMENT — how many of the four
+# coordinates (package, level, type, instance) two cells share, a 0..4 score.
+# It is the kernel of the substrate's view-through-blueprint compatibility
+# check: two NodeIDs sharing more coordinates are more structurally
+# interchangeable. Pure integer comparison; the substrate stays a numeric
+# lattice, not a query language.
+#
+# Three runtimes produce identical results:
+#   - CPython
+#   - TS evalPython
+#   - form-kernel-rust
+
+
+def match1(x, y):
+    if x == y:
+        return 1
+    return 0
+
+
+def compatibility(a_pkg, a_lvl, a_type, a_inst, b_pkg, b_lvl, b_type, b_inst):
+    c = match1(a_pkg, b_pkg) + match1(a_lvl, b_lvl)
+    c = c + match1(a_type, b_type) + match1(a_inst, b_inst)
+    return c
+
+
+# Endpoint's frozen sample input — compatibility between two real lattice
+# positions: a Memory cell at (1, 5, 4, 1) and another at (1, 4, 4, 7).
+# package and type match, level and instance differ. Expected: 2.
+a_pkg = 1
+a_lvl = 5
+a_type = 4
+a_inst = 1
+b_pkg = 1
+b_lvl = 4
+b_type = 4
+b_inst = 7
+
+compatibility(a_pkg, a_lvl, a_type, a_inst, b_pkg, b_lvl, b_type, b_inst)

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
@@ -57,6 +57,7 @@ PARITY_FILES=(
     "examples/python_class_demo.py"
     "examples/python_dict_demo.py"
     "examples/endpoint_nodeid_distance_demo.py"
+    "examples/endpoint_nodeid_compatibility_demo.py"
     "examples/endpoint_weighted_average_demo.py"
     "examples/python_inheritance_demo.py"
     "examples/endpoint_lattice_stats_demo.py"


### PR DESCRIPTION
Answers **"can we write the most-used API routes in the Form kernel?"** by extending the proven transmutation pattern with a new live endpoint.

## What I found first
467 endpoints across 133 routers. The realistic Form-native targets are the **pure-compute** ones — and the bridge already exists: `routers/utils.py` has three endpoints whose body is a Form recipe (`serve_via_kernel` runs the `.fk` on the native kernel, Python fallback if absent). This adds the **fourth**.

## The route: `/api/utils/nodeid_compatibility`
Graded coordinate-agreement (0..4) between two substrate NodeIDs — how many of (package, level, type, instance) match. Sibling of `nodeid_distance` (L1 metric); the kernel of the substrate's view-through-blueprint compatibility check.

## The full loop, proven
- **`.py` → `.fk`**: `python-compile` compiles the pure-Python body to a Form recipe.
- **runs Form-native**: the compiled `.fk` runs to **2 on Go/Rust/TS, matching CPython's 2**.
- **live endpoint**: `GET /api/utils/nodeid_compatibility` returns 200, `compatibility=2`, `runtime=subprocess` (the **Form kernel served it**, not Python) — verified via TestClient.
- **4 tests pass** (canonical=2, all-match=4, no-match=0, fallback agrees); sibling distance test still passes.

## Honest note
`parity_suite.sh`'s ts-eval third runtime crashes mid-run — **pre-existing on main** (confirmed by running main's version), not from this change. Flagged separately. The `.py→.fk→rust` parity this endpoint relies on is proven directly.

This is the realistic shape of "routes in the Form kernel": FastAPI stays the HTTP doorway; the **handler body is a Form recipe** that runs natively, gated by CPython parity. Pure-compute routes transmute cleanly today; DB/external routes route through the storage/DB ports instead (proven separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)