### PR TITLE
tend: promote grounded_value to native-in-Form (CAPABLE 10 → 11)

### DIFF
--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -518,6 +518,61 @@
         ",\"runtime\":\"inline\"}")))))))
 
 ; ===========================================================================
+; /api/utils/grounded_value
+;   the VALUE / REALIZATION / CONFIDENCE reduction of compute_idea_metrics.
+;   params (all scalar, host pre-derives the has_* boolean levels):
+;     lineage_measured_value(12.5) usage_revenue(0.007) spec_actual_value_sum(4.25)
+;     spec_estimated_cost_sum(6.75) lineage_estimated_cost(5.5)
+;     spec_potential_value_sum(20.0) runtime_event_count(7,int) commit_count(3,int)
+;     has_specs_with_data(1.0) has_lineage(1.0) has_friction(0.3)
+;   body: {"computed_actual_value","computed_estimated_cost",
+;          "value_realization_pct","computed_confidence","runtime":"inline"}
+;   math mirrors endpoint_grounded_value_demo.fk EXACTLY (min2/max2/_plus/mul/div,
+;   the guarded ratio + count→level zero-guards, the five-term weighted sum left-
+;   nested, the [0.05,0.95] clamp). int/float mixing (div count 10.0, gt count 0)
+;   promotes as the parity-proven recipe relies on.
+; ===========================================================================
+
+; min2 — the recipe's companion to max2 (max2 already defined above)
+(defn min2 (a b) (if (gt a b) b a))
+
+; value_realization_pct: guarded ratio with a 1.0 ceiling, 0.0 when no potential
+(defn gv_realization (cav spv)
+  (if (gt spv 0) (min2 (div cav spv) 1.0) 0.0))
+
+; has_runtime_data / has_commits: min(1.0, count/divisor), 0.0 when count==0
+(defn gv_level (cnt divisor)
+  (if (gt cnt 0) (min2 1.0 (div cnt divisor)) 0.0))
+
+(defn route_grounded_value (q)
+  (do (let lmv (str_to_float (param_or "lineage_measured_value" q "12.5")))
+  (do (let ur (str_to_float (param_or "usage_revenue" q "0.007")))
+  (do (let savs (str_to_float (param_or "spec_actual_value_sum" q "4.25")))
+  (do (let secs (str_to_float (param_or "spec_estimated_cost_sum" q "6.75")))
+  (do (let lec (str_to_float (param_or "lineage_estimated_cost" q "5.5")))
+  (do (let spvs (str_to_float (param_or "spec_potential_value_sum" q "20.0")))
+  (do (let rec (str_to_int (param_or "runtime_event_count" q "7")))
+  (do (let cc (str_to_int (param_or "commit_count" q "3")))
+  (do (let hsd (str_to_float (param_or "has_specs_with_data" q "1.0")))
+  (do (let hl (str_to_float (param_or "has_lineage" q "1.0")))
+  (do (let hf (str_to_float (param_or "has_friction" q "0.3")))
+  (do (let cav (max2 (max2 lmv ur) savs))
+  (do (let cec (max2 secs lec))
+  (do (let vrp (gv_realization cav spvs))
+  (do (let hrd (gv_level rec 10.0))
+  (do (let hcm (gv_level cc 5.0))
+  (do (let confraw (_plus (_plus (_plus (_plus (mul hsd 0.3) (mul hrd 0.25)) (mul hl 0.25)) (mul hcm 0.1)) (mul hf 0.1)))
+  (do (let conf (max2 0.05 (min2 0.95 confraw)))
+      (str_concat
+        (str_concat
+          (str_concat
+            (str_concat (str_concat "{\"computed_actual_value\":" (value_str cav))
+                        (str_concat ",\"computed_estimated_cost\":" (value_str cec)))
+            (str_concat ",\"value_realization_pct\":" (value_str vrp)))
+          (str_concat ",\"computed_confidence\":" (value_str conf)))
+        ",\"runtime\":\"inline\"}"))))))))))))))))))))
+
+; ===========================================================================
 ; liveness — native, zero inputs (so the shadow answers /health without a hop)
 ; ===========================================================================
 (defn route_health () "ok")
@@ -538,4 +593,5 @@
     (list "/api/utils/marginal_cc_return"  route_marginal_cc_return)
     (list "/api/utils/breath_balance"      route_breath_balance)
     (list "/api/utils/shannon_entropy"     route_shannon_entropy)
