### PR TITLE
attune(kernels): take the flip — kernel-bmf is the default third runtime

### DIFF
--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh
@@ -11,25 +11,23 @@
 #
 # === The third-runtime selector ===
 #
-# The bootstrap exists to prove the Form-native pipeline matches CPython
-# before we can rely on it. Three-way parity (CPython + TS bootstrap +
-# Rust kernel) is the current gate. PARITY_THIRD_RUNTIME chooses which
+# The bootstrap existed to prove the Form-native pipeline matches CPython
+# before we could rely on it. That proof is in: all 20 PARITY_FILES pass
+# three-way under the Form-native walker. PARITY_THIRD_RUNTIME chooses which
 # third runtime fills the seam:
 #
-#   PARITY_THIRD_RUNTIME=ts-eval     (default)
-#     Today's TS bootstrap: parse via lang-python.ts, walk via evalPython.
-#     The path that is named for compost in
-#     kernels/BOOTSTRAP_COMPOST_MANIFEST.md — Phase A.
-#
-#   PARITY_THIRD_RUNTIME=kernel-bmf  (the destination)
+#   PARITY_THIRD_RUNTIME=kernel-bmf  (default — the flip is taken, 2026-06-01)
 #     Form-native: source bytes → BMF source objects → rules in
 #     form-stdlib/grammars/python-bmf.fk → Form recipe → native walker.
-#     Invokes `kernel-bmf-run <file.py>`. As of 2026-06-01, all 20
-#     PARITY_FILES pass three-way under isolated tempdirs (verified from
-#     freshly rebuilt kernels — see kernels/BOOTSTRAP_COMPOST_MANIFEST.md).
-#     The kernel-bmf pipeline now matches CPython on every demo; flipping
-#     the default to kernel-bmf (and composting the Phase-A ts-eval tissue)
-#     is the next directional breath.
+#     Invokes `kernel-bmf-run <file.py>`. All 20 PARITY_FILES pass three-way
+#     under isolated tempdirs (verified from freshly rebuilt Go + Rust
+#     kernels — see kernels/BOOTSTRAP_COMPOST_MANIFEST.md). This is now the
+#     canonical Python runtime; the Phase-A ts-eval tissue is compost-eligible.
+#
+#   PARITY_THIRD_RUNTIME=ts-eval     (legacy bootstrap, still available)
+#     The TS bootstrap: parse via lang-python.ts, walk via evalPython. The
+#     path named for compost in kernels/BOOTSTRAP_COMPOST_MANIFEST.md —
+#     Phase A. Selectable explicitly for as long as that tissue lives.
 #
 # Add new files to PARITY_FILES below as they're ripened.
 # Run from form/form-kernel-ts/.
@@ -37,10 +35,11 @@
 set -euo pipefail
 
 # Third-runtime selector — see header for the migration story.
