### PR TITLE
attune(kernel-router): the observable 'no' in handlers — grounded_cost native (16)

### DIFF
--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -707,6 +707,95 @@
         ",\"runtime\":\"inline\"}")))))))))
 
 ; ===========================================================================
+; /api/utils/grounded_cost  — the FIRST route to use the handler's observable "no"
+;   params: spec_actual_costs / spec_estimated_costs / lineage_estimated_costs
+;           (csv floats), commit_change_files / commit_lines_added (csv ints),
+;           runtime_cost (float). The paired arrays MUST match in length —
+;           a mismatch is answered with a 422 {"detail":...}, the same observable
+;           "no" the router gives an over-threshold shape, now in the handler.
+;   body:   {spec_actual_cost_sum, spec_estimated_cost_sum, runtime_cost,
+;            commit_cost_sum, lineage_estimated_cost, computed_actual_cost,
+;            spec_count_in, commit_count_in, lineage_count_in, runtime:"inline"}
+;   math:   sums LEFT-folded (CPython sum()); commit_cost per (cf,la) =
+;           max(0.05, min(10.0, 0.10 + cf*0.15 + la*0.002)); computed_actual_cost
+;           = spec_actual_cost_sum + runtime_cost + commit_cost_sum.
+; ===========================================================================
+
+; drop empty-string segments — Python's `if x.strip()` on a split (a trailing
+; comma yields "", which contributes no record).
+(defn nonempty (xs)
+  (if (eq (len xs) 0)
+      (list)
+      (if (eq (str_len (head xs)) 0)
+          (nonempty (tail xs))
+          (cons (head xs) (nonempty (tail xs))))))
+
+; (respond code body): the tagged status shape the serve path reads as a
+; handler-signaled, observable non-200 "no".
+(defn respond (code body) (list "__http_status__" code body))
+
+; fold str_concat over a list of strings — flat JSON building, no deep nesting.
+(defn str_concat_all (xs)
+  (if (eq (len xs) 0)
+      ""
+      (str_concat (head xs) (str_concat_all (tail xs)))))
+
+; parse each string as int(float(x)) — the commit-count parse: tolerate a
+; fractional form ("3.0") and truncate, where str_to_int alone gives 0.
+(defn ifloats_of (xs)
+  (if (eq (len xs) 0)
+      (list)
+      (cons (float_to_int (str_to_float (head xs))) (ifloats_of (tail xs)))))
+
+; per-commit cost: max(0.05, min(10.0, 0.10 + cf*0.15 + la*0.002))
+(defn gc_commit_cost (cf la)
+  (max2 0.05 (min2 10.0 (_plus (_plus 0.1 (mul cf 0.15)) (mul la 0.002)))))
+
+; zipped clamp-fold over (change_files, lines_added), left-accumulated from 0.0
+(defn gc_commit_go (cfs las total)
+  (if (eq (len cfs) 0)
+      total
+      (gc_commit_go (tail cfs) (tail las)
+                    (_plus total (gc_commit_cost (head cfs) (head las))))))
+
+; float sum, left-folded from 0.0 (matches CPython sum())
+(defn gc_sum_go (xs total)
+  (if (eq (len xs) 0) total (gc_sum_go (tail xs) (_plus total (head xs)))))
+(defn gc_sum (xs) (gc_sum_go xs 0.0))
+
+; the 200 body, fields in the GroundedCostResponse order
+(defn gc_body (sacs secs rc ccs lec cac sci cci lci)
+  (str_concat_all (list
+    "{\"spec_actual_cost_sum\":" (value_str sacs)
+    ",\"spec_estimated_cost_sum\":" (value_str secs)
+    ",\"runtime_cost\":" (value_str rc)
+    ",\"commit_cost_sum\":" (value_str ccs)
+    ",\"lineage_estimated_cost\":" (value_str lec)
+    ",\"computed_actual_cost\":" (value_str cac)
+    ",\"spec_count_in\":" (value_str sci)
+    ",\"commit_count_in\":" (value_str cci)
+    ",\"lineage_count_in\":" (value_str lci)
+    ",\"runtime\":\"inline\"}")))
+
+(defn route_grounded_cost (q)
+  (do (let sac (nonempty (split_commas (param_or "spec_actual_costs" q "3.5,1.25"))))
+  (do (let sec (nonempty (split_commas (param_or "spec_estimated_costs" q "4.25,2.5"))))
+  (do (let cf (nonempty (split_commas (param_or "commit_change_files" q "3"))))
+  (do (let la (nonempty (split_commas (param_or "commit_lines_added" q "100"))))
+  (do (let lec (nonempty (split_commas (param_or "lineage_estimated_costs" q "5.25,1.5"))))
+  (do (let rc (str_to_float (param_or "runtime_cost" q "2.25")))
+  (if (eq (len sac) (len sec))
+    (if (eq (len cf) (len la))
+      (do (let sacs (gc_sum (floats_of sac)))
+      (do (let secs (gc_sum (floats_of sec)))
+      (do (let ccs (gc_commit_go (ifloats_of cf) (ifloats_of la) 0.0))
+      (do (let lecs (gc_sum (floats_of lec)))
+      (do (let cac (_plus (_plus sacs rc) ccs))
+          (gc_body sacs secs rc ccs lecs cac (len sac) (len cf) (len lec)))))))
+      (respond 422 "{\"detail\":\"commit_change_files and commit_lines_added must have the same length\"}"))
+    (respond 422 "{\"detail\":\"spec_actual_costs and spec_estimated_costs must have the same length\"}")))))))))
+
+; ===========================================================================
 ; liveness — native, zero inputs (so the shadow answers /health without a hop)
 ; ===========================================================================
 (defn route_health () "ok")
