### PR TITLE
tend(form): register SUPER-BP (1.2.99.9502) — heal the super() work's proprioception gap

### DIFF
--- a/form/form-stdlib/blueprint-registry.json
+++ b/form/form-stdlib/blueprint-registry.json
@@ -3602,6 +3602,19 @@
       "pkg": 1,
       "level": 2,
       "type": 99,
+      "inst": 9502,
+      "name": "SUPER-BP",
+      "meaning": "Blueprint for a super() proxy under the BMF evaluator — a sentinel-tagged record carrying (__self__, __start_class__); start-class is the __base__ of the class that defined the executing method, so super().M() resolves M from there with the original self.",
+      "aliases": [],
+      "reuse": 1,
+      "defined_in": [
+        "form/form-stdlib/python-bmf-eval.fk"
+      ]
+    },
+    {
+      "pkg": 1,
+      "level": 2,
+      "type": 99,
       "inst": 1750,
       "name": "HTTP-REQUEST",
       "meaning": "",


### PR DESCRIPTION
## What

Registers `SUPER-BP` (NodeID `1.2.99.9502`) in `blueprint-registry.json`, alongside its already-registered siblings `CLASS-BP` (9500) and `INSTANCE-BP` (9501).

## Why

The super()/inherited-dispatch work (#2273 / #2274) introduced a third BMF value-blueprint — `SUPER-BP`, the sentinel for a `super()` proxy record — but only `CLASS-BP` and `INSTANCE-BP` got registered. `make wellness` was failing:

```
unregistered Blueprint numbers have crept in:
  1.2.99.9502  named locally: ['SUPER-BP']
  FAIL: 1 type-99 NodeID absent from blueprint-registry.json
```

## The original alert was stale

This branch began as an urgent paren-imbalance regression report against `python-bmf-eval.fk`. On investigation, **that regression was already healed on main by #2274** (`fix(bootstrap): … balance CALL arm`). Verified:

- `git show origin/main:form/form-stdlib/python-bmf-eval.fk` scans to **paren depth 0** (and `python-bmf-lift.fk` too).
- `pyfkb-run.sh --kernel rust python_inheritance_demo.py` → **`form(rust): 337`** (file loads + runs).
- Every `python-bmf-*` / `python-class` band green.
- `form/validate.sh` → **`211 ok, 0 divergent`**.

The one genuine residue was this missing registry row — the body using a shape it hadn't named to itself. After the fix, `scan_form_blueprints.py` reports **unregistered type-99: 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)