### PR TITLE
tend(kernel): HTTP/1.1 keep-alive on the kernel-router's client hop

### DIFF
--- a/form/form-kernel-rust/router_keepalive_harness.py
+++ b/form/form-kernel-rust/router_keepalive_harness.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Proof harness for the kernel-router's HTTP/1.1 KEEP-ALIVE.
+
+Where router_body_harness.py proved one request per (HTTP/1.0, close) connection,
+this proves the matured serve primitive: `cli_serve` now serves HTTP/1.1 with
+keep-alive — MULTIPLE requests on ONE TCP connection, each Content-Length-framed
+so the client knows exactly where one response ends and the next begins.
+
+What it asserts (real sockets over loopback, the kernel-router in front of a mock
+CPython upstream — touches NO production routing):
+
+  1. N sequential requests on ONE connection: open a single socket, send N
+     HTTP/1.1 requests WITHOUT closing between them, read N responses by their
+     Content-Length. All N succeed with their OWN correct value (distinct inputs),
+     and every response carries `Connection: keep-alive`. ONE connect, N
+     request/response cycles — the keep-alive property.
+
+  2. Pipelined requests (the leftover-bytes hazard): send two requests in a
+     SINGLE send() — the server's read for request 1 pulls request 2's bytes too;
+     it must NOT drop them. Both responses come back correct. This is the classic
+     keep-alive byte-drop bug, proven absent.
+
+  3. `Connection: close` honored: a request with `Connection: close` -> the
+     response says `Connection: close` and the server closes the socket (the next
+     recv returns EOF), no hang.
+
+  4. HTTP/1.0 default-close (back-compat): an HTTP/1.0 request with no Connection
+     header -> the server closes after responding (HTTP/1.0 default), so the
+     existing HTTP/1.0 harness clients keep working.
+
+  5. Idle timeout reaps the connection: open a connection, send one request, then
+     sit IDLE (send nothing more). The server closes it after ~KEEPALIVE_IDLE
+     seconds (recv returns EOF) — an idle keep-alive connection does NOT pin a
+     worker forever.
+
+  6. An idle keep-alive connection does NOT starve OTHER workers: with >1 worker,
+     while connection A idles (holding one worker in its keep-alive loop), a fresh
+     connection B is served IMMEDIATELY by another worker. (Honest tradeoff: a
+     worker serving a keep-alive client is unavailable to others until close /
+     idle-timeout; this proves the POOL still serves, not that it is free.)
+
+  7. Keep-alive saves the TCP handshake: N requests on one connection vs N fresh
+     connections — the reused connection is measurably faster (no per-request
+     connect()).
+
+Run from form/form-kernel-rust/:
+    cargo build --release
+    python3 router_keepalive_harness.py
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-body-proof.fk"
+
+UPSTREAM_MARKER = "UPSTREAM-CPYTHON-FASTAPI-STANDIN"
+# Mirrors KEEPALIVE_IDLE_TIMEOUT in form-kernel-rust src/main.rs (seconds).
+KEEPALIVE_IDLE = 5.0
+
+
+class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """Mock CPython upstream (stands in for FastAPI; no production routing)."""
+
+    def do_GET(self):  # noqa: N802
+        text = f"{UPSTREAM_MARKER} GET {self.path}\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(text)))
+        self.end_headers()
+        self.wfile.write(text)
+
+    def log_message(self, *args):  # silence per-request logging
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+class Conn:
+    """A persistent client connection that frames responses by Content-Length.
+
+    Unlike a read-until-close client, this reads EXACTLY one response (headers +
+    Content-Length body) and leaves the socket open + any surplus bytes buffered
+    for the next response — exactly what an HTTP/1.1 keep-alive client must do.
+    """
+
+    def __init__(self, port: int, timeout: float = 10.0):
+        self.sock = socket.create_connection(("127.0.0.1", port), timeout=timeout)
+        self.sock.settimeout(timeout)
+        self.buf = b""
+
+    def send(self, raw: bytes) -> None:
+        self.sock.sendall(raw)
+
+    def _fill(self) -> bool:
+        b = self.sock.recv(65536)
+        if not b:
+            return False
+        self.buf += b
+        return True
+
+    def read_response(self):
+        """Read one HTTP response framed by Content-Length. Returns
+        (status, headers_lower_dict, body_text)."""
+        # Read until we have the full header block.
+        while b"\r\n\r\n" not in self.buf:
+            if not self._fill():
+                raise EOFError("connection closed before full response headers")
+        head_b, _, rest = self.buf.partition(b"\r\n\r\n")
+        self.buf = rest
+        head_txt = head_b.decode("utf-8", "replace")
+        lines = head_txt.split("\r\n")
+        status_line = lines[0]
+        status = status_line.split(" ", 1)[1] if " " in status_line else status_line
+        headers = {}
+        for line in lines[1:]:
+            if ":" in line:
+                k, v = line.split(":", 1)
+                headers[k.strip().lower()] = v.strip()
+        n = int(headers.get("content-length", "0"))
+        while len(self.buf) < n:
+            if not self._fill():
+                raise EOFError("connection closed before full response body")
+        body = self.buf[:n].decode("utf-8", "replace")
+        self.buf = self.buf[n:]
+        return status, headers, body
+
+    def recv_is_eof(self, timeout: float) -> bool:
+        """Return True iff the peer closed (recv returns b'') within `timeout`."""
+        self.sock.settimeout(timeout)
+        try:
+            b = self.sock.recv(1)
+            return b == b""
+        except socket.timeout:
+            return False
+        except OSError:
+            return True
+
+    def close(self):
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+def req(method: str, path: str, *, http_version="1.1",
+        connection: str | None = None) -> bytes:
+    lines = [f"{method} {path} HTTP/{http_version}", "Host: 127.0.0.1"]
+    if connection is not None:
+        lines.append(f"Connection: {connection}")
+    return ("\r\n".join(lines) + "\r\n\r\n").encode()
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    up_port = free_port()
+    httpd = http.server.HTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    upstream_url = f"http://127.0.0.1:{up_port}"
+
+    kport = free_port()
+    # >1 worker so test 6 can prove an idle connection doesn't starve the pool.
+    proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(kport), "--routes", str(ROUTES),
+         "--upstream", upstream_url, "--workers", "4"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    failures = []
+    try:
+        wait_for_port(kport)
+
+        # --- 1. N sequential requests on ONE connection ---
+        c = Conn(kport)
+        n = 8
+        all_ok = True
+        for i in range(n):
+            a, b = i, i * 3  # distinct inputs each request
+            c.send(req("GET", f"/sum?a={a}&b={b}"))
+            status, headers, body = c.read_response()
+            want = str(a + b)
+            ok = (status == "200 OK" and body == want
+                  and headers.get("connection") == "keep-alive"
+                  and headers.get("x-form-router") == "native-kernel")
+            all_ok = all_ok and ok
+        c.close()
+        print(f"  [1 conn x {n} reqs ] sequential on ONE connection, distinct "
+              f"inputs -> all {'OK' if all_ok else 'FAIL'} "
+              f"(each Connection: keep-alive, correct sum)")
+        if not all_ok:
+            failures.append(("N sequential on one connection",))
+
+        # --- 2. PIPELINED: two requests in ONE send (leftover-bytes hazard) ---
+        c = Conn(kport)
+        pipelined = (req("GET", "/sum?a=10&b=5") + req("GET", "/sum?a=100&b=23"))
+        c.send(pipelined)  # both requests in a single TCP write
+        s1, h1, b1 = c.read_response()
+        s2, h2, b2 = c.read_response()
+        ok = (s1 == "200 OK" and b1 == "15" and s2 == "200 OK" and b2 == "123")
+        c.close()
+        print(f"  [pipelined 2-in-1 ] two reqs in ONE send -> {b1!r}, {b2!r} "
+              f"(expect '15','123')  {'OK' if ok else 'FAIL'}  "
+              f"(leftover bytes carried, none dropped)")
+        if not ok:
+            failures.append(("pipelined leftover-bytes", s1, b1, s2, b2))
+
+        # --- 3. Connection: close honored ---
+        c = Conn(kport)
+        c.send(req("GET", "/health", connection="close"))
+        status, headers, body = c.read_response()
+        closed = c.recv_is_eof(timeout=2.0)
+        ok = (status == "200 OK" and body == "ok"
+              and headers.get("connection") == "close" and closed)
+        print(f"  [Connection close ] /health Connection: close -> {body!r} "
+              f"resp-conn={headers.get('connection')!r} server-closed={closed}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("Connection: close honored", status, body,
+                             headers.get("connection"), closed))
+
+        # --- 4. HTTP/1.0 default-close (back-compat) ---
+        c = Conn(kport)
+        c.send(req("GET", "/health", http_version="1.0"))  # no Connection header
+        status, headers, body = c.read_response()
+        closed = c.recv_is_eof(timeout=2.0)
+        ok = (status == "200 OK" and body == "ok"
+              and headers.get("connection") == "close" and closed)
+        print(f"  [HTTP/1.0 default ] /health (1.0, no Conn hdr) -> {body!r} "
+              f"resp-conn={headers.get('connection')!r} server-closed={closed}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("HTTP/1.0 default-close", status, body,
+                             headers.get("connection"), closed))
+
+        # --- 6. (run before 5, sharing the idle wait) An idle keep-alive conn
+        #         does NOT starve other workers: open A, send one req, leave A
+        #         IDLE (its worker now loops waiting); immediately serve B on a
+        #         fresh connection — another worker must serve it at once. ---
+        a_conn = Conn(kport)
+        a_conn.send(req("GET", "/sum?a=1&b=1"))  # A's first (and only) request
+        _ = a_conn.read_response()               # A now idles in its keep-alive loop
+        t0 = time.monotonic()
+        b_conn = Conn(kport)
+        b_conn.send(req("GET", "/sum?a=7&b=8", connection="close"))
+        sB, hB, bB = b_conn.read_response()
+        b_serve_ms = (time.monotonic() - t0) * 1000.0
+        b_conn.close()
+        # B served fast (well under the idle timeout) -> A's idle conn did not
+        # block the pool; another worker took B.
+        ok = (sB == "200 OK" and bB == "15" and b_serve_ms < KEEPALIVE_IDLE * 1000 / 2)
+        print(f"  [no-starve pool   ] B served in {b_serve_ms:.1f} ms while A "
+              f"idles -> {bB!r} (expect '15')  {'OK' if ok else 'FAIL'}  "
+              f"(idle keep-alive conn did not starve other workers)")
+        if not ok:
+            failures.append(("idle does not starve pool", sB, bB, b_serve_ms))
+
+        # --- 5. Idle timeout reaps the connection: A (still open, idle since its
+        #         one request above) must be closed by the server after the idle
+        #         timeout — recv returns EOF. Prove it does NOT pin forever. ---
+        elapsed_since_a = time.monotonic() - t0
+        # Wait out the remainder of the idle window plus a margin.
+        wait_left = max(0.0, KEEPALIVE_IDLE - elapsed_since_a) + 2.0
+        a_closed = a_conn.recv_is_eof(timeout=wait_left)
+        a_conn.close()
+        print(f"  [idle timeout reap] idle conn A closed by server after "
+              f"~{KEEPALIVE_IDLE:.0f}s idle (waited {wait_left:.1f}s) -> "
+              f"server-closed={a_closed}  {'OK' if a_closed else 'FAIL'}")
+        if not a_closed:
+            failures.append(("idle timeout reap", a_closed))
+
+        # --- 7. keep-alive saves the TCP handshake (N reused vs N fresh) ---
+        reps = 30
+        # N requests on ONE reused connection.
+        c = Conn(kport)
+        t0 = time.monotonic()
+        for i in range(reps):
+            c.send(req("GET", f"/sum?a={i}&b={i}"))
+            _ = c.read_response()
+        reuse_ms = (time.monotonic() - t0) * 1000.0
+        c.close()
+        # N requests, each a FRESH connection (pays connect() every time).
+        t0 = time.monotonic()
+        for i in range(reps):
+            cc = Conn(kport)
+            cc.send(req("GET", f"/sum?a={i}&b={i}", connection="close"))
+            _ = cc.read_response()
+            cc.close()
+        fresh_ms = (time.monotonic() - t0) * 1000.0
+        saved = fresh_ms - reuse_ms
+        faster = reuse_ms < fresh_ms
+        print(f"  [handshake saving ] {reps} reqs: reused-conn={reuse_ms:.1f} ms "
+              f"vs fresh-conn-each={fresh_ms:.1f} ms -> keep-alive saved "
+              f"{saved:.1f} ms ({'faster' if faster else 'NOT faster'})  "
+              f"{'OK' if faster else 'WARN'}")
+        # This is a performance observation, not a hard gate (loopback connect is
+        # cheap; the saving is real but small over localhost). Only warn.
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+            for f in failures:
+                print(f"   {f}", file=sys.stderr)
+            return 1
+        print("\nok — kernel-router HTTP/1.1 KEEP-ALIVE: multiple requests served "
+              "on ONE connection (Content-Length framed), pipelined leftover bytes "
+              "carried (none dropped), Connection: close honored, HTTP/1.0 "
+              "default-close back-compat, idle connection reaped after the idle "
+              "timeout (worker freed), and an idle keep-alive conn did not starve "
+              "the pool.")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        httpd.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 mod bp_table;
 mod formats;