-    (list "/api/utils/softmax_weights"     route_softmax_weights)))
+    (list "/api/utils/softmax_weights"     route_softmax_weights)
+    (list "/api/utils/grounded_value"      route_grounded_value)))

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -116,6 +116,15 @@ PROMOTED: list[tuple[str, list[str]]] = [
         "?scores=5.0",                   # single element -> [1.0]
         "?scores=2.0,2.0,2.0",           # all equal -> uniform thirds
     ]),
+    ("/api/utils/grounded_value", [
+        "",                              # defaults -> realization 0.625, confidence 0.815
+        "?spec_potential_value_sum=0",   # realization zero-guard -> 0.0
+        "?runtime_event_count=0&commit_count=0",  # count zero-guards -> levels 0.0
+        "?lineage_measured_value=0&usage_revenue=0&spec_actual_value_sum=1&spec_potential_value_sum=3",  # 1/3 long float
+        "?has_specs_with_data=1&has_lineage=1&has_friction=1&runtime_event_count=100&commit_count=100",  # clamp high -> 0.95
+        "?has_specs_with_data=0&has_lineage=0&has_friction=0&runtime_event_count=0&commit_count=0",       # clamp low -> 0.05
+        "?runtime_event_count=3&commit_count=2&has_friction=0.3&has_specs_with_data=0.5&has_lineage=0.5",  # float-assoc artifact
+    ]),
 ]
 
 # A path the manifest does NOT promote -> must fan out to CPython.

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -514,8 +514,10 @@ JSON response object** its FastAPI twin returns — byte-for-byte. These are the
 routes whose Form computation is already parity-proven against CPython by the
 three-way kernel suite (`endpoint_<name>_demo.fk`); promotion replicates their FULL
 HTTP contract — the exact query params with the exact FastAPI defaults, the
-arithmetic in Form, and the exact response document. Ten routes are promoted today
-(the first four scalar/list computes, then six pure-numeric scoring/entropy routes).
+arithmetic in Form, and the exact response document. Eleven routes are promoted
+today (the first four scalar/list computes, six pure-numeric scoring/entropy
+routes, then `grounded_value` — the value/realization/confidence reduction of
+`compute_idea_metrics`, eleven host-derived scalars folded to four floats).
 
 | Promoted route | params | response shape |
 |----------------|--------|----------------|
@@ -529,6 +531,7 @@ arithmetic in Form, and the exact response document. Ten routes are promoted tod
 | `/api/utils/breath_balance` | `gas` `water` `ice` (ints) | `{"balance":<float>,"gas":<int>,"water":<int>,"ice":<int>,"runtime":"inline"}` (incl. `-0.0`) |
 | `/api/utils/shannon_entropy` | `gas` `water` `ice` (ints) | `{"entropy":<float>,"gas":<int>,"water":<int>,"ice":<int>,"runtime":"inline"}` (round 4) |
 | `/api/utils/softmax_weights` | `scores` (csv floats), `temperature` (float) | `{"weights":[…],"scores":[…],"temperature":<float>,"runtime":"inline"}` |
