### PR TITLE
tend: Hati Suci identity + WhatsApp invites + write-gating

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -1,22 +1,28 @@
 """Household — the resident-service nervous system for a Light Hub.
 
 Residents signal a need (food, laundry, a ride, a repair, a room readied);
-the staff see the request, acknowledge it, and complete it — everyone
-watching the same open board, no secrets. When a request needs something
-bought outside (detergent, a part, groceries), the cost rides along on the
-request and can be marked settled, so the small money that has to move
-stays as visible as the care.
+staff see it, acknowledge it, and complete it — everyone watching the same
+open board. Outside-resource costs ride along and get marked settled.
 
-This is the first physical surface of the network's living economy: the
-resonance board (lc-offering) and the visible membrane (lc-economy) made
-operational for a real residence. Identity is light on purpose — a member
-is a name + a role (resident or staff) + a language — so registering is as
-easy as walking in. Backed by the same living graph that holds concepts,
-offerings, and contributors.
+Identity is light and WhatsApp-shaped. A member is a name + a phone + a
+**device token** that remembers them. There are three doors in:
+
+  • bootstrap — the founding resident (only when no resident exists yet),
+  • invite    — a resident vouches someone in by name + role; the invite
+                link carries a token, shared over WhatsApp, that auto-
+                registers and binds the person the moment they tap it,
+  • watch     — anyone can self-register see-only and watch the board.
+
+Seeing is open to any registered cell. **Writing** (asking, tending,
+settling) requires a token that resolves to a member with write access —
+which residents and staff hold by construction, and a plain member holds
+once a resident vouches them. The token is the lock; the invite is the
+vouch. Backed by the same living graph that holds offerings and contributors.
 """
 
 from __future__ import annotations
 
+import secrets
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
@@ -29,125 +35,256 @@ from app.services import graph_service
 router = APIRouter()
 
 
-MemberRole = Literal["resident", "staff"]
+MemberRole = Literal["resident", "staff", "member"]
 RequestKind = Literal[
     "food", "laundry", "cleaning", "ride", "repair", "room", "supplies", "other"
 ]
 RequestStatus = Literal["open", "acknowledged", "in_progress", "completed", "cancelled"]
-CostStatus = Literal["none", "recorded", "paid"]
 
 _MEMBER_TYPE = "household_member"
 _REQUEST_TYPE = "service_request"
+# Roles that carry write access by construction. A plain "member" is
+# see-only until a resident vouches them.
+_WRITE_ROLES = {"resident", "staff"}
 
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _new_token() -> str:
+    # 32 url-safe chars (~192 bits). The device credential and the invite
+    # link payload are the same token: opaque, unguessable, shared 1:1.
+    return secrets.token_urlsafe(24)
+
+
 # --------------------------------------------------------------------------
-# Members — light identity: a name, a role, a language. No password, no gate.
+# Members — light identity: a name, a phone, a device token, a role.
 # --------------------------------------------------------------------------
 
 
-class MemberCreate(BaseModel):
-    name: str = Field(min_length=1, max_length=120)
-    role: MemberRole
-    locale: str = Field(default="en", max_length=8, description="UI language: en, id, …")
-
-
-class MemberResponse(BaseModel):
+class MemberPublic(BaseModel):
+    """What everyone may see about a member — never the token or phone."""
     id: str
     name: str
     role: str
-    locale: str
+    write_access: bool
+    status: str
+    invited_by_name: str | None = None
     created_at: str
 
 
