### PR TITLE
tend: the request lifecycle executes as Form, not a Python if-tree

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -32,6 +32,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from app.services import graph_service
+from app.services.form_kernel_bridge import serve_via_kernel
 
 router = APIRouter()
 
@@ -402,6 +403,46 @@ def _apply(request_id: str, updates: dict[str, Any]) -> RequestResponse:
     return _node_to_request(node)
 
 
+# ── The request lifecycle, as a Form recipe ───────────────────────────
+# advance(status, verb) — the membrane's state machine — runs on the Form
+# kernel (endpoint_household_advance_demo.fk) with a value-identical Python
+# fallback. This is the first household rule to leave the Python if-tree and
+# execute as Form; the carrier here only encodes/decodes and does the I/O.
+# (household-membrane.form, recipes: acknowledge / tend / complete.)
+_STATUS_CODE = {"open": 0, "acknowledged": 1, "in_progress": 2, "completed": 3, "cancelled": 4}
+_CODE_STATUS = {v: k for k, v in _STATUS_CODE.items()}
+_VERB_CODE = {"acknowledge": 0, "start": 1, "complete": 2, "cancel": 3}
+
+
+def _advance_py(status: int, verb: int) -> int:
+    """Value-identical fallback for endpoint_household_advance_demo.fk."""
+    if verb == 0:
+        return 1 if status == 0 else -1
+    if verb == 1:
+        return 2 if status < 2 else -1
+    if verb == 2:
+        return 3 if status < 3 else -1
+    if verb == 3:
+        return 4 if status < 3 else -1
+    return -1
+
+
+def _advance_status(current: str, verb: str) -> str:
+    """Next lifecycle status, computed by the Form recipe on the kernel."""
+    s = _STATUS_CODE.get(current, 0)
+    v = _VERB_CODE[verb]
+    code, _runtime = serve_via_kernel(
+        "endpoint_household_advance_demo.fk",
+        bindings={"status": s, "verb": v},
+        fallback=lambda: _advance_py(s, v),
+        parse=int,
+    )
+    nxt = _CODE_STATUS.get(int(code))
+    if nxt is None:
+        raise HTTPException(status_code=409, detail=f"cannot {verb} a {current} request")
+    return nxt
+
+
 @router.post(
     "/household/requests",
     response_model=RequestResponse,
@@ -473,9 +514,9 @@ async def get_request(request_id: str) -> RequestResponse:
 )
 async def acknowledge_request(request_id: str, body: ActorBody) -> RequestResponse:
     actor = _require_writer(body.actor_token)
-    _load_request(request_id)
+    node = _load_request(request_id)
     return _apply(request_id, {
-        "status": "acknowledged",
+        "status": _advance_status(node.get("status", "open"), "acknowledge"),
         "acknowledged_by": actor.get("id", ""),
         "acknowledged_by_name": actor.get("name", ""),
         "acknowledged_at": _now(),
@@ -490,7 +531,7 @@ async def acknowledge_request(request_id: str, body: ActorBody) -> RequestRespon
 async def start_request(request_id: str, body: ActorBody) -> RequestResponse:
     actor = _require_writer(body.actor_token)
     node = _load_request(request_id)
-    updates: dict[str, Any] = {"status": "in_progress", "started_at": _now()}
+    updates: dict[str, Any] = {"status": _advance_status(node.get("status", "open"), "start"), "started_at": _now()}
     if not _s(node.get("acknowledged_by")):
         updates["acknowledged_by"] = actor.get("id", "")
         updates["acknowledged_by_name"] = actor.get("name", "")
@@ -505,9 +546,9 @@ async def start_request(request_id: str, body: ActorBody) -> RequestResponse:
 )
 async def complete_request(request_id: str, body: CompleteBody) -> RequestResponse:
     actor = _require_writer(body.actor_token)
-    _load_request(request_id)
+    node = _load_request(request_id)
     updates: dict[str, Any] = {
-        "status": "completed",
+        "status": _advance_status(node.get("status", "open"), "complete"),
         "completed_by": actor.get("id", ""),
         "completed_by_name": actor.get("name", ""),
         "completed_at": _now(),
@@ -527,8 +568,8 @@ async def complete_request(request_id: str, body: CompleteBody) -> RequestRespon
 )
 async def cancel_request(request_id: str, body: ActorBody) -> RequestResponse:
     _require_writer(body.actor_token)
-    _load_request(request_id)
-    return _apply(request_id, {"status": "cancelled", "cancelled_at": _now()})
+    node = _load_request(request_id)
+    return _apply(request_id, {"status": _advance_status(node.get("status", "open"), "cancel"), "cancelled_at": _now()})
 
 
 @router.post(

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_household_advance_demo.fk
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_household_advance_demo.fk
@@ -1,0 +1,1 @@
+(do (defn advance (status verb) (if (eq verb 0) (if (eq status 0) 1 -1) (if (eq verb 1) (if (lt status 2) 2 -1) (if (eq verb 2) (if (lt status 3) 3 -1) (if (eq verb 3) (if (lt status 3) 4 -1) -1))))) (let status 0) (let verb 0) (advance status verb))

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_household_advance_demo.py
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_household_advance_demo.py
@@ -1,0 +1,36 @@
+# endpoint_household_advance_demo.py — the Hati Suci request lifecycle,
+# captured as pure Python and compiled to a Form recipe.
+#
+# The household board's state machine: a request moves
+#   open → acknowledged → in_progress → completed,  or is  cancelled.
+# Each move is a (status, verb) pair; `advance` returns the next status
+# code, or -1 for an illegal move. The live lifecycle endpoints in
+# api/app/routers/household.py compute their next status by running THIS
+# recipe on the kernel (serve_via_kernel), with the value-identical
+# Python below as the fallback. FastAPI stays the HTTP doorway; the
+# membrane's lifecycle is a Form recipe — the first household rule to
+# leave the Python if-tree and execute as Form.
+#
+# Encoding — numbers are the substrate's native tongue:
+#   status:  open=0  acknowledged=1  in_progress=2  completed=3  cancelled=4
+#   verb:    acknowledge=0  start=1  complete=2  cancel=3
+# "active" (a request still in motion) is simply status < 3.
+#
+# Three runtimes produce identical results: CPython, TS evalPython, Rust.
+
+
+def advance(status, verb):
+    if verb == 0:                       # acknowledge: only an open request
+        return 1 if status == 0 else -1
+    if verb == 1:                       # start: from open or acknowledged
+        return 2 if status < 2 else -1
+    if verb == 2:                       # complete: any active request
+        return 3 if status < 3 else -1
+    if verb == 3:                       # cancel: any active request
+        return 4 if status < 3 else -1
+    return -1
+
+
+status = 0
+verb = 0
+result = advance(status, verb)


### PR DESCRIPTION
First household rule moved from Python into an executable Form recipe. The membrane's state machine — `advance(status, verb)` over open/acknowledged/in_progress/completed/cancelled — runs on the kernel (`endpoint_household_advance_demo.fk`) via `serve_via_kernel`, the same kernel-or-fallback vehicle the `/api/utils` nodeid endpoints use in production. The four lifecycle endpoints stopped hardcoding their target status; they ask the recipe now. Value-identical Python fallback keeps the board correct until the kernel serves; CI three-way (CPython/TS/Rust) is the parity gate. Flow tests green, truth table proven.

The start of the real thinning: the logic *runs* as Form, not the .form describing while Python executes. The see/write locks and the vouch follow, recipe by recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)