### PR TITLE
tend: friend events in the app, from the shared Google Calendar

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -23,11 +23,13 @@ vouch. Backed by the same living graph that holds offerings and contributors.
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
+import httpx
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
@@ -588,3 +590,139 @@ async def pay_request(request_id: str, body: ActorBody) -> RequestResponse:
         "paid_by_name": actor.get("name", ""),
         "paid_at": _now(),
     })
+
+
+# --------------------------------------------------------------------------
+# Friend events — read from the shared Google Calendar(s), the external
+# substrate. The calendar IS the store; we fetch its iCal feed, parse the
+# upcoming events, and show them. No parallel event store of our own.
+# (household-membrane.form: calendar-port.) Recurrence expansion is the
+# next breath; v1 shows the one-off events friends actually post.
+# --------------------------------------------------------------------------
+_EVENT_WINDOW_DAYS = 120
+
+
+class EventResponse(BaseModel):
+    title: str
+    start: str                      # ISO 8601 UTC
+    end: str | None = None
+    all_day: bool = False
+    location: str | None = None
+    description: str | None = None
+    source: str | None = None       # which calendar it came from
+
+
+def _calendar_urls() -> list[str]:
+    """The shared Google Calendar iCal feeds — config over env, empty until set."""
+    raw = os.environ.get("HATI_SUCI_CALENDAR_ICS", "")
+    urls = [u.strip() for u in raw.split(",") if u.strip()]
+    try:
+        cfg = os.path.expanduser("~/.coherence-network/config.json")
+        if os.path.exists(cfg):
+            with open(cfg) as f:
+                extra = (json.load(f) or {}).get("hati_suci_calendars") or []
+            urls += [str(u).strip() for u in extra if str(u).strip()]
+    except Exception:
+        pass
+    # de-dupe, preserve order
+    seen: set[str] = set()
+    return [u for u in urls if not (u in seen or seen.add(u))]
+
+
+def _ical_unfold(text: str) -> list[str]:
+    """RFC 5545 line unfolding — continuation lines begin with space/tab."""
+    out: list[str] = []
+    for line in text.replace("\r\n", "\n").split("\n"):
+        if line[:1] in (" ", "\t") and out:
+            out[-1] += line[1:]
+        else:
+            out.append(line)
+    return out
+
+
+def _ical_unescape(v: str) -> str:
+    return (v.replace("\\n", "\n").replace("\\N", "\n").replace("\\,", ",")
+            .replace("\\;", ";").replace("\\\\", "\\"))
+
+
+def _parse_ical_dt(value: str, params: str) -> tuple[datetime | None, bool]:
+    """An iCal date/datetime → aware UTC datetime + all_day. Handles trailing Z
+    (UTC), floating/TZID (read as UTC — enough to sort and show the day), and
+    VALUE=DATE all-day."""
+    v = value.strip()
+    all_day = "VALUE=DATE" in params or (len(v) == 8 and "T" not in v)
+    try:
+        if all_day:
+            return datetime.strptime(v[:8], "%Y%m%d").replace(tzinfo=timezone.utc), True
+        return datetime.strptime(v[:15], "%Y%m%dT%H%M%S").replace(tzinfo=timezone.utc), False
+    except ValueError:
+        return None, False
+
+
+def _parse_ical_events(text: str, source: str) -> list[dict]:
+    events: list[dict] = []
+    cur: dict | None = None
+    for line in _ical_unfold(text):
+        if line == "BEGIN:VEVENT":
+            cur = {"source": source}
+        elif line == "END:VEVENT":
+            if cur is not None:
+                events.append(cur)
+            cur = None
+        elif cur is not None and ":" in line:
+            key, val = line.split(":", 1)
+            name = key.split(";", 1)[0].upper()
+            if name == "SUMMARY":
+                cur["title"] = _ical_unescape(val)
+            elif name == "LOCATION":
+                cur["location"] = _ical_unescape(val)
+            elif name == "DESCRIPTION":
+                cur["description"] = _ical_unescape(val)
+            elif name == "DTSTART":
+                dt, ad = _parse_ical_dt(val, key)
+                if dt:
+                    cur["start"], cur["all_day"] = dt, ad
+            elif name == "DTEND":
+                dt, _ = _parse_ical_dt(val, key)
+                if dt:
+                    cur["end"] = dt
+            elif name == "RRULE":
+                cur["recurring"] = True
+    return events
+
+
+@router.get(
+    "/household/events",
+    response_model=list[EventResponse],
+    summary="Upcoming friend events, read from the shared Google Calendar(s)",
+)
+async def list_events(limit: int = Query(default=50, ge=1, le=200)) -> list[EventResponse]:
+    urls = _calendar_urls()
+    if not urls:
+        return []
+    now = datetime.now(timezone.utc)
+    floor, horizon = now - timedelta(hours=12), now + timedelta(days=_EVENT_WINDOW_DAYS)
+    out: list[EventResponse] = []
+    async with httpx.AsyncClient(timeout=12.0, follow_redirects=True) as client:
+        for url in urls:
+            try:
+                r = await client.get(url)
+                if r.status_code != 200:
+                    continue
+                for ev in _parse_ical_events(r.text, url):
+                    start = ev.get("start")
+                    # v1: one-off upcoming events; recurrence expansion is the next breath
+                    if start and not ev.get("recurring") and floor <= start <= horizon:
+                        out.append(EventResponse(
+                            title=ev.get("title", "(untitled)"),
+                            start=start.isoformat(),
+                            end=ev["end"].isoformat() if ev.get("end") else None,
+                            all_day=bool(ev.get("all_day")),
+                            location=ev.get("location"),
+                            description=(ev.get("description") or "")[:500] or None,
+                            source=ev.get("source"),
+                        ))
+            except Exception:
+                continue
+    out.sort(key=lambda e: e.start)
+    return out[:limit]