-# All 20 PARITY_FILES now pass kernel-bmf three-way under isolated tempdirs
-# (2026-06-01). The default stays ts-eval until the flip is taken as its own
-# directional breath; kernel-bmf is ready underneath whenever it is.
-PARITY_THIRD_RUNTIME="${PARITY_THIRD_RUNTIME:-ts-eval}"
+# The flip is taken (2026-06-01): all 20 PARITY_FILES pass kernel-bmf
+# three-way, so the Form-native walker IS the default third runtime. The
+# legacy TS bootstrap (ts-eval) remains available via an explicit
+# PARITY_THIRD_RUNTIME=ts-eval for as long as the Phase-A tissue lives.
+PARITY_THIRD_RUNTIME="${PARITY_THIRD_RUNTIME:-kernel-bmf}"
 
 PARITY_FILES=(
     # First row that passes under PARITY_THIRD_RUNTIME=kernel-bmf — covers
@@ -95,16 +94,16 @@ PATH="$SCRIPT_DIR:$PATH"
 # Resolve the third-runtime invoker. The interface is:
 #   third_runtime_run <file.py>  →  prints the final expression's value to stdout
 #
-# ts-eval: walks the parsed Python tree through the TS evaluator directly.
-#          A distinct path from python-run (which shells to the Rust binary)
-#          — this is what makes parity genuinely three-way today.
+# kernel-bmf (default): invokes the Form-native binary `kernel-bmf-run`
+#             that reads .py via form-stdlib/grammars/python-bmf.fk and
+#             executes via the native walker. This is the canonical Python
+#             runtime as of the 2026-06-01 flip — all 20 PARITY_FILES pass
+#             three-way under it (see kernels/BOOTSTRAP_COMPOST_MANIFEST.md).
 #
-# kernel-bmf: invokes a Form-native binary `kernel-bmf-run` that reads
-#             .py via form-stdlib/grammars/python-bmf.fk and executes via
-#             the native walker. Sibling agents on `template-machinery`
-#             + `python-bmf-driven-parse` are bringing this up. When the
-#             binary lands on $PATH, this selector becomes the default
-#             per kernels/BOOTSTRAP_COMPOST_MANIFEST.md.
+# ts-eval: walks the parsed Python tree through the TS evaluator directly.
+#          A distinct path from python-run (which shells to the Rust binary).
+#          The legacy bootstrap, still selectable explicitly for as long as
+#          the Phase-A tissue lives.
 case "$PARITY_THIRD_RUNTIME" in
     ts-eval)
         third_runtime_run() {
@@ -118,9 +117,10 @@ case "$PARITY_THIRD_RUNTIME" in
             echo "The Form-native path interface:" >&2
             echo "  kernel-bmf-run <source.py>  →  prints the final expression's value" >&2
             echo "" >&2
-            echo "Sibling agents on \`template-machinery\` + \`python-bmf-driven-parse\` are" >&2
-            echo "bringing this binary up. See kernels/BOOTSTRAP_COMPOST_MANIFEST.md for the" >&2
-            echo "migration shape. Until then, run with PARITY_THIRD_RUNTIME=ts-eval (default)." >&2
+            echo "kernel-bmf-run ships next to this script (scripts/kernel-bmf-run); this" >&2
+            echo "script already puts that dir on PATH. If it is still not found, the build" >&2
+            echo "is incomplete — see kernels/BOOTSTRAP_COMPOST_MANIFEST.md for the migration" >&2
+            echo "shape. The legacy bootstrap is available via PARITY_THIRD_RUNTIME=ts-eval." >&2
             exit 2
         fi
         third_runtime_run() {
@@ -171,11 +171,11 @@ else:
     npx tsx src/main.ts python-compile "$f" "$fk_path" >/dev/null 2>&1
     rust_result=$("$RUST_BIN" "$fk_path" 2>&1 | tail -1)
 
-    # Third runtime — selected by PARITY_THIRD_RUNTIME. Today's default
-    # (ts-eval) walks the parsed Python tree through the TS evaluator;
-    # the destination (kernel-bmf) invokes the Form-native walker via
-    # kernel-bmf-run. Either way, this is the third path that makes
-    # parity genuinely three-way.
+    # Third runtime — selected by PARITY_THIRD_RUNTIME. The default
+    # (kernel-bmf) invokes the Form-native walker via kernel-bmf-run; the
+    # legacy ts-eval walks the parsed Python tree through the TS evaluator.
+    # Either way, this is the third path that makes parity genuinely
+    # three-way.
     third_result=$(third_runtime_run "$f")
 
     if [[ "$py_result" == "$rust_result" && "$py_result" == "$third_result" ]]; then

--- a/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
+++ b/kernels/BOOTSTRAP_COMPOST_MANIFEST.md
@@ -16,10 +16,14 @@ already carries a runtime selector that switches the third runtime atomically
 As of 2026-06-01, **all 20** of the `PARITY_FILES` prove three-way green under
 the Form-native walker (isolated-tempdir measurement, freshly rebuilt Go + Rust
 kernels). The last demo (`python_typing_compose_demo`) closed when the
-annotated-parameter lift bug was fixed (see the dated row below). The flip of
-`PARITY_THIRD_RUNTIME` ts-eval → kernel-bmf is now **unblocked**, but it is a
-separate reviewable breath — the default stays `ts-eval` until that flip lands
-on its own. The named Phase-A files compost only once the flip is taken.
+annotated-parameter lift bug was fixed (see the dated row below). **The flip is
+taken (2026-06-01):** `PARITY_THIRD_RUNTIME` now defaults to `kernel-bmf` — the
+Form-native walker is the canonical Python runtime; `ts-eval` remains available
+via an explicit `PARITY_THIRD_RUNTIME=ts-eval`. With the flip taken, the named
+Phase-A Python-adapter files (`lang-python.ts` and siblings) become
+**COMPOST-ELIGIBLE** — the gate that held them ("default until Form-native
+compiles every PARITY_FILES demo") is now met. They are not yet composted;
+that is the next breath, after the flip proves stable.
 
 This is the readiness map. The compost is downstream of green gates.
 
@@ -57,15 +61,17 @@ gate that earns the right to remove the Rust kernel from the bootstrap role
 
 ## Phase A — Bootstrap parsers + emitters
 
-These ship the *current* third runtime (`ts-eval`). They compost when the
-Form-native parser (Form rules over BMF source objects from
-`form-stdlib/grammars/python-bmf.fk` and `typescript-bmf.fk`) proves three-way
-parity per file.
+These shipped the legacy third runtime (`ts-eval`). With the flip taken
+(2026-06-01) the Form-native walker is the default third runtime and every
+`PARITY_FILES` demo proves three-way green under it — so the Python-adapter
+files below are now **COMPOST-ELIGIBLE**. They compost in a sibling PR once the
+flip proves stable; this manifest records them as residue, not yet removed.
 
-**Gate per file:** `PARITY_THIRD_RUNTIME=kernel-bmf
-scripts/parity_suite.sh` reports green on the file. The TS bootstrap is no
-longer the third runtime — the Form-native walker is. When every file in
-`PARITY_FILES` has been promoted, the bootstrap parser files are residue.
+**Gate per file (now met for the Python adapter):**
+`PARITY_THIRD_RUNTIME=kernel-bmf scripts/parity_suite.sh` reports green on every
+file — and it is now the default selector. The TS bootstrap is no longer the
+third runtime; the Form-native walker is. With every file in `PARITY_FILES`
+green, the Python-adapter bootstrap parser files are residue.
 
 ### Python adapter
 
@@ -77,7 +83,12 @@ longer the third runtime — the Form-native walker is. When every file in
 | `form/form-kernel-ts/seedbank/python-adapter/src/lang-python.test.ts` | 342 | TS-side parser/eval unit tests | Form-side rule tests under `form-stdlib/tests/python-grammar-*.fk` (one per shipped construct) |
 | `form/form-kernel-ts/seedbank/python-adapter/src/ctor-convergence.test.ts` | 358 | TS-side convergence unit tests | Form-side equivalence tests asserting NodeID identity for cross-language structural twins |
 
-**Subtotal Phase A — Python adapter: 4245 LOC**
+**Subtotal Phase A — Python adapter: 4245 LOC** — **COMPOST-ELIGIBLE
+(2026-06-01).** The flip to `kernel-bmf` is taken; all 20 `PARITY_FILES` prove
+three-way green under the Form-native walker, so `lang-python.ts` and its
+Phase-A siblings (`lang-python-fk.ts`, `ctor-convergence.ts`, and the two
+`*.test.ts` files) are residue. Not yet removed — composted in a sibling PR
+once the flip proves stable.
 
 ### TypeScript adapter
 
@@ -247,22 +258,23 @@ confirm Shape 2 classification + LOC count.
 `form/form-kernel-ts/seedbank/python-adapter/scripts/parity_suite.sh` carries
 `PARITY_THIRD_RUNTIME` (env-var):
 
-- `ts-eval` (**default**) — the TS bootstrap evaluator (`lang-python.ts` →
-  `evalPython`). Backwards-compatible; every existing gate runs unchanged.
-- `kernel-bmf` (the destination) — invokes `kernel-bmf-run <source.py>`, which
-  reads `.py` via `form-stdlib/grammars/python-bmf.fk`, lifts to PY-BMF-*
-  recipes (`python-bmf-lift.fk`), and walks them through the Form-native
-  interpreter (`python-bmf-eval.fk`) on the Rust kernel. As of 2026-06-01,
-  **all 20 `PARITY_FILES` pass three-way** under it (CPython ==
-  Rust-bootstrap == kernel-bmf) when measured in isolated tempdirs.
+- `kernel-bmf` (**default — the flip is taken, 2026-06-01**) — invokes
+  `kernel-bmf-run <source.py>`, which reads `.py` via
+  `form-stdlib/grammars/python-bmf.fk`, lifts to PY-BMF-* recipes
+  (`python-bmf-lift.fk`), and walks them through the Form-native interpreter
+  (`python-bmf-eval.fk`) on the Rust kernel. **All 20 `PARITY_FILES` pass
+  three-way** under it (CPython == Rust-bootstrap == kernel-bmf) when measured
+  in isolated tempdirs. This is now the canonical Python runtime.
+- `ts-eval` (legacy bootstrap, still available) — the TS bootstrap evaluator
+  (`lang-python.ts` → `evalPython`). Selectable via an explicit
+  `PARITY_THIRD_RUNTIME=ts-eval` for as long as the Phase-A tissue lives.
 
-**The flip is one line** (the `${PARITY_THIRD_RUNTIME:-...}` fallback in
+**The flip was one line** (the `${PARITY_THIRD_RUNTIME:-...}` fallback in
 `parity_suite.sh`), fully reversible, and changes no CI gate — no workflow runs
-the parity suite; the `form/**` gates run only `bash validate.sh`. With all 20
-demos green the flip is **unblocked**; it is held for its own reviewable PR
-rather than ridden in on the fix that closed the last demo. When it is taken,
-the Phase-A Python-adapter bootstrap files (`lang-python.ts` and friends) become
-residue, compostable in a sibling PR.
+the parity suite; the `form/**` gates run only `bash validate.sh`. With the flip
+taken, the Phase-A Python-adapter bootstrap files (`lang-python.ts` and friends)
+are **COMPOST-ELIGIBLE** — residue, compostable in a sibling PR once the flip
+proves stable.
 
 The same selector shape can extend to the TS adapter parity gate
 (`PARITY_THIRD_RUNTIME` over `ts-eval` vs `kernel-bmf-ts`).
@@ -275,8 +287,9 @@ The same selector shape can extend to the TS adapter parity gate
   parity.
 - It does not claim files compost that aren't named here. New bootstrap tissue
   shipped after 2026-05-26 gets a manifest row when added.
-- It does not change the gate's default behavior. `PARITY_THIRD_RUNTIME=ts-eval`
-  stays default; today's parity suite runs unchanged.
+- It does not delete the legacy path on flip. `PARITY_THIRD_RUNTIME=kernel-bmf`
+  is now the default, but `PARITY_THIRD_RUNTIME=ts-eval` still runs the TS
+  bootstrap unchanged for as long as the Phase-A tissue lives.
 
 ---
 
@@ -570,10 +583,18 @@ followed by `:`, drop the annotation tokens up to the next top-level `,`/`)`
 `Dict[str, int]` is not mistaken for a param separator). This is the one
 underlying cause — not special-cased to typing_compose; every typed-parameter
 def in the body now lifts to the correct param list. With it, all 20 demos are
-green and the `PARITY_THIRD_RUNTIME` flip to `kernel-bmf` is **unblocked** — but
-that flip is its own reviewable breath, not ridden in here. Until it lands,
-`ts-eval` stays the default and the Phase-A Python-adapter bootstrap tissue
-(`lang-python.ts` and friends) is **not yet** residue.
+green and the `PARITY_THIRD_RUNTIME` flip to `kernel-bmf` was unblocked.
+
+**The flip is taken (2026-06-01, `claude/take-the-flip`).** With all 20 demos
+green, `parity_suite.sh` now defaults `PARITY_THIRD_RUNTIME` to `kernel-bmf` —
+the Form-native walker is the canonical Python runtime. Independently
+re-verified before the flip: freshly rebuilt Go + Rust kernels off main, the
+official `scripts/parity_suite.sh` run end-to-end under the new default reports
+**20 passing, 0 failing, exit 0**, exercising all 20 `PARITY_FILES` (no
+truncation). `ts-eval` remains available via an explicit
+`PARITY_THIRD_RUNTIME=ts-eval`. With the flip taken, the Phase-A Python-adapter
+bootstrap tissue (`lang-python.ts` and friends) is **COMPOST-ELIGIBLE** —
+residue, compostable in a sibling PR once the flip proves stable.
 
 **What composts when a demo reaches COMPOST READY.** The `.py` input
 **stays** — the parity suite reads it on every run (it's the substrate the


### PR DESCRIPTION
## The flip

All 20 `PARITY_FILES` demos prove three-way green under the Form-native walker. This takes the directional breath the manifest named: `parity_suite.sh`'s `PARITY_THIRD_RUNTIME` default flips `ts-eval` → `kernel-bmf`. The Form-native kernel (source bytes → BMF objects → `python-bmf.fk` rules → recipe → native walker) is now the **canonical Python runtime**. `ts-eval` remains available via an explicit `PARITY_THIRD_RUNTIME=ts-eval`.

## Independently re-verified before flipping

Freshly rebuilt Go + Rust kernels off current main (`4cbab1c0`), then ran the official `scripts/parity_suite.sh` end-to-end under the new `kernel-bmf` default:

```
parity_suite: 20 passing, 0 failing (third runtime: kernel-bmf)
EXIT=0
```

All 20 demos exercised — **no truncation after demo 19**. The earlier `set -euo pipefail` truncation finding does not reproduce on current main with rebuilt kernels; the suite is robust as-is, so no suite-robustness fix was needed. Re-ran with no env var set to confirm the new default path produces the same 20/20 / exit 0.

## Manifest update

`kernels/BOOTSTRAP_COMPOST_MANIFEST.md` records: the flip is taken (2026-06-01); `kernel-bmf` is the default third runtime; the Phase-A ts-eval bootstrap tissue (`lang-python.ts`, `lang-python-fk.ts`, `ctor-convergence.ts`, and the two `*.test.ts`) is now **COMPOST-ELIGIBLE** — the gate that held it ("default until Form-native compiles every PARITY_FILES demo") is met. Not composted in this breath; that is the next step once the flip proves stable.

## Scope

Two files only: `parity_suite.sh` (default + header/inline comments) and `BOOTSTRAP_COMPOST_MANIFEST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)