### PR TITLE
tend(kernel): wellness probe + attribution view for the kernel-native API surface

### DIFF
--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -498,3 +498,90 @@ reported as evidence, never as a test failure — the profile informs the flip
 decision; it does not gate CI. The persistent serve mode starts one
 `form-kernel-rust serve` process per mode, fires all requests over it, and kills
 it on exit; no listener is left running.
+
+## Toward full kernel-native routing + attribution
+
+The four transmuted endpoints are the seed, not the destination. The direction
+Urs named: **serve most/all routes through the kernel → full attribution and
+traceability → an activity view that shows which Blueprints / Recipes / Cells
+are most alive, and which sit inert and want a look at why they're registered
+but never involved.** This section writes that destination down so the next
+breath continues it instead of re-deriving it.
+
+### The destination
+
+A body where the **computational core of every eligible route** runs as a Form
+recipe on the warm in-process kernel. Then every request leaves an attribution
+trace — which arm categories (Blueprints) dispatched, which Form functions
+(Recipes) were called, which natives fired — and the body can **see its own
+execution shape**: hot paths exercised on every request, dormant paths that no
+route reaches. The substrate's promise (content-addressed structural identity)
+becomes a *live* signal: not just "these two cells share a Blueprint" but "this
+Blueprint fired 176 times serving real traffic; that one has never fired —
+why is it here?"
+
+### The path — incremental, each step earning its proof
+
+1. **Transmute routes incrementally.** Each eligible route (pure
+   numeric/structural computation — see "What's eligible" above) lands a `.py`
+   demo + compiled `.fk` recipe, joins `PARITY_FILES`, and calls
+   `serve_via_kernel`. **Every transmuted route earns value-parity proof** (the
+   three-way CPython/TS/Rust gate) before it ships. The growth edge is the
+   `total − served` count the wellness probe names.
+2. **The wellness probe guards the surface.** `sense_kernel_api()` in
+   `scripts/wellness_check.py` senses the kernel-native surface across the five
+   dimensions Urs named — **performance, stability, accuracy, transparency,
+   vitality** — quiet when healthy, specific on drift (a python-fallback that
+   should be inline, a parity break, a latency regression, attribution gone
+   missing). As routes are transmuted, the probe's vitality ratio climbs and the
+   same five signals keep watch over the wider surface. It is the standing
+   sensor that lets the transmutation proceed without fear.
+3. **The attribution-activity view grows with coverage.**
+   `scripts/kernel_attribution_report.py` runs the kernel-served recipes through
+   the kernel's `trace` mode and aggregates the arm / function / native
+   attribution into a ranked view — hot Blueprints, hot Recipes, and natives
+   each resolved to a Blueprint NodeID via `native_blueprint`. It also names the
+   **inert** natives: registered but never fired across today's routes, the
+   "why here, not involved?" candidates. **The view widens by one row per
+   transmuted route** — routes are DATA in `KERNEL_SERVED_RECIPES`; adding a
+   transmuted route to that list extends the activity view with no code change.
+
+### Honest coverage today — and the gap to full coverage
+
+What is **real and complete** for the kernel-served routes today:
+
+- **Value parity** — 4/4, types preserved (inline `value_to_py`).
+- **Arm-dispatch attribution** — every walked arm is counted by category and
+  variant (`MATH.MUL`, `COMPARE.EQ`, `BLOCK.LET`, …).
+- **Native-Blueprint attribution** — every native fired is resolved to its Form
+  category NodeID (`abs → @1.2.27.1`, `len → @1.2.15.1`, …).
+- **Recipe (Form-function) activity** — which named recipes were called, ranked.
+
+What **requires more transmuted routes** before it is real:
+
+- **Per-route Recipe/Cell activity across ALL routes.** The activity view today
+  covers the four pure-compute cores. Full coverage — every route's recipe and
+  the substrate Cells it touches, ranked by liveness across the whole API —
+  arrives only as more routes are transmuted. The view does not fake this; it
+  names its scope (`reached/eligible`) and the path to widen it.
+- **Cell-level liveness** in the substrate sense (which `NamedCell`s a request
+  reads/writes) needs the I/O-carrier routes (substrate ports) transmuted, a
+  separate arc from the pure-compute flip.
+
+The wellness probe and the attribution view are the two instruments that make
+the incremental transmutation **safe and legible**: the probe says *the surface
+is healthy as it grows*, the activity view says *here is what's alive and what's
+inert*. Together they turn "serve everything through the kernel" from a leap
+into a walk — one route at a time, each one sensed and attributed.
+
+### Running these two instruments
+
+```bash
+python3 scripts/wellness_check.py                 # includes sense_kernel_api (quiet when healthy)
+python3 scripts/kernel_attribution_report.py      # ranked Blueprint/Recipe/native activity + inert list
+python3 scripts/kernel_attribution_report.py --json --top 5   # machine-readable, top-N per section
+```
+
+Both degrade gracefully: with no kernel binary or no network they sense what
+they can locally and name what they couldn't reach (the probe), or name the
+missing binary and exit 2 (the report) — never a faked reading.

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 138
+**Total files**: 140
 
 | File | Purpose |
 |---|---|
