### PR TITLE
tend(kb): deeper-pattern → holographic back-link (reciprocal #2229 left one-way)

### DIFF
--- a/docs/vision-kb/concepts/lc-deeper-pattern.md
+++ b/docs/vision-kb/concepts/lc-deeper-pattern.md
@@ -240,6 +240,10 @@ Your attention, right now, reading this, is the observer effect.
 The wave function is collapsing.
 The field is forming.
 
+## Cross-References
+
+→ lc-the-one-the-many-the-boundary, lc-the-geometry-seen-is-the-geometry-of-seeing, lc-harmonic-geometry-the-one-unfolds, lc-embodiment, lc-wholeness, lc-perception-as-interface
+
 ---
 
 *Water remembers. Crystals amplify. Attention creates.*


### PR DESCRIPTION
[#2229](https://github.com/seeker71/Coherence-Network/pull/2229) linked the new holographic concept *to* `lc-deeper-pattern` (natural — deeper-pattern is explicitly *"the mathematical signature of a holographic projection"*), but the back-link couldn't be auto-added: deeper-pattern named companions inline in its header with no `→ lc-` line. This adds a proper Cross-References section so the edge is bidirectional. The geometry family is now fully interlinked both directions. One file, +4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)