### PR TITLE
feat(bootstrap): annotated-assignment lift — python_typing_compose_demo four-way

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -596,8 +596,16 @@
                     ;; function as a native-fn marker). Module name is head child.
                     (py-stmt-result 0
                         (py-bind-from-import-loop (tail kids) env)))
+            (if (node_eq cat PY-BMF-PASS)
+                ;; No-op statement — `pass`, or a bare type annotation
+                ;; (`header: str`) that binds nothing at runtime. Returns 0
+                ;; (Python None analogue) and threads env unchanged. The
+                ;; expression-position py-eval has no PASS arm (a PASS can only
+                ;; arise in statement position), so a bare annotation MUST land
+                ;; here, not in the default expression arm below.
+                (py-stmt-result 0 env)
                 ;; Default: expression statement — eval, env unchanged.
-                (py-stmt-result (py-eval recipe env) env)))))))))))))))
+                (py-stmt-result (py-eval recipe env) env))))))))))))))))
 
     ;; py-eval-module-loop drives a statement sequence to its value. It serves
     ;; two roles: the top-level module (last-statement value semantics) AND a

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -995,6 +995,67 @@
             (intern_node PY-BMF-SUB-ASSIGN
                 (list (intern_trivial_string name) idx value))))
 
+    ;; annotated assignment / bare annotation: `NAME : TYPE [= EXPR]`. The
+    ;; cpython classifier leaves these as kind "expr" / rule "star_expressions"
+    ;; (tokens[1] is ":" not "=" or ":="), so the dispatcher catches them
+    ;; explicitly before the bare-expr arm. The discipline: an annotated
+    ;; assignment IS an assignment with a discarded type slot — erase the
+    ;; annotation and reuse the SAME PY-BMF-ASSIGN lowering, so the runtime
+    ;; value is byte-identical to the un-annotated program. A bare annotation
+    ;; with no value (`header: str`) binds nothing at runtime in CPython, so it
+    ;; lowers to a no-op PY-BMF-PASS (the eval PY-BMF-PASS statement arm threads
+    ;; env unchanged). Both the module-level (`multiplier: int = 1`) and
+    ;; in-function-body (`total: int = self.seed`) cases flow through here
+    ;; identically — the dispatcher runs per-statement at every nesting level.
+    ;;
+    ;; The "=" that separates the (erased) type from the value is found by a
+    ;; depth-0 scan: a subscripted type like `List[Bucket]` carries "[" "]" but
+    ;; never a depth-0 "=", so the scan lands on the real assignment operator.
+
+    ;; ann-assign-eq-index — index of the first depth-0 "=" at or after `i`, or
+    ;; -1 if none (a bare annotation). "[" / "(" / "{" raise depth; their
+    ;; closers lower it; a "=" only counts at depth 0.
+    (defn ann-assign-eq-scan (toks i depth)
+        (if (nil? toks) (sub 0 1)
+            (do
+                (let t (head toks))
+                (if (and (eq depth 0) (tok-op? t "="))
+                    i
+                    (do
+                        (let d2 (if (or (tok-op? t "[") (or (tok-op? t "(") (tok-op? t "{")))
+                                    (add depth 1)
+                                 (if (or (tok-op? t "]") (or (tok-op? t ")") (tok-op? t "}")))
+                                    (sub depth 1)
+                                    depth)))
+                        (ann-assign-eq-scan (tail toks) (add i 1) d2))))))
+
+    ;; stmt-annotated-assign? — 1 iff tokens are `NAME : ...` (a name then a ":"
+    ;; op at index 1). Distinguishes from `NAME := ...` (walrus, op value ":="
+    ;; — a single distinct token, so it does not match here) and from the
+    ;; subscript/attr/aug forms (their index-1 op is "[" / "." / an aug-op).
+    (defn stmt-annotated-assign? (statement-tree)
+        (do
+            (let t (python-statement-tree-tokens statement-tree))
+            (if (lt (len t) 2) 0
+                (if (and (tok-name? (head t))
+                         (tok-op? (nth t 1) ":"))
+                    1 0))))
+
+    ;; lift-annotated-assign — name is token 0; the value (if any) is the token
+    ;; stream after the depth-0 "=". With a value → PY-BMF-ASSIGN (annotation
+    ;; erased, identical to the plain-assignment lowering). With no "=" (bare
+    ;; annotation) → PY-BMF-PASS (runtime no-op).
+    (defn lift-annotated-assign (statement-tree)
+        (do
+            (let t (python-statement-tree-tokens statement-tree))
+            (let name (tok-value (head t)))
+            (let eq-i (ann-assign-eq-scan t 0 0))
+            (if (lt eq-i 0)
+                (intern_node PY-BMF-PASS (empty))
+                (intern_node PY-BMF-ASSIGN
+                    (list (intern_trivial_string name)
+                          (lift-recipe (lift-expr (drop (add eq-i 1) t))))))))
+
     ;; lift-statement dispatches on both `kind` (first-token classifier) and
     ;; `cpython-rule` (the richer rule-name based on token shape). Examples:
     ;;   `x = 5`        — kind "expr", cpython-rule "assignment"
