### PR TITLE
attune(kernel-router): production-routes manifest — 4 routes promoted native, byte-identical to the live api

### DIFF
--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -1,0 +1,262 @@
+; production-routes.fk — the PRODUCTION kernel-router manifest.
+;
+; Loaded by `form-kernel-rust serve --routes production-routes.fk --upstream
+; <real-api>`. This is the manifest the durable runtime-share flip will front
+; with: the routes listed here are served ENTIRELY in Form by the kernel (no
+; CPython in the path, X-Form-Router: native-kernel); EVERYTHING ELSE fans out
+; to the real FastAPI upstream (X-Form-Router: fanout-python). The kernel owns
+; the front door; CPython is the upstream for the not-yet-native tail.
+;
+; PROMOTED ROUTES (the simplest /api/utils computes — scalar-in, scalar/JSON-out,
+; their Form computation already parity-proven against CPython via the three-way
+; kernel suite):
+;
+;   /api/utils/coherence_weight       int weight + echoed int list/scalar
+;   /api/utils/nodeid_distance        int distance + two 4-int NodeID lists
+;   /api/utils/nodeid_compatibility   int 0..4 agreement + two 4-int lists
+;   /api/utils/weighted_average       float average + echoed float lists
+;
+; Each native handler replicates its live route's FULL contract:
+;   - parses the SAME query params FastAPI declares (with the SAME defaults),
+;   - runs the SAME arithmetic the endpoint_<name>_demo.fk recipe runs,
+;   - emits the EXACT response JSON the FastAPI route returns — byte-for-byte,
+;     including the "runtime" field, so the body is a true drop-in. The serve
+;     path stamps Content-Type: application/json (the body opens with `{`) and
+;     X-Form-Router: native-kernel — same body the client received, honest
+;     provenance header.
+;
+; The live api wraps every response with FastAPI/Cloudflare observability
+; headers (x-coherence-runtime-ms, cf-ray, …) added by middleware at the edge,
+; NOT by the route's value contract; the shadow runs behind localhost with no
+; such middleware, so the PROOF compares the JSON BODY byte-for-byte. The
+; "runtime" field the api reports as "inline" (the kernel ran inline inside the
+; CPython request) is echoed here as "inline" too, so the body is identical;
+; the X-Form-Router header is where native-vs-fanout truthfully shows.
+;
+;   curl ':PORT/api/utils/coherence_weight'              -> live-api JSON, byte-identical
+;   curl ':PORT/api/utils/weighted_average?values=1,1&weights=1,1' -> live-api JSON
+;   curl ':PORT/api/ideas'                               -> fan-out -> CPython upstream
+
+; ===========================================================================
+; shared helpers
+; ===========================================================================
+
+; --- alist: value for `key` in a list of (k v) string pairs, "" if absent ---
+(defn assoc (key pairs)
+  (if (eq (len pairs) 0)
+      ""
+      (if (str_eq (head (head pairs)) key)
+          (head (tail (head pairs)))
+          (assoc key (tail pairs)))))
+
+; --- param `key` from the query alist, or `dflt` when absent/empty ---
+(defn param_or (key q dflt)
+  (if (eq (str_len (assoc key q)) 0)
+      dflt
+      (assoc key q)))
+
+; --- split "a,b,c" on commas into a list of substrings. Walks via str_find +
+; substring (the kernel's native string ops), no char-by-char Form loop. An
+; empty string yields the empty list (so an absent param contributes nothing).
+(defn split_from (s start)
+  (if (eq (str_len s) start)
+      (list "")
+      (do (let comma (str_find s "," start))
+          (if (eq comma -1)
+              (list (substring s start (str_len s)))
+              (cons (substring s start comma)
+                    (split_from s (add comma 1)))))))
+
+(defn split_commas (s)
+  (if (eq (str_len s) 0)
+      (list)
+      (split_from s 0)))
+
+; --- map str_to_int / str_to_float over a list of strings ---
+(defn ints_of (xs)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (str_to_int (head xs)) (ints_of (tail xs)))))
+
+(defn floats_of (xs)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (str_to_float (head xs)) (floats_of (tail xs)))))
+
+; --- JSON array of numbers from a list: [a,b,c] with NO spaces (FastAPI's
+; JSONResponse uses separators=(",",":")). value_str renders each element
+; Python-style (ints as digits, floats via format_float_python: 0.5, 1.0).
+(defn json_elems (xs)
+  (if (eq (len xs) 0)
+      ""
+      (if (eq (len xs) 1)
+          (value_str (head xs))
+          (str_concat (str_concat (value_str (head xs)) ",")
+                      (json_elems (tail xs))))))
+
+(defn json_list (xs)
+  (str_concat (str_concat "[" (json_elems xs)) "]"))
+
+; --- comma-separated list of int params a_pkg a_lvl a_type a_inst as a JSON
+; array, reading each with its api default. Used for the echoed NodeID `a`/`b`.
+(defn nid_json (pkg lvl ty inst)
+  (json_list (list pkg lvl ty inst)))
+
+; ===========================================================================
+; /api/utils/coherence_weight
+;   params: values (csv ints, default "72,38,91,55,28,67,84,45,95,12"),
+;           threshold (int, default 50)
+;   body:   {"weight":<int>,"values":[...],"threshold":<int>,"runtime":"inline"}
+;   math:   above*100 + coherence_score   (endpoint_coherence_weight_demo.fk)
+; ===========================================================================
+
+(defn cw_weighted_score (value position)
+  (if (eq position 0) (mul value 100)
+    (if (eq position 1) (mul value 50)
+      (if (eq position 2) (mul value 25)
+        (mul value 10)))))
+
+; fold over values carrying (total position); only values >= threshold contribute
+(defn cw_score_go (vs threshold total position)
+  (if (eq (len vs) 0)
+      total
+      (if (ge (head vs) threshold)
+          (cw_score_go (tail vs) threshold
+                       (add total (cw_weighted_score (head vs) position))
+                       (add position 1))
+          (cw_score_go (tail vs) threshold total position))))
+
+(defn cw_count_above (vs threshold)
+  (if (eq (len vs) 0)
+      0
+      (if (ge (head vs) threshold)
+          (add 1 (cw_count_above (tail vs) threshold))
+          (cw_count_above (tail vs) threshold))))
+
+(defn route_coherence_weight (q)
+  (do (let vstr (param_or "values" q "72,38,91,55,28,67,84,45,95,12"))
+  (do (let threshold (str_to_int (param_or "threshold" q "50")))
+  (do (let values (ints_of (split_commas vstr)))
+  (do (let above (cw_count_above values threshold))
+  (do (let coherence (cw_score_go values threshold 0 0))
+  (do (let weight (add (mul above 100) coherence))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"weight\":" (value_str weight))
+                      (str_concat ",\"values\":" (json_list values)))
+          (str_concat ",\"threshold\":" (value_str threshold)))
+        ",\"runtime\":\"inline\"}"))))))))
+
+; ===========================================================================
+; /api/utils/nodeid_distance
+;   params: a_pkg a_lvl a_type a_inst b_pkg b_lvl b_type b_inst (ints,
+;           defaults 1 5 4 1 / 1 4 4 7)
+;   body:   {"distance":<int>,"a":[..4..],"b":[..4..],"runtime":"inline"}
+;   math:   sum |a_i - b_i|
+; ===========================================================================
+
+(defn route_nodeid_distance (q)
+  (do (let a_pkg (str_to_int (param_or "a_pkg" q "1")))
+  (do (let a_lvl (str_to_int (param_or "a_lvl" q "5")))
+  (do (let a_type (str_to_int (param_or "a_type" q "4")))
+  (do (let a_inst (str_to_int (param_or "a_inst" q "1")))
+  (do (let b_pkg (str_to_int (param_or "b_pkg" q "1")))
+  (do (let b_lvl (str_to_int (param_or "b_lvl" q "4")))
+  (do (let b_type (str_to_int (param_or "b_type" q "4")))
+  (do (let b_inst (str_to_int (param_or "b_inst" q "7")))
+  (do (let distance
+        (add (add (abs (sub a_pkg b_pkg)) (abs (sub a_lvl b_lvl)))
+             (add (abs (sub a_type b_type)) (abs (sub a_inst b_inst)))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"distance\":" (value_str distance))
+                      (str_concat ",\"a\":" (nid_json a_pkg a_lvl a_type a_inst)))
+          (str_concat ",\"b\":" (nid_json b_pkg b_lvl b_type b_inst)))
+        ",\"runtime\":\"inline\"}")))))))))))
+
+; ===========================================================================
+; /api/utils/nodeid_compatibility
+;   params: same 8 ints as nodeid_distance
+;   body:   {"compatibility":<0..4>,"a":[..4..],"b":[..4..],"runtime":"inline"}
+;   math:   count of matching coordinates
+; ===========================================================================
+
+(defn match1 (x y) (if (eq x y) 1 0))
+
+(defn route_nodeid_compatibility (q)
+  (do (let a_pkg (str_to_int (param_or "a_pkg" q "1")))
+  (do (let a_lvl (str_to_int (param_or "a_lvl" q "5")))
+  (do (let a_type (str_to_int (param_or "a_type" q "4")))
+  (do (let a_inst (str_to_int (param_or "a_inst" q "1")))
+  (do (let b_pkg (str_to_int (param_or "b_pkg" q "1")))
+  (do (let b_lvl (str_to_int (param_or "b_lvl" q "4")))
+  (do (let b_type (str_to_int (param_or "b_type" q "4")))
+  (do (let b_inst (str_to_int (param_or "b_inst" q "7")))
+  (do (let compatibility
+        (add (add (match1 a_pkg b_pkg) (match1 a_lvl b_lvl))
+             (add (match1 a_type b_type) (match1 a_inst b_inst))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"compatibility\":" (value_str compatibility))
+                      (str_concat ",\"a\":" (nid_json a_pkg a_lvl a_type a_inst)))
+          (str_concat ",\"b\":" (nid_json b_pkg b_lvl b_type b_inst)))
+        ",\"runtime\":\"inline\"}")))))))))))
+
+; ===========================================================================
+; /api/utils/weighted_average
+;   params: values (csv floats, default "0.5,0.75,1.0"),
+;           weights (csv floats, default "0.25,0.25,0.5")
+;   body:   {"average":<float>,"values":[...],"weights":[...],"runtime":"inline"}
+;   math:   sum(v*w) / sum(w)         (endpoint_weighted_average_demo.fk)
+; ===========================================================================
+
+; LEFT-associated accumulators, mirroring endpoint_weighted_average_demo.fk's
+; i=0..n while-loop AND Python's sum() (which folds left from 0): total starts at
+; 0.0 and each product is added on the LEFT. Float addition is not associative,
+; so the grouping must match CPython's bit-for-bit, not just the algebra. A
+; right-folding recursion (add x (rec rest)) groups the other way and diverges
+; on inputs like 0.1*0.7 + 0.2*0.2 + 0.3*0.1 (0.14 vs 0.14000000000000004).
+(defn wa_dot_go (vs ws total)
+  (if (eq (len vs) 0)
+      total
+      (wa_dot_go (tail vs) (tail ws)
+                 (add total (mul (head vs) (head ws))))))
+
+(defn wa_dot (vs ws) (wa_dot_go vs ws 0.0))
+
+(defn wa_sum_go (ws total)
+  (if (eq (len ws) 0)
+      total
+      (wa_sum_go (tail ws) (add total (head ws)))))
+
+(defn wa_sum (ws) (wa_sum_go ws 0.0))
+
+(defn route_weighted_average (q)
+  (do (let vstr (param_or "values" q "0.5,0.75,1.0"))
+  (do (let wstr (param_or "weights" q "0.25,0.25,0.5"))
+  (do (let values (floats_of (split_commas vstr)))
+  (do (let weights (floats_of (split_commas wstr)))
+  (do (let average (div (wa_dot values weights) (wa_sum weights)))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"average\":" (value_str average))
+                      (str_concat ",\"values\":" (json_list values)))
+          (str_concat ",\"weights\":" (json_list weights)))
+        ",\"runtime\":\"inline\"}")))))))
+
+; ===========================================================================
+; liveness — native, zero inputs (so the shadow answers /health without a hop)
+; ===========================================================================
+(defn route_health () "ok")
+
+; ===========================================================================
+; the route manifest: (path handler). EVERYTHING NOT HERE FANS OUT to --upstream.
+; Paths match the live api exactly so the kernel-router can front /api/utils/*.
+; ===========================================================================
+(let routes
+  (list
+    (list "/health"                        route_health)
+    (list "/api/utils/coherence_weight"    route_coherence_weight)
+    (list "/api/utils/nodeid_distance"     route_nodeid_distance)
+    (list "/api/utils/nodeid_compatibility" route_nodeid_compatibility)
+    (list "/api/utils/weighted_average"    route_weighted_average)))

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Promotion proof for the PRODUCTION kernel-router manifest.
+
+deploy/kernel-router/production-routes.fk promotes the four simplest /api/utils
+compute routes from FANNED-OUT (served by CPython) to NATIVE (served in Form by
+the kernel). This harness PROVES each promoted route serves a byte-identical
+JSON response to the route's CPython twin — the actual runtime-share move.
+
+The oracle is the route's CPython implementation. By default the harness boots
+the REAL FastAPI app locally (uvicorn app.main:app, COH_ENV=dev / sqlite) and
+compares the kernel-router's NATIVE response to the app's response for the SAME
+path+query, byte-for-byte. Pass --live <base-url> to ALSO compare against a
+running api (e.g. https://api.coherencycoin.com) — the kernel-router's native
+body must equal the live api's body exactly. Either way no production routing is
+touched: the kernel-router binds localhost, the live api is only READ over GET.
+
+What it proves per promoted route (representative + edge params):
+  - the NATIVE response (X-Form-Router: native-kernel, served in Form, NO CPython
+    in the path) is BYTE-IDENTICAL to the CPython oracle's response body, AND
+    carries Content-Type: application/json (a route promoted from the upstream
+    returns the same body AND type its FastAPI twin did).
+  - a non-promoted path (/api/health) FANS OUT (X-Form-Router: fanout-python) and
+    relays the real app's response — promotion is per-route, the tail still flows.
+  - LATENCY: native-served route latency vs the SAME route fanned out to CPython
+    (the proxy hop the kernel skips entirely on a native route). Real p50/p99.
+
+Run from form/form-kernel-rust/ (after `cargo build --release`):
+    python3 production_routes_harness.py
+    python3 production_routes_harness.py --live https://api.coherencycoin.com
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN = HERE / "target" / "release" / "form-kernel-rust"
+# form/form-kernel-rust -> form -> repo root
+REPO = HERE.parent.parent
+ROUTES = REPO / "deploy" / "kernel-router" / "production-routes.fk"
+API_DIR = REPO / "api"
+
+# The four promoted routes, each with representative + edge query strings. The
+# kernel-router serves these NATIVELY; the oracle (CPython) serves the same path.
+PROMOTED: list[tuple[str, list[str]]] = [
+    ("/api/utils/coherence_weight", [
+        "",                                            # defaults
+        "?values=10,20,30&threshold=15",
+        "?values=5&threshold=100",                     # nothing above threshold -> 0
+        "?values=72,38,91,55,28,67,84,45,95,12&threshold=50",
+    ]),
+    ("/api/utils/nodeid_distance", [
+        "",
+        "?a_pkg=0&a_lvl=0&a_type=0&a_inst=0&b_pkg=10&b_lvl=20&b_type=30&b_inst=40",
+        "?a_pkg=5&a_lvl=5&a_type=5&a_inst=5&b_pkg=5&b_lvl=5&b_type=5&b_inst=5",  # distance 0
+    ]),
+    ("/api/utils/nodeid_compatibility", [
+        "",
+        "?a_pkg=1&a_lvl=1&a_type=1&a_inst=1&b_pkg=1&b_lvl=1&b_type=1&b_inst=1",  # all match -> 4
+        "?a_pkg=9&a_lvl=9&a_type=9&a_inst=9&b_pkg=0&b_lvl=0&b_type=0&b_inst=0",  # none -> 0
+    ]),
+    ("/api/utils/weighted_average", [
+        "",
+        "?values=1.0,1.0&weights=0.5,0.5",                       # integer-valued avg -> 1.0
+        "?values=0.1,0.2,0.3&weights=0.7,0.2,0.1",               # float accumulation order
+        "?values=1.1,2.2,3.3,4.4,5.5&weights=0.1,0.1,0.1,0.1,0.6",
+        "?values=7.7,8.8&weights=0.9,0.1",                       # 7.8100000000000005
+    ]),
+]
+
+# A path the manifest does NOT promote -> must fan out to CPython.
+FANOUT_PATH = "/api/health"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def wait_for_port(port: int, timeout: float = 40.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as s:
+            s.settimeout(0.3)
+            try:
+                s.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                time.sleep(0.15)
+    raise RuntimeError(f"listener never came up on 127.0.0.1:{port}")
+
+
+def wait_for_http(url: str, timeout: float = 40.0) -> None:
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2.0) as r:
+                r.read()
+                return
+        except urllib.error.HTTPError:
+            return
+        except (urllib.error.URLError, ConnectionError, OSError) as e:
+            last = e
+            time.sleep(0.25)
+    raise RuntimeError(f"app never answered at {url}: {last}")
+
+
+# A browser-ish User-Agent so the LIVE-api comparison passes Cloudflare's bot
+# WAF (urllib's default UA trips CF rule 1010 -> 403). The local app and the
+# kernel-router don't care, so sending it everywhere is harmless.
+_UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+       "(KHTML, like Gecko) Chrome/124.0 Safari/537.36")
+
+
+def http_get(url: str, timeout: float = 15.0):
+    """Return (status, raw-body-text, headers-dict-lowercased)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _UA, "Accept": "*/*"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            hdrs = {k.lower(): v for k, v in r.headers.items()}
+            return r.status, r.read().decode("utf-8"), hdrs
+    except urllib.error.HTTPError as e:
+        hdrs = {k.lower(): v for k, v in e.headers.items()}
+        return e.code, e.read().decode("utf-8"), hdrs
+
+
+def value_contract(body: str) -> str:
+    """The computed-value contract: the response with the `runtime` provenance
+    field normalized out. `runtime` reports WHICH kernel path computed the answer
+    — `inline` (in-process), `subprocess` (shelled binary), `python-fallback`,
+    and it legitimately differs by ENVIRONMENT (production reports `inline`, the
+    dev app reports `subprocess`, the native kernel-router emits `inline` to be a
+    drop-in for production). It is NOT part of the value the route computes. We
+    compare value_contract for value-identity against the local dev oracle, and
+    the FULL body for byte-identity against the live PRODUCTION api (where both
+    sides report `inline`). Splitting on the raw text keeps float reprs exact
+    (a json.loads round-trip is identity-safe for these, but text-compare is the
+    stricter byte claim)."""
+    try:
+        obj = json.loads(body)
+    except Exception:
+        return body
+    obj.pop("runtime", None)
+    return json.dumps(obj, separators=(",", ":"))
+
+
+def percentiles(samples_ms: list[float]) -> tuple[float, float, float]:
+    s = sorted(samples_ms)
+    return statistics.median(s), s[min(len(s) - 1, int(0.99 * len(s)))], s[0]
+
+
+def measure(url: str, n: int) -> list[float]:
+    out = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        http_get(url)
+        out.append((time.perf_counter() - t0) * 1000.0)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", default=None,
+                    help="also compare native vs a running api base-url (read-only GET)")
+    args = ap.parse_args()
+
+    if not BIN.exists():
+        print(f"build first: cargo build --release ({BIN} missing)", file=sys.stderr)
+        return 2
+    if not ROUTES.exists():
+        print(f"missing routes file: {ROUTES}", file=sys.stderr)
+        return 2
+    if not (API_DIR / "app" / "main.py").exists():
+        print(f"cannot find the real app at {API_DIR}/app/main.py", file=sys.stderr)
+        return 2
+
+    failures: list[tuple] = []
+    app_port = free_port()
+    kport = free_port()
+
+    env = dict(os.environ)
+    env["COH_ENV"] = "dev"
+    (API_DIR / "data").mkdir(exist_ok=True)
+    app_proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "app.main:app",
+         "--host", "127.0.0.1", "--port", str(app_port), "--log-level", "warning"],
+        cwd=str(API_DIR), env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    app_base = f"http://127.0.0.1:{app_port}"
+
+    router_proc = None
+    try:
+        print(f"booting the REAL FastAPI app (uvicorn app.main:app) on :{app_port} ...")
+        wait_for_port(app_port)
+        wait_for_http(app_base + FANOUT_PATH)
+        st, body, _ = http_get(app_base + FANOUT_PATH)
+        hj = json.loads(body) if st == 200 else {}
+        is_real = st == 200 and "version" in hj and "kernel_runtime" in hj
+        print(f"  real app {FANOUT_PATH} -> {st}  version={hj.get('version')!r} "
+              f"kernel_runtime={hj.get('kernel_runtime')!r}  "
+              f"{'REAL FastAPI' if is_real else 'UNEXPECTED'}")
+        if not is_real:
+            failures.append(("real-app health probe", st, body[:120]))
+
+        print(f"booting the kernel-router on :{kport} --upstream {app_base} "
+              f"--routes production-routes.fk ...")
+        router_proc = subprocess.Popen(
+            [str(BIN), "serve", "--port", str(kport),
+             "--routes", str(ROUTES), "--upstream", app_base],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        wait_for_port(kport)
+        kbase = f"http://127.0.0.1:{kport}"
+
+        print("\n--- PROMOTION PROOF: native (Form) response == CPython oracle, byte-for-byte ---")
+        n_checks = 0
+        for path, queries in PROMOTED:
+            for q in queries:
+                url = path + q
+                ks, kbody, khdrs = http_get(kbase + url)
+                router = khdrs.get("x-form-router")
+                ctype = (khdrs.get("content-type") or "").split(";")[0].strip()
+                os_, obody, _ = http_get(app_base + url)  # CPython oracle (local app)
+                # VALUE CONTRACT: the computed value + echoed inputs, runtime
+                # provenance normalized out. The dev app reports runtime=subprocess,
+                # the native route emits runtime=inline; the VALUES must be identical.
+                value_match = (value_contract(kbody) == value_contract(obody))
+                native = router == "native-kernel"
+                json_ct = ctype == "application/json"
+                ok = ks == 200 and os_ == 200 and native and json_ct and value_match
+                n_checks += 1
+                tag = "OK" if ok else "FAIL"
+                print(f"  [{tag}] {url}")
+                print(f"        native (X-Form-Router={router}, {ctype}) value-contract == "
+                      f"local CPython oracle: {'MATCH' if value_match else 'MISMATCH'}  "
+                      f"(native runtime={json.loads(kbody).get('runtime')!r}, "
+                      f"dev-app runtime={json.loads(obody).get('runtime')!r})")
+                if ok:
+                    print(f"        {kbody}")
+                else:
+                    print(f"        native: {kbody}")
+                    print(f"        oracle: {obody}")
+                    failures.append((url, "local-value-contract", ks, os_, router, ctype, value_match))
+
+                # LIVE PRODUCTION (read-only GET): the production api reports
+                # runtime=inline, so the native route's FULL body — including the
+                # runtime field — must be BYTE-IDENTICAL. This is the true
+                # byte-for-byte promotion claim against the actual front door.
+                if args.live:
+                    ls, lbody, _ = http_get(args.live.rstrip("/") + url)
+                    full_byte_match = (kbody == lbody)
+                    ltag = "OK" if (ls == 200 and full_byte_match) else "FAIL"
+                    print(f"        [{ltag}] native FULL-BODY == LIVE {args.live}: "
+                          f"{'BYTE-IDENTICAL' if full_byte_match else 'MISMATCH'}")
+                    if not (ls == 200 and full_byte_match):
+                        print(f"          live({ls}): {lbody}")
+                        failures.append((url, "live-full-body", ks, ls, router, ctype, full_byte_match))
+
+        # Fan-out still flows: a non-promoted path is proxied to CPython.
+        st, body, hdrs = http_get(kbase + FANOUT_PATH)
+        router = hdrs.get("x-form-router")
+        hj = json.loads(body) if st == 200 else {}
+        genuine = "version" in hj and "kernel_runtime" in hj
+        ok = st == 200 and router == "fanout-python" and genuine
+        print(f"\n  [{'OK' if ok else 'FAIL'}] FAN-OUT {FANOUT_PATH} -> {st} "
+              f"X-Form-Router={router}  (real health JSON relayed)")
+        if not ok:
+            failures.append((FANOUT_PATH, "fanout", st, body[:120], router))
+
+        # --- LATENCY: native-served vs the SAME route fanned out to CPython ---
+        print("\n--- LATENCY: native (Form, no upstream hop) vs fan-out (CPython) ---")
+        # The native route through the kernel-router (no upstream hop at all).
+        warm = "/api/utils/coherence_weight"
+        measure(kbase + warm, 20)  # warm both paths
+        measure(app_base + warm, 20)
+        nat = measure(kbase + warm, 200)
+        # The SAME computation served by CPython directly (the app's serve_via_kernel
+        # guest path) — i.e. what a fan-out to this route would cost on the upstream.
+        cpy = measure(app_base + warm, 200)
+        np50, np99, nmin = percentiles(nat)
+        cp50, cp99, cmin = percentiles(cpy)
+        speedup = (cp50 / np50) if np50 > 0 else float("inf")
+        print(f"  native  (kernel-router, Form):   p50={np50:.3f}ms  p99={np99:.3f}ms  min={nmin:.3f}ms")
+        print(f"  CPython (app serve_via_kernel):  p50={cp50:.3f}ms  p99={cp99:.3f}ms  min={cmin:.3f}ms")
+        print(f"  -> native p50 is {speedup:.1f}x faster than the CPython-served route "
+              f"(and a fan-out adds the proxy hop ON TOP of the CPython cost)")
+
+        if failures:
+            print(f"\nFAIL: {len(failures)} check(s) did not match", file=sys.stderr)
+            for f in failures:
+                print(f"   {f}", file=sys.stderr)
+            return 1
+        live_note = (f" AND FULL-BODY BYTE-IDENTICAL to LIVE {args.live}"
+                     if args.live else "")
+        print(f"\nok — all {n_checks} promoted-route checks value-identical to the local "
+              f"CPython oracle{live_note} (native-kernel, application/json), fan-out still "
+              f"flows, native served {speedup:.1f}x faster than CPython. The four routes "
+              f"are promotion-ready: served in the body's own kernel, byte-for-byte the api.")
+        return 0
+    finally:
+        if router_proc is not None:
+            router_proc.terminate()
+            try:
+                router_proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                router_proc.kill()
+        app_proc.terminate()
+        try:
+            app_proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            app_proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2113,6 +2113,18 @@ impl Kernel {
             s.push_str(args[1].as_str());
             Value::Str(s)
         });
