### PR TITLE
[codex] Expand BML thesis support

### DIFF
--- a/docs/system_audit/bml_thesis_feature_audit_20260601.md
+++ b/docs/system_audit/bml_thesis_feature_audit_20260601.md
@@ -1,0 +1,148 @@
+# BML Thesis Feature Audit - 2026-06-01
+
+This audit checks the current Form BML support against the thesis and
+companion source material in
+`docs/field/urs/artifacts/master-thesis-2000/`.
+
+## Result
+
+The current work proves substantial BML/BMF support, but it does not yet prove
+FULL thesis `.bml` source compilation into native Form kernel execution.
+
+What is proven today:
+
+- BMF grammar sections such as `section [bml.bmf]` compile to native `.fkb`
+  sidecars and execute through `walk_recipe_here`.
+- The BML/BMF thesis primitive set is represented: `Nil`, `Fail`,
+  `EndOfFile`, `EndOfLine`, `Cut`, `MultiMatch`, and `Primitive`.
+- A BMA-like execution band runs forward and backward, including explicit
+  `DO` and `UNDO` trace proof.
+- A BML class/interface/inheritance component model covers structural bases,
+  delegated bases, inherited interfaces, default interface methods, section
+  property inheritance, class/static flags, member lookup, access checks, and
+  `BML.lang.Application.Main` detection.
+
+What is not proven yet:
+
+- The source compiler scans `section [...]` blocks; it is not yet a
+  standalone thesis `.bml` file compiler.
+- Full `.bml` files from the thesis companion source tree do not compile end to
+  end as source into Form native kernel execution.
+- Most thesis grammar rules are present as a BMF rulebook/manifest, but many
+  still lower through `bml-emit-node-source` instead of a semantic emitter that
+  constructs executable Form/BMA code.
+- The current executable `form.bml` support is a maintenance dialect for Form
+  stdlib authoring, not the full thesis BML language.
+
+## Coverage Numbers
+
+Current local counts from `form/form-stdlib/grammars/bml.fk`:
+
+- `bml-reference-rule-names`: 172 named thesis/reference grammar entries.
+- `section [bml.bmf]`: 163 BML BMF rule entries.
+- `section [bml.bmf]` entries using generic `bml-emit-node-source`: 140.
+- Explicit reversible/native BML source rules with `<=` reverse emitters: 19.
+- Native BML recipe-section compiler rules exposed in `bml-recipe-section`: 19.
+
+These counts mean the grammar surface is recorded, but full semantic lowering
+is not complete rule-for-rule.
+
+## Status Vocabulary
+
+- `native-executed`: source or AST lowers to Form/BMA recipe or ops and is run
+  by `form/validate.sh`.
+- `component-proven`: semantic model functions are exercised in Form tests, but
+  a full source parser/emitter path is not proven.
+- `grammar-manifest`: the rule name or BMF rule exists, but it lowers to a
+  generic source node.
+- `thesis-deferred`: the thesis itself marks the feature unsupported or future.
+- `gap`: required for the full claim, not yet implemented/proven.
+
+## Feature Matrix
+
+| Thesis area | Thesis reference | Current status | Proof / gap |
+| --- | --- | --- | --- |
+| BMF top-down backtracking parser and undoable attributes | `backtracking-model-languages.txt:76-86` | native-executed for current Form/BMF engine, component-proven for BMA undo | `bml-thesis-exit-proof.fk` proves branch undo and forward/backward trace; full thesis ParseStream/Context API remains a gap. |
+| Runtime grammar extension, modify/add/delete rules during parsing | `backtracking-model-languages.txt:78-82` | grammar-manifest | BMF sections can be compiled at runtime to `.fkb`; live mutation of the active grammar during a parse remains a gap. |
+| Grammar-as-objects, nonterminals as classes with inheritance/interfaces | `backtracking-model-languages.txt:86`, `:129-139` | component-proven | BMF reference classes and BML component model are represented; full `.bml` class definitions for every BMF object are not source-compiled. |
+| BMF containers: rule, rule ref, template rule, branch, sequence, repeat | `backtracking-model-languages.txt:144-158` | native-executed for Form BMF object model | Existing BMF compiler/runtime tests cover these shapes; BML thesis source files for those classes remain outside full `.bml` compile. |
+| BMF primitives: Cut, Fail, EOF, EOL, MultiMatch | `backtracking-model-languages.txt:160-169`; `source-samples/BMF-includes.bml:21-27` | native-executed / component-proven | `bmf-thesis-primitives-band.fk` and `bml-thesis-exit-proof.fk` prove rule presence and primitive statement execution. |
+| BMF terminals: char ranges and literals with whitespace control | `backtracking-model-languages.txt:171-174` | native-executed for existing Form BMF subset | Full thesis whitespace/comment placement semantics remain a gap. |
+| Tags and semantic methods | `backtracking-model-languages.txt:176-182` | component-proven in BMF object model | Runtime method predicates with thesis ParseStack/Context API remain a gap. |
+| `.bml` files, packages, imports, program start | `backtracking-model-languages.txt:241-270` | component-proven for package/import objects and Application.Main detection | End-to-end `.bml` file compile and link remains a gap. |
+| Lexical conventions: nested comments, keywords, identifiers, operators, int/hex/bin/float/char/string | `backtracking-model-languages.txt:243-253` | grammar-manifest | Current proof has selected atoms and literals; complete source scanner parity remains a gap. |
+| Binary types, structures, lvalue/rvalue | `backtracking-model-languages.txt:271-275` | grammar-manifest | No full binary layout/get-put code generation proof yet. |
+| Expressions, casts, member access, calls, `instanceof`, arrays, operators, assignment | `backtracking-model-languages.txt:292-594` | grammar-manifest with small executable expression subset | `method-return-add`, `char-lit`, and `array-int` execute; full precedence, overload, cast, assign, bitwise, logical, and member dispatch remain gaps. |
+| Statements: if/select/switch/while/do/loop/for/break/continue/return/choice/try/throw/fail/with | `backtracking-model-languages.txt:596-636` | native-executed for selected BMA subset; grammar-manifest for most source forms | return/break/continue/throw/try/fail/cut/mark/choice/choose execute in proof tests; full control-flow lowering remains a gap. |
+| Companion backtracking syntax: `choose`, `if_fail`, `while_success`, `cut`, `mark` | `companion/bml-search-algorithms.txt:49-78` | native-executed for choose/fail/cut/mark; grammar-manifest for if_fail/while_success | Need semantic lowering for full `if_fail` and `while_success`. |
+| Local and anonymous functions / blocks with context | `companion/bml-search-algorithms.txt:81-89`, `:212-218`; `backtracking-model-languages.txt:234` | grammar-manifest | Closure capture and block execution semantics remain gaps. |
+| Properties and attributes | `backtracking-model-languages.txt:640-689` | component-proven for many helpers; thesis-deferred for several attrs | Tests prove access/class/default/final/deferred/delegate/shared/get/put/strict/relaxed flags as data. Runtime enforcement/codegen is incomplete; thesis itself defers unique, singleton, delegate, shared, strict/relaxed, nostate, const/cost/default/final/inline, out/inout/cast, and access enforcement in lines `651-685`. |
+| Classes, sections, syntax blocks, class interfaces | `backtracking-model-languages.txt:692-695` | component-proven; grammar-manifest for full source | Source headers and component bodies are proven; full class block source compilation remains a gap. |
+| Interfaces and parent interfaces | `backtracking-model-languages.txt:700-703` | component-proven | Interface inheritance/default lookup is proven; full method declaration/implementation separation from source remains a gap. |
+| Multiple inheritance, delegation, inherited interfaces, ambiguity | `backtracking-model-languages.txt:719-723`; `sgb-bml-objects.txt:704-715` | component-proven | Structural/delegated lookup is proven; generated hidden delegate fields, deferred forward calls, and ambiguity diagnostics remain gaps. |
+| Access control | `backtracking-model-languages.txt:724-732` | component-proven as helper predicates; thesis-deferred for enforcement | Full compiler/runtime enforcement remains a gap. |
+| Constructors, inner construction, casts/coercions | `backtracking-model-languages.txt:737-745` | grammar-manifest | Constructor inheritance/default constructor generation and coercion chains remain gaps. |
+| Overloading and templates | `backtracking-model-languages.txt:750-757` | component-proven for template kind restrictions; grammar-manifest for full source | Method/operator overload resolution and template instantiation remain gaps. |
+| Exceptions | `backtracking-model-languages.txt:760-762` | native-executed for int throw/catch proof slice | Arbitrary object exception typing/catch matching remains a gap. |
+| BML syntax blocks and multi-syntax streams | `backtracking-model-languages.txt:1012-1014`; `bml-search-algorithms.txt:239-246` | native-executed for source-section sidecars; gap for object syntax dispatch | `source-compiler-runtime.fk` and `source-compiler-multi-dialect-band.fk` prove section sidecars; parsing arbitrary objects by syntax name remains a gap. |
+| Object runtime definitions, dispatch, casting, instantiators | `sgb-bml-objects.txt:569-655`, `:778-791` | component-proven only for selected lookup helpers | Full instance/interface/method definitions, indexed dispatch, arbitrary interface casts, unique/singleton instantiators, and detached interfaces remain gaps. |
+| Companion `.bml` source samples | `companion/source-samples/*.bml` | gap | `BMF-grammar.bml`, `container-Rule.bml`, `primitive-Cut.bml`, and related files are reference inputs, not passing compile fixtures yet. |
+
+## Companion Source Boundary Checks
+
+Concrete thesis sample constructs that are outside the current executable
+source subset:
+
+- `BMF-includes.bml` starts with `#include "BMF/Argument.bml"`; the current BML
+  rulebook references `include` from `main-rule`, but there is no semantic
+  source include rule.
+- `BMF-grammar.bml` has `class BMF [public] : Application`; current executable
+  BML source handles simplified headers, while full property/body class source
+  is still generic.
+- `BMF-grammar.bml` has initialized fields such as
+  `String m_strDefaultConfigFile = "BMF.cfg";`; the executable `field` proof
+  currently covers `$type $name;`.
+- `BMF-grammar.bml` has array parameters such as `void Main( String[] hArgs )`;
+  current executable method proof covers the no-arg integer-addition slice.
+- `primitive-Cut.bml` calls `System.Cut( hContext.Argument( 0 ))`; current
+  native proof covers the BMA `cut` operation and `cut;` statement slice, not
+  full method-call runtime dispatch.
+- `container-Rule.bml` uses constructors and `self(...)` chaining; constructor
+  lowering and self-call execution are still gaps.
+
+## Exit Criteria For The FULL Claim
+
+To honestly claim full thesis `.bml` compile-to-native support, the repo needs
+all of these passing as machine proof:
+
+1. A `.bml` source scanner/parser that accepts the companion source samples
+   directly, including nested comments, full literals, property blocks,
+   sections, syntax blocks, classes, interfaces, templates, asm, and all
+   statement/expression forms.
+2. A semantic emitter for each thesis/reference grammar rule, replacing the
+   generic `bml-emit-node-source` path where executable meaning is required.
+3. A source-to-model phase that constructs the BML component/object model from
+   real `.bml` files, not only from test-built components.
+4. A model-to-native phase that lowers classes, methods, statements,
+   expressions, exceptions, object dispatch, and backtracking into Form/BMA
+   recipes or ops that the native kernels execute.
+5. A bidirectional source proof for supported rules: source to object/code and
+   object/code back to source where the BMF rule declares a reverse emitter.
+6. A forward/backward execution proof over source-originated programs, not only
+   hand-built AST slices.
+7. A companion-corpus gate that compiles and runs at least
+   `BMF-grammar.bml`, `container-Rule.bml`, `primitive-Cut.bml`, and a
+   `BML.lang.Application` sample.
+
+## Current Proof Commands
+
+The current proof set is still valuable and should stay as the regression band:
+
+```bash
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-stdlib/tests/bmf-thesis-primitives-band.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-class-inheritance-proof.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-full-class-model-proof.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-runtime.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk
+```