@@ -78,6 +78,7 @@
 | [intern_canonical_words.py](intern_canonical_words.py) | intern_canonical_words.py — CLI wrapper for the canonical lexicon interner. |
 | [intern_modality_blueprints.py](intern_modality_blueprints.py) | intern_modality_blueprints.py — CLI wrapper for the cross-modal interner. |
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
+| [kernel_attribution_report.py](kernel_attribution_report.py) | Kernel attribution-activity report — which Blueprints/Recipes/natives fire. |
 | [kernel_readiness_harness.py](kernel_readiness_harness.py) | kernel_readiness_harness.py — readiness evidence for the API → Form-kernel flip. |
 | [local_runner.py](local_runner.py) | Coherence Network runner — thin shim. |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | Measure GitNexus integration value across paired task windows. |
@@ -103,6 +104,7 @@
 | [scan_dyad_candidates.py](scan_dyad_candidates.py) | Refined dyad-pair candidate scan over Living Collective concept cells. |
 | [scan_dyad_candidates_word.py](scan_dyad_candidates_word.py) | WORD-domain prose-structural dyad-pair scan over Living Collective concepts. |
 | [scan_form_blueprints.py](scan_form_blueprints.py) | Scan Form (.fk) sources for `make_nodeid` Blueprint literals and measure |
+| [scan_form_user_blueprints.py](scan_form_user_blueprints.py) | Form User Blueprint Scanner |
 | [schedule_attunement.py](schedule_attunement.py) | Re-attune every presence so newly added concepts get picked up. |
 | [seed_commit_evidence.py](seed_commit_evidence.py) | Seed the commit evidence API from local git history. |
 | [seed_db.py](seed_db.py) | Seed data/coherence.db from spec markdown files, commit evidence JSON, and inline idea data. |

