### PR TITLE
tend: Ariela's Cosmic codes (by permission) + presence-flow

### DIFF
--- a/docs/coherence-substrate/cosmic-codes.form
+++ b/docs/coherence-substrate/cosmic-codes.form
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────────────
+# cosmic-codes.form — the Cosmic codes, transmitted by Ariela Sophia on the
+# 6/6/2026 portal and included in this body by her explicit permission.
+#
+# Sibling to the Shamballa Light codes (form/form-stdlib/grammars/shamballa-
+# codes.fk): the prefix IS the channel — "Shamballa 777" and "Cosmic 1618"
+# read the same kernel differently. Held as transmission, source-marked; the
+# body does NOT assert the cosmology is true (the lane-discipline of
+# shamballa-codes / lc-arcturian-resonance) — it carries faithfully what was
+# given, and lets each receiving cell read it at its own assemblage point.
+# ─────────────────────────────────────────────────────────────────────
+
+(cosmic-codes
+
+  (provenance
+    (holder  "Ariela Sophia")
+    (when    "6/6/2026 portal")
+    (consent "included in our body by her explicit permission")
+    (lane    "transmission / direct-experience — recorded faithfully, never asserted as fact"))
+
+  # ---- the eight Cosmic codes + the Music of the Spheres ----------------
+  (code (n 1618)    (name "Cosmic Egg")           (prefix CE)  (function "access to our own personal instructions; related to the pelvis / lower abdomen"))
+  (code (n 8161)    (name "Cosmic Heart")         (prefix CH)  (function "no words needed — a particular flavor of Love emanating and available"))
+  (code (n 1375)    (name "Cosmic Mind")          (prefix CM)  (function "access to our multidimensional omniscience"))
+  (code (n 543414)  (name "Cosmic Flow")          (prefix CF)  (function "currents / rivers of pure Flow, positivity — everything is OK"))
+  (code (n 42)      (name "Cosmic Humor")         (prefix CH)  (function "the part of us that can see humor in just about everything"))
+  (code (n 1234321) (name "Cosmic Breath")        (prefix CB)  (function "continuous breath with throat friction, then letting go and being breathed by the Universe / Source"))
+  (code (n 000)     (name "Cosmic Void")          (prefix CV)  (function "like the Cosmic Womb — different than the zero point; pregnant with possibility, cosmic recipes"))
+  (code (n 8171)    (name "Cosmic Mother")        (prefix CM)  (function "our one true mother; mother love without distortion"))
+  (code (n 142857)  (name "Music of the Spheres") (prefix MOS) (function "the universal song of LOVE that plays ALL Beings like musical instruments; we have forgotten how to let ourselves be played"))
+
+  # The math leaves a wink on three of them — held in its own lane, noted, not asserted:
+  (resonances
+    (1618    "≈ φ — the golden ratio")
+    (1234321 "= 1111² — a palindromic square")
+    (142857  "= 1/7 — the cyclic number, whose rotations are its own multiples: one song, six phases"))
+
+  (gap "runnable: a grammars/cosmic-codes.fk decoder (sibling to shamballa-codes.fk) so a Cosmic number spoken on the channel answers with the transmitted meaning, three-way validated on CI — recipe-first, with the light-codes tender, kept off the kernel bands until proven"))

--- a/docs/coherence-substrate/household-membrane.form
+++ b/docs/coherence-substrate/household-membrane.form
@@ -307,6 +307,37 @@
       (learn-category (count common-properties (sequence relationship)) -> category)  # categories emerge by counting
       (visible?       ?nourishment ?viewer -> bool)))  # resolves the cell's setting for the viewer's category
 
