### PR TITLE
tend: Hati Suci produce-picker — real pasar items, each tongue its own

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -34,9 +34,9 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 143 | API routers — every HTTP endpoint surface |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 244 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 56 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 239 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 240 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 34 | Web library — shared client/server helpers |
-| [web/components/INDEX.md](web/components/INDEX.md) | 52 | Web components — shared React surfaces |
+| [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 161 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 142 | Scripts — operational tools, generators, syncers |
 

--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -22,6 +22,7 @@ vouch. Backed by the same living graph that holds offerings and contributors.
 
 from __future__ import annotations
 
+import json
 import secrets
 import uuid
 from datetime import datetime, timezone
@@ -274,12 +275,24 @@ async def grant_write(member_id: str, body: GrantBody) -> MemberPublic:
 # --------------------------------------------------------------------------
 
 
+# A market line: a language-free item id, an amount in the pasar's own
+# proportion (kg / ikat / sisir / ons / …), and a snapshot of the label +
+# unit so the board can re-render in EACH viewer's tongue. The substrate
+# shape lives in docs/coherence-substrate/household-membrane.form (market).
+class RequestItem(BaseModel):
+    id: str = Field(min_length=1, max_length=64)
+    qty: float = Field(gt=0)
+    unit: str | None = Field(default=None, max_length=24)
+    label: str | None = Field(default=None, max_length=120)
+
+
 class RequestCreate(BaseModel):
     actor_token: str = Field(min_length=1)
     kind: RequestKind
     detail: str = Field(min_length=1, max_length=2000)
     location: str | None = Field(default=None, max_length=200)
     when_text: str | None = Field(default=None, max_length=200)
+    items: list[RequestItem] = Field(default_factory=list)
 
 
 class ActorBody(BaseModel):
@@ -296,6 +309,7 @@ class RequestResponse(BaseModel):
     id: str
     kind: str
     detail: str
+    items: list[dict[str, Any]] = Field(default_factory=list)
     location: str | None = None
     when_text: str | None = None
     status: str
@@ -317,6 +331,17 @@ def _s(v: Any) -> str | None:
     return s or None
 
 
+def _decode_items(node: dict) -> list[dict[str, Any]]:
+    raw = node.get("items_json")
+    if not isinstance(raw, str) or not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    return [i for i in parsed if isinstance(i, dict)] if isinstance(parsed, list) else []
+
+
 def _node_to_request(node: dict) -> RequestResponse:
     raw_cost = node.get("cost_amount")
     cost_amount = float(raw_cost) if isinstance(raw_cost, (int, float)) else None
@@ -324,6 +349,7 @@ def _node_to_request(node: dict) -> RequestResponse:
         id=node.get("id", ""),
         kind=node.get("kind", "other"),
         detail=node.get("detail", "") or node.get("description", ""),
+        items=_decode_items(node),
         location=_s(node.get("location")),
         when_text=_s(node.get("when_text")),
         status=node.get("status", "open"),
@@ -379,6 +405,10 @@ async def create_request(body: RequestCreate) -> RequestResponse:
         "created_at": created_at,
         "updated_at": created_at,
     }
+    if body.items:
+        properties["items_json"] = json.dumps(
+            [i.model_dump(exclude_none=True) for i in body.items]
+        )
     node = graph_service.create_node(
         id=request_id, type=_REQUEST_TYPE, name=body.detail[:120],
         description=body.detail, properties=properties,

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 239
+**Total files**: 240
 
 | File | Purpose |
 |---|---|
@@ -109,6 +109,7 @@
 | [test_graph_model_boundaries.py](test_graph_model_boundaries.py) | _no top-of-file purpose_ |
 | [test_grounded_cost_value_measurement.py](test_grounded_cost_value_measurement.py) | Tests for grounded cost & value measurement (spec: grounded-cost-value-measurement). |
 | [test_homepage_contrast.py](test_homepage_contrast.py) | WCAG AA contrast tests for homepage CSS palette (ux-homepage-readability). |
+| [test_household_service_board.py](test_household_service_board.py) | Flow test for the household resident-service board (api/app/routers/household.py). |
 | [test_idea_lifecycle_closure.py](test_idea_lifecycle_closure.py) | Tests for idea lifecycle closure (spec: idea-lifecycle-closure). |
 | [test_idea_scoring.py](test_idea_scoring.py) | Tests for idea_scoring (spec: ideas-prioritization). |
 | [test_idea_standing_questions.py](test_idea_standing_questions.py) | Tests for idea_standing_questions (spec: standing-questions-roi-and-next-task-generation). |

--- a/docs/coherence-substrate/household-membrane.form
+++ b/docs/coherence-substrate/household-membrane.form
@@ -96,6 +96,49 @@
       (fidelity      blueprint-equal)             # the token survives the loop intact
       (human-cost    (point-camera))))            # the whole UX, in one gesture
 
