### PR TITLE
attune(kernel-router): promote 6 more compute routes to native-in-Form (4 → 10 capable)

### DIFF
--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -15,6 +15,12 @@
 ;   /api/utils/nodeid_distance        int distance + two 4-int NodeID lists
 ;   /api/utils/nodeid_compatibility   int 0..4 agreement + two 4-int lists
 ;   /api/utils/weighted_average       float average + echoed float lists
+;   /api/utils/simpson_diversity      float 1-sum(p^2) + echoed int counts
+;   /api/utils/idea_score             float (pv*conf)/max(cost+rr,0.5) + echoes
+;   /api/utils/marginal_cc_return     float (gap*conf^2)/(rem+rr*0.5) + echoes
+;   /api/utils/breath_balance         float H/ln(3) (incl -0.0) + echoed ints
+;   /api/utils/shannon_entropy        float round(H/ln(3),4) + echoed ints
+;   /api/utils/softmax_weights        float-list softmax + echoed scores/temp
 ;
 ; Each native handler replicates its live route's FULL contract:
 ;   - parses the SAME query params FastAPI declares (with the SAME defaults),
@@ -245,6 +251,273 @@
         ",\"runtime\":\"inline\"}")))))))
 
 ; ===========================================================================
+; /api/utils/simpson_diversity
+;   params: counts (csv ints, default "2,1,1")
+;   body:   {"diversity":<float>,"counts":[...],"runtime":"inline"}
+;   math:   1 - sum((c/total)^2); total<=0 -> 0.0
+;           (endpoint_simpson_diversity_demo.fk)
+; ===========================================================================
+
+; sum a list of ints
+(defn sum_ints_go (xs total)
+  (if (eq (len xs) 0)
+      total
+      (sum_ints_go (tail xs) (add total (head xs)))))
+
+; LEFT-folded sum of squared proportions: acc starts 0.0, each (c/total_f)^2
+; added on the LEFT, mirroring the recipe's i=0..n while-loop (and Python's
+; sum()). total_f is float so each division is float.
+(defn sd_sumsq_go (xs total_f acc)
+  (if (eq (len xs) 0)
+      acc
+      (do (let p (div (head xs) total_f))
+          (sd_sumsq_go (tail xs) total_f (add acc (mul p p))))))
+
+(defn route_simpson_diversity (q)
+  (do (let cstr (param_or "counts" q "2,1,1"))
+  (do (let counts (ints_of (split_commas cstr)))
+  (do (let total (sum_ints_go counts 0))
+  (do (let diversity
+        (if (le total 0)
+            0.0
+            (do (let total_f (add total 0.0))
+                (sub 1.0 (sd_sumsq_go counts total_f 0.0)))))
+      (str_concat
+        (str_concat (str_concat "{\"diversity\":" (value_str diversity))
+                    (str_concat ",\"counts\":" (json_list counts)))
+        ",\"runtime\":\"inline\"}"))))))
+
+; ===========================================================================
+; /api/utils/idea_score
+;   params: potential_value (8.0) confidence (0.75) estimated_cost (2.0)
+;           resistance_risk (1.0) — all floats
+;   body:   {"score":<f>,"potential_value":<f>,"confidence":<f>,
+;            "estimated_cost":<f>,"resistance_risk":<f>,"runtime":"inline"}
+;   math:   (pv*conf) / max2(ec+rr, 0.5)   (endpoint_idea_score_demo.fk)
+; ===========================================================================
+
+(defn max2 (a b) (if (gt a b) a b))
+
+(defn route_idea_score (q)
+  (do (let potential_value (str_to_float (param_or "potential_value" q "8.0")))
+  (do (let confidence (str_to_float (param_or "confidence" q "0.75")))
+  (do (let estimated_cost (str_to_float (param_or "estimated_cost" q "2.0")))
+  (do (let resistance_risk (str_to_float (param_or "resistance_risk" q "1.0")))
+  (do (let denom (max2 (add estimated_cost resistance_risk) 0.5))
+  (do (let score (div (mul potential_value confidence) denom))
+      (str_concat
+        (str_concat
+          (str_concat
+            (str_concat (str_concat "{\"score\":" (value_str score))
+                        (str_concat ",\"potential_value\":" (value_str potential_value)))
+            (str_concat ",\"confidence\":" (value_str confidence)))
+          (str_concat (str_concat ",\"estimated_cost\":" (value_str estimated_cost))
+                      (str_concat ",\"resistance_risk\":" (value_str resistance_risk))))
+        ",\"runtime\":\"inline\"}"))))))))
+
+; ===========================================================================
+; /api/utils/marginal_cc_return
+;   params: pv (8.0) av (3.0) conf (0.8) ec (4.0) ac (1.0) rr (2.0) — floats
+;   body:   {"marginal_return":<f>,"pv":<f>,"av":<f>,"conf":<f>,"ec":<f>,
+;            "ac":<f>,"rr":<f>,"runtime":"inline"}
+;   math:   (value_gap * conf * conf) / (remaining_cost + rr*0.5)
+;           value_gap = max2(pv-av, 0.0); remaining_cost = max2(ec-ac, 0.1)
+;           (endpoint_marginal_cc_return_demo.fk)
+; ===========================================================================
+
+(defn route_marginal_cc_return (q)
+  (do (let pv (str_to_float (param_or "pv" q "8.0")))
+  (do (let av (str_to_float (param_or "av" q "3.0")))
+  (do (let conf (str_to_float (param_or "conf" q "0.8")))
+  (do (let ec (str_to_float (param_or "ec" q "4.0")))
+  (do (let ac (str_to_float (param_or "ac" q "1.0")))
+  (do (let rr (str_to_float (param_or "rr" q "2.0")))
+  (do (let value_gap (max2 (sub pv av) 0.0))
+  (do (let remaining_cost (max2 (sub ec ac) 0.1))
+  (do (let marginal_return
+        (div (mul (mul value_gap conf) conf)
+             (add remaining_cost (mul rr 0.5))))
+      (str_concat
+        (str_concat
+          (str_concat
+            (str_concat
+              (str_concat (str_concat "{\"marginal_return\":" (value_str marginal_return))
+                          (str_concat ",\"pv\":" (value_str pv)))
+              (str_concat ",\"av\":" (value_str av)))
+            (str_concat (str_concat ",\"conf\":" (value_str conf))
+                        (str_concat ",\"ec\":" (value_str ec))))
+          (str_concat (str_concat ",\"ac\":" (value_str ac))
+                      (str_concat ",\"rr\":" (value_str rr))))
+        ",\"runtime\":\"inline\"}")))))))))))
+
+; ===========================================================================
+; entropy fold shared by breath_balance + shannon_entropy
+;   ent_acc folds p*ln(p) over the three proportions in gas->water->ice order,
+;   adding on the LEFT, guarding each term with p>0 (the log-of-zero guard).
+;   acc starts 0.0; a single-phase distribution leaves acc at 0.0 (ln(1.0)=0.0).
+;   This is exactly the recipes' nested-if accumulation, flattened: the present
+;   terms are summed in source order, absent terms (p<=0) contribute nothing.
+; ===========================================================================
+
+(defn ent_term (acc p)
+  (if (gt p 0.0) (add acc (mul p (math_log p))) acc))
+
+(defn ent_acc (p_gas p_water p_ice)
+  (ent_term (ent_term (ent_term 0.0 p_gas) p_water) p_ice))
+
+; ===========================================================================
+; /api/utils/breath_balance
+;   params: gas (1) water (1) ice (1) — ints
+;   body:   {"balance":<f>,"gas":<i>,"water":<i>,"ice":<i>,"runtime":"inline"}
+;   math:   H / ln(3); H = -1.0 * sum(p*ln(p)); total<=0 -> 0.0
+;           single phase -> -0.0 (the trailing single negation of acc=0.0)
+;           (endpoint_breath_balance_demo.fk)
+; ===========================================================================
+
+(defn route_breath_balance (q)
+  (do (let gas (str_to_int (param_or "gas" q "1")))
+  (do (let water (str_to_int (param_or "water" q "1")))
+  (do (let ice (str_to_int (param_or "ice" q "1")))
+  (do (let total (add (add gas water) ice))
+  (do (let balance
+        (if (le total 0)
+            0.0
+            (do (let total_f (add total 0.0))
+            (do (let p_gas (div gas total_f))
+            (do (let p_water (div water total_f))
+            (do (let p_ice (div ice total_f))
+            (do (let h (mul (sub 0 1.0) (ent_acc p_gas p_water p_ice)))
+            (do (let h_max (math_log 3.0))
+                (div h h_max)))))))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"balance\":" (value_str balance))
+                      (str_concat ",\"gas\":" (value_str gas)))
+          (str_concat (str_concat ",\"water\":" (value_str water))
+                      (str_concat ",\"ice\":" (value_str ice))))
+        ",\"runtime\":\"inline\"}")))))))
+
+; ===========================================================================
+; /api/utils/shannon_entropy
+;   params: gas (1) water (1) ice (1) — ints
+;   body:   {"entropy":<f>,"gas":<i>,"water":<i>,"ice":<i>,"runtime":"inline"}
+;   math:   round(H / ln(3), 4); H = sum(-(p*ln(p))) folded by SUBTRACTION
+;           (so single phase -> +0.0); total==0 -> 0.0; max_entropy<=0 -> 0.0
+;           (endpoint_shannon_entropy_demo.fk)
+; ===========================================================================
+
+; SUBTRACTIVE accumulator: entropy starts 0.0 and each present term is
+; SUBTRACTED (entropy - p*ln(p)) in gas->water->ice order. A single nonzero
+; phase yields +0.0 (0.0 - 0.0), distinct from breath_balance's -0.0.
+(defn sh_term (acc p)
+  (if (gt p 0.0) (sub acc (mul p (math_log p))) acc))
+
+(defn sh_acc (p_gas p_water p_ice)
+  (sh_term (sh_term (sh_term 0.0 p_gas) p_water) p_ice))
+
+(defn route_shannon_entropy (q)
+  (do (let gas (str_to_int (param_or "gas" q "1")))
+  (do (let water (str_to_int (param_or "water" q "1")))
+  (do (let ice (str_to_int (param_or "ice" q "1")))
+  (do (let total (add (add gas water) ice))
+  (do (let entropy
+        (if (eq total 0)
+            0.0
+            (do (let max_entropy (math_log 3))
+            (do (let total_f (add total 0.0))
+            (do (let p_gas (div gas total_f))
+            (do (let p_water (div water total_f))
+            (do (let p_ice (div ice total_f))
+            (do (let h (sh_acc p_gas p_water p_ice))
+                (if (gt max_entropy 0)
+                    (round_ndigits (div h max_entropy) 4)
+                    0.0)))))))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"entropy\":" (value_str entropy))
+                      (str_concat ",\"gas\":" (value_str gas)))
+          (str_concat (str_concat ",\"water\":" (value_str water))
+                      (str_concat ",\"ice\":" (value_str ice))))
+        ",\"runtime\":\"inline\"}")))))))
+
+; ===========================================================================
+; /api/utils/softmax_weights
+;   params: scores (csv floats, default "1.0,2.0,3.0"), temperature (1.0)
+;   body:   {"weights":[...],"scores":[...],"temperature":<f>,"runtime":"inline"}
+;   math:   softmax(scores / temperature). temperature<=0 -> deterministic
+;           (1.0 at the argmax positions, 0.0 elsewhere); if exp-sum==0 ->
+;           uniform 1/n. Mirrors endpoint_softmax_weights_demo.fk EXACTLY:
+;           subtract the running max, exp, LEFT-folded total, divide.
+; ===========================================================================
+
+; running max over a list (first element seeds; ties keep the earlier max,
+; matching the recipe's strict `>` update)
+(defn sm_max_go (xs m)
+  (if (eq (len xs) 0)
+      m
+      (sm_max_go (tail xs) (if (gt (head xs) m) (head xs) m))))
+
+(defn sm_max (xs) (sm_max_go (tail xs) (head xs)))
+
+; deterministic weights: 1.0 where score == max_s, else 0.0 (recipe's
+; temperature<=0 branch). Equality on floats mirrors the recipe's (eq ...).
+(defn sm_det_go (xs max_s)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (if (eq (head xs) max_s) 1.0 0.0)
+            (sm_det_go (tail xs) max_s))))
+
+; exps list: exp((score - max_s)/temperature), built in order
+(defn sm_exps_go (xs max_s temp)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (math_exp (div (sub (head xs) max_s) temp))
+            (sm_exps_go (tail xs) max_s temp))))
+
+; LEFT-folded sum of the exps (total starts 0.0, added left), mirroring the
+; recipe's i=0..n while-loop / Python sum()
+(defn sm_sum_go (xs total)
+  (if (eq (len xs) 0)
+      total
+      (sm_sum_go (tail xs) (add total (head xs)))))
+
+; divide each exp by the total (the normalized softmax weights)
+(defn sm_norm_go (xs total)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (div (head xs) total)
+            (sm_norm_go (tail xs) total))))
+
+; fill a list of length n with a constant (uniform fallback)
+(defn sm_fill_go (n v)
+  (if (eq n 0)
+      (list)
+      (cons v (sm_fill_go (sub n 1) v))))
+
+(defn route_softmax_weights (q)
+  (do (let sstr (param_or "scores" q "1.0,2.0,3.0"))
+  (do (let temperature (str_to_float (param_or "temperature" q "1.0")))
+  (do (let scores (floats_of (split_commas sstr)))
+  (do (let n (len scores))
+  (do (let weights
+        (if (eq n 0)
+            (list)
+            (do (let max_s (sm_max scores))
+                (if (le temperature 0.0)
+                    (sm_det_go scores max_s)
+                    (do (let exps (sm_exps_go scores max_s temperature))
+                    (do (let total (sm_sum_go exps 0.0))
+                        (if (eq total 0.0)
+                            (sm_fill_go n (div 1.0 n))
+                            (sm_norm_go exps total))))))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"weights\":" (json_list weights))
+                      (str_concat ",\"scores\":" (json_list scores)))
+          (str_concat ",\"temperature\":" (value_str temperature)))
+        ",\"runtime\":\"inline\"}")))))))
+
+; ===========================================================================
 ; liveness — native, zero inputs (so the shadow answers /health without a hop)
 ; ===========================================================================
 (defn route_health () "ok")
