### PR TITLE
Release CLI and MCP package versions

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coherence-cli",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coherence-cli",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherence-cli",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Coherence Network CLI — invite anyone or anything to ask what is alive, trace ideas from inception to payout, and contribute with fair attribution.",
   "type": "module",
   "bin": {

--- a/docs/system_audit/commit_evidence_2026-05-31_cli-mcp-package-release.json
+++ b/docs/system_audit/commit_evidence_2026-05-31_cli-mcp-package-release.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-05-31",
+  "thread_branch": "codex/cli-mcp-release-20260531",
+  "commit_scope": "Prepare the CLI and MCP public package surfaces for the merged agent-start packet release by bumping package versions, aligning MCP registry metadata, and refreshing MCP package-lock security drift.",
+  "files_owned": [
+    "cli/package.json",
+    "cli/package-lock.json",
+    "mcp-server/package.json",
+    "mcp-server/package-lock.json",
+    "mcp-server/pyproject.toml",
+    "mcp-server/coherence_mcp_server/__init__.py",
+    "mcp-server/server.json",
+    "docs/system_audit/commit_evidence_2026-05-31_cli-mcp-package-release.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "npm view coherence-cli version dist-tags time --json",
+      "npm view coherence-mcp-server version dist-tags time --json",
+      "npm whoami",
+      "npm version patch --no-git-tag-version (cli)",
+      "npm version patch --no-git-tag-version (mcp-server)",
+      "node --check cli/bin/coh.mjs && node --check cli/lib/commands/agent.mjs && node --check cli/lib/commands/update.mjs && node --check mcp-server/index.mjs",
+      "python3 -m json.tool mcp-server/server.json >/dev/null && python3 -m py_compile mcp-server/coherence_mcp_server/__init__.py mcp-server/coherence_mcp_server/__main__.py mcp-server/coherence_mcp_server/server.py",
+      "npm ci (cli)",
+      "npm ci (mcp-server)",
+      "npm audit --omit=dev --json (cli)",
+      "npm audit fix (mcp-server)",
+      "npm audit --omit=dev --json (mcp-server)",
+      "npm pack --dry-run --json (cli)",
+      "npm pack --dry-run --json (mcp-server)",
+      "npm publish --dry-run --access public (cli)",
+      "npm publish --dry-run --access public (mcp-server)",
+      "COHERENCE_API_URL=https://api.coherencycoin.com node cli/bin/coh.mjs agent invite > /tmp/coh-agent-invite.txt && rg -n \"START PACKET|PRACTICE BREATHS|RETURN TRACE|form\\s+Form is the substrate-native\" /tmp/coh-agent-invite.txt",
+      "node - <<'NODE' npm version availability check for coherence-cli@0.13.4 and coherence-mcp-server@0.5.6 NODE"
+    ],
+    "summary": "Source package metadata is ready for coherence-cli@0.13.4 and coherence-mcp-server@0.5.6. CLI and MCP syntax/metadata checks pass; package dry-run publishes pass; npm audits are clean after MCP lock refresh; local CLI agent invite displays START PACKET, PRACTICE BREATHS, and RETURN TRACE from the live API. npm registry publish remains blocked because this environment is not authenticated."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "Pending push, PR creation, and GitHub check monitoring for the package-version release commit."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "npm publish is pending; local `npm whoami` returned E401 Unauthorized, and npm shows coherence-cli latest=0.13.3 / coherence-mcp-server latest=0.5.5 with next versions unpublished."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Source package release metadata and dry-run proof are complete; actual npm publication needs an authenticated npm session or token."
+  },
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "public-surface-agent-start-packet"
+  ],
+  "task_ids": [
+    "codex-cli-mcp-release-20260531"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "delivery"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cli/package.json",
+    "cli/package-lock.json",
+    "mcp-server/package.json",
+    "mcp-server/package-lock.json",
+    "mcp-server/server.json"
+  ],
+  "change_files": [
+    "cli/package.json",
+    "cli/package-lock.json",
+    "mcp-server/package.json",
+    "mcp-server/package-lock.json",
+    "mcp-server/pyproject.toml",
+    "mcp-server/coherence_mcp_server/__init__.py",
+    "mcp-server/server.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/mcp-server/coherence_mcp_server/__init__.py
+++ b/mcp-server/coherence_mcp_server/__init__.py
@@ -14,5 +14,5 @@ Environment variables:
     COHERENCE_API_KEY   API key for write operations (optional for reads)
 """
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 __all__ = ["__version__"]

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coherence-mcp-server",
-  "version": "0.5.4",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coherence-mcp-server",
-      "version": "0.5.4",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -375,7 +375,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -415,12 +414,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -439,9 +438,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -576,11 +575,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -628,9 +626,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -809,9 +807,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -841,9 +839,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1130,7 +1128,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coherence-mcp-server",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Unified MCP server for Coherence Network — invite agents to ask what is alive, what is grounded, query Form/substrate shape, and return attributed traces.",
   "type": "module",
   "bin": {

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coherence-mcp-server"
-version = "0.5.5"
+version = "0.5.6"
 description = "Unified MCP server for the Coherence Network — typed tool surface for AI agents to browse ideas, read field stories, manage tasks, link identities, and navigate the universal graph."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://registry.modelcontextprotocol.io/schemas/server.json",
   "name": "coherence-mcp-server",
-  "version": "0.5.4",
+  "version": "0.5.6",
   "description": "MCP server for Coherence Network — invite anyone or anything to ask what is alive, what is grounded, browse ideas and field stories, query Form/substrate shape, and return attributed traces.",
   "repository": "https://github.com/seeker71/Coherence-Network",
   "homepage": "https://coherencycoin.com",
@@ -30,7 +30,7 @@
     {
       "registry": "npm",
       "name": "coherence-mcp-server",
-      "version": "0.5.4"
+      "version": "0.5.6"
     }
   ],
   "tools": [


### PR DESCRIPTION
## Summary
- bump coherence-cli to 0.13.4 for the agent-start packet CLI surface
- bump coherence-mcp-server to 0.5.6 across npm, Python, and MCP registry metadata
- refresh MCP package-lock transitive dependencies so npm audit is clean

## Proof
- PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
- make wellness
- node --check cli/bin/coh.mjs && node --check cli/lib/commands/agent.mjs && node --check cli/lib/commands/update.mjs && node --check mcp-server/index.mjs
- python3 -m json.tool mcp-server/server.json >/dev/null && python3 -m py_compile mcp-server/coherence_mcp_server/__init__.py mcp-server/coherence_mcp_server/__main__.py mcp-server/coherence_mcp_server/server.py
- npm ci / npm audit --omit=dev --json / npm pack --dry-run --json for CLI and MCP
- npm publish --dry-run --access public for CLI and MCP
- COHERENCE_API_URL=https://api.coherencycoin.com node cli/bin/coh.mjs agent invite > /tmp/coh-agent-invite.txt and verified START PACKET, PRACTICE BREATHS, RETURN TRACE
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Publish note
Actual npm publish is pending because local npm auth is missing: `npm whoami` returns E401 Unauthorized. Current npm latest remains coherence-cli@0.13.3 and coherence-mcp-server@0.5.5; prepared next versions are 0.13.4 and 0.5.6.

## Evidence
- docs/system_audit/commit_evidence_2026-05-31_cli-mcp-package-release.json