### PR TITLE
tend(kernel): prove the kernel-as-router reversal against the REAL FastAPI app

### DIFF
--- a/form/form-kernel-rust/examples/router-real-app-proof.fk
+++ b/form/form-kernel-rust/examples/router-real-app-proof.fk
@@ -1,0 +1,81 @@
+; router-real-app-proof.fk — the front-door manifest for the REAL-APP proof.
+;
+; Loaded by `form-kernel-rust serve --upstream <real FastAPI>`. It proves the
+; reversed topology IN FRONT OF THE ACTUAL Coherence-Network FastAPI app (not a
+; mock): the kernel owns the socket, serves ONE kernel-eligible route entirely
+; in Form, and fans out EVERY other path to the real running app.
+;
+;   - NATIVE: /api/utils/weighted_average — the substrate's bread-and-butter
+;     coherence-score combinator, served HERE in Form with NO CPython in the
+;     path. It parses the `values` and `weights` query args (comma-separated
+;     floats) and runs the real arithmetic sum(v*w)/sum(w) in the kernel.
+;     This is the SAME computation the real route runs via serve_via_kernel —
+;     the harness proves the native value equals the live app's answer.
+;     X-Form-Router: native-kernel.
+;   - EVERYTHING ELSE (/api/health, /api/ideas, /api/cc/exchange/quote, ...)
+;     fans out to the real FastAPI upstream. X-Form-Router: fanout-python.
+;
+; Authored as .fk S-expression Form — the kernel's native surface, NOT
+; Python-cross-compiled. The handler is Form, walked by the kernel.
+
+; --- alist helper: value for `key` in a list of (k v) string pairs. The serve
+; primitive hands query params (and body fields) to the handler as this alist. ---
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+; --- Parallel fold over two comma-separated float strings, accumulating the
+; weighted-average numerator (sum of v*w) and denominator (sum of w) in ONE
+; left-to-right pass — the SAME accumulation order as the Python route's
+; `sum(v*w for v,w in zip(values, weights))` / `sum(weights)`, so the kernel's
+; float result agrees with the app's bit-for-bit on exact dyadic inputs.
+;
+; State carried per char: vs/ws = the two whole strings; i/j = read cursors;
+; vtok/wtok = the float-token text accumulating since the last comma; num/den =
+; the running numerator/denominator. On a comma in `vs` (the two strings are
+; the same length in tokens), the current (vtok, wtok) pair is converted via
+; str_to_float and folded: num += v*w, den += w; tokens reset. At end-of-string
+; the final pair is folded too.
+;
+; char_at returns "" past the end; str_eq "" "," is false, so the walk halts
+; cleanly when both cursors reach the end.
+(defn wavg_step (vs ws i j vtok wtok num den)
+  (if (eq (str_len vs) i)
+      ; end of values: fold the last token pair, return num/den
+      (div (add num (mul (str_to_float vtok) (str_to_float wtok)))
+           (add den (str_to_float wtok)))
+      (if (str_eq (char_at vs i) ",")
+          ; comma in values: weights has a comma at the SAME token boundary;
+          ; fold this pair, advance BOTH cursors past their commas, reset tokens
+          (wavg_step vs ws (add i 1) (add j 1) "" ""
+                     (add num (mul (str_to_float vtok) (str_to_float wtok)))
+                     (add den (str_to_float wtok)))
+          ; ordinary char: append to vtok; advance the weights cursor over any
+          ; weight chars up to its next comma via a sibling walk
+          (wavg_collect_w vs ws (add i 1) j
+                          (str_concat vtok (char_at vs i)) wtok num den))))
+
+; Advance the weights cursor j, appending weight chars to wtok until the NEXT
+; comma or end in ws, then resume the values walk. Keeps the two token streams
+; aligned without indexing into a parsed list (no list-alloc per request).
+(defn wavg_collect_w (vs ws i j vtok wtok num den)
+  (if (eq (str_len ws) j)
+      (wavg_step vs ws i j vtok wtok num den)
+      (if (str_eq (char_at ws j) ",")
+          (wavg_step vs ws i j vtok wtok num den)
+          (wavg_collect_w vs ws i (add j 1)
+                          vtok (str_concat wtok (char_at ws j)) num den))))
+
+; --- NATIVE handler: weighted average of `values` against `weights`, both
+; comma-separated float query args. Mirrors /api/utils/weighted_average. ---
+(defn route_weighted_average (q)
+  (wavg_step (assoc "values" q) (assoc "weights" q) 0 0 "" "" 0.0 0.0))
+
+; --- the route manifest: (path handler). Everything not here fans out to the
+; real FastAPI upstream. ONE native route; the rest is the real app. ---
+(let routes
+  (list
+    (list "/api/utils/weighted_average" route_weighted_average)))

