### PR TITLE
feat(bootstrap): super() + inherited dispatch — python_inheritance_demo four-way

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -139,14 +139,26 @@
     ;; INSTANCE-BP record with "__class__" set, then run __init__ if present
     ;; (binding self + the call args). Returns the instance.
     (defn py-call-method (cls instance mname arg-values)
-        ;; Look up the method py-closure on the class, bind self=instance +
-        ;; args, walk the body. The closure's first param is the receiver.
+        ;; Resolve the method through the ONE walk (py-resolve-owner), so a
+        ;; method inherited from a base class dispatches without the immediate
+        ;; class defining it — `d.signature()` finds Animal.signature when Dog
+        ;; doesn't override it. Then bind self (param 0) = instance, bind the
+        ;; rest = arg-values, and bind `super` to a proxy carrying (self,
+        ;; owner's __base__): inside the running method, super() resolves from
+        ;; the base of the class that DEFINED this method, with the same self.
+        ;; Single inheritance: one base; MRO is a later breath.
         (do
-            (let cl (record_get cls mname))
+            (let owner (py-resolve-owner cls mname))
+            (let cl (record_get owner mname))
             (let pms (py-closure-params cl))
             (let body (py-closure-body cl))
-            ;; bind self (param 0) = instance, then the rest = arg-values
-            (let env0 (py-env-extend (py-closure-env cl) (head pms) instance))
+            (let super-start
+                (if (record_has owner "__base__")
+                    (record_get owner "__base__")
+                    owner))
+            (let env-super (py-env-extend (py-closure-env cl)
+                               "super" (py-super-proxy instance super-start)))
+            (let env0 (py-env-extend env-super (head pms) instance))
             (let call-env (py-bind-params (tail pms) arg-values env0))
             (py-eval body call-env)))
 
@@ -548,11 +560,24 @@
                     (py-stmt-result closure (py-env-extend env name closure)))
             (if (node_eq cat PY-BMF-CLASS)
                 (do
-                    ;; CLASS children: name-leaf, method-DEF-recipes... Build a
-                    ;; class record (methods as fields) and bind NAME in env.
+                    ;; CLASS children: name-leaf, [base-ref], method-DEF-recipes...
+                    ;; lift emits a PY-BMF-IDENT base-ref as kids[1] for a
+                    ;; subclass (`class Dog(Animal):`); a plain class has a DEF
+                    ;; (or nothing) there. Detect the base-ref by its IDENT
+                    ;; category, env-resolve it to the actual base class record
+                    ;; (a cell-ref, not a slug), and thread it onto the subclass
+                    ;; as "__base__" so dispatch and super walk the chain.
                     (let cname (node_value (head kids)))
-                    (let cls (py-class-build cname (tail kids) env))
-                    (py-stmt-result cls (py-env-extend env cname cls)))
+                    (if (and (gt (len kids) 1)
+                             (node_eq (node_category (nth kids 1)) PY-BMF-IDENT))
+                        (do
+                            (let base-cls (py-eval (nth kids 1) env))
+                            (let cls (py-class-build cname (tail (tail kids)) env))
+                            (record_set cls "__base__" base-cls)
+                            (py-stmt-result cls (py-env-extend env cname cls)))
+                        (do
+                            (let cls (py-class-build cname (tail kids) env))
+                            (py-stmt-result cls (py-env-extend env cname cls)))))
             (if (node_eq cat PY-BMF-ATTR-ASSIGN)
                 (do
                     ;; ATTR-ASSIGN children: obj-recipe, attr-leaf, value-recipe.
@@ -807,6 +832,12 @@
                     ;; intercept-before-lookup shape as range.
                     (if (eq (py-builtin? callee-name) 1)
                         (py-builtin callee-name arg-values)
+                    ;; zero-arg super() — hand back the proxy py-call-method
+                    ;; bound into this method's env under "super". The proxy
+                    ;; carries (self, start-class); the METHOD-CALL arm uses it
+                    ;; to resolve super().M() from the base chain.
+                    (if (str_eq callee-name "super")
+                        (py-env-lookup env "super")
                         (do
                             (let callee (py-env-lookup env callee-name))
                             ;; A from-imported native (`from math import sqrt`)
@@ -847,9 +878,18 @@
                     (let arg-values (py-eval-args (tail (tail kids)) env))
                     (if (py-module? obj)
                         (py-math-resolve mname arg-values)
+                    ;; super().M(args): obj is a super-proxy. Resolve M from the
+                    ;; proxy's start-class (base of the defining class) with the
+                    ;; ORIGINAL self — the SAME py-call-method walk, just a
+                    ;; different start class. super().__init__(...) chains the
+                    ;; base constructor against the already-built instance.
+                    (if (py-super? obj)
+                        (py-call-method (record_get obj "__start_class__")
+                                        (record_get obj "__self__")
+                                        mname arg-values)
                         (do
                             (let cls (record_get obj "__class__"))
-                            (py-call-method cls obj mname arg-values))))
+                            (py-call-method cls obj mname arg-values)))))
             (if (node_eq cat PY-BMF-LIST)
                 ;; LIST children: element-recipes. Value is a Form list
                 ;; of evaluated elements, in source order.

--- a/form/form-stdlib/python-bmf-lift.fk
+++ b/form/form-stdlib/python-bmf-lift.fk
@@ -757,19 +757,37 @@
             (intern_node PY-BMF-ATTR-ASSIGN
                 (list obj (intern_trivial_string attr) value))))
 
