### PR TITLE
tend(deploy): widen VPS-sync retry window so a transient port-22 blip rides through within one run

### DIFF
--- a/.github/workflows/hostinger-auto-deploy.yml
+++ b/.github/workflows/hostinger-auto-deploy.yml
@@ -87,7 +87,14 @@ jobs:
         run: |
           retry_remote() {
             local attempt=1
-            local max_attempts=5
+            # 8 attempts × 20s backoff ≈ a ~5 min retry window (on top of each
+            # scp/ssh's own ConnectTimeout=20). Deploy failures were diagnosed as
+            # `connect ... port 22: Connection timed out` — real intermittent
+            # Hostinger-side VPS reachability blips lasting ~2.5 min, not a
+            # workflow bug. The prior 5×10s span (~2.5 min) exhausted right as the
+            # VPS recovered; the wider window lets a transient blip ride through
+            # WITHIN one run instead of failing and waiting for the next push.
+            local max_attempts=8
             while :; do
               if "$@"; then
                 return 0
@@ -98,8 +105,8 @@ jobs:
                 echo "::error::remote sync command failed after $attempt attempts (rc=$rc): $*"
                 return "$rc"
               fi
-              echo "::warning::remote sync command failed on attempt $attempt (rc=$rc); retrying in 10s: $*"
-              sleep 10
+              echo "::warning::remote sync command failed on attempt $attempt (rc=$rc); retrying in 20s: $*"
+              sleep 20
               attempt=$((attempt + 1))
             done
           }


### PR DESCRIPTION
The Hostinger deploy intermittently fails (~13% / 7d) on the **Sync tracked deploy script to VPS** step with `connect ... port 22: Connection timed out` — diagnosed (earlier this session, with run-log evidence) as **real intermittent Hostinger-side VPS reachability blips** lasting ~2.5 min, not a workflow bug. The prior `retry_remote` span (5 attempts × 10s ≈ 2.5 min) exhausted right as the VPS recovered, so a blip failed the run and waited for the next push to self-heal.

**The tweak:** widen the sync retry to **8 attempts × 20s** (~5 min window, on top of each scp/ssh's own `ConnectTimeout=20`) so a transient blip rides through **within one run**.

**Scoped deliberately:** only the SYNC step (idempotent file-copy — safe to retry generously). The **roll-forward** step runs the non-idempotent actual deploy and is **NOT** given a blind connect-retry here — that needs more care than a reflexive widening, named honestly rather than overreached.

This is the reversible workflow tweak named in the deploy-resilience diagnosis — taken directly rather than deferred to a chip. It mitigates the transient-blip failures but doesn't eliminate the underlying VPS-side reachability (Hostinger infra), which remains the genuine infra item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)