### PR TITLE
tend: Hati Suci resident-service board — first slice of the living-economy membrane

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -9,13 +9,6 @@
 > drill into next, then ~1500 tokens to know which file to read.
 > Total cost to locate any file: under 2K tokens.
 
-## Agent entry (read first)
-
-| Doc | Purpose |
-|---|---|
-| [docs/shared/agent-start-packet.md](docs/shared/agent-start-packet.md) | **First file for any agent** — Form/native runtime primary surface, Python bootstrap compost, read-only query default |
-| [docs/coherence-substrate/INDEX.md](docs/coherence-substrate/INDEX.md) | Substrate + Form notation drill-down |
-
 ## Narrative layer (existing)
 
 | Index | Purpose |
@@ -33,20 +26,19 @@
 | [docs/vision-kb/stories/INDEX.md](docs/vision-kb/stories/INDEX.md) | Field vignettes — scenes from the future |
 | [docs/lineage/INDEX.md](docs/lineage/INDEX.md) | Teaching lineages and presences |
 | [docs/presences/INDEX.md](docs/presences/INDEX.md) | Specific presences in the field |
-| [docs/hati-suci/INDEX.md](docs/hati-suci/INDEX.md) | Hati Suci organ ledger — the first Light Hub sensing its own electricity, water, food |
 
 ## Code layer (auto-generated)
 
 | Index | Files | Purpose |
 |---|---|---|
-| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 142 | API routers — every HTTP endpoint surface |
+| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 143 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 244 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 239 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 160 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 141 | Scripts — operational tools, generators, syncers |
+| [web/app/INDEX.md](web/app/INDEX.md) | 161 | Web routes — every visible page in the app |
+| [scripts/INDEX.md](scripts/INDEX.md) | 142 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/data/web_routes.json
+++ b/api/app/data/web_routes.json
@@ -61,6 +61,7 @@
     "/graph": "web/app/graph/page.tsx",
     "/graph/zoom/[nodeId]": "web/app/graph/zoom/[nodeId]/page.tsx",
     "/graphs": "web/app/graphs/page.tsx",
+    "/hati-suci": "web/app/hati-suci/page.tsx",
     "/here": "web/app/here/page.tsx",
     "/ideas": "web/app/ideas/page.tsx",
     "/ideas/[idea_id]": "web/app/ideas/[idea_id]/page.tsx",

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -687,9 +687,11 @@ app.include_router(coherence.router, prefix="/api", tags=["coherence"])
 from app.routers import practice as practice_router
 from app.routers import sensings as sensings_router
 from app.routers import offerings as offerings_router
+from app.routers import household as household_router
 app.include_router(practice_router.router, prefix="/api", tags=["practice"])
 app.include_router(sensings_router.router, prefix="/api", tags=["sensings"])
 app.include_router(offerings_router.router, prefix="/api", tags=["offerings"])
+app.include_router(household_router.router, prefix="/api", tags=["household"])
 app.include_router(governance.router, prefix="/api", tags=["governance"])
 app.include_router(federation.router, prefix="/api", tags=["federation"])
 app.include_router(field_stories.router, prefix="/api", tags=["field-stories"])

--- a/api/app/routers/INDEX.md
+++ b/api/app/routers/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 142
+**Total files**: 143
 
 | File | Purpose |
 |---|---|
@@ -80,6 +80,7 @@
 | [graph_questions.py](graph_questions.py) | Graph node open-questions router (Spec 182). |
 | [graph_zoom.py](graph_zoom.py) | Fractal zoom navigation router (Spec 182). |
 | [health.py](health.py) | Health check endpoint (spec 001). |
+| [household.py](household.py) | Household — the resident-service nervous system for a Light Hub. |
 | [ideas.py](ideas.py) | Idea portfolio API routes. |
 | [inspired_by.py](inspired_by.py) | Inspired-by router — post a name, a subgraph appears. |
 | [interest.py](interest.py) | Interest registration API — privacy-first community gathering. |

