### PR TITLE
feat(kernel): kernel-as-router reversal — design + proof-of-shape

### DIFF
--- a/form/form-kernel-rust/examples/router-proof.fk
+++ b/form/form-kernel-rust/examples/router-proof.fk
@@ -1,0 +1,67 @@
+; router-proof.fk — the kernel-as-router proof-of-shape manifest.
+;
+; Loaded by `form-kernel-rust serve` (see cli_serve). It proves the REVERSED
+; topology: the kernel is the front-door router, not a guest subroutine inside
+; a CPython request.
+;
+;   - NATIVE routes (listed below) are served ENTIRELY in Form — the kernel
+;     walks the handler recipe and returns the value as the HTTP body. NO
+;     CPython is in the path. X-Form-Router: native-kernel.
+;   - ANY OTHER path FANS OUT to the CPython upstream when serve is started
+;     with --upstream <base-url> (the running FastAPI app). The kernel owns
+;     the front door; CPython is the upstream for the not-yet-native tail.
+;     X-Form-Router: fanout-python.
+;
+; Authored as .fk S-expression Form — the kernel's native surface, NOT
+; Python-cross-compiled. (BML surface -> routes would need the Form surface
+; parser in Rust; named as a build in KERNEL_AS_ROUTER.md.)
+;
+;   curl :PORT/health                          -> "ok"        (native, Form)
+;   curl ':PORT/coherence_weight'              -> 0.8125      (native float math)
+;   curl ':PORT/count_signals?values=a,b,c'    -> "3"         (native, input-driven)
+;   curl :PORT/api/ideas                       -> fan-out -> CPython upstream
+
+; --- tiny alist helper: value for `key` in a list of (k v) string pairs ---
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+; --- NATIVE handler 1: liveness. Pure Form, zero inputs. ---
+(defn route_health ()
+  "ok")
+
+; --- NATIVE handler 2: a real coherence-score combinator in Form float math.
+; Mirrors /api/utils/weighted_average (the substrate's bread-and-butter
+; aggregator), but served HERE by the kernel-router with no CPython hop. The
+; weighted average of three coherence scores (0.5, 0.75, 1.0) against weights
+; (0.25, 0.25, 0.5) — the value-walk runs the whole arithmetic in the kernel
+; and the float result becomes the HTTP body.
+(defn route_coherence_weight ()
+  (div
+    (add (add (mul 0.5 0.25) (mul 0.75 0.25)) (mul 1.0 0.5))
+    (add (add 0.25 0.25) 0.5)))
+
+; --- NATIVE handler 3: input-driven Form compute. Counts comma-separated
+; signals in the `values` query arg by walking the string char-by-char in
+; the kernel (commas + 1). Proves a native handler that reads request input
+; and computes a non-trivial value entirely in Form.
+(defn count_commas (s i n)
+  (if (eq i (str_len s))
+      n
+      (count_commas s (add i 1)
+                    (if (str_eq (char_at s i) ",") (add n 1) n))))
+
+(defn route_count_signals (q)
+  (if (eq (str_len (assoc "values" q)) 0)
+      "0"
+      (int_to_str (add (count_commas (assoc "values" q) 0 0) 1))))
+
+; --- the route manifest: (path handler). Everything not here fans out. ---
+(let routes
+  (list
+    (list "/health"           route_health)
+    (list "/coherence_weight" route_coherence_weight)
+    (list "/count_signals"    route_count_signals)))

