### PR TITLE
feat(kernel): read request bodies in the kernel-router serve primitive

### DIFF
--- a/form/form-kernel-rust/examples/router-body-proof.fk
+++ b/form/form-kernel-rust/examples/router-body-proof.fk
@@ -1,0 +1,51 @@
+; router-body-proof.fk — proves the kernel-router READS REQUEST BODIES.
+;
+; Loaded by `form-kernel-rust serve`. Where router-proof.fk proved GET routing,
+; this manifest proves the matured serve primitive: a native handler receives
+; POST/PUT body fields through the SAME alist a GET handler reads its query
+; params from (form-urlencoded merged in), and a JSON body is captured raw under
+; the reserved key "__body__".
+;
+;   POST /sum         (a=40&b=2, urlencoded)   -> "42"   (body fields summed)
+;   POST /echo_len    ({"k":"v"}, json)        -> length of the raw JSON body
+;   POST /payload_len (payload=<8KB+>, urlenc) -> length of the field value
+;   GET  /health                               -> "ok"   (GET still works)
+
+; --- alist helper: value for `key` in a list of (k v) string pairs ---
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+; --- liveness (GET, no inputs) — proves GET is unchanged ---
+(defn route_health ()
+  "ok")
+
+; --- POST form-urlencoded: read two body fields and SUM them. The handler reads
+; `a` and `b` from the SAME alist a GET handler reads query params from. ---
+(defn route_sum (q)
+  (int_to_str (add (str_to_int (assoc "a" q))
+                   (str_to_int (assoc "b" q)))))
+
+; --- POST application/json: the raw JSON body is captured under "__body__".
+; The handler reads it and returns its character length — proving the kernel
+; captured the raw JSON payload and made it available to Form. ---
+(defn route_echo_len (q)
+  (int_to_str (str_len (assoc "__body__" q))))
+
+; --- POST a single large form field; return the length of its value. When the
+; value is larger than the kernel's initial 8 KiB read buffer, a matching length
+; proves the FULL body was captured across multiple reads (Content-Length
+; honored) — the correctness property the old single-buffer read failed. ---
+(defn route_payload_len (q)
+  (int_to_str (str_len (assoc "payload" q))))
+
+; --- the route manifest: (path handler). Everything not here fans out. ---
+(let routes
+  (list
+    (list "/health"      route_health)
+    (list "/sum"         route_sum)
+    (list "/echo_len"    route_echo_len)
+    (list "/payload_len" route_payload_len)))

