### PR TITLE
tend: batch the canonical-view lookup in /api/ideas?lang=xx (kill the N+1)

### DIFF
--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -99,8 +99,14 @@ def _apply_lang_views(resp: IdeaPortfolioResponse, lang: str | None) -> IdeaPort
 
     if not lang or not translator_service.is_supported(lang):
         return resp
+    # One batched query for the whole listing's canonical views, instead of one
+    # SELECT per idea — the N+1 that made /api/ideas?lang=xx fire up to ~200
+    # queries (limit defaults to 200). Each idea resolves to the SAME record the
+    # per-idea canonical_view returned; the per-idea translate_snippet fallback
+    # below (for ideas without a canonical view) is in-process cached, unchanged.
+    canon = _tcache.canonical_views("idea", [idea.id for idea in resp.ideas], lang)
     for idea in resp.ideas:
-        rec = _tcache.canonical_view("idea", idea.id, lang)
+        rec = canon.get(idea.id)
         if rec and rec.content_hash:
             if rec.content_title:
                 idea.name = rec.content_title

--- a/api/app/services/translation_cache_service.py
+++ b/api/app/services/translation_cache_service.py
@@ -214,6 +214,42 @@ def canonical_view(entity_type: str, entity_id: str, lang: str) -> EntityViewRec
         return rows[0]
 
 
+def canonical_views(
+    entity_type: str, entity_ids: list[str], lang: str
+) -> dict[str, EntityViewRecord]:
+    """The current canonical view for each of ``entity_ids`` in ``lang`` — the
+    N+1-free batch form of ``canonical_view``, one query for the whole list.
+
+    A listing surface (``/api/ideas?lang=xx`` projecting up to 200 ideas into a
+    language view) used to call ``canonical_view`` once per idea — one SELECT per
+    row. This issues a single ``entity_id IN (...)`` query and resolves each
+    entity to the SAME record ``canonical_view`` would return: filtered to
+    canonical status in this lang, the latest by ``updated_at`` winning per entity
+    (identical sort/tie-break). Keyed by entity_id; an entity with no canonical
+    view is simply absent (mirroring ``canonical_view`` returning ``None``).
+    """
+    if not entity_ids:
+        return {}
+    _ensure_schema()
+    with _session() as s:
+        rows = list(s.scalars(
+            select(EntityViewRecord).where(
+                EntityViewRecord.entity_type == entity_type,
+                EntityViewRecord.entity_id.in_(entity_ids),
+                EntityViewRecord.lang == lang,
+                EntityViewRecord.status == STATUS_CANONICAL,
+            )
+        ))
+    by_id: dict[str, list[EntityViewRecord]] = {}
+    for r in rows:
+        by_id.setdefault(r.entity_id, []).append(r)
+    result: dict[str, EntityViewRecord] = {}
+    for eid, recs in by_id.items():
+        recs.sort(key=lambda r: r.updated_at, reverse=True)
+        result[eid] = recs[0]
+    return result
+
+
 def all_canonical_views(entity_type: str, entity_id: str) -> list[EntityViewRecord]:
     """Every canonical view for an entity (one per language)."""
     _ensure_schema()

--- a/api/tests/test_flow_multilingual.py
+++ b/api/tests/test_flow_multilingual.py
@@ -802,3 +802,46 @@ async def test_resonance_cross_domain_substitutes_idea_names():
         assert "pairs" in body
         assert "min_coherence_used" in body
     translator_service.set_backend(None)
+
+
+def test_canonical_views_batch_matches_per_idea():
+    """canonical_views (the batch) returns, for each id, exactly the record the
+    per-idea canonical_view returns — one query for a whole listing instead of
+    one SELECT per idea (the N+1 /api/ideas?lang=xx fired over up to 200 ideas).
+
+    One strange-minimal fixture covers four boundaries: a present view, an absent
+    id (absent from the dict, mirroring canonical_view -> None), latest-by-
+    updated_at winning when an entity has two canonical writes, and empty input.
+    """
+    lang = "de"
+    ids = [f"idea-batch-{uuid4().hex[:8]}" for _ in range(3)]
+    for i in (0, 1):
+        _cache.write_view(
+            entity_type="idea", entity_id=ids[i], lang=lang,
+            content_title=f"Titel {i}", content_description=f"Beschreibung {i}",
+            content_markdown="", author_type="test",
+        )
+    # ids[0] gets a SECOND (newer) canonical write — the latest must win, the same
+    # way canonical_view sorts by updated_at and takes the newest.
+    _cache.write_view(
+        entity_type="idea", entity_id=ids[0], lang=lang,
+        content_title="Titel 0 neu", content_description="neu",
+        content_markdown="", author_type="test",
+    )
+
+    batch = _cache.canonical_views("idea", ids, lang)
+
+    # exactly the ids that have a canonical view; the third is absent
+    assert set(batch.keys()) == {ids[0], ids[1]}
+    assert ids[2] not in batch
+    assert _cache.canonical_view("idea", ids[2], lang) is None
+    # each batch record IS the per-idea canonical_view record (same row + title)
+    for i in (0, 1):
+        per = _cache.canonical_view("idea", ids[i], lang)
+        assert per is not None
+        assert batch[ids[i]].id == per.id
+        assert batch[ids[i]].content_title == per.content_title
+    # latest-wins: ids[0]'s batch record is the newer write
+    assert batch[ids[0]].content_title == "Titel 0 neu"
+    # empty input short-circuits to {} (no query)
+    assert _cache.canonical_views("idea", [], lang) == {}


### PR DESCRIPTION
## What

A non-default-locale idea listing (`/api/ideas?lang=de` — the home page or `/ideas` page in any non-English locale) projected each idea into its language view by calling `translation_cache_service.canonical_view` **once per idea**, and `canonical_view` opens a session + runs a `SELECT` per call. With the listing limit defaulting to 200, that's **up to 200 separate DB queries for one request** — a textbook N+1, adding DB load on a hot endpoint (load the resource-pressured VPS feels in the intermittent `endpoint_ideas` strain).

Adds `canonical_views(entity_type, entity_ids, lang)` — **one `entity_id IN (...)` query** resolving each entity to the SAME record `canonical_view` would return (canonical status in this lang, latest-by-`updated_at` per entity, the identical sort/tie-break; an entity with no view simply absent from the dict). `_apply_lang_views` fetches the whole listing's views once, then reads each from the dict. The per-idea `translate_snippet` fallback (for ideas without a canonical view) is in-process cached and unchanged. **English/default-locale requests already return early before this loop — unaffected.**

## Verification

A unit test pins the batch as a faithful substitute — one fixture, four boundaries: present view, absent id (mirroring `canonical_view` → `None`), latest-of-two-writes winning, empty input → `{}`.

**Honest note on how it's verified:** I verified the batch correct by inspection (a faithful mechanical transform of `canonical_view`), but could **not run it locally** — the FastAPI app/service imports hang in my current (degraded-network) checkout, blocking on external connections at startup. **CI's full pytest suite (`test.yml`) runs the test in a clean environment** — that's the verifying run. If the test check fails, the batch has a flaw I missed and I'll fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)