### PR TITLE
tend(kernel-router): stream the fan-out response body instead of buffering it whole

### DIFF
--- a/form/form-kernel-rust/router_body_harness.py
+++ b/form/form-kernel-rust/router_body_harness.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Proof harness for the kernel-router's REQUEST BODY parsing.
+"""Proof harness for the kernel-router's REQUEST BODY parsing + RESPONSE STREAMING.
 
 Where router_proof_harness.py proved GET routing, this proves the matured serve
 primitive: `cli_serve` now reads the FULL request honoring Content-Length, parses
-the body by Content-Type, and marshals it into the handler frame.
+the body by Content-Type, marshals it into the handler frame, and STREAMS the
+fan-out response body straight back to the client — the body never held whole.
 
-What it asserts (real POSTs over a loopback socket):
+What it asserts (real requests over a loopback socket):
   - a native POST handler reads form-urlencoded body fields through the SAME
     alist a GET handler reads query params from: POST /sum (a=40&b=2) -> "42".
   - a native POST handler sees a JSON body captured raw under "__body__":
@@ -19,6 +20,25 @@ What it asserts (real POSTs over a loopback socket):
   - a non-native POST FANS OUT with its body forwarded: the upstream echoes the
     received body, proving the kernel relayed method + body to Python.
 
+RESPONSE STREAMING (the body-buffer-dissolving proof):
+  - a LARGE (16 MiB) Content-Length-framed fan-out response relays BYTE-IDENTICAL
+    through the router (sha256 of the client body == sha256 of the upstream body,
+    over all 256 byte values — proving the relay is binary-exact, not a lossy
+    UTF-8 round-trip). The body that would have stressed the old whole-body buffer
+    flows through a fixed 64 KiB pipe.
+  - THE BUFFER IS GONE: with COH_ROUTER_RESPONSE_SHAPE_BYTES set to a SMALL 1 MiB
+    threshold, a 16 MiB Content-Length body STILL relays 200 byte-identical. Under
+    the old buffered code that exact threshold would have 502'd the body
+    ("upstream response shape is N bytes — larger than we can hold"); streaming
+    dissolves the gate — the size is no longer a memory ceiling because the body
+    never occupies one buffer. This is the load-bearing proof that the whole-body
+    Vec is gone, not merely larger.
+  - a CHUNKED (Transfer-Encoding: chunked) fan-out response relays correctly: the
+    router passes the raw chunk framing through to the terminating 0-length chunk;
+    the de-chunked body matches the upstream's.
+  - an UNFRAMED (no Content-Length, read-to-close) fan-out response relays
+    correctly: the router pipes upstream→client until the upstream closes.
+
 Touches NO production routing — a mock CPython upstream stands in for FastAPI.
 
 Run from form/form-kernel-rust/:
@@ -27,7 +47,9 @@ Run from form/form-kernel-rust/:
 """
 from __future__ import annotations
 
+import hashlib
 import http.server
+import os
 import socket
 import subprocess
 import sys
@@ -48,6 +70,34 @@ UPSTREAM_MARKER = "UPSTREAM-CPYTHON-FASTAPI-STANDIN"
 OLD_REQUEST_CAP = 1024 * 1024
 DEFAULT_REQUEST_SHAPE = 64 * 1024 * 1024
 
+# --- response-streaming proof fixtures ---
+# A LARGE response body, deterministic and byte-known on both sides. Cycling all
+# 256 byte values makes it BINARY (non-UTF-8 bytes present), so a byte-identical
+# relay proves the router pipes raw bytes — not the old `String::from_utf8_lossy`
+# round-trip that would have corrupted bytes >= 0x80. 16 MiB is far past any single
+# read buffer and large enough that holding it whole would be the old behavior.
+BIG_BODY_LEN = 16 * 1024 * 1024
+_BIG_PATTERN = bytes(range(256))
+BIG_BODY = (_BIG_PATTERN * (BIG_BODY_LEN // 256 + 1))[:BIG_BODY_LEN]
+BIG_BODY_SHA = hashlib.sha256(BIG_BODY).hexdigest()
+
+# The SMALL response shape-threshold the "buffer is gone" case runs the router
+# under: a 16 MiB body STREAMS through it though the threshold is 1 MiB, because
+# the body never occupies a buffer. Under the old buffered code this exact value
+# would have 502'd the 16 MiB body.
+SMALL_RESPONSE_SHAPE = 1024 * 1024
+
+# Bodies for the chunked + unframed (read-to-close) framings — moderate size, also
+# spanning all byte values so the relay is proven binary-exact on those paths too.
+CHUNKED_BODY = (_BIG_PATTERN * 9000)[: 9000 * 256]      # ~2.2 MiB
+UNFRAMED_BODY = (_BIG_PATTERN * 5000)[: 5000 * 256]     # ~1.2 MiB
+
+# An ADVERSARIAL chunked body whose DATA literally contains the bytes `0\r\n\r\n`
+# (the chunk-terminator byte run). A naive byte-scan for the terminator would
+# truncate HERE; the router's chunk-BOUNDARY parser must skip these as data and
+# stop only at the real 0-length chunk. The trap bytes sit in the middle of a chunk.
+CHUNKED_TRAP_BODY = b"before-" + b"0\r\n\r\n" + b"-after-" + (b"x" * 100000) + b"-end"
+
 
 class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
     """The CPython upstream the kernel fans out to (mock FastAPI).
@@ -63,7 +113,81 @@ class _UpstreamHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(text)
 
+    # The streaming-proof responses are written with RAW socket bytes so this mock
+    # controls the EXACT framing per path (Content-Length / chunked / read-to-close)
+    # without changing the handler's default protocol for the existing tests. Each
+    # sends `Connection: close` and closes after — orthogonal to the body streaming
+    # the router proves (the router frames by Content-Length / Transfer-Encoding /
+    # absence, not by the connection lifecycle).
+    def _raw_big(self):
+        # Content-Length-framed LARGE body (16 MiB). The router must pipe exactly
+        # this many bytes to the client, byte-identical, without buffering them.
+        self.close_connection = True
+        head = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/octet-stream\r\n"
+            b"Content-Length: " + str(len(BIG_BODY)).encode() + b"\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.wfile.write(head)
+        self.wfile.write(BIG_BODY)
+
+    def _raw_chunked(self):
+        # Transfer-Encoding: chunked. Write several chunks then the terminating
+        # 0-length chunk. The router relays the raw chunk framing through.
+        self.close_connection = True
+        head = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/octet-stream\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.wfile.write(head)
+        step = 64 * 1024
+        for i in range(0, len(CHUNKED_BODY), step):
+            piece = CHUNKED_BODY[i : i + step]
+            self.wfile.write(f"{len(piece):X}\r\n".encode() + piece + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")  # terminating 0-length chunk
+
+    def _raw_chunked_trap(self):
+        # A chunked response whose chunk DATA contains the terminator byte run
+        # `0\r\n\r\n`. Emitted as ONE chunk so those bytes are data, not a boundary.
+        # The router must relay the whole body and stop only at the real 0-chunk.
+        self.close_connection = True
+        head = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/octet-stream\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.wfile.write(head)
+        body = CHUNKED_TRAP_BODY
+        self.wfile.write(f"{len(body):X}\r\n".encode() + body + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")  # the REAL terminating 0-length chunk
+
+    def _raw_unframed(self):
+        # No Content-Length, no chunked: the body ends at connection close. The
+        # router pipes upstream->client until EOF, then closes the client too.
+        self.close_connection = True
+        head = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/octet-stream\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.wfile.write(head)
+        self.wfile.write(UNFRAMED_BODY)
+        # returning from the handler closes the socket (close_connection=True),
+        # which is the body-end marker for a read-to-close response.
+
     def do_GET(self):  # noqa: N802
+        if self.path == "/stream/big":
+            return self._raw_big()
+        if self.path == "/stream/chunked":
+            return self._raw_chunked()
+        if self.path == "/stream/chunked-trap":
+            return self._raw_chunked_trap()
+        if self.path == "/stream/unframed":
+            return self._raw_unframed()
         self._reply(f"{UPSTREAM_MARKER} GET {self.path}\n".encode())
 
     def do_POST(self):  # noqa: N802
@@ -130,6 +254,64 @@ def raw_request(port: int, method: str, path: str,
     return status, body_b.decode("utf-8", "replace"), router
 
 
+def raw_request_bytes(port: int, method: str, path: str, timeout: float = 30.0):
+    """Send one HTTP/1.1 request and read the FULL raw response as BYTES.
+
+    Returns (status, headers_lower_dict, raw_body_bytes). Reads to connection
+    close (the client hop sends `Connection: close`, so the router closes after
+    the response). The body is returned as exact bytes — never decoded — so a
+    large/binary streamed response can be hashed and compared byte-for-byte. A
+    generous timeout covers a multi-MiB stream over loopback.
+    """
+    head = (
+        f"{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    ).encode()
+    chunks = []
+    with socket.create_connection(("127.0.0.1", port), timeout=timeout) as s:
+        s.sendall(head)
+        s.settimeout(timeout)
+        while True:
+            b = s.recv(262144)
+            if not b:
+                break
+            chunks.append(b)
+    resp = b"".join(chunks)
+    head_b, _, body_b = resp.partition(b"\r\n\r\n")
+    head_txt = head_b.decode("utf-8", "replace")
+    lines = head_txt.splitlines()
+    status_line = lines[0] if lines else ""
+    status = status_line.split(" ", 1)[1] if " " in status_line else status_line
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if ":" in line:
+            name, value = line.split(":", 1)
+            headers[name.strip().lower()] = value.strip()
+    return status, headers, body_b
+
+
+def dechunk(raw: bytes) -> bytes:
+    """Decode an HTTP/1.1 chunked transfer-encoding body to its raw bytes.
+
+    The router relays the chunk framing verbatim (it does NOT de-chunk), so the
+    harness de-chunks here to recover the original body and compare it to the
+    upstream's. Stops at the terminating 0-length chunk.
+    """
+    out = bytearray()
+    i = 0
+    n = len(raw)
+    while i < n:
+        j = raw.find(b"\r\n", i)
+        if j < 0:
+            break
+        size = int(raw[i:j].split(b";", 1)[0], 16)  # ignore any chunk extensions
+        if size == 0:
+            break
+        start = j + 2
+        out += raw[start : start + size]
+        i = start + size + 2  # skip the chunk's trailing CRLF
+    return bytes(out)
+
+
 def oversize_probe(port: int, declared: int, timeout: float = 5.0):
     """Advertise a Content-Length past the threshold, send only a tiny prefix.
 
@@ -178,7 +360,11 @@ def main() -> int:
         return 2
 
     up_port = free_port()
-    httpd = http.server.HTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
+    # ThreadingHTTPServer so a streaming relay (the router holds the upstream
+    # connection open while piping a multi-MiB body) cannot serialize behind / wedge
+    # another concurrent fan-out — a single-threaded upstream could deadlock a worker
+    # pool mid-stream.
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", up_port), _UpstreamHandler)
     up_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     up_thread.start()
     upstream_url = f"http://127.0.0.1:{up_port}"
@@ -189,9 +375,21 @@ def main() -> int:
          "--routes", str(ROUTES), "--upstream", upstream_url],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
+    # A SECOND router under a deliberately SMALL response shape-threshold (1 MiB),
+    # for the "buffer is gone" proof: a 16 MiB body STREAMS through it though the
+    # threshold is 1 MiB. Under the OLD buffered code this exact env would have 502'd
+    # the body ("upstream response shape is N bytes — larger than we can hold").
+    small_port = free_port()
+    small_env = dict(os.environ, COH_ROUTER_RESPONSE_SHAPE_BYTES=str(SMALL_RESPONSE_SHAPE))
+    small_proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(small_port),
+         "--routes", str(ROUTES), "--upstream", upstream_url],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=small_env,
+    )
     failures = []
     try:
         wait_for_port(kport)