--- a/docs/system_audit/commit_evidence_20260531_bml_support.json
+++ b/docs/system_audit/commit_evidence_20260531_bml_support.json
@@ -1,0 +1,133 @@
+{
+  "date": "2026-06-01",
+  "thread_branch": "codex/bml-support-20260531",
+  "commit_scope": "Expand BML thesis-support coverage in the Form BMF grammar, class model, inheritance semantics, primitive manifest, and BMA forward/backward runtime proof layer, with an explicit full-claim coverage audit.",
+  "files_owned": [
+    "form/form-stdlib/grammar-chars.fk",
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/bmf-thesis-primitives-band.fk",
+    "form/form-stdlib/tests/bml-class-inheritance-proof.fk",
+    "form/form-stdlib/tests/bml-full-class-model-proof.fk",
+    "form/form-stdlib/tests/bml-thesis-exit-proof.fk",
+    "form/form-kernel-go/bp_table.go",
+    "form/form-kernel-rust/src/bp_table.rs",
+    "form/form-kernel-ts/src/bp_table.ts",
+    "docs/system_audit/bml_thesis_feature_audit_20260601.md",
+    "docs/system_audit/commit_evidence_20260531_bml_support.json",
+    "scripts/validate_commit_evidence.py"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/bml-support-20260531 && PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-stdlib/tests/bmf-thesis-primitives-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-class-inheritance-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-full-class-model-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-compiler-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-action-runtime-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-reference-compiler-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-stdlib/tests/grammar-chars.fk",
+      "cd api && PYTHONDONTWRITEBYTECODE=1 /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_substrate_form_bml_state.py tests/test_substrate_form_bml_full.py",
+      "git fetch origin main",
+      "git rebase --autostash origin/main",
+      "cd form && ./validate.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260531_bml_support.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": "Focused BMF/BML proof bands passed across Go, Rust, and TypeScript kernels after rebasing onto origin/main: BMF primitives=18, BML class inheritance=8388607, BML full class model=1073741823, BML thesis forward/backward=1073741840. Native source-section proofs pass for bml.bmf/form.bml .fkb sidecar execution. Full Form validation passed with 213 ok, 0 divergent. API BML substrate tests passed with 33 passed. Worktree PR guard passed with ready_for_push=true after rebase. The 2026-06-01 thesis audit explicitly records that full .bml source compile-to-native support is not yet proven."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI not run yet; branch is local."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Production verification is pending until this branch is pushed, reviewed, merged, and deployed."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "BML compiler/runtime support now recognizes the thesis BMF primitive set, richer BML class/interface/inheritance semantics, and BMA-style forward/backward execution proof bands in the native Form kernel validation suite.",
+    "public_endpoints": [
+      "https://coherencycoin.com",
+      "https://api.coherencycoin.com"
+    ],
+    "test_flows": [
+      "cd form && ./validate.sh",
+      "./scripts/verify_web_api_deploy.sh after merge/deploy"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local proof is complete; CI remains pending until push/PR."
+  },
+  "idea_ids": [
+    "idea-realization-engine"
+  ],
+  "spec_ids": [
+    "bml-thesis-reference-support"
+  ],
+  "task_ids": [
+    "bml-support-20260531"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "codex-subagents",
+      "contributor_type": "machine",
+      "roles": [
+        "reference-inventory",
+        "proof-checklist"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "BMF primitive manifest: Nil, Fail, EndOfFile, EndOfLine, Cut, MultiMatch, and Primitive are represented by BML BMF rules and pass form/form-stdlib/tests/bmf-thesis-primitives-band.fk with result 18 across sibling kernels.",
+    "BML class/inheritance proof: form/form-stdlib/tests/bml-class-inheritance-proof.fk passed with result 8388607, proving class headers with structural/delegated bases, section-contained members, structural field lookup, delegated method lookup, self/this/super dispatch, and inherited interfaces.",
+    "BML full class-model proof: form/form-stdlib/tests/bml-full-class-model-proof.fk passed with result 1073741823, proving property helpers, abstract/final/deferred/class/default flags, delegate/shared/get/put/strict/relaxed field attributes, class/static field-method-const predicates, constants, inner classes, access checks, effective section properties on contained members, template class/interface restriction, default interface methods, and BML.lang.Application.Main entry detection with deferred Main rejection.",
+    "BML thesis exit proof: choice/choose aliases, fail/cut/mark statement primitives, section variants, syntax-section presence, BMF reference object model count, branch undo, raise/resume/nostate, and explicit DO/UNDO BMA forward/backward trace pass form/form-stdlib/tests/bml-thesis-exit-proof.fk with result 1073741840.",
+    "BML thesis full-claim audit: docs/system_audit/bml_thesis_feature_audit_20260601.md checks every thesis feature group against current machine proof and records the remaining gap: full companion .bml source files do not yet compile end-to-end into native Form kernel execution.",
+    "Source-section proof: form/form-stdlib/tests/source-compiler-runtime.fk proves section [bml.bmf] compiles to a .bml.bmf.fkb sidecar and executes through walk_recipe_here; source-compiler-multi-dialect-band.fk proves multi-section .fkb sidecar generation including the form.bml maintenance dialect.",
+    "Full Form suite after rebase: cd form && ./validate.sh produced 213 ok, 0 divergent.",
+    "Full Form suite after final rebase: cd form && ./validate.sh produced 215 ok, 0 divergent and regenerated kernel blueprint tables, adding SUPER-BP consistently to Go, Rust, and TypeScript kernels.",
+    "API BML substrate guard: 33 pytest tests passed using the existing primary api venv because this fresh worktree has no api/.venv.",
+    "Local PR guard: scripts/worktree_pr_guard.py --mode local --base-ref origin/main reported ready_for_push=True; check_pr_followthrough reported codex_open_prs=0 and stale_codex_prs=0."
+  ],
+  "change_files": [
+    "form/form-stdlib/grammar-chars.fk",
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/bmf-thesis-primitives-band.fk",
+    "form/form-stdlib/tests/bml-class-inheritance-proof.fk",
+    "form/form-stdlib/tests/bml-full-class-model-proof.fk",
+    "form/form-stdlib/tests/bml-thesis-exit-proof.fk",
+    "form/form-kernel-go/bp_table.go",
+    "form/form-kernel-rust/src/bp_table.rs",
+    "form/form-kernel-ts/src/bp_table.ts",
+    "docs/system_audit/bml_thesis_feature_audit_20260601.md",
+    "docs/system_audit/commit_evidence_20260531_bml_support.json",
+    "scripts/validate_commit_evidence.py"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-kernel-go/bp_table.go
+++ b/form/form-kernel-go/bp_table.go
@@ -390,6 +390,7 @@ var bpTable = map[string][4]uint32{
 	"SQL-OBJ": {1, 2, 99, 10},
 	"SQL-PAIR": {1, 2, 99, 12},
 	"SUBSTRATE-REF": {1, 2, 99, 1712},
+	"SUPER-BP": {1, 2, 99, 9502},
 	"SYMBOL-BIND": {1, 2, 99, 1730},
 	"SYMBOL-NOT-FOUND": {1, 2, 99, 1732},
 	"SYMBOL-TABLE": {1, 2, 99, 1731},

--- a/form/form-kernel-rust/src/bp_table.rs
+++ b/form/form-kernel-rust/src/bp_table.rs
@@ -388,6 +388,7 @@ pub static BP_ENTRIES: &[(&str, [u32; 4])] = &[
     ("SQL-OBJ", [1, 2, 99, 10]),
     ("SQL-PAIR", [1, 2, 99, 12]),
     ("SUBSTRATE-REF", [1, 2, 99, 1712]),
+    ("SUPER-BP", [1, 2, 99, 9502]),
     ("SYMBOL-BIND", [1, 2, 99, 1730]),
     ("SYMBOL-NOT-FOUND", [1, 2, 99, 1732]),
     ("SYMBOL-TABLE", [1, 2, 99, 1731]),

--- a/form/form-kernel-ts/src/bp_table.ts
+++ b/form/form-kernel-ts/src/bp_table.ts
@@ -388,6 +388,7 @@ export const BP_TABLE: Record<string, [number, number, number, number]> = {
   "SQL-OBJ": [1, 2, 99, 10],
   "SQL-PAIR": [1, 2, 99, 12],
   "SUBSTRATE-REF": [1, 2, 99, 1712],
+  "SUPER-BP": [1, 2, 99, 9502],
   "SYMBOL-BIND": [1, 2, 99, 1730],
   "SYMBOL-NOT-FOUND": [1, 2, 99, 1732],
   "SYMBOL-TABLE": [1, 2, 99, 1731],

--- a/form/form-stdlib/grammar-chars.fk
+++ b/form/form-stdlib/grammar-chars.fk
@@ -15,9 +15,10 @@
 ;   (list "eol")                — newline or EOF
 ;   (list "not" pattern)        — negative lookahead (BMF NOT)
 ;   (list "peek" pattern)       — positive lookahead, no consumption
+;   (list "multi-match" p lo hi)— BMF MultiMatch, bounded repetition
 ;
 ; The structural primitives (sequence, choice, star, opt, capture,
-; tag, cut, stop, nil, rule) all work the same way — they compose
+; tag, cut, stop/fail, nil, rule) all work the same way — they compose
 ; character-level matches. Cut + Stop disambiguate exactly the way
 ; BMF intended: at the point the rule decides, not at lex time.
 ;
@@ -208,7 +209,18 @@
             (if (str_eq tag "peek")       (cm-peek p stream rules)
             (if (str_eq tag "cut")        (cm-cut stream)
             (if (str_eq tag "stop")       (cmk-fail "stop")
+            (if (str_eq tag "fail")       (cmk-fail "fail")
             (if (str_eq tag "nil")        (cmk-match (ccap-empty 0) stream)
+            (if (str_eq tag "multi-match")
+                (cm-match-multi-match (head (tail p))
+                                      (head (tail (tail p)))
+                                      (head (tail (tail (tail p))))
+                                      stream rules (empty) 0)
+            (if (str_eq tag "multimatch")
+                (cm-match-multi-match (head (tail p))
+                                      (head (tail (tail p)))
+                                      (head (tail (tail (tail p))))
+                                      stream rules (empty) 0)
             (if (str_eq tag "sequence")
                 (cm-match-sequence (tail p) stream rules (ccap-empty 0))
             (if (str_eq tag "choice")
@@ -222,7 +234,7 @@
                 (cm-match-opt (head (tail p)) stream rules)
             (if (str_eq tag "rule")
                 (cm-match-rule (head (tail p)) stream rules)
-                (cmk-fail (str_concat "unknown char-pattern: " tag)))))))))))))))))))))
+                (cmk-fail (str_concat "unknown char-pattern: " tag))))))))))))))))))))))))
 
     (defn cm-match-sequence (children stream rules acc-caps)
         (if (nil? children) (cmk-match acc-caps stream)
@@ -265,6 +277,25 @@
                 (cmk-match (ccap-set (ccap-empty 0) "items" collected) stream)
                 (cm-match-star child (cmatch-rest m) rules
                                 (cons (cmatch-caps m) collected))))))
