### PR TITLE
tend: cache the home page's slowly-changing data per-locale (the web-strain root)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -76,12 +76,25 @@ const STAT_LABEL_FALLBACKS = {
   coherence: "coherence",
 };
 
-export const revalidate = 90;
+// The home page renders per-locale dynamic — it reads cookies()/headers() to meet
+// the viewer in their language — so the ROUTE itself can't be statically cached
+// (a route-level `revalidate` would be silently ignored under force-dynamic). But
+// its DATA is slowly-changing aggregates (idea summary, resonance, coherence
+// score, node count, featured concept, presence cards), so each fetch caches via
+// `next: { revalidate }` — the same pattern app/substrate and app/wellness use
+// under force-dynamic. Every dynamic render then reuses cached data instead of
+// re-hitting six API endpoints: roughly one wave of fetches per locale per minute,
+// not one per visitor. Keyed by URL, so each locale's ?lang= variant caches apart.
 export const dynamic = "force-dynamic";
+const HOME_DATA_REVALIDATE_SECONDS = 60;
 
 async function loadIdeas(lang: LocaleCode): Promise<IdeasResponse | null> {
   const qs = lang === DEFAULT_LOCALE ? "" : `?lang=${lang}`;
-  return fetchJsonOrNull<IdeasResponse>(`${getApiBase()}/api/ideas${qs}`, {}, 5000);
+  return fetchJsonOrNull<IdeasResponse>(
+    `${getApiBase()}/api/ideas${qs}`,
+    { next: { revalidate: HOME_DATA_REVALIDATE_SECONDS } },
+    5000,
+  );
 }
 
 async function loadResonance(lang: LocaleCode): Promise<ResonanceItem[]> {
@@ -89,7 +102,7 @@ async function loadResonance(lang: LocaleCode): Promise<ResonanceItem[]> {
   try {
     const data = await fetchJsonOrNull<ResonanceItem[] | { ideas?: ResonanceItem[]; items?: ResonanceItem[] }>(
       `${getApiBase()}/api/ideas/resonance?window_hours=72&limit=3${langParam}`,
-      {},
+      { next: { revalidate: HOME_DATA_REVALIDATE_SECONDS } },
       5000,
     );
     if (!data) return [];
@@ -101,7 +114,11 @@ async function loadResonance(lang: LocaleCode): Promise<ResonanceItem[]> {
 }
 
 async function loadCoherenceScore(): Promise<CoherenceScoreResponse | null> {
-  return fetchJsonOrNull<CoherenceScoreResponse>(`${getApiBase()}/api/coherence/score`, {}, 5000);
+  return fetchJsonOrNull<CoherenceScoreResponse>(
+    `${getApiBase()}/api/coherence/score`,
+    { next: { revalidate: HOME_DATA_REVALIDATE_SECONDS } },
+    5000,
+  );
 }
 
 async function loadNodeCount(): Promise<number> {
@@ -111,7 +128,7 @@ async function loadNodeCount(): Promise<number> {
     // stat doesn't need. That list was the home page's slowest data fetch.
     const data = await fetchJsonOrNull<{ count: number }>(
       `${getApiBase()}/api/federation/nodes/count`,
-      {},
+      { next: { revalidate: HOME_DATA_REVALIDATE_SECONDS } },
       5000,
     );
     return typeof data?.count === "number" ? data.count : 1;
@@ -132,7 +149,7 @@ async function loadFeaturedConcept(lang: LocaleCode): Promise<Concept | null> {
   const qs = lang === DEFAULT_LOCALE ? "" : `?lang=${lang}`;
   try {
     const response = await fetch(`${getApiBase()}/api/concepts/lc-pulse${qs}`, {
-      cache: "no-store",
+      next: { revalidate: HOME_DATA_REVALIDATE_SECONDS },
       signal: AbortSignal.timeout(5000),
     });
     if (!response.ok) return null;

--- a/web/lib/fetch.ts
+++ b/web/lib/fetch.ts
@@ -6,6 +6,11 @@ type FetchInput = Parameters<typeof fetch>[0];
 type FetchOptions = Omit<Parameters<typeof fetch>[1], "signal"> & {
   signal?: AbortSignal;
   cache?: RequestCache;
+  // Next.js's per-fetch caching config — declared explicitly because the base
+  // RequestInit augmentation isn't always carried through the Omit above (the
+  // production `next build` type check rejects it otherwise). Lets a caller opt
+  // into time-based revalidation, e.g. the home page's per-locale data cache.
+  next?: { revalidate?: number | false; tags?: string[] };
 };
 
 function withTimeout(signal: AbortSignal | null, timeoutMs: number): AbortSignal {
@@ -54,8 +59,7 @@ export async function fetchJsonOrNull<T>(
   // disable the very caching it asked for. Every existing caller passes neither,
   // so they keep no-store unchanged; caching is strictly opt-in.
   const wantsCaching =
-    options.cache !== undefined ||
-    Boolean((options as { next?: { revalidate?: number } }).next?.revalidate);
+    options.cache !== undefined || Boolean(options.next?.revalidate);
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     const timeout = withTimeout(options.signal ?? null, timeoutMs);

--- a/web/lib/fetch.ts
+++ b/web/lib/fetch.ts
@@ -47,13 +47,23 @@ export async function fetchJsonOrNull<T>(
 ): Promise<T | null> {
   const url = typeof input === "string" ? input : input instanceof URL ? input.href : "(Request)";
 
+  // Force no-store ONLY when the caller asks for neither an explicit cache mode
+  // nor revalidation. A `next: { revalidate }` request (the per-locale data cache
+  // the home page uses to stop re-fetching slowly-changing aggregates on every
+  // dynamic render) must NOT be silently overridden to no-store — that would
+  // disable the very caching it asked for. Every existing caller passes neither,
+  // so they keep no-store unchanged; caching is strictly opt-in.
+  const wantsCaching =
+    options.cache !== undefined ||
+    Boolean((options as { next?: { revalidate?: number } }).next?.revalidate);
+
   for (let attempt = 0; attempt <= retries; attempt++) {
     const timeout = withTimeout(options.signal ?? null, timeoutMs);
     try {
       const response = await fetch(input, {
         ...options,
         signal: timeout,
-        cache: options.cache ?? "no-store",
+        ...(wantsCaching ? {} : { cache: "no-store" as RequestCache }),
       });
       if (!response.ok) {
         if (attempt < retries && isRetryable(response.status)) {

--- a/web/lib/home-presence-traces.ts
+++ b/web/lib/home-presence-traces.ts
@@ -67,9 +67,11 @@ type FieldStoryTraceResponse = {
 async function resolveLiveTraceMetric(traceHref: string): Promise<string | null> {
   if (!traceHref.startsWith("/api/field-stories/")) return null;
 
+  // Cached like the other home-page aggregates (the home render reuses this for
+  // ~a minute instead of re-fetching a trace metric per visitor). Keyed by URL.
   const trace = await fetchJsonOrNull<FieldStoryTraceResponse>(
     `${getApiBase()}${traceHref}`,
-    {},
+    { next: { revalidate: 60 } },
     3500,
     1,
   );


### PR DESCRIPTION
## What

The witness has flagged `web` `strained` all session — the home page cold-rendering ~1.4–2s while other pages serve in ~0.3s. The two earlier fixes (parallelize fetches #2420, lightweight node count #2421) helped at the margin; this addresses the **root**: the home page is per-locale dynamic (`cookies()`/`headers()` for language), so **every visitor triggered six uncached API fetches** for slowly-changing aggregates — the slowest of the six gated each render, and ~3,600 views/day each fired all six.

Now those fetches cache per-URL (so per-locale) for 60s via `next: { revalidate }` — the exact pattern `app/substrate` and `app/wellness` already use **under force-dynamic** (both verified: force-dynamic **and** revalidate; a dynamic route still serves cached fetch data). Most renders reuse cached data instead of re-hitting the API: ~one wave of fetches per locale per minute, not one per visitor — cutting both the latency variance **and** the redundant API/DB load on the most-visited page.

## Changes

- **`web/lib/fetch.ts`** — `fetchJsonOrNull` honors a `next: { revalidate }` request instead of forcing `no-store`. **Strictly opt-in**: every existing caller passes neither `cache` nor `next`, so they keep `no-store` unchanged.
- **`web/app/page.tsx`** — the five data loaders + the featured-concept fetch cache at 60s; the dead route-level `revalidate = 90` (silently ignored under `force-dynamic`) is removed and the caching model named.
- **`web/lib/home-presence-traces.ts`** — the field-story trace metrics cache the same way.

## Safety

- `tsc --noEmit` clean.
- 60s staleness on homepage overview aggregates is well within their vitality (they're not real-time-critical).
- Keyed by URL → each locale's `?lang=` variant caches apart; locale-independent endpoints (`/coherence/score`, `/nodes/count`) share one cache. Correct per-locale behavior preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)