### PR TITLE
tend: condensation needs an O(1) kernel store — the precise next stone, measured

### DIFF
--- a/docs/coherence-substrate/bmf-architecture.form
+++ b/docs/coherence-substrate/bmf-architecture.form
@@ -156,6 +156,25 @@ Two design notes the proving exposed:
   Linear parsing is what lets the 4th file complete on every kernel and lets the
   furthest-reach cell run always-on without cost.
 
+**What condensation needs from the kernel — measured, not guessed.** A fk-level
+memo was built (opt-in, fresh per parse, keyed `name@pos`) and it did *not* make
+the parse fast: the kernel's `record` is a linear-scan slice (`get`/`set` walk
+all fields), so a memo of thousands of `(rule,pos)` entries is **O(n²)** — the
+store itself becomes the cost. And there is no hash/dict native: the only O(1)
+mechanism the kernel exposes is content-addressed **interning** (`intern_node`,
+content → NodeID), which gives node *identity*, not a key→value cache. So the
+real foundational step is one kernel primitive: an **O(1) content-addressed
+condensation store** — either a hash map, or (more in-grain) a result-cache
+keyed by the interned NodeID of the observation `(surface, rule, pos)`. That is
+the substrate's O(1) promise — already true for node identity — extended to
+parse-state. Until it exists, packrat at fk-level can't beat the backtracking;
+with it, condensation is linear and *switch is free* and *observing has no
+penalty* become literally true. The deeper horizon past packrat is a streaming,
+stackless matcher (derivatives / a chart): the cursor advances once, `Alt` is
+parallel item-advance, recursion lives in the data, and the frontier is the
+furthest live item — but even that rests on O(1) condensation underneath. The
+kernel store is the stone the whole arch is waiting on.
+
 ### Template blueprints — the emitting side
 
 ```form


### PR DESCRIPTION
Continues the first-principles thread (*observation condenses to one result*). I **walked** the condensation step rather than theorizing — and the measurement names the exact foundational primitive the substrate is missing.

## Measured
Built an **opt-in, per-parse-fresh packrat memo** at the rule level (key `name@pos`, fresh observation space so it can't collide across inputs). It did **not** make the parse fast. Root cause: the kernel's `record` is a **linear-scan slice** — `get`/`set` walk every field — so a memo of thousands of `(rule, pos)` entries is **O(n²)**; the store itself becomes the cost. And there's **no hash/dict native** — the only O(1) mechanism is content-addressed **interning** (`content → NodeID`), which gives node *identity*, not a key→value cache.

## The precise next stone
One kernel primitive: an **O(1) content-addressed condensation store** — a hash map, or a result-cache keyed by the interned NodeID of the observation `(surface, rule, pos)`. The substrate's O(1) promise — already true for node identity — extended to parse-state. With it: packrat is linear → the deep `BMF-grammar.bml` completes on **every** kernel (Go/TS finish; Rust is the slow pole), the furthest-reach observer runs always-on free, and *switch is free* / *observing has no penalty* become literal. Horizon past packrat: a streaming, stackless matcher (derivatives / chart) — which rests on the same stone.

**Doc-only.** Engine/grammar unchanged from #2479 — no slow or divergent band ships. The map now names the exact next stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)