+        wait_for_port(small_port)
 
         # --- 1. native POST form-urlencoded: body fields summed ---
         status, body, router = raw_request(
@@ -295,26 +493,144 @@ def main() -> int:
         if not names_shape:
             failures.append(("observable named no", status_line, no_body[:160], None))
 
+        # --- 8a. RESPONSE STREAMING — byte-identical LARGE response. A 16 MiB
+        #          Content-Length-framed fan-out body relays BYTE-IDENTICAL through
+        #          the router. Comparing the sha256 (over all 256 byte values)
+        #          proves the relay is binary-exact — not a lossy UTF-8 round-trip —
+        #          at a size that would have stressed the old whole-body buffer. ---
+        status, headers, raw_body = raw_request_bytes(kport, "GET", "/stream/big")
+        got_sha = hashlib.sha256(raw_body).hexdigest()
+        ok = (
+            status == "200 OK"
+            and headers.get("x-form-router") == "fanout-python"
+            and len(raw_body) == BIG_BODY_LEN
+            and got_sha == BIG_BODY_SHA
+            and headers.get("content-length") == str(BIG_BODY_LEN)
+        )
+        print(f"  [stream big 16MiB ] /stream/big -> {status} "
+              f"{len(raw_body)}B (expect {BIG_BODY_LEN}) sha-match={got_sha == BIG_BODY_SHA} "
+              f"CL-relayed={headers.get('content-length') == str(BIG_BODY_LEN)} "
+              f"router={headers.get('x-form-router')}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("stream big byte-identical", status,
+                             f"len={len(raw_body)} sha_ok={got_sha == BIG_BODY_SHA}", got_sha))
+
+        # --- 8b. THE BUFFER IS GONE. The SAME 16 MiB body relays 200 byte-identical
+        #          through a router whose response shape-threshold is only 1 MiB.
+        #          Under the old buffered code this exact env 502'd the body
+        #          ("upstream response shape is N bytes — larger than we can hold").
+        #          It flowing proves the body never occupies a whole-body buffer —
+        #          the size is no longer a memory gate, only the (small) head is. ---
+        status, headers, raw_body = raw_request_bytes(small_port, "GET", "/stream/big")
+        got_sha = hashlib.sha256(raw_body).hexdigest()
+        ok = (
+            status == "200 OK"
+            and headers.get("x-form-router") == "fanout-python"
+            and len(raw_body) == BIG_BODY_LEN
+            and got_sha == BIG_BODY_SHA
+        )
+        print(f"  [buffer-gone 1MiB ] /stream/big through 1 MiB-shape router "
+              f"({BIG_BODY_LEN} >> {SMALL_RESPONSE_SHAPE}) -> {status} "
+              f"{len(raw_body)}B sha-match={got_sha == BIG_BODY_SHA}  "
+              f"{'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("buffer-gone (16MiB through 1MiB shape)", status,
+                             f"len={len(raw_body)} sha_ok={got_sha == BIG_BODY_SHA}", None))
+
+        # --- 8c. CHUNKED response relayed. The upstream responds Transfer-Encoding:
+        #          chunked; the router relays the raw chunk framing through to the
+        #          terminating 0-length chunk. The client sees chunked framing; the
+        #          de-chunked body matches the upstream's byte-for-byte. ---
+        status, headers, raw_body = raw_request_bytes(kport, "GET", "/stream/chunked")
+        is_chunked = headers.get("transfer-encoding", "").lower() == "chunked"
+        decoded = dechunk(raw_body) if is_chunked else raw_body
+        ok = (
+            status == "200 OK"
+            and headers.get("x-form-router") == "fanout-python"
+            and is_chunked
+            and "content-length" not in headers  # chunked has NO Content-Length
+            and decoded == CHUNKED_BODY
+        )
+        print(f"  [stream chunked   ] /stream/chunked -> {status} "
+              f"te-chunked={is_chunked} dechunked={len(decoded)}B "
+              f"(expect {len(CHUNKED_BODY)}) match={decoded == CHUNKED_BODY} "
+              f"router={headers.get('x-form-router')}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("stream chunked relay", status,
+                             f"chunked={is_chunked} len={len(decoded)} "
+                             f"match={decoded == CHUNKED_BODY}", None))
+
+        # --- 8c-trap. CHUNKED with the terminator byte run `0\r\n\r\n` INSIDE chunk
+        #          data. The router's chunk-BOUNDARY parser must skip it as data and
+        #          stop only at the real 0-length chunk — a naive byte-scan would
+        #          truncate the body here. The full de-chunked body must come back. ---
+        status, headers, raw_body = raw_request_bytes(kport, "GET", "/stream/chunked-trap")
+        is_chunked = headers.get("transfer-encoding", "").lower() == "chunked"
+        decoded = dechunk(raw_body) if is_chunked else raw_body
+        ok = (
+            status == "200 OK"
+            and headers.get("x-form-router") == "fanout-python"
+            and is_chunked
+            and decoded == CHUNKED_TRAP_BODY  # not truncated at the in-data terminator
+        )
+        print(f"  [chunked trap     ] /stream/chunked-trap (0CRLFCRLF in data) -> {status} "
+              f"dechunked={len(decoded)}B (expect {len(CHUNKED_TRAP_BODY)}) "
+              f"match={decoded == CHUNKED_TRAP_BODY}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("chunked in-data terminator not truncated", status,
+                             f"len={len(decoded)} expect={len(CHUNKED_TRAP_BODY)} "
+                             f"match={decoded == CHUNKED_TRAP_BODY}", None))
+
+        # --- 8d. UNFRAMED (read-to-close) response relayed. The upstream sends no
+        #          Content-Length and no chunked, then closes; the router pipes
+        #          upstream->client until EOF and closes the client too. The body
+        #          arrives byte-identical; the client response is close-framed. ---
+        status, headers, raw_body = raw_request_bytes(kport, "GET", "/stream/unframed")
+        ok = (
+            status == "200 OK"
+            and headers.get("x-form-router") == "fanout-python"
+            and "content-length" not in headers      # no length: close-framed
+            and headers.get("transfer-encoding", "").lower() != "chunked"
+            and headers.get("connection", "").lower() == "close"
+            and raw_body == UNFRAMED_BODY
+        )
+        print(f"  [stream unframed  ] /stream/unframed -> {status} "
+              f"close-framed={headers.get('connection','').lower() == 'close'} "
+              f"{len(raw_body)}B (expect {len(UNFRAMED_BODY)}) "
+              f"match={raw_body == UNFRAMED_BODY} "
+              f"router={headers.get('x-form-router')}  {'OK' if ok else 'FAIL'}")
+        if not ok:
+            failures.append(("stream unframed relay", status,
+                             f"len={len(raw_body)} match={raw_body == UNFRAMED_BODY}", None))
+
         if failures:
             print(f"\nFAIL: {len(failures)} case(s) did not match", file=sys.stderr)
             for f in failures:
                 print(f"   {f}", file=sys.stderr)
             return 1
-        print("\nok — kernel-router READ REQUEST BODIES: form-urlencoded fields "
-              "merged into the handler alist, JSON captured raw, a >8 KiB body "
-              "fully captured (Content-Length honored), GET unchanged, POST "
-              "fan-out forwarded its body to CPython; a body past the OLD 1 MiB "
-              "cap now FLOWS under the generous default shape, and a shape past "
-              "the current threshold gets an OBSERVABLE, NAMED no (the bytes seen "
-              "+ the changeable COH_ROUTER_REQUEST_SHAPE_BYTES recipe) — awareness, "
-              "not prevention.")
+        print("\nok — kernel-router READ REQUEST BODIES and STREAMS RESPONSES: "
+              "form-urlencoded fields merged into the handler alist, JSON captured "
+              "raw, a >8 KiB body fully captured (Content-Length honored), GET "
+              "unchanged, POST fan-out forwarded its body to CPython; a body past "
+              "the OLD 1 MiB cap now FLOWS under the generous default shape, and a "
+              "shape past the current threshold gets an OBSERVABLE, NAMED no. "
+              "RESPONSE STREAMING: a 16 MiB Content-Length fan-out body relays "
+              "BYTE-IDENTICAL (sha256 over all 256 byte values); the SAME body "
+              "relays 200 byte-identical through a router whose response shape is "
+              "only 1 MiB (the whole-body buffer is GONE — size is no longer the "
+              "gate); a chunked response relays its raw chunk framing through (the "
+              "de-chunked body matches); an unframed read-to-close response pipes "
+              "upstream->client to EOF byte-identical. The router never holds a "
+              "response body whole — it observes circulation AS IT FLOWS.")
         return 0
     finally:
         proc.terminate()
