### PR TITLE
tend(kernel): bidirectional header passthrough on the kernel-router fan-out

### DIFF
--- a/form/form-kernel-rust/router_header_passthrough_harness.py
+++ b/form/form-kernel-rust/router_header_passthrough_harness.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Proof harness for the kernel-router's BIDIRECTIONAL HEADER PASSTHROUGH.
+
+Where router_real_app_harness.py proved the reversed topology fans out method +
+body to the REAL FastAPI app and relays status + body, this proves the matured
+fan-out arm carries HEADERS both ways with reverse-proxy hop-by-hop hygiene:
+
+  UP   — the client's end-to-end REQUEST headers (Authorization, Cookie, Accept*,
+         User-Agent, X-*, Content-Type) reach the upstream, so the fan-out can
+         front an authenticated / content-typed route truthfully. Host is
+         rewritten to the upstream; the client's Content-Length is dropped (the
+         router re-derives it from the body it captured); hop-by-hop headers
+         (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-*, TE,
+         Trailer) are stripped — the router owns its upstream-hop framing.
+  DOWN — the upstream's RESPONSE headers (Content-Type, Set-Cookie,
+         Cache-Control, Location, ETag, X-*) reach the client, so a JSON/HTML
+         route survives the proxy instead of being flattened to text/plain and a
+         cookie/redirect/cache directive is not lost. The router still owns its
+         own client-hop framing (Content-Length, Connection); the upstream's
+         hop-by-hop + framing headers are NOT relayed.
+
+TWO upstreams, each proving what it is best placed to prove (honest split):
+
+  • the REAL FastAPI app (app.main:app, dev sqlite, throwaway port) — proves the
+    DOWN direction against a genuine route: GET /api/health relayed with
+    Content-Type: application/json (the real upstream's), NOT text/plain. Also
+    the no-regression checks: a native route still serves in Form, a fan-out GET
+    still returns the real app's JSON body.
+
+  • a mock ECHO upstream (http.server) — proves what no fixed real route cleanly
+    exposes: (1) the UP direction — it echoes every request header it RECEIVED
+    back in the response body, so the harness can assert the client's
+    Authorization / Cookie / X-Probe arrived and the hop-by-hop Connection /
+    client Content-Length / original Host did NOT; (2) Set-Cookie + Cache-Control
+    relay DOWN; (3) the upstream's own hop-by-hop response headers (a bogus
+    Transfer-Encoding / Connection it emits) are NOT relayed — the router owns
+    that framing.
+
+This is a LOCAL side-by-side proof. It touches NO production routing — the real
+app runs on a throwaway test port against the dev sqlite DB; the production front
+door is untouched.
+
+Run from form/form-kernel-rust/ (after `cargo build --release`):
+    python3 router_header_passthrough_harness.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+# One native route (/sum) + everything else fans out — the body-proof manifest.
+ROUTES = HERE / "examples" / "router-body-proof.fk"
+REAL_ROUTES = HERE / "examples" / "router-real-app-proof.fk"
+# form/form-kernel-rust -> form -> repo root -> api
+API_DIR = HERE.parent.parent / "api"
+
+# A distinctive request header the harness sets and the echo upstream reflects.
+PROBE_AUTH = "Bearer test123"
+PROBE_COOKIE = "session=abc; theme=dark"
+PROBE_X = "hello-upstream"
+
+FANOUT_GET_PATH = "/api/health"  # real app -> application/json
+
+
+# ── echo upstream: reflects the request headers it RECEIVED, sets a cookie ──
+class _EchoHandler(BaseHTTPRequestHandler):
+    """Mock upstream that makes the UP direction observable: it serializes every
+    request header it received into the JSON body, so the harness can assert
+    which client headers arrived and which were (correctly) stripped. It also
+    sets a Set-Cookie + Cache-Control to prove DOWN relay, and emits a bogus
+    hop-by-hop response header to prove the router does NOT relay it."""
+
+    def _echo(self):
+        received = {k.lower(): v for k, v in self.headers.items()}
+        payload = json.dumps({"received_headers": received, "path": self.path}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        # DOWN-relay probes (end-to-end response headers):
+        self.send_header("Set-Cookie", "echosession=xyz789; Path=/; HttpOnly")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Echo-Custom", "relayed-ok")
+        # A hop-by-hop response header the router must NOT relay (it owns framing):
+        self.send_header("Transfer-Encoding", "chunked-but-not-really")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):  # noqa: N802
+        self._echo()
+
+    def do_POST(self):  # noqa: N802
+        # drain any body so the connection frames cleanly
+        n = int(self.headers.get("Content-Length", "0") or "0")
+        if n:
+            self.rfile.read(n)
+        self._echo()
+
+    def log_message(self, *args):  # silence per-request logging
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 40.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.3)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.1)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def wait_for_http(url: str, timeout: float = 40.0) -> None:
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2.0) as r:
+                r.read()
+                return
+        except urllib.error.HTTPError:
+            return
+        except (urllib.error.URLError, ConnectionError, OSError) as e:
+            last = e
+            time.sleep(0.25)
+    raise RuntimeError(f"app never answered at {url}: {last}")
+
+
+def raw_request(port: int, raw: bytes, timeout: float = 10.0):
+    """Send a fully hand-built request over a raw socket and return
+    (status_line, headers_lower_dict_with_multivalue, body_text). Set-Cookie can
+    appear multiple times, so headers map name -> list[str]."""
+    sock = socket.create_connection(("127.0.0.1", port), timeout=timeout)
+    sock.settimeout(timeout)
+    try:
+        sock.sendall(raw)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            b = sock.recv(65536)
+            if not b:
+                break
+            buf += b
+        head_b, _, rest = buf.partition(b"\r\n\r\n")
+        head_txt = head_b.decode("utf-8", "replace")
+        lines = head_txt.split("\r\n")
+        status_line = lines[0]
+        headers: dict[str, list[str]] = {}
+        for line in lines[1:]:
+            if ":" in line:
+                k, v = line.split(":", 1)
+                headers.setdefault(k.strip().lower(), []).append(v.strip())
+        n = 0
+        if "content-length" in headers:
+            n = int(headers["content-length"][0])
+        body = rest
+        while len(body) < n:
+            b = sock.recv(65536)
+            if not b:
+                break
+            body += b
+        body = body[:n]
+        return status_line, headers, body.decode("utf-8", "replace")
+    finally:
+        sock.close()
+
+
+def get_real(url: str, timeout: float = 10.0):
+    """Return (status, content_type, body) via urllib against the real app."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status, r.headers.get("Content-Type"), r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        return e.code, e.headers.get("Content-Type"), e.read().decode("utf-8")
+
+
+def first(headers: dict, name: str):
+    vals = headers.get(name.lower())
+    return vals[0] if vals else None
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists() or not REAL_ROUTES.exists():
+        print("missing routes file(s)", file=sys.stderr)
+        return 2
+    if not (API_DIR / "app" / "main.py").exists():
+        print(f"cannot find the real app at {API_DIR}/app/main.py", file=sys.stderr)
+        return 2
+
+    failures: list[tuple] = []
+
+    # ── 1) echo upstream + router: prove UP, Set-Cookie/Cache DOWN, hop-by-hop ──
+    echo_port = free_port()
+    httpd = ThreadingHTTPServer(("127.0.0.1", echo_port), _EchoHandler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    echo_url = f"http://127.0.0.1:{echo_port}"
+
+    kport = free_port()
+    router_proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(kport), "--routes", str(ROUTES),
+         "--upstream", echo_url],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    real_proc = None
+    real_router_proc = None
+    try:
+        wait_for_port(kport)
+        print("=== UP + DOWN against the ECHO upstream (header observability) ===")
+
+        # Hand-build a request with end-to-end headers AND hop-by-hop noise the
+        # router must strip on the way up. /echo is not native -> fans out.
+        raw = (
+            f"GET /echo/probe HTTP/1.1\r\n"
+            f"Host: client-sent-host.example\r\n"
+            f"Authorization: {PROBE_AUTH}\r\n"
+            f"Cookie: {PROBE_COOKIE}\r\n"
+            f"Accept: application/json\r\n"
+            f"X-Probe: {PROBE_X}\r\n"
+            f"User-Agent: header-passthrough-harness\r\n"
+            f"Connection: keep-alive\r\n"        # hop-by-hop -> must NOT reach upstream
+            f"Content-Length: 999\r\n"           # bogus framing -> router re-derives (0 here)
+            f"\r\n"
+        ).encode()
+        status_line, rheaders, body = raw_request(kport, raw)
+        try:
+            echoed = json.loads(body).get("received_headers", {})
+        except Exception:
+            echoed = {}
+
+        # UP: end-to-end headers arrived at the upstream
+        up_auth = echoed.get("authorization") == PROBE_AUTH
+        up_cookie = echoed.get("cookie") == PROBE_COOKIE
+        up_accept = echoed.get("accept") == "application/json"
+        up_xprobe = echoed.get("x-probe") == PROBE_X
+        up_ua = echoed.get("user-agent") == "header-passthrough-harness"
+        # UP hygiene: Host rewritten to upstream, client Content-Length NOT
+        # forwarded (no body -> router sends none), Connection NOT forwarded
+        host_rewritten = echoed.get("host", "").startswith("127.0.0.1")
+        no_client_cl = echoed.get("content-length") in (None, "0")
+        no_conn_up = "connection" not in echoed or echoed.get("connection", "").lower() != "keep-alive"
+        ok_up = all([up_auth, up_cookie, up_accept, up_xprobe, up_ua,
+                     host_rewritten, no_client_cl, no_conn_up])
+        print(f"  [UP request hdrs ] upstream RECEIVED: "
+              f"Authorization={up_auth} Cookie={up_cookie} Accept={up_accept} "
+              f"X-Probe={up_xprobe} UA={up_ua}")
+        print(f"                     hygiene: Host->upstream={host_rewritten} "
+              f"client-Content-Length-dropped={no_client_cl} "
+              f"Connection-stripped={no_conn_up}  {'OK' if ok_up else 'FAIL'}")
+        print(f"                     (upstream saw Host={echoed.get('host')!r} "
+              f"Content-Length={echoed.get('content-length')!r})")
+        if not ok_up:
+            failures.append(("UP request headers", echoed))
+
+        # DOWN: Set-Cookie + Cache-Control + custom header relayed; Content-Type
+        # is the upstream's application/json; hop-by-hop NOT relayed.
+        down_cookie = first(rheaders, "set-cookie") == "echosession=xyz789; Path=/; HttpOnly"
+        down_cache = first(rheaders, "cache-control") == "no-store"
+        down_custom = first(rheaders, "x-echo-custom") == "relayed-ok"
+        down_ct = (first(rheaders, "content-type") or "").startswith("application/json")
+        # The upstream emitted Transfer-Encoding (hop-by-hop) — router must NOT relay it.
+        no_te_down = "transfer-encoding" not in rheaders
+        # Router owns its client-hop framing.
+        router_framing = (first(rheaders, "connection") in ("keep-alive", "close")
+                          and "content-length" in rheaders
+                          and first(rheaders, "x-form-router") == "fanout-python")
+        ok_down = all([down_cookie, down_cache, down_custom, down_ct,
+                       no_te_down, router_framing])
+        print(f"  [DOWN resp hdrs  ] client RECEIVED: Set-Cookie={down_cookie} "
+              f"Cache-Control={down_cache} X-Echo-Custom={down_custom} "
+              f"Content-Type=json:{down_ct}")
+        print(f"                     hygiene: upstream-Transfer-Encoding-NOT-relayed="
+              f"{no_te_down} router-owns-framing={router_framing}  "
+              f"{'OK' if ok_down else 'FAIL'}")
+        if not ok_down:
+            failures.append(("DOWN response headers", dict(rheaders)))
+
+        # POST with a real body + Content-Type -> body forwarded, Content-Type up.
+        post_body = json.dumps({"hello": "upstream"}).encode()
+        raw_post = (
+            f"POST /echo/post HTTP/1.1\r\n"
+            f"Host: client.example\r\n"
+            f"Content-Type: application/json\r\n"
+            f"X-Probe: {PROBE_X}\r\n"
+            f"Content-Length: {len(post_body)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode() + post_body
+        _, _, pbody = raw_request(kport, raw_post)
+        try:
+            pe = json.loads(pbody).get("received_headers", {})
+        except Exception:
+            pe = {}
+        post_ct = pe.get("content-type") == "application/json"
+        post_cl = pe.get("content-length") == str(len(post_body))
+        post_x = pe.get("x-probe") == PROBE_X
+        ok_post = post_ct and post_cl and post_x
+        print(f"  [POST body+hdrs  ] upstream saw Content-Type={post_ct} "
+              f"Content-Length(re-derived={len(post_body)})={post_cl} "
+              f"X-Probe={post_x}  {'OK' if ok_post else 'FAIL'}")
+        if not ok_post:
+            failures.append(("POST body + headers up", pe))
+
+    finally:
+        router_proc.terminate()
+        try:
+            router_proc.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            router_proc.kill()
+        httpd.shutdown()
+
+    # ── 2) REAL FastAPI app: prove DOWN Content-Type relay + no-regression ──
+    app_port = free_port()
+    env = dict(os.environ)
+    env["COH_ENV"] = "dev"
+    (API_DIR / "data").mkdir(exist_ok=True)
+    real_proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "app.main:app",
+         "--host", "127.0.0.1", "--port", str(app_port), "--log-level", "warning"],
+        cwd=str(API_DIR), env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    app_base = f"http://127.0.0.1:{app_port}"
+    try:
+        print("\n=== DOWN Content-Type relay against the REAL FastAPI app ===")
+        wait_for_port(app_port)
+        wait_for_http(app_base + FANOUT_GET_PATH)
+        # Confirm it's genuinely the real app AND note its real content-type.
+        st, app_ct, abody = get_real(app_base + FANOUT_GET_PATH)
+        try:
+            hj = json.loads(abody)
+        except Exception:
+            hj = {}
+        is_real = st == 200 and "version" in hj and "kernel_runtime" in hj
+        real_ct_json = (app_ct or "").startswith("application/json")
+        print(f"  real app {FANOUT_GET_PATH} -> {st} Content-Type={app_ct!r} "
+              f"{'REAL FastAPI (json)' if is_real and real_ct_json else 'UNEXPECTED'}")
+        if not (is_real and real_ct_json):
+            failures.append(("real-app health probe", st, app_ct, abody[:120]))
+
+        kport2 = free_port()
+        real_router_proc = subprocess.Popen(
+            [str(BIN), "serve", "--port", str(kport2),
+             "--routes", str(REAL_ROUTES), "--upstream", app_base],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        wait_for_port(kport2)
+
+        # DOWN through the router: the client must now see application/json (the
+        # upstream's real type), NOT text/plain.
+        raw = (
+            f"GET {FANOUT_GET_PATH} HTTP/1.1\r\n"
+            f"Host: client.example\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        ).encode()
+        status_line, rheaders, body = raw_request(kport2, raw)
+        router_ct = first(rheaders, "content-type")
+        relayed_json = (router_ct or "").startswith("application/json")
+        not_textplain = "text/plain" not in (router_ct or "")
+        try:
+            kj = json.loads(body)
+        except Exception:
+            kj = {}
+        genuine = "version" in kj and "kernel_runtime" in kj
+        is_fanout = first(rheaders, "x-form-router") == "fanout-python"
+        ok = relayed_json and not_textplain and genuine and is_fanout and status_line.endswith("200 OK")
+        print(f"  [DOWN real CT    ] {FANOUT_GET_PATH} through router -> "
+              f"Content-Type={router_ct!r} (was text/plain before this build)")
+        print(f"                     relayed-json={relayed_json} "
+              f"not-text-plain={not_textplain} genuine-app-body={genuine} "
+              f"X-Form-Router={first(rheaders, 'x-form-router')}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("real-app DOWN content-type relay", status_line, router_ct, body[:160]))
+
+        # No-regression: native route still serves text/plain value in Form.
+        raw_native = (
+            "GET /api/utils/weighted_average?values=0.5,0.75,1.0&weights=0.25,0.25,0.5 HTTP/1.1\r\n"
+            "Host: client.example\r\nConnection: close\r\n\r\n"
+        ).encode()
+        nstatus, nheaders, nbody = raw_request(kport2, raw_native)
+        native_ok = (nstatus.endswith("200 OK")
+                     and first(nheaders, "x-form-router") == "native-kernel"
+                     and (first(nheaders, "content-type") or "").startswith("text/plain"))
+        try:
+            nval = float(nbody)
+        except ValueError:
+            nval = None
+        native_ok = native_ok and nval is not None
+        print(f"  [no-regress nat  ] native weighted_average -> value={nval} "
+              f"Content-Type={first(nheaders, 'content-type')!r} "
+              f"X-Form-Router={first(nheaders, 'x-form-router')}  "
+              f"{'OK' if native_ok else 'FAIL'}")
+        if not native_ok:
+            failures.append(("no-regression native route", nstatus, nbody[:120]))
+
+    finally:
+        for p in (real_router_proc, real_proc):
+            if p is None:
+                continue
+            p.terminate()
+            try:
+                p.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                try:
+                    p.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    pass
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+        for f in failures:
+            print(f"   {f}", file=sys.stderr)
+        return 1
+    print("\nok — bidirectional header passthrough with hop-by-hop hygiene: the "
+          "client's end-to-end REQUEST headers (Authorization/Cookie/Accept/"
+          "X-Probe/UA + Content-Type on POST) reached the upstream with Host "
+          "rewritten and client Content-Length/Connection stripped; the "
+          "upstream's RESPONSE headers (Set-Cookie/Cache-Control/X-Echo-Custom) "
+          "and its real Content-Type (application/json from the REAL FastAPI "
+          "app, not text/plain) reached the client; hop-by-hop headers were "
+          "stripped both ways and the router kept ownership of its framing; "
+          "native routes still serve in Form unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6388,8 +6388,8 @@ fn handle_request(
             // never drained, so the connection's framing is broken: close it.
             let status = "413 Payload Too Large".to_string();
             let msg = format!("request body exceeds {} bytes\n", MAX_BODY_BYTES);
-            let _ =
-                stream.write_all(http_response(&status, &msg, "local-control", false).as_bytes());
+            let _ = stream
+                .write_all(http_response(&status, &msg, "local-control", false, "", &[]).as_bytes());
             return false;
         }
         RequestRead::Error => return false, // idle close / read-timeout / EOF — loop ends
@@ -6405,6 +6405,12 @@ fn handle_request(
     // (k v) pairs; a JSON / other body lands as a single ("__body__", raw) pair.
     let content_type = parse_content_type(&head);
     request_data.extend(parse_request_body(&content_type, &body_bytes));
+    // The full client request header list (request line excluded), captured once
+    // so the fan-out arm can forward the client's end-to-end headers
+    // (Authorization, Cookie, Accept*, …) to the upstream. Native handlers don't
+    // read headers yet (a named-later breath — KERNEL_AS_ROUTER.md handler-inputs
+    // row), but the fan-out arm needs them now to front authenticated routes.
+    let req_headers = parse_headers(&head);
 
     // The router decision: a path with a native Form handler is served
     // entirely in the kernel; a path with no handler fans out to the
@@ -6412,6 +6418,14 @@ fn handle_request(
     let body: String;
     let status: String;
     let router: &str;
+    // The response's Content-Type and other relayed headers: a fan-out fills
+    // these from the UPSTREAM's real response (so a JSON/HTML route survives the
+    // proxy and its Set-Cookie/Cache-Control reach the client); native/404
+    // responses leave them empty, so the ONE emit shape (http_response) defaults
+    // the type to text/plain and relays no extra headers — the router owns all
+    // framing on those arms.
+    let mut resp_content_type = String::new();
+    let mut resp_headers: Vec<(String, String)> = Vec::new();
     if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
         // NATIVE: served entirely in Form, no Python in the path.
         // Build the request alist as Value::List of (key, value) pairs — query
@@ -6435,8 +6449,9 @@ fn handle_request(
                 path,
                 cl.params.len()
             );
-            let _ = stream
-                .write_all(http_response(&status, &body, "native-kernel-error", false).as_bytes());
+            let _ = stream.write_all(
+                http_response(&status, &body, "native-kernel-error", false, "", &[]).as_bytes(),
+            );
             return false; // close on error — keep the framing unambiguous
         }
         let result = walk(k, arena, cl.body, call_frame);
@@ -6447,13 +6462,20 @@ fn handle_request(
         // FAN-OUT: no native handler — forward to the Python upstream and
         // relay its response. The kernel owns the front door; Python is the
         // upstream for the not-yet-native tail. Each worker issues its own
-        // independent fan-out hop, passing the request's METHOD and BODY so a
-        // POST that fans out to Python carries its payload (Content-Type +
-        // Content-Length set from the captured body).
-        let (fanout_status, fanout_body) =
-            fanout_request(upstream_base, &method, &target, &content_type, &body_bytes);
-        status = fanout_status;
-        body = fanout_body;
+        // independent fan-out hop. The client's METHOD, BODY, and end-to-end
+        // request headers (Authorization, Cookie, Accept*, …) are forwarded so
+        // an authenticated/content-typed route is fronted truthfully; the
+        // UPSTREAM's response Content-Type + end-to-end headers (Set-Cookie,
+        // Cache-Control, Location, …) are relayed back so the client receives
+        // the upstream's real type and cookies, not a flattened text/plain.
+        // Hop-by-hop headers are stripped both ways; the router owns the framing
+        // on its client hop (Content-Length, Connection — http_response writes
+        // those, the relayed set cannot clobber them).
+        let fanout = fanout_request(upstream_base, &method, &target, &req_headers, &body_bytes);
+        status = fanout.status;
+        body = fanout.body;
+        resp_content_type = fanout.content_type;
+        resp_headers = fanout.headers;
         router = "fanout-python";
     } else {
         // No native handler and no upstream configured.
@@ -6462,9 +6484,22 @@ fn handle_request(
         router = "local-control";
     }
     // Frame the response with an accurate Content-Length and the keep-alive
-    // verdict. If the write fails the peer is gone — close the loop.
+    // verdict, the upstream's Content-Type + relayed end-to-end headers on a
+    // fan-out (empty -> text/plain + no extra headers on native/404). The router
+    // owns Content-Length + Connection; the relayed set was already filtered to
+    // exclude those. If the write fails the peer is gone — close the loop.
     if stream
-        .write_all(http_response(&status, &body, router, keep_alive).as_bytes())
+        .write_all(
+            http_response(
+                &status,
+                &body,
+                router,
+                keep_alive,
+                &resp_content_type,
+                &resp_headers,
+            )
+            .as_bytes(),
+        )
         .is_err()
     {
         return false;
@@ -6869,6 +6904,74 @@ fn find_header_end(raw: &[u8]) -> Option<usize> {
         .map(|i| i + 4)
 }
 
+// Parse a raw header block (the lines AFTER the request/status line, terminator
+// excluded) into an ordered list of (name, value) pairs — names kept as sent so
+// they relay verbatim, values trimmed. The first line (request line on the way
+// up, status line on the way back) is the caller's; this skips it. This is the
+// ONE header-capture shape both hops use: the request headers forwarded to the
+// upstream and the upstream's response headers relayed to the client both come
+// from here, so a header is never silently dropped because two code paths parsed
+// the block differently.
+fn parse_headers(head: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in head.lines().skip(1) {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            out.push((name.trim().to_string(), value.trim().to_string()));
+        }
+    }
+    out
+}
+
+// HOP-BY-HOP headers (RFC 7230 §6.1) — meaningful only for a SINGLE transport
+// hop, NEVER forwarded by a proxy to the next hop. The router is a hop on both
+// sides: it owns its client-hop framing (Connection/Content-Length) and its
+// upstream-hop framing independently, so these must be stripped in BOTH
+// directions rather than blindly relayed. `Connection`, `Keep-Alive`,
+// `Transfer-Encoding`, `Upgrade`, the `Proxy-*` pair, plus the rarely-seen TE /
+// Trailer. Content-Length is handled separately (the router sets its own from
+// the body it holds), so it is treated as framing the router owns, not relayed.
+fn is_hop_by_hop(name: &str) -> bool {
+    let n = name.trim();
+    n.eq_ignore_ascii_case("connection")
+        || n.eq_ignore_ascii_case("keep-alive")
+        || n.eq_ignore_ascii_case("transfer-encoding")
+        || n.eq_ignore_ascii_case("upgrade")
+        || n.eq_ignore_ascii_case("proxy-authenticate")
+        || n.eq_ignore_ascii_case("proxy-authorization")
+        || n.eq_ignore_ascii_case("te")
+        || n.eq_ignore_ascii_case("trailer")
+}
+
+// Whether a request header should be forwarded UP to the upstream. Strips the
+// hop-by-hop set (the router owns its upstream-hop framing) AND the framing the
+// router re-derives from the body it captured: `Host` is rewritten to the
+// upstream host, and `Content-Length` is set from the captured body's true
+// length (a forwarded client Content-Length could disagree with the bytes the
+// router actually holds — double-framing). Everything end-to-end —
+// Authorization, Cookie, Accept*, User-Agent, X-*, Content-Type, … — passes.
+fn forward_request_header(name: &str) -> bool {
+    let n = name.trim();
+    !(is_hop_by_hop(n)
+        || n.eq_ignore_ascii_case("host")
+        || n.eq_ignore_ascii_case("content-length"))
+}
+
+// Whether an upstream RESPONSE header should be relayed DOWN to the client.
+// Strips the hop-by-hop set AND the framing the router owns on its client hop:
+// `Content-Length` (the router sets its own from the body it relays) and
+// `Content-Type` (relayed via the dedicated content_type slot in the emit shape,
+// so it is not duplicated here). Everything else end-to-end — Set-Cookie,
+// Cache-Control, Location, ETag, X-*, … — passes through to the client.
+fn relay_response_header(name: &str) -> bool {
+    let n = name.trim();
+    !(is_hop_by_hop(n)
+        || n.eq_ignore_ascii_case("content-length")
+        || n.eq_ignore_ascii_case("content-type"))
+}
+
 // Pull the Content-Length value out of a raw header block (case-insensitive
 // header name). Returns None when absent or unparseable.
 fn parse_content_length(head: &str) -> Option<usize> {
@@ -7033,44 +7136,97 @@ fn fanout_request(
     upstream: &str,
     method: &str,
     target: &str,
-    content_type: &str,
+    req_headers: &[(String, String)],
     body: &[u8],
-) -> (String, String) {
-    match fanout_request_result(upstream, method, target, content_type, body) {
+) -> FanoutResult {
+    match fanout_request_result(upstream, method, target, req_headers, body) {
         Ok(v) => v,
-        Err(e) => (
-            "502 Bad Gateway".to_string(),
-            format!("fan-out upstream error: {}\n", e),
-        ),
+        Err(e) => FanoutResult {
+            status: "502 Bad Gateway".to_string(),
+            content_type: String::new(),
+            headers: Vec::new(),
+            body: format!("fan-out upstream error: {}\n", e),
+        },
     }
 }
 
-// Build an HTTP/1.1 response. Every response carries an ACCURATE Content-Length
-// (we hold the whole body, so we frame it exactly) — that is what makes
-// keep-alive work without chunked encoding: the client knows precisely where the
-// body ends and the next response begins. `keep_alive` sets the Connection
-// header: `keep-alive` when the connection will serve more requests, `close` on
-// the final response (client asked to close, idle timeout, EOF, or an error
-// whose framing is uncertain). Chunked transfer encoding is a named-later breath
+// The ONE response-emit shape — core-abstraction-first: every response (native,
+// fan-out, error) is written here, so the framing the router owns is written in
+// exactly one place and cannot diverge between arms.
+//
+// FRAMING THE ROUTER OWNS (always, on every response):
+//   - Content-Length: ACCURATE, from the body it holds — that is what makes
+//     keep-alive work without chunked encoding (the client knows precisely where
+//     the body ends and the next response begins).
+//   - Connection: `keep-alive` when the connection will serve more requests,
+//     `close` on the final response (client asked to close, idle timeout, EOF,
+//     or an error whose framing is uncertain).
+//   - X-Form-Router: which arm served this (`native-kernel` / `fanout-python` /
+//     a control marker).
+// These are the router's client-hop framing; a relayed upstream header can NEVER
+// clobber them (hop-by-hop + Content-Length/Content-Type are filtered out of
+// `relayed` by relay_response_header before they reach here).
+//
+// `content_type` is the response's Content-Type: the upstream's real one on a
+// fan-out (so a JSON/HTML route survives the proxy instead of being flattened to
+// text/plain), or the native default `text/plain; charset=utf-8` when empty.
+// `relayed` is the upstream's other end-to-end headers (Set-Cookie,
+// Cache-Control, Location, ETag, X-*, …) on a fan-out, EMPTY for native/error
+// responses. Chunked transfer encoding remains a named-later breath
 // (KERNEL_AS_ROUTER.md HTTP-version row).
-fn http_response(status: &str, body: &str, router: &str, keep_alive: bool) -> String {
-    format!(
-        "HTTP/1.1 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nX-Form-Router: {}\r\nConnection: {}\r\n\r\n{}",
+fn http_response(
+    status: &str,
+    body: &str,
+    router: &str,
+    keep_alive: bool,
+    content_type: &str,
+    relayed: &[(String, String)],
+) -> String {
+    let ct = if content_type.trim().is_empty() {
+        "text/plain; charset=utf-8"
+    } else {
+        content_type.trim()
+    };
+    // Start with the framing the router owns, then append the relayed end-to-end
+    // headers verbatim (each already filtered to exclude hop-by-hop and the
+    // router-owned framing). Content-Type carries its own dedicated line.
+    let mut out = format!(
+        "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nX-Form-Router: {}\r\nConnection: {}\r\n",
         status,
+        ct,
         body.as_bytes().len(),
         router,
         if keep_alive { "keep-alive" } else { "close" },
-        body
-    )
+    );
+    for (name, value) in relayed {
+        out.push_str(&format!("{}: {}\r\n", name, value));
+    }
+    out.push_str("\r\n");
+    out.push_str(body);
+    out
+}
+
+// The fan-out hop's full result: the upstream's status line, its CONTENT-TYPE
+// (so the client gets a JSON/HTML route's real type, not a flattened
+// text/plain), its other RELAYABLE end-to-end response headers (Set-Cookie,
+// Cache-Control, Location, …), and the body. Hop-by-hop and router-owned framing
+// headers are already filtered out of `headers` (and Content-Type lifted into
+// its own slot) so the caller relays them safely beside the router's own
+// framing.
+struct FanoutResult {
+    status: String,
+    content_type: String,
+    headers: Vec<(String, String)>,
+    body: String,
 }
 
 fn fanout_request_result(
     upstream: &str,
     method: &str,
     target: &str,
-    content_type: &str,
+    req_headers: &[(String, String)],
     body: &[u8],
-) -> Result<(String, String), String> {
+) -> Result<FanoutResult, String> {
     let (host, port, base_path) = parse_http_upstream(upstream)?;
     let request_target = format!(
         "{}{}",
@@ -7079,18 +7235,27 @@ fn fanout_request_result(
     );
     let mut stream = TcpStream::connect((host.as_str(), port))
         .map_err(|e| format!("connect {}:{}: {}", host, port, e))?;
-    // Forward the request line with the ORIGINAL method, then the headers, then
-    // the body bytes. A POST/PUT/PATCH that fans out to Python carries its body
-    // (Content-Length tells the upstream how much to read); Content-Type is
-    // relayed when the original request had one. GET/HEAD send no body.
+    // Forward the request line with the ORIGINAL method. The router owns the
+    // upstream-hop framing: `Host` is rewritten to the upstream, `Connection:
+    // close` is the router's choice (it does not reuse the upstream connection —
+    // a named-later breath), and Content-Length is set from the body the router
+    // actually captured. The CLIENT's end-to-end headers (Authorization, Cookie,
+    // Accept*, User-Agent, Content-Type, X-*, …) are then forwarded verbatim so
+    // an authenticated/content-typed route is fronted truthfully; hop-by-hop and
+    // router-owned framing headers are filtered by forward_request_header.
     let mut head = format!(
         "{} {} HTTP/1.0\r\nHost: {}\r\nConnection: close\r\n",
         method, request_target, host
     );
-    if !body.is_empty() {
-        if !content_type.is_empty() {
-            head.push_str(&format!("Content-Type: {}\r\n", content_type));
+    for (name, value) in req_headers {
+        if forward_request_header(name) {
+            head.push_str(&format!("{}: {}\r\n", name, value));
         }
+    }
+    // Content-Length from the captured body's TRUE length (never the client's
+    // forwarded one, which could disagree with the bytes we hold). GET/HEAD with
+    // no body send no Content-Length.
+    if !body.is_empty() {
         head.push_str(&format!("Content-Length: {}\r\n", body.len()));
     }
     head.push_str("\r\n");
@@ -7104,19 +7269,35 @@ fn fanout_request_result(
         .read_to_end(&mut response_bytes)
         .map_err(|e| format!("read response: {}", e))?;
     let response = String::from_utf8_lossy(&response_bytes).to_string();
-    let mut lines = response.lines();
-    let status = lines
+    let status = response
+        .lines()
         .next()
         .and_then(|line| line.split_once(' ').map(|(_, rest)| rest.to_string()))
         .unwrap_or_else(|| "502 Bad Gateway".to_string());
-    let body = match response.find("\r\n\r\n") {
-        Some(i) => response[i + 4..].to_string(),
+    // Split the head block from the body. The head string (terminator excluded)
+    // feeds parse_content_type / parse_headers — the SAME parsers the request
+    // side uses (one header-capture shape, both directions).
+    let (head_block, body_text) = match response.find("\r\n\r\n") {
+        Some(i) => (&response[..i], response[i + 4..].to_string()),
         None => match response.find("\n\n") {
-            Some(i) => response[i + 2..].to_string(),
-            None => String::new(),
+            Some(i) => (&response[..i], response[i + 2..].to_string()),
+            None => (response.as_str(), String::new()),
         },
     };
-    Ok((status, body))
+    let content_type = parse_content_type(head_block);
+    // Relay the upstream's other end-to-end response headers; hop-by-hop and the
+    // router-owned framing (Content-Length, Content-Type) are filtered out so
+    // they cannot clobber the framing http_response writes.
+    let headers: Vec<(String, String)> = parse_headers(head_block)
+        .into_iter()
+        .filter(|(name, _)| relay_response_header(name))
+        .collect();
+    Ok(FanoutResult {
+        status,
+        content_type,
+        headers,
+        body: body_text,
+    })
 }
 
 fn parse_http_upstream(upstream: &str) -> Result<(String, u16, String), String> {

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -146,12 +146,12 @@ gap, named precisely:
 | **HTTP version** | serves HTTP/1.1 with keep-alive — a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), each response Content-Length-framed so the client knows exactly where one ends and the next begins; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request, never dropped | chunked transfer encoding (today every response is Content-Length-framed; a streamed/unknown-length body would need chunked), upstream connection reuse on the fan-out hop (the fan-out still opens a fresh upstream connection per request), HTTP/2 behind Traefik |
 | **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
 | **Request parsing** | reads the full request honoring Content-Length (a body larger than the initial 8 KiB read is captured across as many socket reads as it needs); parses `application/x-www-form-urlencoded` bodies into the same `(key value)` alist the query string uses, captures `application/json` (and any other body) raw under the reserved key `__body__`; 1 MiB body cap rejected with 413; any method (POST/PUT/PATCH/GET) | full header map exposed to handlers; a structural JSON→Form-value parse (today JSON is raw-captured, not parsed); larger/streamed/chunked bodies |
-| **Fan-out proxy** | forwards the original method and the request body (Content-Type + Content-Length set from the captured body) so a POST that fans out to the upstream carries its payload; status+body relayed as text/plain | request/response header passthrough, response content-type/headers relayed, streaming, connection reuse, timeouts, retries |
+| **Fan-out proxy** | forwards the original method, the request body, and the client's end-to-end request headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*, …) — hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, TE, Trailer) stripped, Host rewritten to the upstream, Content-Length re-derived from the captured body — and relays the upstream's response headers back (Content-Type so a JSON/HTML route survives the proxy, Set-Cookie, Cache-Control, Location, ETag, X-\*, …), with the router owning the client-hop framing (its own Content-Length + Connection; the upstream's hop-by-hop/framing headers are not relayed) | chunked/streaming response bodies, upstream connection reuse, timeouts, retries |
 | **Handler inputs** | 0 or 1 arg — the request alist, carrying query params AND parsed body fields uniformly (form-urlencoded merged in; JSON/other body under `__body__`), so a handler reads a field the same way regardless of how it arrived | path params and headers marshalled into the handler frame; a richer body shape than a flat alist (e.g. structural JSON) |
 | **Errors / observability** | 404/413/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
 
-None of these is exotic; each is a named breath. Three of the load-bearing ones
+None of these is exotic; each is a named breath. Four of the load-bearing ones
 are built. **Concurrency**: the kernel's per-process intern table
 (`lc-native-kernel-binary` names this: *"Not multi-process"*) makes the
 production shape a **pool of kernel workers behind the accept loop**, each
@@ -174,9 +174,21 @@ bytes from one request are carried into the next, never dropped (the pipelining
 hazard). The honest tradeoff: a worker serving a keep-alive client is
 unavailable to the pool until the connection closes or the idle timeout fires —
 standard thread-per-connection behavior, tuned by the idle-timeout value and the
-worker count. The remaining rows (chunked transfer, upstream connection reuse on
-the fan-out hop, full header passthrough, a structural JSON→Form parse,
-streaming, TLS/lifecycle, observability) are still open breaths.
+worker count. **Header passthrough**: the fan-out hop is a real reverse proxy on
+both sides — it forwards the client's end-to-end request headers to the upstream
+(Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*) and relays the
+upstream's response headers back (Content-Type so a JSON/HTML route keeps its
+type instead of flattening to text/plain, plus Set-Cookie, Cache-Control,
+Location, ETag, X-\*), with RFC 7230 §6.1 hop-by-hop hygiene applied in both
+directions (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, TE,
+Trailer stripped), Host rewritten to the upstream, and the router keeping
+ownership of its client-hop framing (its own Content-Length + Connection, which a
+relayed upstream header can never clobber). One response-emit shape writes every
+response — native, fan-out, and error — so the framing is authored in a single
+place and the relayed upstream headers sit beside it without forking the logic.
+The remaining rows (chunked transfer, upstream connection reuse on the fan-out
+hop, a structural JSON→Form parse, streaming, TLS/lifecycle, observability) are
+still open breaths.
 
 ## The BML preference
 
@@ -215,11 +227,14 @@ which the `X-Form-Router` header makes directly countable from access logs.
 
 ## Proof-of-shape — what is demonstrated, and what it is not
 
-Three harnesses prove the shape against a mock CPython upstream; a fourth
+A family of harnesses proves the shape against a mock CPython upstream — routing,
+concurrency, body-reading, keep-alive, and header passthrough; another
 ([below](#proof-against-the-real-fastapi-app--not-a-mock)) proves it against the
-**real FastAPI app**. Start with the mock harnesses — they isolate routing,
-concurrency, and body-reading — then read the real-app proof for the
-flip-decision evidence.
+**real FastAPI app** (the header-passthrough harness proves both ways — the mock
+echo upstream for request-header observability, the real app for the
+content-type relay). Start with the mock harnesses — they isolate each property —
+then read the real-app proof for the flip-decision evidence. The full list lives
+in [Sources](#sources).
 
 [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py)
 spins up a mock CPython upstream (standing in for FastAPI — so the proof touches
@@ -340,23 +355,26 @@ a small, measured proxy toll to keep working unchanged.
 **NOT shown / not claimed:** full production-readiness. The server serves
 HTTP/1.1 with keep-alive (proven by `router_keepalive_harness.py` — multiple
 requests on one connection, `Connection` honored both ways, idle-timeout reaping,
-pipelining bytes carried), but the **upstream fan-out hop still opens a fresh
-connection per request** (the client→router hop reuses connections; the
-router→upstream hop does not yet — so the proxy-hop latency above is measured on
-a non-reused upstream connection), and the accept loop is
-thread-per-connection-blocked (it parallelizes to the worker count, not an async
-reactor; a worker serving a keep-alive client is held until that connection
-closes or times out). Responses are Content-Length-framed, not chunked; JSON
-bodies are raw-captured, not structurally parsed into Form values;
-request/response headers beyond the body are not yet passed through (the fan-out
-relays status + body as text/plain, not the upstream's content-type/headers). The
-real-app proof ran against the dev sqlite DB; the production deployment shape
-(TLS/Traefik front, the routes.fk covering the real native-eligible set,
-header/content-type passthrough so a JSON route's content-type survives the
-proxy) is the remaining build. Concurrency, request-body reading, the
-**real-app fan-out + native side-by-side**, and **HTTP/1.1 keep-alive on the
-client→router hop** are now shown; chunked transfer, upstream connection reuse,
-header-passthrough, and structural-JSON are the rest.
+pipelining bytes carried) and the fan-out hop passes headers both ways with
+hop-by-hop hygiene (proven by `router_header_passthrough_harness.py` — the
+client's Authorization/Cookie/Accept/X-\* reach the upstream with Host rewritten
+and hop-by-hop stripped; the upstream's Content-Type/Set-Cookie/Cache-Control
+reach the client; verified against the REAL FastAPI app, whose `/api/health`
+relays as `application/json` rather than the old flattened text/plain). What
+stays open: the **upstream fan-out hop still opens a fresh connection per
+request** (the client→router hop reuses connections; the router→upstream hop does
+not yet — so the proxy-hop latency above is measured on a non-reused upstream
+connection), and the accept loop is thread-per-connection-blocked (it
+parallelizes to the worker count, not an async reactor; a worker serving a
+keep-alive client is held until that connection closes or times out). Responses
+are Content-Length-framed, not chunked; JSON bodies are raw-captured, not
+structurally parsed into Form values. The real-app proof ran against the dev
+sqlite DB; the production deployment shape (TLS/Traefik front, the routes.fk
+covering the real native-eligible set) is the remaining build. Concurrency,
+request-body reading, **bidirectional header passthrough**, the **real-app
+fan-out + native side-by-side**, and **HTTP/1.1 keep-alive on the client→router
+hop** are now shown; chunked transfer, upstream connection reuse, and
+structural-JSON are the rest.
 
 ## The flip is Urs's decision
 
@@ -384,6 +402,7 @@ test port so the reversal can be weighed with evidence rather than assertion.
 - [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
 - [`form/form-kernel-rust/router_keepalive_harness.py`](../form/form-kernel-rust/router_keepalive_harness.py) — the HTTP/1.1 keep-alive proof: N sequential requests on ONE connection (Content-Length framed, distinct inputs, each correct), pipelined two-in-one-send (leftover bytes carried, none dropped), `Connection: close` honored, HTTP/1.0 default-close back-compat, idle-timeout reaping the connection (worker freed), an idle connection NOT starving the pool, and the per-request handshake saving (reused vs fresh connection). Mock upstream — no production routing.
+- [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.


### PR DESCRIPTION
## What

Matures the kernel-router's fan-out arm into a real reverse proxy on **both** sides, closing the *Fan-out proxy → request/response header passthrough* gap in `kernels/KERNEL_AS_ROUTER.md`.

Before, `fanout_request` forwarded only method + body (Content-Type/Content-Length) and relayed status + body as **text/plain** — dropping Authorization/Cookie/Accept on the way up and Content-Type/Set-Cookie/Cache-Control on the way back. A JSON route fanned out lost its content-type; an authenticated route lost its auth. The fan-out could not truthfully front real authenticated/content-typed routes.

## The build — bidirectional, with RFC 7230 §6.1 hop-by-hop hygiene

- **Request headers UP**: the client's end-to-end headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*) are forwarded to the upstream. Hop-by-hop (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, TE, Trailer) **stripped**; `Host` rewritten to the upstream; `Content-Length` re-derived from the **captured body** (never the client's, which could mismatch the bytes the router holds).
- **Response headers DOWN**: the upstream's response headers (Content-Type, Set-Cookie, Cache-Control, Location, ETag, X-\*) are relayed to the client. The router keeps ownership of its **client-hop framing** (its own Content-Length + Connection per the keep-alive logic); the upstream's hop-by-hop/framing headers are not relayed and cannot clobber the router's.
- **ONE response-emit shape** (`http_response`) writes every response — native, fan-out, error. Native/error pass empty content-type (defaults `text/plain`) + no relayed headers; the fan-out passes the upstream's. `read_request` already kept the full head block; `parse_headers` parses it once — the **same parser** used in both directions (no fork).

## Proof — against the REAL FastAPI app

`form/form-kernel-rust/router_header_passthrough_harness.py` (two upstreams, honest split):

- **Mock echo upstream** (request-header observability): the client's `Authorization: Bearer test123` / `Cookie` / `Accept` / `X-Probe` / `User-Agent` **reached the upstream**, with `Host` rewritten to `127.0.0.1` and the client's bogus `Content-Length: 999` + `Connection: keep-alive` stripped. The upstream's `Set-Cookie` / `Cache-Control` / `X-Echo-Custom` **relayed back**; its hop-by-hop `Transfer-Encoding` did **not**. POST body forwarded with re-derived Content-Length + Content-Type up.
- **REAL `app.main:app`** (uvicorn, dev sqlite): `GET /api/health` through the router now relays `Content-Type: application/json` — the upstream's real type, **not the old flattened text/plain** — with the genuine app body. A native route still serves `text/plain` value in Form.

No-regression: the keepalive, body, concurrency, and real-app harnesses all still pass. Three-way `validate.sh` green — 258 ok, only the **pre-existing untracked** `seeded-bytes-recipe-band.fk` diverges (an `add_mod_u64` unbound-function band that is not part of this change and not committed).

## Scope / honesty

- **NO production routing flip.** FastAPI stays the live front door; `cli_serve` isn't wired to production. This matures the serve primitive only.
- **Closed**: bidirectional end-to-end header passthrough with hop-by-hop hygiene (Host rewrite, framing owned by the router).
- **Stays open**: chunked/streaming response bodies, upstream connection reuse on the fan-out hop, HTTP/2, retries/timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)