### PR TITLE
tend: roster is who's here; newcomer self-names; native share sheet

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -138,6 +138,13 @@ def _member_by_token(token: str | None) -> dict | None:
     return None
 
 
+def _is_placeholder_name(name: str) -> bool:
+    """A role-only invite carries 'New {role}' until the newcomer claims it
+    with their own name on first open — the self-name half of `bind` in
+    docs/coherence-substrate/household-membrane.form."""
+    return not name or name.startswith("New ")
+
+
 def _create_member(name: str, role: str, *, write_access: bool, status: str,
                    phone: str | None, locale: str = "en",
                    invited_by: str = "", invited_by_name: str = "") -> dict:
@@ -218,12 +225,23 @@ async def create_invite(body: InviteBody) -> MemberPrivate:
     response_model=MemberPrivate,
     summary="Resolve your identity by device token (activates an invite on first open)",
 )
-async def whoami(token: str = Query(min_length=1)) -> MemberPrivate:
+async def whoami(
+    token: str = Query(min_length=1),
+    name: str | None = Query(default=None),
+) -> MemberPrivate:
     node = _member_by_token(token)
     if not node:
         raise HTTPException(status_code=404, detail="unknown token")
+    # bind: activate an invited cell, and let the newcomer claim their own
+    # name (only over a placeholder — never clobber a real one).
+    kwargs: dict[str, Any] = {}
     if node.get("status") == "invited":
-        node = graph_service.update_node(node["id"], properties={"status": "active"}) or node
+        kwargs["properties"] = {"status": "active"}
+    claimed = (name or "").strip()
+    if claimed and _is_placeholder_name(node.get("name", "")):
+        kwargs["name"] = claimed[:80]
+    if kwargs:
+        node = graph_service.update_node(node["id"], **kwargs) or node
     return _member_private(node)
 
 
@@ -233,7 +251,9 @@ async def whoami(token: str = Query(min_length=1)) -> MemberPrivate:
     summary="Everyone in the household — public view, no tokens or phones",
 )
 async def list_members(role: str | None = Query(default=None)) -> list[MemberPublic]:
-    members = _all_members()
+    # The roster is the people actually here (Form: `see open-to active-member`).
+    # Pending invites stay off it until the newcomer opens their link.
+    members = [m for m in _all_members() if m.get("status") == "active"]
     if role:
         members = [m for m in members if m.get("role") == role]
     members.sort(key=lambda n: n.get("created_at", ""))

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -213,6 +213,7 @@ export default function HatiSuciPage() {
   const [inviteLink, setInviteLink] = useState<{ name: string; url: string; whatsapp: string; qr: string } | null>(null);
   const [contactPickerOk, setContactPickerOk] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [claimInput, setClaimInput] = useState("");
 
   const [completingId, setCompletingId] = useState<string | null>(null);
   const [costAmount, setCostAmount] = useState("");
@@ -309,6 +310,7 @@ export default function HatiSuciPage() {
   const canWrite = !!member?.write_access;
   const isResident = member?.role === "resident";
   const marketKind = kind === "food" || kind === "supplies";
+  const needsName = !!member && /^New (resident|staff|member)$/i.test(member.name);
 
   const pick = useCallback((x: L) => x[lang] ?? x.en, [lang]);
 
@@ -451,6 +453,40 @@ export default function HatiSuciPage() {
     }
   }, [makeInvite]);
 
+  // Share the invite via the OS share sheet (iOS + Android) — the newcomer's
+  // contact is chosen inside WhatsApp/Messages, never typed here. Falls back
+  // to WhatsApp's own picker where the share sheet isn't available (desktop).
+  const shareInvite = useCallback(
+    async (url: string) => {
+      const text = t("hatiSuci.invite.shareText");
+      const nav = navigator as Navigator & {
+        share?: (d: { title?: string; text?: string; url?: string }) => Promise<void>;
+      };
+      if (nav.share) {
+        try {
+          await nav.share({ title: "Hati Suci", text, url });
+          return;
+        } catch {
+          /* cancelled */
+        }
+      }
+      window.open(`https://wa.me/?text=${encodeURIComponent(`${text} ${url}`)}`, "_blank", "noopener");
+    },
+    [t],
+  );
+
+  // The self-name half of bind: a newcomer claims their own name on arrival
+  // (the invite carried only a role). No one ever types another's name.
+  const claimName = useCallback(async () => {
+    const nm = claimInput.trim();
+    if (!nm || !token) return;
+    const me = await getJSON<Member>(
+      `/api/household/me?token=${encodeURIComponent(token)}&name=${encodeURIComponent(nm)}`,
+    );
+    if (me) setMember(me);
+    setClaimInput("");
+  }, [claimInput, token]);
+
   useEffect(() => {
     setContactPickerOk("contacts" in navigator && "ContactsManager" in window);
   }, []);