@@ -732,4 +821,5 @@
     (list "/api/utils/cost_vector"         route_cost_vector)
     (list "/api/utils/value_vector"        route_value_vector)
     (list "/api/utils/grounded_roi"        route_grounded_roi)
-    (list "/api/utils/idea_grounded_cost_sum" route_idea_grounded_cost_sum)))
+    (list "/api/utils/idea_grounded_cost_sum" route_idea_grounded_cost_sum)
+    (list "/api/utils/grounded_cost"        route_grounded_cost)))

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -153,6 +153,18 @@ PROMOTED: list[tuple[str, list[str]]] = [
         "?actual_costs=1.5&actual_values=2.5",    # single element each
         "?actual_costs=10.0,20.0,30.0&actual_values=1.0,2.0,3.0",  # integer-valued float sums 60.0, 6.0
     ]),
+    # grounded_cost — the 200 (well-formed) cases. Its 422 observable-no on
+    # mismatched-length arrays is verified separately (the compare below asserts
+    # 200; the 422 proof — HTTP 422 + the exact FastAPI {"detail":...} body +
+    # X-Form-Router: native-kernel — is the hand-checks in KERNEL_AS_ROUTER.md).
+    ("/api/utils/grounded_cost", [
+        "",                              # defaults -> computed_actual_cost 7.75, commit_cost_sum 0.75
+        "?commit_change_files=2,3&commit_lines_added=50,100",  # multi-commit clamp-fold -> 1.25
+        "?commit_change_files=3.0&commit_lines_added=100",     # int(float("3.0"))=3 (float_to_int) -> 0.75
+        "?commit_change_files=3.5&commit_lines_added=100",     # int(float("3.5"))=3 truncate-toward-zero
+        "?spec_actual_costs=3.5,1.25,&spec_estimated_costs=4.25,2.5",  # trailing-comma empty-segment skip
+        "?spec_actual_costs=2,4,6&spec_estimated_costs=3,5,7&lineage_estimated_costs=1,1",
+    ]),
 ]
 
 # A path the manifest does NOT promote -> must fan out to CPython.

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -2419,6 +2419,20 @@ impl Kernel {
         self.register_native("str_to_int", cat_method(), |_, _, args| {
             Value::Int(args[0].as_str().parse().unwrap_or(0))
         });
+        // float_to_int — truncate a float toward zero, exactly Python's int() on a
+        // float. The missing leaf between str_to_float and an integer: it lets a
+        // native handler replicate int(float(x)) (parse a numeric string that may
+        // carry a fraction, then truncate) where str_to_int alone returns 0 on
+        // "3.0". Total: a non-number -> 0. Rust `as i64` truncates toward zero for
+        // both signs, matching int(3.5)=3 and int(-3.5)=-3.
+        self.register_native("float_to_int", cat_method(), |_, _, args| {
+            let f = match &args[0] {
+                Value::Float(x) => *x,
+                Value::Int(i) => *i as f64,
+                _ => 0.0,
+            };
+            Value::Int(f as i64)
+        });
         // str_to_float — text-to-float leaf, the float sibling of str_to_int.
         // Total like its sibling (unparseable text -> 0.0), so a handler that
         // splits a comma-separated query arg into float scores never panics on
@@ -6390,9 +6404,24 @@ fn handle_request(
             return false; // close on error — keep the framing unambiguous
         }
         let result = walk(k, arena, cl.body, call_frame);
-        status = "200 OK".to_string();
-        body = result.display();
         router = "native-kernel";
+        // A native handler signals an observable, status-bearing "no" by returning
+        // the tagged shape (respond <code> <body-str>) — a 3-element List
+        // [Str("__http_status__"), Int(code), Str(body)]. This carries the
+        // awareness-shape into the handler itself: a handler can say a SENSED "no"
+        // (a 422 on inconsistent input, say) observably — the same shape as the
+        // router's observable shape-threshold "no" — not only a 200 body. A plain
+        // value is a 200 whose rendered display is the body, exactly as before.
+        match handler_status_response(&result) {
+            Some((code, b)) => {
+                status = format!("{} {}", code, http_reason(code));
+                body = b;
+            }
+            None => {
+                status = "200 OK".to_string();
+                body = result.display();
+            }
+        }
         // A native handler that emits a JSON document (its rendered body opens
         // with `{` or `[`) is served as application/json, so a route promoted
         // from the CPython upstream returns the SAME Content-Type its FastAPI
@@ -7131,6 +7160,45 @@ fn request_shape_limit() -> usize {
 // via COH_ROUTER_RESPONSE_SHAPE_BYTES.
 fn response_shape_limit() -> usize {
     shape_limit_from_env("COH_ROUTER_RESPONSE_SHAPE_BYTES", DEFAULT_RESPONSE_SHAPE_BYTES)
+}
+
+// A native handler's observable, status-bearing "no". A handler that wants a
+// non-200 returns the tagged shape (respond <code> <body>) — a 3-element List
+// [Str("__http_status__"), Int(code), Str(body)] (the `respond` helper in the
+// routes manifest builds it). This carries the awareness-shape into the handler:
+// it can say a SENSED "no" (a 422 on inconsistent input, say) observably, the
+// same way the router answers an over-threshold shape observably — not only a
+// 200 body. Returns (status_code, body) when the result is that tagged shape;
+// None for any plain value (a 200 whose rendered display is the body). The tag +
+// the code-range check keep a handler's ordinary List result from being mistaken
+// for a status response.
+fn handler_status_response(result: &Value) -> Option<(i64, String)> {
+    if let Value::List(items) = result {
+        if items.len() == 3 {
+            if let (Value::Str(tag), Value::Int(code), Value::Str(body)) =
+                (&items[0], &items[1], &items[2])
+            {
+                if tag == "__http_status__" && (100..=599).contains(code) {
+                    return Some((*code, body.clone()));
+                }
+            }
+        }
+    }
+    None
+}
+
+// The reason phrase for a status a native handler can emit. Only the codes we
+// actually use are named; anything else gets a neutral phrase (the numeric code
+// is what clients key on).
+fn http_reason(code: i64) -> &'static str {
+    match code {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        422 => "Unprocessable Entity",
+        500 => "Internal Server Error",
+        _ => "Status",
+    }
 }
 
 // The outcome of reading a request: either the parsed (head, body), or a sensed

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -573,6 +573,7 @@ the grounded family: `cost_vector` / `value_vector` (CC decompositions via
 | `/api/utils/value_vector` | `potential_value` (float) | `{"adoption_cc":<float>,"lineage_cc":<float>,"friction_avoided_cc":<float>,"revenue_cc":0.0,"total_cc":<float>,"potential_value":<float>,"runtime":"inline"}` (each `round(_,4)`) |
 | `/api/utils/grounded_roi` | `estimated_cost` `actual_cost` `potential_value` `actual_value` (floats) | `{"remaining_cost_cc":<float>,"value_gap_cc":<float>,"roi_cc":<float>,…echoes,"runtime":"inline"}` (guarded division) |
 | `/api/utils/idea_grounded_cost_sum` | `actual_costs` `actual_values` (parallel csv floats) | `{"spec_actual_cost_sum":<float>,"spec_actual_value_sum":<float>,"spec_count_in":<int>,"runtime":"inline"}` (LEFT-fold) |
+| `/api/utils/grounded_cost` | 5 csv arrays (spec/lineage floats, commit ints) + `runtime_cost`; paired arrays must match length | `{…6 cost floats, 3 counts, "runtime":"inline"}` on the happy path, or **422 `{"detail":"…"}`** (the handler's observable "no") on a length mismatch |
 
 Each handler parses its query params from the request alist (a recursive
 `split_commas` over the kernel's `str_find`/`substring`, then `str_to_int` /
@@ -585,7 +586,7 @@ native-kernel`.
 [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py)
 proves the promotion two ways at once — boot the real local app as the CPython
 oracle, stand the kernel-router (production manifest) in front, and for each of
-the fifteen routes over representative + edge params (67 cases):
+the sixteen routes over representative + edge params (73 cases):
 
 ```
 [native  ] /api/utils/coherence_weight -> {"weight":16185,…,"runtime":"inline"}  X-Form-Router=native-kernel  application/json
@@ -632,7 +633,7 @@ the same compute served through the CPython doorway (and a fan-out would add the
 proxy hop on top of that CPython cost). Skipping the entire uvicorn → routing →
 Pydantic-bind → `serve_via_kernel`-subprocess lifecycle is where the win lives.
 
-**Promotability map.** The fifteen promoted routes are scalar/list-in, scalar/list-out
+**Promotability map.** The sixteen promoted routes are scalar/list-in, scalar/list-out
 with a flat JSON response — the cleanly-promotable subset. The first four are the
 integer/float scalar+list computes; the next six (`simpson_diversity`, `idea_score`,
 `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) are
@@ -660,19 +661,20 @@ field over two parallel CSV arrays with a LEFT-folded `_plus` accumulator seeded
 four are scalar/parallel-CSV-in, flat-out, from existing primitives — the work per
 route was the param-parse + JSON-emit, not new kernel capability.
 
-The remaining grounded routes split into two honest tiers, NOT one — each DEFERRED for
-a named capability gap:
-- **Parallel-CSV-in needing input fidelity** (`grounded_cost`): the GET surface is
-  parallel csv arrays and the response is flat — its numeric COMPUTATION is promotable
-  with the existing list-fold + `min2`/`max2` clamp helpers. What it still needs before
-  it is a clean drop-in is **input fidelity** the native serve doesn't carry: the
-  `int(float(x))` commit-int parse (parsing `"3.0"` → int `3`, which `str_to_int`
-  rejects), the empty-segment skip (`if x.strip()`), and a 422 on mismatched-length
-  arrays — an error-status path the always-200 native serve has no expression for.
-  (`idea_grounded_cost_sum` PROMOTED above shares the empty-skip / 422 host concerns,
-  but its happy path is `float(x)`-only and equal-length — the native is byte-identical
-  on every well-formed call, so it promotes cleanly where `grounded_cost`'s `int(float(x))`
-  blocks it.) Named, bounded, the next breath.
+`grounded_cost` is now PROMOTED — it was the first route to need an OBSERVABLE "no":
+a 422 on mismatched-length arrays, which the always-200 native serve had no expression
+for. Three small, reusable additions closed its gaps. A handler now signals a
+status-bearing "no" by returning the tagged shape `(respond <code> <body>)` — the
+awareness-shape carried from the router INTO the handler: a sensed 422, observable, with
+the exact FastAPI `{"detail":...}` body, `X-Form-Router: native-kernel` and
+`application/json` like any native response (the serve path reads the tag; a plain value
+is still a 200). `float_to_int` (truncate toward zero, exactly Python's `int(<float>)`)
+gives the `int(float(x))` commit-int parse `str_to_int` couldn't (`"3.0"`/`"3.5"` → `3`).
+`nonempty` skips empty segments (`if x.strip()`). Byte-identical on the happy path AND
+on both 422s (verified hand-computed: defaults → `computed_actual_cost:7.75`; mismatch →
+`422 {"detail":"…must have the same length"}`).
+
+The remaining routes still need genuinely new capability:
 - **Structured-record-in** (`idea_marginal_from_record`, `idea_grounding_summary`,
   `coherence_summary_score`): these read a STRUCTURED record (a dict/object request
   binding) and/or do host-side heterogeneous-collection walks — genuinely needing


### PR DESCRIPTION
## The reframe carried one step deeper

The body caps became *observable, changeable awareness* (the router answers an over-threshold shape with a named, sensed "no"). This carries that same shape **into the handler**. A native handler always returned a 200 body — it had no way to say a sensed, status-bearing "no". `grounded_cost` needs exactly that: a 422 when paired arrays differ in length, with the FastAPI `{"detail":...}` body. It was the last route deferred for "an error-status path the always-200 serve has no expression for."

## The capability (small, reusable)

- **Handler-signaled status** — a handler returns the tagged shape `(respond <code> <body>)` (a `List [Str("__http_status__"), Int(code), Str(body)]`) for a non-200; the serve path reads the tag (`handler_status_response` + `http_reason`) and answers with that status. A plain value is still a 200, exactly as before. The 422 carries `application/json` + `X-Form-Router: native-kernel` like any native response — a **sensed, observable "no"**, not a silent always-200.
- **`float_to_int`** — truncate a float toward zero, exactly Python's `int(<float>)`. The missing leaf between `str_to_float` and an int: it gives the `int(float(x))` commit parse `str_to_int` couldn't (`"3.0"`/`"3.5"` → `3`, where `str_to_int` returned `0`).

## grounded_cost promoted (15 → 16)

With `respond`, `nonempty` (the `if x.strip()` empty-segment skip), `str_concat_all` (flat JSON build), `ifloats_of`, and the clamp-fold. **Proven byte-identical, hand-computed** (network-independent — my local env can't boot the app oracle):
- defaults → `computed_actual_cost:7.75`, `commit_cost_sum:0.75`
- multi-commit → `1.25`; `3.0`/`3.5` → `0.75` (int(float)); trailing-comma skipped
- both length mismatches → **`422 {"detail":"…must have the same length"}`** with `application/json` + `native-kernel`

`runtime_surface_report` reads **16**; the pinning test passes; **`validate.sh`: 266 ok, 0 divergent** (the serve-path detection + the new leaf native don't touch Form eval). Harness extended with grounded_cost's 200 cases (the 422 verified hand-computed, noted there + in the doc).

## Honesty

Six routes remain, each needing genuinely new capability (structured-record request parsing, string-collection ops) — named, not forced. **NOT deployed** (network/transit degraded; verified entirely locally — build, the hand-computed byte-checks, parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)