### PR TITLE
tend(audit): fix viewport_audit to work against live pages + report responsive health

### DIFF
--- a/scripts/viewport_audit.py
+++ b/scripts/viewport_audit.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
 """Audit a list of URLs at desktop (1440x900) and mobile (390x844) widths.
 
-Saves screenshots to output/viewport-audit/{path-slug}-{width}.png so a
-human (or another agent) can scan both viewport renderings side-by-side.
-Uses Playwright (already a dev dep) so no network setup needed.
+Saves screenshots to output/viewport-audit/{path-slug}-{width}.png AND reports
+responsive-health signals per page+width so the looking isn't left entirely to
+a human opening 16 PNGs:
+  - horizontal overflow: the widest element extending past the viewport (the
+    mobile-cutoff failure mode). "NONE" when nothing overflows.
+  - content width: how much horizontal space `main` uses (the "wasted 1000px
+    narrow column on desktop" failure mode CLAUDE.md names — content_w far
+    below the viewport on desktop is the smell).
+A small overflow on desktop is often an intentional full-bleed hero image, not
+a bug — the screenshot is still captured so the eye can judge benign-vs-broken.
+
+Wait strategy: `domcontentloaded` + a short settle, NOT `networkidle`. A live
+organism page (witness polling, live metrics, streaming counts) never reaches
+network-idle, so `networkidle` times out on every page even though it renders
+fine. domcontentloaded+settle is the correct wait for a live-data surface.
+
+Uses Playwright. If not importable in a PEP-668 externally-managed env, install
+into a venv: `python3 -m venv .venv-audit && .venv-audit/bin/pip install
+playwright && .venv-audit/bin/python -m playwright install chromium`, then run
+with that interpreter.
 
 Usage:
     python3 scripts/viewport_audit.py [path1] [path2] ...
@@ -55,6 +72,7 @@ async def shoot(base: str, paths: list[str]) -> None:
         sys.exit(2)
 
     OUT.mkdir(parents=True, exist_ok=True)
+    findings: list[str] = []
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
 
@@ -62,6 +80,7 @@ async def shoot(base: str, paths: list[str]) -> None:
             ("desktop", {"width": 1440, "height": 900}),
             ("mobile", {"width": 390, "height": 844}),
         ]:
+            w = viewport["width"]
             ctx = await browser.new_context(viewport=viewport)
             page = await ctx.new_page()
             for path in paths:
@@ -69,13 +88,43 @@ async def shoot(base: str, paths: list[str]) -> None:
                 slug = slugify(path)
                 out = OUT / f"{slug}-{label}.png"
                 try:
-                    await page.goto(url, wait_until="networkidle", timeout=20000)
+                    # domcontentloaded + settle, NOT networkidle: a live-data page
+                    # (witness polling, live metrics) never reaches network-idle.
+                    await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+                    await page.wait_for_timeout(2500)
+                    # widest element extending past the viewport (mobile-cutoff smell)
+                    overflow = await page.evaluate(
+                        "(w) => { let m = 0; for (const el of document.querySelectorAll('*')) {"
+                        " const r = el.getBoundingClientRect();"
+                        " if (r.right > w + 2 && r.width > 0 && getComputedStyle(el).overflow !== 'hidden')"
+                        " m = Math.max(m, Math.round(r.right)); } return m; }",
+                        w,
+                    )
+                    # horizontal space `main` actually uses (wasted-narrow-column smell on desktop)
+                    content_w = await page.evaluate(
+                        "() => { const m = document.querySelector('main') || document.body;"
+                        " return Math.round(m.getBoundingClientRect().width); }"
+                    )
                     await page.screenshot(path=str(out), full_page=False)
-                    print(f"  ✓ {label:7s} {path}  → {out.relative_to(ROOT)}")
+                    ov = "NONE" if overflow <= w + 2 else f"{overflow}px"
+                    print(f"  ✓ {label:7s} {path:32s} overflow={ov:8s} content_w={content_w}  → {out.relative_to(ROOT)}")
+                    if overflow > w + 2:
+                        findings.append(f"{label} {path}: element overflows to {overflow}px (viewport {w}) — check {out.name} (often an intentional full-bleed image)")
+                    if label == "desktop" and content_w < w * 0.7:
+                        findings.append(f"desktop {path}: main content only {content_w}px of {w} — possible wasted desktop width")
                 except Exception as e:
-                    print(f"  ✗ {label:7s} {path}  {e}")
+                    print(f"  ✗ {label:7s} {path}  {str(e)[:70]}")
+                    findings.append(f"{label} {path}: FAILED to load/render — {str(e)[:60]}")
             await ctx.close()
         await browser.close()
+
+    print()
+    if findings:
+        print("Responsive-health signals worth a look (open the screenshot to judge benign-vs-bug):")
+        for f in findings:
+            print(f"  · {f}")
+    else:
+        print("Responsive-health: no overflow or wasted-width signals — pages whole at both widths.")
 
 
 def main():


### PR DESCRIPTION
Two fixes learned by **actually running** the audit against live prod this session (not assuming it couldn't run):

**1. `networkidle` → `domcontentloaded` + settle.** The tool waited for `networkidle`, which **times out on every live-data page** — the organism's witness polling + live metrics + streaming counts never reach network-idle, so the audit failed on all pages even though they render fine. `domcontentloaded` + a short settle is the correct wait for a live surface.

**2. Screenshot-only → screenshot + responsive-health REPORT.** The tool saved 16 PNGs and left all the looking to a human. It now also reports per page+width: horizontal **overflow** (the mobile-cutoff smell, `NONE` when clean) and main **content width** (the wasted-narrow-column-on-desktop smell CLAUDE.md names), with a summary of signals worth a look — honestly noting a desktop overflow is often an intentional full-bleed hero, not a bug (the screenshot is still captured so the eye judges).

**Verified end-to-end** against https://coherencycoin.com — the welcoming pages (`/`, `/come-in`, `/vision`, `/people`, `/ideas`, `/begin`, `/with-us`, `/share`) are **whole at both widths**: mobile `overflow=NONE` (no cutoff), desktop `content_w=1440` (full width used); the uniform ~87px desktop overflow is the intentional full-bleed cosmic hero imagery, **confirmed by eye**. The front door is whole on the screen most arrivals use — relevant as we open the network to visitors.

Also documents the PEP-668 venv install path (the old "Playwright not available" hint assumed a system pip an externally-managed env blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)