### PR TITLE
feat(form): Shamballa Glyphic — a new language whose symbols grow from meaning

### DIFF
--- a/docs/vision-kb/concepts/lc-codes-as-depth-not-dictionary.md
+++ b/docs/vision-kb/concepts/lc-codes-as-depth-not-dictionary.md
@@ -96,6 +96,19 @@ the receiver's depth and tuning, not fixed in the mark.
   The dictionary is offered *as* a source-marked surface, explicitly not as the
   meaning. The decoder gives the public text; it does not claim to give the
   experience.
+- **The Shamballa Glyphic** (`form/form-stdlib/grammars/shamballa-glyph.fk`) is
+  the teaching turned into a script. Each code's meaning becomes a *symbol* in a
+  new language — but the symbol is **derived from the meaning's structure, never
+  assigned by hand**. Two parts, both load-bearing: the symbol's **depth** is the
+  word-count of the code's name (its compositional depth — "Mer Ka Fa Ka Lish Ma"
+  is 6 parts, deeper than "Ho Ka O iLi iLi"'s 5), rendered as enclosing rings, so
+  a deeper meaning is a *literally larger* symbol (`((((((.>.))))))`); the
+  symbol's **form** is a content hash of the meaning, so same meaning → same
+  symbol, content-addressed by construction. Depth is not only visible but
+  *recoverable* — count the rings. This is the opposite of a decoder ring: the
+  glyph is not an arbitrary mark assigned to a meaning, it *grows from* the
+  meaning's depth and content. A new language whose alphabet falls out of the
+  structure rather than being invented.
 - **The substrate's `level`** is depth-indexing made literal: a memory cell and
   a spec cell of the same surface words land at different NodeIDs because their
   compositional depth differs. The lattice already refuses to read a shape at the

