### PR TITLE
tend(form-http): lift the Response and Request classes into the BML hierarchy

### DIFF
--- a/form/form-stdlib/http-parse.fk
+++ b/form/form-stdlib/http-parse.fk
@@ -26,8 +26,9 @@
 ;     (http-headers  req-node)  → list of HEADER recipes
 ;     (http-body     req-node)  → string
 ;
-; Input shape (lines separated by \n; real HTTP uses \r\n but for
-; simplicity we accept \n):
+; Input shape (lines separated by \r\n or \n; real HTTP uses CRLF, whose
+; trailing \r the parser strips at each line end, so a bare-\n request
+; parses identically):
 ;
 ;   GET /api/health HTTP/1.1\n
 ;   Host: example.com\n
@@ -68,6 +69,18 @@
 ;; http-find-char — index of `needle` (a single-char string) starting
 ;; at `from`, or -1 if absent. Thin wrapper for readability.
 (defn http-find-char (s needle from) (str_find s needle from))
+
+;; http-line-end — the CONTENT end of a line whose terminating '\n' is at
+;; index `nl`, content starting at `i`. Real HTTP separates lines with CRLF;
+;; if the byte just before the '\n' is '\r' (ASCII 13), the content ends one
+;; earlier, so the '\r' never leaks into a method/version/header token and a
+;; CRLF blank line reads as genuinely empty. A bare '\n' line is unchanged —
+;; the parser accepts both wire shapes. The `(lt i nl)` guard keeps us from
+;; reading before the line's own start on an empty line.
+(defn http-line-end (s i nl)
+    (if (lt i nl)
+        (if (eq (ord (char_at s (sub nl 1))) 13) (sub nl 1) nl)
+        nl))
 
 ;; http-skip-space-once — when char at index `i` is ASCII space (32),
 ;; advance one position; otherwise return i. The HTTP header grammar
