### PR TITLE
tend: parallelize the home page's server-side data fetches

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -182,9 +182,15 @@ export default async function Home() {
     title: t(step.titleKey) || step.title,
     description: t(step.descKey) || step.description,
   }));
-  const homePresenceCards = await getHomePresenceTraceCards(lang);
-
-  const [ideasData, resonanceItems, coherenceScore, nodeCount, featuredConcept] = await Promise.all([
+  // All server-side data the home render needs, fetched in ONE parallel wave.
+  // getHomePresenceTraceCards fans out its own /api/field-stories calls, so
+  // awaiting it ahead of the others used to add a whole sequential network
+  // phase to every dynamic (per-locale) render — the home page's cold-render
+  // latency. It depends only on `lang` (resolved above) and is independent of
+  // the other loaders, so it joins the same Promise.all: total render-blocking
+  // fetch time becomes max(6) instead of getHomePresenceTraceCards + max(5).
+  const [homePresenceCards, ideasData, resonanceItems, coherenceScore, nodeCount, featuredConcept] = await Promise.all([
+    getHomePresenceTraceCards(lang),
     loadIdeas(lang),
     loadResonance(lang),
     loadCoherenceScore(),


### PR DESCRIPTION
## What

The home page (`web/app/page.tsx`) is per-locale dynamic — it reads `cookies()`/`headers()` to render in the viewer's language on first visit, so every request is a fresh SSR with blocking data fetches (no ISR cache is possible for a per-cookie page). The witness has flagged the **web organ `strained`** intermittently this session: the home page cold-renders around **~2s** while other pages serve in ~0.3s.

The avoidable cost: `getHomePresenceTraceCards` (which fans out its own `/api/field-stories` calls) was `await`ed **sequentially ahead of** the five-way `Promise.all` — a whole extra network phase on every render. It depends only on `lang` and is independent of the other loaders, so it now joins the same parallel wave.

**Render-blocking fetch time drops from `(getHomePresenceTraceCards + max(5))` to `max(6)`.**

## Safety

- Behaviour-identical: same six data sources, same results, same error semantics (every loader uses `fetchJsonOrNull` / returns a safe fallback — no new throw paths).
- Pure concurrency reorder; `homePresenceCards` is still consumed unchanged in the render.
- `tsc --noEmit` clean. Rendered output unchanged (no layout/content change → no viewport regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)