### PR TITLE
tend(audit): stop external-tools audit false-positives on keywords + local functions

### DIFF
--- a/docs/system_audit/external_tools_registry.json
+++ b/docs/system_audit/external_tools_registry.json
@@ -42,6 +42,7 @@
     "ssh-keyscan",
     "test",
     "timeout",
+    "touch",
     "which"
   ],
   "dependency_ecosystems": [

--- a/scripts/audit_external_tools.py
+++ b/scripts/audit_external_tools.py
@@ -10,9 +10,29 @@ from pathlib import Path
 from typing import Any
 
 
+# Matches a shell function definition opening line, e.g.:
+#   run_validate() { ... }
+#   retry_remote() {
+#   c() {
+_FUNC_DEF_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{?\s*$")
+
+
 def _load_registry(path: Path) -> dict[str, Any]:
     with path.open(encoding="utf-8") as f:
         return json.load(f)
+
+
+def _function_def_name(line: str) -> str | None:
+    """Return the function name if ``line`` opens a shell function definition.
+
+    A locally-defined function is not external tooling, so its name must be
+    excluded both as a definition and at every call site (``retry_remote scp ...``).
+    """
+    s = line.strip()
+    if s.startswith("- "):
+        s = s[2:].strip()
+    m = _FUNC_DEF_RE.match(s)
+    return m.group(1) if m else None
 
 
 def _discover_workflow_actions(workflows_dir: Path) -> set[str]:
@@ -44,7 +64,7 @@ def _extract_command(line: str) -> str | None:
     # Ignore shell function definitions like:
     #   run_validate() { ... }
     #   c() { ... }
-    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*\(\)\s*\{?\s*$", s):
+    if _FUNC_DEF_RE.match(s):
         return None
 
     # Handle command substitution assignments like:
@@ -106,6 +126,7 @@ def _extract_command(line: str) -> str | None:
         "break",
         "continue",
         "local",
+        "return",
     }
     if token in shell_keywords:
         return None
@@ -123,6 +144,9 @@ def _extract_command(line: str) -> str | None:
 
 def _discover_workflow_cli_tools(workflows_dir: Path) -> set[str]:
     tools: set[str] = set()
+    # Names defined as shell functions inside run blocks. Calls to these
+    # (e.g. ``retry_remote scp ...``) are local helpers, not external tools.
+    local_functions: set[str] = set()
     run_re = re.compile(r"^(\s*)run:\s*\|\s*$")
 
     for wf in sorted(workflows_dir.glob("*.yml")):
@@ -178,6 +202,10 @@ def _discover_workflow_cli_tools(workflows_dir: Path) -> set[str]:
                 if heredoc_start:
                     heredoc_end = heredoc_start.group(1)
 
+                func_name = _function_def_name(stripped)
+                if func_name:
+                    local_functions.add(func_name)
+
                 cmd = _extract_command(stripped)
                 if cmd:
                     tools.add(cmd)
@@ -188,7 +216,7 @@ def _discover_workflow_cli_tools(workflows_dir: Path) -> set[str]:
                 in_continuation = stripped.endswith("\\")
                 i += 1
 
-    return tools
+    return tools - local_functions
 
 
 def _discover_dependency_ecosystems(repo_root: Path) -> set[str]:


### PR DESCRIPTION
## What

The **External Tools Audit** (`scripts/audit_external_tools.py`, run by `.github/workflows/external-tools-audit.yml`) was failing 100% on **false positives**, flagging three items as "untracked workflow CLI tools" that are not external tooling: `['retry_remote', 'return', 'touch']`.

A check is a sensing readout, not an authority. When it cries wolf on bash keywords and workflow-local helper functions, the **extractor** is the drift — not the workflows. This heals the extractor so the audit senses *true* external tools, while keeping its real catching-power intact.

## The three, judged individually

| Item | What it actually is | Fix | Home |
|------|--------------------|-----|------|
| `return` | bash keyword (`return 0` / `return "$rc"` in the `retry_remote` body) | add to builtin/keyword exclude list | **extractor** |
| `retry_remote` | locally-defined bash function (`retry_remote() {...}`), called as `retry_remote scp ...` | collect defined function names, exclude calls to them | **extractor** |
| `touch` | POSIX coreutil (`touch ~/.ssh/known_hosts`) | register alongside sibling coreutils | **registry** |

**Why `touch` → registry, not exclude:** this audit *tracks* baseline coreutils in the registry rather than excluding them — the policy note says exactly this, and `cat`/`chmod`/`cp`/`mkdir`/`echo`/`printf` are all already registered. `touch` is the direct sibling of those, so it joins them in `workflow_cli_tools`. The extractor-vs-registry choice was made per-item, not by stuffing all three into the registry to silence the check.

**Why `return` + `retry_remote` → extractor, not registry:** they are unambiguously *not* external tools (a keyword and a local function). Fixing the extractor is the core-abstraction home — the local-function exclusion generalizes so the *next* workflow-local helper won't false-positive either. Factored the function-def pattern into `_FUNC_DEF_RE` / `_function_def_name` so definition-skip and name-collection share one shape.

## Proof

- `python3 scripts/audit_external_tools.py` → `Audit OK: True`, all untracked lists `[]`.
- `--fail-on-untracked` (what the CI workflow runs) exits `0` → the workflow passes.
- **Catching-power intact:** a temp `run:` block with a genuinely-unregistered tool (`wget`), a local helper (`my_helper() { return 0 }` called as `my_helper curl ...`), `touch`, and `return` produced `untracked tools: ['wget']`, `ok: False` — the real external tool is still caught; only the keyword + local function are excluded.
- `python3 scripts/wellness_check.py` runs clean; no new failures. The 7-day Contracts readout still shows the historical 1/1 failure of the prior scheduled run — it flips green once the workflow runs again post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)