### PR TITLE
tend(form-http): the Server — data-driven dispatch completes the BML hierarchy

### DIFF
--- a/form/form-stdlib/http-server.fk
+++ b/form/form-stdlib/http-server.fk
@@ -1,0 +1,86 @@
+; http-server.fk — the Server: dispatch a raw HTTP request to its handler.
+;
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk
+;
+; THE PRINCIPLE (Urs): the dispatch is DATA-DRIVEN. Routes are kh-route data;
+; handlers are closures in a registry keyed by name; the Server is ONE generic
+; flow — parse, route, dispatch, render. No endpoint is named in the recipe.
+; Adding a route is adding a kh-route row and a registry entry, never an edit to
+; the flow. Only FLOW and CHOICE live here; the routes and handler names are DATA.
+;
+; The shape:
+;   kh-serve(routes, registry, raw) -> wire string
+;     parse    : raw -> kh-request                       (http-request.fk)
+;     route    : kh-request + routes -> best candidate    (kernel-http.fk Router)
+;     match?   : did a real route win? (path pressure < 500)
+;     dispatch : candidate -> handler(kh-request) -> kh-response
+;     render   : kh-response -> wire string               (http-render.fk)
+;
+; A handler is handler(kh-request) -> kh-response — it reads the request through
+; the Request class (kh-request-path, kh-field-value, …) and returns a Response.
+; The registry is a list of (name, handler) pairs; the route's handler-name
+; selects the closure. First-class: the closure is looked up, bound, and called
+; — proven identical across Go/Rust/TS.
+
+section [form.bml] {
+
+    ;; ---- the match decision : did a real route win? -----------------
+    ;; The Router always returns a best candidate, even a poor one. A real match
+    ;; is one whose PATH pressure is below the miss score (500): 0 for an exact
+    ;; path, 25 for a wildcard prefix. We read the path row from the candidate's
+    ;; pressure matrix by AXIS, not by position, so the check holds if the matrix
+    ;; order ever changes — the axis name is the contract, the slot is not.
+    def kh-matrix-pressure-for(matrix, axis) = if nil?(matrix) then 500 else if str_eq(kh-pressure-row-axis(head(matrix)), axis) then kh-pressure-row-pressure(head(matrix)) else kh-matrix-pressure-for(tail(matrix), axis);
+    def kh-candidate-matched?(candidate) = if nil?(candidate) then false else lt(kh-matrix-pressure-for(kh-route-candidate-matrix(candidate), "path"), 500);
+
+    ;; ---- the handler registry : (name, handler) pairs ---------------
+    ;; Look up a handler closure by the name its route carries. The registry is
+    ;; DATA — a list of (name, closure) pairs — and the lookup walks it
+    ;; generically. Returns the handler WRAPPED in a one-element list when found,
+    ;; empty when not, so the caller tests presence by LENGTH: nil? cannot tell a
+    ;; closure from empty (a closure reads as length 0), but a one-element
+    ;; wrapper has length 1 no matter what it holds. A route naming a handler the
+    ;; registry does not hold is a wiring gap the caller surfaces as 500.
+    def kh-handler-of(registry, name) = if nil?(registry) then empty else if str_eq(nth(head(registry), 0), name) then list(nth(head(registry), 1)) else kh-handler-of(tail(registry), name);
+
+    ;; ---- the Server's own framing responses -------------------------
+    ;; When no handler runs, the Server still answers honestly: 404 when no route
+    ;; matched (the path is named so the caller sees what missed), 500 when a
+    ;; route matched but its handler is not registered (a wiring gap, not the
+    ;; client's fault — named so the gap is visible).
+    def kh-not-found(request) = kh-response(404, list(), str_concat("no route for ", kh-request-path(request)));
+    def kh-no-handler(name) = kh-response(500, list(), str_concat("no handler registered for ", name));
+
+    ;; ---- dispatch : a matched candidate -> the handler's kh-response -
+    ;; Resolve the handler from the route's name; if registered (the wrapper is
+    ;; non-empty), invoke it on the request; else the 500 wiring-gap response.
+    ;; The handler never sees routing — it receives a kh-request and returns a
+    ;; kh-response, nothing more.
+    def kh-dispatch(registry, candidate, request) {
+        let name = kh-route-handler(kh-route-candidate-route(candidate));
+        let found = kh-handler-of(registry, name);
+        if eq(len(found), 0) then kh-no-handler(name) else kh-invoke-found(found, request);
+    }
+
+    ;; invoke the found handler on the request. Bound to a name first because
+    ;; Form calls in verb position — ((head found) request) does not parse, but a
+    ;; named closure does. `found` is non-empty here (the caller checked length).
+    def kh-invoke-found(found, request) {
+        let handler = head(found);
+        handler(request);
+    }
+
+    ;; ---- the Server : raw request -> wire response ------------------
+    ;; One flow, every shape and size: parse the bytes into a kh-request, let the
+    ;; Router score the routes, dispatch to the matched handler (or 404), render
+    ;; the kh-response to the wire. The whole front door — bytes in, bytes out,
+    ;; every decision a value you can name and trace.
+    def kh-serve(routes, registry, raw) {
+        let request = kh-request-from-raw(raw);
+        let candidate = kh-select-route-candidate-for-request(routes, request);
+        let response = if kh-candidate-matched?(candidate) then kh-dispatch(registry, candidate, request) else kh-not-found(request);
+        kh-serve-response(response);
+    }
+
+    0;
+}

