### PR TITLE
tend(attribution): embodiment projection — fired NodeIDs toward the body's lived center

### DIFF
--- a/docs/vision-kb/concepts/lc-the-trace-is-the-memory.md
+++ b/docs/vision-kb/concepts/lc-the-trace-is-the-memory.md
@@ -98,15 +98,19 @@ through lived execution** — `|projection| → 0` is the readout.
 The `kernel_attribution_report` ([`lc-the-body-senses-itself`](lc-the-body-senses-itself.md))
 today ranks hot Blueprints by re-running recipes and counting arm
 dispatches. That is a snapshot of *frequency*, computed fresh each time.
-This concept names what it should become:
+This concept names what it should become — and move (3) is now a working
+readout over that snapshot:
 
 - **From snapshot to memory.** The trace is recorded as edge-events, not
   recomputed. The body remembers its execution rather than re-deriving it.
+  *(Still the named next build — the snapshot evaporates after each run.)*
 - **From count to convergence.** "This Blueprint fired 176 times" becomes
-  "these categories have converged toward shared value-equivalence
-  (`|projection|` small); these others fired but stayed far; these never
-  fired at all (projection undefined — inert, the *why are you here?*
-  candidates)."
+  "these categories project nearest the activity-weighted center
+  (`|projection|` small); these others fired but sit farther in NodeID
+  space; these never fired at all (projection undefined — inert, the *why
+  are you here?* candidates)." *This is live now in
+  `embodiment_projection` — over the current snapshot, not yet the
+  accumulated edge-event memory.*
 - **From frequency to embodiment.** A category can fire often and still
   not be embodied *with* the body's center if it never converges toward
   the categories that carry the live practice. Convergence-toward-zero,
@@ -188,10 +192,20 @@ convergence off the accumulation.
   NodeIDs. That distance is the embodiment scalar's first concrete form;
   the projection toward zero generalizes it across a category's accumulated
   edge-events.
-- **`scripts/kernel_attribution_report.py`** — the current snapshot
-  attribution view. This concept names its evolution: from recomputed
-  frequency-count to persisted per-category edge-event memory with a
-  convergence projection.
+- **`scripts/kernel_attribution_report.py`** — the snapshot attribution view,
+  now carrying **move (3) as a working instrument**: its `embodiment_projection`
+  reads the activity-weighted centroid of the fired Blueprint NodeIDs as the
+  body's lived center and projects each fired category to its Manhattan
+  NodeID-distance from that center (the `/api/utils/nodeid_distance` metric
+  reused, not re-invented). `|projection| → 0` marks the categories nearest the
+  structural center of what actually fires; the inert natives form the
+  *projection-undefined* class (zero edge-events — the "why are you here?"
+  candidates). Honest scope: this is the projection over the **current
+  snapshot** (per-Blueprint fire counts recomputed each run). Moves (1) and (2)
+  — persisting each trace as an edge-event so the memory accumulates across
+  runs, and the per-category co-firing query that learns value-equivalence from
+  that accumulation — are the named next build. Run `python3
+  scripts/kernel_attribution_report.py` to see the ranked projection.
 
 The body holds this concept as **the correction that turns the attribution
 view from a snapshot into memory.** Today the body re-runs its recipes to

--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -545,6 +545,14 @@ why is it here?"
    "why here, not involved?" candidates. **The view widens by one row per
    transmuted route** — routes are DATA in `KERNEL_SERVED_RECIPES`; adding a
    transmuted route to that list extends the activity view with no code change.
+   The report also carries an **embodiment projection**
+   ([`lc-the-trace-is-the-memory`](../docs/vision-kb/concepts/lc-the-trace-is-the-memory.md),
+   move 3): each fired Blueprint NodeID is projected to its Manhattan distance
+   from the activity-weighted NodeID centroid (the `/api/utils/nodeid_distance`
+   metric reused), so `|projection| → 0` names the categories nearest the
+   structural center of what fires, and the inert natives form the
+   projection-undefined class. Honest scope: snapshot projection now; the
+   persisted per-category edge-event memory is the named next build.
 
 ### The capability ledger — what's banked, what gates the rest
 

