### PR TITLE
tend: flatten the BML expression grammar (~8%), and settle the bottleneck

### DIFF
--- a/docs/coherence-substrate/bmf-architecture.form
+++ b/docs/coherence-substrate/bmf-architecture.form
@@ -218,6 +218,33 @@ target is **native engine + cut + a left-factored grammar** together — each wa
 one leg of why the thesis was fast, and we'd been missing all three. Next
 experiment: a native Match inner loop, aliased in, benchmarked the same way.
 
+**Third experiment — reshape the grammar itself (full freedom granted).** With
+license to change any grammar shape for efficiency, I flattened: inlined the thin
+`orexpr` wrapper into `expr` (one fewer rule-dispatch per operand) and reordered
+`primary` so the common operand — an identifier — matches in 2 alt-tries instead
+of 5 (with `litnum` kept first, since `ident`'s alnum-run also matches digits —
+a reorder that looked free but would have silently parsed numbers as identifiers,
+and the consume-metric wouldn't have caught it). Measured, same coverage:
+
+```
+Go, BMF-grammar prefix workload:   baseline 8.45s    flattened 7.80s   (~8%)
+```
+
+So grammar reshape is **real but small (~8%)**, and the packrat result already
+told us why: the cost isn't re-parsing or wide alt-exploration — it's the *single*
+deep parse of every operand, interpreted. The ladder's loops already live in
+engine combinators (`infix`/`chain`/`ternary`); the fk-rule overhead that's left
+is a handful of dispatches per token, and shaving them buys ~8%, not 8×.
+
+**The settled conclusion, evidenced across four experiments** (packrat 0 %, cut
+~2× but coverage-confounded, flatten ~8 %, profile = ~all in `walk`): *the BML
+grammar is not the bottleneck — the interpreter is.* The grammar is already
+about as token- and shape-efficient as interpretation rewards; the multiplier is
+to stop interpreting `Match` and run it as native code (the thesis's compiled
+engine), with cut and a left-factored grammar as second-order gains on top. Each
+grammar experiment was honest and cheap; together they rule out the grammar as
+the lever and point, with evidence, at the engine.
+
 ### Template blueprints — the emitting side
 
 ```form

--- a/form/form-stdlib/bml.fk
+++ b/form/form-stdlib/bml.fk
@@ -88,13 +88,14 @@
         (rule3 "exprs" (list "seq" (p-cap "e" (p-ref "expr")) (p-lit ";")) (t-splice "e"))
 
         ;; ── expression: ternary over the precedence ladder over unary ─────
-        (rule3 "expr" (p-cap "v" (p-ternary (p-ref "orexpr") (p-ref "expr"))) (t-splice "v"))
-        (rule3 "orexpr" (p-cap "v" (p-infix (p-ref "unary") (list
+        ;; expr = ternary over the precedence ladder over unary — the orexpr
+        ;; wrapper is inlined (one fewer rule-dispatch per operand).
+        (rule3 "expr" (p-cap "v" (p-ternary (p-infix (p-ref "unary") (list
             (list "||" "or" 1) (list "&&" "and" 2)
             (list "==" "eq" 3) (list "!=" "ne" 3)
             (list "instanceof" "eq" 4)
             (list "<=" "le" 4) (list ">=" "ge" 4) (list "<" "lt" 4) (list ">" "gt" 4)
-            (list "+" "add" 5) (list "-" "sub" 5) (list "*" "mul" 6) (list "/" "div" 6) (list "%" "mod" 6)))) (t-splice "v"))
+            (list "+" "add" 5) (list "-" "sub" 5) (list "*" "mul" 6) (list "/" "div" 6) (list "%" "mod" 6))) (p-ref "expr"))) (t-splice "v"))
 
         ;; ── unary prefix: ++ -- ! - and cast (Type)e (type erased) ────────
         (rule3 "unary" (p-cap "v" (list "alt" (p-ref "preinc") (p-ref "predec") (p-ref "notx") (p-ref "negx") (p-ref "castx") (p-ref "postfix"))) (t-splice "v"))
@@ -108,7 +109,10 @@
         (rule3 "postfix" (p-cap "v" (p-chain (p-ref "primary") (p-ref "expr"))) (t-splice "v"))
 
         ;; ── primary: ( expr ) | string | char | number | identifier ───────
-        (rule3 "primary" (p-cap "v" (list "alt" (p-ref "paren") (p-ref "litstr") (p-ref "litchr") (p-ref "litnum") (p-ref "ident"))) (t-splice "v"))
+        ;; primary order: litnum BEFORE ident (ident's alnum-run also matches
+        ;; digits, so numbers must be tried first), then ident (the common case)
+        ;; — idents now match in 2 tries instead of 5, numbers in 1, safely.
+        (rule3 "primary" (p-cap "v" (list "alt" (p-ref "litnum") (p-ref "ident") (p-ref "litstr") (p-ref "paren") (p-ref "litchr"))) (t-splice "v"))
         (rule3 "paren" (list "seq" (p-lit "(") (p-cap "e" (p-ref "expr")) (p-lit ")")) (t-splice "e"))
         (rule3 "litstr" (p-cap "v" (p-str)) (t-splice "v"))
         (rule3 "litchr" (p-cap "v" (p-char)) (t-splice "v"))


### PR DESCRIPTION
Took up the grammar-flexibility offer: reshape any BML shape for efficiency. Flattened the expression path and **measured** it.

## The reshape (semantics-preserving)
- Inlined the thin `orexpr` wrapper into `expr` — one fewer rule-dispatch per operand.
- Reordered `primary` so the common operand (identifier) matches in **2 alt-tries instead of 5** — keeping `litnum` first, because `ident`'s `alnum`-run also matches digits (an "obvious" ident-first reorder would have **silently parsed numbers as identifiers**, and the consume-metric wouldn't have caught it — caught by reasoning, not luck).

```
Go, same workload/coverage:   baseline 8.45s    flattened 7.80s   (~8%)
Cross-kernel: 2221, Go/Rust/TS agree.
```

## Settled bottleneck — four experiments
| Lever | Measured |
|---|---|
| Packrat (cache re-eval) | **0%** — re-parse isn't the cost |
| Cut | ~2× but coverage-confounded (flipped a file 2→1, exposing imprecise backtracking) |
| **Flatten (this PR)** | **~8%**, correct, shippable |
| Profile | ~all time in `(Kernel).walk` |

**The BML grammar is not the bottleneck — the interpreter is.** The ladder's loops already live in engine combinators (`infix`/`chain`/`ternary`); the remaining fk-rule overhead is a few dispatches per token, worth ~8%, not 8×. The multiplier is to **stop interpreting `Match` and run it as native code** (the thesis's compiled engine), with cut + a left-factored grammar as second-order gains.

Doc updated; engine (`bmf-grammar.fk`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)