### PR TITLE
feat(kernel): build the inline PyO3 carrier — warm in-process kernel, no spawn, no loopback

### DIFF
--- a/form/form-kernel-rust/src/lib.rs
+++ b/form/form-kernel-rust/src/lib.rs
@@ -62,6 +62,12 @@ fn value_to_py(py: Python<'_>, v: &Value) -> PyResult<PyObject> {
         // Value::display(); avoids touching the private Closure fields.
         Value::Closure(_) => v.display().into_py(py),
         Value::Nid(n) => format!("@{}.{}.{}.{}", n.pkg, n.level, n.ty, n.inst).into_py(py),
+        // Records (structured cells) render as their display string — the
+        // same surface the CLI prints. The transmuted endpoints return
+        // scalars/lists; a Record reaching here means a recipe shape the
+        // inline path doesn't structurally unwrap yet, so we hand back the
+        // honest display text rather than fabricate a Python dict.
+        Value::Record(_) => v.display().into_py(py),
     };
     Ok(obj)
 }

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -3159,7 +3159,7 @@ impl Kernel {
         // Sibling parity with form-kernel-go + form-kernel-ts.
         self.register_native("bp", cat_witness(), |_, _, args| {
             let name = args[0].as_str();
-            for (entry_name, [pkg, level, ty, inst]) in crate::bp_table::BP_ENTRIES {
+            for (entry_name, [pkg, level, ty, inst]) in self::bp_table::BP_ENTRIES {
                 if *entry_name == name {
                     return Value::Nid(NodeID {
                         pkg: *pkg,

--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -22,6 +22,13 @@ green demo count cannot give.
 > number is the one that decides the flip; the per-request-spawn number was an
 > artifact of the wrong harness shape. Both are stated below so the correction
 > is legible.
+>
+> **The production carrier landed (2026-06-01).** The inline PyO3 extension the
+> serve evidence pointed at is now **built and measured** — it removes the
+> HTTP/1.0 loopback the serve number was dominated by, landing at **~0.05–0.13 ms
+> p50, sub-200µs p99, faster than serve on all four endpoints (~4.5–4.9× on the
+> integer ones)**. The warm in-process kernel is no longer a prediction; it is a
+> measured profile. See "The inline PyO3 carrier" below.
 
 ## What's eligible for the flip, and what stays CPython
 
@@ -54,7 +61,10 @@ Per request it:
 2. `inject_bindings(...)` — rewrites the `(let ...)` input literals in-process (µs).
 3. **The dispatch fork**, fastest path available:
    - `inline` — the `form_kernel_rust` PyO3 extension, a C call into Rust, no
-     spawn. **Not built in this environment** (nor, today, in the deploy image).
+     spawn. **Built and measured in this worktree (2026-06-01)** via
+     `maturin develop --release` into the API venv; the hot path the
+     persistent-serve evidence pointed at. The deploy image still needs the
+     build step (named below).
    - `subprocess` — fork+exec the `form-kernel-rust` binary on a temp `.fk`.
      **This is the path that serves today** wherever the binary is present.
    - `python-fallback` — the inline-CPython twin, when no kernel is reachable.
@@ -175,7 +185,79 @@ plainly:
 The serve mode proves **the persistent shape is sound and sub-ms**. The
 production carrier of that shape is the **inline PyO3** path (a warm `Kernel`
 held in-process, called by FastAPI with no socket at all) — same warm-kernel
-win, no HTTP/1.0 limits.
+win, no HTTP/1.0 limits. **That carrier is now built and measured** — next
+section.
+
+## The inline PyO3 carrier — the production hot path, built and measured
+
+The persistent-serve number is dominated by HTTP/1.0 loopback, not compute. The
+inline carrier removes the loopback entirely: the `form_kernel_rust` PyO3
+extension is imported **once** at `form_kernel_bridge` module load — a warm Rust
+runtime living *inside* the Python process — and each request is a C call
+straight into `compile_and_run`, returning an already-typed Python value
+(`int`/`float`/`list`). No process spawn, no socket. This is the path
+`serve_via_kernel` takes first whenever `inline_available()` is true.
+
+**What was built (2026-06-01).** The PyO3 surface already existed in source
+([`form/form-kernel-rust/src/lib.rs`](../form/form-kernel-rust/src/lib.rs),
+`Cargo.toml` `[lib] crate-type=["cdylib","rlib"]` + `pyo3` feature,
+`pyproject.toml` maturin config, bridge wired to `compile_and_run`) but had
+**never been built** — it didn't compile against the current kernel. Two shallow
+breaks fixed:
+
+1. `src/main.rs` `crate::bp_table::BP_ENTRIES` → `self::bp_table::BP_ENTRIES` —
+   a path that resolves in **both** the bin build (where `main.rs` is the crate
+   root) and the lib build (where `main.rs` is `mod kernel`).
+2. `src/lib.rs` `value_to_py` gained the missing `Value::Record(_)` arm
+   (renders via the kernel's own `display()`, same surface as the CLI).
+
+Then `maturin develop --release` (maturin 1.13.3, Rust 1.95, CPython 3.11,
+abi3-py39) built and installed `form_kernel_rust` into the API venv. The bridge
+loads it (`inline_available() == True`, `active_runtime() == "inline"`) and
+`serve_via_kernel` returns typed values via the warm kernel with no spawn.
+
+**Measured (2026-06-01, this worktree, release build, `--inline --persistent
+--iters 300`):**
+
+| Endpoint | Value parity | CPython p50 | Serve p50 | **Inline p50** | **Inline p99** | Serve→Inline |
+|----------|:---:|---:|---:|---:|---:|---:|
+| `coherence_weight` | ✓ 16185 | 0.0008 ms | 0.176 ms | **0.128 ms** | **0.190 ms** | 1.4× faster |
+| `nodeid_distance` | ✓ 7 | 0.0004 ms | 0.244 ms | **0.050 ms** | **0.078 ms** | 4.9× faster |
+| `nodeid_compatibility` | ✓ 2 | 0.0004 ms | 0.241 ms | **0.054 ms** | **0.085 ms** | 4.5× faster |
+| `weighted_average` | ✓ 0.8125 | 0.0004 ms | 0.107 ms | **0.092 ms** | **0.139 ms** | 1.2× faster |
+
+**Inline beats serve on all four, and the loopback was the difference.** On the
+two integer NodeID endpoints — which marshal real inputs both ways (no frozen
+sample) — inline is **~4.5–4.9× faster** than serve, landing at **sub-100µs p99**
+(0.078 / 0.085 ms). That delta is precisely the HTTP/1.0 connect + request-line
++ read/write round-trip that serve pays and inline does not. `coherence_weight`
+and `weighted_average` carry list/float inputs that the inline path injects as
+`.fk` literals per request (the inject + larger recipe walk), so their win over
+serve is smaller (1.2–1.4×) but still real, and still sub-200µs p99.
+
+**Value parity holds exactly inline** — 16185 / 7 / 2 / 0.8125, with types
+preserved (ints stay `int`, 0.8125 is a `float`, via `value_to_py`). The inline
+path returns the response model's headline scalar directly; the host echoes the
+other fields, same as serve.
+
+**Why the CPython ratio is still the wrong lens.** Inline p50 / CPython p50 reads
+as ~130–250× — but CPython's headline is a sub-microsecond arithmetic loop with
+**zero transport and zero recipe machinery**. Inline's ~0.05–0.13 ms includes
+inject + a C boundary crossing + a full recipe walk. Judge on the **absolute**:
+**sub-100µs p99 for the integer endpoints, sub-200µs for the list/float ones** —
+negligible against FastAPI routing + Pydantic + the network, which dwarf it.
+
+**Honest limit of these inline numbers.** The inline path still re-parses the
+`.fk` source per request inside `compile_and_run` — it removes the *spawn* and
+the *loopback*, not the per-request parse. For these tiny recipes the parse is a
+small fraction of the sub-100µs envelope, but a fully warm carrier would hold the
+*pre-parsed recipe root* and re-walk only with fresh bindings (the same shape
+`cli_serve` already uses internally with its loaded `routes` list). Exposing a
+`load_route(name, src) → handle` + `run(handle, bindings) → value` pair on the
+PyO3 module — reusing the kernel's existing `read_root_from_source` + `walk` with
+a fresh child frame — is the named next refinement; the current
+`compile_and_run` surface already proves the spawn-and-loopback removal, which
+was the whole readiness gap.
 
 ## JIT — what `register_jit` and `jit_compile` actually do today
 
@@ -225,18 +307,26 @@ for the *operator* subset and the named extension for the rest.**
 
 Two models, stated separately so the correction is legible:
 
-| Endpoint | PATH A (per-req fork+exec — WRONG model) | **Persistent serve (apples-to-apples)** |
-|----------|------------------------------------------|------------------------------------------|
-| `coherence_weight` | NOT-YET — +5 ms/req spawn | **READY (shape)** — 0.189 ms p50, 0.265 ms p99 |
-| `nodeid_distance` | NOT-YET — spawn-bound | **READY (shape)** — 0.231 ms p50, 0.288 ms p99 |
-| `nodeid_compatibility` | NOT-YET — spawn-bound | **READY (shape)** — 0.235 ms p50, 0.278 ms p99 |
-| `weighted_average` | NOT-YET — spawn-bound | **READY (shape)** — 0.090 ms p50, 0.192 ms p99 |
+| Endpoint | PATH A (per-req fork+exec — WRONG model) | Persistent serve (HTTP loopback) | **Inline PyO3 (production carrier)** |
+|----------|------------------------------------------|----------------------------------|--------------------------------------|
+| `coherence_weight` | NOT-YET — +5 ms/req spawn | 0.176 ms p50, 0.190 ms p99 | **0.128 ms p50, 0.190 ms p99 — READY** |
+| `nodeid_distance` | NOT-YET — spawn-bound | 0.244 ms p50, 0.288 ms p99 | **0.050 ms p50, 0.078 ms p99 — READY** |
+| `nodeid_compatibility` | NOT-YET — spawn-bound | 0.241 ms p50, 0.278 ms p99 | **0.054 ms p50, 0.085 ms p99 — READY** |
+| `weighted_average` | NOT-YET — spawn-bound | 0.107 ms p50, 0.192 ms p99 | **0.092 ms p50, 0.139 ms p99 — READY** |
 
-"READY (shape)" means: correct (4/4 value parity over the warm channel), stable
-percentiles, and a sub-ms absolute latency envelope under the persistent model.
-It is **not** "ship it" — the serve mode's HTTP/1.0 / single-thread / string-arg
-limits above mean the *production* carrier is inline PyO3, not this listener.
-The shape is proven; the production path is named.
+The three-way profile: per-request **fork+exec** (~5 ms, the wrong model) →
+**persistent serve** (~0.1–0.24 ms, sub-ms but HTTP/1.0-loopback-bound) →
+**inline PyO3** (~0.05–0.13 ms, the loopback gone). Each step removes a
+transport cost the previous paid; inline is the floor a synchronous in-process
+kernel can reach for these recipes.
+
+"READY" here means: correct (4/4 value parity inline, types preserved), stable
+percentiles, and a **sub-100µs-to-sub-200µs absolute envelope with no spawn and
+no socket** — the warm-in-process carrier the readiness evidence named. It is
+**healthy to carry the four transmuted endpoints' computational core.** What
+remains before a production flip is the deploy-image build of the extension and
+the per-request-parse refinement (both named below), not a profile question —
+the profile is met.
 
 Read precisely:
 
@@ -246,25 +336,35 @@ Read precisely:
   p99 under 0.29 ms — and most of that is HTTP/1.0 loopback, not recipe
   execution. The per-request-spawn ~5 ms was an artifact of the wrong harness
   shape, never the kernel's cost.
-- **The production carrier is the warm kernel held in-process.** The serve mode
-  proves the shape; **inline PyO3** (a `Kernel` loaded once at module import,
-  called by FastAPI with no socket) carries it without the HTTP/1.0 /
-  single-thread / string-arg limits. The bridge already routes to an `inline`
-  path when the `form_kernel_rust` extension is built — building that extension
-  in the deploy image is what turns "READY (shape)" into "READY (production)".
+- **The production carrier is built and measured.** **Inline PyO3** (the
+  `form_kernel_rust` extension imported once at module load, called by FastAPI
+  with no socket) is now built in this worktree and measured at **0.05–0.13 ms
+  p50, sub-200µs p99 — faster than serve on all four, ~4.5–4.9× faster on the
+  integer endpoints where the HTTP loopback was the whole difference.** The
+  bridge routes to it first when available. What turns this into "READY
+  (production)" is the **deploy-image build** of the extension (the same
+  `maturin develop --release` this worktree ran), plus the per-request-parse
+  refinement — not a further profile question.
 
-The number that matters for the flip decision: **with the kernel persistent,
-request→response is ~0.2 ms — sub-millisecond, HTTP-negligible.** The flip needs
-a **warm kernel** (inline PyO3, or a long-lived serve process), not a per-call
-shell-out. That requirement is now backed by a measured persistent profile, not
-a prediction.
+The number that matters for the flip decision: **with the kernel inline,
+request→response compute is ~0.05–0.13 ms — sub-100µs p99 on the integer
+endpoints, HTTP-negligible.** The flip needs a **warm kernel**; the warm kernel
+now exists as a built PyO3 extension with a measured profile, not a prediction.
 
 ## What's needed before a real flip
 
-1. **Build the inline PyO3 kernel** (`form_kernel_rust`) in the API image and
-   re-run with `--persistent` — confirm the in-process `inline` path lands at or
-   below the serve number (it should be *faster*, with no socket round-trip).
-   That is the load-ready, production-carrier measurement.
+1. **Build the inline PyO3 kernel in the deploy image.** ✅ **Built and measured
+   in this worktree (2026-06-01)** — `maturin develop --release` into the API
+   venv; inline lands **below** the serve number (~4.5–4.9× faster on the integer
+   endpoints, sub-200µs p99 across all four). What remains is reproducing that
+   build **in the deploy image**: add `maturin` to the API image build and run
+   `cd form/form-kernel-rust && maturin build --release` (or `develop` into the
+   image's venv) so `form_kernel_rust` imports in production. Then the live
+   `active_runtime()` reports `inline` and `/api/health` shows the hot path.
+   *Refinement:* the current `compile_and_run` surface re-parses the `.fk` per
+   request — expose a `load_route + run(handle, bindings)` pair on the PyO3
+   module (reusing `read_root_from_source` + `walk` with a fresh child frame, the
+   shape `cli_serve` already uses) to drop the per-request parse too.
 2. **Marshal real inputs over the channel.** The two list/float endpoints
    currently compute a frozen sample under serve because the string-only query
    alist plus the missing `split` / `str_to_float` natives can't carry a list.
@@ -294,11 +394,18 @@ a prediction.
 ```bash
 python3 scripts/kernel_readiness_harness.py                          # PATH A, 50 iters
 python3 scripts/kernel_readiness_harness.py --persistent             # + the warm serve path (apples-to-apples)
+python3 scripts/kernel_readiness_harness.py --inline                 # + the warm in-process PyO3 path (production carrier)
+python3 scripts/kernel_readiness_harness.py --inline --persistent    # the full three-way profile
 python3 scripts/kernel_readiness_harness.py --persistent --jit       # + serve+jit mode and the JIT demonstrator
-python3 scripts/kernel_readiness_harness.py --iters 1000 --persistent # load replay
+python3 scripts/kernel_readiness_harness.py --iters 1000 --inline    # load replay, inline
 python3 scripts/kernel_readiness_harness.py --path-b                 # include PATH B
 python3 scripts/kernel_readiness_harness.py --json out.json          # machine-readable
 ```
+
+The `--inline` mode requires the `form_kernel_rust` PyO3 extension built into
+the running interpreter (`maturin develop --release` from
+`form/form-kernel-rust/`); when it is absent the harness reports the inline
+verdict as `UNAVAILABLE` and the other modes are unaffected.
 
 The harness exits nonzero **only** on a value-parity failure. Slowness is
 reported as evidence, never as a test failure — the profile informs the flip

--- a/scripts/kernel_readiness_harness.py
+++ b/scripts/kernel_readiness_harness.py
@@ -360,6 +360,31 @@ def make_kernel_path_a_thunk(case: CaptureCall, fk_source: str, bridge) -> Calla
     return thunk
 
 
+def make_inline_thunk(case: CaptureCall, fk_source: str, bridge) -> Callable[[], Any]:
+    """INLINE per-request thunk: inject bindings + a C call into the warm PyO3
+    kernel — NO process spawn, NO socket loopback.
+
+    This is precisely serve_via_kernel's per-request work on the hot path: the
+    `form_kernel_rust` extension is imported ONCE at module load (a warm Rust
+    runtime living in the Python process); each request injects literals and
+    calls `compile_and_run`, returning an already-typed Python value. The only
+    per-request cost is inject (µs) + parse + recipe execution in-process — the
+    spawn AND the HTTP/1.0 loopback that dominate PATH A and SERVE are both
+    gone. This is the production hot path the readiness evidence named.
+    """
+    def thunk() -> Any:
+        injected = bridge.inject_bindings(fk_source, case.bindings)
+        value = bridge.run_inline(injected)
+        # run_inline returns a native typed value (int/float/list); parse is a
+        # no-op for the int/float cases (int(int)==int, float(float)==float).
+        try:
+            return case.parse(value)
+        except (TypeError, ValueError):
+            return case.parse(str(value))
+
+    return thunk
+
+
 def make_path_b_thunk(demo_py: str) -> Callable[[], Any]:
     """PATH B thunk: the full pyfkb-run.sh --kernel rust pipeline per call.
 
@@ -618,11 +643,18 @@ class ReadinessResult:
     serve_jit_value: Any = None
     serve_verdict: Optional[str] = None
     serve_marshalled: bool = False           # True when a real query string carried inputs
+    # Inline (PyO3) — the warm in-process kernel, no spawn, no loopback. The
+    # production hot path. Populated only when --inline runs.
+    inline: Optional[Profile] = None
+    inline_value: Any = None
+    inline_value_match: Optional[bool] = None
+    ratio_inline_p50: Optional[float] = None  # inline p50 / cpython p50
+    inline_verdict: Optional[str] = None
 
     def to_dict(self) -> dict:
         d = asdict(self)
         # drop raw sample arrays from json for size; percentiles are kept
-        for k in ("cpython", "kernel_a", "path_b", "serve", "serve_jit"):
+        for k in ("cpython", "kernel_a", "path_b", "serve", "serve_jit", "inline"):
             if d.get(k) is not None:
                 d[k].pop("samples_ms", None)
         return d
@@ -667,6 +699,72 @@ def _serve_verdict(value_match: bool, ratio: Optional[float], prof: Profile) -> 
                 f"low-single-digit-ms, dominated by HTTP/1.0 loopback, not compute")
     return (f"REVIEW — warm channel p99={prof.p99_ms:.3f}ms exceeds 10ms; "
             f"investigate loopback/marshalling overhead")
+
+
+def _inline_verdict(value_match: bool, ratio: Optional[float], prof: Profile) -> str:
+    """Readiness verdict under the INLINE (PyO3) model — spawn AND loopback gone.
+
+    Inline removes BOTH the per-request process spawn (PATH A) and the HTTP/1.0
+    loopback (SERVE). What remains is inject (µs) + a C call + recipe execution.
+    CPython's pure-compute p50 is sub-microsecond, so even a small constant
+    overhead reads as a large MULTIPLE — judge on the ABSOLUTE p99 against a
+    per-request budget, same posture as the serve verdict but with a tighter
+    envelope (no socket).
+    """
+    if prof.error:
+        return f"NOT-YET — inline path errored: {prof.error}"
+    if not value_match:
+        return "NOT-YET — value parity FAILED on the inline (PyO3) path"
+    if ratio is None:
+        return "UNKNOWN — could not compute inline ratio"
+    if prof.p99_ms <= 0.1:
+        return (f"READY — warm in-process kernel, p50={prof.p50_ms:.4f}ms "
+                f"p99={prof.p99_ms:.4f}ms; sub-100µs, no spawn, no loopback")
+    if prof.p99_ms <= 1.0:
+        return (f"READY (shape) — inline p50={prof.p50_ms:.4f}ms "
+                f"p99={prof.p99_ms:.4f}ms; sub-ms in-process, spawn+loopback removed")
+    if prof.p99_ms <= 5.0:
+        return (f"HEALTHY-ENVELOPE — inline p99={prof.p99_ms:.4f}ms; low-ms, "
+                f"recipe execution + inject, no transport")
+    return (f"REVIEW — inline p99={prof.p99_ms:.4f}ms exceeds 5ms; "
+            f"investigate recipe-walk / inject overhead")
+
+
+def measure_inline(
+    results: List[ReadinessResult],
+    cases: List[CaptureCall],
+    iters: int,
+    bridge,
+) -> None:
+    """Fill inline fields on `results` using the warm PyO3 kernel.
+
+    The `form_kernel_rust` extension is already imported once at bridge module
+    load — that IS the warm kernel. Each case re-uses the same compiled .fk the
+    PATH A measurement built (held in /tmp by run_readiness_case), injects its
+    bindings, and calls run_inline. CPython's baseline is reused from each
+    ReadinessResult so the comparison is against the identical warm-CPython
+    number PATH A and SERVE used.
+    """
+    if not bridge.inline_available():
+        for r in results:
+            r.inline_verdict = "UNAVAILABLE — form_kernel_rust PyO3 extension not importable"
+        return
+    for case in cases:
+        r = next((x for x in results if x.name == case.name), None)
+        if r is None:
+            continue
+        fk_source = (Path("/tmp") / f"kr_{case.name}.fk").read_text(encoding="utf-8")
+        prof, val = profile_runtime(
+            f"{case.name}/inline", make_inline_thunk(case, fk_source, bridge), iters
+        )
+        r.inline = prof
+        r.inline_value = val
+        r.inline_value_match = (not prof.error) and _values_agree(r.cpython_value, val)
+        if r.cpython.p50_ms > 0 and prof.p50_ms > 0 and not prof.error:
+            r.ratio_inline_p50 = prof.p50_ms / r.cpython.p50_ms
+        r.inline_verdict = _inline_verdict(
+            bool(r.inline_value_match), r.ratio_inline_p50, prof
+        )
 
 
 def measure_persistent_serve(
@@ -797,6 +895,7 @@ def render(
     iters: int,
     include_path_b: bool,
     include_serve: bool = False,
+    include_inline: bool = False,
     jit_demo: Optional["JitDemo"] = None,
 ) -> str:
     L: List[str] = []
@@ -808,6 +907,9 @@ def render(
     if include_serve:
         L.append("SERVE  = persistent `form-kernel-rust serve` — routes load ONCE, "
                  "request→response over the warm process (apples-to-apples w/ CPython)")
+    if include_inline:
+        L.append("INLINE = warm PyO3 `form_kernel_rust` in-process — C call into Rust, "
+                 "NO spawn, NO loopback (the production hot path)")
     if include_path_b:
         L.append("PATH B = pyfkb full python-bmf pipeline per call (naive shell-out)")
     L.append("=" * 78)
@@ -845,6 +947,21 @@ def render(
                          f"p99={r.serve_jit.p99_ms:.4f}  (no-op for this recipe — see JIT note)")
             if r.serve_verdict is not None:
                 L.append(f"   SERVE VERD : {r.serve_verdict}")
+        if r.inline is not None or r.inline_verdict is not None:
+            if r.inline is None:
+                L.append(f"   inline     : {r.inline_verdict}")
+            elif r.inline.error:
+                L.append(f"   inline     : ERROR {r.inline.error}")
+            else:
+                L.append(f"   inline     : p50={r.inline.p50_ms:.5f}ms p95={r.inline.p95_ms:.5f} "
+                         f"p99={r.inline.p99_ms:.5f} mean={r.inline.mean_ms:.5f} sd={r.inline.stdev_ms:.5f}")
+                L.append(f"   inline val : {r.inline_value!r}  match="
+                         f"{'YES' if r.inline_value_match else 'NO'}  (PyO3, no spawn, no loopback)")
+                if r.ratio_inline_p50 is not None:
+                    L.append(f"   inline rt  : inline p50 / cpython p50 = {r.ratio_inline_p50:.1f}x "
+                             f"(absolute p99={r.inline.p99_ms:.5f}ms — judge on the ABSOLUTE)")
+                if r.inline_verdict is not None:
+                    L.append(f"   INLINE VERD: {r.inline_verdict}")
         if r.path_b is not None:
             if r.path_b.error:
                 L.append(f"   PATH B     : ERROR {r.path_b.error}")
@@ -881,6 +998,12 @@ def render(
         s_match = sum(1 for r in results if r.serve_value_match)
         L.append(f"SUMMARY (SERVE): {len(results)} calls — {s_match}/{len(results)} value-parity"
                  f" · {s_ready} READY-shape · {s_healthy} HEALTHY-ENVELOPE")
+    if include_inline:
+        i_ready = sum(1 for r in results if (r.inline_verdict or "").startswith("READY"))
+        i_healthy = sum(1 for r in results if (r.inline_verdict or "").startswith("HEALTHY"))
+        i_match = sum(1 for r in results if r.inline_value_match)
+        L.append(f"SUMMARY (INLINE): {len(results)} calls — {i_match}/{len(results)} value-parity"
+                 f" · {i_ready} READY · {i_healthy} HEALTHY-ENVELOPE")
     L.append("Value parity is the floor; the profile decides readiness. See "
              "kernels/API_KERNEL_READINESS.md for the readiness map.")
     L.append("=" * 78)
@@ -899,6 +1022,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--path-b", action="store_true", help="also profile the pyfkb PATH B")
     ap.add_argument("--persistent", action="store_true",
                     help="also measure the PERSISTENT serve path (the apples-to-apples model)")
+    ap.add_argument("--inline", action="store_true",
+                    help="also measure the INLINE PyO3 path (warm in-process kernel, no spawn/loopback)")
     ap.add_argument("--jit", action="store_true",
                     help="with --persistent: add the +jit serve mode; also runs the JIT demonstrator")
     ap.add_argument("--json", help="write machine-readable results to this path")
@@ -932,11 +1057,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(f"serve routes file missing at {SERVE_ROUTES}", file=sys.stderr)
             return 2
         measure_persistent_serve(results, cases, args.iters, with_jit=args.jit)
+    if args.inline:
+        measure_inline(results, cases, args.iters, bridge)
     if args.jit:
         jit_demo = profile_jit_demonstrator(args.iters)
 
     print(render(results, args.iters, args.path_b,
-                 include_serve=args.persistent, jit_demo=jit_demo))
+                 include_serve=args.persistent, include_inline=args.inline,
+                 jit_demo=jit_demo))
 
     if args.json:
         Path(args.json).write_text(


### PR DESCRIPTION
## The inline carrier, built and measured

The transmuted endpoints' production hot path, made real. The PyO3 surface (`lib.rs` cdylib, `Cargo.toml` `pyo3` feature, `pyproject.toml` maturin, bridge wired to `compile_and_run`) existed in source but had **never been built** — it didn't compile against the current kernel. Two shallow breaks fixed, then `maturin develop --release` builds `form_kernel_rust` into the API venv. The bridge loads it (`active_runtime() == "inline"`) and serves typed values via the warm in-process kernel — no process spawn, no socket loopback.

### Fixes to make it build (additive, both surfaces)
- `src/main.rs`: `crate::bp_table` → `self::bp_table` — a path that resolves in **both** the bin build (`main.rs` = crate root) and the lib build (`main.rs` = `mod kernel`).
- `src/lib.rs`: `value_to_py` gained the missing `Value::Record(_)` arm (renders via the kernel's own `display()`).

### Measured (`--inline --persistent --iters 300`), value-parity 4/4 exact

| Endpoint | Serve p50 | **Inline p50** | **Inline p99** | Serve→Inline |
|---|---|---|---|---|
| coherence_weight (16185) | 0.176 ms | **0.128 ms** | 0.190 ms | 1.4× |
| nodeid_distance (7) | 0.244 ms | **0.050 ms** | 0.078 ms | 4.9× |
| nodeid_compatibility (2) | 0.241 ms | **0.054 ms** | 0.085 ms | 4.5× |
| weighted_average (0.8125) | 0.107 ms | **0.092 ms** | 0.139 ms | 1.2× |

Inline beats serve on all four. On the two integer endpoints (real inputs both ways) inline is **~4.5–4.9× faster, sub-100µs p99** — the HTTP/1.0 loopback serve paid is gone. The three-way profile: fork+exec (~5 ms) → persistent serve (~0.1–0.24 ms, loopback-bound) → inline PyO3 (~0.05–0.13 ms). Each step removes a transport cost.

### No regression
- `cargo build --release` still produces the `form-kernel-rust` binary (verified, runs distance=7).
- `form/validate.sh` green: 217 ok, 1 divergent (the excepted seeded-bytes band).
- Subprocess fallback intact: forcing inline absent serves distance=7 via subprocess.
- Value-parity holds exactly inline, types preserved.

### What remains
Deploy-image maturin build (so `form_kernel_rust` imports in prod), and a `load_route + run(handle, bindings)` PyO3 pair to drop the per-request `.fk` parse (reusing `read_root_from_source` + `walk`). Both named in `kernels/API_KERNEL_READINESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)