--- a/scripts/kernel_attribution_report.py
+++ b/scripts/kernel_attribution_report.py
@@ -402,12 +402,19 @@ def aggregate() -> dict:
             "blueprint": native_blueprint(name),
         }
 
+    inert = _inert_natives(set(native_counts))
     return {
         "per_recipe": per_recipe,
         "arms": dict(arm_counts),
         "functions": dict(fn_counts),
         "natives": natives_with_bp,
-        "inert_natives": _inert_natives(set(native_counts)),
+        "inert_natives": inert,
+        # Embodiment projection (lc-the-trace-is-the-memory, move 3): the fired
+        # Blueprint NodeIDs projected toward the activity-weighted center;
+        # |projection| -> 0 = the body's lived structural center. The inert
+        # block carries the undefined-projection class.
+        "embodiment": embodiment_projection(natives_with_bp),
+        "embodiment_inert": embodiment_inert(natives_with_bp, inert),
         "reached": reached,
         "eligible": len(KERNEL_SERVED_RECIPES),
     }
@@ -443,6 +450,178 @@ def _inert_natives(fired: set[str]) -> list[str]:
     return sorted(_REGISTERED_NATIVES_SAMPLE - fired)
 
 
+# ---------------------------------------------------------------------------
+# Embodiment projection — lc-the-trace-is-the-memory, move (3).
+#
+# The concept: categories genuinely embodied — co-fired by real execution —
+# develop a shared value-equivalence whose scalar projection approaches zero;
+# inert categories (registered, never fired) stay far / undefined. This is the
+# working instrument over the CURRENT attribution snapshot. It reuses the
+# body's OWN structural distance — the Manhattan distance over the NodeID
+# 4-tuple (pkg, level, type, instance) that /api/utils/nodeid_distance
+# computes (see endpoint_nodeid_distance_demo.py / utils.nodeid_distance_py) —
+# rather than inventing a new metric. Core-abstraction-first: ONE projection
+# mechanism over the fired Blueprint NodeIDs as DATA.
+#
+# Honest scope (printed, not buried): this projects over the per-Blueprint
+# fire counts the report already aggregates — a snapshot, not yet the
+# persisted edge-event memory the concept names as the larger next build.
+# What it measures is real: structural distance from the activity-weighted
+# center of what actually fires. What it is NOT: a record that accumulates
+# across runs (each run recomputes the snapshot), nor a value-equivalence
+# learned from co-firing history (that needs the edge-event ledger).
+# ---------------------------------------------------------------------------
+
+
+def _parse_nodeid(nid: str | None) -> tuple[int, int, int, int] | None:
+    """Parse a Blueprint NodeID string '@pkg.level.type.inst' to a 4-tuple."""
+    if not nid or not nid.startswith("@"):
+        return None
+    parts = nid[1:].split(".")
+    if len(parts) != 4:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
+    except ValueError:
+        return None
+
+
+def _nodeid_distance(
+    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+) -> float:
+    """Manhattan distance over the NodeID 4-tuple — the body's own metric.
+
+    Identical shape to utils.nodeid_distance_py / endpoint_nodeid_distance_demo:
+    sum of absolute differences across (pkg, level, type, instance). Floats are
+    allowed because the embodied center is an activity-weighted centroid (a
+    mean position), not a discrete lattice node.
+    """
+    return sum(abs(a[i] - b[i]) for i in range(4))
+
+
+def embodiment_projection(natives: dict) -> dict:
+    """Project each fired Blueprint NodeID category toward the embodied center.
+
+    Input: the ``natives`` map from ``aggregate()`` — {native_name -> {count,
+    blueprint}}. Natives sharing a Blueprint NodeID ARE one category
+    (content-addressing: same structure, same query key), so the projection's
+    primary unit is the distinct fired NodeID, with its member natives and
+    total fire-count.
+
+    The embodied center is the **activity-weighted centroid** of the fired
+    NodeID 4-tuples — each NodeID weighted by its total fire-count. It is the
+    "center of mass of what fires": the structural position the bulk of live
+    execution clusters around. The projection of a category is its Manhattan
+    NodeID-distance from that centroid (the body's own nodeid_distance shape).
+
+    The honest property the concept demands holds: ``|projection| -> 0`` for
+    the categories structurally closest to the activity center, which are the
+    ones the highest-fire natives belong to; categories farther in NodeID
+    space project larger. Inert categories are handled separately by
+    ``embodiment_inert`` — zero edge-events means projection **undefined**, a
+    distinct class, never ranked near zero by coordinate accident.
+
+    Returns:
+      - center:    [pkg, level, type, inst] activity-weighted centroid (floats)
+      - total_fires: total fire-count across all fired NodeIDs (the weight sum)
+      - categories: [{blueprint, nodeid, fires, share, projection, natives}]
+                    sorted by projection ascending (most-embodied first).
+    """
+    # Collapse natives -> distinct fired Blueprint NodeIDs (the categories).
+    by_node: dict[str, dict] = {}
+    for name, info in natives.items():
+        bp = info.get("blueprint")
+        tup = _parse_nodeid(bp)
+        if tup is None:
+            # A fired native whose NodeID won't resolve has no structural
+            # position — it can't be projected. Honest: skip from the geometric
+            # projection (it still appears in the hot-natives section).
+            continue
+        slot = by_node.setdefault(
+            bp, {"nodeid": tup, "fires": 0, "natives": []}
+        )
+        slot["fires"] += int(info.get("count", 0))
+        slot["natives"].append(name)
+
+    if not by_node:
+        return {"center": None, "total_fires": 0, "categories": []}
+
+    total = sum(s["fires"] for s in by_node.values()) or 1
+    center = tuple(
+        sum(s["nodeid"][i] * s["fires"] for s in by_node.values()) / total
+        for i in range(4)
+    )
+
+    categories: list[dict] = []
+    for bp, s in by_node.items():
+        categories.append(
+            {
+                "blueprint": bp,
+                "nodeid": list(s["nodeid"]),
+                "fires": s["fires"],
+                "share": round(s["fires"] / total, 4),
+                "projection": round(_nodeid_distance(s["nodeid"], center), 4),
+                "natives": sorted(s["natives"]),
+            }
+        )
+    # Most-embodied first: smallest |projection|, ties broken by more fires.
+    categories.sort(key=lambda c: (c["projection"], -c["fires"]))
+
+    return {
+        "center": [round(c, 4) for c in center],
+        "total_fires": total,
+        "categories": categories,
+    }
+
+
+def embodiment_inert(natives: dict, inert_names: list[str]) -> dict:
+    """The inert class — registered natives that never fired.
+
+    The concept's "no edge-events -> projection undefined" partition: these are
+    not ranked near zero, they are far-by-definition. Where a NodeID resolves,
+    we report its structural distance from the embodied center FOR CONTEXT (so
+    an operator can see how far out the never-fired tissue sits), but the
+    projection itself stays ``None`` — undefined — because zero activity means
+    the category has not converged toward anything. Where no NodeID resolves,
+    the native carries no structural position at all: the purest "why are you
+    here, never involved?" candidate.
+
+    Needs the projection's center, so the caller passes the fired ``natives``
+    to recompute it (cheap; keeps this function pure over its inputs).
+    """
+    proj = embodiment_projection(natives)
+    center = proj["center"]
+    rows: list[dict] = []
+    for name in inert_names:
+        bp = native_blueprint(name)
+        if bp == "null":  # the kernel's sentinel for an uncatalogued native
+            bp = None
+        tup = _parse_nodeid(bp)
+        dist = (
+            round(_nodeid_distance(tup, tuple(center)), 4)
+            if (tup is not None and center is not None)
+            else None
+        )
+        rows.append(
+            {
+                "native": name,
+                "blueprint": bp,
+                "nodeid": list(tup) if tup else None,
+                "projection": None,  # undefined: zero edge-events
+                "structural_distance": dist,  # context only, not the projection
+            }
+        )
+    # Resolvable ones first (sorted by structural distance), unresolvable last.
+    rows.sort(
+        key=lambda r: (
+            r["structural_distance"] is None,
+            r["structural_distance"] if r["structural_distance"] is not None else 0.0,
+            r["native"],
+        )
+    )
+    return {"center": center, "inert": rows}
+
+
 def _ranked(counts: dict, top: int | None) -> list[tuple]:
     items = sorted(counts.items(), key=lambda kv: (-_count_of(kv[1]), kv[0]))
     return items[:top] if top else items
