### PR TITLE
tend: seal the Hati Suci app — self-contained surface

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,9 +34,9 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 143 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 244 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 239 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 240 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
-| [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
+| [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 161 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 142 | Scripts — operational tools, generators, syncers |
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -12,6 +12,7 @@ import { RouteReadPing } from "@/components/content/RouteReadPing";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ExpertModeProvider } from "@/components/expert-mode-context";
 import { MobileBottomNav } from "@/components/mobile-bottom-nav";
+import ChromeGate from "@/components/ChromeGate";
 import { MessagesProvider } from "@/components/MessagesProvider";
 import { loadPublicWebConfig } from "@/lib/app-config";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
@@ -124,14 +125,16 @@ export default async function RootLayout({
           <RouteReadPing />
           <ThemeProvider>
             <ExpertModeProvider>
-              <SiteHeader />
+              <ChromeGate><SiteHeader /></ChromeGate>
               <LiveUpdatesController />
               <main id="main-content" className="pb-16 md:pb-0">
                 {children}
                 <RouteEditablePageContent />
               </main>
-              <MobileBottomNav />
-              <SubstrateBadge />
+              <ChromeGate>
+                <MobileBottomNav />
+                <SubstrateBadge />
+              </ChromeGate>
             </ExpertModeProvider>
           </ThemeProvider>
         </MessagesProvider>

--- a/web/components/ChromeGate.tsx
+++ b/web/components/ChromeGate.tsx
@@ -1,0 +1,20 @@
+// ChromeGate — hides the site-wide chrome (header, bottom nav, badge) on
+// self-contained app surfaces so members/staff can't accidentally wander out
+// of the Hati Suci app into the rest of the site with no way back. The app's
+// own header lives inside the page; identity is localStorage, so it carries
+// across regardless of chrome. Backend is shared; only the surface is sealed.
+"use client";
+
+import { usePathname } from "next/navigation";
+
+// Routes that render as their own contained app (no marketing-site chrome).
+const CONTAINED_PREFIXES = ["/hati-suci"];
+
+export default function ChromeGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() || "";
+  const contained = CONTAINED_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p + "/"),
+  );
+  if (contained) return null;
+  return <>{children}</>;
+}

--- a/web/components/INDEX.md
+++ b/web/components/INDEX.md
@@ -4,13 +4,14 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 52
+**Total files**: 53
 
 | File | Purpose |
 |---|---|
 | [AnonymousMeetingTrace.tsx](AnonymousMeetingTrace.tsx) | _no top-of-file purpose_ |
 | [AskingThread.tsx](AskingThread.tsx) | _no top-of-file purpose_ |
 | [AssetRenderer.tsx](AssetRenderer.tsx) | _no top-of-file purpose_ |
+| [ChromeGate.tsx](ChromeGate.tsx) | ChromeGate — hides the site-wide chrome (header, bottom nav, badge) on |
 | [EnablePush.tsx](EnablePush.tsx) | _no top-of-file purpose_ |
 | [ExplorePager.tsx](ExplorePager.tsx) | _no top-of-file purpose_ |
 | [FeedTabs.tsx](FeedTabs.tsx) | _no top-of-file purpose_ |


### PR DESCRIPTION
Members/staff could tap the site nav and leave the app with no way back. A `ChromeGate` (usePathname) hides `SiteHeader`, `MobileBottomNav`, and `SubstrateBadge` on `/hati-suci` — the app becomes its own surface (different web page from a surface POV, shared backend). Identity carries (localStorage). Easy, contained, nowhere to get lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)