### PR TITLE
feat(form): carry float64 VALUE through the .fkb artifact wire format (three-way)

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -4209,6 +4209,14 @@ func runBench() {
 const (
 	formBinaryLeaf      uint32 = 0
 	formBinaryComposite uint32 = 1
+	// FLOAT64 carries its VALUE, not its index. A float64 trivial NodeID's
+	// Inst is a per-kernel f64s-table index — meaningless in another kernel.
+	// So a float node serializes as [formBinaryFloat64][8 bytes IEEE-754
+	// little-endian] and each kernel re-interns the value on read (fresh
+	// local index). The dedicated tag also sidesteps the divergent per-kernel
+	// float type numbering (Rust TrivFloat64=5, Go/TS=7): the value travels
+	// in bytes, not the index nor the local type-tag.
+	formBinaryFloat64 uint32 = 2
 )
 
 func pushU32(bytes []byte, v uint32) []byte {
@@ -4223,6 +4231,27 @@ func readU32(bytes []byte, pos int) (uint32, int) {
 	return v, pos + 4
 }
 
+// pushF64LE — append an IEEE-754 f64 as 8 little-endian bytes (the payload of
+// a formBinaryFloat64 node). Sibling parity with Rust/TS little-endian writers.
+func pushF64LE(bytes []byte, f float64) []byte {
+	bits := math.Float64bits(f)
+	return append(bytes,
+		byte(bits), byte(bits>>8), byte(bits>>16), byte(bits>>24),
+		byte(bits>>32), byte(bits>>40), byte(bits>>48), byte(bits>>56))
+}
+
+func readF64LE(bytes []byte, pos int) (float64, int) {
+	bits := uint64(bytes[pos]) |
+		uint64(bytes[pos+1])<<8 |
+		uint64(bytes[pos+2])<<16 |
+		uint64(bytes[pos+3])<<24 |
+		uint64(bytes[pos+4])<<32 |
+		uint64(bytes[pos+5])<<40 |
+		uint64(bytes[pos+6])<<48 |
+		uint64(bytes[pos+7])<<56
+	return math.Float64frombits(bits), pos + 8
+}
+
 func serializeNid(k *Kernel, nid NodeID, bytes []byte) []byte {
 	if r, ok := k.byID[nid]; ok {
 		bytes = pushU32(bytes, formBinaryComposite)
@@ -4231,6 +4260,11 @@ func serializeNid(k *Kernel, nid NodeID, bytes []byte) []byte {
 		for _, c := range r.Children {
 			bytes = serializeNid(k, c, bytes)
 		}
+		return bytes
+	}
+	if nid.Level == LevelTrivial && nid.Type == TrivFloat64 {
+		bytes = pushU32(bytes, formBinaryFloat64)
+		bytes = pushF64LE(bytes, k.decodeFloat64(nid.Inst))
 		return bytes
 	}
 	bytes = pushU32(bytes, formBinaryLeaf)
@@ -4243,6 +4277,11 @@ func serializeNid(k *Kernel, nid NodeID, bytes []byte) []byte {
 
 func deserializeNid(k *Kernel, bytes []byte, pos int, scope uint32) (NodeID, int) {
 	tag, pos := readU32(bytes, pos)
+	if tag == formBinaryFloat64 {
+		var value float64
+		value, pos = readF64LE(bytes, pos)
+		return k.internTrivialFloat64(value), pos
+	}
 	if tag == formBinaryLeaf {
 		var pkg, level, ty, inst uint32
 		pkg, pos = readU32(bytes, pos)
@@ -4347,6 +4386,14 @@ func deserializeArtifact(k *Kernel, bytes []byte) (NodeID, error) {
 
 func deserializeNidWithStrings(k *Kernel, bytes []byte, pos int, stringsTable []string, scope uint32) (NodeID, int) {
 	tag, pos := readU32(bytes, pos)
+	if tag == formBinaryFloat64 {
+		if pos+8 > len(bytes) {
+			panic("form binary: truncated float64")
+		}
+		var value float64
+		value, pos = readF64LE(bytes, pos)
+		return k.internTrivialFloat64(value), pos
+	}
 	if tag == formBinaryLeaf {
 		var pkg, level, ty, inst uint32
 		pkg, pos = readU32(bytes, pos)

--- a/form/form-kernel-rust/examples/router-bml-proof.bml
+++ b/form/form-kernel-rust/examples/router-bml-proof.bml
@@ -18,9 +18,10 @@
 ; ordinary Form before the kernel serves a request. In this dialect each
 ; `def name(args) = expr;` is a single line (the multi-line shape is the block
 ; form `def name(args) { ... }`); the expressions nest `if c then a else b` and
-; `f(a, b)` calls freely. The compute here is integer/string — the values cross
-; the source compiler's .fkb artifact intact; a BML float-literal handler is a
-; further breath (see KERNEL_AS_ROUTER.md "BML preference").
+; `f(a, b)` calls freely. Integer, string, AND float values cross the source
+; compiler's .fkb artifact intact: a float trivial node carries its IEEE-754
+; value in the wire format (not a per-kernel overflow-table index), so the
+; float-literal handler below serves the right value (see KERNEL_AS_ROUTER.md).
 
 section [form.bml] {
     ; tiny alist helper: value for `key` in a list of (k v) string pairs
@@ -44,8 +45,16 @@ section [form.bml] {
 
     def route_count_signals(q) = if eq(str_len(assoc("values", q)), 0) then "0" else int_to_str(add(count_commas(assoc("values", q), 0, 0), 1));
 
+    ; NATIVE handler 4: a FLOAT handler. Real float arithmetic in Form — the
+    ; weighted average (0.5*0.25 + 1.0*0.75) of two coherence weights, = 0.875.
+    ; The float literals and the float result lower through the source compiler's
+    ; .fkb artifact (the routes binding is reconstituted via read_form_binary), so
+    ; this route proves a BML float survives the artifact round-trip end-to-end:
+    ; the handler returns a Value::Float, the router renders it as the body.
+    def route_coherence_weight() = add(mul(0.5, 0.25), mul(1.0, 0.75));
+
     ; the route manifest: (path handler). Everything not here fans out. The
     ; kernel resolves this top-level `routes` binding exactly as it does for the
     ; S-expression manifest — the BML section lowered it to the same shape.
-    let routes = list(list("/health", route_health), list("/weighted_sum", route_weighted_sum), list("/count_signals", route_count_signals));
+    let routes = list(list("/health", route_health), list("/weighted_sum", route_weighted_sum), list("/count_signals", route_count_signals), list("/coherence_weight", route_coherence_weight));
 }

--- a/form/form-kernel-rust/router_bml_proof_harness.py
+++ b/form/form-kernel-rust/router_bml_proof_harness.py
@@ -20,9 +20,13 @@ What it spins up:
      touches NO production routing.
 
 What it asserts:
-  - the BML-authored native routes (/health, /weighted_sum, /count_signals)
-    return the BML handler's value with header X-Form-Router: native-kernel —
-    the kernel served them in Form, NO CPython hop, the handler authored in BML.
+  - the BML-authored native routes (/health, /weighted_sum, /coherence_weight,
+    /count_signals) return the BML handler's value with header X-Form-Router:
+    native-kernel — the kernel served them in Form, NO CPython hop, the handler
+    authored in BML. /coherence_weight is a FLOAT route: its float literals and
+    float result lower through the source compiler's .fkb artifact (which now
+    carries float VALUES, not per-kernel overflow-table indices), so a BML
+    float-literal handler serves the correct value (0.875) end-to-end.
   - the BML answer EQUALS the S-expression oracle's answer for the same route —
     BML surface syntax lowered to the same Form shape an S-expr handler is.
   - a non-native path FANS OUT to the CPython upstream (X-Form-Router:
@@ -79,6 +83,9 @@ ORACLE_SEXPR = """
 (defn route_weighted_sum ()
   (int_to_str (add (add (mul 3 2) (mul 5 1)) (mul 7 4))))
 
+(defn route_coherence_weight ()
+  (add (mul 0.5 0.25) (mul 1.0 0.75)))
+
 (defn count_commas (s i n)
   (if (eq i (str_len s))
       n
@@ -92,9 +99,10 @@ ORACLE_SEXPR = """
 
 (let routes
   (list
-    (list "/health"        route_health)
-    (list "/weighted_sum"  route_weighted_sum)
-    (list "/count_signals" route_count_signals)))
+    (list "/health"          route_health)
+    (list "/weighted_sum"    route_weighted_sum)
+    (list "/count_signals"   route_count_signals)
+    (list "/coherence_weight" route_coherence_weight)))
 """
 
 
@@ -209,6 +217,7 @@ def main() -> int:
         cases = [
             "/health",
             "/weighted_sum",
+            "/coherence_weight",  # FLOAT route: 0.5*0.25 + 1.0*0.75 = 0.875
             "/count_signals?values=0.5,0.75,1.0",
             "/count_signals?values=a",
             "/count_signals",  # no values -> "0"

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -8376,8 +8376,23 @@ fn read_u32(bytes: &[u8], pos: usize) -> (u32, usize) {
     (v, pos + 4)
 }
 
+// read_f64_le — 8-byte IEEE-754 little-endian f64, the payload of a
+// FORM_BINARY_FLOAT64 node. Sibling parity with Go/TS little-endian readers.
+fn read_f64_le(bytes: &[u8], pos: usize) -> (f64, usize) {
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&bytes[pos..pos + 8]);
+    (f64::from_le_bytes(buf), pos + 8)
+}
+
 const FORM_BINARY_LEAF: u32 = 0;
 const FORM_BINARY_COMPOSITE: u32 = 1;
+// FLOAT64 carries its VALUE, not its index. A float64 trivial NodeID's `inst`
+// is a per-kernel f64s-table index — meaningless in another kernel. So a float
+// node serializes as [FORM_BINARY_FLOAT64][8 bytes IEEE-754 little-endian] and
+// each kernel re-interns the value on read (fresh local index). The dedicated
+// tag also sidesteps the divergent per-kernel float `ty` numbering (Rust 5,
+// Go/TS 7): the value, not the index nor the local type-tag, travels in bytes.
+const FORM_BINARY_FLOAT64: u32 = 2;
 
 fn serialize_nid(k: &Kernel, nid: NodeID, bytes: &mut Vec<u8>) {
     if let Some(recipe) = k.by_id.get(&nid) {
@@ -8387,6 +8402,9 @@ fn serialize_nid(k: &Kernel, nid: NodeID, bytes: &mut Vec<u8>) {
         for &c in &recipe.children {
             serialize_nid(k, c, bytes);
         }
+    } else if nid.level == LEVEL_TRIVIAL && nid.ty == TRIV_FLOAT64 {
+        push_u32(bytes, FORM_BINARY_FLOAT64);
+        bytes.extend_from_slice(&k.decode_float64(nid.inst).to_le_bytes());
     } else {
         push_u32(bytes, FORM_BINARY_LEAF);
         push_u32(bytes, nid.pkg);
@@ -8398,6 +8416,10 @@ fn serialize_nid(k: &Kernel, nid: NodeID, bytes: &mut Vec<u8>) {
 
 fn deserialize_nid(k: &mut Kernel, bytes: &[u8], pos: usize, scope: u32) -> (NodeID, usize) {
     let (tag, p) = read_u32(bytes, pos);
+    if tag == FORM_BINARY_FLOAT64 {
+        let (value, p) = read_f64_le(bytes, p);
+        return (k.intern_trivial_float64(value), p);
+    }
     if tag == FORM_BINARY_LEAF {
         let (pkg, p) = read_u32(bytes, p);
         let (level, p) = read_u32(bytes, p);
@@ -8491,6 +8513,13 @@ fn deserialize_nid_with_strings(
     scope: u32,
 ) -> Result<(NodeID, usize), String> {
     let (tag, p) = read_u32(bytes, pos);
+    if tag == FORM_BINARY_FLOAT64 {
+        if p + 8 > bytes.len() {
+            return Err("form binary: truncated float64".to_string());
+        }
+        let (value, p) = read_f64_le(bytes, p);
+        return Ok((k.intern_trivial_float64(value), p));
+    }
     if tag == FORM_BINARY_LEAF {
         let (pkg, p) = read_u32(bytes, p);
         let (level, p) = read_u32(bytes, p);

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -4195,6 +4195,13 @@ const FORM_BINARY_MAGIC_V1 = Buffer.from("FORMBIN1", "ascii");
 const FORM_BINARY_MAGIC = Buffer.from("FORMBIN2", "ascii");
 const FORM_BINARY_LEAF = 0;
 const FORM_BINARY_COMPOSITE = 1;
+// FLOAT64 carries its VALUE, not its index. A float64 trivial NodeID's `inst`
+// is a per-kernel f64s-table index — meaningless in another kernel. So a float
+// node serializes as [FORM_BINARY_FLOAT64][8 bytes IEEE-754 little-endian] and
+// each kernel re-interns the value on read (fresh local index). The dedicated
+// tag also sidesteps the divergent per-kernel float type numbering (Rust
+// FLOAT64=5, Go/TS=7): the value travels in bytes, not the index nor the tag.
+const FORM_BINARY_FLOAT64 = 2;
 
 function pushU32(out: number[], v: number): void {
   const n = v >>> 0;
@@ -4211,6 +4218,21 @@ function readU32(bytes: Uint8Array, pos: number): [number, number] {
   return [v >>> 0, pos + 4];
 }
 
+// pushF64LE / readF64LE — an IEEE-754 f64 as 8 little-endian bytes (the payload
+// of a FORM_BINARY_FLOAT64 node). Sibling parity with Rust/Go little-endian.
+function pushF64LE(out: number[], f: number): void {
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, f, true);
+  for (let i = 0; i < 8; i++) out.push(view.getUint8(i));
+}
+
+function readF64LE(bytes: Uint8Array, pos: number): [number, number] {
+  if (pos + 8 > bytes.length) throw new Error("form binary: truncated float64");
+  const view = new DataView(new ArrayBuffer(8));
+  for (let i = 0; i < 8; i++) view.setUint8(i, bytes[pos + i]!);
+  return [view.getFloat64(0, true), pos + 8];
+}
+
 function serializeNode(k: Kernel, nid: NodeID, out: number[]): void {
   const recipe = k.recipeAt(nid);
   if (recipe) {
@@ -4218,6 +4240,11 @@ function serializeNode(k: Kernel, nid: NodeID, out: number[]): void {
     serializeNode(k, recipe.category, out);
     pushU32(out, recipe.children.length);
     for (const child of recipe.children) serializeNode(k, child, out);
+    return;
+  }
+  if (nid.level === Level.TRIVIAL && nid.type === Triv.FLOAT64) {
+    pushU32(out, FORM_BINARY_FLOAT64);
+    pushF64LE(out, k.decodeFloat64(nid.inst));
     return;
   }
   pushU32(out, FORM_BINARY_LEAF);
@@ -4230,6 +4257,11 @@ function serializeNode(k: Kernel, nid: NodeID, out: number[]): void {
 function deserializeRawNode(k: Kernel, bytes: Uint8Array, pos: number, scope: number): [NodeID, number] {
   let tag: number;
   [tag, pos] = readU32(bytes, pos);
+  if (tag === FORM_BINARY_FLOAT64) {
+    let value: number;
+    [value, pos] = readF64LE(bytes, pos);
+    return [k.internTrivialFloat64(value), pos];
+  }
   if (tag === FORM_BINARY_LEAF) {
     let pkg: number;
     let level: number;
@@ -4263,6 +4295,11 @@ function deserializeNode(
 ): [NodeID, number] {
   let tag: number;
   [tag, pos] = readU32(bytes, pos);
+  if (tag === FORM_BINARY_FLOAT64) {
+    let value: number;
+    [value, pos] = readF64LE(bytes, pos);
+    return [k.internTrivialFloat64(value), pos];
+  }
   if (tag === FORM_BINARY_LEAF) {
     let pkg: number;
     let level: number;

--- a/form/form-samples/float-artifact-roundtrip.fk
+++ b/form/form-samples/float-artifact-roundtrip.fk
@@ -1,0 +1,35 @@
+; float-artifact-roundtrip.fk — a float survives the .fkb artifact wire format.
+;
+; The .fkb wire format serializes a trivial node by walking its Recipe tree.
+; A float64 trivial node's `inst` is a per-kernel f64s-overflow-table INDEX —
+; meaningless in another kernel. So the wire format embeds the float VALUE: a
+; float64 node serializes as [FLOAT64-tag][8 bytes IEEE-754 little-endian], and
+; each kernel re-interns the value on read (a fresh LOCAL index). Values travel
+; in bytes; indices stay local. This band round-trips a float through
+; recipe_to_bytes -> bytes_to_recipe and confirms the value survives EXACTLY,
+; three-way (Rust == Go == TS, bit-identical), both as a bare leaf and nested
+; inside a composite Recipe — the shape a BML float-literal route lowers to.
+;
+; The proof command is the sibling gate: cd form && ./validate.sh
+;
+; Expected output: 0.8125 — the float recovered from the artifact, unchanged.
+; (A lost value would emit a different number or diverge across kernels; a
+; structurally-broken round-trip emits the -1.0 sentinel.)
+(do
+    ;; intern 0.8125 (binary-exact: 13/16, no rounding) and round-trip the bare
+    ;; float NODE through the artifact bytes.
+    (let original (intern_trivial_float "0.8125"))
+    (let leaf-back (bytes_to_recipe (recipe_to_bytes original)))
+
+    ;; nest the same float inside a composite Recipe and round-trip THAT — the
+    ;; realistic case (a float literal living in a route handler's tree). Pull
+    ;; the float child back out after the round-trip.
+    (let wrapped (intern_node (intern_trivial_string "weight") (list original)))
+    (let wrapped-back (bytes_to_recipe (recipe_to_bytes wrapped)))
+    (let nested-back (head (node_children wrapped-back)))
+
+    ;; both recoveries must content-address back to the ORIGINAL float (equal
+    ;; value -> equal local index under content-addressing -> node_eq true).
+    (if (and (node_eq leaf-back original) (node_eq nested-back original))
+        (float_value leaf-back)   ;; emit the recovered value: 0.8125
+        -1.0))                    ;; sentinel: the value did not survive

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -254,6 +254,38 @@
                 (and (gt (str_len value) 1) (fsc-int-loop? value 1))
                 (fsc-int-loop? value 0)))))
 
+    ;; fsc-float? — a decimal float literal: optional leading "-", digits, one
+    ;; ".", digits (e.g. "0.5", "-1.25"). Digits on both sides of the dot, exactly
+    ;; one dot. The form.bml expr compiler interns these as trivial float nodes
+    ;; (intern_trivial_float); the wire format carries the f64 value through the
+    ;; .fkb artifact the router reconstitutes from, so a BML float route serves.
+    (defn fsc-float-dot-loop? (s i seen-dot)
+        (if (ge i (str_len s)) seen-dot
+            (do
+                (let ch (char_at s i))
+                (if (str_eq ch ".")
+                    (if seen-dot false (fsc-float-dot-loop? s (add i 1) true))
+                    (if (fsc-digit? ch)
+                        (fsc-float-dot-loop? s (add i 1) seen-dot)
+                        false)))))
+
+    (defn fsc-float-body? (body)
+        ;; need at least one digit before AND after the dot: shortest is "d.d"
+        ;; (len 3), first and last chars are digits, exactly one dot inside.
+        (if (lt (str_len body) 3) false
+        (if (fsc-digit? (char_at body 0))
+        (if (fsc-digit? (char_at body (sub (str_len body) 1)))
+            (fsc-float-dot-loop? body 0 false)
+            false) false)))
+
+    (defn fsc-float? (s)
+        (do
+            (let value (fsc-trim s))
+            (if (eq (str_len value) 0) false
+            (if (str_eq (char_at value 0) "-")
+                (fsc-float-body? (fsc-sub value 1 (str_len value)))
+                (fsc-float-body? value)))))
+
     (defn fsc-bml-find-comma-loop (s i depth quoted)
         (if (ge i (str_len s)) (sub 0 1)
             (do
@@ -657,11 +689,12 @@
             (if (str_eq expr "true")  (fsc-rec-true)
             (if (str_eq expr "false") (fsc-rec-false)
             (if (str_eq expr "null")  (fsc-rec-ident "null")
+            (if (fsc-float? expr) (intern_trivial_float expr)
             (if (fsc-int? expr) (intern_trivial_int (str_to_int expr))
             (if (str_eq (char_at expr 0) "\"")
                 (intern_trivial_string
                     (fsc-unescape-str (fsc-sub expr 1 (fsc-last-char-index expr))))
-                (fsc-rec-ident expr))))))))))))
+                (fsc-rec-ident expr)))))))))))))
 
     (defn fsc-compile-form-bml-def-recipe (line)
         (do

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -265,20 +265,23 @@ S-expression — the BML surface lowered to the same Form shape. A raw
 S-expression manifest is unchanged: it has no `section [...]`, so it never
 touches the source-compiler and `read_root_from_source` reads it directly.
 
-Honest scope of the BML authoring path as it stands: the `form.bml` dialect
-lowers `def name(args) = expr;` (single-line), the block form `def name(args)
-{ ... }`, nested `if c then a else b`, `f(a, b)` calls, and integer/string
-literals — the proof's handlers (a multi-step integer aggregator, an
-input-driven counter, liveness) are authored in it and their values cross the
-source-compiler's `.fkb` artifact intact. A BML **float-literal** handler is the
-next breath: the compiler can lower a float in-process, but the `.fkb` artifact
-format carries a float as an overflow-table index, not the value, so a lowered
-float does not yet survive the cross-kernel round-trip (a float-value embedding
-across all three kernels' artifact (de)serializers is the named build).
-An S-expression manifest serves floats today — the kernel's `.fk` source reader
-reads float tokens directly (the existing `router-proof.fk`'s 0.8125
-coherence-weight is one) — so float routes have a path; only the BML→`.fkb` route
-waits on that artifact change.
+Honest scope of the BML authoring path: the `form.bml` dialect lowers `def
+name(args) = expr;` (single-line), the block form `def name(args) { ... }`,
+nested `if c then a else b`, `f(a, b)` calls, and integer, string, AND float
+literals. The proof's handlers — a multi-step integer aggregator, an
+input-driven counter, liveness, and a **float** route (`route_coherence_weight`,
+`0.5*0.25 + 1.0*0.75 = 0.875`) — are authored in it, and their values cross the
+source-compiler's `.fkb` artifact intact. A float trivial node carries its
+IEEE-754 value in the wire format (a dedicated `FORM_BINARY_FLOAT64` node tag
+followed by 8 little-endian bytes), so the value travels in the bytes and each
+kernel re-interns it into its own overflow table on read — the per-kernel table
+index never crosses the wire. The float-literal route therefore serves the
+correct value end-to-end (`router_bml_proof_harness.py` checks `/coherence_weight
+-> 0.875`, `native-kernel`), and the artifact round-trip is bit-identical across
+Rust, Go, and TS (`form-samples/float-artifact-roundtrip.fk`). An S-expression
+manifest serves floats the same way — the kernel's `.fk` source reader reads
+float tokens directly (the existing `router-proof.fk`'s 0.8125 coherence-weight
+is one).
 
 Either way the handler is Form, walked by the kernel — never a Python function
 the kernel calls. That is the point of the reversal: the front door speaks the


### PR DESCRIPTION
## The gap

A float64 trivial node's `inst` is a per-kernel `f64s` overflow-table **index** — meaningless in another kernel. The `.fkb` wire format serialized a node by its NodeID, so a float crossed `recipe_to_bytes`→`bytes_to_recipe` (and `write_form_binary`→`read_form_binary`) as an index into the *writer's* table, not its value. A BML float-literal route, source-compiled-at-load to a `.fkb`, lost its float — the blocker named in `kernels/KERNEL_AS_ROUTER.md`.

## The fix — value travels, index stays local

A float64 trivial node now serializes as a dedicated node tag `FORM_BINARY_FLOAT64 = 2` followed by **8 IEEE-754 little-endian bytes**. On read, each kernel re-interns the value into its OWN overflow table (fresh local index). The value travels in the bytes; the index is kernel-local and re-derived on read.

The dedicated tag also sidesteps a real cross-kernel divergence: the per-kernel float type numbering differs (Rust `TRIV_FLOAT64 = 5`, Go/TS `= 7`; and `ty = 5` is `INT64` in Go/TS). Neither the index nor the local type-tag crosses the wire — only the value. Mirrored exactly across the **3 serialize + 3 deserialize** sites; int/string encoding unchanged (they already round-trip). No committed `.fkb` contains a float, so no stored artifact breaks; no magic version bump needed.

The `form.bml` router dialect now also lexes float literals (`fsc-float?` → `intern_trivial_float`) — the missing surface half, so a BML float-literal handler lowers to a float node that survives the artifact the router reconstitutes from.

## Proof

- **`form-samples/float-artifact-roundtrip.fk`** round-trips a float through the artifact (bare leaf + nested in a composite) and emits `0.8125` bit-identical across Rust/Go/TS via `validate.sh`.
- **Literal cross-kernel A→B**: Rust writes a float `.fkb`, Go and TS read back `0.8125` (and the reverse direction); the `FORM_BINARY_FLOAT64` tag+payload bytes are byte-identical across all three writers.
- **`router_bml_proof_harness.py`** serves `/coherence_weight` (`0.5*0.25 + 1.0*0.75`) → `0.875`, `X-Form-Router: native-kernel`, equal to the S-expression oracle — a BML float-literal route serves end-to-end, no CPython.
- **`validate.sh`: 264 ok, 0 divergent** — int/string round-trip not regressed; the source-compiler / BML bands still pass three-way.

## Scope / honesty

Kernel + form-stdlib change only; `cli_serve` serves no production route — **no production routing flip**. Wire-format change is to the float-node encoding only; int/string nodes and the `FORMBIN2` magic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)