--- a/form/form-kernel-rust/router_real_app_harness.py
+++ b/form/form-kernel-rust/router_real_app_harness.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Real-app proof for the kernel-as-router REVERSAL — no mock upstream.
+
+Where router_proof_harness.py / router_body_harness.py prove the reversed
+topology against a MOCK CPython upstream (an http.server standin), this harness
+proves it IN FRONT OF THE ACTUAL Coherence-Network FastAPI app: it boots the
+real `app.main:app` under uvicorn on a test port, stands the kernel-router in
+front of it, and exercises both arms end-to-end against the live app.
+
+This is a LOCAL side-by-side proof. It touches NO production routing — the real
+app runs on a throwaway test port against the dev sqlite DB; the production
+front door is untouched.
+
+What it boots:
+  1. the REAL FastAPI app — `python -m uvicorn app.main:app` on a free port,
+     COH_ENV=dev so it uses the sqlite fallback DB. This is the genuine app
+     (816 routes), not a mock: /api/health returns the real health JSON,
+     /api/utils/* run the app's serve_via_kernel guest path, /api/ideas reads
+     the real DB.
+  2. the kernel-router — `form-kernel-rust serve --routes router-real-app-proof.fk
+     --upstream http://127.0.0.1:<app>` on another free port. ONE native route
+     (/api/utils/weighted_average, served in Form); everything else fans out to
+     the real app.
+
+What it proves (all measured against the LIVE app, not asserted):
+  - NATIVE: GET /api/utils/weighted_average -> served in Form, X-Form-Router:
+    native-kernel, NO CPython in the path. Its value EQUALS what the real app
+    returns for the same route (the app computes it via serve_via_kernel; the
+    kernel-router computes the same arithmetic natively) — proving the router
+    serves the SAME answer the app would.
+  - FAN-OUT (GET): GET /api/health -> proxied to the real app, X-Form-Router:
+    fanout-python, and the body is the REAL app's health JSON (status/version/
+    uptime/kernel_runtime fields — genuinely FastAPI, not a marker).
+  - FAN-OUT (POST): POST /api/cc/exchange/quote with a JSON body -> proxied to
+    the real app with the body forwarded, X-Form-Router: fanout-python, and the
+    body is the real app's quote response (a quote_id + rate from the live
+    exchange route).
+  - LATENCY (real numbers): native-route latency through the kernel-router; the
+    same fan-out route hit (a) directly on FastAPI vs (b) through the router —
+    the proxy-hop overhead; and the native route through the router vs the same
+    computation through the app's own serve_via_kernel guest path. p50/p99.
+
+Run from form/form-kernel-rust/ (after `cargo build --release`):
+    python3 router_real_app_harness.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-real-app-proof.fk"
+# form/form-kernel-rust -> form -> repo root -> api
+API_DIR = HERE.parent.parent / "api"
+
+# The one native route the kernel-router serves in Form; the real app serves the
+# same path via serve_via_kernel, so the two answers must agree.
+NATIVE_PATH = "/api/utils/weighted_average"
+NATIVE_QUERY = "values=0.5,0.75,1.0&weights=0.25,0.25,0.5"
+
+# A GET route the router does NOT handle natively -> fans out to the real app.
+FANOUT_GET_PATH = "/api/health"
+# A real POST route -> fans out with its body forwarded to the real app.
+FANOUT_POST_PATH = "/api/cc/exchange/quote"
+FANOUT_POST_BODY = json.dumps(
+    {"from_asset": "USD", "to_asset": "CC", "amount": 100}
+).encode()
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 40.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.3)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.15)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def wait_for_http(url: str, timeout: float = 40.0) -> None:
+    """The real app's port opens before its routes are ready; poll until a
+    request actually returns (uvicorn binds, then runs the lifespan)."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2.0) as r:
+                r.read()
+                return
+        except urllib.error.HTTPError:
+            return  # a 4xx/5xx still means the app is answering
+        except (urllib.error.URLError, ConnectionError, OSError) as e:
+            last = e
+            time.sleep(0.25)
+    raise RuntimeError(f"app never answered at {url}: {last}")
+
+
+def http_get(url: str, timeout: float = 10.0):
+    """Return (status, body-text, X-Form-Router header)."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8"), r.headers.get("X-Form-Router")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8"), e.headers.get("X-Form-Router")
+
+
+def http_post(url: str, body: bytes, content_type: str = "application/json",
+              timeout: float = 10.0):
+    req = urllib.request.Request(url, data=body, method="POST",
+                                 headers={"Content-Type": content_type})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8"), r.headers.get("X-Form-Router")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8"), e.headers.get("X-Form-Router")
+
+
+def percentiles(samples_ms: list[float]) -> tuple[float, float, float]:
+    s = sorted(samples_ms)
+    p50 = statistics.median(s)
+    p99 = s[min(len(s) - 1, int(0.99 * len(s)))]
+    return p50, p99, s[0]
+
+
+def measure_get(url: str, n: int) -> list[float]:
+    out = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        http_get(url)
+        out.append((time.perf_counter() - t0) * 1000.0)
+    return out
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+    if not (API_DIR / "app" / "main.py").exists():
+        print(f"cannot find the real app at {API_DIR}/app/main.py", file=sys.stderr)
+        return 2
+
+    failures: list[tuple] = []
+    app_port = free_port()
+    kport = free_port()
+
+    # 1. boot the REAL FastAPI app on the dev sqlite path.
+    env = dict(os.environ)
+    env["COH_ENV"] = "dev"
+    (API_DIR / "data").mkdir(exist_ok=True)
+    app_proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "app.main:app",
+         "--host", "127.0.0.1", "--port", str(app_port), "--log-level", "warning"],
+        cwd=str(API_DIR), env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    app_base = f"http://127.0.0.1:{app_port}"
+
+    router_proc = None
+    try:
+        print(f"booting the REAL FastAPI app (uvicorn app.main:app) on :{app_port} ...")
+        wait_for_port(app_port)
+        wait_for_http(app_base + FANOUT_GET_PATH)
+        # Confirm it is genuinely the real app, not a stand-in.
+        st, body, _ = http_get(app_base + FANOUT_GET_PATH)
+        try:
+            hj = json.loads(body)
+        except Exception:
+            hj = {}
+        is_real = st == 200 and "version" in hj and "kernel_runtime" in hj
+        print(f"  real app /api/health -> {st}  status={hj.get('status')!r} "
+              f"version={hj.get('version')!r} kernel_runtime={hj.get('kernel_runtime')!r}  "
+              f"{'REAL FastAPI' if is_real else 'UNEXPECTED'}")
+        if not is_real:
+            failures.append(("real-app health probe", st, body[:120]))
+
+        # The app's own answer for the native route (its serve_via_kernel path) —
+        # the oracle the kernel-router's native value must match.
+        st, body, _ = http_get(app_base + NATIVE_PATH + "?" + NATIVE_QUERY)
+        app_native = json.loads(body) if st == 200 else {}
+        app_avg = app_native.get("average")
+        print(f"  real app {NATIVE_PATH} -> {st}  average={app_avg} "
+              f"runtime={app_native.get('runtime')!r}  (the oracle)")
+
+        # 2. boot the kernel-router in front of the real app.
+        print(f"booting the kernel-router on :{kport} --upstream {app_base} ...")
+        router_proc = subprocess.Popen(
+            [str(BIN), "serve", "--port", str(kport),
+             "--routes", str(ROUTES), "--upstream", app_base],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        wait_for_port(kport)
+        kbase = f"http://127.0.0.1:{kport}"
+
+        print("\n--- PROOF: native in Form, fan-out to the REAL app ---")
+
+        # --- NATIVE: served in Form, value must equal the real app's answer ---
+        st, body, router = http_get(kbase + NATIVE_PATH + "?" + NATIVE_QUERY)
+        kr_avg = None
+        try:
+            kr_avg = float(body)
+        except ValueError:
+            pass
+        matches_app = (app_avg is not None and kr_avg is not None
+                       and abs(kr_avg - float(app_avg)) < 1e-12)
+        ok = st == 200 and router == "native-kernel" and matches_app
+        print(f"  [native  ] {NATIVE_PATH} -> {st} body={body!r} "
+              f"X-Form-Router={router}")
+        print(f"             kernel-router native value={kr_avg}  ==  "
+              f"real-app value={app_avg}  -> {'MATCH' if matches_app else 'MISMATCH'}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("native weighted_average", st, body, router))
+
+        # --- FAN-OUT GET: the real app's health JSON, relayed by the router ---
+        st, body, router = http_get(kbase + FANOUT_GET_PATH)
+        try:
+            hj = json.loads(body)
+        except Exception:
+            hj = {}
+        genuine = "version" in hj and "kernel_runtime" in hj and "uptime_seconds" in hj
+        ok = st == 200 and router == "fanout-python" and genuine
+        print(f"  [fanout G] {FANOUT_GET_PATH} -> {st} X-Form-Router={router}  "
+              f"(real health JSON: status={hj.get('status')!r} "
+              f"version={hj.get('version')!r})  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("fanout GET /api/health", st, body[:160], router))
+
+        # --- FAN-OUT POST: body forwarded, the real app's quote response ---
+        st, body, router = http_post(kbase + FANOUT_POST_PATH, FANOUT_POST_BODY)
+        try:
+            qj = json.loads(body)
+        except Exception:
+            qj = {}
+        genuine_quote = "quote_id" in qj and "rate" in qj
+        ok = st == 200 and router == "fanout-python" and genuine_quote
+        print(f"  [fanout P] {FANOUT_POST_PATH} (JSON body) -> {st} "
+              f"X-Form-Router={router}  (real quote: quote_id={qj.get('quote_id')!r} "
+              f"rate={qj.get('rate')})  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("fanout POST /api/cc/exchange/quote", st, body[:160], router))
+
+        # 3. MEASUREMENTS (real numbers, not asserted).
+        print("\n--- MEASURED LATENCY (real app, real hops) ---")
+        N = 300
+        WARM = 30
+        for _ in range(WARM):  # warm both paths
+            http_get(kbase + NATIVE_PATH + "?" + NATIVE_QUERY)
+            http_get(kbase + FANOUT_GET_PATH)
+            http_get(app_base + FANOUT_GET_PATH)
+            http_get(app_base + NATIVE_PATH + "?" + NATIVE_QUERY)
+
+        # (a) native route through the kernel-router (served in Form, no CPython)
+        nat_router = measure_get(kbase + NATIVE_PATH + "?" + NATIVE_QUERY, N)
+        # (b) the SAME computation through the real app's serve_via_kernel guest path
+        nat_app = measure_get(app_base + NATIVE_PATH + "?" + NATIVE_QUERY, N)
+        # (c) the fan-out route DIRECTLY on FastAPI
+        fan_direct = measure_get(app_base + FANOUT_GET_PATH, N)
+        # (d) the SAME fan-out route THROUGH the kernel-router (proxy hop)
+        fan_router = measure_get(kbase + FANOUT_GET_PATH, N)
+
+        def line(label, s):
+            p50, p99, mn = percentiles(s)
+            print(f"  {label:<52} p50={p50:7.3f} ms  p99={p99:7.3f} ms  min={mn:7.3f} ms")
+            return p50, p99
+
+        print(f"  (n={N} per path, {WARM} warmup, whole-request wall time incl. loopback)")
+        nr50, _ = line(f"native {NATIVE_PATH} THROUGH kernel-router (Form)", nat_router)
+        na50, _ = line(f"native {NATIVE_PATH} via app serve_via_kernel guest", nat_app)
+        fd50, _ = line(f"fan-out {FANOUT_GET_PATH} DIRECT on FastAPI", fan_direct)
+        fr50, _ = line(f"fan-out {FANOUT_GET_PATH} THROUGH kernel-router proxy", fan_router)
+
+        print("\n--- THE HONEST READ ---")
+        proxy_overhead = fr50 - fd50
+        native_saving = na50 - nr50
+        print(f"  proxy-hop overhead (fan-out): through-router p50 {fr50:.3f} ms "
+              f"- direct p50 {fd50:.3f} ms = {proxy_overhead:+.3f} ms "
+              f"({proxy_overhead/fd50*100:+.1f}% of the direct call)")
+        print(f"  native-route saving: app guest-path p50 {na50:.3f} ms "
+              f"- kernel-router native p50 {nr50:.3f} ms = {native_saving:+.3f} ms "
+              f"(the native route skips the whole CPython request lifecycle)")
+        print(f"  native through router is {na50/nr50:.1f}x faster than the same "
+              f"computation through the app's CPython request + serve_via_kernel.")
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+            for f in failures:
+                print(f"   {f}", file=sys.stderr)
+            return 1
+        print("\nok — the kernel-router served a NATIVE route in Form (value == "
+              "the real app's), and FANNED OUT GET + POST to the REAL FastAPI app "
+              "(genuine app responses, body forwarded). Real numbers above.")
+        return 0
+    finally:
+        for p in (router_proc, app_proc):
+            if p is None:
+                continue
+            p.terminate()
+            try:
+                p.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                try:
+                    p.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2333,6 +2333,15 @@ impl Kernel {
         self.register_native("str_to_int", cat_method(), |_, _, args| {
             Value::Int(args[0].as_str().parse().unwrap_or(0))
         });
+        // str_to_float — text-to-float leaf, the float sibling of str_to_int.
+        // Total like its sibling (unparseable text -> 0.0), so a handler that
+        // splits a comma-separated query arg into float scores never panics on
+        // a stray token. This is what lets a native route parse arbitrary
+        // float inputs from the request (e.g. weighted_average's values/weights)
+        // and run the real arithmetic in Form, rather than serving a constant.
+        self.register_native("str_to_float", cat_method(), |_, _, args| {
+            Value::Float(args[0].as_str().parse().unwrap_or(0.0))
+        });
         self.register_native("ord", cat_access(), |_, _, args| {
             let s = args[0].as_str();
             if s.is_empty() {

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -203,6 +203,12 @@ which the `X-Form-Router` header makes directly countable from access logs.
 
 ## Proof-of-shape — what is demonstrated, and what it is not
 
+Three harnesses prove the shape against a mock CPython upstream; a fourth
+([below](#proof-against-the-real-fastapi-app--not-a-mock)) proves it against the
+**real FastAPI app**. Start with the mock harnesses — they isolate routing,
+concurrency, and body-reading — then read the real-app proof for the
+flip-decision evidence.
+
 [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py)
 spins up a mock CPython upstream (standing in for FastAPI — so the proof touches
 NO production routing) and the kernel-router fanning out to it, then exercises
@@ -268,13 +274,70 @@ fans out carries its body to the upstream (the mock CPython echoes the forwarded
 `hello=world&n=7`); and an over-cap body is rejected with 413 on the
 Content-Length header alone, never buffered.
 
+## Proof against the REAL FastAPI app — not a mock
+
+The three harnesses above fan out to a mock CPython upstream. The flip-decision
+question is sharper: does the kernel-router work in front of OUR actual app?
+[`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py)
+answers it. It boots the **real `app.main:app`** under uvicorn on a test port
+(`COH_ENV=dev`, the sqlite fallback DB — 816 routes, the genuine app, not a
+stand-in), stands the kernel-router in front of it
+([`router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk):
+one native route, the rest fan out), and exercises both arms end-to-end against
+the live app. This is a LOCAL side-by-side proof on throwaway ports — the
+production front door is untouched.
+
+```
+real app /api/health                  -> 200  status='ok' version='1.0.0' kernel_runtime='subprocess'  REAL FastAPI
+real app /api/utils/weighted_average  -> 200  average=0.8125 runtime='subprocess'  (the oracle)
+
+[native  ] /api/utils/weighted_average -> 200 '0.8125' X-Form-Router=native-kernel
+           kernel-router native value 0.8125 == real-app value 0.8125  -> MATCH
+[fanout G] /api/health                 -> 200 X-Form-Router=fanout-python  (real health JSON: status='ok' version='1.0.0')
+[fanout P] /api/cc/exchange/quote      -> 200 X-Form-Router=fanout-python  (real quote: quote_id='1ad6ce783c33' rate=1.0)
+
+native  /api/utils/weighted_average THROUGH kernel-router (Form)        p50= 0.197 ms  p99= 0.272 ms
+native  /api/utils/weighted_average via app serve_via_kernel guest      p50=10.983 ms  p99=12.819 ms
+fan-out /api/health DIRECT on FastAPI                                   p50= 4.432 ms  p99= 5.302 ms
+fan-out /api/health THROUGH kernel-router proxy                         p50= 4.732 ms  p99= 6.166 ms
+
+proxy-hop overhead (fan-out):  +0.300 ms  (+6.8% of the direct call)
+native-route saving:           +10.79 ms  (the native route skips the whole CPython request lifecycle — ~56x faster)
+```
+
+**Shown against the real app (measured, not asserted):** the kernel-router
+serves `/api/utils/weighted_average` **entirely in Form** — it parses the
+`values`/`weights` query args and runs the real `sum(v*w)/sum(w)` arithmetic in
+the kernel (the `str_to_float` leaf native, the float sibling of `str_to_int`,
+is what lets it parse arbitrary float inputs rather than serve a constant) — and
+its value **equals the live app's answer** for the same route (the app computes
+it via `serve_via_kernel`; the kernel-router computes the same answer with no
+CPython in the path). It **fans out** `/api/health` (GET) and
+`/api/cc/exchange/quote` (POST, body forwarded) to the real FastAPI, relaying
+**genuine app responses** — the real health JSON (status/version/uptime/
+kernel_runtime) and a real exchange quote (a server-issued `quote_id` + rate),
+not a mock marker. The numbers are the honest input to the flip decision: the
+**proxy hop costs ~0.2–0.3 ms (~5–7%)** on a fan-out route — a real localhost TCP
+hop over the kernel's HTTP/1.0, the price of fronting; the **native route saves
+~10.8 ms (~56x)** by skipping the entire CPython request lifecycle (uvicorn
+parse → routing → Pydantic bind → `serve_via_kernel` subprocess spawn →
+response model), serving the value-walk directly. A hot native route is far
+cheaper than the same compute reached through the CPython doorway; the tail pays
+a small, measured proxy toll to keep working unchanged.
+
 **NOT shown / not claimed:** full production-readiness. The proof is HTTP/1.0
-(no keep-alive), with a mock upstream, and the accept loop is
-thread-per-request-blocked (it parallelizes to the worker count, not an async
-reactor); JSON bodies are raw-captured, not structurally parsed into Form
-values; request/response headers beyond the body are not yet passed through.
-Concurrency and request-body reading are now shown; the other rows above are the
-remaining build.
+(no keep-alive — every request is a fresh connection on both hops), and the
+accept loop is thread-per-request-blocked (it parallelizes to the worker count,
+not an async reactor); JSON bodies are raw-captured, not structurally parsed
+into Form values; request/response headers beyond the body are not yet passed
+through (the fan-out relays status + body as text/plain, not the upstream's
+content-type/headers). The real-app proof ran against the dev sqlite DB; the
+production deployment shape (TLS/Traefik front, the routes.fk covering the real
+native-eligible set, header/content-type passthrough so a JSON route's
+content-type survives the proxy) is the remaining build. Concurrency,
+request-body reading, and the **real-app fan-out + native side-by-side** are now
+shown; the HTTP/1.1, header-passthrough, and structural-JSON rows above are the
+rest.
 
 ## The flip is Urs's decision
 
@@ -295,10 +358,12 @@ test port so the reversal can be weighed with evidence rather than assertion.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape, now reading the full request + body), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read and content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (the X-Form-Router header).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape, now reading the full request + body), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read and content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (the X-Form-Router header), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
-- [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement.
-- [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413.
+- [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement (mock upstream).
+- [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413 (mock upstream).
 - [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
+- [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
+- [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.


### PR DESCRIPTION
## What this proves

The kernel-as-router fan-out was proven only against a **mock** CPython upstream (`UPSTREAM-CPYTHON-FASTAPI-STANDIN`). This closes the honest gap to a flip decision: it proves the kernel-router works **in front of OUR actual FastAPI app**.

A **LOCAL side-by-side proof** — throwaway ports, **production routing untouched**. It boots the real `app.main:app` under uvicorn (`COH_ENV=dev`, sqlite fallback, 816 routes — the genuine app, not a mock) and stands the kernel-router in front of it.

### Both arms, against the live app
- **NATIVE** `/api/utils/weighted_average` — served entirely in Form (the handler parses the `values`/`weights` query args and runs `sum(v*w)/sum(w)` in the kernel), `X-Form-Router: native-kernel`, no CPython in the path. Its value **equals the live app's answer** (`0.8125`) for the same route — the app computes it via `serve_via_kernel`; the kernel-router computes the same answer natively. A new `str_to_float` leaf native (the float sibling of `str_to_int`) is what lets the handler parse arbitrary float inputs rather than serve a constant.
- **FAN-OUT (GET)** `/api/health` — proxied to the real app, `X-Form-Router: fanout-python`, body is the **real health JSON** (status/version/uptime/kernel_runtime).
- **FAN-OUT (POST)** `/api/cc/exchange/quote` (JSON body forwarded) — proxied to the real app, `X-Form-Router: fanout-python`, body is a **real exchange quote** (server-issued `quote_id` + rate).

### Measured (real app, real hops — not asserted)
```
native  /api/utils/weighted_average THROUGH kernel-router (Form)    p50= 0.197 ms  p99= 0.272 ms
native  /api/utils/weighted_average via app serve_via_kernel guest  p50=10.983 ms  p99=12.819 ms
fan-out /api/health DIRECT on FastAPI                               p50= 4.432 ms  p99= 5.302 ms
fan-out /api/health THROUGH kernel-router proxy                     p50= 4.732 ms  p99= 6.166 ms
```
- **Proxy-hop overhead** (fronting cost): **+0.2–0.3 ms (~5–7%)** on a fan-out route — a real localhost TCP hop over the kernel's HTTP/1.0.
- **Native-route saving**: **~10.8 ms (~56x)** — the native route skips the whole CPython request lifecycle (uvicorn parse → routing → Pydantic → serve_via_kernel subprocess → response model).

## Honesty / scope
- **No production routing flip.** Real app + kernel-router run locally on test ports, side by side. The production FastAPI front door is untouched. **The flip is Urs's decision.**
- The local run had broad real coverage (the dev sqlite DB has data — `/api/ideas`, `/api/contributors`, the `/api/utils/*` compute routes, the exchange quote all ran). Even partial real coverage would be the honest advance over the mock; here it's substantial.
- **What still gates a real flip** (named in the doc): HTTP/1.1 keep-alive, request/response header + content-type passthrough, structural JSON→Form parse, the production deployment shape (TLS/Traefik), and the routes.fk covering the real native-eligible set.

## Reusable harness + doc
- `form/form-kernel-rust/router_real_app_harness.py` — boots both, runs the proofs, tears both down. Repeatable (verified across two runs; stable numbers).
- `form/form-kernel-rust/examples/router-real-app-proof.fk` — one native route, the rest fan out.
- `kernels/KERNEL_AS_ROUTER.md` — present-tense update: the fan-out is now proven against the real FastAPI app with the measured overhead, not only a mock.

## No-regression
- `cargo build --release` green (only pre-existing dead-code warnings).
- `validate.sh`: **258 ok, 0 divergent** (excluding one pre-existing untracked-debris file `seeded-bytes-recipe-band.fk` that is not on main and does not use `str_to_float`). The existing mock proof harness still passes.
- No leaked servers/ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)