--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -1,0 +1,375 @@
+"""Household — the resident-service nervous system for a Light Hub.
+
+Residents signal a need (food, laundry, a ride, a repair, a room readied);
+the staff see the request, acknowledge it, and complete it — everyone
+watching the same open board, no secrets. When a request needs something
+bought outside (detergent, a part, groceries), the cost rides along on the
+request and can be marked settled, so the small money that has to move
+stays as visible as the care.
+
+This is the first physical surface of the network's living economy: the
+resonance board (lc-offering) and the visible membrane (lc-economy) made
+operational for a real residence. Identity is light on purpose — a member
+is a name + a role (resident or staff) + a language — so registering is as
+easy as walking in. Backed by the same living graph that holds concepts,
+offerings, and contributors.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.services import graph_service
+
+router = APIRouter()
+
+
+MemberRole = Literal["resident", "staff"]
+RequestKind = Literal[
+    "food", "laundry", "cleaning", "ride", "repair", "room", "supplies", "other"
+]
+RequestStatus = Literal["open", "acknowledged", "in_progress", "completed", "cancelled"]
+CostStatus = Literal["none", "recorded", "paid"]
+
+_MEMBER_TYPE = "household_member"
+_REQUEST_TYPE = "service_request"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------
+# Members — light identity: a name, a role, a language. No password, no gate.
+# --------------------------------------------------------------------------
+
+
+class MemberCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    role: MemberRole
+    locale: str = Field(default="en", max_length=8, description="UI language: en, id, …")
+
+
+class MemberResponse(BaseModel):
+    id: str
+    name: str
+    role: str
+    locale: str
+    created_at: str
+
+
+def _node_to_member(node: dict) -> MemberResponse:
+    return MemberResponse(
+        id=node.get("id", ""),
+        name=node.get("name", "") or node.get("member_name", ""),
+        role=node.get("role", "resident"),
+        locale=node.get("locale", "en") or "en",
+        created_at=node.get("created_at", "") or node.get("observed_at", ""),
+    )
+
+
+def _get_member(member_id: str) -> dict | None:
+    node = graph_service.get_node(member_id)
+    if node and node.get("type") == _MEMBER_TYPE:
+        return node
+    return None
+
+
+def _member_name(member_id: str | None) -> str:
+    if not member_id:
+        return ""
+    node = _get_member(member_id)
+    return node.get("name", "") if node else ""
+
+
+@router.post(
+    "/household/members",
+    response_model=MemberResponse,
+    status_code=201,
+    summary="Register a resident or staff member (light identity)",
+)
+async def create_member(body: MemberCreate) -> MemberResponse:
+    member_id = f"member-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:6]}"
+    created_at = _now()
+    properties: dict[str, Any] = {
+        "role": body.role,
+        "locale": body.locale or "en",
+        "created_at": created_at,
+    }
+    node = graph_service.create_node(
+        id=member_id,
+        type=_MEMBER_TYPE,
+        name=body.name,
+        description=f"{body.role} of the household",
+        properties=properties,
+    )
+    return _node_to_member(node)
+
+
+@router.get(
+    "/household/members",
+    response_model=list[MemberResponse],
+    summary="Everyone in the household — residents and staff",
+)
+async def list_members(role: str | None = Query(default=None)) -> list[MemberResponse]:
+    try:
+        response = graph_service.list_nodes(type=_MEMBER_TYPE, limit=500)
+        nodes = response.get("items", []) if isinstance(response, dict) else (response or [])
+    except Exception:
+        nodes = []
+    members = [n for n in nodes if n.get("type") == _MEMBER_TYPE]
+    if role:
+        members = [n for n in members if n.get("role") == role]
+    members.sort(key=lambda n: n.get("created_at", ""))
+    return [_node_to_member(n) for n in members]
+
+
+# --------------------------------------------------------------------------
+# Requests — the open board. Added → acknowledged → in_progress → completed.
+# --------------------------------------------------------------------------
+
+
+class RequestCreate(BaseModel):
+    requester_id: str = Field(min_length=1)
+    kind: RequestKind
+    detail: str = Field(min_length=1, max_length=2000, description="What is needed")
+    location: str | None = Field(default=None, max_length=200, description="Where (which house, the garden, …)")
+    when_text: str | None = Field(default=None, max_length=200, description="When it's needed, in plain words")
+
+
+class ActorBody(BaseModel):
+    actor_id: str = Field(min_length=1, description="The member performing this action")
+
+
+class CompleteBody(ActorBody):
+    cost_amount: float | None = Field(default=None, ge=0, description="Cost of any outside resources")
+    cost_currency: str = Field(default="IDR", max_length=8)
+    cost_note: str | None = Field(default=None, max_length=400)
+
+
+class RequestResponse(BaseModel):
+    id: str
+    kind: str
+    detail: str
+    location: str | None = None
+    when_text: str | None = None
+    status: str
+    requester_id: str
+    requester_name: str
+    acknowledged_by: str | None = None
+    acknowledged_by_name: str | None = None
+    acknowledged_at: str | None = None
+    started_at: str | None = None
+    completed_by: str | None = None
+    completed_by_name: str | None = None
+    completed_at: str | None = None
+    cancelled_at: str | None = None
+    cost_amount: float | None = None
+    cost_currency: str = "IDR"
+    cost_note: str | None = None
+    cost_status: str = "none"
+    paid_by: str | None = None
+    paid_by_name: str | None = None
+    paid_at: str | None = None
+    created_at: str
+    updated_at: str
+
+
+def _s(v: Any) -> str | None:
+    s = str(v).strip() if v is not None else ""
+    return s or None
+
+
+def _node_to_request(node: dict) -> RequestResponse:
+    raw_cost = node.get("cost_amount")
+    cost_amount = float(raw_cost) if isinstance(raw_cost, (int, float)) else None
+    return RequestResponse(
+        id=node.get("id", ""),
+        kind=node.get("kind", "other"),
+        detail=node.get("detail", "") or node.get("description", ""),
+        location=_s(node.get("location")),
+        when_text=_s(node.get("when_text")),
+        status=node.get("status", "open"),
+        requester_id=node.get("requester_id", ""),
+        requester_name=node.get("requester_name", "") or "",
+        acknowledged_by=_s(node.get("acknowledged_by")),
+        acknowledged_by_name=_s(node.get("acknowledged_by_name")),
+        acknowledged_at=_s(node.get("acknowledged_at")),
+        started_at=_s(node.get("started_at")),
+        completed_by=_s(node.get("completed_by")),
+        completed_by_name=_s(node.get("completed_by_name")),
+        completed_at=_s(node.get("completed_at")),
+        cancelled_at=_s(node.get("cancelled_at")),
+        cost_amount=cost_amount,
+        cost_currency=node.get("cost_currency", "IDR") or "IDR",
+        cost_note=_s(node.get("cost_note")),
+        cost_status=node.get("cost_status", "none") or "none",
+        paid_by=_s(node.get("paid_by")),
+        paid_by_name=_s(node.get("paid_by_name")),
+        paid_at=_s(node.get("paid_at")),
+        created_at=node.get("created_at", "") or node.get("observed_at", ""),
+        updated_at=node.get("updated_at", "") or node.get("created_at", ""),
+    )
+
+
+def _load_request(request_id: str) -> dict:
+    node = graph_service.get_node(request_id)
+    if not node or node.get("type") != _REQUEST_TYPE:
+        raise HTTPException(status_code=404, detail=f"request {request_id!r} not found")
+    return node
+
+
+def _apply(request_id: str, updates: dict[str, Any]) -> RequestResponse:
+    updates["updated_at"] = _now()
+    node = graph_service.update_node(request_id, properties=updates)
+    if node is None:
+        raise HTTPException(status_code=404, detail=f"request {request_id!r} not found")
+    return _node_to_request(node)
+
+
+@router.post(
+    "/household/requests",
+    response_model=RequestResponse,
+    status_code=201,
+    summary="Ask the field for something (food, laundry, a ride, a repair…)",
+)
+async def create_request(body: RequestCreate) -> RequestResponse:
+    requester = _get_member(body.requester_id)
+    if not requester:
+        raise HTTPException(status_code=400, detail=f"member {body.requester_id!r} not found")
+    request_id = f"request-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:6]}"
+    created_at = _now()
+    properties: dict[str, Any] = {
+        "kind": body.kind,
+        "detail": body.detail,
+        "location": body.location or "",
+        "when_text": body.when_text or "",
+        "status": "open",
+        "requester_id": body.requester_id,
+        "requester_name": requester.get("name", ""),
+        "cost_status": "none",
+        "cost_currency": "IDR",
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    node = graph_service.create_node(
+        id=request_id,
+        type=_REQUEST_TYPE,
+        name=body.detail[:120],
+        description=body.detail,
+        properties=properties,
+    )
+    return _node_to_request(node)
+
+
+@router.get(
+    "/household/requests",
+    response_model=list[RequestResponse],
+    summary="The open board — every request, what's done and what's waiting",
+)
+async def list_requests(
+    status: str | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=500),
+) -> list[RequestResponse]:
+    try:
+        response = graph_service.list_nodes(type=_REQUEST_TYPE, limit=500)
+        nodes = response.get("items", []) if isinstance(response, dict) else (response or [])
+    except Exception:
+        nodes = []
+    requests = [n for n in nodes if n.get("type") == _REQUEST_TYPE]
+    if status:
+        requests = [n for n in requests if n.get("status") == status]
+    requests.sort(key=lambda n: n.get("created_at", ""), reverse=True)
+    return [_node_to_request(n) for n in requests[:limit]]
+
+
+@router.get(
+    "/household/requests/{request_id}",
+    response_model=RequestResponse,
+    summary="A single request in full",
+)
+async def get_request(request_id: str) -> RequestResponse:
+    return _node_to_request(_load_request(request_id))
+
+
+@router.post(
+    "/household/requests/{request_id}/acknowledge",
+    response_model=RequestResponse,
+    summary="A staff member sees it and takes it on",
+)
+async def acknowledge_request(request_id: str, body: ActorBody) -> RequestResponse:
+    _load_request(request_id)
+    return _apply(request_id, {
+        "status": "acknowledged",
+        "acknowledged_by": body.actor_id,
+        "acknowledged_by_name": _member_name(body.actor_id),
+        "acknowledged_at": _now(),
+    })
+
+
+@router.post(
+    "/household/requests/{request_id}/start",
+    response_model=RequestResponse,
+    summary="Work on it has begun",
+)
+async def start_request(request_id: str, body: ActorBody) -> RequestResponse:
+    node = _load_request(request_id)
+    updates: dict[str, Any] = {"status": "in_progress", "started_at": _now()}
+    if not _s(node.get("acknowledged_by")):
+        updates["acknowledged_by"] = body.actor_id
+        updates["acknowledged_by_name"] = _member_name(body.actor_id)
+        updates["acknowledged_at"] = _now()
+    return _apply(request_id, updates)
+
+
+@router.post(
+    "/household/requests/{request_id}/complete",
+    response_model=RequestResponse,
+    summary="It's done — optionally recording the cost of any outside resources",
+)
+async def complete_request(request_id: str, body: CompleteBody) -> RequestResponse:
+    _load_request(request_id)
+    updates: dict[str, Any] = {
+        "status": "completed",
+        "completed_by": body.actor_id,
+        "completed_by_name": _member_name(body.actor_id),
+        "completed_at": _now(),
+    }
+    if body.cost_amount and body.cost_amount > 0:
+        updates["cost_amount"] = float(body.cost_amount)
+        updates["cost_currency"] = body.cost_currency or "IDR"
+        updates["cost_note"] = body.cost_note or ""
+        updates["cost_status"] = "recorded"
+    return _apply(request_id, updates)
+
+
+@router.post(
+    "/household/requests/{request_id}/cancel",
+    response_model=RequestResponse,
+    summary="No longer needed",
+)
+async def cancel_request(request_id: str, body: ActorBody) -> RequestResponse:
+    _load_request(request_id)
+    return _apply(request_id, {"status": "cancelled", "cancelled_at": _now()})
+
+
+@router.post(
+    "/household/requests/{request_id}/pay",
+    response_model=RequestResponse,
+    summary="Mark the outside-resource cost as settled",
+)
+async def pay_request(request_id: str, body: ActorBody) -> RequestResponse:
+    node = _load_request(request_id)
+    if node.get("cost_status") not in ("recorded", "paid"):
+        raise HTTPException(status_code=400, detail="this request has no recorded cost to settle")
+    return _apply(request_id, {
+        "cost_status": "paid",
+        "paid_by": body.actor_id,
+        "paid_by_name": _member_name(body.actor_id),
+        "paid_at": _now(),
+    })

--- a/api/tests/test_household_service_board.py
+++ b/api/tests/test_household_service_board.py
@@ -1,0 +1,94 @@
+"""Flow test for the household resident-service board (api/app/routers/household.py).
+
+One strange-minimal flow that exercises the whole nervous system: a resident
+asks, a staff member sees it and carries it through, an outside-resource cost
+rides along and gets settled — and the two guards that keep it honest (a
+request needs a real member; a settle needs a recorded cost).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _member(client, name, role):
+    res = client.post("/api/household/members", json={"name": name, "role": role})
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+def test_request_moves_from_ask_to_done_with_settled_cost(client):
+    resident = _member(client, "Ayu", "resident")
+    staff = _member(client, "Wayan", "staff")
+
+    # The ask
+    res = client.post("/api/household/requests", json={
+        "requester_id": resident["id"],
+        "kind": "laundry",
+        "detail": "two sets of bed linen for the lumbung",
+        "location": "Lumbung house",
+        "when_text": "before sunset",
+    })
+    assert res.status_code == 201, res.text
+    req = res.json()
+    assert req["status"] == "open"
+    assert req["requester_name"] == "Ayu"
+    rid = req["id"]
+
+    # It shows on the open board everyone sees
+    board = client.get("/api/household/requests").json()
+    assert any(r["id"] == rid for r in board)
+
+    # Staff sees it and carries it through
+    ack = client.post(f"/api/household/requests/{rid}/acknowledge", json={"actor_id": staff["id"]}).json()
+    assert ack["status"] == "acknowledged"
+    assert ack["acknowledged_by_name"] == "Wayan"
+
+    started = client.post(f"/api/household/requests/{rid}/start", json={"actor_id": staff["id"]}).json()
+    assert started["status"] == "in_progress"
+
+    # Done — with an outside-resource cost recorded
+    done = client.post(f"/api/household/requests/{rid}/complete", json={
+        "actor_id": staff["id"],
+        "cost_amount": 25000,
+        "cost_note": "detergent",
+    }).json()
+    assert done["status"] == "completed"
+    assert done["completed_by_name"] == "Wayan"
+    assert done["cost_amount"] == 25000
+    assert done["cost_status"] == "recorded"
+
+    # The small money that moved is settled — and visible
+    paid = client.post(f"/api/household/requests/{rid}/pay", json={"actor_id": staff["id"]}).json()
+    assert paid["cost_status"] == "paid"
+    assert paid["paid_by_name"] == "Wayan"
+
+
+def test_request_needs_a_real_member(client):
+    res = client.post("/api/household/requests", json={
+        "requester_id": "member-does-not-exist",
+        "kind": "food",
+        "detail": "lunch for two",
+    })
+    assert res.status_code == 400
+
+
+def test_settle_needs_a_recorded_cost(client):
+    resident = _member(client, "Komang", "resident")
+    staff = _member(client, "Made", "staff")
+    rid = client.post("/api/household/requests", json={
+        "requester_id": resident["id"],
+        "kind": "ride",
+        "detail": "scooter to the market",
+    }).json()["id"]
+    # Completed with no outside cost → nothing to settle
+    client.post(f"/api/household/requests/{rid}/complete", json={"actor_id": staff["id"]})
+    res = client.post(f"/api/household/requests/{rid}/pay", json={"actor_id": staff["id"]})
+    assert res.status_code == 400

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 141
+**Total files**: 142
 
 | File | Purpose |
 |---|---|
