### PR TITLE
attune(kernel): runtime-surface instrument — CPython vs kernel runtime-share, honestly

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 140 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 141 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -304,6 +304,39 @@ healthy as it grows*, the activity view says *here is what's alive and what's
 inert*. Together they turn "serve everything through the kernel" from a leap
 into a walk — one route at a time, each one sensed and attributed.
 
+## Runtime awareness — usage and runtime-share are distinct axes
+
+The journey is from Python-runtime toward kernel-runtime, so the metric that
+matters is **how much execution runs Form-native**, not how many routes name the
+kernel. Two axes hide inside "kernel-served," and only naming both keeps the
+reading honest:
+
+- **Kernel USAGE** — how many routes call the kernel at all. ~22 of 784 routes
+  (~2.8%) serve their computational core through the kernel.
+- **Python RUNTIME-SHARE** — how much of a request's execution actually leaves
+  CPython. On every kernel-served route the kernel is a **called subroutine
+  inside a CPython request**: FastAPI routes, the params bind, Pydantic
+  validates, `serve_via_kernel` orchestrates (preload, parse, fallback), the
+  kernel walks the recipe, and Pydantic serializes the response — only the
+  recipe walk is Form-native. The request lifecycle stays CPython by design (the
+  eligibility seam above).
+
+These axes move independently, sometimes in opposite directions. Transmuting a
+route raises USAGE and can ADD CPython at the same time: each one lands a FastAPI
+handler, a Pydantic response model, and a value-identical `*_py` fallback, so net
+Python LOC can grow even as more routes touch the kernel. The honest baseline:
+the kernel is a **guest-subroutine, not the runtime or the router** — 0 routes
+are served kernel-FIRST. That zero is the ground the reversal (kernel as the
+front door) moves; runtime-share is the dial that reads the move.
+
+`scripts/runtime_surface_report.py` is the sensing instrument for this axis — it
+reports the route ratio, the per-route CPython-vs-kernel layering, the CPython
+weight in the kernel-router files, and where the body sits on the journey. The
+wellness probe carries the one-line version in its kernel-native vitality
+reading. The attribution view answers *which Blueprints fire*; the runtime-surface
+view answers *how much actually left CPython* — companion instruments, distinct
+questions.
+
 ## Running the evidence
 
 ```bash
@@ -316,6 +349,8 @@ python3 scripts/kernel_readiness_harness.py --json out.json       # machine-read
 python3 scripts/wellness_check.py                 # includes sense_kernel_api (quiet when healthy)
 python3 scripts/kernel_attribution_report.py      # ranked Blueprint/Recipe/native activity + inert list
 python3 scripts/kernel_attribution_report.py --json --top 5   # machine-readable, top-N per section
+python3 scripts/runtime_surface_report.py         # CPython-vs-kernel runtime share — usage vs runtime-share axes
+python3 scripts/runtime_surface_report.py --json  # machine-readable runtime-surface reading
 ```
 
 The readiness harness exits nonzero only on a value-parity failure — slowness is

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 140
+**Total files**: 141
 
 | File | Purpose |
 |---|---|
@@ -101,6 +101,7 @@
 | [run_claude_impl_with_report.py](run_claude_impl_with_report.py) | Run one Claude impl task (pinned spec), wait for terminal state, then write a report. |
 | [run_form_practice.py](run_form_practice.py) | Run any Form practice and record substrate cells plus witness ledger. |
 | [run_pinned_idea_acceptance.py](run_pinned_idea_acceptance.py) | Pinned-idea (portfolio-governance) acceptance: one path, proof at each step. |
+| [runtime_surface_report.py](runtime_surface_report.py) | Runtime-surface report — how much of the API runs in CPython vs the Form kernel. |
 | [scan_code_spec_references.py](scan_code_spec_references.py) | spec: full-code-traceability |
 | [scan_dyad_candidates.py](scan_dyad_candidates.py) | Refined dyad-pair candidate scan over Living Collective concept cells. |
 | [scan_dyad_candidates_word.py](scan_dyad_candidates_word.py) | WORD-domain prose-structural dyad-pair scan over Living Collective concepts. |

