### PR TITLE
fix(form): Shamballa Glyphic depth off-by-one (word-count +1 too high)

### DIFF
--- a/form/form-stdlib/grammars/shamballa-glyph.fk
+++ b/form/form-stdlib/grammars/shamballa-glyph.fk
@@ -35,13 +35,16 @@
     ;; ---- word-count as compositional depth --------------------------------
     ;; Depth = number of space-separated parts in the name. A name composed of
     ;; more parts is deeper — its meaning is built from more components.
+    ;; acc increments at each word-START (space→non-space transition), so it is
+    ;; the full word-count when the loop ends — return it directly. (An earlier
+    ;; terminal clause added a spurious +1; "Mer Ka Fa Ka Lish Ma" is 6 words.)
     (defn glyph-words-loop (s i n acc prev-space)
-        (if (ge i n) (if prev-space acc (add acc 1))
+        (if (ge i n) acc
             (do
                 (let is-space (str_eq (substring s i (add i 1)) " "))
                 (if is-space
                     (glyph-words-loop s (add i 1) n acc 1)
-                    (if prev-space
+                    (if (eq prev-space 1)
                         (glyph-words-loop s (add i 1) n (add acc 1) 0)
                         (glyph-words-loop s (add i 1) n acc 0))))))
     (defn glyph-depth-of-name (name) (glyph-words-loop name 0 (str_len name) 0 1))


### PR DESCRIPTION
**Heals a latent bug I shipped in [#2218](https://github.com/seeker71/Coherence-Network/pull/2218).**

`glyph-words-loop` increments `acc` at each word-**start**, so `acc` already holds the full count when the loop ends — but the terminal clause added a spurious `+1`, turning `Mer Ka Fa Ka Lish Ma` (6 words) into 7. The glyph-band's depth assertion expected 6, got 7, so the band ran **1111, not 11111** on all three kernels.

## The honest account
The three kernels **agreed** on the wrong value (1111), so it was not a true three-way divergence — the "1 divergent" reading I acted on when merging #2218 was transient (likely the band file mid-write during that validate run). The real fault was a *uniform wrong answer* my grep-mangled terminal output hid; reading the JSON `result` field directly exposed it. Either way: I merged a band that didn't actually pass its own spec, and this corrects it forward from current main.

## The fix
Return `acc` directly (drop the +1); make the `prev-space` test bool-safe (`(eq prev-space 1)`) for TS strictness.

## Now correct
glyph-band → **11111 three-way** — depth recoverable = the name's true word-count (6 rings for the 6-part name). Full suite **195 ok, 0 divergent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)