-def _node_to_member(node: dict) -> MemberResponse:
-    return MemberResponse(
+class MemberPrivate(MemberPublic):
+    """Returned only to the member themselves (carries the credential)."""
+    token: str
+    phone: str | None = None
+
+
+class RegisterBody(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    phone: str | None = Field(default=None, max_length=40)
+    locale: str = Field(default="en", max_length=8)
+
+
+class BootstrapBody(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    phone: str | None = Field(default=None, max_length=40)
+
+
+class InviteBody(BaseModel):
+    inviter_token: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=120)
+    role: MemberRole = "member"
+    phone: str | None = Field(default=None, max_length=40)
+
+
+def _member_public(node: dict) -> MemberPublic:
+    return MemberPublic(
         id=node.get("id", ""),
-        name=node.get("name", "") or node.get("member_name", ""),
-        role=node.get("role", "resident"),
-        locale=node.get("locale", "en") or "en",
+        name=node.get("name", ""),
+        role=node.get("role", "member"),
+        write_access=bool(node.get("write_access")),
+        status=node.get("status", "active"),
+        invited_by_name=(node.get("invited_by_name") or None),
         created_at=node.get("created_at", "") or node.get("observed_at", ""),
     )
 
 
-def _get_member(member_id: str) -> dict | None:
-    node = graph_service.get_node(member_id)
-    if node and node.get("type") == _MEMBER_TYPE:
-        return node
+def _member_private(node: dict) -> MemberPrivate:
+    pub = _member_public(node).model_dump()
+    return MemberPrivate(**pub, token=node.get("token", ""), phone=(node.get("phone") or None))
+
+
+def _all_members() -> list[dict]:
+    try:
+        response = graph_service.list_nodes(type=_MEMBER_TYPE, limit=1000)
+        nodes = response.get("items", []) if isinstance(response, dict) else (response or [])
+    except Exception:
+        nodes = []
+    return [n for n in nodes if n.get("type") == _MEMBER_TYPE]
+
+
+def _resident_exists() -> bool:
+    return any(m.get("role") == "resident" for m in _all_members())
+
+
+def _member_by_token(token: str | None) -> dict | None:
+    if not token:
+        return None
+    for m in _all_members():
+        if m.get("token") and m.get("token") == token:
+            return m
     return None
 
 
-def _member_name(member_id: str | None) -> str:
-    if not member_id:
-        return ""
-    node = _get_member(member_id)
-    return node.get("name", "") if node else ""
+def _create_member(name: str, role: str, *, write_access: bool, status: str,
+                   phone: str | None, locale: str = "en",
+                   invited_by: str = "", invited_by_name: str = "") -> dict:
+    member_id = f"member-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:6]}"
+    created_at = _now()
+    properties: dict[str, Any] = {
+        "role": role,
+        "locale": locale or "en",
+        "phone": phone or "",
+        "token": _new_token(),
+        "write_access": bool(write_access),
+        "status": status,
+        "invited_by": invited_by,
+        "invited_by_name": invited_by_name,
+        "created_at": created_at,
+    }
+    return graph_service.create_node(
+        id=member_id,
+        type=_MEMBER_TYPE,
+        name=name,
+        description=f"{role} of the household",
+        properties=properties,
+    )
+
+
+@router.post(
+    "/household/bootstrap",
+    response_model=MemberPrivate,
+    status_code=201,
+    summary="Create the founding resident (only when no resident exists yet)",
+)
+async def bootstrap_resident(body: BootstrapBody) -> MemberPrivate:
+    if _resident_exists():
+        raise HTTPException(status_code=409, detail="a resident already exists; ask them for an invite")
+    node = _create_member(body.name, "resident", write_access=True, status="active", phone=body.phone)
+    return _member_private(node)
 
 
 @router.post(
     "/household/members",
-    response_model=MemberResponse,
+    response_model=MemberPrivate,
     status_code=201,
-    summary="Register a resident or staff member (light identity)",
+    summary="Self-register to watch the board (see-only until a resident vouches you)",
 )
-async def create_member(body: MemberCreate) -> MemberResponse:
-    member_id = f"member-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:6]}"
-    created_at = _now()
-    properties: dict[str, Any] = {
-        "role": body.role,
-        "locale": body.locale or "en",
-        "created_at": created_at,
-    }
-    node = graph_service.create_node(
-        id=member_id,
-        type=_MEMBER_TYPE,
-        name=body.name,
-        description=f"{body.role} of the household",
-        properties=properties,
+async def register_member(body: RegisterBody) -> MemberPrivate:
+    node = _create_member(body.name, "member", write_access=False, status="active",
+                          phone=body.phone, locale=body.locale)
+    return _member_private(node)
+
+
+@router.post(
+    "/household/invites",
+    response_model=MemberPrivate,
+    status_code=201,
+    summary="A resident vouches someone in by name + role; the returned token is the invite-link payload",
+)
+async def create_invite(body: InviteBody) -> MemberPrivate:
+    inviter = _member_by_token(body.inviter_token)
+    if not inviter or inviter.get("role") != "resident":
+        raise HTTPException(status_code=403, detail="only a resident can invite")
+    role = body.role
+    write_access = role in _WRITE_ROLES
+    node = _create_member(
+        body.name, role, write_access=write_access, status="invited",
+        phone=body.phone, invited_by=inviter.get("id", ""),
+        invited_by_name=inviter.get("name", ""),
     )
-    return _node_to_member(node)
+    # The token is returned to the inviter, who shares the join link
+    # (built client-side as {origin}/hati-suci?token=…) over WhatsApp.
+    return _member_private(node)
+
+
+@router.get(
+    "/household/me",
+    response_model=MemberPrivate,
+    summary="Resolve your identity by device token (activates an invite on first open)",
+)
+async def whoami(token: str = Query(min_length=1)) -> MemberPrivate:
+    node = _member_by_token(token)
+    if not node:
+        raise HTTPException(status_code=404, detail="unknown token")
+    if node.get("status") == "invited":
+        node = graph_service.update_node(node["id"], properties={"status": "active"}) or node
+    return _member_private(node)
 
 
 @router.get(
     "/household/members",
-    response_model=list[MemberResponse],
-    summary="Everyone in the household — residents and staff",
+    response_model=list[MemberPublic],
+    summary="Everyone in the household — public view, no tokens or phones",
 )
-async def list_members(role: str | None = Query(default=None)) -> list[MemberResponse]:
-    try:
-        response = graph_service.list_nodes(type=_MEMBER_TYPE, limit=500)
-        nodes = response.get("items", []) if isinstance(response, dict) else (response or [])
-    except Exception:
-        nodes = []
-    members = [n for n in nodes if n.get("type") == _MEMBER_TYPE]
+async def list_members(role: str | None = Query(default=None)) -> list[MemberPublic]:
+    members = _all_members()
     if role:
-        members = [n for n in members if n.get("role") == role]
+        members = [m for m in members if m.get("role") == role]
     members.sort(key=lambda n: n.get("created_at", ""))
-    return [_node_to_member(n) for n in members]
+    return [_member_public(m) for m in members]
+
+
+def _require_writer(token: str | None) -> dict:
+    member = _member_by_token(token)
+    if not member:
+        raise HTTPException(status_code=401, detail="register or open your invite link first")
+    if not member.get("write_access"):
+        raise HTTPException(status_code=403, detail="a resident needs to grant you write access first")
+    return member
+
+
+class GrantBody(BaseModel):
+    actor_token: str = Field(min_length=1)
+
+
+@router.post(
+    "/household/members/{member_id}/grant-write",
+    response_model=MemberPublic,
+    summary="A resident grants a member full write access (the vouch)",
+)
+async def grant_write(member_id: str, body: GrantBody) -> MemberPublic:
+    actor = _member_by_token(body.actor_token)
+    if not actor or actor.get("role") != "resident":
+        raise HTTPException(status_code=403, detail="only a resident can grant write access")
+    node = graph_service.get_node(member_id)
+    if not node or node.get("type") != _MEMBER_TYPE:
+        raise HTTPException(status_code=404, detail="member not found")
+    node = graph_service.update_node(member_id, properties={"write_access": True}) or node
+    return _member_public(node)
 
 
 # --------------------------------------------------------------------------
 # Requests — the open board. Added → acknowledged → in_progress → completed.
+# Seeing is open; every mutation requires a write-capable device token.
 # --------------------------------------------------------------------------
 
 
 class RequestCreate(BaseModel):
-    requester_id: str = Field(min_length=1)
+    actor_token: str = Field(min_length=1)
     kind: RequestKind
-    detail: str = Field(min_length=1, max_length=2000, description="What is needed")
-    location: str | None = Field(default=None, max_length=200, description="Where (which house, the garden, …)")
-    when_text: str | None = Field(default=None, max_length=200, description="When it's needed, in plain words")
+    detail: str = Field(min_length=1, max_length=2000)
+    location: str | None = Field(default=None, max_length=200)
+    when_text: str | None = Field(default=None, max_length=200)
 
 
 class ActorBody(BaseModel):
-    actor_id: str = Field(min_length=1, description="The member performing this action")
+    actor_token: str = Field(min_length=1)
 
 
 class CompleteBody(ActorBody):
-    cost_amount: float | None = Field(default=None, ge=0, description="Cost of any outside resources")
+    cost_amount: float | None = Field(default=None, ge=0)
     cost_currency: str = Field(default="IDR", max_length=8)
     cost_note: str | None = Field(default=None, max_length=400)
 
@@ -161,21 +298,13 @@ class RequestResponse(BaseModel):
     status: str
     requester_id: str
     requester_name: str
-    acknowledged_by: str | None = None
     acknowledged_by_name: str | None = None
-    acknowledged_at: str | None = None
-    started_at: str | None = None
-    completed_by: str | None = None
     completed_by_name: str | None = None
-    completed_at: str | None = None
-    cancelled_at: str | None = None
     cost_amount: float | None = None
     cost_currency: str = "IDR"
     cost_note: str | None = None
     cost_status: str = "none"
-    paid_by: str | None = None
     paid_by_name: str | None = None
-    paid_at: str | None = None
     created_at: str
     updated_at: str
 
@@ -197,21 +326,13 @@ def _node_to_request(node: dict) -> RequestResponse:
         status=node.get("status", "open"),
         requester_id=node.get("requester_id", ""),
         requester_name=node.get("requester_name", "") or "",
-        acknowledged_by=_s(node.get("acknowledged_by")),
         acknowledged_by_name=_s(node.get("acknowledged_by_name")),
-        acknowledged_at=_s(node.get("acknowledged_at")),
-        started_at=_s(node.get("started_at")),
-        completed_by=_s(node.get("completed_by")),
         completed_by_name=_s(node.get("completed_by_name")),
-        completed_at=_s(node.get("completed_at")),
-        cancelled_at=_s(node.get("cancelled_at")),
         cost_amount=cost_amount,
         cost_currency=node.get("cost_currency", "IDR") or "IDR",
         cost_note=_s(node.get("cost_note")),
         cost_status=node.get("cost_status", "none") or "none",
-        paid_by=_s(node.get("paid_by")),
         paid_by_name=_s(node.get("paid_by_name")),
-        paid_at=_s(node.get("paid_at")),
         created_at=node.get("created_at", "") or node.get("observed_at", ""),
         updated_at=node.get("updated_at", "") or node.get("created_at", ""),
     )
@@ -236,12 +357,10 @@ def _apply(request_id: str, updates: dict[str, Any]) -> RequestResponse:
     "/household/requests",
     response_model=RequestResponse,
     status_code=201,
-    summary="Ask the field for something (food, laundry, a ride, a repair…)",
+    summary="Ask the field for something (write access required)",
 )
 async def create_request(body: RequestCreate) -> RequestResponse:
-    requester = _get_member(body.requester_id)
-    if not requester:
-        raise HTTPException(status_code=400, detail=f"member {body.requester_id!r} not found")
+    actor = _require_writer(body.actor_token)
     request_id = f"request-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:6]}"
     created_at = _now()
     properties: dict[str, Any] = {
@@ -250,19 +369,16 @@ async def create_request(body: RequestCreate) -> RequestResponse:
         "location": body.location or "",
         "when_text": body.when_text or "",
         "status": "open",
-        "requester_id": body.requester_id,
-        "requester_name": requester.get("name", ""),
+        "requester_id": actor.get("id", ""),
+        "requester_name": actor.get("name", ""),
         "cost_status": "none",
         "cost_currency": "IDR",
         "created_at": created_at,
         "updated_at": created_at,
     }
     node = graph_service.create_node(
-        id=request_id,
-        type=_REQUEST_TYPE,
-        name=body.detail[:120],
-        description=body.detail,
-        properties=properties,
+        id=request_id, type=_REQUEST_TYPE, name=body.detail[:120],
+        description=body.detail, properties=properties,
     )
     return _node_to_request(node)
 
@@ -303,11 +419,12 @@ async def get_request(request_id: str) -> RequestResponse:
     summary="A staff member sees it and takes it on",
 )
 async def acknowledge_request(request_id: str, body: ActorBody) -> RequestResponse:
