### PR TITLE
tend: the placeholder-name decision leaves Python for the kernel

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -141,11 +141,27 @@ def _member_by_token(token: str | None) -> dict | None:
     return None
 
 
+def _is_placeholder_name_k(name: str) -> int:
+    """Value-identical fallback for endpoint_placeholder_name_demo.fk."""
+    if len(name) == 0:
+        return 1
+    if len(name) < 4:
+        return 0
+    return 1 if name[0:4] == "New " else 0
+
+
 def _is_placeholder_name(name: str) -> bool:
     """A role-only invite carries 'New {role}' until the newcomer claims it
-    with their own name on first open — the self-name half of `bind` in
-    docs/coherence-substrate/household-membrane.form."""
-    return not name or name.startswith("New ")
+    with their own name on first open — the self-name half of `bind`. The
+    decision runs on the Form kernel (endpoint_placeholder_name_demo.fk),
+    Python the value-identical fallback."""
+    val, _runtime = serve_via_kernel(
+        "endpoint_placeholder_name_demo.fk",
+        bindings={"name": name},
+        fallback=lambda: _is_placeholder_name_k(name),
+        parse=int,
+    )
+    return bool(val)
 
 
 def _create_member(name: str, role: str, *, write_access: bool, status: str,

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_placeholder_name_demo.fk
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_placeholder_name_demo.fk
@@ -1,0 +1,1 @@
+(do (defn slen (s) (str_len s)) (defn starts (s p) (if (lt (slen s) (slen p)) 0 (if (str_eq (substring s 0 (slen p)) p) 1 0))) (defn is_placeholder (name) (if (eq (slen name) 0) 1 (starts name "New "))) (let name "New resident") (is_placeholder name))

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_placeholder_name_demo.py
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_placeholder_name_demo.py
@@ -1,0 +1,34 @@
+# endpoint_placeholder_name_demo.py — the "is this a placeholder name?"
+# decision of the household membrane, captured as pure Python and compiled to
+# a Form recipe.
+#
+# A role-only invite carries "New {role}" until the newcomer claims their own
+# name on first open (household-membrane.form: bind ?token ?self-name). Whether
+# a name is still that placeholder — empty, or beginning "New " — is a decision,
+# not carrier, so it runs on the Form kernel with this Python as the value-
+# identical fallback. Returns 1 for placeholder, 0 for a real name. Built only
+# from str_len / substring / str_eq so it mirrors the kernel ops exactly.
+
+
+def slen(s):
+    return len(s)
+
+
+def str_eq(a, b):
+    return a == b
+
+
+def starts(s, p):
+    if slen(s) < slen(p):
+        return 0
+    return 1 if str_eq(s[0:slen(p)], p) else 0
+
+
+def is_placeholder(name):
+    if slen(name) == 0:
+        return 1
+    return starts(name, "New ")
+
+
+name = "New resident"
+result = is_placeholder(name)       # -> 1


### PR DESCRIPTION
is_placeholder(name) — empty or begins 'New ' — moves from a Python startswith to a Form recipe (serve_via_kernel, value-identical Python fallback). Twin tested 8 cases, flow tests green. One more self-inflicted-Python wound tended onto the kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)