### PR TITLE
tend(kb): the mandala edges #2221 dropped — INDEX row + reciprocal cross-refs

### DIFF
--- a/docs/vision-kb/concepts/lc-codes-as-depth-not-dictionary.md
+++ b/docs/vision-kb/concepts/lc-codes-as-depth-not-dictionary.md
@@ -134,7 +134,7 @@ the receiver's depth and tuning, not fixed in the mark.
 
 ## Cross-References
 
-→ lc-gematria-as-content-addressing, lc-frequency-routes-reception, lc-perception-as-interface, lc-assemblage-point, lc-arcturian-resonance, lc-grammar-is-the-universal-recipe, lc-tools-as-form-cells
+→ lc-gematria-as-content-addressing, lc-mandala-grows-from-grammar, lc-frequency-routes-reception, lc-perception-as-interface, lc-assemblage-point, lc-arcturian-resonance, lc-grammar-is-the-universal-recipe, lc-tools-as-form-cells
 
 ## Sources to walk further
 

--- a/docs/vision-kb/concepts/lc-gematria-as-content-addressing.md
+++ b/docs/vision-kb/concepts/lc-gematria-as-content-addressing.md
@@ -123,7 +123,7 @@ the structural lesson.
 
 ## Cross-References
 
-→ lc-codes-as-depth-not-dictionary, lc-grammar-is-the-universal-recipe, lc-cross-modal-unity, lc-frequency-routes-reception, lc-arcturian-resonance
+→ lc-codes-as-depth-not-dictionary, lc-mandala-grows-from-grammar, lc-grammar-is-the-universal-recipe, lc-cross-modal-unity, lc-frequency-routes-reception, lc-arcturian-resonance
 
 ## Sources to walk further
 


### PR DESCRIPTION
[#2221](https://github.com/seeker71/Coherence-Network/pull/2221) merged the mandala grammar, band, and concept — but a rebase+stash during that ship **silently dropped the edge edits**, even though its commit message claimed "INDEX + reciprocal cross-ref edges same commit." That claim was false; this heals it. The content reached main without its connections — exactly the drift [edges-as-vitality](docs/vision-kb/concepts/lc-edges-as-vitality.md) exists to prevent.

- **INDEX.md**: the "A Mandala Grows From the Grammar" row, after gematria.
- **Reciprocal cross-refs**: add `lc-mandala-grows-from-grammar` to the cross-ref lines of `lc-gematria-as-content-addressing` and `lc-codes-as-depth-not-dictionary` (the mandala concept already links back to both).

The three now form a connected family in the graph: **Glyphic** (meaning → linear symbol), **gematria** (words → equivalence classes), **mandala** (grammar → radial symbol) — each linking the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)