### PR TITLE
attune: prove bml file native execution

### DIFF
--- a/docs/system_audit/bml_thesis_feature_audit_20260601.md
+++ b/docs/system_audit/bml_thesis_feature_audit_20260601.md
@@ -17,6 +17,10 @@ What is proven today:
   `EndOfFile`, `EndOfLine`, `Cut`, `MultiMatch`, and `Primitive`.
 - A BMA-like execution band runs forward and backward, including explicit
   `DO` and `UNDO` trace proof.
+- A real `.bml` file can now be scanned from disk, parsed through BML BMF
+  executable rules, lowered into BMA, and run forward/backward through the
+  native kernels for the focused thesis exit slice in
+  `form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml`.
 - A BML class/interface/inheritance component model covers structural bases,
   delegated bases, inherited interfaces, default interface methods, section
   property inheritance, class/static flags, member lookup, access checks, and
@@ -24,8 +28,8 @@ What is proven today:
 
 What is not proven yet:
 
-- The source compiler scans `section [...]` blocks; it is not yet a
-  standalone thesis `.bml` file compiler.
+- The source compiler can scan a focused standalone executable `.bml` stream,
+  but it is not yet a full thesis `.bml` file compiler.
 - Full `.bml` files from the thesis companion source tree do not compile end to
   end as source into Form native kernel execution.
 - Most thesis grammar rules are present as a BMF rulebook/manifest, but many
@@ -87,6 +91,7 @@ is not complete rule-for-rule.
 | BML syntax blocks and multi-syntax streams | `backtracking-model-languages.txt:1012-1014`; `bml-search-algorithms.txt:239-246` | native-executed for source-section sidecars; gap for object syntax dispatch | `source-compiler-runtime.fk` and `source-compiler-multi-dialect-band.fk` prove section sidecars; parsing arbitrary objects by syntax name remains a gap. |
 | Object runtime definitions, dispatch, casting, instantiators | `sgb-bml-objects.txt:569-655`, `:778-791` | component-proven only for selected lookup helpers | Full instance/interface/method definitions, indexed dispatch, arbitrary interface casts, unique/singleton instantiators, and detached interfaces remain gaps. |
 | Companion `.bml` source samples | `companion/source-samples/*.bml` | gap | `BMF-grammar.bml`, `container-Rule.bml`, `primitive-Cut.bml`, and related files are reference inputs, not passing compile fixtures yet. |
+| Focused `.bml` file-to-native execution | `bml-thesis-forward-backward-demo.bml` | native-executed | `bml-thesis-file-execution-proof.fk` scans a real `.bml` file, parses `state-int` plus `try-throw-return`, lowers to BMA, runs DO/UNDO, and verifies restored state. |
 
 ## Companion Source Boundary Checks
 
