### PR TITLE
attune(kernels): register make_float32 + make_float64 in Rust (three-way float-construction parity)

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -804,12 +804,11 @@ impl Kernel {
     // NodeID by construction. NaN bit patterns are NOT canonicalized here (f32
     // NaNs are uncommon at the substrate boundary); a typed-numeric layer above
     // collapses them if needed. Sibling parity with Go/TS internTrivialFloat32.
-    // This kernel never CREATES a float32 (float literals parse as float64); the
-    // primitive exists so a float32 leaf from a sibling kernel reads back here.
-    // Uncalled in Rust by design — the decode side (decode_float32, the
-    // TRIV_FLOAT32 dispatch arms) carries the read-parity; this is the symmetric
-    // constructor kept for sibling parity with Go/TS internTrivialFloat32.
-    #[allow(dead_code)]
+    // Float *literals* in .fk source still parse as float64; this constructor is
+    // reached when Form code explicitly asks for a float32 via the make_float32
+    // native (sibling of Go/TS make_float32), and the decode side
+    // (decode_float32, the TRIV_FLOAT32 dispatch arms) carries the read-parity.
+    // Constructor and decoder are now both live three-way.
     pub(crate) fn intern_trivial_float32(&self, f: f32) -> NodeID {
         NodeID {
             pkg: 1,
@@ -3873,6 +3872,22 @@ impl Kernel {
         self.register_native("intern_trivial_float", cat_witness(), |k, _, args| {
             let f: f64 = args[0].as_str().parse().unwrap_or(0.0);
             Value::Nid(k.intern_trivial_float64(f))
+        });
+        // make_float32 / make_float64 — intern a float-valued substrate trivial
+        // from a numeric arg (int or float, coerced via as_float). Sibling
+        // parity with Go (internTrivialFloat32/64 + VNodeID) and TS
+        // (internTrivialFloat32/64 + boxValue). Where intern_trivial_float takes
+        // the float's *source text*, these take the *value* — the verb Form code
+        // calls when it holds a number and wants the substrate identity of the
+        // typed float (FLOAT32 = type 6, FLOAT64 = type 7). Read back with
+        // float_value. 0.5 is exact in both widths, so make_float32(0.5) and
+        // make_float64(0.5) both decode to 0.5 three-way; the NODE-level type
+        // tag (6 vs 7) stays distinct even where the value-level f64 collapses.
+        self.register_native("make_float32", cat_witness(), |k, _, args| {
+            Value::Nid(k.intern_trivial_float32(args[0].as_float() as f32))
+        });
+        self.register_native("make_float64", cat_witness(), |k, _, args| {
+            Value::Nid(k.intern_trivial_float64(args[0].as_float()))
         });
         self.register_native("float_value", cat_method(), |k, _, args| {
             let n = args[0].as_nid();

--- a/form/form-stdlib/tests/float-natives-band.fk
+++ b/form/form-stdlib/tests/float-natives-band.fk
@@ -43,7 +43,7 @@
 ; in-kernel type tag stays off the wire for floats; portability rides on
 ; the value, not the constant.
 ;
-; The aggregate score is 1 per passing check; full pass = 26.
+; The aggregate score is 1 per passing check; full pass = 28.
 ;
 ; In service of `numeric-types-plan` (kernels carry one current-epoch
 ; IEEE 754 path while the substrate moves toward format-recipes) and
@@ -136,21 +136,43 @@
     (let s25 (if (eq (node_type (intern_trivial_float "0.8125")) 7) 1 0))
 
     ;; A float32 trivial's type tag is 6 three-way, and a float32 leaf
-    ;; reads back its IEEE value in every kernel. Rust never PRODUCES a
-    ;; float32 (float literals parse as float64; make_float32 is a Go/TS
-    ;; native), but Rust READS one: a hand-built type-6 leaf carrying the
-    ;; IEEE bits of 0.5f32 (0x3F000000 = 1056964608) decodes to 0.5 via
-    ;; float_value in all three kernels. Before alignment Rust panicked
-    ;; on type 6; now it recognizes float32 for sibling read-parity.
+    ;; reads back its IEEE value in every kernel. A hand-built type-6 leaf
+    ;; carrying the IEEE bits of 0.5f32 (0x3F000000 = 1056964608) decodes
+    ;; to 0.5 via float_value in all three kernels. Before alignment Rust
+    ;; panicked on type 6; now it recognizes float32 for sibling read-parity.
     (let f32-leaf (make_nodeid 1 1 6 1056964608))
     (let s26 (if (and (eq (node_type f32-leaf) 6)
                       (eq (float_value f32-leaf) 0.5)) 1 0))
 
+    ;; ── 9. Float CONSTRUCTION — make_float32 / make_float64 three-way ──
+    ;; The construction verbs: take a number, intern the typed float
+    ;; trivial, return its NodeID. Sibling parity with Go/TS
+    ;; (internTrivialFloat32/64). Rust registers these too as of the
+    ;; construction-parity work — before it, make_float32/make_float64
+    ;; were UNBOUND in Rust while Go/TS bound them, so any recipe calling
+    ;; them diverged (error in Rust, value in Go/TS). Now all three agree.
+    ;;
+    ;; 0.5 is exact in both IEEE widths. The NODE-level type tag stays
+    ;; distinct (make_float32 → type 6, make_float64 → type 7), proving the
+    ;; constructors hit the right intern path; the value-level read-back
+    ;; (float_value) is 0.5 in every kernel. Rust's Value::Float is f64 and
+    ;; the f32 leaf's value collapses to f64 0.5 on decode — that collapse
+    ;; is honest and identical to Go (VFloat is f64); TS keeps an f32 value
+    ;; kind but the numeric value is the same 0.5. The gate compares value
+    ;; equality against an exact literal, so all three MUST agree.
+    (let mf32 (make_float32 0.5))
+    (let mf64 (make_float64 0.5))
+    (let s27 (if (and (eq (node_type mf32) 6)
+                      (eq (node_type mf64) 7)) 1 0))
+    (let s28 (if (and (eq (float_value mf32) 0.5)
+                      (eq (float_value mf64) 0.5)) 1 0))
+
     ;; ── Aggregate — int + int through MATH (no float in result) ───
     ;; Every sub-score is 1 or 0; the sum flows through the I32 path
-    ;; in every kernel and prints as a plain integer. Full pass = 26.
+    ;; in every kernel and prints as a plain integer. Full pass = 28.
     (add s1 (add s2 (add s3 (add s4 (add s5
     (add s6 (add s7 (add s8 (add s9 (add s10
     (add s11 (add s12 (add s13 (add s14 (add s15
     (add s16 (add s17 (add s18 (add s19 (add s20
-    (add s21 (add s22 (add s23 (add s24 (add s25 s26))))))))))))))))))))))))))
+    (add s21 (add s22 (add s23 (add s24 (add s25
+    (add s26 (add s27 s28))))))))))))))))))))))))))))


