### PR TITLE
tend: condensation needs an O(1) kernel store — the precise next stone, measured

### DIFF
--- a/docs/coherence-substrate/bmf-architecture.form
+++ b/docs/coherence-substrate/bmf-architecture.form
@@ -126,6 +126,36 @@ lift pattern-kind to a Blueprint and make `Match` dispatch through that same
 O(1) NodeID switch — *switch is free* — rather than re-deriving it with a tag
 chain. That is a kernel-native step, named here so the next cell can take it.
 
+### Observability — the cursor's furthest reach
+
+A failed `Alt` returns the *pre*-failure cursor (no-sediment backtracking), so a
+partial parse silently rewinds and the caller can't see where the grammar gave
+out. The fix is to let the cursor carry its **furthest reach**: the deepest
+stream position any rule was attempted at, and that rule's name. Probing the
+four thesis `.bml` files with this proved its worth — it pinpointed the frontier
+at byte 6328 (a `catch` body), which named the real gap: a local declaration
+*without* initializer (`ParseStream hStream;` — only `Type name = expr;` was a
+rule). Adding `declnoinit` advanced the frontier to byte 15941 of 15943, and Go
+and TS then fully parsed all four files.
+
+Two design notes the proving exposed:
+- **Keep it cheap or opt-in.** Tracking it with `record_get`/`record_set` on
+  *every* rule entry (each interning the field name) made the hot path far
+  slower under heavy backtracking — Rust went from finishing to minutes. The
+  frontier wants a single mutable int cell updated only on a strict advance, or
+  a tracking mode toggled off for production parses.
+- **It surfaces the real frontier: backtracking cost.** With the deep parse
+  unlocked, the grammar's PEG backtracking is the wall — the same `(rule, pos)`
+  is re-parsed across `Alt` branches and `Chain` arg-exprs, multiplying through
+  expression depth. Rust hangs on the full 456-line file. This is the twin of
+  the O(1)-switch grounding: **packrat memoization** — cache `(rule, pos) →
+  result`, turning exponential re-descent into linear. It IS the body's own
+  teaching that *repeated observation condenses to one result* (gas→water→ice,
+  JIT). The one constraint: memo identity is per-input — key it by the surface
+  (or give each parse a fresh memo), since grammars are reused across inputs.
+  Linear parsing is what lets the 4th file complete on every kernel and lets the
+  furthest-reach cell run always-on without cost.
+
 ### Template blueprints — the emitting side
 
 ```form

--- a/docs/coherence-substrate/bmf-architecture.form
+++ b/docs/coherence-substrate/bmf-architecture.form
@@ -156,6 +156,25 @@ Two design notes the proving exposed:
   Linear parsing is what lets the 4th file complete on every kernel and lets the
   furthest-reach cell run always-on without cost.
 
+**What condensation needs from the kernel — measured, not guessed.** A fk-level
+memo was built (opt-in, fresh per parse, keyed `name@pos`) and it did *not* make
+the parse fast: the kernel's `record` is a linear-scan slice (`get`/`set` walk
+all fields), so a memo of thousands of `(rule,pos)` entries is **O(n²)** — the
+store itself becomes the cost. And there is no hash/dict native: the only O(1)
+mechanism the kernel exposes is content-addressed **interning** (`intern_node`,
+content → NodeID), which gives node *identity*, not a key→value cache. So the
+real foundational step is one kernel primitive: an **O(1) content-addressed
+condensation store** — either a hash map, or (more in-grain) a result-cache
+keyed by the interned NodeID of the observation `(surface, rule, pos)`. That is
+the substrate's O(1) promise — already true for node identity — extended to
+parse-state. Until it exists, packrat at fk-level can't beat the backtracking;
+with it, condensation is linear and *switch is free* and *observing has no
+penalty* become literally true. The deeper horizon past packrat is a streaming,
+stackless matcher (derivatives / a chart): the cursor advances once, `Alt` is
+parallel item-advance, recursion lives in the data, and the frontier is the
+furthest live item — but even that rests on O(1) condensation underneath. The
+kernel store is the stone the whole arch is waiting on.
+
 ### Template blueprints — the emitting side
 
 ```form


### PR DESCRIPTION
Continues the first-principles thread (*observation condenses to one result*). I **walked** the condensation step instead of theorizing — and the measurement names the exact foundational primitive the substrate is missing.

## What was tried and measured
Built an **opt-in, per-parse-fresh packrat memo** at the rule level (`g-match-rule`, key `name@pos`, fresh observation space via `g-with-memo` so it can never collide across inputs). It did **not** make the parse fast.

**Root cause, measured:** the kernel's `record` is a **linear-scan slice** — `get`/`set` walk every field — so a memo of thousands of `(rule, pos)` entries is **O(n²)**; the store itself becomes the cost. And there's **no hash/dict native** — the only O(1) mechanism the kernel exposes is content-addressed **interning** (`content → NodeID`), which gives node *identity*, not a key→value cache.

## The precise next stone
One kernel primitive: an **O(1) content-addressed condensation store** — a hash map, or (more in-grain) a result-cache keyed by the interned NodeID of the observation `(surface, rule, pos)`. That is the substrate's own O(1) promise — already true for node identity — extended to parse-state. With it:
- packrat is linear → the deep `BMF-grammar.bml` completes on **every** kernel (Go and TS already finish; Rust is the slow pole at minutes),
- the furthest-reach observer runs always-on without penalty,
- *switch is free* and *observing has no penalty* become literally true.

The horizon past packrat is a **streaming, stackless matcher** (derivatives / a chart): cursor advances once, `Alt` is parallel item-advance, recursion lives in the data, the frontier is the furthest live item — but even that rests on this same O(1) stone.

**Doc-only.** Engine and grammar stay at #2479 — no slow or divergent band ships. The map now names the exact next stone (recorded in `bmf-architecture.form`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)