@@ -6334,32 +6334,49 @@ fn build_worker_kernel(
 
 // Handle ONE request on a worker's own kernel+arena. This is the single factored
 // serving shape (core-abstraction-first): the routing decision (native Form
-// handler vs fan-out to the Python upstream vs 404) lives here ONCE, and the
-// worker pool simply parallelizes calling it. Because `k` and `arena` belong to
-// the calling worker alone, concurrent requests on different workers never share
-// mutable kernel state — each request's value-walk is isolated.
+// handler vs fan-out to the Python upstream vs 404) lives here ONCE, and both the
+// worker pool (parallelism) and the keep-alive loop (multiple requests per
+// connection) simply call it. Because `k` and `arena` belong to the calling
+// worker alone, concurrent requests on different workers never share mutable
+// kernel state — each request's value-walk is isolated.
+//
+// Returns whether the connection should be KEPT ALIVE for the next request:
+// the client's intent (HTTP/1.1 default-keep-alive unless `Connection: close`;
+// HTTP/1.0 close-unless-`keep-alive`) AND no server-side reason to close. An
+// idle/EOF read, a 413 (body undrained — framing broken), and a handler error
+// all return `false` so the keep-alive loop ends and the stream is dropped.
+// `carry` holds bytes read past this request's end (pipelining) for the next
+// call on the same connection.
 fn handle_request(
-    mut stream: TcpStream,
+    stream: &mut TcpStream,
+    carry: &mut Vec<u8>,
     k: &mut Kernel,
     arena: &mut Arena,
     route_pairs: &RoutePairs,
     upstream: &Option<String>,
-) {
-    // Read the FULL request: the header block, then exactly Content-Length
-    // body bytes if present (read_request honors Content-Length across as many
-    // socket reads as the body needs — a body larger than one buffer is fully
-    // captured). Still HTTP/1.0, Connection: close; keep-alive and chunked
-    // transfer remain named breaths (KERNEL_AS_ROUTER.md request row).
-    let (head, body_bytes) = match read_request(&mut stream) {
+) -> bool {
+    // Read the FULL request: the header block, then exactly Content-Length body
+    // bytes if present (read_request honors Content-Length across as many socket
+    // reads as the body needs — a body larger than one buffer is fully captured —
+    // and carries any over-read bytes into `carry` for the next request on this
+    // persistent connection). HTTP/1.1 keep-alive with Content-Length framing;
+    // chunked transfer remains a named breath (KERNEL_AS_ROUTER.md request row).
+    let (head, body_bytes) = match read_request(stream, carry) {
         RequestRead::Ok(h, b) => (h, b),
         RequestRead::TooLarge => {
+            // Reject on the Content-Length header alone — the oversized body is
+            // never drained, so the connection's framing is broken: close it.
             let status = "413 Payload Too Large".to_string();
             let msg = format!("request body exceeds {} bytes\n", MAX_BODY_BYTES);
-            let _ = stream.write_all(http_response(&status, &msg, "local-control").as_bytes());
-            return;
+            let _ =
+                stream.write_all(http_response(&status, &msg, "local-control", false).as_bytes());
+            return false;
         }
-        RequestRead::Error => return,
+        RequestRead::Error => return false, // idle close / read-timeout / EOF — loop ends
     };
+    // The client's keep-alive intent for THIS connection (server may still close
+    // on an error below).
+    let keep_alive = head_keep_alive(&head);
     let (method, target, path, mut request_data) = parse_request_line(&head);
     // Parse the body by Content-Type and MERGE its fields into the same alist
     // the handler reads (core-abstraction-first: ONE request-data shape, whether
@@ -6398,9 +6415,9 @@ fn handle_request(
                 path,
                 cl.params.len()
             );
-            let _ =
-                stream.write_all(http_response(&status, &body, "native-kernel-error").as_bytes());
-            return;
+            let _ = stream
+                .write_all(http_response(&status, &body, "native-kernel-error", false).as_bytes());
+            return false; // close on error — keep the framing unambiguous
         }
         let result = walk(k, arena, cl.body, call_frame);
         status = "200 OK".to_string();
@@ -6424,12 +6441,62 @@ fn handle_request(
         body = format!("no route for {}\n", path);
         router = "local-control";
     }
-    let _ = stream.write_all(http_response(&status, &body, router).as_bytes());
+    // Frame the response with an accurate Content-Length and the keep-alive
+    // verdict. If the write fails the peer is gone — close the loop.
+    if stream
+        .write_all(http_response(&status, &body, router, keep_alive).as_bytes())
+        .is_err()
+    {
+        return false;
+    }
+    keep_alive
+}
+
+// How long an idle kept-alive connection may sit between requests before the
+// server closes it and frees the worker. HTTP/1.1 keep-alive holds the socket
+// open after a response so the next request reuses the same TCP connection
+// (saving a handshake each time); without a cap an idle client would pin a
+// worker forever and starve the pool (thread-per-connection: a worker serving
+// one keep-alive client is unavailable to others until the connection closes or
+// this timeout fires). 5s is a conservative default — long enough that a normal
+// client's back-to-back requests stay on one connection, short enough that an
+// abandoned connection frees its worker quickly. The production tuning knobs are
+// THIS value and the worker count (cli_serve --workers).
+const KEEPALIVE_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Serve a connection's full keep-alive LIFETIME: repeatedly handle requests on
+// the SAME TcpStream until the client closes it, an error/EOF arrives, the idle
+// read-timeout fires, or a response forces close (client `Connection: close`,
+// 413, handler error). This wraps the per-request handle_request in a loop —
+// the per-request serving shape stays ONE factored function (core-abstraction-
+// first); keep-alive is the loop around it, not a fork of the logic.
+//
+// An idle read-timeout (KEEPALIVE_IDLE_TIMEOUT) is set on the stream so a
+// connection that goes quiet between requests does not pin this worker forever:
+// the next read_request returns Error (the timeout surfaces as a read error),
+// the loop ends, the stream drops, and the worker returns to the queue free to
+// serve another connection.
+fn serve_connection(
+    mut stream: TcpStream,
+    k: &mut Kernel,
+    arena: &mut Arena,
+    route_pairs: &RoutePairs,
+    upstream: &Option<String>,
+) {
+    // Idle timeout so a held-open keep-alive connection cannot starve the pool.
+    let _ = stream.set_read_timeout(Some(KEEPALIVE_IDLE_TIMEOUT));
+    // Bytes already read past one request's end belong to the NEXT request on
+    // this connection (pipelining) — carried across loop iterations so no byte
+    // is dropped between requests.
+    let mut carry: Vec<u8> = Vec::new();
+    // Serve requests on this one connection until handle_request says to close.
+    while handle_request(&mut stream, &mut carry, k, arena, route_pairs, upstream) {}
 }
 
 // One kernel worker. Builds its OWN Kernel + Arena (the routes.fk loaded once
 // into it at startup — !Sync, never shared), then pulls accepted streams from
-// the shared work queue and serves each via the factored handle_request. N of
+// the shared work queue and serves each connection's full keep-alive lifetime
+// via serve_connection (which loops handle_request on the one stream). N of
 // these run concurrently behind the accept loop; because each owns its kernel,
 // concurrent requests never corrupt one another's state.
 fn worker_loop(
@@ -6458,7 +6525,7 @@ fn worker_loop(
             guard.recv()
         };
         match stream {
-            Ok(s) => handle_request(s, &mut k, &mut arena, &route_pairs, &upstream),
+            Ok(s) => serve_connection(s, &mut k, &mut arena, &route_pairs, &upstream),
             // Sender dropped (listener closed) — drain done, worker exits.
             Err(_) => return,
         }
@@ -6690,28 +6757,50 @@ enum RequestRead {
 // This replaces the old single 8 KiB read: it honors Content-Length across as
 // many `read` calls as the body needs, so a body larger than one buffer is
 // fully captured (the correctness property the single-buffer read failed).
-fn read_request(stream: &mut TcpStream) -> RequestRead {
-    let mut raw: Vec<u8> = Vec::with_capacity(8192);
+//
+// KEEP-ALIVE: `carry` holds bytes that arrived on this persistent connection
+// but belong to the NEXT request — the classic pipelining hazard. A single
+// `read` can pull the tail of request N AND the head (or all) of request N+1;
+// those extra bytes must NOT be dropped between requests. So this fn (1) seeds
+// its read buffer from `carry` before touching the socket, and (2) stashes any
+// bytes captured past this request's end (header terminator + Content-Length)
+// back into `carry` for the next call. The next iteration of the keep-alive
+// loop therefore starts exactly at the next request's first byte. A clean EOF
+// with no bytes buffered (idle connection closed or read-timeout fired) returns
+// `Error`, which the keep-alive loop reads as "connection done — stop looping."
+fn read_request(stream: &mut TcpStream, carry: &mut Vec<u8>) -> RequestRead {
+    // Seed from any leftover bytes carried in from the previous request on this
+    // same connection (drained out of `carry`), then read more as needed.
+    let mut raw: Vec<u8> = std::mem::take(carry);
     let mut buf = [0u8; 8192];
-    // Phase 1: read until the header terminator is seen (or EOF / cap).
-    let header_end: Option<usize> = loop {
-        match stream.read(&mut buf) {
-            Ok(0) => break find_header_end(&raw), // peer closed; use what we have
-            Ok(n) => {
-                raw.extend_from_slice(&buf[..n]);
-                if let Some(t) = find_header_end(&raw) {
-                    break Some(t);
+    // Phase 1: read until the header terminator is seen (or EOF / cap). The
+    // carried bytes may ALREADY contain the full header block, so check before
+    // the first socket read — otherwise a pipelined request would block on a
+    // read that never comes.
+    let header_end: Option<usize> = if let Some(t) = find_header_end(&raw) {
+        Some(t)
+    } else {
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) => break find_header_end(&raw), // peer closed; use what we have
+                Ok(n) => {
+                    raw.extend_from_slice(&buf[..n]);
+                    if let Some(t) = find_header_end(&raw) {
+                        break Some(t);
+                    }
+                    // Guard: the header block alone must not grow without bound.
+                    if raw.len() > MAX_BODY_BYTES {
+                        return RequestRead::TooLarge;
+                    }
                 }
-                // Guard: the header block alone must not grow without bound.
-                if raw.len() > MAX_BODY_BYTES {
-                    return RequestRead::TooLarge;
-                }
+                // A read error here also covers the idle read-timeout firing on
+                // a kept-alive connection (WouldBlock/TimedOut) — the loop ends.
+                Err(_) => return RequestRead::Error,
             }
-            Err(_) => return RequestRead::Error,
         }
     };
     if raw.is_empty() {
-        return RequestRead::Error; // nothing arrived at all
+        return RequestRead::Error; // nothing arrived at all (clean EOF / idle close)
     }
     // `header_end` is the index just past "\r\n\r\n" when found. The head text
     // (terminator excluded) is everything before it; if no terminator was seen
@@ -6723,20 +6812,32 @@ fn read_request(stream: &mut TcpStream) -> RequestRead {
     let head = String::from_utf8_lossy(&raw[..head_end_excl_term]).to_string();
 
     // Phase 2: if Content-Length says there's a body, read exactly that many
-    // bytes, counting whatever already arrived past the header terminator.
-    let mut body: Vec<u8> = raw[body_start..].to_vec();
-    if let Some(total) = parse_content_length(&head) {
-        if total > MAX_BODY_BYTES {
-            return RequestRead::TooLarge; // oversized — caller answers 413
-        }
-        while body.len() < total {
-            match stream.read(&mut buf) {
-                Ok(0) => break, // peer closed early; return the partial body honestly
-                Ok(n) => body.extend_from_slice(&buf[..n]),
-                Err(_) => break,
+    // bytes, counting whatever already arrived past the header terminator. With
+    // NO Content-Length there is no body — everything past the terminator
+    // belongs to the NEXT request and is carried forward (not mis-read as this
+    // request's body, which would corrupt a keep-alive connection).
+    let total = match parse_content_length(&head) {
+        Some(t) => {
+            if t > MAX_BODY_BYTES {
+                return RequestRead::TooLarge; // oversized — caller answers 413
             }
+            t
         }
-        body.truncate(total); // never hand back more than Content-Length promised
+        None => 0,
+    };
+    let mut body: Vec<u8> = raw[body_start..].to_vec();
+    while body.len() < total {
+        match stream.read(&mut buf) {
+            Ok(0) => break, // peer closed early; return the partial body honestly
+            Ok(n) => body.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+    // Any bytes captured past this request's body belong to the NEXT request on
+    // the connection — carry them forward so the next read_request starts there.
+    if body.len() > total {
+        carry.extend_from_slice(&body[total..]);
+        body.truncate(total);
     }
     RequestRead::Ok(head, body)
 }
@@ -6774,6 +6875,40 @@ fn parse_content_type(head: &str) -> String {
         }
     }
     String::new()
+}
+
+// Decide whether the CLIENT wants the connection kept alive, per RFC 7230. The
+// request line's HTTP version sets the default; an explicit `Connection` header
+// overrides it:
+//   HTTP/1.1 (and higher) -> keep-alive by default; close only if the client
+//     sent `Connection: close`.
+//   HTTP/1.0 -> close by default; keep-alive only if the client sent the
+//     legacy `Connection: keep-alive`.
+// The server may still force-close on top of this (e.g. an error whose framing
+// is uncertain) — that is the caller's decision; this only reads client intent.
+fn head_keep_alive(head: &str) -> bool {
+    let request_line = head.lines().next().unwrap_or("");
+    let is_http11_or_higher = request_line
+        .rsplit(' ')
+        .next()
+        .map(|v| v == "HTTP/1.1" || (v.starts_with("HTTP/") && v > "HTTP/1.0"))
+        .unwrap_or(false);
+    // The Connection header value (lowercased) if present.
+    let mut connection: Option<String> = None;
+    for line in head.lines().skip(1) {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("connection") {
+                connection = Some(value.trim().to_ascii_lowercase());
+                break;
+            }
+        }
+    }
+    match connection.as_deref() {
+        Some(v) if v.split(',').any(|t| t.trim() == "close") => false,
+        Some(v) if v.split(',').any(|t| t.trim() == "keep-alive") => true,
+        // No explicit token -> the HTTP version's default.
+        _ => is_http11_or_higher,
+    }
 }
 
 // Parse a request body into the SAME (key, value) alist shape the query string
@@ -6890,12 +7025,21 @@ fn fanout_request(
     }
 }
 
-fn http_response(status: &str, body: &str, router: &str) -> String {
+// Build an HTTP/1.1 response. Every response carries an ACCURATE Content-Length
+// (we hold the whole body, so we frame it exactly) — that is what makes
+// keep-alive work without chunked encoding: the client knows precisely where the
+// body ends and the next response begins. `keep_alive` sets the Connection
+// header: `keep-alive` when the connection will serve more requests, `close` on
+// the final response (client asked to close, idle timeout, EOF, or an error
+// whose framing is uncertain). Chunked transfer encoding is a named-later breath
+// (KERNEL_AS_ROUTER.md HTTP-version row).
+fn http_response(status: &str, body: &str, router: &str, keep_alive: bool) -> String {
     format!(
-        "HTTP/1.0 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nX-Form-Router: {}\r\nConnection: close\r\n\r\n{}",
+        "HTTP/1.1 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nX-Form-Router: {}\r\nConnection: {}\r\n\r\n{}",
         status,
         body.as_bytes().len(),
         router,
+        if keep_alive { "keep-alive" } else { "close" },
         body
     )
 }

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -143,7 +143,7 @@ gap, named precisely:
 
 | Gap | cli_serve today | Production front door needs |
 |-----|-----------------|-----------------------------|
-| **HTTP version** | HTTP/1.0, `Connection: close` per request | HTTP/1.1 + keep-alive (and ideally HTTP/2 behind Traefik), chunked transfer |
+| **HTTP version** | serves HTTP/1.1 with keep-alive — a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), each response Content-Length-framed so the client knows exactly where one ends and the next begins; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request, never dropped | chunked transfer encoding (today every response is Content-Length-framed; a streamed/unknown-length body would need chunked), upstream connection reuse on the fan-out hop (the fan-out still opens a fresh upstream connection per request), HTTP/2 behind Traefik |
 | **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
 | **Request parsing** | reads the full request honoring Content-Length (a body larger than the initial 8 KiB read is captured across as many socket reads as it needs); parses `application/x-www-form-urlencoded` bodies into the same `(key value)` alist the query string uses, captures `application/json` (and any other body) raw under the reserved key `__body__`; 1 MiB body cap rejected with 413; any method (POST/PUT/PATCH/GET) | full header map exposed to handlers; a structural JSON→Form-value parse (today JSON is raw-captured, not parsed); larger/streamed/chunked bodies |
 | **Fan-out proxy** | forwards the original method and the request body (Content-Type + Content-Length set from the captured body) so a POST that fans out to the upstream carries its payload; status+body relayed as text/plain | request/response header passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
@@ -151,7 +151,7 @@ gap, named precisely:
 | **Errors / observability** | 404/413/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
 
-None of these is exotic; each is a named breath. Two of the load-bearing ones
+None of these is exotic; each is a named breath. Three of the load-bearing ones
 are built. **Concurrency**: the kernel's per-process intern table
 (`lc-native-kernel-binary` names this: *"Not multi-process"*) makes the
 production shape a **pool of kernel workers behind the accept loop**, each
@@ -162,9 +162,21 @@ captured across multiple reads), parses `application/x-www-form-urlencoded`
 bodies into the same handler alist the query string uses, captures
 `application/json` raw under `__body__`, and the fan-out hop forwards the method
 and body to the upstream — so a POST is served (or fanned out) with its payload,
-not just a GET. The remaining rows (HTTP/1.1 keep-alive, full header passthrough,
-a structural JSON→Form parse, streaming, TLS/lifecycle, observability) are still
-open breaths.
+not just a GET. **HTTP/1.1 keep-alive**: a worker serves a whole connection's
+lifetime — `handle_request` (the one factored per-request shape) runs in a loop
+on the same `TcpStream`, so multiple requests reuse one TCP connection; each
+response is HTTP/1.1 with an accurate Content-Length (the framing that lets a
+client read one response and the next without chunked encoding); the
+`Connection` header is honored both ways (HTTP/1.1 stays open unless the client
+sends `close`, HTTP/1.0 closes unless it sends `keep-alive`); a 5s idle
+read-timeout reaps a quiet connection so it frees its worker; and over-read
+bytes from one request are carried into the next, never dropped (the pipelining
+hazard). The honest tradeoff: a worker serving a keep-alive client is
+unavailable to the pool until the connection closes or the idle timeout fires —
+standard thread-per-connection behavior, tuned by the idle-timeout value and the
+worker count. The remaining rows (chunked transfer, upstream connection reuse on
+the fan-out hop, full header passthrough, a structural JSON→Form parse,
+streaming, TLS/lifecycle, observability) are still open breaths.
 
 ## The BML preference
 
@@ -325,19 +337,26 @@ response model), serving the value-walk directly. A hot native route is far
 cheaper than the same compute reached through the CPython doorway; the tail pays
 a small, measured proxy toll to keep working unchanged.
 
-**NOT shown / not claimed:** full production-readiness. The proof is HTTP/1.0
-(no keep-alive — every request is a fresh connection on both hops), and the
-accept loop is thread-per-request-blocked (it parallelizes to the worker count,
-not an async reactor); JSON bodies are raw-captured, not structurally parsed
-into Form values; request/response headers beyond the body are not yet passed
-through (the fan-out relays status + body as text/plain, not the upstream's
-content-type/headers). The real-app proof ran against the dev sqlite DB; the
-production deployment shape (TLS/Traefik front, the routes.fk covering the real
-native-eligible set, header/content-type passthrough so a JSON route's
-content-type survives the proxy) is the remaining build. Concurrency,
-request-body reading, and the **real-app fan-out + native side-by-side** are now
-shown; the HTTP/1.1, header-passthrough, and structural-JSON rows above are the
-rest.
+**NOT shown / not claimed:** full production-readiness. The server serves
+HTTP/1.1 with keep-alive (proven by `router_keepalive_harness.py` — multiple
+requests on one connection, `Connection` honored both ways, idle-timeout reaping,
+pipelining bytes carried), but the **upstream fan-out hop still opens a fresh
+connection per request** (the client→router hop reuses connections; the
+router→upstream hop does not yet — so the proxy-hop latency above is measured on
+a non-reused upstream connection), and the accept loop is
+thread-per-connection-blocked (it parallelizes to the worker count, not an async
+reactor; a worker serving a keep-alive client is held until that connection
+closes or times out). Responses are Content-Length-framed, not chunked; JSON
+bodies are raw-captured, not structurally parsed into Form values;
+request/response headers beyond the body are not yet passed through (the fan-out
+relays status + body as text/plain, not the upstream's content-type/headers). The
+real-app proof ran against the dev sqlite DB; the production deployment shape
+(TLS/Traefik front, the routes.fk covering the real native-eligible set,
+header/content-type passthrough so a JSON route's content-type survives the
+proxy) is the remaining build. Concurrency, request-body reading, the
+**real-app fan-out + native side-by-side**, and **HTTP/1.1 keep-alive on the
+client→router hop** are now shown; chunked transfer, upstream connection reuse,
+header-passthrough, and structural-JSON are the rest.
 
 ## The flip is Urs's decision
 
@@ -358,12 +377,13 @@ test port so the reversal can be weighed with evidence rather than assertion.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `handle_request` (the single factored serving shape, now reading the full request + body), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read and content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (the X-Form-Router header), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement (mock upstream).
 - [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413 (mock upstream).
 - [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
+- [`form/form-kernel-rust/router_keepalive_harness.py`](../form/form-kernel-rust/router_keepalive_harness.py) — the HTTP/1.1 keep-alive proof: N sequential requests on ONE connection (Content-Length framed, distinct inputs, each correct), pipelined two-in-one-send (leftover bytes carried, none dropped), `Connection: close` honored, HTTP/1.0 default-close back-compat, idle-timeout reaping the connection (worker freed), an idle connection NOT starving the pool, and the per-request handshake saving (reused vs fresh connection). Mock upstream — no production routing.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.


### PR DESCRIPTION
## What

Mature the kernel-as-router serve primitive (`cli_serve` in `form/form-kernel-rust/src/main.rs`) toward production transport: it now serves **HTTP/1.1 with keep-alive** — a worker holds the accepted connection and serves **multiple requests on it**, instead of HTTP/1.0 close-per-request. This closes the *"HTTP version → HTTP/1.1 + keep-alive"* gap in `kernels/KERNEL_AS_ROUTER.md`.

**NO production routing flip.** FastAPI stays the live front door; this matures the serve primitive only.

## The build (client→router hop — the load-bearing half)

- **`serve_connection`** wraps the ONE factored `handle_request` in a loop on the same `TcpStream` (core-abstraction-first: keep-alive is the loop, not a fork of the serving logic). Loops until the client closes, EOF/read-timeout fires, or a response forces close.
- **`head_keep_alive`** reads the client's intent: HTTP/1.1 default-keep-alive unless `Connection: close`; HTTP/1.0 close-unless-`keep-alive`. The server force-closes on 413 (body undrained → framing broken) and handler errors.
- **`http_response`** is now HTTP/1.1 with an accurate **Content-Length** on every response (the framing that makes keep-alive work without chunked encoding) and a parameterized `Connection` header.
- **`read_request`** carries over-read bytes into the next request via a `carry` buffer — the classic **pipelining hazard**. A single read can pull request N's tail AND request N+1's head; those bytes are stashed and prepended to the next read, never dropped. A no-Content-Length request keeps no body, so anything past the header terminator is carried (not mis-read as this request's body).
- A **5s idle read-timeout** (`KEEPALIVE_IDLE_TIMEOUT`) reaps a quiet connection so it frees its worker rather than pinning it forever.

## Honest scope

- **Closed**: client→router HTTP/1.1 keep-alive with Content-Length framing + idle timeout + pipelining-safe leftover-byte carry.
- **Still open (named next)**: upstream connection reuse on the fan-out hop (the fan-out still opens a fresh upstream connection per request); chunked transfer encoding; header passthrough; structural JSON→Form parse; HTTP/2.
- **Worker-occupancy tradeoff (named, not hidden)**: a worker serving a keep-alive client is unavailable to the pool until the connection closes or the idle timeout fires — standard thread-per-connection behavior, tuned by the timeout value + worker count.

## Proof — `router_keepalive_harness.py` (mock upstream, no production routing)

```
[1 conn x 8 reqs ] sequential on ONE connection, distinct inputs -> all OK (each Connection: keep-alive, correct sum)
[pipelined 2-in-1 ] two reqs in ONE send -> '15', '123'  OK  (leftover bytes carried, none dropped)
[Connection close ] /health Connection: close -> 'ok' resp-conn='close' server-closed=True  OK
[HTTP/1.0 default ] /health (1.0, no Conn hdr) -> 'ok' resp-conn='close' server-closed=True  OK
[no-starve pool   ] B served in 0.2 ms while A idles -> '15'  OK  (idle conn did not starve other workers)
[idle timeout reap] idle conn A closed by server after ~5s idle -> server-closed=True  OK
[handshake saving ] 30 reqs: reused-conn=2.4 ms vs fresh-conn-each=5.4 ms -> keep-alive saved 3.0 ms (faster)  OK
```

## Green

- `cargo build --release` — 0 errors.
- `form && ./validate.sh` — **258 ok**; the one divergence (`seeded-bytes-recipe-band.fk`) is untracked debris, not this change; `compression-fold-band → 111111`.
- Existing harnesses (body, proof, concurrency, real-app) all still pass — HTTP/1.1 + Content-Length is backward-compatible with the existing clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)