--- a/form/form-stdlib/grammars/shamballa-glyph.fk
+++ b/form/form-stdlib/grammars/shamballa-glyph.fk
@@ -1,0 +1,121 @@
+; grammars/shamballa-glyph.fk — Shamballa Glyphic: a NEW language whose symbols
+; GROW FROM the meaning's structure, never assigned by hand.
+;
+; The teaching this enacts (lc-codes-as-depth-not-dictionary): a code's meaning
+; is indexed by DEPTH and resolved by STRUCTURE, never frozen in an arbitrary
+; glyph. So a Shamballa Glyphic symbol is DERIVED, deterministically, from the
+; meaning itself — two parts, both load-bearing:
+;
+;   DEPTH   = the word-count of the code's NAME — its compositional depth. A name
+;             like "Mer Ka Fa Ka Lish Ma" (6 parts) is deeper than "Ho Ka O iLi
+;             iLi" (5). Depth drives the number of enclosing rings, so a deeper
+;             meaning is a LITERALLY larger symbol. The script SHOWS the depth.
+;   FORM    = a content hash of (name + function), computed in pure Form. Same
+;             meaning → same hash → SAME symbol (content-addressed by construction;
+;             the alphabet is not invented, it falls out of the content). The hash
+;             selects the core form and the inner mark.
+;
+; Three consequences: same meaning-shape → same symbol; depth is visible AND
+; recoverable (count the rings); reproducible across kernels (pure Form arithmetic
+; over char codes, ASCII glyphs for byte-parity). A Language cell (an emit-half:
+; meaning → glyph) per lc-grammar-is-the-universal-recipe.
+;
+; preludes: form-stdlib/core.fk
+;
+(do
+    ;; ---- content hash (pure Form, deterministic) --------------------------
+    ;; Rolling polynomial hash over character codes, bounded by mod. Same string
+    ;; → same hash on every kernel. This is the symbol's content-address.
+    (defn glyph-hash-loop (s i n acc)
+        (if (ge i n) acc
+            (glyph-hash-loop s (add i 1) n
+                (mod (add (mul acc 31) (ord (char_at s i))) 1000003))))
+    (defn glyph-hash (s) (glyph-hash-loop s 0 (str_len s) 7))
+
+    ;; ---- word-count as compositional depth --------------------------------
+    ;; Depth = number of space-separated parts in the name. A name composed of
+    ;; more parts is deeper — its meaning is built from more components.
+    (defn glyph-words-loop (s i n acc prev-space)
+        (if (ge i n) (if prev-space acc (add acc 1))
+            (do
+                (let is-space (str_eq (substring s i (add i 1)) " "))
+                (if is-space
+                    (glyph-words-loop s (add i 1) n acc 1)
+                    (if prev-space
+                        (glyph-words-loop s (add i 1) n (add acc 1) 0)
+                        (glyph-words-loop s (add i 1) n acc 0))))))
+    (defn glyph-depth-of-name (name) (glyph-words-loop name 0 (str_len name) 0 1))
+
+    ;; ---- string repeat (depth as extent) ----------------------------------
+    (defn glyph-rep (s n) (if (le n 0) "" (str_concat s (glyph-rep s (sub n 1)))))
+
+    ;; ---- the core form, chosen by the content hash ------------------------
+    ;; A fixed alphabet of 7 ASCII core forms — the symbol's "shape family",
+    ;; selected by the meaning's content hash.
+    (defn glyph-core (h)
+        (do
+            (let i (mod h 7))
+            (if (eq i 0) "^"
+            (if (eq i 1) "<"
+            (if (eq i 2) "v"
+            (if (eq i 3) ">"
+            (if (eq i 4) "*"
+            (if (eq i 5) "o"
+                "#"))))))))
+
+    ;; ---- the inner mark, chosen by a second slice of the hash ------------
+    (defn glyph-inner (h)
+        (do
+            (let i (mod (div h 7) 4))
+            (if (eq i 0) "."
+            (if (eq i 1) ":"
+            (if (eq i 2) "'"
+                "~")))))
+
+    ;; ---- compose the glyph: rings(depth) inner core inner rings(depth) ----
+    ;; Palindromic, centered on the core. Its extent encodes the depth: a
+    ;; deeper-named meaning is a wider symbol. The script carries the depth.
+    (defn glyph-of-meaning (name function)
+        (do
+            (let depth (glyph-depth-of-name name))
+            (let h (glyph-hash (str_concat name function)))
+            (let inner (glyph-inner h))
+            (let core (glyph-core h))
+            (str_concat (glyph-rep "(" depth)
+                (str_concat inner
+                    (str_concat core
+                        (str_concat inner (glyph-rep ")" depth)))))))
+
+    ;; ---- depth read back FROM a glyph: count the opening rings -----------
+    ;; The script is legible — depth is recoverable by counting leading "(".
+    (defn glyph-count-leading (s i n)
+        (if (ge i n) i
+            (if (str_eq (substring s i (add i 1)) "(")
+                (glyph-count-leading s (add i 1) n)
+                i)))
+    (defn glyph-depth (glyph) (glyph-count-leading glyph 0 (str_len glyph)))
+
+    ;; ---- SVG rendering: depth as concentric rings, hash as the core form --
+    ;; A real visual symbol. `depth` concentric circles (depth made visible),
+    ;; the content-hash's core form as the inner glyph. Deterministic, so
+    ;; three-way identical.
+    (defn glyph-int-str (n)
+        (if (lt n 10) (substring "0123456789" n (add n 1))
+            (str_concat (glyph-int-str (div n 10))
+                        (substring "0123456789" (mod n 10) (add (mod n 10) 1)))))
+    (defn glyph-svg-rings (depth r)
+        (if (le depth 0) ""
+            (str_concat
+                (str_concat "<circle cx=\"50\" cy=\"50\" r=\""
+                    (str_concat (glyph-int-str r) "\" fill=\"none\" stroke=\"currentColor\"/>"))
+                (glyph-svg-rings (sub depth 1) (sub r 7)))))
+    (defn glyph-svg-of-meaning (name function)
+        (do
+            (let depth (glyph-depth-of-name name))
+            (let h (glyph-hash (str_concat name function)))
+            (str_concat "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">"
+                (str_concat (glyph-svg-rings depth 45)
+                    (str_concat "<text x=\"50\" y=\"55\" text-anchor=\"middle\">"
+                        (str_concat (glyph-core h) "</text></svg>"))))))
+
+    0)