@@ -259,4 +532,10 @@
     (list "/api/utils/coherence_weight"    route_coherence_weight)
     (list "/api/utils/nodeid_distance"     route_nodeid_distance)
     (list "/api/utils/nodeid_compatibility" route_nodeid_compatibility)
-    (list "/api/utils/weighted_average"    route_weighted_average)))
+    (list "/api/utils/weighted_average"    route_weighted_average)
+    (list "/api/utils/simpson_diversity"   route_simpson_diversity)
+    (list "/api/utils/idea_score"          route_idea_score)
+    (list "/api/utils/marginal_cc_return"  route_marginal_cc_return)
+    (list "/api/utils/breath_balance"      route_breath_balance)
+    (list "/api/utils/shannon_entropy"     route_shannon_entropy)
+    (list "/api/utils/softmax_weights"     route_softmax_weights)))

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Promotion proof for the PRODUCTION kernel-router manifest.
 
-deploy/kernel-router/production-routes.fk promotes the four simplest /api/utils
-compute routes from FANNED-OUT (served by CPython) to NATIVE (served in Form by
-the kernel). This harness PROVES each promoted route serves a byte-identical
-JSON response to the route's CPython twin — the actual runtime-share move.
+deploy/kernel-router/production-routes.fk promotes the cleanly-promotable
+/api/utils compute routes (scalar/list-in → flat-JSON-out) from FANNED-OUT
+(served by CPython) to NATIVE (served in Form by the kernel). This harness PROVES
+each promoted route serves a byte-identical JSON response to the route's CPython
+twin — the actual runtime-share move. The PROMOTED list below is the source of
+truth for which routes + query strings are proven (extend it as routes promote).
 
 The oracle is the route's CPython implementation. By default the harness boots
 the REAL FastAPI app locally (uvicorn app.main:app, COH_ENV=dev / sqlite) and