+    actor = _require_writer(body.actor_token)
     _load_request(request_id)
     return _apply(request_id, {
         "status": "acknowledged",
-        "acknowledged_by": body.actor_id,
-        "acknowledged_by_name": _member_name(body.actor_id),
+        "acknowledged_by": actor.get("id", ""),
+        "acknowledged_by_name": actor.get("name", ""),
         "acknowledged_at": _now(),
     })
 
@@ -318,11 +435,12 @@ async def acknowledge_request(request_id: str, body: ActorBody) -> RequestRespon
     summary="Work on it has begun",
 )
 async def start_request(request_id: str, body: ActorBody) -> RequestResponse:
+    actor = _require_writer(body.actor_token)
     node = _load_request(request_id)
     updates: dict[str, Any] = {"status": "in_progress", "started_at": _now()}
     if not _s(node.get("acknowledged_by")):
-        updates["acknowledged_by"] = body.actor_id
-        updates["acknowledged_by_name"] = _member_name(body.actor_id)
+        updates["acknowledged_by"] = actor.get("id", "")
+        updates["acknowledged_by_name"] = actor.get("name", "")
         updates["acknowledged_at"] = _now()
     return _apply(request_id, updates)
 
@@ -333,11 +451,12 @@ async def start_request(request_id: str, body: ActorBody) -> RequestResponse:
     summary="It's done — optionally recording the cost of any outside resources",
 )
 async def complete_request(request_id: str, body: CompleteBody) -> RequestResponse:
+    actor = _require_writer(body.actor_token)
     _load_request(request_id)
     updates: dict[str, Any] = {
         "status": "completed",
-        "completed_by": body.actor_id,
-        "completed_by_name": _member_name(body.actor_id),
+        "completed_by": actor.get("id", ""),
+        "completed_by_name": actor.get("name", ""),
         "completed_at": _now(),
     }
     if body.cost_amount and body.cost_amount > 0:
@@ -354,6 +473,7 @@ async def complete_request(request_id: str, body: CompleteBody) -> RequestRespon
     summary="No longer needed",
 )
 async def cancel_request(request_id: str, body: ActorBody) -> RequestResponse:
+    _require_writer(body.actor_token)
     _load_request(request_id)
     return _apply(request_id, {"status": "cancelled", "cancelled_at": _now()})
 
@@ -364,12 +484,13 @@ async def cancel_request(request_id: str, body: ActorBody) -> RequestResponse:
     summary="Mark the outside-resource cost as settled",
 )
 async def pay_request(request_id: str, body: ActorBody) -> RequestResponse:
+    actor = _require_writer(body.actor_token)
     node = _load_request(request_id)
     if node.get("cost_status") not in ("recorded", "paid"):
         raise HTTPException(status_code=400, detail="this request has no recorded cost to settle")
     return _apply(request_id, {
         "cost_status": "paid",
-        "paid_by": body.actor_id,
-        "paid_by_name": _member_name(body.actor_id),
+        "paid_by": actor.get("id", ""),
+        "paid_by_name": actor.get("name", ""),
         "paid_at": _now(),
     })

--- a/api/tests/test_household_service_board.py
+++ b/api/tests/test_household_service_board.py
@@ -1,9 +1,10 @@
 """Flow test for the household resident-service board (api/app/routers/household.py).
 
-One strange-minimal flow that exercises the whole nervous system: a resident
-asks, a staff member sees it and carries it through, an outside-resource cost
-rides along and gets settled — and the two guards that keep it honest (a
-request needs a real member; a settle needs a recorded cost).
+The whole nervous system in one strange-minimal flow: a founding resident
+bootstraps, vouches a staff member in by invite (the link's token auto-binds
+on /me), the staff member tends a request through to a settled cost — and the
+two locks that keep it honest: a see-only member cannot write until a resident
+grants it, and an invite can only come from a resident.
 """
 from __future__ import annotations
 
@@ -18,77 +19,77 @@ def client():
     return TestClient(app)
 
 
