### PR TITLE
tend: batch the canonical-view N+1s across the language-view endpoints

### DIFF
--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -333,11 +333,15 @@ async def list_concepts(
     result = concept_service.list_concepts(limit=limit, offset=offset)
     if target_lang and translator_service.is_supported(target_lang) and target_lang != translator_service.DEFAULT_LOCALE:
         items = result.get("items") or result.get("concepts") or []
+        # One batched query for the whole listing's canonical views instead of
+        # one SELECT per concept — the same N+1 shape /api/ideas?lang=xx had.
+        _cids = [c.get("id") for c in items if isinstance(c, dict) and c.get("id")]
+        canon = translation_cache.canonical_views("concept", _cids, target_lang)
         for c in items:
             cid = c.get("id") if isinstance(c, dict) else None
             if not cid:
                 continue
-            rec = translation_cache.canonical_view("concept", cid, target_lang)
+            rec = canon.get(cid)
             if rec:
                 if rec.content_title:
                     c["name"] = rec.content_title
@@ -411,11 +415,15 @@ async def list_concepts_by_domain(
     result = concept_service.list_concepts_by_domain(domain, limit=limit)
     if target_lang and translator_service.is_supported(target_lang) and target_lang != translator_service.DEFAULT_LOCALE:
         items = result.get("items") or result.get("concepts") or []
+        # One batched query for the whole listing's canonical views instead of
+        # one SELECT per concept — the same N+1 shape /api/ideas?lang=xx had.
+        _cids = [c.get("id") for c in items if isinstance(c, dict) and c.get("id")]
+        canon = translation_cache.canonical_views("concept", _cids, target_lang)
         for c in items:
             cid = c.get("id") if isinstance(c, dict) else None
             if not cid:
                 continue
-            rec = translation_cache.canonical_view("concept", cid, target_lang)
+            rec = canon.get(cid)
             if rec:
                 if rec.content_title:
                     c["name"] = rec.content_title

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -309,11 +309,17 @@ async def get_resonance(
 
     items, total = get_resonance_feed_page(window_hours=window_hours, limit=limit, offset=offset)
     if lang and translator_service.is_supported(lang) and lang != translator_service.DEFAULT_LOCALE:
+        # One batched query for the whole feed's canonical views instead of one
+        # SELECT per idea — the same N+1 shape /api/ideas?lang=xx had. Each idea
+        # resolves to the SAME record the per-idea canonical_view returned.
+        canon = _tcache.canonical_views(
+            "idea", [it.get("idea_id") or it.get("id") for it in items if (it.get("idea_id") or it.get("id"))], lang
+        )
         for it in items:
             iid = it.get("idea_id") or it.get("id")
             if not iid:
                 continue
-            rec = _tcache.canonical_view("idea", iid, lang)
+            rec = canon.get(iid)
             if rec and rec.content_title:
                 it["name"] = rec.content_title
                 if rec.content_description and "description" in it:

--- a/api/app/routers/resonance.py
+++ b/api/app/routers/resonance.py
@@ -95,14 +95,27 @@ def _idea_to_dict(idea) -> dict:
     }
 
 
-def _pair_to_out(pair: "resonance_svc.ResonancePair", lang: str | None = None) -> ResonancePairOut:
+def _pair_to_out(
+    pair: "resonance_svc.ResonancePair",
+    lang: str | None = None,
+    canon: dict | None = None,
+) -> ResonancePairOut:
     name_a = pair.name_a
     name_b = pair.name_b
     if lang and lang in SUPPORTED_LOCALES and lang != DEFAULT_LOCALE:
-        view_a = _tcache.canonical_view("idea", pair.idea_id_a, lang)
+        # ``canon`` is the listing's canonical views fetched in ONE batched query
+        # by the caller (collecting every pair's a+b idea_id), so a page of pairs
+        # is one SELECT instead of two-per-pair. Each lookup resolves to the SAME
+        # record the per-idea canonical_view returned; when no batch is supplied
+        # (other callers) fall back to the per-idea query, identical behavior.
+        if canon is None:
+            view_a = _tcache.canonical_view("idea", pair.idea_id_a, lang)
+            view_b = _tcache.canonical_view("idea", pair.idea_id_b, lang)
+        else:
+            view_a = canon.get(pair.idea_id_a)
+            view_b = canon.get(pair.idea_id_b)
         if view_a and view_a.content_title:
             name_a = view_a.content_title
-        view_b = _tcache.canonical_view("idea", pair.idea_id_b, lang)
         if view_b and view_b.content_title:
             name_b = view_b.content_title
     return ResonancePairOut(
@@ -153,8 +166,14 @@ async def get_cross_domain_resonances(
         min_coherence=min_coherence,
     )
     effective_min = max(min_coherence, resonance_svc.CROSS_DOMAIN_MIN_COHERENCE)
+    # One batched canonical-view query over every pair's a+b idea_id instead of
+    # two SELECTs per pair (the N+1 _pair_to_out otherwise fired per pair).
+    canon = None
+    if target_lang and target_lang in SUPPORTED_LOCALES and target_lang != DEFAULT_LOCALE:
+        _ids = [pid for p in pairs for pid in (p.idea_id_a, p.idea_id_b) if pid]
+        canon = _tcache.canonical_views("idea", _ids, target_lang)
     return CrossDomainResponse(
-        pairs=[_pair_to_out(p, target_lang) for p in pairs],
+        pairs=[_pair_to_out(p, target_lang, canon) for p in pairs],
         total=len(pairs),
         min_coherence_used=effective_min,
     )
@@ -198,8 +217,14 @@ async def get_resonance_for_idea(
     )
 
     source_name = source_dict.get("name", idea_id)
+    canon = None
     if target_lang and target_lang in SUPPORTED_LOCALES and target_lang != DEFAULT_LOCALE:
-        src_view = _tcache.canonical_view("idea", idea_id, target_lang)
+        # One batched canonical-view query over the source idea plus every
+        # match pair's a+b idea_id, instead of one SELECT for the source name
+        # and two per match (the N+1 _pair_to_out otherwise fired per match).
+        _ids = [idea_id] + [pid for p in matches for pid in (p.idea_id_a, p.idea_id_b) if pid]
+        canon = _tcache.canonical_views("idea", _ids, target_lang)
+        src_view = canon.get(idea_id)
         if src_view and src_view.content_title:
             source_name = src_view.content_title
 
@@ -207,7 +232,7 @@ async def get_resonance_for_idea(
         idea_id=idea_id,
         name=source_name,
         domain=domain,
-        matches=[_pair_to_out(p, target_lang) for p in matches],
+        matches=[_pair_to_out(p, target_lang, canon) for p in matches],
         total=len(matches),
     )
 

--- a/api/app/routers/spec_registry.py
+++ b/api/app/routers/spec_registry.py
@@ -36,8 +36,12 @@ def _apply_spec_lang(items: list[SpecRegistryEntry], lang: str | None) -> list[S
     from app.services import translation_cache_service as _tcache
     if not lang or not translator_service.is_supported(lang) or lang == translator_service.DEFAULT_LOCALE:
         return items
+    # One batched query for the whole listing's canonical views instead of one
+    # SELECT per spec — the same N+1 shape /api/ideas?lang=xx had. Each spec
+    # resolves to the SAME record the per-spec canonical_view returned.
+    canon = _tcache.canonical_views("spec", [spec.spec_id for spec in items], lang)
     for spec in items:
-        rec = _tcache.canonical_view("spec", spec.spec_id, lang)
+        rec = canon.get(spec.spec_id)
         if rec and rec.content_title:
             spec.title = rec.content_title
         if rec and rec.content_description:

--- a/api/tests/test_flow_multilingual.py
+++ b/api/tests/test_flow_multilingual.py
@@ -845,3 +845,48 @@ def test_canonical_views_batch_matches_per_idea():
     assert batch[ids[0]].content_title == "Titel 0 neu"
     # empty input short-circuits to {} (no query)
     assert _cache.canonical_views("idea", [], lang) == {}
+
+
+def test_resonance_pair_to_out_batch_matches_per_call():
+    """resonance._pair_to_out projects the SAME names whether it reads each view
+    via a per-idea canonical_view (canon=None) or from a pre-batched dict (canon
+    supplied) — the batch threaded into the listing must be a faithful substitute
+    for the two-SELECTs-per-pair it replaces.
+
+    Strange-minimal: one pair where side A has a German canonical view and side B
+    has none. That single pair exercises the title override (A), the absent-view
+    None branch (B keeps its anchor name), and batch-vs-per-call agreement at once.
+    """
+    from app.routers import resonance as _res
+    from app.services import idea_resonance_service as _rs
+
+    lang = "de"
+    id_a = f"idea-pair-a-{uuid4().hex[:8]}"
+    id_b = f"idea-pair-b-{uuid4().hex[:8]}"  # deliberately gets NO view
+    _cache.write_view(
+        entity_type="idea", entity_id=id_a, lang=lang,
+        content_title="Symbiose", content_description="",
+        content_markdown="", author_type="test",
+    )
+
+    pair = _rs.ResonancePair(
+        idea_id_a=id_a, name_a="Symbiosis", domain_a=["biology"],
+        idea_id_b=id_b, name_b="Microservices", domain_b=["software"],
+        crk_score=0.9, ot_distance=0.1, coherence=0.85, d_codex=0.2,
+        cross_domain=True, strong=True, discovered_at="2026-06-03T00:00:00Z",
+    )
+
+    # The batch the listing would build (collecting both pair ids in one query).
+    canon = _cache.canonical_views("idea", [id_a, id_b], lang)
+
+    per_call = _res._pair_to_out(pair, lang)            # canon=None → per-idea SELECTs
+    batched = _res._pair_to_out(pair, lang, canon)      # reads from the pre-batched dict
+
+    # A's name comes from the German view; B has no view so keeps its anchor name.
+    assert per_call.name_a == "Symbiose"
+    assert per_call.name_b == "Microservices"
+    # Faithful substitute: batched output is identical to the per-call output.
+    assert batched.name_a == per_call.name_a
+    assert batched.name_b == per_call.name_b
+    # The absent id is simply not in the batch dict (mirrors canonical_view -> None).
+    assert id_b not in canon


### PR DESCRIPTION
PR #2436 added `canonical_views(entity_type, entity_ids, lang)` and killed the `/api/ideas?lang=xx` N+1. The same shape — a loop calling `canonical_view` once per item, each call opening a session + running a SELECT — lived on several more hot listing endpoints. Each fix is the same faithful transform: one batched `entity_id IN (...)` query before the loop, then a dict lookup per item. Each item resolves to the **same** record `canonical_view` returned (canonical status in lang, latest-by-`updated_at` per entity, identical tie-break; absent when no view). Same output, fewer queries — the DB load the resource-pressured VPS feels in the intermittent endpoint strain.

## Batched (clean read loops)
ids knowable before the loop, result used as a pure dict lookup, no side effects:
- `spec_registry._apply_spec_lang` — one query over every `spec_id` in the listing.
- `concepts.list_concepts` and `concepts.list_concepts_by_domain` — one query over every concept id per listing.
- `ideas.get_resonance` (`/ideas/resonance`) — one query over the feed's idea ids (a second ideas loop, distinct from `_apply_lang_views` already fixed in #2436).
- `resonance.get_cross_domain_resonances` and `resonance.get_resonance_for_idea` — `_pair_to_out` fired two SELECTs per pair; now the caller batches every pair's a+b idea_id (plus the source idea in `get_resonance_for_idea`) in one query and threads the dict in. `_pair_to_out` keeps an identical per-call fallback when no batch is supplied, so any other caller is unchanged.

## Deferred (would not be a faithful substitute)
documented, not forced:
- `graph._name_or_desc_translated` — reached only via `_project_node` from the single-node GET `/graph/nodes/{id}`; there is no list of ids before any loop, so a batch would be a one-element no-op.
- `contributors._project_contributor_node` — single-contributor GET, not a loop; the `canonical_view is None` check also gates an attune-on-miss write block.
- `edges._project_edge_stub` — **is** called in a loop (`list_edges` over edge stubs), but the `is None` check gates an attune-on-miss write (`write_view` + `attune`); a repeated node_id's first iteration writes a canonical view that later iterations would then find present, so a pre-loop snapshot would change how many attune side-effects fire. Not faithful — left as per-stub.

## Test
A focused test pins the non-trivial site: `resonance._pair_to_out` projects the same names whether it reads each view per-idea (`canon=None`) or from a pre-batched dict — one pair, side A with a German view, side B with none, covering the title override, the absent-view None branch, and batch-vs-per-call agreement at once.

## Verification
The FastAPI app import hangs in the degraded-network checkout that dispatched this (startup blocks on external connections), so local pytest can't run; all 5 files byte-compile clean. CI's full pytest suite (Thread Gates → Run API tests) is the verifying run, as it was for #2436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)