### PR TITLE
fix(kb): theme-resonance-band — class207 cons-order (101111 → 111111)

### DIFF
--- a/form/form-stdlib/tests/theme-resonance-band.fk
+++ b/form/form-stdlib/tests/theme-resonance-band.fk
@@ -50,12 +50,15 @@
             (if (str_eq (head class13) "ahava")
                 (if (str_eq (head (tail class13)) "echad") 1000 0) 0) 0))
 
-    ;; --- the equivalence class for 207 = {or, raz} ----------------------
+    ;; --- the equivalence class for 207 = {raz, or} ----------------------
+    ;; gem-equivalents conses while scanning, so it returns later-seeded-first:
+    ;; "or" is seeded before "raz", so the class reads {raz, or}. The class
+    ;; membership is the point (both share 207); the order is the engine's.
     (let class207 (gem-equivalents 207))
     (let class207-ok
         (if (eq (len class207) 2)
-            (if (str_eq (head class207) "or")
-                (if (str_eq (head (tail class207)) "raz") 10000 0) 0) 0))
+            (if (str_eq (head class207) "raz")
+                (if (str_eq (head (tail class207)) "or") 10000 0) 0) 0))
 
     ;; --- separation is real: life, fuller-life, and wholeness are DISTINCT
     ;; gifts, not collapsed into one. chai (18) ≠ chayim (68) ≠ shalom (376).


### PR DESCRIPTION
**Heals a band I merged broken in [#2225](https://github.com/seeker71/Coherence-Network/pull/2225).** The band ran **101111, not 111111** — the `class207-ok` bit (b5) asserted `gem-equivalents 207 = {or, raz}`, but `gem-equiv-loop` conses while scanning, returning later-seeded-first: **{raz, or}**. The class *membership* was always correct (or and raz both = 207); only my asserted **order** was backwards.

## The honest account
This is the **second** time I shipped a band that didn't pass its own spec (after the glyph off-by-one), despite saying I'd corrected the practice. The edges landed clean this time, but I read `198 ok, 0 divergent` as victory **without confirming the band's own digit**. A green suite summary can coexist with a band that agrees three-ways on a *wrong value* — uniform agreement is not correctness.

## The concrete correction
After validate: `grep` the **specific band's verdict** and confirm it equals the all-ones target. Not the suite summary — the band's own number. That is the check that would have caught both this and the glyph bug before merge.

Fixed: assert `{raz, or}`. Band → **111111** three-way; suite **198 ok, 0 divergent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)