### PR TITLE
tend(kernels): persistent-serve readiness — the apples-to-apples kernel profile

### DIFF
--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -11,6 +11,18 @@ Companion to [`scripts/substrate_parity_harness.py`](../scripts/substrate_parity
 (value/structure parity) — this one adds the profile-under-load axis that a
 green demo count cannot give.
 
+> **The correction this doc carries (2026-06-01).** An earlier pass measured a
+> per-request fork+exec of the kernel (PATH A) and read ~5 ms/call. That was the
+> **wrong serving model**, and not a fair comparison: CPython serves from a
+> warm, already-loaded process — it does **not** fork an interpreter per
+> request. The honest counterpart is a **persistent kernel** that loads the
+> routes ONCE and then runs request→response over the live process. With spawn
+> removed, per-request latency drops from ~5 ms to **~0.1–0.23 ms p50**
+> (sub-millisecond, ~20–40× faster than the spawn-bound path). The persistent
+> number is the one that decides the flip; the per-request-spawn number was an
+> artifact of the wrong harness shape. Both are stated below so the correction
+> is legible.
+
 ## What's eligible for the flip, and what stays CPython
 
 The flip is for the **pure-computation core** of an endpoint, not the whole
@@ -96,61 +108,200 @@ every invocation. **This path cannot serve load as a per-call shell-out** — it
 is a correctness/parity instrument. It only becomes a serving path with a
 persistent kernel process that compiles the preludes once and stays warm.
 
+## The persistent-serve model — the apples-to-apples number
+
+The fix to the wrong comparison is already in the kernel:
+[`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs)
+`cli_serve` (`form-kernel-rust serve --port P --routes file.fk`). It loads a
+`routes.fk` ONCE into a long-lived `Kernel + Arena`, holds the top-level
+`routes` binding (a list of `(path handler-closure)` pairs), starts an HTTP/1.0
+listener, and dispatches each request to the matching handler with a **fresh
+child frame** — **no per-request process spawn, no per-request source-compile.**
+This is the warm-process counterpart to a CPython worker.
+
+The route table the harness registers is
+[`scripts/kernel_readiness_routes.fk`](../scripts/kernel_readiness_routes.fk):
+the four endpoint computations bound once as `(defn …)` recipes (the SAME bodies
+the live endpoints run, captured from the `endpoint_*_demo.py` shapes), each
+wrapped in a handler closure. A request → handler call → recipe walk → response
+body is one in-process movement.
+
+**Measured (2026-06-01, this worktree, release build,
+`--persistent --iters 200`):**
+
+| Endpoint | Value parity | CPython p50 | **Serve p50** | Serve p95 / p99 | Serve verdict |
+|----------|:---:|---:|---:|---:|---|
+| `coherence_weight` | ✓ 16185 | 0.0007 ms | **0.189 ms** | 0.243 / 0.265 ms | READY (shape) |
+| `nodeid_distance` | ✓ 7 | 0.0004 ms | **0.231 ms** | 0.262 / 0.288 ms | READY (shape) |
+| `nodeid_compatibility` | ✓ 2 | 0.0004 ms | **0.235 ms** | 0.264 / 0.278 ms | READY (shape) |
+| `weighted_average` | ✓ 0.8125 | 0.0004 ms | **0.090 ms** | 0.134 / 0.192 ms | READY (shape) |
+
+**The real ratio, spawn removed.** Per-request latency over the warm channel is
+**~0.09–0.24 ms p50, p99 under 0.29 ms** — sub-millisecond, **~20–40× faster
+than the ~5 ms spawn-bound PATH A.** Against CPython's bare-compute p50
+(~0.0004 ms) the *ratio* still reads as a few-hundred×, but that ratio is the
+wrong lens: CPython's headline is a sub-microsecond arithmetic loop with **zero
+transport**, while the kernel number includes a full HTTP/1.0 loopback
+round-trip. Judge on the **absolute**: ~0.2 ms request→response is negligible
+overhead for an HTTP endpoint (the network and FastAPI's own routing dwarf it).
+
+**What the ~0.2 ms is made of.** It is dominated by the HTTP/1.0 loopback
+(connect + request line + 8 KiB read + response write) and the string-alist
+marshalling, **not** recipe execution. The recipe walk itself is the same
+~0.15 ms (or less, for these tiny recipes) the PATH A breakdown isolated. So the
+persistent serve confirms the earlier prediction empirically: **the kernel was
+never the bottleneck — the spawn was.**
+
+### Honest limits of the serve mode (proof-of-shape, not production)
+
+`cli_serve` is a ~50-line raw `std::net` HTTP/1.0 listener. It is the right shape
+to *measure* the persistent model; it is **not** a production HTTP server. Named
+plainly:
+
+- **HTTP/1.0, no keep-alive** — every request is a fresh TCP connection. A real
+  serving path wants keep-alive or an in-process call (PyO3), which removes even
+  the connect cost.
+- **Single-threaded, sequential** — one request at a time. No concurrency.
+- **String-only query alist** — the query string arrives as `(list (key value)…)`
+  with every value a STRING. The two integer NodeID endpoints marshal cleanly
+  (8 int query params, parsed with `str_to_int`); `coherence_weight` and
+  `weighted_average` take a **list** (and floats), and the kernel ships no
+  `split` / `str_to_float` native, so their handlers compute the **frozen
+  sample input** — the recipe body that runs is identical to live, but the
+  per-request *inputs* are not yet marshalled from the wire. List/float query
+  marshalling is the named gap, not a measured failure.
+- **No Pydantic, no validation, no async** — those stay in FastAPI regardless.
+
+The serve mode proves **the persistent shape is sound and sub-ms**. The
+production carrier of that shape is the **inline PyO3** path (a warm `Kernel`
+held in-process, called by FastAPI with no socket at all) — same warm-kernel
+win, no HTTP/1.0 limits.
+
+## JIT — what `register_jit` and `jit_compile` actually do today
+
+Two distinct mechanisms live in the kernel, and the honest readiness map keeps
+them apart:
+
+- **`register_jit form-name native-name`** (main.rs ~line 2669) — **aliases** a
+  Form recipe name to an *existing host-native*. It is a dispatch hint, not a
+  compiler: it only speeds a recipe when an equivalent native already exists
+  (e.g. aliasing a Form `my-count` to native `len`). For the four endpoint
+  recipes there is **no native equivalent**, so `register_jit` buys nothing.
+- **`jit_compile form-name`** (main.rs ~line 2733) — a **real recipe→machine-code
+  compiler**: it emits Rust source from the Form recipe, invokes the system
+  `rustc --crate-type=cdylib`, loads the `.so` via `libloading`, and dispatches
+  subsequent calls through the native function pointer. This is genuine native
+  compilation, not aliasing.
+
+**What `jit_compile` buys, measured.** On a recipe *inside its emit subset* —
+`fib` written with the operator forms `emit_rust_source` covers
+(`add`/`sub`/`lt`) — the harness measured **8× `fib(30)` walked = ~10,375 ms vs
+recipe→native = ~485 ms: a ~21× speedup, INCLUDING the one-time rustc compile.**
+Steady-state (compile amortized) is higher still. The compiler is real and the
+win is large.
+
+**Why it is a no-op for the four endpoints — the precise gap.** `jit_compile`
+returns **0** (honest "unavailable") for all four endpoint recipes. The cause is
+**emit coverage**, not the compiler:
+
+- `emit_rust_source` / `emit_expr` cover the **operator** recipe shapes —
+  `RB_MATH` (`add sub mul div mod`), `RB_COMPARE`, `RB_LOGIC`, `RB_COND`, and
+  calls to **sibling Form functions**. They emit i64-only Rust.
+- The Python adapter compiles arithmetic to **native calls** — `_plus`, `abs`,
+  `_get`, `_iter`, `head`, `tail`, `len`, `nth` — which fall through to
+  `RB_FNCALL` against natives the emitter cannot inline (it would have to call
+  back into the walker). The endpoint recipes also use **lists and floats**,
+  both outside the i64 emit subset entirely.
+
+So the gap to a real recipe-JIT *for these endpoints* is concrete: the emitter
+needs (1) native-builtin inlining or a native→Rust shim for `_plus`/`abs`/list
+ops, (2) **f64** emission (today it is i64-only), and (3) list/iteration
+lowering. None of that is exotic — it is emit-coverage work on a compiler that
+already produces and loads real machine code. Until then: **persistent serve is
+what gets the endpoints to sub-ms; `jit_compile` is the proven path to native
+for the *operator* subset and the named extension for the rest.**
+
 ## Honest verdict — per call
 
-| Endpoint | Verdict (subprocess PATH A today) |
-|----------|-----------------------------------|
-| `coherence_weight` | **NOT-YET via subprocess** — correct, but +5 ms/req spawn. Sub-ms compute. |
-| `nodeid_distance` | **NOT-YET via subprocess** — same shape: correct, spawn-bound. |
-| `nodeid_compatibility` | **NOT-YET via subprocess** — same. |
-| `weighted_average` | **NOT-YET via subprocess** — same. |
+Two models, stated separately so the correction is legible:
 
-The blanket-"ready" costume is refused. Read precisely:
+| Endpoint | PATH A (per-req fork+exec — WRONG model) | **Persistent serve (apples-to-apples)** |
+|----------|------------------------------------------|------------------------------------------|
+| `coherence_weight` | NOT-YET — +5 ms/req spawn | **READY (shape)** — 0.189 ms p50, 0.265 ms p99 |
+| `nodeid_distance` | NOT-YET — spawn-bound | **READY (shape)** — 0.231 ms p50, 0.288 ms p99 |
+| `nodeid_compatibility` | NOT-YET — spawn-bound | **READY (shape)** — 0.235 ms p50, 0.278 ms p99 |
+| `weighted_average` | NOT-YET — spawn-bound | **READY (shape)** — 0.090 ms p50, 0.192 ms p99 |
 
-- **Correctness is met.** 4/4 value parity, stable percentiles, shape intact.
-- **The subprocess path is not load-ready** — not because the kernel is slow
-  (it isn't; ~0.15 ms compute) but because **per-request fork+exec adds ~5 ms**.
-  At low request volume on a low-latency budget that is tolerable; as a default
-  serving path under real traffic it is the wrong shape.
-- **The fix is not faster compute — it's removing the spawn.** The `inline`
-  (PyO3) path the bridge already routes to drops per-request cost to the
-  ~0.15 ms execute (≈sub-ms, HTTP-negligible). That is the path a flip should
-  ride. Build `form_kernel_rust` as a PyO3 extension in the deploy image, and
-  the same recipes that are NOT-YET via subprocess become READY via inline.
+"READY (shape)" means: correct (4/4 value parity over the warm channel), stable
+percentiles, and a sub-ms absolute latency envelope under the persistent model.
+It is **not** "ship it" — the serve mode's HTTP/1.0 / single-thread / string-arg
+limits above mean the *production* carrier is inline PyO3, not this listener.
+The shape is proven; the production path is named.
 
-The number that matters for Urs's decision: **the kernel is ~0.15 ms; the
-shell-out is ~5 ms.** The flip needs a **persistent/warm kernel path**
-(inline PyO3, or a long-lived kernel process), **not** a per-call shell-out.
+Read precisely:
+
+- **Correctness is met.** 4/4 value parity over the warm channel, stable
+  percentiles, response shape intact.
+- **Under the persistent model the kernel is sub-ms.** ~0.09–0.24 ms p50,
+  p99 under 0.29 ms — and most of that is HTTP/1.0 loopback, not recipe
+  execution. The per-request-spawn ~5 ms was an artifact of the wrong harness
+  shape, never the kernel's cost.
+- **The production carrier is the warm kernel held in-process.** The serve mode
+  proves the shape; **inline PyO3** (a `Kernel` loaded once at module import,
+  called by FastAPI with no socket) carries it without the HTTP/1.0 /
+  single-thread / string-arg limits. The bridge already routes to an `inline`
+  path when the `form_kernel_rust` extension is built — building that extension
+  in the deploy image is what turns "READY (shape)" into "READY (production)".
+
+The number that matters for the flip decision: **with the kernel persistent,
+request→response is ~0.2 ms — sub-millisecond, HTTP-negligible.** The flip needs
+a **warm kernel** (inline PyO3, or a long-lived serve process), not a per-call
+shell-out. That requirement is now backed by a measured persistent profile, not
+a prediction.
 
 ## What's needed before a real flip
 
 1. **Build the inline PyO3 kernel** (`form_kernel_rust`) in the API image and
-   re-run this harness — confirm `inline` path p50 lands at the ~0.15 ms
-   compute floor. That is the load-ready measurement.
-2. **Capture real traffic.** Today's inputs are **representative-derived** from
+   re-run with `--persistent` — confirm the in-process `inline` path lands at or
+   below the serve number (it should be *faster*, with no socket round-trip).
+   That is the load-ready, production-carrier measurement.
+2. **Marshal real inputs over the channel.** The two list/float endpoints
+   currently compute a frozen sample under serve because the string-only query
+   alist plus the missing `split` / `str_to_float` natives can't carry a list.
+   Add list/float wire-marshalling (or do it inline via PyO3 where Python hands
+   the kernel typed values directly) so every endpoint marshals its real inputs.
+3. **Capture real traffic.** Today's inputs are **representative-derived** from
    the endpoints' query defaults / Pydantic contracts, *not* sampled from
    production. Add a request-log → replay corpus so the profile reflects real
    value distributions (list sizes, edge cases), not one frozen input each.
-3. **Grow the captured-call corpus** to cover input-size scaling (10 → 100 →
-   1000-element value lists) — spawn cost is fixed, but recipe-execute cost
-   scales with input; the crossover where kernel compute beats CPython is worth
-   measuring.
-4. **Load levels.** Re-run at `--iters 1000`+ and under concurrency to confirm
-   stability holds (no fd leak from temp `.fk` churn, no spawn contention) at
-   serving rates, not just 50 sequential calls.
-5. **Latency envelope that counts as healthy:** for an HTTP endpoint, p99 kernel
-   overhead under ~1 ms over the CPython baseline. The inline path is expected
-   to meet this; the subprocess path will not.
+4. **Grow the captured-call corpus** to cover input-size scaling (10 → 100 →
+   1000-element value lists) — the persistent overhead is fixed, but recipe
+   execution scales with input; the crossover where kernel compute beats CPython
+   is worth measuring.
+5. **JIT the hot paths.** Extend `emit_rust_source` to cover the native-builtin
+   and f64/list shapes the endpoint recipes use (today it is i64 + operators +
+   sibling-calls only), so `jit_compile` can lower them to native — the same
+   compiler that already buys ~21× on the operator subset.
+6. **Load levels + concurrency.** Re-run at `--iters 1000`+ and under concurrent
+   clients to confirm stability holds at serving rates (the serve mode is
+   single-threaded — concurrency needs PyO3-inline or a threaded listener).
+7. **Latency envelope that counts as healthy:** for an HTTP endpoint, p99 kernel
+   overhead under ~1 ms over the CPython baseline. The persistent serve already
+   meets this (p99 < 0.3 ms); inline PyO3 is expected to beat it.
 
 ## Running the evidence
 
 ```bash
-python3 scripts/kernel_readiness_harness.py                 # PATH A, 50 iters
-python3 scripts/kernel_readiness_harness.py --iters 1000    # load replay
-python3 scripts/kernel_readiness_harness.py --path-b        # include PATH B
-python3 scripts/kernel_readiness_harness.py --json out.json # machine-readable
+python3 scripts/kernel_readiness_harness.py                          # PATH A, 50 iters
+python3 scripts/kernel_readiness_harness.py --persistent             # + the warm serve path (apples-to-apples)
+python3 scripts/kernel_readiness_harness.py --persistent --jit       # + serve+jit mode and the JIT demonstrator
+python3 scripts/kernel_readiness_harness.py --iters 1000 --persistent # load replay
+python3 scripts/kernel_readiness_harness.py --path-b                 # include PATH B
+python3 scripts/kernel_readiness_harness.py --json out.json          # machine-readable
 ```
 
 The harness exits nonzero **only** on a value-parity failure. Slowness is
 reported as evidence, never as a test failure — the profile informs the flip
-decision; it does not gate CI.
+decision; it does not gate CI. The persistent serve mode starts one
+`form-kernel-rust serve` process per mode, fires all requests over it, and kills
+it on exit; no listener is left running.

--- a/scripts/kernel_readiness_harness.py
+++ b/scripts/kernel_readiness_harness.py
@@ -95,6 +95,9 @@ ADAPTER = REPO / "form" / "form-kernel-ts" / "seedbank" / "python-adapter"
 EXAMPLES = ADAPTER / "examples"
 RUST_BIN = REPO / "form" / "form-kernel-rust" / "target" / "release" / "form-kernel-rust"
 PYFKB = REPO / "form" / "scripts" / "pyfkb-run.sh"
+# The persistent-serve route table: registered ONCE into a warm kernel by
+# `form-kernel-rust serve`. Holds the same recipe bodies the live endpoints run.
+SERVE_ROUTES = REPO / "scripts" / "kernel_readiness_routes.fk"
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +129,13 @@ class CaptureCall:
     parse: Callable[[str], Any]
     response_shape: List[str]
     provenance: str
+    # Persistent-serve fields: the route path registered in SERVE_ROUTES and
+    # the query string fired per request. `serve_query` is "" when the handler
+    # computes a frozen sample (list/float args the string-only serve alist
+    # can't carry — see SERVE_ROUTES header); a real query string when the
+    # endpoint's inputs marshal cleanly (the two integer NodeID endpoints).
+    serve_path: str = ""
+    serve_query: str = ""
 
 
 # --- CPython reference implementations: copied verbatim from the endpoint
@@ -174,6 +184,8 @@ CASES: List[CaptureCall] = [
         parse=int,
         response_shape=["weight", "values", "threshold", "runtime"],
         provenance="representative-derived from query defaults in utils.py (NOT traffic-sampled)",
+        serve_path="/coherence_weight",
+        serve_query="",  # list arg — handler computes frozen sample (serve alist is string-only)
     ),
     CaptureCall(
         name="nodeid_distance",
@@ -186,6 +198,8 @@ CASES: List[CaptureCall] = [
         parse=int,
         response_shape=["distance", "a", "b", "runtime"],
         provenance="representative-derived from Query defaults in utils.py (NOT traffic-sampled)",
+        serve_path="/nodeid_distance",
+        serve_query="a_pkg=1&a_lvl=5&a_type=4&a_inst=1&b_pkg=1&b_lvl=4&b_type=4&b_inst=7",
     ),
     CaptureCall(
         name="nodeid_compatibility",
@@ -198,6 +212,8 @@ CASES: List[CaptureCall] = [
         parse=int,
         response_shape=["compatibility", "a", "b", "runtime"],
         provenance="representative-derived from Query defaults in utils.py (NOT traffic-sampled)",
+        serve_path="/nodeid_compatibility",
+        serve_query="a_pkg=1&a_lvl=5&a_type=4&a_inst=1&b_pkg=1&b_lvl=4&b_type=4&b_inst=7",
     ),
     CaptureCall(
         name="weighted_average",
@@ -207,6 +223,8 @@ CASES: List[CaptureCall] = [
         parse=float,
         response_shape=["average", "values", "weights", "runtime"],
         provenance="representative-derived from query defaults in utils.py (NOT traffic-sampled)",
+        serve_path="/weighted_average",
+        serve_query="",  # list+float args — handler computes frozen sample
     ),
 ]
 
@@ -364,6 +382,213 @@ def make_path_b_thunk(demo_py: str) -> Callable[[], Any]:
 
 
 # ---------------------------------------------------------------------------
+# Persistent serve — the apples-to-apples model Urs named.
+#
+# A per-request fork+exec (PATH A) is the WRONG comparison: CPython serves from
+# a warm, already-loaded process; it does not fork an interpreter per request.
+# The honest counterpart is `form-kernel-rust serve`: it loads SERVE_ROUTES
+# ONCE into a long-lived Kernel+Arena, then dispatches each HTTP/1.0 GET to the
+# matching handler closure with a fresh child frame — NO per-request spawn, NO
+# per-request source-compile. This is the number that decides the flip.
+#
+# The +jit variant asks the warm kernel to `jit_compile` each route's recipe at
+# load (real recipe→machine-code via rustc cdylib). For the four endpoint
+# recipes this is a no-op the harness MEASURES and reports honestly: their
+# bodies use `_plus` / `abs` / list natives outside the JIT subset, so
+# jit_compile returns 0. The JIT mechanism IS real (proven on a pure-operator
+# recipe — see profile_jit_demonstrator); the gap is the emit coverage, not the
+# compiler. Both facts are evidence.
+# ---------------------------------------------------------------------------
+
+import http.client
+import socket
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class PersistentServe:
+    """Start `form-kernel-rust serve` once; hold it warm for the whole run.
+
+    Context manager: __enter__ spawns the listener on a free port, waits until
+    it accepts, and yields self; __exit__ kills it. The whole point is that the
+    kernel + routes load EXACTLY ONCE — every request inside the block is
+    request→handler→recipe-walk→response over the already-loaded process, the
+    apples-to-apples counterpart to a warm CPython worker.
+
+    `jit=True` writes a sibling routes file that appends `(jit_compile "<fn>")`
+    for each endpoint computation so the warm kernel attempts a recipe→native
+    compile at load. Honest by construction: if jit_compile returns 0 the route
+    still serves via recipe-walk (same value), and the latency simply won't move
+    — which is itself the measured finding.
+    """
+
+    # The endpoint computation function each route dispatches into — the name
+    # jit_compile would target. (Handlers themselves close over these.)
+    JIT_TARGETS = ["coherence_weight", "manhattan", "compatibility", "weighted_average"]
+
+    def __init__(self, routes_path: Path, jit: bool = False):
+        self.jit = jit
+        self.port = _free_port()
+        self._proc: Optional[subprocess.Popen] = None
+        self._tmp_routes: Optional[Path] = None
+        if jit:
+            base = routes_path.read_text(encoding="utf-8")
+            lines = [base, "\n; +jit: attempt real recipe→native compile at load"]
+            for fn in self.JIT_TARGETS:
+                lines.append(f'(let _jit_{fn} (jit_compile "{fn}"))')
+            import tempfile as _tf
+            fd = _tf.NamedTemporaryFile("w", suffix="_jit.fk", delete=False)
+            fd.write("\n".join(lines))
+            fd.close()
+            self._tmp_routes = Path(fd.name)
+            self.routes_path = self._tmp_routes
+            self.jit_results: Dict[str, Optional[int]] = {fn: None for fn in self.JIT_TARGETS}
+        else:
+            self.routes_path = routes_path
+            self.jit_results = {}
+
+    def __enter__(self) -> "PersistentServe":
+        self._proc = subprocess.Popen(
+            [str(RUST_BIN), "serve", "--port", str(self.port),
+             "--routes", str(self.routes_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        # Wait until the listener accepts (bounded) — the one-time load cost.
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.2):
+                    break
+            except OSError:
+                if self._proc.poll() is not None:
+                    err = self._proc.stderr.read().decode() if self._proc.stderr else ""
+                    raise RuntimeError(f"serve exited during startup: {err}")
+                time.sleep(0.02)
+        else:
+            raise RuntimeError("serve did not start listening within 10s")
+        return self
+
+    def request(self, path: str, query: str) -> str:
+        """One HTTP/1.0 GET over the warm kernel; return the response body."""
+        target = path if not query else f"{path}?{query}"
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10.0)
+        try:
+            conn.request("GET", target)
+            resp = conn.getresponse()
+            return resp.read().decode().strip()
+        finally:
+            conn.close()
+
+    def __exit__(self, *exc) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        if self._tmp_routes is not None:
+            try:
+                self._tmp_routes.unlink()
+            except OSError:
+                pass
+
+
+def make_serve_thunk(server: PersistentServe, case: CaptureCall) -> Callable[[], Any]:
+    """Per-request thunk: one HTTP GET over the already-loaded kernel."""
+    def thunk() -> Any:
+        body = server.request(case.serve_path, case.serve_query)
+        return case.parse(body)
+    return thunk
+
+
+# ---------------------------------------------------------------------------
+# JIT demonstrator — what a REAL recipe→machine-code compile buys, measured.
+#
+# The four endpoint recipes are outside the JIT emit subset, so jit_compile is
+# a no-op for them. To still answer "what does real JIT do?" with a NUMBER, we
+# measure the compiler on a recipe that IS in the subset: fib expressed in the
+# operator forms emit_rust_source covers (`add`/`sub`/`lt`). Walked vs compiled,
+# same kernel, same input. This isolates the JIT speedup from the endpoint gap.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JitDemo:
+    available: bool          # rustc present + compile returned 1
+    compile_returned: int    # raw jit_compile return (1 ok / 0 unavailable / -1 unbound)
+    walked_p50_ms: float
+    jit_p50_ms: float
+    speedup: Optional[float]
+    note: str
+
+
+def profile_jit_demonstrator(iters: int) -> JitDemo:
+    """Measure walked-vs-jit on an in-subset recipe (fib via add/sub/lt)."""
+    # Drive MANY fib calls inside ONE kernel run so the recipe-execution cost
+    # dominates the fixed spawn (+ one-time rustc compile in the jit case). A
+    # single fib(28) is ~comparable to spawn; a loop of K fib(30) makes the
+    # walk-vs-native delta the thing the wall clock measures.
+    n, k = 30, 8
+    fib_def = "(defn fib (n) (if (lt n 2) n (add (fib (sub n 1)) (fib (sub n 2)))))"
+    loop_def = f"(defn loopk (i acc) (if (eq i 0) acc (loopk (sub i 1) (add acc (fib {n})))))"
+    walked_fk = f"{fib_def}\n{loop_def}\n(loopk {k} 0)"
+    jit_fk = f'{fib_def}\n(let _c (jit_compile "fib"))\n{loop_def}\n(loopk {k} 0)'
+
+    def run(src: str) -> str:
+        import tempfile as _tf
+        f = _tf.NamedTemporaryFile("w", suffix=".fk", delete=False)
+        f.write(src)
+        f.close()
+        try:
+            p = subprocess.run([str(RUST_BIN), f.name], capture_output=True,
+                               text=True, timeout=60)
+            return p.stdout.rstrip("\n").splitlines()[-1]
+        finally:
+            os.unlink(f.name)
+
+    # Probe jit_compile's return code once.
+    probe_fk = (
+        f"(defn fib (n) (if (lt n 2) n (add (fib (sub n 1)) (fib (sub n 2)))))\n"
+        f'(jit_compile "fib")'
+    )
+    try:
+        compile_returned = int(run(probe_fk))
+    except Exception:
+        compile_returned = -2
+
+    if compile_returned != 1:
+        return JitDemo(
+            available=False, compile_returned=compile_returned,
+            walked_p50_ms=0.0, jit_p50_ms=0.0, speedup=None,
+            note="jit_compile did not return 1 (rustc missing or recipe outside subset)",
+        )
+
+    # These thunks include subprocess spawn + the run; we report the RATIO of
+    # walked to jit so the shared spawn cost cancels and the recipe-execution
+    # delta is what surfaces. n is chosen so walk-cost >> spawn-cost.
+    # Few iters — each run is heavy (seconds for the walked case).
+    reps = max(3, min(8, iters // 12))
+    walked_prof, _ = profile_runtime("jit-demo/walked", lambda: run(walked_fk),
+                                     reps, warmup=1)
+    jit_prof, _ = profile_runtime("jit-demo/compiled", lambda: run(jit_fk),
+                                  reps, warmup=1)
+    speedup = (walked_prof.p50_ms / jit_prof.p50_ms) if jit_prof.p50_ms else None
+    return JitDemo(
+        available=True, compile_returned=1,
+        walked_p50_ms=walked_prof.p50_ms, jit_p50_ms=jit_prof.p50_ms,
+        speedup=speedup,
+        note=f"{k}x fib({n}) walked vs recipe→native (rustc cdylib); jit incl. one-time compile",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Readiness case result + the per-case driver (uses the ONE engine for both).
 # ---------------------------------------------------------------------------
 
@@ -382,12 +607,23 @@ class ReadinessResult:
     value_match: bool
     ratio_a_p50: Optional[float]     # kernel PATH A p50 / cpython p50
     verdict: str
+    # Persistent-serve (the apples-to-apples model). Populated only when the
+    # serve measurement runs (--persistent); None otherwise so PATH A output is
+    # unchanged when serve isn't requested.
+    serve: Optional[Profile] = None
+    serve_value: Any = None
+    serve_value_match: Optional[bool] = None
+    ratio_serve_p50: Optional[float] = None  # serve p50 / cpython p50
+    serve_jit: Optional[Profile] = None
+    serve_jit_value: Any = None
+    serve_verdict: Optional[str] = None
+    serve_marshalled: bool = False           # True when a real query string carried inputs
 
     def to_dict(self) -> dict:
         d = asdict(self)
         # drop raw sample arrays from json for size; percentiles are kept
-        for k in ("cpython", "kernel_a", "path_b"):
-            if d[k] is not None:
+        for k in ("cpython", "kernel_a", "path_b", "serve", "serve_jit"):
+            if d.get(k) is not None:
                 d[k].pop("samples_ms", None)
         return d
 
@@ -410,6 +646,80 @@ def _verdict(value_match: bool, ratio: Optional[float], ka: Profile) -> str:
         f"NOT-YET — {ratio:.0f}x CPython p50; per-call subprocess spawn dominates. "
         f"Needs a persistent/inline (PyO3) kernel before a flip carries load."
     )
+
+
+def _serve_verdict(value_match: bool, ratio: Optional[float], prof: Profile) -> str:
+    """Readiness verdict under the PERSISTENT-SERVE model (spawn removed)."""
+    if prof.error:
+        return f"NOT-YET — serve path errored: {prof.error}"
+    if not value_match:
+        return "NOT-YET — value parity FAILED over the warm channel"
+    if ratio is None:
+        return "UNKNOWN — could not compute serve ratio"
+    # Absolute envelope matters more than the ratio here: CPython's pure-compute
+    # p50 is sub-microsecond, so any HTTP round-trip is a large MULTIPLE yet may
+    # be a tiny ABSOLUTE overhead. Judge on absolute p99 against an HTTP budget.
+    if prof.p99_ms <= 2.0:
+        return (f"READY (shape) — warm channel, p50={prof.p50_ms:.3f}ms "
+                f"p99={prof.p99_ms:.3f}ms; sub-2ms request→response, no spawn")
+    if prof.p99_ms <= 10.0:
+        return (f"HEALTHY-ENVELOPE — warm channel p99={prof.p99_ms:.3f}ms; "
+                f"low-single-digit-ms, dominated by HTTP/1.0 loopback, not compute")
+    return (f"REVIEW — warm channel p99={prof.p99_ms:.3f}ms exceeds 10ms; "
+            f"investigate loopback/marshalling overhead")
+
+
+def measure_persistent_serve(
+    results: List[ReadinessResult],
+    cases: List[CaptureCall],
+    iters: int,
+    with_jit: bool,
+) -> None:
+    """Fill serve fields on `results` using ONE warm kernel per mode.
+
+    The kernel + routes load EXACTLY ONCE per mode (the whole apples-to-apples
+    point). Every case's requests fire over that single warm process. CPython's
+    baseline is already on each ReadinessResult (cpython profile) — we reuse it
+    so the comparison is against the identical warm-CPython number PATH A used.
+    """
+    by_name = {r.name: r for r in results}
+
+    # Mode: kernel-persistent-serve. One warm server, all cases.
+    with PersistentServe(SERVE_ROUTES, jit=False) as server:
+        for case in cases:
+            r = by_name.get(case.name)
+            if r is None:
+                continue
+            prof, val = profile_runtime(
+                f"{case.name}/serve", make_serve_thunk(server, case), iters
+            )
+            r.serve = prof
+            r.serve_value = case.parse(str(val)) if not isinstance(val, (int, float)) else val
+            r.serve_value_match = (not prof.error) and _values_agree(r.cpython_value, val)
+            r.serve_marshalled = bool(case.serve_query)
+            if r.cpython.p50_ms > 0 and prof.p50_ms > 0 and not prof.error:
+                r.ratio_serve_p50 = prof.p50_ms / r.cpython.p50_ms
+            r.serve_verdict = _serve_verdict(
+                bool(r.serve_value_match), r.ratio_serve_p50, prof
+            )
+
+    if not with_jit:
+        return
+
+    # Mode: kernel-persistent-serve+jit. Same shape, warm kernel attempts a
+    # recipe→native compile of each endpoint computation at load.
+    with PersistentServe(SERVE_ROUTES, jit=True) as server:
+        for case in cases:
+            r = by_name.get(case.name)
+            if r is None:
+                continue
+            prof, val = profile_runtime(
+                f"{case.name}/serve+jit", make_serve_thunk(server, case), iters
+            )
+            r.serve_jit = prof
+            r.serve_jit_value = (
+                case.parse(str(val)) if not isinstance(val, (int, float)) else val
+            )
 
 
 def run_readiness_case(
@@ -482,13 +792,22 @@ def _values_agree(a: Any, b: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def render(results: List[ReadinessResult], iters: int, include_path_b: bool) -> str:
+def render(
+    results: List[ReadinessResult],
+    iters: int,
+    include_path_b: bool,
+    include_serve: bool = False,
+    jit_demo: Optional["JitDemo"] = None,
+) -> str:
     L: List[str] = []
     L.append("=" * 78)
     L.append("kernel_readiness_harness — API → Form-kernel flip evidence")
     L.append(f"rust binary: {RUST_BIN}  (present: {RUST_BIN.is_file()})")
     L.append(f"iterations/runtime: {iters}  (after 5-run warmup; steady-state)")
     L.append("PATH A = live endpoint dispatch (compile-once .fk + per-req fork+exec)")
+    if include_serve:
+        L.append("SERVE  = persistent `form-kernel-rust serve` — routes load ONCE, "
+                 "request→response over the warm process (apples-to-apples w/ CPython)")
     if include_path_b:
         L.append("PATH B = pyfkb full python-bmf pipeline per call (naive shell-out)")
     L.append("=" * 78)
@@ -509,6 +828,23 @@ def render(results: List[ReadinessResult], iters: int, include_path_b: bool) -> 
                      f"p99={r.kernel_a.p99_ms:.4f} mean={r.kernel_a.mean_ms:.4f} sd={r.kernel_a.stdev_ms:.4f}")
         if r.ratio_a_p50 is not None:
             L.append(f"   ratio (p50): kernel A / cpython = {r.ratio_a_p50:.1f}x")
+        if r.serve is not None:
+            marsh = "real-query-args" if r.serve_marshalled else "frozen-sample (list/float arg)"
+            if r.serve.error:
+                L.append(f"   serve      : ERROR {r.serve.error}")
+            else:
+                L.append(f"   serve      : p50={r.serve.p50_ms:.4f}ms p95={r.serve.p95_ms:.4f} "
+                         f"p99={r.serve.p99_ms:.4f} mean={r.serve.mean_ms:.4f} sd={r.serve.stdev_ms:.4f}")
+                L.append(f"   serve val  : {r.serve_value!r}  match="
+                         f"{'YES' if r.serve_value_match else 'NO'}  [{marsh}]")
+                if r.ratio_serve_p50 is not None:
+                    L.append(f"   serve ratio: serve p50 / cpython p50 = {r.ratio_serve_p50:.0f}x "
+                             f"(absolute p99={r.serve.p99_ms:.3f}ms — judge on the ABSOLUTE)")
+            if r.serve_jit is not None and not r.serve_jit.error:
+                L.append(f"   serve+jit  : p50={r.serve_jit.p50_ms:.4f}ms "
+                         f"p99={r.serve_jit.p99_ms:.4f}  (no-op for this recipe — see JIT note)")
+            if r.serve_verdict is not None:
+                L.append(f"   SERVE VERD : {r.serve_verdict}")
         if r.path_b is not None:
             if r.path_b.error:
                 L.append(f"   PATH B     : ERROR {r.path_b.error}")
@@ -517,13 +853,34 @@ def render(results: List[ReadinessResult], iters: int, include_path_b: bool) -> 
                 L.append(f"   PATH B     : p50={r.path_b.p50_ms:.1f}ms  ({ratio_b:.0f}x cpython) "
                          f"— full prelude re-compile per call")
         L.append(f"   VERDICT    : {r.verdict}")
+    if jit_demo is not None:
+        L.append("")
+        L.append("── JIT (real recipe→machine-code, measured on an in-subset recipe)")
+        if not jit_demo.available:
+            L.append(f"   jit_compile returned {jit_demo.compile_returned} — {jit_demo.note}")
+        else:
+            L.append(f"   {jit_demo.note}")
+            L.append(f"   walked  p50 = {jit_demo.walked_p50_ms:.1f} ms")
+            L.append(f"   jit     p50 = {jit_demo.jit_p50_ms:.1f} ms")
+            if jit_demo.speedup is not None:
+                L.append(f"   speedup     = {jit_demo.speedup:.0f}x (recipe→native via rustc cdylib)")
+        L.append("   NOTE: the 4 endpoint recipes are OUTSIDE the JIT emit subset")
+        L.append("         (their bodies use `_plus`/`abs`/list natives, not the")
+        L.append("         operator forms emit_rust_source covers), so jit_compile is a")
+        L.append("         no-op FOR THEM. The compiler is real; the gap is emit coverage.")
     L.append("")
     L.append("=" * 78)
     ready = sum(1 for r in results if r.verdict.startswith("READY"))
     slow = sum(1 for r in results if r.verdict.startswith("CORRECT-BUT-SLOWER"))
     notyet = sum(1 for r in results if r.verdict.startswith("NOT-YET"))
-    L.append(f"SUMMARY: {len(results)} calls — {ready} READY · {slow} CORRECT-BUT-SLOWER "
-             f"· {notyet} NOT-YET")
+    L.append(f"SUMMARY (PATH A): {len(results)} calls — {ready} READY · "
+             f"{slow} CORRECT-BUT-SLOWER · {notyet} NOT-YET")
+    if include_serve:
+        s_ready = sum(1 for r in results if (r.serve_verdict or "").startswith("READY"))
+        s_healthy = sum(1 for r in results if (r.serve_verdict or "").startswith("HEALTHY"))
+        s_match = sum(1 for r in results if r.serve_value_match)
+        L.append(f"SUMMARY (SERVE): {len(results)} calls — {s_match}/{len(results)} value-parity"
+                 f" · {s_ready} READY-shape · {s_healthy} HEALTHY-ENVELOPE")
     L.append("Value parity is the floor; the profile decides readiness. See "
              "kernels/API_KERNEL_READINESS.md for the readiness map.")
     L.append("=" * 78)
@@ -540,6 +897,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--iters", type=int, default=50, help="timed iterations per runtime")
     ap.add_argument("--endpoint", help="run only this endpoint by name")
     ap.add_argument("--path-b", action="store_true", help="also profile the pyfkb PATH B")
+    ap.add_argument("--persistent", action="store_true",
+                    help="also measure the PERSISTENT serve path (the apples-to-apples model)")
+    ap.add_argument("--jit", action="store_true",
+                    help="with --persistent: add the +jit serve mode; also runs the JIT demonstrator")
     ap.add_argument("--json", help="write machine-readable results to this path")
     args = ap.parse_args(argv)
 
@@ -564,7 +925,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         run_readiness_case(c, args.iters, bridge, include_path_b=args.path_b)
         for c in cases
     ]
-    print(render(results, args.iters, args.path_b))
+
+    jit_demo = None
+    if args.persistent:
+        if not SERVE_ROUTES.is_file():
+            print(f"serve routes file missing at {SERVE_ROUTES}", file=sys.stderr)
+            return 2
+        measure_persistent_serve(results, cases, args.iters, with_jit=args.jit)
+    if args.jit:
+        jit_demo = profile_jit_demonstrator(args.iters)
+
+    print(render(results, args.iters, args.path_b,
+                 include_serve=args.persistent, jit_demo=jit_demo))
 
     if args.json:
         Path(args.json).write_text(

--- a/scripts/kernel_readiness_routes.fk
+++ b/scripts/kernel_readiness_routes.fk
@@ -1,0 +1,187 @@
+; kernel_readiness_routes.fk — the persistent-serve registration for the
+; API → Form-kernel readiness measurement.
+;
+; This file is loaded ONCE by `form-kernel-rust serve --port P --routes <this>`.
+; The serve mode (form/form-kernel-rust/src/main.rs cli_serve) reads the
+; top-level `routes` binding into a long-lived Kernel + Arena, then dispatches
+; each HTTP/1.0 GET to the matching handler closure with a fresh child frame.
+; NO per-request process spawn, NO per-request source-compile — the apples-to-
+; apples counterpart to CPython serving from a warm process.
+;
+; The 4 endpoint computations below are the SAME recipe bodies the live
+; endpoints run (api/app/routers/utils.py via form_kernel_bridge), captured
+; from form-kernel-ts/seedbank/python-adapter/examples/endpoint_*_demo.py and
+; compiled to .fk. Here they are bound once into the persistent kernel and
+; wrapped in handler closures so a request → handler call → recipe walk →
+; response body is one in-process movement.
+;
+; Arg marshalling, named honestly:
+;   - The serve mode passes the query string as a list-of-(key value) pairs
+;     where every value is a STRING (HTTP/1.0, no typed body). `alist_get`
+;     reads a value out by key; `str_to_int` parses an int.
+;   - nodeid_distance / nodeid_compatibility take 8 integer query params each
+;     — full request→response marshalling, real per-request inputs.
+;   - coherence_weight / weighted_average take a LIST (and floats). The serve
+;     alist is string-only and the kernel ships no `split` / `str_to_float`
+;     native, so these handlers compute the endpoint's FROZEN sample input
+;     (the same input the harness and parity_suite use). This isolates the
+;     measurement to persistent dispatch + recipe execution; list/float query
+;     marshalling is an HTTP-layer gap named in API_KERNEL_READINESS.md, not
+;     the number under test. The recipe body that runs is identical to live.
+
+; --- query-alist reader: pairs is (list (list k v) ...), all v are strings ---
+(defn alist_get (pairs key)
+  (if (eq (len pairs) 0)
+    ""
+    (do
+      (let row (head pairs))
+      (if (str_eq (nth row 0) key)
+        (nth row 1)
+        (alist_get (tail pairs) key)))))
+
+; ===================================================================
+; coherence_weight — endpoint_coherence_weight_demo.py recipe body
+; ===================================================================
+(defn weighted_score (value position)
+  (if (eq position 0) (mul value 100)
+    (if (eq position 1) (mul value 50)
+      (if (eq position 2) (mul value 25)
+        (mul value 10)))))
+(defn coherence_score (values threshold)
+  (do (let total 0)
+    (do (let position 0)
+      (do
+        (do
+          (defn _cw_for (_remaining total position)
+            (if (eq (len _remaining) 0) (list total position)
+              (do (let v (head _remaining))
+                (if (ge v threshold)
+                  (do (let total (_plus total (weighted_score v position)))
+                    (let position (_plus position 1)))
+                  false)
+                (_cw_for (tail _remaining) total position))))
+          (let _r (_cw_for (_iter values) total position))
+          (let total (nth _r 0))
+          (let position (nth _r 1)))
+        total))))
+(defn count_above (values threshold)
+  (do (let n 0)
+    (do
+      (do
+        (defn _ca_for (_remaining n)
+          (if (eq (len _remaining) 0) n
+            (do (let v (head _remaining))
+              (if (ge v threshold) (let n (_plus n 1)) false)
+              (_ca_for (tail _remaining) n))))
+        (let n (_ca_for (_iter values) n)))
+      n)))
+(defn coherence_weight (values threshold)
+  (do (let above (count_above values threshold))
+    (do (let coherence (coherence_score values threshold))
+      (_plus (mul above 100) coherence))))
+
+; ===================================================================
+; nodeid_distance — endpoint_nodeid_distance_demo.py recipe body
+; ===================================================================
+(defn manhattan (a_pkg a_lvl a_type a_inst b_pkg b_lvl b_type b_inst)
+  (do
+    (let d (_plus (abs (sub a_pkg b_pkg)) (abs (sub a_lvl b_lvl))))
+    (do
+      (let d (_plus (_plus d (abs (sub a_type b_type))) (abs (sub a_inst b_inst))))
+      d)))
+
+; ===================================================================
+; nodeid_compatibility — endpoint_nodeid_compatibility_demo.py recipe body
+; ===================================================================
+(defn match1 (x y) (if (eq x y) 1 0))
+(defn compatibility (a_pkg a_lvl a_type a_inst b_pkg b_lvl b_type b_inst)
+  (do
+    (let c (_plus (match1 a_pkg b_pkg) (match1 a_lvl b_lvl)))
+    (do
+      (let c (_plus (_plus c (match1 a_type b_type)) (match1 a_inst b_inst)))
+      c)))
+
+; ===================================================================
+; weighted_average — endpoint_weighted_average_demo.py recipe body
+; ===================================================================
+(defn dot (values weights)
+  (do (let total 0.0)
+    (do (let i 0)
+      (do (let n (len values))
+        (do
+          (do
+            (defn _dot_while (total i)
+              (if (lt i n)
+                (do
+                  (do (let total (_plus total (mul (_get values i) (_get weights i))))
+                    (let i (_plus i 1)))
+                  (_dot_while total i))
+                (list total i)))
+            (let _r (_dot_while total i))
+            (let total (nth _r 0))
+            (let i (nth _r 1)))
+          total)))))
+(defn sum_floats (weights)
+  (do (let total 0.0)
+    (do (let i 0)
+      (do (let n (len weights))
+        (do
+          (do
+            (defn _sf_while (total i)
+              (if (lt i n)
+                (do
+                  (do (let total (_plus total (_get weights i)))
+                    (let i (_plus i 1)))
+                  (_sf_while total i))
+                (list total i)))
+            (let _r (_sf_while total i))
+            (let total (nth _r 0))
+            (let i (nth _r 1)))
+          total)))))
+(defn weighted_average (values weights)
+  (do (let numerator (dot values weights))
+    (do (let denominator (sum_floats weights))
+      (div numerator denominator))))
+
+; ===================================================================
+; Handler closures — request (query alist) → recipe call → response
+; ===================================================================
+
+; coherence_weight: frozen sample input (list marshalling gap, see header).
+(defn route_coherence_weight (q)
+  (coherence_weight (list 72 38 91 55 28 67 84 45 95 12) 50))
+
+; nodeid_distance: 8 integer query params, full request→response marshalling.
+(defn route_nodeid_distance (q)
+  (manhattan
+    (str_to_int (alist_get q "a_pkg"))
+    (str_to_int (alist_get q "a_lvl"))
+    (str_to_int (alist_get q "a_type"))
+    (str_to_int (alist_get q "a_inst"))
+    (str_to_int (alist_get q "b_pkg"))
+    (str_to_int (alist_get q "b_lvl"))
+    (str_to_int (alist_get q "b_type"))
+    (str_to_int (alist_get q "b_inst"))))
+
+; nodeid_compatibility: 8 integer query params, full request→response marshalling.
+(defn route_nodeid_compatibility (q)
+  (compatibility
+    (str_to_int (alist_get q "a_pkg"))
+    (str_to_int (alist_get q "a_lvl"))
+    (str_to_int (alist_get q "a_type"))
+    (str_to_int (alist_get q "a_inst"))
+    (str_to_int (alist_get q "b_pkg"))
+    (str_to_int (alist_get q "b_lvl"))
+    (str_to_int (alist_get q "b_type"))
+    (str_to_int (alist_get q "b_inst"))))
+
+; weighted_average: frozen sample input (list+float marshalling gap, see header).
+(defn route_weighted_average (q)
+  (weighted_average (list 0.5 0.75 1.0) (list 0.25 0.25 0.5)))
+
+; --- the persistent route table: registered ONCE into the warm kernel ---
+(let routes (list
+  (list "/coherence_weight"     route_coherence_weight)
+  (list "/nodeid_distance"      route_nodeid_distance)
+  (list "/nodeid_compatibility" route_nodeid_compatibility)
+  (list "/weighted_average"     route_weighted_average)))


### PR DESCRIPTION
## The correction

The prior readiness pass (PR #2287) measured a **per-request fork+exec** of the kernel and read ~5 ms/call. That was the **wrong serving model** — CPython serves from a warm, already-loaded process and does not fork an interpreter per request. This wave measures the honest counterpart: a **persistent kernel** that loads the routes ONCE (`form-kernel-rust serve`) and runs request→response over the live process. NO per-request spawn, NO per-request source-compile.

## Apples-to-apples numbers (release build, `--persistent --iters 200`)

| Endpoint | Value parity | CPython p50 | **Serve p50** | Serve p99 |
|----------|:---:|---:|---:|---:|
| `coherence_weight` | ✓ 16185 | 0.0007 ms | **0.189 ms** | 0.265 ms |
| `nodeid_distance` | ✓ 7 | 0.0004 ms | **0.231 ms** | 0.288 ms |
| `nodeid_compatibility` | ✓ 2 | 0.0004 ms | **0.235 ms** | 0.278 ms |
| `weighted_average` | ✓ 0.8125 | 0.0004 ms | **0.090 ms** | 0.192 ms |

**With spawn removed, per-request latency is ~0.09–0.24 ms p50 (p99 < 0.29 ms) — sub-millisecond, ~20–40× faster than the spawn-bound ~5 ms PATH A.** Most of the ~0.2 ms is HTTP/1.0 loopback, not recipe execution. The kernel was never the bottleneck; the spawn was.

## JIT — precise and honest

- `register_jit` **aliases** a recipe to an *existing native* — no-op for these recipes (no native equivalent).
- `jit_compile` is a **real recipe→machine-code compiler** (emit Rust → `rustc --crate-type=cdylib` → libloading). Measured **~21× speedup** on an in-subset `fib` (8×fib(30): walked ~10,375 ms vs native ~485 ms, incl. one-time compile).
- It returns **0** for the four endpoint recipes: their bodies use `_plus`/`abs`/list natives and **floats**, outside the i64-operator emit subset. An **emit-coverage gap** on a working compiler — the doc names the concrete extensions needed (native-builtin inlining, f64 emission, list lowering).

## What landed (evidence only — no flip)

- `scripts/kernel_readiness_routes.fk` — the 4 endpoint computations bound once as Form handler closures into a top-level `routes` list.
- `scripts/kernel_readiness_harness.py` — one engine over `(endpoint, runtime-mode ∈ {cpython-warm, kernel-persistent-serve, +jit})`; `PersistentServe` holds one warm kernel per mode; JIT demonstrator isolates the recipe→native speedup. New `--persistent` / `--jit` flags.
- `kernels/API_KERNEL_READINESS.md` — corrected model stated explicitly, persistent profile, JIT finding, serve-mode limits (HTTP/1.0, single-thread, string-arg), per-endpoint verdict, path to a real flip (inline PyO3 as the production carrier).

`PARITY_THIRD_RUNTIME` and live endpoint dispatch are **unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)