@@ -1020,10 +1081,11 @@
             (if (eq (stmt-attr-assign? statement-tree) 1) (lift-attr-assign statement-tree)
             (if (eq (stmt-aug-op? statement-tree) 1) (lift-aug-assign statement-tree)
             (if (eq (stmt-subscript-assign? statement-tree) 1) (lift-subscript-assign statement-tree)
+            (if (eq (stmt-annotated-assign? statement-tree) 1) (lift-annotated-assign statement-tree)
             (if (str_eq kind "expr")             (lift-expr-stmt statement-tree)
                 (do
                     (trace "lift-statement: unsupported kind/rule" (list kind rule))
-                    (intern_node PY-BMF-PASS (empty))))))))))))))))))
+                    (intern_node PY-BMF-PASS (empty)))))))))))))))))))
 
     ;; ---- module lifter (the public surface) ------------------------
     ;;


### PR DESCRIPTION
## What

Brings `python_typing_compose_demo` to full **four-way parity** by closing its last leg — the Form-native (kernel-bmf) path. CPython == Rust-bootstrap == ts-eval == kernel-bmf == **241**.

## The gate (before)

The Form-native lift dropped module-level and in-body annotated assignments:
- `red: Bucket = Bucket("red", 3, 4)`, `multiplier: int = 1` (module-level, with value)
- `total: int = self.seed` (in function body, with value)
- `header: str` (bare annotation, no value)

The cpython classifier (`python-statement-cpython-rule-from-tokens`) leaves these as kind `"expr"` / rule `"star_expressions"` — `tokens[1]` is `:`, not `=` or `:=`. The lift dispatcher matched none of the existing assignment forms (attr `.`, aug `+=`, subscript `[`) and fell to `kind "expr"` → `lift-expr-stmt`, which lifted only the bare target IDENT and discarded the binding. Later reads hit `py-env-lookup: undefined name red`, then `_plus: unsupported operand types`.

## Where the chain broke

The lift's statement dispatch — not the parser/scanner. The `:` and `=` tokens are already produced by the scanner (confirmed by a live token dump). The fix is bounded lift work.

## The fix

`form/form-stdlib/python-bmf-lift.fk`:
- `stmt-annotated-assign?` — recognizes `NAME : ...` (name, then `:` op at index 1)
- `lift-annotated-assign` — core-abstraction-first: an annotated assignment IS an assignment with a discarded type slot. The `=` is found by a **depth-0 scan** (so subscripted types like `List[Bucket]` don't confuse it); the value tokens after it lift through the existing `PY-BMF-ASSIGN` lowering, annotation erased. No value (`header: str`) → no-op `PY-BMF-PASS`.
- one dispatch row, before the `kind "expr"` arm

`form/form-stdlib/python-bmf-eval.fk`:
- `PY-BMF-PASS` arm in `py-eval-statement` — a true no-op statement (returns 0, threads env unchanged). The expression-position `py-eval` has no PASS arm, so a bare annotation must land here.

Annotation erasure is structural: the runtime value is byte-identical to the un-annotated program.

## Proof + regression

- **Four legs = 241**, each measured in its own isolated tempdir.
- **Regression** (shared dispatch path): 9 baseline demos re-measured under kernel-bmf in isolation — none regressed (`python_bridge` 720, `python_imperative` 45370, `python_range` 41650, `python_builtins` 131, `python_substrate` 17680, `endpoint_coherence_weight` 16185, `python_float` 4.875, `python_import` 20.853981633974485, `python_class` 176).
- `form/validate.sh`: **209 ok, 1 divergent** (= baseline; the 1 is pre-existing untracked `seeded-bytes-recipe-band.fk` `unbound add_mod_u64`, excepted). python-bmf eval/lift/class/typeann bands all green. parity_suite 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)