@@ -74,6 +76,45 @@ PROMOTED: list[tuple[str, list[str]]] = [
         "?values=0.1,0.2,0.3&weights=0.7,0.2,0.1",               # float accumulation order
         "?values=1.1,2.2,3.3,4.4,5.5&weights=0.1,0.1,0.1,0.1,0.6",
         "?values=7.7,8.8&weights=0.9,0.1",                       # 7.8100000000000005
+    ]),
+    # ----- batch 2: scalar/list compute routes (this pass) -----
+    ("/api/utils/simpson_diversity", [
+        "",                              # defaults 2,1,1 -> 0.625
+        "?counts=5",                     # single category -> 0.0 (no diversity)
+        "?counts=1,1,1",                 # 1/3 squared float -> 0.6666666666666667
+        "?counts=3,2,1",                 # 0.6111111111111112
+        "?counts=0",                     # total<=0 guard -> 0.0
+    ]),
+    ("/api/utils/idea_score", [
+        "",                              # defaults -> 2.0
+        "?potential_value=0.1&confidence=0.2&estimated_cost=0.0&resistance_risk=0.0",  # floor + 0.04000000000000001
+        "?potential_value=1&confidence=1&estimated_cost=3&resistance_risk=0",          # denom=3 -> 0.3333333333333333
+        "?potential_value=10&confidence=0.5&estimated_cost=2&resistance_risk=2",       # denom=4
+    ]),
+    ("/api/utils/marginal_cc_return", [
+        "",                              # defaults -> 0.8
+        "?pv=2&av=5",                    # value_gap floor 0 -> 0.0
+        "?ec=1&ac=5&rr=0&pv=10&av=0&conf=1",  # remaining_cost floor 0.1 -> 100.0
+        "?pv=5&av=1&conf=0.5&ec=3&ac=1&rr=1", # mid-range floats
+    ]),
+    ("/api/utils/breath_balance", [
+        "",                              # defaults 1,1,1 -> 0.9999999999999998
+        "?gas=5&water=0&ice=0",          # single phase -> -0.0 (trailing negation)
+        "?gas=0&water=0&ice=0",          # total<=0 -> 0.0
+        "?gas=3&water=2&ice=1",          # 0.9206198357143047
+    ]),
+    ("/api/utils/shannon_entropy", [
+        "",                              # defaults 1,1,1 -> 1.0
+        "?gas=5&water=0&ice=0",          # single phase -> +0.0 (subtractive acc)
+        "?gas=0&water=0&ice=0",          # total==0 -> 0.0
+        "?gas=3&water=2&ice=1",          # rounded to 4 places
+    ]),
+    ("/api/utils/softmax_weights", [
+        "",                              # defaults 1,2,3 temp 1 -> distribution
+        "?scores=1.0,3.0,2.0&temperature=0",  # deterministic -> [0.0,1.0,0.0]
+        "?scores=0.1,0.2,0.3",           # adversarial floats
+        "?scores=5.0",                   # single element -> [1.0]
+        "?scores=2.0,2.0,2.0",           # all equal -> uniform thirds
     ]),
 ]
 
