### PR TITLE
tend(audit): add /vision /people /ideas to viewport DEFAULT_PATHS

### DIFF
--- a/scripts/viewport_audit.py
+++ b/scripts/viewport_audit.py
@@ -39,6 +39,9 @@ from pathlib import Path
 DEFAULT_PATHS = [
     "/",
     "/come-in",
+    "/vision",   # the concept list — where the living KB reaches visitors
+    "/people",   # the presences / contributors index
+    "/ideas",    # the ideas index
     "/one-sheet",
     "/silence",
     "/silence/built",


### PR DESCRIPTION
The default viewport audit skipped the three core welcoming **index** pages visitors actually arrive at — `/vision` (the living KB concept list), `/people` (the presences index), `/ideas` (the ideas index). CLAUDE.md: *"Add the page to DEFAULT_PATHS when you create a new welcoming surface."*

Verified all three **whole at both widths** via the tool against live prod: mobile `overflow=NONE`, desktop `content_w=1440` (full width used), the uniform ~87px overflow is the intentional full-bleed hero. So `python3 scripts/viewport_audit.py` (no args) now checks the **real front door**, not a partial list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)