### PR TITLE
attune: board reads witnessed by the field's cells, not the public

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -286,7 +286,11 @@ def _is_active(status: str) -> bool:
     return bool(val)
 
 
-async def list_members(role: str | None = Query(default=None)) -> list[MemberPublic]:
+async def list_members(
+    token: str | None = Query(default=None),
+    role: str | None = Query(default=None),
+) -> list[MemberPublic]:
+    _require_member(token)        # the roster is the field's own; see open-to active-member
     # The roster is the people actually here (Form: `see open-to active-member`).
     # Pending invites stay off it until the newcomer opens their link.
     members = [m for m in _all_members() if _is_active(m.get("status", ""))]
@@ -294,6 +298,17 @@ async def list_members(role: str | None = Query(default=None)) -> list[MemberPub
         members = [m for m in members if m.get("role") == role]
     members.sort(key=lambda n: n.get("created_at", ""))
     return [_member_public(m) for m in members]
+
+
+def _require_member(token: str | None) -> dict:
+    """The see-lock — `see open-to active-member` (household-membrane.form). Any
+    registered cell sees the board, even a see-only watcher; the unregistered
+    public does not. The board carries who asked, where it goes, and what it
+    cost — the field's own tissue, witnessed by its cells, not the open internet."""
+    member = _member_by_token(token)
+    if not member:
+        raise HTTPException(status_code=401, detail="register or open your invite link to see the board")
+    return member
 
 
 def _require_writer(token: str | None) -> dict:
@@ -515,12 +530,14 @@ async def create_request(body: RequestCreate) -> RequestResponse:
 @router.get(
     "/household/requests",
     response_model=list[RequestResponse],
-    summary="The open board — every request, what's done and what's waiting",
+    summary="The board — every request, visible to any registered cell here",
 )
 async def list_requests(
+    token: str | None = Query(default=None),
     status: str | None = Query(default=None),
     limit: int = Query(default=200, ge=1, le=500),
 ) -> list[RequestResponse]:
+    _require_member(token)        # see open-to active-member
     try:
         response = graph_service.list_nodes(type=_REQUEST_TYPE, limit=500)
         nodes = response.get("items", []) if isinstance(response, dict) else (response or [])
@@ -538,7 +555,8 @@ async def list_requests(
     response_model=RequestResponse,
     summary="A single request in full",
 )
-async def get_request(request_id: str) -> RequestResponse:
+async def get_request(request_id: str, token: str | None = Query(default=None)) -> RequestResponse:
+    _require_member(token)        # see open-to active-member
     return _node_to_request(_load_request(request_id))
 
 
@@ -737,7 +755,8 @@ def _request_trace(node: dict) -> RequestTrace:
     response_model=RequestTrace,
     summary="The request's full trace — followed, accounted, attributed, witnessed",
 )
-async def request_trace(request_id: str) -> RequestTrace:
+async def request_trace(request_id: str, token: str | None = Query(default=None)) -> RequestTrace:
+    _require_member(token)        # witnessed by the field's cells, not the open internet
     return _request_trace(_load_request(request_id))
 
 

--- a/api/tests/test_household_service_board.py
+++ b/api/tests/test_household_service_board.py
@@ -178,6 +178,10 @@ def test_request_trace_follows_attributes_and_witnesses(client):
     }).json()
     rid = r["id"]
 
+    # The board itself is open only to a registered cell, not the public.
+    assert client.get("/api/household/requests").status_code == 401
+    assert client.get(f"/api/household/requests?token={rtok}").status_code == 200
+
     # Walk its whole life; each transition attributes itself to a cell.
     client.post(f"/api/household/requests/{rid}/acknowledge", json={"actor_token": rtok})
     client.post(f"/api/household/requests/{rid}/start", json={"actor_token": rtok})
@@ -186,7 +190,9 @@ def test_request_trace_follows_attributes_and_witnesses(client):
     })
     client.post(f"/api/household/requests/{rid}/pay", json={"actor_token": rtok})
 
-    trace = client.get(f"/api/household/requests/{rid}/trace").json()
+    # The trace is the field's tissue — witnessed by its cells, not the public.
+    assert client.get(f"/api/household/requests/{rid}/trace").status_code == 401
+    trace = client.get(f"/api/household/requests/{rid}/trace?token={rtok}").json()
     # Core, compact: who + where.
     assert trace["requester_name"] == "Wayan"
     assert trace["location"] == "Bale Vishnu"
@@ -203,6 +209,6 @@ def test_request_trace_follows_attributes_and_witnesses(client):
         "actor_token": rtok, "kind": "ride", "detail": "airport run",
     }).json()
     client.post(f"/api/household/requests/{r2['id']}/cancel", json={"actor_token": rtok})
-    t2 = client.get(f"/api/household/requests/{r2['id']}/trace").json()
+    t2 = client.get(f"/api/household/requests/{r2['id']}/trace?token={rtok}").json()
     assert [s["step"] for s in t2["steps"]] == ["requested", "cancelled"]
     assert t2["progress"] == 0 and t2["settled"] is False

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -289,13 +289,27 @@ export default function HatiSuciPage() {
   }, [customItems]);
 
   const load = useCallback(async () => {
-    const r = await getJSON<ServiceRequest[]>("/api/household/requests?limit=200");
-    if (r) setRequests(r);
-    const m = await getJSON<PublicMember[]>("/api/household/members");
-    if (m) setMembers(m);
+    // The board is the field's tissue — who asked, where it goes, the cost.
+    // Seeing is open to an active member (even a see-only watcher), not the
+    // public (household-membrane.form: see open-to active-member). Fetch it
+    // only with a token; an unregistered visitor sees the join screen.
+    const tk = member?.token;
+    if (tk) {
+      const r = await getJSON<ServiceRequest[]>(
+        `/api/household/requests?limit=200&token=${encodeURIComponent(tk)}`,
+      );
+      setRequests(r ?? []);
+      const m = await getJSON<PublicMember[]>(
+        `/api/household/members?token=${encodeURIComponent(tk)}`,
+      );
+      setMembers(m ?? []);
+    } else {
+      setRequests([]);
+      setMembers([]);
+    }
     const ev = await getJSON<FriendEvent[]>("/api/household/events");
     if (ev) setEvents(ev);
-  }, []);
+  }, [member]);
 
   useEffect(() => {
     void load();


### PR DESCRIPTION
`see open-to active-member` — but the board's read surface had drifted open. `list_requests`, `get_request`, the request trace, and the member roster took no token, so anyone could read who asked / where it goes / the cost / who tended. That is the field's tissue; witnessed = witnessed by its bound cells, not the internet.

Now all four require an active-member token (even see-only watch) via `_require_member` — the same lock the gatherings list already applied; missing/invalid → 401. The web board fetches only with a token (an unregistered visitor sees the join screen). Events stay open (shared-calendar port by design).

Flow test proves the board + trace deny the public and admit a registered cell. 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)