### PR TITLE
tend(bootstrap): pin return-inside-if short-circuit — band cell 13, three-way green

### DIFF
--- a/form/form-stdlib/tests/python-bmf-eval-band.fk
+++ b/form/form-stdlib/tests/python-bmf-eval-band.fk
@@ -76,6 +76,13 @@
         ;; body list onto a (cond . body) child stream.
         (intern_node PY-BMF-WHILE (cons cond body-stmts)))
 
+    (defn mk-py-if-stmt (cond body-stmts)
+        ;; IF-STMT children: cond-recipe, body-stmt-recipes... — same
+        ;; (cond . body) child stream as WHILE. Distinct from PY-BMF-IF,
+        ;; the ternary *expression* (cond/then/else) py-if builds: this is
+        ;; the statement-level `if cond:` whose body can `return`.
+        (intern_node PY-BMF-IF-STMT (cons cond body-stmts)))
+
     (defn mk-leaf-str (s) (intern_trivial_string s))
 
     (defn mk-py-lambda (pms body)
@@ -311,13 +318,49 @@
     (let cell12-value (py-run cell12))                         ; 35
     (let cell12-score (if (eq cell12-value 35) 12000 0))
 
+    ;; ---- cell 13: return inside a statement-level `if` short-circuits.
+    ;; The strange-minimal early-guard the substrate demos lean on, run on
+    ;; BOTH its paths in one expression so a single cell pins the whole
+    ;; boundary:
+    ;;   def g(p):
+    ;;       if p == 0:
+    ;;           return 100
+    ;;       return 10
+    ;;   g(0) + g(5)
+    ;; CPython: 100 + 10 = 110. If a `return` inside `if cond:` failed to
+    ;; short-circuit the enclosing function (the pre-#2264 gap), g(0) would
+    ;; fall through to `return 10` and the sum would collapse to 20 — so
+    ;; this cell reads exactly the return-signal the IF-STMT arm threads
+    ;; through py-eval-body-loop / py-eval-module-loop. The guard-hit path
+    ;; (p==0 → return short-circuits) and the guard-miss path (if skipped →
+    ;; fallthrough return) are both exercised. A multi-statement body is a
+    ;; PY-BMF-MODULE the DEF closure walks via the MODULE arm's module-loop.
+    (let g-body
+        (py-module
+            (list
+                (mk-py-if-stmt
+                    (py-compare (py-ident "p") "==" (py-int-lit 0))
+                    (list (py-return (py-int-lit 100))))
+                (py-return (py-int-lit 10)))))
+    (let cell13
+        (py-module
+            (list
+                (py-def "g" (list "p") g-body)
+                (py-binop
+                    (py-call "g" (list (py-int-lit 0)))
+                    "+"
+                    (py-call "g" (list (py-int-lit 5)))))))
+    (let cell13-value (py-run cell13))                         ; 110
+    (let cell13-score (if (eq cell13-value 110) 13000 0))
+
     ;; ---- aggregate ---------------------------------------------------
     ;; Cell-N awards N*1000 when its value matches CPython. Total when
-    ;; every cell agrees: (1+2+3+4+5+6+7+8+9+10+11+12)*1000 = 78000.
+    ;; every cell agrees: (1+2+...+13)*1000 = 91000.
     ;; Any single cell failing leaves the aggregate sensitive to which
-    ;; arm broke — a cell-9 failure shows up as 78000-9000=69000.
+    ;; arm broke — a cell-9 failure shows up as 91000-9000=82000, a
+    ;; cell-13 (return-short-circuit) regression as 91000-13000=78000.
 
     (sum (list cell1-score cell2-score cell3-score cell4-score
                cell5-score cell6-score cell7-score
                cell8-score cell9-score cell10-score
-               cell11-score cell12-score)))
+               cell11-score cell12-score cell13-score)))

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -348,7 +348,7 @@ returns the statement count (15), not the program's CPython value (40949).
 The driver swaps to a recipe-walking expression in the same script when G4
 (closure interpreter) lands; the orchestration shape stays.
 