@@ -577,6 +613,31 @@ export default function HatiSuciPage() {
           {langToggle}
         </header>
 
+        {/* New arrival names themselves (the invite carried only a role) */}
+        {needsName && (
+          <section className="space-y-2 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4">
+            <p className="text-sm text-foreground">{t("hatiSuci.claim.prompt")}</p>
+            <div className="flex gap-2">
+              <input
+                value={claimInput}
+                onChange={(e) => setClaimInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") claimName();
+                }}
+                placeholder={t("hatiSuci.reg.namePlaceholder")}
+                className="flex-1 rounded-xl border border-border/40 bg-background px-3 py-2 text-base outline-none focus:border-primary/60"
+              />
+              <button
+                onClick={claimName}
+                disabled={!claimInput.trim()}
+                className="rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {t("hatiSuci.claim.button")}
+              </button>
+            </div>
+          </section>
+        )}
+
         {/* Invite (residents only) */}
         {isResident && (
           <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-4 space-y-3">
@@ -625,14 +686,12 @@ export default function HatiSuciPage() {
                 </div>
                 <p className="break-all rounded-lg bg-background/60 px-2 py-1.5 text-[11px] text-muted-foreground">{inviteLink.url}</p>
                 <div className="flex gap-2">
-                  <a
-                    href={inviteLink.whatsapp}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <button
+                    onClick={() => shareInvite(inviteLink.url)}
                     className="flex-1 rounded-lg border border-emerald-500/40 px-3 py-2 text-center text-sm font-medium text-emerald-600 dark:text-emerald-400"
                   >
-                    {t("hatiSuci.invite.shareWhatsApp")}
-                  </a>
+                    {t("hatiSuci.invite.share")}
+                  </button>
                   <button
                     onClick={() => copyLink(inviteLink.url)}
                     className="rounded-lg border border-border/40 px-3 py-2 text-sm text-muted-foreground hover:bg-accent/40"

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -32,7 +32,9 @@
       "scanToJoin": "Kamera hierauf richten, um als {name} beizutreten",
       "pickContact": "Aus Kontakten",
       "makeQr": "Beitritts-QR erstellen",
-      "noTyping": "Kontakt wählen oder QR zeigen — kein Tippen."
+      "noTyping": "Kontakt wählen oder QR zeigen — kein Tippen.",
+      "share": "Einladung teilen",
+      "shareText": "Tritt dem Hati-Suci-Haushaltsbrett bei"
     },
     "people": {
       "heading": "Wartet auf Freigabe",
@@ -97,6 +99,10 @@
       "customAdd": "Hinzufügen",
       "hint": "Zum Hinzufügen tippen — Menge danach setzen",
       "yourList": "Deine Liste"
+    },
+    "claim": {
+      "prompt": "Willkommen! Wie sollen wir dich nennen?",
+      "button": "Das bin ich"
     }
   },
   "_attunement": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -32,7 +32,9 @@
       "scanToJoin": "Point a camera here to join as {name}",
       "pickContact": "From contacts",
       "makeQr": "Make join QR",
-      "noTyping": "Pick a contact or show the QR — no typing."
+      "noTyping": "Pick a contact or show the QR — no typing.",
+      "share": "Share invite",
+      "shareText": "Join the Hati Suci household board"
     },
     "people": {
       "heading": "Waiting for a vouch",
@@ -97,6 +99,10 @@
       "customAdd": "Add",
       "hint": "Tap to add — set the amount after",
       "yourList": "Your list"
+    },
+    "claim": {
+      "prompt": "Welcome! What should we call you?",
+      "button": "That's me"
     }
   },
   "_attunement": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -32,7 +32,9 @@
       "scanToJoin": "Apunta una cámara aquí para unirte como {name}",
       "pickContact": "De contactos",
       "makeQr": "Crear QR de acceso",
-      "noTyping": "Elige un contacto o muestra el QR — sin escribir."
+      "noTyping": "Elige un contacto o muestra el QR — sin escribir.",
+      "share": "Compartir invitación",
+      "shareText": "Únete al tablero del hogar Hati Suci"
     },
     "people": {
       "heading": "Esperando aprobación",
@@ -97,6 +99,10 @@
       "customAdd": "Añadir",
       "hint": "Toca para añadir — ajusta la cantidad",
       "yourList": "Tu lista"
+    },
+    "claim": {
+      "prompt": "¡Bienvenido! ¿Cómo te llamas?",
+      "button": "Soy yo"
     }
   },
   "_attunement": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -32,7 +32,9 @@
       "scanToJoin": "Arahkan kamera ke sini untuk bergabung sebagai {name}",
       "pickContact": "Dari kontak",
       "makeQr": "Buat QR gabung",
-      "noTyping": "Pilih kontak atau tunjukkan QR — tanpa mengetik."
+      "noTyping": "Pilih kontak atau tunjukkan QR — tanpa mengetik.",
+      "share": "Bagikan undangan",
+      "shareText": "Gabung ke papan rumah Hati Suci"
     },
     "people": {
       "heading": "Menunggu persetujuan",
@@ -97,6 +99,10 @@
       "customAdd": "Tambah",
       "hint": "Ketuk untuk menambah — atur jumlah setelah",
       "yourList": "Daftar kamu"
+    },
+    "claim": {
+      "prompt": "Selamat datang! Siapa nama kamu?",
+      "button": "Itu saya"
     }
   },
   "_attunement": {


### PR DESCRIPTION
Aligns the carrier to household-membrane.form:
- **Roster = active members** ('see open-to active-member') — pending invites no longer clutter the list.
- **Newcomer claims their own name on arrival** ('bind ?token ?self-name') — invite carries only a role; no one types another's name.
- **Share via the OS share sheet** (navigator.share) so the contact is picked in WhatsApp/Messages — works on iPhone (no in-app contact picker there). Desktop falls back to WhatsApp's picker.

Fixes the duplicate-member + 'New member' clutter and the 'couldn't pick a contact' report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)