### PR TITLE
feat(kernel-router): compare mode — live native-vs-CPython shadow diff, zero-risk cutover

### DIFF
--- a/Dockerfile.kernel-router
+++ b/Dockerfile.kernel-router
@@ -97,6 +97,14 @@ COPY form/form-stdlib/ /app/form/form-stdlib/
 # /routes/shadow-routes.fk to promote native routes.
 COPY deploy/kernel-router/shadow-routes.fk /routes/shadow-routes.fk
 
+# The PRODUCTION routes manifest (+ its route-data registry): promotes the
+# /api/utils compute routes to NATIVE. COMPARE mode points ROUTES_FILE here so
+# there are native routes to shadow-compare against the CPython upstream (see
+# docker-compose.kernel-router.yml + COMPARE_MODE.md). The route-data file is
+# loaded alongside the manifest by the same convention validate.sh uses.
+COPY deploy/kernel-router/production-routes.fk /routes/production-routes.fk
+COPY deploy/kernel-router/production-routes-data.json /routes/production-routes-data.json
+
 # The entrypoint resolves env at RUN time so PORT / UPSTREAM_URL / ROUTES_FILE
 # are container-configurable (compose env, -e flags) without rebuilding.
 COPY deploy/kernel-router/entrypoint.sh /app/entrypoint.sh

--- a/deploy/kernel-router/COMPARE_MODE.md
+++ b/deploy/kernel-router/COMPARE_MODE.md
@@ -1,0 +1,147 @@
+# Kernel-Router COMPARE Mode — live native-vs-CPython shadow diff
+
+COMPARE mode is the **zero-risk shadow step** before the kernel-router becomes the
+real front door. Instead of a risky one-time flip from CPython to the kernel, the
+kernel-router runs **in front** of the CPython app and, for every native route,
+**self-compares its answer against CPython on live traffic** while still returning
+CPython's (safe) response. Divergence, latency, and downtime are measured against
+production traffic *before* any cutover. The cutover then becomes a **single env
+toggle**, not a leap.
+
+This is the read-time companion to the deploy overlay in
+[`docker-compose.kernel-router.yml`](docker-compose.kernel-router.yml) and the flip
+described in [`kernels/KERNEL_AS_ROUTER.md`](../../kernels/KERNEL_AS_ROUTER.md).
+
+## The design (one flag couples *compare* and *which-response-to-return*)
+
+`COH_ROUTER_COMPARE` — read **once at startup** (never per request) by the
+kernel-router (`cli_serve` in `form/form-kernel-rust/src/main.rs`).
+
+When it is set (`1`/`true`) **AND** an upstream is configured, every NATIVE route:
+
+1. **Serves natively** from the kernel (timed → `native_ms`).
+2. **Shadow-fans-out the same request** (method, target, headers, body) to the
+   CPython upstream over the same keep-alive `UpstreamPool` the fan-out tail uses,
+   and **captures the full response into memory** (timed → `cpython_ms`).
+3. **Compares** byte-for-byte: `status_match = native_status == cpython_status`,
+   `body_match = native_body == cpython_body` (exact bytes), `matched = both`.
+4. **Logs** one structured `[compare]` line to stdout (captured by `docker logs`);
+   on a mismatch a bounded diff snippet (~200 bytes each side) follows.
+5. **Returns CPython's response** — the user gets exactly what direct-CPython would
+   serve. This is the safety property: **zero behavior change**. If the shadow
+   fan-out errors, it falls back to returning the **native** response (a shadow
+   hiccup must never 5xx the user) and logs `compare_fanout_failed`.
+
+Every response also carries the header **`X-Form-Compare: matched | mismatch |
+cpython_error`** (alongside the existing `X-Form-Router: native-kernel`), so an
+external monitor reads per-request verdicts without parsing logs.
+
+When `COH_ROUTER_COMPARE` is **unset** (the default **and** the post-validation
+cutover state), the native arm is **unchanged**: serve native, return native, no
+fan-out, no overhead. **The cutover is literally turning compare off.**
+
+Only the NATIVE arm is touched. Non-native paths already fan out to CPython — there
+is nothing to compare.
+
+## The one-flag toggle
+
+| `COH_ROUTER_COMPARE` | Native route behavior | Use |
+|----------------------|-----------------------|-----|
+| `1` / `true`         | Serve native, compare vs CPython, **return CPython** | **Validation** — watch divergence on live traffic |
+| unset / `""`         | Serve native, **return native**, no fan-out | **Cutover** — the native kernel is the answer |
+
+The toggle lives in [`docker-compose.kernel-router.yml`](docker-compose.kernel-router.yml)
+(`environment: COH_ROUTER_COMPARE: "1"`). Cutover = set it to `""` (or remove it)
+and `docker compose up -d kernel-router`. Rollback = set it back. Instant, no data
+migration.
+
+## Reading divergence
+
+**Per-request** (no log access needed): read the `X-Form-Compare` response header.
+
+```bash
+curl -sI http://localhost:8088/api/utils/coherence_weight?values=10,20,30 \
+  | grep -i x-form-compare
+# X-Form-Compare: matched
+```
+
+**In the logs** — every comparison is one greppable line on stdout:
+
+```
+[compare] route=/api/utils/coherence_weight matched=true status_native="200 OK" \
+  status_cpython="200 OK" status_match=true body_match=true native_ms=0.31 \
+  cpython_ms=12.74 nbytes=91 cbytes=91
+```
+
+A mismatch adds bounded snippets:
+
+```
+[compare] route=/api/utils/foo matched=false ... body_match=false ...
+[compare] route=/api/utils/foo mismatch_native_snippet="0.80"
+[compare] route=/api/utils/foo mismatch_cpython_snippet="0.81"
+```
+
+A shadow-upstream failure (the user still got the native answer, 200):
+
+```
+[compare] route=/api/utils/foo compare_fanout_failed error="..." native_ms=0.2 returning=native
+```
+
+**Aggregate** with [`compare_summary.py`](compare_summary.py) — folds `[compare]`
+lines from stdin into a per-route table (count, mismatch, cpython_error, p50
+native_ms vs cpython_ms):
+
+```bash
+docker logs coherence-network-kernel-router 2>&1 \
+  | python3 deploy/kernel-router/compare_summary.py
+```
+
+```
+route                                          count  mismatch  cpy_err  p50_native_ms  p50_cpython_ms
+------------------------------------------------------------------------------------------------------
+/api/utils/coherence_weight                     1843         0        0          0.310          12.740
+...
+totals: compared=… mismatch=0 cpython_error=0  =>  CLEAN — safe to cut over (unset COH_ROUTER_COMPARE)
+```
+
+## Safe rollout
+
+1. **Insert the compare-mode front door.** Bring up the kernel-router overlay with
+   `COH_ROUTER_COMPARE=1` and `UPSTREAM_URL=http://api:8000`, pointed at a manifest
+   with native routes (`production-routes.fk`). Traefik/prod is **untouched** — the
+   overlay only adds the service; the flip (re-pointing Traefik) is a separate,
+   intent-level step documented in `docker-compose.kernel-router.yml`.
+2. **Watch the log clean.** Run real traffic (or replay) through the router and run
+   `compare_summary.py`. Watch until `mismatch=0` and `cpython_error≈0` across every
+   route over a representative window. Any mismatch row names a route whose native
+   handler diverges from CPython — fix the handler (or its manifest), redeploy, keep
+   watching. The user is never affected: they got CPython the whole time.
+3. **Cut over.** Once the window is clean, set `COH_ROUTER_COMPARE=""` and
+   `docker compose up -d kernel-router`. Native routes now serve+return native, with
+   the proxy hop skipped entirely. Rollback is setting it back to `"1"`.
+
+The flip of Traefik onto the kernel-router (making it the real front door for
+`api.coherencycoin.com`) is the **separate** stakes-and-intent step in
+`docker-compose.kernel-router.yml` — the commented `traefik.*` labels. Compare mode
+and the Traefik flip are independent: you can run compare mode behind a shadow port
+first, then flip Traefik, then cut compare off — each reversible on its own.
+
+## Proof
+
+The compare-mode mechanics are proven by
+[`form/form-kernel-rust/production_routes_harness.py --compare`](../../form/form-kernel-rust/production_routes_harness.py):
+
+- **Stub mechanics** (network-independent): a trivial native route against a tiny
+  stub upstream drives all three verdicts — `matched` (returns the body,
+  `X-Form-Compare: matched`), `mismatch` (returns the *CPython* body, logs the diff
+  snippets), `cpython_error` (dead upstream → returns *native*, 200, never a 5xx),
+  plus normal-mode-unchanged (compare unset → native served+returned, no header, no
+  `[compare]` logs).
+- **Real-app oracle**: a promoted native route compared against the live CPython app
+  returns the CPython body, carries `X-Form-Compare: matched`, and logs `[compare]
+  ... matched=true` with both latencies.
+
+Latency: in compare mode the user waits for CPython anyway, so response latency ≈
+CPython's; the native serve + the byte compare add ~nothing (`native_ms` is a
+fraction of a millisecond against CPython's tens). The summary's `p50_native_ms` vs
+`p50_cpython_ms` columns make the post-cutover speedup visible *before* cutting over.