@@ -306,8 +347,8 @@ def main() -> int:
                      if args.live else "")
         print(f"\nok — all {n_checks} promoted-route checks value-identical to the local "
               f"CPython oracle{live_note} (native-kernel, application/json), fan-out still "
-              f"flows, native served {speedup:.1f}x faster than CPython. The four routes "
-              f"are promotion-ready: served in the body's own kernel, byte-for-byte the api.")
+              f"flows, native served {speedup:.1f}x faster than CPython. The {len(PROMOTED)} "
+              f"routes are promotion-ready: served in the body's own kernel, byte-for-byte the api.")
         return 0
     finally:
         if router_proc is not None:

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -507,14 +507,15 @@ shown; chunked transfer and structural-JSON are the rest.
 The real-app proof above runs ONE native route returning a scalar value. The
 PRODUCTION manifest
 [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk)
-takes the next step the durable flip needs: it PROMOTES the four simplest
-`/api/utils` compute routes from the fan-out tail (served by CPython) to NATIVE
-(served entirely in Form), each returning the **full JSON response object** its
-FastAPI twin returns — byte-for-byte. These are the routes whose Form computation
-is already parity-proven against CPython by the three-way kernel suite
-(`endpoint_<name>_demo.fk`); promotion replicates their FULL HTTP contract — the
-exact query params with the exact FastAPI defaults, the arithmetic in Form, and
-the exact response document.
+takes the next step the durable flip needs: it PROMOTES the cleanly-promotable
+`/api/utils` compute routes (scalar/list-in → flat-JSON-out) from the fan-out tail
+(served by CPython) to NATIVE (served entirely in Form), each returning the **full
+JSON response object** its FastAPI twin returns — byte-for-byte. These are the
+routes whose Form computation is already parity-proven against CPython by the
+three-way kernel suite (`endpoint_<name>_demo.fk`); promotion replicates their FULL
+HTTP contract — the exact query params with the exact FastAPI defaults, the
+arithmetic in Form, and the exact response document. Ten routes are promoted today
+(the first four scalar/list computes, then six pure-numeric scoring/entropy routes).
 
 | Promoted route | params | response shape |
 |----------------|--------|----------------|