+| `/api/utils/grounded_value` | 11 scalars (`lineage_measured_value`, `usage_revenue`, `spec_*`, `*_count` ints, `has_*` levels) | `{"computed_actual_value":<float>,"computed_estimated_cost":<float>,"value_realization_pct":<float>,"computed_confidence":<float>,"runtime":"inline"}` |
 
 Each handler parses its query params from the request alist (a recursive
 `split_commas` over the kernel's `str_find`/`substring`, then `str_to_int` /
@@ -541,7 +544,7 @@ native-kernel`.
 [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py)
 proves the promotion two ways at once — boot the real local app as the CPython
 oracle, stand the kernel-router (production manifest) in front, and for each of
-the ten routes over representative + edge params (41 cases):
+the eleven routes over representative + edge params (48 cases):
 
 ```
 [native  ] /api/utils/coherence_weight -> {"weight":16185,…,"runtime":"inline"}  X-Form-Router=native-kernel  application/json
@@ -549,9 +552,11 @@ the ten routes over representative + edge params (41 cases):
            FULL-BODY     == LIVE  https://api.coherencycoin.com: BYTE-IDENTICAL
 [native  ] /api/utils/breath_balance?gas=5&water=0&ice=0 -> {"balance":-0.0,…}  FULL-BODY == LIVE: BYTE-IDENTICAL
 [native  ] /api/utils/softmax_weights?scores=0.1,0.2,0.3 -> {"weights":[0.3006096053557273,…]}  FULL-BODY == LIVE: BYTE-IDENTICAL
-… all 41 cases, incl. adversarial floats (0.14000000000000004, 0.04000000000000001,
-  0.6666666666666667), CPython's -0.0 vs +0.0 on single-phase entropy, and
-  deterministic + uniform softmax
+… all 48 cases, incl. adversarial floats (0.14000000000000004, 0.04000000000000001,
+  0.6666666666666667), CPython's -0.0 vs +0.0 on single-phase entropy, the
+  grounded_value confidence weighted-sum's float-assoc artifact
+  (0.42000000000000004, 0.5800000000000001) and its [0.05, 0.95] clamp + zero-
+  guards, and deterministic + uniform softmax
 
 native  (kernel-router, Form):   p50=0.241 ms  p99=0.343 ms
 CPython (app serve_via_kernel):  p50=11.02 ms  p99=12.54 ms
@@ -582,7 +587,7 @@ the same compute served through the CPython doorway (and a fan-out would add the
 proxy hop on top of that CPython cost). Skipping the entire uvicorn → routing →
 Pydantic-bind → `serve_via_kernel`-subprocess lifecycle is where the win lives.
 
-**Promotability map.** The ten promoted routes are scalar/list-in, scalar/list-out
+**Promotability map.** The eleven promoted routes are scalar/list-in, scalar/list-out
 with a flat JSON response — the cleanly-promotable subset. The first four are the
 integer/float scalar+list computes; the next six (`simpson_diversity`, `idea_score`,
 `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) are
@@ -590,14 +595,30 @@ the pure-numeric scoring/entropy routes — same handler primitives plus the `ma
 / `math_exp` / `round_ndigits` natives their recipes already exercise (`breath_balance`
 even reproduces CPython's `-0.0` on a single-phase distribution, byte-for-byte; the
 work per route was authoring the param-parse + JSON-emit, not new kernel capability).
-The routes that read a STRUCTURED record (`idea_marginal_from_record`,
-`idea_grounding_summary`, `coherence_summary_score`) or fold parallel arrays into
-records / return nested objects (`grounded_cost`, `grounded_value`, `cost_vector`,
-`value_vector`, `grounded_roi`) need the request-side structural-record marshalling
-in the native handler (still an open breath) before their full contract can be
-replicated natively — the flat-JSON helpers here parse only csv-of-scalars. This
-manifest is the durable flip's native surface, ready for the cutover; it does NOT
-flip — the standing shadow still fans out every route.
+The eleventh, `grounded_value`, is the same flat shape one step deeper: eleven
+host-derived SCALARS (the host pre-resolves the boolean-over-record `has_*` levels)
+folded to four floats via `min2`/`max2`/`_plus`/`div`, the guarded ratio and
+count→level zero-guards, the five-term weighted sum, and the `[0.05, 0.95]` clamp —
+all from existing primitives. Its wire contract is all-scalar-in / flat-out, so it
+needed NO structural marshalling (an earlier reading mislabeled it as nested — many
+flat fields is not a nested object).
+
+The remaining grounded routes split into two honest tiers, NOT one:
+- **Parallel-CSV-in, flat-multi-field-out** (`grounded_cost`, and the `cost_vector`
+  / `value_vector` / `grounded_roi` family): the GET surface is parallel csv arrays
+  and the response is flat (no nesting) — their numeric COMPUTATION is promotable
+  with the existing list-fold helpers plus a two-list clamp-fold (`mul` already
+  promotes int×float as the recipe relies on). What `grounded_cost` still needs
+  before it is a clean drop-in is **input fidelity**, not new response capability:
+  the `int(float(x))` commit-int parse, the empty-segment skip (`if x.strip()`), and
+  the 422 on mismatched-length arrays. Named, bounded, the next breath.
+- **Structured-record-in** (`idea_marginal_from_record`, `idea_grounding_summary`,
+  `coherence_summary_score`): these read a STRUCTURED record (a dict/object request
+  binding) — genuinely needing request-side structural-record marshalling in the
+  native handler (still an open breath).
+
+This manifest is the durable flip's native surface, ready for the cutover; it does
+NOT flip — the standing shadow still fans out every route.
 
 ## The flip — sensed to the bone, the decision is intent not permission
 
@@ -733,8 +754,8 @@ door is FastAPI.
 - [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
-- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): ten promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`, `simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit; the entropy routes carry `math_log`/`round_ndigits` and `breath_balance` reproduces CPython's `-0.0` exactly.
-- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all ten routes over representative + edge params (41 cases, incl. adversarial floats, `-0.0`, deterministic + uniform softmax) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.24 ms) vs CPython-served (~11 ms) latency, the ~45x runtime-share win. Read-only against the live api; tears the local app + router down.
+- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): eleven promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`, `simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`, `grounded_value`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit; the entropy routes carry `math_log`/`round_ndigits`, `breath_balance` reproduces CPython's `-0.0` exactly, and `grounded_value` folds eleven host-derived scalars (the value/realization/confidence reduction of `compute_idea_metrics`) through `min2`/`max2`/`_plus` with the `[0.05,0.95]` confidence clamp.
+- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all eleven routes over representative + edge params (48 cases, incl. adversarial floats, `-0.0`, deterministic + uniform softmax, and `grounded_value`'s confidence float-assoc artifact + clamp/zero-guards) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.24 ms) vs CPython-served (~11 ms) latency, the ~45x runtime-share win. Read-only against the live api; tears the local app + router down.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.
 
 ### The deployable artifact (the kernel-router as a standalone server)


### PR DESCRIPTION
## What

Promotes `/api/utils/grounded_value` from CPython-fanout to **native-in-Form** in the kernel-router, proven byte-identical to the live api. CAPABLE routes 10 → 11.

The promotability map had marked `grounded_value` as needing "request-side structural-record marshalling / nested response." That was wrong: its actual wire contract is **eleven host-derived scalars in → a flat four-float JSON out** (the host pre-resolves the boolean-over-record `has_*` levels). Many flat fields is not a nested object — it was the clean-promotable shape one step deeper, wrongly in the blocked pile.

## The handler

`route_grounded_value` mirrors `endpoint_grounded_value_demo.fk` **exactly** — the value/realization/confidence reduction of `compute_idea_metrics`:
- `computed_actual_value = max(lineage_measured_value, usage_revenue, spec_actual_value_sum)`
- `computed_estimated_cost = max(spec_estimated_cost_sum, lineage_estimated_cost)`
- `value_realization_pct = min(value/potential, 1.0)` guarded by `potential > 0`
- `has_runtime_data / has_commits = min(1.0, count/N)` guarded by `count > 0`
- `computed_confidence = clamp(5-term weighted sum, 0.05, 0.95)`

Added `min2` + `gv_realization`/`gv_level` guard helpers. int/float mixing (`div count 10.0`, `gt count 0`) promotes as the parity-proven recipe relies on.

## Proof (byte-identical, not just value-identical)

7 cases verified with direct curl, native-kernel vs `https://api.coherencycoin.com`, **char-for-char identical**:
- defaults → `value_realization_pct:0.625, computed_confidence:0.815`
- `spec_potential_value_sum=0` → realization zero-guard `0.0`
- `runtime_event_count=0&commit_count=0` → level zero-guards
- long-float realization → `0.3333333333333333`
- confidence clamp HIGH → `0.95`, LOW → `0.05`
- **float-assoc artifacts** → `0.42000000000000004`, `0.5800000000000001` (proves `_plus`'s left-nested accumulation matches CPython's float associativity bit-for-bit)

The harness (`production_routes_harness.py`) now covers **all 11 routes / 48 cases**, value-identical to the local CPython oracle AND full-body byte-identical to live. Native p50 ~0.25ms vs CPython-served ~13ms (**46×**).

## Instrument + map

- `runtime_surface_report.py` reads CAPABLE **10 → 11** automatically (it reads the manifest as DATA). The pinning test (`test_runtime_surface_native_routes.py`) still passes.
- `KERNEL_AS_ROUTER.md` promotability map **corrected** into three honest tiers: scalar-in (promoted, incl. `grounded_value`), parallel-CSV-in/flat-out (`grounded_cost` family — computation-ready, input-fidelity pending: the `int(float())` parse, empty-segment skip, 422 length-mismatch), and structured-record-in (`idea_grounding_summary`/`coherence_summary_score` — genuinely needs request-side marshalling). The earlier map conflated the first two with the third.

## Honesty

This grows the native surface the durable flip will front; it does **NOT** flip — the standing shadow still fans out every route. Proven entirely with a local app + local kernel-router against the live api (read-only GETs); Traefik untouched, prod health verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)