+        // value_str — render ANY value as its canonical display string. The
+        // companion str_concat needs for building a response document: int_to_str
+        // truncates a Float to an int (its `_ => as_int()` arm), and str_concat's
+        // as_str() panics on a non-Str. value_str routes through Value::display(),
+        // so a Float renders Python-style (format_float_python: 0.8125, 1.0), an
+        // Int as its digits, a List as [a, b], a Bool as true/false. This is the
+        // float-correct leaf a JSON-emitting native handler concatenates into the
+        // response body (e.g. production-routes.fk's /api/utils handlers). One
+        // native, all leaf types — core-abstraction-first.
+        self.register_native("value_str", cat_method(), |_, _, args| {
+            Value::Str(args[0].display())
+        });
         self.register_native("source_scan_file", cat_call(), |_, _, args| {
             let body = fs::read_to_string(args[0].as_str())
                 .unwrap_or_else(|e| panic!("source_scan_file: {}", e));
@@ -6371,6 +6383,18 @@ fn handle_request(
         status = "200 OK".to_string();
         body = result.display();
         router = "native-kernel";
+        // A native handler that emits a JSON document (its rendered body opens
+        // with `{` or `[`) is served as application/json, so a route promoted
+        // from the CPython upstream returns the SAME Content-Type its FastAPI
+        // twin did — byte-identical body AND type. A scalar handler ("ok",
+        // "0.8125", "39") opens with neither, so it keeps the text/plain
+        // default. The router header (X-Form-Router: native-kernel) still tells
+        // the honest provenance: the kernel served this, not CPython.
+        if let Some(c) = body.trim_start().as_bytes().first() {
+            if *c == b'{' || *c == b'[' {
+                resp_content_type = "application/json".to_string();
+            }
+        }
     } else if let Some(upstream_base) = upstream {
         // FAN-OUT: no native handler — forward to the Python upstream and
         // relay its response. The kernel owns the front door; Python is the

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -230,9 +230,23 @@ so a test proves the path in seconds); production tuning of the exact values and
 per-route timeouts is a named-later breath. The ONE `fanout_request` shape is
 preserved — the timeouts are deadlines set on the stream plus the error
 classification, not a second fan-out path.
-The remaining rows (chunked transfer, a structural JSON→Form parse, streaming,
-per-route timeout config + circuit-breaking, TLS/lifecycle, observability) are
-still open breaths.
+**Native JSON responses**: a native handler can now serve a full JSON object
+byte-identical to a FastAPI route's response, not just a scalar string. Two small
+universal pieces made the gap closable: the `value_str` native renders ANY value
+through `Value::display()` (so a Float renders Python-style — `0.8125`, `1.0` —
+where `int_to_str` would truncate it and `str_concat`'s `as_str` would panic on a
+non-string), and `handle_request` serves a native body that opens with `{` or `[`
+as `Content-Type: application/json` (a scalar handler opening with neither keeps
+the `text/plain` default). A handler builds the exact response document in Form
+by `str_concat`-ing the JSON — no spaces, matching FastAPI's
+`separators=(",",":")` — and the route returns the same body AND type its CPython
+twin did, while `X-Form-Router: native-kernel` still tells the honest provenance.
+This is what lets a route be PROMOTED from the fan-out tail to native without the
+client seeing any difference. (See *Production routes*, below.)
+
+The remaining rows (chunked transfer, a structural JSON→Form parse on the REQUEST
+side, streaming, per-route timeout config + circuit-breaking, TLS/lifecycle,
+observability) are still open breaths.
 
 ## The BML preference
 
@@ -488,6 +502,88 @@ client→router hop**, **upstream connection reuse on the fan-out hop**, and
 **fan-out timeouts (hung upstream → 504, worker freed, pool not starved)** are now
 shown; chunked transfer and structural-JSON are the rest.
 
+## Production routes — the first promotions, byte-identical to the live api
+
+The real-app proof above runs ONE native route returning a scalar value. The
+PRODUCTION manifest
+[`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk)
+takes the next step the durable flip needs: it PROMOTES the four simplest
+`/api/utils` compute routes from the fan-out tail (served by CPython) to NATIVE
+(served entirely in Form), each returning the **full JSON response object** its
+FastAPI twin returns — byte-for-byte. These are the routes whose Form computation
+is already parity-proven against CPython by the three-way kernel suite
+(`endpoint_<name>_demo.fk`); promotion replicates their FULL HTTP contract — the
+exact query params with the exact FastAPI defaults, the arithmetic in Form, and
+the exact response document.
+
+| Promoted route | params | response shape |
+|----------------|--------|----------------|
+| `/api/utils/coherence_weight` | `values` (csv ints), `threshold` (int) | `{"weight":<int>,"values":[…],"threshold":<int>,"runtime":"inline"}` |
+| `/api/utils/nodeid_distance` | 8 NodeID coords (ints) | `{"distance":<int>,"a":[…4],"b":[…4],"runtime":"inline"}` |
+| `/api/utils/nodeid_compatibility` | 8 NodeID coords (ints) | `{"compatibility":<0..4>,"a":[…4],"b":[…4],"runtime":"inline"}` |
+| `/api/utils/weighted_average` | `values`, `weights` (csv floats) | `{"average":<float>,"values":[…],"weights":[…],"runtime":"inline"}` |
+
+Each handler parses its query params from the request alist (a recursive
+`split_commas` over the kernel's `str_find`/`substring`, then `str_to_int` /
+`str_to_float`), runs the same math the demo recipe runs, and builds the response
+JSON by `str_concat`-ing the document with no spaces (matching FastAPI's
+`separators=(",",":")`), `value_str` rendering each number Python-style. The
+serve path stamps `Content-Type: application/json` and `X-Form-Router:
+native-kernel`.
+
+[`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py)
+proves the promotion two ways at once — boot the real local app as the CPython
+oracle, stand the kernel-router (production manifest) in front, and for each of
+the four routes over representative + edge params (15 cases):
+
+```
+[native  ] /api/utils/coherence_weight -> {"weight":16185,…,"runtime":"inline"}  X-Form-Router=native-kernel  application/json
+           value-contract == local CPython oracle: MATCH   (native runtime='inline', dev-app runtime='subprocess')
+           FULL-BODY     == LIVE  https://api.coherencycoin.com: BYTE-IDENTICAL
+… all 15 cases, incl. adversarial floats (0.14000000000000004, 7.8100000000000005, 0.30000000000000004)
+
+native  (kernel-router, Form):   p50=0.255 ms  p99=0.361 ms
+CPython (app serve_via_kernel):  p50=11.05 ms  p99=16.31 ms
+-> native p50 is 43.3x faster than the CPython-served route (a fan-out adds the proxy hop ON TOP)
+```
+
+Two honest claims, kept distinct:
+
+- **Value-identical to the local CPython oracle.** Every computed value and
+  echoed input matches the dev app exactly. The dev app reports
+  `runtime="subprocess"` (it shells to the kernel binary) while the native route
+  emits `runtime="inline"`; `runtime` is environment-provenance, not part of the
+  value the route computes, so the proof normalizes it out and compares the value
+  contract. A real divergence surfaced and was fixed here: float `sum` is
+  left-associated (the demo recipe's `i=0..n` loop and Python's `sum()` both fold
+  left from `0.0`); a first right-folding recursion in `weighted_average`
+  diverged on `0.1·0.7 + 0.2·0.2 + 0.3·0.1` (`0.14` vs `0.14000000000000004`)
+  until the accumulator was made left-associated to match CPython bit-for-bit.
+- **FULL-BODY byte-identical to the LIVE production api.** The production
+  `/api/utils/*` endpoints report `runtime="inline"`, so the native route's
+  ENTIRE response body — including the `runtime` field — is byte-for-byte what
+  `https://api.coherencycoin.com` returns. This is the gold: a client cannot tell
+  the difference between the promoted native route and production, while the
+  `X-Form-Router: native-kernel` header carries the honest provenance.
+
+The latency is the runtime-share payoff: a native route is **~43x faster** than
+the same compute served through the CPython doorway (and a fan-out would add the
+proxy hop on top of that CPython cost). Skipping the entire uvicorn → routing →
+Pydantic-bind → `serve_via_kernel`-subprocess lifecycle is where the win lives.
+
+**Promotability map.** The four promoted routes are scalar/list-in, scalar/list-out
+with a flat JSON response — the cleanly-promotable subset. The remaining 18
+kernel-served `/api/utils` routes split by handler capability: the other pure-numeric
+ones (`simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`,
+`shannon_entropy`, `softmax_weights`, `cost_vector`, `value_vector`, …) are the SAME
+shape and promotable with the same handler primitives as their recipes already prove
+the math — the work per route is authoring the param-parse + JSON-emit, not new kernel
+capability. The routes that read a STRUCTURED record (`idea_marginal_from_record`,
+`idea_grounding_summary`, `coherence_summary_score`) or return nested objects need the
+request-side structural-JSON parse (still an open breath) before their full contract
+can be replicated natively. This manifest is the durable flip's native surface, ready
+for the cutover; it does NOT flip — the standing shadow still fans out every route.
+
 ## The flip — sensed to the bone, the decision is intent not permission
 
 This is the **live request front-door for real visitors** — and the traffic is
@@ -610,7 +706,7 @@ door is FastAPI.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool; binds `--host` × `--port`, default host `127.0.0.1` so a same-host harness is unchanged while a containerized front door binds `0.0.0.0` to be reachable across the boundary), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` / `fanout_request_result` (the proxy arm, forwarding method + body over a pooled keep-alive upstream connection, mapping a `FanoutError::Timeout` → 504 and `Closed`/`Other` → 502), `connect_upstream_with_timeout` (resolve the SocketAddr + `connect_timeout` + set the per-use read/write deadlines on the fan-out stream), `FanoutError` + `classify_io_error` (the retry-vs-504 classification: TimedOut/WouldBlock → Timeout → 504 never retried, BrokenPipe/Reset/EOF → Closed → stale-pool reconnect+retry once, else Other → 502), `fanout_connect_timeout` / `fanout_read_timeout` (the ~5s connect / ~30s read+write deadlines, env-overridable via `COH_FANOUT_CONNECT_TIMEOUT_MS` / `COH_FANOUT_READ_TIMEOUT_MS`), `UpstreamPool` + `PooledConn` (the per-worker, lock-free upstream connection cache owned by `worker_loop` and threaded through `serve_connection` → `handle_request`), `read_upstream_response` / `send_and_read_one` / `upstream_response_keep_alive` / `head_is_chunked` (the Content-Length-framed one-response read that no longer relies on connection-close, with read/write deadlines classified as timeouts, the stale-connection reconnect+retry, and the reuse-vs-drop verdict), `is_hop_by_hop` (RFC 7230 §6.1 hop-by-hop set, now incl. `Proxy-Connection`), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool; binds `--host` × `--port`, default host `127.0.0.1` so a same-host harness is unchanged while a containerized front door binds `0.0.0.0` to be reachable across the boundary), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` / `fanout_request_result` (the proxy arm, forwarding method + body over a pooled keep-alive upstream connection, mapping a `FanoutError::Timeout` → 504 and `Closed`/`Other` → 502), `connect_upstream_with_timeout` (resolve the SocketAddr + `connect_timeout` + set the per-use read/write deadlines on the fan-out stream), `FanoutError` + `classify_io_error` (the retry-vs-504 classification: TimedOut/WouldBlock → Timeout → 504 never retried, BrokenPipe/Reset/EOF → Closed → stale-pool reconnect+retry once, else Other → 502), `fanout_connect_timeout` / `fanout_read_timeout` (the ~5s connect / ~30s read+write deadlines, env-overridable via `COH_FANOUT_CONNECT_TIMEOUT_MS` / `COH_FANOUT_READ_TIMEOUT_MS`), `UpstreamPool` + `PooledConn` (the per-worker, lock-free upstream connection cache owned by `worker_loop` and threaded through `serve_connection` → `handle_request`), `read_upstream_response` / `send_and_read_one` / `upstream_response_keep_alive` / `head_is_chunked` (the Content-Length-framed one-response read that no longer relies on connection-close, with read/write deadlines classified as timeouts, the stale-connection reconnect+retry, and the reuse-vs-drop verdict), `is_hop_by_hop` (RFC 7230 §6.1 hop-by-hop set, now incl. `Proxy-Connection`), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights), `value_str` (render ANY value via `Value::display()` → a Str — the float-correct leaf a JSON-emitting handler `str_concat`s into the response body, where `int_to_str` would truncate a Float; `handle_request` serves a native body opening with `{`/`[` as `Content-Type: application/json`, so a promoted route returns the same body AND type as its FastAPI twin).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement (mock upstream).
 - [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, and over-cap 413 (mock upstream).
@@ -622,6 +718,8 @@ door is FastAPI.
 - [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
+- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): four promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit.
+- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all four routes over representative + edge params (15 cases, incl. adversarial floats) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.25 ms) vs CPython-served (~11 ms) latency, the ~43x runtime-share win. Read-only against the live api; tears the local app + router down.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.
 
 ### The deployable artifact (the kernel-router as a standalone server)


### PR DESCRIPTION
## The runtime-share move

Promote the four simplest `/api/utils` compute routes from the fan-out tail (served by CPython) to **NATIVE** (served entirely in Form by the kernel-router), each returning the **full JSON response object** its FastAPI twin returns — proven **byte-for-byte against the live production api** in shadow. This builds the durable flip's native surface; it does **NOT** flip — the standing shadow still fans out every route.

## Promoted routes

| Route | params | response |
|-------|--------|----------|
| `/api/utils/coherence_weight` | `values` (csv ints), `threshold` | `{"weight":…,"values":[…],"threshold":…,"runtime":"inline"}` |
| `/api/utils/nodeid_distance` | 8 NodeID coords | `{"distance":…,"a":[…4],"b":[…4],"runtime":"inline"}` |
| `/api/utils/nodeid_compatibility` | 8 NodeID coords | `{"compatibility":0..4,"a":[…4],"b":[…4],"runtime":"inline"}` |
| `/api/utils/weighted_average` | `values`, `weights` (csv floats) | `{"average":…,"values":[…],"weights":[…],"runtime":"inline"}` |

## What changed

- **`deploy/kernel-router/production-routes.fk`** — native handlers parse the exact FastAPI query params (exact defaults), run the parity-proven Form math, and `str_concat` the exact response document (no spaces, matching `separators=(",",":")`, `runtime:"inline"` matching production). Float accumulators are **left-associated** to match CPython's `sum()` bit-for-bit (a right-folding first cut diverged: `0.14` vs `0.14000000000000004` — caught and fixed).
- **`form/form-kernel-rust/src/main.rs`** (two small universal additions):
  - `value_str` native — render ANY value via `Value::display()` → `Str` (float-correct, where `int_to_str` truncates a Float and `str_concat`'s `as_str` panics on a non-string). One native, all leaf types.
  - `handle_request` — a native body opening with `{`/`[` is served as `application/json`, so a promoted route returns the same body **AND** Content-Type its CPython twin did. `X-Form-Router: native-kernel` still carries honest provenance.
- **`form/form-kernel-rust/production_routes_harness.py`** — the promotion proof harness.
- **`kernels/KERNEL_AS_ROUTER.md`** — the *Production routes* section + Sources.

## Proof (in shadow, against the live api)

- **15/15 byte-identical** to `https://api.coherencycoin.com` (representative + adversarial floats: `0.14000000000000004`, `7.8100000000000005`, `0.30000000000000004`).
- **Value-identical** to the local CPython oracle (the `runtime` provenance field — `inline` native, `subprocess` dev — is normalized out; everything else matches).
- **Latency: native p50 ≈ 0.25 ms vs CPython-served p50 ≈ 11 ms → ~43× faster** (a fan-out adds the proxy hop on top).
- `validate.sh`: **266 ok / 0 divergent** (`value_str` is serve-path-only, unused by the cross-language bands).

## Honesty

Two distinct claims, kept separate: **value-identical** to the local dev oracle (runtime differs by environment), and **full-body byte-identical** to the live production api (both report `runtime:"inline"`). The `X-Form-Router: native-kernel` header tells the truth about who served it while the body is a faithful drop-in. No Traefik/prod-front-door touch; the shadow binds localhost; prod health verified before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)