+
+    (defn cm-match-multi-match (child min-count max-count stream rules collected count)
+        (if (ge count max-count)
+            (cmk-match (ccap-set (ccap-empty 0) "items" collected) stream)
+            (do
+                (let m (cm-match-pattern child stream rules))
+                (if (cfail-cut? m) m
+                (if (cfail? m)
+                    (if (ge count min-count)
+                        (cmk-match (ccap-set (ccap-empty 0) "items" collected) stream)
+                        (cmk-fail "multi-match minimum not reached"))
+                    (if (eq (cs-index (cmatch-rest m)) (cs-index stream))
+                        (if (ge count min-count)
+                            (cmk-match (ccap-set (ccap-empty 0) "items" collected) stream)
+                            (cmk-fail "multi-match made no progress"))
+                        (cm-match-multi-match child min-count max-count
+                                              (cmatch-rest m) rules
+                                              (cons (cmatch-caps m) collected)
+                                              (add count 1))))))))
 
     (defn cm-match-opt (child stream rules)
         (do

--- a/form/form-stdlib/grammars/bml.fk
+++ b/form/form-stdlib/grammars/bml.fk
@@ -130,6 +130,568 @@
     (defn comp-bml-fields (component)
         (nth component 2))
 
+    (defn bml-component-kind? (component kind)
+        (str_eq (comp-bml-kind component) kind))
+
+    (defn bml-model (classes interfaces)
+        (list "bml-model" classes interfaces))
+
+    (defn bml-model-classes (model) (nth model 1))
+    (defn bml-model-interfaces (model) (nth model 2))
+
+    (defn bml-interface-ref-component (name)
+        (comp-bml-component "InterfaceRef" (list name)))
+
+    (defn bml-class-name (class-component)
+        (nth (comp-bml-fields class-component) 0))
+
+    (defn bml-class-properties (class-component)
+        (nth (comp-bml-fields class-component) 1))
+
+    (defn bml-class-supers (class-component)
+        (nth (comp-bml-fields class-component) 2))
+
+    (defn bml-class-body (class-component)
+        (nth (comp-bml-fields class-component) 3))
+
+    (defn bml-class-structural-base-name (class-component)
+        (if (nil? (bml-class-supers class-component)) ""
+            (head (bml-class-supers class-component))))
+
+    (defn bml-class-delegation-base-names (class-component)
+        (if (nil? (bml-class-supers class-component)) (empty)
+            (tail (bml-class-supers class-component))))
+
+    (defn bml-interface-name (interface-component)
+        (nth (comp-bml-fields interface-component) 0))
+
+    (defn bml-interface-properties (interface-component)
+        (nth (comp-bml-fields interface-component) 1))
+
+    (defn bml-interface-parent-name (interface-component)
+        (nth (comp-bml-fields interface-component) 2))
+
+    (defn bml-interface-body (interface-component)
+        (nth (comp-bml-fields interface-component) 3))
+
+    (defn bml-section-body (section-component)
+        (nth (comp-bml-fields section-component) 2))
+
+    (defn bml-field-type (field-component)
+        (nth (comp-bml-fields field-component) 0))
+
+    (defn bml-field-name (field-component)
+        (nth (comp-bml-fields field-component) 1))
+
+    (defn bml-method-return (method-component)
+        (nth (comp-bml-fields method-component) 0))
+
+    (defn bml-method-name (method-component)
+        (nth (comp-bml-fields method-component) 1))
+
+    (defn bml-method-body (method-component)
+        (nth (comp-bml-fields method-component) 3))
+
+    (defn bml-interface-ref-name (interface-ref)
+        (head (comp-bml-fields interface-ref)))
+
+    (defn bml-property-component (name value)
+        (comp-bml-component "Property" (list name value)))
+
+    (defn bml-property-name (property)
+        (nth (comp-bml-fields property) 0))
+
+    (defn bml-property-value (property)
+        (nth (comp-bml-fields property) 1))
+
+    (defn bml-properties-find (properties name)
+        (if (nil? properties) (empty)
+            (if (str_eq (bml-property-name (head properties)) name)
+                (head properties)
+                (bml-properties-find (tail properties) name))))
+
+    (defn bml-properties-has? (properties name)
+        (if (nil? (bml-properties-find properties name)) false true))
+
+    (defn bml-properties-value (properties name default-value)
+        (do
+            (let property (bml-properties-find properties name))
+            (if (nil? property) default-value
+                (bml-property-value property))))
+
+    (defn bml-access-level (properties)
+        (if (bml-properties-has? properties "private") "private"
+            (if (bml-properties-has? properties "protected") "protected"
+                (if (bml-properties-has? properties "public") "public"
+                    (bml-properties-value properties "access" "public")))))
+
+    (defn bml-section-name (section-component)
+        (nth (comp-bml-fields section-component) 0))
+
+    (defn bml-section-properties (section-component)
+        (nth (comp-bml-fields section-component) 1))
+
+    (defn bml-field-properties (field-component)
+        (nth (comp-bml-fields field-component) 2))
+
+    (defn bml-const-type (const-component)
+        (nth (comp-bml-fields const-component) 0))
+
+    (defn bml-const-name (const-component)
+        (nth (comp-bml-fields const-component) 1))
+
+    (defn bml-const-properties (const-component)
+        (nth (comp-bml-fields const-component) 2))
+
+    (defn bml-const-value (const-component)
+        (nth (comp-bml-fields const-component) 3))
+
+    (defn bml-method-properties (method-component)
+        (nth (comp-bml-fields method-component) 2))
+
+    (defn bml-template-parameters (template-component)
+        (nth (comp-bml-fields template-component) 0))
+
+    (defn bml-template-kind (template-component)
+        (nth (comp-bml-fields template-component) 1))
+
+    (defn bml-template-body (template-component)
+        (nth (comp-bml-fields template-component) 2))
+
+    (defn bml-template-valid-kind? (template-component)
+        (if (str_eq (bml-template-kind template-component) "class") true
+            (str_eq (bml-template-kind template-component) "interface")))
+
+    (defn bml-class-abstract? (class-component)
+        (bml-properties-has? (bml-class-properties class-component) "abstract"))
+
+    (defn bml-class-final? (class-component)
+        (bml-properties-has? (bml-class-properties class-component) "final"))
+
+    (defn bml-method-abstract? (method-component)
+        (bml-properties-has? (bml-method-properties method-component) "abstract"))
+
+    (defn bml-method-final? (method-component)
+        (bml-properties-has? (bml-method-properties method-component) "final"))
+
+    (defn bml-method-default? (method-component)
+        (bml-properties-has? (bml-method-properties method-component) "default"))
+
+    (defn bml-method-deferred? (method-component)
+        (bml-properties-has? (bml-method-properties method-component) "deferred"))
+
+    (defn bml-method-class? (method-component)
+        (bml-properties-has? (bml-method-properties method-component) "class"))
+
+    (defn bml-field-delegate? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "delegate"))
+
+    (defn bml-field-class? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "class"))
+
+    (defn bml-field-shared? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "shared"))
+
+    (defn bml-field-get? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "get"))
+
+    (defn bml-field-put? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "put"))
+
+    (defn bml-field-strict? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "strict"))
+
+    (defn bml-field-relaxed? (field-component)
+        (bml-properties-has? (bml-field-properties field-component) "relaxed"))
+
+    (defn bml-const-class? (const-component)
+        (bml-properties-has? (bml-const-properties const-component) "class"))
+
+    (defn bml-member-name (component)
+        (if (bml-component-kind? component "Field")
+            (bml-field-name component)
+            (if (bml-component-kind? component "Method")
+                (bml-method-name component)
+                (if (bml-component-kind? component "Const")
+                    (bml-const-name component)
+                    (if (bml-component-kind? component "Class")
+                        (bml-class-name component)
+                        "")))))
+
+    (defn bml-member-properties (component)
+        (if (bml-component-kind? component "Field")
+            (bml-field-properties component)
+            (if (bml-component-kind? component "Method")
+                (bml-method-properties component)
+                (if (bml-component-kind? component "Const")
+                    (bml-const-properties component)
+                    (if (bml-component-kind? component "Class")
+                        (bml-class-properties component)
+                        (empty))))))
+
+    (defn bml-model-find-class-loop (classes name)
+        (if (nil? classes) (empty)
+            (if (str_eq (bml-class-name (head classes)) name)
+                (head classes)
+                (bml-model-find-class-loop (tail classes) name))))
+
+    (defn bml-model-find-class (model name)
+        (bml-model-find-class-loop (bml-model-classes model) name))
+
+    (defn bml-model-find-interface-loop (interfaces name)
+        (if (nil? interfaces) (empty)
+            (if (str_eq (bml-interface-name (head interfaces)) name)
+                (head interfaces)
+                (bml-model-find-interface-loop (tail interfaces) name))))
+
+    (defn bml-model-find-interface (model name)
+        (bml-model-find-interface-loop (bml-model-interfaces model) name))
+
+    (defn bml-body-members-of-kind (items kind)
+        (if (nil? items) (empty)
+            (do
+                (let item (head items))
+                (let rest (bml-body-members-of-kind (tail items) kind))
+                (if (bml-component-kind? item kind)
+                    (cons item rest)
+                    (if (bml-component-kind? item "Section")
+                        (append (bml-body-members-of-kind (bml-section-body item) kind) rest)
+                        rest)))))
+
+    (defn bml-body-member-effective-properties (items kind name inherited-properties)
+        (if (nil? items) (empty)
+            (do
+                (let item (head items))
+                (if (bml-component-kind? item kind)
+                    (if (str_eq (bml-member-name item) name)
+                        (append inherited-properties (bml-member-properties item))
+                        (bml-body-member-effective-properties (tail items) kind name inherited-properties))
+                    (if (bml-component-kind? item "Section")
+                        (do
+                            (let section-found
+                                (bml-body-member-effective-properties
+                                    (bml-section-body item)
+                                    kind
+                                    name
+                                    (append inherited-properties (bml-section-properties item))))
+                            (if (nil? section-found)
+                                (bml-body-member-effective-properties (tail items) kind name inherited-properties)
+                                section-found))
+                        (bml-body-member-effective-properties (tail items) kind name inherited-properties))))))
+
+    (defn bml-class-member-effective-properties (class-component kind name)
+        (bml-body-member-effective-properties (bml-class-body class-component) kind name (empty)))
+
+    (defn bml-class-own-fields (class-component)
+        (bml-body-members-of-kind (bml-class-body class-component) "Field"))
+
+    (defn bml-class-own-methods (class-component)
+        (bml-body-members-of-kind (bml-class-body class-component) "Method"))
+
+    (defn bml-class-interface-refs (class-component)
+        (bml-body-members-of-kind (bml-class-body class-component) "InterfaceRef"))
+
+    (defn bml-interface-own-methods (interface-component)
+        (bml-body-members-of-kind (bml-interface-body interface-component) "Method"))
+
+    (defn bml-class-own-constants (class-component)
+        (bml-body-members-of-kind (bml-class-body class-component) "Const"))
+
+    (defn bml-class-own-inner-classes (class-component)
+        (bml-body-members-of-kind (bml-class-body class-component) "Class"))
+
+    (defn bml-find-field (fields name)
+        (if (nil? fields) (empty)
+            (if (str_eq (bml-field-name (head fields)) name)
+                (head fields)
+                (bml-find-field (tail fields) name))))
+
+    (defn bml-find-method (methods name)
+        (if (nil? methods) (empty)
+            (if (str_eq (bml-method-name (head methods)) name)
+                (head methods)
+                (bml-find-method (tail methods) name))))
+
+    (defn bml-find-const (constants name)
+        (if (nil? constants) (empty)
+            (if (str_eq (bml-const-name (head constants)) name)
+                (head constants)
+                (bml-find-const (tail constants) name))))
+
+    (defn bml-find-inner-class (classes name)
+        (if (nil? classes) (empty)
+            (if (str_eq (bml-class-name (head classes)) name)
+                (head classes)
+                (bml-find-inner-class (tail classes) name))))
+
+    (defn bml-class-structural-fields (model class-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let base (bml-class-structural-base-name class-component))
+                    (append
+                        (if (str_eq base "") (empty)
+                            (bml-class-structural-fields model base))
+                        (bml-class-own-fields class-component))))))
+
+    (defn bml-class-field-lookup-structural (model class-name field-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let own (bml-find-field (bml-class-own-fields class-component) field-name))
+                    (if (nil? own)
+                        (do
+                            (let base (bml-class-structural-base-name class-component))
+                            (if (str_eq base "") (empty)
+                                (bml-class-field-lookup-structural model base field-name)))
+                        own)))))
+
+    (defn bml-class-const-lookup-structural (model class-name const-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let own (bml-find-const (bml-class-own-constants class-component) const-name))
+                    (if (nil? own)
+                        (do
+                            (let base (bml-class-structural-base-name class-component))
+                            (if (str_eq base "") (empty)
+                                (bml-class-const-lookup-structural model base const-name)))
+                        own)))))
+
+    (defn bml-class-inner-class-lookup-structural (model class-name inner-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let own (bml-find-inner-class (bml-class-own-inner-classes class-component) inner-name))
+                    (if (nil? own)
+                        (do
+                            (let base (bml-class-structural-base-name class-component))
+                            (if (str_eq base "") (empty)
+                                (bml-class-inner-class-lookup-structural model base inner-name)))
+                        own)))))
+
+    (defn bml-class-extends-structural? (model actual-name expected-name)
+        (if (str_eq actual-name expected-name) true
+            (do
+                (let class-component (bml-model-find-class model actual-name))
+                (if (nil? class-component) false
+                    (do
+                        (let base (bml-class-structural-base-name class-component))
+                        (if (str_eq base "") false
+                            (bml-class-extends-structural? model base expected-name)))))))
+
+    (defn bml-class-can-extend? (model base-name)
+        (do
+            (let base-component (bml-model-find-class model base-name))
+            (if (nil? base-component) false
+                (if (bml-class-final? base-component) false true))))
+
+    (defn bml-member-accessible? (model owner-class from-class properties)
+        (do
+            (let access (bml-access-level properties))
+            (if (str_eq access "private")
+                (str_eq owner-class from-class)
+                (if (str_eq access "protected")
+                    (bml-class-extends-structural? model from-class owner-class)
+                    true))))
+
+    (defn bml-class-all-delegation-bases (model class-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let base (bml-class-structural-base-name class-component))
+                    (append
+                        (bml-class-delegation-base-names class-component)
+                        (if (str_eq base "") (empty)
+                            (bml-class-all-delegation-bases model base)))))))
+
+    (defn bml-method-binding (self-class this-class method-component)
+        (list "bml-method-binding" self-class this-class method-component))
+
+    (defn bml-method-binding-self (binding) (nth binding 1))
+    (defn bml-method-binding-this (binding) (nth binding 2))
+    (defn bml-method-binding-method (binding) (nth binding 3))
+
+    (defn bml-class-method-lookup-bases (model bases self-class method-name)
+        (if (nil? bases) (empty)
+            (do
+                (let found (bml-class-method-lookup-in-class model (head bases) self-class method-name))
+                (if (nil? found)
+                    (bml-class-method-lookup-bases model (tail bases) self-class method-name)
+                    found))))
+
+    (defn bml-class-method-lookup-in-class (model class-name self-class method-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let own (bml-find-method (bml-class-own-methods class-component) method-name))
+                    (if (nil? own)
+                        (bml-class-method-lookup-bases
+                            model
+                            (bml-class-supers class-component)
+                            self-class
+                            method-name)
+                        (bml-method-binding self-class class-name own))))))
+
+    (defn bml-class-method-lookup (model class-name method-name)
+        (bml-class-method-lookup-in-class model class-name class-name method-name))
+
+    (defn bml-invoke-from-context (model self-class _this-class method-name)
+        (bml-class-method-lookup-in-class model self-class self-class method-name))
+
+    (defn bml-super-invoke (model self-class this-class method-name)
+        (do
+            (let class-component (bml-model-find-class model this-class))
+            (if (nil? class-component) (empty)
+                (bml-class-method-lookup-bases
+                    model
+                    (bml-class-supers class-component)
+                    self-class
+                    method-name))))
+
+    (defn bml-class-method-override-allowed? (model class-name method-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) false
+                (do
+                    (let own (bml-find-method (bml-class-own-methods class-component) method-name))
+                    (if (nil? own) true
+                        (do
+                            (let inherited
+                                (bml-class-method-lookup-bases
+                                    model
+                                    (bml-class-supers class-component)
+                                    class-name
+                                    method-name))
+                            (if (nil? inherited) true
+                                (if (bml-method-final? (bml-method-binding-method inherited))
+                                    false
+                                    true))))))))
+
+    (defn bml-interface-method-lookup (model interface-name method-name)
+        (do
+            (let interface-component (bml-model-find-interface model interface-name))
+            (if (nil? interface-component) (empty)
+                (do
+                    (let own (bml-find-method (bml-interface-own-methods interface-component) method-name))
+                    (if (nil? own)
+                        (do
+                            (let parent (bml-interface-parent-name interface-component))
+                            (if (str_eq parent "") (empty)
+                                (bml-interface-method-lookup model parent method-name)))
+                        own)))))
+
+    (defn bml-interface-default-method-lookup (model interface-name method-name)
+        (do
+            (let method (bml-interface-method-lookup model interface-name method-name))
+            (if (nil? method) (empty)
+                (if (bml-method-default? method) method
+                    (empty)))))
+
+    (defn bml-interface-refs-default-method-lookup (model refs method-name)
+        (if (nil? refs) (empty)
+            (do
+                (let found
+                    (bml-interface-default-method-lookup
+                        model
+                        (bml-interface-ref-name (head refs))
+                        method-name))
+                (if (nil? found)
+                    (bml-interface-refs-default-method-lookup model (tail refs) method-name)
+                    found))))
+
+    (defn bml-class-bases-interface-default-method-lookup (model bases method-name)
+        (if (nil? bases) (empty)
+            (do
+                (let found
+                    (bml-class-interface-default-method-lookup model (head bases) method-name))
+                (if (nil? found)
+                    (bml-class-bases-interface-default-method-lookup model (tail bases) method-name)
+                    found))))
+
+    (defn bml-class-interface-default-method-lookup (model class-name method-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) (empty)
+                (do
+                    (let own (bml-find-method (bml-class-own-methods class-component) method-name))
+                    (if (nil? own)
+                        (do
+                            (let own-interface
+                                (bml-interface-refs-default-method-lookup
+                                    model
+                                    (bml-class-interface-refs class-component)
+                                    method-name))
+                            (if (nil? own-interface)
+                                (bml-class-bases-interface-default-method-lookup
+                                    model
+                                    (bml-class-supers class-component)
+                                    method-name)
+                                own-interface))
+                        (empty))))))
+
+    (defn bml-interface-extends? (model actual-name expected-name)
+        (if (str_eq actual-name expected-name) true
+            (do
+                (let interface-component (bml-model-find-interface model actual-name))
+                (if (nil? interface-component) false
+                    (do
+                        (let parent (bml-interface-parent-name interface-component))
+                        (if (str_eq parent "") false
+                            (bml-interface-extends? model parent expected-name)))))))
+
+    (defn bml-interface-refs-support? (model refs interface-name)
+        (if (nil? refs) false
+            (if (bml-interface-extends? model (bml-interface-ref-name (head refs)) interface-name)
+                true
+                (bml-interface-refs-support? model (tail refs) interface-name))))
+
+    (defn bml-class-bases-support-interface? (model bases interface-name)
+        (if (nil? bases) false
+            (if (bml-class-supports-interface? model (head bases) interface-name)
+                true
+                (bml-class-bases-support-interface? model (tail bases) interface-name))))
+
+    (defn bml-class-supports-interface? (model class-name interface-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) false
+                (if (bml-interface-refs-support?
+                        model
+                        (bml-class-interface-refs class-component)
+                        interface-name)
+                    true
+                    (bml-class-bases-support-interface?
+                        model
+                        (bml-class-supers class-component)
+                        interface-name)))))
+
+    (defn bml-class-own-concrete-method? (class-component method-name)
+        (do
+            (let method (bml-find-method (bml-class-own-methods class-component) method-name))
+            (if (nil? method) false
+                (if (bml-method-abstract? method) false
+                    (if (bml-method-deferred? method) false true)))))
+
+    (defn bml-class-concrete? (class-component)
+        (if (bml-class-abstract? class-component) false true))
+
+    (defn bml-application-main-entry? (model class-name)
+        (do
+            (let class-component (bml-model-find-class model class-name))
+            (if (nil? class-component) false
+                (if (if (bml-class-extends-structural? model class-name "BML.lang.Application")
+                        true
+                        (bml-class-extends-structural? model class-name "Application"))
+                    (bml-class-own-concrete-method? class-component "Main")
+                    false))))
+
     (defn bml-comp-one (kind objects field)
         (comp-bml-component kind (list (bmf-collection-value objects field))))
 
