### PR TITLE
tend(form-http): the Form-native accept-loop — the front door is a recipe

### DIFF
--- a/form/form-stdlib/http-socket.fk
+++ b/form/form-stdlib/http-socket.fk
@@ -1,0 +1,48 @@
+; http-socket.fk — bind the Server to a real socket: the Form-native accept-loop.
+;
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk form-stdlib/http-server.fk
+;
+; THE BOUNDARY (Urs): kh-serve (http-server.fk) is PURE — a request string in, a
+; wire string out, no I/O, three-way-identical. This file is the ONLY place the
+; Server touches a socket. The kernel's job shrinks to one native call —
+; socket_listen opens the port — and hands the listener to Form; everything
+; after (accept, recv, parse, route, dispatch, render, send) is Form. That is
+; "the kernel minimal, the rest Form" made literal: the front door is a recipe.
+;
+;   kh-serve-conn(conn, routes, registry)      one connection: recv -> serve -> send -> close
+;   kh-serve-listener(listener, …, count)      the accept-loop over the listener
+;
+; The socket natives (socket_recv/send/close/accept) are the kernel's minimal
+; surface; the loop and the serving are Form. Proven over a real TCP round-trip
+; (Go/Rust; the TS kernel's socket worker hangs the harness, so it sits out the
+; socket bands — the pure kh-serve is already TS-proven in http-server-band).
+
+section [form.bml] {
+
+    ;; serve ONE connection through the pure Server: read the request bytes, run
+    ;; them through kh-serve, write the wire response, close. Returns what was
+    ;; sent so a witness can assert the round-trip. 65536 is the recv buffer for
+    ;; a single read of the request line + headers (a streamed body would loop
+    ;; the recv — a later refinement; the front-door requests we route fit one).
+    def kh-serve-conn(conn, routes, registry) {
+        let request_bytes = socket_recv(conn, 65536);
+        let response = kh-serve(routes, registry, request_bytes);
+        let sent = socket_send(conn, response);
+        let closed = socket_close(conn);
+        response;
+    }
+
+    ;; the accept-loop: accept and serve `count` connections, then stop. The
+    ;; kernel opens the port (socket_listen) and hands the listener in; Form runs
+    ;; the loop. A live server passes a large count (or this recurses until the
+    ;; listener closes); a witness passes the exact number it will send so the
+    ;; loop terminates deterministically. The recursion advances on `count`, not
+    ;; on any unbounded input — it is the loop, named.
+    def kh-serve-listener(listener, routes, registry, count) = if le(count, 0) then 0 else kh-serve-listener-step(listener, routes, registry, count);
+    def kh-serve-listener-step(listener, routes, registry, count) {
+        let served = kh-serve-conn(socket_accept(listener), routes, registry);
+        kh-serve-listener(listener, routes, registry, sub(count, 1));
+    }
+
+    0;
+}

