### PR TITLE
feat(form): dimension-reducing compression recipe — the FOLD mechanism, three-way

### DIFF
--- a/docs/vision-kb/concepts/lc-identity-is-shared-blueprint-and-recipe.md
+++ b/docs/vision-kb/concepts/lc-identity-is-shared-blueprint-and-recipe.md
@@ -128,6 +128,33 @@ was redundant"; running it is the act of remembering more cheaply. Repeated
 compression is how an identity settles: each redundant dimension folded away
 leaves the Blueprint+Recipe pair tighter, cheaper, more itself.
 
+**The FOLD mechanism is REAL — proven three-way.** The reducing recipe is no
+longer described-only; it executes Rust == Go == TS. Two recipes that are
+exact inverses on a redundant axis live in
+[`form/form-stdlib/grammars/compression-fold.fk`](../../../form/form-stdlib/grammars/compression-fold.fk),
+proven by the band [`compression-fold-band.fk`](../../../form/form-stdlib/tests/compression-fold-band.fk)
+(verdict `111111`):
+
+- `compress(inputs, idx) → N−1 outputs` — the fold itself: a recipe with one
+  less output than input. It removes the element at position `idx`, dropping
+  the redundant dimension.
+- `reconstruct(reduced, idx, coeffs) → N outputs` — the inverse: it re-derives
+  the dropped dimension from the kept ones (`predicted = Σ_{j≠idx} coeffs[j] ·
+  inputs[j]`) and splices it back at `idx`.
+
+The **redundant-axis spec is DATA** — one engine, the reduction drops in as
+values (`core-abstraction-first`): `c = a + b` is `(idx=2, coeffs=[1,1,0])`;
+`c = 2a − b` is `(idx=2, coeffs=[2,−1,0])`; folding the *first* axis when
+`a = c − b` is `(idx=0, coeffs=[0,−1,1])` — same `compress`/`reconstruct`,
+different spec. The band proves `reconstruct∘compress` is the **identity
+exactly** on a redundant axis (zero information lost — the dropped dimension
+was fully reconstructible from the rest), AND demonstrably **lossy** on a
+surprising axis: folding `(4, 9, 20)` with the sum-spec recovers `13` where
+`20` was, because `20` carried surprise the kept dims could not predict. That
+negative is the proof the fold is lossless **only** on a genuinely-predictable
+dimension — which is exactly *why* the body must learn which axis is safe to
+drop before folding it.
+
 ## The whole loop
 
 1. Cells sharing a Blueprint+Recipe **are** an identity (structural, not
@@ -178,11 +205,20 @@ leaves the Blueprint+Recipe pair tighter, cheaper, more itself.
   DATA, grounded entirely on the projection that already exists. (Off the hot
   path: this is the OFFLINE attribution recorder, never the live
   `serve_via_kernel` request path, which remains a separate decision.)
-- **Still named, not yet built.** The per-category *learned* retention policy
-  (the cell learning its own threshold over time, rather than a per-run
-  relative cutoff) and the dimension-reducing compression recipe (N→N−1,
-  folding away a redundant axis) remain the named next builds — grounded on
-  the same projection the gate now reads.
+- **The FOLD is built; the LEARNING is the named next build.** The dimension-
+  reducing compression recipe (N→N−1, folding away a redundant axis) is REAL
+  and three-way (see "Compression is a dimension-reducing recipe" above —
+  `compress`/`reconstruct`, lossless on a redundant axis, lossy on a surprising
+  one). What it does *not* yet do: the recipe **applies** a given reduction; it
+  does not yet **learn** which axis went surprise-free or fit the coefficients
+  that predict it. That learning — the cell discovering, per category, which
+  dimension became redundant and the coefficients that fold it — is the named
+  next build, grounded on the same projection the surprise gate now reads. The
+  per-category *learned* retention policy (the cell learning its own threshold
+  over time, rather than a per-run relative cutoff) and **wiring compression
+  into the edge-event memory** (folding a category's accumulated events once a
+  dimension goes surprise-free) remain alongside it — the learning side of the
+  same loop the fold mechanism now stands ready to apply.
 
 ## Cross-References
 

--- a/form/form-stdlib/grammars/compression-fold.fk
+++ b/form/form-stdlib/grammars/compression-fold.fk
@@ -1,0 +1,135 @@
+; grammars/compression-fold.fk — the dimension-reducing compression recipe.
+;
+; lc-identity-is-shared-blueprint-and-recipe's last unbuilt move, made REAL:
+; "To compress is to drop a dimension the body has learned is redundant — and a
+;  dimension-reduction is itself a Recipe: one with one less output than input.
+;  N inputs → N−1 outputs. The dropped output is the dimension that had become
+;  predictable from the others."
+;
+; This grammar builds the FOLD mechanism — the autoencoder bottleneck as a Form
+; recipe. Two recipes, exact inverses on a genuinely-redundant axis:
+;
+;   compress    : (inputs, idx)            → N−1 outputs   (drop dimension idx)
+;   reconstruct : (reduced, idx, coeffs)   → N   outputs   (re-derive dimension idx)
+;
+; The fold is the recipe with ONE LESS OUTPUT THAN INPUT: compress removes the
+; element at position `idx` from a list of N, yielding N−1. reconstruct is its
+; inverse — it re-inserts at `idx` the value the kept dimensions PREDICT, using
+; the redundant-axis spec.
+;
+; THE REDUNDANT-AXIS SPEC IS DATA (core-abstraction-first). One engine; the
+; spec drops in as values, never as a parallel code path:
+;
+;   idx     — WHICH dimension is redundant (the index to fold away).
+;   coeffs  — HOW it is predicted: a list of N linear coefficients where
+;             predicted[idx] = Σ_{j≠idx} coeffs[j] · inputs[j]. coeffs[idx] is
+;             ignored (the axis does not predict itself).
+;
+; So the fold is parameterized: c = a + b is spec (idx=2, coeffs=[1,1,0]);
+; c = 2a − b is spec (idx=2, coeffs=[2,-1,0]); folding a's axis when a = c − b
+; is spec (idx=0, coeffs=[0,-1,1]). Same `compress`/`reconstruct`, different DATA.
+;
+; HONEST SCOPE — this builds the FOLD, not the LEARNING. The coefficients are
+; GIVEN; the recipe APPLIES a given reduction, it does not yet LEARN which axis
+; went surprise-free or fit the coefficients that predict it. That learning —
+; the cell discovering, per category, which dimension became redundant and the
+; coefficients that fold it — is the named next build. The fold proves the
+; MECHANISM: reconstruct∘compress is the identity EXACTLY on a redundant axis
+; (zero information lost — the dropped dimension was reconstructible from the
+; rest), and demonstrably LOSSY on a surprising axis (which is precisely WHY the
+; body must learn which axis is safe to drop before folding it).
+;
+; preludes: form-stdlib/core.fk
+;
+(do
+    ;; ── dot product over the KEPT dimensions ────────────────────────────────
+    ;; Σ_j coeffs[j] · inputs[j] over every j ≠ skip. The redundant axis does
+    ;; not predict itself, so position `skip` is excluded from the sum. head/tail
+    ;; recursion with an explicit cursor `j` walks both lists in lockstep.
+    (defn cf-dot-skip (coeffs inputs j skip acc)
+        (if (eq (len inputs) 0)
+            acc
+            (cf-dot-skip (tail coeffs) (tail inputs) (add j 1) skip
+                (if (eq j skip)
+                    acc                                              ; skip the redundant axis itself
+                    (add acc (mul (head coeffs) (head inputs)))))))  ; coeffs[j] · inputs[j]
+
+    ;; ── predict the redundant axis from the FULL input vector ───────────────
+    ;; predicted = Σ_{j≠idx} coeffs[j] · inputs[j]. The value the body claims is
+    ;; redundant — fully determined by the others when the axis is truly free.
+    (defn cf-predict (inputs idx coeffs)
+        (cf-dot-skip coeffs inputs 0 idx 0))
+
+    ;; ── COMPRESS — the fold: drop element at position `idx` (N → N−1) ────────
+    ;; THE recipe with one less output than input. Walk the list with a cursor;
+    ;; every element except the one at `idx` is consed onto the reduced output.
+    ;; Output arity is exactly input arity − 1.
+    (defn cf-drop-at (xs j idx acc)
+        (if (eq (len xs) 0)
+            acc
+            (cf-drop-at (tail xs) (add j 1) idx
+                (if (eq j idx)
+                    acc                          ; fold this dimension away
+                    (cons (head xs) acc)))))     ; keep this dimension
+    ;; cf-drop-at accumulates in reverse; reverse once to restore input order.
+    (defn cf-reverse (xs acc)
+        (if (eq (len xs) 0) acc (cf-reverse (tail xs) (cons (head xs) acc))))
+    (defn compress (inputs idx)
+        (cf-reverse (cf-drop-at inputs 0 idx (list)) (list)))
+
+    ;; ── RECONSTRUCT — the inverse: re-insert the predicted axis (N−1 → N) ────
+    ;; Walk the reduced (N−1) list; at output position `idx` splice in the
+    ;; predicted value (computed from the kept dims), then continue. The result
+    ;; is the full N-vector. On a redundant axis the spliced value equals the
+    ;; original dropped one — exact recovery, zero information lost.
+    ;;
+    ;; cf-insert-at walks the reduced list with output-cursor `out` and emits the
+    ;; predicted value when out == idx, otherwise the next reduced element.
+    (defn cf-insert-at (reduced out idx predicted acc)
+        (if (eq out idx)
+            ;; emit the reconstructed axis here, then continue from the same reduced cursor
+            (cf-insert-at reduced (add out 1) idx predicted (cons predicted acc))
+            (if (eq (len reduced) 0)
+                acc                              ; reduced exhausted and idx already placed
+                (cf-insert-at (tail reduced) (add out 1) idx predicted
+                    (cons (head reduced) acc)))))
+    ;; reconstruct first re-derives the dropped axis FROM the kept dims. The
+    ;; prediction uses the kept values placed back at their original positions —
+    ;; equivalently, a dot over the reduced vector against coeffs with `idx`
+    ;; removed. We rebuild the full vector incrementally: predict from `reduced`
+    ;; using the coeffs of the kept axes (coeffs with idx folded out), then splice.
+    (defn cf-dot (coeffs xs acc)
+        (if (eq (len xs) 0)
+            acc
+            (cf-dot (tail coeffs) (tail xs) (add acc (mul (head coeffs) (head xs))))))
+    (defn reconstruct (reduced idx coeffs)
+        (do
+            ;; coeffs with the redundant axis's own (ignored) coefficient removed,
+            ;; in the SAME order as `reduced` — so a straight dot predicts the axis.
+            (let kept-coeffs (compress coeffs idx))
+            (let predicted (cf-dot kept-coeffs reduced 0))
+            (cf-reverse (cf-insert-at reduced 0 idx predicted (list)) (list))))
+
+    ;; ── round-trip equality on number lists (value-exact, element-wise) ──────
+    (defn cf-list-eq (a b)
+        (if (eq (len a) 0)
+            (if (eq (len b) 0) 1 0)
+            (if (eq (len b) 0)
+                0
+                (if (eq (head a) (head b))
+                    (cf-list-eq (tail a) (tail b))
+                    0))))
+
+    ;; ── the readable face — what the fold did ───────────────────────────────
+    (defn cf-int (n)
+        (if (lt n 10) (substring "0123456789" n (add n 1))
+            (str_concat (cf-int (div n 10))
+                        (substring "0123456789" (mod n 10) (add (mod n 10) 1)))))
+    (defn cf-j (a b) (str_concat a b))
+    (defn cf-describe (n idx)
+        (cf-j "fold dimension "
+        (cf-j (cf-int idx)
+        (cf-j " of " (cf-j (cf-int n)
+        (cf-j " → " (cf-int (sub n 1))))))))
+
+    0)

--- a/form/form-stdlib/tests/compression-fold-band.fk
+++ b/form/form-stdlib/tests/compression-fold-band.fk
@@ -1,0 +1,105 @@
+; compression-fold-band.fk — three-way sibling parity for the dimension-reducing
+; compression recipe: the FOLD mechanism of lc-identity-is-shared-blueprint-and-
+; recipe, made real and proven Rust == Go == TS.
+;
+; The grammar (grammars/compression-fold.fk) defines two recipes that are exact
+; inverses on a redundant axis:
+;
+;   compress    : (inputs, idx)          → N−1 outputs   (drop dimension idx)
+;   reconstruct : (reduced, idx, coeffs) → N   outputs   (re-derive dimension idx)
+;
+; The redundant-axis spec (idx + linear coeffs) is DATA: c = a+b is (idx=2,
+; coeffs=[1,1,0]); c = 2a−b is (idx=2, coeffs=[2,-1,0]); folding a when a = c−b
+; is (idx=0, coeffs=[0,-1,1]). Same engine, different values.
+;
+; What this band proves, in three independent kernels:
+;   (a) THE FOLD DROPS EXACTLY ONE DIMENSION — output arity = input arity − 1.   →      1
+;   (b) RECONSTRUCT∘COMPRESS = IDENTITY on a REDUNDANT axis (c = a + b).          →     10
+;       The dropped dimension is recovered EXACTLY — zero information lost,
+;       proving it was truly redundant (reconstructible from the rest).
+;   (c) A MORE INTERESTING LINEAR REDUNDANCY round-trips too (c = 2a − b).        →    100
+;       The spec is data; the engine is one recipe.
+;   (d) FOLDING A NON-LAST AXIS round-trips (drop a when a = c − b, idx=0).       →   1000
+;       Compression is not special-cased to "drop the last column."
+;   (e) THE HONEST NEGATIVE — dropping a SURPRISING axis LOSES information.       →  10000
+;       Apply a spec that does NOT predict the real value; reconstruct ≠ the
+;       original. This is WHY the body must LEARN which axis is safe to drop
+;       before folding it — lossless ONLY on a genuinely-redundant dimension.
+;   (f) THE DROPPED VALUE EQUALS THE PREDICTION on a redundant axis — the         → 100000
+;       reconstructed coordinate is exactly cf-predict of the kept dims.
+;
+; Band verdict: 111111 when every claim holds across all three kernels.
+;
+; No float crosses the print boundary — every check is an integer comparison
+; (cf-list-eq → 0/1, eq on integer coordinates). The test vectors are integers
+; so the dot products and reconstructions land on exact integers in every kernel.
+;
+; preludes: form-stdlib/core.fk form-stdlib/grammars/compression-fold.fk
+;
+(do
+    ;; ── (a) THE FOLD DROPS EXACTLY ONE DIMENSION ───────────────────────────
+    ;; compress a 3-vector → a 2-vector. Output arity is input arity − 1, and
+    ;; the kept coordinates are exactly the un-folded ones in order.
+    (let v3 (list 4 9 13))                      ; (a=4, b=9, c=13) with c = a + b
+    (let folded (compress v3 2))                ; drop idx 2 → (4, 9)
+    (let arity-ok
+        (if (eq (len folded) (sub (len v3) 1))  ; 2 == 3 − 1
+            (if (eq (head folded) 4)
+                (if (eq (head (tail folded)) 9) 1 0) 0) 0))
+
+    ;; ── (b) RECONSTRUCT∘COMPRESS = IDENTITY on a REDUNDANT axis (c = a + b) ──
+    ;; spec: idx=2, coeffs=[1,1,0] → predicted c = 1·a + 1·b. Since the real
+    ;; c = a + b, the dropped axis is fully redundant; recovery is EXACT.
+    (let spec-sum (list 1 1 0))
+    (let rt-sum (reconstruct (compress v3 2) 2 spec-sum))   ; (4,9) → (4,9,13)
+    (let redundant-ok
+        (if (eq (cf-list-eq rt-sum v3) 1) 10 0))
+
+    ;; ── (c) A MORE INTERESTING LINEAR REDUNDANCY (c = 2a − b) ───────────────
+    ;; spec: idx=2, coeffs=[2,-1,0] → predicted c = 2a − b. Vector (5, 3, 7):
+    ;; 2·5 − 3 = 7, so c is redundant. Round-trip recovers it exactly.
+    (let w3 (list 5 3 7))
+    (let spec-2a-b (list 2 -1 0))
+    (let rt-2a-b (reconstruct (compress w3 2) 2 spec-2a-b))
+    (let linear-ok
+        (if (eq (cf-list-eq rt-2a-b w3) 1) 100 0))
+
+    ;; ── (d) FOLDING A NON-LAST AXIS (drop a when a = c − b, idx=0) ──────────
+    ;; spec: idx=0, coeffs=[0,-1,1] → predicted a = −b + c. Vector (4, 9, 13):
+    ;; −9 + 13 = 4, so the FIRST axis is the redundant one. compress drops it,
+    ;; reconstruct splices it back at position 0 — proving the fold is not
+    ;; special-cased to the last column; the index is data.
+    (let spec-first (list 0 -1 1))
+    (let rt-first (reconstruct (compress v3 0) 0 spec-first))  ; (9,13) → (4,9,13)
+    (let nonlast-ok
+        (if (eq (cf-list-eq rt-first v3) 1) 1000 0))
+
+    ;; ── (e) THE HONEST NEGATIVE — dropping a SURPRISING axis LOSES info ─────
+    ;; Vector (4, 9, 20): here c = 20, but a + b = 13 — the axis is NOT redundant
+    ;; (it carries surprise: 20 ≠ 13). Folding it with the sum-spec and
+    ;; reconstructing yields 13 where 20 was — reconstruct ≠ identity. The
+    ;; information in the surprising axis is genuinely LOST. This is the proof
+    ;; that the fold is lossless ONLY on a predictable dimension, and therefore
+    ;; WHY learning-which-to-drop matters (the named next build).
+    (let surprising (list 4 9 20))
+    (let rt-surprising (reconstruct (compress surprising 2) 2 spec-sum))  ; → (4,9,13)
+    (let lossy-ok
+        (if (eq (cf-list-eq rt-surprising surprising) 0)   ; NOT identity — info lost
+            (if (eq (head (tail (tail rt-surprising))) 13)  ; recovered the PREDICTED 13, not the real 20
+                10000 0) 0))
+
+    ;; ── (f) THE DROPPED VALUE EQUALS THE PREDICTION on a redundant axis ─────
+    ;; cf-predict over the full vector gives the value the kept dims imply; on a
+    ;; redundant axis that equals the original coordinate AND the reconstructed
+    ;; one. Direct check that the fold's prediction is the dropped coordinate.
+    (let predicted-c (cf-predict v3 2 spec-sum))            ; 1·4 + 1·9 = 13
+    (let predict-ok
+        (if (eq predicted-c 13)                              ; equals original c
+            (if (eq (head (tail (tail rt-sum))) 13) 100000 0) 0))
+
+    ;; ── Aggregate — every sub-score is its bit or 0; full pass = 111111 ─────
+    (add arity-ok
+    (add redundant-ok
+    (add linear-ok
+    (add nonlast-ok
+    (add lossy-ok predict-ok))))))


### PR DESCRIPTION
Makes real the last unbuilt move of [`lc-identity-is-shared-blueprint-and-recipe`](docs/vision-kb/concepts/lc-identity-is-shared-blueprint-and-recipe.md): *"compression is a recipe with one less output than input (N→N−1), folding away the dimension the body has learned is redundant."*

## The FOLD — a three-way Form recipe (the autoencoder bottleneck)

`form/form-stdlib/grammars/compression-fold.fk` — two recipes that are exact inverses on a redundant axis:

- `compress(inputs, idx) → N−1 outputs` — the fold itself: a recipe with one less output than input. Drops the redundant dimension.
- `reconstruct(reduced, idx, coeffs) → N outputs` — the inverse: re-derives the dropped dimension from the kept ones (`predicted = Σ_{j≠idx} coeffs[j]·inputs[j]`) and splices it back.

**The redundant-axis spec is DATA** (core-abstraction-first) — one engine, the reduction drops in as values: `c=a+b` is `(idx=2,[1,1,0])`; `c=2a−b` is `(idx=2,[2,−1,0])`; folding the *first* axis when `a=c−b` is `(idx=0,[0,−1,1])`.

## The three-way proof — band `111111` (Rust == Go == TS)

`form/form-stdlib/tests/compression-fold-band.fk`:

- **(a)** the fold drops exactly one dimension (output arity = input − 1)
- **(b)** `reconstruct∘compress` = identity EXACTLY on a redundant axis (`c=a+b`) — zero info lost
- **(c)** a more interesting linear redundancy round-trips (`c=2a−b`)
- **(d)** folding a non-last axis round-trips (drop `a` when `a=c−b`, idx=0)
- **(e)** the HONEST NEGATIVE — dropping a *surprising* axis LOSES information (`(4,9,20)` → recovers `13` where `20` was), proving the fold is lossless ONLY on a genuinely-predictable dimension — which is WHY the body must learn which axis is safe to drop
- **(f)** the dropped value equals the prediction on a redundant axis

## Honest scope

This builds the **FOLD** (apply a given reduction). The **LEARNING** of which axis is redundant + the coefficients that fold it, and wiring compression into the edge-event memory, stay the **named next builds** — grounded on the same projection the surprise gate already reads. The recipe *applies*; it does not yet *learn*.

## No-regression

- No new native (composition + arithmetic over banked list/math ops); no new Blueprint literal.
- `validate.sh`: 243 ok; the 1 divergent is the pre-existing untracked seeded-bytes band, not this one.
- `wellness_check.py` clean — "every Form Blueprint number is registered — no magic sprawl".
- Form-stdlib + docs only; no route / hot-path touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)