--- a/scripts/kernel_attribution_report.py
+++ b/scripts/kernel_attribution_report.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Kernel attribution-activity report — which Blueprints/Recipes/natives fire.
+
+The first real step toward the larger direction Urs named: serve most/all API
+routes through the Form kernel for full attribution + traceability, then SEE
+which Blueprints / Recipes / Cells are most active versus which sit inert and
+need a look at why they're registered but never involved.
+
+What it does, honestly scoped to what's measurable today
+--------------------------------------------------------
+The kernel's ``trace`` subcommand
+(`form/form-kernel-rust/src/main.rs` :: ``cli_trace`` / ``Trace``) emits, per
+run, the arm-dispatch counts (FNCALL, BLOCK, MATH, METHOD, …), the Form
+functions called, and the host-natives fired. The kernel's ``native_blueprint``
+native resolves each native name to its Form-category Blueprint NodeID
+(e.g. ``abs`` → ``@1.2.27.1``). This report:
+
+  1. Runs each **kernel-served recipe** (the transmuted-endpoint ``.fk`` shapes
+     in `form/form-kernel-ts/seedbank/python-adapter/examples/`) through
+     ``trace`` — recipes as DATA, one walk each, no special-casing.
+  2. AGGREGATES the arm / function / native counts across all recipes into a
+     single ranked view: which Blueprints (arm categories), which Recipes
+     (Form functions), and which natives fired MOST.
+  3. Resolves the fired natives to their Blueprint NodeIDs via
+     ``native_blueprint`` — the transparency thread: every native call is
+     attributable to a Form category.
+  4. Names the **inert** surfaces: registered natives that NEVER fired across
+     the kernel-served recipes. These are the "why is this here and not being
+     involved?" candidates Urs asked to see.
+
+Honest coverage statement (printed, not buried)
+-----------------------------------------------
+The activity view is over the **kernel-served routes today** — the four
+transmuted endpoints' computational cores. The trace gives **arm + native-
+Blueprint attribution**, which is real and complete for what runs. Full
+per-route Recipe/Cell-level activity across ALL routes requires more routes
+transmuted to the kernel; the view widens as coverage grows. This report names
+that path rather than faking coverage.
+
+Run
+---
+    python3 scripts/kernel_attribution_report.py            # human-readable
+    python3 scripts/kernel_attribution_report.py --json      # machine-readable
+    python3 scripts/kernel_attribution_report.py --top 5     # top-N per section
+
+Exit 0 always when the kernel binary is present (it is a sensing, not a gate).
+Exit 2 when the kernel binary is absent — names what it couldn't reach.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# The kernel-served recipes today: the four transmuted-endpoint computational
+# cores. Each is the committed `.fk` whose body the live endpoint runs. Routes
+# as DATA — adding a transmuted route here widens the activity view by one row,
+# no code change. The expected_result is the documented value-parity anchor
+# (API_KERNEL_READINESS.md) so a recipe that traces to the WRONG value is
+# visible in the same pass as its activity.
+KERNEL_SERVED_RECIPES: list[dict[str, object]] = [
+    {
+        "route": "/api/utils/coherence_weight",
+        "recipe": "endpoint_coherence_weight_demo.fk",
+        "expected_result": "16185",
+    },
+    {
+        "route": "/api/utils/nodeid_distance",
+        "recipe": "endpoint_nodeid_distance_demo.fk",
+        "expected_result": "7",
+    },
+    {
+        "route": "/api/utils/nodeid_compatibility",
+        "recipe": "endpoint_nodeid_compatibility_demo.fk",
+        "expected_result": "2",
+    },
+    {
+        "route": "/api/utils/weighted_average",
+        "recipe": "endpoint_weighted_average_demo.fk",
+        "expected_result": "0.8125",
+    },
+]
+
+_EXAMPLES_DIR = (
+    ROOT / "form" / "form-kernel-ts" / "seedbank" / "python-adapter" / "examples"
+)
+_KERNEL_BIN = (
+    ROOT / "form" / "form-kernel-rust" / "target" / "release" / "form-kernel-rust"
+)
+
+
+def kernel_bin() -> Path:
+    """The form-kernel-rust binary path (honors FORM_KERNEL_RUST_BIN)."""
+    override = os.environ.get("FORM_KERNEL_RUST_BIN")
+    return Path(override) if override else _KERNEL_BIN
+
+
+def kernel_available() -> bool:
+    p = kernel_bin()
+    return p.is_file() and os.access(p, os.X_OK)
+
+
+def _run_kernel(args: list[str], timeout: float = 20.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(kernel_bin()), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def trace_recipe(recipe_path: Path) -> dict | None:
+    """Run a recipe through the kernel's trace mode; return parsed JSON or None."""
+    proc = _run_kernel(["trace", str(recipe_path)])
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def native_blueprint(name: str) -> str | None:
+    """Resolve a native name to its Form-category Blueprint NodeID, or None."""
+    proc = _run_kernel(["--expr", f'(native_blueprint "{name}")'])
+    out = proc.stdout.strip()
+    if proc.returncode != 0 or not out:
+        return None
+    # The native returns a NodeID like "@1.2.27.1"; the binary may print it on
+    # its own line. Take the last non-empty line that looks like a NodeID.
+    for line in reversed(out.splitlines()):
+        line = line.strip()
+        if line.startswith("@"):
+            return line
+    return out.splitlines()[-1].strip() if out else None
+
+
+# ---------------------------------------------------------------------------
+# The ONE aggregation mechanism — recipes as DATA, summed into a ranked view.
+# ---------------------------------------------------------------------------
+
+
+def aggregate() -> dict:
+    """Trace every kernel-served recipe and aggregate the attribution signal.
+
+    Returns a dict with:
+      - per_recipe:  [{route, recipe, result, expected, parity, elapsed_us,
+                       missing}]  (missing == recipe `.fk` not on disk)
+      - arms:        {arm_variant_name -> total count}     (Blueprint activity)
+      - functions:   {form-fn name -> total count}          (Recipe activity)
+      - natives:     {native name -> {count, blueprint}}    (native activity)
+      - inert_natives:  [names registered in the kernel that never fired]
+      - reached:     count of recipes actually traced
+      - eligible:    count of recipes named (== reached + missing + failed)
+    """
+    arm_counts: dict[str, int] = defaultdict(int)
+    fn_counts: dict[str, int] = defaultdict(int)
+    native_counts: dict[str, int] = defaultdict(int)
+    per_recipe: list[dict] = []
+    reached = 0
+
+    for entry in KERNEL_SERVED_RECIPES:
+        recipe_name = str(entry["recipe"])
+        recipe_path = _EXAMPLES_DIR / recipe_name
+        rec: dict = {
+            "route": entry["route"],
+            "recipe": recipe_name,
+            "expected": entry["expected_result"],
+        }
+        if not recipe_path.is_file():
+            # The `.fk` is a deploy-time-compiled artifact; in a fresh worktree
+            # it may be absent. Name it, don't fake a trace.
+            rec.update({"missing": True, "result": None, "parity": None})
+            per_recipe.append(rec)
+            continue
+
+        trace = trace_recipe(recipe_path)
+        if trace is None:
+            rec.update({"failed": True, "result": None, "parity": None})
+            per_recipe.append(rec)
+            continue
+
+        reached += 1
+        result = str(trace.get("result", ""))
+        rec["result"] = result
+        rec["elapsed_us"] = trace.get("elapsed_us")
+        rec["parity"] = result == str(entry["expected_result"])
+
+        tr = trace.get("trace", {})
+        for v in tr.get("variants", []):
+            arm_counts[v.get("arm_variant_name", "?")] += int(v.get("count", 0))
+        for f in tr.get("functions", []):
+            fn_counts[f.get("name", "?")] += int(f.get("count", 0))
+        for n in tr.get("natives", []):
+            native_counts[n.get("name", "?")] += int(n.get("count", 0))
+        per_recipe.append(rec)
+
+    # Attribute each fired native to its Blueprint NodeID (transparency thread).
+    natives_with_bp: dict[str, dict] = {}
+    for name, count in native_counts.items():
+        natives_with_bp[name] = {
+            "count": count,
+            "blueprint": native_blueprint(name),
+        }
+
+    return {
+        "per_recipe": per_recipe,
+        "arms": dict(arm_counts),
+        "functions": dict(fn_counts),
+        "natives": natives_with_bp,
+        "inert_natives": _inert_natives(set(native_counts)),
+        "reached": reached,
+        "eligible": len(KERNEL_SERVED_RECIPES),
+    }
+
+
+# Registered natives the kernel ships. Sourced from the kernel's own
+# `register_native(...)` calls (main.rs). We don't need the full set to be
+# exhaustive — the honest signal is "these are registered and never fired
+# across the kernel-served recipes," i.e. dormant relative to TODAY's
+# coverage. A native firing on no current route is a candidate for "why is it
+# here / which route would exercise it." This list names the natives an
+# operator would expect a richer route surface to involve.
+_REGISTERED_NATIVES_SAMPLE = {
+    # arithmetic / list ops the endpoint recipes DO use
+    "_plus", "abs", "_get", "_iter", "head", "tail", "len", "nth",
+    # natives registered but NOT exercised by the four pure-compute recipes —
+    # they wait for routes that do I/O, structure, or witness work.
+    "native_blueprint", "trace", "fetch", "print", "str", "concat",
+    "map", "filter", "fold", "range", "str_to_int", "str_to_float",
+    "split", "to_json", "from_json",
+}
+
+
+def _inert_natives(fired: set[str]) -> list[str]:
+    """Registered natives that never fired across the kernel-served recipes.
+
+    Honest framing: 'inert relative to today's four pure-compute routes', not
+    'dead code'. Each is a native a future transmuted route (I/O, structure,
+    witness) would exercise — naming them is the 'why here, not involved?'
+    view Urs asked for. The list grows accurate as more natives are catalogued
+    and shrinks as more routes are transmuted.
+    """
+    return sorted(_REGISTERED_NATIVES_SAMPLE - fired)
+
+
+def _ranked(counts: dict, top: int | None) -> list[tuple]:
+    items = sorted(counts.items(), key=lambda kv: (-_count_of(kv[1]), kv[0]))
+    return items[:top] if top else items
+
+
+def _count_of(value) -> int:
+    return value["count"] if isinstance(value, dict) else int(value)
+
+
+def render(report: dict, top: int | None) -> str:
+    out: list[str] = []
+    out.append("# Kernel attribution-activity report")
+    out.append("")
+    out.append(
+        f"Kernel-served routes traced: {report['reached']}/{report['eligible']} "
+        "(the transmuted-endpoint computational cores)."
+    )
+    out.append("")
+
+    # Per-recipe: value parity + elapsed, so a wrong value shows next to activity.
+    out.append("## Recipes traced (value-parity anchored)")
+    out.append("")
+    for r in report["per_recipe"]:
+        if r.get("missing"):
+            out.append(f"  · {r['route']}  —  recipe `.fk` absent (not compiled here)")
+            continue
+        if r.get("failed"):
+            out.append(f"  · {r['route']}  —  trace FAILED")
+            continue
+        parity = "✓" if r.get("parity") else "✗ PARITY BREAK"
+        us = r.get("elapsed_us")
+        us_str = f"{us}µs" if us is not None else "?"
+        out.append(
+            f"  · {r['route']}  →  {r['result']} (expected {r['expected']}) "
+            f"{parity}  ·  {us_str}"
+        )
+    out.append("")
+
+    # Blueprint activity (arm categories — the Form Blueprints exercised).
+    out.append("## Hot Blueprints (arm-dispatch categories)")
+    out.append("")
+    for name, count in _ranked(report["arms"], top):
+        out.append(f"  {count:>6}  {name}")
+    out.append("")
+
+    # Recipe activity (Form functions invoked).
+    out.append("## Hot Recipes (Form functions called)")
+    out.append("")
+    if report["functions"]:
+        for name, count in _ranked(report["functions"], top):
+            out.append(f"  {count:>6}  {name}")
+    else:
+        out.append("  (no named Form functions — recipes inline their bodies)")
+    out.append("")
+
+    # Native activity, each attributed to its Blueprint NodeID.
+    out.append("## Hot natives (each attributed to its Blueprint NodeID)")
+    out.append("")
+    for name, info in _ranked(report["natives"], top):
+        bp = info.get("blueprint") or "?"
+        out.append(f"  {info['count']:>6}  {name:<16} {bp}")
+    out.append("")
+
+    # Inert — the 'why here, not involved?' candidates.
+    out.append("## Inert natives (registered, never fired across these routes)")
+    out.append("")
+    if report["inert_natives"]:
+        out.append(
+            "  These natives are registered in the kernel but no kernel-served"
+        )
+        out.append(
+            "  route exercises them today. Each is a candidate for 'why is this"
+        )
+        out.append(
+            "  here, and which route would involve it?' — they wait for routes"
+        )
+        out.append("  that do I/O, structure, or witness work, not pure arithmetic:")
+        out.append("")
+        out.append("    " + ", ".join(report["inert_natives"]))
+    else:
+        out.append("  (every catalogued native fired — full involvement)")
+    out.append("")
+
+    # The honest coverage statement — printed, not buried.
+    out.append("## Coverage — what this view sees, and the path to full coverage")
+    out.append("")
+    out.append(
+        "  Today the view covers the kernel-served routes: the four transmuted-"
+    )
+    out.append(
+        "  endpoint computational cores. The attribution is real and complete"
+    )
+    out.append(
+        "  for what runs — arm-dispatch + native-Blueprint resolution. Full"
+    )
+    out.append(
+        "  per-route Recipe/Cell activity across ALL routes requires more routes"
+    )
+    out.append(
+        "  transmuted to the kernel. The path: transmute routes incrementally"
+    )
+    out.append(
+        "  (each earns value parity), the wellness probe guards the surface, and"
+    )
+    out.append("  this activity view widens by one row per transmuted route.")
+    out.append("")
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--top", type=int, default=None, help="top-N per section")
+    args = parser.parse_args(argv)
+
+    if not kernel_available():
+        msg = (
+            f"kernel binary not found at {kernel_bin()} — "
+            "build it (cargo build --release in form/form-kernel-rust) to trace."
+        )
+        if args.json:
+            print(json.dumps({"error": msg, "reached": 0}, indent=2))
+        else:
+            print(f"(could not reach the kernel binary)\n  {msg}")
+        return 2
+
+    report = aggregate()
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render(report, args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1441,6 +1441,279 @@ def sense_deploy_lag() -> list[str]:
     return lines
 
 
+# Kernel-native API surface — the readiness envelope this probe senses against.
+# From kernels/API_KERNEL_READINESS.md: the route-preload carrier lands the
+# integer endpoints at 3-4µs p50 and the list/float ones at 17-48µs p50; the
+# inline-with-parse path is sub-200µs p99. A LOCAL `trace` walk (cold subprocess
+# kernel, no warm preloader) is a coarser instrument — it includes parse + a
+# fresh process's first walk — so the wellness threshold is deliberately loose:
+# it catches a recipe that has regressed by an ORDER of magnitude (something
+# structurally wrong), not p50 micro-jitter. The precise p50 profile is the
+# harness's job (scripts/kernel_readiness_harness.py); this probe senses gross
+# drift on the live surface.
+_KERNEL_TRACE_REGRESSION_US = 5000  # a single recipe trace over ~5ms ⇒ look
+
+
+def sense_kernel_api() -> list[str]:
+    """Is the kernel-native API surface breathing across all five dimensions?
+
+    The body just brought four endpoints' computational cores live serving
+    ``runtime: "inline"`` through the warm in-process Form kernel
+    (api/app/routers/utils.py → form_kernel_bridge.serve_via_kernel). This probe
+    senses that surface the way Urs named it — performance, stability, accuracy,
+    transparency, vitality — each as a concrete signal, quiet when healthy and
+    specific when it drifts.
+
+    ONE sensing mechanism: the kernel-served routes are DATA
+    (kernel_attribution_report.KERNEL_SERVED_RECIPES); the probe walks them once
+    locally (the kernel `trace` gives value + elapsed + attribution in one pass)
+    and, when prod is reachable, reads the live ``runtime`` each endpoint serves.
+
+    Degrades gracefully like sense_deploy_lag: with no live kernel/network it
+    senses what it can LOCALLY (binary present, recipes parse, value parity,
+    attribution present) and from the readiness doc, and SAYS what it couldn't
+    reach — it never fakes a live reading.
+
+    The drift it is built to catch (each a real failure mode, not performed
+    caution):
+      - Stability: an endpoint silently serving ``python-fallback`` — the body
+        quietly losing Form-native execution (the exact drift that hid for a
+        deploy: kernel loaded but endpoints on python-fallback for missing
+        recipes). NAMED, not glossed.
+      - Accuracy: a kernel that serves the WRONG value — parity break caught,
+        not just a slow one.
+      - Performance: the kernel path degraded off the fast carrier, or a recipe
+        trace regressed by an order of magnitude.
+      - Transparency: attribution/trace signal missing — the body can no longer
+        see which Blueprints/recipes a call exercised.
+      - Vitality: how MUCH of the API is kernel-served — the ratio and the
+        growth edge toward most/all routes through the kernel.
+    """
+    import importlib.util
+    import urllib.request
+    import urllib.error
+
+    lines: list[str] = []
+
+    # Load the attribution module (single source of truth for the kernel-served
+    # routes + the trace/aggregate mechanism). If it can't load, say so and stop
+    # — the probe shares ONE mechanism with the activity view by design.
+    attr_path = ROOT / "scripts" / "kernel_attribution_report.py"
+    if not attr_path.is_file():
+        return ["  drift: scripts/kernel_attribution_report.py missing — "
+                "cannot sense the kernel-native surface"]
+    try:
+        spec = importlib.util.spec_from_file_location("kernel_attribution_report", attr_path)
+        attr = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+        spec.loader.exec_module(attr)  # type: ignore[union-attr]
+    except Exception as exc:
+        return [f"  drift: could not load kernel_attribution_report ({exc})"]
+
+    served = attr.KERNEL_SERVED_RECIPES
+    n_served = len(served)
+
+    # --- LOCAL sensing: trace each kernel-served recipe once (value + elapsed +
+    # attribution in a single walk). Routes as DATA — one loop, all dimensions.
+    local_unreached = not attr.kernel_available()
+    parity_breaks: list[str] = []
+    missing_recipes: list[str] = []
+    slow_recipes: list[str] = []
+    attribution_present = False
+    traced = 0
+    if not local_unreached:
+        report = attr.aggregate()
+        traced = report.get("reached", 0)
+        for r in report.get("per_recipe", []):
+            if r.get("missing"):
+                missing_recipes.append(str(r["route"]))
+                continue
+            if r.get("failed"):
+                parity_breaks.append(f"{r['route']} (trace failed)")
+                continue
+            if not r.get("parity"):
+                parity_breaks.append(
+                    f"{r['route']} → {r.get('result')} (expected {r.get('expected')})"
+                )
+            us = r.get("elapsed_us")
+            if isinstance(us, (int, float)) and us > _KERNEL_TRACE_REGRESSION_US:
+                slow_recipes.append(f"{r['route']} ({us}µs)")
+        # Transparency: did the trace actually yield attribution? (hot blueprints
+        # + natives attributed to NodeIDs). Empty attribution on a surface that
+        # ran = the body can't see what it exercised.
+        attribution_present = bool(report.get("arms")) and bool(report.get("natives"))
+
+    # --- LIVE sensing: prod /api/health + /utils/kernel_status + each endpoint's
+    # runtime. Reachability is optional (like sense_deploy_lag) — name what we
+    # couldn't reach rather than failing.
+    api = os.environ.get("COHERENCE_API_BASE", "https://api.coherencycoin.com")
+
+    def _get(path: str):
+        try:
+            req = urllib.request.Request(
+                f"{api}{path}", headers={"User-Agent": "wellness-kernel/1.0"}
+            )
+            with urllib.request.urlopen(req, timeout=6) as resp:
+                return json.load(resp)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+            return None
+
+    health = _get("/api/health")
+    live_runtime = health.get("kernel_runtime") if health else None
+    live_fallbacks: list[str] = []
+    live_runtimes_seen: set[str] = set()
+    live_unreached = health is None
+    if not live_unreached:
+        # Stability: each transmuted endpoint should report inline/preload, not
+        # python-fallback. Hit each with its defaults (no query → documented
+        # sample input), read the `runtime` field.
+        endpoint_paths = {
+            "/api/utils/coherence_weight": "/api/utils/coherence_weight",
+            "/api/utils/nodeid_distance": "/api/utils/nodeid_distance",
+            "/api/utils/nodeid_compatibility": "/api/utils/nodeid_compatibility",
+            "/api/utils/weighted_average": "/api/utils/weighted_average",
+        }
+        for route in (str(s["route"]) for s in served):
+            path = endpoint_paths.get(route)
+            if not path:
+                continue
+            body = _get(path)
+            if body is None:
+                continue
+            rt = body.get("runtime")
+            if rt:
+                live_runtimes_seen.add(rt)
+            if rt == "python-fallback":
+                live_fallbacks.append(route)
+
+    # --- Compose the reading. Quiet when healthy; specific lines on drift. The
+    # attention markers (drift:/missing/could not reach) and compost markers
+    # (within budget/aligned) steer build_reading's shared shape.
+
+    # Vitality: how much of the API is kernel-served.
+    total_routes = _count_api_routes()
+    if total_routes:
+        pct = 100.0 * n_served / total_routes
+        lines.append(
+            f"  vitality: {n_served}/{total_routes} API routes kernel-served "
+            f"({pct:.1f}%) — the {total_routes - n_served} on pure Python are the growth edge "
+            "toward most/all routes through the kernel"
+        )
+    else:
+        lines.append(
+            f"  vitality: {n_served} routes kernel-served (total-route count unread)"
+        )
+
+    # Stability.
+    if live_unreached:
+        lines.append(f"  stability: could not reach {api}/api/health — sensed locally only")
+    elif live_runtime in ("inline", "preload"):
+        if live_fallbacks:
+            lines.append(
+                "  drift: stability — these endpoints served python-fallback "
+                "(Form-native execution lost): " + ", ".join(live_fallbacks)
+            )
+        else:
+            seen = ", ".join(sorted(live_runtimes_seen)) or live_runtime
+            lines.append(
+                f"  stability: production kernel_runtime '{live_runtime}'; "
+                f"endpoints serving via kernel ({seen}) — no fallback"
+            )
+    elif live_runtime == "python-fallback":
+        lines.append(
+            "  drift: stability — production kernel_runtime is 'python-fallback'; "
+            "the body has lost Form-native execution on this surface"
+        )
+    elif live_runtime:
+        lines.append(f"  stability: production kernel_runtime '{live_runtime}'")
+    else:
+        lines.append("  stability: /api/health did not report kernel_runtime")
+
+    # Performance.
+    if local_unreached:
+        lines.append(
+            "  performance: kernel binary not built locally — could not trace; "
+            "per kernels/API_KERNEL_READINESS.md the route-preload carrier lands "
+            "3-48µs p50 (run scripts/kernel_readiness_harness.py for the live profile)"
+        )
+    elif slow_recipes:
+        lines.append(
+            "  drift: performance — recipe trace over the order-of-magnitude "
+            "threshold (structurally wrong?): " + ", ".join(slow_recipes)
+        )
+    elif "python-fallback" in live_runtimes_seen or live_runtime == "python-fallback":
+        lines.append(
+            "  drift: performance — kernel degraded off the fast carrier to python-fallback"
+        )
+    else:
+        lines.append(
+            f"  performance: {traced}/{n_served} recipes trace within the local envelope; "
+            "fast carrier intact (inline/preload)"
+        )
+
+    # Accuracy (value parity).
+    if local_unreached:
+        lines.append("  accuracy: parity unverified locally (kernel binary absent)")
+    elif parity_breaks:
+        lines.append(
+            "  drift: accuracy — kernel value-parity BREAK: " + "; ".join(parity_breaks)
+        )
+    elif missing_recipes:
+        lines.append(
+            "  accuracy: recipes absent (not compiled here), parity unverified for: "
+            + ", ".join(missing_recipes)
+        )
+    else:
+        lines.append(
+            f"  accuracy: {traced}/{n_served} recipes match documented value parity"
+        )
+
+    # Transparency / attribution.
+    if local_unreached:
+        lines.append(
+            "  transparency: attribution unsensed locally (kernel binary absent)"
+        )
+    elif attribution_present:
+        lines.append(
+            "  transparency: attribution present — hot Blueprints + natives "
+            "(each resolved to a NodeID) visible via "
+            "scripts/kernel_attribution_report.py"
+        )
+    else:
+        lines.append(
+            "  drift: transparency — trace produced no attribution; the body "
+            "can't see which Blueprints/recipes the calls exercised"
+        )
+
+    # A quiet closing line so a fully-healthy reading lands a compost marker.
+    drifted = any(line.strip().startswith("drift:") for line in lines)
+    if not drifted and not live_unreached and not local_unreached:
+        lines.append(
+            "  kernel-native surface breathing within envelope — no action needed"
+        )
+
+    return lines
+
+
+def _count_api_routes() -> int:
+    """Count route decorators across api/app/routers/*.py — the vitality denominator.
+
+    A coarse count (every @router.<verb>(...) decorator) — enough to size the
+    growth edge (kernel-served vs total). Returns 0 if the routers dir is
+    unreadable, so the vitality line degrades to a bare served-count.
+    """
+    routers = ROOT / "api" / "app" / "routers"
+    if not routers.is_dir():
+        return 0
+    pattern = re.compile(r"@router\.(get|post|patch|put|delete)\(")
+    total = 0
+    for p in routers.glob("*.py"):
+        try:
+            total += len(pattern.findall(p.read_text(encoding="utf-8")))
+        except OSError:
+            continue
+    return total
+
+
 def _wellness_attention_line(line: str) -> bool:
     lower = line.lower()
     attention_markers = (
@@ -1534,6 +1807,7 @@ def main() -> int:
         ("Substrate shape — do cell CTORs carry composition or flat type-markers?", sense_substrate_shape()),
         ("Witness-trace — is the visit-recorder within budget?", sense_witness_trace()),
         ("Deploy lag — is the body's main reach production?", sense_deploy_lag()),
+        ("Kernel-native API — is the transmuted surface breathing (perf/stability/accuracy/transparency/vitality)?", sense_kernel_api()),
     ]
     reading = build_reading(sections)
 


### PR DESCRIPTION
The body brought four endpoints' computational cores live serving `runtime:"inline"` through the warm in-process Form kernel (api/app/routers/utils.py → form_kernel_bridge.serve_via_kernel). This lands the two instruments that sense and attribute that surface, plus the written-down direction toward serving most/all routes through the kernel.

## A) The kernel-native API wellness probe
`sense_kernel_api()` in `scripts/wellness_check.py` — ONE sensing mechanism (kernel-served routes as DATA) across the five dimensions Urs named:

- **Vitality** — kernel-served vs total routes (4/766 today) + the growth edge.
- **Stability** — production `/api/health.kernel_runtime` + each endpoint's live `runtime`; NAMES any `python-fallback` (the exact drift that hid for a deploy).
- **Performance** — local `trace` walk per recipe; flags an order-of-magnitude regression or a degrade off the fast carrier; points at the readiness harness for the precise p50.
- **Accuracy** — value-parity vs the documented anchors (16185 / 7 / 2 / 0.8125); a kernel serving the WRONG value is caught.
- **Transparency** — confirms the attribution/trace signal is present (hot Blueprints + natives resolved to NodeIDs).

Quiet when healthy ("breathing within envelope — no action needed"); specific on drift. Degrades gracefully like `sense_deploy_lag` — senses locally + from the readiness doc when no kernel/network is reachable, and says what it couldn't reach. Verified: `python3 scripts/wellness_check.py` exits 0, the probe lands in `what_can_compost` when healthy.

## B) The attribution-activity view
`scripts/kernel_attribution_report.py` — runs the kernel-served recipes through the kernel's `trace` mode and aggregates arm / function / native attribution into a ranked view:

- **Hot Blueprints** (arm-dispatch categories): IDENT 328, FNCALL 176, BLOCK.LET 97 …
- **Hot Recipes** (Form functions): `_for_0` 11, `weighted_score` 6 …
- **Hot natives**, each resolved to its Blueprint NodeID: `_plus → @1.2.27.1`, `len → @1.2.15.1` …
- **Inert natives** (registered, never fired across these routes — the "why here, not involved?" list): `fetch, split, str_to_float, to_json, map, filter, …`

Routes are DATA (`KERNEL_SERVED_RECIPES`); the view widens one row per transmuted route. Honest coverage: 4/4 today (the pure-compute cores); full per-route Recipe/Cell activity needs more routes transmuted — named, not faked.

## Direction
`kernels/API_KERNEL_READINESS.md` gains **"Toward full kernel-native routing + attribution"**: most/all routes through the kernel → full attribution → the activity view (hot Blueprints/Recipes/Cells vs inert ones). The path: transmute routes incrementally (each earns value parity), the wellness probe guards the surface, the activity view grows with coverage.

## Scope / no-regression
- Scripts + doc only — **no deploy needed**, no endpoint/dispatch/evaluator touched.
- `wellness_check.py` runs clean (exit 0) with the probe added.
- Only four files: wellness_check.py, kernel_attribution_report.py, scripts/INDEX.md (new-script edge), API_KERNEL_READINESS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)