--- a/form/form-kernel-rust/router_body_harness.py
+++ b/form/form-kernel-rust/router_body_harness.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Proof harness for the kernel-router's REQUEST BODY parsing.
+
+Where router_proof_harness.py proved GET routing, this proves the matured serve
+primitive: `cli_serve` now reads the FULL request honoring Content-Length, parses
+the body by Content-Type, and marshals it into the handler frame.
+
+What it asserts (real POSTs over a loopback socket):
+  - a native POST handler reads form-urlencoded body fields through the SAME
+    alist a GET handler reads query params from: POST /sum (a=40&b=2) -> "42".
+  - a native POST handler sees a JSON body captured raw under "__body__":
+    POST /echo_len ({...}) -> the JSON body's character length.
+  - a body LARGER than the kernel's initial 8 KiB read is fully captured
+    (Content-Length honored across multiple reads): POST /payload_len with an
+    >8 KiB field value -> that exact length. This is the correctness property
+    the old single 8 KiB buffer read failed.
+  - GET is unchanged: GET /health -> "ok" (native), and a non-native GET fans
+    out to the CPython upstream.
+  - a non-native POST FANS OUT with its body forwarded: the upstream echoes the
+    received body, proving the kernel relayed method + body to Python.
+
+Touches NO production routing — a mock CPython upstream stands in for FastAPI.
+
+Run from form/form-kernel-rust/:
+    cargo build --release
+    python3 router_body_harness.py
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-body-proof.fk"
+
+UPSTREAM_MARKER = "UPSTREAM-CPYTHON-FASTAPI-STANDIN"
+# Mirrors the kernel's MAX_BODY_BYTES (form-kernel-rust src/main.rs).
+MAX_BODY_BYTES = 1024 * 1024
+
+
+class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """The CPython upstream the kernel fans out to (mock FastAPI).
+
+    GET returns a marker + path. POST/PUT/PATCH read the forwarded body and
+    echo it back, so the harness can prove the kernel relayed method + body.
+    """
+
+    def _reply(self, text: bytes):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(text)))
+        self.end_headers()
+        self.wfile.write(text)
+
+    def do_GET(self):  # noqa: N802
+        self._reply(f"{UPSTREAM_MARKER} GET {self.path}\n".encode())
+
+    def do_POST(self):  # noqa: N802
+        n = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(n) if n else b""
+        ctype = self.headers.get("Content-Type", "<none>")
+        body = (
+            f"{UPSTREAM_MARKER} POST {self.path} ctype={ctype} "
+            f"body={raw.decode('utf-8', 'replace')}\n"
+        ).encode()
+        self._reply(body)
+
+    def log_message(self, *args):  # silence per-request logging
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def raw_request(port: int, method: str, path: str,
+                body: bytes = b"", content_type: str | None = None,
+                timeout: float = 5.0):
+    """Send one HTTP/1.0 request over a fresh socket; return (status, body, router)."""
+    lines = [f"{method} {path} HTTP/1.0", "Host: 127.0.0.1"]
+    if body:
+        if content_type:
+            lines.append(f"Content-Type: {content_type}")
+        lines.append(f"Content-Length: {len(body)}")
+    lines.append("Connection: close")
+    head = ("\r\n".join(lines) + "\r\n\r\n").encode()
+    with socket.create_connection(("127.0.0.1", port), timeout=timeout) as s:
+        s.sendall(head + body)
+        chunks = []
+        while True:
+            b = s.recv(65536)
+            if not b:
+                break
+            chunks.append(b)
+    resp = b"".join(chunks)
+    head_b, _, body_b = resp.partition(b"\r\n\r\n")
+    head_txt = head_b.decode("utf-8", "replace")
+    status_line = head_txt.splitlines()[0] if head_txt else ""
+    status = status_line.split(" ", 1)[1] if " " in status_line else status_line
+    router = None
+    for line in head_txt.splitlines()[1:]:
+        if line.lower().startswith("x-form-router:"):
+            router = line.split(":", 1)[1].strip()
+    return status, body_b.decode("utf-8", "replace"), router
+
+
+def oversize_probe(port: int, declared: int, timeout: float = 5.0):
+    """Advertise a Content-Length over the cap but send only a tiny body prefix.
+
+    The server must reject on the header alone (it must not block waiting for a
+    body it will never read) and answer 413. Returns the status line. Tolerates
+    the connection reset that can follow the server closing mid-send.
+    """
+    head = (
+        f"POST /payload_len HTTP/1.0\r\nHost: 127.0.0.1\r\n"
+        f"Content-Type: application/x-www-form-urlencoded\r\n"
+        f"Content-Length: {declared}\r\nConnection: close\r\n\r\n"
+    ).encode()
+    s = socket.create_connection(("127.0.0.1", port), timeout=timeout)
+    try:
+        s.sendall(head + b"payload=" + b"y" * 100)  # tiny prefix only
+        try:
+            s.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        s.settimeout(timeout)
+        resp = b""
+        try:
+            while True:
+                b = s.recv(65536)
+                if not b:
+                    break
+                resp += b
+        except (ConnectionResetError, socket.timeout):
+            pass
+    finally:
+        s.close()
+    txt = resp.decode("utf-8", "replace")
+    return txt.splitlines()[0] if txt else "<empty>"
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    up_port = free_port()
+    httpd = http.server.HTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
+    up_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    up_thread.start()
+    upstream_url = f"http://127.0.0.1:{up_port}"
+
+    kport = free_port()
+    proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(kport),
+         "--routes", str(ROUTES), "--upstream", upstream_url],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    failures = []
+    try:
+        wait_for_port(kport)
+
+        # --- 1. native POST form-urlencoded: body fields summed ---
+        status, body, router = raw_request(
+            kport, "POST", "/sum", b"a=40&b=2",
+            "application/x-www-form-urlencoded")
+        ok = status == "200 OK" and body == "42" and router == "native-kernel"
+        print(f"  [native POST form ] /sum a=40&b=2 -> {status} {body!r} "
+              f"router={router}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("POST /sum", status, body, router))
+
+        # --- 2. native POST JSON: raw body captured under __body__ ---
+        json_body = b'{"name":"coherence","weight":0.8125}'
+        status, body, router = raw_request(
+            kport, "POST", "/echo_len", json_body, "application/json")
+        ok = (status == "200 OK" and body == str(len(json_body))
+              and router == "native-kernel")
+        print(f"  [native POST json ] /echo_len ({len(json_body)}B JSON) -> "
+              f"{status} {body!r} (expect {len(json_body)}) router={router}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("POST /echo_len", status, body, router))
+
+        # --- 3. >8 KiB body fully captured (Content-Length across reads) ---
+        big_n = 20000  # well past the 8192-byte initial read
+        big_val = "x" * big_n
+        big_body = ("payload=" + big_val).encode()
+        status, body, router = raw_request(
+            kport, "POST", "/payload_len", big_body,
+            "application/x-www-form-urlencoded")
+        ok = (status == "200 OK" and body == str(big_n)
+              and router == "native-kernel")
+        print(f"  [native POST >8KiB] /payload_len ({len(big_body)}B body) -> "
+              f"{status} field-len={body} (expect {big_n}) router={router}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("POST /payload_len >8KiB", status, body, router))
+
+        # --- 4. GET unchanged: native ---
+        status, body, router = raw_request(kport, "GET", "/health")
+        ok = status == "200 OK" and body == "ok" and router == "native-kernel"
+        print(f"  [native GET       ] /health -> {status} {body!r} "
+              f"router={router}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("GET /health", status, body, router))
+
+        # --- 5. GET unchanged: fan-out to CPython upstream ---
+        status, body, router = raw_request(kport, "GET", "/api/whatever")
+        ok = (status == "200 OK" and UPSTREAM_MARKER in body
+              and "GET /api/whatever" in body and router == "fanout-python")
+        print(f"  [fanout GET       ] /api/whatever -> {status} via CPython "
+              f"router={router}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("GET /api/whatever", status, body, router))
+
+        # --- 6. POST fan-out: method + body forwarded to CPython upstream ---
+        fan_body = b"hello=world&n=7"
+        status, body, router = raw_request(
+            kport, "POST", "/api/echo", fan_body,
+            "application/x-www-form-urlencoded")
+        ok = (status == "200 OK" and UPSTREAM_MARKER in body
+              and "POST /api/echo" in body
+              and "body=hello=world&n=7" in body
+              and router == "fanout-python")
+        print(f"  [fanout POST body ] /api/echo (body forwarded) -> {status} "
+              f"router={router}  {'OK' if ok else 'FAIL'}")
+        print(f"       upstream saw: {body.strip()!r}")
+        if not ok:
+            failures.append(("POST /api/echo fanout", status, body, router))
+
+        # --- 7. over-cap body rejected with 413 on the Content-Length header
+        #         alone (the OOM guard: a huge declared body is never buffered) ---
+        declared = MAX_BODY_BYTES + 5000
+        status_line = oversize_probe(kport, declared)
+        ok = "413" in status_line
+        print(f"  [over-cap 413     ] declared CL={declared} (> {MAX_BODY_BYTES} "
+              f"cap) -> {status_line!r}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("over-cap 413", status_line, "", None))
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+            for f in failures:
+                print(f"   {f}", file=sys.stderr)
+            return 1
+        print("\nok — kernel-router READ REQUEST BODIES: form-urlencoded fields "
+              "merged into the handler alist, JSON captured raw, a >8 KiB body "
+              "fully captured (Content-Length honored), GET unchanged, POST "
+              "fan-out forwarded its body to CPython.")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        httpd.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6336,15 +6336,29 @@ fn handle_request(
     route_pairs: &RoutePairs,
     upstream: &Option<String>,
 ) {
-    // Read up to 8 KiB of request — enough for line + headers; this
-    // is HTTP/1.0, no chunked bodies, no keep-alive.
-    let mut buf = [0u8; 8192];
-    let n = match stream.read(&mut buf) {
-        Ok(n) => n,
-        Err(_) => return,
+    // Read the FULL request: the header block, then exactly Content-Length
+    // body bytes if present (read_request honors Content-Length across as many
+    // socket reads as the body needs — a body larger than one buffer is fully
+    // captured). Still HTTP/1.0, Connection: close; keep-alive and chunked
+    // transfer remain named breaths (KERNEL_AS_ROUTER.md request row).
+    let (head, body_bytes) = match read_request(&mut stream) {
+        RequestRead::Ok(h, b) => (h, b),
+        RequestRead::TooLarge => {
+            let status = "413 Payload Too Large".to_string();
+            let msg = format!("request body exceeds {} bytes\n", MAX_BODY_BYTES);
+            let _ = stream.write_all(http_response(&status, &msg, "local-control").as_bytes());
+            return;
+        }
+        RequestRead::Error => return,
     };
-    let req = String::from_utf8_lossy(&buf[..n]).to_string();
-    let (method, target, path, query) = parse_request_line(&req);
+    let (method, target, path, mut request_data) = parse_request_line(&head);
+    // Parse the body by Content-Type and MERGE its fields into the same alist
+    // the handler reads (core-abstraction-first: ONE request-data shape, whether
+    // a field arrived as a query param or a body field). Query fields come
+    // first; body fields are appended. form-urlencoded fields land as plain
+    // (k v) pairs; a JSON / other body lands as a single ("__body__", raw) pair.
+    let content_type = parse_content_type(&head);
+    request_data.extend(parse_request_body(&content_type, &body_bytes));
 
     // The router decision: a path with a native Form handler is served
     // entirely in the kernel; a path with no handler fans out to the
@@ -6352,16 +6366,14 @@ fn handle_request(
     let body: String;
     let status: String;
     let router: &str;
-    if method != "GET" {
-        // GET-only doorway today; non-idempotent verbs are a named build.
-        status = "405 Method Not Allowed".to_string();
-        body = format!("method not allowed: {}\n", method);
-        router = "local-control";
-    } else if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
+    if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
         // NATIVE: served entirely in Form, no Python in the path.
-        // Build the query alist as Value::List of (key, value) pairs.
+        // Build the request alist as Value::List of (key, value) pairs — query
+        // params AND body fields, uniformly (form-urlencoded merged in;
+        // JSON/other captured under "__body__"). The handler reads them the same
+        // way regardless of how each field arrived.
         let q_alist = Value::List(
-            query
+            request_data
                 .iter()
                 .map(|(k, v)| Value::List(vec![Value::Str(k.clone()), Value::Str(v.clone())]))
                 .collect(),
@@ -6389,8 +6401,11 @@ fn handle_request(
         // FAN-OUT: no native handler — forward to the Python upstream and
         // relay its response. The kernel owns the front door; Python is the
         // upstream for the not-yet-native tail. Each worker issues its own
-        // independent fan-out hop.
-        let (fanout_status, fanout_body) = fanout_get(upstream_base, &target);
+        // independent fan-out hop, passing the request's METHOD and BODY so a
+        // POST that fans out to Python carries its payload (Content-Type +
+        // Content-Length set from the captured body).
+        let (fanout_status, fanout_body) =
+            fanout_request(upstream_base, &method, &target, &content_type, &body_bytes);
         status = fanout_status;
         body = fanout_body;
         router = "fanout-python";
@@ -6641,6 +6656,159 @@ fn cli_serve(args: &[String]) -> i32 {
     0
 }
 
+// Maximum request body the router will read into memory. A body larger than
+// this is rejected with 413 rather than letting a malicious/huge Content-Length
+// OOM the process. 1 MiB is generous for form posts and JSON payloads; true
+// streaming bodies are a named-later breath (KERNEL_AS_ROUTER.md request row).
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+// The outcome of reading a request: either the parsed (head, body), or a signal
+// that the body exceeded MAX_BODY_BYTES (the caller answers 413), or a read
+// error / empty peer (the caller drops the connection silently).
+enum RequestRead {
+    Ok(String, Vec<u8>),
+    TooLarge,
+    Error,
+}
+
+// Read a full HTTP request: the header block (up to the `\r\n\r\n` terminator)
+// followed by exactly `Content-Length` body bytes if that header is present.
+// The first read may already contain some or all of the body (it arrived in the
+// same TCP segment), so bytes captured past the terminator are counted toward
+// the body and only the remainder is read from the socket. Returns the raw head
+// string (request line + headers, terminator excluded) and the body bytes.
+//
+// This replaces the old single 8 KiB read: it honors Content-Length across as
+// many `read` calls as the body needs, so a body larger than one buffer is
+// fully captured (the correctness property the single-buffer read failed).
+fn read_request(stream: &mut TcpStream) -> RequestRead {
+    let mut raw: Vec<u8> = Vec::with_capacity(8192);
+    let mut buf = [0u8; 8192];
+    // Phase 1: read until the header terminator is seen (or EOF / cap).
+    let header_end: Option<usize> = loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break find_header_end(&raw), // peer closed; use what we have
+            Ok(n) => {
+                raw.extend_from_slice(&buf[..n]);
+                if let Some(t) = find_header_end(&raw) {
+                    break Some(t);
+                }
+                // Guard: the header block alone must not grow without bound.
+                if raw.len() > MAX_BODY_BYTES {
+                    return RequestRead::TooLarge;
+                }
+            }
+            Err(_) => return RequestRead::Error,
+        }
+    };
+    if raw.is_empty() {
+        return RequestRead::Error; // nothing arrived at all
+    }
+    // `header_end` is the index just past "\r\n\r\n" when found. The head text
+    // (terminator excluded) is everything before it; if no terminator was seen
+    // the whole buffer is the head and there is no body.
+    let (head_end_excl_term, body_start) = match header_end {
+        Some(t) => (t - 4, t),
+        None => (raw.len(), raw.len()),
+    };
+    let head = String::from_utf8_lossy(&raw[..head_end_excl_term]).to_string();
+
+    // Phase 2: if Content-Length says there's a body, read exactly that many
+    // bytes, counting whatever already arrived past the header terminator.
+    let mut body: Vec<u8> = raw[body_start..].to_vec();
+    if let Some(total) = parse_content_length(&head) {
+        if total > MAX_BODY_BYTES {
+            return RequestRead::TooLarge; // oversized — caller answers 413
+        }
+        while body.len() < total {
+            match stream.read(&mut buf) {
+                Ok(0) => break, // peer closed early; return the partial body honestly
+                Ok(n) => body.extend_from_slice(&buf[..n]),
+                Err(_) => break,
+            }
+        }
+        body.truncate(total); // never hand back more than Content-Length promised
+    }
+    RequestRead::Ok(head, body)
+}
+
+// Find the index just past the first "\r\n\r\n" header terminator, if present.
+fn find_header_end(raw: &[u8]) -> Option<usize> {
+    raw.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|i| i + 4)
+}
+
+// Pull the Content-Length value out of a raw header block (case-insensitive
+// header name). Returns None when absent or unparseable.
+fn parse_content_length(head: &str) -> Option<usize> {
+    for line in head.lines() {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                return value.trim().parse::<usize>().ok();
+            }
+        }
+    }
+    None
+}
+
+// Pull the Content-Type value (lowercased, parameters stripped) out of a raw
+// header block. "application/json; charset=utf-8" -> "application/json".
+fn parse_content_type(head: &str) -> String {
+    for line in head.lines() {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-type") {
+                let v = value.trim();
+                let main = v.split(';').next().unwrap_or(v);
+                return main.trim().to_ascii_lowercase();
+            }
+        }
+    }
+    String::new()
+}
+
+// Parse a request body into the SAME (key, value) alist shape the query string
+// already uses, so a handler reads body fields exactly like query fields
+// (core-abstraction-first: ONE request-data shape regardless of how the data
+// arrived). The marshalling depends on Content-Type:
+//   - application/x-www-form-urlencoded -> each `k=v&...` pair url-decoded into
+//     the alist (reuses the query-pair parsing), so a form-POST handler sees its
+//     fields uniformly with query params.
+//   - application/json -> the raw JSON string is captured under the reserved key
+//     `__body__` so a handler CAN read it via (assoc "__body__" q). A full
+//     JSON->Form-value parse is a deeper, named-later breath; raw-capture is the
+//     honest first step that already lets a handler process the payload.
+//   - anything else (with a non-empty body) -> the raw bytes captured under
+//     `__body__`. The handler always gets a well-formed alist.
+fn parse_request_body(content_type: &str, body: &[u8]) -> Vec<(String, String)> {
+    if body.is_empty() {
+        return Vec::new();
+    }
+    if content_type == "application/x-www-form-urlencoded" {
+        let s = String::from_utf8_lossy(body);
+        let mut pairs = Vec::new();
+        for pair in s.split('&') {
+            if pair.is_empty() {
+                continue;
+            }
+            let (k, v) = match pair.find('=') {
+                Some(i) => (pair[..i].to_string(), pair[i + 1..].to_string()),
+                None => (pair.to_string(), String::new()),
+            };
+            pairs.push((url_decode(&k), url_decode(&v)));
+        }
+        pairs
+    } else {
+        // application/json and everything else: capture the raw body so the
+        // handler can process it. JSON is left as the raw string by design
+        // (raw-capture, not yet a structural parse).
+        vec![(
+            "__body__".to_string(),
+            String::from_utf8_lossy(body).to_string(),
+        )]
+    }
+}
+
 // Parse the request line "GET /path?k=v HTTP/1.0" into
 // (method, target, path, query).
 // Query string is decoded as a flat list of (key, value) pairs — sufficient
@@ -6697,8 +6865,14 @@ fn url_decode(s: &str) -> String {
     out
 }
 
-fn fanout_get(upstream: &str, target: &str) -> (String, String) {
-    match fanout_get_result(upstream, target) {
+fn fanout_request(
+    upstream: &str,
+    method: &str,
+    target: &str,
+    content_type: &str,
+    body: &[u8],
+) -> (String, String) {
+    match fanout_request_result(upstream, method, target, content_type, body) {
         Ok(v) => v,
         Err(e) => (
             "502 Bad Gateway".to_string(),
@@ -6717,7 +6891,13 @@ fn http_response(status: &str, body: &str, router: &str) -> String {
     )
 }
 
-fn fanout_get_result(upstream: &str, target: &str) -> Result<(String, String), String> {
+fn fanout_request_result(
+    upstream: &str,
+    method: &str,
+    target: &str,
+    content_type: &str,
+    body: &[u8],
+) -> Result<(String, String), String> {
     let (host, port, base_path) = parse_http_upstream(upstream)?;
     let request_target = format!(
         "{}{}",
@@ -6726,17 +6906,31 @@ fn fanout_get_result(upstream: &str, target: &str) -> Result<(String, String), S
     );
     let mut stream = TcpStream::connect((host.as_str(), port))
         .map_err(|e| format!("connect {}:{}: {}", host, port, e))?;
-    let request = format!(
-        "GET {} HTTP/1.0\r\nHost: {}\r\nConnection: close\r\n\r\n",
-        request_target, host
+    // Forward the request line with the ORIGINAL method, then the headers, then
+    // the body bytes. A POST/PUT/PATCH that fans out to Python carries its body
+    // (Content-Length tells the upstream how much to read); Content-Type is
+    // relayed when the original request had one. GET/HEAD send no body.
+    let mut head = format!(
+        "{} {} HTTP/1.0\r\nHost: {}\r\nConnection: close\r\n",
+        method, request_target, host
     );
+    if !body.is_empty() {
+        if !content_type.is_empty() {
+            head.push_str(&format!("Content-Type: {}\r\n", content_type));
+        }
+        head.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    head.push_str("\r\n");
+    let mut request: Vec<u8> = head.into_bytes();
+    request.extend_from_slice(body);
     stream
-        .write_all(request.as_bytes())
+        .write_all(&request)
         .map_err(|e| format!("write request: {}", e))?;
-    let mut response = String::new();
+    let mut response_bytes = Vec::new();
     stream
-        .read_to_string(&mut response)
+        .read_to_end(&mut response_bytes)
         .map_err(|e| format!("read response: {}", e))?;
+    let response = String::from_utf8_lossy(&response_bytes).to_string();
     let mut lines = response.lines();
     let status = lines
         .next()

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -145,19 +145,26 @@ gap, named precisely:
 |-----|-----------------|-----------------------------|
 | **HTTP version** | HTTP/1.0, `Connection: close` per request | HTTP/1.1 + keep-alive (and ideally HTTP/2 behind Traefik), chunked transfer |
 | **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
-| **Request parsing** | request line + flat string query alist; 8 KiB cap; GET only | full header map, request bodies (POST/PUT/PATCH), content-type aware parsing, larger/streamed bodies |
-| **Fan-out proxy** | GET only, status+body relayed as text/plain, no header passthrough | method + header + body passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
-| **Handler inputs** | 0 or 1 arg (the query alist) | path params, headers, parsed bodies marshalled into the handler frame |
-| **Errors / observability** | 404/405/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
+| **Request parsing** | reads the full request honoring Content-Length (a body larger than the initial 8 KiB read is captured across as many socket reads as it needs); parses `application/x-www-form-urlencoded` bodies into the same `(key value)` alist the query string uses, captures `application/json` (and any other body) raw under the reserved key `__body__`; 1 MiB body cap rejected with 413; any method (POST/PUT/PATCH/GET) | full header map exposed to handlers; a structural JSON→Form-value parse (today JSON is raw-captured, not parsed); larger/streamed/chunked bodies |
+| **Fan-out proxy** | forwards the original method and the request body (Content-Type + Content-Length set from the captured body) so a POST that fans out to the upstream carries its payload; status+body relayed as text/plain | request/response header passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
+| **Handler inputs** | 0 or 1 arg — the request alist, carrying query params AND parsed body fields uniformly (form-urlencoded merged in; JSON/other body under `__body__`), so a handler reads a field the same way regardless of how it arrived | path params and headers marshalled into the handler frame; a richer body shape than a flat alist (e.g. structural JSON) |
+| **Errors / observability** | 404/413/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
 
-None of these is exotic; each is a named breath. Concurrency was the
-load-bearing one and it is built: the kernel's per-process intern table
+None of these is exotic; each is a named breath. Two of the load-bearing ones
+are built. **Concurrency**: the kernel's per-process intern table
 (`lc-native-kernel-binary` names this: *"Not multi-process"*) makes the
 production shape a **pool of kernel workers behind the accept loop**, each
 holding its own `Kernel + Arena`, rather than one shared mutable kernel — and
-that pool is now what `cli_serve` runs. The remaining rows are still open
-breaths.
+that pool is now what `cli_serve` runs. **Request bodies**: `cli_serve` reads
+the full request honoring Content-Length (a body past the initial 8 KiB read is
+captured across multiple reads), parses `application/x-www-form-urlencoded`
+bodies into the same handler alist the query string uses, captures
+`application/json` raw under `__body__`, and the fan-out hop forwards the method
+and body to the upstream — so a POST is served (or fanned out) with its payload,
+not just a GET. The remaining rows (HTTP/1.1 keep-alive, full header passthrough,
+a structural JSON→Form parse, streaming, TLS/lifecycle, observability) are still
+open breaths.
 
 ## The BML preference
 
@@ -236,10 +243,38 @@ critical correctness property of a per-worker-kernel pool); and N workers delive
 multiples of single-worker throughput on CPU-bearing concurrent load (the single
 worker serializes the value-walks; the pool parallelizes them across cores).
 
-**NOT shown / not claimed:** full production-readiness. The proof is HTTP/1.0,
-GET-only, with a mock upstream, and the accept loop is thread-per-request-blocked
-(it parallelizes to the worker count, not an async reactor). Concurrency itself
-is now shown; the other rows above are the remaining build.
+[`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py)
+proves the request-body row above — the matured serve primitive reads bodies, not
+just GET tails:
+
+```
+[native POST form ] /sum a=40&b=2          -> 200 '42'    router=native-kernel  OK
+[native POST json ] /echo_len (36B JSON)   -> 200 '36'    router=native-kernel  OK
+[native POST >8KiB] /payload_len (20008B)  -> 200 '20000' router=native-kernel  OK
+[native GET       ] /health                -> 200 'ok'    router=native-kernel  OK
+[fanout GET       ] /api/whatever          -> 200 via CPython router=fanout-python OK
+[fanout POST body ] /api/echo (body fwd)   -> 200 via CPython router=fanout-python OK
+[over-cap 413     ] declared CL=1053576    -> 413 Payload Too Large  OK
+```
+
+**Also shown (measured):** a native POST handler reads form-urlencoded body
+fields through the SAME alist a GET handler reads query params from (`a=40&b=2`
+→ `42`); a JSON body is captured raw under `__body__` and handed to Form (the
+36-byte JSON's length comes back); a body **larger than the initial 8 KiB read**
+is fully captured across multiple reads honoring Content-Length (a 20 KB field
+value returns its exact length — the correctness property the old single-buffer
+read failed); GET is unchanged on both the native and fan-out arms; a POST that
+fans out carries its body to the upstream (the mock CPython echoes the forwarded
+`hello=world&n=7`); and an over-cap body is rejected with 413 on the
+Content-Length header alone, never buffered.
+
+**NOT shown / not claimed:** full production-readiness. The proof is HTTP/1.0
+(no keep-alive), with a mock upstream, and the accept loop is
+thread-per-request-blocked (it parallelizes to the worker count, not an async
+reactor); JSON bodies are raw-captured, not structurally parsed into Form
+values; request/response headers beyond the body are not yet passed through.
+Concurrency and request-body reading are now shown; the other rows above are the
+remaining build.
 
 ## The flip is Urs's decision
 
@@ -260,8 +295,10 @@ test port so the reversal can be weighed with evidence rather than assertion.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape), `fan_out_to_upstream` (the proxy arm), `http_response_routed` (the X-Form-Router header).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape, now reading the full request + body), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read and content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (the X-Form-Router header).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement.
+- [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413.
+- [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.


### PR DESCRIPTION
## What

Matures the kernel-as-router **serve primitive** so it reads request bodies. `cli_serve` previously read one 8 KiB buffer and discarded everything after the `\r\n\r\n` header terminator — GET-only with a flat query alist. This closes the "Request parsing → request bodies" gap named in `kernels/KERNEL_AS_ROUTER.md`.

## The build

- **Full-request read honoring Content-Length.** `read_request` reads until the header terminator, then reads exactly `Content-Length` more bytes — counting whatever already arrived in the first segment, looping `stream.read` as many times as the body needs. A body larger than the initial 8 KiB read is fully captured (the correctness property the single-buffer read failed). 1 MiB cap; an oversized declared body is rejected with **413** on the Content-Length header alone, never buffered.
- **Content-type body parsing.** `application/x-www-form-urlencoded` → each `k=v` pair url-decoded and **merged into the same alist the handler already reads** (core-abstraction-first: ONE request-data shape whether a field arrived as a query param or a body field, so a form-POST handler reads its fields exactly like a GET handler reads query params). `application/json` (and any other body) → captured raw under the reserved key `__body__` so a handler can process it. A structural JSON→Form parse stays a named-later breath; raw-capture is the honest first step.
- **Handler frame.** Merged-alist (not a second binding): the handler signature stays `(q)`; it reads body fields the same way it reads query params via `assoc`. Cleanest given how the route closure is invoked with the query alist.
- **Fan-out forwards method + body.** `fanout_get` → `fanout_request`: forwards the original method and body (Content-Type + Content-Length set from the captured body), so a POST that fans out to the Python upstream carries its payload.

## Proof

`router_body_harness.py` + `examples/router-body-proof.fk` — real POSTs over a loopback socket against a mock CPython upstream (no production routing touched):

```
[native POST form ] /sum a=40&b=2          -> 200 '42'    router=native-kernel  OK
[native POST json ] /echo_len (36B JSON)   -> 200 '36'    router=native-kernel  OK
[native POST >8KiB] /payload_len (20008B)  -> 200 '20000' router=native-kernel  OK   (full body across reads)
[native GET       ] /health                -> 200 'ok'    router=native-kernel  OK
[fanout GET       ] /api/whatever          -> 200 via CPython router=fanout-python OK
[fanout POST body ] /api/echo (body fwd)   -> 200 via CPython router=fanout-python OK   (upstream saw the body)
[over-cap 413     ] declared CL=1053576    -> 413 Payload Too Large  OK
```

The original GET harness (`router_proof_harness.py`) still passes — no regression.

## Three-way / build

`form/validate.sh` (FULL): **257 ok, 1 divergent** — the 1 divergent is the pre-existing **untracked** `seeded-bytes-recipe-band.fk` (`add_mod_u64` unbound across all three kernels), not introduced here; no NEW divergence. compression-fold-band → `111111`. `cargo build --release` produces the binary.

## Scope / honesty

Matures the **serve primitive only**. **No production routing flip** — FastAPI stays the live front door; `cli_serve` isn't wired to production, so no live-route impact. **Closed:** body reading (Content-Length-honored full read, >8 KiB captured), form-urlencoded → handler alist, raw JSON capture, fan-out body forwarding, 413 over-cap guard. **Still open:** structural JSON→Form parse (today raw-capture), streaming/chunked bodies, HTTP/1.1 keep-alive, full header passthrough. Design doc request-parsing / fan-out / handler-inputs rows updated present-tense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)