-def _member(client, name, role):
-    res = client.post("/api/household/members", json={"name": name, "role": role})
-    assert res.status_code == 201, res.text
-    return res.json()
+def test_invite_carries_role_and_write_flows_through(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Giles"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    assert resident.status_code == 201, resident.text
+    rtok = resident.json()["token"]
+    assert resident.json()["role"] == "resident"
+    assert resident.json()["write_access"] is True
 
-
-def test_request_moves_from_ask_to_done_with_settled_cost(client):
-    resident = _member(client, "Ayu", "resident")
-    staff = _member(client, "Wayan", "staff")
-
-    # The ask
-    res = client.post("/api/household/requests", json={
-        "requester_id": resident["id"],
-        "kind": "laundry",
-        "detail": "two sets of bed linen for the lumbung",
-        "location": "Lumbung house",
-        "when_text": "before sunset",
+    # Resident invites a staff member; the invite returns the link token.
+    inv = client.post("/api/household/invites", json={
+        "inviter_token": rtok, "name": "Wayan", "role": "staff",
     })
-    assert res.status_code == 201, res.text
-    req = res.json()
-    assert req["status"] == "open"
-    assert req["requester_name"] == "Ayu"
-    rid = req["id"]
+    assert inv.status_code == 201, inv.text
+    stok = inv.json()["token"]
+    assert inv.json()["role"] == "staff"
+    assert inv.json()["status"] == "invited"
 
-    # It shows on the open board everyone sees
-    board = client.get("/api/household/requests").json()
-    assert any(r["id"] == rid for r in board)
+    # Opening the link (GET /me) activates the invite and binds the device.
+    me = client.get(f"/api/household/me?token={stok}")
+    assert me.status_code == 200
+    assert me.json()["status"] == "active"
+    assert me.json()["write_access"] is True
 
-    # Staff sees it and carries it through
-    ack = client.post(f"/api/household/requests/{rid}/acknowledge", json={"actor_id": staff["id"]}).json()
-    assert ack["status"] == "acknowledged"
-    assert ack["acknowledged_by_name"] == "Wayan"
-
-    started = client.post(f"/api/household/requests/{rid}/start", json={"actor_id": staff["id"]}).json()
-    assert started["status"] == "in_progress"
-
-    # Done — with an outside-resource cost recorded
-    done = client.post(f"/api/household/requests/{rid}/complete", json={
-        "actor_id": staff["id"],
-        "cost_amount": 25000,
-        "cost_note": "detergent",
-    }).json()
-    assert done["status"] == "completed"
-    assert done["completed_by_name"] == "Wayan"
-    assert done["cost_amount"] == 25000
-    assert done["cost_status"] == "recorded"
-
-    # The small money that moved is settled — and visible
-    paid = client.post(f"/api/household/requests/{rid}/pay", json={"actor_id": staff["id"]}).json()
-    assert paid["cost_status"] == "paid"
-    assert paid["paid_by_name"] == "Wayan"
-
-
-def test_request_needs_a_real_member(client):
-    res = client.post("/api/household/requests", json={
-        "requester_id": "member-does-not-exist",
-        "kind": "food",
-        "detail": "lunch for two",
-    })
-    assert res.status_code == 400
-
-
-def test_settle_needs_a_recorded_cost(client):
-    resident = _member(client, "Komang", "resident")
-    staff = _member(client, "Made", "staff")
+    # Staff asks + tends a request through, recording + settling a cost.
     rid = client.post("/api/household/requests", json={
-        "requester_id": resident["id"],
-        "kind": "ride",
-        "detail": "scooter to the market",
+        "actor_token": stok, "kind": "laundry", "detail": "linen for the lumbung",
     }).json()["id"]
-    # Completed with no outside cost → nothing to settle
-    client.post(f"/api/household/requests/{rid}/complete", json={"actor_id": staff["id"]})
-    res = client.post(f"/api/household/requests/{rid}/pay", json={"actor_id": staff["id"]})
-    assert res.status_code == 400
+    assert client.post(f"/api/household/requests/{rid}/acknowledge", json={"actor_token": stok}).json()["status"] == "acknowledged"
+    done = client.post(f"/api/household/requests/{rid}/complete", json={
+        "actor_token": stok, "cost_amount": 25000, "cost_note": "detergent",
+    }).json()
+    assert done["status"] == "completed" and done["cost_status"] == "recorded"
+    assert client.post(f"/api/household/requests/{rid}/pay", json={"actor_token": stok}).json()["cost_status"] == "paid"
+
+
+def test_see_only_member_cannot_write_until_vouched(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Ita"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; vouch flow skipped")
+    rtok = resident.json()["token"]
+
+    # A self-registered member is see-only.
+    member = client.post("/api/household/members", json={"name": "Komang"}).json()
+    mtok = member["token"]
+    assert member["write_access"] is False
+
+    # Writing is locked (403) until a resident vouches.
+    blocked = client.post("/api/household/requests", json={
+        "actor_token": mtok, "kind": "food", "detail": "lunch for two",
+    })
+    assert blocked.status_code == 403
+
+    # Resident grants write; now the same member can ask.
+    grant = client.post(f"/api/household/members/{member['id']}/grant-write", json={"actor_token": rtok})
+    assert grant.status_code == 200 and grant.json()["write_access"] is True
+    ok = client.post("/api/household/requests", json={
+        "actor_token": mtok, "kind": "food", "detail": "lunch for two",
+    })
+    assert ok.status_code == 201
+
+
+def test_only_a_resident_can_invite(client):
+    # A bare self-registered member's token cannot create invites.
+    member = client.post("/api/household/members", json={"name": "Drifter"}).json()
+    res = client.post("/api/household/invites", json={
+        "inviter_token": member["token"], "name": "Someone", "role": "staff",
+    })
+    assert res.status_code == 403
+
+    # An unknown token cannot write.
+    assert client.post("/api/household/requests", json={
+        "actor_token": "not-a-real-token", "kind": "other", "detail": "x",
+    }).status_code == 401

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -1,15 +1,34 @@
 // Hati Suci — the resident-service nervous system (first Light Hub membrane).
-// Mobile-first, bilingual (EN/ID). One open board everyone sees: residents
-// ask for food / laundry / a ride / a repair; staff acknowledge and complete;
-// outside-resource costs ride along and get marked settled. No secrets.
+// Mobile-first, bilingual. Light identity: a device token remembers you;
+// residents invite others by name + role via a WhatsApp-shareable link that
+// auto-registers and binds them on first tap. Seeing is open to any registered
+// cell; writing (asking, tending, settling) needs a resident's vouch.
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useT } from "@/components/MessagesProvider";
 
-type Role = "resident" | "staff";
-type Member = { id: string; name: string; role: Role; locale: string };
+type Role = "resident" | "staff" | "member";
+type Member = {
+  id: string;
+  name: string;
+  role: Role;
+  write_access: boolean;
+  status: string;
+  token: string;
+  phone?: string | null;
+  invited_by_name?: string | null;
+};
+type PublicMember = {
+  id: string;
+  name: string;
+  role: Role;
+  write_access: boolean;
+  status: string;
+  invited_by_name?: string | null;
+  created_at: string;
+};
 
 type Kind = "food" | "laundry" | "cleaning" | "ride" | "repair" | "room" | "supplies" | "other";
 type Status = "open" | "acknowledged" | "in_progress" | "completed" | "cancelled";
@@ -45,7 +64,7 @@ const KINDS: { key: Kind; emoji: string }[] = [
   { key: "other", emoji: "✨" },
 ];
 
-const STORAGE_KEY = "hatiSuci.member";
+const TOKEN_KEY = "hatiSuci.token";
 
 async function postJSON<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(path, {
@@ -55,6 +74,16 @@ async function postJSON<T>(path: string, body: unknown): Promise<T> {
   });
   if (!res.ok) throw new Error(`${res.status}`);
   return (await res.json()) as T;
+}
+
+async function getJSON<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(path);
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
 }
 
 function setLocaleCookie(locale: string) {
@@ -80,43 +109,65 @@ function StatusBadge({ status }: { status: Status }) {
 export default function HatiSuciPage() {
   const t = useT();
   const [member, setMember] = useState<Member | null>(null);
+  const [resolved, setResolved] = useState(false);
   const [requests, setRequests] = useState<ServiceRequest[]>([]);
-  const [loaded, setLoaded] = useState(false);
+  const [members, setMembers] = useState<PublicMember[]>([]);
 
-  // registration form
-  const [regName, setRegName] = useState("");
-  const [regRole, setRegRole] = useState<Role>("resident");
-
-  // new-request form
+  const [joinName, setJoinName] = useState("");
   const [kind, setKind] = useState<Kind>("food");
   const [detail, setDetail] = useState("");
   const [location, setLocation] = useState("");
   const [whenText, setWhenText] = useState("");
   const [busy, setBusy] = useState(false);
 
-  // per-card completion (optional outside-resource cost)
+  const [invName, setInvName] = useState("");
+  const [invRole, setInvRole] = useState<Role>("member");
+  const [invPhone, setInvPhone] = useState("");
+  const [inviteLink, setInviteLink] = useState<{ name: string; url: string; whatsapp: string } | null>(null);
+  const [copied, setCopied] = useState(false);
+
   const [completingId, setCompletingId] = useState<string | null>(null);
   const [costAmount, setCostAmount] = useState("");
   const [costNote, setCostNote] = useState("");
 
+  // Identity: ?token in URL → store + clean; then localStorage token → /me.
   useEffect(() => {
+    let token: string | null = null;
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) setMember(JSON.parse(raw) as Member);
+      const url = new URL(window.location.href);
+      const qt = url.searchParams.get("token");
+      if (qt) {
+        localStorage.setItem(TOKEN_KEY, qt);
+        url.searchParams.delete("token");
+        window.history.replaceState({}, "", url.pathname + url.search);
+      }
+      token = localStorage.getItem(TOKEN_KEY);
     } catch {
       /* ignore */
     }
+    if (!token) {
+      setResolved(true);
+      return;
+    }
+    void (async () => {
+      const me = await getJSON<Member>(`/api/household/me?token=${encodeURIComponent(token)}`);
+      if (me) setMember(me);
+      else {
+        try {
+          localStorage.removeItem(TOKEN_KEY);
+        } catch {
+          /* ignore */
+        }
+      }
+      setResolved(true);
+    })();
   }, []);
 
   const load = useCallback(async () => {
-    try {
-      const res = await fetch("/api/household/requests?limit=200");
-      if (res.ok) setRequests((await res.json()) as ServiceRequest[]);
-    } catch {
-      /* keep last good */
-    } finally {
-      setLoaded(true);
-    }
+    const r = await getJSON<ServiceRequest[]>("/api/household/requests?limit=200");
+    if (r) setRequests(r);
+    const m = await getJSON<PublicMember[]>("/api/household/members");
+    if (m) setMembers(m);
   }, []);
 
   useEffect(() => {
@@ -125,31 +176,34 @@ export default function HatiSuciPage() {
     return () => window.clearInterval(timer);
   }, [load]);
 
-  const register = useCallback(async () => {
-    const name = regName.trim();
+  const watch = useCallback(async () => {
+    const name = joinName.trim();
     if (!name) return;
     setBusy(true);
     try {
-      const created = await postJSON<Member>("/api/household/members", {
+      const m = await postJSON<Member>("/api/household/members", {
         name,
-        role: regRole,
         locale: document.documentElement.lang || "en",
       });
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(created));
-      setMember(created);
+      localStorage.setItem(TOKEN_KEY, m.token);
+      setMember(m);
     } catch {
       /* surfaced via disabled state */
     } finally {
       setBusy(false);
     }
-  }, [regName, regRole]);
+  }, [joinName]);
+
+  const token = member?.token ?? "";
+  const canWrite = !!member?.write_access;
+  const isResident = member?.role === "resident";
 
   const submitRequest = useCallback(async () => {
-    if (!member || !detail.trim()) return;
+    if (!token || !detail.trim()) return;
     setBusy(true);
     try {
       await postJSON("/api/household/requests", {
-        requester_id: member.id,
+        actor_token: token,
         kind,
         detail: detail.trim(),
         location: location.trim() || null,
@@ -159,22 +213,24 @@ export default function HatiSuciPage() {
       setLocation("");
       setWhenText("");
       await load();
+    } catch {
+      /* ignore */
     } finally {
       setBusy(false);
     }
-  }, [member, detail, kind, location, whenText, load]);
+  }, [token, detail, kind, location, whenText, load]);
 
   const act = useCallback(
     async (id: string, verb: string, extra: Record<string, unknown> = {}) => {
-      if (!member) return;
+      if (!token) return;
       try {
-        await postJSON(`/api/household/requests/${id}/${verb}`, { actor_id: member.id, ...extra });
+        await postJSON(`/api/household/requests/${id}/${verb}`, { actor_token: token, ...extra });
         await load();
       } catch {
-        /* ignore — board refreshes on next tick */
+        /* ignore */
       }
     },
-    [member, load],
+    [token, load],
   );
 
   const confirmComplete = useCallback(
@@ -192,9 +248,63 @@ export default function HatiSuciPage() {
     [act, costAmount, costNote],
   );
 
+  const makeInvite = useCallback(async () => {
+    if (!token || !invName.trim()) return;
+    setBusy(true);
+    try {
+      const inv = await postJSON<Member>("/api/household/invites", {
+        inviter_token: token,
+        name: invName.trim(),
+        role: invRole,
+        phone: invPhone.trim() || null,
+      });
+      const url = `${window.location.origin}/hati-suci?token=${encodeURIComponent(inv.token)}`;
+      const msg = `${t("hatiSuci.whatsappMsg", { name: invName.trim() })} ${url}`;
+      const digits = invPhone.replace(/[^0-9]/g, "");
+      const whatsapp = digits
+        ? `https://wa.me/${digits}?text=${encodeURIComponent(msg)}`
+        : `https://wa.me/?text=${encodeURIComponent(msg)}`;
+      setInviteLink({ name: invName.trim(), url, whatsapp });
+      setInvName("");
+      setInvPhone("");
+      await load();
+    } catch {
+      /* ignore */
+    } finally {
+      setBusy(false);
+    }
+  }, [token, invName, invRole, invPhone, t, load]);
+
+  const grantWrite = useCallback(
+    async (memberId: string) => {
+      if (!token) return;
+      try {
+        await postJSON(`/api/household/members/${memberId}/grant-write`, { actor_token: token });
+        await load();
+      } catch {
+        /* ignore */
+      }
+    },
+    [token, load],
+  );
+
   const switchUser = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    try {
+      localStorage.removeItem(TOKEN_KEY);
+    } catch {
+      /* ignore */
+    }
     setMember(null);
+  }, []);
+
+  const copyLink = useCallback((url: string) => {
+    try {
+      void navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
   }, []);
 
   const sorted = useMemo(() => {
@@ -206,9 +316,11 @@ export default function HatiSuciPage() {
     });
   }, [requests]);
 
-  const isStaff = member?.role === "staff";
+  const pendingVouch = useMemo(
+    () => members.filter((m) => !m.write_access && m.role === "member"),
+    [members],
+  );
 
-  // ---- Language toggle (always available) ----
   const langToggle = (
     <div className="flex gap-1 text-xs">
       {["en", "id"].map((l) => (
@@ -226,7 +338,17 @@ export default function HatiSuciPage() {
     </div>
   );
 
-  // ---- Registration gate ----
+  if (!resolved) {
+    return (
+      <main className="min-h-screen px-4 py-8">
+        <div className="mx-auto w-full max-w-md">
+          <p className="text-muted-foreground">{t("hatiSuci.title")}…</p>
+        </div>
+      </main>
+    );
+  }
+
+  // ---- Join gate (no identity yet) ----
   if (!member) {
     return (
       <main className="min-h-screen px-4 py-8">
@@ -236,35 +358,20 @@ export default function HatiSuciPage() {
             {langToggle}
           </div>
           <p className="text-sm text-muted-foreground">{t("hatiSuci.tagline")}</p>
-          <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 space-y-4">
-            <p className="text-sm text-muted-foreground">{t("hatiSuci.reg.prompt")}</p>
+          <div className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-5 space-y-3">
+            <p className="text-sm text-muted-foreground">{t("hatiSuci.join.openInvite")}</p>
             <input
-              value={regName}
-              onChange={(e) => setRegName(e.target.value)}
+              value={joinName}
+              onChange={(e) => setJoinName(e.target.value)}
               placeholder={t("hatiSuci.reg.namePlaceholder")}
               className="w-full rounded-xl border border-border/40 bg-background px-4 py-3 text-base outline-none focus:border-primary/60"
             />
-            <div className="grid grid-cols-2 gap-2">
-              {(["resident", "staff"] as Role[]).map((r) => (
-                <button
-                  key={r}
-                  onClick={() => setRegRole(r)}
-                  className={`rounded-xl border px-3 py-3 text-sm transition-colors ${
-                    regRole === r
-                      ? "border-primary/60 bg-primary/10 text-foreground"
-                      : "border-border/40 text-muted-foreground hover:bg-accent/40"
-                  }`}
-                >
-                  {t(`hatiSuci.role.${r}`)}
-                </button>
-              ))}
-            </div>
             <button
-              onClick={register}
-              disabled={busy || !regName.trim()}
+              onClick={watch}
+              disabled={busy || !joinName.trim()}
               className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
             >
-              {t("hatiSuci.reg.enter")}
+              {t("hatiSuci.join.watch")}
             </button>
           </div>
         </div>
@@ -280,7 +387,8 @@ export default function HatiSuciPage() {
           <div>
             <h1 className="text-2xl font-light tracking-tight">{t("hatiSuci.title")}</h1>
             <p className="text-sm text-muted-foreground">
-              {t("hatiSuci.you")}: <span className="text-foreground">{member.name}</span> · {t(`hatiSuci.role.${member.role}`)}{" "}
+              {t("hatiSuci.you")}: <span className="text-foreground">{member.name}</span> · {t(`hatiSuci.role.${member.role}`)}
+              {!canWrite ? ` · ${t("hatiSuci.seeOnly")}` : ""}{" "}
               <button onClick={switchUser} className="underline underline-offset-2 hover:text-foreground">
                 {t("hatiSuci.switchUser")}
               </button>
@@ -289,54 +397,147 @@ export default function HatiSuciPage() {
           {langToggle}
         </header>
 
-        {/* Ask the field */}
-        <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-3">
-          <h2 className="text-base font-medium">{t("hatiSuci.add.heading")}</h2>
-          <div className="grid grid-cols-4 gap-2">
-            {KINDS.map((k) => (
-              <button
-                key={k.key}
-                onClick={() => setKind(k.key)}
-                className={`flex flex-col items-center gap-1 rounded-xl border px-1 py-2 text-xs transition-colors ${
-                  kind === k.key
-                    ? "border-primary/60 bg-primary/10 text-foreground"
-                    : "border-border/40 text-muted-foreground hover:bg-accent/40"
-                }`}
-              >
-                <span className="text-xl leading-none">{k.emoji}</span>
-                <span className="text-center leading-tight">{t(`hatiSuci.kind.${k.key}`)}</span>
-              </button>
-            ))}
-          </div>
-          <textarea
-            value={detail}
-            onChange={(e) => setDetail(e.target.value)}
-            placeholder={t("hatiSuci.add.detailPlaceholder")}
-            rows={2}
-            className="w-full rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
-          />
-          <div className="grid grid-cols-2 gap-2">
-            <input
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              placeholder={t("hatiSuci.add.locationPlaceholder")}
-              className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+        {/* Invite (residents only) */}
+        {isResident && (
+          <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-3">
+            <h2 className="text-base font-medium">{t("hatiSuci.invite.heading")}</h2>
+            <div className="grid grid-cols-3 gap-2">
+              {(["resident", "staff", "member"] as Role[]).map((r) => (
+                <button
+                  key={r}
+                  onClick={() => setInvRole(r)}
+                  className={`rounded-xl border px-2 py-2 text-sm transition-colors ${
+                    invRole === r
+                      ? "border-primary/60 bg-primary/10 text-foreground"
+                      : "border-border/40 text-muted-foreground hover:bg-accent/40"
+                  }`}
+                >
+                  {t(`hatiSuci.role.${r}`)}
+                </button>
+              ))}
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                value={invName}
+                onChange={(e) => setInvName(e.target.value)}
+                placeholder={t("hatiSuci.invite.namePlaceholder")}
+                className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+              />
+              <input
+                value={invPhone}
+                onChange={(e) => setInvPhone(e.target.value)}
+                inputMode="tel"
+                placeholder={t("hatiSuci.invite.phonePlaceholder")}
+                className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+              />
+            </div>
+            <button
+              onClick={makeInvite}
+              disabled={busy || !invName.trim()}
+              className="w-full rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {t("hatiSuci.invite.create")}
+            </button>
+
+            {inviteLink && (
+              <div className="space-y-2 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3">
+                <p className="text-xs text-muted-foreground">
+                  {t("hatiSuci.invite.linkFor", { name: inviteLink.name })}
+                </p>
+                <p className="break-all rounded-lg bg-background/60 px-2 py-1.5 text-xs text-foreground">{inviteLink.url}</p>
+                <div className="flex gap-2">
+                  <a
+                    href={inviteLink.whatsapp}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex-1 rounded-lg bg-emerald-500 px-3 py-2 text-center text-sm font-medium text-white"
+                  >
+                    {t("hatiSuci.invite.shareWhatsApp")}
+                  </a>
+                  <button
+                    onClick={() => copyLink(inviteLink.url)}
+                    className="rounded-lg border border-border/40 px-3 py-2 text-sm text-muted-foreground hover:bg-accent/40"
+                  >
+                    {copied ? t("hatiSuci.invite.copied") : t("hatiSuci.invite.copy")}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Vouch see-only members into write */}
+            {pendingVouch.length > 0 && (
+              <div className="space-y-1.5 pt-1">
+                <p className="text-xs text-muted-foreground">{t("hatiSuci.people.heading")}</p>
+                {pendingVouch.map((m) => (
+                  <div key={m.id} className="flex items-center justify-between rounded-lg bg-background/50 px-3 py-1.5 text-sm">
+                    <span className="text-foreground">{m.name} <span className="text-muted-foreground">· {t("hatiSuci.seeOnly")}</span></span>
+                    <button
+                      onClick={() => grantWrite(m.id)}
+                      className="rounded-md border border-sky-500/40 px-2 py-1 text-xs text-sky-500 hover:bg-sky-500/10"
+                    >
+                      {t("hatiSuci.people.grantWrite")}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Ask the field (writers) or a gentle note (see-only) */}
+        {canWrite ? (
+          <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-3">
+            <h2 className="text-base font-medium">{t("hatiSuci.add.heading")}</h2>
+            <div className="grid grid-cols-4 gap-2">
+              {KINDS.map((k) => (
+                <button
+                  key={k.key}
+                  onClick={() => setKind(k.key)}
+                  className={`flex flex-col items-center gap-1 rounded-xl border px-1 py-2 text-xs transition-colors ${
+                    kind === k.key
+                      ? "border-primary/60 bg-primary/10 text-foreground"
+                      : "border-border/40 text-muted-foreground hover:bg-accent/40"
+                  }`}
+                >
+                  <span className="text-xl leading-none">{k.emoji}</span>
+                  <span className="text-center leading-tight">{t(`hatiSuci.kind.${k.key}`)}</span>
+                </button>
+              ))}
+            </div>
+            <textarea
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
+              placeholder={t("hatiSuci.add.detailPlaceholder")}
+              rows={2}
+              className="w-full rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
             />
-            <input
-              value={whenText}
-              onChange={(e) => setWhenText(e.target.value)}
-              placeholder={t("hatiSuci.add.whenPlaceholder")}
-              className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
-            />
-          </div>
-          <button
-            onClick={submitRequest}
-            disabled={busy || !detail.trim()}
-            className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
-          >
-            {t("hatiSuci.add.button")}
-          </button>
-        </section>
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                placeholder={t("hatiSuci.add.locationPlaceholder")}
+                className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+              />
+              <input
+                value={whenText}
+                onChange={(e) => setWhenText(e.target.value)}
+                placeholder={t("hatiSuci.add.whenPlaceholder")}
+                className="rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+              />
+            </div>
+            <button
+              onClick={submitRequest}
+              disabled={busy || !detail.trim()}
+              className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {t("hatiSuci.add.button")}
+            </button>
+          </section>
+        ) : (
+          <p className="rounded-2xl border border-dashed border-border/40 px-4 py-4 text-center text-sm text-muted-foreground">
+            {t("hatiSuci.noWriteNote")}
+          </p>
+        )}
 
         {/* The open board */}
         <section className="space-y-3">
@@ -345,7 +546,7 @@ export default function HatiSuciPage() {
             <span className="text-xs text-muted-foreground">{t("hatiSuci.board.everyoneSees")}</span>
           </div>
 
-          {loaded && sorted.length === 0 && (
+          {sorted.length === 0 && (
             <p className="rounded-2xl border border-dashed border-border/40 px-4 py-8 text-center text-sm text-muted-foreground">
               {t("hatiSuci.board.empty")}
             </p>
@@ -381,7 +582,6 @@ export default function HatiSuciPage() {
                   </p>
                 )}
 
-                {/* Outside-resource cost */}
                 {r.cost_status && r.cost_status !== "none" && (
                   <div className="flex items-center justify-between rounded-xl bg-background/60 px-3 py-2 text-xs">
                     <span className="text-muted-foreground">
@@ -394,20 +594,21 @@ export default function HatiSuciPage() {
                         {r.paid_by_name ? ` · ${r.paid_by_name}` : ""}
                       </span>
                     ) : (
-                      <button
-                        onClick={() => act(r.id, "pay")}
-                        className="rounded-md border border-emerald-500/40 px-2 py-1 text-emerald-500 hover:bg-emerald-500/10"
-                      >
-                        {t("hatiSuci.act.markPaid")}
-                      </button>
+                      canWrite && (
+                        <button
+                          onClick={() => act(r.id, "pay")}
+                          className="rounded-md border border-emerald-500/40 px-2 py-1 text-emerald-500 hover:bg-emerald-500/10"
+                        >
+                          {t("hatiSuci.act.markPaid")}
+                        </button>
+                      )
                     )}
                   </div>
                 )}
 
-                {/* Actions */}
-                {active && (isStaff || mine) && (
+                {active && canWrite && (
                   <div className="flex flex-wrap gap-2 pt-1">
-                    {isStaff && r.status === "open" && (
+                    {r.status === "open" && (
                       <button
                         onClick={() => act(r.id, "acknowledge")}
                         className="rounded-lg border border-sky-500/40 px-3 py-1.5 text-sm text-sky-500 hover:bg-sky-500/10"
@@ -415,7 +616,7 @@ export default function HatiSuciPage() {
                         {t("hatiSuci.act.acknowledge")}
                       </button>
                     )}
-                    {isStaff && (r.status === "open" || r.status === "acknowledged") && (
+                    {(r.status === "open" || r.status === "acknowledged") && (
                       <button
                         onClick={() => act(r.id, "start")}
                         className="rounded-lg border border-indigo-500/40 px-3 py-1.5 text-sm text-indigo-400 hover:bg-indigo-500/10"
@@ -423,7 +624,7 @@ export default function HatiSuciPage() {
                         {t("hatiSuci.act.start")}
                       </button>
                     )}
-                    {isStaff && completingId !== r.id && (
+                    {completingId !== r.id && (
                       <button
                         onClick={() => setCompletingId(r.id)}
                         className="rounded-lg border border-emerald-500/40 px-3 py-1.5 text-sm text-emerald-500 hover:bg-emerald-500/10"
@@ -431,7 +632,7 @@ export default function HatiSuciPage() {
                         {t("hatiSuci.act.complete")}
                       </button>
                     )}
-                    {(isStaff || mine) && (
+                    {(mine || isResident) && (
                       <button
                         onClick={() => act(r.id, "cancel")}
                         className="rounded-lg border border-border/40 px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent/40"
@@ -442,7 +643,6 @@ export default function HatiSuciPage() {
                   </div>
                 )}
 
-                {/* Complete with optional outside-resource cost */}
                 {completingId === r.id && (
                   <div className="space-y-2 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3">
                     <p className="text-xs text-muted-foreground">{t("hatiSuci.cost.heading")}</p>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -9,7 +9,28 @@
       "namePlaceholder": "Dein Name",
       "enter": "Ins Haus eintreten"
     },
-    "role": { "resident": "Bewohner", "staff": "Personal" },
+    "role": { "resident": "Bewohner", "staff": "Personal", "member": "Mitglied" },
+    "seeOnly": "nur-lesen",
+    "noWriteNote": "Ein Bewohner kann dir Schreibzugriff geben, um Anfragen zu stellen und zu betreuen.",
+    "join": {
+      "openInvite": "Öffne deinen Einladungslink zum Beitreten — oder gib deinen Namen ein, um die Tafel zu sehen.",
+      "watch": "Tafel ansehen"
+    },
+    "invite": {
+      "heading": "Jemanden einladen",
+      "namePlaceholder": "Ihr Name",
+      "phonePlaceholder": "WhatsApp-Nr. (optional)",
+      "create": "Einladungslink erstellen",
+      "shareWhatsApp": "Auf WhatsApp teilen",
+      "copy": "Link kopieren",
+      "copied": "Kopiert!",
+      "linkFor": "Einladungslink für {name} — teile ihn auf WhatsApp:"
+    },
+    "people": {
+      "heading": "Wartet auf Freigabe",
+      "grantWrite": "Schreibzugriff geben"
+    },
+    "whatsappMsg": "{name}, du bist zur Hati-Suci-Tafel eingeladen:",
     "add": {
       "heading": "Das Feld bitten",
       "detailPlaceholder": "Was brauchst du?",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -9,7 +9,28 @@
       "namePlaceholder": "Your name",
       "enter": "Enter the house"
     },
-    "role": { "resident": "Resident", "staff": "Staff" },
+    "role": { "resident": "Resident", "staff": "Staff", "member": "Member" },
+    "seeOnly": "see-only",
+    "noWriteNote": "A resident can grant you write access to add and tend requests.",
+    "join": {
+      "openInvite": "Open your invite link to join — or enter your name to watch the board.",
+      "watch": "Watch the board"
+    },
+    "invite": {
+      "heading": "Invite someone",
+      "namePlaceholder": "Their name",
+      "phonePlaceholder": "WhatsApp no. (optional)",
+      "create": "Make invite link",
+      "shareWhatsApp": "Share on WhatsApp",
+      "copy": "Copy link",
+      "copied": "Copied!",
+      "linkFor": "Invite link for {name} — share it on WhatsApp:"
+    },
+    "people": {
+      "heading": "Waiting for a vouch",
+      "grantWrite": "Grant write"
+    },
+    "whatsappMsg": "{name}, you're invited to the Hati Suci board:",
     "add": {
       "heading": "Ask the field",
       "detailPlaceholder": "What do you need?",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -9,7 +9,28 @@
       "namePlaceholder": "Tu nombre",
       "enter": "Entrar en la casa"
     },
-    "role": { "resident": "Residente", "staff": "Personal" },
+    "role": { "resident": "Residente", "staff": "Personal", "member": "Miembro" },
+    "seeOnly": "solo-ver",
+    "noWriteNote": "Un residente puede darte acceso de escritura para añadir y atender solicitudes.",
+    "join": {
+      "openInvite": "Abre tu enlace de invitación para unirte — o escribe tu nombre para ver el tablón.",
+      "watch": "Ver el tablón"
+    },
+    "invite": {
+      "heading": "Invitar a alguien",
+      "namePlaceholder": "Su nombre",
+      "phonePlaceholder": "Nº de WhatsApp (opcional)",
+      "create": "Crear enlace de invitación",
+      "shareWhatsApp": "Compartir por WhatsApp",
+      "copy": "Copiar enlace",
+      "copied": "¡Copiado!",
+      "linkFor": "Enlace de invitación para {name} — compártelo por WhatsApp:"
+    },
+    "people": {
+      "heading": "Esperando aprobación",
+      "grantWrite": "Dar escritura"
+    },
+    "whatsappMsg": "{name}, estás invitado al tablón de Hati Suci:",
     "add": {
       "heading": "Pídele al campo",
       "detailPlaceholder": "¿Qué necesitas?",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -9,7 +9,28 @@
       "namePlaceholder": "Nama Anda",
       "enter": "Masuk ke rumah"
     },
-    "role": { "resident": "Penghuni", "staff": "Staf" },
+    "role": { "resident": "Penghuni", "staff": "Staf", "member": "Anggota" },
+    "seeOnly": "hanya-lihat",
+    "noWriteNote": "Penghuni dapat memberi Anda akses tulis untuk menambah dan menangani permintaan.",
+    "join": {
+      "openInvite": "Buka tautan undangan Anda untuk bergabung — atau masukkan nama untuk melihat papan.",
+      "watch": "Lihat papan"
+    },
+    "invite": {
+      "heading": "Undang seseorang",
+      "namePlaceholder": "Nama mereka",
+      "phonePlaceholder": "No. WhatsApp (opsional)",
+      "create": "Buat tautan undangan",
+      "shareWhatsApp": "Bagikan di WhatsApp",
+      "copy": "Salin tautan",
+      "copied": "Tersalin!",
+      "linkFor": "Tautan undangan untuk {name} — bagikan di WhatsApp:"
+    },
+    "people": {
+      "heading": "Menunggu persetujuan",
+      "grantWrite": "Beri akses tulis"
+    },
+    "whatsappMsg": "{name}, Anda diundang ke papan Hati Suci:",
     "add": {
       "heading": "Minta bantuan",
       "detailPlaceholder": "Apa yang Anda butuhkan?",


### PR DESCRIPTION
The membrane's trust layer, as Urs shaped it: phone-as-key, a device token that remembers you, the **WhatsApp invite-link that auto-registers and *is* the vouch**, write gated on a resident's approval, residents bootstrapping from the first cell.

- bootstrap (founding resident) · invite (resident vouches name+role, link token auto-binds on /me) · watch (self-register see-only)
- seeing open to any registered cell; **writing server-gated** on a write-capable token
- resident invite UI: pick role, optional WhatsApp number → `Share on WhatsApp` (wa.me) + copy link; vouch see-only members into write
- tokens/phones never returned in the public members list
- 3/3 flow test (invite→activate→write→settle; see-only locked until vouched; only residents invite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)