--- a/form/form-stdlib/tests/http-server-band.fk
+++ b/form/form-stdlib/tests/http-server-band.fk
@@ -1,0 +1,68 @@
+; tests/http-server-band.fk — sibling-witness band for http-server.fk.
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk form-stdlib/http-server.fk
+;
+; Iteration 3 of lifting the HTTP server into the BML class hierarchy: the
+; Server. Proves the full dispatch — a raw HTTP/1.1 request string flows
+; parse -> Router -> handler -> render -> wire — across every shape: two matched
+; routes (one whose handler reads the request and declares its own content-type),
+; an unmatched path (404 naming what missed), and a matched route whose handler
+; is unregistered (500, the wiring gap made visible).
+;
+; The handlers, routes, and registry are DEMO data this band supplies; the
+; Server names none of them — it is one generic flow over data. Emits a bit-sum
+; (31 when all pass). Identical across Go/Rust/TS proves the dispatch — including
+; the first-class handler call — is correct and portable.
+
+;; demo handlers : handler(kh-request) -> kh-response. A handler reads the
+;; request through the Request class and returns a Response; it never sees
+;; routing. demo-echo reads the path and declares application/json.
+(defn demo-health (request) (kh-response 200 (list) "ok"))
+(defn demo-echo (request)
+    (kh-response 200
+        (list (kh-header "Content-Type" "application/json"))
+        (str_concat "{\"path\":\"" (str_concat (kh-request-path request) "\"}"))))
+
+;; demo routes (DATA) + registry (name -> handler closure). "ghost" names a
+;; handler the registry does NOT hold — the wiring gap CHECK 5 exercises.
+(let demo-routes
+    (list (kh-route "health" "GET" "/health" 0 "health" "" 100)
+          (kh-route "echo"   "GET" "/echo"   0 "echo"   "" 100)
+          (kh-route "ghost"  "GET" "/ghost"  0 "ghost-handler" "" 100)))
+(let demo-registry
+    (list (list "health" demo-health)
+          (list "echo"   demo-echo)))
+
+;; CHECK 1 (bit 1) — GET /health dispatches to demo-health: a 200 whose body is
+;; "ok" and whose content-type is the text/plain default (the handler set none).
+(let r-health (kh-serve demo-routes demo-registry "GET /health HTTP/1.1\r\nHost: x\r\n\r\n"))
+(let ok-health
+    (if (str_eq r-health "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nX-Form-Router: native-kernel\r\n\r\nok")
+        1 0))
+
+;; CHECK 2 (bit 2) — GET /echo dispatches to demo-echo, which READS the request
+;; path and declares application/json. Body {"path":"/echo"} is 16 bytes; the
+;; handler's content-type is preserved, the framing headers added.
+(let r-echo (kh-serve demo-routes demo-registry "GET /echo HTTP/1.1\r\nHost: x\r\n\r\n"))
+(let ok-echo
+    (if (str_eq r-echo "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nX-Form-Router: native-kernel\r\nContent-Type: application/json\r\n\r\n{\"path\":\"/echo\"}")
+        2 0))
+
+;; CHECK 3 (bit 4) — an unmatched path yields the Server's 404.
+(let r-404 (kh-serve demo-routes demo-registry "GET /nope HTTP/1.1\r\nHost: x\r\n\r\n"))
+(let ok-404 (if (ge (str_find r-404 "HTTP/1.1 404 Not Found\r\n" 0) 0) 4 0))
+
+;; CHECK 4 (bit 8) — the 404 body names the path that missed.
+(let ok-404-body (if (ge (str_find r-404 "no route for /nope" 0) 0) 8 0))
+
+;; CHECK 5 (bit 16) — GET /ghost MATCHES a route, but "ghost-handler" is not in
+;; the registry: the Server answers 500, the wiring gap made visible rather than
+;; crashing or silently 404-ing.
+(let r-ghost (kh-serve demo-routes demo-registry "GET /ghost HTTP/1.1\r\nHost: x\r\n\r\n"))
+(let ok-ghost (if (ge (str_find r-ghost "HTTP/1.1 500 Internal Server Error\r\n" 0) 0) 16 0))
+
+;; verdict — sum of the bit-weighted checks; 31 when all pass.
+(add ok-health
+(add ok-echo
+(add ok-404
+(add ok-404-body
+     ok-ghost))))


