### PR TITLE
fix(self-improve): classify post-preflight 404 as infra, not hard failure

### DIFF
--- a/api/scripts/run_self_improve_cycle.py
+++ b/api/scripts/run_self_improve_cycle.py
@@ -79,6 +79,15 @@ def _is_infra_error(message: str) -> bool:
         or "bad gateway" in lowered
         or "service unavailable" in lowered
         or "gateway timeout" in lowered
+        # 404 reaches this classifier only inside the cycle, after the infra
+        # preflight has already confirmed /api/health and /api/agent/tasks are
+        # answering. A 404 on a route the preflight just exercised is a transient
+        # routing/edge hiccup (Traefik/Cloudflare briefly losing the upstream),
+        # not a code regression — so it belongs in the infra_blocked lane
+        # (exit 0, no red gate) rather than a hard cycle failure. A genuinely
+        # missing route is caught earlier by the preflight's tasks probe.
+        or "status=404" in lowered
+        or "http 404" in lowered
     )
 
 


### PR DESCRIPTION
## What the contract caught

The **Self Improve Cycle** workflow (`.github/workflows/self-improve-cycle.yml`, daily cron) went red on 2026-05-31 (run [26711995252](https://github.com/seeker71/Coherence-Network/actions/runs/26711995252)). That single failure inside a quiet 7-day window is what `wellness_check.py` surfaced as "Contracts — Self Improve Cycle — 1/2 failed (50%)".

## Root cause (evidence-bearing)

From `--log-failed`, the cycle's own report:
```
"status": "failed",
"failed_stage": "plan_submit_or_wait",
"failure_error": "task submit failed (status=404) HTTP 404",
```
The plan stage's `POST /api/agent/tasks` returned **HTTP 404 on all 3 attempts** within a ~2-minute window. The infra preflight that ran immediately before (12:01 / 12:09 / 12:11) reported `health_ok=true`, `gates_ok=true`, `deploy_active=false` — and the route demonstrably exists (live `GET /api/agent/tasks` → 200, `POST {}` → 422). No Hostinger deploy was active in that window. So the 404 was a **transient routing/edge hiccup** (Traefik/Cloudflare briefly losing the upstream), not a code regression.

## Why it turned red

`_is_infra_error()` listed 5xx, 429, timeouts, and connection errors as `infra_blocked` (exit 0, infra issue, no red gate) but **not 404**. So a transient 404 fell through to `status=failed` → exit 2 → red job + "Self-improve cycle failing" issue #2246.

## The fix

Add `status=404` / `http 404` to the single `_is_infra_error` classifier. A 404 reaches this classifier **only inside the cycle, after preflight already exercised the same routes** — that makes it an infra symptom. This does not blind the contract:
- A genuinely missing route is caught earlier by the preflight's `/api/agent/tasks?limit=1` probe and `/api/health`.
- `422` (validation), `403` (auth), and `"... did not complete"` (stage failures) stay hard failures — real regressions still surface.

Verified with a standalone test of the classifier against the real failing message plus 5xx / timeout / 422 / 403 / "did not complete" counterexamples — all classify as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)