@@ -450,6 +629,11 @@ def _ranked(counts: dict, top: int | None) -> list[tuple]:
 
 def _count_of(value) -> int:
     return value["count"] if isinstance(value, dict) else int(value)
+
+
+def _ranked_categories(categories: list[dict], top: int | None) -> list[dict]:
+    """Embodiment categories are pre-sorted by projection; apply --top only."""
+    return categories[:top] if top else categories
 
 
 def render(report: dict, top: int | None) -> str:
@@ -504,6 +688,78 @@ def render(report: dict, top: int | None) -> str:
     for name, info in _ranked(report["natives"], top):
         bp = info.get("blueprint") or "?"
         out.append(f"  {info['count']:>6}  {name:<16} {bp}")
+    out.append("")
+
+    # Embodiment projection — lc-the-trace-is-the-memory, move (3).
+    emb = report.get("embodiment") or {}
+    out.append("## Embodiment projection (|projection| → 0 = the body's lived center)")
+    out.append("")
+    if emb.get("categories"):
+        center = emb["center"]
+        center_str = ".".join(f"{c:g}" for c in center)
+        out.append(
+            f"  Embodied center (activity-weighted NodeID centroid of {emb['total_fires']} "
+            f"fires): @{center_str}"
+        )
+        out.append(
+            "  Each fired Blueprint NodeID category projected to its Manhattan"
+        )
+        out.append(
+            "  distance from that center (the body's own nodeid_distance metric)."
+        )
+        out.append(
+            "  Smaller = nearer the structural center of what actually fires."
+        )
+        out.append("")
+        out.append("    proj  fires  share  Blueprint    natives")
+        for c in _ranked_categories(emb["categories"], top):
+            members = ", ".join(c["natives"])
+            out.append(
+                f"    {c['projection']:>6.3f}  {c['fires']:>4}  {c['share']:>5.3f}  "
+                f"{c['blueprint']:<11}  {members}"
+            )
+        out.append("")
+        # The inert / undefined-projection class.
+        inert_block = report.get("embodiment_inert") or {}
+        inert_rows = inert_block.get("inert") or []
+        out.append(
+            "  Inert categories — never fired, projection UNDEFINED (no edge-events):"
+        )
+        out.append(
+            "  the 'why are you here, not involved?' class. structural-dist is"
+        )
+        out.append(
+            "  context only (how far the never-fired tissue sits), NOT a projection."
+        )
+        out.append("")
+        for r in inert_rows:
+            bp = r["blueprint"] or "(no NodeID — no structural position)"
+            sd = r["structural_distance"]
+            sd_str = f"struct-dist {sd:>6.3f}" if sd is not None else "struct-dist     —"
+            out.append(f"    undefined  {sd_str}  {bp:<11}  {r['native']}")
+    else:
+        out.append(
+            "  (no fired Blueprint NodeIDs resolved — projection unavailable)"
+        )
+    out.append("")
+    out.append(
+        "  Honest scope: this projects over the CURRENT attribution snapshot"
+    )
+    out.append(
+        "  (per-Blueprint fire counts recomputed this run), not yet the"
+    )
+    out.append(
+        "  persisted edge-event memory the concept names. It measures structural"
+    )
+    out.append(
+        "  distance from the activity-weighted center of what fires — real, but"
+    )
+    out.append(
+        "  a snapshot. The edge-event ledger (accumulating across runs, learning"
+    )
+    out.append(
+        "  value-equivalence from co-firing history) is the named next build."
+    )
     out.append("")
 
     # Inert — the 'why here, not involved?' candidates.

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1519,6 +1519,7 @@ def sense_kernel_api() -> list[str]:
     missing_recipes: list[str] = []
     slow_recipes: list[str] = []
     attribution_present = False
