### PR TITLE
tend(kernel-router): bring parity-proven handlers into kh-serve, byte-identical

### DIFF
--- a/deploy/kernel-router/form-routes.fk
+++ b/deploy/kernel-router/form-routes.fk
@@ -1,0 +1,24 @@
+; form-routes.fk — the --form route layer for the kernel-router. Each handler is
+; a thin wrapper (http-adapter.fk: kh-request-as-alist + kh-ok-json) around the
+; parity-proven alist handler in production-routes.fk, so kh-serve dispatches to
+; the CPython-proven formula UNCHANGED — byte-identical to Python, with the HTTP
+; around it now traceable Form.
+;
+; Deploy manifest = HTTP stack + http-adapter.fk + production-routes.fk + this.
+; As more routes are wrapped here, the load balancer routes their paths to the
+; kernel-router and their Python implementations are removed, one proven route
+; at a time.
+
+(defn cw-native       (request) (kh-ok-json (route_coherence_weight    (kh-request-as-alist request))))
+(defn ndist-native    (request) (kh-ok-json (route_nodeid_distance     (kh-request-as-alist request))))
+(defn ncompat-native  (request) (kh-ok-json (route_nodeid_compatibility (kh-request-as-alist request))))
+
+(let routes
+  (list (kh-route "coherence_weight"     "GET" "/api/utils/coherence_weight"     0 "cw-native"      "" 100)
+        (kh-route "nodeid_distance"       "GET" "/api/utils/nodeid_distance"       0 "ndist-native"   "" 100)
+        (kh-route "nodeid_compatibility"  "GET" "/api/utils/nodeid_compatibility"  0 "ncompat-native" "" 100)))
+(let registry
+  (list (list "cw-native" cw-native)
+        (list "ndist-native" ndist-native)
+        (list "ncompat-native" ncompat-native)))
+0

--- a/form/form-stdlib/http-adapter.fk
+++ b/form/form-stdlib/http-adapter.fk
@@ -1,0 +1,34 @@
+; http-adapter.fk — bridge the parity-proven alist handlers into kh-serve.
+;
+; preludes: form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk
+;
+; THE PRINCIPLE (Urs): the /api/utils computes in
+; deploy/kernel-router/production-routes.fk were proven byte-identical to CPython
+; via the three-way kernel suite. We do NOT rewrite a proven formula to fit a new
+; request/response shape — that would risk the parity we already earned. Instead
+; this adapter lets kh-serve dispatch to those handlers UNCHANGED: it converts a
+; kh-request's query into the (k v) alist the handlers read (via param_or/assoc),
+; and wraps the handler's JSON string in a kh-response. The formula is untouched;
+; only the shells change. A native route's registry entry is then a thin wrapper:
+;
+;   (defn cw-native (request)
+;     (kh-ok-json (route_coherence_weight (kh-request-as-alist request))))
+;
+; — the proven handler verbatim inside the kh-serve shell, so the kernel-router's
+; response stays byte-for-byte the CPython response while the HTTP around it is
+; now traceable Form.
+
+section [form.bml] {
+
+    ;; a kh-request's query (a kh-field list) -> the (name value) alist the proven
+    ;; handlers read through param_or / assoc. One pair per field; names and
+    ;; values are carried through, never literals here.
+    def kh-fields-as-pairs(fields) = if nil?(fields) then list() else cons(list(kh-field-name(head(fields)), kh-field-value(head(fields))), kh-fields-as-pairs(tail(fields)));
+    def kh-request-as-alist(request) = kh-fields-as-pairs(kh-request-query(request));
+
+    ;; wrap a handler's JSON-string body in a 200 application/json kh-response.
+    ;; The handler returns the exact CPython JSON text; this only frames it.
+    def kh-ok-json(body) = kh-response(200, list(kh-header("Content-Type", "application/json")), body);
+
+    0;
+}

--- a/form/form-stdlib/tests/http-adapter-band.fk
+++ b/form/form-stdlib/tests/http-adapter-band.fk
@@ -1,0 +1,40 @@
+; tests/http-adapter-band.fk — sibling-witness band for http-adapter.fk.
+; preludes: form-stdlib/http-parse.fk form-stdlib/kernel-http.fk form-stdlib/http-request.fk form-stdlib/http-render.fk form-stdlib/http-adapter.fk
+;
+; Proves the adapter that brings parity-proven alist handlers into kh-serve: a
+; kh-request's query becomes the (name value) alist param_or/assoc read, and a
+; handler's JSON string wraps into a 200 application/json kh-response. Emits a
+; bit-sum (15 when all pass); identical Go/Rust/TS proves the bridge is portable.
+
+(let req (kh-request-from-raw "GET /api/utils/coherence_weight?values=72,38&threshold=50 HTTP/1.1\r\nHost: x\r\n\r\n"))
+(let alist (kh-request-as-alist req))
+
+;; CHECK 1 (bit 1) — the query becomes a 2-pair alist.
+(let ok-len (if (eq (len alist) 2) 1 0))
+
+;; CHECK 2 (bit 2) — the first pair is ("values" "72,38") (comma stays in value).
+(let p1 (head alist))
+(let ok-values
+    (if (str_eq (head p1) "values")
+        (if (str_eq (head (tail p1)) "72,38") 2 0)
+        0))
+
+;; CHECK 3 (bit 4) — the second pair is ("threshold" "50").
+(let p2 (head (tail alist)))
+(let ok-threshold
+    (if (str_eq (head p2) "threshold")
+        (if (str_eq (head (tail p2)) "50") 4 0)
+        0))
+
+;; CHECK 4 (bit 8) — kh-ok-json wraps a JSON string in a 200 application/json
+;; kh-response that renders to the wire with the body intact.
+(let resp (kh-serve-response (kh-ok-json "{\"ok\":1}")))
+(let ok-json
+    (if (ge (str_find resp "HTTP/1.1 200 OK" 0) 0)
+        (if (ge (str_find resp "Content-Type: application/json" 0) 0)
+            (if (ge (str_find resp "{\"ok\":1}" 0) 0) 8 0)
+            0)
+        0))
+
+;; verdict — 15 when all pass.
+(add ok-len (add ok-values (add ok-threshold ok-json)))


### PR DESCRIPTION
Bridges the CPython-parity-proven alist handlers into `kh-serve` WITHOUT rewriting their formulas (preserving the parity). `http-adapter.fk`: `kh-request-as-alist` + `kh-ok-json`; a native route is a one-line wrapper around the proven handler.

**Byte-identical to LIVE Python** (curl-compared against api.coherencycoin.com), served via `serve --form`:
- /api/utils/coherence_weight (default + custom query)
- /api/utils/nodeid_distance
- /api/utils/nodeid_compatibility

Three-way proven: http-adapter-band → 15 (Go/Rust/TS). The rest of the ~13 /api/utils computes follow the same wrapper; each Python implementation drops as its route proves out under real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)