### PR TITLE
fix(bootstrap): repair broken python-bmf-eval — define py-resolve-owner + balance CALL arm

### DIFF
--- a/form/form-stdlib/python-bmf-eval.fk
+++ b/form/form-stdlib/python-bmf-eval.fk
@@ -135,6 +135,36 @@
     (defn py-class? (v) (and (record? v) (node_eq (record_blueprint v) CLASS-BP)))
     (defn py-instance? (v) (and (record? v) (node_eq (record_blueprint v) INSTANCE-BP)))
 
+    ;; --- inheritance: ONE method-resolution walk ------------------------
+    ;; py-resolve-owner — given a class record and a method name, return the
+    ;; class in the __base__ chain that actually DEFINES the method (starting
+    ;; at `cls`, walking "__base__" until found). This single walk grounds
+    ;; BOTH normal dispatch (start at the instance's __class__) AND super
+    ;; dispatch (start at the base of the method's defining class): same
+    ;; operation, different start class. When no class in the chain defines
+    ;; the method, the honest missing-method panic surfaces the site.
+    (defn py-resolve-owner (cls mname)
+        (if (record_has cls mname)
+            cls
+            (if (record_has cls "__base__")
+                (py-resolve-owner (record_get cls "__base__") mname)
+                (do
+                    (trace "py-resolve-owner: no such method" mname)
+                    (head (empty))))))
+
+    ;; --- super proxy ----------------------------------------------------
+    ;; A super() value is a sentinel-tagged record carrying (self, start-class).
+    ;; start-class is the __base__ of the class that DEFINED the currently
+    ;; executing method — so super().M() resolves M from there, with the
+    ;; original self. py-call-method binds one of these into each method's env
+    ;; under "super"; the CALL arm hands it back when the body writes super().
+    (let SUPER-BP (make_nodeid 1 2 99 9502))
+    (defn py-super-proxy (self-obj start-class)
+        (do
+            (let p (record_new SUPER-BP "__self__" self-obj))
+            (record_set p "__start_class__" start-class)))
+    (defn py-super? (v) (and (record? v) (node_eq (record_blueprint v) SUPER-BP)))
+
     ;; py-instantiate — construct an instance of a class record: a fresh
     ;; INSTANCE-BP record with "__class__" set, then run __init__ if present
     ;; (binding self + the call args). Returns the instance.
@@ -857,7 +887,7 @@
                                                     (py-closure-params callee)
                                                     arg-values
                                                     captured-with-self))
-                                    (py-eval (py-closure-body callee) call-env))))))))
+                                    (py-eval (py-closure-body callee) call-env)))))))))
             (if (node_eq cat PY-BMF-ATTR)
                 (do
                     ;; ATTR children: obj-recipe, attr-leaf. When obj is an


### PR DESCRIPTION
## Critical fix

PR #2273 (commit 4b8d1380, \"super() + inherited dispatch\") merged a `python-bmf-eval.fk` that **references** `py-resolve-owner` and `py-super-proxy` in `py-call-method` but **never defines them**, and left the top-level `(do ...)` one paren short. The interpreter fails to load on every kernel — first `parse error: unclosed ( opened at line 1`, then once balanced `unbound function: py-resolve-owner`. Every Python-on-kernel band was broken on main; the original four-way claim was never actually exercised through the kernel-bmf pipeline (it was validated only against a raw `cat`-concatenation of the BML-dialect preludes, which the kernel cannot parse).

## What this does

Lands the two edits that never made it into #2273:

1. **Helper definitions** — `py-resolve-owner` (the ONE base-chain method-resolution walk), the `SUPER-BP` super-proxy constructor `py-super-proxy`, and `py-super?` — defined **before** `py-call-method` so the forward reference resolves.
2. **CALL arm paren balance** — the added `(if (str_eq callee-name \"super\") ...)` branch needs one more closing `)` on the arm's terminal line.

The design from #2273 is otherwise intact: `py-resolve-owner` grounds both normal dispatch (start at the instance's `__class__`, so `d.signature()` falls through to `Animal.signature`) and super dispatch (start at the base of the defining class). `py-call-method` binds a super-proxy `(self, owner's __base__)` into each method env; the CALL arm hands the proxy back for zero-arg `super()`; the METHOD-CALL arm re-enters `py-call-method` on a super-proxy receiver. The lift-side base capture (already on main, correct) emits the base as a `PY-BMF-IDENT` cell-ref.

## Proof (real kernel-bmf pipeline — `pyfkb-run.sh --kernel rust`, BML preludes source-compiled via the Go kernel)

`python_inheritance_demo`: **form(rust) = 337 == CPython 337**.

## Regression — `form/validate.sh` (three-way authority)

**209 ok, 1 divergent** (pre-existing untracked `seeded-bytes-recipe-band.fk` only). Python bands all green: `python-bmf-eval-band` 78000, `python-bmf-lift-band` 155000, **`python-class-band` 31100** (was 30100 — the +1000 cell is the inheritance/super proof, go==rust), `python-export-band` 562.

Demos via `pyfkb-run.sh --kernel rust` unchanged: python_class 176, python_bridge 720, python_imperative 45370, python_range 41650, python_builtins 131, python_substrate 17680, endpoint_coherence_weight 16185, python_float 4.875, python_import 20.853981633974485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)