@@ -138,12 +151,16 @@
 (defn http-collect-headers-loop (s i acc)
     (do
         (let nl (http-find-newline s i))
-        (if (eq nl i)
-            ;; blank line — headers done; body starts after this \n.
+        (let ce (http-line-end s i nl))
+        (if (eq ce i)
+            ;; blank line (empty content — bare \n or a lone \r before \n);
+            ;; headers done; body starts after this \n.
             (list (http-headers-from-list (http-reverse acc))
                   (if (lt nl (str_len s)) (add nl 1) nl))
             (do
-                (let header (http-parse-header-line s i nl))
+                ;; parse to the CONTENT end (ce), so a trailing \r is excluded
+                ;; from the header value rather than collected as part of it.
+                (let header (http-parse-header-line s i ce))
                 (let next-i (if (lt nl (str_len s)) (add nl 1) nl))
                 (if (eq nl (str_len s))
                     ;; reached end-of-input with no blank line —
@@ -173,7 +190,10 @@
         (if (eq line1-end 0)
             (http-error)
             (do
-                (let parts (http-parse-request-line s line1-end))
+                ;; parse the request line to its CONTENT end, so a CRLF
+                ;; version token ("HTTP/1.1\r") sheds its trailing \r.
+                (let line1-ce (http-line-end s 0 line1-end))
+                (let parts (http-parse-request-line s line1-ce))
                 (if (eq (len parts) 0)
                     ;; request-line parser already returned an error sentinel.
                     parts

--- a/form/form-stdlib/http-render.fk
+++ b/form/form-stdlib/http-render.fk
@@ -1,0 +1,113 @@
+; http-render.fk — render a kh-response value into an HTTP/1.1 wire string.
+;
+; preludes: form-stdlib/kernel-http.fk
+;
+; THE PRINCIPLE (Urs): data and strings do not belong in recipes; only flow
+; and choice do. This file is the Response-layer proof of that principle. The
+; thing it replaces — http-serve.fk's hs-build-response / hs-reason /
+; hs-content-type — froze the data INTO the control flow: status phrases as a
+; nested if-chain, MIME types as a nested if-chain, the wire format as a
+; ten-deep str_concat with the header strings welded in. To add a status code
+; you edited code; to add a content-type you edited code; the framing could not
+; be inspected or extended without rewriting it.
+;
+; Here the data is DATA — a token-efficient lookup table — and ONE generic
+; recipe renders any kh-response by walking its header list. Adding a status
+; phrase or a MIME rule is appending a row. Changing the framing is changing
+; the render recipe, which contains no domain strings, only structure.
+;
+; Layering: a kh-response (kernel-http.fk) carries (status, headers, body),
+; where headers is a list of kh-header (name, value). The render walks that
+; list — Content-Type / Content-Length / X-Form-Router are kh-header DATA the
+; caller attaches, NOT literals baked into the framing. The status line pulls
+; its reason phrase from the status table. The result is the wire string.
+;
+; What stays a recipe (flow/choice): the status line shape "HTTP/1.1 c r\r\n",
+; the per-header "name: value\r\n" shape, the blank-line terminator, the lookup
+; walks. What is data: every status code↔phrase, the body-prefix↔MIME rules,
+; and the headers themselves (as kh-header values on the response).
+
+section [form.bml] {
+
+    ;; ---- the status table : code -> reason phrase (DATA) -------------
+    ;; A list of (code phrase) rows. To teach the server a new status, add a
+    ;; row — no recipe changes. The phrase is courtesy; the integer carries the
+    ;; meaning, so an unlisted code still renders (with a neutral phrase) rather
+    ;; than failing. Ordered by how often these handlers actually answer.
+    ;; (Single-line: the local source-compiler compiles calls that span lines
+    ;; wrong — `list(` + newline becomes `list()` with the rows left raw. So the
+    ;; rows live on one line, the body's proven idiom; iteration #7 — teaching
+    ;; the compiler multi-line calls — is what lets this table breathe vertically.)
+    let kh-status-table = list(list(200, "OK"), list(400, "Bad Request"), list(404, "Not Found"), list(422, "Unprocessable Entity"), list(500, "Internal Server Error"));
+
+    ;; generic table lookup: first row whose head equals `key` -> its second
+    ;; element; `fallback` when no row matches — the status table's lookup walk.
+    ;; (Keyed by eq on integer status codes; string-keyed lookup would need
+    ;; str_eq, since the kernels disagree on eq over strings — which is why the
+    ;; content-type default below is a constant, not a sniffed table.)
+    def kh-lookup(table, key, fallback) = if nil?(table) then fallback else if eq(nth(head(table), 0), key) then nth(head(table), 1) else kh-lookup(tail(table), key, fallback);
+
+    ;; reason phrase for a status code, from the table. Unlisted -> "Status"
+    ;; (neutral, honest — the code is what the client keys on).
+    def kh-reason(code) = kh-lookup(kh-status-table, code, "Status");
+
+    ;; ---- the default content-type (DATA) -----------------------------
+    ;; The framing supplies a Content-Type ONLY when the handler declared none.
+    ;; The handler knows its body's type — JSON, html, an image — and says so by
+    ;; attaching a kh-header; the render walks whatever it attached. Sniffing the
+    ;; body's first byte to guess the type was a fragile heuristic (a JSON string
+    ;; body opens with '"', a number with a digit) AND leaned on eq over string
+    ;; keys, where the sibling kernels disagree. So the default is one honest
+    ;; constant: when no type is declared the bytes are opaque, and text/plain is
+    ;; the safe, non-executable label a browser will not run.
+    let kh-default-content-type = "text/plain";
+
+    ;; ---- render : kh-response -> wire string (generic) ---------------
+    ;; Walk the header list, emitting "name: value\r\n" per kh-header. No header
+    ;; name is hardcoded here — the caller decides which headers the response
+    ;; carries by building them as kh-header DATA. This is the whole reason the
+    ;; framing is now extensible: a new header is a value, not an edit.
+    def kh-render-headers(headers) = if nil?(headers) then "" else str_concat(str_concat(kh-header-name(head(headers)), str_concat(": ", str_concat(kh-header-value(head(headers)), "\r\n"))), kh-render-headers(tail(headers)));
+
+    ;; the status line: "HTTP/1.1 <code> <reason>\r\n". int_to_str renders the
+    ;; code as portable digits (no Rust-only value_str on the framing path).
+    def kh-status-line(code) = str_concat("HTTP/1.1 ", str_concat(int_to_str(code), str_concat(" ", str_concat(kh-reason(code), "\r\n"))));
+
+    ;; (kh-response-render response) -> the full HTTP/1.1 wire STRING.
+    ;; status line + rendered headers + blank line + body. The response's
+    ;; headers list IS the wire header block — Content-Type/Content-Length/
+    ;; X-Form-Router are expected to be present on it as kh-header data (see
+    ;; kh-response-finalize, which attaches the framing headers a handler did
+    ;; not). Pure: a value in, a string out; no I/O, three-way-identical.
+    def kh-response-render(response) = str_concat(kh-status-line(kh-response-status(response)), str_concat(kh-render-headers(kh-response-headers(response)), str_concat("\r\n", kh-response-body(response))));
+
+    ;; (kh-response-finalize response) -> a kh-response with the transport
+    ;; framing headers attached: Content-Type (the default, unless the response
+    ;; already declares one), Content-Length (the body's byte length), and
+    ;; X-Form-Router: native-kernel (honest provenance). A handler builds a
+    ;; kh-response with its OWN semantic headers (or none); finalize adds the
+    ;; framing the wire requires, so the handler never concerns itself with
+    ;; Content-Length. Idempotent on Content-Type: if the handler set one,
+    ;; kh-header-present? leaves it.
+    def kh-response-finalize(response) {
+        let status = kh-response-status(response);
+        let headers = kh-response-headers(response);
+        let body = kh-response-body(response);
+        ;; cons builds a stack — to render in the order Content-Type,
+        ;; Content-Length, X-Form-Router (then the handler's own headers), cons
+        ;; in reverse: X-Form-Router first (innermost), Content-Type last
+        ;; (outermost). Content-Type is left to the handler if it already set one.
+        let with_router = cons(kh-header("X-Form-Router", "native-kernel"), headers);
+        let with_cl = cons(kh-header("Content-Length", int_to_str(str_len(body))), with_router);
+        let with_ct = if kh-header-present?(with_cl, "Content-Type") then with_cl else cons(kh-header("Content-Type", kh-default-content-type), with_cl);
+        kh-response(status, with_ct, body);
+    }
+
+    ;; (kh-serve-response response) -> the wire string for a handler response:
+    ;; finalize (attach framing headers) then render. This is the Response
+    ;; layer's single public entry — a handler returns a kh-response, this is
+    ;; what reaches the socket.
+    def kh-serve-response(response) = kh-response-render(kh-response-finalize(response));
+
+    0;
+}

--- a/form/form-stdlib/http-request.fk
+++ b/form/form-stdlib/http-request.fk
@@ -1,0 +1,78 @@
+; http-request.fk — lift a raw HTTP/1.1 request string into a kh-request value.
+;
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk
+;
+; THE PRINCIPLE (Urs): the engine speaks the Request CLASS, not an ad-hoc tree.
+; http-parse.fk is the lexer — it walks the wire bytes into a substrate node.
+; This adapter lifts that node into kh-request (kernel-http.fk's Request class),
+; the value the Router (kh-select-route-candidate-for-request) and the handlers
+; consume. Parse is transport; kh-request is the domain. The boundary is here,
+; named, so neither side reaches across it.
+;
+; kh-request(method, path, headers, query, body):
+;   method  — the request method string ("GET" …).
+;   path    — the PATH ONLY (query string stripped). A handler routes on the
+;             path; the query is data it reads separately, as typed fields.
+;   headers — a list of kh-header (the Header class), one per parsed header.
+;   query   — a list of kh-field (the Field class), parsed from the query
+;             string. A handler reads kh-field-value(…, name), not a raw string.
+;   body    — the body string.
+;
+; Why kh-field, not a bare (k v) alist: the query belongs in the hierarchy. A
+; field is a named value with the same shape as a header — kh-field-present? /
+; kh-field-value already exist in kernel-http.fk, so a handler reads query and
+; header data through one vocabulary.
+
+section [form.bml] {
+
+    ;; ---- query layer : path/query split, k=v&… -> kh-field list -------
+
+    ;; the path up to the first '?', or the whole path when there is none.
+    ;; Bind the '?' index once (block-let) rather than scanning twice. The block
+    ;; spans lines — the local source-compiler reads multi-line blocks correctly
+    ;; but mangles single-line ones (the `let` gets dropped); the body's blocks
+    ;; (kernel-http.fk) follow the same shape.
+    def kh-req-path-only(path) {
+        let qi = str_find(path, "?", 0);
+        if eq(qi, -1) then path else substring(path, 0, qi);
+    }
+
+    ;; the query string after the first '?', or "" when there is none.
+    def kh-req-query-str(path) {
+        let qi = str_find(path, "?", 0);
+        if eq(qi, -1) then "" else substring(path, add(qi, 1), str_len(path));
+    }
+
+    ;; a "k=v" segment -> kh-field(k, v). Split on the FIRST '=' so a value
+    ;; containing '=' stays whole; no '=' -> kh-field(segment, "").
+    def kh-req-field-of(seg) {
+        let ei = str_find(seg, "=", 0);
+        if eq(ei, -1) then kh-field(seg, "") else kh-field(substring(seg, 0, ei), substring(seg, add(ei, 1), str_len(seg)));
+    }
+
+    ;; the query string -> kh-field list. Split on '&', each segment to a field.
+    ;; Walks via str_find/substring; recursion advances the cursor past each '&'.
+    def kh-req-fields-loop(s, start) {
+        let amp = str_find(s, "&", start);
+        if eq(amp, -1) then list(kh-req-field-of(substring(s, start, str_len(s)))) else cons(kh-req-field-of(substring(s, start, amp)), kh-req-fields-loop(s, add(amp, 1)));
+    }
+    def kh-req-fields(qs) = if eq(str_len(qs), 0) then empty else kh-req-fields-loop(qs, 0);
+
+    ;; ---- header layer : parsed HTTP-HEADER nodes -> kh-header list ----
+    ;; http-headers(node) returns a list of the parser's HEADER nodes; each
+    ;; lifts to a kh-header value. The recipe walks the list; the names/values
+    ;; are data carried through, never literals here.
+    def kh-req-headers(parsed) = if nil?(parsed) then empty else cons(kh-header(http-header-name(head(parsed)), http-header-value(head(parsed))), kh-req-headers(tail(parsed)));
+
+    ;; ---- the adapter : raw request string -> kh-request --------------
+    ;; Parse to the lexer node, then read its parts through the http-* accessors
+    ;; and assemble the kh-request. The full path is split: kh-request carries
+    ;; the path-only for routing and the parsed fields for the handler.
+    def kh-request-from-raw(raw) {
+        let node = http-parse-request(raw);
+        let full-path = http-path(node);
+        kh-request(http-method(node), kh-req-path-only(full-path), kh-req-headers(http-headers(node)), kh-req-fields(kh-req-query-str(full-path)), http-body(node));
+    }
+
+    0;
+}

--- a/form/form-stdlib/tests/http-render-band.fk
+++ b/form/form-stdlib/tests/http-render-band.fk
@@ -1,0 +1,76 @@
+; tests/http-render-band.fk — sibling-witness band for http-render.fk.
+; preludes: form-stdlib/kernel-http.fk form-stdlib/http-render.fk
+;
+; Iteration 1 of lifting the HTTP server into the BML class hierarchy: the
+; Response layer, data-driven. This band proves what the lift is FOR — that the
+; status phrases are now DATA looked up from a table (not frozen into an
+; if-chain), that one generic recipe walks a kh-response's header list to frame
+; it, that the content-type is the handler's declared kh-header (or an honest
+; text/plain default), and that kh-serve-response renders any kh-response to the
+; wire.
+;
+; Each check contributes a distinct bit; the band emits their sum (63 when all
+; pass). Identical across Go, Rust, and TypeScript is the proof the Response
+; render is correct and three-way-portable — built IN the hierarchy
+; (kernel-http.fk's kh-response), not beside it.
+
+;; CHECK 1 (bit 1) — the status table is DATA. Listed codes resolve to their
+;; phrase; an UNLISTED code falls to the neutral "Status" (the lookup's
+;; fallback) instead of failing. Add a code by adding a row, not a branch.
+(let ok-reason
+    (if (str_eq (kh-reason 200) "OK")
+        (if (str_eq (kh-reason 422) "Unprocessable Entity")
+            (if (str_eq (kh-reason 999) "Status") 1 0)
+            0)
+        0))
+
+;; CHECK 2 (bit 2) — the default content-type. A response that declares no
+;; Content-Type gets text/plain from the framing — an honest label for opaque
+;; bytes. (A handler with a real type attaches its own kh-header; CHECK 4 / 6.)
+(let resp-default (kh-serve-response (kh-response 200 (list) "ok")))
+(let ok-default
+    (if (ge (str_find resp-default "Content-Type: text/plain" 0) 0) 2 0))
+
+;; CHECK 3 (bit 4) — the generic header walk. A list of kh-header values renders
+;; to "name: value\r\n" per header, in order — no header name hardcoded in the
+;; recipe. Two headers in, two CRLF-terminated lines out.
+(let ok-headers
+    (if (str_eq (kh-render-headers (list (kh-header "A" "1") (kh-header "B" "2")))
+                "A: 1\r\nB: 2\r\n")
+        4 0))
+
+;; CHECK 4 (bit 8) — the full wire render of a handler-declared JSON response.
+;; The handler attaches Content-Type: application/json; finalize preserves it
+;; and adds Content-Length (the body {"w":1} is 7 bytes) and X-Form-Router, then
+;; the generic render frames the whole thing. Exact-match across all three
+;; kernels is the proof the wire string is byte-identical.
+(let resp200 (kh-serve-response (kh-response 200 (list (kh-header "Content-Type" "application/json")) "{\"w\":1}")))
+(let expected200
+    "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nX-Form-Router: native-kernel\r\nContent-Type: application/json\r\n\r\n{\"w\":1}")
+(let ok-render (if (str_eq resp200 expected200) 8 0))
+
+;; CHECK 5 (bit 16) — a 422 (a handler's observable "no") renders the right
+;; status line, the phrase pulled from the table. "HTTP/1.1 422 Unprocessable
+;; Entity" is 33 bytes.
+(let resp422 (kh-serve-response (kh-response 422 (list) "{\"detail\":\"x\"}")))
+(let ok-422
+    (if (str_eq (substring resp422 0 33) "HTTP/1.1 422 Unprocessable Entity")
+        16 0))
+
+;; CHECK 6 (bit 32) — Content-Type idempotency. When the handler already set a
+;; Content-Type, finalize does NOT add the default: the response carries the
+;; handler's text/html and the text/plain default never appears.
+(let resp-ct
+    (kh-serve-response (kh-response 200 (list (kh-header "Content-Type" "text/html")) "x")))
+(let ok-idempotent
+    (if (ge (str_find resp-ct "Content-Type: text/html" 0) 0)
+        (if (eq (str_find resp-ct "text/plain" 0) -1) 32 0)
+        0))
+
+;; verdict — sum of the bit-weighted checks; 63 when all pass.
+(add ok-reason
+(add ok-default
+(add ok-headers
+(add ok-render
+(add ok-422
+     ok-idempotent)))))

--- a/form/form-stdlib/tests/http-request-band.fk
+++ b/form/form-stdlib/tests/http-request-band.fk
@@ -1,0 +1,47 @@
+; tests/http-request-band.fk — sibling-witness band for http-request.fk.
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk
+;
+; Iteration 2 of lifting the HTTP server into the BML class hierarchy: the
+; Request class. Proves kh-request-from-raw lifts a raw HTTP/1.1 request string
+; into a kh-request value — method, path-only (query stripped), the query parsed
+; to kh-field, the headers to kh-header, the body — and that the assembled value
+; is kh-request-valid?. The engine now speaks the class the Router consumes.
+;
+; Each check contributes a distinct bit; the band emits their sum (31 when all
+; pass). Identical across Go/Rust/TS proves the lift is correct and portable.
+
+(let raw "GET /api/utils/coherence_weight?threshold=90 HTTP/1.1\r\nHost: x\r\n\r\n")
+(let req (kh-request-from-raw raw))
+
+;; CHECK 1 (bit 1) — the method, lifted off the request line.
+(let ok-method (if (str_eq (kh-request-method req) "GET") 1 0))
+
+;; CHECK 2 (bit 2) — the path is the path-ONLY form: the "?threshold=90" query
+;; is split off, so a handler routes on "/api/utils/coherence_weight".
+(let ok-path (if (str_eq (kh-request-path req) "/api/utils/coherence_weight") 2 0))
+
+;; CHECK 3 (bit 4) — the query string parsed into the Field class: one
+;; kh-field whose name is "threshold" and value "90". Typed data, not a string.
+(let query (kh-request-query req))
+(let ok-query
+    (if (eq (len query) 1)
+        (if (str_eq (kh-field-name (head query)) "threshold")
+            (if (str_eq (kh-field-value (head query)) "90") 4 0)
+            0)
+        0))
+
+;; CHECK 4 (bit 8) — the Host header lifted into the Header class, found by
+;; name through kernel-http.fk's own kh-header-present?.
+(let ok-header (if (kh-header-present? (kh-request-headers req) "Host") 8 0))
+
+;; CHECK 5 (bit 16) — the assembled request satisfies kh-request-valid?: a
+;; known method, a rooted path, every header a kh-header, every field a
+;; kh-field. The class validates itself.
+(let ok-valid (if (kh-request-valid? req) 16 0))
+
+;; verdict — sum of the bit-weighted checks; 31 when all pass.
+(add ok-method
+(add ok-path
+(add ok-query
+(add ok-header
+     ok-valid))))


### PR DESCRIPTION
## Lifting HTTP into the BML class hierarchy — iterations 1 & 2

Part of moving HTTP off the kernel (Rust) and off procedural one-liners onto a data-driven BML class hierarchy on `kernel-http.fk`, traceable end-to-end. **Only FLOW and CHOICE live in the recipes; status phrases, content-types, and field/header data are DATA.**

### What this PR lands — the two foundational classes + a lexer heal

**Iteration 1 — `http-render.fk` (the Response layer).** Status phrases are a DATA table looked up generically; one recipe walks a `kh-response`'s header list to frame the wire (no header name hardcoded); content-type is the handler's declared `kh-header` or an honest `text/plain` default. The old first-byte content-sniff was fragile (a JSON string body opens with `"`, a number with a digit) AND leaned on `eq` over string keys, where the sibling kernels diverge (go/rs/ts gave 61/error/63) — removing it raises the bar and closes the divergence.

**Iteration 2 — `http-request.fk` (the Request class).** Lifts the parser's node into `kh-request(method, path, headers, query, body)` — the value the pressure-scored Router (`kh-select-route-candidate-for-request`, already on `kernel-http.fk`) consumes directly. Headers become `kh-header`, the query string becomes `kh-field`. Parse is transport; `kh-request` is the domain; the boundary is named.

**Healed in the lexer — `http-parse.fk`.** Strip a trailing `\r` at each line end, so real HTTP CRLF parses identically to bare `\n`. Previously a CRLF blank line was collected as a spurious malformed header, which the conversion then choked on.

### Proof — three-way (Go / Rust / TS)

| band | sum | full-pass |
|---|---|---|
| http-render-band (iter 1) | 63 | 63 |
| http-request-band (iter 2) | 31 | 31 |
| http-parse-band (regression) | 11 | 11 |
| http-serve-band (regression) | 1023 | 1023 |
| http-serve-socket-band (regression) | 63 | 63 (Go/Rust) |

### The arc — where this is going

1. ✅ Router — already on `kernel-http.fk` (pressure-scored).
2. ✅ Response render — this PR.
3. ✅ Request class — this PR.
4. ⬜ Server dispatch — tie `kh-request-from-raw` → Router → `handler(kh-request) → kh-response` → `kh-serve-response`.
5. ⬜ Wire the kernel's accept-loop to the Server; compost the Rust HTTP.
6. ⬜ All routes native + compare-in-Form.
7. ⬜ Teach the source-compiler multi-line calls, so the recipes read as cleanly as they are structured.

Foundational classes only — nothing serves live traffic yet. The live flip (kernel as front door) stays gated on an explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