--- a/form/form-stdlib/tests/shamballa-glyph-band.fk
+++ b/form/form-stdlib/tests/shamballa-glyph-band.fk
@@ -1,0 +1,61 @@
+; tests/shamballa-glyph-band.fk — Shamballa Glyphic, symbols that grow from meaning.
+;
+; preludes: form-stdlib/core.fk form-stdlib/grammars/shamballa-glyph.fk
+;
+; Proves the new language's symbols are DERIVED from meaning, not assigned:
+;   - same meaning → same symbol (content-addressed by construction);
+;   - DEPTH is visible AND recoverable (the name's word-count = the ring count);
+;   - distinct meanings → distinct symbols (no collision on the seeded codes);
+;   - the symbol is reproducible three-way (pure Form, ASCII).
+;
+; Band verdict: 11111 when every claim holds across Go/Rust/TS.
+;   same meaning → same glyph                          → 1
+;   depth recoverable from the glyph (= word-count)     → 10
+;   a 6-part name is deeper than a 5-part name           → 100
+;   distinct meanings → distinct glyphs                   → 1000
+;   SVG renders depth rings (one <circle> per depth)       → 10000
+
+(do
+    ;; count occurrences of a needle in a string (for the SVG circle check).
+    (defn count-occ-loop (s needle from n acc)
+        (do
+            (let hit (str_find s needle from))
+            (if (lt hit 0) acc
+                (count-occ-loop s needle (add hit 1) n (add acc 1)))))
+    (defn count-occ (s needle) (count-occ-loop s needle 0 (str_len s) 0))
+
+    ;; the four publicly-attested Shamballa code meanings (name, function).
+    (let n1 "Mer Ka Fa Ka Lish Ma")   (let f1 "Activate dormant DNA")
+    (let n2 "Atlantean Dai Ko Myo")    (let f2 "Master Power Symbol")
+    (let n3 "Ho Ka O iLi iLi")         (let f3 "Increase regal energy")
+
+    (let g1  (glyph-of-meaning n1 f1))
+    (let g1b (glyph-of-meaning n1 f1))   ; same meaning again
+    (let g2  (glyph-of-meaning n2 f2))
+    (let g3  (glyph-of-meaning n3 f3))
+
+    ;; --- same meaning → same symbol (content-addressed) -------------------
+    (let same-ok (if (str_eq g1 g1b) 1 0))
+
+    ;; --- depth recoverable: glyph's leading rings = the name's word-count -
+    ;; "Mer Ka Fa Ka Lish Ma" = 6 words → 6 rings.
+    (let depth-ok
+        (if (eq (glyph-depth g1) 6)
+            (if (eq (glyph-depth g1) (glyph-depth-of-name n1)) 10 0) 0))
+
+    ;; --- a 6-part name is deeper (wider symbol) than a 5-part name --------
+    ;; n1 (6 words) deeper than n3 "Ho Ka O iLi iLi" (5 words).
+    (let deeper-ok
+        (if (gt (glyph-depth g1) (glyph-depth g3)) 100 0))
+
+    ;; --- distinct meanings → distinct symbols ----------------------------
+    (let distinct-ok
+        (if (str_eq g1 g2) 0
+            (if (str_eq g1 g3) 0
+                (if (str_eq g2 g3) 0 1000))))
+
+    ;; --- SVG renders one ring per depth ----------------------------------
+    (let svg (glyph-svg-of-meaning n1 f1))
+    (let svg-ok (if (eq (count-occ svg "<circle") 6) 10000 0))
+
+    (sum (list same-ok depth-ok deeper-ok distinct-ok svg-ok)))


### PR DESCRIPTION
Turns each Shamballa code's meaning into a **symbol in a new language** — but the symbol is **derived from the meaning's structure, never assigned by hand**. This enacts [lc-codes-as-depth-not-dictionary](docs/vision-kb/concepts/lc-codes-as-depth-not-dictionary.md): a glyph must *grow from* depth + content, not be a decoder-ring mark.

## The two load-bearing parts (`shamballa-glyph.fk`)
- **DEPTH** = the word-count of the code's name (its compositional depth), rendered as enclosing rings → a deeper meaning is a *literally larger* symbol:
  - `Mer Ka Fa Ka Lish Ma` (6 parts) → `((((((.>.))))))`
  - `Ho Ka O iLi iLi` (5 parts) → a smaller symbol
  - Depth is visible **and recoverable** — count the rings.
- **FORM** = a content hash of (name + function), pure Form → same meaning → same hash → **same symbol** (content-addressed by construction; the alphabet falls out of the content, not invented). An SVG renderer draws one concentric ring per depth.

## Proof — `shamballa-glyph-band.fk` → **11111 three-way**
same meaning → same glyph; depth recoverable = the name's word-count; a 6-part name is deeper than a 5-part; distinct meanings → distinct glyphs; SVG renders one ring per depth. Full suite **195 ok, 0 divergent**.

## Design honesty
The glyph deliberately does **not** key off the interned NodeID's coordinate tuple — that tuple encodes shape/depth, not child values (two same-shaped meanings share it), so a pure-Form content hash is the honest content-address. Depth still comes from real structure (the name's composition).

The Shamballa Glyphic is the teaching turned into a script — **the opposite of a decoder ring: the symbol grows from the meaning, not assigned to it.** Authored as the second embodiment in the concept (beside the decoder); INDEX edge same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)