### PR TITLE
fix(form-ts): mirror Rust _get flat-alist string-key arm

### DIFF
--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1564,6 +1564,18 @@ export class Kernel {
         }
         return { kind: "null" };
       }
+      // String key on an untagged list → record-field read. A Python class
+      // instance is a flat alist (list "__class__" "Counter" "n" 3 …).
+      // Mirrors the Rust _get (Value::List, Value::Str) arm: walk pairs from
+      // slot 0, match the string key, return the following value; an absent
+      // field throws (Rust panics) rather than falling into the index path.
+      if (v.kind === "list" && idx.kind === "str") {
+        for (let i = 0; i + 1 < v.list.length; i += 2) {
+          const kk = v.list[i]!;
+          if (kk.kind === "str" && kk.str === idx.str) return v.list[i + 1]!;
+        }
+        throw new Error(`_get: no field '${idx.str}' on record`);
+      }
       if (v.kind === "list") {
         const i = idx.kind === "int" ? idx.int : 0;
         if (i < 0 || i >= v.list.length) return { kind: "null" };


### PR DESCRIPTION
## What

The TS Form kernel's `_get` native was missing the **flat-alist string-key** arm the Rust kernel has. When `recv` is an untagged `Value::List` `[k,v,k,v,…]` and `key` is a string, Rust walks it as a (k,v) record alist; TS skipped straight to the int-index path with `idx = 0` and returned element 0.

A Python class instance is a flat alist `(list "__class__" "Counter" "n" 7)`. Reading attribute `"n"` returned `"__class__"` instead of `7` — a Rust↔TS sibling divergence.

## The arm added (mirrors Rust `main.rs` `_get` `(Value::List, Value::Str)` branch)

```ts
// String key on an untagged list → record-field read. A Python class
// instance is a flat alist (list "__class__" "Counter" "n" 3 …).
if (v.kind === "list" && idx.kind === "str") {
  for (let i = 0; i + 1 < v.list.length; i += 2) {
    const kk = v.list[i]!;
    if (kk.kind === "str" && kk.str === idx.str) return v.list[i + 1]!;
  }
  throw new Error(`_get: no field '${idx.str}' on record`);
}
```

Inserted between the dict-tag lookup and the int-index path, matching Rust's branch order. Integer-index and dict-tag paths unchanged. Absent field throws (Rust panics) rather than falling into the index path.

## Proof — Rust↔TS source + behavioral parity (NOT a validate band)

Same `.fk` through both kernels, byte-identical:

| expr | Rust | TS before | TS after |
|------|------|-----------|----------|
| `(_get (list "__class__" "Counter" "n" 7) "n")` | `7` | `"__class__"` | `7` |
| `(_get (list "k1" "V1" "k2" "V2") "k2")` | `"V2"` | — | `"V2"` |
| `(_get (list 10 20 30) 1)` | `20` | `20` | `20` |
| `(_get "hello" 1)` | `"e"` | `"e"` | `"e"` |
| `(_get (_dict_new "a" 1 "b" 2) "b")` | `2` | `2` | `2` |

- python-adapter parity suite: **20/20 ts-eval leg green** (`python_class_demo` → 9, `python_inheritance_demo` → 9 — the `_get` attribute-read paths; the compiled `.fk` uses `_get` 6×).
- `tsc --noEmit`: clean.
- `form/validate.sh`: **209 ok, 1 divergent** (pre-existing untracked `seeded-bytes-recipe-band.fk`) — unchanged.

No `_get` band was added to `validate.sh`/form-samples: it would make Go panic `unbound function "_get"` (Go has no `_get`), creating a new divergence. The proof is Rust↔TS parity + the parity suite, not a validate band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)