### PR TITLE
tend: places, houses & attention vocabulary enter the body

### DIFF
--- a/docs/coherence-substrate/household-membrane.form
+++ b/docs/coherence-substrate/household-membrane.form
@@ -160,6 +160,7 @@
 
     (event-extension                                 # present when kind = event
       (status (one-of (proposed confirmed delayed))) # the field watches this
+      (where  (cell-ref place))                      # usually one of the two common places; sometimes a house
       (when   (date ?d))                             # the event's own moment
       (hosts  (sequence (cell-ref member))))         # zero to many hold it
 
@@ -181,6 +182,52 @@
       (answer open-to (visible-to ?question))        # you answer what reaches you
       (see    open-to active-member)))               # every answer, every tally, visible to all here
 
+  # ── Places & houses: where the field gathers and dwells ───────────
+  #
+  # A PLACE is a named spot at Hati Suci with a precise location. Most
+  # events land at one of the two common places; a house can host one too,
+  # less often. A HOUSE is a place you dwell in — it has rooms, residents,
+  # a WiFi name, and things that need tending. Location is set by SENSOR:
+  # a resident standing in the place taps once and the phone's GPS pins it.
+  # (The house knows its WiFi NAME as data — useful to share; the web still
+  # can't read the phone's live SSID, so GPS is the locator.)
+
+  (place
+    (place-shape
+      (name  ?prose)                       # "Yoga Shala", "Fire Circle", "Bamboo House"
+      (gps   (lat ?µ) (lon ?µ))            # precise, in micro-degrees
+      (wifi  ?ssid)                        # the place's WiFi name (data; not read live)
+      (kind  (one-of (common house))))     # two commons hold most events; houses host occasionally
+    (locate
+      (set-by  pin-while-present)          # the sensor sets it: stand here, tap once
+      (nearest (recipe nearest-place ?lat ?lon -> place))))  # GPS → place, a Form recipe
+
+  (house                                   # a place you dwell in (kind = house)
+    (is-a place)
+    (rooms (sequence room))                # the rooms within
+    (resident-placement
+      (member stays-in (room ?r)))         # each resident's house + room, on their cell
+
+    (attention                             # things that need tending — one board signal per issue
+      (issue-shape
+        (of    open-signal)                # it IS a board signal: ask → acknowledge → tend → complete (already Form)
+        (house (cell-ref house))
+        (room  (cell-ref room))
+        (what  (cell-ref issue-kind))      # the common thing, below
+        (detail ?prose))
+      (common                              # the recurring things — each (id, icon, multilingual)
+        (fridge       (en "fridge")              (id "kulkas"))
+        (wifi         (en "WiFi")                (id "wifi"))
+        (toilet       (en "toilet")              (id "toilet"))
+        (stove-gas    (en "stove — out of gas")  (id "kompor — gas habis"))
+        (stove-broken (en "stove — not working") (id "kompor rusak"))
+        (hot-water    (en "hot water")           (id "air panas"))
+        (water        (en "water")               (id "air"))
+        (electricity  (en "electricity")         (id "listrik"))
+        (broken       (en "something broke")     (id "ada yang rusak"))
+        (other        (en "needs tending")       (id "perlu diurus")))
+      (learns "the list grows: a custom issue typed once is remembered as its own tile, the way a custom market item is — the body learns what recurs")))
+
   # ── Carrier (downstream — named so it stays thin) ──────────────────
   (carrier
     (route     /api/household/*)        # HTTP fan-out over the recipes above
@@ -194,4 +241,5 @@
     (g2 "household.py is the CURRENT carrier but still holds the logic; it thins to serve_via_kernel over these recipes once g1 lands")
     (g3 "qr-grammar (version/ecc/mask) interns as DATA so two callers of household.join share one Recipe NodeID — same shape, same coordinate")
     (g4 "the market catalog interns as substrate DATA (one MarketItem Blueprint, many instances) served from /api/household/market — today it lives as a typed projection in the web carrier; g4 unifies the source so resident and staff read one catalog, each in their tongue")
-    (g5 "the gathering recipes — visible-to (audience predicate), tally (head-counts), advance-event (status machine) — execute on the kernel via serve_via_kernel, same vehicle proven for advance(status,verb); the carrier (route + web poll UI) follows recipe-first, never logic-in-Python")))
+    (g5 "the gathering recipes — visible-to (audience predicate), tally (head-counts), advance-event (status machine) — execute on the kernel via serve_via_kernel, same vehicle proven for advance(status,verb); the carrier (route + web poll UI) follows recipe-first, never logic-in-Python")
+    (g6 "places & houses carrier: place cells (name, gps-by-pin, wifi, kind), house rooms + resident-placement, the attention issue-vocabulary (market-picker pattern), and the nearest-place Form recipe — built recipe-first when the place/house names land; a house-issue rides the existing board lifecycle, not new machinery")))


### PR DESCRIPTION
Place = named spot + precise GPS (pin-to-set) + WiFi-name-as-data + kind (common/house). Two commons host most events; a house is a dwelling-place (rooms, resident-placement) with an attention vocabulary of recurring issues (fridge, wifi, toilet, stove gas/broken, water, electricity, …), multilingual, learning. A house-issue rides the board lifecycle already on the kernel; an event's `where` → a place. g6 = carrier assembles existing executing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)