### PR TITLE
attune(kernel-router): cap native-handler input — close the stack-overflow process-kill

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -7049,6 +7049,33 @@ fn handle_request(
             );
             return false; // close on error — keep the framing unambiguous
         }
+        // SECURITY: bound the eval input BEFORE running the handler. A native
+        // handler recurses once per element of a param it splits into a list (a
+        // `values=1,1,1,…` list), and the evaluator is not tail-call-optimized — so
+        // an oversized crafted param recurses deep enough to overflow the worker
+        // stack and abort the whole process (see NATIVE_HANDLER_INPUT_LIMIT). The
+        // deepest possible recursion is bounded by the LARGEST single user param's
+        // byte length (each param is a separate, sequential list walk; router
+        // context fields are not user-controlled and are excluded). Answer an
+        // oversized param with a 413 observably instead of evaluating it. A real
+        // native query's params are tiny.
+        let max_param_bytes: usize = request_data
+            .iter()
+            .map(|(_, v)| v.len())
+            .max()
+            .unwrap_or(0);
+        if max_param_bytes > NATIVE_HANDLER_INPUT_LIMIT {
+            let status = "413 Payload Too Large".to_string();
+            let body = format!(
+                "native handler param {} bytes exceeds the {}-byte limit\n",
+                max_param_bytes, NATIVE_HANDLER_INPUT_LIMIT
+            );
+            record_router_metrics(router_metrics, &path, "native-kernel-error");
+            let _ = stream.write_all(
+                http_response(&status, &body, "native-kernel-error", false, "", &[]).as_bytes(),
+            );
+            return false; // close — the oversized request was fully read; drop it
+        }
         let result = walk(k, arena, cl.body, call_frame);
         router = "native-kernel";
         // A native handler can return the first-class KernelHTTPResponse cell:
@@ -7207,6 +7234,21 @@ const MAX_REQUEST_READ_TIMEOUT_DEFAULT_MS: u64 = 30_000;
 fn max_request_read_timeout() -> Duration {
     Duration::from_millis(MAX_REQUEST_READ_TIMEOUT_DEFAULT_MS)
 }
+
+// SECURITY: the largest TOTAL input (query + body param bytes) a NATIVE Form
+// handler will evaluate. The Form evaluator is a tree-walker WITHOUT tail-call
+// optimization, and the native handlers recurse once per input list element
+// (`ints_of`, `split_commas`, the score folds, …). So a crafted param like
+// `values=1,1,1,…` with hundreds of thousands of elements — a few hundred KB,
+// still UNDER the request-body shape cap — recurses deep enough to OVERFLOW the
+// worker stack and ABORT THE WHOLE PROCESS (every worker dies): a one-request
+// remote kill, confirmed empirically (~200k elements aborts). A real native-route
+// query is a handful of small params; this caps the eval input far above any
+// legitimate use and far below the overflow, so an oversized input is answered
+// (413) instead of evaluated. (The proper fix — TCO in the evaluator — is a
+// separate, parity-bearing change; this serve-path bound makes native routes safe
+// to serve in the meantime.)
+const NATIVE_HANDLER_INPUT_LIMIT: usize = 16 * 1024;
 
 // A fan-out hop failure, classified so the caller knows whether to RETRY or 504:
 //   - Timeout: the upstream is reachable but SLOW/HUNG — connect, write, or read


### PR DESCRIPTION
## What — a CRITICAL one-request remote process-kill

The third serve-path security finding, and **more severe than the review flagged**. The review marked the native-eval recursion *"dormant at the flip"*. **Empirical test against the built binary proved otherwise:** a single GET to a native route with `values=1,1,1,…` (200k elements, ~400KB — **under** the request-body cap) overflows the worker stack → `fatal runtime error: stack overflow, aborting` → **the whole process dies, every worker, instantly.** Live the moment any native route serves traffic.

**Root cause:** native handlers recurse once per input list element (`ints_of`, the score folds, …) and the Form evaluator is a tree-walker **without tail-call optimization**, so a long enough list recurses past the 16 MiB worker stack. The ~1 MiB request-body cap is far too loose to bound it.

## Fix (serve path — no Form eval touched)

Before running a native handler, reject a request whose **largest single user param** exceeds `NATIVE_HANDLER_INPUT_LIMIT` (16 KiB — each param is a separate sequential list walk, so the largest bounds the deepest recursion; router-context fields excluded). An oversized param gets a **413** instead of crashing the process.

## Proven against the binary

| input | before | after |
|---|---|---|
| 200k-element list (~400KB) | **process abort** | **413, process alive** |
| legit `values=10,20,30` | `{"weight":3700,…}` | **byte-identical** |
| 4000-element list (~8KB, under cap) | (ok) | **200, evaluates** |
| 10000-element list (~20KB, over cap) | (ok/risky) | **413** |

Byte-identical output preserved for every legitimate input. The proper fix — TCO in the evaluator — is a separate parity-bearing change; this bound makes the native routes safe to serve **now**.

## All three serve-path findings now closed

- **#1 slowloris DoS** (HIGH) — #2441
- **#2 lone-CR header injection** (MEDIUM) — #2442
- **#3 native-handler stack-overflow** (CRITICAL) — this PR

Serve-path only — parity unaffected (the local `source-language-route-class-template-band` divergence is the known broken-local-source-compiler flake; main's CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)