### PR TITLE
tend(form): heal bml-action-runtime-band char-lit source to match grammar

### DIFF
--- a/form/form-stdlib/tests/bml-action-runtime-band.fk
+++ b/form/form-stdlib/tests/bml-action-runtime-band.fk
@@ -131,7 +131,7 @@
     (let char-rt
         (bmf-roundtrip
             (bml-bmf-find-rule "char-lit" bml-bmf-rules)
-            (list (bml-src-op "'") (bml-src-string "x") (bml-src-op "'"))))
+            (list (bml-src-char "x"))))
     (let array-rt
         (bmf-roundtrip
             (bml-bmf-find-rule "array-int" bml-bmf-rules)


### PR DESCRIPTION
## What

`form/form-stdlib/tests/bml-action-runtime-band.fk` was a tracked validation divergence: it failed `form/validate.sh` three-way (Go: `trivialValue composite`, Rust: `as_str: Null`, TS: `expected list`) and had apparently never passed.

## Diagnosis

The reported suspect — the global `bml-bmf-rules` being "never bound" — was a **false lead from a literal text grep**. `bml-bmf-rules` *is* bound: the `section [bml.bmf]` block in `grammars/bml.fk` is lowered by `source-compiler.fk` (`fsc-bmf-section-recipe` emits `(let <dialect>-bmf-rules ...)` into a `.fkb` sidecar). validate.sh's `prepare_sources` source-compiles any file containing `^section [`, so the binding is present at runtime. The sibling band `language-bmf-bidirectional.fk` already exercises the identical `bml-bmf-find-rule "field" bml-bmf-rules` and passes three-way (346) — proof the symbol resolves.

The real defect was the band's own **source-token data** for the `char-lit` roundtrip. The grammar rule is:

```
char-lit ::= $value:char => bml-emit-char-lit <= bml-source-char-lit;
```

a single `$value:char` capture (one `bml-char` token). The band fed three tokens — `(bml-src-op "'") (bml-src-string "x") (bml-src-op "'")` — which don't match. `bmf-roundtrip` then extracted a Null/empty where `bml-emit-char-lit` / `bml-source-char-lit` expected a value, crashing the three kernels divergently.

Bisected via nine probe-bands: `field-source` (16), `restore` (30), `cut` (44), `header` (960), all `action-score` sub-blocks, and `array-int` all pass three-way; only the `char-lit` source line broke.

## Fix

Feed the single `(bml-src-char "x")` token the grammar defines. No grammar change — test-data only, the lowest-risk honest fix.

## Proof

- Band now passes three-way in isolation **and** in the validate.sh harness: `✓ stdlib/bml-action-runtime-band.fk → 8388680` (Go == Rust == TS).
- Sibling `language-bmf-bidirectional.fk` was never broken (separate, already-passing band); same `bml-bmf-rules` reference, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)