@@ -143,6 +148,7 @@ cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-s
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-class-inheritance-proof.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-full-class-model-proof.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-file-execution-proof.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-runtime.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk
 ```

--- a/docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json
+++ b/docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json
@@ -1,0 +1,98 @@
+{
+  "date": "2026-06-01",
+  "thread_branch": "codex/bml-thesis-file-proof-20260601",
+  "commit_scope": "Add a real .bml file-to-native execution proof for the focused BML thesis forward/backward exit slice, and keep the full companion-file gap explicit.",
+  "files_owned": [
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml",
+    "form/form-stdlib/tests/bml-thesis-file-execution-proof.fk",
+    "docs/system_audit/bml_thesis_feature_audit_20260601.md",
+    "docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-file-execution-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk",
+      "cd form && ./validate.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": "Focused real-file BML proof passed with result 131071. Existing BML thesis exit proof passed with result 1073741840. Full Form validation passed with 217 ok, 0 divergent. Rebase, PR guard, and follow-through guard run before push."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Production verification is pending until merge/deploy. This change touches form/form-stdlib and docs, so public runtime deploy may rely on the follow-on deploy path when no service path changes."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "A checked-in .bml file can be scanned from disk, parsed through BML BMF executable rules, lowered to BMA, and run forward/backward through the Form native kernels for the focused thesis exit slice.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com",
+      "https://coherencycoin.com"
+    ],
+    "test_flows": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-file-execution-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk",
+      "./scripts/verify_web_api_deploy.sh after merge/deploy"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Focused proof is implemented locally; full validation, CI, and deployment proof are pending."
+  },
+  "idea_ids": [
+    "idea-realization-engine"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "bml-thesis-file-proof-20260601"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "exit criteria"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml is a real checked-in .bml source file.",
+    "bml-source-scan-file reads .bml bytes through fsc-file-source-cursor and emits BML source objects.",
+    "bml-source-file-parse-executable parses the scanned source objects through BML BMF executable rules.",
+    "bml-source-file-compile-executable lowers the parsed source-originated BML AST into a BMA program.",
+    "bml-thesis-file-execution-proof.fk verifies token count, parsed rule names, zero parse rest, BMA op count, DO/UNDO trace counts, final return value, and restored empty run state.",
+    "docs/system_audit/bml_thesis_feature_audit_20260601.md keeps the full companion-file compiler gap explicit."
+  ],
+  "change_files": [
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml",
+    "form/form-stdlib/tests/bml-thesis-file-execution-proof.fk",
+    "docs/system_audit/bml_thesis_feature_audit_20260601.md",
+    "docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/grammars/bml.fk
+++ b/form/form-stdlib/grammars/bml.fk
@@ -23,6 +23,111 @@
     (defn bml-src-list (value) (bmf-atom "bml-list" value))
     (defn bml-src-code (value) (bmf-atom "bml-code" value))
 
+    ;; --- file source scanner ----------------------------------------
+    ;; This is the real file boundary for BML proof: bytes on disk become
+    ;; BML source objects before any BMF rule or BMA lowering can run.
+
+    (defn bml-source-keywords (_x)
+        (list "package" "import" "class" "interface" "template" "section"
+              "syntax" "const" "enum" "operator" "for" "while" "loop"
+              "switch" "select" "case" "default" "if" "else" "if_fail"
+              "while_success" "return" "break" "continue" "try" "catch"
+              "throw" "fail" "cut" "mark" "save" "restore" "discard"
+              "choice" "choose" "asm" "instanceof" "library" "naming"
+              "conventions" "DefaultMethods" "Nil" "Fail" "EndOfFile"
+              "EndOfLine" "Cut" "MultiMatch" "Primitive"))
+
+    (defn bml-source-ops (_x)
+        (list "<<prim" ".*" "::=" "=>" "<=" ">>>=" ">>=" "<<=" ">>>"
+              ">>" "<<" "++" "--" "==" "!=" ">=" "<=" ":=" "*=" "/="
+              "%=" "+=" "-=" "&=" "|=" "^=" "&&" "||" ".." "#("
+              "{" "}" "(" ")" "[" "]" ";" "," ":" "." "+" "-" "*" "/"
+              "%" "=" "'" "<" ">" "!" "~" "?" "|" "&" "^" "$"))
+
+    (defn bml-source-dialect (_x)
+        (fsc-source-dialect
+            (bml-source-keywords 0)
+            "bml-keyword"
+            "bml-name"
+            "bml-int"
+            "bml-string"
+            "bml-op"
+            "bml-eof"
+            (bml-source-ops 0)))
+
+    (defn bml-line-comment-prefix (_x) (str_concat "/" "/"))
+    (defn bml-block-comment-open (_x) (str_concat "/" "*"))
+    (defn bml-block-comment-close (_x) (str_concat "*" "/"))
+
+    (defn bml-source-skip-line-comment (cursor)
+        (if (fsc-source-cursor-end? cursor) cursor
+            (if (str_eq (fsc-source-cursor-char cursor) "\n") cursor
+                (bml-source-skip-line-comment
+                    (fsc-source-cursor-advance cursor)))))
+
+    (defn bml-source-skip-block-comment (cursor)
+        (if (fsc-source-cursor-end? cursor) cursor
+            (if (fsc-source-cursor-prefix? cursor (bml-block-comment-close 0))
+                (fsc-source-advance-n cursor 2)
+                (bml-source-skip-block-comment
+                    (fsc-source-cursor-advance cursor)))))
+
+    (defn bml-source-scan-skip (cursor)
+        (do
+            (let start (fsc-source-scan-skip cursor))
+            (if (fsc-source-cursor-prefix? start (bml-line-comment-prefix 0))
+                (bml-source-scan-skip
+                    (bml-source-skip-line-comment
+                        (fsc-source-advance-n start 2)))
+            (if (fsc-source-cursor-prefix? start (bml-block-comment-open 0))
+                (bml-source-scan-skip
+                    (bml-source-skip-block-comment
+                        (fsc-source-advance-n start 2)))
+                start))))
+
+    (defn bml-source-scan-next (cursor)
+        (do
+            (let start (bml-source-scan-skip cursor))
+            (let ch (fsc-source-cursor-char start))
+            (if (fsc-source-cursor-end? start)
+                (fsc-scan-result
+                    (fsc-source-object "bml-eof" "" start start)
+                    start)
+            (if (str_eq ch "\"")
+                (fsc-source-scan-string start "bml-string")
+            (if (fsc-digit? ch)
+                (fsc-source-scan-int start "bml-int")
+            (if (fsc-source-name-start-char? ch)
+                (fsc-source-scan-name
+                    start
+                    (bml-source-keywords 0)
+                    "bml-keyword"
+                    "bml-name")
+                (fsc-source-scan-op
+                    start
+                    "bml-op"
+                    (bml-source-ops 0))))))))
+
+    (defn bml-source-scan-text-loop (cursor acc)
+        (do
+            (let result (bml-source-scan-next cursor))
+            (let object (fsc-scan-result-object result))
+            (if (str_eq (bmf-object-kind object) "bml-eof")
+                (reverse-list acc)
+                (bml-source-scan-text-loop
+                    (fsc-scan-result-cursor result)
+                    (cons object acc)))))
+
+    (defn bml-source-scan-text (source)
+        (bml-source-scan-text-loop
+            (fsc-source-cursor source 0 1 0)
+            (empty)))
+
+    (defn bml-source-scan-file (path)
+        (bml-source-scan-text-loop
+            (fsc-file-source-cursor path 0 1 0 (file_size path))
+            (empty)))
+
     (defn bml-kw (value) (object-lit "bml-keyword" value))
     (defn bml-op (value) (object-lit "bml-op" value))
     (defn bml-ref (name) (object-lit "bml-ref" name))
@@ -1368,6 +1473,93 @@
 
     (defn apply-bml-bmf-rule (rule-name objects)
         (apply-object-rule (bml-bmf-find-rule rule-name bml-bmf-rules) objects))
+
+    (defn bml-bmf-match-node (match)
+        (bmf-object-value (cap-get (match-caps match) "result")))
+
+    (defn bml-source-executable-rules (_x)
+        (list "try-throw-return"
+              "choice-fail-int"
+              "choose-fail-int"
+              "state-int"
+              "return-int"
+              "fail-simple"
+              "cut-simple"
+              "mark-simple"
+              "throw-int"))
+
+    (defn bml-source-parse-step (ok rule node rest)
+        (list "bml-source-parse-step" ok rule node rest))
+
+    (defn bml-source-parse-step-ok? (step) (nth step 1))
+    (defn bml-source-parse-step-rule (step) (nth step 2))
+    (defn bml-source-parse-step-node (step) (nth step 3))
+    (defn bml-source-parse-step-rest (step) (nth step 4))
+
+    (defn bml-source-parse-executable-step-loop (objects rule-names)
+        (if (nil? rule-names)
+            (bml-source-parse-step false "" (empty) objects)
+            (do
+                (let rule-name (head rule-names))
+                (let m (apply-bml-bmf-rule rule-name objects))
+                (if (match? m)
+                    (bml-source-parse-step
+                        true
+                        rule-name
+                        (bml-bmf-match-node m)
+                        (match-rest m))
+                    (bml-source-parse-executable-step-loop
+                        objects
+                        (tail rule-names))))))
+
+    (defn bml-source-parse-executable-step (objects)
+        (bml-source-parse-executable-step-loop
+            objects
+            (bml-source-executable-rules 0)))
+
+    (defn bml-source-exec-parse-result (ok nodes rest rules)
+        (list "bml-source-exec-parse-result" ok nodes rest rules))
+
+    (defn bml-source-exec-parse-ok? (result) (nth result 1))
+    (defn bml-source-exec-parse-nodes (result) (nth result 2))
+    (defn bml-source-exec-parse-rest (result) (nth result 3))
+    (defn bml-source-exec-parse-rules (result) (nth result 4))
+    (defn bml-source-exec-parse-node (result)
+        (bml-ast-block (bml-source-exec-parse-nodes result)))
+
+    (defn bml-source-parse-executable-stream-loop (objects nodes rules)
+        (if (nil? objects)
+            (bml-source-exec-parse-result
+                true
+                (reverse-list nodes)
+                objects
+                (reverse-list rules))
+            (do
+                (let step (bml-source-parse-executable-step objects))
+                (if (bml-source-parse-step-ok? step)
+                    (bml-source-parse-executable-stream-loop
+                        (bml-source-parse-step-rest step)
+                        (cons (bml-source-parse-step-node step) nodes)
+                        (cons (bml-source-parse-step-rule step) rules))
+                    (bml-source-exec-parse-result
+                        false
+                        (reverse-list nodes)
+                        objects
+                        (reverse-list rules))))))
+
+    (defn bml-source-parse-executable-stream (objects)
+        (bml-source-parse-executable-stream-loop
+            objects
+            (empty)
+            (empty)))
+
+    (defn bml-source-file-parse-executable (path)
+        (bml-source-parse-executable-stream (bml-source-scan-file path)))
+
+    (defn bml-source-file-compile-executable (path)
+        (bml-compile-program
+            (bml-source-exec-parse-node
+                (bml-source-file-parse-executable path))))
 
     (defn bml-thesis-bmf-primitive-rule-count-loop (rule-names)
         (if (nil? rule-names) 0

--- a/form/form-stdlib/tests/bml-thesis-file-execution-proof.fk
+++ b/form/form-stdlib/tests/bml-thesis-file-execution-proof.fk
@@ -1,0 +1,42 @@
+; tests/bml-thesis-file-execution-proof.fk - real .bml file to native DO/UNDO proof
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk
+
+(do
+    (defn score-bool (value bit)
+        (if value bit 0))
+
+    (defn score-int (actual expected bit)
+        (if (eq actual expected) bit 0))
+
+    (defn score-str (actual expected bit)
+        (if (str_eq actual expected) bit 0))
+
+    (let path "form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml")
+    (let source-objects (bml-source-scan-file path))
+    (let parsed (bml-source-file-parse-executable path))
+    (let program (bml-source-file-compile-executable path))
+    (let result (bma-run-forward-backward program))
+    (let forward-state (bma-forward-backward-forward-state result))
+    (let restored-state (bma-forward-backward-restored-state result))
+    (let trace (bma-forward-backward-trace result))
+
+    (sum
+        (list
+            (score-int (len source-objects) 18 1)
+            (score-str (bmf-object-kind (head source-objects)) "bml-keyword" 2)
+            (score-str (bmf-object-value (head source-objects)) "save" 4)
+            (score-bool (bml-source-exec-parse-ok? parsed) 8)
+            (score-int (len (bml-source-exec-parse-rest parsed)) 0 16)
+            (score-int (len (bml-source-exec-parse-rules parsed)) 2 32)
+            (score-str (head (bml-source-exec-parse-rules parsed)) "state-int" 64)
+            (score-str (nth (bml-source-exec-parse-rules parsed) 1) "try-throw-return" 128)
+            (score-int (len (comp-program-ops program)) 4 256)
+            (score-int (bma-trace-count-mode trace "DO") 4 512)
+            (score-int (bma-trace-count-mode trace "UNDO") 4 1024)
+            (score-int (bma-trace-count-op trace "save") 2 2048)
+            (score-int (bma-trace-count-op trace "try") 2 4096)
+            (score-int (comp-vm-pop-value forward-state) 7 8192)
+            (score-str (comp-vm-mode forward-state) "return" 16384)
+            (score-int (len (comp-vm-stack restored-state)) 0 32768)
+            (score-str (comp-vm-mode restored-state) "run" 65536))))

--- a/form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml
+++ b/form/form-stdlib/tests/fixtures/bml-thesis-forward-backward-demo.bml
@@ -1,0 +1,14 @@
+//////////////////////////////////////////////////////////////////////
+//
+// Name: bml-thesis-forward-backward-demo.bml
+// Platform: Form native kernel
+//
+//////////////////////////////////////////////////////////////////////
+
+/* A minimal executable BML stream for the thesis exit proof:
+   source file -> BML scanner -> BMF rules -> BMA program -> DO/UNDO trace. */
+
+save;
+4;
+discard;
+try { throw 1; } catch { return 7; }


### PR DESCRIPTION
## Summary
- add a real checked-in .bml thesis exit fixture
- add BML file scanning and focused executable stream parsing in the BML grammar layer
- prove file-derived BML lowers to BMA and runs native forward/backward with DO/UNDO trace
- update the BML thesis audit to keep the full companion-file gap explicit

## Proof
- make prompt-guide
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-file-execution-proof.fk -> 131071
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk -> 1073741840
- cd form && ./validate.sh -> 217 ok, 0 divergent
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-01_bml_thesis_file_execution.json
- git fetch origin main && git rebase origin/main
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict