### PR TITLE
tend: runtime-surface instrument sees the kernel-router's native surface

### DIFF
--- a/api/tests/test_runtime_surface_native_routes.py
+++ b/api/tests/test_runtime_surface_native_routes.py
@@ -1,0 +1,85 @@
+"""The runtime-surface instrument SEES the kernel-router's native surface.
+
+``scripts/runtime_surface_report.py`` reports how much execution has left
+CPython for the Form kernel. Its honest distinction is between kernel-first
+SERVED (the kernel as the live front door — still 0, Traefik routes to CPython)
+and kernel-first CAPABLE (native handlers in the kernel-router manifest that
+serve the WHOLE request lifecycle in Form, proven byte-identical in shadow,
+awaiting the front-door flip).
+
+``kernel_first_capable_routes()`` reads that CAPABLE count from the manifest
+``deploy/kernel-router/production-routes.fk`` as DATA. The subtle contract: the
+manifest mentions the same ``/api/...`` paths in BOTH ``;``-comment lines and
+``(list "<path>" <handler>)`` bindings — the parser must return each route once,
+from its binding, never from a comment, and must exclude non-``/api`` probes like
+``/health``. This pins that contract with a strange-minimal synthetic manifest
+(a comment path before the routes block, a comment path inside it, a ``/health``
+binding, and two real bindings) plus a pin against the real checked-in manifest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_report():
+    src = REPO_ROOT / "scripts" / "runtime_surface_report.py"
+    spec = importlib.util.spec_from_file_location("runtime_surface_report_under_test", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_parser_reads_bindings_not_comments(monkeypatch, tmp_path):
+    """One strange manifest, four boundaries: comment-before-block and
+    comment-inside-block are ignored, ``/health`` is excluded, and only the two
+    real ``/api`` bindings are returned."""
+    manifest = tmp_path / "production-routes.fk"
+    manifest.write_text(
+        "; a comment mentioning /api/commented/before — must be ignored\n"
+        "(defn route_health () \"ok\")\n"
+        "(let routes\n"
+        "  (list\n"
+        "    ; a comment mentioning /api/commented/inside — must be ignored\n"
+        "    (list \"/health\"        route_health)\n"
+        "    (list \"/api/real/one\"  route_one)\n"
+        "    (list \"/api/real/two\"  route_two)))\n"
+    )
+    mod = _load_report()
+    monkeypatch.setattr(mod, "_KERNEL_ROUTER_MANIFEST", manifest)
+
+    routes = mod.kernel_first_capable_routes()
+
+    assert routes == ["/api/real/one", "/api/real/two"], routes
+    assert "/health" not in routes  # non-/api probe excluded
+    assert not any("commented" in r for r in routes)  # comments never captured
+
+
+def test_absent_manifest_degrades_to_empty(monkeypatch, tmp_path):
+    """No manifest → empty CAPABLE list (the report degrades, never crashes)."""
+    mod = _load_report()
+    monkeypatch.setattr(mod, "_KERNEL_ROUTER_MANIFEST", tmp_path / "missing.fk")
+    assert mod.kernel_first_capable_routes() == []
+
+
+def test_real_manifest_native_routes_are_served_zero_capable_four():
+    """The real instrument: 0 served kernel-first at the front door, and the
+    production manifest's native ``/api/utils`` routes are all CAPABLE. Pins the
+    SERVED/CAPABLE split the runtime-share journey tracks (a promotion that adds
+    a 5th native route updates this — a healthy forcing-function, not a brittle
+    string match: the assertion is the set the manifest actually binds)."""
+    mod = _load_report()
+    report = mod.build_report()
+
+    assert report["kernel_first_served_routes"] == 0  # no front-door flip
+    capable = report["kernel_first_capable_route_names"]
+    assert report["kernel_first_capable_routes"] == len(capable)
+    # every CAPABLE route is a real /api path read from the manifest's bindings
+    assert capable, "production manifest binds no native /api routes"
+    assert all(r.startswith("/api/") for r in capable), capable
+    assert len(capable) == len(set(capable)), f"duplicates: {capable}"
+    # back-compat alias stays pinned to SERVED (0 at the front door)
+    assert report["kernel_first_routes"] == report["kernel_first_served_routes"]

--- a/kernels/API_KERNEL_READINESS.md
+++ b/kernels/API_KERNEL_READINESS.md
@@ -324,10 +324,15 @@ reading honest:
 These axes move independently, sometimes in opposite directions. Transmuting a
 route raises USAGE and can ADD CPython at the same time: each one lands a FastAPI
 handler, a Pydantic response model, and a value-identical `*_py` fallback, so net
-Python LOC can grow even as more routes touch the kernel. The honest baseline:
-the kernel is a **guest-subroutine, not the runtime or the router** — 0 routes
-are served kernel-FIRST. That zero is the ground the reversal (kernel as the
-front door) moves; runtime-share is the dial that reads the move.
+Python LOC can grow even as more routes touch the kernel. The honest baseline at
+the live front door: the kernel is a **guest-subroutine, not the runtime or the
+router** — 0 routes are served kernel-FIRST (Traefik routes every live request to
+CPython). But the reversal is no longer hypothetical: the kernel-router manifest
+(`deploy/kernel-router/production-routes.fk`) now binds native handlers that serve
+the **whole request lifecycle** in Form, proven byte-identical to the live api in
+shadow — kernel-first **CAPABLE** routes awaiting the front-door flip. Runtime-
+share is the dial that reads the move, and it has two honest readings now: SERVED
+(0, the live front door) and CAPABLE (the proven native surface, ready to front).
 
 `scripts/runtime_surface_report.py` is the sensing instrument for this axis — it
 reports the route ratio, the per-route CPython-vs-kernel layering, the CPython

--- a/scripts/runtime_surface_report.py
+++ b/scripts/runtime_surface_report.py
@@ -56,9 +56,13 @@ What is measured vs stated (the honesty bar)
     files; it is offered as evidence of the layering's weight, NOT as a precise
     "fraction of runtime" (wall-clock fraction depends on inputs and is dominated
     by FastAPI+Pydantic+network for any real request — stated, not faked).
-  • Kernel-FIRST routes = 0 is exact: no route is served by the kernel as the
-    front door; every kernel-served route is a CPython handler that calls the
-    kernel as a subroutine.
+  • Kernel-FIRST has two honest readings, both exact. SERVED = 0: no route is
+    served by the kernel at the LIVE front door (Traefik routes every request to
+    CPython; the 22 kernel-served routes are CPython handlers calling the kernel
+    as a subroutine). CAPABLE = the count of native handlers in the kernel-router
+    manifest (deploy/kernel-router/production-routes.fk) — whole-lifecycle-Form
+    routes proven byte-identical in shadow, awaiting the front-door flip. CAPABLE
+    is the native surface that EXISTS; SERVED is what fronts live traffic.
 
 This is a SENSING instrument — read-only, no behavior change, like the wellness
 probe and the attribution report. It tells the body the unflattering truth about
@@ -105,6 +109,42 @@ _KERNEL_ROUTER_FILES = [
     "kernel_grounding.py",
     "kernel_scoring.py",
 ]
+
+# The PRODUCTION kernel-router manifest. Routes with a native Form handler bound
+# here are served ENTIRELY in Form by the kernel-router — routing, query binding,
+# the compute, AND the JSON response all Form-native, no CPython in the path. That
+# is the whole request lifecycle, a categorically deeper move than serve_via_kernel
+# (which keeps the lifecycle in CPython and calls the kernel as a guest subroutine).
+_KERNEL_ROUTER_MANIFEST = ROOT / "deploy" / "kernel-router" / "production-routes.fk"
+
+
+def kernel_first_capable_routes() -> list[str]:
+    """API routes with a NATIVE Form handler in the kernel-router manifest.
+
+    These serve their ENTIRE request lifecycle in Form (X-Form-Router:
+    native-kernel) — the categorical step past serve_via_kernel's guest
+    subroutine. They are CAPABLE / proven-byte-identical-in-shadow, NOT yet
+    served at the live front door: the manifest is what the durable runtime-share
+    flip will front with, but until that flip Traefik still routes every request
+    to CPython. So this is the native surface that EXISTS and is proven, awaiting
+    the front-door cutover — distinct from kernel-first SERVED, which stays 0.
+
+    Read from the manifest's ``(let routes ...)`` block as DATA (the manifest is
+    the one source); ``/health`` and other non-``/api`` probes are excluded so the
+    count compares apples-to-apples with the route total. The ``;``-comment lines
+    that mention ``/api/...`` paths never match the ``(list "<path>" <handler>)``
+    shape, so the scan reads bindings only. Returns [] if the manifest is absent
+    (the report degrades to the SERVED count and says so).
+    """
+    if not _KERNEL_ROUTER_MANIFEST.is_file():
+        return []
+    try:
+        text = _KERNEL_ROUTER_MANIFEST.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    idx = text.find("(let routes")
+    block = text[idx:] if idx != -1 else text
+    return re.findall(r'\(list\s+"(/api/[^"]+)"\s+[A-Za-z_]\w*\)', block)
 
 
 def _load_attribution_module():
@@ -207,6 +247,9 @@ def build_report() -> dict:
     cpy = kernel_router_cpython_loc()
     py_fallbacks = _count_py_fallbacks()
 
+    capable = kernel_first_capable_routes()
+    n_capable = len(capable)
+
     usage_pct = (100.0 * n_served / total_routes) if total_routes else None
     loc_per_route = (cpy["total"] / n_served) if n_served else None
 
@@ -215,7 +258,19 @@ def build_report() -> dict:
         "total_routes": total_routes,
         "kernel_served_routes": n_served,
         "kernel_served_pct": round(usage_pct, 1) if usage_pct is not None else None,
-        "kernel_first_routes": 0,  # exact: no route is served kernel-FIRST
+        # kernel-FIRST = the kernel as the FRONT DOOR (whole lifecycle in Form).
+        # Two honest sub-counts the journey needs kept apart:
+        #   SERVED  — served kernel-first at the LIVE front door. Still 0: Traefik
+        #             routes every request to CPython; the manifest is not yet the
+        #             front door (the durable flip is Urs's go + presence).
+        #   CAPABLE — native handlers proven byte-identical in shadow in the router
+        #             manifest, whole lifecycle in Form, awaiting the front-door
+        #             flip. This is the native surface that EXISTS today — the
+        #             runtime-share metric genuinely moving, not route-count.
+        "kernel_first_served_routes": 0,
+        "kernel_first_capable_routes": n_capable,
+        "kernel_first_capable_route_names": capable,
+        "kernel_first_routes": 0,  # back-compat alias of SERVED: 0 at the front door
         "served_route_names": served_routes,
         # --- Axis 2: the per-route CPython-vs-kernel layering ---
         "kernel_router_cpython_loc": cpy["total"],
@@ -260,11 +315,26 @@ def render_human(r: dict) -> str:
     else:
         w(f"  {r['kernel_served_routes']} routes kernel-served (total-route count unread).")
     w(
-        f"  Routes served kernel-FIRST (kernel as the front door): "
-        f"{r['kernel_first_routes']}."
+        f"  Served kernel-FIRST at the LIVE front door (kernel as the runtime, "
+        f"whole lifecycle in Form): {r['kernel_first_served_routes']}."
     )
-    w("  Every kernel-served route is a CPython handler that calls the kernel as")
-    w("  a SUBROUTINE inside the request. The kernel is a guest, not the runtime.")
+    cap = r.get("kernel_first_capable_routes", 0)
+    if cap:
+        names = ", ".join(r.get("kernel_first_capable_route_names", []))
+        w(
+            f"  Kernel-FIRST CAPABLE (native handler proven byte-identical in the"
+        )
+        w(
+            f"  router manifest, whole lifecycle in Form, awaiting the front-door"
+        )
+        w(f"  flip): {cap} — {names}.")
+        w("  This is the native surface that EXISTS today: the compute AND the")
+        w("  request lifecycle run Form-native, no CPython in the path. It is the")
+        w("  runtime-share metric genuinely moving, distinct from route-count.")
+    w("  The 22 kernel-SERVED routes above are a different, shallower thing: each")
+    w("  is a CPython handler that calls the kernel as a SUBROUTINE inside the")
+    w("  request — the kernel is a guest there. The capable routes flip that: the")
+    w("  kernel is the runtime, CPython is the upstream for the not-yet-native tail.")
     w("")
 
     # --- Axis 2 ---
@@ -320,16 +390,29 @@ def render_human(r: dict) -> str:
     w("## Axis 4 — where the body is on the journey (Python-runtime → kernel-runtime)")
     w("")
     pct = r["kernel_served_pct"]
+    cap = r.get("kernel_first_capable_routes", 0)
     w(
-        f"  Honestly low. {pct}% of routes touch the kernel at all; 0% are served"
+        f"  Still honestly low at the front door. {pct}% of routes touch the kernel"
         if pct is not None
-        else "  Honestly low. 0% are served"
+        else "  Still honestly low at the front door"
     )
-    w("  kernel-FIRST. The kernel runs the pure-compute core of 22 routes as a")
-    w("  guest-subroutine inside CPython; it is not the runtime and not the router.")
-    w("  This is the baseline the reversal (kernel-as-front-door) would move. The")
-    w("  metric to track is runtime-SHARE moving toward the kernel — not route-count")
-    w("  alone, which can rise while CPython rises with it.")
+    w("  at all (as a guest-subroutine); 0 are SERVED kernel-first — Traefik still")
+    w("  routes every live request to CPython.")
+    w("")
+    if cap:
+        w(f"  But the reversal is no longer hypothetical. {cap} routes are now")
+        w("  kernel-FIRST CAPABLE: native handlers in the router manifest, proven")
+        w("  byte-identical to the live api in shadow, whole lifecycle in Form. The")
+        w("  capable count moved 0 → {0}: the native front-door surface EXISTS and".format(cap))
+        w("  is proven. What remains is the cutover (Traefik → kernel-router), which")
+        w("  is a deliberate two-person live-traffic moment, not more code.")
+    else:
+        w("  The reversal (kernel-as-front-door) has no proven native surface yet.")
+    w("")
+    w("  The metric to track is runtime-SHARE moving toward the kernel — and it has")
+    w("  two honest readings now: kernel-first SERVED (0, the live front door) and")
+    w("  kernel-first CAPABLE (the proven native surface, ready to front). Route-")
+    w("  count alone stays the wrong metric: it can rise while CPython rises with it.")
     w("")
 
     if not r["attribution_module_available"]:

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1610,13 +1610,35 @@ def sense_kernel_api() -> list[str]:
         # The honest runtime-share nuance: route-COUNT is kernel USAGE, not the
         # runtime-SHARE that actually left CPython. Even kernel-served routes run
         # the kernel as a guest-subroutine — routing/binding/validation/response
-        # stay CPython; 0 routes are served kernel-FIRST. Track runtime-share,
-        # not route-count (scripts/runtime_surface_report.py).
-        lines.append(
-            "  vitality: runtime-share — those routes run the kernel as a "
-            "guest-subroutine inside CPython (0 kernel-first); usage and "
-            "runtime-share are distinct axes (scripts/runtime_surface_report.py)"
-        )
+        # stay CPython; 0 routes are served kernel-FIRST at the live front door.
+        # But the kernel-router manifest now holds native handlers that serve the
+        # WHOLE lifecycle in Form, proven byte-identical in shadow — the CAPABLE
+        # surface, read from the one source (runtime_surface_report, no duplicated
+        # parse). Track runtime-share, not route-count.
+        n_capable = None
+        rsr_path = ROOT / "scripts" / "runtime_surface_report.py"
+        if rsr_path.is_file():
+            try:
+                _spec = importlib.util.spec_from_file_location("runtime_surface_report", rsr_path)
+                _rsr = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+                _spec.loader.exec_module(_rsr)  # type: ignore[union-attr]
+                n_capable = len(_rsr.kernel_first_capable_routes())
+            except Exception:
+                n_capable = None
+        if n_capable:
+            lines.append(
+                f"  vitality: runtime-share — 0 routes served kernel-FIRST at the front "
+                f"door (those {n_served} run the kernel as a guest-subroutine inside "
+                f"CPython), but {n_capable} are kernel-first CAPABLE: native handlers "
+                "proven byte-identical in shadow, whole lifecycle in Form, awaiting the "
+                "front-door flip (scripts/runtime_surface_report.py)"
+            )
+        else:
+            lines.append(
+                "  vitality: runtime-share — those routes run the kernel as a "
+                "guest-subroutine inside CPython (0 kernel-first); usage and "
+                "runtime-share are distinct axes (scripts/runtime_surface_report.py)"
+            )
     else:
         lines.append(
             f"  vitality: {n_served} routes kernel-served (total-route count unread)"


### PR DESCRIPTION
## What

The runtime-surface report (`scripts/runtime_surface_report.py`) hardcoded `kernel_first_routes: 0` — "no route is served by the kernel as the front door." True for live traffic, but the instrument was **blind** to what now exists: `deploy/kernel-router/production-routes.fk` binds 4 native handlers that serve the **whole request lifecycle** in Form, proven byte-identical to the live api in shadow (PR #2416).

This teaches the instrument to see that native surface, splitting the one blind zero into two honest readings the runtime-share journey needs kept apart:

| Reading | Count | Meaning |
|---------|-------|---------|
| kernel-first **SERVED** | 0 | the kernel as the LIVE front door — Traefik still routes every request to CPython; the durable flip is Urs's go + presence |
| kernel-first **CAPABLE** | 4 | native handlers proven byte-identical in shadow, whole lifecycle in Form, awaiting the front-door flip — the native surface that EXISTS today |

`kernel_first_capable_routes()` reads the CAPABLE count from the manifest as DATA (one source). The **wellness probe** threads it through its kernel-native vitality line via the same loader (no duplicated parse), so the body's daily self-sensing names the native surface, not just "22 routes kernel-served (2.8%)".

## Why

This is the *awareness* half of the directive: "better awareness of how much runs in CPython vs the form kernel." Promoting routes moves the share; this instrument is what *witnesses* the move — and will show the runtime-share jump the moment the front-door flip lands. The instrument's whole value is honesty, so the served-vs-capable distinction stays sharp: CAPABLE is what's proven, SERVED is what fronts live traffic.

## Proof

- `runtime_surface_report.py --json` → `kernel_first_served_routes: 0`, `kernel_first_capable_routes: 4`, names the 4 `/api/utils/*` routes.
- New test `test_runtime_surface_native_routes.py` (3 tests, pass in 0.48s) pins the parser's subtle contract: the manifest mentions the same `/api/...` paths in **both** comments and bindings — the parser returns each once from its binding, ignores comment-before-block (scoping) and comment-inside-block (shape-match), excludes `/health` (non-`/api`). Four boundaries, one strange-minimal synthetic manifest. Plus graceful degrade on absent manifest, plus a pin against the real manifest.
- `API_KERNEL_READINESS.md` healed to the served-vs-capable truth.
- Read-only sensing instrument (exit 0 always); no behavior change, no live-traffic touch, Traefik untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)