@@ -522,6 +523,12 @@ the exact response document.
 | `/api/utils/nodeid_distance` | 8 NodeID coords (ints) | `{"distance":<int>,"a":[…4],"b":[…4],"runtime":"inline"}` |
 | `/api/utils/nodeid_compatibility` | 8 NodeID coords (ints) | `{"compatibility":<0..4>,"a":[…4],"b":[…4],"runtime":"inline"}` |
 | `/api/utils/weighted_average` | `values`, `weights` (csv floats) | `{"average":<float>,"values":[…],"weights":[…],"runtime":"inline"}` |
+| `/api/utils/simpson_diversity` | `counts` (csv ints) | `{"diversity":<float>,"counts":[…],"runtime":"inline"}` |
+| `/api/utils/idea_score` | `potential_value` `confidence` `estimated_cost` `resistance_risk` (floats) | `{"score":<float>,…echoes,"runtime":"inline"}` |
+| `/api/utils/marginal_cc_return` | `pv` `av` `conf` `ec` `ac` `rr` (floats) | `{"marginal_return":<float>,…echoes,"runtime":"inline"}` |
+| `/api/utils/breath_balance` | `gas` `water` `ice` (ints) | `{"balance":<float>,"gas":<int>,"water":<int>,"ice":<int>,"runtime":"inline"}` (incl. `-0.0`) |
+| `/api/utils/shannon_entropy` | `gas` `water` `ice` (ints) | `{"entropy":<float>,"gas":<int>,"water":<int>,"ice":<int>,"runtime":"inline"}` (round 4) |
+| `/api/utils/softmax_weights` | `scores` (csv floats), `temperature` (float) | `{"weights":[…],"scores":[…],"temperature":<float>,"runtime":"inline"}` |
 
 Each handler parses its query params from the request alist (a recursive
 `split_commas` over the kernel's `str_find`/`substring`, then `str_to_int` /
@@ -534,17 +541,21 @@ native-kernel`.
 [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py)
 proves the promotion two ways at once — boot the real local app as the CPython
 oracle, stand the kernel-router (production manifest) in front, and for each of
-the four routes over representative + edge params (15 cases):
+the ten routes over representative + edge params (41 cases):
 
 ```
 [native  ] /api/utils/coherence_weight -> {"weight":16185,…,"runtime":"inline"}  X-Form-Router=native-kernel  application/json
            value-contract == local CPython oracle: MATCH   (native runtime='inline', dev-app runtime='subprocess')
            FULL-BODY     == LIVE  https://api.coherencycoin.com: BYTE-IDENTICAL
-… all 15 cases, incl. adversarial floats (0.14000000000000004, 7.8100000000000005, 0.30000000000000004)
+[native  ] /api/utils/breath_balance?gas=5&water=0&ice=0 -> {"balance":-0.0,…}  FULL-BODY == LIVE: BYTE-IDENTICAL
+[native  ] /api/utils/softmax_weights?scores=0.1,0.2,0.3 -> {"weights":[0.3006096053557273,…]}  FULL-BODY == LIVE: BYTE-IDENTICAL
+… all 41 cases, incl. adversarial floats (0.14000000000000004, 0.04000000000000001,
+  0.6666666666666667), CPython's -0.0 vs +0.0 on single-phase entropy, and
+  deterministic + uniform softmax
 
-native  (kernel-router, Form):   p50=0.255 ms  p99=0.361 ms
-CPython (app serve_via_kernel):  p50=11.05 ms  p99=16.31 ms
--> native p50 is 43.3x faster than the CPython-served route (a fan-out adds the proxy hop ON TOP)
+native  (kernel-router, Form):   p50=0.241 ms  p99=0.343 ms
+CPython (app serve_via_kernel):  p50=11.02 ms  p99=12.54 ms
+-> native p50 is 45.7x faster than the CPython-served route (a fan-out adds the proxy hop ON TOP)
 ```
 
 Two honest claims, kept distinct:
@@ -571,18 +582,22 @@ the same compute served through the CPython doorway (and a fan-out would add the
 proxy hop on top of that CPython cost). Skipping the entire uvicorn → routing →
 Pydantic-bind → `serve_via_kernel`-subprocess lifecycle is where the win lives.
 
-**Promotability map.** The four promoted routes are scalar/list-in, scalar/list-out
-with a flat JSON response — the cleanly-promotable subset. The remaining 18
-kernel-served `/api/utils` routes split by handler capability: the other pure-numeric
-ones (`simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`,
-`shannon_entropy`, `softmax_weights`, `cost_vector`, `value_vector`, …) are the SAME
-shape and promotable with the same handler primitives as their recipes already prove
-the math — the work per route is authoring the param-parse + JSON-emit, not new kernel
-capability. The routes that read a STRUCTURED record (`idea_marginal_from_record`,
-`idea_grounding_summary`, `coherence_summary_score`) or return nested objects need the
-request-side structural-JSON parse (still an open breath) before their full contract
-can be replicated natively. This manifest is the durable flip's native surface, ready
-for the cutover; it does NOT flip — the standing shadow still fans out every route.
+**Promotability map.** The ten promoted routes are scalar/list-in, scalar/list-out
+with a flat JSON response — the cleanly-promotable subset. The first four are the
+integer/float scalar+list computes; the next six (`simpson_diversity`, `idea_score`,
+`marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) are
+the pure-numeric scoring/entropy routes — same handler primitives plus the `math_log`
+/ `math_exp` / `round_ndigits` natives their recipes already exercise (`breath_balance`
+even reproduces CPython's `-0.0` on a single-phase distribution, byte-for-byte; the
+work per route was authoring the param-parse + JSON-emit, not new kernel capability).
+The routes that read a STRUCTURED record (`idea_marginal_from_record`,
+`idea_grounding_summary`, `coherence_summary_score`) or fold parallel arrays into
+records / return nested objects (`grounded_cost`, `grounded_value`, `cost_vector`,
+`value_vector`, `grounded_roi`) need the request-side structural-record marshalling
+in the native handler (still an open breath) before their full contract can be
+replicated natively — the flat-JSON helpers here parse only csv-of-scalars. This
+manifest is the durable flip's native surface, ready for the cutover; it does NOT
+flip — the standing shadow still fans out every route.
 
 ## The flip — sensed to the bone, the decision is intent not permission
 