-**Open contract — false-green correction (2026-06-01).** Two rows that had
+**Resolved — false-green correction (2026-06-01).** Two rows that had
 been recorded COMPOST READY on 2026-06-01 —
 `python_substrate_demo.py` (claimed three-way `17680`) and
 `endpoint_coherence_weight_demo.py` (claimed three-way `16185`) — were
@@ -384,7 +384,11 @@ demos re-measured **three-way green at their true values** under isolated
 tempdirs — `python_substrate_demo` `17680/17680/17680`,
 `endpoint_coherence_weight_demo` `16185/16185/16185`. Their COMPOST READY rows
 are restored above; the honest count climbs back by two, on real parity this
-time. See the PROVEN return-signal row for the mechanism.
+time. See the PROVEN return-signal row for the mechanism. The short-circuit is
+now pinned against regression by cell 13 of
+`form-stdlib/tests/python-bmf-eval-band.fk` — the early-guard `g(0) + g(5)`
+shape, three-way green at `110` (a regression would collapse it to `20`),
+folded into the band aggregate `91000`.
 
 **Resolved contract — the import arm landed (2026-06-01, #2266).** The third
 false-green removed in the integrity sweep is re-earned. The Form-native
@@ -429,7 +433,7 @@ its own focused PR):
 - `PY-BMF-DICT` + dict-literal lift + key access
 - `PY-BMF-CLASS` + method binding + `PY-BMF-ATTR` for `obj.field`
 - `PY-BMF-FOR` + iterator protocol on lists / ranges — **landed for `range(...)`**: `lift-for` + the PY-BMF-FOR eval arm carry `for i in range(...)`. The lift lifts the iterable as a general expression (not a range-only special-case) and the eval iterates whatever Form list it evaluates to, so `for v in <list-variable>` also walks. `python_range_demo.py` reached COMPOST READY 2026-05-31.
