### PR TITLE
fix(deploy): heal in-container substrate ingest (No module named 'app')

### DIFF
--- a/scripts/coh_substrate.py
+++ b/scripts/coh_substrate.py
@@ -26,7 +26,15 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "api"))
+# The `app` package lives at api/app in the repo, but the api CONTAINER flattens
+# api/ onto its root (Dockerfile.api: WORKDIR /app, COPY api/ ./), so there the
+# package root is REPO_ROOT itself (/app/app), not REPO_ROOT/api. Insert whichever
+# candidate actually holds the package so the same script runs in both layouts —
+# this is why the in-container deploy ingest failed with "No module named 'app'".
+for _candidate in (REPO_ROOT / "api", REPO_ROOT):
+    if (_candidate / "app").is_dir():
+        sys.path.insert(0, str(_candidate))
+        break
 
 from app.services.substrate import (  # noqa: E402
     annotate_path,


### PR DESCRIPTION
The Hostinger deploy runs the substrate ingester **inside the api container** and it failed every deploy with `ModuleNotFoundError: No module named 'app'` — non-blocking, so deploys stayed green while the substrate lattice silently never re-ingested changed concepts (the structural view went stale).

**Root cause — layout mismatch.** `coh_substrate.py` did `sys.path.insert(0, str(REPO_ROOT / "api"))`, correct in the repo (app at `api/app`) but wrong in the container, which flattens `api/` onto its root (`Dockerfile.api`: `WORKDIR /app`, `COPY api/ ./`) so the package root is `/app` itself and `/app/api` doesn't exist.

**Fix.** Insert whichever candidate root actually holds the `app` package — `REPO_ROOT/api` (repo) or `REPO_ROOT` (container). One file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)