### PR TITLE
attune(kernels): align Rust float trivial type-tags to the Go/TS majority

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -130,10 +130,10 @@ const (
 	// so the inst carries an index into the kernel's `f64s` overflow table.
 	// Canonicalization on intern: NaN bit patterns collapse to qNaN, -0.0
 	// collapses to +0.0, ±Inf stay distinct (mirrors Rust + TS sibling
-	// kernels). Matches TS kernel's Triv.FLOAT64 = 7. (The Rust kernel uses
-	// 5 for FLOAT64 internally — each kernel's trivial-type constants are
-	// private to its substrate; cross-kernel parity rides on .fk source
-	// where the token shape — digits+dot vs digits — names the type.)
+	// kernels). The trivial float type tags are aligned three-way — Rust,
+	// Go, and TS all carry FLOAT32 = 6 and FLOAT64 = 7. Cross-kernel parity
+	// also rides on .fk source, where the token shape (digits+dot vs digits)
+	// names the type, and on the .fkb value-carrying float record.
 	TrivFloat64 uint32 = 7
 )
 
@@ -4213,9 +4213,10 @@ const (
 	// Inst is a per-kernel f64s-table index — meaningless in another kernel.
 	// So a float node serializes as [formBinaryFloat64][8 bytes IEEE-754
 	// little-endian] and each kernel re-interns the value on read (fresh
-	// local index). The dedicated tag also sidesteps the divergent per-kernel
-	// float type numbering (Rust TrivFloat64=5, Go/TS=7): the value travels
-	// in bytes, not the index nor the local type-tag.
+	// local index). The trivial float type tag (FLOAT64 = 7 three-way) never
+	// rides the wire either: the value travels in bytes, not the index nor
+	// the local type-tag, so the .fkb stays portable regardless of how each
+	// kernel numbers its trivial types.
 	formBinaryFloat64 uint32 = 2
 )
 

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -239,13 +239,20 @@ pub(crate) const TRIV_INT: u32 = 1;
 pub(crate) const TRIV_STRING: u32 = 2;
 const TRIV_BOOL: u32 = 3;
 const TRIV_NULL: u32 = 4;
-// FLOAT64 — value lives in the kernel's `f64s` overflow table; the inst
-// field carries the table index. Sibling TS kernel uses Triv.FLOAT64 = 7;
-// we use 5 here because the Rust kernel never shipped 8/16/32 variants and
-// FLOAT64 is the next number after NULL. Both kernels read .fk source where
-// the type tag is implicit in token shape (digits+dot vs digits), so the
-// numeric constants stay private to each side.
-pub(crate) const TRIV_FLOAT64: u32 = 5;
+// FLOAT32 — IEEE 754 32-bit value stored inline; the inst field carries the
+// IEEE bit pattern reinterpreted as u32. No overflow table needed (32 bits fit
+// the 32-bit inst slot). This kernel parses float literals only as float64, so
+// nothing here CREATES a float32; the type + intern + decode exist so a float32
+// leaf written by a sibling kernel reads back the same value. Aligned three-way:
+// FLOAT32 = 6 across Rust/Go/TS.
+pub(crate) const TRIV_FLOAT32: u32 = 6;
+// FLOAT64 — value lives in the kernel's `f64s` overflow table (64 bits exceed
+// the 32-bit inst slot); the inst field carries the table index. Aligned
+// three-way: FLOAT64 = 7 across Rust/Go/TS. The .fkb wire format never puts
+// this tag on the wire — a float64 node serializes via the dedicated
+// FORM_BINARY_FLOAT64 record carrying the 8-byte value, so cross-kernel
+// portability rides on the value, not the type constant.
+pub(crate) const TRIV_FLOAT64: u32 = 7;
 
 // Per-RBasic instance constants
 const RMATH_PLUS: u32 = 1;
@@ -791,6 +798,32 @@ impl Kernel {
             .unwrap_or_else(|| panic!("decode_float64: bad index {}", inst))
     }
 
