### PR TITLE
feat(kernel-router): upstream connection reuse on the fan-out hop

### DIFF
--- a/form/form-kernel-rust/router_header_passthrough_harness.py
+++ b/form/form-kernel-rust/router_header_passthrough_harness.py
@@ -238,7 +238,9 @@ def main() -> int:
             f"Accept: application/json\r\n"
             f"X-Probe: {PROBE_X}\r\n"
             f"User-Agent: header-passthrough-harness\r\n"
-            f"Connection: keep-alive\r\n"        # hop-by-hop -> must NOT reach upstream
+            f"Connection: close\r\n"             # client's hop-by-hop -> router does NOT relay it
+            f"Keep-Alive: timeout=99\r\n"        # hop-by-hop -> must NOT reach upstream
+            f"Proxy-Connection: close\r\n"       # Proxy-* hop-by-hop -> must NOT reach upstream
             f"Content-Length: 999\r\n"           # bogus framing -> router re-derives (0 here)
             f"\r\n"
         ).encode()
@@ -255,20 +257,35 @@ def main() -> int:
         up_xprobe = echoed.get("x-probe") == PROBE_X
         up_ua = echoed.get("user-agent") == "header-passthrough-harness"
         # UP hygiene: Host rewritten to upstream, client Content-Length NOT
-        # forwarded (no body -> router sends none), Connection NOT forwarded
+        # forwarded (no body -> router sends none), and the client's hop-by-hop
+        # connection-management headers NOT relayed. The router OWNS its
+        # upstream-hop framing: it does not pass the client's `Connection`
+        # verbatim — it writes its OWN `Connection: keep-alive` to reuse the
+        # upstream connection across fan-outs. So the proof of hygiene is (a) the
+        # client's distinctive hop-by-hop headers (`Keep-Alive`, `Proxy-Connection`)
+        # are absent upstream, and (b) the upstream's `Connection` is the router's
+        # own keep-alive (NOT the client's relayed `close`).
         host_rewritten = echoed.get("host", "").startswith("127.0.0.1")
         no_client_cl = echoed.get("content-length") in (None, "0")
-        no_conn_up = "connection" not in echoed or echoed.get("connection", "").lower() != "keep-alive"
+        no_keepalive_up = "keep-alive" not in echoed
+        no_proxyconn_up = "proxy-connection" not in echoed
+        # The client sent `Connection: close`; the router must NOT relay that —
+        # it writes its own keep-alive for upstream connection reuse.
+        router_owns_conn = echoed.get("connection", "").lower() == "keep-alive"
         ok_up = all([up_auth, up_cookie, up_accept, up_xprobe, up_ua,
-                     host_rewritten, no_client_cl, no_conn_up])
+                     host_rewritten, no_client_cl, no_keepalive_up,
+                     no_proxyconn_up, router_owns_conn])
         print(f"  [UP request hdrs ] upstream RECEIVED: "
               f"Authorization={up_auth} Cookie={up_cookie} Accept={up_accept} "
               f"X-Probe={up_xprobe} UA={up_ua}")
         print(f"                     hygiene: Host->upstream={host_rewritten} "
               f"client-Content-Length-dropped={no_client_cl} "
-              f"Connection-stripped={no_conn_up}  {'OK' if ok_up else 'FAIL'}")
+              f"client-hop-by-hop-stripped={no_keepalive_up and no_proxyconn_up} "
+              f"router-owns-Connection(keep-alive)={router_owns_conn}  "
+              f"{'OK' if ok_up else 'FAIL'}")
         print(f"                     (upstream saw Host={echoed.get('host')!r} "
-              f"Content-Length={echoed.get('content-length')!r})")
+              f"Content-Length={echoed.get('content-length')!r} "
+              f"Connection={echoed.get('connection')!r})")
         if not ok_up:
             failures.append(("UP request headers", echoed))
 