@@ -251,6 +813,13 @@
             "BMFInline" "BMFTag" "BMFExpr" "BMFTerm" "BMFFactor" "BMFItemMethod"
             "BMFItem" "BMFOpt" "BMFMust" "BMFAttribute"))
 
+    (let bml-thesis-bmf-primitives
+        (list "Nil" "Fail" "EndOfFile" "EndOfLine" "Cut" "MultiMatch" "Primitive"))
+
+    (let bml-thesis-bmf-primitive-rule-names
+        (list "bmf-nil" "bmf-fail" "bmf-end-of-file" "bmf-end-of-line"
+              "bmf-cut-primitive" "bmf-multi-match" "bmf-primitive-base"))
+
     (let bml-compiler-rules
         (list
             (list "bml-package"
@@ -351,6 +920,9 @@
     (defn bml-reference-rule-count (_x)
         (len bml-reference-rule-names))
 
+    (defn bml-thesis-bmf-primitive-count (_x)
+        (len bml-thesis-bmf-primitives))
+
     (defn apply-bml-compiler-rule (rule-name objects)
         (apply-object-rule (bml-compiler-find-rule rule-name bml-compiler-rules) objects))
 
@@ -361,6 +933,16 @@
             (bmf-collection-value objects "name")
             (bmf-collection-value objects "base")
             (intern_node BML-AST-BLOCK (empty))))
+
+    (defn bml-emit-class-two-base-header (objects)
+        (comp-bml-component
+            "Class"
+            (list
+                (bmf-collection-value objects "name")
+                (empty)
+                (list (bmf-collection-value objects "first")
+                      (bmf-collection-value objects "second"))
+                (empty))))
 
     (defn bml-source-class-header (object)
         (do
@@ -562,6 +1144,24 @@
                             (intern_node BML-AST-INT
                                          (list (bml-cap-int objects "value")))))))))
 