--- a/form/form-stdlib/tests/http-socket-band.fk
+++ b/form/form-stdlib/tests/http-socket-band.fk
@@ -1,0 +1,61 @@
+; tests/http-socket-band.fk — real-socket witness for http-socket.fk.
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk form-stdlib/http-server.fk form-stdlib/http-socket.fk
+;
+; Iteration 4 of lifting the HTTP server into the BML hierarchy: the Form-native
+; accept-loop. Proves the WHOLE stack serves over a real TCP socket end-to-end —
+; a client sends a raw HTTP request; kh-serve-listener accepts it, runs it
+; through kh-serve (parse -> route -> dispatch -> render), sends the wire
+; response, closes; the client reads the response off the wire and it is the
+; handler's 200 with native provenance. This is the proof the live flip is safe:
+; the data-driven hierarchy serves a real request over a real socket.
+;
+; Single-threaded backlog pattern (as the sibling http-serve-socket-band): the
+; client connects and sends BEFORE the server accepts, so the bytes buffer in
+; the socket for kh-serve-listener's recv. Emits a bit-sum (15 when all pass).
+; Go/Rust only — the TS socket worker hangs the harness; the pure kh-serve is
+; TS-proven in http-server-band.
+
+;; a demo handler + the string helpers the assertions need.
+(defn demo-cw (request)
+    (kh-response 200 (list (kh-header "Content-Type" "application/json")) "{\"ok\":true}"))
+(defn sb-starts (s prefix)
+    (if (lt (str_len s) (str_len prefix)) false (str_eq (substring s 0 (str_len prefix)) prefix)))
+(defn sb-contains (s needle) (ge (str_find s needle 0) 0))
+
+(let demo-routes (list (kh-route "cw" "GET" "/cw" 0 "cw" "" 100)))
+(let demo-registry (list (list "cw" demo-cw)))
+
+(do
+    (let request "GET /cw HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+
+    ;; the kernel's one native step: open the port. Everything after is Form.
+    (let srv (socket_listen 0))
+    (let listen-ok (if (ge srv 0) 1 0))
+    (let port (socket_port srv))
+    (let port-ok (if (gt port 0) 2 0))
+
+    ;; client connects (handshake -> backlog) and sends BEFORE the server
+    ;; accepts; the bytes buffer for kh-serve-listener's recv.
+    (let cli (socket_connect "127.0.0.1" port))
+    (let sent (socket_send cli request))
+
+    ;; Form runs the accept-loop for exactly one connection: accept the buffered
+    ;; client, recv -> kh-serve -> send -> close, then stop.
+    (let served (kh-serve-listener srv demo-routes demo-registry 1))
+
+    ;; the client reads the response off the wire (the conn was closed after the
+    ;; send, so one recv gets the whole framed response).
+    (let wire (socket_recv cli 65536))
+    (socket_close cli)
+    (socket_close srv)
+
+    ;; CHECK 3 (bit 4) — the wire carries the handler's body.
+    (let body-ok (if (sb-contains wire "{\"ok\":true}") 4 0))
+    ;; CHECK 4 (bit 8) — the wire framing is a native 200 with honest provenance.
+    (let frame-ok
+        (if (sb-starts wire "HTTP/1.1 200 OK\r\n")
+            (if (sb-contains wire "X-Form-Router: native-kernel\r\n") 8 0)
+            0))
+
+    ;; verdict — 15 when listen, port, the served body, and the framing agree.
+    (add listen-ok (add port-ok (add body-ok frame-ok))))


### PR DESCRIPTION
## The Form-native accept-loop — the front door is a recipe (iteration 4)

Builds on #2453 + #2454. `http-socket.fk` binds the pure Server (`kh-serve`) to a real socket. The kernel's only step is `socket_listen` (open the port); **Form does everything after** — accept, recv, parse, route, dispatch, render, send, close.

```
kh-serve-conn(conn, routes, registry)    one connection: recv -> kh-serve -> send -> close
kh-serve-listener(listener, ..., count)  the accept-loop, in Form
```

This is "the kernel minimal, the rest Form" made literal. The socket natives (`socket_recv`/`send`/`accept`/`close`) are the kernel's surface; the loop and the serving are recipes. With iterations 1-3 the **whole stack is now Form-native**: parse → Request → Router → dispatch → Response → socket loop.

### Proof — real TCP round-trip

| band | sum | full-pass |
|---|---|---|
| http-socket-band | 15 | 15 (Go/Rust) |

A client sends a raw request; `kh-serve-listener` accepts it (single-threaded backlog pattern), serves it through `kh-serve`, sends the wire response, closes; the client reads back the handler's `200 OK` with `X-Form-Router: native-kernel`. The pure `kh-serve` is separately TS-proven in `http-server-band` (31); the TS socket worker hangs the harness, so it sits out the socket bands like the sibling `http-serve-socket-band`.

### The arc

1. ✅ Router · 2. ✅ Response · 3. ✅ Request · 4. ✅ Server dispatch (#2454) · 4a. ✅ **Socket loop — this PR.**
5. ⬜ Wire the kernel's `cli_serve` to `kh-serve-listener`; compost the 11.5K-line Rust HTTP + fear-caps. **The flip — the live front door, gated on go.**
6. ⬜ Real routes native + fan-out to Python for non-native endpoints.
7. ⬜ Teach the source-compiler multi-line calls.

The stack is proven serving over a socket. Nothing serves live traffic yet — the flip stays gated on an explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
