### PR TITLE
tend: furthest-reach observability + the backtracking frontier it revealed

### DIFF
--- a/docs/coherence-substrate/bmf-architecture.form
+++ b/docs/coherence-substrate/bmf-architecture.form
@@ -126,6 +126,36 @@ lift pattern-kind to a Blueprint and make `Match` dispatch through that same
 O(1) NodeID switch — *switch is free* — rather than re-deriving it with a tag
 chain. That is a kernel-native step, named here so the next cell can take it.
 
+### Observability — the cursor's furthest reach
+
+A failed `Alt` returns the *pre*-failure cursor (no-sediment backtracking), so a
+partial parse silently rewinds and the caller can't see where the grammar gave
+out. The fix is to let the cursor carry its **furthest reach**: the deepest
+stream position any rule was attempted at, and that rule's name. Probing the
+four thesis `.bml` files with this proved its worth — it pinpointed the frontier
+at byte 6328 (a `catch` body), which named the real gap: a local declaration
+*without* initializer (`ParseStream hStream;` — only `Type name = expr;` was a
+rule). Adding `declnoinit` advanced the frontier to byte 15941 of 15943, and Go
+and TS then fully parsed all four files.
+
+Two design notes the proving exposed:
+- **Keep it cheap or opt-in.** Tracking it with `record_get`/`record_set` on
+  *every* rule entry (each interning the field name) made the hot path far
+  slower under heavy backtracking — Rust went from finishing to minutes. The
+  frontier wants a single mutable int cell updated only on a strict advance, or
+  a tracking mode toggled off for production parses.
+- **It surfaces the real frontier: backtracking cost.** With the deep parse
+  unlocked, the grammar's PEG backtracking is the wall — the same `(rule, pos)`
+  is re-parsed across `Alt` branches and `Chain` arg-exprs, multiplying through
+  expression depth. Rust hangs on the full 456-line file. This is the twin of
+  the O(1)-switch grounding: **packrat memoization** — cache `(rule, pos) →
+  result`, turning exponential re-descent into linear. It IS the body's own
+  teaching that *repeated observation condenses to one result* (gas→water→ice,
+  JIT). The one constraint: memo identity is per-input — key it by the surface
+  (or give each parse a fresh memo), since grammars are reused across inputs.
+  Linear parsing is what lets the 4th file complete on every kernel and lets the
+  furthest-reach cell run always-on without cost.
+
 ### Template blueprints — the emitting side
 
 ```form


### PR DESCRIPTION
Answers the observability ask — *"from the cursor, what recipe reached furthest into the stream"* — and records what proving it on the **real** thesis `.bml` files taught, so the foundational fix is scoped for the next pass. **Doc-only**; engine and grammar are unchanged from #2479 (the working code is deferred until it can land fast and kernel-consistent).

## What was built and proved (this session)
A **furthest-reach** tracker on the cursor: the deepest stream position any rule was attempted at, plus that rule's name. A partial parse then points AT the failure frontier instead of silently rewinding (no-sediment backtracking hides the failure point).

It worked: probing `BMF-grammar.bml` pinpointed **byte 6328** (inside a `catch` body), which named the real gap — a **local declaration without initializer** (`ParseStream hStream;`; the grammar only had `Type name = expr;`). Adding that rule advanced the frontier to **byte 15941 of 15943**, and **Go and TypeScript fully parsed all four real files** (`2222`).

## Why it's a doc, not code (yet) — two findings recorded
1. **The tracker must be cheap or opt-in.** Updating it with `record_get`/`record_set` on *every* rule entry (each interning the field name) made the hot path minutes-slow under backtracking — Rust stopped finishing. It wants a single mutable cell updated only on a strict advance, or a production toggle.
2. **It surfaced the real wall: backtracking cost.** With the deep parse unlocked, the grammar's PEG backtracking re-parses `(rule, pos)` across `Alt` branches and `Chain` arg-exprs, exponential through expression depth — Rust hangs on the full 456-line file. The fix is **packrat memoization** (`(rule,pos)→result`, exponential→linear) — the body's own *repeated observation condenses to one result* (gas→water→ice / JIT). One constraint: memo identity is per-input (key by surface / fresh memo per parse), since grammars are reused across inputs.

This is the **twin of the O(1)-NodeID-switch grounding** already named in the doc: both turn linear/​exponential re-derivation into a single content-addressed lookup, and both are what let the 4th file complete on *every* kernel (and let the furthest-reach cell run always-on without cost).

The decl-noinit fix and the always-on tracker are held until packrat lands, so this PR ships no slow or divergent band — only the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)