@@ -68,6 +68,7 @@
 | [git_artifact_perceptron.py](git_artifact_perceptron.py) | git_artifact_perceptron.py — the smallest real version of the form perceptron. |
 | [git_artifact_perceptron_substrate.py](git_artifact_perceptron_substrate.py) | git_artifact_perceptron_substrate.py — the substrate-native perceptron. |
 | [grammar_coverage.py](grammar_coverage.py) | grammar_coverage.py — surface which file formats have Form grammars. |
+| [guided_somatic_exit.py](guided_somatic_exit.py) | Guided Somatic Exit — daily practice for walking out of the fear-pattern loop. |
 | [healing_modality_recipe_proof.py](healing_modality_recipe_proof.py) | healing_modality_recipe_proof.py — practitioner-with-receiver as Recipe. |
 | [idea_to_task_bridge.py](idea_to_task_bridge.py) | Idea-to-Task Bridge — automatically generate tasks from open ideas. |
 | [import_creations.py](import_creations.py) | Auto-import creations into the graph from external sources. |

--- a/scripts/viewport_audit.py
+++ b/scripts/viewport_audit.py
@@ -54,6 +54,7 @@ DEFAULT_PATHS = [
     "/people/contributor%3Aactualize-earth-4d812a0238eb",
     "/substrate",
     "/portfolio/investments",
+    "/hati-suci",   # the resident-service nervous system (first Light Hub membrane)
 ]
 ROOT = Path(__file__).resolve().parents[1]
 OUT = ROOT / "output" / "viewport-audit"