--- a/form/form-kernel-rust/router_upstream_reuse_harness.py
+++ b/form/form-kernel-rust/router_upstream_reuse_harness.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Proof harness for the kernel-router's UPSTREAM CONNECTION REUSE on the fan-out hop.
+
+The client->router hop already reuses connections (HTTP/1.1 keep-alive, proven by
+router_keepalive_harness.py). This proves the SYMMETRIC build: the router->upstream
+hop now REUSES a per-worker keep-alive connection to the upstream instead of
+opening a fresh TCP connection per fan-out. The handshake to the upstream is
+amortized across requests — connections << requests.
+
+The hard part this must get right is the classic keep-alive PROXY bug: with the
+upstream connection held open (no `Connection: close`), the router can no longer
+read the response with read-to-close. It MUST frame each response by its
+Content-Length, reading EXACTLY one response, so the next request on the reused
+connection is not corrupted by leftover bytes. If the framing is wrong, distinct
+requests on a reused connection bleed into each other — this harness sends DISTINCT
+requests on the reused connection and proves each gets its OWN correct response.
+
+What it asserts (real sockets over loopback, the kernel-router with --workers 1 so
+ALL fan-outs funnel through ONE worker's ONE pooled upstream connection — touches
+NO production routing):
+
+  1. Connections << requests (the handshake amortized): a connection-COUNTING mock
+     upstream counts every TCP accept(). Fire N sequential fan-out requests through
+     ONE worker. The upstream sees N requests but accepts FAR fewer connections
+     (ideally 1) — the reused connection carried them all. The symmetric saving to
+     the client-hop keep-alive, proven by counting the upstream's accepts.
+
+  2. Correctness across the reused connection (no response-framing bleed): the N
+     fan-out requests above each carry a DISTINCT path/marker; each response is the
+     upstream's OWN correct answer for THAT request. The Content-Length framing read
+     exactly one response each time — the classic proxy keep-alive bug, proven
+     absent on a genuinely reused connection.
+
+  3. Reuse is faster than fresh-connect-each: N fan-outs on the reused connection
+     vs N fan-outs each forcing a fresh upstream connection (a counting upstream
+     that sends `Connection: close`, so the router cannot pool it). Real p50/p99;
+     the reused path saves the per-request upstream handshake.
+
+  4. Stale pooled connection -> transparent reconnect+retry: the upstream serves a
+     few requests on the reused connection, then CLOSES it from its side (an idle
+     timeout on the upstream's side). The next fan-out finds the pooled connection
+     dead; the router must transparently reconnect and retry ONCE, returning the
+     correct response — never a client-facing error.
+
+Run from form/form-kernel-rust/:
+    cargo build --release
+    python3 router_upstream_reuse_harness.py
+"""
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+ROUTES = HERE / "examples" / "router-body-proof.fk"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+class CountingUpstream:
+    """A raw-socket HTTP/1.1 upstream that COUNTS accepted TCP connections.
+
+    This is the instrument the whole proof rests on: it makes connection REUSE
+    directly observable. Each accept() increments `connections`; each request
+    served increments `requests`. With reuse, connections << requests.
+
+    It speaks HTTP/1.1 keep-alive: each response is Content-Length-framed and the
+    socket is held open for the next request on it, so the router can pool it.
+
+    Three modes shape the connection lifecycle:
+      - default: every response is `Connection: keep-alive`; the socket stays open
+        -> the router pools and reuses it (the reuse proof).
+      - `connection_close=True`: every response carries `Connection: close`, so the
+        router CANNOT pool it -> models fresh-connect-each (the latency baseline).
+      - `stale_after=N`: responses stay `Connection: keep-alive` (the router DOES
+        pool the connection), but after serving N requests the upstream SILENTLY
+        closes the socket WITHOUT a `Connection: close` signal. This models a real
+        upstream-side idle timeout: the pooled connection is now dead, but the
+        router only learns that when it tries to REUSE it, so the next fan-out must
+        transparently reconnect+retry. This is the GENUINE stale-pool path,
+        distinct from a clean `Connection: close` (which the router never pools).
+
+    """
+
+    def __init__(self, *, connection_close: bool = False,
+                 stale_after: int | None = None):
+        self.connection_close = connection_close
+        self.stale_after = stale_after
+        self.connections = 0
+        self.requests = 0
+        self._lock = threading.Lock()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(64)
+        self.port = self.sock.getsockname()[1]
+        self._stop = False
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def _serve(self):
+        self.sock.settimeout(0.3)
+        while not self._stop:
+            try:
+                conn, _ = self.sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            with self._lock:
+                self.connections += 1
+            threading.Thread(target=self._serve_conn, args=(conn,), daemon=True).start()
+
+    def _serve_conn(self, conn: socket.socket):
+        conn.settimeout(10.0)
+        buf = b""
+        served_on_this = 0
+        try:
+            while not self._stop:
+                # Read one request: head, then exactly Content-Length body bytes.
+                while b"\r\n\r\n" not in buf:
+                    b = conn.recv(65536)
+                    if not b:
+                        return  # client closed the connection
+                    buf += b
+                head_b, _, rest = buf.partition(b"\r\n\r\n")
+                buf = rest
+                head = head_b.decode("latin-1")
+                clen = 0
+                path = "/"
+                first = head.split("\r\n", 1)[0]
+                parts = first.split(" ")
+                if len(parts) >= 2:
+                    path = parts[1]
+                for line in head.split("\r\n")[1:]:
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        if k.strip().lower() == "content-length":
+                            clen = int(v.strip() or "0")
+                while len(buf) < clen:
+                    b = conn.recv(65536)
+                    if not b:
+                        return
+                    buf += b
+                _body = buf[:clen]
+                buf = buf[clen:]
+
+                with self._lock:
+                    self.requests += 1
+                served_on_this += 1
+
+                # The response body echoes the request PATH so the harness can
+                # prove each distinct request got its OWN correct response (the
+                # no-framing-bleed property on a reused connection).
+                payload = f"UPSTREAM path={path}".encode()
+                # `connection_close` mode signals close on EVERY response (router
+                # never pools). `stale_after` mode keeps the keep-alive SIGNAL
+                # (router DOES pool) but silently drops the socket after N requests
+                # (the genuine stale-pool path the router must reconnect through).
+                signal_close = self.connection_close
+                stale_drop = (
+                    self.stale_after is not None and served_on_this >= self.stale_after
+                )
+                conn_hdr = "close" if signal_close else "keep-alive"
+                resp = (
+                    f"HTTP/1.1 200 OK\r\n"
+                    f"Content-Type: text/plain; charset=utf-8\r\n"
+                    f"Content-Length: {len(payload)}\r\n"
+                    f"Connection: {conn_hdr}\r\n"
+                    f"\r\n"
+                ).encode() + payload
+                conn.sendall(resp)
+                if signal_close:
+                    return  # clean close-each: router will not have pooled this
+                if stale_drop:
+                    # Keep-alive was SIGNALLED, so the router pooled this socket —
+                    # now drop it silently. The router learns it's dead only on the
+                    # next reuse attempt -> transparent reconnect+retry.
+                    return
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def stop(self):
+        self._stop = True
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+def fanout(kport: int, path: str, timeout: float = 10.0):
+    """One fan-out request through the router on a FRESH client connection (so the
+    CLIENT hop is not what's being reused — we are measuring the UPSTREAM hop).
+    Returns (status, headers_lower, body_text)."""
+    s = socket.create_connection(("127.0.0.1", kport), timeout=timeout)
+    s.settimeout(timeout)
+    try:
+        # Connection: close on the CLIENT hop so each fan-out is its own client
+        # connection — isolating the upstream-hop reuse as the thing under test.
+        req = (f"GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+               f"Connection: close\r\n\r\n").encode()
+        s.sendall(req)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            b = s.recv(65536)
+            if not b:
+                break
+            buf += b
+        head_b, _, rest = buf.partition(b"\r\n\r\n")
+        head = head_b.decode("latin-1")
+        lines = head.split("\r\n")
+        status = lines[0].split(" ", 1)[1] if " " in lines[0] else lines[0]
+        headers = {}
+        for line in lines[1:]:
+            if ":" in line:
+                k, v = line.split(":", 1)
+                headers[k.strip().lower()] = v.strip()
+        n = int(headers.get("content-length", "0"))
+        body = rest
+        while len(body) < n:
+            b = s.recv(65536)
+            if not b:
+                break
+            body += b
+        return status, headers, body[:n].decode("utf-8", "replace")
+    finally:
+        s.close()
+
+
+def start_router(kport: int, upstream_url: str, workers: int = 1) -> subprocess.Popen:
+    return subprocess.Popen(
+        [str(BIN), "serve", "--port", str(kport), "--routes", str(ROUTES),
+         "--upstream", upstream_url, "--workers", str(workers)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+
+    failures = []
+
+    # ===================================================================
+    # 1+2. Connections << requests AND correctness across the reused conn.
+    # ONE worker -> ALL fan-outs funnel through ONE pooled upstream connection.
+    # ===================================================================
+    up = CountingUpstream()
+    kport = free_port()
+    proc = start_router(kport, up.url, workers=1)
+    try:
+        wait_for_port(kport)
+        n = 20
+        all_correct = True
+        for i in range(n):
+            # Each request a DISTINCT path -> the upstream echoes it back; a
+            # framing bleed would return the WRONG path for some request.
+            path = f"/api/reuse_probe_{i}"
+            status, headers, body = fanout(kport, path)
+            want = f"UPSTREAM path={path}"
+            ok = (status == "200 OK" and body == want
+                  and headers.get("x-form-router") == "fanout-python")
+            all_correct = all_correct and ok
+            if not ok:
+                failures.append(("reuse correctness", i, status, body, want))
+        time.sleep(0.1)
+        conns = up.connections
+        reqs = up.requests
+        # The whole point: N requests, FAR fewer upstream connections.
+        reuse_proven = conns < n and reqs >= n
+        ideal = conns == 1
+        print(f"  [conns<<reqs ] {reqs} fan-out requests through 1 worker -> "
+              f"upstream accepted {conns} connection(s)  "
+              f"{'OK' if reuse_proven else 'FAIL'}"
+              f"{'  (ideal: ONE reused connection)' if ideal else ''}")
+        print(f"  [no-bleed    ] each of {n} DISTINCT requests on the reused "
+              f"connection got its OWN correct response -> "
+              f"{'OK' if all_correct else 'FAIL'}  (Content-Length framing read "
+              f"exactly one response each time — the classic proxy bug, absent)")
+        if not reuse_proven:
+            failures.append(("connections not << requests", conns, reqs, n))
+        if not all_correct:
+            failures.append(("response framing bleed on reused connection",))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        up.stop()
+
+    # ===================================================================
+    # 3. Reuse is faster than fresh-connect-each (the handshake amortized).
+    # Compare: a keep-alive upstream (router pools it) vs a close-each upstream
+    # (router must reconnect every fan-out). Same router code; the ONLY difference
+    # is whether the upstream lets the connection be reused.
+    # ===================================================================
+    reps = 60
+
+    def measure(connection_close: bool) -> tuple[float, float, float, int]:
+        up = CountingUpstream(connection_close=connection_close)
+        kport = free_port()
+        proc = start_router(kport, up.url, workers=1)
+        lats = []
+        try:
+            wait_for_port(kport)
+            # warmup
+            for _ in range(5):
+                fanout(kport, "/api/warmup")
+            for i in range(reps):
+                t0 = time.perf_counter()
+                fanout(kport, f"/api/perf_{i}")
+                lats.append((time.perf_counter() - t0) * 1000.0)
+            time.sleep(0.05)
+            conns = up.connections
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            up.stop()
+        lats.sort()
+        p50 = lats[len(lats) // 2]
+        p99 = lats[min(len(lats) - 1, int(len(lats) * 0.99))]
+        total = sum(lats)
+        return p50, p99, total, conns
+
+    reuse_p50, reuse_p99, reuse_total, reuse_conns = measure(connection_close=False)
+    fresh_p50, fresh_p99, fresh_total, fresh_conns = measure(connection_close=True)
+    faster = reuse_total < fresh_total
+    print(f"  [reuse vs fresh] {reps} fan-outs each:")
+    print(f"                   REUSED upstream conn ({reuse_conns} accept(s)):       "
+          f"p50={reuse_p50:.3f} ms  p99={reuse_p99:.3f} ms  total={reuse_total:.1f} ms")
+    print(f"                   FRESH conn each ({fresh_conns} accept(s), close-each): "
+          f"p50={fresh_p50:.3f} ms  p99={fresh_p99:.3f} ms  total={fresh_total:.1f} ms")
+    print(f"                   reuse saved {fresh_total - reuse_total:.1f} ms total "
+          f"({'faster' if faster else 'NOT faster'}); fresh-each opened "
+          f"{fresh_conns} connections vs reuse's {reuse_conns}  "
+          f"{'OK' if faster else 'WARN'}")
+    # The connection-count contrast is the HARD gate (proves reuse structurally);
+    # the latency saving is real but small over loopback, so it only warns.
+    if not (reuse_conns < fresh_conns and reuse_conns <= 2):
+        failures.append(("reuse did not reduce upstream connections",
+                         reuse_conns, fresh_conns))
+
+    # ===================================================================
+    # 4. Stale pooled connection -> transparent reconnect+retry (no client error).
+    # The GENUINE stale path: the upstream SIGNALS keep-alive (so the router POOLS
+    # the connection) but silently drops the socket after `stale_after` requests
+    # (modeling an upstream-side idle timeout the router is not told about). The
+    # router's pooled connection is now dead; the NEXT fan-out's reuse attempt
+    # fails on the read, and the router must transparently reconnect+retry ONCE,
+    # returning the correct response — never a client-facing error.
+    # ===================================================================
+    stale_after = 3
+    up = CountingUpstream(stale_after=stale_after)
+    kport = free_port()
+    proc = start_router(kport, up.url, workers=1)
+    try:
+        wait_for_port(kport)
+        all_ok = True
+        results = []
+        # Trace with stale_after=3: #1 opens conn1 (keep-alive signalled -> pooled);
+        # #2,#3 reuse conn1; the upstream silently drops conn1 after #3. #4 finds
+        # the pooled conn1 DEAD on reuse -> reconnect+retry on conn2 (served fresh
+        # there); #5,#6 reuse conn2; dropped after #6; #7 stale again -> conn3;
+        # #8 reuses conn3. Every client fan-out must succeed; the upstream is
+        # reconnected once per stale cycle.
+        total_reqs = 8
+        for i in range(total_reqs):
+            path = f"/api/stale_probe_{i}"
+            status, headers, body = fanout(kport, path)
+            want = f"UPSTREAM path={path}"
+            ok = (status == "200 OK" and body == want
+                  and headers.get("x-form-router") == "fanout-python")
+            results.append((i, status, body == want))
+            all_ok = all_ok and ok
+        time.sleep(0.1)
+        conns = up.connections
+        reqs = up.requests
+        # The client saw zero errors; the upstream was reconnected (conns > 1)
+        # because the pooled connection went stale and the router transparently
+        # opened a fresh one. Each client request was served exactly once
+        # (a stale reuse failed on the READ before the upstream counted it, so the
+        # retry on a fresh connection is that request's first served instance).
+        print(f"  [stale-retry ] upstream silently drops the POOLED keep-alive conn "
+              f"every {stale_after} reqs; {total_reqs} client fan-outs -> all "
+              f"{'OK' if all_ok else 'FAIL'} "
+              f"(upstream: {conns} connections, {reqs} requests served)")
+        print(f"                 a stale POOLED connection triggered a transparent "
+              f"reconnect+retry, never a client-facing error  "
+              f"{'OK' if all_ok else 'FAIL'}")
+        if not all_ok:
+            failures.append(("stale-connection retry surfaced an error", results))
+        # The upstream must have been reconnected (more than 1 connection) -> proof
+        # the stale path actually fired, not that the connection never closed.
+        if conns < 2:
+            failures.append(("stale path did not fire (upstream never reconnected)",
+                             conns))
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        up.stop()
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+        for f in failures:
+            print(f"   {f}", file=sys.stderr)
+        return 1
+    print("\nok — kernel-router UPSTREAM CONNECTION REUSE: a per-worker keep-alive "
+          "connection to the upstream is reused across fan-outs (connections << "
+          "requests, the handshake amortized — the symmetric saving to the client "
+          "hop); each response is Content-Length-framed so distinct requests on the "
+          "reused connection never bleed (the classic proxy keep-alive bug, absent); "
+          "and a stale pooled connection triggers a transparent reconnect+retry, "
+          "never a client-facing error. NO production routing touched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6418,6 +6418,7 @@ fn handle_request(
     arena: &mut Arena,
     route_pairs: &RoutePairs,
     upstream: &Option<String>,
+    upstream_pool: &mut UpstreamPool,
 ) -> bool {
     // Read the FULL request: the header block, then exactly Content-Length body
     // bytes if present (read_request honors Content-Length across as many socket
@@ -6506,16 +6507,26 @@ fn handle_request(
         // FAN-OUT: no native handler — forward to the Python upstream and
         // relay its response. The kernel owns the front door; Python is the
         // upstream for the not-yet-native tail. Each worker issues its own
-        // independent fan-out hop. The client's METHOD, BODY, and end-to-end
-        // request headers (Authorization, Cookie, Accept*, …) are forwarded so
-        // an authenticated/content-typed route is fronted truthfully; the
-        // UPSTREAM's response Content-Type + end-to-end headers (Set-Cookie,
-        // Cache-Control, Location, …) are relayed back so the client receives
-        // the upstream's real type and cookies, not a flattened text/plain.
-        // Hop-by-hop headers are stripped both ways; the router owns the framing
-        // on its client hop (Content-Length, Connection — http_response writes
-        // those, the relayed set cannot clobber them).
-        let fanout = fanout_request(upstream_base, &method, &target, &req_headers, &body_bytes);
+        // independent fan-out hop over its OWN per-worker upstream connection
+        // pool (no locking — the worker is serial and owns the pool the way it
+        // owns its Kernel + Arena), so repeated fan-outs REUSE one keep-alive
+        // connection to the upstream and amortize the TCP handshake. The client's
+        // METHOD, BODY, and end-to-end request headers (Authorization, Cookie,
+        // Accept*, …) are forwarded so an authenticated/content-typed route is
+        // fronted truthfully; the UPSTREAM's response Content-Type + end-to-end
+        // headers (Set-Cookie, Cache-Control, Location, …) are relayed back so
+        // the client receives the upstream's real type and cookies, not a
+        // flattened text/plain. Hop-by-hop headers are stripped both ways; the
+        // router owns the framing on its client hop (Content-Length, Connection —
+        // http_response writes those, the relayed set cannot clobber them).
+        let fanout = fanout_request(
+            upstream_base,
+            &method,
+            &target,
+            &req_headers,
+            &body_bytes,
+            upstream_pool,
+        );
         status = fanout.status;
         body = fanout.body;
         resp_content_type = fanout.content_type;
@@ -6581,6 +6592,7 @@ fn serve_connection(
     arena: &mut Arena,
     route_pairs: &RoutePairs,
     upstream: &Option<String>,
+    upstream_pool: &mut UpstreamPool,
 ) {
     // Idle timeout so a held-open keep-alive connection cannot starve the pool.
     let _ = stream.set_read_timeout(Some(KEEPALIVE_IDLE_TIMEOUT));
@@ -6589,7 +6601,11 @@ fn serve_connection(
     // is dropped between requests.
     let mut carry: Vec<u8> = Vec::new();
     // Serve requests on this one connection until handle_request says to close.
-    while handle_request(&mut stream, &mut carry, k, arena, route_pairs, upstream) {}
+    // The worker's upstream connection pool (`upstream_pool`) outlives a single
+    // client connection — it is owned by the worker and threaded through every
+    // connection it serves, so a keep-alive upstream connection opened while
+    // serving client A is reused for client B on the same worker.
+    while handle_request(&mut stream, &mut carry, k, arena, route_pairs, upstream, upstream_pool) {}
 }
 
 // One kernel worker. Builds its OWN Kernel + Arena (the routes.fk loaded once
@@ -6612,6 +6628,13 @@ fn worker_loop(
             return;
         }
     };
+    // This worker's OWN upstream connection pool — keep-alive connections to the
+    // fan-out upstream, reused across every client connection this worker serves.
+    // No locking: the worker is serial (it serves one client connection at a
+    // time) and owns its pool exactly as it owns its Kernel + Arena (the !Sync
+    // isolation from the worker pool). Repeated fan-outs therefore amortize the
+    // TCP handshake to the upstream instead of paying a fresh connect each time.
+    let mut upstream_pool = UpstreamPool::new();
     loop {
         // Lock only to dequeue one stream, then release before serving so the
         // workers truly run in parallel (the lock guards the queue, not the
@@ -6624,7 +6647,14 @@ fn worker_loop(
             guard.recv()
         };
         match stream {
-            Ok(s) => serve_connection(s, &mut k, &mut arena, &route_pairs, &upstream),
+            Ok(s) => serve_connection(
+                s,
+                &mut k,
+                &mut arena,
+                &route_pairs,
+                &upstream,
+                &mut upstream_pool,
+            ),
             // Sender dropped (listener closed) — drain done, worker exits.
             Err(_) => return,
         }
@@ -6974,9 +7004,13 @@ fn parse_headers(head: &str) -> Vec<(String, String)> {
 // sides: it owns its client-hop framing (Connection/Content-Length) and its
 // upstream-hop framing independently, so these must be stripped in BOTH
 // directions rather than blindly relayed. `Connection`, `Keep-Alive`,
-// `Transfer-Encoding`, `Upgrade`, the `Proxy-*` pair, plus the rarely-seen TE /
-// Trailer. Content-Length is handled separately (the router sets its own from
-// the body it holds), so it is treated as framing the router owns, not relayed.
+// `Transfer-Encoding`, `Upgrade`, the `Proxy-*` set, plus the rarely-seen TE /
+// Trailer. `Proxy-Connection` is the non-standard-but-widespread connection-
+// management header — a proxy must never pass it on, exactly because the router
+// now writes its OWN `Connection` for upstream reuse and a leaked
+// `Proxy-Connection` would carry the client's stale connection intent past the
+// hop. Content-Length is handled separately (the router sets its own from the
+// body it holds), so it is treated as framing the router owns, not relayed.
 fn is_hop_by_hop(name: &str) -> bool {
     let n = name.trim();
     n.eq_ignore_ascii_case("connection")
@@ -6985,6 +7019,7 @@ fn is_hop_by_hop(name: &str) -> bool {
         || n.eq_ignore_ascii_case("upgrade")
         || n.eq_ignore_ascii_case("proxy-authenticate")
         || n.eq_ignore_ascii_case("proxy-authorization")
+        || n.eq_ignore_ascii_case("proxy-connection")
         || n.eq_ignore_ascii_case("te")
         || n.eq_ignore_ascii_case("trailer")
 }
@@ -7176,14 +7211,265 @@ fn url_decode(s: &str) -> String {
     out
 }
 
+// A single pooled upstream connection: the live keep-alive TcpStream plus any
+// bytes read past one response's end (pipelining/over-read on the upstream hop —
+// the SAME hazard the client hop's `carry` solves). The over-read bytes belong
+// to the NEXT response on this connection and must be seeded into the next read,
+// never dropped — a mis-framed pooled connection corrupts the next request, the
+// classic keep-alive proxy bug.
+struct PooledConn {
+    stream: TcpStream,
+    carry: Vec<u8>,
+}
+
+// A per-worker cache of keep-alive upstream connections, keyed by (host, port).
+// Because a worker handles requests SERIALLY on its own thread (the per-worker
+// Kernel + Arena isolation from the worker pool), this needs NO locking: the
+// worker OWNS its pool the way it owns its kernel. For a single upstream this is
+// effectively one reusable connection that amortizes the TCP handshake across
+// every fan-out the worker serves, the symmetric saving to the client-hop
+// keep-alive (the router→upstream hop, where the client→router hop already
+// reuses connections). The connection is taken out on use and returned only if
+// the upstream kept it alive (Content-Length-framed, no `Connection: close`),
+// so a half-consumed or close-marked connection is never reused.
+//
+// Honest scope of reuse: a connection is pooled only when its response was
+// Content-Length-framed AND the upstream did not signal close. A chunked or
+// unframed (read-to-close) response is read correctly but its connection is
+// dropped, not pooled — chunked-body reuse remains a named-later breath.
+#[derive(Default)]
+struct UpstreamPool {
+    conns: HashMap<(String, u16), PooledConn>,
+}
+
+impl UpstreamPool {
+    fn new() -> Self {
+        UpstreamPool {
+            conns: HashMap::new(),
+        }
+    }
+    // Take the pooled connection for this upstream if one is cached (removing it
+    // so an error path can drop it without leaving a poisoned entry; a clean
+    // response puts it back via `store`).
+    fn take(&mut self, host: &str, port: u16) -> Option<PooledConn> {
+        self.conns.remove(&(host.to_string(), port))
+    }
+    // Return a still-good connection to the pool for the next fan-out to reuse.
+    fn store(&mut self, host: &str, port: u16, conn: PooledConn) {
+        self.conns.insert((host.to_string(), port), conn);
+    }
+}
+
+// The framing outcome of reading ONE upstream response, plus whether the
+// connection may be REUSED. With the upstream keep-alive (no `Connection: close`
+// on its side) the upstream does NOT close after the body, so the response can
+// no longer be read with `read_to_end` (that only terminates on close). The
+// response must be framed:
+//   - Content-Length present  -> read exactly that many body bytes; any surplus
+//     read past them is the NEXT response's bytes, carried forward; the
+//     connection is REUSABLE (unless the upstream sent `Connection: close`).
+//   - Transfer-Encoding: chunked -> not yet decoded; read to close and do NOT
+//     reuse (named-later breath). Falls into the close path below.
+//   - neither, and the upstream keeps the connection open -> length is unknown;
+//     this cannot be safely framed for reuse, so read to close and do NOT reuse.
+struct UpstreamResponse {
+    status: String,
+    content_type: String,
+    headers: Vec<(String, String)>,
+    body: String,
+    // The keep-alive verdict for the UPSTREAM connection: true iff the response
+    // was Content-Length-framed (so we know exactly where it ended) AND the
+    // upstream did not signal `Connection: close`. Only then may the connection
+    // return to the pool; otherwise it is dropped.
+    reusable: bool,
+    // Bytes read past this response's framed end — the next response's head/body
+    // on a reused connection. Carried back into the PooledConn so the next read
+    // starts exactly there. Empty when the connection won't be reused.
+    leftover: Vec<u8>,
+}
+
+// Read exactly ONE HTTP response from a (possibly reused) upstream connection,
+// framing it by Content-Length so the read does not depend on the upstream
+// closing — the property that makes connection reuse possible. `carry` seeds the
+// read with any bytes left over from the PREVIOUS response on this same
+// connection (the over-read hazard, mirrored from the client hop's read_request).
+//
+// Errors (a broken pipe, an immediate EOF before any byte) propagate up so the
+// caller can transparently reconnect+retry on a stale pooled connection.
+fn read_upstream_response(stream: &mut TcpStream, carry: Vec<u8>) -> Result<UpstreamResponse, String> {
+    // Phase 1: read until the header terminator, seeding from carried bytes.
+    let mut raw: Vec<u8> = carry;
+    let mut buf = [0u8; 8192];
+    let header_end: usize = match find_header_end(&raw) {
+        Some(t) => t,
+        None => loop {
+            match stream.read(&mut buf) {
+                Ok(0) => {
+                    // EOF before any header terminator. If NOTHING arrived this
+                    // was a dead/stale connection — signal so the caller retries.
+                    if raw.is_empty() {
+                        return Err("upstream closed before response (stale connection)".to_string());
+                    }
+                    // Some bytes but no terminator — a malformed/truncated head.
+                    break raw.len();
+                }
+                Ok(n) => {
+                    raw.extend_from_slice(&buf[..n]);
+                    if let Some(t) = find_header_end(&raw) {
+                        break t;
+                    }
+                    if raw.len() > MAX_BODY_BYTES {
+                        return Err("upstream response head too large".to_string());
+                    }
+                }
+                Err(e) => return Err(format!("read upstream response head: {}", e)),
+            }
+        },
+    };
+    let (head_end_excl_term, body_start) = if header_end >= 4 && raw.len() >= header_end {
+        (header_end - 4, header_end)
+    } else {
+        (raw.len(), raw.len())
+    };
+    let head = String::from_utf8_lossy(&raw[..head_end_excl_term]).to_string();
+    // The status line is everything after "HTTP/x.y " on the first head line.
+    let status = head
+        .lines()
+        .next()
+        .and_then(|line| line.split_once(' ').map(|(_, rest)| rest.to_string()))
+        .unwrap_or_else(|| "502 Bad Gateway".to_string());
+    let content_type = parse_content_type(&head);
+    let headers: Vec<(String, String)> = parse_headers(&head)
+        .into_iter()
+        .filter(|(name, _)| relay_response_header(name))
+        .collect();
+    // Does the UPSTREAM intend to keep this connection alive? It is an HTTP/1.x
+    // peer; honor an explicit `Connection: close` (and HTTP/1.0's close default).
+    let upstream_keep_alive = upstream_response_keep_alive(&head);
+    let is_chunked = head_is_chunked(&head);
+
+    // Phase 2: frame the body. Content-Length is the path that allows reuse.
+    if let Some(total) = parse_content_length(&head) {
+        if total > MAX_BODY_BYTES {
+            return Err("upstream response body too large".to_string());
+        }
+        let mut body: Vec<u8> = raw[body_start..].to_vec();
+        while body.len() < total {
+            match stream.read(&mut buf) {
+                Ok(0) => {
+                    // Upstream closed before the full framed body — the response
+                    // is incomplete; cannot be trusted or reused.
+                    return Err("upstream closed mid-body (short Content-Length read)".to_string());
+                }
+                Ok(n) => body.extend_from_slice(&buf[..n]),
+                Err(e) => return Err(format!("read upstream response body: {}", e)),
+            }
+        }
+        // Any bytes past the framed body are the NEXT response's — carry forward.
+        let leftover: Vec<u8> = if body.len() > total {
+            let extra = body[total..].to_vec();
+            body.truncate(total);
+            extra
+        } else {
+            Vec::new()
+        };
+        let body_text = String::from_utf8_lossy(&body).to_string();
+        // REUSABLE only when Content-Length-framed AND the upstream kept it alive.
+        let reusable = upstream_keep_alive;
+        return Ok(UpstreamResponse {
+            status,
+            content_type,
+            headers,
+            body: body_text,
+            reusable,
+            leftover: if reusable { leftover } else { Vec::new() },
+        });
+    }
+
+    // No Content-Length: chunked OR unframed. Neither is safely reusable here
+    // (chunked decode is a named-later breath; unframed length is only knowable
+    // by the upstream closing). Read to close and DROP this connection. Note for
+    // honesty: a chunked body is returned with its raw chunk framing intact (not
+    // de-chunked) — correct enough to relay the bytes, but the connection is not
+    // pooled, so the next request opens a fresh one. `is_chunked` is captured so
+    // the fall-through is a conscious decision, not an accident.
+    let _ = is_chunked;
+    let mut body: Vec<u8> = raw[body_start..].to_vec();
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break, // upstream closed — the unframed body is complete
+            Ok(n) => {
+                body.extend_from_slice(&buf[..n]);
+                if body.len() > MAX_BODY_BYTES {
+                    return Err("upstream response body too large".to_string());
+                }
+            }
+            Err(e) => return Err(format!("read upstream response body (to close): {}", e)),
+        }
+    }
+    let body_text = String::from_utf8_lossy(&body).to_string();
+    Ok(UpstreamResponse {
+        status,
+        content_type,
+        headers,
+        body: body_text,
+        reusable: false, // read-to-close / chunked: never pool this connection
+        leftover: Vec::new(),
+    })
+}
+
+// Whether the UPSTREAM signalled it will keep its connection open after this
+// response, per RFC 7230: HTTP/1.1 stays open unless `Connection: close`;
+// HTTP/1.0 closes unless `Connection: keep-alive`. Mirrors head_keep_alive but
+// reads a RESPONSE's status line (the HTTP version sits in the same first token).
+fn upstream_response_keep_alive(head: &str) -> bool {
+    let status_line = head.lines().next().unwrap_or("");
+    let is_http11_or_higher = status_line
+        .split(' ')
+        .next()
+        .map(|proto| proto >= "HTTP/1.1")
+        .unwrap_or(false);
+    let mut explicit: Option<bool> = None;
+    for line in head.lines().skip(1) {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("connection") {
+                let v = value.trim().to_ascii_lowercase();
+                if v.contains("close") {
+                    explicit = Some(false);
+                } else if v.contains("keep-alive") {
+                    explicit = Some(true);
+                }
+            }
+        }
+    }
+    explicit.unwrap_or(is_http11_or_higher)
+}
+
+// Whether the upstream response uses chunked transfer encoding (so the body is
+// NOT Content-Length-framed). Used only to make the no-Content-Length fall-through
+// a conscious, named decision: chunked bodies are read-to-close and not pooled.
+fn head_is_chunked(head: &str) -> bool {
+    for line in head.lines() {
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("transfer-encoding")
+                && value.trim().to_ascii_lowercase().contains("chunked")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn fanout_request(
     upstream: &str,
     method: &str,
     target: &str,
     req_headers: &[(String, String)],
     body: &[u8],
+    pool: &mut UpstreamPool,
 ) -> FanoutResult {
-    match fanout_request_result(upstream, method, target, req_headers, body) {
+    match fanout_request_result(upstream, method, target, req_headers, body, pool) {
         Ok(v) => v,
         Err(e) => FanoutResult {
             status: "502 Bad Gateway".to_string(),
@@ -7264,12 +7550,30 @@ struct FanoutResult {
     body: String,
 }
 
+// Send a fully-built request on `stream` and read exactly ONE Content-Length-
+// framed response back, seeding the read with `carry` (bytes left over from a
+// PRIOR response on this same reused connection). Factored out so the stale-
+// pooled-connection RETRY path runs the identical send+read shape — one fan-out
+// hop logic, used for both the first attempt and the retry (core-abstraction-
+// first: the retry is not a fork, it is the same shape on a fresh socket).
+fn send_and_read_one(
+    stream: &mut TcpStream,
+    request: &[u8],
+    carry: Vec<u8>,
+) -> Result<UpstreamResponse, String> {
+    stream
+        .write_all(request)
+        .map_err(|e| format!("write request: {}", e))?;
+    read_upstream_response(stream, carry)
+}
+
 fn fanout_request_result(
     upstream: &str,
     method: &str,
     target: &str,
     req_headers: &[(String, String)],
     body: &[u8],
+    pool: &mut UpstreamPool,
 ) -> Result<FanoutResult, String> {
     let (host, port, base_path) = parse_http_upstream(upstream)?;
     let request_target = format!(
@@ -7277,18 +7581,21 @@ fn fanout_request_result(
         base_path,
         if target.starts_with('/') { target } else { "/" }
     );
-    let mut stream = TcpStream::connect((host.as_str(), port))
-        .map_err(|e| format!("connect {}:{}: {}", host, port, e))?;
-    // Forward the request line with the ORIGINAL method. The router owns the
-    // upstream-hop framing: `Host` is rewritten to the upstream, `Connection:
-    // close` is the router's choice (it does not reuse the upstream connection —
-    // a named-later breath), and Content-Length is set from the body the router
-    // actually captured. The CLIENT's end-to-end headers (Authorization, Cookie,
-    // Accept*, User-Agent, Content-Type, X-*, …) are then forwarded verbatim so
-    // an authenticated/content-typed route is fronted truthfully; hop-by-hop and
-    // router-owned framing headers are filtered by forward_request_header.
+    // Build the request bytes ONCE — reused verbatim for the first attempt and
+    // for the stale-connection retry. The router owns the upstream-hop framing:
+    // `Host` is rewritten to the upstream; `Connection: keep-alive` asks the
+    // upstream to hold the connection open so the NEXT fan-out reuses it (the
+    // handshake amortized across requests — the symmetric saving to the client
+    // hop's keep-alive); HTTP/1.1 so keep-alive is the default and the response
+    // can be Content-Length-framed (the framing that lets us read exactly one
+    // response without relying on the upstream closing). Content-Length is set
+    // from the body the router actually captured. The CLIENT's end-to-end headers
+    // (Authorization, Cookie, Accept*, User-Agent, Content-Type, X-*, …) are
+    // forwarded verbatim so an authenticated/content-typed route is fronted
+    // truthfully; hop-by-hop and router-owned framing headers are filtered by
+    // forward_request_header.
     let mut head = format!(
-        "{} {} HTTP/1.0\r\nHost: {}\r\nConnection: close\r\n",
+        "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n",
         method, request_target, host
     );
     for (name, value) in req_headers {
@@ -7305,42 +7612,80 @@ fn fanout_request_result(
     head.push_str("\r\n");
     let mut request: Vec<u8> = head.into_bytes();
     request.extend_from_slice(body);
-    stream
-        .write_all(&request)
-        .map_err(|e| format!("write request: {}", e))?;
-    let mut response_bytes = Vec::new();
-    stream
-        .read_to_end(&mut response_bytes)
-        .map_err(|e| format!("read response: {}", e))?;
-    let response = String::from_utf8_lossy(&response_bytes).to_string();
-    let status = response
-        .lines()
-        .next()
-        .and_then(|line| line.split_once(' ').map(|(_, rest)| rest.to_string()))
-        .unwrap_or_else(|| "502 Bad Gateway".to_string());
-    // Split the head block from the body. The head string (terminator excluded)
-    // feeds parse_content_type / parse_headers — the SAME parsers the request
-    // side uses (one header-capture shape, both directions).
-    let (head_block, body_text) = match response.find("\r\n\r\n") {
-        Some(i) => (&response[..i], response[i + 4..].to_string()),
-        None => match response.find("\n\n") {
-            Some(i) => (&response[..i], response[i + 2..].to_string()),
-            None => (response.as_str(), String::new()),
-        },
+
+    // GET-OR-CREATE FROM POOL, wrapping the connect step (core-abstraction-first:
+    // the only thing the pool changes is connection lifecycle — fresh vs reused;
+    // the request build + response framing are identical either way). If a live
+    // connection is pooled for this upstream, try it first; a pooled connection
+    // may have been closed by the upstream's idle timeout since it was returned,
+    // so a write/read failure on it is EXPECTED — drop it and reconnect+retry
+    // ONCE transparently, never surfacing the stale-pool error to the client.
+    // This stale-then-reconnect is the standard, expected behavior of a keep-
+    // alive client connection pool.
+    let response = if let Some(mut pooled) = pool.take(&host, port) {
+        let carry = std::mem::take(&mut pooled.carry);
+        match send_and_read_one(&mut pooled.stream, &request, carry) {
+            Ok(resp) => {
+                // Reused connection served the response. Return it to the pool
+                // iff the upstream kept it alive and we framed it cleanly.
+                if resp.reusable {
+                    pool.store(
+                        &host,
+                        port,
+                        PooledConn {
+                            stream: pooled.stream,
+                            carry: resp.leftover.clone(),
+                        },
+                    );
+                }
+                resp
+            }
+            Err(_) => {
+                // Stale pooled connection (upstream idle-closed it, or a broken
+                // pipe). Drop it and open a FRESH connection, retrying the SAME
+                // request once. A failure on the fresh connection is a real
+                // upstream error and propagates.
+                drop(pooled);
+                let mut fresh = TcpStream::connect((host.as_str(), port))
+                    .map_err(|e| format!("connect {}:{}: {}", host, port, e))?;
+                let resp = send_and_read_one(&mut fresh, &request, Vec::new())?;
+                if resp.reusable {
+                    pool.store(
+                        &host,
+                        port,
+                        PooledConn {
+                            stream: fresh,
+                            carry: resp.leftover.clone(),
+                        },
+                    );
+                }
+                resp
+            }
+        }
+    } else {
+        // No pooled connection — open a fresh one (the first fan-out, or after a
+        // non-reusable response dropped the previous connection).
+        let mut fresh = TcpStream::connect((host.as_str(), port))
+            .map_err(|e| format!("connect {}:{}: {}", host, port, e))?;
+        let resp = send_and_read_one(&mut fresh, &request, Vec::new())?;
+        if resp.reusable {
+            pool.store(
+                &host,
+                port,
+                PooledConn {
+                    stream: fresh,
+                    carry: resp.leftover.clone(),
+                },
+            );
+        }
+        resp
     };
-    let content_type = parse_content_type(head_block);
-    // Relay the upstream's other end-to-end response headers; hop-by-hop and the
-    // router-owned framing (Content-Length, Content-Type) are filtered out so
-    // they cannot clobber the framing http_response writes.
-    let headers: Vec<(String, String)> = parse_headers(head_block)
-        .into_iter()
-        .filter(|(name, _)| relay_response_header(name))
-        .collect();
+
     Ok(FanoutResult {
-        status,
-        content_type,
-        headers,
-        body: body_text,
+        status: response.status,
+        content_type: response.content_type,
+        headers: response.headers,
+        body: response.body,
     })
 }
 

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -143,15 +143,15 @@ gap, named precisely:
 
 | Gap | cli_serve today | Production front door needs |
 |-----|-----------------|-----------------------------|
-| **HTTP version** | serves HTTP/1.1 with keep-alive — a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), each response Content-Length-framed so the client knows exactly where one ends and the next begins; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request, never dropped | chunked transfer encoding (today every response is Content-Length-framed; a streamed/unknown-length body would need chunked), upstream connection reuse on the fan-out hop (the fan-out still opens a fresh upstream connection per request), HTTP/2 behind Traefik |
+| **HTTP version** | serves HTTP/1.1 with keep-alive on BOTH hops — on the client hop a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), and on the fan-out hop each worker reuses a per-worker keep-alive connection to the upstream (the router→upstream handshake amortized across requests, the symmetric saving); every response is Content-Length-framed so the reader knows exactly where one ends and the next begins; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet client connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request on both hops, never dropped | chunked transfer encoding (today every response is Content-Length-framed; a streamed/unknown-length body would need chunked — and an upstream chunked response is read-to-close and not pooled), HTTP/2 behind Traefik |
 | **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
 | **Request parsing** | reads the full request honoring Content-Length (a body larger than the initial 8 KiB read is captured across as many socket reads as it needs); parses `application/x-www-form-urlencoded` bodies into the same `(key value)` alist the query string uses, captures `application/json` (and any other body) raw under the reserved key `__body__`; 1 MiB body cap rejected with 413; any method (POST/PUT/PATCH/GET) | full header map exposed to handlers; a structural JSON→Form-value parse (today JSON is raw-captured, not parsed); larger/streamed/chunked bodies |
-| **Fan-out proxy** | forwards the original method, the request body, and the client's end-to-end request headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*, …) — hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, TE, Trailer) stripped, Host rewritten to the upstream, Content-Length re-derived from the captured body — and relays the upstream's response headers back (Content-Type so a JSON/HTML route survives the proxy, Set-Cookie, Cache-Control, Location, ETag, X-\*, …), with the router owning the client-hop framing (its own Content-Length + Connection; the upstream's hop-by-hop/framing headers are not relayed) | chunked/streaming response bodies, upstream connection reuse, timeouts, retries |
+| **Fan-out proxy** | reuses a per-worker keep-alive connection to the upstream, framing each response by Content-Length, reconnecting transparently on a stale pooled connection — repeated fan-outs amortize the upstream TCP handshake instead of opening a fresh connection per request. Forwards the original method, the request body, and the client's end-to-end request headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*, …) — hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, Proxy-Connection, TE, Trailer) stripped, Host rewritten to the upstream, Content-Length re-derived from the captured body, the router writing its OWN `Connection: keep-alive` to the upstream — and relays the upstream's response headers back (Content-Type so a JSON/HTML route survives the proxy, Set-Cookie, Cache-Control, Location, ETag, X-\*, …), with the router owning the client-hop framing (its own Content-Length + Connection; the upstream's hop-by-hop/framing headers are not relayed) | chunked/streaming response bodies (an upstream chunked response is read-to-close and its connection not pooled), fan-out timeouts and retries beyond the single stale-connection retry |
 | **Handler inputs** | 0 or 1 arg — the request alist, carrying query params AND parsed body fields uniformly (form-urlencoded merged in; JSON/other body under `__body__`), so a handler reads a field the same way regardless of how it arrived | path params and headers marshalled into the handler frame; a richer body shape than a flat alist (e.g. structural JSON) |
 | **Errors / observability** | 404/413/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
 
-None of these is exotic; each is a named breath. Four of the load-bearing ones
+None of these is exotic; each is a named breath. Five of the load-bearing ones
 are built. **Concurrency**: the kernel's per-process intern table
 (`lc-native-kernel-binary` names this: *"Not multi-process"*) makes the
 production shape a **pool of kernel workers behind the accept loop**, each
@@ -186,9 +186,29 @@ ownership of its client-hop framing (its own Content-Length + Connection, which 
 relayed upstream header can never clobber). One response-emit shape writes every
 response — native, fan-out, and error — so the framing is authored in a single
 place and the relayed upstream headers sit beside it without forking the logic.
-The remaining rows (chunked transfer, upstream connection reuse on the fan-out
-hop, a structural JSON→Form parse, streaming, TLS/lifecycle, observability) are
-still open breaths.
+**Upstream connection reuse**: the fan-out hop reuses a per-worker keep-alive
+connection to the upstream instead of opening a fresh one per request — the
+symmetric build to the client-hop keep-alive, on the router→upstream hop. Each
+worker owns its own small connection pool keyed by `(host, port)`, with NO
+locking: a worker handles requests serially on its thread, so it owns its pool
+exactly as it owns its `Kernel + Arena` (the per-worker isolation from the
+concurrency build). The router writes its own `Connection: keep-alive` to the
+upstream and frames the response by Content-Length — it can no longer rely on the
+upstream closing the connection to know where the body ends (that was how the old
+read-to-close worked), so it reads exactly one Content-Length-framed response and
+carries any over-read bytes forward for the next response on the connection (the
+classic keep-alive proxy bug — a mis-framed read corrupts the next request — held
+off by the same carry discipline the client hop uses). A pooled connection may
+have been idle-closed by the upstream since it was returned; on a reuse whose
+write or read fails, the router transparently reconnects once and retries the
+same request, never surfacing a stale-pool error to the client. The honest scope:
+reuse applies to Content-Length-framed responses; an upstream chunked or
+unframed response is read-to-close and its connection is dropped, not pooled
+(chunked-body reuse is a named-later breath). The ONE `fanout_request` shape is
+preserved — the pool only changes the connection lifecycle (reused vs fresh); the
+request build and response framing are identical either way.
+The remaining rows (chunked transfer, a structural JSON→Form parse, streaming,
+fan-out timeouts, TLS/lifecycle, observability) are still open breaths.
 
 ## The BML preference
 
@@ -344,8 +364,9 @@ CPython in the path). It **fans out** `/api/health` (GET) and
 **genuine app responses** — the real health JSON (status/version/uptime/
 kernel_runtime) and a real exchange quote (a server-issued `quote_id` + rate),
 not a mock marker. The numbers are the honest input to the flip decision: the
-**proxy hop costs ~0.2–0.3 ms (~5–7%)** on a fan-out route — a real localhost TCP
-hop over the kernel's HTTP/1.0, the price of fronting; the **native route saves
+**proxy hop costs ~0.2–0.3 ms (~3–7%)** on a fan-out route — a real localhost TCP
+hop over the kernel's HTTP/1.1 keep-alive connection to the upstream (reused, no
+per-request handshake), the price of fronting; the **native route saves
 ~10.8 ms (~56x)** by skipping the entire CPython request lifecycle (uvicorn
 parse → routing → Pydantic bind → `serve_via_kernel` subprocess spawn →
 response model), serving the value-walk directly. A hot native route is far
@@ -353,28 +374,33 @@ cheaper than the same compute reached through the CPython doorway; the tail pays
 a small, measured proxy toll to keep working unchanged.
 
 **NOT shown / not claimed:** full production-readiness. The server serves
-HTTP/1.1 with keep-alive (proven by `router_keepalive_harness.py` — multiple
-requests on one connection, `Connection` honored both ways, idle-timeout reaping,
-pipelining bytes carried) and the fan-out hop passes headers both ways with
+HTTP/1.1 with keep-alive on BOTH hops: the client→router hop (proven by
+`router_keepalive_harness.py` — multiple requests on one connection, `Connection`
+honored both ways, idle-timeout reaping, pipelining bytes carried) AND the
+router→upstream fan-out hop (proven by `router_upstream_reuse_harness.py` against
+a connection-counting upstream — N fan-outs through one worker land on ONE
+reused upstream connection, distinct requests on it each read their OWN
+Content-Length-framed response with no bleed, and a stale pooled connection is
+transparently reconnected+retried). The fan-out hop passes headers both ways with
 hop-by-hop hygiene (proven by `router_header_passthrough_harness.py` — the
 client's Authorization/Cookie/Accept/X-\* reach the upstream with Host rewritten
-and hop-by-hop stripped; the upstream's Content-Type/Set-Cookie/Cache-Control
-reach the client; verified against the REAL FastAPI app, whose `/api/health`
-relays as `application/json` rather than the old flattened text/plain). What
-stays open: the **upstream fan-out hop still opens a fresh connection per
-request** (the client→router hop reuses connections; the router→upstream hop does
-not yet — so the proxy-hop latency above is measured on a non-reused upstream
-connection), and the accept loop is thread-per-connection-blocked (it
-parallelizes to the worker count, not an async reactor; a worker serving a
-keep-alive client is held until that connection closes or times out). Responses
-are Content-Length-framed, not chunked; JSON bodies are raw-captured, not
-structurally parsed into Form values. The real-app proof ran against the dev
-sqlite DB; the production deployment shape (TLS/Traefik front, the routes.fk
-covering the real native-eligible set) is the remaining build. Concurrency,
-request-body reading, **bidirectional header passthrough**, the **real-app
-fan-out + native side-by-side**, and **HTTP/1.1 keep-alive on the client→router
-hop** are now shown; chunked transfer, upstream connection reuse, and
-structural-JSON are the rest.
+and hop-by-hop stripped, the router writing its own `Connection: keep-alive`; the
+upstream's Content-Type/Set-Cookie/Cache-Control reach the client; verified
+against the REAL FastAPI app, whose `/api/health` relays as `application/json`
+rather than the old flattened text/plain). What stays open: chunked/streaming
+upstream response bodies (an upstream chunked response is read-to-close and not
+pooled), fan-out timeouts and retries beyond the single stale-connection retry,
+and the accept loop is thread-per-connection-blocked (it parallelizes to the
+worker count, not an async reactor; a worker serving a keep-alive client is held
+until that connection closes or times out). Responses are Content-Length-framed,
+not chunked; JSON bodies are raw-captured, not structurally parsed into Form
+values. The real-app proof ran against the dev sqlite DB; the production
+deployment shape (TLS/Traefik front, the routes.fk covering the real
+native-eligible set) is the remaining build. Concurrency, request-body reading,
+**bidirectional header passthrough**, the **real-app fan-out + native
+side-by-side**, **HTTP/1.1 keep-alive on the client→router hop**, and
+**upstream connection reuse on the fan-out hop** are now shown; chunked transfer
+and structural-JSON are the rest.
 
 ## The flip is Urs's decision
 
@@ -395,13 +421,14 @@ test port so the reversal can be weighed with evidence rather than assertion.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` (the proxy arm, forwarding method + body), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` / `fanout_request_result` (the proxy arm, forwarding method + body over a pooled keep-alive upstream connection), `UpstreamPool` + `PooledConn` (the per-worker, lock-free upstream connection cache owned by `worker_loop` and threaded through `serve_connection` → `handle_request`), `read_upstream_response` / `send_and_read_one` / `upstream_response_keep_alive` / `head_is_chunked` (the Content-Length-framed one-response read that no longer relies on connection-close, the stale-connection reconnect+retry, and the reuse-vs-drop verdict), `is_hop_by_hop` (RFC 7230 §6.1 hop-by-hop set, now incl. `Proxy-Connection`), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement (mock upstream).
 - [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413 (mock upstream).
 - [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
-- [`form/form-kernel-rust/router_keepalive_harness.py`](../form/form-kernel-rust/router_keepalive_harness.py) — the HTTP/1.1 keep-alive proof: N sequential requests on ONE connection (Content-Length framed, distinct inputs, each correct), pipelined two-in-one-send (leftover bytes carried, none dropped), `Connection: close` honored, HTTP/1.0 default-close back-compat, idle-timeout reaping the connection (worker freed), an idle connection NOT starving the pool, and the per-request handshake saving (reused vs fresh connection). Mock upstream — no production routing.
+- [`form/form-kernel-rust/router_keepalive_harness.py`](../form/form-kernel-rust/router_keepalive_harness.py) — the HTTP/1.1 keep-alive proof (CLIENT→router hop): N sequential requests on ONE connection (Content-Length framed, distinct inputs, each correct), pipelined two-in-one-send (leftover bytes carried, none dropped), `Connection: close` honored, HTTP/1.0 default-close back-compat, idle-timeout reaping the connection (worker freed), an idle connection NOT starving the pool, and the per-request handshake saving (reused vs fresh connection). Mock upstream — no production routing.
+- [`form/form-kernel-rust/router_upstream_reuse_harness.py`](../form/form-kernel-rust/router_upstream_reuse_harness.py) — the upstream connection reuse proof (router→UPSTREAM hop): against a connection-COUNTING mock upstream with `--workers 1`, N fan-outs land on ONE reused upstream connection (connections << requests — the handshake amortized); each of N DISTINCT requests on the reused connection reads its OWN correct Content-Length-framed response (no response-framing bleed, the classic proxy keep-alive bug proven absent); reused-vs-fresh-connect latency (the reused path opens 1 connection where close-each opens N); and a stale POOLED keep-alive connection (the upstream silently drops it after N requests) triggers a transparent reconnect+retry, never a client-facing error. Mock upstream — no production routing.
 - [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.


### PR DESCRIPTION
## What

The client→router hop already reuses connections (HTTP/1.1 keep-alive, #2385). This is the **symmetric build for the router→upstream hop**: `cli_serve`'s fan-out now reuses a **per-worker keep-alive connection** to the upstream instead of opening a fresh TCP connection per request, amortizing the upstream handshake across fan-outs.

Closes the *"upstream connection reuse on the fan-out hop"* gap in `kernels/KERNEL_AS_ROUTER.md`.

## The build (core-abstraction-first — the ONE `fanout_request` shape is preserved; the pool only changes connection lifecycle, fresh vs reused)

- **`UpstreamPool` + `PooledConn`** — a per-worker, **lock-free** cache of keep-alive upstream connections keyed by `(host, port)`. A worker handles requests serially on its thread, so it owns its pool exactly as it owns its `Kernel + Arena` (the per-worker `!Sync` isolation from #2379). Owned by `worker_loop`, threaded through `serve_connection` → `handle_request` → `fanout_request`.
- **Content-Length response framing** — the router writes its own `Connection: keep-alive` to the upstream over HTTP/1.1, so it can no longer rely on the upstream *closing* to know where the body ends (the old `read_to_end`). `read_upstream_response` reads exactly ONE Content-Length-framed response and carries over-read bytes forward for the next response on the connection — the classic keep-alive proxy bug (a mis-framed read corrupts the next request) held off by the same carry discipline the client hop uses.
- **Stale-connection retry** — a pooled connection idle-closed by the upstream surfaces as a write/read failure on reuse; the router transparently reconnects once and retries the same request, never surfacing a stale-pool error to the client.
- **Proxy-Connection** added to the RFC 7230 §6.1 hop-by-hop set (a proxy must never pass the client's connection-management header on, now that the router writes its own `Connection` for upstream reuse).

## Proof — `router_upstream_reuse_harness.py` (connection-COUNTING upstream, `--workers 1`)

```
[conns<<reqs ] 20 fan-out requests through 1 worker -> upstream accepted 1 connection(s)  OK  (ideal: ONE reused connection)
[no-bleed    ] each of 20 DISTINCT requests on the reused connection got its OWN correct response -> OK
[reuse vs fresh] 60 fan-outs each:
               REUSED upstream conn (1 accept(s)):       p50=0.203 ms  total=12.5 ms
               FRESH conn each (65 accept(s), close-each): p50=0.257 ms  total=16.9 ms
               reuse saved 4.4 ms total; fresh-each opened 65 connections vs reuse's 1  OK
[stale-retry ] upstream silently drops the POOLED keep-alive conn every 3 reqs; 8 client fan-outs -> all OK (upstream: 3 connections, 8 requests served)
```

- **connections << requests**: 20 fan-outs through one worker → ONE reused upstream connection (the handshake amortized).
- **no framing bleed**: 20 DISTINCT requests on the reused connection each read their OWN correct response (the classic proxy keep-alive bug, proven absent on a genuinely reused connection).
- **stale-retry**: the upstream *signals* keep-alive (router pools) but silently drops the socket after N requests; the next fan-out's reuse fails on the read and the router transparently reconnects+retries — zero client-facing errors across 3 reconnections.

## Honest scope

- **NO production routing flip.** FastAPI stays the live front door; `cli_serve` is the serve primitive matured, not wired to production.
- **Closed**: upstream connection reuse with Content-Length response framing + stale-reconnect retry.
- **Stays open**: chunked/streaming upstream response bodies (an upstream chunked response is read-to-close and *not* pooled — named in the doc), HTTP/2, fan-out timeouts and retries beyond the single stale-connection retry.

## Verification

- All existing harnesses pass: keepalive, body, header-passthrough (updated for the new keep-alive reality + tighter hop-by-hop hygiene), concurrency, real-app (fan-out GET/POST to real FastAPI/uvicorn, +0.2 ms proxy hop over the reused connection).
- Three-way `validate.sh` green: **compression-fold-band → 111111**, 260 ok. The 2 divergent bands (`bml-action-runtime-band`, `seeded-bytes-recipe-band`) are pre-existing on main and unrelated (both report the same unbound-function error on all three kernels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)