--- a/docs/coherence-substrate/household-membrane.form
+++ b/docs/coherence-substrate/household-membrane.form
@@ -338,6 +338,21 @@
       (through the-AI-presence)                    # cells speak / interact through the AI as the place's medium
       (sensing-visible-to-the-sensed true)))       # whoever is sensed can see the sensing
 
+  # ── Calendar port: friend events live in a shared calendar, not here ─
+  #
+  # Friend events are not stored by us — they live in shared Google Calendars
+  # the field already keeps. The calendar is an external SHARED SUBSTRATE (a
+  # port, like the substrate's storage / resource ports): we read its iCal feed
+  # and show the upcoming events; the calendar stays the store, editable by
+  # everyone who holds it, outside the app. Adding an event opens the calendar.
+
+  (calendar-port
+    (store    google-calendar)              # the shared substrate, outside the app
+    (read     (ical-feed -> (sequence event)))   # fetch + parse the .ics, show upcoming
+    (write    (add -> open-calendar))       # adding opens Google Calendar (API write is later)
+    (kin      (port storage resource))      # a sibling of the substrate's other ports
+    (no-parallel-store "the calendar IS the store — we never duplicate events into our own DB"))
+
   # ── Carrier (downstream — named so it stays thin) ──────────────────
   (carrier
     (route     /api/household/*)        # HTTP fan-out over the recipes above
@@ -354,4 +369,5 @@
     (g5 "the gathering recipes — visible-to (audience predicate), tally (head-counts), advance-event (status machine) — execute on the kernel via serve_via_kernel, same vehicle proven for advance(status,verb); the carrier (route + web poll UI) follows recipe-first, never logic-in-Python")
     (g6 "organism carrier: place cells composed of thing-cells (+ room cells for houses) seeded from the at-hati-suci map, the shepherd relation (a member tends a cell — a season of care), resident room-placement, attention raised-on-a-thing flowing to that cell's shepherd (market-picker pattern, raised by anyone), and the nearest-place Form recipe — built recipe-first; an attention rides the board lifecycle already on the kernel, not new machinery")
     (g7 "visits & nourishment carrier: visit cells (host, windows, slots) + the swap codec (DM offer ⇄ accept, the join shape), the nourishment ledger (suggested-gift, automatic record, observable tally) on the kernel, and visibility LEARNED per relationship-category — where the category IS the relationship's content-addressed Blueprint (common properties → shared coordinate), so a cell's one choice holds across same-shape relationships; payment rail is a carrier integration, the ledger is substrate; kin to lc-offering / lc-economy")
-    (g8 "presence-flow carrier: phone-as-proxy presence (no check-in), consent-gated sovereign location share (coarse/precise, to chosen-or-learned group via the visibility recipe), auto staff-presence, and opt-in revocable cameras/mics where cells speak through the AI presence — built recipe-first, the sensing always visible to the sensed; privacy is sovereign, never a default that exposes")))
+    (g8 "presence-flow carrier: phone-as-proxy presence (no check-in), consent-gated sovereign location share (coarse/precise, to chosen-or-learned group via the visibility recipe), auto staff-presence, and opt-in revocable cameras/mics where cells speak through the AI presence — built recipe-first, the sensing always visible to the sensed; privacy is sovereign, never a default that exposes")
+    (g9 "calendar-port carrier: GET /household/events reads the configured shared-calendar iCal feeds and shows upcoming one-off friend events (SHIPPED); recurrence expansion (RRULE) and write-back (add-event via the Google API, or an add-to-calendar link) follow")))

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -39,6 +39,18 @@ type Status = "open" | "acknowledged" | "in_progress" | "completed" | "cancelled
 // fallback when the catalog doesn't know the id (custom items).
 type RequestItem = { id: string; qty: number; unit?: string; label?: string };
 
+// A friend event, read from the shared Google Calendar (the calendar is the
+// store; the app only reads its iCal feed). household-membrane.form: calendar-port.
+type FriendEvent = {
+  title: string;
+  start: string;
+  end?: string | null;
+  all_day?: boolean;
+  location?: string | null;
+  description?: string | null;
+  source?: string | null;
+};
+
 type ServiceRequest = {
   id: string;
   kind: Kind;
@@ -194,6 +206,7 @@ export default function HatiSuciPage() {
   const [member, setMember] = useState<Member | null>(null);
   const [resolved, setResolved] = useState(false);
   const [requests, setRequests] = useState<ServiceRequest[]>([]);
+  const [events, setEvents] = useState<FriendEvent[]>([]);
   const [members, setMembers] = useState<PublicMember[]>([]);
 
   const [joinName, setJoinName] = useState("");
@@ -280,6 +293,8 @@ export default function HatiSuciPage() {
     if (r) setRequests(r);
     const m = await getJSON<PublicMember[]>("/api/household/members");
     if (m) setMembers(m);
+    const ev = await getJSON<FriendEvent[]>("/api/household/events");
+    if (ev) setEvents(ev);
   }, []);
 
   useEffect(() => {
@@ -885,6 +900,33 @@ export default function HatiSuciPage() {
           <p className="rounded-2xl border border-dashed border-border/40 px-4 py-4 text-center text-sm text-muted-foreground">
             {t("hatiSuci.noWriteNote")}
           </p>
+        )}
+
+        {/* Friend events — read from the shared calendar */}
+        {events.length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-base font-medium">{t("hatiSuci.events.heading")}</h2>
+            {events.map((e, i) => {
+              const d = new Date(e.start);
+              const when = e.all_day
+                ? d.toLocaleDateString(lang, { weekday: "short", month: "short", day: "numeric" })
+                : d.toLocaleString(lang, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+              return (
+                <article key={i} className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-3">
+                  <div className="flex items-start gap-3">
+                    <span className="text-xl leading-none">📅</span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-foreground break-words">{e.title}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {when}
+                        {e.location ? ` · ${e.location}` : ""}
+                      </p>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </section>
         )}
 
         {/* The open board */}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -103,6 +103,9 @@
     "claim": {
       "prompt": "Willkommen! Wie sollen wir dich nennen?",
       "button": "Das bin ich"
+    },
+    "events": {
+      "heading": "Events von Freunden"
     }
   },
   "_attunement": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -103,6 +103,9 @@
     "claim": {
       "prompt": "Welcome! What should we call you?",
       "button": "That's me"
+    },
+    "events": {
+      "heading": "Friend events"
     }
   },
   "_attunement": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -103,6 +103,9 @@
     "claim": {
       "prompt": "¡Bienvenido! ¿Cómo te llamas?",
       "button": "Soy yo"
+    },
+    "events": {
+      "heading": "Eventos de amigos"
     }
   },
   "_attunement": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -103,6 +103,9 @@
     "claim": {
       "prompt": "Selamat datang! Siapa nama kamu?",
       "button": "Itu saya"
+    },
+    "events": {
+      "heading": "Acara teman"
     }
   },
   "_attunement": {


### PR DESCRIPTION
First piece of the wider vision to reach the app. Friend events live in the shared Google Calendars (the calendar is the store, a port); GET /household/events reads the iCal feeds (unfolding/all-day/timed/escaping, sample-tested), and an Events section shows upcoming one-off events in /hati-suci. Config: HATI_SUCI_CALENDAR_ICS or config.json — empty until set. Recurrence + write-back = g9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)