--- a/form/form-kernel-rust/router_proof_harness.py
+++ b/form/form-kernel-rust/router_proof_harness.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Proof-of-shape harness for the kernel-as-router REVERSAL.
+
+Proves the inverted topology at small scale: the Form kernel is the front-door
+ROUTER. It owns the listening socket, serves NATIVE routes entirely in Form
+(no CPython in the path), and FANS OUT every other path to a CPython upstream.
+
+What it spins up:
+  1. a tiny CPython HTTP upstream (stands in for the real FastAPI app) on one
+     port — every kernel-served route in production today (763 of them) would
+     live behind this. The harness mocks it so the proof touches NO production
+     routing.
+  2. `form-kernel-rust serve --routes examples/router-proof.fk --upstream <mock>`
+     on another port — the kernel as the front door.
+
+What it asserts:
+  - native routes (/health, /coherence_weight, /count_signals) return the Form
+    handler's value with header X-Form-Router: native-kernel — proving the
+    kernel served them in Form with NO CPython hop.
+  - a non-native path (/api/whatever) is FANNED OUT to the CPython upstream:
+    the response carries the upstream's marker AND header X-Form-Router:
+    fanout-python — proving the kernel owns the routing decision and forwards
+    the not-yet-native tail to Python.
+  - it MEASURES native-route latency (the inverted front door must stay fast).
+
+Run from form/form-kernel-rust/:
+    cargo build --release
+    python3 router_proof_harness.py
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import statistics
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-proof.fk"
+
+UPSTREAM_MARKER = "UPSTREAM-CPYTHON-FASTAPI-STANDIN"
+
+
+class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """The CPython upstream the kernel fans out to (mock FastAPI)."""
+
+    def do_GET(self):  # noqa: N802
+        body = f"{UPSTREAM_MARKER} served {self.path}\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # silence per-request logging
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def fetch(url: str):
+    """Return (status, body, router-header) for a GET."""
+    try:
+        with urllib.request.urlopen(url, timeout=3.0) as r:
+            return r.status, r.read().decode("utf-8"), r.headers.get("X-Form-Router")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8"), e.headers.get("X-Form-Router")
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    # 1. CPython upstream (mock FastAPI) — the fan-out target.
+    up_port = free_port()
+    httpd = http.server.HTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
+    up_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    up_thread.start()
+    upstream_url = f"http://127.0.0.1:{up_port}"
+
+    # 2. The kernel as the front-door router, fanning out to the upstream.
+    kport = free_port()
+    proc = subprocess.Popen(
+        [
+            str(BIN), "serve",
+            "--port", str(kport),
+            "--routes", str(ROUTES),
+            "--upstream", upstream_url,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    failures = []
+    try:
+        wait_for_port(kport)
+        base = f"http://127.0.0.1:{kport}"
+
+        # --- NATIVE arm: served in Form, no CPython in the path ---
+        cases = [
+            ("/health", "ok"),
+            ("/coherence_weight", "0.8125"),
+            ("/count_signals?values=0.5,0.75,1.0", "3"),
+            ("/count_signals?values=a", "1"),
+        ]
+        for path, expect in cases:
+            status, body, router = fetch(base + path)
+            ok = status == 200 and body == expect and router == "native-kernel"
+            print(f"  [native ] {path:<38} -> {status} {body!r} "
+                  f"X-Form-Router={router}  {'OK' if ok else 'FAIL'}")
+            if not ok:
+                failures.append((path, status, body, router))
+
+        # --- FAN-OUT arm: forwarded to the CPython upstream ---
+        for path in ("/api/ideas", "/api/whatever/deep/path"):
+            status, body, router = fetch(base + path)
+            ok = (
+                status == 200
+                and UPSTREAM_MARKER in body
+                and path in body
+                and router == "fanout-python"
+            )
+            print(f"  [fanout ] {path:<38} -> {status} via CPython "
+                  f"X-Form-Router={router}  {'OK' if ok else 'FAIL'}")
+            if not ok:
+                failures.append((path, status, body, router))
+
+        # --- MEASURE native-route latency (the front door must stay fast) ---
+        N = 200
+        samples = []
+        for _ in range(N):
+            t0 = time.perf_counter()
+            fetch(base + "/coherence_weight")
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        samples.sort()
+        p50 = statistics.median(samples)
+        p99 = samples[int(0.99 * len(samples)) - 1]
+        print(f"\n  native /coherence_weight over {N} reqs: "
+              f"p50={p50:.3f} ms  p99={p99:.3f} ms  min={samples[0]:.3f} ms")
+        print("  (whole-request wall time incl. loopback socket; the Form "
+              "value-walk is the sub-fraction.)")
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+            return 1
+        print("\nok — kernel OWNED the front door: native routes served in "
+              "Form (no CPython), tail fanned out to CPython upstream.")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        httpd.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6205,7 +6205,7 @@ Subcommands:
   query <path>                         parse any file as a Form object tree
   trace [--expr \"...\" | <file.fk>]     run with arm-dispatch tracing
   fetch <url>                          GET a URL (network resource)
-  serve --port <p> --routes <file.fk>  HTTP/1.0 listener dispatching to Form recipes
+  serve --port <p> --routes <file.fk> [--upstream <base-url>]\n                                       kernel front-door ROUTER: native Form handlers\n                                       for listed paths, fan-out to the CPython upstream\n                                       for the rest (HTTP/1.0 proof-of-shape)
 
 Source adapter modes:
   <file.fk> [more.fk ...]              run .fk files
@@ -6247,6 +6247,13 @@ fn cli_serve(args: &[String]) -> i32 {
     // --port <p> --routes <file.fk>
     let mut port: u16 = 8001;
     let mut routes_path: Option<String> = None;
+    // --upstream <base-url> turns the listener into the front-door ROUTER:
+    // a path with a native Form handler is served entirely in the kernel
+    // (no CPython in the path); a path with no native handler FANS OUT to
+    // the CPython upstream (the running FastAPI app) over HTTP. Absent this
+    // flag an unmatched path is a 404 — the original proof-of-shape behavior,
+    // unchanged, so existing callers see no difference.
+    let mut upstream: Option<String> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -6270,6 +6277,14 @@ fn cli_serve(args: &[String]) -> i32 {
                     return 2;
                 }
                 routes_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--upstream" => {
+                if i + 1 >= args.len() {
+                    eprintln!("serve: --upstream requires a base-url argument");
+                    return 2;
+                }
+                upstream = Some(args[i + 1].trim_end_matches('/').to_string());
                 i += 2;
             }
             other => {
@@ -6343,13 +6358,17 @@ fn cli_serve(args: &[String]) -> i32 {
         }
     };
     eprintln!(
-        "form-kernel-rust serve: listening on 127.0.0.1:{} ({} route{})",
+        "form-kernel-rust serve: listening on 127.0.0.1:{} ({} native route{})",
         port,
         route_pairs.len(),
         if route_pairs.len() == 1 { "" } else { "s" }
     );
     for r in &route_pairs {
-        eprintln!("  {}", r.0);
+        eprintln!("  {} -> native (Form handler)", r.0);
+    }
+    match &upstream {
+        Some(u) => eprintln!("  *  -> fan-out to CPython upstream {}", u),
+        None => eprintln!("  *  -> 404 (no --upstream; fan-out arm inactive)"),
     }
 
     for incoming in listener.incoming() {
@@ -6367,12 +6386,19 @@ fn cli_serve(args: &[String]) -> i32 {
         let req = String::from_utf8_lossy(&buf[..n]).to_string();
         let (method, path, query) = parse_request_line(&req);
 
+        // The router decision: a path with a native Form handler is served
+        // entirely in the kernel; a path with no handler fans out to the
+        // CPython upstream (if --upstream is set) or 404s.
         let body: String;
         let status: &str;
+        let router: &str;
         if method != "GET" {
+            // GET-only doorway today; non-idempotent verbs are a named build.
             status = "405 Method Not Allowed";
+            router = "native-kernel";
             body = format!("method not allowed: {}\n", method);
         } else if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
+            // NATIVE: served entirely in Form, no CPython in the path.
             // Build the query alist as Value::List of (key, value) pairs.
             let q_alist = Value::List(
                 query
@@ -6385,23 +6411,39 @@ fn cli_serve(args: &[String]) -> i32 {
             if cl.params.len() == 1 {
                 arena.bind(call_frame, cl.params[0], q_alist);
             } else if cl.params.len() != 0 {
-                status = "500 Internal Server Error";
-                body = format!(
-                    "handler for {} wants {} params; serve passes 0 or 1\n",
-                    path,
-                    cl.params.len()
+                let _ = stream.write_all(
+                    http_response_routed(
+                        "500 Internal Server Error",
+                        &format!(
+                            "handler for {} wants {} params; serve passes 0 or 1\n",
+                            path,
+                            cl.params.len()
+                        ),
+                        "native-kernel",
+                    )
+                    .as_bytes(),
                 );
-                let _ = stream.write_all(http_response(status, &body).as_bytes());
                 continue;
             }
             let result = walk(&mut k, &mut arena, cl.body, call_frame);
             status = "200 OK";
+            router = "native-kernel";
             body = result.display();
+        } else if let Some(base) = &upstream {
+            // FAN-OUT: no native handler — forward to the CPython upstream and
+            // relay its response. The kernel owns the front door; CPython is
+            // the upstream for the not-yet-native tail.
+            let (up_status, up_body) = fan_out_to_upstream(base, &path, &query);
+            let _ =
+                stream.write_all(http_response_routed(&up_status, &up_body, "fanout-python").as_bytes());
+            continue;
         } else {
+            // No native handler and no upstream configured.
             status = "404 Not Found";
-            body = format!("no route for {}\n", path);
+            router = "native-kernel";
+            body = format!("no route for {} (no --upstream; fan-out arm inactive)\n", path);
         }
-        let _ = stream.write_all(http_response(status, &body).as_bytes());
+        let _ = stream.write_all(http_response_routed(status, &body, router).as_bytes());
     }
     0
 }
@@ -6461,13 +6503,56 @@ fn url_decode(s: &str) -> String {
     out
 }
 
-fn http_response(status: &str, body: &str) -> String {
+// Build a response the kernel-router emits. The X-Form-Router header makes the
+// routing decision legible to clients — the inverted topology's analog of the
+// guest path's `runtime` field: the caller can see whether the kernel served
+// this in Form (no CPython hop) or fanned out. `router` is "native-kernel" for
+// Form-handled paths, "fanout-python" for proxied paths, or a status note.
+fn http_response_routed(status: &str, body: &str, router: &str) -> String {
     format!(
-        "HTTP/1.0 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.0 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nX-Form-Router: {}\r\nConnection: close\r\n\r\n{}",
         status,
         body.len(),
+        router,
         body
     )
+}
+
+// Fan-out arm: the kernel-router received a request for a path with NO native
+// Form handler, so it forwards to the CPython upstream (the running FastAPI
+// app) and relays the response. This is the real proxy hop, not a stub — the
+// kernel owns the front door and CPython is the upstream for the not-yet-native
+// tail. Proof-of-shape scope: GET only, status + body relayed as text/plain,
+// X-Form-Router: fanout-python stamped so the hop is visible. The production
+// build (named in KERNEL_AS_ROUTER.md) adds method/header/body passthrough,
+// streaming, and connection reuse.
+fn fan_out_to_upstream(base: &str, path: &str, query: &[(String, String)]) -> (String, String) {
+    let mut url = format!("{}{}", base, path);
+    if !query.is_empty() {
+        let qs: Vec<String> = query
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        url.push('?');
+        url.push_str(&qs.join("&"));
+    }
+    match ureq::get(&url).call() {
+        Ok(resp) => {
+            let code = resp.status();
+            let reason = resp.status_text().to_string();
+            let body = resp.into_string().unwrap_or_default();
+            (format!("{} {}", code, reason), body)
+        }
+        Err(ureq::Error::Status(code, resp)) => {
+            let reason = resp.status_text().to_string();
+            let body = resp.into_string().unwrap_or_default();
+            (format!("{} {}", code, reason), body)
+        }
+        Err(e) => (
+            "502 Bad Gateway".to_string(),
+            format!("kernel-router: fan-out to upstream failed: {}\n", e),
+        ),
+    }
 }
 
 fn cli_list(args: &[String]) -> i32 {

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -1,0 +1,244 @@
+# Kernel as router — the request front-door reversal
+
+> The reversal Urs named: **make the Form kernel the router / starting point of
+> request handling**, fanning out to CPython only for the not-yet-native tail.
+> Today CPython (FastAPI) is the runtime and the kernel is a called
+> guest-subroutine. This inverts that topology.
+
+This is the structural complement of [`API_KERNEL_READINESS.md`](API_KERNEL_READINESS.md).
+That document holds *"FastAPI stays the doorway; the kernel serves the
+pure-compute core of eligible routes."* This one holds the inversion: **the
+kernel IS the doorway; CPython is the upstream for the routes the kernel does
+not yet serve natively.** Same body, two phases of the same arc — the readiness
+map grows the native surface; this design moves the front door onto it.
+
+The seed already exists and is measured: `form-kernel-rust serve` (`cli_serve`
+in [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs))
+is a kernel-resident HTTP listener that loads a `routes.fk` once into a
+long-lived `Kernel + Arena`, holds the top-level `routes` binding (a list of
+`(path, handler-closure)`), and dispatches each request to the matching Form
+handler. No FastAPI, no CPython in that path. This design makes that primitive
+PRIMARY and adds the fan-out arm.
+
+## Today: the kernel is a guest inside a CPython request
+
+```
+   visitor
+     │  HTTP
+     ▼
+┌──────────────────────────────────────────────────────────────┐
+│  FastAPI (CPython) — THE RUNTIME / FRONT DOOR                  │
+│    route match (path + method)                                 │
+│    Pydantic bind + validate                                    │
+│    ┌────────────────────────────────────────────┐             │
+│    │  serve_via_kernel(recipe, bindings, …)      │  ← the      │
+│    │    Form kernel walks the compute core       │    kernel   │
+│    │    returns a scalar / list value            │    is a     │
+│    └────────────────────────────────────────────┘    GUEST    │
+│    wrap value in the response model                            │
+└──────────────────────────────────────────────────────────────┘
+     │
+     ▼  JSON
+   visitor
+```
+
+The kernel runs *inside* a CPython request, for the **23 compute cores**
+(across 8 `kernel_*` router families) that call `serve_via_kernel`. The other
+~762 of the 785 endpoints never touch the kernel. Python owns the socket, the
+routing, the validation, the lifecycle. The kernel is reached only after
+CPython has already decided everything.
+
+## Reversed: the kernel is the front-door router
+
+```
+   visitor
+     │  HTTP
+     ▼
+┌──────────────────────────────────────────────────────────────┐
+│  form-kernel-rust serve — THE RUNTIME / FRONT DOOR (ROUTER)   │
+│    parse request line (method, path, query)                   │
+│    look up path in the routes.fk manifest                      │
+│                                                                │
+│    ┌── path HAS a native Form handler ──────────────┐         │
+│    │   walk the handler recipe in the kernel         │  served │
+│    │   value → HTTP body                              │  in     │
+│    │   X-Form-Router: native-kernel                   │  FORM   │
+│    └─────────────────────────────────────────────────┘  (no   │
+│                                                          CPython)│
+│    ┌── path has NO native handler (the tail) ────────┐         │
+│    │   FAN OUT: forward to the CPython upstream       │  served │
+│    │   relay the upstream response                    │  by     │
+│    │   X-Form-Router: fanout-python                   │  Python │
+│    └──────────────────┬──────────────────────────────┘         │
+└───────────────────────┼────────────────────────────────────────┘
+                         │  HTTP (localhost / unix socket)
+                         ▼
+              ┌──────────────────────────────┐
+              │  FastAPI (CPython) UPSTREAM   │  ← Python is now the
+              │  the ~762 not-yet-native      │    fan-out target for
+              │  routes, unchanged            │    the tail, not the
+              └──────────────────────────────┘    front door
+```
+
+The kernel owns the listening socket. It decides native-vs-fan-out per request.
+Native routes never touch CPython; the tail keeps working because the kernel
+proxies it to the same FastAPI app that serves it today — unchanged.
+
+## How a route is classified: the routes.fk manifest
+
+The manifest is the single source of routing truth. A route is **native** iff
+the manifest binds a Form handler for its path; **everything else fans out**.
+
+```lisp
+; routes.fk — the front-door manifest (S-expression Form, the kernel's
+; native surface). Native handlers are Form recipes; the tail is implicit.
+(defn route_coherence_weight (q) ...)   ; a native compute core, in Form
+(defn route_health () "ok")
+
+(let routes
+  (list
+    (list "/health"           route_health)            ; native
+    (list "/coherence_weight" route_coherence_weight)  ; native
+    ; /api/ideas, /api/contributors, … — NOT listed → fan out to CPython
+    ))
+```
+
+Classification is **closed-world by presence**: listed ⇒ native, absent ⇒
+fan-out. There is no per-route "fanout" declaration to drift — the absence IS
+the declaration. As a route moves from fan-out to native, it gains a line in
+the manifest and a Form handler; nothing else in the topology changes.
+
+A working manifest with three native handlers (liveness, a real float
+coherence-weight combinator, and an input-driven signal counter) lives at
+[`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk).
+
+## The fan-out mechanism
+
+`cli_serve` gains a `--upstream <base-url>` flag. When set, a path with no
+native handler is forwarded to `<base-url><path>?<query>` and the upstream
+response is relayed. The kernel already carries an HTTP client (`ureq`, used by
+the `fetch` subcommand), so this is a **real proxy hop, not a stub**:
+
+```
+form-kernel-rust serve \
+  --port 80 \
+  --routes routes.fk \
+  --upstream http://127.0.0.1:8000   # the running FastAPI app
+```
+
+`fan_out_to_upstream(base, path, query)` issues the GET, relays the upstream's
+status and body, and stamps `X-Form-Router: fanout-python`. Absent `--upstream`,
+an unmatched path is a 404 — the original proof-of-shape behavior, unchanged, so
+nothing that runs `serve` today sees a difference.
+
+Every response carries an `X-Form-Router` header — `native-kernel` or
+`fanout-python` — the inverted topology's analog of the guest path's `runtime`
+field: a client can see, per request, whether the kernel served it in Form or
+fanned it out to Python.
+
+## What must grow on the kernel side for a REAL front door
+
+`cli_serve` is an honest **proof-of-shape**, not a production front door. The
+gap, named precisely:
+
+| Gap | cli_serve today | Production front door needs |
+|-----|-----------------|-----------------------------|
+| **HTTP version** | HTTP/1.0, `Connection: close` per request | HTTP/1.1 + keep-alive (and ideally HTTP/2 behind Traefik), chunked transfer |
+| **Concurrency** | single-threaded `for incoming in listener.incoming()` — one request at a time | a thread pool or async accept loop; the `Kernel + Arena` is `!Sync` today, so either a kernel-per-worker pool or an arena-sharding pass |
+| **Request parsing** | request line + flat string query alist; 8 KiB cap; GET only | full header map, request bodies (POST/PUT/PATCH), content-type aware parsing, larger/streamed bodies |
+| **Fan-out proxy** | GET only, status+body relayed as text/plain, no header passthrough | method + header + body passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
+| **Handler inputs** | 0 or 1 arg (the query alist) | path params, headers, parsed bodies marshalled into the handler frame |
+| **Errors / observability** | 404/405/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
+| **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
+
+None of these is exotic; each is a named breath. The concurrency item is the
+load-bearing one — the kernel's per-process intern table (`lc-native-kernel-binary`
+names this: *"Not multi-process"*) means a production router is a **pool of
+kernel workers behind the accept loop**, not one shared mutable kernel.
+
+## The BML preference
+
+Native handlers and the routes manifest are **Form-native tissue, not
+Python-cross-compiled**. The proof manifest is authored as `.fk` S-expression
+Form — the kernel's native surface that `read_root_from_source` reads directly.
+BML surface syntax (`defn name(a, b) = do { ... };`) is the preferred authoring
+tongue because it exposes Form features directly (Python reaches Form only via
+the bolted-on adapter SDK); serving a BML-authored manifest needs the Form
+surface parser in Rust (the `.recipelib.json` tongue_caches → S-expression
+converter named in [`lc-native-kernel-binary`](../docs/vision-kb/concepts/lc-native-kernel-binary.md)).
+Either way the handler is Form, walked by the kernel — never a Python function
+the kernel calls. That is the point of the reversal: the front door speaks the
+body's own tongue.
+
+## The migration path — runtime-share, not route-count
+
+The flip is incremental and reversible at every step:
+
+1. **Kernel-router in front, owning a FEW native routes, fan-out for the rest.**
+   The 23 compute cores that already run on the kernel are the first native
+   handlers; the other ~762 routes fan out to the unchanged FastAPI app. From
+   the visitor's side nothing changes; from the body's side the front door has
+   moved.
+2. **Native coverage grows.** Each route whose compute core is already a Form
+   recipe (the `serve_via_kernel` routes) becomes a manifest entry. The
+   readiness map in `API_KERNEL_READINESS.md` is the queue.
+3. **The CPython surface shrinks** as routes move from fan-out to native — the
+   tail the kernel proxies gets shorter.
+
+**The metric that matters is runtime-SHARE moving to the kernel, not
+route-count.** A handful of hot routes can carry most of the request volume; a
+long tail of rarely-hit admin routes can stay CPython indefinitely with no cost.
+The honest measure is *fraction of requests (and of CPU-time) served natively*,
+which the `X-Form-Router` header makes directly countable from access logs.
+
+## Proof-of-shape — what is demonstrated, and what it is not
+
+[`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py)
+spins up a mock CPython upstream (standing in for FastAPI — so the proof touches
+NO production routing) and the kernel-router fanning out to it, then exercises
+both arms:
+
+```
+[native ] /health                            -> 200 'ok'      X-Form-Router=native-kernel  OK
+[native ] /coherence_weight                  -> 200 '0.8125'  X-Form-Router=native-kernel  OK
+[native ] /count_signals?values=0.5,0.75,1.0 -> 200 '3'       X-Form-Router=native-kernel  OK
+[fanout ] /api/ideas                         -> 200 via CPython X-Form-Router=fanout-python OK
+[fanout ] /api/whatever/deep/path            -> 200 via CPython X-Form-Router=fanout-python OK
+
+native /coherence_weight over 200 reqs: p50=0.163 ms  p99=0.244 ms  min=0.101 ms
+```
+
+**Shown (measured, not asserted):** the kernel OWNS the front door; it routes
+each request; it serves native routes entirely in Form with no CPython in the
+path (real float arithmetic and input-driven string computation, not echoes);
+it fans out the tail to a CPython upstream over a real HTTP hop; sub-millisecond
+native latency (whole-request wall time including the loopback socket — the Form
+value-walk is a sub-fraction).
+
+**NOT shown / not claimed:** production-readiness. The proof is HTTP/1.0,
+single-threaded, GET-only, with a mock upstream. The production build is the
+table above.
+
+## The flip is Urs's decision
+
+This is the **live request front-door for real visitors** — high-stakes. This
+design and proof establish that the inverted topology *works* and name the build
+precisely. **The production flip — putting the kernel-router in front of the
+real FastAPI app — is Urs's explicit decision, not shipped here.** Today's
+front door (FastAPI) is untouched; this is the design plus a side proof on a
+test port so the reversal can be weighed with evidence rather than assertion.
+
+## Cross-references
+
+- [`API_KERNEL_READINESS.md`](API_KERNEL_READINESS.md) — the topology this inverts; the queue of native-eligible routes.
+- [`SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md`](SUBSTRATE_AS_DEPLOYMENT_RUNTIME.md) — the deeper destination: the substrate as the runtime, of which the kernel-router is the request-handling face.
+- [`README.md`](README.md) — the three sibling kernels; the router is the Rust kernel's front-door face.
+- [`lc-native-kernel-binary`](../docs/vision-kb/concepts/lc-native-kernel-binary.md) — the native binary, its serve primitive, and the per-process / concurrency honesty this build must answer.
+- [`lc-one-kernel-many-tongues`](../docs/vision-kb/concepts/lc-one-kernel-many-tongues.md), [`lc-the-kernel-knows-itself`](../docs/vision-kb/concepts/lc-the-kernel-knows-itself.md) — the kernel speaking the body's own tongue and reading its own routing.
+
+## Sources
+
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener), `fan_out_to_upstream` (the proxy arm), `http_response_routed` (the X-Form-Router header).
+- [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
+- [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end proof + measurement.
+- [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.

--- a/kernels/README.md
+++ b/kernels/README.md
@@ -105,6 +105,8 @@ Three-digit overhead is interpreter-typical. The compiled-path (TS) closes to ~1
 
 **Serving the API from the kernel** is a distinct, measured question — see [`API_KERNEL_READINESS.md`](API_KERNEL_READINESS.md). The recipe *executes* in ~0.15 ms (competitive); the readiness gap for the transmuted `/api/utils/*` endpoints is the per-request **process spawn** (~5 ms via subprocess), not compute. The evidence (value parity ✓ on all four, p50/p95/p99 under replay, the spawn-vs-compute split) says the flip needs a **persistent/inline (PyO3) kernel**, not a per-call shell-out. Run it: `python3 scripts/kernel_readiness_harness.py`.
 
+**Reversing the topology** — making the kernel the request *front-door router* rather than a guest subroutine inside a CPython request — is designed and proven at small scale in [`KERNEL_AS_ROUTER.md`](KERNEL_AS_ROUTER.md). `form-kernel-rust serve` owns the listening socket, serves native routes entirely in Form (no CPython in the path, sub-ms), and fans out the not-yet-native tail to the FastAPI upstream over a real HTTP hop. The production flip is the live front-door — named honestly as a separate decision.
+
 ## What's possible now that other frameworks struggle with
 
 - **Identity that crosses languages.** Two recipes written in Rust and TypeScript that mean the same thing get the same NodeID. No serialization, no schema, no version negotiation. The lattice IS the protocol.


### PR DESCRIPTION
## The reversal

Invert the request topology Urs named: make the **Form kernel the front-door ROUTER** that serves native routes entirely in Form and fans out the not-yet-native tail to the CPython (FastAPI) upstream — the inverse of today's shape where CPython is the runtime and the kernel is a called guest-subroutine inside a CPython request.

This is the structural complement of `kernels/API_KERNEL_READINESS.md` ("FastAPI stays the doorway"). That doc grows the native surface; this one moves the front door onto it.

**Design + side proof only. Production request routing is NOT touched.** The live FastAPI front-door is unchanged; the proof runs on a test port against a mock upstream. The production flip is named as Urs's explicit decision (it's the live front-door for real visitors).

## What's here

- **`cli_serve` gains `--upstream <base-url>`** (`form/form-kernel-rust/src/main.rs`): a path with a native Form handler is served in-kernel (no CPython in the path); any other path is forwarded to the CPython upstream via a **real `ureq` HTTP hop, not a stub**. Absent `--upstream`, unmatched paths still 404 — original `cli_serve` behavior unchanged (verified: `test_serve.py` still green).
- **`X-Form-Router` header** (`native-kernel` | `fanout-python`) makes the routing decision legible per request — the inverted topology's analog of the guest path's `runtime` field.
- **`examples/router-proof.fk`** — native-handler manifest authored as `.fk` S-expression Form (the kernel's native surface), **NOT Python-cross-compiled**: liveness, a real float coherence-weight combinator (mirrors `/api/utils/weighted_average`), an input-driven signal counter.
- **`router_proof_harness.py`** — spins up a mock CPython upstream (stands in for FastAPI, so NO production routing is touched) + the kernel router, exercises both arms, measures native latency.
- **`kernels/KERNEL_AS_ROUTER.md`** — the reversed topology, route classification (closed-world manifest: listed ⇒ native, absent ⇒ fan-out), the fan-out mechanism, the honest production-build gap (HTTP/1.1 + keep-alive, concurrency / kernel-worker pool, real proxy passthrough), the BML preference, and the migration metric (**runtime-SHARE, not route-count**).

## Proof run (measured, not asserted)

```
[native ] /health                            -> 200 'ok'      X-Form-Router=native-kernel  OK
[native ] /coherence_weight                  -> 200 '0.8125'  X-Form-Router=native-kernel  OK
[native ] /count_signals?values=0.5,0.75,1.0 -> 200 '3'       X-Form-Router=native-kernel  OK
[fanout ] /api/ideas                         -> 200 via CPython X-Form-Router=fanout-python OK

native /coherence_weight over 200 reqs: p50=0.166 ms  p99=0.251 ms  min=0.095 ms
```

The kernel OWNS the front door: it routes each request, serves native routes entirely in Form with no CPython in the path, and fans out the tail to a CPython upstream over a real HTTP hop. Sub-millisecond native latency (whole-request wall time incl. loopback socket).

## Honest gap

`cli_serve` is a proof-of-shape: HTTP/1.0, single-threaded, GET-only, mock upstream. A real front-door needs the build named in the design doc. The proof shows the inverted topology *works* at small scale; it is not production-ready, and the flip is Urs's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)