-- `PY-BMF-IF-STMT` + statement-level `if cond: body` lift — **landed** (lift 2026-06-01; return-short-circuit 2026-06-01, `claude/return-signal-fix`): a category distinct from the `PY-BMF-IF` ternary expression (ontology inst 575, auto-bound via `form-ontology-loader.fk`). `lift-if-statement` lifts the header condition with the while colon-stripper and the children as statements, emitting `PY-BMF-IF-STMT(cond, body-stmts...)`; the eval arm on `py-eval-statement` evaluates the condition once and runs the body when truthy (non-zero, the int-bool convention `py-while` uses). **The return-short-circuit gap is closed:** a statement-result now carries a third `returned` slot, `py-eval-body-loop` stops on it and propagates the result, every block arm (IF-STMT / FOR / WHILE) reads it off the body-loop result, and `py-eval-module-loop` (the function-body walker) yields the returned value — so a `return` inside an `if` / `for` / `while` body short-circuits the enclosing function. Minimal proof (each in its own tempdir): `def f():` with `if 1==1: return 1` then `return 2` now yields `1` (matching CPython), `return` inside a `for` yields `9`, `return` inside a `while` yields `128`, the `weighted_score` guard `f(0)` yields `700` — all three-way. This re-earned `python_substrate_demo.py` (`17680`) and `endpoint_coherence_weight_demo.py` (`16185`) on true parity. `elif` / `else` clauses remain a later breath. No kernel native, no grammar edit — the fix is purely in the interpreter's control-flow plumbing.
+- `PY-BMF-IF-STMT` + statement-level `if cond: body` lift — **landed** (lift 2026-06-01; return-short-circuit 2026-06-01, `claude/return-signal-fix`): a category distinct from the `PY-BMF-IF` ternary expression (ontology inst 575, auto-bound via `form-ontology-loader.fk`). `lift-if-statement` lifts the header condition with the while colon-stripper and the children as statements, emitting `PY-BMF-IF-STMT(cond, body-stmts...)`; the eval arm on `py-eval-statement` evaluates the condition once and runs the body when truthy (non-zero, the int-bool convention `py-while` uses). **The return-short-circuit gap is closed:** a statement-result now carries a third `returned` slot, `py-eval-body-loop` stops on it and propagates the result, every block arm (IF-STMT / FOR / WHILE) reads it off the body-loop result, and `py-eval-module-loop` (the function-body walker) yields the returned value — so a `return` inside an `if` / `for` / `while` body short-circuits the enclosing function. Minimal proof (each in its own tempdir): `def f():` with `if 1==1: return 1` then `return 2` now yields `1` (matching CPython), `return` inside a `for` yields `9`, `return` inside a `while` yields `128`, the `weighted_score` guard `f(0)` yields `700` — all three-way. This re-earned `python_substrate_demo.py` (`17680`) and `endpoint_coherence_weight_demo.py` (`16185`) on true parity. `elif` / `else` clauses remain a later breath. No kernel native, no grammar edit — the fix is purely in the interpreter's control-flow plumbing. **Pinned against regression** by cell 13 of `form-stdlib/tests/python-bmf-eval-band.fk` — the dual-path early guard `g(0) + g(5)` (`if p == 0: return 100` else fallthrough `return 10`), three-way green at `110` where a lost short-circuit would collapse the sum to `20`; folded into the band aggregate `91000`.
 - `PY-BMF-LAMBDA` + closure capture in expressions — **landed**: `lift-lambda` + the PY-BMF-LAMBDA eval arm (closure built, walked by PY-BMF-CALL) carry single-expression lambdas assigned, passed as arguments, and used in arithmetic; `python_lambda_demo.py` reached COMPOST READY 2026-05-31 (arms shipped in #2185; this row records the demo closing three-way with them).
 - `PY-BMF-AUG-ASSIGN` (`x += 1`) and multi-target assignment
 


### PR DESCRIPTION
## What

Adds a regression guard for the `#2264` return-signal fix — a `return` inside a statement-level `if cond:` (or `for`/`while`) body short-circuits the enclosing function. That fix landed but had **no test**: the eval band only covered `return` via the ternary *expression* (`py-if`), never statement-level `if cond: return`. A silent revert of the IF-STMT / loop short-circuit would pass the band undetected — the exact `#2261` false-green shape this whole lineage was healing.

## The cell

Cell 13 of `form/form-stdlib/tests/python-bmf-eval-band.fk` — the strange-minimal early guard the substrate demos lean on, run on **both** paths in one expression so a single cell pins the whole boundary:

```python
def g(p):
    if p == 0:
        return 100
    return 10
g(0) + g(5)   # CPython 110; collapses to 20 if the short-circuit regresses
```

`g(0)` exercises return-short-circuits-on-truthy-guard; `g(5)` exercises if-skipped-fallthrough-return. The multi-statement body is a `PY-BMF-MODULE` the DEF closure walks via the MODULE arm's `py-eval-module-loop`, so the cell reads exactly the `returned` slot threaded through `py-eval-body-loop` → `py-eval-module-loop`. Band aggregate `78000 → 91000`.

## Proof (three-way)

- `cd form && ./validate.sh` → **211 ok, 0 divergent** (Go / Rust / TypeScript agree; `python-bmf-eval-band.fk → 91000`).
- `PARITY_THIRD_RUNTIME=kernel-bmf ./scripts/parity_suite.sh` → both re-earned demos still three-way green (`python_substrate_demo 17680`, `endpoint_coherence_weight_demo 16185`), each measured in its own isolated tempdir.
- Minimal repros confirmed: `def f(): if 1==1: return 1` then `return 2` → `1`; `def g(p): if p==0: return 100` then `return 10`, `g(0)` → `100`.

## Manifest

The `.fk` fix + the two PROVEN rows + the IF-STMT "landed" flip already shipped in `#2264`. This PR only:
- retitles the now-resolved "false-green correction" note from **Open contract → Resolved**, and
- points both that note and the landed IF-STMT entry at cell 13 as the regression pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)