-    ;; class-statement: `class NAME :` with method `def`s as children. Lifts
-    ;; to PY-BMF-CLASS(name-leaf, method-def-recipes...). The eval arm builds
-    ;; a class value (methods keyed by name) and binds NAME in the env; calling
-    ;; NAME(args) constructs an instance record and runs __init__.
+    ;; class-statement. Two header shapes:
+    ;;   `class NAME :`            → PY-BMF-CLASS(name-leaf, method-defs...)
+    ;;   `class NAME ( BASE ) :`   → PY-BMF-CLASS(name-leaf, base-ref, method-defs...)
+    ;; The base is emitted as a PY-BMF-IDENT referencing the base CLASS cell —
+    ;; structure-first, so the eval arm env-resolves it to the actual base class
+    ;; record (a cell-ref, not a slug) and threads it onto the subclass as
+    ;; "__base__". The eval arm distinguishes the two shapes by testing whether
+    ;; kids[1] is an IDENT (a base-ref) or a DEF (a method) — single-inheritance
+    ;; today; the MRO list is a later breath.
+    ;;
+    ;; tokens[0]=class, tokens[1]=name. When tokens[2]="(", the base name is
+    ;; tokens[3] (`class Dog ( Animal ) :`).
     (defn lift-class (statement-tree)
         (do
             (let tokens (python-statement-tree-tokens statement-tree))
             (let children (python-statement-tree-children statement-tree))
-            ;; tokens[0]=class, tokens[1]=name
             (let name (tok-value (nth tokens 1)))
             (let method-recipes (lift-statements children))
-            (intern_node PY-BMF-CLASS
-                (cons (intern_trivial_string name) method-recipes))))
+            (if (and (gt (len tokens) 3)
+                     (str_eq (tok-value (nth tokens 2)) "("))
+                ;; subclass: base-ref (PY-BMF-IDENT for the base name) sits
+                ;; between the name leaf and the method defs.
+                (intern_node PY-BMF-CLASS
+                    (cons (intern_trivial_string name)
+                          (cons (intern_node PY-BMF-IDENT
+                                    (list (intern_trivial_string
+                                              (tok-value (nth tokens 3)))))
+                                method-recipes)))
+                ;; no base: original shape, unchanged.
+                (intern_node PY-BMF-CLASS
+                    (cons (intern_trivial_string name) method-recipes)))))
 
     ;; expr-statement: just an expression in statement position.
 


### PR DESCRIPTION
## What

Closes the deepest remaining gate in the Python class tail: the Form-native (kernel-bmf) interpreter now resolves `super()` and walks the base chain for inherited method dispatch. `python_inheritance_demo` reaches **four-way parity** (CPython == rust == ts-eval == kernel-bmf == **337**).

## Before

The kernel-bmf leg returned **107** (not 337), tracing `py-env-lookup: undefined name super` twice — once for `super().__init__(name, 100)` in `Dog.__init__`, once for `super().speak()` in `Dog.speak`. The other three legs already gave 337.

## Four sub-gates, all closed in the two `.fk` files (no kernel change)

1. **base capture (lift)** — `lift-class` detects `class NAME ( BASE ) :` (the base name is `tokens[3]` when `tokens[2]` is `(`) and emits the base as a `PY-BMF-IDENT` cell-ref between the name leaf and the method defs. Plain `class NAME :` keeps its original child shape.
2. **base thread (eval CLASS arm)** — when `kids[1]` is an IDENT base-ref, the arm env-resolves it to the actual base class record and sets `"__base__"` on the subclass.
3. **inherited dispatch + super share ONE resolution walk** — `py-resolve-owner` walks the `__base__` chain to the class that defines a method. Normal dispatch starts at the instance's `__class__` (so `d.signature()` falls through to `Animal.signature`); super starts at the base of the defining class. Both go through the same `py-call-method`.
4. **super eval** — `py-call-method` binds a super-proxy `(self, owner's __base__)` into each method's env. The CALL arm hands back the bound proxy for zero-arg `super()`; the METHOD-CALL arm detects a super-proxy receiver and re-enters `py-call-method` with the proxy's start-class and original self — same walk, different start.

## Proof (each leg in its own isolated tempdir)

`CPython == rust(via TS compile) == ts-eval == kernel-bmf == 337`

## Regression (shared dispatch/class paths, re-measured under isolation — none regressed)

python_class 176 · python_typing_compose 241 · python_bridge 720 · python_imperative 45370 · python_range 41650 · python_builtins 131 · python_substrate 17680 · endpoint_coherence_weight 16185 · python_float 4.875 · python_import 20.853981633974485

`form/validate.sh`: **209 ok, 1 divergent** (pre-existing untracked `seeded-bytes-recipe-band.fk`, excepted) — no new divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)