+    // intern_trivial_float32 — IEEE 754 32-bit inline encoding. The float's bit
+    // pattern (via f32::to_bits) lives directly in the inst slot; no overflow
+    // table needed. Two f32 values with the same bit pattern share the same
+    // NodeID by construction. NaN bit patterns are NOT canonicalized here (f32
+    // NaNs are uncommon at the substrate boundary); a typed-numeric layer above
+    // collapses them if needed. Sibling parity with Go/TS internTrivialFloat32.
+    // This kernel never CREATES a float32 (float literals parse as float64); the
+    // primitive exists so a float32 leaf from a sibling kernel reads back here.
+    // Uncalled in Rust by design — the decode side (decode_float32, the
+    // TRIV_FLOAT32 dispatch arms) carries the read-parity; this is the symmetric
+    // constructor kept for sibling parity with Go/TS internTrivialFloat32.
+    #[allow(dead_code)]
+    pub(crate) fn intern_trivial_float32(&self, f: f32) -> NodeID {
+        NodeID {
+            pkg: 1,
+            level: LEVEL_TRIVIAL,
+            ty: TRIV_FLOAT32,
+            inst: f.to_bits(),
+        }
+    }
+
+    // decode_float32 — read back the IEEE bit pattern from the inst slot.
+    pub(crate) fn decode_float32(&self, inst: u32) -> f32 {
+        f32::from_bits(inst)
+    }
+
     pub(crate) fn intern_string(&mut self, s: &str) -> NodeID {
         if let Some(&idx) = self.str_idx.get(s) {
             return NodeID {
@@ -1096,6 +1129,7 @@ impl Kernel {
             TRIV_STRING => Value::Str(self.strs[n.inst as usize].clone()),
             TRIV_BOOL => Value::Bool(n.inst != 0),
             TRIV_NULL => Value::Null,
+            TRIV_FLOAT32 => Value::Float(self.decode_float32(n.inst) as f64),
             TRIV_FLOAT64 => Value::Float(self.decode_float64(n.inst)),
             _ => panic!("trivial_value: unknown trivial type {}", n.ty),
         }
@@ -3843,6 +3877,7 @@ impl Kernel {
         self.register_native("float_value", cat_method(), |k, _, args| {
             let n = args[0].as_nid();
             match n.ty {
+                TRIV_FLOAT32 => Value::Float(k.decode_float32(n.inst) as f64),
                 TRIV_FLOAT64 => Value::Float(k.decode_float64(n.inst)),
                 _ => panic!("float_value expects a float NodeID"),
             }
@@ -4534,7 +4569,7 @@ fn emit_expr(k: &Kernel, n: NodeID, scope: &mut EmitScope<'_>) -> Option<Emitted
             } else {
                 "false".to_string()
             })),
-            // STRING / NULL / FLOAT64 — not on the JIT path.
+            // STRING / NULL / FLOAT32 / FLOAT64 — not on the JIT path.
             _ => None,
         };
     }
@@ -8389,9 +8424,10 @@ const FORM_BINARY_COMPOSITE: u32 = 1;
 // FLOAT64 carries its VALUE, not its index. A float64 trivial NodeID's `inst`
 // is a per-kernel f64s-table index — meaningless in another kernel. So a float
 // node serializes as [FORM_BINARY_FLOAT64][8 bytes IEEE-754 little-endian] and
-// each kernel re-interns the value on read (fresh local index). The dedicated
-// tag also sidesteps the divergent per-kernel float `ty` numbering (Rust 5,
-// Go/TS 7): the value, not the index nor the local type-tag, travels in bytes.
+// each kernel re-interns the value on read (fresh local index). The trivial
+// float `ty` numbering is aligned three-way (FLOAT64 = 7 across Rust/Go/TS),
+// and it never rides the wire anyway: the value, not the index nor the local
+// type-tag, travels in bytes, so the .fkb stays portable by construction.
 const FORM_BINARY_FLOAT64: u32 = 2;
 
 fn serialize_nid(k: &Kernel, nid: NodeID, bytes: &mut Vec<u8>) {

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -4198,9 +4198,10 @@ const FORM_BINARY_COMPOSITE = 1;
 // FLOAT64 carries its VALUE, not its index. A float64 trivial NodeID's `inst`
 // is a per-kernel f64s-table index — meaningless in another kernel. So a float
 // node serializes as [FORM_BINARY_FLOAT64][8 bytes IEEE-754 little-endian] and
-// each kernel re-interns the value on read (fresh local index). The dedicated
-// tag also sidesteps the divergent per-kernel float type numbering (Rust
-// FLOAT64=5, Go/TS=7): the value travels in bytes, not the index nor the tag.
+// each kernel re-interns the value on read (fresh local index). The trivial
+// float type tag (FLOAT64 = 7 three-way across Rust/Go/TS) never rides the wire
+// either: the value travels in bytes, not the index nor the local type-tag, so
+// the .fkb stays portable regardless of how each kernel numbers its types.
 const FORM_BINARY_FLOAT64 = 2;
 
 function pushU32(out: number[], v: number): void {

--- a/form/form-stdlib/tests/float-natives-band.fk
+++ b/form/form-stdlib/tests/float-natives-band.fk
@@ -1,11 +1,11 @@
 ; float-natives-band.fk — three-way sibling parity for IEEE 754 floats.
 ;
-; The kernels carry float64 trivials in distinct shapes (Rust uses TRIV
-; type tag 5, TypeScript uses 7, Go uses 7) but the .fk source sees one
-; surface: `1.5` is a float, `1` is an int. This band exercises that
-; surface across every operation Form code can perform on floats today
-; through paths that produce identical integer-aggregate output in all
-; three sibling kernels — Go, Rust, TypeScript.
+; The trivial type space is aligned three-way: FLOAT32 = 6, FLOAT64 = 7
+; across Rust, Go, and TypeScript. The .fk source sees one surface — `1.5`
+; is a float, `1` is an int — and the in-kernel NodeID type tag now agrees
+; too (asserted below). This band exercises that surface across every
+; operation Form code can perform on floats today through paths that
+; produce identical integer-aggregate output in all three sibling kernels.
 ;
 ; What's tested through three-way agreement:
 ;
@@ -34,15 +34,16 @@
 ;     The band scores integers (or non-integer floats) only — no integer-
 ;     valued float ever crosses the print boundary.
 ;
-;   • Binary artifact mode (--binary). Every kernel serializes FLOAT64
-;     trivials with its private overflow-table index in the leaf's
-;     `inst` slot; cross-kernel deserialization can't read the value
-;     back without the table. The format-recipe migration in
-;     numeric-types-plan.md resolves this by carrying the IEEE bits
-;     directly under the format-recipe. This band runs in source mode
-;     only; --binary remains a separate breath.
+;   • Binary artifact mode (--binary) carries floats too. A FLOAT64 trivial
+; serializes through a dedicated wire record (FORM_BINARY_FLOAT64) holding
+; the 8-byte IEEE value, not the per-kernel overflow-table index — each
+; kernel re-interns the value on read with a fresh local index. So the
+; float survives the .fkb round-trip three-way (proven in
+; float-artifact-roundtrip.fk under both source and --binary modes). The
+; in-kernel type tag stays off the wire for floats; portability rides on
+; the value, not the constant.
 ;
-; The aggregate score is 1 per passing check; full pass = 24.
+; The aggregate score is 1 per passing check; full pass = 26.
 ;
 ; In service of `numeric-types-plan` (kernels carry one current-epoch
 ; IEEE 754 path while the substrate moves toward format-recipes) and
@@ -127,11 +128,29 @@
     (let s24        (if (lt pow-sqrt-2 1.4142136)
                         (if (gt pow-sqrt-2 1.4142135) 1 0) 0))
 
+    ;; ── 8. Trivial type-tag alignment — three-way agreement ───────
+    ;; A float64 trivial's NodeID type tag is 7 in every kernel (Rust
+    ;; was 5 before alignment; Go and TS were already 7). node_type
+    ;; reads the raw tag; this check fails three-way if any kernel
+    ;; drifts the FLOAT64 constant.
+    (let s25 (if (eq (node_type (intern_trivial_float "0.8125")) 7) 1 0))
+
+    ;; A float32 trivial's type tag is 6 three-way, and a float32 leaf
+    ;; reads back its IEEE value in every kernel. Rust never PRODUCES a
+    ;; float32 (float literals parse as float64; make_float32 is a Go/TS
+    ;; native), but Rust READS one: a hand-built type-6 leaf carrying the
+    ;; IEEE bits of 0.5f32 (0x3F000000 = 1056964608) decodes to 0.5 via
+    ;; float_value in all three kernels. Before alignment Rust panicked
+    ;; on type 6; now it recognizes float32 for sibling read-parity.
+    (let f32-leaf (make_nodeid 1 1 6 1056964608))
+    (let s26 (if (and (eq (node_type f32-leaf) 6)
+                      (eq (float_value f32-leaf) 0.5)) 1 0))
+
     ;; ── Aggregate — int + int through MATH (no float in result) ───
     ;; Every sub-score is 1 or 0; the sum flows through the I32 path
-    ;; in every kernel and prints as a plain integer. Full pass = 24.
+    ;; in every kernel and prints as a plain integer. Full pass = 26.
     (add s1 (add s2 (add s3 (add s4 (add s5
     (add s6 (add s7 (add s8 (add s9 (add s10
     (add s11 (add s12 (add s13 (add s14 (add s15
     (add s16 (add s17 (add s18 (add s19 (add s20
-    (add s21 (add s22 (add s23 s24))))))))))))))))))))))))
+    (add s21 (add s22 (add s23 (add s24 (add s25 s26))))))))))))))))))))))))))