### PR DESCRIPTION
## The Server — data-driven dispatch (iteration 3, completes the BML HTTP hierarchy mechanism)

Builds on #2453 (Response + Request classes). `http-server.fk` is the Server: one generic flow over data — parse, route, dispatch, render — that ties the classes into a running dispatch.

### The flow

```
kh-serve(routes, registry, raw) -> wire string
  parse    : raw -> kh-request                     (http-request.fk)
  route    : kh-request + routes -> best candidate  (kernel-http.fk Router)
  match?   : path pressure < 500
  dispatch : candidate -> handler(kh-request) -> kh-response
  render   : kh-response -> wire string             (http-render.fk)
```

**Data-driven, no endpoint in the recipe.** Routes are `kh-route` DATA; handlers are closures in a registry keyed by name; the route's handler-name selects the closure (first-class — looked up, bound, called, proven identical Go/Rust/TS). Adding a route is a `kh-route` row + a registry entry, never an edit to the flow.

**Every shape answered.** A matched route runs its handler; an unmatched path is 404 (naming what missed); a matched route whose handler is unregistered is 500 (the wiring gap made visible, not a crash or a silent 404).

**A gotcha lifted:** handler presence is tested by a one-element wrapper's length, not `nil?` — a closure reads as length 0, so `nil?` cannot tell a found handler from empty.

### Proof — three-way (Go/Rust/TS)

| band | sum | full-pass |
|---|---|---|
| http-server-band | 31 | 31 |

Checks: matched `/health` (200, text/plain default), matched `/echo` (handler reads the path + declares application/json), unmatched `/nope` (404), the 404 body names the missed path, `/ghost` matched-but-unregistered (500).

### The hierarchy mechanism is complete

1. ✅ Router — `kernel-http.fk` (pressure-scored).
2. ✅ Response render — #2453.
3. ✅ Request class — #2453.
4. ✅ **Server dispatch — this PR.**
5. ⬜ Wire the kernel's accept-loop to `kh-serve`; compost the Rust HTTP + fear-caps.
6. ⬜ All production routes native + compare-in-Form.
7. ⬜ Teach the source-compiler multi-line calls, so the recipes read as cleanly as they are structured.

The Server is generic and proven with demo fixtures; nothing serves live traffic yet. The live flip (kernel as front door) stays gated on an explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