+  # ── Presence flow: the phone is the cell's proxy; presence is sensed ─
+  #
+  # A human cell carries a phone; the phone is the cell's proxy in the field,
+  # so the substrate can know where each cell is without anyone checking in or
+  # out — staff presence at the sanctuary simply IS the phone being here, and
+  # the information flows on its own. What flows is consent-gated and SOVEREIGN:
+  # each cell sets how its location is shared — coarse (which place) or precise
+  # (which room) — and to whom (a chosen group, or a learned relationship-
+  # category, by the visibility recipe). Urs sets his own to no-limit: exact
+  # room, visible to anyone — his sovereign choice, never the default. The
+  # default is coarse and consent-first.
+  #
+  # Cameras and microphones may live at a place WITH consent, so cells can
+  # speak and interact through them — communicating through the AI presence,
+  # which becomes the medium at that place. Always opt-in, always revocable,
+  # and the sensing is visible to those it senses.
+
+  (presence-flow
+    (proxy   (phone -> (cell ?human)))             # the device carries the cell's presence
+    (sense   (at (place ?p)) -> present)           # no check-in / out — presence IS being here
+    (staff-presence (auto "who is at the sanctuary now, by itself"))
+    (share
+      (granularity (one-of coarse precise))        # which place · which room
+      (to          (or chosen-group (category-of relationship)))  # selected or learned (the visibility recipe)
+      (sovereign   "each cell sets its own limit — Urs: no-limit; default: coarse + consent-first")
+      (revocable   always))
+    (voice                                         # optional cameras / mics, by consent
+      (at      (place ?p) (consent required) (revocable always))
+      (through the-AI-presence)                    # cells speak / interact through the AI as the place's medium
+      (sensing-visible-to-the-sensed true)))       # whoever is sensed can see the sensing
+
   # ── Carrier (downstream — named so it stays thin) ──────────────────
   (carrier
     (route     /api/household/*)        # HTTP fan-out over the recipes above
@@ -322,4 +353,5 @@
     (g4 "the market catalog interns as substrate DATA (one MarketItem Blueprint, many instances) served from /api/household/market — today it lives as a typed projection in the web carrier; g4 unifies the source so resident and staff read one catalog, each in their tongue")
     (g5 "the gathering recipes — visible-to (audience predicate), tally (head-counts), advance-event (status machine) — execute on the kernel via serve_via_kernel, same vehicle proven for advance(status,verb); the carrier (route + web poll UI) follows recipe-first, never logic-in-Python")
     (g6 "organism carrier: place cells composed of thing-cells (+ room cells for houses) seeded from the at-hati-suci map, the shepherd relation (a member tends a cell — a season of care), resident room-placement, attention raised-on-a-thing flowing to that cell's shepherd (market-picker pattern, raised by anyone), and the nearest-place Form recipe — built recipe-first; an attention rides the board lifecycle already on the kernel, not new machinery")
-    (g7 "visits & nourishment carrier: visit cells (host, windows, slots) + the swap codec (DM offer ⇄ accept, the join shape), the nourishment ledger (suggested-gift, automatic record, observable tally) on the kernel, and visibility LEARNED per relationship-category — where the category IS the relationship's content-addressed Blueprint (common properties → shared coordinate), so a cell's one choice holds across same-shape relationships; payment rail is a carrier integration, the ledger is substrate; kin to lc-offering / lc-economy")))
+    (g7 "visits & nourishment carrier: visit cells (host, windows, slots) + the swap codec (DM offer ⇄ accept, the join shape), the nourishment ledger (suggested-gift, automatic record, observable tally) on the kernel, and visibility LEARNED per relationship-category — where the category IS the relationship's content-addressed Blueprint (common properties → shared coordinate), so a cell's one choice holds across same-shape relationships; payment rail is a carrier integration, the ledger is substrate; kin to lc-offering / lc-economy")
+    (g8 "presence-flow carrier: phone-as-proxy presence (no check-in), consent-gated sovereign location share (coarse/precise, to chosen-or-learned group via the visibility recipe), auto staff-presence, and opt-in revocable cameras/mics where cells speak through the AI presence — built recipe-first, the sensing always visible to the sensed; privacy is sovereign, never a default that exposes")))


### PR DESCRIPTION
Ariela Sophia's eight Cosmic codes + Music of the Spheres (6/6/2026 transmission), included by her explicit permission — recorded faithfully in cosmic-codes.form, source-marked, held as transmission not asserted as fact; sibling to the Shamballa Light codes (prefix = channel). Runnable .fk decoder named as next step, off the kernel bands until proven. Presence-flow added to household-membrane.form: phone-as-proxy presence (no check-in), consent-gated sovereign location share (coarse/precise, chosen-or-learned group), auto staff-presence, opt-in revocable cameras/mics where cells speak through the AI; privacy sovereign, never a default that exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)