### PR TITLE
attune(kernel-router): drop control-char headers — close the lone-CR injection

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -8250,7 +8250,20 @@ fn parse_headers(head: &str) -> Vec<(String, String)> {
             continue;
         }
         if let Some((name, value)) = line.split_once(':') {
-            out.push((name.trim().to_string(), value.trim().to_string()));
+            let (name, value) = (name.trim(), value.trim());
+            // Drop any header carrying a raw CR, LF, or NUL in its name or value.
+            // `head.lines()` splits on `\n` and strips a trailing `\r`, but a LONE
+            // CR (a `\r` not followed by `\n`) survives INSIDE a value — a header /
+            // request-injection (smuggling) and response-splitting vector when this
+            // header is relayed verbatim to the next hop (the upstream on the
+            // request hop, the client on the response hop). A legitimate header
+            // never contains these control bytes; dropping such a header forwards
+            // no control character to either hop, regardless of how lenient the
+            // far end's parser is.
+            if name.bytes().chain(value.bytes()).any(|b| b == b'\r' || b == b'\n' || b == 0) {
+                continue;
+            }
+            out.push((name.to_string(), value.to_string()));
         }
     }
     out
@@ -8727,6 +8740,36 @@ mod router_context_tests {
             Value::Int(i) => i.to_string(),
             v => v.display(),
         }
+    }
+
+    #[test]
+    fn parse_headers_drops_control_char_injection() {
+        // A lone CR inside a value (the request-smuggling / response-splitting
+        // vector) survives head.lines() — which splits on \n and strips only a
+        // TRAILING \r — so "X-Smuggle: v\rContent-Length: 0" arrives as one line
+        // with a raw \r in the value. parse_headers MUST drop it, not relay it
+        // verbatim to the next hop.
+        let head = "GET / HTTP/1.1\nHost: x\nX-Smuggle: v\rContent-Length: 0\nAccept: text/html\n";
+        let hs = parse_headers(head);
+        let names: Vec<&str> = hs.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"Host") && names.contains(&"Accept"), "legit header dropped: {:?}", hs);
+        assert!(!names.contains(&"X-Smuggle"), "CR-injected header was relayed: {:?}", hs);
+        // NO relayed header carries ANY control byte (CR / LF / NUL).
+        for (n, v) in &hs {
+            assert!(
+                !n.bytes().chain(v.bytes()).any(|b| b == b'\r' || b == b'\n' || b == 0),
+                "control byte survived in header {:?}: {:?}",
+                n, v
+            );
+        }
+        // A NUL in a value is likewise dropped; a clean header beside it survives.
+        let hs2 = parse_headers("GET / HTTP/1.1\nX-Nul: a\0b\nOk: yes\n");
+        assert_eq!(
+            hs2.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
+            vec!["Ok"],
+            "{:?}",
+            hs2
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The second finding from the serve-path security review (follow-up to #2441, the slowloris DoS).

`parse_headers` — the **one** header-capture shape **both** hops use (request headers forwarded to the upstream, upstream response headers relayed to the client) — trimmed each value but kept a **lone CR** inside it. `read_request` terminates the header block on `\r\n\r\n` and `parse_headers` splits on `\n` (stripping only a *trailing* `\r`), so a value like `v\rContent-Length: 0\r…` survives verbatim and is relayed to the next hop — a **request-smuggling / header-injection** vector toward the upstream and a **response-splitting** vector toward the client.

**Latent today** (the production uvicorn/h11 upstream rejects the injected bytes with a 400), but a real flaw the moment the far end is any more CR-lenient (a stdlib `http.server`, a second backend, an intermediary). A front door shouldn't forward control characters and rely on the backend to reject them.

## Fix

`parse_headers` drops any header whose name or value contains a raw `\r`, `\n`, or NUL — closing **both** hops at once. A legitimate header never carries these bytes; dropping such a header forwards no control character either way, regardless of how lenient the far end's parser is.

**Unit test** `parse_headers_drops_control_char_injection` proves the CR-injected and NUL-bearing headers are dropped while the legit headers beside them survive (`cargo test` passing).

Serve-path only — no Form eval touched (the local `source-language-route-class-template-band` divergence is the known broken-local-source-compiler flake; main's CI green).

## Review status

- **#1 slowloris DoS (HIGH)** — fixed + merged (#2441), proven.
- **#2 lone-CR injection (this PR, MEDIUM/latent)** — fixed + unit-tested.
- **Native-handler recursion bound** — dormant at the flip (empty shadow routes); flagged for the route-promotion checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)