@@ -718,8 +733,8 @@ door is FastAPI.
 - [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
-- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): four promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit.
-- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all four routes over representative + edge params (15 cases, incl. adversarial floats) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.25 ms) vs CPython-served (~11 ms) latency, the ~43x runtime-share win. Read-only against the live api; tears the local app + router down.
+- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): ten promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`, `simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit; the entropy routes carry `math_log`/`round_ndigits` and `breath_balance` reproduces CPython's `-0.0` exactly.
+- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all ten routes over representative + edge params (41 cases, incl. adversarial floats, `-0.0`, deterministic + uniform softmax) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.24 ms) vs CPython-served (~11 ms) latency, the ~45x runtime-share win. Read-only against the live api; tears the local app + router down.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.
 
 ### The deployable artifact (the kernel-router as a standalone server)


### PR DESCRIPTION
## What

Promotes the next batch of cleanly-promotable `/api/utils` compute routes from CPython-fanout to **NATIVE-in-Form** in the kernel-router manifest (`deploy/kernel-router/production-routes.fk`), each proven **byte-identical to the live api** in localhost shadow. Grows the native front-door surface the durable runtime-share flip will front. **Does NOT flip** — Traefik untouched, shadow localhost-only, only read-only GETs against the live api. The kernel binary is **not touched** (`value_str` + `math_log`/`math_exp`/`round_ndigits` + the JSON content-type native already exist).

