### PR TITLE
tend(kernel-router): the recipe streams — kernel hands the socket handle, no pre-read

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -7372,7 +7372,10 @@ fn worker_loop(
     // every connection runs the Form serve pipeline directly — Form does parse,
     // route, dispatch, render; the kernel only opens the socket and walks it.
     let form_serve: Option<(Arc<Closure>, Value, Value)> = if form_mode {
-        let kh_id = k.intern_string("kh-serve").inst;
+        // kh-serve-conn (http-socket.fk) is the STREAMING entry: it takes the
+        // socket handle and owns the I/O. (kh-serve, the pure string-in/string-out
+        // core, is what kh-serve-conn calls between the recv and send loops.)
+        let kh_id = k.intern_string("kh-serve-conn").inst;
         match arena.lookup(root_env, kh_id) {
             Some(Value::Closure(c)) => {
                 let routes_id = k.intern_string("routes").inst;
@@ -7385,7 +7388,8 @@ fn worker_loop(
             }
             _ => {
                 eprintln!(
-                    "serve --form: worker {} could not resolve kh-serve as a closure",
+                    "serve --form: worker {} could not resolve kh-serve-conn as a closure \
+                     (the manifest must prelude http-socket.fk)",
                     id
                 );
                 return;
@@ -7831,36 +7835,31 @@ fn load_route_data_registry(
 // balancer routes only native paths here, a 404 from kh-serve means a path the
 // balancer should not have sent — honest, not a fan-out concern.
 fn serve_connection_form(
-    mut stream: TcpStream,
+    stream: TcpStream,
     k: &mut Kernel,
     arena: &mut Arena,
-    kh_serve: &Arc<Closure>,
+    kh_serve_conn: &Arc<Closure>,
     routes_val: &Value,
     registry_val: &Value,
 ) {
-    use std::io::Read;
-    let mut buf = vec![0u8; 65536];
-    let n = match stream.read(&mut buf) {
-        Ok(n) if n > 0 => n,
-        _ => return, // EOF / error — close
-    };
-    let raw = String::from_utf8_lossy(&buf[..n]).to_string();
-    if kh_serve.params.len() != 3 {
-        let _ = stream
-            .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
+    // STREAMING: the kernel does NOT pre-read a buffer. It registers the accepted
+    // connection as a Form socket handle and hands that handle to the recipe;
+    // kh-serve-conn (http-socket.fk) owns ALL the I/O — loop-recv the request
+    // (socket_recv until framed), run kh-serve, loop-send the response
+    // (socket_send until drained), close. The bytes flow through Form, not a Rust
+    // buffer. kh-serve-conn(conn, routes, registry).
+    if kh_serve_conn.params.len() != 3 {
         return;
     }
-    // apply (kh-serve routes registry raw): bind the three params, walk the body.
-    let frame = arena.new_frame_with_capacity(Some(kh_serve.env), 3);
-    arena.bind(frame, kh_serve.params[0], routes_val.clone());
-    arena.bind(frame, kh_serve.params[1], registry_val.clone());
-    arena.bind(frame, kh_serve.params[2], Value::Str(raw));
-    let result = walk(k, arena, kh_serve.body, frame);
-    let wire = match result {
-        Value::Str(s) => s,
-        other => other.display(),
-    };
-    let _ = stream.write_all(wire.as_bytes());
+    let h = socket_register(SocketKind::Stream(Mutex::new(stream)));
+    let frame = arena.new_frame_with_capacity(Some(kh_serve_conn.env), 3);
+    arena.bind(frame, kh_serve_conn.params[0], Value::Int(h));
+    arena.bind(frame, kh_serve_conn.params[1], routes_val.clone());
+    arena.bind(frame, kh_serve_conn.params[2], registry_val.clone());
+    let _ = walk(k, arena, kh_serve_conn.body, frame);
+    // The recipe closes the handle (socket_close); drop it here too so a recipe
+    // that returned early never leaks a handle per connection.
+    socket_drop(h);
 }
 
 fn cli_serve(args: &[String]) -> i32 {

--- a/form/form-stdlib/http-socket.fk
+++ b/form/form-stdlib/http-socket.fk
@@ -19,17 +19,35 @@
 
 section [form.bml] {
 
-    ;; serve ONE connection through the pure Server: read the request bytes, run
-    ;; them through kh-serve, write the wire response, close. Returns what was
-    ;; sent so a witness can assert the round-trip. 65536 is the recv buffer for
-    ;; a single read of the request line + headers (a streamed body would loop
-    ;; the recv — a later refinement; the front-door requests we route fit one).
+    ;; ---- streaming read : loop recv until the request is framed -------
+    ;; socket_recv returns up to `max` bytes per call; the kernel does NOT assume
+    ;; one read holds the whole request. Loop until the request line + headers are
+    ;; complete (the \r\n\r\n terminator). An empty recv (EOF / peer closed) ends
+    ;; the read with what arrived — kh-serve answers an incomplete request rather
+    ;; than hanging. (A Content-Length body is read the same way — a later breath;
+    ;; the /api/utils GETs the router fronts carry none.) The recursion is bounded
+    ;; by request-size / 64 KiB — a handful of frames, NOT the unbounded accept
+    ;; loop, so it never approaches the stack ceiling.
+    def kh-headers-complete?(s) = ge(str_find(s, "\r\n\r\n", 0), 0);
+    def kh-recv-more(conn, acc, chunk) = if eq(str_len(chunk), 0) then acc else kh-recv-request(conn, str_concat(acc, chunk));
+    def kh-recv-request(conn, acc) = if kh-headers-complete?(acc) then acc else kh-recv-more(conn, acc, socket_recv(conn, 65536));
+
+    ;; ---- streaming write : loop send until every byte is on the wire --
+    ;; socket_send may write fewer bytes than asked; loop from the unsent offset
+    ;; so a large response is never assumed to leave in one send. (Chunked
+    ;; PRODUCTION — a handler yielding the body in pieces — is a later breath;
+    ;; this streams the transport, kh-serve renders the body whole for now.)
+    def kh-send-all(conn, s, from) = if ge(from, str_len(s)) then 0 else kh-send-all(conn, s, add(from, socket_send(conn, substring(s, from, str_len(s)))));
+
+    ;; serve ONE connection by STREAMING. The kernel hands this recipe the socket
+    ;; HANDLE; the recipe owns all the I/O — the kernel never pre-reads a buffer,
+    ;; the bytes flow through Form. Loop-recv the request, run it through the pure
+    ;; kh-serve, loop-send the response, close.
     def kh-serve-conn(conn, routes, registry) {
-        let request_bytes = socket_recv(conn, 65536);
-        let response = kh-serve(routes, registry, request_bytes);
-        let sent = socket_send(conn, response);
-        let closed = socket_close(conn);
-        response;
+        let request = kh-recv-request(conn, "");
+        let response = kh-serve(routes, registry, request);
+        let sent = kh-send-all(conn, response, 0);
+        socket_close(conn);
     }
 
     ;; the accept-loop: accept and serve `count` connections, then stop. The


### PR DESCRIPTION
The `--form` serve path was buffered — one 65 KB read, whole request as a string, whole response written at once (and the single read truncated anything larger or split across packets). The recipe can and should stream the bytes.

Now the kernel registers the accepted connection as a Form socket handle and hands it to the recipe; `kh-serve-conn` (http-socket.fk) owns the I/O: **loop-recv** until the request is framed (CRLF-CRLF; empty recv ends it, never hangs), `kh-serve`, **loop-send** until the whole response is drained, close. The kernel never pre-reads a buffer — the bytes flow through Form. The recv loop is bounded by request-size / 64 KiB, far from the stack ceiling.

Proven: `http-socket-band` → 15 over a real socket (Go/Rust, streaming recipe); `serve --form` byte-identical to the live Python for coherence_weight, nodeid_distance, nodeid_compatibility.

Content-Length request body + chunked response *production* are named later breaths; this streams the transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)