--- a/scripts/runtime_surface_report.py
+++ b/scripts/runtime_surface_report.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Runtime-surface report — how much of the API runs in CPython vs the Form kernel.
+
+The sibling instrument to ``kernel_attribution_report.py``. That one answers
+*which Blueprints fire* when the kernel runs. This one answers a different,
+blunter question the body keeps fooling itself about: **how much execution has
+actually left CPython for the Form kernel?**
+
+The honest gap this names
+-------------------------
+"22 routes kernel-served" is true and easy to read as progress. It is also a
+flattering half-truth. Two distinct axes hide inside that one number:
+
+  • **kernel USAGE** — how many routes call the kernel at all (22 of 784, ~2.8%).
+  • **Python RUNTIME-SHARE** — how much of a request's execution actually runs
+    Form-native rather than CPython.
+
+These are NOT the same, and the body must track the second one to honestly
+report the journey from Python-runtime toward kernel-runtime. Even on a
+kernel-served route the kernel is a **called subroutine inside a CPython
+request**, never the runtime:
+
+    FastAPI routes the request           → CPython
+    Query/path params bind + coerce       → CPython
+    Pydantic validates the inputs         → CPython
+    serve_via_kernel orchestrates         → CPython  (preload, parse, fallback)
+        └─ the kernel walks the recipe    → Form-native  ← the ONLY kernel part
+    parse(value) re-wraps to a Py type    → CPython
+    Pydantic builds + serializes response → CPython
+
+The kernel handles the **pure-compute core**; the entire request lifecycle —
+routing, binding, validation, orchestration, response — stays CPython by design
+(the eligibility seam in ``kernels/API_KERNEL_READINESS.md``). So "kernel-served"
+overstates how much runtime left CPython. This report states both numbers and
+the layering between them, so the move toward kernel-runtime tracks the RIGHT
+metric (runtime-share), not just the route count.
+
+The counter-intuitive truth, made concrete
+-------------------------------------------
+Transmuting a route INCREASES kernel usage but can ADD CPython: each transmuted
+route lands a FastAPI handler, a Pydantic response model, AND a value-identical
+``*_py`` fallback (run when no kernel is reachable). The computation moves to the
+kernel; the request lifecycle plus a CPython twin of the math stay in the host.
+Net Python LOC may GROW even as kernel usage grows. This report measures that
+directly: the CPython lines now sitting in the kernel-router files, and the count
+of ``*_py`` fallbacks that transmutation added.
+
+What is measured vs stated (the honesty bar)
+--------------------------------------------
+  • Route counts are EXACT — the same ``@router.<verb>(`` decorator scan the
+    wellness probe's vitality denominator uses, so the two readings agree.
+  • Kernel-served routes are the ``KERNEL_SERVED_RECIPES`` list imported from
+    ``kernel_attribution_report`` (routes as DATA — one source, no duplication).
+  • The per-route layering is STRUCTURAL FACT — read off a real handler. The
+    CPython-LOC-per-kernel-route figure is a real line count of the kernel-router
+    files; it is offered as evidence of the layering's weight, NOT as a precise
+    "fraction of runtime" (wall-clock fraction depends on inputs and is dominated
+    by FastAPI+Pydantic+network for any real request — stated, not faked).
+  • Kernel-FIRST routes = 0 is exact: no route is served by the kernel as the
+    front door; every kernel-served route is a CPython handler that calls the
+    kernel as a subroutine.
+
+This is a SENSING instrument — read-only, no behavior change, like the wellness
+probe and the attribution report. It tells the body the unflattering truth about
+its runtime-split so the reversal (kernel-as-router) has a baseline to move.
+
+Run
+---
+    python3 scripts/runtime_surface_report.py            # human-readable
+    python3 scripts/runtime_surface_report.py --json     # machine-readable
+
+Exit 0 always — a sensing readout, never a gate.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_ROUTERS_DIR = ROOT / "api" / "app" / "routers"
+
+# The route-decorator scan, IDENTICAL to wellness_check._count_api_routes so the
+# total-route denominator this report prints matches the wellness vitality line
+# to the route. (head/options are excluded the same way — the kernel-served
+# surface is all get/post, so the comparison stays apples-to-apples.)
+_ROUTE_RE = re.compile(r"@router\.(get|post|patch|put|delete)\(")
+
+# The CPython routers that hold the transmuted (kernel-served) endpoints. Each
+# file carries the request-lifecycle code that stays CPython on every kernel
+# request: the async handler (routing + query binding), the Pydantic response
+# model (validation + serialization), and the value-identical ``*_py`` fallback.
+# These are the files whose Python LOC is the per-route CPython weight — the
+# honest counterweight to "the computation moved to the kernel". Named as DATA;
+# the set tracks the kernel_* router family in api/app/routers/.
+_KERNEL_ROUTER_FILES = [
+    "kernel_shared.py",      # the shared /utils router + query/result coercion
+    "kernel_nodeid.py",
+    "kernel_grounded_cv.py",
+    "kernel_matching.py",
+    "kernel_breath.py",
+    "kernel_grounding.py",
+    "kernel_scoring.py",
+]
+
+
+def _load_attribution_module():
+    """Import kernel_attribution_report for KERNEL_SERVED_RECIPES + trace helpers.
+
+    Loaded by path (sibling script, not a package) so this report reuses the ONE
+    canonical kernel-served-routes list rather than duplicating it. Returns the
+    module, or None if it cannot be loaded (the report then degrades to route
+    counts only and says so).
+    """
+    path = ROOT / "scripts" / "kernel_attribution_report.py"
+    if not path.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("kernel_attribution_report", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        return mod
+    except Exception:
+        return None
+
+
+def count_total_routes() -> int:
+    """Total API route decorators across api/app/routers/*.py (probe-exact)."""
+    if not _ROUTERS_DIR.is_dir():
+        return 0
+    total = 0
+    for p in _ROUTERS_DIR.glob("*.py"):
+        try:
+            total += len(_ROUTE_RE.findall(p.read_text(encoding="utf-8")))
+        except OSError:
+            continue
+    return total
+
+
+def _code_lines(path: Path) -> int:
+    """Non-blank, non-comment Python lines in a file (a coarse LOC measure).
+
+    Drops blank lines and full-line ``#`` comments. Not a tokenizer — a stable,
+    honest order-of-magnitude count of the CPython that lives in the file. Good
+    enough to size the per-route request-lifecycle weight; not claimed as exact.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    return sum(1 for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#"))
+
+
+def _count_py_fallbacks() -> int:
+    """Count the value-identical ``*_py`` fallback functions in the kernel routers.
+
+    These are the CPython twins of the kernel recipes — the math, re-implemented
+    in Python, run when no kernel is reachable (fresh checkout / CI without the
+    compile step / kernel absent). They are net-NEW CPython that transmutation
+    ADDED: demonstrable evidence that kernel usage and Python-runtime-reduction
+    are different axes. ``def <name>_py(`` across the kernel-router files.
+    """
+    pat = re.compile(r"\bdef\s+[A-Za-z_][A-Za-z0-9_]*_py\s*\(")
+    n = 0
+    for name in _KERNEL_ROUTER_FILES:
+        p = _ROUTERS_DIR / name
+        if p.is_file():
+            try:
+                n += len(pat.findall(p.read_text(encoding="utf-8")))
+            except OSError:
+                continue
+    return n
+
+
+def kernel_router_cpython_loc() -> dict:
+    """The CPython LOC that lives in the kernel-served routers, per file + total.
+
+    This is the per-route request-lifecycle weight that stays CPython on every
+    kernel request — handlers, Pydantic models, and ``*_py`` fallbacks. Set
+    against "22 routes serve their compute on the kernel", it is the honest
+    counterweight: the computation moved; this Python did not.
+    """
+    per_file = {}
+    total = 0
+    for name in _KERNEL_ROUTER_FILES:
+        p = _ROUTERS_DIR / name
+        loc = _code_lines(p) if p.is_file() else 0
+        per_file[name] = loc
+        total += loc
+    return {"per_file": per_file, "total": total, "present": [n for n in per_file if (_ROUTERS_DIR / n).is_file()]}
+
+
+def build_report() -> dict:
+    """Assemble the runtime-surface reading — the two axes and the honest numbers."""
+    total_routes = count_total_routes()
+    attr = _load_attribution_module()
+
+    served_routes: list[str] = []
+    attr_available = attr is not None
+    if attr_available:
+        served_routes = [str(e["route"]) for e in attr.KERNEL_SERVED_RECIPES]
+    n_served = len(served_routes)
+
+    cpy = kernel_router_cpython_loc()
+    py_fallbacks = _count_py_fallbacks()
+
+    usage_pct = (100.0 * n_served / total_routes) if total_routes else None
+    loc_per_route = (cpy["total"] / n_served) if n_served else None
+
+    return {
+        # --- Axis 1: route-level coverage (kernel USAGE) ---
+        "total_routes": total_routes,
+        "kernel_served_routes": n_served,
+        "kernel_served_pct": round(usage_pct, 1) if usage_pct is not None else None,
+        "kernel_first_routes": 0,  # exact: no route is served kernel-FIRST
+        "served_route_names": served_routes,
+        # --- Axis 2: the per-route CPython-vs-kernel layering ---
+        "kernel_router_cpython_loc": cpy["total"],
+        "kernel_router_cpython_loc_per_file": cpy["per_file"],
+        "cpython_loc_per_kernel_route": round(loc_per_route, 1) if loc_per_route else None,
+        # --- Axis 3: usage vs runtime-reduction are different axes ---
+        "py_fallback_functions_added": py_fallbacks,
+        # --- meta ---
+        "attribution_module_available": attr_available,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering — the honest reading, stated plainly. The whole value of this
+# instrument is the UNFLATTERING framing, so the prose carries it explicitly.
+# ---------------------------------------------------------------------------
+
+
+def render_human(r: dict) -> str:
+    out: list[str] = []
+    w = out.append
+
+    w("# Runtime-surface report — CPython vs Form-kernel runtime share")
+    w("")
+    w("How much of the API actually runs Form-native, stated honestly. The")
+    w("companion attribution report says WHICH Blueprints fire; this says HOW")
+    w("MUCH execution has left CPython. They are different questions.")
+    w("")
+
+    # --- Axis 1 ---
+    w("## Axis 1 — kernel USAGE (route-level coverage)")
+    w("")
+    if r["total_routes"]:
+        w(
+            f"  {r['kernel_served_routes']}/{r['total_routes']} API routes are "
+            f"kernel-served ({r['kernel_served_pct']}%)."
+        )
+        w(
+            f"  {r['total_routes'] - r['kernel_served_routes']} routes run entirely "
+            "on CPython — the growth edge."
+        )
+    else:
+        w(f"  {r['kernel_served_routes']} routes kernel-served (total-route count unread).")
+    w(
+        f"  Routes served kernel-FIRST (kernel as the front door): "
+        f"{r['kernel_first_routes']}."
+    )
+    w("  Every kernel-served route is a CPython handler that calls the kernel as")
+    w("  a SUBROUTINE inside the request. The kernel is a guest, not the runtime.")
+    w("")
+
+    # --- Axis 2 ---
+    w("## Axis 2 — the per-route split (what runs where)")
+    w("")
+    w("  On a kernel-served route, the execution layers like this:")
+    w("")
+    w("    FastAPI routes the request            → CPython")
+    w("    Query/path params bind + coerce        → CPython")
+    w("    Pydantic validates the inputs          → CPython")
+    w("    serve_via_kernel orchestrates          → CPython  (preload/parse/fallback)")
+    w("        └─ the kernel walks the recipe     → Form-native  ← the ONLY kernel part")
+    w("    parse(value) re-wraps to a Python type → CPython")
+    w("    Pydantic builds + serializes response  → CPython")
+    w("")
+    w("  The kernel handles the pure-compute CORE; routing, binding, validation,")
+    w("  orchestration, and response stay CPython by design (the eligibility seam).")
+    w("")
+    if r["kernel_router_cpython_loc"]:
+        w(
+            f"  Weight of that CPython: {r['kernel_router_cpython_loc']} code lines "
+            f"across the {len(r['kernel_router_cpython_loc_per_file'])} kernel-router files "
+            f"serve {r['kernel_served_routes']} routes"
+        )
+        if r["cpython_loc_per_kernel_route"]:
+            w(
+                f"  (~{r['cpython_loc_per_kernel_route']} CPython lines per kernel-served route — "
+                "handlers + Pydantic models + fallbacks)."
+            )
+        w("  Each route's pure-compute core, by contrast, is ONE Form recipe expression.")
+        w(
+            "  (LOC sizes the layering's weight; it is NOT a wall-clock runtime fraction — "
+            "for any real request FastAPI+Pydantic+network dwarf the recipe walk.)"
+        )
+    w("")
+
+    # --- Axis 3 ---
+    w("## Axis 3 — kernel USAGE and Python RUNTIME-REDUCTION are different axes")
+    w("")
+    w("  Adding a kernel-served route INCREASES usage but can ADD CPython.")
+    w("  Transmuting a route lands a FastAPI handler, a Pydantic response model,")
+    w("  AND a value-identical *_py fallback. The computation moves to the kernel;")
+    w("  the request lifecycle plus a CPython twin of the math stay in the host —")
+    w("  so net Python LOC may GROW even as kernel usage grows.")
+    w("")
+    w(
+        f"  Demonstrable: {r['py_fallback_functions_added']} *_py fallback functions live in the "
+        "kernel routers — CPython the transmutation ADDED, not removed."
+    )
+    w("")
+
+    # --- Axis 4 ---
+    w("## Axis 4 — where the body is on the journey (Python-runtime → kernel-runtime)")
+    w("")
+    pct = r["kernel_served_pct"]
+    w(
+        f"  Honestly low. {pct}% of routes touch the kernel at all; 0% are served"
+        if pct is not None
+        else "  Honestly low. 0% are served"
+    )
+    w("  kernel-FIRST. The kernel runs the pure-compute core of 22 routes as a")
+    w("  guest-subroutine inside CPython; it is not the runtime and not the router.")
+    w("  This is the baseline the reversal (kernel-as-front-door) would move. The")
+    w("  metric to track is runtime-SHARE moving toward the kernel — not route-count")
+    w("  alone, which can rise while CPython rises with it.")
+    w("")
+
+    if not r["attribution_module_available"]:
+        w("  note: kernel_attribution_report not importable — kernel-served count")
+        w("        unread; route total + CPython-LOC axes still measured.")
+        w("")
+
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Runtime-surface report — CPython vs Form-kernel runtime share."
+    )
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1607,6 +1607,16 @@ def sense_kernel_api() -> list[str]:
             f"({pct:.1f}%) — the {total_routes - n_served} on pure Python are the growth edge "
             "toward most/all routes through the kernel"
         )
+        # The honest runtime-share nuance: route-COUNT is kernel USAGE, not the
+        # runtime-SHARE that actually left CPython. Even kernel-served routes run
+        # the kernel as a guest-subroutine — routing/binding/validation/response
+        # stay CPython; 0 routes are served kernel-FIRST. Track runtime-share,
+        # not route-count (scripts/runtime_surface_report.py).
+        lines.append(
+            "  vitality: runtime-share — those routes run the kernel as a "
+            "guest-subroutine inside CPython (0 kernel-first); usage and "
+            "runtime-share are distinct axes (scripts/runtime_surface_report.py)"
+        )
     else:
         lines.append(
             f"  vitality: {n_served} routes kernel-served (total-route count unread)"


### PR DESCRIPTION
## The awareness gap this names

The body's high-level move is **from Python-runtime toward kernel-runtime**, but the only number we read — "22 routes kernel-served" — flatters us. Even those routes run the kernel as a **guest-subroutine inside CPython**: FastAPI routes the request, params bind, Pydantic validates, `serve_via_kernel` orchestrates (preload/parse/fallback), the kernel walks the recipe, Pydantic serializes the response — **only the recipe walk is Form-native**. The request lifecycle stays CPython by design.

So two axes hide inside "kernel-served," and only naming both is honest:

- **Kernel USAGE** — how many routes call the kernel at all: **22/784 (2.8%)**.
- **Python RUNTIME-SHARE** — how much execution actually left CPython: low, and the kernel is a guest, not the runtime. **0 routes are served kernel-FIRST.**

These move independently. Transmuting a route raises USAGE and can ADD CPython at once — each lands a FastAPI handler + Pydantic response model + value-identical `*_py` fallback, so **net Python LOC can grow even as kernel usage grows**.

## What this ships

A read-only sensing instrument, `scripts/runtime_surface_report.py` (companion to `kernel_attribution_report.py` — that answers *which Blueprints fire*; this answers *how much left CPython*). Routes-as-DATA: it imports `KERNEL_SERVED_RECIPES` from the attribution report, no duplication.

Honest numbers it reports (real, not flattering):

| Reading | Value |
|---|---|
| Total API routes (probe-exact `@router.<verb>(`) | **784** |
| Kernel-served routes | **22 (2.8%)** |
| Routes served kernel-FIRST | **0** |
| CPython LOC in the 7 kernel-router files (serving 22 routes) | **1975** (~89.8/route) |
| `*_py` fallback functions transmutation ADDED | **18** |

The per-route layering is structural fact (read off a real handler); the LOC figure sizes the layering's weight and is explicitly **not** claimed as a wall-clock runtime fraction.

## Also

- **Wellness probe** (`sense_kernel_api`): the kernel vitality reading now carries the one-line runtime-share nuance — usage and runtime-share are distinct axes; 0 kernel-first. Probe stays clean (kernel-native section: *breathing within envelope — no action needed*).
- **`kernels/API_KERNEL_READINESS.md`**: a destination-voiced "Runtime awareness — usage and runtime-share are distinct axes" section names the frame, the guest-subroutine baseline, and that runtime-share is the dial the reversal moves.
- **Edges**: `scripts/INDEX.md` + `MANIFEST.md` regenerated for the new script.

## No-regression

- Read-only instrument; no route/kernel/recipe change.
- `python3 scripts/wellness_check.py` exits 0; kernel-native surface breathing.
- Report runs in both human and `--json` modes with honest numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)