`kernel_first_capable_routes`: **4 → 10**.

## Routes promoted (6)

Each is a `(defn route_<name> (q) ...)` native Form handler that parses the SAME query params with the SAME FastAPI defaults, runs the SAME math its `endpoint_<name>_demo.fk` recipe runs (mirrored exactly, incl. LEFT-associated float folds), and emits the live api's full JSON body byte-for-byte (no spaces, key order, `runtime:"inline"`):

| Route | Math | Edge proven |
|-------|------|-------------|
| `simpson_diversity` | `1 - sum((c/total)^2)`, LEFT-folded; `total<=0 → 0.0` | `counts=1,1,1 → 0.6666666666666667` |
| `idea_score` | `(pv*conf)/max2(ec+rr, 0.5)` | floor + `0.04000000000000001` |
| `marginal_cc_return` | `(gap*conf^2)/(rem+rr*0.5)`; gap/rem floored | `remaining_cost` floor → `100.0` |
| `breath_balance` | `H/ln(3)`; trailing single negation | single-phase → **`-0.0`** (byte-exact) |
| `shannon_entropy` | `round(H/ln(3), 4)`; subtractive accumulator | single-phase → **`+0.0`** (distinct from breath) |
| `softmax_weights` | `softmax(scores/temp)` (list-out) | deterministic `[0.0,1.0,0.0]`, uniform thirds |

