### PR TITLE
[codex] Make stale sibling continuity warnings nonblocking

### DIFF
--- a/api/tests/test_worktree_continuity_guard.py
+++ b/api/tests/test_worktree_continuity_guard.py
@@ -39,6 +39,81 @@ def test_dirty_only_risk_is_guidance_not_blocking() -> None:
     assert mod._is_blocking_risk(["dirty_integration_candidate"]) is False
     assert mod._is_blocking_risk(["dirty_integration_candidate", "detached_head"]) is True
     assert mod._is_blocking_risk(["ahead_without_upstream"]) is True
+    assert mod._is_blocking_risk(["stale_ahead_without_upstream"]) is False
+
+
+def test_fresh_ahead_without_upstream_stays_blocking(monkeypatch, tmp_path: Path) -> None:
+    mod = _load_module()
+    repo_root = tmp_path / "repo"
+    current = repo_root / "current"
+    sibling = repo_root / "sibling"
+    current.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        mod,
+        "_parse_worktrees",
+        lambda _repo_root: [
+            {"worktree": str(current), "branch": "refs/heads/codex/current"},
+            {"worktree": str(sibling), "branch": "refs/heads/codex/fresh-local"},
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_branch_name",
+        lambda _wt_path, branch_ref: branch_ref.replace("refs/heads/", "", 1),
+    )
+    monkeypatch.setattr(mod, "_status_paths", lambda _wt_path: [])
+    monkeypatch.setattr(mod, "_ahead_behind_vs_main", lambda wt_path: (1, 0) if wt_path == sibling else (0, 0))
+    monkeypatch.setattr(mod, "_upstream_exists", lambda wt_path: wt_path == current)
+    monkeypatch.setattr(mod, "_patch_equivalent_to_main", lambda _wt_path: False)
+    monkeypatch.setattr(mod, "_newest_ahead_commit_age_hours", lambda _wt_path, _now_epoch: 2.0)
+
+    risks = mod.collect_risks(repo_root, current)
+
+    assert len(risks) == 1
+    assert risks[0].risks == ["ahead_without_upstream"]
+    assert risks[0].newest_ahead_commit_age_hours == 2.0
+    assert mod._is_blocking_risk(risks[0].risks) is True
+
+
+def test_stale_ahead_without_upstream_is_guidance_not_blocking(monkeypatch, tmp_path: Path) -> None:
+    mod = _load_module()
+    repo_root = tmp_path / "repo"
+    current = repo_root / "current"
+    sibling = repo_root / "sibling"
+    current.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        mod,
+        "_parse_worktrees",
+        lambda _repo_root: [
+            {"worktree": str(current), "branch": "refs/heads/codex/current"},
+            {"worktree": str(sibling), "branch": "refs/heads/codex/old-local"},
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_branch_name",
+        lambda _wt_path, branch_ref: branch_ref.replace("refs/heads/", "", 1),
+    )
+    monkeypatch.setattr(mod, "_status_paths", lambda _wt_path: [])
+    monkeypatch.setattr(mod, "_ahead_behind_vs_main", lambda wt_path: (3, 20) if wt_path == sibling else (0, 0))
+    monkeypatch.setattr(mod, "_upstream_exists", lambda wt_path: wt_path == current)
+    monkeypatch.setattr(mod, "_patch_equivalent_to_main", lambda _wt_path: False)
+    monkeypatch.setattr(
+        mod,
+        "_newest_ahead_commit_age_hours",
+        lambda _wt_path, _now_epoch: mod.STALE_AHEAD_WITHOUT_UPSTREAM_WARNING_AGE_HOURS,
+    )
+
+    risks = mod.collect_risks(repo_root, current)
+
+    assert len(risks) == 1
+    assert risks[0].risks == ["stale_ahead_without_upstream"]
+    assert risks[0].newest_ahead_commit_age_hours == mod.STALE_AHEAD_WITHOUT_UPSTREAM_WARNING_AGE_HOURS
+    assert mod._is_blocking_risk(risks[0].risks) is False
 
 
 def test_patch_equivalent_ahead_worktree_is_guidance_not_blocking(monkeypatch, tmp_path: Path) -> None:

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -35,7 +35,7 @@ Mandatory for every prompt (new or follow-up). This command is continuation-safe
 - clean worktree: runs cheap entry checks (`CLAUDE.md` orientation, branch/worktree safety, sibling continuity guidance),
 - dirty worktree: runs the same cheap entry checks and treats the prompt as in-flight continuation,
 - detached HEAD: fails fast with exact branch attach commands.