-        try:
-            proc.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        small_proc.terminate()
+        for p in (proc, small_proc):
+            try:
+                p.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                p.kill()
         httpd.shutdown()
 
 

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6352,14 +6352,15 @@ fn handle_request(
     let body: String;
     let status: String;
     let router: &str;
-    // The response's Content-Type and other relayed headers: a fan-out fills
-    // these from the UPSTREAM's real response (so a JSON/HTML route survives the
-    // proxy and its Set-Cookie/Cache-Control reach the client); native/404
-    // responses leave them empty, so the ONE emit shape (http_response) defaults
-    // the type to text/plain and relays no extra headers — the router owns all
-    // framing on those arms.
+    // The response's Content-Type for the BUFFERED arms (native / 404). The
+    // fan-out arm streams and returns early — it relays the upstream's Content-Type
+    // and end-to-end headers itself, so they never reach this buffered emit. A
+    // native handler emitting JSON sets the type below; a 404 leaves it empty, so
+    // the ONE emit shape (http_response) defaults to text/plain. `resp_headers`
+    // stays empty on both buffered arms — native/404 relay no extra end-to-end
+    // headers; the router owns all framing on those arms.
     let mut resp_content_type = String::new();
-    let mut resp_headers: Vec<(String, String)> = Vec::new();
+    let resp_headers: Vec<(String, String)> = Vec::new();
     if let Some((_, cl)) = route_pairs.iter().find(|(p, _)| *p == path) {
         // NATIVE: served entirely in Form, no Python in the path.
         // Build the request alist as Value::List of (key, value) pairs — query
@@ -6405,22 +6406,28 @@ fn handle_request(
             }
         }
     } else if let Some(upstream_base) = upstream {
-        // FAN-OUT: no native handler — forward to the Python upstream and
-        // relay its response. The kernel owns the front door; Python is the
-        // upstream for the not-yet-native tail. Each worker issues its own
-        // independent fan-out hop over its OWN per-worker upstream connection
-        // pool (no locking — the worker is serial and owns the pool the way it
-        // owns its Kernel + Arena), so repeated fan-outs REUSE one keep-alive
-        // connection to the upstream and amortize the TCP handshake. The client's
-        // METHOD, BODY, and end-to-end request headers (Authorization, Cookie,
-        // Accept*, …) are forwarded so an authenticated/content-typed route is
-        // fronted truthfully; the UPSTREAM's response Content-Type + end-to-end
-        // headers (Set-Cookie, Cache-Control, Location, …) are relayed back so
-        // the client receives the upstream's real type and cookies, not a
-        // flattened text/plain. Hop-by-hop headers are stripped both ways; the
-        // router owns the framing on its client hop (Content-Length, Connection —
-        // http_response writes those, the relayed set cannot clobber them).
-        let fanout = fanout_request(
+        // FAN-OUT (STREAMING): no native handler — forward to the Python upstream
+        // and PIPE its response body straight back to the client, with the whole
+        // body NEVER held in one buffer. The kernel owns the front door; Python is
+        // the upstream for the not-yet-native tail. Each worker issues its own
+        // independent fan-out hop over its OWN per-worker upstream connection pool
+        // (no locking — the worker is serial and owns the pool the way it owns its
+        // Kernel + Arena), so repeated fan-outs REUSE one keep-alive connection to
+        // the upstream and amortize the TCP handshake. The client's METHOD, BODY,
+        // and end-to-end request headers (Authorization, Cookie, Accept*, …) are
+        // forwarded so an authenticated/content-typed route is fronted truthfully;
+        // the UPSTREAM's response status, Content-Type, and end-to-end headers
+        // (Set-Cookie, Cache-Control, Location, …) are relayed back, then the body
+        // is streamed byte-identical (raw bytes, no UTF-8 round-trip) in fixed 64
+        // KiB chunks. Hop-by-hop headers are stripped both ways; the router owns
+        // the client-hop framing (Content-Length echoed for a Length body,
+        // Transfer-Encoding: chunked relayed for a chunked body, close-framing for
+        // an unframed one; Connection per the client's intent). This arm does its
+        // OWN client write (head + streamed body) and returns the client keep-alive
+        // verdict directly — it does NOT fall through to the buffered emit below.
+        return fanout_stream_to_client(
+            stream,
+            keep_alive,
             upstream_base,
             &method,
             &target,
@@ -6428,11 +6435,6 @@ fn handle_request(
             &body_bytes,
             upstream_pool,
         );
-        status = fanout.status;
-        body = fanout.body;
-        resp_content_type = fanout.content_type;
-        resp_headers = fanout.headers;
-        router = "fanout-python";
     } else {
         // No native handler and no upstream configured.
         status = "404 Not Found".to_string();
@@ -7535,48 +7537,70 @@ impl UpstreamPool {
     }
 }
 
-// The framing outcome of reading ONE upstream response, plus whether the
-// connection may be REUSED. With the upstream keep-alive (no `Connection: close`
-// on its side) the upstream does NOT close after the body, so the response can
-// no longer be read with `read_to_end` (that only terminates on close). The
-// response must be framed:
-//   - Content-Length present  -> read exactly that many body bytes; any surplus
-//     read past them is the NEXT response's bytes, carried forward; the
-//     connection is REUSABLE (unless the upstream sent `Connection: close`).
-//   - Transfer-Encoding: chunked -> not yet decoded; read to close and do NOT
-//     reuse (named-later breath). Falls into the close path below.
-//   - neither, and the upstream keeps the connection open -> length is unknown;
-//     this cannot be safely framed for reuse, so read to close and do NOT reuse.
-struct UpstreamResponse {
+// How the upstream framed its response body, which decides how the router frames
+// the SAME body to the client and whether the body can be PIPED chunk-by-chunk
+// without ever holding it whole. The router never buffers the body — it observes
+// it AS IT FLOWS — so the framing is all the router needs to relay byte-identical:
+//   - Length(n)  -> Content-Length present: pipe exactly `n` body bytes upstream
+//     →client. The client gets the SAME Content-Length; both connections stay
+//     framed (the client knows precisely where the body ends), so the upstream
+//     connection is REUSABLE (unless it signalled close) and the client's
+//     keep-alive intent is honored.
+//   - Chunked    -> Transfer-Encoding: chunked: relay the raw chunk framing
+//     straight through to the client (NOT de-chunked) until the terminating
+//     0-length chunk. Chunked is self-delimiting, so the client stays framed and
+//     its keep-alive intent is honored; the upstream connection is NOT pooled
+//     (chunked-body reuse is a named-later breath).
+//   - Close      -> neither Content-Length nor chunked: the body's length is only
+//     knowable by the upstream closing. Pipe upstream→client until EOF, then the
+//     client connection MUST close too (no other way to mark the body's end), so
+//     keep-alive is forced off on this hop.
+enum ResponseFraming {
+    Length(usize),
+    Chunked,
+    Close,
+}
+
+// The PARSED HEAD of one upstream response — everything the router needs to write
+// the client response head and decide how to pipe the body — WITHOUT the body. The
+// body never lands in a buffer; only the small head is read whole (it must be, to
+// parse status + framing + relayed headers). `body_prefix` is the leading body
+// bytes that arrived in the SAME read as the head terminator (the head read always
+// over-reads a little); they are written to the client first, then the rest of the
+// body is piped straight from the socket.
+struct UpstreamHead {
     status: String,
     content_type: String,
     headers: Vec<(String, String)>,
-    body: String,
-    // The keep-alive verdict for the UPSTREAM connection: true iff the response
-    // was Content-Length-framed (so we know exactly where it ended) AND the
-    // upstream did not signal `Connection: close`. Only then may the connection
-    // return to the pool; otherwise it is dropped.
-    reusable: bool,
-    // Bytes read past this response's framed end — the next response's head/body
-    // on a reused connection. Carried back into the PooledConn so the next read
-    // starts exactly there. Empty when the connection won't be reused.
-    leftover: Vec<u8>,
+    // The upstream connection's keep-alive intent (false on `Connection: close`
+    // or HTTP/1.0 default). Combined with Length framing to decide pooling.
+    upstream_keep_alive: bool,
+    framing: ResponseFraming,
+    // Body bytes already read past the head terminator (the head read's natural
+    // over-read). Piped to the client before the rest of the body is streamed.
+    body_prefix: Vec<u8>,
 }
 
-// Read exactly ONE HTTP response from a (possibly reused) upstream connection,
-// framing it by Content-Length so the read does not depend on the upstream
-// closing — the property that makes connection reuse possible. `carry` seeds the
-// read with any bytes left over from the PREVIOUS response on this same
-// connection (the over-read hazard, mirrored from the client hop's read_request).
+// Read ONLY the HEAD of one upstream response from a (possibly reused) connection,
+// framing it so the BODY can be piped chunk-by-chunk afterward without ever being
+// held whole. `carry` seeds the read with any bytes left over from the PREVIOUS
+// response on this same connection (the over-read hazard, mirrored from the client
+// hop's read_request). The head is small and must be buffered to parse; the body
+// is NOT read here — it streams in `stream_body_to_client` after the client head
+// is written. This split is what lets the stale-pooled-connection retry stay safe:
+// a `Closed` (EOF before any byte) is detectable HERE, before a single body byte
+// has been relayed to the client, so the caller can transparently reconnect+retry.
 //
 // Errors (a broken pipe, an immediate EOF before any byte) propagate up so the
 // caller can transparently reconnect+retry on a stale pooled connection.
-fn read_upstream_response(stream: &mut TcpStream, carry: Vec<u8>) -> Result<UpstreamResponse, FanoutError> {
-    // Phase 1: read until the header terminator, seeding from carried bytes.
+fn read_upstream_head(stream: &mut TcpStream, carry: Vec<u8>) -> Result<UpstreamHead, FanoutError> {
+    // Read until the header terminator, seeding from carried bytes. Only the head
+    // accumulates in `raw`; the body is streamed afterward, never buffered.
     let mut raw: Vec<u8> = carry;
     let mut buf = [0u8; 8192];
-    // The shape we can hold for this upstream response right now — the live,
-    // changeable recipe, sensed against the bytes the upstream returns below.
+    // The HEAD is the only thing we hold whole; the shape-threshold here bounds the
+    // head alone (a runaway header block), never the body — the body streams, so
+    // its size is no longer a memory gate.
     let response_limit = response_shape_limit();
     let header_end: usize = match find_header_end(&raw) {
         Some(t) => t,
@@ -7636,89 +7660,319 @@ fn read_upstream_response(stream: &mut TcpStream, carry: Vec<u8>) -> Result<Upst
     // Does the UPSTREAM intend to keep this connection alive? It is an HTTP/1.x
     // peer; honor an explicit `Connection: close` (and HTTP/1.0's close default).
     let upstream_keep_alive = upstream_response_keep_alive(&head);
-    let is_chunked = head_is_chunked(&head);
-
-    // Phase 2: frame the body. Content-Length is the path that allows reuse.
-    if let Some(total) = parse_content_length(&head) {
-        if total > response_limit {
-            return Err(FanoutError::Other(format!(
-                "upstream response shape is {} bytes — larger than we can hold right now \
-                 (threshold {}; change COH_ROUTER_RESPONSE_SHAPE_BYTES, or stream it)",
-                total, response_limit,
-            )));
-        }
-        let mut body: Vec<u8> = raw[body_start..].to_vec();
-        while body.len() < total {
-            match stream.read(&mut buf) {
-                Ok(0) => {
-                    // Upstream closed before the full framed body — the response
-                    // is incomplete; cannot be trusted or reused. NOT retried (we
-                    // already got the head, the request may have side-effected).
-                    return Err(FanoutError::Other(
-                        "upstream closed mid-body (short Content-Length read)".to_string(),
-                    ));
-                }
-                Ok(n) => body.extend_from_slice(&buf[..n]),
-                // A read deadline mid-body on a stalled upstream -> Timeout -> 504.
-                Err(e) => return Err(classify_io_error(&e, "read upstream response body")),
-            }
-        }
-        // Any bytes past the framed body are the NEXT response's — carry forward.
-        let leftover: Vec<u8> = if body.len() > total {
-            let extra = body[total..].to_vec();
-            body.truncate(total);
-            extra
-        } else {
-            Vec::new()
-        };
-        let body_text = String::from_utf8_lossy(&body).to_string();
-        // REUSABLE only when Content-Length-framed AND the upstream kept it alive.
-        let reusable = upstream_keep_alive;
-        return Ok(UpstreamResponse {
-            status,
-            content_type,
-            headers,
-            body: body_text,
-            reusable,
-            leftover: if reusable { leftover } else { Vec::new() },
-        });
-    }
-
-    // No Content-Length: chunked OR unframed. Neither is safely reusable here
-    // (chunked decode is a named-later breath; unframed length is only knowable
-    // by the upstream closing). Read to close and DROP this connection. Note for
-    // honesty: a chunked body is returned with its raw chunk framing intact (not
-    // de-chunked) — correct enough to relay the bytes, but the connection is not
-    // pooled, so the next request opens a fresh one. `is_chunked` is captured so
-    // the fall-through is a conscious decision, not an accident.
-    let _ = is_chunked;
-    let mut body: Vec<u8> = raw[body_start..].to_vec();
-    loop {
-        match stream.read(&mut buf) {
-            Ok(0) => break, // upstream closed — the unframed body is complete
-            Ok(n) => {
-                body.extend_from_slice(&buf[..n]);
-                if body.len() > response_limit {
-                    return Err(FanoutError::Other(format!(
-                        "upstream response passed the {} bytes we can hold right now while \
-                         streaming to close (change COH_ROUTER_RESPONSE_SHAPE_BYTES)",
-                        response_limit,
-                    )));
-                }
-            }
-            // A read deadline while draining a read-to-close body -> Timeout -> 504.
-            Err(e) => return Err(classify_io_error(&e, "read upstream response body (to close)")),
-        }
-    }
-    let body_text = String::from_utf8_lossy(&body).to_string();
-    Ok(UpstreamResponse {
+    // The framing decides how the body is piped (and whether the connection pools).
+    // Content-Length wins; else chunked (self-delimiting, relayed raw); else close.
+    let framing = if let Some(total) = parse_content_length(&head) {
+        ResponseFraming::Length(total)
+    } else if head_is_chunked(&head) {
+        ResponseFraming::Chunked
+    } else {
+        ResponseFraming::Close
+    };
+    // The leading body bytes that arrived alongside the head terminator. Piped to
+    // the client first; the head itself is dropped (the client gets the router's
+    // own framed head, not the upstream's raw one).
+    let body_prefix = raw[body_start..].to_vec();
+    Ok(UpstreamHead {
         status,
         content_type,
         headers,
-        body: body_text,
-        reusable: false, // read-to-close / chunked: never pool this connection
-        leftover: Vec::new(),
+        upstream_keep_alive,
+        framing,
+        body_prefix,
     })
+}
+
+// The outcome of piping ONE response body upstream→client: whether the upstream
+// connection may be REUSED (pooled) and any bytes read past this response's framed
+// end (the next response's head/body on a reused connection, carried forward so the
+// next read starts exactly there). Mirrors the old UpstreamResponse's reuse verdict,
+// but the BODY itself never appears here — it has already flowed to the client.
+struct BodyOutcome {
+    reusable: bool,
+    leftover: Vec<u8>,
+}
+
+// PIPE one response body from the upstream stream straight to the client stream,
+// in fixed-size chunks reused across reads — the whole body is NEVER held in one
+// buffer. `body_prefix` is the leading body bytes already read with the head; they
+// go to the client first, then the rest streams from the socket. The framing tells
+// us where the body ends:
+//   - Length(total): write exactly `total` body bytes (prefix counted), then any
+//     surplus read past them is the NEXT response's bytes -> leftover; the
+//     connection is REUSABLE iff the upstream kept it alive.
+//   - Chunked: relay the raw chunk framing through until the terminating 0-length
+//     chunk (`0\r\n\r\n`); the client stays framed, the connection is NOT pooled.
+//   - Close: relay until the upstream closes (EOF); the connection is dropped and
+//     the client connection must close too.
+//
+// Honest mid-stream failure: once the client head is written (the caller's job,
+// BEFORE calling this), a stall or close mid-body can no longer become a clean 504
+// — the head already went out. A read deadline / upstream close mid-body surfaces
+// as an Err here; the caller closes the client connection, and the client sees a
+// truncated body — the truthful outcome of an upstream that died mid-stream.
+fn stream_body_to_client(
+    upstream: &mut TcpStream,
+    client: &mut TcpStream,
+    framing: &ResponseFraming,
+    body_prefix: &[u8],
+) -> Result<BodyOutcome, FanoutError> {
+    // 64 KiB pipe buffer, reused across every read — the only body-sized memory the
+    // router ever holds is this one fixed chunk, regardless of the body's length.
+    let mut buf = [0u8; 65536];
+    match *framing {
+        ResponseFraming::Length(total) => {
+            // Write the prefix first, but only up to `total` (a prefix can over-read
+            // into the NEXT response on a reused connection — that surplus is the
+            // leftover, never written to this client).
+            let from_prefix = body_prefix.len().min(total);
+            if from_prefix > 0 {
+                client
+                    .write_all(&body_prefix[..from_prefix])
+                    .map_err(|e| classify_io_error(&e, "write response body prefix to client"))?;
+            }
+            let mut written = from_prefix;
+            // The leftover is any prefix bytes past `total` (the next response).
+            let leftover: Vec<u8> = if body_prefix.len() > total {
+                body_prefix[total..].to_vec()
+            } else {
+                Vec::new()
+            };
+            // Pipe the remaining body bytes straight from the upstream socket.
+            while written < total {
+                let want = (total - written).min(buf.len());
+                match upstream.read(&mut buf[..want]) {
+                    Ok(0) => {
+                        // Upstream closed before the full framed body — the response
+                        // is incomplete and the client head already went out, so the
+                        // client sees a truncated body. NOT a clean error path.
+                        return Err(FanoutError::Other(
+                            "upstream closed mid-body (short Content-Length read)".to_string(),
+                        ));
+                    }
+                    Ok(n) => {
+                        client
+                            .write_all(&buf[..n])
+                            .map_err(|e| classify_io_error(&e, "write response body to client"))?;
+                        written += n;
+                    }
+                    // A read deadline mid-body on a stalled upstream. The head is
+                    // already sent, so this can't be a 504; it propagates and the
+                    // caller closes the client connection.
+                    Err(e) => return Err(classify_io_error(&e, "read upstream response body")),
+                }
+            }
+            // Content-Length framing is the precondition for reuse; the caller ANDs
+            // this with the upstream's keep-alive intent (from the head) before
+            // pooling. The leftover is meaningful only on a reused connection, but
+            // the caller drops it if it decides not to pool — so it is returned as-is.
+            Ok(BodyOutcome { reusable: true, leftover })
+        }
+        ResponseFraming::Chunked => {
+            // Relay the raw chunk framing straight through (NOT de-chunked) to the
+            // client, while a small incremental PARSER tracks the chunk boundaries so
+            // we stop at the TRUE terminating 0-length chunk — never at a `0\r\n\r\n`
+            // byte sequence that merely happens to appear inside chunk DATA (the
+            // hazard a naive byte-scan has). The parser consumes the same bytes it
+            // relays; it never accumulates the body, only the current chunk's
+            // size-line and a tiny amount of framing. The connection is never pooled.
+            let mut parser = ChunkParser::new();
+            // The prefix (chunk framing that arrived with the head) is relayed first
+            // and fed through the parser — the body may have started, or even fully
+            // arrived, in the same read as the head.
+            if !body_prefix.is_empty() {
+                client
+                    .write_all(body_prefix)
+                    .map_err(|e| classify_io_error(&e, "write chunked body prefix to client"))?;
+                if parser.feed(body_prefix)? {
+                    // The whole chunked body (through the terminating 0-chunk) already
+                    // arrived with the head.
+                    return Ok(BodyOutcome { reusable: false, leftover: Vec::new() });
+                }
+            }
+            loop {
+                match upstream.read(&mut buf) {
+                    Ok(0) => break, // upstream closed — relay ends (best-effort)
+                    Ok(n) => {
+                        client
+                            .write_all(&buf[..n])
+                            .map_err(|e| classify_io_error(&e, "write chunked body to client"))?;
+                        if parser.feed(&buf[..n])? {
+                            break; // terminating 0-length chunk relayed — body done
+                        }
+                    }
+                    Err(e) => {
+                        return Err(classify_io_error(&e, "read upstream chunked response body"))
+                    }
+                }
+            }
+            // Chunked is relayed raw and the connection is never pooled.
+            Ok(BodyOutcome { reusable: false, leftover: Vec::new() })
+        }
+        ResponseFraming::Close => {
+            // No Content-Length, no chunked: the body ends when the upstream closes.
+            // Pipe the prefix, then everything until EOF; the connection is dropped.
+            if !body_prefix.is_empty() {
+                client
+                    .write_all(body_prefix)
+                    .map_err(|e| classify_io_error(&e, "write unframed body prefix to client"))?;
+            }
+            loop {
+                match upstream.read(&mut buf) {
+                    Ok(0) => break, // upstream closed — the unframed body is complete
+                    Ok(n) => {
+                        client
+                            .write_all(&buf[..n])
+                            .map_err(|e| classify_io_error(&e, "write unframed body to client"))?;
+                    }
+                    Err(e) => {
+                        return Err(classify_io_error(
+                            &e,
+                            "read upstream response body (to close)",
+                        ))
+                    }
+                }
+            }
+            Ok(BodyOutcome { reusable: false, leftover: Vec::new() })
+        }
+    }
+}
+
+// An incremental HTTP/1.1 chunked-transfer parser that tracks chunk BOUNDARIES so
+// the streaming relay stops at the TRUE terminating 0-length chunk — not at a
+// `0\r\n\r\n` byte run that merely appears inside chunk DATA. It is fed the same
+// bytes the relay writes to the client and never accumulates the body: it holds
+// only the current size/trailer LINE (tiny) and the remaining-bytes counter for the
+// chunk currently being skipped over. `feed` returns true once the terminating
+// 0-length chunk (and its trailer section) has been consumed. This is FRAMING
+// tracking, not de-chunking — the bytes still relay raw and verbatim.
+enum ChunkPhase {
+    // Reading a chunk-size line (hex digits + optional `;extension`) up to CRLF.
+    Size,
+    // Skipping `remaining` data bytes of the current chunk.
+    Data { remaining: usize },
+    // Consuming the 2-byte CRLF that follows a chunk's data (`have` seen so far).
+    DataCrlf { have: u8 },
+    // After the 0-length chunk: consuming the trailer section line-by-line until the
+    // terminating empty line.
+    Trailer,
+}
+
+struct ChunkParser {
+    phase: ChunkPhase,
+    // The current size or trailer LINE being accumulated until its CRLF. Bounded by
+    // a sanity cap so a malformed upstream can't grow it without limit.
+    line: Vec<u8>,
+}
+
+impl ChunkParser {
+    fn new() -> Self {
+        ChunkParser { phase: ChunkPhase::Size, line: Vec::new() }
+    }
+
+    // Feed the next slice of relayed bytes. Returns Ok(true) when the terminating
+    // 0-length chunk + trailer have been fully consumed (the body is complete), else
+    // Ok(false) (more bytes expected). A malformed size line is an Other error.
+    fn feed(&mut self, mut data: &[u8]) -> Result<bool, FanoutError> {
+        // A chunk-size / trailer line longer than this is treated as malformed — a
+        // real size line is a handful of bytes; this only guards against a runaway
+        // upstream, it is not a body-size limit (the body itself never lands here).
+        const MAX_LINE: usize = 16 * 1024;
+        while !data.is_empty() {
+            match self.phase {
+                ChunkPhase::Size => {
+                    // Accumulate up to and including the CRLF that ends the size line.
+                    if let Some(pos) = data.iter().position(|&b| b == b'\n') {
+                        self.line.extend_from_slice(&data[..pos]); // up to (excl) \n
+                        data = &data[pos + 1..];
+                        // The size is the hex prefix before any `;` extension or CR.
+                        let line = std::mem::take(&mut self.line);
+                        let size = parse_chunk_size(&line)?;
+                        if size == 0 {
+                            self.phase = ChunkPhase::Trailer;
+                        } else {
+                            self.phase = ChunkPhase::Data { remaining: size };
+                        }
+                    } else {
+                        self.line.extend_from_slice(data);
+                        data = &[];
+                        if self.line.len() > MAX_LINE {
+                            return Err(FanoutError::Other(
+                                "chunked size line too long (malformed upstream)".to_string(),
+                            ));
+                        }
+                    }
+                }
+                ChunkPhase::Data { remaining } => {
+                    let take = remaining.min(data.len());
+                    data = &data[take..];
+                    let left = remaining - take;
+                    self.phase = if left == 0 {
+                        ChunkPhase::DataCrlf { have: 0 }
+                    } else {
+                        ChunkPhase::Data { remaining: left }
+                    };
+                }
+                ChunkPhase::DataCrlf { have } => {
+                    // Consume exactly two bytes (CR LF) following the chunk data.
+                    let need = 2 - have as usize;
+                    let take = need.min(data.len());
+                    data = &data[take..];
+                    let now = have + take as u8;
+                    self.phase = if now >= 2 {
+                        ChunkPhase::Size
+                    } else {
+                        ChunkPhase::DataCrlf { have: now }
+                    };
+                }
+                ChunkPhase::Trailer => {
+                    // Consume trailer lines until the terminating empty line. Each
+                    // line ends at `\n`; an empty line (just CR before it, or nothing)
+                    // ends the body.
+                    if let Some(pos) = data.iter().position(|&b| b == b'\n') {
+                        self.line.extend_from_slice(&data[..pos]);
+                        data = &data[pos + 1..];
+                        let line = std::mem::take(&mut self.line);
+                        // Empty (after trimming a trailing CR) => end of body.
+                        let trimmed: &[u8] = if line.last() == Some(&b'\r') {
+                            &line[..line.len() - 1]
+                        } else {
+                            &line
+                        };
+                        if trimmed.is_empty() {
+                            return Ok(true);
+                        }
+                        // A non-empty trailer header line — keep consuming.
+                    } else {
+                        self.line.extend_from_slice(data);
+                        data = &[];
+                        if self.line.len() > MAX_LINE {
+                            return Err(FanoutError::Other(
+                                "chunked trailer line too long (malformed upstream)".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+}
+
+// Parse a chunk-size line's hex value — the digits BEFORE any `;extension` or CR.
+// e.g. `1a3f`, `1a3f;name=val`, `0`. An empty or non-hex prefix is malformed.
+fn parse_chunk_size(line: &[u8]) -> Result<usize, FanoutError> {
+    // Cut at the first `;` (chunk extension) or CR, whichever comes first.
+    let end = line
+        .iter()
+        .position(|&b| b == b';' || b == b'\r')
+        .unwrap_or(line.len());
+    let hex = &line[..end];
+    let s = std::str::from_utf8(hex)
+        .map_err(|_| FanoutError::Other("chunked size not UTF-8 (malformed)".to_string()))?
+        .trim();
+    usize::from_str_radix(s, 16)
+        .map_err(|_| FanoutError::Other(format!("bad chunked size line: {:?}", s)))
 }
 
 // Whether the UPSTREAM signalled it will keep its connection open after this
@@ -7764,34 +8018,25 @@ fn head_is_chunked(head: &str) -> bool {
     false
 }
 
-fn fanout_request(
-    upstream: &str,
-    method: &str,
-    target: &str,
-    req_headers: &[(String, String)],
-    body: &[u8],
-    pool: &mut UpstreamPool,
-) -> FanoutResult {
-    match fanout_request_result(upstream, method, target, req_headers, body, pool) {
-        Ok(v) => v,
-        // A TIMEOUT (hung/slow upstream: connect, write, or read deadline expired)
-        // becomes a clean 504 Gateway Timeout — the client gets a definite answer
-        // instead of a hang, and the worker is already free (the stale connection
-        // was dropped on the error path, never returned to the pool). A Closed or
-        // Other failure is a 502 Bad Gateway (the upstream is reachable but the
-        // hop failed). This is the single place the fan-out error maps to a status.
-        Err(FanoutError::Timeout(e)) => FanoutResult {
-            status: "504 Gateway Timeout".to_string(),
-            content_type: String::new(),
-            headers: Vec::new(),
-            body: format!("upstream timeout: {}\n", e),
-        },
-        Err(FanoutError::Closed(e)) | Err(FanoutError::Other(e)) => FanoutResult {
-            status: "502 Bad Gateway".to_string(),
-            content_type: String::new(),
-            headers: Vec::new(),
-            body: format!("fan-out upstream error: {}\n", e),
-        },
+// Map a fan-out hop failure that happened BEFORE any body byte reached the client
+// (connect/write failed, the head read failed, the stale-pool retry failed) into a
+// small BUFFERED error response written through the ONE emit shape. A TIMEOUT
+// (hung/slow upstream: connect, write, or head-read deadline expired) becomes a
+// clean 504 Gateway Timeout; a Closed or Other failure is a 502 Bad Gateway. This
+// is the single place the fan-out error maps to a status — and it is only reachable
+// while the client head is UNWRITTEN, so a clean framed error is still possible
+// (once the head is out and the body is streaming, a mid-stream failure can no
+// longer become a status — it closes the client connection instead).
+fn fanout_error_response(err: &FanoutError) -> (String, String) {
+    match err {
+        FanoutError::Timeout(e) => (
+            "504 Gateway Timeout".to_string(),
+            format!("upstream timeout: {}\n", e),
+        ),
+        FanoutError::Closed(e) | FanoutError::Other(e) => (
+            "502 Bad Gateway".to_string(),
+            format!("fan-out upstream error: {}\n", e),
+        ),
     }
 }
 
@@ -7882,31 +8127,78 @@ fn http_response(
     out
 }
 
-// The fan-out hop's full result: the upstream's status line, its CONTENT-TYPE
-// (so the client gets a JSON/HTML route's real type, not a flattened
-// text/plain), its other RELAYABLE end-to-end response headers (Set-Cookie,
-// Cache-Control, Location, …), and the body. Hop-by-hop and router-owned framing
-// headers are already filtered out of `headers` (and Content-Type lifted into
-// its own slot) so the caller relays them safely beside the router's own
-// framing.
-struct FanoutResult {
-    status: String,
-    content_type: String,
-    headers: Vec<(String, String)>,
-    body: String,
+// Write ONLY the client response HEAD for a STREAMING fan-out, then the body is
+// piped separately (so the body never lands in a buffer). The framing the router
+// owns is authored here exactly as `http_response` authors it, except the
+// body-length line varies with how the body will be streamed:
+//   - Length(n): `Content-Length: n` — the SAME length the upstream declared, so
+//     the client knows precisely where the body ends; both connections stay framed.
+//   - Chunked: `Transfer-Encoding: chunked` (NO Content-Length) — the raw chunk
+//     framing is relayed through, self-delimiting, so the client stays framed.
+//   - Close: neither line — the body's end is the connection close itself, so the
+//     client reads to close (and `keep_alive` must already be false here).
+// X-Form-Router and the relayed end-to-end headers (Set-Cookie, Cache-Control, …)
+// are written the same as the buffered path; a relayed upstream header can NEVER
+// clobber the router-owned framing (Content-Length/Content-Type/Connection +
+// Transfer-Encoding are filtered out of `relayed` by relay_response_header /
+// is_hop_by_hop before they reach here).
+fn write_response_head(
+    client: &mut TcpStream,
+    status: &str,
+    router: &str,
+    keep_alive: bool,
+    content_type: &str,
+    relayed: &[(String, String)],
+    framing: &ResponseFraming,
+) -> Result<(), FanoutError> {
+    let ct = if content_type.trim().is_empty() {
+        "text/plain; charset=utf-8"
+    } else {
+        content_type.trim()
+    };
+    let mut out = format!("HTTP/1.1 {}\r\nContent-Type: {}\r\n", status, ct);
+    match *framing {
+        ResponseFraming::Length(n) => {
+            out.push_str(&format!("Content-Length: {}\r\n", n));
+        }
+        ResponseFraming::Chunked => {
+            // The router relays the upstream's chunk framing verbatim, so the
+            // client hop is chunked too — it owns this Transfer-Encoding (the
+            // upstream's was stripped as hop-by-hop on the way in).
+            out.push_str("Transfer-Encoding: chunked\r\n");
+        }
+        ResponseFraming::Close => {
+            // No length line: the body ends at connection close. keep_alive is
+            // forced false by the caller on this framing.
+        }
+    }
+    out.push_str(&format!(
+        "X-Form-Router: {}\r\nConnection: {}\r\n",
+        router,
+        if keep_alive { "keep-alive" } else { "close" },
+    ));
+    for (name, value) in relayed {
+        out.push_str(&format!("{}: {}\r\n", name, value));
+    }
+    out.push_str("\r\n");
+    client
+        .write_all(out.as_bytes())
+        .map_err(|e| classify_io_error(&e, "write response head to client"))
 }
 
-// Send a fully-built request on `stream` and read exactly ONE Content-Length-
-// framed response back, seeding the read with `carry` (bytes left over from a
-// PRIOR response on this same reused connection). Factored out so the stale-
-// pooled-connection RETRY path runs the identical send+read shape — one fan-out
-// hop logic, used for both the first attempt and the retry (core-abstraction-
-// first: the retry is not a fork, it is the same shape on a fresh socket).
-fn send_and_read_one(
+// Send a fully-built request on `stream` and read exactly ONE response HEAD back,
+// seeding the read with `carry` (bytes left over from a PRIOR response on this same
+// reused connection). The BODY is NOT read here — it streams afterward, straight to
+// the client, never buffered. Factored out so the stale-pooled-connection RETRY
+// path runs the identical send+read-head shape — one fan-out hop logic, used for
+// both the first attempt and the retry (core-abstraction-first: the retry is not a
+// fork, it is the same shape on a fresh socket). The retry is SAFE precisely because
+// it ends at the head: a `Closed` here means no body byte has reached the client.
+fn send_and_read_head(
     stream: &mut TcpStream,
     request: &[u8],
     carry: Vec<u8>,
-) -> Result<UpstreamResponse, FanoutError> {
+) -> Result<UpstreamHead, FanoutError> {
     // A write deadline (FANOUT_READ_TIMEOUT, set as the write timeout too) surfaces
     // here as Timeout if the upstream accepts but never drains its receive buffer.
     // A broken pipe / reset on a POOLED connection the upstream already closed is
@@ -7917,36 +8209,71 @@ fn send_and_read_one(
     stream
         .write_all(request)
         .map_err(|e| classify_io_error(&e, "write request"))?;
-    read_upstream_response(stream, carry)
+    read_upstream_head(stream, carry)
 }
 
-fn fanout_request_result(
+// The verdict a streaming fan-out returns to the keep-alive serve loop: whether the
+// CLIENT connection may serve another request. `true` keeps it open; `false` closes
+// it (the client asked to close, the response was close-framed/unframed, OR a
+// mid-stream failure left the connection in an uncertain state — the only honest
+// move is to close). It is the same bool `handle_request` returns on its other arms,
+// named for intent at the streaming boundary.
+type ClientKeepAlive = bool;
+
+// STREAM a fan-out: forward the client's request to the upstream and PIPE the
+// upstream's response body straight back to the client, with the whole body NEVER
+// held in one buffer. This replaces the old buffer-then-emit fan-out: the router
+// observes the circulation AS IT FLOWS.
+//
+// The shape, end to end:
+//   1. Build the upstream request ONCE (reused verbatim for the stale-pool retry).
+//   2. Get-or-create the pooled upstream connection; send the request and read the
+//      response HEAD (small, buffered to parse). A `Closed` here — and ONLY here,
+//      before any body byte has reached the client — triggers a transparent
+//      reconnect+retry (the stale-pool path), exactly as before. A Timeout/Other
+//      before the head propagates to a buffered 504/502 written to the client.
+//   3. Once the head is parsed, decide the CLIENT framing (Length echoes the
+//      upstream's Content-Length; Chunked relays the chunk framing; Close means the
+//      body ends at connection close so the client connection must close too), write
+//      the client response head, then PIPE the body upstream→client in fixed chunks.
+//   4. On a Length-framed response the upstream connection is pooled IFF the upstream
+//      kept it alive; chunked/unframed connections are dropped (never pooled).
+//
+// Honest mid-stream truncation: after the client head is written, a stall or close
+// mid-body can no longer become a clean 504 — the head already went out. Such a
+// failure closes the client connection (returns false); the client sees a truncated
+// body, the truthful outcome of an upstream that died mid-stream.
+fn fanout_stream_to_client(
+    client: &mut TcpStream,
+    client_keep_alive: ClientKeepAlive,
     upstream: &str,
     method: &str,
     target: &str,
     req_headers: &[(String, String)],
     body: &[u8],
     pool: &mut UpstreamPool,
-) -> Result<FanoutResult, FanoutError> {
-    let (host, port, base_path) = parse_http_upstream(upstream).map_err(FanoutError::Other)?;
+) -> ClientKeepAlive {
+    // Parse the upstream + build the request bytes. A bad upstream URL is an Other
+    // error -> a buffered 502 (the head is unwritten, so a clean status is possible).
+    let (host, port, base_path) = match parse_http_upstream(upstream) {
+        Ok(v) => v,
+        Err(e) => {
+            return emit_buffered_fanout_error(client, client_keep_alive, &FanoutError::Other(e))
+        }
+    };
     let request_target = format!(
         "{}{}",
         base_path,
         if target.starts_with('/') { target } else { "/" }
     );
-    // Build the request bytes ONCE — reused verbatim for the first attempt and
-    // for the stale-connection retry. The router owns the upstream-hop framing:
-    // `Host` is rewritten to the upstream; `Connection: keep-alive` asks the
-    // upstream to hold the connection open so the NEXT fan-out reuses it (the
-    // handshake amortized across requests — the symmetric saving to the client
-    // hop's keep-alive); HTTP/1.1 so keep-alive is the default and the response
-    // can be Content-Length-framed (the framing that lets us read exactly one
-    // response without relying on the upstream closing). Content-Length is set
-    // from the body the router actually captured. The CLIENT's end-to-end headers
-    // (Authorization, Cookie, Accept*, User-Agent, Content-Type, X-*, …) are
-    // forwarded verbatim so an authenticated/content-typed route is fronted
-    // truthfully; hop-by-hop and router-owned framing headers are filtered by
-    // forward_request_header.
+    // Build the request bytes ONCE — reused verbatim for the first attempt and the
+    // stale-connection retry. The router owns the upstream-hop framing: `Host` is
+    // rewritten to the upstream; `Connection: keep-alive` asks the upstream to hold
+    // the connection open so the NEXT fan-out reuses it; HTTP/1.1 so keep-alive is
+    // the default and the response can be Content-Length-framed. Content-Length is
+    // set from the body the router actually captured. The CLIENT's end-to-end
+    // headers (Authorization, Cookie, Accept*, …) are forwarded verbatim; hop-by-hop
+    // and router-owned framing headers are filtered by forward_request_header.
     let mut head = format!(
         "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n",
         method, request_target, host
@@ -7956,9 +8283,6 @@ fn fanout_request_result(
             head.push_str(&format!("{}: {}\r\n", name, value));
         }
     }
-    // Content-Length from the captured body's TRUE length (never the client's
-    // forwarded one, which could disagree with the bytes we hold). GET/HEAD with
-    // no body send no Content-Length.
     if !body.is_empty() {
         head.push_str(&format!("Content-Length: {}\r\n", body.len()));
     }
@@ -7966,98 +8290,125 @@ fn fanout_request_result(
     let mut request: Vec<u8> = head.into_bytes();
     request.extend_from_slice(body);
 
-    // GET-OR-CREATE FROM POOL, wrapping the connect step (core-abstraction-first:
-    // the only thing the pool changes is connection lifecycle — fresh vs reused;
-    // the request build + response framing are identical either way). If a live
-    // connection is pooled for this upstream, try it first.
-    //
-    // The retry-vs-504 discipline lives in the error CLASSIFICATION, not in a
-    // fork of the fan-out shape:
-    //   - Closed: the pooled connection was idle-closed by the upstream (EOF /
-    //     broken pipe on reuse). This is EXPECTED for a keep-alive pool — drop it,
-    //     open a FRESH connection, retry the SAME request ONCE. Standard stale-pool
-    //     behavior, never surfaced to the client.
-    //   - Timeout: the upstream is reachable but HUNG (connect/write/read deadline
-    //     expired). Retrying does NOT help — the upstream is hung, a retry only
-    //     doubles the latency before the same deadline — so a Timeout PROPAGATES
-    //     immediately to a 504. This is what keeps a timeout from becoming an
-    //     infinite (or even doubled) retry loop.
-    //   - Other: a malformed/oversized response — propagates to a 502.
-    // The connection is taken OUT of the pool before use, so any error path simply
-    // drops it (it is never returned to the pool) and the worker is freed.
-    let response = if let Some(mut pooled) = pool.take(&host, port) {
-        let carry = std::mem::take(&mut pooled.carry);
-        match send_and_read_one(&mut pooled.stream, &request, carry) {
-            Ok(resp) => {
-                // Reused connection served the response. Return it to the pool
-                // iff the upstream kept it alive and we framed it cleanly.
-                if resp.reusable {
-                    pool.store(
-                        &host,
-                        port,
-                        PooledConn {
-                            stream: pooled.stream,
-                            carry: resp.leftover.clone(),
-                        },
-                    );
+    // GET-OR-CREATE FROM POOL + read the HEAD, with the stale-pool retry living in
+    // the error CLASSIFICATION (not a fork): a Closed pooled connection reconnects
+    // and retries the SAME request ONCE; a Timeout/Other propagates. The connection
+    // is taken OUT of the pool before use, so any error path drops it (never pooled)
+    // and the worker is freed. This whole step ends at the HEAD — no body byte has
+    // reached the client yet — so a retry here is safe and an error here can still
+    // be a clean buffered 504/502.
+    let (mut upstream_stream, head) = match pool.take(&host, port) {
+        Some(mut pooled) => {
+            let carry = std::mem::take(&mut pooled.carry);
+            match send_and_read_head(&mut pooled.stream, &request, carry) {
+                Ok(h) => (pooled.stream, h),
+                // ONLY a Closed (stale pooled connection) reconnects+retries once.
+                Err(FanoutError::Closed(_)) => {
+                    drop(pooled);
+                    let mut fresh = match connect_upstream_with_timeout(&host, port) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            return emit_buffered_fanout_error(client, client_keep_alive, &e)
+                        }
+                    };
+                    match send_and_read_head(&mut fresh, &request, Vec::new()) {
+                        Ok(h) => (fresh, h),
+                        Err(e) => {
+                            return emit_buffered_fanout_error(client, client_keep_alive, &e)
+                        }
+                    }
                 }
-                resp
-            }
-            // ONLY a Closed (stale pooled connection) reconnects+retries once. A
-            // Timeout or Other on the pooled connection propagates unchanged — a
-            // hung upstream must not be retried (it would just hang again).
-            Err(FanoutError::Closed(_)) => {
-                drop(pooled);
-                let mut fresh = connect_upstream_with_timeout(&host, port)?;
-                // A failure on the FRESH connection is a real upstream error and
-                // propagates (Timeout -> 504, else 502) — the retry is at most ONCE.
-                let resp = send_and_read_one(&mut fresh, &request, Vec::new())?;
-                if resp.reusable {
-                    pool.store(
-                        &host,
-                        port,
-                        PooledConn {
-                            stream: fresh,
-                            carry: resp.leftover.clone(),
-                        },
-                    );
+                // Timeout (hung upstream) or Other (bad head) — drop the connection
+                // and emit a buffered 504/502; the client head is still unwritten.
+                Err(e) => {
+                    drop(pooled);
+                    return emit_buffered_fanout_error(client, client_keep_alive, &e);
                 }
-                resp
-            }
-            Err(other) => {
-                // Timeout (hung upstream) or Other (bad response) — drop the
-                // connection (already taken from the pool) and propagate; the
-                // worker is freed and the client gets a 504/502, not a hang.
-                drop(pooled);
-                return Err(other);
             }
         }
-    } else {
-        // No pooled connection — open a fresh one (the first fan-out, or after a
-        // non-reusable response dropped the previous connection). A connect-timeout
-        // here (unreachable/blackholed upstream) is a Timeout -> 504; a resolve
-        // failure is Other -> 502.
-        let mut fresh = connect_upstream_with_timeout(&host, port)?;
-        let resp = send_and_read_one(&mut fresh, &request, Vec::new())?;
-        if resp.reusable {
-            pool.store(
-                &host,
-                port,
-                PooledConn {
-                    stream: fresh,
-                    carry: resp.leftover.clone(),
-                },
-            );
+        None => {
+            // No pooled connection — open a fresh one (the first fan-out, or after a
+            // non-reusable response dropped the previous connection).
+            let mut fresh = match connect_upstream_with_timeout(&host, port) {
+                Ok(s) => s,
+                Err(e) => return emit_buffered_fanout_error(client, client_keep_alive, &e),
+            };
+            match send_and_read_head(&mut fresh, &request, Vec::new()) {
+                Ok(h) => (fresh, h),
+                Err(e) => return emit_buffered_fanout_error(client, client_keep_alive, &e),
+            }
         }
-        resp
     };
 
-    Ok(FanoutResult {
-        status: response.status,
-        content_type: response.content_type,
-        headers: response.headers,
-        body: response.body,
-    })
+    // The head is in hand. Decide the CLIENT-hop framing + keep-alive, write the
+    // client head, then PIPE the body. Close-framed/unframed bodies force the client
+    // connection closed (no body-end marker but the close itself); Length/Chunked
+    // self-delimit, so the client's own keep-alive intent is honored.
+    let client_kept = match head.framing {
+        ResponseFraming::Close => false,
+        _ => client_keep_alive,
+    };
+    if write_response_head(
+        client,
+        &head.status,
+        "fanout-python",
+        client_kept,
+        &head.content_type,
+        &head.headers,
+        &head.framing,
+    )
+    .is_err()
+    {
+        // The client is gone before the body even started — close the connection.
+        return false;
+    }
+
+    // PIPE the body straight from the upstream to the client. The body never lands
+    // in a buffer; only a fixed 64 KiB chunk moves at a time.
+    let upstream_kept = head.upstream_keep_alive;
+    match stream_body_to_client(&mut upstream_stream, client, &head.framing, &head.body_prefix) {
+        Ok(outcome) => {
+            // Pool the upstream connection IFF the body was Length-framed AND the
+            // upstream kept it alive — exactly the old reuse rule, now decided after
+            // the body has streamed rather than after it was buffered.
+            if outcome.reusable && upstream_kept {
+                pool.store(
+                    &host,
+                    port,
+                    PooledConn {
+                        stream: upstream_stream,
+                        carry: outcome.leftover,
+                    },
+                );
+            }
+            client_kept
+        }
+        // A mid-body failure (upstream stalled/closed after the head went out). The
+        // client head is already written, so this can't be a clean status — the
+        // client connection closes and the client sees a truncated body, the honest
+        // outcome. The upstream connection is dropped (not pooled).
+        Err(_) => false,
+    }
+}
+
+// Emit a small BUFFERED 504/502 to the client through the ONE emit shape, then
+// return the client keep-alive verdict. Reachable ONLY while the client head is
+// unwritten (a pre-body fan-out failure), so a clean framed error is still possible.
+// A successful write keeps the client connection's intent (a 502 is a complete,
+// framed response — the connection can serve more); a failed write closes it.
+fn emit_buffered_fanout_error(
+    client: &mut TcpStream,
+    client_keep_alive: ClientKeepAlive,
+    err: &FanoutError,
+) -> ClientKeepAlive {
+    let (status, body) = fanout_error_response(err);
+    if client
+        .write_all(http_response(&status, &body, "fanout-python", client_keep_alive, "", &[]).as_bytes())
+        .is_err()
+    {
+        return false;
+    }
+    client_keep_alive
 }
 
 fn parse_http_upstream(upstream: &str) -> Result<(String, u16, String), String> {

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -143,10 +143,10 @@ gap, named precisely:
 
 | Gap | cli_serve today | Production front door needs |
 |-----|-----------------|-----------------------------|
-| **HTTP version** | serves HTTP/1.1 with keep-alive on BOTH hops — on the client hop a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), and on the fan-out hop each worker reuses a per-worker keep-alive connection to the upstream (the router→upstream handshake amortized across requests, the symmetric saving); every response is Content-Length-framed so the reader knows exactly where one ends and the next begins; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet client connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request on both hops, never dropped | chunked transfer encoding (today every response is Content-Length-framed; a streamed/unknown-length body would need chunked — and an upstream chunked response is read-to-close and not pooled), HTTP/2 behind Traefik |
+| **HTTP version** | serves HTTP/1.1 with keep-alive on BOTH hops — on the client hop a worker holds the accepted connection and serves multiple requests on it (one TCP handshake amortized across the connection), and on the fan-out hop each worker reuses a per-worker keep-alive connection to the upstream (the router→upstream handshake amortized across requests, the symmetric saving); a native/error response is Content-Length-framed, and a fan-out STREAMS the upstream's framing through (Content-Length echoed, or `Transfer-Encoding: chunked` relayed, or close-framed) so the client always knows where the body ends; the client's intent is honored (HTTP/1.1 default-keep-alive unless `Connection: close`, HTTP/1.0 close-unless-`keep-alive`); a 5s idle read-timeout closes a quiet client connection so it cannot pin a worker; over-read bytes (pipelining) are carried into the next request on both hops, never dropped | HTTP/2 behind Traefik (a chunked upstream response now relays through but its connection is not pooled — chunked-body pool reuse is a named-later breath) |
 | **Concurrency** | the accept loop dispatches each accepted stream to a POOL of kernel workers (`--workers`, default the host's available parallelism), each owning its own `Kernel + Arena` (the `!Sync` constraint) with `routes.fk` loaded once per worker; concurrent requests run lock-free on isolated kernels — measured ~3–5x throughput over a single worker under 50-way concurrent CPU-bearing load, with no cross-request state bleed | an async/work-stealing accept loop (the thread-per-request-blocked model caps at the worker count); shared read-only routing structure to drop the per-worker re-parse |
 | **Request parsing** | reads the full request honoring Content-Length (a body larger than the initial 8 KiB read is captured across as many socket reads as it needs); parses `application/x-www-form-urlencoded` bodies into the same `(key value)` alist the query string uses, captures `application/json` (and any other body) raw under the reserved key `__body__`; a generous request shape-threshold (64 MiB default, `COH_ROUTER_REQUEST_SHAPE_BYTES`) observed and answered observably when a body is larger than a worker can hold; any method (POST/PUT/PATCH/GET) | full header map exposed to handlers; a structural JSON→Form-value parse (today JSON is raw-captured, not parsed); larger/streamed/chunked bodies |
-| **Fan-out proxy** | reuses a per-worker keep-alive connection to the upstream, framing each response by Content-Length, reconnecting transparently on a stale pooled connection — repeated fan-outs amortize the upstream TCP handshake instead of opening a fresh connection per request. Bounds each fan-out with a connect timeout (~5s) and a read/write timeout (~30s) so a hung upstream returns a 504 and frees the worker rather than pinning it; a read-timeout is not retried (the upstream is hung — a retry would only re-hang and double the latency), a connect-timeout may retry once (in case a pooled-addr was bad), distinct from the stale-close path which reconnects+retries once on an idle-closed pooled connection. Forwards the original method, the request body, and the client's end-to-end request headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*, …) — hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, Proxy-Connection, TE, Trailer) stripped, Host rewritten to the upstream, Content-Length re-derived from the captured body, the router writing its OWN `Connection: keep-alive` to the upstream — and relays the upstream's response headers back (Content-Type so a JSON/HTML route survives the proxy, Set-Cookie, Cache-Control, Location, ETag, X-\*, …), with the router owning the client-hop framing (its own Content-Length + Connection; the upstream's hop-by-hop/framing headers are not relayed) | chunked/streaming response bodies (an upstream chunked response is read-to-close and its connection not pooled), per-route timeout config and circuit-breaking, retries beyond the single stale-connection / connect-timeout retry |
+| **Fan-out proxy** | STREAMS the upstream response body straight to the client — the body is NEVER held whole; only the small response head is buffered (to parse status + framing + relayed headers), then the body is piped in a fixed 64 KiB chunk reused across reads. A Content-Length body is relayed with the SAME length (both hops stay framed, the connection pools IFF the upstream kept it alive); a chunked body has its raw chunk framing relayed through to the TRUE terminating 0-length chunk (a chunk-BOUNDARY parser tracks where chunks end so a `0\r\n\r\n` byte run inside chunk data never truncates the relay), self-delimiting so the client stays framed, the connection not pooled; an unframed (read-to-close) body is piped to EOF and the client connection then closes. Reuses a per-worker keep-alive connection to the upstream, reconnecting transparently on a stale pooled connection — repeated fan-outs amortize the upstream TCP handshake instead of opening a fresh connection per request. Bounds each fan-out with a connect timeout (~5s) and a read/write timeout (~30s) so a hung upstream returns a 504 and frees the worker rather than pinning it; a read-timeout is not retried (the upstream is hung — a retry would only re-hang and double the latency), a connect-timeout may retry once (in case a pooled-addr was bad), distinct from the stale-close path which reconnects+retries once on an idle-closed pooled connection. The retry lives at the HEAD read (before any body byte reaches the client), so it stays safe; a stall mid-body after the head is sent closes the client connection (a truncated body — the honest outcome of an upstream that died mid-stream), since the status was already written. Forwards the original method, the request body, and the client's end-to-end request headers (Authorization, Cookie, Accept\*, User-Agent, Content-Type, X-\*, …) — hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, Upgrade, Proxy-\*, Proxy-Connection, TE, Trailer) stripped, Host rewritten to the upstream, Content-Length re-derived from the captured body, the router writing its OWN `Connection: keep-alive` to the upstream — and relays the upstream's response headers back (Content-Type so a JSON/HTML route survives the proxy, Set-Cookie, Cache-Control, Location, ETag, X-\*, …), with the router owning the client-hop framing (its own Content-Length / Transfer-Encoding / Connection; the upstream's hop-by-hop/framing headers are not relayed) | STREAMING the REQUEST body (today the request body is still buffered before the fan-out; the response streams), per-route timeout config and circuit-breaking, retries beyond the single stale-connection / connect-timeout retry |
 | **Handler inputs** | 0 or 1 arg — the request alist, carrying query params AND parsed body fields uniformly (form-urlencoded merged in; JSON/other body under `__body__`), so a handler reads a field the same way regardless of how it arrived | path params and headers marshalled into the handler frame; a richer body shape than a flat alist (e.g. structural JSON) |
 | **Errors / observability** | 404/413/500 as plain text | structured errors, access logs, the trace surface wired to the witness, metrics |
 | **TLS / lifecycle** | plain TCP on 127.0.0.1, runs until killed | TLS termination (or behind Traefik), graceful shutdown, health/readiness, config reload |
@@ -195,18 +195,21 @@ exactly as it owns its `Kernel + Arena` (the per-worker isolation from the
 concurrency build). The router writes its own `Connection: keep-alive` to the
 upstream and frames the response by Content-Length — it can no longer rely on the
 upstream closing the connection to know where the body ends (that was how the old
-read-to-close worked), so it reads exactly one Content-Length-framed response and
-carries any over-read bytes forward for the next response on the connection (the
-classic keep-alive proxy bug — a mis-framed read corrupts the next request — held
-off by the same carry discipline the client hop uses). A pooled connection may
-have been idle-closed by the upstream since it was returned; on a reuse whose
-write or read fails, the router transparently reconnects once and retries the
-same request, never surfacing a stale-pool error to the client. The honest scope:
-reuse applies to Content-Length-framed responses; an upstream chunked or
-unframed response is read-to-close and its connection is dropped, not pooled
-(chunked-body reuse is a named-later breath). The ONE `fanout_request` shape is
-preserved — the pool only changes the connection lifecycle (reused vs fresh); the
-request build and response framing are identical either way.
+read-to-close worked), so it reads one response's HEAD, STREAMS exactly the
+Content-Length-framed body straight to the client, and carries any over-read bytes
+(read past the framed body in the head read) forward for the next response on the
+connection (the classic keep-alive proxy bug — a mis-framed read corrupts the next
+request — held off by the same carry discipline the client hop uses). A pooled
+connection may have been idle-closed by the upstream since it was returned; on a
+reuse whose write or HEAD read fails, the router transparently reconnects once and
+retries the same request, never surfacing a stale-pool error to the client — the
+retry lives at the head read, before any body byte has reached the client, so it
+stays safe. The honest scope: reuse applies to Content-Length-framed responses; an
+upstream chunked or unframed response is streamed through but its connection is
+dropped, not pooled (chunked-body pool reuse is a named-later breath). The ONE
+`fanout_stream_to_client` shape is preserved — the pool only changes the connection
+lifecycle (reused vs fresh); the request build, head read, and body streaming are
+identical either way.
 **Fan-out timeouts**: each fan-out hop is bounded by a connect timeout (~5s) and a
 read/write timeout (~30s) so a SLOW or HUNG upstream cannot pin a worker forever —
 the client-hop already reaps an idle connection (`KEEPALIVE_IDLE_TIMEOUT`); this is
@@ -227,9 +230,11 @@ once — a timeout is deliberately NOT the stale-close path, so a timeout never
 becomes an infinite (or even doubled) retry loop. The timeout values are sane
 defaults (overridable via `COH_FANOUT_CONNECT_TIMEOUT_MS` / `COH_FANOUT_READ_TIMEOUT_MS`
 so a test proves the path in seconds); production tuning of the exact values and
-per-route timeouts is a named-later breath. The ONE `fanout_request` shape is
-preserved — the timeouts are deadlines set on the stream plus the error
-classification, not a second fan-out path.
+per-route timeouts is a named-later breath. The ONE `fanout_stream_to_client` shape
+is preserved — the timeouts are deadlines set on the stream plus the error
+classification, not a second fan-out path; a timeout on the HEAD read becomes a
+buffered 504 (the client head is still unwritten), and the head-read retry stays the
+single safe retry point.
 **Native JSON responses**: a native handler can now serve a full JSON object
 byte-identical to a FastAPI route's response, not just a scalar string. Two small
 universal pieces made the gap closable: the `value_str` native renders ANY value
@@ -477,41 +482,59 @@ upstream that accepts the connection but never responds — the router returns a
 blackholed upstream returns a clean 504/502 rather than hanging; with N workers a
 hung fan-out occupies ONE worker for at most the connect+read timeout while the rest
 of the pool keeps serving 20 native requests in milliseconds — the pool is NOT
-starved; a read-timeout returns 504 ONCE, not reconnect+retried). The fan-out
-path still buffers each upstream response whole; request and response now share one
-**awareness-shape** for that buffer — the largest shape a worker holds in memory,
-a generous default (64 MiB each) named as a common recipe and changeable at any time
-via `COH_ROUTER_REQUEST_SHAPE_BYTES` / `COH_ROUTER_RESPONSE_SHAPE_BYTES`. This is
-awareness, not prevention: the shape is observed first, and one larger than we can
-hold right now is answered *observably* — the response names the bytes seen, the
-threshold we hold this moment, and that it is a recipe we can change together —
-never a silent wall. The earlier 1 MiB-request / 64 MiB-response split carried the
-inherited fear posture ("a request body is untrusted client input"), untrue in this
-space where the sender is us and circulation is welcome the moment its shape can be
-observed. That old asymmetry's 1 MiB ceiling on the *response* side had 502'd the real
+starved; a read-timeout returns 504 ONCE, not reconnect+retried). The fan-out path
+STREAMS the upstream response body straight to the client — the body is NEVER held
+whole. Only the small response HEAD is buffered (to parse status + framing +
+relayed headers); the body is then piped in a fixed 64 KiB chunk reused across
+reads (Content-Length echoed and the body relayed exactly, or `Transfer-Encoding:
+chunked` relayed through to the true terminating 0-length chunk, or close-framed and
+piped to EOF). This is proven by `router_body_harness.py`: a 16 MiB Content-Length
+body relays BYTE-IDENTICAL (sha256 over all 256 byte values — the raw-byte relay
+also fixes the old `String::from_utf8_lossy` round-trip that would have corrupted
+bytes ≥ 0x80), and — the load-bearing proof the buffer is GONE — that SAME 16 MiB
+body still relays 200 byte-identical through a router whose response shape-threshold
+is only 1 MiB; under the old buffered code that exact threshold 502'd the body
+(`upstream response shape is 16777216 bytes — larger than we can hold`, observed
+directly against the origin/main binary). Streaming dissolves the size gate: the
+body never occupies a worker-memory buffer, so its length is no longer a ceiling.
+The REQUEST body is still buffered before the fan-out (a named-next breath — request
+streaming); on that request side, and for the small response head, the
+**awareness-shape** still governs — the largest shape a worker holds in memory, a
+generous default (64 MiB) named as a common recipe and changeable at any time via
+`COH_ROUTER_REQUEST_SHAPE_BYTES` / `COH_ROUTER_RESPONSE_SHAPE_BYTES` (the response
+threshold now bounds the HEAD alone). This is awareness, not prevention: the shape
+is observed first, and one larger than we can hold right now is answered
+*observably* — the response names the bytes seen, the threshold we hold this moment,
+and that it is a recipe we can change together — never a silent wall. The earlier
+1 MiB-request / 64 MiB-response split carried the inherited fear posture ("a request
+body is untrusted client input"), untrue in this space where the sender is us and
+circulation is welcome the moment its shape can be observed. That old asymmetry's
+1 MiB ceiling on the *response* side had 502'd the real
 `/api/concepts/domain/living-collective`
 (≈1.7 MB Content-Length-framed JSON) with `upstream response body too large` while
-api served it 200 direct — the blocker the 2026-06-03 live flip surfaced. The fix
-(PR #2413, on main at 32d1cadd) is verified on the production VPS: the cap-fixed
-kernel-router in shadow relays that 1.7 MB route at `200`, byte-identical to the
-upstream (sha256 of the 1,704,424-byte body matches direct, X-Form-Router:
-fanout-python on the response), the proxy hop adding ~2–4 ms over direct on a body
-that size. "Byte-identical" now holds for the real large routes, not only the
-small ones. Still open:
-chunked/streaming upstream response bodies (an upstream chunked response is
-read-to-close and not pooled), per-route timeout config + circuit-breaking and
-retries beyond the single stale-connection / connect-timeout retry, and the accept
-loop is thread-per-connection-blocked (it parallelizes to the worker count, not an
-async reactor; a worker serving a keep-alive client is held until that connection
-closes or times out). Responses are Content-Length-framed, not chunked; JSON bodies
-are raw-captured, not structurally parsed into Form values. The real-app proof ran
-against the dev sqlite DB; the production deployment shape (TLS/Traefik front, the
-routes.fk covering the real native-eligible set) is the remaining build.
+api served it 200 direct — the blocker the 2026-06-03 live flip surfaced. Raising
+the cap (PR #2413, on main at 32d1cadd) first relieved that route in shadow on the
+production VPS (1.7 MB relayed 200, byte-identical, ~2–4 ms proxy hop); streaming now
+removes the ceiling entirely — a body of any size relays without a whole-body buffer.
+"Byte-identical" holds for the real large routes, not only the small ones. Still
+open: STREAMING the REQUEST body (the response streams; the request body is still
+buffered before the fan-out), chunked-body POOL reuse (a chunked upstream response
+relays through but its connection is not pooled), per-route timeout config +
+circuit-breaking and retries beyond the single stale-connection / connect-timeout
+retry, and the accept loop is thread-per-connection-blocked (it parallelizes to the
+worker count, not an async reactor; a worker serving a keep-alive client is held
+until that connection closes or times out). JSON bodies are raw-captured, not
+structurally parsed into Form values. The real-app proof ran against the dev sqlite
+DB; the production deployment shape (TLS/Traefik front, the routes.fk covering the
+real native-eligible set) is the remaining build.
 Concurrency, request-body reading, **bidirectional header passthrough**, the
 **real-app fan-out + native side-by-side**, **HTTP/1.1 keep-alive on the
-client→router hop**, **upstream connection reuse on the fan-out hop**, and
-**fan-out timeouts (hung upstream → 504, worker freed, pool not starved)** are now
-shown; chunked transfer and structural-JSON are the rest.
+client→router hop**, **upstream connection reuse on the fan-out hop**,
+**fan-out timeouts (hung upstream → 504, worker freed, pool not starved)**, and
+**RESPONSE STREAMING (the upstream body piped straight to the client, byte-identical,
+never held whole — incl. a chunked relay through the true 0-chunk and a 16 MiB body
+flowing past a 1 MiB threshold)** are now shown; REQUEST-body streaming and
+structural-JSON are the rest.
 
 ## Production routes — the first promotions, byte-identical to the live api
 
@@ -755,10 +778,10 @@ door is FastAPI.
 
 ## Sources
 
-- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool; binds `--host` × `--port`, default host `127.0.0.1` so a same-host harness is unchanged while a containerized front door binds `0.0.0.0` to be reachable across the boundary), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_request` / `fanout_request_result` (the proxy arm, forwarding method + body over a pooled keep-alive upstream connection, mapping a `FanoutError::Timeout` → 504 and `Closed`/`Other` → 502), `connect_upstream_with_timeout` (resolve the SocketAddr + `connect_timeout` + set the per-use read/write deadlines on the fan-out stream), `FanoutError` + `classify_io_error` (the retry-vs-504 classification: TimedOut/WouldBlock → Timeout → 504 never retried, BrokenPipe/Reset/EOF → Closed → stale-pool reconnect+retry once, else Other → 502), `fanout_connect_timeout` / `fanout_read_timeout` (the ~5s connect / ~30s read+write deadlines, env-overridable via `COH_FANOUT_CONNECT_TIMEOUT_MS` / `COH_FANOUT_READ_TIMEOUT_MS`), `UpstreamPool` + `PooledConn` (the per-worker, lock-free upstream connection cache owned by `worker_loop` and threaded through `serve_connection` → `handle_request`), `read_upstream_response` / `send_and_read_one` / `upstream_response_keep_alive` / `head_is_chunked` (the Content-Length-framed one-response read that no longer relies on connection-close, with read/write deadlines classified as timeouts, the stale-connection reconnect+retry, and the reuse-vs-drop verdict), `is_hop_by_hop` (RFC 7230 §6.1 hop-by-hop set, now incl. `Proxy-Connection`), `http_response` (HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights), `value_str` (render ANY value via `Value::display()` → a Str — the float-correct leaf a JSON-emitting handler `str_concat`s into the response body, where `int_to_str` would truncate a Float; `handle_request` serves a native body opening with `{`/`[` as `Content-Type: application/json`, so a promoted route returns the same body AND type as its FastAPI twin).
+- [`form/form-kernel-rust/src/main.rs`](../form/form-kernel-rust/src/main.rs) — `cli_serve` (the front-door listener, dispatching to the worker pool; binds `--host` × `--port`, default host `127.0.0.1` so a same-host harness is unchanged while a containerized front door binds `0.0.0.0` to be reachable across the boundary), `worker_loop` + `build_worker_kernel` (a worker's own `Kernel + Arena` with `routes.fk` loaded per worker), `serve_connection` (the keep-alive loop — runs `handle_request` repeatedly on one `TcpStream` until close/EOF/idle-timeout, sets the `KEEPALIVE_IDLE_TIMEOUT` read-timeout, carries pipelined leftover bytes), `handle_request` (the single factored per-request serving shape, reading the full request + body and returning the keep-alive verdict), `head_keep_alive` (the `Connection`-header + HTTP-version keep-alive decision), `read_request` / `parse_content_length` / `parse_content_type` / `parse_request_body` (the Content-Length-honored read that carries over-read bytes forward, and the content-type body parse), `fanout_stream_to_client` (the STREAMING proxy arm — builds the upstream request, gets-or-creates the pooled connection, reads the response HEAD with the stale-pool reconnect+retry, writes the client response head, then PIPES the body straight to the client; pools the upstream connection IFF Length-framed and kept alive; on a pre-body failure emits a buffered 504/502, on a mid-body failure closes the client connection), `emit_buffered_fanout_error` + `fanout_error_response` (the pre-body fan-out failure → buffered 504/502 mapping, reachable only while the client head is unwritten), `connect_upstream_with_timeout` (resolve the SocketAddr + `connect_timeout` + set the per-use read/write deadlines on the fan-out stream), `FanoutError` + `classify_io_error` (the retry-vs-504 classification: TimedOut/WouldBlock → Timeout → 504 never retried, BrokenPipe/Reset/EOF → Closed → stale-pool reconnect+retry once, else Other → 502), `fanout_connect_timeout` / `fanout_read_timeout` (the ~5s connect / ~30s read+write deadlines, env-overridable via `COH_FANOUT_CONNECT_TIMEOUT_MS` / `COH_FANOUT_READ_TIMEOUT_MS`), `UpstreamPool` + `PooledConn` (the per-worker, lock-free upstream connection cache owned by `worker_loop` and threaded through `serve_connection` → `handle_request`), `read_upstream_head` / `send_and_read_head` / `UpstreamHead` / `ResponseFraming` / `upstream_response_keep_alive` / `head_is_chunked` (read ONLY the response head — small, buffered to parse — and decide the body framing Length/Chunked/Close; the body is NOT read here, it streams), `stream_body_to_client` / `BodyOutcome` (pipe the body in a fixed 64 KiB chunk reused across reads, never holding it whole — Content-Length echoed and relayed exactly with over-read carried forward, chunked relayed raw through the true 0-chunk, unframed piped to EOF), `ChunkParser` + `parse_chunk_size` (the incremental chunk-BOUNDARY parser that finds the TRUE terminating 0-length chunk so a `0\r\n\r\n` run inside chunk data never truncates the relay), `is_hop_by_hop` (RFC 7230 §6.1 hop-by-hop set, now incl. `Proxy-Connection`), `http_response` (the BUFFERED emit for native/404/error — HTTP/1.1 with accurate Content-Length, the `Connection` + X-Form-Router headers) / `write_response_head` (the STREAMING client head — same router-owned framing, with Content-Length / Transfer-Encoding: chunked / close-framing per the body that follows), `str_to_float` (the float-parsing leaf native that lets a native handler parse float query args, e.g. weighted_average's values/weights), `value_str` (render ANY value via `Value::display()` → a Str — the float-correct leaf a JSON-emitting handler `str_concat`s into the response body, where `int_to_str` would truncate a Float; `handle_request` serves a native body opening with `{`/`[` as `Content-Type: application/json`, so a promoted route returns the same body AND type as its FastAPI twin).
 - [`form/form-kernel-rust/examples/router-proof.fk`](../form/form-kernel-rust/examples/router-proof.fk) — the native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_proof_harness.py`](../form/form-kernel-rust/router_proof_harness.py) — the end-to-end topology proof + native-latency measurement (mock upstream).
-- [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, a body past the OLD 1 MiB cap now flowing under the generous default shape, and a shape past the current threshold answered with an observable, named "no" (the bytes seen + the changeable `COH_ROUTER_REQUEST_SHAPE_BYTES` recipe) (mock upstream).
+- [`form/form-kernel-rust/router_body_harness.py`](../form/form-kernel-rust/router_body_harness.py) — the request-body + RESPONSE-STREAMING proof: a native POST handler reading form-urlencoded fields, a raw JSON capture, a >8 KiB body captured across reads, POST fan-out body forwarding, a body past the OLD 1 MiB cap now flowing under the generous default shape, and a shape past the current threshold answered with an observable, named "no" (the bytes seen + the changeable `COH_ROUTER_REQUEST_SHAPE_BYTES` recipe); then the streaming proofs — a 16 MiB Content-Length fan-out body relayed BYTE-IDENTICAL (sha256 over all 256 byte values), the SAME body relayed 200 byte-identical through a router whose response shape is only 1 MiB (THE BUFFER IS GONE — size no longer the gate), a chunked response relayed through with its de-chunked body matching, an adversarial chunked body with `0\r\n\r\n` INSIDE chunk data NOT truncated (the boundary parser finds the real 0-chunk), and an unframed read-to-close response piped to EOF byte-identical (mock upstream).
 - [`form/form-kernel-rust/examples/router-body-proof.fk`](../form/form-kernel-rust/examples/router-body-proof.fk) — the body-reading native-handler manifest (Form, not cross-compiled).
 - [`form/form-kernel-rust/router_concurrency_harness.py`](../form/form-kernel-rust/router_concurrency_harness.py) — the worker-pool concurrency proof: 50 parallel clients, no cross-request state bleed, 1-worker vs N-worker throughput.
 - [`form/form-kernel-rust/router_keepalive_harness.py`](../form/form-kernel-rust/router_keepalive_harness.py) — the HTTP/1.1 keep-alive proof (CLIENT→router hop): N sequential requests on ONE connection (Content-Length framed, distinct inputs, each correct), pipelined two-in-one-send (leftover bytes carried, none dropped), `Connection: close` honored, HTTP/1.0 default-close back-compat, idle-timeout reaping the connection (worker freed), an idle connection NOT starving the pool, and the per-request handshake saving (reused vs fresh connection). Mock upstream — no production routing.


### PR DESCRIPTION
## What

The kernel-router's fan-out proxy now **streams** the upstream response body straight to the client — it no longer reads the whole response into memory and then handles. The router observes circulation **as it flows**, never holding the body whole. This completes the awareness-shape work on main: the response shape-threshold (`COH_ROUTER_RESPONSE_SHAPE_BYTES`) now bounds only the small response **head**; the body size is no longer a worker-memory ceiling.

## How (`form/form-kernel-rust/src/main.rs`)

- `read_upstream_response` (whole-body read) → **`read_upstream_head`** (head only; decides `ResponseFraming::{Length, Chunked, Close}`) + **`stream_body_to_client`** (pipes the body in a fixed 64 KiB chunk reused across reads — Content-Length echoed and relayed exactly with over-read carried forward, chunked relayed raw, unframed piped to EOF).
- `fanout_request` / `fanout_request_result` / `send_and_read_one` / `UpstreamResponse` / `FanoutResult` **composted** → **`fanout_stream_to_client`** + `send_and_read_head` + `write_response_head` + `emit_buffered_fanout_error`.
- The stale-pool reconnect+retry stays at the **head** read (before any body byte reaches the client) → still safe. A stall mid-body after the head is sent closes the client connection (truncated body — the honest outcome of an upstream that died mid-stream).
- `handle_request`'s fan-out arm streams + returns directly; native/404/error keep the buffered `http_response`.
- **`ChunkParser`**: an incremental chunk-**boundary** parser that finds the TRUE terminating 0-length chunk, so a `0\r\n\r\n` byte run inside chunk data never truncates the relay.
- The relay is now raw-byte exact (no `String::from_utf8_lossy` round-trip that would corrupt bytes ≥ 0x80).
- **`X-Form-Router`** preserved on every response.

## Proof (`router_body_harness.py`, all 14 cases pass)

```
[stream big 16MiB ] /stream/big -> 200 16777216B sha-match=True CL-relayed=True  OK
[buffer-gone 1MiB ] /stream/big through 1 MiB-shape router (16MiB >> 1MiB) -> 200 sha-match=True  OK
[stream chunked   ] /stream/chunked -> 200 te-chunked=True dechunked-match=True  OK
[chunked trap     ] /stream/chunked-trap (0CRLFCRLF in data) -> 200 not-truncated  OK
[stream unframed  ] /stream/unframed -> 200 close-framed=True match=True  OK
```

- **Byte-identical**: a 16 MiB Content-Length body relays byte-identical (sha256 over all 256 byte values).
- **The buffer is GONE**: the SAME 16 MiB body relays 200 byte-identical through a router whose response shape-threshold is only **1 MiB**. Verified by **contrast against the origin/main binary**, which 502s that exact case (`upstream response shape is 16777216 bytes — larger than we can hold`). The body never occupies a whole-body buffer; size is no longer the gate.
- Chunked (incl. the adversarial in-data terminator) + unframed read-to-close relayed correctly.
- Every other router harness still passes: routing, keep-alive, **upstream reuse**, fan-out timeout, header passthrough, **real-app fan-out + native**, shadow.

`validate.sh`: **266 ok, 0 divergent** (the serve path doesn't touch Form eval). `cargo build --release` clean (0 new warnings).

## Not done (named honestly)

**Request-body streaming** is the next breath: the response streams, but the request body is still buffered before the fan-out. The large buffers were on the response side (the 64 MiB cap, the real ~1.7 MB JSON), so response streaming dissolves the actual ceiling; request streaming entangles the keep-alive/retry safety (a streamed request body can't be re-sent on a stale-pool retry) and is left clean for a separate pass.

Verified **locally** (parity + harness). **Not deployed** — left for a paced deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)