### PR TITLE
tend(kernel-router): dispatch the serve accept-loop to a pool of kernel workers

### DIFF
--- a/form/form-kernel-rust/router_concurrency_harness.py
+++ b/form/form-kernel-rust/router_concurrency_harness.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Concurrency proof for the kernel-as-router WORKER POOL.
+
+The companion to router_proof_harness.py. That harness proves the inverted
+topology (the kernel owns the front door, native in Form, tail fanned out).
+THIS one proves the load-bearing concurrency gap named in KERNEL_AS_ROUTER.md
+is closed: `cli_serve` now dispatches accepted streams to a POOL of kernel
+workers, each owning its OWN Kernel + Arena (the `!Sync` per-process intern
+table means a pool, not one shared mutable kernel).
+
+Three properties, all MEASURED (not asserted):
+
+  1. CORRECT UNDER CONCURRENCY — 50 parallel clients all get HTTP 200 with the
+     right native value and X-Form-Router: native-kernel. No request is dropped
+     or corrupted when many hit at once.
+
+  2. NO CROSS-REQUEST STATE BLEED — the critical correctness property of the
+     pool. Each client sends a DIFFERENT input to the input-driven native
+     handler (/count_signals?values=<k commas> → k+1) and must get back its OWN
+     k+1, never another client's. Because each worker has its own Kernel+Arena,
+     concurrent value-walks with different inputs cannot bleed into one another.
+     If the pool shared mutable kernel state, overlapping requests would corrupt
+     each other's frame bindings and the per-client fingerprints would scramble.
+
+  3. THE POOL ACTUALLY PARALLELIZES — single-worker (--workers 1) vs N-worker
+     throughput under the SAME concurrent load. With CPU-bearing native handlers
+     (the recursive char-walk over a long input string), one worker serializes
+     the walks; N workers run them on N cores. We report req/s and p50/p99 for
+     both and show N-worker throughput climbs above 1-worker. Real numbers.
+
+Run from form/form-kernel-rust/:
+    cargo build --release
+    python3 router_concurrency_harness.py
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-proof.fk"
+
+# How many parallel clients hammer the server at once.
+CONCURRENCY = 50
+# Requests per throughput measurement (spread across the CONCURRENCY clients).
+LOAD_REQUESTS = 600
+# CPU weight per request: the native /count_signals handler walks the input
+# string char-by-char in the kernel (recursive Form). A long input makes each
+# request carry real CPU so a single worker visibly serializes while N workers
+# parallelize. ~4000 commas keeps each request a few ms of pure value-walk.
+HEAVY_COMMAS = 4000
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 8.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def fetch(url: str):
+    """Return (status, body, router-header) for a GET."""
+    try:
+        with urllib.request.urlopen(url, timeout=30.0) as r:
+            return r.status, r.read().decode("utf-8"), r.headers.get("X-Form-Router")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8"), e.headers.get("X-Form-Router")
+    except Exception as e:  # noqa: BLE001 - report the failure as a tuple
+        return -1, f"{type(e).__name__}: {e}", None
+
+
+def start_server(workers: int, port: int) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [
+            str(BIN), "serve",
+            "--port", str(port),
+            "--routes", str(ROUTES),
+            "--workers", str(workers),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    wait_for_port(port)
+    return proc
+
+
+def stop_server(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=3.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2.0)
+
+
+def prove_no_bleed(base: str) -> list:
+    """Fire CONCURRENCY parallel clients, EACH with a different input, and check
+    every client gets back ITS OWN correct value. /count_signals?values=<k
+    commas> returns k+1, so client k expects str(k+1) — a unique per-client
+    fingerprint. Any cross-request bleed scrambles the mapping."""
+    # k=0 would mean an empty values arg (the handler returns "0"); start at 1
+    # so each client has a non-trivial distinct comma-count fingerprint.
+    inputs = list(range(1, CONCURRENCY + 1))
+
+    def one(k: int):
+        url = f"{base}/count_signals?values={',' * k}"  # k commas -> k+1 fields
+        status, body, router = fetch(url)
+        return k, status, body, router
+
+    results = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
+        for k, status, body, router in ex.map(one, inputs):
+            results[k] = (status, body, router)
+
+    failures = []
+    for k in inputs:
+        status, body, router = results[k]
+        expect = str(k + 1)
+        ok = status == 200 and body == expect and router == "native-kernel"
+        if not ok:
+            failures.append((k, expect, status, body, router))
+    return failures
+
+
+def measure_throughput(base: str, label: str) -> dict:
+    """Drive LOAD_REQUESTS heavy native requests through CONCURRENCY parallel
+    clients and report wall-clock throughput + latency percentiles."""
+    heavy_url = f"{base}/count_signals?values={',' * HEAVY_COMMAS}"
+    expect = str(HEAVY_COMMAS + 1)
+
+    def one(_i: int):
+        t0 = time.perf_counter()
+        status, body, _router = fetch(heavy_url)
+        dt = (time.perf_counter() - t0) * 1000.0
+        return dt, (status == 200 and body == expect)
+
+    latencies = []
+    correct = 0
+    t_start = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
+        for dt, ok in ex.map(one, range(LOAD_REQUESTS)):
+            latencies.append(dt)
+            correct += 1 if ok else 0
+    wall = time.perf_counter() - t_start
+
+    latencies.sort()
+    p50 = statistics.median(latencies)
+    p99 = latencies[min(len(latencies) - 1, int(0.99 * len(latencies)))]
+    rps = LOAD_REQUESTS / wall if wall > 0 else float("inf")
+    print(
+        f"  [{label:>10}] {LOAD_REQUESTS} reqs @ {CONCURRENCY} parallel: "
+        f"{rps:8.1f} req/s  p50={p50:6.2f} ms  p99={p99:7.2f} ms  "
+        f"correct={correct}/{LOAD_REQUESTS}"
+    )
+    return {"rps": rps, "p50": p50, "p99": p99, "correct": correct, "wall": wall}
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    ncpu = os.cpu_count() or 4
+    n_workers = min(max(ncpu, 4), 8)  # the multi-worker pool size to compare
+    print(f"host cores={ncpu}; comparing 1 worker vs {n_workers} workers; "
+          f"{CONCURRENCY} parallel clients\n")
+
+    failures = []
+
+    # ---- Property 1 + 2: correctness + NO cross-request bleed under load ----
+    # Run against the MULTI-worker pool — the case where bleed would appear if
+    # workers shared mutable kernel state.
+    port = free_port()
+    proc = start_server(n_workers, port)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        bleed_failures = prove_no_bleed(base)
+        if bleed_failures:
+            print(f"  [no-bleed ] {CONCURRENCY} parallel clients, DISTINCT inputs "
+                  f"-> FAIL ({len(bleed_failures)} mismatched)")
+            for k, expect, status, body, router in bleed_failures[:8]:
+                print(f"      client k={k}: expected {expect!r} got "
+                      f"status={status} body={body!r} router={router}")
+            failures.extend(bleed_failures)
+        else:
+            print(f"  [no-bleed ] {CONCURRENCY} parallel clients, each a DISTINCT "
+                  f"input -> ALL got their OWN correct value (k commas -> k+1). "
+                  f"No cross-request state bleed.")
+    finally:
+        stop_server(proc)
+
+    # ---- Property 3: the pool actually parallelizes (1 vs N under load) ----
+    print()
+    port1 = free_port()
+    proc1 = start_server(1, port1)
+    try:
+        single = measure_throughput(f"http://127.0.0.1:{port1}", "1 worker")
+    finally:
+        stop_server(proc1)
+
+    portn = free_port()
+    procn = start_server(n_workers, portn)
+    try:
+        multi = measure_throughput(f"http://127.0.0.1:{portn}", f"{n_workers} workers")
+    finally:
+        stop_server(procn)
+
+    speedup = multi["rps"] / single["rps"] if single["rps"] > 0 else 0.0
+    print(f"\n  speedup ({n_workers} workers / 1 worker): {speedup:.2f}x "
+          f"throughput under {CONCURRENCY}-way concurrent load")
+
+    if single["correct"] != LOAD_REQUESTS or multi["correct"] != LOAD_REQUESTS:
+        print("  FAIL: some heavy requests returned wrong/failed values",
+              file=sys.stderr)
+        failures.append(("throughput-correctness",))
+
+    # The pool must measurably beat the single worker on CPU-bearing concurrent
+    # load. We require a real margin (>1.3x) so a noisy near-1.0 result fails
+    # rather than passing on jitter — the claim is "the pool parallelizes," and
+    # that claim needs a number, not a vibe.
+    if speedup < 1.3:
+        print(f"\nFAIL: {n_workers}-worker throughput did not exceed 1-worker by a "
+              f"real margin ({speedup:.2f}x < 1.3x) — pool not parallelizing",
+              file=sys.stderr)
+        return 1
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} correctness failure(s)", file=sys.stderr)
+        return 1
+
+    print("\nok — worker pool: correct under 50-way concurrency, NO cross-request "
+          f"state bleed (each isolated kernel), and {speedup:.2f}x throughput from "
+          f"{n_workers} workers vs 1. The concurrency gap is closed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -23,7 +23,9 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
 use std::time::Instant;
 
 mod bp_table;
@@ -6243,6 +6245,202 @@ Source adapter modes:
 // argument. The walker turns either return value into a string for
 // the response body via `Value::display()`.
 
+// Per-worker thread stack. The kernel value-walk is a recursive tree-walker, so
+// a deeply self-recursive native handler consumes real stack. 16 MiB comfortably
+// exceeds the typical main-thread stack (~8 MiB), so a pooled worker handles at
+// least the recursion depth the single-threaded serve path did before the pool.
+const WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+// The route manifest a worker resolves from its own kernel+arena: a list of
+// (path, handler-closure). Each closure's `env` is a frame index INTO THAT
+// worker's arena, so route_pairs are NOT shareable across workers — every
+// worker re-loads routes.fk into its own Kernel+Arena and resolves its own
+// copy. This is the !Sync constraint the pool answers (lc-native-kernel-binary:
+// the per-process intern table means a pool of kernel workers, not one shared
+// mutable kernel).
+type RoutePairs = Vec<(String, Arc<Closure>)>;
+
+// Resolve the top-level `routes` binding from a kernel+arena that has already
+// walked the manifest source. Pulled out of cli_serve so BOTH the single-path
+// load and each worker's per-thread load run the SAME resolution shape. Returns
+// the (path, closure) pairs, or an error string for the caller to report.
+fn build_route_pairs(
+    k: &mut Kernel,
+    arena: &Arena,
+    root_env: FrameId,
+    routes_path: &str,
+) -> Result<RoutePairs, String> {
+    let routes_name = k.intern_string("routes").inst;
+    let routes_val = match arena.lookup(root_env, routes_name) {
+        Some(v) => v,
+        None => {
+            return Err(format!(
+                "{} must bind a top-level `routes` list",
+                routes_path
+            ))
+        }
+    };
+    match &routes_val {
+        Value::List(xs) => xs
+            .iter()
+            .map(|row| match row {
+                Value::List(ys) if ys.len() == 2 => {
+                    let path = match &ys[0] {
+                        Value::Str(s) => s.clone(),
+                        _ => return Err("route key must be a string".to_string()),
+                    };
+                    let cl = match &ys[1] {
+                        Value::Closure(c) => c.clone(),
+                        _ => {
+                            return Err(format!("route value for {} must be a closure", path))
+                        }
+                    };
+                    Ok((path, cl))
+                }
+                _ => Err("each route must be (path closure)".to_string()),
+            })
+            .collect(),
+        _ => Err("`routes` must be a list of (path closure) pairs".to_string()),
+    }
+}
+
+// Build a worker's OWN Kernel + Arena from the manifest source, resolve its own
+// route_pairs, and return all three. Called once per worker at startup (loading
+// the source N times is fine — it is once-per-worker, not per-request). The
+// returned arena owns the frames the route closures capture, so it must stay
+// alive alongside the kernel for the worker's lifetime.
+fn build_worker_kernel(
+    src: &str,
+    routes_path: &str,
+) -> Result<(Kernel, Arena, RoutePairs), String> {
+    let mut k = Kernel::new();
+    let root = read_root_from_source(&mut k, src);
+    let mut arena = Arena::new();
+    let root_env = arena.new_frame(None);
+    k.active_roots = vec![root];
+    let _ = walk(&mut k, &mut arena, root, root_env);
+    let route_pairs = build_route_pairs(&mut k, &arena, root_env, routes_path)?;
+    Ok((k, arena, route_pairs))
+}
+
+// Handle ONE request on a worker's own kernel+arena. This is the single factored
+// serving shape (core-abstraction-first): the routing decision (native Form
+// handler vs fan-out to the Python upstream vs 404) lives here ONCE, and the
+// worker pool simply parallelizes calling it. Because `k` and `arena` belong to
+// the calling worker alone, concurrent requests on different workers never share
+// mutable kernel state — each request's value-walk is isolated.
+fn handle_request(
+    mut stream: TcpStream,
+    k: &mut Kernel,
+    arena: &mut Arena,
+    route_pairs: &RoutePairs,
+    upstream: &Option<String>,
+) {
+    // Read up to 8 KiB of request — enough for line + headers; this
+    // is HTTP/1.0, no chunked bodies, no keep-alive.
+    let mut buf = [0u8; 8192];
+    let n = match stream.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+    let (method, target, path, query) = parse_request_line(&req);
+
+    // The router decision: a path with a native Form handler is served
+    // entirely in the kernel; a path with no handler fans out to the
+    // Python upstream (if --upstream is set) or 404s.
+    let body: String;
+    let status: String;
+    let router: &str;
+    if method != "GET" {
+        // GET-only doorway today; non-idempotent verbs are a named build.
+        status = "405 Method Not Allowed".to_string();
+        body = format!("method not allowed: {}\n", method);
+        router = "local-control";
+    } else if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
+        // NATIVE: served entirely in Form, no Python in the path.
+        // Build the query alist as Value::List of (key, value) pairs.
+        let q_alist = Value::List(
+            query
+                .iter()
+                .map(|(k, v)| Value::List(vec![Value::Str(k.clone()), Value::Str(v.clone())]))
+                .collect(),
+        );
+        let cl = cl.clone();
+        let call_frame = arena.new_frame_with_capacity(Some(cl.env), cl.params.len());
+        if cl.params.len() == 1 {
+            arena.bind(call_frame, cl.params[0], q_alist);
+        } else if cl.params.len() != 0 {
+            let status = "500 Internal Server Error".to_string();
+            let body = format!(
+                "handler for {} wants {} params; serve passes 0 or 1\n",
+                path,
+                cl.params.len()
+            );
+            let _ =
+                stream.write_all(http_response(&status, &body, "native-kernel-error").as_bytes());
+            return;
+        }
+        let result = walk(k, arena, cl.body, call_frame);
+        status = "200 OK".to_string();
+        body = result.display();
+        router = "native-kernel";
+    } else if let Some(upstream_base) = upstream {
+        // FAN-OUT: no native handler — forward to the Python upstream and
+        // relay its response. The kernel owns the front door; Python is the
+        // upstream for the not-yet-native tail. Each worker issues its own
+        // independent fan-out hop.
+        let (fanout_status, fanout_body) = fanout_get(upstream_base, &target);
+        status = fanout_status;
+        body = fanout_body;
+        router = "fanout-python";
+    } else {
+        // No native handler and no upstream configured.
+        status = "404 Not Found".to_string();
+        body = format!("no route for {}\n", path);
+        router = "local-control";
+    }
+    let _ = stream.write_all(http_response(&status, &body, router).as_bytes());
+}
+
+// One kernel worker. Builds its OWN Kernel + Arena (the routes.fk loaded once
+// into it at startup — !Sync, never shared), then pulls accepted streams from
+// the shared work queue and serves each via the factored handle_request. N of
+// these run concurrently behind the accept loop; because each owns its kernel,
+// concurrent requests never corrupt one another's state.
+fn worker_loop(
+    id: usize,
+    src: Arc<String>,
+    routes_path: Arc<String>,
+    upstream: Arc<Option<String>>,
+    rx: Arc<Mutex<mpsc::Receiver<TcpStream>>>,
+) {
+    let (mut k, mut arena, route_pairs) = match build_worker_kernel(&src, &routes_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("serve: worker {} failed to load routes: {}", id, e);
+            return;
+        }
+    };
+    loop {
+        // Lock only to dequeue one stream, then release before serving so the
+        // workers truly run in parallel (the lock guards the queue, not the
+        // request handling).
+        let stream = {
+            let guard = match rx.lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            guard.recv()
+        };
+        match stream {
+            Ok(s) => handle_request(s, &mut k, &mut arena, &route_pairs, &upstream),
+            // Sender dropped (listener closed) — drain done, worker exits.
+            Err(_) => return,
+        }
+    }
+}
+
 fn cli_serve(args: &[String]) -> i32 {
     // --port <p> --routes <file.fk> [--upstream <http-base-url>]
     let mut port: u16 = 8001;
@@ -6254,6 +6452,12 @@ fn cli_serve(args: &[String]) -> i32 {
     // flag an unmatched path is a 404 — the original proof-of-shape behavior,
     // unchanged, so existing callers see no difference.
     let mut upstream: Option<String> = None;
+    // --workers <n> sizes the pool of kernel workers behind the accept loop.
+    // Each worker owns its own Kernel + Arena (the !Sync constraint), so the
+    // pool gives REAL concurrency, not one shared mutable kernel serialized.
+    // Default: the host's available parallelism (capped sane), so the box's
+    // cores are used out of the box; 0 or unset falls back to the default.
+    let mut workers: Option<usize> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -6287,6 +6491,20 @@ fn cli_serve(args: &[String]) -> i32 {
                 upstream = Some(args[i + 1].trim_end_matches('/').to_string());
                 i += 2;
             }
+            "--workers" => {
+                if i + 1 >= args.len() {
+                    eprintln!("serve: --workers requires a number");
+                    return 2;
+                }
+                workers = match args[i + 1].parse() {
+                    Ok(w) => Some(w),
+                    Err(_) => {
+                        eprintln!("serve: --workers must be a number");
+                        return 2;
+                    }
+                };
+                i += 2;
+            }
             other => {
                 eprintln!("serve: unknown argument: {}", other);
                 return 2;
@@ -6308,47 +6526,21 @@ fn cli_serve(args: &[String]) -> i32 {
         }
     };
 
-    // Load the routes file into a long-lived kernel + arena. The root
-    // frame holds the `routes` binding after the file runs; each request
-    // gets a child frame so handler-local lets don't pollute the root.
-    let mut k = Kernel::new();
-    let root = read_root_from_source(&mut k, &src);
-    let mut arena = Arena::new();
-    let root_env = arena.new_frame(None);
-    k.active_roots = vec![root];
-    let _ = walk(&mut k, &mut arena, root, root_env);
+    // Validate the manifest ONCE up front (in the main thread) so a broken
+    // routes.fk fails fast with a clear message before any worker spins up.
+    // Each worker re-loads the same source into its OWN kernel+arena below.
+    if let Err(e) = build_worker_kernel(&src, &routes_path) {
+        eprintln!("serve: {}", e);
+        return 1;
+    }
 
-    let routes_name = k.intern_string("routes").inst;
-    let routes_val = match arena.lookup(root_env, routes_name) {
-        Some(v) => v,
-        None => {
-            eprintln!("serve: {} must bind a top-level `routes` list", routes_path);
-            return 1;
-        }
-    };
-    let route_pairs: Vec<(String, Arc<Closure>)> = match &routes_val {
-        Value::List(xs) => xs
-            .iter()
-            .map(|row| match row {
-                Value::List(ys) if ys.len() == 2 => {
-                    let path = match &ys[0] {
-                        Value::Str(s) => s.clone(),
-                        _ => panic!("serve: route key must be a string"),
-                    };
-                    let cl = match &ys[1] {
-                        Value::Closure(c) => c.clone(),
-                        _ => panic!("serve: route value for {} must be a closure", path),
-                    };
-                    (path, cl)
-                }
-                _ => panic!("serve: each route must be (path closure)"),
-            })
-            .collect(),
-        _ => {
-            eprintln!("serve: `routes` must be a list of (path closure) pairs");
-            return 1;
-        }
-    };
+    // Size the pool. Default to the host's available parallelism so the box's
+    // cores are used; cap at 64 so a pathological --workers can't exhaust the
+    // thread table; floor at 1 so the pool always has at least one worker.
+    let default_workers = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    let n_workers = workers.unwrap_or(default_workers).clamp(1, 64);
 
     let listener = match TcpListener::bind(("127.0.0.1", port)) {
         Ok(l) => l,
@@ -6357,84 +6549,94 @@ fn cli_serve(args: &[String]) -> i32 {
             return 1;
         }
     };
-    eprintln!(
-        "form-kernel-rust serve: listening on 127.0.0.1:{} ({} native route{})",
-        port,
-        route_pairs.len(),
-        if route_pairs.len() == 1 { "" } else { "s" }
-    );
-    for r in &route_pairs {
-        eprintln!("  {} -> native (Form handler)", r.0);
+
+    // The shared work queue: the accept loop sends each accepted stream; the
+    // receiver is shared across workers behind a Mutex (the classic std
+    // threadpool — mpsc + Arc<Mutex<Receiver>>). The lock guards only the
+    // dequeue; request handling runs lock-free on each worker's own kernel,
+    // so N workers serve N requests truly in parallel.
+    let (tx, rx) = mpsc::channel::<TcpStream>();
+    let rx = Arc::new(Mutex::new(rx));
+    let src = Arc::new(src);
+    let routes_path_arc = Arc::new(routes_path);
+    let upstream_arc = Arc::new(upstream);
+
+    // Spawn the pool. Each worker builds its OWN Kernel + Arena from the source
+    // (routes.fk loaded once per worker at startup), then drains the queue.
+    // Workers get an EXPLICIT generous stack: the kernel's value-walk is a
+    // recursive tree-walker, so a deeply self-recursive native handler needs
+    // real stack depth. A spawned thread's default stack (~2 MiB on many
+    // platforms) is smaller than the main thread's (~8 MiB), and a Rust stack
+    // overflow ABORTS THE PROCESS (it is not a catchable panic) — so an
+    // under-sized worker stack would let one pathological request take the
+    // whole server down. WORKER_STACK_SIZE exceeds the typical main-thread
+    // stack so a worker handles at least the recursion depth the single-thread
+    // path did. (Unbounded recursion is still the handler's responsibility; the
+    // generous stack matches the prior behavior rather than promising infinity.)
+    let mut handles = Vec::with_capacity(n_workers);
+    for id in 0..n_workers {
+        let src = Arc::clone(&src);
+        let routes_path = Arc::clone(&routes_path_arc);
+        let upstream = Arc::clone(&upstream_arc);
+        let rx = Arc::clone(&rx);
+        let builder = thread::Builder::new()
+            .name(format!("kernel-worker-{}", id))
+            .stack_size(WORKER_STACK_SIZE);
+        match builder.spawn(move || {
+            worker_loop(id, src, routes_path, upstream, rx);
+        }) {
+            Ok(h) => handles.push(h),
+            Err(e) => {
+                eprintln!("serve: failed to spawn worker {}: {}", id, e);
+                // Workers already spawned keep serving; a partial pool is
+                // better than none. If NONE spawned, the accept loop's send
+                // will fail and we stop cleanly below.
+            }
+        }
     }
-    match &upstream {
+    if handles.is_empty() {
+        eprintln!("serve: no workers could be spawned");
+        return 1;
+    }
+
+    // Re-resolve the route list once (in the main thread, throwaway kernel)
+    // purely to print the startup banner — the workers hold the live copies.
+    if let Ok((_, _, route_pairs)) = build_worker_kernel(&src, &routes_path_arc) {
+        eprintln!(
+            "form-kernel-rust serve: listening on 127.0.0.1:{} ({} worker{}, {} native route{})",
+            port,
+            n_workers,
+            if n_workers == 1 { "" } else { "s" },
+            route_pairs.len(),
+            if route_pairs.len() == 1 { "" } else { "s" }
+        );
+        for r in &route_pairs {
+            eprintln!("  {} -> native (Form handler)", r.0);
+        }
+    }
+    match upstream_arc.as_ref() {
         Some(u) => eprintln!("  *  -> fan-out to Python upstream {}", u),
         None => eprintln!("  *  -> 404 (no --upstream; fan-out arm inactive)"),
     }
 
+    // The accept loop is now thin: it only hands each accepted stream to the
+    // pool. The kernel work happens on the workers, concurrently.
     for incoming in listener.incoming() {
-        let mut stream = match incoming {
+        let stream = match incoming {
             Ok(s) => s,
             Err(_) => continue,
         };
-        // Read up to 8 KiB of request — enough for line + headers; this
-        // is HTTP/1.0, no chunked bodies, no keep-alive.
-        let mut buf = [0u8; 8192];
-        let n = match stream.read(&mut buf) {
-            Ok(n) => n,
-            Err(_) => continue,
-        };
-        let req = String::from_utf8_lossy(&buf[..n]).to_string();
-        let (method, target, path, query) = parse_request_line(&req);
-
-        // The router decision: a path with a native Form handler is served
-        // entirely in the kernel; a path with no handler fans out to the
-        // Python upstream (if --upstream is set) or 404s.
-        let body: String;
-        let status: String;
-        let router: &str;
-        if method != "GET" {
-            status = "405 Method Not Allowed".to_string();
-            body = format!("method not allowed: {}\n", method);
-            router = "local-control";
-        } else if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
-            // NATIVE: served entirely in Form, no Python in the path.
-            // Build the query alist as Value::List of (key, value) pairs.
-            let q_alist = Value::List(
-                query
-                    .iter()
-                    .map(|(k, v)| Value::List(vec![Value::Str(k.clone()), Value::Str(v.clone())]))
-                    .collect(),
-            );
-            let cl = cl.clone();
-            let call_frame = arena.new_frame_with_capacity(Some(cl.env), cl.params.len());
-            if cl.params.len() == 1 {
-                arena.bind(call_frame, cl.params[0], q_alist);
-            } else if cl.params.len() != 0 {
-                status = "500 Internal Server Error".to_string();
-                body = format!(
-                    "handler for {} wants {} params; serve passes 0 or 1\n",
-                    path,
-                    cl.params.len()
-                );
-                let _ = stream
-                    .write_all(http_response(&status, &body, "native-kernel-error").as_bytes());
-                continue;
-            }
-            let result = walk(&mut k, &mut arena, cl.body, call_frame);
-            status = "200 OK".to_string();
-            body = result.display();
-            router = "native-kernel";
-        } else if let Some(upstream_base) = &upstream {
-            let (fanout_status, fanout_body) = fanout_get(upstream_base, &target);
-            status = fanout_status;
-            body = fanout_body;
-            router = "fanout-python";
-        } else {
-            status = "404 Not Found".to_string();
-            body = format!("no route for {}\n", path);
-            router = "local-control";
+        if tx.send(stream).is_err() {
+            // All workers gone — nothing can serve; stop accepting.
+            break;
         }
-        let _ = stream.write_all(http_response(&status, &body, router).as_bytes());
+    }
+
+    // Listener ended: drop the sender so workers see the channel close and
+    // exit, then join them so no thread is leaked.
+    drop(tx);
+    for h in handles {
+        let _ = h.join();
     }
     0
 }

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -144,17 +144,20 @@ gap, named precisely:
 | Gap | cli_serve today | Production front door needs |
 |-----|-----------------|-----------------------------|
 | **HTTP version** | HTTP/1.0, `Connection: close` per request | HTTP/1.1 + keep-alive (and ideally HTTP/2 behind Traefik), chunked transfer |
-| **Concurrency** | single-threaded `for incoming in listener.incoming()` — one request at a time | a thread pool or async accept loop; the `Kernel + Arena` is `!Sync` today, so either a kernel-per-worker pool or an arena-sharding pass |
+| **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
 | **Request parsing** | request line + flat string query alist; 8 KiB cap; GET only | full header map, request bodies (POST/PUT/PATCH), content-type aware parsing, larger/streamed bodies |
 | **Fan-out proxy** | GET only, status+body relayed as text/plain, no header passthrough | method + header + body passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
 | **Handler inputs** | 0 or 1 arg (the query alist) | path params, headers, parsed bodies marshalled into the handler frame |
 | **Errors / observability** | 404/405/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
 
-None of these is exotic; each is a named breath. The concurrency item is the
-load-bearing one — the kernel's per-process intern table (`lc-native-kernel-binary`
-names this: *"Not multi-process"*) means a production router is a **pool of
-kernel workers behind the accept loop**, not one shared mutable kernel.
+None of these is exotic; each is a named breath. Concurrency was the
+load-bearing one and it is built: the kernel's per-process intern table
+(`lc-native-kernel-binary` names this: *"Not multi-process"*) makes the
+production shape a **pool of kernel workers behind the accept loop**, each
+holding its own `Kernel + Arena`, rather than one shared mutable kernel — and
+that pool is now what `cli_serve` runs. The remaining rows are still open
+breaths.
 
 ## The BML preference
 
@@ -215,9 +218,28 @@ it fans out the tail to a CPython upstream over a real HTTP hop; sub-millisecond
 native latency (whole-request wall time including the loopback socket — the Form
 value-walk is a sub-fraction).
 
-**NOT shown / not claimed:** production-readiness. The proof is HTTP/1.0,
-single-threaded, GET-only, with a mock upstream. The production build is the
-table above.
+[`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py)
+proves the worker pool under concurrent load — the load-bearing concurrency row
+above. It fires 50 parallel clients and measures three properties:
+
+```
+[no-bleed ] 50 parallel clients, each a DISTINCT input -> ALL got their OWN correct value (k commas -> k+1). No cross-request state bleed.
+[  1 worker] 600 reqs @ 50 parallel:    113.3 req/s  p50=437.94 ms  p99= 470.00 ms  correct=600/600
+[ 8 workers] 600 reqs @ 50 parallel:    555.1 req/s  p50= 84.02 ms  p99= 111.53 ms  correct=600/600
+speedup (8 workers / 1 worker): 4.90x throughput under 50-way concurrent load
+```
+
+**Also shown (measured):** the pool serves correctly under 50-way concurrency;
+each worker's isolated `Kernel + Arena` means concurrent requests with DIFFERENT
+inputs each return their OWN correct value with no cross-request state bleed (the
+critical correctness property of a per-worker-kernel pool); and N workers deliver
+multiples of single-worker throughput on CPU-bearing concurrent load (the single
+worker serializes the value-walks; the pool parallelizes them across cores).
+
+**NOT shown / not claimed:** full production-readiness. The proof is HTTP/1.0,
+GET-only, with a mock upstream, and the accept loop is thread-per-request-blocked
+(it parallelizes to the worker count, not an async reactor). Concurrency itself
+is now shown; the other rows above are the remaining build.
 
 ## The flip is Urs's decision
 
@@ -238,7 +260,8 @@ test port so the reversal can be weighed with evidence rather than assertion.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener), `fan_out_to_upstream` (the proxy arm), `http_response_routed` (the X-Form-Router header).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape), `fan_out_to_upstream` (the proxy arm), `http_response_routed` (the X-Form-Router header).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
-- [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end proof + measurement.
+- [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement.
+- [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.


### PR DESCRIPTION
## What

`cli_serve` (the kernel-as-router serve primitive) served one request at a time on a single `Kernel + Arena`. The accept loop now dispatches each accepted `TcpStream` to a **POOL of kernel workers**, each owning its **own `Kernel + Arena`** — the `!Sync` per-process intern table the design (`kernels/KERNEL_AS_ROUTER.md`) names as the load-bearing concurrency gap: *a pool of kernel workers, not one shared mutable kernel*.

## How

- **`--workers <n>`** flag, default the host's `available_parallelism()` (clamped 1..64).
- Each worker runs `build_worker_kernel` once at startup: its own `Kernel + Arena` with `routes.fk` loaded into it. Route closures capture arena-local frame indices, so `route_pairs` can't cross worker boundaries — each worker re-resolves its own copy.
- The routing/serving logic is factored into **one `handle_request` shape** (native Form handler vs fan-out vs 404); the pool just parallelizes calling it (core-abstraction-first).
- Shared work queue: `mpsc::channel<TcpStream>` with the receiver behind `Arc<Mutex<Receiver>>` (classic std threadpool). The lock guards only the dequeue; request handling runs lock-free on each worker's own kernel.
- Workers get an explicit **16 MiB stack** (`thread::Builder::stack_size`): the value-walk is a recursive tree-walker and a Rust stack overflow aborts the whole process, so a worker must hold at least the recursion depth the single-thread main stack did. Verified: a 4000-deep recursive handler crashed the default-stack worker; the larger stack serves it and the server survives.
- Graceful shutdown: listener end → drop sender → workers drain + exit → joined (no leaked threads).

## Proof (measured, not asserted)

`form/form-kernel-rust/router_concurrency_harness.py` — 50 parallel clients:

```
[no-bleed ] 50 parallel clients, each a DISTINCT input -> ALL got their OWN correct value (k commas -> k+1). No cross-request state bleed.
[  1 worker] 600 reqs @ 50 parallel:    113.3 req/s  p50=437.94 ms  p99= 470.00 ms  correct=600/600
[ 8 workers] 600 reqs @ 50 parallel:    555.1 req/s  p50= 84.02 ms  p99= 111.53 ms  correct=600/600
speedup (8 workers / 1 worker): 4.90x throughput under 50-way concurrent load
```

- **No cross-request state bleed** — the critical correctness property: each worker's isolated kernel means concurrent requests with different inputs each return their own correct value.
- **Correct under concurrency** — `correct=600/600` for both 1 and N workers.
- **The pool parallelizes** — ~3-5x throughput (varies with host load; single-worker pinned ~111 req/s, N-worker scales with cores); p50 437ms → 84ms.

The existing `router_proof_harness.py` (topology + native latency) still passes against the pooled server.

## Three-way build

`form/validate.sh` (full): **257 ok, 1 divergent**. `compression-fold-band → 111111`. The lone divergence is the **pre-existing untracked** `seeded-bytes-recipe-band.fk` (`add_mod_u64` unbound) — `??` in git, not in this change. No NEW divergence. `cargo build --release` produces the binary.

## Scope / honesty

This matures the **serve primitive only**. The **concurrency gap is closed**. The other named gaps stay open per the design table: HTTP/1.1 keep-alive, full request/body parsing, header passthrough; the accept loop is thread-per-request-blocked (parallelizes to the worker count, not an async reactor). The design doc's concurrency row is updated in present-tense voice.

**NO production routing flip** — FastAPI stays the live front-door. cli_serve is not wired to production, so no live-route impact. The flip remains Urs's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)