### PR DESCRIPTION
## The gap (verified on main 4322df2c)

Rust was missing the `make_float32` / `make_float64` construction natives that **Go** (`form/form-kernel-go/main.go` ~2069) and **TS** (`form/form-kernel-ts/src/kernel.ts` ~2812) both register. So `(make_float32 0.5)` / `(make_float64 0.5)` round-tripped in Go/TS but errored **UNBOUND in Rust** — the last float-construction divergence across the three sibling kernels (`grep -c make_float32 main.rs` = 0 before this).

## The fix — register both natives in Rust (mirror Go/TS)

Rust already held both intern primitives — `intern_trivial_float32` (IEEE-32 inline encoding, ~813) and `intern_trivial_float64` (overflow-table f64, ~766) — but the f32 constructor was marked `#[allow(dead_code)]` "uncalled by design," wired only to the decode side. This wires both to callable natives right after `intern_trivial_float`, mirroring Go/TS exactly:

```rust
self.register_native("make_float32", cat_witness(), |k, _, args| {
    Value::Nid(k.intern_trivial_float32(args[0].as_float() as f32))
});
self.register_native("make_float64", cat_witness(), |k, _, args| {
    Value::Nid(k.intern_trivial_float64(args[0].as_float()))
});
```

Same category (`cat_witness()` ↔ Go/TS `catWitness`), same value-coercion (`as_float` ↔ Go `asFloat` / TS `argFloat`), same return shape (`Value::Nid` ↔ Go `VNodeID` / TS `boxValue`). The "uncalled in Rust by design" comment on `intern_trivial_float32` is reconciled to present-tense and `#[allow(dead_code)]` is removed — the constructor IS now reached.

## Proof — three-way

`float-natives-band.fk` gains **section 9**: `make_float32(0.5)` → NODE type **6**, `make_float64(0.5)` → NODE type **7** (constructors hit the right intern path), and `float_value` reads both back as **0.5** in every kernel. Band score **26 → 28**.

- **Natives present in all three**: `grep` make_float32 + make_float64 → 2 each (Rust/Go/TS).
- **Full `validate.sh`: 265 ok, 0 divergent** — no regression (float-artifact-roundtrip, type-tag assertions, all bands still three-way green).
- `cargo build --release` + `go build` clean; TS runs via tsx.

## Honest scope

- **NO production routing flip** — contained kernel-native parity addition reusing existing intern primitives.
- **f32-value collapse named honestly**: Rust's `Value::Float` is f64 (as is Go's `VFloat`), so a float32 leaf decodes to f64 `0.5`; the value-level may collapse but the **NODE-level type tag (6 vs 7) stays distinct** three-way. The gate uses `0.5` — exact in both IEEE widths — so all three kernels MUST agree on the value. No f32-precision-distinctness claimed that Rust lacks at the value level.
- The float arc — value-portable artifact (#2401), type-tag-consistent (#2403), construction-parity (here) — is now **complete three-way**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)