### PR TITLE
feat(kernel-router): serve a BML-authored routes manifest (source-compile-at-load)

### DIFF
--- a/form/form-kernel-rust/examples/router-bml-proof.bml
+++ b/form/form-kernel-rust/examples/router-bml-proof.bml
@@ -1,0 +1,51 @@
+; router-bml-proof.bml — the kernel-as-router proof, authored in BML SURFACE syntax.
+;
+; The sibling of examples/router-proof.fk. Native handlers + the routes manifest
+; written in the BML surface tongue (`def name(args) = expr;`), NOT raw
+; S-expression and NOT Python-cross-compiled. `form-kernel-rust serve --routes
+; <this> --stdlib form-stdlib` SOURCE-COMPILES this manifest at load — reusing
+; the EXISTING form-stdlib source compiler (form-source-compile-file lowering the
+; form.bml dialect) into the S-expression Form the kernel walks — then serves it.
+; The handler is Form, walked by the kernel: the BML surface is the authoring
+; tongue, lowered by the body's own compiler, never a Rust-side reimplementation.
+;
+;   curl :PORT/health                          -> "ok"   (native, Form)
+;   curl ':PORT/weighted_sum'                  -> 39     (native multi-step int math)
+;   curl ':PORT/count_signals?values=a,b,c'    -> "3"    (native, input-driven)
+;   curl :PORT/api/ideas                       -> fan-out -> CPython upstream
+;
+; Everything inside the form.bml section below is BML surface syntax, lowered to
+; ordinary Form before the kernel serves a request. In this dialect each
+; `def name(args) = expr;` is a single line (the multi-line shape is the block
+; form `def name(args) { ... }`); the expressions nest `if c then a else b` and
+; `f(a, b)` calls freely. The compute here is integer/string — the values cross
+; the source compiler's .fkb artifact intact; a BML float-literal handler is a
+; further breath (see KERNEL_AS_ROUTER.md "BML preference").
+
+section [form.bml] {
+    ; tiny alist helper: value for `key` in a list of (k v) string pairs
+    def assoc(key, pairs) = if eq(len(pairs), 0) then "" else if str_eq(head(head(pairs)), key) then head(tail(head(pairs))) else assoc(key, tail(pairs));
+
+    ; NATIVE handler 1: liveness. Pure Form, zero inputs (`def name() = ...`).
+    def route_health() = "ok";
+
+    ; NATIVE handler 2: a real multi-step aggregator in Form integer math. The
+    ; weighted sum of three signal counts (3, 5, 7) against weights (2, 1, 4) —
+    ; (3*2)+(5*1)+(7*4) = 39. The value-walk runs the whole arithmetic in the
+    ; kernel and the int result becomes the HTTP body. The same shape an
+    ; S-expression handler would compute — proven equal in the harness.
+    def route_weighted_sum() = int_to_str(add(add(mul(3, 2), mul(5, 1)), mul(7, 4)));
+
+    ; NATIVE handler 3: input-driven Form compute. Counts comma-separated
+    ; signals in the `values` query arg by walking the string char-by-char in
+    ; the kernel (commas + 1). Reads request input, computes a non-trivial
+    ; value entirely in Form.
+    def count_commas(s, i, n) = if eq(i, str_len(s)) then n else count_commas(s, add(i, 1), if str_eq(char_at(s, i), ",") then add(n, 1) else n);
+
+    def route_count_signals(q) = if eq(str_len(assoc("values", q)), 0) then "0" else int_to_str(add(count_commas(assoc("values", q), 0, 0), 1));
+
+    ; the route manifest: (path handler). Everything not here fans out. The
+    ; kernel resolves this top-level `routes` binding exactly as it does for the
+    ; S-expression manifest — the BML section lowered it to the same shape.
+    let routes = list(list("/health", route_health), list("/weighted_sum", route_weighted_sum), list("/count_signals", route_count_signals));
+}

--- a/form/form-kernel-rust/examples/router-proof.fk
+++ b/form/form-kernel-rust/examples/router-proof.fk
@@ -13,8 +13,10 @@
 ;     X-Form-Router: fanout-python.
 ;
 ; Authored as .fk S-expression Form — the kernel's native surface, NOT
