### PR TITLE
tend(kernel-router): promote worldview_alignment + tag_match_score to native Form (16→18 routes)

### DIFF
--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -21,6 +21,9 @@
 ;   /api/utils/breath_balance         float H/ln(3) (incl -0.0) + echoed ints
 ;   /api/utils/shannon_entropy        float round(H/ln(3),4) + echoed ints
 ;   /api/utils/softmax_weights        float-list softmax + echoed scores/temp
+;   /api/utils/worldview_alignment    float cosine of two parallel vectors +
+;                                       matched-axis string list (400 on len mismatch)
+;   /api/utils/tag_match_score        float str_eq-membership ratio + deduped tag lists
 ;
 ; Each native handler replicates its live route's FULL contract:
 ;   - parses the SAME query params FastAPI declares (with the SAME defaults),
@@ -60,6 +63,25 @@
   (if (eq (str_len (assoc key q)) 0)
       dflt
       (assoc key q)))
+
+; --- is `key` PRESENT in the alist (regardless of its value, "" included)? ---
+; The query-string `?k=` arrives as the present pair ("k" ""); a truly absent
+; param has no pair at all. has_key distinguishes the two, where assoc alone
+; cannot (both yield "").
+(defn has_key (key pairs)
+  (if (eq (len pairs) 0)
+      false
+      (if (str_eq (head (head pairs)) key)
+          true
+          (has_key key (tail pairs)))))
+
+; --- param `key` from the alist when PRESENT (its value, even ""), else `dflt`.
+; This mirrors FastAPI EXACTLY for a `str = "<default>"` query param: the default
+; applies ONLY when the param is absent; `?k=` is a present empty string, NOT the
+; default. (param_or coalesces empty→default, which is right for the numeric
+; routes but wrong for a list param whose empty IS a meaningful empty list.)
+(defn param_present (key q dflt)
+  (if (has_key key q) (assoc key q) dflt))
 
 ; --- split "a,b,c" on commas into a list of substrings. Walks via str_find +
 ; substring (the kernel's native string ops), no char-by-char Form loop. An
@@ -102,6 +124,22 @@
 
 (defn json_list (xs)
   (str_concat (str_concat "[" (json_elems xs)) "]"))
+
+; --- JSON array of STRINGS from a list: ["a","b","c"] with NO spaces, each
+; element double-quoted (FastAPI's JSONResponse renders a list[str] this way).
+; The empty list renders as []. Used for the echoed string fields (matched_axes,
+; the deduped tag lists). ASCII tag/axis names need no escaping — they carry no
+; quotes/backslashes, the same plain-token assumption split_commas already makes.
+(defn json_str_elems (xs)
+  (if (eq (len xs) 0)
+      ""
+      (if (eq (len xs) 1)
+          (str_concat (str_concat "\"" (head xs)) "\"")
+          (str_concat (str_concat (str_concat "\"" (head xs)) "\",")
+                      (json_str_elems (tail xs))))))
+
+(defn json_str_list (xs)
+  (str_concat (str_concat "[" (json_str_elems xs)) "]"))
 
 ; --- comma-separated list of int params a_pkg a_lvl a_type a_inst as a JSON
 ; array, reading each with its api default. Used for the echoed NodeID `a`/`b`.
@@ -796,6 +834,149 @@
     (respond 422 "{\"detail\":\"spec_actual_costs and spec_estimated_costs must have the same length\"}")))))))))
 
 ; ===========================================================================