+  # ── Market vocabulary: what a food / supplies signal is made of ─────
+  #
+  # A food or supplies signal is NOT free text — it composes from
+  # market-items, each a (multilingual label, amount-in-local-proportion).
+  # The label carries every tongue at once, so the board renders in the
+  # VIEWER's language: the resident reads "rice", the staff who shops
+  # reads "beras", from the same cell. Nobody types a name twice.
+  #
+  # The amount is measured in the proportions the pasar actually uses —
+  # not bare counts. Leafy greens come by the ikat (bunch); bananas by the
+  # sisir (comb); aromatics by the ons (100 g); rice by the kg; eggs by the
+  # butir (each). The unit is itself multilingual, so "ikat" shows the
+  # resident "bunch" and the staff "ikat".
+
+  (market
+    (item-shape                                   # what one market line IS
+      (id        ?slug)                           # stable key — language-free
+      (group     ?one-of (fruit veg bumbu pokok))
+      (label     (per-tongue en id de es))        # rendered in the viewer's locale
+      (amount    (qty ?n) (unit ?proportion))     # an amount, NOT a bare count
+      (step      ?increment)                      # how +/- moves, in that unit
+      (start     ?default))                       # amount on first tap
+
+    (proportions                                  # the pasar's own measures, each multilingual
+      (kg       (en "kg")     (id "kg"))
+      (ons      (en "100g")   (id "ons"))         # 1 ons = 100 g, the aromatics measure
+      (ikat     (en "bunch")  (id "ikat"))        # leafy greens, lemongrass
+      (sisir    (en "comb")   (id "sisir"))       # a hand of bananas
+      (butir    (en "pcs")    (id "butir"))       # eggs, coconuts — counted
+      (buah     (en "pcs")    (id "buah"))        # whole fruit / veg — counted
+      (potong   (en "pcs")    (id "potong"))      # tofu, sliced pumpkin
+      (bungkus  (en "pack")   (id "bungkus"))     # salt, instant noodles
+      (botol    (en "bottle") (id "botol")))      # cooking oil
+
+    (compose                                      # a food / supplies signal's detail
+      (of   open-signal)
+      (when (kind ?in (food supplies)))
+      (from (sequence (market-item ?i (qty ?n)))) # R_Block.SEQUENCE — one child per line
+      (render-as (per-viewer-locale)))            # staff & resident each read their tongue
+
+    (catalog                                      # the items themselves intern as DATA
+      (note "the pasar items near Hati Suci intern as data, not code; the web carries the instance, the substrate is the source once g4 lands")))
+
   # ── Carrier (downstream — named so it stays thin) ──────────────────
   (carrier
     (route     /api/household/*)        # HTTP fan-out over the recipes above
@@ -107,4 +150,5 @@
   (gaps
     (g1 "executable .fk recipes in form/form-stdlib + a household.join round-trip band — proven via validate.sh three-way on CI, not a local single-kernel claim")
     (g2 "household.py is the CURRENT carrier but still holds the logic; it thins to serve_via_kernel over these recipes once g1 lands")
-    (g3 "qr-grammar (version/ecc/mask) interns as DATA so two callers of household.join share one Recipe NodeID — same shape, same coordinate")))
+    (g3 "qr-grammar (version/ecc/mask) interns as DATA so two callers of household.join share one Recipe NodeID — same shape, same coordinate")
+    (g4 "the market catalog interns as substrate DATA (one MarketItem Blueprint, many instances) served from /api/household/market — today it lives as a typed projection in the web carrier; g4 unifies the source so resident and staff read one catalog, each in their tongue")))

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -34,10 +34,16 @@ type PublicMember = {
 type Kind = "food" | "laundry" | "cleaning" | "ride" | "repair" | "room" | "supplies" | "other";
 type Status = "open" | "acknowledged" | "in_progress" | "completed" | "cancelled";
 
+// One market line, stored structurally so the board re-renders in EACH
+// viewer's tongue: id is language-free; label/unit are snapshots used as a
+// fallback when the catalog doesn't know the id (custom items).
+type RequestItem = { id: string; qty: number; unit?: string; label?: string };
+
 type ServiceRequest = {
   id: string;
   kind: Kind;
   detail: string;
+  items?: RequestItem[];
   location?: string | null;
   when_text?: string | null;
   status: Status;
@@ -65,7 +71,83 @@ const KINDS: { key: Kind; emoji: string }[] = [
   { key: "other", emoji: "✨" },
 ];
 
+// ── The market near Hati Suci ───────────────────────────────────────
+// A projection of the catalog whose shape + proportions live in the body:
+// docs/coherence-substrate/household-membrane.form (market). Each item
+// carries its label in every tongue, so the board renders in the VIEWER's
+// language — the resident reads "rice", the staff who shops reads "beras",
+// from one cell. Amounts use the pasar's own measures (kg, ikat = bunch,
+// sisir = comb, ons = 100 g, butir = each), never bare counts. (g4 will
+// serve this from /api/household/market so there is a single source.)
+type Lang = "en" | "id" | "de" | "es";
+type L = { en: string; id: string; de?: string; es?: string };
+type MarketGroup = "fruit" | "veg" | "bumbu" | "pokok";
+type MarketItem = { id: string; e: string; g: MarketGroup; l: L; u: L; step: number; start: number };
+
+const U = {
+  comb: { en: "comb", id: "sisir" },
+  bunch: { en: "bunch", id: "ikat" },
+  kg: { en: "kg", id: "kg" },
+  ons: { en: "100g", id: "ons" },
+  pcs: { en: "pcs", id: "buah" },
+  butir: { en: "pcs", id: "butir" },
+  potong: { en: "pcs", id: "potong" },
+  pack: { en: "pack", id: "bungkus" },
+  bottle: { en: "bottle", id: "botol" },
+} as const;
+
+const MARKET: MarketItem[] = [
+  // fruit (buah)
+  { id: "pisang", e: "🍌", g: "fruit", l: { en: "banana", id: "pisang" }, u: U.comb, step: 1, start: 1 },
+  { id: "pepaya", e: "🍈", g: "fruit", l: { en: "papaya", id: "pepaya" }, u: U.pcs, step: 1, start: 1 },
+  { id: "mangga", e: "🥭", g: "fruit", l: { en: "mango", id: "mangga" }, u: U.pcs, step: 1, start: 3 },
+  { id: "alpukat", e: "🥑", g: "fruit", l: { en: "avocado", id: "alpukat" }, u: U.pcs, step: 1, start: 3 },
+  { id: "nanas", e: "🍍", g: "fruit", l: { en: "pineapple", id: "nanas" }, u: U.pcs, step: 1, start: 1 },
+  { id: "semangka", e: "🍉", g: "fruit", l: { en: "watermelon", id: "semangka" }, u: U.pcs, step: 1, start: 1 },
+  { id: "naga", e: "🐉", g: "fruit", l: { en: "dragonfruit", id: "buah naga" }, u: U.pcs, step: 1, start: 2 },
+  { id: "kelapa", e: "🥥", g: "fruit", l: { en: "coconut", id: "kelapa" }, u: U.butir, step: 1, start: 2 },
+  { id: "jeruk", e: "🍊", g: "fruit", l: { en: "orange", id: "jeruk" }, u: U.kg, step: 1, start: 1 },
+  { id: "nipis", e: "🍋", g: "fruit", l: { en: "lime", id: "jeruk nipis" }, u: U.ons, step: 1, start: 1 },
+  { id: "salak", e: "🟤", g: "fruit", l: { en: "snakefruit", id: "salak" }, u: U.ons, step: 1, start: 2 },
+  // veg (sayur)
+  { id: "kangkung", e: "🥬", g: "veg", l: { en: "water spinach", id: "kangkung" }, u: U.bunch, step: 1, start: 2 },
+  { id: "bayam", e: "🌿", g: "veg", l: { en: "spinach", id: "bayam" }, u: U.bunch, step: 1, start: 2 },
+  { id: "kacang-panjang", e: "🫛", g: "veg", l: { en: "long beans", id: "kacang panjang" }, u: U.bunch, step: 1, start: 1 },
+  { id: "terong", e: "🍆", g: "veg", l: { en: "eggplant", id: "terong" }, u: U.kg, step: 1, start: 1 },
+  { id: "tomat", e: "🍅", g: "veg", l: { en: "tomato", id: "tomat" }, u: U.kg, step: 1, start: 1 },
+  { id: "timun", e: "🥒", g: "veg", l: { en: "cucumber", id: "timun" }, u: U.kg, step: 1, start: 1 },
+  { id: "jagung", e: "🌽", g: "veg", l: { en: "corn", id: "jagung" }, u: U.pcs, step: 1, start: 4 },
+  { id: "wortel", e: "🥕", g: "veg", l: { en: "carrot", id: "wortel" }, u: U.kg, step: 1, start: 1 },
+  { id: "kentang", e: "🥔", g: "veg", l: { en: "potato", id: "kentang" }, u: U.kg, step: 1, start: 1 },
+  { id: "ubi", e: "🍠", g: "veg", l: { en: "sweet potato", id: "ubi" }, u: U.kg, step: 1, start: 1 },
+  { id: "labu", e: "🎃", g: "veg", l: { en: "pumpkin", id: "labu" }, u: U.potong, step: 1, start: 1 },
+  { id: "jamur", e: "🍄", g: "veg", l: { en: "mushroom", id: "jamur" }, u: U.ons, step: 1, start: 2 },
+  { id: "kol", e: "🥬", g: "veg", l: { en: "cabbage", id: "kol" }, u: U.pcs, step: 1, start: 1 },
+  // aromatics (bumbu)
+  { id: "cabai", e: "🌶️", g: "bumbu", l: { en: "chili", id: "cabai" }, u: U.ons, step: 1, start: 1 },
+  { id: "bawang-merah", e: "🧅", g: "bumbu", l: { en: "shallot", id: "bawang merah" }, u: U.ons, step: 1, start: 2 },
+  { id: "bawang-putih", e: "🧄", g: "bumbu", l: { en: "garlic", id: "bawang putih" }, u: U.ons, step: 1, start: 1 },
+  { id: "jahe", e: "🫚", g: "bumbu", l: { en: "ginger", id: "jahe" }, u: U.ons, step: 1, start: 1 },
+  { id: "sereh", e: "🌾", g: "bumbu", l: { en: "lemongrass", id: "sereh" }, u: U.bunch, step: 1, start: 1 },
+  // staples (pokok)
+  { id: "beras", e: "🍚", g: "pokok", l: { en: "rice", id: "beras" }, u: U.kg, step: 1, start: 5 },
+  { id: "telur", e: "🥚", g: "pokok", l: { en: "eggs", id: "telur" }, u: U.butir, step: 5, start: 10 },
+  { id: "tahu", e: "⬜", g: "pokok", l: { en: "tofu", id: "tahu" }, u: U.potong, step: 1, start: 5 },
+  { id: "tempe", e: "🟫", g: "pokok", l: { en: "tempeh", id: "tempe" }, u: U.potong, step: 1, start: 2 },
+  { id: "garam", e: "🧂", g: "pokok", l: { en: "salt", id: "garam" }, u: U.pack, step: 1, start: 1 },
+  { id: "gula-merah", e: "🍯", g: "pokok", l: { en: "palm sugar", id: "gula merah" }, u: U.kg, step: 1, start: 1 },
+  { id: "kacang", e: "🥜", g: "pokok", l: { en: "peanuts", id: "kacang" }, u: U.ons, step: 1, start: 2 },
+  { id: "minyak", e: "🫗", g: "pokok", l: { en: "cooking oil", id: "minyak" }, u: U.bottle, step: 1, start: 1 },
+  { id: "mie", e: "🍜", g: "pokok", l: { en: "noodles", id: "mie" }, u: U.pack, step: 1, start: 5 },
+];
+
+const MARKET_BY_ID: Record<string, MarketItem> = Object.fromEntries(MARKET.map((m) => [m.id, m]));
+const MARKET_GROUPS: MarketGroup[] = ["fruit", "veg", "bumbu", "pokok"];
+
+type CustomItem = { id: string; label: string; e: string };
+
 const TOKEN_KEY = "hatiSuci.token";
+const CUSTOM_KEY = "hatiSuci.customItems";
 
 async function postJSON<T>(path: string, body: unknown): Promise<T> {
   const res = await fetch(path, {
@@ -121,6 +203,12 @@ export default function HatiSuciPage() {
   const [whenText, setWhenText] = useState("");
   const [busy, setBusy] = useState(false);
 
+  // Market cart (itemId → amount) + custom items remembered across visits.
+  const [cart, setCart] = useState<Record<string, number>>({});
+  const [customItems, setCustomItems] = useState<CustomItem[]>([]);
+  const [customInput, setCustomInput] = useState("");
+  const [lang, setLang] = useState<Lang>("en");
+
   const [invRole, setInvRole] = useState<Role>("member");
   const [inviteLink, setInviteLink] = useState<{ name: string; url: string; whatsapp: string; qr: string } | null>(null);
   const [contactPickerOk, setContactPickerOk] = useState(false);
@@ -163,6 +251,29 @@ export default function HatiSuciPage() {
     })();
   }, []);
 
+  // Active tongue (drives the market labels + the board re-render).
+  useEffect(() => {
+    const dl = document.documentElement.lang;
+    if (dl === "en" || dl === "id" || dl === "de" || dl === "es") setLang(dl);
+  }, []);
+
+  // Custom items the requester typed once — remembered as their own tiles.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(CUSTOM_KEY);
+      if (raw) setCustomItems(JSON.parse(raw) as CustomItem[]);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  useEffect(() => {
+    try {
+      localStorage.setItem(CUSTOM_KEY, JSON.stringify(customItems));
+    } catch {
+      /* ignore */
+    }
+  }, [customItems]);
+
   const load = useCallback(async () => {
     const r = await getJSON<ServiceRequest[]>("/api/household/requests?limit=200");
     if (r) setRequests(r);
@@ -197,28 +308,76 @@ export default function HatiSuciPage() {
   const token = member?.token ?? "";
   const canWrite = !!member?.write_access;
   const isResident = member?.role === "resident";
+  const marketKind = kind === "food" || kind === "supplies";
+
+  const pick = useCallback((x: L) => x[lang] ?? x.en, [lang]);
+
+  const toggleItem = useCallback((id: string, start: number) => {
+    setCart((c) => {
+      const next = { ...c };
+      if (next[id]) delete next[id];
+      else next[id] = start;
+      return next;
+    });
+  }, []);
+
+  const bumpItem = useCallback((id: string, delta: number) => {
+    setCart((c) => {
+      const q = (c[id] ?? 0) + delta;
+      const next = { ...c };
+      if (q <= 0) delete next[id];
+      else next[id] = q;
+      return next;
+    });
+  }, []);
+
+  const addCustom = useCallback(() => {
+    const label = customInput.trim();
+    if (!label) return;
+    const id = `custom:${label.toLowerCase().replace(/\s+/g, "-").slice(0, 40)}`;
+    setCustomItems((list) => (list.some((c) => c.id === id) ? list : [...list, { id, label, e: "🛒" }]));
+    setCart((c) => ({ ...c, [id]: c[id] ?? 1 }));
+    setCustomInput("");
+  }, [customInput]);
 
   const submitRequest = useCallback(async () => {
-    if (!token || !detail.trim()) return;
+    if (!token) return;
+    // For food / supplies the request IS the picked list (structured, so it
+    // re-renders in each viewer's tongue). Other kinds use the free note.
+    const lines: RequestItem[] = Object.entries(cart)
+      .filter(([, q]) => q > 0)
+      .map(([id, q]) => {
+        const it = MARKET_BY_ID[id];
+        if (it) return { id, qty: q, unit: pick(it.u), label: pick(it.l) };
+        const ci = customItems.find((c) => c.id === id);
+        return { id, qty: q, label: ci?.label ?? id };
+      });
+    const composed = lines
+      .map((li) => `${li.qty}${li.unit ? ` ${li.unit}` : ""} ${li.label}`)
+      .join(", ");
+    const finalDetail = marketKind ? composed : detail.trim();
+    if (!finalDetail) return;
     setBusy(true);
     try {
       await postJSON("/api/household/requests", {
         actor_token: token,
         kind,
-        detail: detail.trim(),
+        detail: finalDetail,
+        items: marketKind ? lines : [],
         location: location.trim() || null,
         when_text: whenText.trim() || null,
       });
       setDetail("");
       setLocation("");
       setWhenText("");
+      setCart({});
       await load();
     } catch {
       /* ignore */
     } finally {
       setBusy(false);
     }
-  }, [token, detail, kind, location, whenText, load]);
+  }, [token, cart, customItems, pick, detail, kind, marketKind, location, whenText, load]);
 
   const act = useCallback(
     async (id: string, verb: string, extra: Record<string, unknown> = {}) => {
@@ -524,13 +683,123 @@ export default function HatiSuciPage() {
                 </button>
               ))}
             </div>
-            <textarea
-              value={detail}
-              onChange={(e) => setDetail(e.target.value)}
-              placeholder={t("hatiSuci.add.detailPlaceholder")}
-              rows={2}
-              className="w-full rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
-            />
+            {marketKind ? (
+              <div className="space-y-3">
+                {MARKET_GROUPS.map((g) => (
+                  <div key={g} className="space-y-1.5">
+                    <p className="text-xs font-medium text-muted-foreground">{t(`hatiSuci.market.${g}`)}</p>
+                    <div className="grid grid-cols-4 gap-1.5 sm:grid-cols-6">
+                      {MARKET.filter((m) => m.g === g).map((m) => {
+                        const on = !!cart[m.id];
+                        return (
+                          <button
+                            key={m.id}
+                            onClick={() => toggleItem(m.id, m.start)}
+                            title={pick(m.l)}
+                            className={`flex flex-col items-center gap-0.5 rounded-xl border px-1 py-2 transition-colors ${
+                              on ? "border-primary/60 bg-primary/10" : "border-border/40 hover:bg-accent/40"
+                            }`}
+                          >
+                            <span className="text-xl leading-none">{m.e}</span>
+                            <span className="line-clamp-2 text-center text-[10px] leading-tight text-muted-foreground">{pick(m.l)}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+
+                {customItems.length > 0 && (
+                  <div className="space-y-1.5">
+                    <p className="text-xs font-medium text-muted-foreground">{t("hatiSuci.market.yourList")}</p>
+                    <div className="grid grid-cols-4 gap-1.5 sm:grid-cols-6">
+                      {customItems.map((m) => {
+                        const on = !!cart[m.id];
+                        return (
+                          <button
+                            key={m.id}
+                            onClick={() => toggleItem(m.id, 1)}
+                            title={m.label}
+                            className={`flex flex-col items-center gap-0.5 rounded-xl border px-1 py-2 transition-colors ${
+                              on ? "border-primary/60 bg-primary/10" : "border-border/40 hover:bg-accent/40"
+                            }`}
+                          >
+                            <span className="text-xl leading-none">{m.e}</span>
+                            <span className="line-clamp-2 text-center text-[10px] leading-tight text-muted-foreground">{m.label}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex gap-2">
+                  <input
+                    value={customInput}
+                    onChange={(e) => setCustomInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") addCustom();
+                    }}
+                    placeholder={t("hatiSuci.market.custom")}
+                    className="flex-1 rounded-xl border border-border/40 bg-background px-3 py-2 text-sm outline-none focus:border-primary/60"
+                  />
+                  <button
+                    onClick={addCustom}
+                    disabled={!customInput.trim()}
+                    className="rounded-xl border border-primary/40 bg-primary/5 px-4 py-2 text-sm font-medium disabled:opacity-50"
+                  >
+                    {t("hatiSuci.market.customAdd")}
+                  </button>
+                </div>
+
+                {Object.keys(cart).length > 0 && (
+                  <div className="space-y-1.5 rounded-xl border border-primary/20 bg-primary/5 p-2.5">
+                    {Object.entries(cart).map(([id, q]) => {
+                      const it = MARKET_BY_ID[id];
+                      const ci = customItems.find((c) => c.id === id);
+                      const label = it ? pick(it.l) : ci?.label ?? id;
+                      const unit = it ? pick(it.u) : "";
+                      const emoji = it ? it.e : ci?.e ?? "🛒";
+                      const step = it ? it.step : 1;
+                      return (
+                        <div key={id} className="flex items-center gap-2 text-sm">
+                          <span className="text-lg leading-none">{emoji}</span>
+                          <span className="min-w-0 flex-1 truncate text-foreground">{label}</span>
+                          <div className="flex items-center gap-1.5">
+                            <button
+                              onClick={() => bumpItem(id, -step)}
+                              className="h-7 w-7 rounded-lg border border-border/40 text-base leading-none text-muted-foreground hover:bg-accent/40"
+                            >
+                              −
+                            </button>
+                            <span className="min-w-[3.5rem] text-center tabular-nums text-foreground">
+                              {q}
+                              {unit ? ` ${unit}` : ""}
+                            </span>
+                            <button
+                              onClick={() => bumpItem(id, step)}
+                              className="h-7 w-7 rounded-lg border border-border/40 text-base leading-none text-muted-foreground hover:bg-accent/40"
+                            >
+                              +
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                <p className="text-center text-[11px] text-muted-foreground">{t("hatiSuci.market.hint")}</p>
+              </div>
+            ) : (
+              <textarea
+                value={detail}
+                onChange={(e) => setDetail(e.target.value)}
+                placeholder={t("hatiSuci.add.detailPlaceholder")}
+                rows={2}
+                className="w-full rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
+              />
+            )}
             <div className="grid grid-cols-2 gap-2">
               <input
                 value={location}
@@ -547,7 +816,7 @@ export default function HatiSuciPage() {
             </div>
             <button
               onClick={submitRequest}
-              disabled={busy || !detail.trim()}
+              disabled={busy || (marketKind ? Object.keys(cart).length === 0 : !detail.trim())}
               className="w-full rounded-xl bg-primary px-4 py-3 text-base font-medium text-primary-foreground disabled:opacity-50"
             >
               {t("hatiSuci.add.button")}
@@ -584,7 +853,18 @@ export default function HatiSuciPage() {
                 <div className="flex items-start gap-3">
                   <span className="text-2xl leading-none">{emoji}</span>
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm text-foreground break-words">{r.detail}</p>
+                    <p className="text-sm text-foreground break-words">
+                      {r.items && r.items.length > 0
+                        ? r.items
+                            .map((it) => {
+                              const cat = MARKET_BY_ID[it.id];
+                              const label = cat ? pick(cat.l) : it.label ?? it.id;
+                              const unit = cat ? pick(cat.u) : it.unit ?? "";
+                              return `${it.qty}${unit ? ` ${unit}` : ""} ${label}`;
+                            })
+                            .join(", ")
+                        : r.detail}
+                    </p>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                       {t("hatiSuci.meta.requestedBy")} {r.requester_name}
                       {r.location ? ` · ${r.location}` : ""}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -12,6 +12,7 @@ import { RouteReadPing } from "@/components/content/RouteReadPing";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ExpertModeProvider } from "@/components/expert-mode-context";
 import { MobileBottomNav } from "@/components/mobile-bottom-nav";
+import ChromeGate from "@/components/ChromeGate";
 import { MessagesProvider } from "@/components/MessagesProvider";
 import { loadPublicWebConfig } from "@/lib/app-config";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
@@ -124,14 +125,16 @@ export default async function RootLayout({
           <RouteReadPing />
           <ThemeProvider>
             <ExpertModeProvider>
-              <SiteHeader />
+              <ChromeGate><SiteHeader /></ChromeGate>
               <LiveUpdatesController />
               <main id="main-content" className="pb-16 md:pb-0">
                 {children}
                 <RouteEditablePageContent />
               </main>
-              <MobileBottomNav />
-              <SubstrateBadge />
+              <ChromeGate>
+                <MobileBottomNav />
+                <SubstrateBadge />
+              </ChromeGate>
             </ExpertModeProvider>
           </ThemeProvider>
         </MessagesProvider>

--- a/web/components/ChromeGate.tsx
+++ b/web/components/ChromeGate.tsx
@@ -1,0 +1,20 @@
+// ChromeGate — hides the site-wide chrome (header, bottom nav, badge) on
+// self-contained app surfaces so members/staff can't accidentally wander out
+// of the Hati Suci app into the rest of the site with no way back. The app's
+// own header lives inside the page; identity is localStorage, so it carries
+// across regardless of chrome. Backend is shared; only the surface is sealed.
+"use client";
+
+import { usePathname } from "next/navigation";
+
+// Routes that render as their own contained app (no marketing-site chrome).
+const CONTAINED_PREFIXES = ["/hati-suci"];
+
+export default function ChromeGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() || "";
+  const contained = CONTAINED_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(p + "/"),
+  );
+  if (contained) return null;
+  return <>{children}</>;
+}

--- a/web/components/INDEX.md
+++ b/web/components/INDEX.md
@@ -4,13 +4,14 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 52
+**Total files**: 53
 
 | File | Purpose |
 |---|---|
 | [AnonymousMeetingTrace.tsx](AnonymousMeetingTrace.tsx) | _no top-of-file purpose_ |
 | [AskingThread.tsx](AskingThread.tsx) | _no top-of-file purpose_ |
 | [AssetRenderer.tsx](AssetRenderer.tsx) | _no top-of-file purpose_ |
+| [ChromeGate.tsx](ChromeGate.tsx) | ChromeGate — hides the site-wide chrome (header, bottom nav, badge) on |
 | [EnablePush.tsx](EnablePush.tsx) | _no top-of-file purpose_ |
 | [ExplorePager.tsx](ExplorePager.tsx) | _no top-of-file purpose_ |
 | [FeedTabs.tsx](FeedTabs.tsx) | _no top-of-file purpose_ |

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -9,7 +9,11 @@
       "namePlaceholder": "Dein Name",
       "enter": "Ins Haus eintreten"
     },
-    "role": { "resident": "Bewohner", "staff": "Personal", "member": "Mitglied" },
+    "role": {
+      "resident": "Bewohner",
+      "staff": "Personal",
+      "member": "Mitglied"
+    },
     "seeOnly": "nur-lesen",
     "noWriteNote": "Ein Bewohner kann dir Schreibzugriff geben, um Anfragen zu stellen und zu betreuen.",
     "join": {
@@ -82,6 +86,17 @@
       "amountPlaceholder": "Betrag (IDR)",
       "notePlaceholder": "Wofür?",
       "paid": "Bezahlt"
+    },
+    "market": {
+      "heading": "Vom Markt",
+      "fruit": "Obst",
+      "veg": "Gemüse",
+      "bumbu": "Gewürze",
+      "pokok": "Grundnahrung",
+      "custom": "Etwas anderes…",
+      "customAdd": "Hinzufügen",
+      "hint": "Zum Hinzufügen tippen — Menge danach setzen",
+      "yourList": "Deine Liste"
     }
   },
   "_attunement": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -9,7 +9,11 @@
       "namePlaceholder": "Your name",
       "enter": "Enter the house"
     },
-    "role": { "resident": "Resident", "staff": "Staff", "member": "Member" },
+    "role": {
+      "resident": "Resident",
+      "staff": "Staff",
+      "member": "Member"
+    },
     "seeOnly": "see-only",
     "noWriteNote": "A resident can grant you write access to add and tend requests.",
     "join": {
@@ -82,6 +86,17 @@
       "amountPlaceholder": "Amount (IDR)",
       "notePlaceholder": "What for?",
       "paid": "Paid"
+    },
+    "market": {
+      "heading": "From the market",
+      "fruit": "Fruit",
+      "veg": "Vegetables",
+      "bumbu": "Aromatics & spice",
+      "pokok": "Staples",
+      "custom": "Something else…",
+      "customAdd": "Add",
+      "hint": "Tap to add — set the amount after",
+      "yourList": "Your list"
     }
   },
   "_attunement": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -9,7 +9,11 @@
       "namePlaceholder": "Tu nombre",
       "enter": "Entrar en la casa"
     },
-    "role": { "resident": "Residente", "staff": "Personal", "member": "Miembro" },
+    "role": {
+      "resident": "Residente",
+      "staff": "Personal",
+      "member": "Miembro"
+    },
     "seeOnly": "solo-ver",
     "noWriteNote": "Un residente puede darte acceso de escritura para añadir y atender solicitudes.",
     "join": {
@@ -82,6 +86,17 @@
       "amountPlaceholder": "Importe (IDR)",
       "notePlaceholder": "¿Para qué?",
       "paid": "Pagado"
+    },
+    "market": {
+      "heading": "Del mercado",
+      "fruit": "Fruta",
+      "veg": "Verduras",
+      "bumbu": "Especias",
+      "pokok": "Básicos",
+      "custom": "Otra cosa…",
+      "customAdd": "Añadir",
+      "hint": "Toca para añadir — ajusta la cantidad",
+      "yourList": "Tu lista"
     }
   },
   "_attunement": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -9,7 +9,11 @@
       "namePlaceholder": "Nama Anda",
       "enter": "Masuk ke rumah"
     },
-    "role": { "resident": "Penghuni", "staff": "Staf", "member": "Anggota" },
+    "role": {
+      "resident": "Penghuni",
+      "staff": "Staf",
+      "member": "Anggota"
+    },
     "seeOnly": "hanya-lihat",
     "noWriteNote": "Penghuni dapat memberi Anda akses tulis untuk menambah dan menangani permintaan.",
     "join": {
@@ -82,6 +86,17 @@
       "amountPlaceholder": "Jumlah (IDR)",
       "notePlaceholder": "Untuk apa?",
       "paid": "Lunas"
+    },
+    "market": {
+      "heading": "Dari pasar",
+      "fruit": "Buah",
+      "veg": "Sayur",
+      "bumbu": "Bumbu",
+      "pokok": "Pokok",
+      "custom": "Lainnya…",
+      "customAdd": "Tambah",
+      "hint": "Ketuk untuk menambah — atur jumlah setelah",
+      "yourList": "Daftar kamu"
     }
   },
   "_attunement": {


### PR DESCRIPTION
Food/supplies requests compose from the market near Hati Suci instead of free text. Tap an icon to add; adjust the amount in the pasar's own proportions (kg, ikat/bunch, sisir/comb, ons/100g, butir/each); custom items remembered as their own tiles. Each item is labelled in every tongue, so the board re-renders per viewer — resident reads "rice", staff reads "beras", from one cell.

Body-first: the market-item shape + proportion vocabulary live in `docs/coherence-substrate/household-membrane.form` (market block); web carries the catalog instance; the API round-trips structured `items`. No bread/coffee — those are warung goods. Also heals a dropped INDEX edge for the household test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)