+    embodiment_center: list | None = None  # lc-the-trace-is-the-memory, move 3
     traced = 0
     if not local_unreached:
         report = attr.aggregate()
@@ -1541,6 +1542,11 @@ def sense_kernel_api() -> list[str]:
         # + natives attributed to NodeIDs). Empty attribution on a surface that
         # ran = the body can't see what it exercised.
         attribution_present = bool(report.get("arms")) and bool(report.get("natives"))
+        # Deeper transparency: the embodiment projection's lived center (the
+        # activity-weighted NodeID centroid). Present = the body can see not
+        # just WHAT fired but which categories sit nearest its execution center.
+        emb = report.get("embodiment") or {}
+        embodiment_center = emb.get("center")
 
     # --- LIVE sensing: prod /api/health + /utils/kernel_status + each endpoint's
     # runtime. Reachability is optional (like sense_deploy_lag) — name what we
@@ -1676,10 +1682,14 @@ def sense_kernel_api() -> list[str]:
             "  transparency: attribution unsensed locally (kernel binary absent)"
         )
     elif attribution_present:
+        center_note = ""
+        if embodiment_center:
+            center_str = ".".join(f"{c:g}" for c in embodiment_center)
+            center_note = f"; embodiment center @{center_str} (|proj|→0 = lived center)"
         lines.append(
             "  transparency: attribution present — hot Blueprints + natives "
             "(each resolved to a NodeID) visible via "
-            "scripts/kernel_attribution_report.py"
+            f"scripts/kernel_attribution_report.py{center_note}"
         )
     else:
         lines.append(


### PR DESCRIPTION
Turns `lc-the-trace-is-the-memory` move (3) — *embodiment is a scalar projection toward zero* — into a working read-only instrument in `scripts/kernel_attribution_report.py`, over the data the report already aggregates (per-Blueprint fire counts + NodeIDs).

## The projection (honest, grounded)
- **Embodied center** = the **activity-weighted centroid** of the fired Blueprint NodeID 4-tuples — each NodeID weighted by its total fire-count. The "center of mass of what fires."
- **Projection per category** = Manhattan NodeID-distance from that center, **reusing the body's own `/api/utils/nodeid_distance` metric** (sum of abs differences over `(pkg, level, type, inst)`), not a new ad-hoc one. `|projection| → 0` = nearest the structural center of live execution.
- **Inert categories** = registered-but-never-fired natives → **projection UNDEFINED** (zero edge-events), a distinct class — never ranked near zero by coordinate accident. Resolvable NodeIDs show a `structural_distance` for context only; uncatalogued ones carry no structural position (the purest "why are you here?").

## Sanity check (real numbers)
`_plus` (arithmetic `@1.2.27.1`, 111 fires — the single most-fired native) projects nearest at **1.64**; list/block `@1.2.34.1` at 8.64; subscript `@1.2.15.1` at 10.36. Highest-activity → near zero, inert → far/undefined. Ranking is honest.

## Honest scope
Snapshot projection now (fire counts recomputed each run). The persisted per-category **edge-event memory** the concept names (moves 1–2) is the larger next build — stated in code, report output, and the concept doc.

## Changes
- `kernel_attribution_report.py`: `embodiment_projection()` + `embodiment_inert()` over fired/inert natives as DATA; text + `--json` + `--top` sections added; existing sections intact.
- `wellness_check.py`: transparency line carries the embodiment center.
- `lc-the-trace-is-the-memory.md` + `API_KERNEL_READINESS.md`: move 3 marked implemented over the snapshot; edges current.

## No-regression
- Report runs; `--json` valid; `--top` honored.
- `wellness_check.py` clean (kernel-native surface breathing; blueprint scan stays healed).
- No kernel/route change — 19 routes unbroken; no `.fk` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)