+; /api/utils/worldview_alignment  — COSINE SIMILARITY, the FIRST kernel-native
+;   route to fold a parallel float-vector dot+norm (belief_service.cosine_alignment_score).
+;   params: contributor_vec (csv floats, default "0.6,0.0,0.8,0.0,0.0,0.0"),
+;           idea_vec (csv floats, default "0.8,0.0,0.6,0.0,0.0,0.0"),
+;           axis_names (csv strings, default the fixed BeliefAxis order).
+;   400 (observable "no" via respond) when len(cv) != len(iv).
+;   body:   {"score":<f>,"matched_axes":["..."],"contributor_vec":[<f>],
+;            "idea_vec":[<f>],"runtime":"inline"}  (WorldviewAlignmentResponse order)
+;   math (endpoint_worldview_alignment_demo.fk EXACTLY): a SINGLE i=0..n loop folds
+;     dot += a_i*b_i, norm_a += a_i*a_i, norm_b += b_i*b_i — each accumulator
+;     LEFT-associated from 0.0 (mirrors CPython `dot += ...`). Three independent
+;     left-folds give the SAME per-accumulator grouping as the one-loop `+=`.
+;     denom = sqrt(norm_a)*sqrt(norm_b) (math_sqrt, IEEE-correct three-way);
+;     score = (denom>0 ? dot/denom : 0.5); then clamp max(0.0,min(1.0,score)).
+;   matched_axes: HOST-side naming in the recipe-twin, replicated here — the
+;     axis-name strings where cv[i]>0.3 AND iv[i]>0.3, walked in parallel over
+;     min(len(cv),len(names)) (the route's range(min(len(cv),len(names)))).
+; ===========================================================================
+
+; left-folded dot over two parallel float lists (total seeded 0.0, added LEFT)
+(defn wv_dot_go (a b total)
+  (if (eq (len a) 0)
+      total
+      (wv_dot_go (tail a) (tail b) (add total (mul (head a) (head b))))))
+
+; left-folded sum-of-squares over one float list (each x*x added LEFT from 0.0)
+(defn wv_normsq_go (xs total)
+  (if (eq (len xs) 0)
+      total
+      (wv_normsq_go (tail xs) (add total (mul (head xs) (head xs))))))
+
+; clamp to [0.0, 1.0] — max(0.0, min(1.0, s)), mirroring the recipe's nested ifs
+(defn wv_clamp (s) (max2 0.0 (min2 1.0 s)))
+
+; matched_axes: the axis names at positions where cv>0.3 AND iv>0.3, walked in
+; parallel and stopping when EITHER the names or the vectors run out — the
+; native of range(min(len(cv),len(names))). cv/iv are equal-length (the 400 guard
+; already fired otherwise), so cv running out == iv running out == the min bound.
+(defn wv_matched_go (cv iv names)
+  (if (eq (len names) 0)
+      (list)
+      (if (eq (len cv) 0)
+          (list)
+          (if (if (gt (head cv) 0.3) (gt (head iv) 0.3) false)
+              (cons (head names) (wv_matched_go (tail cv) (tail iv) (tail names)))
+              (wv_matched_go (tail cv) (tail iv) (tail names))))))
+
+(defn route_worldview_alignment (q)
+  (do (let cvstr (param_present "contributor_vec" q "0.6,0.0,0.8,0.0,0.0,0.0"))
+  (do (let ivstr (param_present "idea_vec" q "0.8,0.0,0.6,0.0,0.0,0.0"))
+  (do (let nstr (param_present "axis_names" q "scientific,spiritual,pragmatic,holistic,relational,systemic"))
+  (do (let cv (floats_of (nonempty (split_commas cvstr))))
+  (do (let iv (floats_of (nonempty (split_commas ivstr))))
+  (if (eq (len cv) (len iv))
+    (do (let names (nonempty (split_commas nstr)))
+    (do (let dot (wv_dot_go cv iv 0.0))
+    (do (let norm_c (wv_normsq_go cv 0.0))
+    (do (let norm_i (wv_normsq_go iv 0.0))
+    (do (let denom (mul (math_sqrt norm_c) (math_sqrt norm_i)))
+    (do (let score (wv_clamp (if (gt denom 0.0) (div dot denom) 0.5)))
+    (do (let matched (wv_matched_go cv iv names))
+        (str_concat
+          (str_concat
+            (str_concat
+              (str_concat (str_concat "{\"score\":" (value_str score))
+                          (str_concat ",\"matched_axes\":" (json_str_list matched)))
+              (str_concat ",\"contributor_vec\":" (json_list cv)))
+            (str_concat ",\"idea_vec\":" (json_list iv)))
+          ",\"runtime\":\"inline\"}"))))))))
+    (respond 400 "{\"detail\":\"contributor_vec and idea_vec must have equal length (parallel axis vectors)\"}"))))))))
+
+; ===========================================================================
+; /api/utils/tag_match_score  — EXACT STRING MEMBERSHIP (str_eq over a list),
+;   belief_service.score_tag_match_lists. Equality counterpart to the substring
+;   fold concept_match_score uses on the CPython side.
+;   params: contributor_tags (csv strings, default "energy,flow,coherence,field"),
+;           idea_tags (csv strings, default "energy,flow").
+;   body:   {"score":<f>,"contributor_tags":["..."],"idea_tags":["..."],
+;            "runtime":"inline"}  (TagMatchScoreResponse order)
+;   math:   the host dedups BOTH lists first-seen-order (Python set() collapses
+;     duplicates; the route keeps a stable order for the echo). matched = how many
+;     UNIQUE contributor tags appear in idea_tags (str_eq membership fold). Since
+;     contributor is deduped, this equals |contributor_set & idea_set|. score =
+;     0.5 when EITHER deduped list is empty, else max(0.0,min(1.0, matched/|contributor|)).
+;     matched is a FLOAT count (0.0, +1.0 per hit) over an int denominator — the
+;     recipe's (div matched (len contributor)), float÷int promoting (1.0/3 ==
+;     0.3333333333333333, bit-identical to CPython).
+; ===========================================================================
+
+; member? — is `needle` str_eq any element of `xs` (the inner contains_exact fold)
+(defn tm_member (needle xs)
+  (if (eq (len xs) 0)
+      false
+      (if (str_eq (head xs) needle)
+          true
+          (tm_member needle (tail xs)))))
+
+; first-seen-order dedup: keep each element the FIRST time it appears, drop later
+; repeats — the native of the route's _dedup (Python set()-with-stable-order).
+; `seen` accumulates the kept prefix; membership tests it with str_eq.
+(defn tm_dedup_go (xs seen)
+  (if (eq (len xs) 0)
+      seen
+      (if (tm_member (head xs) seen)
+          (tm_dedup_go (tail xs) seen)
+          (tm_dedup_go (tail xs) (cons (head xs) seen)))))
+
+; tm_dedup_go builds `seen` by consing onto the FRONT (reversed order); rebuild
+; the original first-seen order by reversing once at the end.
+(defn tm_reverse_go (xs acc)
+  (if (eq (len xs) 0) acc (tm_reverse_go (tail xs) (cons (head xs) acc))))
+
+(defn tm_dedup (xs) (tm_reverse_go (tm_dedup_go xs (list)) (list)))
+
+; matched = float count of `needles` (deduped contributor) present in `hay`
+; (deduped idea), via str_eq membership — the recipe's match_count, hits 0.0 +1.0
+(defn tm_match_go (needles hay hits)
+  (if (eq (len needles) 0)
+      hits
+      (if (tm_member (head needles) hay)
+          (tm_match_go (tail needles) hay (add hits 1.0))
+          (tm_match_go (tail needles) hay hits))))
+
+(defn route_tag_match_score (q)
+  (do (let cstr (param_present "contributor_tags" q "energy,flow,coherence,field"))
+  (do (let istr (param_present "idea_tags" q "energy,flow"))
+  (do (let ct (tm_dedup (nonempty (split_commas cstr))))
+  (do (let it (tm_dedup (nonempty (split_commas istr))))
+  (do (let score
+        (if (eq (len ct) 0)
+            0.5
+            (if (eq (len it) 0)
+                0.5
+                (do (let matched (tm_match_go ct it 0.0))
+                    (max2 0.0 (min2 1.0 (div matched (len ct))))))))
+      (str_concat
+        (str_concat
+          (str_concat (str_concat "{\"score\":" (value_str score))
+                      (str_concat ",\"contributor_tags\":" (json_str_list ct)))
+          (str_concat ",\"idea_tags\":" (json_str_list it)))
+        ",\"runtime\":\"inline\"}")))))))
+
+; ===========================================================================
 ; liveness — native, zero inputs (so the shadow answers /health without a hop)
 ; ===========================================================================
 (defn route_health () "ok")
