### PR TITLE
fix(web): use $-reference override idiom for viem/postcss — unblock Dependabot

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -49,9 +49,9 @@
     "vitest": "^4.1.7"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "$postcss",
     "uuid": "^11.1.1",
-    "viem": "^2.50.4",
+    "viem": "$viem",
     "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
The Dependabot **`npm_and_yarn in /web`** job failed on every run (the persistent ~50% of the Dependabot Updates contract) with:
```
npm error code EOVERRIDE
Override for viem@... conflicts with direct dependency
```

**Root cause:** `web/package.json`'s `overrides` block had **literal** version overrides (`"viem": "^2.50.4"`, `"postcss": "^8.5.10"`) for two packages that are **also direct dependencies**. npm forbids overriding a direct dependency with a literal version — so every web npm update (including **security patches**) failed to resolve. (`uuid`/`ws` are transitive-only, so their literal overrides are correct and kept.)

**Fix:** the documented npm idiom for "force all transitive copies to match the direct dep" — `"viem": "$viem"`, `"postcss": "$postcss"`. Preserves the security intent of `45143cdf` ("Clear web audit findings with bounded overrides" — transitive copies still deduped to the safe direct version) while satisfying npm's rule.

**Proven:** `npm install --package-lock-only --dry-run --ignore-scripts` (the exact command Dependabot ran that EOVERRIDE'd) now returns `up to date`, exit 0 — no EOVERRIDE. Lockfile unchanged (the idiom resolves to the same versions). **Web dependency updates can flow again.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)