--- a/deploy/kernel-router/compare_summary.py
+++ b/deploy/kernel-router/compare_summary.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""compare_summary.py — aggregate the kernel-router's COMPARE-mode [compare] logs.
+
+COMPARE mode (COH_ROUTER_COMPARE=1) emits one structured `[compare]` line per
+native request to stdout (captured by `docker logs`). This reader folds those
+lines — fed on stdin — into a PER-ROUTE summary so a rollout can read divergence
+and latency at a glance without eyeballing thousands of lines:
+
+    docker logs coherence-network-kernel-router 2>&1 | \\
+        python3 deploy/kernel-router/compare_summary.py
+
+What it reports per route:
+  - count            requests compared
+  - mismatch         responses where native != CPython (status or body)
+  - cpython_error    shadow fan-outs that failed (the user still got native)
+  - p50 native_ms    median native serve time
+  - p50 cpython_ms   median CPython serve time (what the user actually waited for)
+
+A CLEAN rollout shows mismatch=0 and cpython_error≈0 across every route — the
+green light to cut over (unset COH_ROUTER_COMPARE). Any mismatch row names a route
+whose native handler diverges from CPython; grep that route's [compare] lines for
+the mismatch_native_snippet / mismatch_cpython_snippet to see the divergence.
+
+Network-independent and unit-testable: the parsing + folding is pure (parse_line,
+summarize); only main() touches stdin.
+
+The line format this parses (key=value, space-separated; values may be quoted by
+the Rust {:?} debug for the status fields, which this strips):
+
+    [compare] route=/api/utils/coherence_weight matched=true status_native="200 OK" \\
+        status_cpython="200 OK" status_match=true body_match=true native_ms=0.31 \\
+        cpython_ms=12.74 nbytes=91 cbytes=91
+    [compare] route=/api/utils/foo compare_fanout_failed error="..." native_ms=0.2 returning=native
+"""
+from __future__ import annotations
+
+import re
+import sys
+from statistics import median
+
+
+# One [compare] record, parsed from a log line. A `matched` line carries the full
+# comparison; a `compare_fanout_failed` line carries only route + the failure flag
+# (the user got native, the shadow upstream hiccuped).
+def parse_line(line: str) -> dict | None:
+    """Parse ONE [compare] log line into a dict, or None if it is not one.
+
+    The mismatch diff-snippet lines (`mismatch_native_snippet=...`) are NOT
+    records — they carry no `matched=`/`compare_fanout_failed` and are skipped so
+    they do not inflate counts.
+    """
+    line = line.strip()
+    if not line.startswith("[compare]"):
+        return None
+    rest = line[len("[compare]"):].strip()
+
+    # The shadow-error record: the upstream fan-out failed, native was returned.
+    if "compare_fanout_failed" in rest:
+        m = re.search(r"route=(\S+)", rest)
+        if not m:
+            return None
+        rec = {"route": m.group(1), "kind": "cpython_error"}
+        nm = re.search(r"native_ms=([0-9.]+)", rest)
+        if nm:
+            rec["native_ms"] = float(nm.group(1))
+        return rec
+
+    # A full comparison record requires matched= AND both latencies. The
+    # diff-snippet follow-up lines lack matched=, so they fall through to None.
+    if "matched=" not in rest:
+        return None
+    m = re.search(r"route=(\S+)", rest)
+    if not m:
+        return None
+    rec: dict = {"route": m.group(1), "kind": "compare"}
+    matched = re.search(r"\bmatched=(true|false)\b", rest)
+    if not matched:
+        return None
+    rec["matched"] = matched.group(1) == "true"
+    nm = re.search(r"native_ms=([0-9.]+)", rest)
+    cm = re.search(r"cpython_ms=([0-9.]+)", rest)
+    if not nm or not cm:
+        return None
+    rec["native_ms"] = float(nm.group(1))
+    rec["cpython_ms"] = float(cm.group(1))
+    return rec
+
+
+def summarize(lines) -> dict[str, dict]:
+    """Fold an iterable of log lines into {route: summary}. Pure — no I/O."""
+    agg: dict[str, dict] = {}
+
+    def slot(route: str) -> dict:
+        return agg.setdefault(route, {
+            "count": 0, "mismatch": 0, "cpython_error": 0,
+            "native_ms": [], "cpython_ms": [],
+        })
+
+    for line in lines:
+        rec = parse_line(line)
+        if rec is None:
+            continue
+        s = slot(rec["route"])
+        if rec["kind"] == "cpython_error":
+            s["cpython_error"] += 1
+            if "native_ms" in rec:
+                s["native_ms"].append(rec["native_ms"])
+            continue
+        s["count"] += 1
+        if not rec["matched"]:
+            s["mismatch"] += 1
+        s["native_ms"].append(rec["native_ms"])
+        s["cpython_ms"].append(rec["cpython_ms"])
+    return agg
+
+
+def _p50(xs: list[float]) -> float:
+    return median(xs) if xs else 0.0
+
+
+def render(agg: dict[str, dict]) -> str:
+    """Render the per-route summary table as text."""
+    if not agg:
+        return "no [compare] lines found on stdin (is COMPARE mode on, and are native routes being hit?)"
+    rows = []
+    header = (f"{'route':<44} {'count':>7} {'mismatch':>9} {'cpy_err':>8} "
+              f"{'p50_native_ms':>14} {'p50_cpython_ms':>15}")
+    rows.append(header)
+    rows.append("-" * len(header))
+    total = mismatches = errors = 0
+    for route in sorted(agg):
+        s = agg[route]
+        total += s["count"]
+        mismatches += s["mismatch"]
+        errors += s["cpython_error"]
+        rows.append(
+            f"{route:<44} {s['count']:>7} {s['mismatch']:>9} {s['cpython_error']:>8} "
+            f"{_p50(s['native_ms']):>14.3f} {_p50(s['cpython_ms']):>15.3f}"
+        )
+    rows.append("-" * len(header))
+    verdict = ("CLEAN — no divergence; safe to cut over (unset COH_ROUTER_COMPARE)"
+               if mismatches == 0 else
+               f"{mismatches} MISMATCH(es) — investigate before cutover")
+    rows.append(f"totals: compared={total} mismatch={mismatches} cpython_error={errors}  =>  {verdict}")
+    return "\n".join(rows)
+
+
+def main() -> int:
+    print(render(summarize(sys.stdin)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/kernel-router/docker-compose.kernel-router.yml
+++ b/deploy/kernel-router/docker-compose.kernel-router.yml
@@ -58,10 +58,29 @@ services:
     restart: unless-stopped
     environment:
       # The fan-out target: the api service on the shared compose network. In
-      # shadow mode EVERY request goes here (empty routes manifest).
+      # shadow mode EVERY request goes here (empty routes manifest). In COMPARE
+      # mode the native routes are ALSO shadow-compared against this same upstream.
       UPSTREAM_URL: "http://api:8000"
       KERNEL_ROUTER_PORT: "8080"
-      ROUTES_FILE: "/routes/shadow-routes.fk"
+      # COMPARE mode wants a manifest WITH native routes so there is something to
+      # compare. production-routes.fk promotes the /api/utils compute routes; the
+      # router serves them from the kernel, compares each against CPython, and
+      # returns CPython's response (zero behavior change). The shadow-routes.fk
+      # manifest (empty -> all fan-out) is the COMPARE-off all-CPython baseline.
+      ROUTES_FILE: "/routes/production-routes.fk"
+      # production-routes.fk is a source-authored (BML `section [...]`) manifest, so
+      # it is source-compiled at load and NEEDS the form-stdlib. The image bakes it
+      # at /app/form/form-stdlib (see Dockerfile.kernel-router); the entrypoint
+      # passes --stdlib only when STDLIB_DIR is set, so it must be set here. (The
+      # empty shadow-routes.fk is raw S-expression and needs no stdlib — drop this
+      # line if you point ROUTES_FILE back at the shadow manifest.)
+      STDLIB_DIR: "/app/form/form-stdlib"
+      # COMPARE MODE — the zero-risk shadow step before the cutover. With "1" every
+      # NATIVE route is shadow-compared against UPSTREAM_URL and CPython's (safe)
+      # response is returned; X-Form-Compare + [compare] logs carry the per-request
+      # verdict. THE CUTOVER IS SETTING THIS TO "" (or removing it): then native
+      # routes serve+return native, no fan-out, no overhead. See COMPARE_MODE.md.
+      COH_ROUTER_COMPARE: "1"
       # KERNEL_ROUTER_WORKERS: "4"   # optional pool size; default = host parallelism
     depends_on:
       # The fan-out upstream must exist; the router proxies to it.

--- a/deploy/kernel-router/entrypoint.sh
+++ b/deploy/kernel-router/entrypoint.sh
@@ -7,6 +7,13 @@
 #   KERNEL_ROUTER_HOST  the interface the router binds    (default 0.0.0.0)
 #   UPSTREAM_URL        the CPython fan-out target        (default http://api:8000)
 #   ROUTES_FILE         the routes manifest               (default /routes/shadow-routes.fk)
+#   COH_ROUTER_COMPARE  COMPARE mode: 1/true -> every NATIVE route is shadow-
+#                       compared against UPSTREAM_URL and CPython's (safe) response
+#                       is returned (zero behavior change; X-Form-Compare +
+#                       [compare] logs carry the verdict). Read by the binary from
+#                       the process env directly — passed through, not a CLI flag.
+#                       Unset -> native routes serve+return native (the cutover).
+#                       See deploy/kernel-router/COMPARE_MODE.md.
 #
 # HOST binding: the kernel's `serve` defaults to 127.0.0.1 (loopback) — correct
 # for a same-host proof harness, but UNREACHABLE across the container boundary
@@ -44,5 +51,14 @@ if [ -n "${KERNEL_ROUTER_WORKERS:-}" ]; then
   set -- "$@" --workers "$KERNEL_ROUTER_WORKERS"
 fi
 
-echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM (shadow mode: empty routes -> all fan-out)"
+# COMPARE mode is read by the binary directly from the process env (not a CLI
+# flag), so it is already in scope for the exec below. Surface its state in the
+# launch line so an operator reading container logs knows the posture.
+COMPARE="${COH_ROUTER_COMPARE:-}"
+case "$(printf '%s' "$COMPARE" | tr '[:upper:]' '[:lower:]')" in
+  1|true) COMPARE_NOTE=" [COMPARE on: native routes shadow-compared vs $UPSTREAM, CPython returned]" ;;
+  *)      COMPARE_NOTE="" ;;
+esac
+
+echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM (shadow mode: empty routes -> all fan-out)$COMPARE_NOTE"
 exec /app/bin/form-kernel-rust "$@"

--- a/form/form-kernel-rust/production_routes_harness.py
+++ b/form/form-kernel-rust/production_routes_harness.py
@@ -33,12 +33,15 @@ Run from form/form-kernel-rust/ (after `cargo build --release`):
 from __future__ import annotations
 
 import argparse
+import http.server
 import json
 import os
 import socket
 import statistics
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -49,6 +52,11 @@ BIN = HERE / "target" / "release" / "form-kernel-rust"
 # form/form-kernel-rust -> form -> repo root
 REPO = HERE.parent.parent
 ROUTES = REPO / "deploy" / "kernel-router" / "production-routes.fk"
+# production-routes.fk opens a BML `section [...]` block, so it is source-compiled
+# at load and needs the form-stdlib. `serve --stdlib` defaults to "form-stdlib"
+# relative to cwd (which does not exist beside this harness), so we pass the
+# absolute path. Harmless for a raw S-expression manifest (only used on a section).
+STDLIB = REPO / "form" / "form-stdlib"
 API_DIR = REPO / "api"
 
 # The four promoted routes, each with representative + edge query strings. The
@@ -346,10 +354,240 @@ def measure(url: str, n: int) -> list[float]:
     return out
 
 
+# ----------------------------------------------------------------------------
+# COMPARE MODE proof.
+#
+# COMPARE mode (COH_ROUTER_COMPARE=1) is the zero-risk SHADOW step before the
+# cutover: the kernel-router serves a native route from the kernel, then issues
+# the SAME request to the CPython upstream, compares the two responses
+# byte-for-byte, LOGS one structured `[compare]` line (native_ms vs cpython_ms,
+# matched verdict), and RETURNS THE CPYTHON RESPONSE — so the user gets exactly
+# what direct-CPython would serve (the safety property; ZERO behavior change). The
+# cutover is literally turning compare OFF: then the native arm serves+returns
+# native with no fan-out. This proof exercises BOTH mechanics paths:
+#   * stub_mechanics_proof — network-independent: a tiny http.server stub upstream
+#     proves the matched / mismatch / cpython_error verdicts, the return-upstream
+#     property, the X-Form-Compare header, and the [compare] log line WITHOUT
+#     needing the real app (so it runs even in a degraded-net sandbox).
+#   * compare_oracle_proof — against the REAL CPython app: a promoted native route
+#     (byte-identical to its CPython twin, as the main harness proves) compared in
+#     compare mode returns the CPython body, carries X-Form-Compare: matched, and
+#     logs [compare] matched=true with both latencies. Runs only when the app booted.
+
+
+def read_compare_lines(proc: subprocess.Popen) -> tuple[list[str], str, str]:
+    """Terminate `proc` and return (its [compare] stdout lines, full stdout, stderr)."""
+    proc.terminate()
+    try:
+        out, err = proc.communicate(timeout=4)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+    out = out or ""
+    err = err or ""
+    return [ln for ln in out.splitlines() if ln.startswith("[compare]")], out, err
+
+
+def boot_router_compare(routes_path: str, upstream: str, port: int) -> subprocess.Popen:
+    """Boot the kernel-router in COMPARE mode (COH_ROUTER_COMPARE=1) against `upstream`.
+
+    --stdlib is passed so a source-authored (BML `section`) manifest — like
+    production-routes.fk — source-compiles at load. It is a no-op for the raw
+    S-expression stub manifest.
+    """
+    env = dict(os.environ)
+    env["COH_ROUTER_COMPARE"] = "1"
+    proc = subprocess.Popen(
+        [str(BIN), "serve", "--port", str(port),
+         "--routes", routes_path, "--upstream", upstream,
+         "--stdlib", str(STDLIB)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+    )
+    wait_for_port(port)
+    time.sleep(0.3)  # let the worker pool finish loading routes
+    return proc
+
+
+def stub_mechanics_proof(failures: list) -> None:
+    """Network-independent proof of the compare-mode mechanics against a stub upstream.
+
+    A trivial native route (/ping -> "ping-native") + a tiny http.server whose body
+    we control lets us drive all three verdicts deterministically:
+      - mismatch: stub returns a DIFFERENT body -> X-Form-Compare: mismatch, user
+        gets the STUB (CPython) body, [compare] matched=false with diff snippets.
+      - matched: stub returns the SAME body -> X-Form-Compare: matched, [compare]
+        matched=true.
+      - cpython_error: a DEAD upstream -> the user still gets the NATIVE body with a
+        200 (NEVER a 5xx for a shadow hiccup), X-Form-Compare: cpython_error,
+        [compare] compare_fanout_failed returning=native.
+    """
+    print("\n=== COMPARE-MODE MECHANICS (stub upstream, network-independent) ===")
+    with tempfile.NamedTemporaryFile("w", suffix=".fk", delete=False) as f:
+        f.write('(defn route_ping () "ping-native")\n'
+                '(let routes (list (list "/ping" route_ping)))\n')
+        routes_path = f.name
+
+    def serve_stub(body: bytes) -> tuple[http.server.HTTPServer, int]:
+        class Stub(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *a):  # silence
+                pass
+
+        port = free_port()
+        httpd = http.server.HTTPServer(("127.0.0.1", port), Stub)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        wait_for_port(port)
+        return httpd, port
+
+    try:
+        # ---- MISMATCH: native "ping-native" vs stub "ping-cpython" ----
+        httpd, sport = serve_stub(b"ping-cpython")
+        kport = free_port()
+        proc = boot_router_compare(routes_path, f"http://127.0.0.1:{sport}", kport)
+        ks, kbody, khdrs = http_get(f"http://127.0.0.1:{kport}/ping")
+        cmp_hdr = khdrs.get("x-form-compare")
+        clines, _, cerr = read_compare_lines(proc)
+        httpd.shutdown()
+        got_upstream = kbody == "ping-cpython"          # safety: user gets CPython
+        mismatch_hdr = cmp_hdr == "mismatch"
+        mismatch_log = any("matched=false" in l and "native_ms=" in l and "cpython_ms=" in l
+                           for l in clines)
+        banner = any("COMPARE mode ON" in l for l in cerr.splitlines())
+        ok = ks == 200 and got_upstream and mismatch_hdr and mismatch_log and banner
+        print(f"  [{'OK' if ok else 'FAIL'}] MISMATCH: returned={kbody!r} "
+              f"X-Form-Compare={cmp_hdr!r} (user gets CPython body)")
+        for l in clines:
+            print(f"        {l}")
+        if not ok:
+            failures.append(("compare-stub-mismatch", ks, kbody, cmp_hdr, mismatch_log, banner))
+
+        # ---- MATCHED: native "ping-native" vs stub "ping-native" ----
+        httpd, sport = serve_stub(b"ping-native")
+        kport = free_port()
+        proc = boot_router_compare(routes_path, f"http://127.0.0.1:{sport}", kport)
+        ks, kbody, khdrs = http_get(f"http://127.0.0.1:{kport}/ping")
+        cmp_hdr = khdrs.get("x-form-compare")
+        clines, _, _ = read_compare_lines(proc)
+        httpd.shutdown()
+        matched_hdr = cmp_hdr == "matched"
+        matched_log = any("matched=true" in l and "body_match=true" in l
+                          and "native_ms=" in l and "cpython_ms=" in l for l in clines)
+        ok = ks == 200 and kbody == "ping-native" and matched_hdr and matched_log
+        print(f"  [{'OK' if ok else 'FAIL'}] MATCHED: returned={kbody!r} "
+              f"X-Form-Compare={cmp_hdr!r}")
+        for l in clines:
+            print(f"        {l}")
+        if not ok:
+            failures.append(("compare-stub-matched", ks, kbody, cmp_hdr, matched_log))
+
+        # ---- CPYTHON_ERROR: a DEAD upstream -> fall back to native, no 5xx ----
+        deadport = free_port()  # freed; nothing listens
+        kport = free_port()
+        proc = boot_router_compare(routes_path, f"http://127.0.0.1:{deadport}", kport)
+        ks, kbody, khdrs = http_get(f"http://127.0.0.1:{kport}/ping")
+        cmp_hdr = khdrs.get("x-form-compare")
+        clines, _, _ = read_compare_lines(proc)
+        err_hdr = cmp_hdr == "cpython_error"
+        err_log = any("compare_fanout_failed" in l and "returning=native" in l for l in clines)
+        # SAFETY: a shadow-upstream failure must NEVER 5xx the user — native body, 200.
+        ok = ks == 200 and kbody == "ping-native" and err_hdr and err_log
+        print(f"  [{'OK' if ok else 'FAIL'}] CPYTHON_ERROR (dead upstream): "
+              f"status={ks} returned={kbody!r} X-Form-Compare={cmp_hdr!r} "
+              f"(shadow failure -> NATIVE, no 5xx)")
+        for l in clines:
+            print(f"        {l}")
+        if not ok:
+            failures.append(("compare-stub-cpython-error", ks, kbody, cmp_hdr, err_log))
+
+        # ---- NORMAL MODE: compare UNSET -> native served+returned, no header/log ----
+        httpd, sport = serve_stub(b"would-be-cpython")
+        kport = free_port()
+        env = dict(os.environ)
+        env.pop("COH_ROUTER_COMPARE", None)
+        nproc = subprocess.Popen(
+            [str(BIN), "serve", "--port", str(kport), "--routes", routes_path,
+             "--upstream", f"http://127.0.0.1:{sport}"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, text=True,
+        )
+        wait_for_port(kport)
+        time.sleep(0.3)
+        ks, kbody, khdrs = http_get(f"http://127.0.0.1:{kport}/ping")
+        cmp_hdr = khdrs.get("x-form-compare")
+        router_hdr = khdrs.get("x-form-router")
+        clines, _, nerr = read_compare_lines(nproc)
+        httpd.shutdown()
+        ok = (ks == 200 and kbody == "ping-native" and router_hdr == "native-kernel"
+              and cmp_hdr is None and not clines
+              and not any("COMPARE mode ON" in l for l in nerr.splitlines()))
+        print(f"  [{'OK' if ok else 'FAIL'}] NORMAL MODE (compare unset): returned={kbody!r} "
+              f"X-Form-Router={router_hdr!r} X-Form-Compare={cmp_hdr!r} "
+              f"(native unchanged; no [compare] logs={len(clines)})")
+        if not ok:
+            failures.append(("compare-normal-unchanged", ks, kbody, router_hdr, cmp_hdr, len(clines)))
+    finally:
+        try:
+            os.unlink(routes_path)
+        except OSError:
+            pass
+
+
+def compare_oracle_proof(app_base: str, failures: list) -> None:
+    """Compare-mode proof against the REAL CPython app oracle.
+
+    A promoted native route is byte-identical to its CPython twin (the main harness
+    proves this). In compare mode the kernel-router therefore: returns the CPython
+    body (== the native body here), carries X-Form-Compare: matched, and logs a
+    [compare] matched=true line with both native_ms and cpython_ms. This is the
+    return-CPython safety property + the structured log, proven on a REAL route.
+    """
+    print("\n=== COMPARE-MODE PROOF against the REAL CPython app oracle ===")
+    kport = free_port()
+    proc = boot_router_compare(str(ROUTES), app_base, kport)
+    kbase = f"http://127.0.0.1:{kport}"
+    routes = [
+        "/api/utils/coherence_weight?values=10,20,30&threshold=15",
+        "/api/utils/weighted_average?values=0.1,0.2,0.3&weights=0.7,0.2,0.1",
+        "/api/utils/softmax_weights?scores=1.0,3.0,2.0&temperature=0",
+    ]
+    results = []
+    for url in routes:
+        ks, kbody, khdrs = http_get(kbase + url)
+        cmp_hdr = khdrs.get("x-form-compare")
+        os_, obody, _ = http_get(app_base + url)  # the CPython oracle directly
+        results.append((url, ks, kbody, cmp_hdr, os_, obody))
+    clines, _, _ = read_compare_lines(proc)
+
+    for (url, ks, kbody, cmp_hdr, os_, obody) in results:
+        returned_cpython = value_contract(kbody) == value_contract(obody)  # user got CPython
+        matched_hdr = cmp_hdr == "matched"
+        route_path = url.split("?")[0]
+        has_log = any(route_path in l and "matched=true" in l
+                      and "native_ms=" in l and "cpython_ms=" in l for l in clines)
+        ok = ks == 200 and os_ == 200 and returned_cpython and matched_hdr and has_log
+        print(f"  [{'OK' if ok else 'FAIL'}] {url}")
+        print(f"        returned body == CPython oracle: {'YES' if returned_cpython else 'NO'}  "
+              f"X-Form-Compare={cmp_hdr!r}  [compare] matched=true logged: {'YES' if has_log else 'NO'}")
+        if not ok:
+            print(f"        router-body: {kbody}")
+            print(f"        oracle-body: {obody}")
+            failures.append((url, "compare-oracle", ks, os_, cmp_hdr, returned_cpython, has_log))
+    print(f"  ({len([l for l in clines if 'matched=true' in l])} [compare] matched=true lines captured)")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--live", default=None,
                     help="also compare native vs a running api base-url (read-only GET)")
+    ap.add_argument("--compare", action="store_true",
+                    help="run the COMPARE-MODE proof: stub mechanics (matched/mismatch/"
+                         "cpython_error/normal) network-independent + the real-app oracle "
+                         "(returns CPython body, X-Form-Compare: matched, [compare] log)")
     args = ap.parse_args()
 
     if not BIN.exists():
@@ -361,6 +599,58 @@ def main() -> int:
     if not (API_DIR / "app" / "main.py").exists():
         print(f"cannot find the real app at {API_DIR}/app/main.py", file=sys.stderr)
         return 2
+
+    # COMPARE-MODE proof path. The stub mechanics are network-independent (they run
+    # even in a degraded-net sandbox); the real-app oracle proof is attempted but
+    # gracefully SKIPPED if the app cannot boot here (it still runs on CI). This is
+    # a self-contained mode that does not run the full promotion harness.
+    if args.compare:
+        cfailures: list[tuple] = []
+        stub_mechanics_proof(cfailures)
+
+        # Best-effort: boot the REAL app and run the oracle proof. If it does not
+        # come up in this environment, say so and SKIP (CI's environment boots it).
+        app_port = free_port()
+        env = dict(os.environ)
+        env["COH_ENV"] = "dev"
+        (API_DIR / "data").mkdir(exist_ok=True)
+        app_proc = subprocess.Popen(
+            [sys.executable, "-m", "uvicorn", "app.main:app",
+             "--host", "127.0.0.1", "--port", str(app_port), "--log-level", "warning"],
+            cwd=str(API_DIR), env=env,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        app_base = f"http://127.0.0.1:{app_port}"
+        try:
+            try:
+                wait_for_port(app_port, timeout=30.0)
+                wait_for_http(app_base + FANOUT_PATH, timeout=30.0)
+                booted = True
+            except RuntimeError as e:
+                booted = False
+                print(f"\n=== COMPARE-MODE oracle proof SKIPPED: app did not boot here "
+                      f"({e}) — the stub mechanics above prove the compare/log/return-upstream/"
+                      f"header path; CI's Run-API-tests environment boots the app and runs the "
+                      f"oracle proof. ===")
+            if booted:
+                compare_oracle_proof(app_base, cfailures)
+        finally:
+            app_proc.terminate()
+            try:
+                app_proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                app_proc.kill()
+
+        if cfailures:
+            print(f"\nFAIL: {len(cfailures)} compare-mode check(s) did not hold", file=sys.stderr)
+            for f in cfailures:
+                print(f"   {f}", file=sys.stderr)
+            return 1
+        print("\nok — COMPARE MODE proven: matched/mismatch/cpython_error verdicts fire, "
+              "the user always gets the CPython response (or native on a shadow error, never a "
+              "5xx), X-Form-Compare carries the per-request verdict, [compare] logs both "
+              "latencies, and normal mode (compare unset) leaves the native arm unchanged.")
+        return 0
 
     failures: list[tuple] = []
     app_port = free_port()

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -6931,6 +6931,12 @@ fn handle_request(
     upstream: &Option<String>,
     upstream_pool: &mut UpstreamPool,
     router_metrics: &Arc<Mutex<RouterMetrics>>,
+    // COMPARE mode: when true AND an upstream is configured, every NATIVE route is
+    // shadow-compared against the CPython upstream and the upstream's (safe)
+    // response is returned to the client. Read once at startup (cli_serve) and
+    // threaded here like `upstream` — never an env::var per request. The default
+    // (false) leaves the native arm UNCHANGED — the cutover is turning this off.
+    compare: bool,
 ) -> bool {
     // Read the FULL request: the header block, then exactly Content-Length body
     // bytes if present (read_request honors Content-Length across as many socket
@@ -6984,8 +6990,12 @@ fn handle_request(
     // The router decision: a path with a native Form handler is served
     // entirely in the kernel; a path with no handler fans out to the
     // Python upstream (if --upstream is set) or 404s.
-    let body: String;
-    let status: String;
+    // `body`/`status` are `mut` because COMPARE mode replaces the native response
+    // with the captured CPython response after the shadow comparison (the safety
+    // property: the user gets exactly what direct-CPython would serve). Without
+    // compare mode they are assigned exactly once per arm, as before.
+    let mut body: String;
+    let mut status: String;
     let router: &str;
     // The response's Content-Type for the BUFFERED arms (native / 404). The
     // fan-out arm streams and returns early — it relays the upstream's Content-Type
@@ -7076,6 +7086,12 @@ fn handle_request(
             );
             return false; // close — the oversized request was fully read; drop it
         }
+        // Time the native serve (the eval walk + the response build below) so
+        // compare mode can report native_ms vs cpython_ms on the SAME request.
+        // The timer is started even when compare is off — an Instant::now() is a
+        // few nanoseconds and keeps the timed region a single shape — but it is
+        // only READ inside the compare block.
+        let native_started = Instant::now();
         let result = walk(k, arena, cl.body, call_frame);
         router = "native-kernel";
         // A native handler can return the first-class KernelHTTPResponse cell:
@@ -7110,6 +7126,99 @@ fn handle_request(
             if let Some(c) = body.trim_start().as_bytes().first() {
                 if *c == b'{' || *c == b'[' {
                     resp_content_type = "application/json".to_string();
+                }
+            }
+        }
+        // COMPARE MODE: the native arm just served this route from the kernel. When
+        // compare is on AND an upstream is configured, shadow-fan-out the SAME
+        // request to the CPython upstream, compare the two responses byte-for-byte,
+        // LOG one structured line, and RETURN THE CPYTHON RESPONSE — so the user
+        // gets exactly what direct-CPython would serve (ZERO behavior change; this
+        // is the safety property that makes the front-door insertion risk-free). The
+        // cutover is literally turning compare off: then this whole block is skipped
+        // and the native response above is returned unchanged.
+        if compare {
+            if let Some(upstream_base) = upstream {
+                let native_ms = native_started.elapsed().as_secs_f64() * 1000.0;
+                let native_status = status.clone();
+                let native_body = body.clone();
+                let cpython_started = Instant::now();
+                match fanout_capture(
+                    upstream_base,
+                    &method,
+                    &target,
+                    &req_headers,
+                    &body_bytes,
+                    upstream_pool,
+                ) {
+                    Ok(captured) => {
+                        let cpython_ms = cpython_started.elapsed().as_secs_f64() * 1000.0;
+                        let status_match = native_status == captured.status;
+                        let body_match = native_body.as_bytes() == captured.body.as_slice();
+                        let matched = status_match && body_match;
+                        // ONE greppable structured line to stdout (docker logs
+                        // capture it). On a mismatch a bounded diff snippet follows
+                        // so a divergence is debuggable without flooding.
+                        println!(
+                            "[compare] route={} matched={} status_native={:?} status_cpython={:?} \
+                             status_match={} body_match={} native_ms={:.2} cpython_ms={:.2} \
+                             nbytes={} cbytes={}",
+                            path,
+                            matched,
+                            native_status,
+                            captured.status,
+                            status_match,
+                            body_match,
+                            native_ms,
+                            cpython_ms,
+                            native_body.as_bytes().len(),
+                            captured.body.len(),
+                        );
+                        if !matched {
+                            println!(
+                                "[compare] route={} mismatch_native_snippet={:?}",
+                                path,
+                                compare_snippet(native_body.as_bytes()),
+                            );
+                            println!(
+                                "[compare] route={} mismatch_cpython_snippet={:?}",
+                                path,
+                                compare_snippet(&captured.body),
+                            );
+                        }
+                        // RETURN CPYTHON'S RESPONSE (the safety property): replace
+                        // the native status/body with the captured upstream
+                        // response. The Content-Type is re-derived from the
+                        // returned body so a JSON body keeps application/json. The
+                        // X-Form-Compare header carries the verdict so an external
+                        // monitor can read it per-request without parsing logs.
+                        status = captured.status;
+                        body = String::from_utf8_lossy(&captured.body).to_string();
+                        resp_content_type = String::new();
+                        if let Some(c) = body.trim_start().as_bytes().first() {
+                            if *c == b'{' || *c == b'[' {
+                                resp_content_type = "application/json".to_string();
+                            }
+                        }
+                        resp_headers.push((
+                            "X-Form-Compare".to_string(),
+                            if matched { "matched" } else { "mismatch" }.to_string(),
+                        ));
+                    }
+                    Err(e) => {
+                        // The shadow upstream hiccuped. NEVER 5xx the user for a
+                        // shadow failure — fall back to the NATIVE response (already
+                        // in status/body) and log the failure. X-Form-Compare reports
+                        // cpython_error so a monitor sees the shadow gap.
+                        let (_status, msg) = fanout_error_response(&e);
+                        println!(
+                            "[compare] route={} compare_fanout_failed error={:?} \
+                             native_ms={:.2} returning=native",
+                            path, msg, native_ms,
+                        );
+                        resp_headers
+                            .push(("X-Form-Compare".to_string(), "cpython_error".to_string()));
+                    }
                 }
             }
         }
@@ -7311,6 +7420,7 @@ fn serve_connection(
     upstream: &Option<String>,
     upstream_pool: &mut UpstreamPool,
     router_metrics: &Arc<Mutex<RouterMetrics>>,
+    compare: bool,
 ) {
     // Idle timeout so a held-open keep-alive connection cannot starve the pool.
     let _ = stream.set_read_timeout(Some(KEEPALIVE_IDLE_TIMEOUT));
@@ -7339,6 +7449,7 @@ fn serve_connection(
         upstream,
         upstream_pool,
         router_metrics,
+        compare,
     ) {}
 }
 
@@ -7356,6 +7467,9 @@ fn worker_loop(
     upstream: Arc<Option<String>>,
     rx: Arc<Mutex<mpsc::Receiver<TcpStream>>>,
     router_metrics: Arc<Mutex<RouterMetrics>>,
+    // COMPARE mode, decided once at startup (cli_serve reads COH_ROUTER_COMPARE) and
+    // copied into each worker. A plain bool — it does not change per request.
+    compare: bool,
 ) {
     let (mut k, mut arena, route_specs) =
         match build_worker_kernel_with_route_data(&program, &routes_path, &route_data) {
@@ -7392,6 +7506,7 @@ fn worker_loop(
                 &upstream,
                 &mut upstream_pool,
                 &router_metrics,
+                compare,
             ),
             // Sender dropped (listener closed) — drain done, worker exits.
             Err(_) => return,
@@ -7898,6 +8013,22 @@ fn cli_serve(args: &[String]) -> i32 {
             }
         }
     }
+    // COMPARE mode, read ONCE here at startup (never env::var per request). When
+    // COH_ROUTER_COMPARE is set ("1"/"true", case-insensitive) AND an upstream is
+    // configured, every NATIVE route is shadow-compared against the CPython upstream
+    // and the CPython (safe) response is returned to the client — divergence,
+    // latency, and downtime are measured on LIVE traffic before any cutover, with
+    // ZERO behavior change (the user always gets exactly CPython's response). The
+    // cutover is literally turning this off: unset COH_ROUTER_COMPARE and the native
+    // arm serves+returns native, no fan-out, no overhead. Compare mode with no
+    // upstream configured is inert (there is nothing to compare against).
+    let compare = match env::var("COH_ROUTER_COMPARE") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        }
+        Err(_) => false,
+    };
     let routes_path = match routes_path {
         Some(p) => p,
         None => {
@@ -8013,6 +8144,7 @@ fn cli_serve(args: &[String]) -> i32 {
                 upstream,
                 rx,
                 router_metrics,
+                compare,
             );
         }) {
             Ok(h) => handles.push(h),
@@ -8053,6 +8185,24 @@ fn cli_serve(args: &[String]) -> i32 {
     match upstream_arc.as_ref() {
         Some(u) => eprintln!("  *  -> fan-out to Python upstream {}", u),
         None => eprintln!("  *  -> 404 (no --upstream; fan-out arm inactive)"),
+    }
+    // COMPARE-mode banner: make the shadow-comparison state visible at startup so an
+    // operator reading the logs knows whether native routes are being compared (and
+    // CPython returned) or served+returned natively. Compare needs an upstream to
+    // compare against; with none it is inert.
+    if compare {
+        match upstream_arc.as_ref() {
+            Some(u) => eprintln!(
+                "  COMPARE mode ON: native routes shadow-compared against {} and CPython's \
+                 response returned (X-Form-Compare: matched|mismatch|cpython_error; grep [compare] \
+                 in the logs). Cutover = unset COH_ROUTER_COMPARE.",
+                u
+            ),
+            None => eprintln!(
+                "  COMPARE mode requested but INERT: COH_ROUTER_COMPARE is set with no --upstream \
+                 to compare against; native routes serve+return native."
+            ),
+        }
     }
 
     // The accept loop is now thin: it only hands each accepted stream to the
@@ -9373,6 +9523,43 @@ mod route_spec_tests {
     }
 }
 
+#[cfg(test)]
+mod compare_mode_tests {
+    use super::*;
+
+    // The strange-minimal de-chunk case: a two-chunk body whose stream is SPLIT mid
+    // chunk-size-line across two feeds (the over-read hazard the streaming relay
+    // also faces). One assertion proves feed_collecting decodes the payload (size
+    // lines + CRLFs dropped), stops at the terminating 0-chunk, and survives the
+    // boundary split — the same ChunkParser engine the streaming relay uses, now
+    // collecting the decoded body for the buffered compare capture.
+    #[test]
+    fn feed_collecting_dechunks_across_a_split_boundary() {
+        // "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n" decodes to "hello world".
+        let full = b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+        // Split mid-stream — partway through the second chunk's size line — so the
+        // parser must carry partial framing across the two feeds.
+        let split = 11; // inside "6\r\n world" framing
+        let mut parser = ChunkParser::new();
+        let mut body = Vec::new();
+        assert_eq!(parser.feed_collecting(&full[..split], &mut body).unwrap(), false);
+        assert_eq!(parser.feed_collecting(&full[split..], &mut body).unwrap(), true);
+        assert_eq!(body, b"hello world");
+    }
+
+    // compare_snippet bounds the mismatch diff: a body under the cap returns whole,
+    // a body over it is truncated with a marker — so a divergence log never floods.
+    #[test]
+    fn compare_snippet_bounds_the_diff() {
+        assert_eq!(compare_snippet(b"short body"), "short body");
+        let big = vec![b'x'; 500];
+        let snip = compare_snippet(&big);
+        assert!(snip.starts_with(&"x".repeat(200)));
+        assert!(snip.ends_with("…(truncated)"));
+        assert!(snip.len() < 500); // bounded, not the whole 500-byte body
+    }
+}
+
 fn url_decode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let bytes = s.as_bytes();
@@ -9800,10 +9987,33 @@ impl ChunkParser {
         }
     }
 
-    // Feed the next slice of relayed bytes. Returns Ok(true) when the terminating
-    // 0-length chunk + trailer have been fully consumed (the body is complete), else
-    // Ok(false) (more bytes expected). A malformed size line is an Other error.
-    fn feed(&mut self, mut data: &[u8]) -> Result<bool, FanoutError> {
+    // Feed the next slice of relayed bytes for BOUNDARY tracking only (the streaming
+    // relay path: the bytes are written to the client raw, this parser just finds
+    // where the terminating 0-chunk is). Returns Ok(true) when the body is complete.
+    fn feed(&mut self, data: &[u8]) -> Result<bool, FanoutError> {
+        self.feed_inner(data, None)
+    }
+
+    // Feed the next slice and COLLECT the decoded DATA bytes into `sink` (the
+    // buffered de-chunk path: compare mode reads the whole body into memory). The
+    // chunk size-lines, CRLFs, and trailer are consumed but NOT appended — only the
+    // payload bytes — so the result is the decoded body, byte-for-byte comparable to
+    // a Content-Length body. Same engine as `feed`; collection is a parameter, not a
+    // parallel parser (core-abstraction-first).
+    fn feed_collecting(&mut self, data: &[u8], sink: &mut Vec<u8>) -> Result<bool, FanoutError> {
+        self.feed_inner(data, Some(sink))
+    }
+
+    // The ONE chunked-framing engine. Tracks chunk boundaries to the true
+    // terminating 0-length chunk; when `sink` is Some, appends the DATA-phase bytes
+    // it walks over (the decoded payload) to it. Returns Ok(true) when the
+    // terminating 0-length chunk + trailer have been fully consumed, else Ok(false).
+    // A malformed size line is an Other error.
+    fn feed_inner(
+        &mut self,
+        mut data: &[u8],
+        mut sink: Option<&mut Vec<u8>>,
+    ) -> Result<bool, FanoutError> {
         // A chunk-size / trailer line longer than this is treated as malformed — a
         // real size line is a handful of bytes; this only guards against a runaway
         // upstream, it is not a body-size limit (the body itself never lands here).
@@ -9835,6 +10045,10 @@ impl ChunkParser {
                 }
                 ChunkPhase::Data { remaining } => {
                     let take = remaining.min(data.len());
+                    // Collect the decoded payload bytes when a sink is present.
+                    if let Some(s) = sink.as_deref_mut() {
+                        s.extend_from_slice(&data[..take]);
+                    }
                     data = &data[take..];
                     let left = remaining - take;
                     self.phase = if left == 0 {
@@ -10320,6 +10534,258 @@ fn fanout_stream_to_client(
         // outcome. The upstream connection is dropped (not pooled).
         Err(_) => false,
     }
+}
+
+// A bounded, lossy-UTF-8 view of the FIRST ~200 bytes of a body, for the compare
+// mismatch diff. The {:?} debug of the returned String escapes control bytes, so a
+// divergence is legible in one log line without flooding (a large body's tail is
+// dropped) and without raw control characters breaking the log stream.
+fn compare_snippet(bytes: &[u8]) -> String {
+    const SNIPPET_BYTES: usize = 200;
+    let take = bytes.len().min(SNIPPET_BYTES);
+    let mut s = String::from_utf8_lossy(&bytes[..take]).to_string();
+    if bytes.len() > take {
+        s.push_str("…(truncated)");
+    }
+    s
+}
+
+// The fully-BUFFERED capture of one upstream response — status line + body bytes,
+// held whole in memory. This is the COMPARE-mode shadow read: the native arm has
+// already served the request from the kernel; compare mode then issues the SAME
+// request to the CPython upstream and captures its complete response so the two
+// can be compared byte-for-byte AND the (safe) CPython body returned to the
+// client. Unlike `fanout_stream_to_client`, this NEVER touches the client socket
+// — it only reads the upstream — and it holds the body whole (the compute routes
+// return tiny bodies, so buffering is the right shape here; streaming is for the
+// unbounded fan-out tail). The status string is the upstream's exact status line
+// (e.g. "200 OK"); body is the raw bytes for an exact `==` compare against the
+// native body.
+struct CapturedResp {
+    status: String,
+    body: Vec<u8>,
+}
+
+// Read the FULL body of one upstream response into memory, given the head's
+// framing. This is the buffered twin of `stream_body_to_client`: same framing
+// decisions (Length reads exactly `n` bytes; Chunked de-chunks to the true
+// terminating 0-length chunk; Close reads to EOF), but it ACCUMULATES the body
+// into a Vec instead of piping it to a client. `body_prefix` is the leading body
+// bytes that arrived alongside the head terminator (the head read's natural
+// over-read) — they seed the buffer. The response shape limit bounds the held
+// body so a runaway upstream cannot exhaust the worker. The de-chunked body is
+// the DECODED payload (chunk size-lines and CRLFs removed), so it compares
+// byte-for-byte against a native body the same way a Content-Length body does.
+//
+// Returns `(body, leftover)`. `leftover` is any prefix bytes past the framed end
+// of a Length-framed body — the NEXT response on a reused connection — mirroring
+// the streaming path's `BodyOutcome.leftover`, so the pooled connection's carry
+// stays correct even if the head read over-read into a pipelined next response.
+// (Compare mode is strictly serial, so this is normally empty; carrying it keeps
+// the buffered path as correct as the streaming one rather than relying on that.)
+// Chunked and Close bodies pool nothing, so their leftover is always empty.
+fn read_body_fully(
+    stream: &mut TcpStream,
+    framing: &ResponseFraming,
+    body_prefix: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), FanoutError> {
+    let limit = response_shape_limit();
+    let mut buf = [0u8; 65536];
+    match *framing {
+        ResponseFraming::Length(total) => {
+            let mut body = Vec::with_capacity(total.min(limit));
+            let from_prefix = body_prefix.len().min(total);
+            body.extend_from_slice(&body_prefix[..from_prefix]);
+            // Any prefix bytes past `total` are the NEXT response (over-read by the
+            // head read) — carried, never part of this body.
+            let leftover: Vec<u8> = if body_prefix.len() > total {
+                body_prefix[total..].to_vec()
+            } else {
+                Vec::new()
+            };
+            while body.len() < total {
+                let want = (total - body.len()).min(buf.len());
+                match stream.read(&mut buf[..want]) {
+                    Ok(0) => {
+                        return Err(FanoutError::Other(
+                            "upstream closed mid-body (short Content-Length read)".to_string(),
+                        ))
+                    }
+                    Ok(n) => body.extend_from_slice(&buf[..n]),
+                    Err(e) => return Err(classify_io_error(&e, "read upstream response body")),
+                }
+            }
+            Ok((body, leftover))
+        }
+        ResponseFraming::Chunked => {
+            // De-chunk into the decoded payload: feed every byte (prefix first,
+            // then socket reads) through the same boundary-tracking ChunkParser the
+            // streaming relay uses, but collect the DATA bytes it reports instead of
+            // relaying them raw. Stops at the true terminating 0-length chunk.
+            let mut parser = ChunkParser::new();
+            let mut body: Vec<u8> = Vec::new();
+            let mut feed = |bytes: &[u8], body: &mut Vec<u8>| -> Result<bool, FanoutError> {
+                let done = parser.feed_collecting(bytes, body)?;
+                if body.len() > limit {
+                    return Err(FanoutError::Other(format!(
+                        "upstream chunked body is larger than we can hold right now \
+                         ({} bytes observed, threshold {})",
+                        body.len(),
+                        limit,
+                    )));
+                }
+                Ok(done)
+            };
+            if !body_prefix.is_empty() && feed(body_prefix, &mut body)? {
+                return Ok((body, Vec::new()));
+            }
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break, // upstream closed — best-effort end of relay
+                    Ok(n) => {
+                        if feed(&buf[..n], &mut body)? {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        return Err(classify_io_error(&e, "read upstream chunked response body"))
+                    }
+                }
+            }
+            // Chunked connections are never pooled (matching the streaming path), so
+            // no leftover needs carrying.
+            Ok((body, Vec::new()))
+        }
+        ResponseFraming::Close => {
+            let mut body: Vec<u8> = body_prefix.to_vec();
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break, // EOF marks the end of an unframed body
+                    Ok(n) => {
+                        body.extend_from_slice(&buf[..n]);
+                        if body.len() > limit {
+                            return Err(FanoutError::Other(format!(
+                                "upstream unframed body is larger than we can hold right now \
+                                 ({} bytes observed, threshold {})",
+                                body.len(),
+                                limit,
+                            )));
+                        }
+                    }
+                    Err(e) => {
+                        return Err(classify_io_error(
+                            &e,
+                            "read upstream response body (to close)",
+                        ))
+                    }
+                }
+            }
+            // A close-framed connection ends at EOF and is never pooled, so there
+            // is no next-response leftover to carry.
+            Ok((body, Vec::new()))
+        }
+    }
+}
+
+// COMPARE-mode fan-out: issue the SAME request the native arm just served to the
+// CPython upstream and CAPTURE its full response (status + body bytes) into
+// memory, WITHOUT touching the client socket. This reuses the exact upstream-hop
+// machinery `fanout_stream_to_client` uses — `parse_http_upstream`, the request
+// build (Host rewrite + client end-to-end headers forwarded), the per-worker
+// `UpstreamPool` keep-alive connection with the stale-pool reconnect+retry-once,
+// `connect_upstream_with_timeout`'s bounded connect/read/write deadlines,
+// `read_upstream_head` — so the shadow read is the SAME hop the cutover will use,
+// not a second code path (core-abstraction-first). The difference is the tail: it
+// READS the whole body into memory (`read_body_fully`) instead of piping it to a
+// client. On any upstream error it returns the FanoutError so the caller can fall
+// back to the native response (the shadow upstream hiccuping must never 5xx the
+// user). The captured connection is pooled IFF the upstream kept it alive AND the
+// body was Length-framed (the same reuse rule the streaming path applies).
+fn fanout_capture(
+    upstream: &str,
+    method: &str,
+    target: &str,
+    req_headers: &[(String, String)],
+    body: &[u8],
+    pool: &mut UpstreamPool,
+) -> Result<CapturedResp, FanoutError> {
+    let (host, port, base_path) = parse_http_upstream(upstream).map_err(FanoutError::Other)?;
+    let request_target = format!(
+        "{}{}",
+        base_path,
+        if target.starts_with('/') { target } else { "/" }
+    );
+    // Build the upstream request ONCE — reused verbatim for the stale-pool retry.
+    // Identical framing to the streaming path: Host rewritten to the upstream;
+    // Connection: keep-alive so the NEXT hop reuses the connection; the client's
+    // end-to-end headers forwarded (hop-by-hop / router-owned filtered out).
+    let mut head = format!(
+        "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: keep-alive\r\n",
+        method, request_target, host
+    );
+    for (name, value) in req_headers {
+        if forward_request_header(name) {
+            head.push_str(&format!("{}: {}\r\n", name, value));
+        }
+    }
+    if !body.is_empty() {
+        head.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    head.push_str("\r\n");
+    let mut request: Vec<u8> = head.into_bytes();
+    request.extend_from_slice(body);
+
+    // Get-or-create the pooled connection + read the HEAD, with the stale-pool
+    // retry living in the error CLASSIFICATION exactly as the streaming path does:
+    // a Closed pooled connection reconnects and retries the SAME request ONCE; a
+    // Timeout/Other propagates to the caller (which falls back to native).
+    let (mut upstream_stream, head) = match pool.take(&host, port) {
+        Some(mut pooled) => {
+            let carry = std::mem::take(&mut pooled.carry);
+            match send_and_read_head(&mut pooled.stream, &request, carry) {
+                Ok(h) => (pooled.stream, h),
+                Err(FanoutError::Closed(_)) => {
+                    drop(pooled);
+                    let mut fresh = connect_upstream_with_timeout(&host, port)?;
+                    let h = send_and_read_head(&mut fresh, &request, Vec::new())?;
+                    (fresh, h)
+                }
+                Err(e) => {
+                    drop(pooled);
+                    return Err(e);
+                }
+            }
+        }
+        None => {
+            let mut fresh = connect_upstream_with_timeout(&host, port)?;
+            let h = send_and_read_head(&mut fresh, &request, Vec::new())?;
+            (fresh, h)
+        }
+    };
+
+    // Read the full body into memory, then pool the connection IFF it was
+    // Length-framed AND the upstream kept it alive (the same reuse rule the
+    // streaming path applies after the body has moved). A chunked/unframed body is
+    // read correctly but its connection is dropped (never pooled). Any read error
+    // drops the connection and propagates (caller falls back to native).
+    let reusable = matches!(head.framing, ResponseFraming::Length(_));
+    let upstream_kept = head.upstream_keep_alive;
+    let (body_bytes, leftover) =
+        read_body_fully(&mut upstream_stream, &head.framing, &head.body_prefix)?;
+    if reusable && upstream_kept {
+        pool.store(
+            &host,
+            port,
+            PooledConn {
+                stream: upstream_stream,
+                carry: leftover,
+            },
+        );
+    }
+    Ok(CapturedResp {
+        status: head.status,
+        body: body_bytes,
+    })
 }
 
 // Emit a small BUFFERED 504/502 to the client through the ONE emit shape, then

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -328,6 +328,54 @@ long tail of rarely-hit admin routes can stay CPython indefinitely with no cost.
 The honest measure is *fraction of requests (and of CPU-time) served natively*,
 which the `X-Form-Router` header makes directly countable from access logs.
 
+### COMPARE mode — the zero-risk shadow diff before any cutover
+
+Promoting a route from fan-out to native is reversible, but it is still a *change
+of who computes the answer*. COMPARE mode removes the leap entirely: the
+kernel-router runs in front with native routes active, but instead of a one-time
+flip from CPython to the kernel it **self-compares every native route against
+CPython on live traffic and returns CPython's (safe) response** — so divergence,
+latency, and downtime are measured against production traffic *before* the cutover.
+
+A **single env flag** — `COH_ROUTER_COMPARE`, read once at startup (`cli_serve`),
+threaded into `handle_request` like `upstream` — couples *compare* and
+*which-response-to-return*:
+
+- **`COH_ROUTER_COMPARE=1`** (validation): a native route serves from the kernel
+  (timed → `native_ms`), then the **same** request is shadow-fanned-out to the
+  CPython upstream over the same keep-alive `UpstreamPool` and its full response
+  **captured into memory** (timed → `cpython_ms`). The two are compared
+  byte-for-byte; one greppable `[compare]` line is logged to stdout (a bounded diff
+  snippet on a mismatch); and **CPython's response is returned** — zero behavior
+  change (the safety property). A shadow fan-out failure falls back to the native
+  response (a shadow hiccup must never 5xx the user) and logs `compare_fanout_failed`.
+  Every response carries **`X-Form-Compare: matched | mismatch | cpython_error`**
+  alongside `X-Form-Router: native-kernel`, so a monitor reads per-request verdicts
+  without parsing logs.
+- **`COH_ROUTER_COMPARE` unset** (the default *and* the post-validation cutover
+  state): the native arm is **unchanged** — serve native, return native, no fan-out,
+  no overhead. **The cutover is literally turning compare off.**
+
+The buffered capture (`fanout_capture` → `read_body_fully`) reuses the streaming
+fan-out's exact upstream hop (`parse_http_upstream`, the request build, the
+stale-pool reconnect+retry, `connect_upstream_with_timeout`, `read_upstream_head`)
+and differs only in the tail — it reads the whole (small, compute-route) body into
+memory instead of piping it. The chunked path shares the streaming relay's
+boundary-tracking `ChunkParser`, collecting the decoded payload through the same
+engine (`feed_collecting`).
+
+Reading divergence: the `X-Form-Compare` header per request, `grep [compare]` in
+`docker logs`, or [`deploy/kernel-router/compare_summary.py`](../deploy/kernel-router/compare_summary.py)
+to fold the log into a per-route table (count, mismatch, cpython_error, p50
+native_ms vs cpython_ms). The full design, the one-flag toggle, and the safe
+rollout live in [`deploy/kernel-router/COMPARE_MODE.md`](../deploy/kernel-router/COMPARE_MODE.md);
+the mechanics are proven by `production_routes_harness.py --compare` (stub verdicts,
+network-independent, + the real-app oracle).
+
+COMPARE mode and the Traefik flip are **independent** reversible steps: run compare
+behind a shadow port → watch the log clean → cut compare off → (separately) flip
+Traefik onto the router. Each rolls back on its own.
+
 ## Proof-of-shape — what is demonstrated, and what it is not
 
 A family of harnesses proves the shape against a mock CPython upstream — routing,


### PR DESCRIPTION
## The idea (Urs's): dual-run + compare, instead of a risky flip

Rather than a one-time leap from CPython to the kernel-router as the front door, the router runs **in front and self-compares** — so divergence, latency, and downtime are measured on *live* traffic before any cutover, and the cutover becomes a single env toggle, not a leap.

## One flag couples compare + safety

`COH_ROUTER_COMPARE=1` → for each native route, the router serves it natively **and** buffered-fans-out the same request to CPython, diffs the two, logs the verdict + both latencies, and **returns CPython's response**. So inserting the router changes *nothing the user sees* (behaviorally CPython), while every native route is validated against CPython on real traffic. **The cutover is literally turning the flag off** — the native arm then serves native, now *proven* by the shadow phase.

## Mechanics — proven network-independent (harness `--compare`, stub upstream)

Verified with my own eyes (no app/prod needed):
- **MISMATCH** → returns CPython's body, `X-Form-Compare: mismatch`, `[compare]` log with `native_ms`/`cpython_ms` + bounded diff snippets. **User gets CPython.**
- **MATCHED** → `X-Form-Compare: matched`, `body_match=true`.
- **CPYTHON_ERROR** (dead/slow upstream) → falls back to **native, no 5xx** — a shadow failure never breaks the user. `X-Form-Compare: cpython_error`.
- **NORMAL** (flag unset) → native arm untouched, no fan-out, no `[compare]` logs, zero overhead.

## Implementation

- `main.rs`: a buffered fan-out (`fanout_capture`/`read_body_fully`/`CapturedResp`, with chunked-dechunk handling) reuses the existing upstream connect + timeouts; the compare block sits in the **native arm only** (fan-out routes are already CPython). The flag is read **once at startup** in `cli_serve` and threaded into `handle_request` — no per-request env lookup. **Serve-path only; Form eval untouched** (three-way parity unaffected — validate.sh shows no *new* divergence; the one local `source-language-route-class-template-band` divergence is the known broken-local-source-compiler artifact, unrelated, and passes in CI).
- `deploy/kernel-router/`: `COMPARE_MODE.md` (design, the one-flag toggle, reading divergence via the `[compare]` log or `X-Form-Compare` header, the safe rollout), `compare_summary.py` (aggregates `[compare]` lines → per-route count/mismatch/p50-latency), and compose/entrypoint/Dockerfile wired for the flag.

## Not deployed

The Traefik re-point + running it beside the api on the VPS is **your go** (a two-person live-traffic moment) and SSH-gated from here. The config is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)