@@ -822,4 +1003,6 @@
     (list "/api/utils/value_vector"        route_value_vector)
     (list "/api/utils/grounded_roi"        route_grounded_roi)
     (list "/api/utils/idea_grounded_cost_sum" route_idea_grounded_cost_sum)
-    (list "/api/utils/grounded_cost"        route_grounded_cost)))
+    (list "/api/utils/grounded_cost"        route_grounded_cost)
+    (list "/api/utils/worldview_alignment"  route_worldview_alignment)
+    (list "/api/utils/tag_match_score"      route_tag_match_score)))

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -165,6 +165,35 @@ PROMOTED: list[tuple[str, list[str]]] = [
         "?spec_actual_costs=3.5,1.25,&spec_estimated_costs=4.25,2.5",  # trailing-comma empty-segment skip
         "?spec_actual_costs=2,4,6&spec_estimated_costs=3,5,7&lineage_estimated_costs=1,1",
     ]),
+    # worldview_alignment — COSINE of two parallel float vectors. The 200 (equal-
+    # length) cases. Its 400 observable-no on mismatched-length vectors is verified
+    # separately (the compare below asserts 200; the 400 proof — HTTP 400 + the exact
+    # FastAPI {"detail":...} body + X-Form-Router: native-kernel — is hand-checked,
+    # like grounded_cost's 422). Defaults land on 0.96; the irrational case lands on
+    # 1/sqrt(2)=0.7071067811865475 (three-way bit-identical); the both-empty case is
+    # the present-empty -> [] path (param_present, not the default) -> 0.5 zero-denom.
+    ("/api/utils/worldview_alignment", [
+        "",                              # defaults -> 0.96, matched ["scientific","pragmatic"]
+        "?contributor_vec=1.0,1.0,0.0&idea_vec=1.0,0.0,0.0&axis_names=a,b,c",  # 1/sqrt(2) irrational cosine
+        "?contributor_vec=0.0,0.0&idea_vec=0.5,0.5&axis_names=x,y",  # zero-denom guard -> 0.5, matched []
+        "?contributor_vec=&idea_vec=&axis_names=",  # present-empty vectors -> [], 0.5 (NOT the default)
+        "?contributor_vec=0.5,0.4,0.2&idea_vec=0.4,0.5,0.9&axis_names=p,q,r",  # partial cosine + matched ["p","q"]
+        "?contributor_vec=0.6,0.8&idea_vec=0.6,0.8&axis_names=only_one",  # names shorter than vec -> matched ["only_one"]
+    ]),
+    # tag_match_score — EXACT str_eq membership ratio over deduped tag lists.
+    # All cases are 200 (the empty-list guard is a 0.5 BODY, not a non-200). The
+    # present-empty params route through param_present to [] (the 0.5 guard), NOT
+    # to the defaults; dedup is first-seen-order; matched/len(contributor) is a
+    # float÷int (1/3 = 0.3333333333333333, bit-identical to CPython).
+    ("/api/utils/tag_match_score", [
+        "",                              # defaults -> 0.5 (energy,flow ⊂ contributor; 2/4)
+        "?contributor_tags=a,b&idea_tags=a,b",        # full overlap -> 1.0
+        "?contributor_tags=&idea_tags=energy",        # present-empty contributor -> [], 0.5 guard
+        "?contributor_tags=energy&idea_tags=",        # present-empty idea -> [], 0.5 guard
+        "?contributor_tags=a,a,b&idea_tags=a",        # dedup [a,b], matched 1/2 -> 0.5
+        "?contributor_tags=a,b,c&idea_tags=a",        # 1/3 -> 0.3333333333333333
+        "?contributor_tags=a,b,&idea_tags=a",         # trailing-comma empty-segment skip -> [a,b]
+    ]),
 ]
 
 # A path the manifest does NOT promote -> must fan out to CPython.

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -574,6 +574,8 @@ the grounded family: `cost_vector` / `value_vector` (CC decompositions via
 | `/api/utils/grounded_roi` | `estimated_cost` `actual_cost` `potential_value` `actual_value` (floats) | `{"remaining_cost_cc":<float>,"value_gap_cc":<float>,"roi_cc":<float>,…echoes,"runtime":"inline"}` (guarded division) |
 | `/api/utils/idea_grounded_cost_sum` | `actual_costs` `actual_values` (parallel csv floats) | `{"spec_actual_cost_sum":<float>,"spec_actual_value_sum":<float>,"spec_count_in":<int>,"runtime":"inline"}` (LEFT-fold) |
 | `/api/utils/grounded_cost` | 5 csv arrays (spec/lineage floats, commit ints) + `runtime_cost`; paired arrays must match length | `{…6 cost floats, 3 counts, "runtime":"inline"}` on the happy path, or **422 `{"detail":"…"}`** (the handler's observable "no") on a length mismatch |
+| `/api/utils/worldview_alignment` | `contributor_vec` `idea_vec` (parallel csv floats), `axis_names` (csv strings); the two vectors must match length | `{"score":<float>,"matched_axes":["…"],"contributor_vec":[…],"idea_vec":[…],"runtime":"inline"}` (cosine via `math_sqrt`), or **400 `{"detail":"…"}`** (the handler's observable "no") on a length mismatch |
+| `/api/utils/tag_match_score` | `contributor_tags` `idea_tags` (csv strings) | `{"score":<float>,"contributor_tags":["…"],"idea_tags":["…"],"runtime":"inline"}` (`str_eq` membership ratio over first-seen-deduped lists; 0.5 empty-guard) |
 
 Each handler parses its query params from the request alist (a recursive
 `split_commas` over the kernel's `str_find`/`substring`, then `str_to_int` /
@@ -586,7 +588,7 @@ native-kernel`.
 [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py)
 proves the promotion two ways at once — boot the real local app as the CPython
 oracle, stand the kernel-router (production manifest) in front, and for each of
-the sixteen routes over representative + edge params (73 cases):
+the eighteen routes over representative + edge params (86 cases):
 
 ```
 [native  ] /api/utils/coherence_weight -> {"weight":16185,…,"runtime":"inline"}  X-Form-Router=native-kernel  application/json
@@ -596,13 +598,17 @@ the sixteen routes over representative + edge params (73 cases):
 [native  ] /api/utils/softmax_weights?scores=0.1,0.2,0.3 -> {"weights":[0.3006096053557273,…]}  FULL-BODY == LIVE: BYTE-IDENTICAL
 [native  ] /api/utils/cost_vector?estimated_cost=33.333 -> {"human_attention_cc":8.3332,…}  round_ndigits half-to-even (NOT 8.3333)
 [native  ] /api/utils/idea_grounded_cost_sum?actual_costs=0.1,0.2,0.3&… -> {"spec_actual_cost_sum":0.6000000000000001,…}  LEFT-fold matches CPython sum()
-… all 67 cases, incl. adversarial floats (0.14000000000000004, 0.04000000000000001,
+[native  ] /api/utils/worldview_alignment?contributor_vec=1.0,1.0,0.0&idea_vec=1.0,0.0,0.0 -> {"score":0.7071067811865475,…}  cosine 1/sqrt(2), three-way bit-identical
+[native  ] /api/utils/tag_match_score?contributor_tags=a,b,c&idea_tags=a -> {"score":0.3333333333333333,…}  str_eq membership ratio, float÷int
+… all 86 cases, incl. adversarial floats (0.14000000000000004, 0.04000000000000001,
   0.6666666666666667, 0.9999999999999999), CPython's -0.0 vs +0.0 on single-phase
   entropy, the grounded_value confidence weighted-sum's float-assoc artifact
   (0.42000000000000004, 0.5800000000000001) and its [0.05, 0.95] clamp + zero-
   guards, deterministic + uniform softmax, the grounded family's round_ndigits
   half-to-even (8.3332, 16.6675), grounded_roi's guarded division + max-as-
-  comparison, and idea_grounded_cost_sum's LEFT-folded float-field sum
+  comparison, idea_grounded_cost_sum's LEFT-folded float-field sum, worldview_alignment's
+  cosine (irrational 0.7071067811865475 + present-empty-vector → 0.5 zero-denom) and
+  tag_match_score's first-seen dedup + str_eq membership ratio (1/3 = 0.3333333333333333)
 
 native  (kernel-router, Form):   p50=0.241 ms  p99=0.343 ms
 CPython (app serve_via_kernel):  p50=11.02 ms  p99=12.54 ms
@@ -633,7 +639,7 @@ the same compute served through the CPython doorway (and a fan-out would add the
 proxy hop on top of that CPython cost). Skipping the entire uvicorn → routing →
 Pydantic-bind → `serve_via_kernel`-subprocess lifecycle is where the win lives.
 
-**Promotability map.** The sixteen promoted routes are scalar/list-in, scalar/list-out
+**Promotability map.** The eighteen promoted routes are scalar/list-in, scalar/list-out
 with a flat JSON response — the cleanly-promotable subset. The first four are the
 integer/float scalar+list computes; the next six (`simpson_diversity`, `idea_score`,
 `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`) are
@@ -680,14 +686,31 @@ The remaining routes still need genuinely new capability:
   binding) and/or do host-side heterogeneous-collection walks — genuinely needing
   request-side structural-record marshalling in the native handler (still an open breath).
 
-The three belief/concept matching routes (`concept_match_score`, `tag_match_score`,
-`worldview_alignment`) are also DEFERRED, each for a named string-collection gap the
-flat-numeric helpers don't carry: `concept_match_score` echoes regex-tokenized keywords
-(`re.findall` + stopword filter — host text preprocessing the kernel-router can't
-reproduce); `tag_match_score` needs string-list dedup + a `str_eq` membership fold;
-`worldview_alignment`'s scalar cosine IS replicable (`math_sqrt`), but its `matched_axes`
-output zips float predicates with axis-name strings into a string list — string-collection
-construction the helpers lack.
+`worldview_alignment` and `tag_match_score` are now PROMOTED — the two belief-resonance
+routes whose string-collection gaps closed with two small, reusable additions. The
+`json_str_list` helper renders a `list[str]` as a JSON string array (`["a","b"]`, no
+spaces, each element quoted) — the echo shape both routes (and any future string-list
+route) need. The `param_present`/`has_key` helpers mirror FastAPI's "default only when
+the param is ABSENT": a `?k=` present-empty query value routes to the empty list (a
+meaningful empty), NOT to the default — the distinction `param_or`'s empty→default
+coalescing erased, observable on the empty-vector / empty-tag-list cases. With those,
+`worldview_alignment` runs the COSINE in Form (the parallel dot+norm fold, `math_sqrt`
+norms, guarded ratio, `[0,1]` clamp — irrational cosines like `1/sqrt(2)` three-way
+bit-identical) and names `matched_axes` host-side-equivalently (the `cv>0.3 AND iv>0.3`
+zip over `min(len(vec),len(names))`), with a **400** observable-"no" (via `respond`) on
+a length mismatch; `tag_match_score` runs the `str_eq` membership ratio over first-seen-
+order-deduped lists (the `tm_dedup` + `tm_member` fold), with the `0.5` empty-guard
+(`1/3 = 0.3333333333333333`, float÷int, bit-exact). Both are byte-identical to the
+CPython oracle across representative + edge params (verified by the harness against the
+real app; the 400 hand-checked like grounded_cost's 422).
+
+`concept_match_score` stays DEFERRED for a genuine host-preprocessing gap the kernel-router
+can't reproduce: it echoes regex-tokenized `keywords` (`_extract_keywords`'s
+`re.findall(r"\b[a-zA-Z]{3,}\b", …)` + a stopword set + dedup) and `concept_keywords` in
+its response, so the WIRE BODY — not just the score — depends on a regex tokenizer +
+stopword list living in `concept_auto_tagger`. Forcing regex tokenization into the kernel
+is the wrong build; the score's str_find membership fold is replicable, but the echoed
+host-tokenized arrays are not, so the route is not cleanly byte-identical natively.
 
 This manifest is the durable flip's native surface, ready for the cutover; it does
 NOT flip — the standing shadow still fans out every route.


### PR DESCRIPTION
Promotes two belief-resonance `/api/utils` routes from CPython-fanout to **NATIVE-in-Form** in `deploy/kernel-router/production-routes.fk` — more of the body's runtime traceable in its own senses, each native route carrying `X-Form-Router: native-kernel`.

## Promoted (2)
- **`worldview_alignment`** — COSINE of two parallel float vectors (`belief_service.cosine_alignment_score`). dot + both norms folded LEFT-associated (mirroring CPython `+=`), `denom = math_sqrt(norm_a)*math_sqrt(norm_b)`, guarded ratio (`denom>0` else 0.5), `[0,1]` clamp. `matched_axes` named host-equivalently (`cv>0.3 AND iv>0.3` zip over `min(len(vec),len(names))`). A **400** observable-"no" (via `respond`) on a length mismatch.
- **`tag_match_score`** — EXACT `str_eq` membership ratio (`belief_service.score_tag_match_lists`). First-seen-order dedup of both lists, `matched = |contributor ∩ idea|`, `max(0,min(1, matched/|contributor|))`, 0.5 empty-guard. `matched` is a float count over an int denominator (`1/3 = 0.3333333333333333`, bit-exact).

## Deferred (1, honest gap)
- **`concept_match_score`** — its response **echoes regex-tokenized `keywords`** (`_extract_keywords`' `re.findall(r"\b[a-zA-Z]{3,}\b", …)` + a stopword set + dedup). The wire BODY — not just the score — depends on a regex tokenizer living in `concept_auto_tagger`, which the kernel-router can't reproduce. The score's `str_find` fold is replicable; the echoed host-tokenized arrays are not. Named in the manifest + `KERNEL_AS_ROUTER.md`.

## Helpers (reusable)
- `json_str_list` — `list[str]` → JSON string array (no spaces, each element quoted).
- `param_present`/`has_key` — mirror FastAPI's "default only when the param is ABSENT": `?k=` is a present empty string, NOT the default. (`param_or`'s empty→default coalescing erased the distinction — observable on the empty-vector / empty-tag-list cases.)

No Rust kernel native added — reuses `math_sqrt`/`str_eq`/`div`/etc.

## Proof (local, network-independent — prod transit degraded; **NOT deployed**)
- `production_routes_harness.py` booted the **real local FastAPI app as the CPython oracle** + the kernel-router in front: **all 86 promoted-route checks value-identical to the app, byte-for-byte, 0 FAIL** (incl. the 13 new worldview+tag cases). Native ~35x faster than CPython-served.
- worldview defaults cosine = `0.96`, `matched_axes ["scientific","pragmatic"]`; irrational `1/sqrt(2)=0.7071067811865475` three-way bit-identical; the 400 carries the exact FastAPI detail + `application/json` + `X-Form-Router: native-kernel`.
- `form/validate.sh`: **266 ok, 0 divergent** — three-way kernel parity unaffected.
- `runtime_surface_report` `kernel_first_capable_routes` **16 → 18**; pinning test `tests/test_runtime_surface_native_routes.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)