### PR TITLE
tend(bootstrap): record python_lambda_demo COMPOST READY — three-way green with existing arms

### DIFF
--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -345,7 +345,7 @@ its own focused PR):
 - `PY-BMF-DICT` + dict-literal lift + key access
 - `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`
 - `PY-BMF-FOR` + iterator protocol on lists / ranges — **landed**: `lift-for` + the PY-BMF-FOR eval arm carry `for i in range(...)`; `python_range_demo.py` reached COMPOST READY 2026-05-31. Iterator-over-list shapes still ride the same arm as they ripen.
-- `PY-BMF-LAMBDA` + closure capture in expressions
+- `PY-BMF-LAMBDA` + closure capture in expressions — **landed**: `lift-lambda` + the PY-BMF-LAMBDA eval arm (closure built, walked by PY-BMF-CALL) carry single-expression lambdas assigned, passed as arguments, and used in arithmetic; `python_lambda_demo.py` reached COMPOST READY 2026-05-31 (arms shipped in #2185; this row records the demo closing three-way with them).
 - `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment
 
 Each PROVEN row brings one more `PARITY_FILES` demo green under


### PR DESCRIPTION
Records `python_lambda_demo.py` as **COMPOST READY** in `kernels/BOOTSTRAP_COMPOST_MANIFEST.md`.

## What this proves
The lambda lift arm (`lift-lambda` → `PY-BMF-LAMBDA`, `python-bmf-lift.fk:171`) and the `PY-BMF-LAMBDA` interpreter arm (`python-bmf-eval.fk:192`) both shipped in #2185. The demo was never promoted even though the arms already close it three-way.

Measured Form-native (`PARITY_THIRD_RUNTIME=kernel-bmf` via `kernel-bmf-run`):

| Runtime | Value |
|---|---|
| CPython | `216` |
| Rust (bootstrap, compiled `.fk`) | `216` |
| `kernel-bmf-run` (Form-native) | `216` |

The demo drives single-expression lambdas assigned to names, passed as arguments to a higher-order function (`apply_twice(f, v): return f(f(v))`), inline lambdas, and lambdas in local variables used in arithmetic.

## Why no new code
Same lesson as `python_string` (#2254): the primitive was already there; the demo just needed promoting. **No new bridge arm, no kernel change** — reachability proven by evidence, not assumed. Moves the COMPOST READY count 7 → 8 of the 20 `PARITY_FILES` demos. Also marks `PY-BMF-LAMBDA` landed in the open-contract pending list.

## Verification
- `form/validate.sh`: **185 ok, 0 divergent** (doc-only change — validate walks `form-samples/` + `form-stdlib/`, never the manifest, so no new divergence is possible).
- Staged only the manifest; the parity suite regenerates `examples/*.fk` and those were not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)