### PR TITLE
tend: heal stale INDEX edges (test file that didn't land, drifted counts)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,7 +34,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 142 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 244 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 238 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 239 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 238
+**Total files**: 239
 
 | File | Purpose |
 |---|---|
@@ -161,6 +161,7 @@
 | [test_runtime_api.py](test_runtime_api.py) | Tests for the canonical-route-registry-and-runtime-mapping spec |
 | [test_runtime_event_store_precedence.py](test_runtime_event_store_precedence.py) | Regression tests for runtime telemetry DB precedence. |
 | [test_runtime_mode_and_events.py](test_runtime_mode_and_events.py) | _no top-of-file purpose_ |
+| [test_runtime_surface_native_routes.py](test_runtime_surface_native_routes.py) | The runtime-surface instrument SEES the kernel-router's native surface. |
 | [test_session_greeting.py](test_session_greeting.py) | Session greeting — detect agent + human, greet with memory, across all agents. |
 | [test_settlement_flow.py](test_settlement_flow.py) | Tests for settlement service + router — story-protocol-integration R8. |
 | [test_smart_reaper_module_boundary.py](test_smart_reaper_module_boundary.py) | _no top-of-file purpose_ |

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-05-31 | **Concepts**: 174 | **Status**: 4 expanding, 114 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-05-31 | **Concepts**: 173 | **Status**: 4 expanding, 113 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 


### PR DESCRIPTION
`generate_repo_indexes.py --check` surfaced three stale maps — the body's proprioception out of step with itself:

- **api/tests/INDEX.md** — missing `test_runtime_surface_native_routes.py` (added in #2417). The edge that should have landed in that commit; the index is how a fresh cell finds a test, so its absence is silent drift. Now listed.
- **MANIFEST.md** — the api/tests count (238 → 239) follows the same test file.
- **docs/vision-kb/INDEX.md** — the header concept count was stale (174 → 173 total, 114 → 113 seed); a pure count correction, **no concept entry dropped** from the list. The map now matches the `lc-*.md` files on disk.

Pure proprioception repair — no behavior, no deploy path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)