### PR TITLE
tend(external-proof): treat Cloudflare 52x as the transient it is, not a hard fail

### DIFF
--- a/scripts/external_proof_demo.py
+++ b/scripts/external_proof_demo.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, Optional
 
 
 AUTH_FAILED_EXIT = 2
-TRANSIENT_FAILED_EXIT = 3  # 5xx / gateway / connection — not a code regression
+TRANSIENT_FAILED_EXIT = 3  # 5xx gateway / Cloudflare 52x origin-unreachable / connection — not a code regression
 
 
 def _idea_create_payload() -> Dict[str, Any]:
@@ -141,10 +141,13 @@ class ProofRunner:
                     file=sys.stderr,
                 )
                 raise SystemExit(TRANSIENT_FAILED_EXIT)
-            if response.status_code in (502, 503, 504):
+            if response.status_code in (502, 503, 504, 520, 521, 522, 523, 524):
                 print(
-                    f"[TRANSIENT] HTTP {response.status_code} — gateway/upstream blip, "
-                    "not a code regression. Workflow will treat as advisory.",
+                    f"[TRANSIENT] HTTP {response.status_code} — gateway/upstream blip "
+                    "or Cloudflare origin unreachable (the api answers 52x while it "
+                    "restarts mid-deploy, until it is back). The witness tracks api "
+                    "up/down; this proof verifies the lifecycle only when the api "
+                    "answers. Not a code regression — workflow retries, then advisory.",
                     file=sys.stderr,
                 )
                 print(


### PR DESCRIPTION
The post-merge External proof races the deploy; when its first call hits the api restarting, Cloudflare returns 522 (origin unreachable), which wasn't in the transient list (502/503/504) and hard-failed. Adds the Cloudflare 52x family (520-524) so it exits TRANSIENT_FAILED_EXIT and the workflow's existing retry-after-30s + advisory fallback handles it — the api is back within the window. The witness tracks api up/down; this proof verifies the lifecycle only when the api answers.

Evidence: PR #2456's External proof failed on a 522 at 18:29:44; the same run's later calls passed; #2457's proof passed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)