### PR TITLE
tend: gitignore mcp.json — keep local MCP token out of git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ out/
 .env.*
 !.env.example
 
+# Local MCP server config — commonly embeds API tokens; keep out of git
+mcp.json
+
 # Test / coverage
 .coverage
 htmlcov/


### PR DESCRIPTION
Adds `mcp.json` to `.gitignore`. A local `mcp.json` at the repo root carries a live Hostinger API token in plaintext and was previously un-ignored — one `git add -A` away from leaking. This protects it.

Scope: one line in `.gitignore`. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)