## Proof — byte-identical in shadow

`form/form-kernel-rust/production_routes_harness.py --live https://api.coherencycoin.com` boots the real app as the local CPython oracle, stands the kernel-router (production manifest) in front, and for **all 41 cases (10 routes)** proves the native body is **FULL-BODY byte-identical to the live production api** — including adversarial floats, CPython's `-0.0` vs `+0.0` single-phase entropy, and deterministic + uniform softmax. Native p50 **~0.24 ms** vs ~11 ms CPython-served (**45.7x**).

```
[OK] /api/utils/breath_balance?gas=5&water=0&ice=0
        {"balance":-0.0,"gas":5,"water":0,"ice":0,"runtime":"inline"}
        [OK] native FULL-BODY == LIVE https://api.coherencycoin.com: BYTE-IDENTICAL
[OK] /api/utils/softmax_weights?scores=0.1,0.2,0.3
        {"weights":[0.3006096053557273,0.3322249935333473,0.3671654011109255],...}
        [OK] native FULL-BODY == LIVE https://api.coherencycoin.com: BYTE-IDENTICAL
ok — all 41 promoted-route checks ... FULL-BODY BYTE-IDENTICAL to LIVE
```

## Instrument movement

- `scripts/runtime_surface_report.py --json`: `kernel_first_capable_routes` **4 → 10**, with the 6 new names.
- The wellness probe reads the same count (no duplicated number — it imports `kernel_first_capable_routes()`).
- `api/tests/test_runtime_surface_native_routes.py` still passes (asserts all CAPABLE routes are unique `/api` paths read from the manifest bindings).

## Not promoted (needs more handler capability)

Routes whose contract needs request-side **structured-record marshalling** or **nested-object responses** — the flat-JSON helpers here parse only csv-of-scalars:
- `grounded_cost` / `grounded_value` / `cost_vector` / `value_vector` / `grounded_roi` — fold parallel arrays into list-of-records; multi-field nested response.
- `idea_marginal_from_record` / `idea_grounding_summary` / `coherence_summary_score` — read a structured record binding.

## No live-traffic touch

Traefik untouched; shadow localhost-only; prod `/api/health` verified `ok` before + after; only read-only GETs against the live api. `production-routes.fk` and `kernels/KERNEL_AS_ROUTER.md` are outside the deploy filter paths, so this does not trigger a prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)