-- sibling continuity guard: treats dirty siblings as guidance and fails fast only for blocking continuity risks such as detached or unpushed-ahead sibling history.
+- sibling continuity guard: treats dirty siblings, patch-equivalent siblings, and old unpushed-ahead sibling branches as guidance. It fails fast only for blocking continuity risks such as detached worktrees or recent unpushed-ahead sibling history.
 - autonomous worker sidecars under `.claude/worktrees/*` are excluded from sibling continuity risk so Claude workers can run in parallel without blocking Codex prompt entry.
 
 Full proof on demand: `./scripts/prompt_entry_gate.sh --force-full`.
@@ -58,7 +58,7 @@ git add <files> && git commit -m "<message>"   # if changes are ready
 git push -u origin "$(git rev-parse --abbrev-ref HEAD)"   # if branch has no upstream
 ```
 
-If the work is intentionally in progress, continue from that same worktree/thread instead of starting a new one. Dirty sibling worktrees are integration candidates, not abandoned scratchpads: resume that branch, merge/cherry-pick it, or commit it intentionally before starting another thread.
+If the work is intentionally in progress, continue from that same worktree/thread instead of starting a new one. Dirty and old unpushed-ahead sibling worktrees are integration candidates, not abandoned scratchpads: resume that branch, merge/cherry-pick it, or commit it intentionally before it needs to ship.
 
 SQLite artifact rule:
 

--- a/docs/system_audit/commit_evidence_2026-06-01_prompt_continuity_sibling_warning.json
+++ b/docs/system_audit/commit_evidence_2026-06-01_prompt_continuity_sibling_warning.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-06-01",
+  "thread_branch": "codex/prompt-continuity-sibling-warning-20260601",
+  "commit_scope": "Downgrade old unpushed-ahead sibling worktrees to prompt-entry guidance while keeping recent unpushed-ahead and detached sibling worktrees blocking.",
+  "files_owned": [
+    "scripts/worktree_continuity_guard.py",
+    "scripts/prompt_entry_gate.sh",
+    "api/tests/test_worktree_continuity_guard.py",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/system_audit/commit_evidence_2026-06-01_prompt_continuity_sibling_warning.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 -m py_compile scripts/worktree_continuity_guard.py",
+      "python3 -m pytest api/tests/test_worktree_continuity_guard.py -v",
+      "python3 -m ruff check scripts/worktree_continuity_guard.py api/tests/test_worktree_continuity_guard.py",
+      "python3 scripts/worktree_continuity_guard.py --fail-on-blocking-risk",
+      "make prompt-guide"
+    ],
+    "notes": [
+      "The initial worktree-local command `cd api && .venv/bin/pytest tests/test_worktree_continuity_guard.py -v` failed before running tests because this new worktree has no api/.venv: `zsh:1: no such file or directory: .venv/bin/pytest`.",
+      "The focused pytest rerun used the available Python runner from the same worktree and passed 7 tests.",
+      "Live continuity output reported risk_count=49 and blocking_risk_count=0 while preserving stale_ahead_without_upstream and dirty_integration_candidate guidance rows.",
+      "make prompt-guide completed without PROMPT_GATE_SKIP_CONTINUITY in this worktree."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "No runtime endpoint behavior changed by this prompt-entry process change."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused local proof passes; CI and deploy validation are pending."
+  },
+  "idea_ids": [
+    "repository-health"
+  ],
+  "spec_ids": [
+    "repository-workflow-health"
+  ],
+  "task_ids": [
+    "prompt-continuity-sibling-warning-20260601"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "workflow policy"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/tests/test_worktree_continuity_guard.py: fresh ahead-without-upstream stays blocking",
+    "api/tests/test_worktree_continuity_guard.py: stale ahead-without-upstream is guidance",
+    "scripts/worktree_continuity_guard.py --fail-on-blocking-risk: blocking_risk_count=0",
+    "make prompt-guide: completed without PROMPT_GATE_SKIP_CONTINUITY"
+  ],
+  "change_files": [
+    "api/tests/test_worktree_continuity_guard.py",
+    "docs/WORKTREE-QUICKSTART.md",
+    "docs/system_audit/commit_evidence_2026-06-01_prompt_continuity_sibling_warning.json",
+    "scripts/prompt_entry_gate.sh",
+    "scripts/worktree_continuity_guard.py"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/prompt_entry_gate.sh
+++ b/scripts/prompt_entry_gate.sh
@@ -91,7 +91,7 @@ if [[ "${PROMPT_GATE_SKIP_CONTINUITY:-0}" != "1" ]]; then
   fi
   if ! python3 scripts/worktree_continuity_guard.py "${continuity_args[@]}"; then
     echo "prompt-entry-guide: sibling worktree continuity risk detected."
-    echo "Dirty siblings are guidance; detached or unpushed-ahead siblings can strand history."
+    echo "Dirty or stale sibling branches are guidance; detached or recent unpushed-ahead siblings can strand history."
     echo "Continue from that worktree, attach/push it, or merge/cherry-pick its branch before starting new work."
     echo "Temporary bypass while tending continuity awareness: PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide"
     exit 1

--- a/scripts/worktree_continuity_guard.py
+++ b/scripts/worktree_continuity_guard.py
@@ -12,6 +12,7 @@ import argparse
 import fnmatch
 import json
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,6 +26,7 @@ class WorktreeRisk:
     ahead_of_main: int
     behind_main: int
     has_upstream: bool
+    newest_ahead_commit_age_hours: float | None
     patch_equivalent_to_main: bool
     risks: list[str]
 
@@ -33,6 +35,8 @@ BLOCKING_RISK_LABELS = {
     "detached_head",
     "ahead_without_upstream",
 }
+
+STALE_AHEAD_WITHOUT_UPSTREAM_WARNING_AGE_HOURS = 48.0
 
 SKIPPABLE_LOCAL_ARTIFACT_PATTERNS = (
     "api/data/*.db",
@@ -188,8 +192,30 @@ def _patch_equivalent_to_main(worktree_path: Path) -> bool:
     return bool(rows) and all(row.startswith("-") for row in rows)
 
 
+def _newest_ahead_commit_age_hours(worktree_path: Path, now_epoch: float) -> float | None:
+    proc = _run_git(["log", "-1", "--format=%ct", "HEAD", "--not", "origin/main"], worktree_path)
+    if proc.returncode != 0:
+        return None
+    raw_epoch = proc.stdout.strip()
+    if not raw_epoch:
+        return None
+    try:
+        commit_epoch = int(raw_epoch)
+    except ValueError:
+        return None
+    return max(0.0, (now_epoch - commit_epoch) / 3600)
+
+
+def _is_stale_ahead_without_upstream(age_hours: float | None) -> bool:
+    return (
+        age_hours is not None
+        and age_hours >= STALE_AHEAD_WITHOUT_UPSTREAM_WARNING_AGE_HOURS
+    )
+
+
 def collect_risks(repo_root: Path, current_path: Path) -> list[WorktreeRisk]:
     risks: list[WorktreeRisk] = []
+    now_epoch = time.time()
     for row in _parse_worktrees(repo_root):
         wt_path = Path(str(row.get("worktree", "")).strip()).resolve()
         if not wt_path.exists():
@@ -206,6 +232,11 @@ def collect_risks(repo_root: Path, current_path: Path) -> list[WorktreeRisk]:
         ahead, behind = _ahead_behind_vs_main(wt_path)
         has_upstream = _upstream_exists(wt_path)
         patch_equivalent = ahead > 0 and _patch_equivalent_to_main(wt_path)
+        ahead_age_hours = (
+            _newest_ahead_commit_age_hours(wt_path, now_epoch)
+            if ahead > 0 and not has_upstream
+            else None
+        )
         risk_labels: list[str] = []
         if detached:
             risk_labels.append("detached_head")
@@ -214,7 +245,10 @@ def collect_risks(repo_root: Path, current_path: Path) -> list[WorktreeRisk]:
         if patch_equivalent:
             risk_labels.append("integrated_patch_equivalent")
         elif ahead > 0 and not has_upstream:
-            risk_labels.append("ahead_without_upstream")
+            if _is_stale_ahead_without_upstream(ahead_age_hours):
+                risk_labels.append("stale_ahead_without_upstream")
+            else:
+                risk_labels.append("ahead_without_upstream")
         if risk_labels:
             risks.append(
                 WorktreeRisk(
@@ -225,6 +259,7 @@ def collect_risks(repo_root: Path, current_path: Path) -> list[WorktreeRisk]:
                     ahead_of_main=ahead,
                     behind_main=behind,
                     has_upstream=has_upstream,
+                    newest_ahead_commit_age_hours=ahead_age_hours,
                     patch_equivalent_to_main=patch_equivalent,
                     risks=risk_labels,
                 )
@@ -261,6 +296,7 @@ def main() -> int:
                 "ahead_of_main": item.ahead_of_main,
                 "behind_main": item.behind_main,
                 "has_upstream": item.has_upstream,
+                "newest_ahead_commit_age_hours": item.newest_ahead_commit_age_hours,
                 "patch_equivalent_to_main": item.patch_equivalent_to_main,
                 "risks": item.risks,
                 "blocking": _is_blocking_risk(item.risks),
@@ -279,11 +315,13 @@ def main() -> int:
         for item in payload["risks"]:
             labels = ",".join(item["risks"])
             severity = "blocking" if item["blocking"] else "guidance"
+            age = item["newest_ahead_commit_age_hours"]
+            age_text = f" ahead_age={age:.1f}h" if isinstance(age, (int, float)) else ""
             print(
                 " - "
                 f"{item['path']} branch={item['branch']} "
                 f"ahead={item['ahead_of_main']} behind={item['behind_main']} "
-                f"upstream={'yes' if item['has_upstream'] else 'no'} "
+                f"upstream={'yes' if item['has_upstream'] else 'no'}{age_text} "
                 f"severity={severity} risks={labels}"
             )
 


### PR DESCRIPTION
## Summary
- keeps detached and recent unpushed-ahead sibling worktrees as blocking continuity risks
- downgrades old unpushed-ahead siblings to visible guidance with an ahead-age readout
- updates prompt-entry wording and the worktree quickstart so clean new worktrees no longer inherit old branch debt as a hard blocker

## Validation
- reproduced original make prompt-guide failure before the patch
- python3 -m pytest api/tests/test_worktree_continuity_guard.py -v -> 7 passed
- python3 -m ruff check scripts/worktree_continuity_guard.py api/tests/test_worktree_continuity_guard.py -> passed
- python3 scripts/worktree_continuity_guard.py --fail-on-blocking-risk -> blocking_risk_count=0
- make prompt-guide -> passed
- python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence -> passed
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main -> ready_for_push=True
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict -> stale_codex_prs=0