### PR DESCRIPTION
## What

The trivial-NodeID `type` constants for floats genuinely diverged across the three Form kernels — a known-but-unreconciled inconsistency the Rust code itself documented:

| | FLOAT32 | FLOAT64 |
|---|---|---|
| **Rust (before)** | — (none) | **5** |
| Go | 6 | 7 |
| TS | 6 | 7 |

Any path that compared or reasoned about a float NodeID's *type* across kernels (outside the value-carrying `.fkb` record) saw two numbers for the same logical type — the same shape that bit float64 before #2401 started carrying the VALUE on the wire. Latent because the artifact path avoids the local tag, but a real landmine.

## The fix — align Rust to the Go/TS majority + documented intent

- **Rust `TRIV_FLOAT64`: 5 → 7.** Every use-site rides the named constant (`intern_trivial_float64`, `trivial_value` dispatch, `float_value` native, `serialize_nid`) — there was **no hardcoded 5** in the float path, so the tag change is safe. The type-5 slot is now unused, consistent with Go/TS.
- **Add Rust `TRIV_FLOAT32 = 6`** with `intern_trivial_float32` + `decode_float32` and dispatch arms in `trivial_value` / `float_value`. Honest scope: Rust never *produces* a float32 (literals parse as float64); this is **deserialize-recognition** so a float32 leaf written by a sibling kernel reads its IEEE value back instead of panicking on an unknown type. Full Rust float32 *interning* (a `make_float32` native, float32 literals) is a further breath.
- **Reconciled the stale divergence comments** across all three kernels (the Rust constant + serialize comments, two Go comments, one TS comment) to present-tense: `FLOAT32 = 6, FLOAT64 = 7` three-way.

## Wire format untouched

The `.fkb` carries the float VALUE via the dedicated `FORM_BINARY_FLOAT64` record, not the local type tag, so portability rides on the value — changing the constant does not touch the wire. **No production routing change.**

## Proof (three-way: Rust == Go == TS)

- Constants now match: `FLOAT32 = 6`, `FLOAT64 = 7` in all three kernels.
- `cargo build` + `go build` + `tsc --noEmit` all clean.
- `./validate.sh` (full) → **265 ok, 0 divergent**.
- `float-artifact-roundtrip.fk` → **0.8125** three-way, in both source and `--binary` mode (the #2401 work intact).
- `float-natives-band.fk` → **26** three-way, with two new checks: a float64 trivial's type tag is 7 in every kernel, and a hand-built type-6 leaf (IEEE bits of `0.5f32`) decodes to `0.5` in every kernel (Rust's float32 read-parity; it panicked on type 6 before).
- All three kernel binaries run the float demo and emit `0.8125`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)