-; Python-cross-compiled. (BML surface -> routes would need the Form surface
-; parser in Rust; named as a build in KERNEL_AS_ROUTER.md.)
+; Python-cross-compiled. A BML-surface sibling of this manifest serves too:
+; examples/router-bml-proof.bml is source-compiled at load via the form-stdlib
+; form.bml dialect (serve --routes <bml> --stdlib form-stdlib). See the "BML
+; preference" section in KERNEL_AS_ROUTER.md.
 ;
 ;   curl :PORT/health                          -> "ok"        (native, Form)
 ;   curl ':PORT/coherence_weight'              -> 0.8125      (native float math)

--- a/form/form-kernel-rust/router_bml_proof_harness.py
+++ b/form/form-kernel-rust/router_bml_proof_harness.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Proof-of-shape harness for a BML-AUTHORED kernel-router manifest.
+
+Sibling of router_proof_harness.py. That harness proves the kernel-as-router
+topology against an S-EXPRESSION manifest (examples/router-proof.fk). This one
+proves the runtime-share-aligned step Urs named: a route handler authored in BML
+SURFACE syntax (`def name(args) = expr;`) serves through the kernel with NO
+Python and NO hand-written S-expression — the BML manifest is SOURCE-COMPILED at
+load via the body's own form-stdlib compiler (form-source-compile-file over the
+form.bml dialect), then served exactly like a native S-expression manifest.
+
+What it spins up:
+  1. `form-kernel-rust serve --routes examples/router-bml-proof.bml
+     --stdlib form-stdlib --upstream <mock>` — the BML manifest source-compiled
+     AT LOAD, the kernel as the front door, fanning out the tail.
+  2. (oracle) `form-kernel-rust serve --routes <temp S-expr manifest>` — the same
+     three handlers authored in raw S-expression Form, on a second port. Its
+     answers are the oracle the BML answers are checked EQUAL to.
+  3. a tiny CPython upstream (mock FastAPI) — the fan-out target, so the proof
+     touches NO production routing.
+
+What it asserts:
+  - the BML-authored native routes (/health, /weighted_sum, /count_signals)
+    return the BML handler's value with header X-Form-Router: native-kernel —
+    the kernel served them in Form, NO CPython hop, the handler authored in BML.
+  - the BML answer EQUALS the S-expression oracle's answer for the same route —
+    BML surface syntax lowered to the same Form shape an S-expr handler is.
+  - a non-native path FANS OUT to the CPython upstream (X-Form-Router:
+    fanout-python) — the BML manifest's tail proxies to Python like any manifest.
+  - the server's startup log NAMES the BML source-compile (the at-load lowering
+    actually ran; the route was not secretly an S-expression file).
+  - it MEASURES native-route latency (the BML-authored front door stays fast —
+    once lowered at load, a BML route is the same value-walk as an S-expr one).
+
+Run from form/form-kernel-rust/ (cwd must let --stdlib form-stdlib resolve, i.e.
+run from form/form-kernel-rust with ../form-stdlib, or pass an absolute --stdlib):
+    cargo build --release
+    python3 router_bml_proof_harness.py
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+BML_ROUTES = HERE / "examples" / "router-bml-proof.bml"
+# The form-stdlib dir the BML manifest is source-compiled through. The kernel's
+# default --stdlib is "form-stdlib" relative to cwd; we pass the absolute path so
+# the harness works regardless of the cwd it is launched from.
+STDLIB_DIR = HERE.parent / "form-stdlib"
+
+UPSTREAM_MARKER = "UPSTREAM-CPYTHON-FASTAPI-STANDIN"
+
+# The S-expression ORACLE manifest: the SAME three handlers as the BML manifest,
+# authored in raw S-expression Form. The harness serves this on its own port and
+# checks the BML answers EQUAL these — proving the BML surface lowered to the same
+# Form value an S-expr handler computes. route_weighted_sum is the multi-step
+# integer aggregator (3*2)+(5*1)+(7*4)=39, identical to the BML handler.
+ORACLE_SEXPR = """
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+(defn route_health () "ok")
+
+(defn route_weighted_sum ()
+  (int_to_str (add (add (mul 3 2) (mul 5 1)) (mul 7 4))))
+
+(defn count_commas (s i n)
+  (if (eq i (str_len s))
+      n
+      (count_commas s (add i 1)
+                    (if (str_eq (char_at s i) ",") (add n 1) n))))
+
+(defn route_count_signals (q)
+  (if (eq (str_len (assoc "values" q)) 0)
+      "0"
+      (int_to_str (add (count_commas (assoc "values" q) 0 0) 1))))
+
+(let routes
+  (list
+    (list "/health"        route_health)
+    (list "/weighted_sum"  route_weighted_sum)
+    (list "/count_signals" route_count_signals)))
+"""
+
+
+class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
+    """The CPython upstream the kernel fans out to (mock FastAPI)."""
+
+    def do_GET(self):  # noqa: N802
+        body = f"{UPSTREAM_MARKER} served {self.path}\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # silence per-request logging
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 8.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.2)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.05)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def fetch(url: str):
+    """Return (status, body, router-header) for a GET."""
+    try:
+        with urllib.request.urlopen(url, timeout=3.0) as r:
+            return r.status, r.read().decode("utf-8"), r.headers.get("X-Form-Router")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8"), e.headers.get("X-Form-Router")
+
+
+def serve_value(base: str, path: str) -> str:
+    status, body, _ = fetch(base + path)
+    if status != 200:
+        raise RuntimeError(f"oracle {path} -> {status}")
+    return body
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not BML_ROUTES.exists():
+        print(f"missing BML routes file: {BML_ROUTES}", file=sys.stderr)
+        return 2
+    if not STDLIB_DIR.exists():
+        print(f"missing form-stdlib dir: {STDLIB_DIR}", file=sys.stderr)
+        return 2
+
+    # 1. CPython upstream (mock FastAPI) — the fan-out target.
+    up_port = free_port()
+    httpd = http.server.HTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
+    up_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    up_thread.start()
+    upstream_url = f"http://127.0.0.1:{up_port}"
+
+    # 2. The kernel as the front-door router, serving the BML-authored manifest
+    #    (source-compiled at load) and fanning out the tail to the upstream.
+    kport = free_port()
+    bml_proc = subprocess.Popen(
+        [
+            str(BIN), "serve",
+            "--port", str(kport),
+            "--routes", str(BML_ROUTES),
+            "--stdlib", str(STDLIB_DIR),
+            "--upstream", upstream_url,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # 3. The S-expression ORACLE: the same handlers in raw Form, on its own port.
+    oracle_file = tempfile.NamedTemporaryFile(
+        "w", suffix=".fk", prefix="router-oracle-", delete=False
+    )
+    oracle_file.write(ORACLE_SEXPR)
+    oracle_file.flush()
+    oracle_file.close()
+    oport = free_port()
+    oracle_proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(oport), "--routes", oracle_file.name],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    failures = []
+    try:
+        wait_for_port(kport)
+        wait_for_port(oport)
+        base = f"http://127.0.0.1:{kport}"
+        oracle = f"http://127.0.0.1:{oport}"
+
+        # --- NATIVE arm: BML-authored handlers, served in Form, no CPython ---
+        #     each checked against the S-expression oracle's answer (EQUAL).
+        cases = [
+            "/health",
+            "/weighted_sum",
+            "/count_signals?values=0.5,0.75,1.0",
+            "/count_signals?values=a",
+            "/count_signals",  # no values -> "0"
+        ]
+        for path in cases:
+            status, body, router = fetch(base + path)
+            want = serve_value(oracle, path)  # the S-expr handler's answer
+            ok = status == 200 and body == want and router == "native-kernel"
+            print(f"  [bml-native] {path:<38} -> {status} {body!r} "
+                  f"X-Form-Router={router}  ==oracle({want!r})  "
+                  f"{'OK' if ok else 'FAIL'}")
+            if not ok:
+                failures.append(("native", path, status, body, router, want))
+
+        # --- FAN-OUT arm: the BML manifest's tail proxies to CPython too ---
+        for path in ("/api/ideas", "/api/whatever/deep/path"):
+            status, body, router = fetch(base + path)
+            ok = (
+                status == 200
+                and UPSTREAM_MARKER in body
+                and path in body
+                and router == "fanout-python"
+            )
+            print(f"  [bml-fanout] {path:<38} -> {status} via CPython "
+                  f"X-Form-Router={router}  {'OK' if ok else 'FAIL'}")
+            if not ok:
+                failures.append(("fanout", path, status, body, router, None))
+
+        # --- MEASURE native-route latency (the BML front door must stay fast) ---
+        N = 200
+        samples = []
+        for _ in range(N):
+            t0 = time.perf_counter()
+            fetch(base + "/weighted_sum")
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        samples.sort()
+        p50 = statistics.median(samples)
+        p99 = samples[int(0.99 * len(samples)) - 1]
+        print(f"\n  BML-native /weighted_sum over {N} reqs: "
+              f"p50={p50:.3f} ms  p99={p99:.3f} ms  min={samples[0]:.3f} ms")
+        print("  (whole-request wall time incl. loopback socket; once lowered at "
+              "load, a BML route is the same value-walk as an S-expr one.)")
+
+        # --- the at-load source-compile must have actually run ---
+        # Give the process a moment to flush its startup banner, then read it.
+        time.sleep(0.1)
+        bml_proc.terminate()
+        try:
+            _, stderr = bml_proc.communicate(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            bml_proc.kill()
+            _, stderr = bml_proc.communicate()
+        compiled_named = "source-compiled" in (stderr or "") and "form.bml" in (stderr or "")
+        print(f"\n  startup log named the BML source-compile: "
+              f"{'OK' if compiled_named else 'FAIL'}")
+        if not compiled_named:
+            print("  --- server stderr ---", file=sys.stderr)
+            print(stderr, file=sys.stderr)
+            failures.append(("startup", "source-compile banner", None, None, None, None))
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
+            return 1
+        print("\nok — a BML-AUTHORED route served through the kernel: native "
+              "handlers written in BML surface syntax, source-compiled at load "
+              "via form-stdlib, served in Form (no CPython, no hand S-expr), "
+              "their answers EQUAL the S-expression oracle's; the tail fanned "
+              "out to CPython.")
+        return 0
+    finally:
+        for p in (bml_proc, oracle_proc):
+            if p.poll() is None:
+                p.terminate()
+                try:
+                    p.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    p.kill()
+        httpd.shutdown()
+        try:
+            Path(oracle_file.name).unlink()
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6264,7 +6264,7 @@ Subcommands:
   query <path>                         parse any file as a Form object tree
   trace [--expr \"...\" | <file.fk>]     run with arm-dispatch tracing
   fetch <url>                          GET a URL (network resource)
-  serve --port <p> --routes <file.fk> [--upstream <base-url>]\n                                       kernel front-door router: native Form handlers\n                                       for listed paths, fan-out to the Python upstream\n                                       for the rest (HTTP/1.0 proof-of-shape)
+  serve --port <p> --routes <file> [--upstream <base-url>] [--stdlib <dir>]\n                                       kernel front-door router: native Form handlers\n                                       for listed paths, fan-out to the Python upstream\n                                       for the rest. --routes may be raw S-expression\n                                       Form or a BML-authored `section [form.bml]`\n                                       manifest (source-compiled at load via --stdlib,\n                                       default form-stdlib)
 
 Source adapter modes:
   <file.fk> [more.fk ...]              run .fk files
@@ -6731,6 +6731,179 @@ fn worker_loop(
     }
 }
 
+// The form-stdlib preludes a BML manifest is source-compiled through, in load
+// order: json.fk + cache.fk feed the ontology loader, which binds the Form
+// category/primitive tables source-compiler.fk lowers a `section [...]` against.
+// This is the SAME prelude set + lowering `form/validate.sh prepare_sources`
+// runs to source-compile a `section [...]` file — the router reuses the body's
+// own compiler, not a Rust reimplementation of the BML surface parser.
+const SOURCE_COMPILE_PRELUDES: [&str; 4] = [
+    "json.fk",
+    "cache.fk",
+    "form-ontology-loader.fk",
+    "source-compiler.fk",
+];
+
+// A routes manifest is BML-authored (vs raw S-expression) iff it opens a
+// `section [...]` block — the source-compiler's own section marker. The check
+// is the same `section [` line-prefix scan form-source-compile-loop uses to
+// find sections, so "needs lowering" and "has a section" are the one judgement.
+fn manifest_is_bml(src: &str) -> bool {
+    src.lines().any(|line| line.trim_start().starts_with("section ["))
+}
+
+// Source-compile a BML-authored routes manifest to the S-expression Form the
+// kernel walks, returning the lowered source. This is PATH A — source-compile
+// AT LOAD: the router accepts a BML manifest directly, lowering it through the
+// body's own form-stdlib source-compiler (the same `form-source-compile-file`
+// the validate path uses) before `read_root_from_source` reads it. The compile
+// writes a `.fkb` Recipe sidecar next to the lowered `.fk` (the compiled output
+// references it via `walk_recipe_here (read_form_binary "...")`), so both files
+// live in `work_dir`, which the caller keeps alive for the server's lifetime.
+//
+// Reuse, not reinvention: the 4 preludes + driver are concatenated and walked
+// by a fresh kernel exactly as `validate.sh` loads them — the BML surface parser
+// (form.bml dialect in source-compiler.fk) is Form-stdlib tissue, run here, never
+// duplicated in Rust. Called ONCE in the main thread before workers spawn, so the
+// lowering cost is paid once at startup, not per-worker and not per-request; each
+// worker then loads the lowered `.fk` exactly as it loads a raw S-expression one.
+fn source_compile_bml_manifest(
+    routes_path: &str,
+    stdlib_dir: &str,
+    work_dir: &std::path::Path,
+) -> Result<String, String> {
+    // work_dir is absolute (env::temp_dir()); out_path therefore is too.
+    let out_path = work_dir.join("routes-compiled.fk");
+    let out_str = out_path.to_string_lossy().to_string();
+
+    // The source-compiler's ontology loader reads its data files by paths
+    // RELATIVE to "form-stdlib/" (e.g. read_with_cache "form-stdlib/form-ontology.json")
+    // — exactly as validate.sh runs it with cwd = form/. So the compile must run
+    // with the working directory set to the PARENT of the stdlib dir, where
+    // "form-stdlib/..." resolves. We set cwd for the (single-threaded, pre-worker)
+    // compile and restore it after. Because cwd changes, routes_path and out_path
+    // are made ABSOLUTE before they go into the driver, so they resolve regardless.
+    let stdlib_path = std::path::Path::new(stdlib_dir);
+    let stdlib_abs = stdlib_path
+        .canonicalize()
+        .map_err(|e| format!("source-compile: --stdlib {}: {}", stdlib_dir, e))?;
+    let stdlib_parent = stdlib_abs
+        .parent()
+        .ok_or_else(|| format!("source-compile: --stdlib {} has no parent dir", stdlib_dir))?
+        .to_path_buf();
+    let stdlib_name = stdlib_abs
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "form-stdlib".to_string());
+    let routes_abs = std::path::Path::new(routes_path)
+        .canonicalize()
+        .map_err(|e| format!("source-compile: --routes {}: {}", routes_path, e))?
+        .to_string_lossy()
+        .to_string();
+
+    // Concatenate the form-stdlib preludes (read from stdlib_dir) and a one-line
+    // driver that calls the source-compiler over the BML manifest. The kernel's
+    // multi-file load joins files with "\n"; we build the same joined source so
+    // the driver sees every prelude's bindings.
+    let mut parts: Vec<String> = Vec::with_capacity(SOURCE_COMPILE_PRELUDES.len() + 1);
+    for name in SOURCE_COMPILE_PRELUDES {
+        let p = stdlib_abs.join(name);
+        match fs::read_to_string(&p) {
+            Ok(s) => parts.push(s),
+            Err(e) => {
+                return Err(format!(
+                    "source-compile: read prelude {}: {} (is --stdlib {} correct?)",
+                    p.display(),
+                    e,
+                    stdlib_dir
+                ))
+            }
+        }
+    }
+    // The driver runs the existing form-source-compile-file: lower every
+    // `section [...]` in routes_path into Recipe + .fkb sidecar, emit the
+    // S-expression Form (with walk_recipe_here drivers) to out_path. Absolute
+    // paths so they resolve under the changed cwd.
+    parts.push(format!(
+        "(do (form-source-compile-file {} {}))",
+        sexp_string_literal(&routes_abs),
+        sexp_string_literal(&out_str)
+    ));
+    let driver_src = parts.join("\n");
+
+    // Set cwd to the stdlib's parent so the ontology loader's "form-stdlib/..."
+    // relative reads resolve, run the compile, then restore cwd. Restoring is
+    // important: the rest of cli_serve (and the workers) expect the original cwd.
+    let prev_cwd = env::current_dir()
+        .map_err(|e| format!("source-compile: read cwd: {}", e))?;
+    // Guard against a surprising layout where the stdlib's parent isn't named to
+    // match the loader's hardcoded "form-stdlib/" prefix — if the dir name isn't
+    // "form-stdlib", the relative reads would still miss. Name it explicitly.
+    if stdlib_name != "form-stdlib" {
+        return Err(format!(
+            "source-compile: --stdlib must point at a directory named 'form-stdlib' \
+             (the source-compiler reads form-stdlib/form-ontology.json relative to its parent); \
+             got {}",
+            stdlib_abs.display()
+        ));
+    }
+    env::set_current_dir(&stdlib_parent)
+        .map_err(|e| format!("source-compile: chdir {}: {}", stdlib_parent.display(), e))?;
+
+    // Walk the compile in a throwaway kernel — its only purpose is the file
+    // side-effects (out_path + .fkb sidecar). run_source already builds a fresh
+    // Kernel + Arena and walks the source; a parse/lowering failure surfaces as a
+    // kernel panic, which the spawned worker thread in main() turns into a clean
+    // process message. We run it on a generous-stack thread because the BML
+    // lowering is deeply recursive (the source-compiler walks the section body).
+    let compile_result = std::thread::Builder::new()
+        .name("bml-source-compile".to_string())
+        .stack_size(FORM_KERNEL_STACK_BYTES)
+        .spawn(move || {
+            let _ = run_source(&driver_src);
+        })
+        .map_err(|e| format!("source-compile: spawn compile thread: {}", e))
+        .and_then(|h| {
+            h.join().map_err(|_| {
+                "source-compile: lowering the BML manifest panicked (see message above)"
+                    .to_string()
+            })
+        });
+
+    // Restore cwd before propagating any compile error, so a failed compile never
+    // leaves the process in the stdlib's parent.
+    let _ = env::set_current_dir(&prev_cwd);
+    compile_result?;
+
+    // Read the lowered S-expression Form back as the manifest source the router
+    // loads. If it is absent, the section never lowered (a malformed manifest).
+    fs::read_to_string(&out_path).map_err(|e| {
+        format!(
+            "source-compile: lowered manifest {} not produced: {} (does {} contain a `section [...]` block?)",
+            out_path.display(),
+            e,
+            routes_path
+        )
+    })
+}
+
+// Quote a path/string as an S-expression string literal for the compile driver:
+// wrap in double quotes, escaping backslash and double-quote. Paths with a quote
+// or backslash are exotic but must not break the driver's parse.
+fn sexp_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn cli_serve(args: &[String]) -> i32 {
     // --port <p> --routes <file.fk> [--upstream <http-base-url>]
     let mut port: u16 = 8001;
@@ -6748,6 +6921,12 @@ fn cli_serve(args: &[String]) -> i32 {
     // Default: the host's available parallelism (capped sane), so the box's
     // cores are used out of the box; 0 or unset falls back to the default.
     let mut workers: Option<usize> = None;
+    // --stdlib <dir> points at the form-stdlib directory whose source-compiler a
+    // BML-authored manifest is lowered through (PATH A — source-compile at load).
+    // It is used ONLY when the manifest opens a `section [...]` block; a raw
+    // S-expression manifest never touches it. Default: "form-stdlib" relative to
+    // the cwd, the same relative path validate.sh uses.
+    let mut stdlib_dir: String = "form-stdlib".to_string();
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -6795,6 +6974,14 @@ fn cli_serve(args: &[String]) -> i32 {
                 };
                 i += 2;
             }
+            "--stdlib" => {
+                if i + 1 >= args.len() {
+                    eprintln!("serve: --stdlib requires a directory argument");
+                    return 2;
+                }
+                stdlib_dir = args[i + 1].clone();
+                i += 2;
+            }
             other => {
                 eprintln!("serve: unknown argument: {}", other);
                 return 2;
@@ -6808,12 +6995,45 @@ fn cli_serve(args: &[String]) -> i32 {
             return 2;
         }
     };
-    let src = match fs::read_to_string(&routes_path) {
+    let raw_src = match fs::read_to_string(&routes_path) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("serve: read {}: {}", routes_path, e);
             return 1;
         }
+    };
+
+    // PATH A — source-compile at load. If the manifest is BML-authored (opens a
+    // `section [...]` block), lower it ONCE here in the main thread through the
+    // body's own form-stdlib source-compiler into the S-expression Form the
+    // kernel walks; the workers then load that lowered source exactly as they
+    // load a raw S-expression manifest. `_compile_work_dir` holds the temp dir
+    // (the lowered .fk + its .fkb Recipe sidecar) alive for the server's life —
+    // dropping it would unlink the .fkb a worker's `walk_recipe_here` reads.
+    let mut _compile_work_dir: Option<PathBuf> = None;
+    let src = if manifest_is_bml(&raw_src) {
+        let dir = env::temp_dir().join(format!("form-router-bml-{}", std::process::id()));
+        if let Err(e) = fs::create_dir_all(&dir) {
+            eprintln!("serve: create source-compile work dir {}: {}", dir.display(), e);
+            return 1;
+        }
+        match source_compile_bml_manifest(&routes_path, &stdlib_dir, &dir) {
+            Ok(lowered) => {
+                eprintln!(
+                    "form-kernel-rust serve: BML manifest {} source-compiled via {} (form.bml dialect)",
+                    routes_path, stdlib_dir
+                );
+                _compile_work_dir = Some(dir);
+                lowered
+            }
+            Err(e) => {
+                eprintln!("serve: {}", e);
+                let _ = fs::remove_dir_all(&dir);
+                return 1;
+            }
+        }
+    } else {
+        raw_src
     };
 
     // Validate the manifest ONCE up front (in the main thread) so a broken

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -237,16 +237,53 @@ still open breaths.
 ## The BML preference
 
 Native handlers and the routes manifest are **Form-native tissue, not
-Python-cross-compiled**. The proof manifest is authored as `.fk` S-expression
-Form — the kernel's native surface that `read_root_from_source` reads directly.
-BML surface syntax (`defn name(a, b) = do { ... };`) is the preferred authoring
-tongue because it exposes Form features directly (Python reaches Form only via
-the bolted-on adapter SDK); serving a BML-authored manifest needs the Form
-surface parser in Rust (the `.recipelib.json` tongue_caches → S-expression
-converter named in [`lc-native-kernel-binary`](../docs/vision-kb/concepts/lc-native-kernel-binary.md)).
+Python-cross-compiled**. BML surface syntax (`def name(args) = expr;`) is the
+preferred authoring tongue because it exposes Form features directly — Python
+reaches Form only through the bolted-on adapter SDK — and the router serves a
+BML-authored manifest today.
+
+The BML surface parser is not a Rust build — it already lives in Form-stdlib.
+`form-stdlib/source-compiler.fk`'s `form.bml` dialect lowers a `section [form.bml]
+{ ... }` block into ordinary Form, the same `form-source-compile-file` lowering
+`form/validate.sh prepare_sources` runs to source-compile any section file. The
+router reuses that compiler directly: `serve --routes <manifest> --stdlib
+form-stdlib` SOURCE-COMPILES a BML manifest **at load** (the manifest is BML iff
+it opens a `section [...]` block), in the main thread before any worker spawns,
+through the four form-stdlib preludes (`json.fk` + `cache.fk` +
+`form-ontology-loader.fk` + `source-compiler.fk`) — then loads the lowered
+S-expression with the SAME `read_root_from_source` an S-expression manifest uses.
+The lowering writes a `.fkb` Recipe sidecar the lowered manifest reads via
+`walk_recipe_here`; both live in a temp dir held for the server's lifetime. The
+cost is paid once at startup, not per-worker and not per-request: a worker loads
+the lowered `.fk` exactly as it loads a raw S-expression one.
+[`examples/router-bml-proof.bml`](../form/form-kernel-rust/examples/router-bml-proof.bml)
+is a working BML-authored manifest;
+[`router_bml_proof_harness.py`](../form/form-kernel-rust/router_bml_proof_harness.py)
+proves each BML route serves the correct value in Form (`X-Form-Router:
+native-kernel`, no CPython) and EQUAL to the same handler authored in
+S-expression — the BML surface lowered to the same Form shape. A raw
+S-expression manifest is unchanged: it has no `section [...]`, so it never
+touches the source-compiler and `read_root_from_source` reads it directly.
+
+Honest scope of the BML authoring path as it stands: the `form.bml` dialect
+lowers `def name(args) = expr;` (single-line), the block form `def name(args)
+{ ... }`, nested `if c then a else b`, `f(a, b)` calls, and integer/string
+literals — the proof's handlers (a multi-step integer aggregator, an
+input-driven counter, liveness) are authored in it and their values cross the
+source-compiler's `.fkb` artifact intact. A BML **float-literal** handler is the
+next breath: the compiler can lower a float in-process, but the `.fkb` artifact
+format carries a float as an overflow-table index, not the value, so a lowered
+float does not yet survive the cross-kernel round-trip (a float-value embedding
+across all three kernels' artifact (de)serializers is the named build).
+An S-expression manifest serves floats today — the kernel's `.fk` source reader
+reads float tokens directly (the existing `router-proof.fk`'s 0.8125
+coherence-weight is one) — so float routes have a path; only the BML→`.fkb` route
+waits on that artifact change.
+
 Either way the handler is Form, walked by the kernel — never a Python function
 the kernel calls. That is the point of the reversal: the front door speaks the
-body's own tongue.
+body's own tongue, and now it can be authored in the body's own surface syntax,
+lowered by the body's own compiler.
 
 ## The migration path — runtime-share, not route-count
 


### PR DESCRIPTION
## What

The kernel-router now accepts a routes manifest written in **BML surface syntax** (`def name(args) = expr;`), not only raw S-expression — proving the runtime-share-aligned direction Urs named: *prefer BML to Python; BML exposes Form features directly*.

`serve --routes <manifest> --stdlib form-stdlib` detects a BML manifest (it opens a `section [...]` block) and **source-compiles it at load** — in the main thread before any worker spawns — through the body's own form-stdlib source-compiler (the same `form-source-compile-file` lowering `validate.sh`'s `prepare_sources` runs), then loads the lowered S-expression with the same `read_root_from_source` an S-expression manifest uses.

## Path A — source-compile-at-load (reuse, not reinvent)

The BML surface parser is **not** a Rust build — it already lives in form-stdlib's `form.bml` dialect (`source-compiler.fk`). The router reuses it directly:
- detect BML (`section [...]` line prefix — the compiler's own marker),
- concatenate the 4 form-stdlib preludes (`json.fk` + `cache.fk` + `form-ontology-loader.fk` + `source-compiler.fk`) + a `form-source-compile-file` driver,
- walk it in a throwaway kernel (the ontology loader reads `form-stdlib/...` relative paths, so the compile sets cwd to the stdlib's parent and restores it after),
- load the lowered `.fk` (+ its `.fkb` Recipe sidecar) exactly as a raw S-expression manifest.

Cost is paid **once at startup**, not per-worker and not per-request.

## Proof

- `form/form-kernel-rust/examples/router-bml-proof.bml` — a working BML-authored manifest (a multi-step integer aggregator `(3*2)+(5*1)+(7*4)=39`, an input-driven counter, liveness — all in `def name(args) = expr;` surface syntax).
- `form/form-kernel-rust/router_bml_proof_harness.py` — each BML route serves the correct value in Form (`X-Form-Router: native-kernel`, no CPython) **and EQUAL to the same handler authored in S-expression** (an oracle on a second port). The tail fans out to a mock CPython upstream. Startup log named the source-compile.

```
[bml-native] /health            -> 200 'ok' native-kernel ==oracle('ok')  OK
[bml-native] /weighted_sum      -> 200 '39' native-kernel ==oracle('39')  OK
[bml-native] /count_signals?... -> 200 '3'  native-kernel ==oracle('3')   OK
[bml-fanout] /api/ideas         -> 200 via CPython fanout-python           OK
startup log named the BML source-compile: OK
```

## Doc correction

`kernels/KERNEL_AS_ROUTER.md` "BML preference" said *"serving a BML-authored manifest needs the Form surface parser in Rust"* — corrected to present-tense: the parser exists in Form-stdlib and the router serves a BML manifest through source-compile-at-load.

## Honest scope

- Integer/string handlers cross the source-compiler's `.fkb` artifact intact. A BML **float-literal** handler is the next breath: the compiler can lower a float in-process, but the `.fkb` format carries a float as an overflow-table index, not the value, so a lowered float does not yet survive the cross-kernel round-trip (a float-value embedding across all three kernels' artifact (de)serializers is the named build). S-expression manifests serve floats today (the kernel's `.fk` source reader reads float tokens directly).
- **NO production routing flip.** FastAPI stays the live front door; this matures the serve primitive only.

## Verification

- `cargo build --release` green.
- `cd form && ./validate.sh` (full three-way): **263 ok, 0 divergent** (the existing `bml-thesis-*`, `compression-fold-band`, and source-section bands that exercise the BML parser/source-compiler all pass).
- Existing S-expression manifest unchanged: it has no `section [...]`, so it never touches the compiler; `router_proof_harness.py` shape intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)