### PR TITLE
tend(kb): correct vision-kb INDEX status breakdown to sum to 166

### DIFF
--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-31 | **Concepts**: 166 | **Status**: 4 expanding, 94 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-05-31 | **Concepts**: 166 | **Status**: 4 expanding, 106 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 


### PR DESCRIPTION
The `**Status**:` segment in `docs/vision-kb/INDEX.md` summed to 154 while the body holds **166** canonical concepts (rebased onto #2236, which added `lc-every-edge-runs-both-ways` and bumped the headline to 166 but left the stale breakdown).

**Counted from the body** (`docs/vision-kb/concepts/*.md`, excluding the one `.de.md` locale variant of an existing concept):

| status | actual | header before |
|--------|-------:|--------------:|
| expanding | 4 | 4 ✓ |
| seed | **106** | 94 ✗ |
| deepening | 55 | 55 ✓ |
| living | 1 | 1 ✓ |
| **sum** | **166** | 154 |

Only `seed` had drifted (94 → 106). The `Concepts: 166` headline and `Transmissions held` segment are correct and untouched. The session-start wellness check independently reports the body aligned at this concept count.

Docs-only one-line correction; no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)