+    (defn bml-emit-fail-simple (_objects)
+        (bml-ast-fail 0))
+
+    (defn bml-source-fail-simple (_object)
+        (list (bml-src-keyword "fail") (bml-src-op ";")))
+
+    (defn bml-emit-cut-simple (_objects)
+        (bml-ast-cut 0))
+
+    (defn bml-source-cut-simple (_object)
+        (list (bml-src-keyword "cut") (bml-src-op ";")))
+
+    (defn bml-emit-mark-simple (_objects)
+        (bml-ast-save 0))
+
+    (defn bml-source-mark-simple (_object)
+        (list (bml-src-keyword "mark") (bml-src-op ";")))
+
     (defn bml-emit-state-int (objects)
         (bml-ast-block
             (list (bml-ast-save 0)
@@ -608,11 +1208,16 @@
       import-simple ::= "import" $name:name ";" => bml-emit-import-simple <= bml-source-import-simple;
       import-star-simple ::= "import" $name:name ".*" ";" => bml-emit-import-star-simple <= bml-source-import-star-simple;
       class-header ::= "class" $name:name ":" $base:name => bml-emit-class-header <= bml-source-class-header;
+      class-two-base-header ::= "class" $name:name ":" $first:name "," $second:name => bml-emit-class-two-base-header;
       class ::= "class" spc cut class-name properties super-class-list class-block => bml-emit-node-source;
       interface-header ::= "interface" $name:name ":" $parent:name => bml-emit-interface-header <= bml-source-interface-header;
       interface ::= "interface" cut class-name properties parent-interface interface-block => bml-emit-node-source;
       template ::= "template" "<" cut template-parameter-list ">" class-or-interface => bml-emit-node-source;
       section-header ::= "section" "[" $property:property "]" => bml-emit-section-header;
+      section-comma-header ::= "section" "[" $first:property "," $second:property "]" => bml-emit-node-source;
+      section-named-header ::= "section" $name:name "[" $property:property "]" => bml-emit-node-source;
+      section-named-comma-header ::= "section" $name:name "[" $first:property "," $second:property "]" => bml-emit-node-source;
+      section-library-header ::= "section" "[" "library" "=" $value:string "]" => bml-emit-node-source;
       class-section ::= "section" spc cut properties class-block => bml-emit-node-source;
       syntax-section ::= "syntax" spc cut "[" $name:name "]" "{" bmf-rule-list bmf-attribute-list "}" => bml-emit-node-source;
       class-block ::= "{" template class-section syntax-section class-interface code-block class const method field "}" => bml-emit-node-source;
@@ -631,11 +1236,13 @@
       method ::= method-head properties code-block => bml-emit-node-source;
       method-head ::= "operator" spc cut full-class-name "|" interface-ref method-name => bml-emit-node-source;
       parameter ::= field-definition => bml-emit-node-source;
-      statement ::= for while loop switch select if return break continue try throw fail with choose asm expression-statement code-block => bml-emit-node-source;
+      statement ::= for while loop switch select if if-fail while-success return break continue try throw fail mark-simple cut-simple with choice choose asm expression-statement code-block => bml-emit-node-source;
       code-block ::= "{" cut statement-list "}" => bml-emit-node-source;
       expression-statement ::= expression ";" => bml-emit-node-source;
       for ::= label "for" "(" cut for-init expression ";" expression ")" statement => bml-emit-node-source;
       while ::= label "while" "(" cut expression ")" statement => bml-emit-node-source;
+      if-fail ::= "if_fail" code-block => bml-emit-node-source;
+      while-success ::= "while_success" code-block => bml-emit-node-source;
       loop ::= label "loop" spc cut statement => bml-emit-node-source;
       switch ::= "switch" "(" cut expression ")" switch-block => bml-emit-node-source;
       select ::= "select" "(" cut expression ")" switch-block => bml-emit-node-source;
@@ -652,6 +1259,13 @@
       try ::= "try" spc cut statement "catch" "(" interface-ref field-name properties ")" statement => bml-emit-node-source;
       throw-int ::= "throw" $value:int ";" => bml-emit-throw-int <= bml-source-throw-int;
       throw ::= "throw" spc cut expression ";" cut => bml-emit-node-source;
+      fail-simple ::= "fail" ";" => bml-emit-fail-simple <= bml-source-fail-simple;
+      fail ::= fail-simple => bml-emit-node-source;
+      cut-simple ::= "cut" ";" => bml-emit-cut-simple <= bml-source-cut-simple;
+      mark-simple ::= "mark" ";" => bml-emit-mark-simple <= bml-source-mark-simple;
+      nostate-property ::= "nostate" => bml-emit-node-source;
+      choice-fail-int ::= "choice" "{" "fail" ";" "}" "," "{" "return" $value:int ";" "}" => bml-emit-choose-fail-int;
+      choice ::= "choice" code-block choose-tail => bml-emit-node-source;
       choose-fail-int ::= "choose" "{" "fail" ";" "}" "," "{" "return" $value:int ";" "}" => bml-emit-choose-fail-int;
       choose ::= "choose" code-block choose-tail => bml-emit-node-source;
       asm ::= "asm" cut "{" asm-local-decl-list asm-statement-list "}" => bml-emit-node-source;
@@ -717,10 +1331,19 @@
       bmf-lit ::= bmf-bang-prefix string bmf-bang-suffix => bml-emit-node-source;
       bmf-range ::= bmf-char ".." bmf-char => bml-emit-node-source;
       bmf-char ::= "\\" cut int "|" "'" cut bmf-char-body "'" => bml-emit-node-source;
-      bmf-basis ::= bmf-range "|" bmf-lit "|" bmf-call-base => bml-emit-node-source;
+      bmf-basis ::= bmf-range "|" bmf-lit "|" bmf-call-base "|" bmf-primitive => bml-emit-node-source;
       bmf-literal ::= float "|" int "|" string "|" "#" cut field-name => bml-emit-node-source;
       bmf-call ::= $base:name bmf-call-args => bml-emit-node-source;
       bmf-call-base ::= bmf-call => bml-emit-node-source;
+      bmf-primitive ::= bmf-nil "|" bmf-fail "|" bmf-end-of-file "|" bmf-end-of-line "|" bmf-cut-primitive "|" bmf-multi-match "|" bmf-primitive-base => bml-emit-node-source;
+      bmf-nil ::= "Nil" => bml-emit-node-source;
+      bmf-fail ::= "Fail" => bml-emit-node-source;
+      bmf-end-of-file ::= "EndOfFile" => bml-emit-node-source;
+      bmf-end-of-line ::= "EndOfLine" => bml-emit-node-source;
+      bmf-cut-primitive ::= "Cut" => bml-emit-node-source;
+      bmf-multi-match ::= "MultiMatch" => bml-emit-node-source;
+      bmf-multi-match-count ::= "MultiMatch" "(" bmf-expr "," int ")" => bml-emit-node-source;
+      bmf-primitive-base ::= "Primitive" => bml-emit-node-source;
       bmf-prim ::= "<<prim" spc id ">>" => bml-emit-node-source;
       bmf-inline ::= "<<" bmf-expr ">>" => bml-emit-node-source;
       bmf-tag ::= "$" $tag:name cut ":" => bml-emit-node-source;
@@ -746,6 +1369,15 @@
     (defn apply-bml-bmf-rule (rule-name objects)
         (apply-object-rule (bml-bmf-find-rule rule-name bml-bmf-rules) objects))
 
+    (defn bml-thesis-bmf-primitive-rule-count-loop (rule-names)
+        (if (nil? rule-names) 0
+            (add
+                (if (nil? (bml-bmf-find-rule (head rule-names) bml-bmf-rules)) 0 1)
+                (bml-thesis-bmf-primitive-rule-count-loop (tail rule-names)))))
+
+    (defn bml-thesis-bmf-primitive-rule-count (_x)
+        (bml-thesis-bmf-primitive-rule-count-loop bml-thesis-bmf-primitive-rule-names))
+
     ;; --- native source sections -------------------------------------
 
     (let bml-recipe-section
@@ -761,9 +1393,13 @@
                 (compiler-rule "bml" "continue-simple" "BML continue object to BMA ops" bml-emit-continue-simple)
                 (compiler-rule "bml" "throw-int" "BML throw object to BMA ops" bml-emit-throw-int)
                 (compiler-rule "bml" "try-throw-return" "BML try object to BMA ops" bml-emit-try-throw-return)
+                (compiler-rule "bml" "fail-simple" "BML fail primitive to BMA ops" bml-emit-fail-simple)
+                (compiler-rule "bml" "cut-simple" "BML cut primitive to BMA ops" bml-emit-cut-simple)
+                (compiler-rule "bml" "mark-simple" "BML mark primitive to BMA save ops" bml-emit-mark-simple)
                 (compiler-rule "bml" "char-lit" "BML char literal source objects" bml-emit-char-lit)
                 (compiler-rule "bml" "array-int" "BML array literal source objects" bml-emit-array-int)
                 (compiler-rule "bml" "method-return-add" "BML method object to BMA ops" bml-emit-method-return-add)
+                (compiler-rule "bml" "choice-fail-int" "BML thesis choice object to BMA ops" bml-emit-choose-fail-int)
                 (compiler-rule "bml" "choose-fail-int" "BML choice object to BMA ops" bml-emit-choose-fail-int)
                 (compiler-rule "bml" "state-int" "BML state object to BMA ops" bml-emit-state-int))))
 
@@ -782,9 +1418,13 @@
     (defn bma-break (label) (bma-op "break" label))
     (defn bma-continue (label) (bma-op "continue" label))
     (defn bma-throw (_x) (bma-op "throw" 0))
+    (defn bma-raise (_x) (bma-op "raise" 0))
+    (defn bma-resume (_x) (bma-op "resume" 0))
     (defn bma-save (_x) (bma-op "save" 0))
+    (defn bma-mark (_x) (bma-op "mark" 0))
     (defn bma-restore (_x) (bma-op "restore" 0))
     (defn bma-discard (_x) (bma-op "discard" 0))
+    (defn bma-nostate (_x) (bma-op "nostate" 0))
     (defn bma-fail (_x) (bma-op "fail" 0))
     (defn bma-cut (_x) (bma-op "cut" 0))
     (defn bma-choose (branches) (bma-op "choose" branches))
@@ -884,14 +1524,18 @@
             (if (str_eq name "break") (comp-vm-with-mode state "break")
             (if (str_eq name "continue") (comp-vm-with-mode state "continue")
             (if (str_eq name "throw") (comp-vm-with-mode state "throw")
+            (if (str_eq name "raise") (comp-vm-with-mode state "raise")
+            (if (str_eq name "resume") (comp-vm-with-mode state "run")
             (if (str_eq name "save") (comp-vm-save state)
+            (if (str_eq name "mark") (comp-vm-save state)
             (if (str_eq name "restore") (comp-vm-restore state)
             (if (str_eq name "discard") (comp-vm-discard state)
+            (if (str_eq name "nostate") state
             (if (str_eq name "fail") (comp-vm-with-mode state "fail")
             (if (str_eq name "cut") (comp-vm-with-mode state "cut")
             (if (str_eq name "choose") (bma-exec-choose-branches (comp-op-value op) state)
             (if (str_eq name "try") (bma-exec-try-branches (comp-op-value op) state)
-                state))))))))))))))))
+                state))))))))))))))))))))
 
     (defn bma-exec-ops (ops state)
         (if (nil? ops) state
@@ -904,5 +1548,88 @@
 
     (defn bma-run-value (program)
         (comp-vm-pop-value (bma-run-program program)))
+
+    ;; Thesis exit proof: record the executable BMA stream in forward
+    ;; DO mode, then replay the trace backward in UNDO mode by restoring
+    ;; each op's saved pre-state.
+    (defn bma-trace-entry (mode op before after)
+        (list "bma-trace-entry" mode (comp-op-name op) before after))
+
+    (defn bma-trace-mode (entry) (nth entry 1))
+    (defn bma-trace-op-name (entry) (nth entry 2))
+    (defn bma-trace-before (entry) (nth entry 3))
+    (defn bma-trace-after (entry) (nth entry 4))
+
+    (defn bma-trace-result (state trace)
+        (list "bma-trace-result" state trace))
+
+    (defn bma-trace-result-state (result) (nth result 1))
+    (defn bma-trace-result-trace (result) (nth result 2))
+
+    (defn bma-run-program-forward-trace-loop (ops state trace)
+        (if (nil? ops)
+            (bma-trace-result state (reverse trace))
+            (if (str_eq (comp-vm-mode state) "run")
+                (do
+                    (let op (head ops))
+                    (let after (bma-exec-op op state))
+                    (bma-run-program-forward-trace-loop
+                        (tail ops)
+                        after
+                        (cons (bma-trace-entry "DO" op state after) trace)))
+                (bma-trace-result state (reverse trace)))))
+
+    (defn bma-run-program-forward-trace (program)
+        (bma-run-program-forward-trace-loop
+            (comp-program-ops program)
+            (comp-vm-empty 0)
+            (empty)))
+
+    (defn bma-run-program-backward-trace-loop (entries state trace)
+        (if (nil? entries)
+            (bma-trace-result state (reverse trace))
+            (do
+                (let entry (head entries))
+                (let before (bma-trace-before entry))
+                (let op (bma-op (bma-trace-op-name entry) 0))
+                (bma-run-program-backward-trace-loop
+                    (tail entries)
+                    before
+                    (cons (bma-trace-entry "UNDO" op state before) trace)))))
+
+    (defn bma-run-program-backward-trace (forward-result)
+        (bma-run-program-backward-trace-loop
+            (reverse (bma-trace-result-trace forward-result))
+            (bma-trace-result-state forward-result)
+            (empty)))
+
+    (defn bma-forward-backward-result (forward-state restored-state trace)
+        (list "bma-forward-backward" forward-state restored-state trace))
+
+    (defn bma-forward-backward-forward-state (result) (nth result 1))
+    (defn bma-forward-backward-restored-state (result) (nth result 2))
+    (defn bma-forward-backward-trace (result) (nth result 3))
+
+    (defn bma-run-forward-backward (program)
+        (do
+            (let forward (bma-run-program-forward-trace program))
+            (let backward (bma-run-program-backward-trace forward))
+            (bma-forward-backward-result
+                (bma-trace-result-state forward)
+                (bma-trace-result-state backward)
+                (append (bma-trace-result-trace forward)
+                        (bma-trace-result-trace backward)))))
+
+    (defn bma-trace-count-mode (trace mode)
+        (if (nil? trace) 0
+            (add
+                (if (str_eq (bma-trace-mode (head trace)) mode) 1 0)
+                (bma-trace-count-mode (tail trace) mode))))
+
+    (defn bma-trace-count-op (trace op-name)
+        (if (nil? trace) 0
+            (add
+                (if (str_eq (bma-trace-op-name (head trace)) op-name) 1 0)
+                (bma-trace-count-op (tail trace) op-name))))
 
     0)

--- a/form/form-stdlib/tests/bmf-thesis-primitives-band.fk
+++ b/form/form-stdlib/tests/bmf-thesis-primitives-band.fk
@@ -1,0 +1,82 @@
+; tests/bmf-thesis-primitives-band.fk - BMF thesis primitive manifest
+;
+; preludes: form-stdlib/grammar-chars.fk
+;
+; Proves the primitive set registered by the 2000 BMF reference:
+; Nil, Fail, EndOfFile, EndOfLine, Cut, and MultiMatch.
+
+(do
+    (defn bool-score (b bit)
+        (if b bit 0))
+
+    (defn emit-1 (_caps) (intern_trivial_int 1))
+    (let rules-nil
+        (list
+            (list "start"
+                  (list "sequence"
+                        (list "nil")
+                        (list "string" "ok")
+                        (list "eof"))
+                  emit-1)))
+    (let probe-nil (walk_recipe (cm-parse "ok" rules-nil "start")))
+
+    (defn emit-2 (_caps) (intern_trivial_int 2))
+    (let rules-fail
+        (list
+            (list "start"
+                  (list "choice"
+                        (list "sequence" (list "string" "x") (list "fail"))
+                        (list "sequence" (list "string" "x") (list "eof")))
+                  emit-2)))
+    (let probe-fail (walk_recipe (cm-parse "x" rules-fail "start")))
+
+    (defn emit-3 (_caps) (intern_trivial_int 3))
+    (let rules-eof
+        (list
+            (list "start"
+                  (list "sequence" (list "string" "a") (list "eof"))
+                  emit-3)))
+    (let probe-eof (walk_recipe (cm-parse "a" rules-eof "start")))
+
+    (defn emit-4 (_caps) (intern_trivial_int 4))
+    (let rules-eol
+        (list
+            (list "start"
+                  (list "sequence"
+                        (list "string" "a")
+                        (list "eol")
+                        (list "string" "b")
+                        (list "eof"))
+                  emit-4)))
+    (let probe-eol (walk_recipe (cm-parse "a\nb" rules-eol "start")))
+
+    (let cut-match
+        (cm-match-pattern
+            (list "choice"
+                  (list "sequence" (list "string" "a") (list "cut") (list "fail"))
+                  (list "sequence" (list "string" "a") (list "eof")))
+            (mk-cstream "a")
+            (empty)))
+    (let probe-cut (bool-score (cfail? cut-match) 5))
+
+    (defn emit-letters (caps)
+        (intern_trivial_string (ccap-get caps "letters")))
+    (let alpha (list "char-range" 97 122))
+    (let rules-multi
+        (list
+            (list "start"
+                  (list "sequence"
+                        (list "capture" "letters"
+                              (list "multi-match" alpha 2 3))
+                        (list "string" "!")
+                        (list "eof"))
+                  emit-letters)))
+    (let probe-multi
+        (str_len (node_value (cm-parse "abc!" rules-multi "start"))))
+
+    (add probe-nil
+    (add probe-fail
+    (add probe-eof
+    (add probe-eol
+    (add probe-cut probe-multi)))))
+)

--- a/form/form-stdlib/tests/bml-class-inheritance-proof.fk
+++ b/form/form-stdlib/tests/bml-class-inheritance-proof.fk
@@ -1,0 +1,164 @@
+; tests/bml-class-inheritance-proof.fk - BML class and inheritance model proof
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk
+;
+; Proves the object-model commitments from the BML thesis/reference:
+; classes carry fields, methods, sections, and interfaces; the first
+; superclass is the structural base; additional superclasses are delegated;
+; method lookup is behavioral and starts at self; field lookup is structural
+; and starts at this; interface support is inherited through interface and
+; class parent chains.
+
+(do
+    (defn bool-score (b bit)
+        (if b bit 0))
+
+    (defn int-score (actual expected bit)
+        (if (eq actual expected) bit 0))
+
+    (defn str-score (actual expected bit)
+        (if (str_eq actual expected) bit 0))
+
+    (defn result-object (m)
+        (cap-get (match-caps m) "result"))
+
+    (defn result-value (m)
+        (bmf-object-value (result-object m)))
+
+    (defn test-field (field-type name)
+        (comp-bml-component "Field" (list field-type name (empty))))
+
+    (defn test-method (name value)
+        (comp-bml-component
+            "Method"
+            (list "int" name (empty) (bml-ast-return (bml-ast-int value)))))
+
+    (defn test-section (name items)
+        (comp-bml-component "Section" (list name (empty) items)))
+
+    (defn test-class (name supers body)
+        (comp-bml-component "Class" (list name (empty) supers body)))
+
+    (defn test-interface (name parent body)
+        (comp-bml-component "Interface" (list name (empty) parent body)))
+
+    (defn binding-this-score (binding expected bit)
+        (if (nil? binding) 0
+            (str-score (bml-method-binding-this binding) expected bit)))
+
+    (defn binding-self-score (binding expected bit)
+        (if (nil? binding) 0
+            (str-score (bml-method-binding-self binding) expected bit)))
+
+    (defn field-name-score (field expected bit)
+        (if (nil? field) 0
+            (str-score (bml-field-name field) expected bit)))
+
+    ;; Source rule proof for multiple class bases: the source spelling
+    ;; `class E : C, D` becomes one structural base (C) and one delegated
+    ;; base (D) in the class component.
+    (let parsed-class-match
+        (apply-bml-bmf-rule "class-two-base-header"
+            (list (bml-src-keyword "class") (bml-src-name "E")
+                  (bml-src-op ":") (bml-src-name "C")
+                  (bml-src-op ",") (bml-src-name "D"))))
+    (let parsed-class (result-value parsed-class-match))
+    (let source-score
+        (add (bool-score (match? parsed-class-match) 1)
+        (add (str-score (bml-class-name parsed-class) "E" 2)
+        (add (str-score (bml-class-structural-base-name parsed-class) "C" 4)
+             (int-score (len (bml-class-delegation-base-names parsed-class)) 1 8)))))
+
+    (let field-a (test-field "int" "a"))
+    (let field-b (test-field "int" "b"))
+    (let field-c (test-field "int" "c"))
+    (let field-d (test-field "int" "d"))
+    (let field-e (test-field "int" "e"))
+
+    (let method-foo-a (test-method "foo" 1))
+    (let method-goo-a (test-method "goo" 2))
+    (let method-b-only (test-method "bOnly" 3))
+    (let method-d-only (test-method "dOnly" 4))
+    (let method-goo-e (test-method "goo" 5))
+    (let method-draw (test-method "draw" 6))
+    (let method-click (test-method "click" 7))
+
+    (let interface-renderable
+        (test-interface "Renderable" "" (list method-draw)))
+    (let interface-clickable
+        (test-interface "Clickable" "Renderable" (list method-click)))
+
+    (let class-a
+        (test-class "A" (empty) (list field-a method-foo-a method-goo-a)))
+    (let class-b
+        (test-class "B" (empty) (list field-b method-b-only)))
+    (let class-c
+        (test-class "C" (list "A" "B") (list field-c)))
+    (let class-d
+        (test-class "D" (empty) (list field-d method-d-only)))
+    (let class-e
+        (test-class
+            "E"
+            (list "C" "D")
+            (list
+                (test-section "public" (list field-e method-goo-e))
+                (bml-interface-ref-component "Clickable"))))
+
+    (let model
+        (bml-model
+            (list class-e class-c class-a class-b class-d)
+            (list interface-clickable interface-renderable)))
+
+    ;; Section-contained members are visible to the class model.
+    (let section-member-score
+        (add (int-score (len (bml-class-own-fields class-e)) 1 16)
+             (field-name-score (bml-find-field (bml-class-own-fields class-e) "e") "e" 32)))
+
+    ;; Structural inheritance uses the first superclass only: E -> C -> A.
+    ;; Delegated base objects are the remaining superclasses: E delegates D,
+    ;; and C delegates B.
+    (let structural-fields (bml-class-structural-fields model "E"))
+    (let delegation-bases (bml-class-all-delegation-bases model "E"))
+    (let structure-score
+        (add (str-score (bml-class-structural-base-name class-e) "C" 64)
+        (add (str-score (bml-class-structural-base-name class-c) "A" 128)
+        (add (int-score (len structural-fields) 3 256)
+        (add (int-score (len delegation-bases) 2 512)
+        (add (field-name-score (bml-class-field-lookup-structural model "E" "a") "a" 1024)
+             (bool-score (nil? (bml-class-field-lookup-structural model "E" "b")) 2048)))))))
+
+    ;; Behavioral method lookup searches from self and lets the most-derived
+    ;; definition win. Inherited methods retain their implementation context.
+    (let foo-binding (bml-class-method-lookup model "E" "foo"))
+    (let goo-binding (bml-class-method-lookup model "E" "goo"))
+    (let d-binding (bml-class-method-lookup model "E" "dOnly"))
+    (let method-score
+        (add (binding-this-score foo-binding "A" 4096)
+        (add (binding-self-score foo-binding "E" 8192)
+        (add (binding-this-score goo-binding "E" 16384)
+             (binding-this-score d-binding "D" 32768)))))
+
+    ;; From inside A.foo, invoking goo() still starts at self=E, so E.goo
+    ;; overrides A.goo. super.goo from E starts at E's bases and reaches A.
+    (let self-dispatch (bml-invoke-from-context model "E" "A" "goo"))
+    (let super-dispatch (bml-super-invoke model "E" "E" "goo"))
+    (let dispatch-score
+        (add (binding-this-score self-dispatch "E" 65536)
+        (add (binding-self-score self-dispatch "E" 131072)
+             (binding-this-score super-dispatch "A" 262144))))
+
+    ;; Interface inheritance: E directly supports Clickable and, through the
+    ;; interface parent chain, also supports Renderable. Clickable inherits
+    ;; Renderable.draw.
+    (let interface-score
+        (add (bool-score (bml-class-supports-interface? model "E" "Clickable") 524288)
+        (add (bool-score (bml-class-supports-interface? model "E" "Renderable") 1048576)
+        (add (bool-score (not (nil? (bml-interface-method-lookup model "Clickable" "click"))) 2097152)
+             (bool-score (not (nil? (bml-interface-method-lookup model "Clickable" "draw"))) 4194304)))))
+
+    (add source-score
+    (add section-member-score
+    (add structure-score
+    (add method-score
+    (add dispatch-score interface-score)))))
+)

--- a/form/form-stdlib/tests/bml-full-class-model-proof.fk
+++ b/form/form-stdlib/tests/bml-full-class-model-proof.fk
@@ -1,0 +1,233 @@
+; tests/bml-full-class-model-proof.fk - full BML class model proof band
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk
+;
+; Proves the class-model features that sit beside inheritance: attribute
+; contracts, constants, inner classes, templates, default interface methods,
+; member access, final/abstract/deferred/class flags, and Application.Main.
+
+(do
+    (defn bool-score (b bit)
+        (if b bit 0))
+
+    (defn int-score (actual expected bit)
+        (if (eq actual expected) bit 0))
+
+    (defn str-score (actual expected bit)
+        (if (str_eq actual expected) bit 0))
+
+    (defn both (a b)
+        (if a b false))
+
+    (defn test-prop (name value)
+        (bml-property-component name value))
+
+    (defn test-field-props (field-type name props)
+        (comp-bml-component "Field" (list field-type name props)))
+
+    (defn test-method-props (name props value)
+        (comp-bml-component
+            "Method"
+            (list "int" name props (bml-ast-return (bml-ast-int value)))))
+
+    (defn test-const (const-type name props value)
+        (comp-bml-component "Const" (list const-type name props value)))
+
+    (defn test-section (name props items)
+        (comp-bml-component "Section" (list name props items)))
+
+    (defn test-class-props (name props supers body)
+        (comp-bml-component "Class" (list name props supers body)))
+
+    (defn test-interface (name parent body)
+        (comp-bml-component "Interface" (list name (empty) parent body)))
+
+    (let access-prop (test-prop "access" "protected"))
+    (let abstract-class
+        (test-class-props "AbstractThing" (list (test-prop "abstract" "true")) (empty) (empty)))
+    (let final-base
+        (test-class-props "FinalBase" (list (test-prop "final" "true")) (empty) (empty)))
+
+    (let locked-base-method
+        (test-method-props "locked" (list (test-prop "final" "true")) 1))
+    (let locked-override-method
+        (test-method-props "locked" (empty) 2))
+    (let deferred-method
+        (test-method-props "later" (list (test-prop "deferred" "true")) 3))
+    (let class-method
+        (test-method-props "staticName" (list (test-prop "class" "true")) 4))
+    (let section-method
+        (test-method-props "sectionWork" (empty) 8))
+    (let default-render
+        (test-method-props "render" (list (test-prop "default" "true")) 5))
+    (let main-abstract
+        (test-method-props "Main" (list (test-prop "abstract" "true")) 0))
+    (let main-concrete
+        (test-method-props "Main" (empty) 6))
+
+    (let rich-field
+        (test-field-props
+            "int"
+            "slot"
+            (list
+                (test-prop "delegate" "true")
+                (test-prop "shared" "true")
+                (test-prop "class" "true")
+                (test-prop "get" "true")
+                (test-prop "put" "true")
+                (test-prop "strict" "true"))))
+    (let relaxed-field
+        (test-field-props "int" "loose" (list (test-prop "relaxed" "true"))))
+
+    (let answer-const (test-const "int" "Answer" (list (test-prop "public" "true")) 99))
+    (let private-const (test-const "int" "Secret" (list (test-prop "private" "true")) 7))
+    (let class-const (test-const "int" "SharedAnswer" (list (test-prop "class" "true")) 100))
+    (let section-const (test-const "int" "SectionAnswer" (empty) 101))
+    (let protected-field (test-field-props "int" "guarded" (list access-prop)))
+    (let public-field (test-field-props "int" "open" (list (test-prop "public" "true"))))
+    (let inner-class (test-class-props "Nested" (empty) (empty) (empty)))
+    (let nested-section
+        (test-section "protected-zone" (list access-prop) (list answer-const inner-class)))
+    (let class-public-section
+        (test-section
+            "class-public"
+            (list (test-prop "class" "true") (test-prop "public" "true"))
+            (list section-method section-const)))
+
+    (let base-with-members
+        (test-class-props
+            "BaseWithMembers"
+            (empty)
+            (empty)
+            (list
+                rich-field relaxed-field private-const class-const protected-field
+                public-field locked-base-method nested-section class-public-section)))
+    (let override-child
+        (test-class-props
+            "OverrideChild"
+            (empty)
+            (list "BaseWithMembers")
+            (list locked-override-method deferred-method class-method)))
+    (let access-child
+        (test-class-props "AccessChild" (empty) (list "BaseWithMembers") (empty)))
+    (let app-base
+        (test-class-props
+            "BML.lang.Application"
+            (list (test-prop "abstract" "true"))
+            (empty)
+            (list main-abstract)))
+    (let app-program
+        (test-class-props "Demo.Program" (empty) (list "BML.lang.Application") (list main-concrete)))
+    (let app-no-main
+        (test-class-props "Demo.NoMain" (empty) (list "BML.lang.Application") (empty)))
+    (let app-deferred-main
+        (test-class-props "Demo.DeferredMain" (empty) (list "BML.lang.Application") (list deferred-method)))
+    (let defaults-interface
+        (test-interface "ButtonDefaults" "" (list default-render)))
+    (let widget
+        (test-class-props
+            "Widget"
+            (empty)
+            (empty)
+            (list (bml-interface-ref-component "ButtonDefaults"))))
+
+    (let model
+        (bml-model
+            (list
+                abstract-class final-base base-with-members override-child access-child
+                app-base app-program app-no-main app-deferred-main widget)
+            (list defaults-interface)))
+
+    (let template-class
+        (comp-bml-component "Template" (list (list "T") "class" (list base-with-members))))
+    (let template-interface
+        (comp-bml-component "Template" (list (list "T") "interface" (list defaults-interface))))
+    (let template-block
+        (comp-bml-component "Template" (list (list "T") "block" (empty))))
+
+    (let property-score
+        (add (str-score (bml-properties-value (list access-prop) "access" "") "protected" 1)
+        (add (bool-score (bml-class-abstract? abstract-class) 2)
+        (add (bool-score (not (bml-class-concrete? abstract-class)) 4)
+        (add (bool-score (bml-class-final? final-base) 8)
+             (bool-score (not (bml-class-can-extend? model "FinalBase")) 16))))))
+
+    (let method-score
+        (add (bool-score (not (bml-class-method-override-allowed? model "OverrideChild" "locked")) 32)
+        (add (bool-score (bml-method-deferred? deferred-method) 64)
+             (bool-score (bml-method-class? class-method) 128))))
+
+    (let access-score
+        (add (bool-score (bml-member-accessible? model "BaseWithMembers" "BaseWithMembers" (bml-const-properties private-const)) 256)
+        (add (bool-score (not (bml-member-accessible? model "BaseWithMembers" "Widget" (bml-const-properties private-const))) 512)
+        (add (bool-score (bml-member-accessible? model "BaseWithMembers" "AccessChild" (bml-field-properties protected-field)) 1024)
+             (bool-score (bml-member-accessible? model "BaseWithMembers" "Widget" (bml-field-properties public-field)) 2048)))))
+
+    (let field-score
+        (add (bool-score (both (bml-field-delegate? rich-field) (bml-field-class? rich-field)) 4096)
+        (add (bool-score (bml-field-shared? rich-field) 8192)
+        (add (bool-score (bml-field-get? rich-field) 16384)
+        (add (bool-score (bml-field-put? rich-field) 32768)
+        (add (bool-score (both (bml-field-strict? rich-field) (not (bml-field-relaxed? rich-field))) 65536)
+             (bool-score (both (bml-field-relaxed? relaxed-field) (not (bml-field-strict? relaxed-field))) 131072)))))))
+
+    (let inherited-const (bml-class-const-lookup-structural model "OverrideChild" "Answer"))
+    (let inherited-inner (bml-class-inner-class-lookup-structural model "OverrideChild" "Nested"))
+    (let member-score
+        (add (bool-score (both (str_eq (bml-const-name inherited-const) "Answer") (bml-const-class? class-const)) 262144)
+        (add (int-score (bml-const-value inherited-const) 99 524288)
+             (str-score (bml-class-name inherited-inner) "Nested" 1048576))))
+
+    (let template-score
+        (add (bool-score (bml-template-valid-kind? template-class) 2097152)
+        (add (bool-score (bml-template-valid-kind? template-interface) 4194304)
+             (bool-score
+                (both
+                    (not (bml-template-valid-kind? template-block))
+                    (both
+                        (not (bml-template-valid-kind? (comp-bml-component "Template" (list (list "T") "method" (empty)))))
+                        (not (bml-template-valid-kind? (comp-bml-component "Template" (list (list "T") "field" (empty)))))))
+                8388608))))
+
+    (let interface-score
+        (add (bool-score (not (nil? (bml-interface-default-method-lookup model "ButtonDefaults" "render"))) 16777216)
+             (bool-score (not (nil? (bml-class-interface-default-method-lookup model "Widget" "render"))) 33554432)))
+
+    (let application-score
+        (add (bool-score (bml-application-main-entry? model "Demo.Program") 67108864)
+             (bool-score
+                (both
+                    (not (bml-application-main-entry? model "Demo.NoMain"))
+                    (not (bml-application-main-entry? model "Demo.DeferredMain")))
+                134217728)))
+
+    (let section-method-props
+        (bml-class-member-effective-properties base-with-members "Method" "sectionWork"))
+    (let section-const-props
+        (bml-class-member-effective-properties base-with-members "Const" "SectionAnswer"))
+    (let section-score
+        (add
+            (bool-score
+                (both
+                    (str_eq (bml-section-name nested-section) "protected-zone")
+                    (both
+                        (bml-properties-has? section-method-props "class")
+                        (bml-properties-has? section-method-props "public")))
+                268435456)
+            (bool-score
+                (both
+                    (str_eq (bml-access-level (bml-section-properties nested-section)) "protected")
+                    (both
+                        (bml-properties-has? section-const-props "class")
+                        (bml-properties-has? section-const-props "public")))
+                536870912)))
+
+    (add property-score
+    (add method-score
+    (add access-score
+    (add field-score
+    (add member-score
+    (add template-score
+    (add interface-score
+    (add application-score section-score))))))))
+)

--- a/form/form-stdlib/tests/bml-thesis-exit-proof.fk
+++ b/form/form-stdlib/tests/bml-thesis-exit-proof.fk
@@ -1,0 +1,170 @@
+; tests/bml-thesis-exit-proof.fk - thesis BML/BMF support and BMA undo proof
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk
+
+(do
+    (defn bool-score (b bit)
+        (if b bit 0))
+
+    (defn int-score (actual expected bit)
+        (if (eq actual expected) bit 0))
+
+    (defn mode-score (state mode bit)
+        (if (str_eq (comp-vm-mode state) mode) bit 0))
+
+    (defn result-object (m)
+        (cap-get (match-caps m) "result"))
+
+    (defn result-value (m)
+        (bmf-object-value (result-object m)))
+
+    ;; BMF primitive manifest from BMF-includes.bml and RegisterPrimitives().
+    (let manifest-score
+        (add (int-score (bml-thesis-bmf-primitive-count 0) 7 1)
+             (int-score (bml-thesis-bmf-primitive-rule-count 0) 7 2)))
+
+    (let nil-match (apply-bml-bmf-rule "bmf-nil" (list (bml-src-keyword "Nil"))))
+    (let fail-prim-match (apply-bml-bmf-rule "bmf-fail" (list (bml-src-keyword "Fail"))))
+    (let eof-match (apply-bml-bmf-rule "bmf-end-of-file" (list (bml-src-keyword "EndOfFile"))))
+    (let eol-match (apply-bml-bmf-rule "bmf-end-of-line" (list (bml-src-keyword "EndOfLine"))))
+    (let cut-prim-match (apply-bml-bmf-rule "bmf-cut-primitive" (list (bml-src-keyword "Cut"))))
+    (let multi-match (apply-bml-bmf-rule "bmf-multi-match" (list (bml-src-keyword "MultiMatch"))))
+    (let primitive-base-match (apply-bml-bmf-rule "bmf-primitive-base" (list (bml-src-keyword "Primitive"))))
+    (let primitive-parse-score
+        (add (bool-score (match? nil-match) 4)
+        (add (bool-score (match? fail-prim-match) 8)
+        (add (bool-score (match? eof-match) 16)
+        (add (bool-score (match? eol-match) 32)
+        (add (bool-score (match? cut-prim-match) 64)
+        (add (bool-score (match? multi-match) 128)
+             (bool-score (match? primitive-base-match) 256))))))))
+
+    ;; Thesis spellings and current alias both lower to the same CHOOSE AST.
+    (let choice-match
+        (apply-bml-bmf-rule "choice-fail-int"
+            (list (bml-src-keyword "choice") (bml-src-op "{")
+                  (bml-src-keyword "fail") (bml-src-op ";") (bml-src-op "}")
+                  (bml-src-op ",") (bml-src-op "{")
+                  (bml-src-keyword "return") (bml-src-int "8")
+                  (bml-src-op ";") (bml-src-op "}"))))
+    (let choose-match
+        (apply-bml-bmf-rule "choose-fail-int"
+            (list (bml-src-keyword "choose") (bml-src-op "{")
+                  (bml-src-keyword "fail") (bml-src-op ";") (bml-src-op "}")
+                  (bml-src-op ",") (bml-src-op "{")
+                  (bml-src-keyword "return") (bml-src-int "9")
+                  (bml-src-op ";") (bml-src-op "}"))))
+    (let choice-score
+        (add (bma-run-value (bml-compile-program (result-value choice-match)))
+             (bma-run-value (bml-compile-program (result-value choose-match)))))
+
+    ;; Control primitives exposed as BML statements.
+    (let fail-match
+        (apply-bml-bmf-rule "fail-simple"
+            (list (bml-src-keyword "fail") (bml-src-op ";"))))
+    (let fail-state (bma-run-program (bml-compile-program (result-value fail-match))))
+
+    (let cut-match
+        (apply-bml-bmf-rule "cut-simple"
+            (list (bml-src-keyword "cut") (bml-src-op ";"))))
+    (let cut-state (bma-run-program (bml-compile-program (result-value cut-match))))
+
+    (let mark-match
+        (apply-bml-bmf-rule "mark-simple"
+            (list (bml-src-keyword "mark") (bml-src-op ";"))))
+    (let mark-state (bma-run-program (bml-compile-program (result-value mark-match))))
+    (let control-score
+        (add (mode-score fail-state "fail" 512)
+        (add (mode-score cut-state "cut" 1024)
+             (int-score (len (comp-vm-snapshots mark-state)) 1 2048))))
+
+    ;; Section forms from the reference: anonymous, multi-property, named,
+    ;; named multi-property, and library-valued.
+    (let section-public
+        (apply-bml-bmf-rule "section-header"
+            (list (bml-src-keyword "section") (bml-src-op "[")
+                  (bml-src-prop "public") (bml-src-op "]"))))
+    (let section-class-public
+        (apply-bml-bmf-rule "section-comma-header"
+            (list (bml-src-keyword "section") (bml-src-op "[")
+                  (bml-src-prop "class") (bml-src-op ",")
+                  (bml-src-prop "public") (bml-src-op "]"))))
+    (let section-named
+        (apply-bml-bmf-rule "section-named-header"
+            (list (bml-src-keyword "section") (bml-src-name "Insertion")
+                  (bml-src-op "[") (bml-src-prop "public") (bml-src-op "]"))))
+    (let section-named-comma
+        (apply-bml-bmf-rule "section-named-comma-header"
+            (list (bml-src-keyword "section") (bml-src-name "Insertion")
+                  (bml-src-op "[") (bml-src-prop "public") (bml-src-op ",")
+                  (bml-src-prop "abstract") (bml-src-op "]"))))
+    (let section-library
+        (apply-bml-bmf-rule "section-library-header"
+            (list (bml-src-keyword "section") (bml-src-op "[")
+                  (bml-src-keyword "library") (bml-src-op "=")
+                  (bml-src-string "MYLIBRARY.DLL") (bml-src-op "]"))))
+    (let section-score
+        (add (bool-score (match? section-public) 4096)
+        (add (bool-score (match? section-class-public) 8192)
+        (add (bool-score (match? section-named) 16384)
+        (add (bool-score (match? section-named-comma) 32768)
+             (bool-score (match? section-library) 65536))))))
+
+    ;; BMF object model and syntax section rule remain present.
+    (let reference-score
+        (add (int-score (len (nth bml-bmf-reference-model 4)) 10 131072)
+             (bool-score (not (nil? (bml-bmf-find-rule "syntax-section" bml-bmf-rules))) 262144)))
+
+    ;; Forward/backward exit proof: run BMA forward, then replay the trace
+    ;; backward. The restored state is the empty initial VM state; the trace
+    ;; carries explicit DO and UNDO entries.
+    (let trace-node
+        (bml-ast-block
+            (list (bml-ast-save 0)
+                  (bml-ast-int 4)
+                  (bml-ast-restore 0)
+                  (bml-ast-return
+                      (bml-ast-add (bml-ast-int 2) (bml-ast-int 5))))))
+    (let trace-program (bml-compile-program trace-node))
+    (let trace-result (bma-run-forward-backward trace-program))
+    (let trace (bma-forward-backward-trace trace-result))
+    (let forward-state (bma-forward-backward-forward-state trace-result))
+    (let restored-state (bma-forward-backward-restored-state trace-result))
+    (let trace-score
+        (add (int-score (bma-trace-count-mode trace "DO") 7 524288)
+        (add (int-score (bma-trace-count-mode trace "UNDO") 7 1048576)
+        (add (int-score (comp-vm-pop-value forward-state) 7 2097152)
+        (add (mode-score forward-state "return" 4194304)
+        (add (int-score (len (comp-vm-stack restored-state)) 0 8388608)
+             (mode-score restored-state "run" 16777216)))))))
+
+    ;; Backtracking state proof: failed branch mutation is not retained.
+    (let branch-node
+        (bml-ast-choose
+            (list
+                (bml-ast-block (list (bml-ast-int 1) (bml-ast-fail 0)))
+                (bml-ast-block (list (bml-ast-return (bml-ast-int 7)))))))
+    (let branch-state (bma-run-program (bml-compile-program branch-node)))
+    (let branch-score
+        (add (int-score (len (comp-vm-stack branch-state)) 1 33554432)
+             (int-score (comp-vm-pop-value branch-state) 7 67108864)))
+
+    ;; Angelic assembler control names represented at BMA level.
+    (let raise-state (bma-exec-op (bma-raise 0) (comp-vm-empty 0)))
+    (let resume-state (bma-exec-op (bma-resume 0) raise-state))
+    (let nostate-state
+        (bma-exec-op (bma-nostate 0) (comp-vm-push (comp-vm-empty 0) 3)))
+    (let assembler-score
+        (add (mode-score raise-state "raise" 134217728)
+        (add (mode-score resume-state "run" 268435456)
+             (int-score (comp-vm-pop-value nostate-state) 3 536870912))))
+
+    (add manifest-score
+    (add primitive-parse-score
+    (add choice-score
+    (add control-score
+    (add section-score
+    (add reference-score
+    (add trace-score
+    (add branch-score assembler-score))))))))
+)

--- a/scripts/validate_commit_evidence.py
+++ b/scripts/validate_commit_evidence.py
@@ -12,7 +12,7 @@ from typing import Any
 VALID_STATUS = {"pass", "fail", "pending"}
 VALID_CHANGE_INTENTS = {"runtime_feature", "runtime_fix", "process_only", "docs_only", "test_only"}
 VALID_E2E_STATUS = {"pass", "fail", "pending"}
-RUNTIME_PATH_PREFIXES = ("api/app/", "web/app/", "web/components/")
+RUNTIME_PATH_PREFIXES = ("api/app/", "web/app/", "web/components/", "form/")
 REQUIRED_TOP_LEVEL = {
     "date",
     "thread_branch",


### PR DESCRIPTION
## Summary
- expands BML thesis-facing BMF primitive, class/interface, inheritance, and BMA forward/backward proof support
- records an explicit thesis feature audit, including what is proven and what is still not a full .bml source compiler claim
- regenerates Form kernel blueprint lookup tables so Go, Rust, and TypeScript kernels include SUPER-BP consistently
- updates commit-evidence validation so Form kernel/compiler paths count as runtime changes

## Validation
- PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
- cd form && ./validate.sh -> 215 ok, 0 divergent
- cd api && PYTHONDONTWRITEBYTECODE=1 /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_substrate_form_bml_state.py tests/test_substrate_form_bml_full.py -> 33 passed
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main -> ready_for_push=True
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict -> stale_codex_prs=0

## Notes
This does not claim full thesis .bml source-to-native compilation yet. The audit names the remaining exit criteria for that claim.