--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 160
+**Total files**: 161
 
 | Route | File | Purpose |
 |---|---|---|
@@ -67,6 +67,7 @@
 | `/graph` | [page.tsx](graph/page.tsx) | _no top-of-file purpose_ |
 | `/graph/zoom/[nodeId]` | [page.tsx](graph/zoom/[nodeId]/page.tsx) | _no top-of-file purpose_ |
 | `/graphs` | [page.tsx](graphs/page.tsx) | _no top-of-file purpose_ |
+| `/hati-suci` | [page.tsx](hati-suci/page.tsx) | Hati Suci — the resident-service nervous system (first Light Hub membrane). |
 | `/here` | [page.tsx](here/page.tsx) | _no top-of-file purpose_ |
 | `/ideas/[idea_id]/edit` | [page.tsx](ideas/[idea_id]/edit/page.tsx) | Idea edit surface — mirrors the asymmetry-closing for /vision/{id}/edit. |
 | `/ideas/[idea_id]` | [page.tsx](ideas/[idea_id]/page.tsx) | _no top-of-file purpose_ |

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -1,0 +1,487 @@
+// Hati Suci — the resident-service nervous system (first Light Hub membrane).
+// Mobile-first, bilingual (EN/ID). One open board everyone sees: residents
+// ask for food / laundry / a ride / a repair; staff acknowledge and complete;
+// outside-resource costs ride along and get marked settled. No secrets.
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useT } from "@/components/MessagesProvider";
+
+type Role = "resident" | "staff";
+type Member = { id: string; name: string; role: Role; locale: string };
+
+type Kind = "food" | "laundry" | "cleaning" | "ride" | "repair" | "room" | "supplies" | "other";
+type Status = "open" | "acknowledged" | "in_progress" | "completed" | "cancelled";
+
+type ServiceRequest = {
+  id: string;
+  kind: Kind;
+  detail: string;
+  location?: string | null;
+  when_text?: string | null;
+  status: Status;
+  requester_id: string;
+  requester_name: string;
+  acknowledged_by_name?: string | null;
+  completed_by_name?: string | null;
+  cost_amount?: number | null;
+  cost_currency?: string;
+  cost_note?: string | null;
+  cost_status?: "none" | "recorded" | "paid";
+  paid_by_name?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const KINDS: { key: Kind; emoji: string }[] = [
+  { key: "food", emoji: "🍲" },
+  { key: "laundry", emoji: "🧺" },
+  { key: "cleaning", emoji: "🧹" },
+  { key: "ride", emoji: "🛵" },
+  { key: "repair", emoji: "🔧" },
+  { key: "room", emoji: "🛏️" },
+  { key: "supplies", emoji: "🛒" },
+  { key: "other", emoji: "✨" },
+];
+
+const STORAGE_KEY = "hatiSuci.member";
+
+async function postJSON<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return (await res.json()) as T;
+}
+
+function setLocaleCookie(locale: string) {
+  document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${60 * 60 * 24 * 365}`;
+}
+
+function StatusBadge({ status }: { status: Status }) {
+  const t = useT();
+  const tone: Record<Status, string> = {
+    open: "bg-amber-500/15 text-amber-500 border-amber-500/30",
+    acknowledged: "bg-sky-500/15 text-sky-500 border-sky-500/30",
+    in_progress: "bg-indigo-500/15 text-indigo-400 border-indigo-500/30",
+    completed: "bg-emerald-500/15 text-emerald-500 border-emerald-500/30",
+    cancelled: "bg-muted text-muted-foreground border-border/40",
+  };
+  return (
+    <span className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${tone[status]}`}>
+      {t(`hatiSuci.status.${status}`)}
+    </span>
+  );
+}
+
+export default function HatiSuciPage() {
+  const t = useT();
+  const [member, setMember] = useState<Member | null>(null);
+  const [requests, setRequests] = useState<ServiceRequest[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  // registration form
+  const [regName, setRegName] = useState("");
+  const [regRole, setRegRole] = useState<Role>("resident");
+
+  // new-request form
+  const [kind, setKind] = useState<Kind>("food");
+  const [detail, setDetail] = useState("");
+  const [location, setLocation] = useState("");
+  const [whenText, setWhenText] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // per-card completion (optional outside-resource cost)
+  const [completingId, setCompletingId] = useState<string | null>(null);
+  const [costAmount, setCostAmount] = useState("");
+  const [costNote, setCostNote] = useState("");
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) setMember(JSON.parse(raw) as Member);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/household/requests?limit=200");
+      if (res.ok) setRequests((await res.json()) as ServiceRequest[]);
+    } catch {
+      /* keep last good */
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    const timer = window.setInterval(() => void load(), 10_000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  const register = useCallback(async () => {
+    const name = regName.trim();
+    if (!name) return;
+    setBusy(true);
+    try {
+      const created = await postJSON<Member>("/api/household/members", {
+        name,
+        role: regRole,
+        locale: document.documentElement.lang || "en",
+      });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(created));
+      setMember(created);
+    } catch {
+      /* surfaced via disabled state */
+    } finally {
+      setBusy(false);
+    }
+  }, [regName, regRole]);
+
+  const submitRequest = useCallback(async () => {
+    if (!member || !detail.trim()) return;
+    setBusy(true);
+    try {
+      await postJSON("/api/household/requests", {
+        requester_id: member.id,
+        kind,
+        detail: detail.trim(),
+        location: location.trim() || null,
+        when_text: whenText.trim() || null,
+      });
+      setDetail("");
+      setLocation("");
+      setWhenText("");
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }, [member, detail, kind, location, whenText, load]);
+
+  const act = useCallback(
+    async (id: string, verb: string, extra: Record<string, unknown> = {}) => {
+      if (!member) return;
+      try {
+        await postJSON(`/api/household/requests/${id}/${verb}`, { actor_id: member.id, ...extra });
+        await load();
+      } catch {
+        /* ignore — board refreshes on next tick */
+      }
+    },
+    [member, load],
+  );
+
+  const confirmComplete = useCallback(
+    async (id: string) => {
+      const amount = parseFloat(costAmount);
+      await act(id, "complete", {
+        cost_amount: Number.isFinite(amount) && amount > 0 ? amount : null,
+        cost_note: costNote.trim() || null,
+        cost_currency: "IDR",
+      });
+      setCompletingId(null);
+      setCostAmount("");
+      setCostNote("");
+    },
+    [act, costAmount, costNote],
+  );
+
+  const switchUser = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setMember(null);
+  }, []);
+
+  const sorted = useMemo(() => {
+    const rank: Record<Status, number> = { open: 0, acknowledged: 1, in_progress: 2, completed: 3, cancelled: 4 };
+    return [...requests].sort((a, b) => {
+      const r = rank[a.status] - rank[b.status];
+      if (r !== 0) return r;
+      return b.created_at.localeCompare(a.created_at);
+    });
+  }, [requests]);
+
+  const isStaff = member?.role === "staff";
+
+  // ---- Language toggle (always available) ----
+  const langToggle = (
+    <div className="flex gap-1 text-xs">
+      {["en", "id"].map((l) => (
+        <button
+          key={l}
+          onClick={() => {
+            setLocaleCookie(l);
+            window.location.reload();
+          }}
+          className="rounded-md border border-border/40 px-2 py-1 uppercase text-muted-foreground hover:text-foreground hover:bg-accent/60"
+        >
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+
+  // ---- Registration gate ----
+  if (!member) {
+    return (
+      <main className="min-h-screen px-4 py-8">
+        <div className="mx-auto w-full max-w-md space-y-5">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-light tracking-tight">{t("hatiSuci.title")}</h1>
+            {langToggle}
+          </div>
+          <p className="text-sm text-muted-foreground">{t("hatiSuci.tagline")}</p>
+          <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 space-y-4">
+            <p className="text-sm text-muted-foreground">{t("hatiSuci.reg.prompt")}</p>
+            <input
+              value={regName}
+              onChange={(e) => setRegName(e.target.value)}
+              placeholder={t("hatiSuci.reg.namePlaceholder")}
+              className="w-full rounded-xl border border-border/40 bg-background px-4 py-3 text-base outline-none focus:border-primary/60"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              {(["resident", "staff"] as Role[]).map((r) => (
+                <button
+                  key={r}
+                  onClick={() => setRegRole(r)}
+                  className={`rounded-xl border px-3 py-3 text-sm transition-colors ${
+                    regRole === r
+                      ? "border-primary/60 bg-primary/10 text-foreground"
+                      : "border-border/40 text-muted-foreground hover:bg-accent/40"
+                  }`}
+                >
+                  {t(`hatiSuci.role.${r}`)}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={register}
+              disabled={busy || !regName.trim()}
+              className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {t("hatiSuci.reg.enter")}
+            </button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  // ---- Main board ----
+  return (
+    <main className="min-h-screen px-4 py-6">
+      <div className="mx-auto w-full max-w-2xl space-y-5">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-light tracking-tight">{t("hatiSuci.title")}</h1>
+            <p className="text-sm text-muted-foreground">
+              {t("hatiSuci.you")}: <span className="text-foreground">{member.name}</span> · {t(`hatiSuci.role.${member.role}`)}{" "}
+              <button onClick={switchUser} className="underline underline-offset-2 hover:text-foreground">
+                {t("hatiSuci.switchUser")}
+              </button>
+            </p>
+          </div>
+          {langToggle}
+        </header>
+
+        {/* Ask the field */}
+        <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-3">
+          <h2 className="text-base font-medium">{t("hatiSuci.add.heading")}</h2>
+          <div className="grid grid-cols-4 gap-2">
+            {KINDS.map((k) => (
+              <button
+                key={k.key}
+                onClick={() => setKind(k.key)}
+                className={`flex flex-col items-center gap-1 rounded-xl border px-1 py-2 text-xs transition-colors ${
+                  kind === k.key
+                    ? "border-primary/60 bg-primary/10 text-foreground"
+                    : "border-border/40 text-muted-foreground hover:bg-accent/40"
+                }`}
+              >
+                <span className="text-xl leading-none">{k.emoji}</span>
+                <span className="text-center leading-tight">{t(`hatiSuci.kind.${k.key}`)}</span>
+              </button>
+            ))}
+          </div>
+          <textarea
+            value={detail}
+            onChange={(e) => setDetail(e.target.value)}
+            placeholder={t("hatiSuci.add.detailPlaceholder")}
+            rows={2}
+            className="w-full rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <input
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder={t("hatiSuci.add.locationPlaceholder")}
+              className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+            />
+            <input
+              value={whenText}
+              onChange={(e) => setWhenText(e.target.value)}
+              placeholder={t("hatiSuci.add.whenPlaceholder")}
+              className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+            />
+          </div>
+          <button
+            onClick={submitRequest}
+            disabled={busy || !detail.trim()}
+            className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {t("hatiSuci.add.button")}
+          </button>
+        </section>
+
+        {/* The open board */}
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-medium">{t("hatiSuci.board.heading")}</h2>
+            <span className="text-xs text-muted-foreground">{t("hatiSuci.board.everyoneSees")}</span>
+          </div>
+
+          {loaded && sorted.length === 0 && (
+            <p className="rounded-2xl border border-dashed border-border/40 px-4 py-8 text-center text-sm text-muted-foreground">
+              {t("hatiSuci.board.empty")}
+            </p>
+          )}
+
+          {sorted.map((r) => {
+            const emoji = KINDS.find((k) => k.key === r.kind)?.emoji ?? "✨";
+            const active = r.status !== "completed" && r.status !== "cancelled";
+            const mine = r.requester_id === member.id;
+            return (
+              <article
+                key={r.id}
+                className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-2"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-2xl leading-none">{emoji}</span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm text-foreground break-words">{r.detail}</p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {t("hatiSuci.meta.requestedBy")} {r.requester_name}
+                      {r.location ? ` · ${r.location}` : ""}
+                      {r.when_text ? ` · ${r.when_text}` : ""}
+                    </p>
+                  </div>
+                  <StatusBadge status={r.status} />
+                </div>
+
+                {(r.acknowledged_by_name || r.completed_by_name) && (
+                  <p className="text-xs text-muted-foreground">
+                    {r.completed_by_name
+                      ? `${t("hatiSuci.meta.completedBy")} ${r.completed_by_name}`
+                      : `${t("hatiSuci.meta.acknowledgedBy")} ${r.acknowledged_by_name}`}
+                  </p>
+                )}
+
+                {/* Outside-resource cost */}
+                {r.cost_status && r.cost_status !== "none" && (
+                  <div className="flex items-center justify-between rounded-xl bg-background/60 px-3 py-2 text-xs">
+                    <span className="text-muted-foreground">
+                      💸 {r.cost_currency} {Number(r.cost_amount || 0).toLocaleString()}
+                      {r.cost_note ? ` · ${r.cost_note}` : ""}
+                    </span>
+                    {r.cost_status === "paid" ? (
+                      <span className="text-emerald-500">
+                        {t("hatiSuci.cost.paid")}
+                        {r.paid_by_name ? ` · ${r.paid_by_name}` : ""}
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => act(r.id, "pay")}
+                        className="rounded-md border border-emerald-500/40 px-2 py-1 text-emerald-500 hover:bg-emerald-500/10"
+                      >
+                        {t("hatiSuci.act.markPaid")}
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Actions */}
+                {active && (isStaff || mine) && (
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    {isStaff && r.status === "open" && (
+                      <button
+                        onClick={() => act(r.id, "acknowledge")}
+                        className="rounded-lg border border-sky-500/40 px-3 py-1.5 text-sm text-sky-500 hover:bg-sky-500/10"
+                      >
+                        {t("hatiSuci.act.acknowledge")}
+                      </button>
+                    )}
+                    {isStaff && (r.status === "open" || r.status === "acknowledged") && (
+                      <button
+                        onClick={() => act(r.id, "start")}
+                        className="rounded-lg border border-indigo-500/40 px-3 py-1.5 text-sm text-indigo-400 hover:bg-indigo-500/10"
+                      >
+                        {t("hatiSuci.act.start")}
+                      </button>
+                    )}
+                    {isStaff && completingId !== r.id && (
+                      <button
+                        onClick={() => setCompletingId(r.id)}
+                        className="rounded-lg border border-emerald-500/40 px-3 py-1.5 text-sm text-emerald-500 hover:bg-emerald-500/10"
+                      >
+                        {t("hatiSuci.act.complete")}
+                      </button>
+                    )}
+                    {(isStaff || mine) && (
+                      <button
+                        onClick={() => act(r.id, "cancel")}
+                        className="rounded-lg border border-border/40 px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent/40"
+                      >
+                        {t("hatiSuci.act.cancel")}
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Complete with optional outside-resource cost */}
+                {completingId === r.id && (
+                  <div className="space-y-2 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3">
+                    <p className="text-xs text-muted-foreground">{t("hatiSuci.cost.heading")}</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <input
+                        value={costAmount}
+                        onChange={(e) => setCostAmount(e.target.value)}
+                        inputMode="numeric"
+                        placeholder={t("hatiSuci.cost.amountPlaceholder")}
+                        className="rounded-lg border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+                      />
+                      <input
+                        value={costNote}
+                        onChange={(e) => setCostNote(e.target.value)}
+                        placeholder={t("hatiSuci.cost.notePlaceholder")}
+                        className="rounded-lg border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => confirmComplete(r.id)}
+                        className="flex-1 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-medium text-white"
+                      >
+                        {t("hatiSuci.act.complete")}
+                      </button>
+                      <button
+                        onClick={() => setCompletingId(null)}
+                        className="rounded-lg border border-border/40 px-3 py-2 text-sm text-muted-foreground"
+                      >
+                        {t("hatiSuci.act.cancelAction")}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1,4 +1,64 @@
 {
+  "hatiSuci": {
+    "title": "Hati Suci",
+    "tagline": "Die Haus-Tafel — bitte darum, und das Feld kümmert sich. Alle sehen es, nichts ist verborgen.",
+    "you": "Du",
+    "switchUser": "wechseln",
+    "reg": {
+      "prompt": "Willkommen. Wer bist du im Haus?",
+      "namePlaceholder": "Dein Name",
+      "enter": "Ins Haus eintreten"
+    },
+    "role": { "resident": "Bewohner", "staff": "Personal" },
+    "add": {
+      "heading": "Das Feld bitten",
+      "detailPlaceholder": "Was brauchst du?",
+      "locationPlaceholder": "Wo? (welches Haus, Garten…)",
+      "whenPlaceholder": "Wann?",
+      "button": "An die Tafel senden"
+    },
+    "kind": {
+      "food": "Essen",
+      "laundry": "Wäsche",
+      "cleaning": "Reinigung",
+      "ride": "Fahrt",
+      "repair": "Reparatur",
+      "room": "Zimmer",
+      "supplies": "Vorräte",
+      "other": "Sonstiges"
+    },
+    "board": {
+      "heading": "Die Tafel",
+      "everyoneSees": "alle sehen",
+      "empty": "Die Tafel ist leer. Nichts wartet."
+    },
+    "status": {
+      "open": "Offen",
+      "acknowledged": "Gesehen",
+      "in_progress": "In Arbeit",
+      "completed": "Fertig",
+      "cancelled": "Abgebrochen"
+    },
+    "meta": {
+      "requestedBy": "erbeten von",
+      "acknowledgedBy": "übernommen von",
+      "completedBy": "erledigt von"
+    },
+    "act": {
+      "acknowledge": "Ich übernehme",
+      "start": "Beginnen",
+      "complete": "Fertig",
+      "cancel": "Abbrechen",
+      "cancelAction": "Abbrechen",
+      "markPaid": "Als bezahlt markieren"
+    },
+    "cost": {
+      "heading": "Wurde Geld für externe Mittel gebraucht? (optional)",
+      "amountPlaceholder": "Betrag (IDR)",
+      "notePlaceholder": "Wofür?",
+      "paid": "Bezahlt"
+    }
+  },
   "_attunement": {
     "lang": "de",
     "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,4 +1,64 @@
 {
+  "hatiSuci": {
+    "title": "Hati Suci",
+    "tagline": "The household board — ask, and the field tends it. Everyone sees, nothing hidden.",
+    "you": "You",
+    "switchUser": "switch",
+    "reg": {
+      "prompt": "Welcome. Who are you in the house?",
+      "namePlaceholder": "Your name",
+      "enter": "Enter the house"
+    },
+    "role": { "resident": "Resident", "staff": "Staff" },
+    "add": {
+      "heading": "Ask the field",
+      "detailPlaceholder": "What do you need?",
+      "locationPlaceholder": "Where? (which house, garden…)",
+      "whenPlaceholder": "When?",
+      "button": "Send to the board"
+    },
+    "kind": {
+      "food": "Food",
+      "laundry": "Laundry",
+      "cleaning": "Cleaning",
+      "ride": "Ride",
+      "repair": "Repair",
+      "room": "Room",
+      "supplies": "Supplies",
+      "other": "Other"
+    },
+    "board": {
+      "heading": "The board",
+      "everyoneSees": "everyone sees",
+      "empty": "The board is clear. Nothing is waiting."
+    },
+    "status": {
+      "open": "Open",
+      "acknowledged": "Seen",
+      "in_progress": "In progress",
+      "completed": "Done",
+      "cancelled": "Cancelled"
+    },
+    "meta": {
+      "requestedBy": "asked by",
+      "acknowledgedBy": "taken by",
+      "completedBy": "done by"
+    },
+    "act": {
+      "acknowledge": "I'll take it",
+      "start": "Start",
+      "complete": "Done",
+      "cancel": "Cancel",
+      "cancelAction": "Cancel",
+      "markPaid": "Mark paid"
+    },
+    "cost": {
+      "heading": "Did this need money for outside resources? (optional)",
+      "amountPlaceholder": "Amount (IDR)",
+      "notePlaceholder": "What for?",
+      "paid": "Paid"
+    }
+  },
   "_attunement": {
     "lang": "en",
     "role": "anchor",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1,4 +1,64 @@
 {
+  "hatiSuci": {
+    "title": "Hati Suci",
+    "tagline": "El tablón de la casa — pídelo, y el campo lo atiende. Todos lo ven, nada se oculta.",
+    "you": "Tú",
+    "switchUser": "cambiar",
+    "reg": {
+      "prompt": "Bienvenido. ¿Quién eres en la casa?",
+      "namePlaceholder": "Tu nombre",
+      "enter": "Entrar en la casa"
+    },
+    "role": { "resident": "Residente", "staff": "Personal" },
+    "add": {
+      "heading": "Pídele al campo",
+      "detailPlaceholder": "¿Qué necesitas?",
+      "locationPlaceholder": "¿Dónde? (qué casa, jardín…)",
+      "whenPlaceholder": "¿Cuándo?",
+      "button": "Enviar al tablón"
+    },
+    "kind": {
+      "food": "Comida",
+      "laundry": "Lavandería",
+      "cleaning": "Limpieza",
+      "ride": "Transporte",
+      "repair": "Reparación",
+      "room": "Habitación",
+      "supplies": "Suministros",
+      "other": "Otro"
+    },
+    "board": {
+      "heading": "El tablón",
+      "everyoneSees": "todos lo ven",
+      "empty": "El tablón está despejado. Nada espera."
+    },
+    "status": {
+      "open": "Abierto",
+      "acknowledged": "Visto",
+      "in_progress": "En curso",
+      "completed": "Hecho",
+      "cancelled": "Cancelado"
+    },
+    "meta": {
+      "requestedBy": "pedido por",
+      "acknowledgedBy": "tomado por",
+      "completedBy": "hecho por"
+    },
+    "act": {
+      "acknowledge": "Lo tomo",
+      "start": "Empezar",
+      "complete": "Hecho",
+      "cancel": "Cancelar",
+      "cancelAction": "Cancelar",
+      "markPaid": "Marcar pagado"
+    },
+    "cost": {
+      "heading": "¿Necesitó dinero para recursos externos? (opcional)",
+      "amountPlaceholder": "Importe (IDR)",
+      "notePlaceholder": "¿Para qué?",
+      "paid": "Pagado"
+    }
+  },
   "_attunement": {
     "lang": "es",
     "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1,4 +1,64 @@
 {
+  "hatiSuci": {
+    "title": "Hati Suci",
+    "tagline": "Papan rumah — minta, dan kami merawatnya bersama. Semua terlihat, tidak ada yang disembunyikan.",
+    "you": "Anda",
+    "switchUser": "ganti",
+    "reg": {
+      "prompt": "Selamat datang. Siapa Anda di rumah ini?",
+      "namePlaceholder": "Nama Anda",
+      "enter": "Masuk ke rumah"
+    },
+    "role": { "resident": "Penghuni", "staff": "Staf" },
+    "add": {
+      "heading": "Minta bantuan",
+      "detailPlaceholder": "Apa yang Anda butuhkan?",
+      "locationPlaceholder": "Di mana? (rumah mana, kebun…)",
+      "whenPlaceholder": "Kapan?",
+      "button": "Kirim ke papan"
+    },
+    "kind": {
+      "food": "Makanan",
+      "laundry": "Cucian",
+      "cleaning": "Bersih-bersih",
+      "ride": "Antar-jemput",
+      "repair": "Perbaikan",
+      "room": "Kamar",
+      "supplies": "Perlengkapan",
+      "other": "Lainnya"
+    },
+    "board": {
+      "heading": "Papan",
+      "everyoneSees": "semua melihat",
+      "empty": "Papan kosong. Tidak ada yang menunggu."
+    },
+    "status": {
+      "open": "Terbuka",
+      "acknowledged": "Dilihat",
+      "in_progress": "Sedang dikerjakan",
+      "completed": "Selesai",
+      "cancelled": "Dibatalkan"
+    },
+    "meta": {
+      "requestedBy": "diminta oleh",
+      "acknowledgedBy": "diambil oleh",
+      "completedBy": "diselesaikan oleh"
+    },
+    "act": {
+      "acknowledge": "Saya ambil",
+      "start": "Mulai",
+      "complete": "Selesai",
+      "cancel": "Batal",
+      "cancelAction": "Batal",
+      "markPaid": "Tandai lunas"
+    },
+    "cost": {
+      "heading": "Apakah ini perlu uang untuk sumber daya luar? (opsional)",
+      "amountPlaceholder": "Jumlah (IDR)",
+      "notePlaceholder": "Untuk apa?",
+      "paid": "Lunas"
+    }
+  },
   "_attunement": {
     "lang": "id",
     "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",


### PR DESCRIPTION
First app for Hati Suci: the resident-service nervous system. Residents ask the field for food / laundry / a ride / a repair / a room / supplies; staff see the open board, acknowledge, and carry each request through to done; outside-resource costs ride along on the request and get marked settled. One board everyone sees — no secrets.

**Mobile-first**, **bilingual EN/ID** (DE/ES added for locale parity), **light identity** (name + role, no password — registering is as easy as walking in).

- `api/app/routers/household.py` — members + full request lifecycle (open → acknowledged → in_progress → completed; cost recorded → paid), on the living graph, mirroring `offerings.py`
- `web/app/hati-suci/page.tsx` — the board at `/hati-suci`
- flow test green (ask → seen → in-progress → done+cost → settled, + 2 guards)

First slice of idea `aab1aa02` — the embodied membrane of the living economy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)