### PR TITLE
tend: live cell-map — the grounds, who is where, presence decay

### DIFF
--- a/api/app/routers/household.py
+++ b/api/app/routers/household.py
@@ -78,6 +78,7 @@ class MemberPublic(BaseModel):
     created_at: str
     at_place: str | None = None       # the place cell this member is present at (coarse, consent-first)
     at_place_name: str | None = None  # its display name, for the roster
+    at_place_since: str | None = None  # when they last reported here (ISO) — the decay clock
 
 
 class MemberPrivate(MemberPublic):
@@ -115,6 +116,7 @@ def _member_public(node: dict) -> MemberPublic:
         created_at=node.get("created_at", "") or node.get("observed_at", ""),
         at_place=_s(node.get("at_place")),
         at_place_name=_s(node.get("at_place_name")),
+        at_place_since=_s(node.get("at_place_since")),
     )
 
 

--- a/web/app/hati-suci/page.tsx
+++ b/web/app/hati-suci/page.tsx
@@ -20,6 +20,7 @@ type Member = {
   token: string;
   phone?: string | null;
   invited_by_name?: string | null;
+  at_place?: string | null;
 };
 type PublicMember = {
   id: string;
@@ -29,7 +30,59 @@ type PublicMember = {
   status: string;
   invited_by_name?: string | null;
   created_at: string;
+  at_place?: string | null;
+  at_place_name?: string | null;
+  at_place_since?: string | null; // ISO of last report — the decay clock
 };
+
+// A place cell at Hati Suci (household-membrane.form: place).
+type Place = {
+  id: string;
+  name: string;
+  kind: string; // house | gathering | tended | organ
+  lat?: number | null;
+  lon?: number | null;
+  wifi?: string | null;
+  pinned?: boolean;
+};
+
+// Where each place sits on the grounds, 0–100% of the map box — read from the
+// at-hati-suci layout in household-membrane.form (NW temple/kitchen/office;
+// N brahma/krishna/bhima; center vishnu+bale+pool with fire-pit on its north
+// edge; E arjuna/yoga-studio; SW ganesha; S wormery/vibration/water-garden/
+// fish-pond; W gardens). GPS pins refine this when a place is pinned on site.
+const LAYOUT: Record<string, { x: number; y: number }> = {
+  "place-temple": { x: 16, y: 14 }, "place-kitchen": { x: 28, y: 11 },
+  "place-office": { x: 22, y: 22 }, "place-compost-shed": { x: 10, y: 24 },
+  "place-brahma": { x: 44, y: 12 }, "place-krishna": { x: 55, y: 11 },
+  "place-bhima": { x: 66, y: 14 },
+  "place-vishnu": { x: 49, y: 44 }, "place-bale-vishnu": { x: 58, y: 47 },
+  "place-fire-pit": { x: 49, y: 50 }, "place-pool": { x: 49, y: 58 },
+  "place-arjuna": { x: 81, y: 38 }, "place-yoga-studio": { x: 84, y: 52 },
+  "place-ganesha": { x: 17, y: 78 },
+  "place-wormery": { x: 38, y: 82 }, "place-bale-wormery": { x: 46, y: 86 },
+  "place-vibration-tunnel": { x: 56, y: 85 }, "place-water-garden": { x: 66, y: 82 },
+  "place-fish-pond": { x: 74, y: 86 },
+  "place-gardens": { x: 9, y: 50 }, "place-entrance": { x: 30, y: 93 },
+};
+
+const KIND_COLOR: Record<string, string> = {
+  house: "#a78bfa", gathering: "#38bdf8", tended: "#34d399", organ: "#fbbf24",
+};
+
+// Visual decay: how present a report still looks, from the age of its last
+// report. Fresh (<2 min) = full; fades over the next ~13 min; gone after ~15.
+// Knowing fades when circulation stops — lc-the-trace-is-the-memory, made visible.
+function presenceLife(since?: string | null): number {
+  if (!since) return 0;
+  const ms = Date.now() - new Date(since).getTime();
+  if (!isFinite(ms) || ms < 0) return 1;
+  const FRESH = 2 * 60_000;
+  const GONE = 15 * 60_000;
+  if (ms <= FRESH) return 1;
+  if (ms >= GONE) return 0;
+  return 1 - (ms - FRESH) / (GONE - FRESH);
+}
 
 type Kind = "food" | "laundry" | "cleaning" | "ride" | "repair" | "room" | "supplies" | "other";
 type Status = "open" | "acknowledged" | "in_progress" | "completed" | "cancelled";
@@ -230,6 +283,8 @@ export default function HatiSuciPage() {
   const [requests, setRequests] = useState<ServiceRequest[]>([]);
   const [gatherings, setGatherings] = useState<Gathering[]>([]);
   const [gatherText, setGatherText] = useState("");
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [locating, setLocating] = useState(false);
   const [events, setEvents] = useState<FriendEvent[]>([]);
   const [members, setMembers] = useState<PublicMember[]>([]);
 
@@ -331,10 +386,15 @@ export default function HatiSuciPage() {
         `/api/household/gatherings?token=${encodeURIComponent(tk)}`,
       );
       setGatherings(g ?? []);
+      const pl = await getJSON<Place[]>(
+        `/api/household/places?token=${encodeURIComponent(tk)}`,
+      );
+      setPlaces(pl ?? []);
     } else {
       setRequests([]);
       setMembers([]);
       setGatherings([]);
+      setPlaces([]);
     }
     const ev = await getJSON<FriendEvent[]>("/api/household/events");
     if (ev) setEvents(ev);
@@ -464,6 +524,44 @@ export default function HatiSuciPage() {
     } catch {
       /* ignore */
     }
+  }, [token, load]);
+
+  // Presence: tap a place to be there. Coarse, consent by the act of tapping.
+  const setHere = useCallback(async (placeId: string) => {
+    if (!token) return;
+    try {
+      await postJSON("/api/household/presence", { actor_token: token, place_id: placeId });
+      await load();
+    } catch {
+      /* ignore */
+    }
+  }, [token, load]);
+
+  // The phone's GPS finds the nearest place (the by-pin door) and reports it.
+  const locateMe = useCallback(() => {
+    if (!token || !("geolocation" in navigator)) return;
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        try {
+          const lat = Math.round(pos.coords.latitude * 1e6); // micro-degrees, as pins store
+          const lon = Math.round(pos.coords.longitude * 1e6);
+          const near = await getJSON<Place>(
+            `/api/household/nearest?token=${encodeURIComponent(token)}&lat=${lat}&lon=${lon}`,
+          );
+          if (near?.id) {
+            await postJSON("/api/household/presence", { actor_token: token, place_id: near.id });
+            await load();
+          }
+        } catch {
+          /* ignore */
+        } finally {
+          setLocating(false);
+        }
+      },
+      () => setLocating(false),
+      { enableHighAccuracy: true, timeout: 10_000 },
+    );
   }, [token, load]);
 
   const act = useCallback(
@@ -998,6 +1096,84 @@ export default function HatiSuciPage() {
             })}
           </section>
         )}
+
+        {/* The grounds — a live map of the cells, and who is at each (presence fades as reports age) */}
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-medium">{t("hatiSuci.map.heading")}</h2>
+            <button
+              onClick={locateMe}
+              disabled={locating}
+              className="rounded-lg border border-emerald-500/40 px-2.5 py-1 text-xs text-emerald-400 hover:bg-emerald-500/10 disabled:opacity-40"
+            >
+              {locating ? t("hatiSuci.map.locating") : `📍 ${t("hatiSuci.map.locateMe")}`}
+            </button>
+          </div>
+
+          {places.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-border/40 px-4 py-8 text-center text-sm text-muted-foreground">
+              {t("hatiSuci.map.empty")}
+            </p>
+          ) : (
+            <div className="relative aspect-square w-full overflow-hidden rounded-2xl border border-border/30 bg-[radial-gradient(circle_at_50%_45%,rgba(56,189,248,0.06),transparent_70%)]">
+              {places.map((p) => {
+                const pos = LAYOUT[p.id];
+                if (!pos) return null;
+                const here = members.filter((m) => m.at_place === p.id);
+                const mine = member?.at_place === p.id;
+                const color = KIND_COLOR[p.kind] ?? "#94a3b8";
+                return (
+                  <button
+                    key={p.id}
+                    onClick={() => setHere(p.id)}
+                    className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-0.5"
+                    style={{ left: `${pos.x}%`, top: `${pos.y}%` }}
+                    title={p.name}
+                  >
+                    <span
+                      className="block rounded-full"
+                      style={{
+                        width: mine ? 14 : 9,
+                        height: mine ? 14 : 9,
+                        background: color,
+                        boxShadow: mine ? `0 0 0 3px ${color}40` : "none",
+                      }}
+                    />
+                    <span className="whitespace-nowrap text-[9px] leading-none text-muted-foreground">
+                      {p.name}
+                    </span>
+                    {here.length > 0 && (
+                      <span className="flex gap-0.5">
+                        {here.map((m) => {
+                          const life = presenceLife(m.at_place_since);
+                          if (life <= 0) return null;
+                          return (
+                            <span
+                              key={m.id}
+                              title={m.name}
+                              className="block h-2 w-2 rounded-full bg-foreground"
+                              style={{ opacity: 0.2 + 0.8 * life, filter: `saturate(${life})` }}
+                            />
+                          );
+                        })}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
+            {Object.entries(KIND_COLOR).map(([k, c]) => (
+              <span key={k} className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full" style={{ background: c }} />
+                {t(`hatiSuci.map.kind.${k}`)}
+              </span>
+            ))}
+            <span className="ml-auto">{t("hatiSuci.map.decayNote")}</span>
+          </div>
+        </section>
 
         {/* Gatherings — raise a question or event; everyone answers; the field sees the tally */}
         <section className="space-y-3">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -118,6 +118,19 @@
       "interested": "Interessiert",
       "no": "Kann nicht",
       "coming": "kommen"
+    },
+    "map": {
+      "heading": "Das Gelände",
+      "locateMe": "Meinen Ort finden",
+      "locating": "suche…",
+      "empty": "Noch keine Orte. Ein Bewohner sät das Gelände, dann füllt sich die Karte.",
+      "decayNote": "Präsenz verblasst, wenn Meldungen altern",
+      "kind": {
+        "house": "Haus",
+        "gathering": "Versammlung",
+        "tended": "gepflegt",
+        "organ": "Arbeit"
+      }
     }
   },
   "_attunement": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -118,6 +118,19 @@
       "interested": "Interested",
       "no": "Can't",
       "coming": "coming"
+    },
+    "map": {
+      "heading": "The grounds",
+      "locateMe": "Find my place",
+      "locating": "locating…",
+      "empty": "No places yet. A resident seeds the grounds, then the map fills.",
+      "decayNote": "presence fades as reports age",
+      "kind": {
+        "house": "house",
+        "gathering": "gathering",
+        "tended": "tended",
+        "organ": "working"
+      }
     }
   },
   "_attunement": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -118,6 +118,19 @@
       "interested": "Interesado",
       "no": "No puedo",
       "coming": "vienen"
+    },
+    "map": {
+      "heading": "Los terrenos",
+      "locateMe": "Encontrar mi lugar",
+      "locating": "ubicando…",
+      "empty": "Aún no hay lugares. Un residente siembra los terrenos y el mapa se llena.",
+      "decayNote": "la presencia se desvanece cuando los reportes envejecen",
+      "kind": {
+        "house": "casa",
+        "gathering": "encuentro",
+        "tended": "cuidado",
+        "organ": "trabajo"
+      }
     }
   },
   "_attunement": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -118,6 +118,19 @@
       "interested": "Tertarik",
       "no": "Tidak bisa",
       "coming": "datang"
+    },
+    "map": {
+      "heading": "Tanah Hati Suci",
+      "locateMe": "Cari tempatku",
+      "locating": "mencari…",
+      "empty": "Belum ada tempat. Warga menanam tanah, lalu peta terisi.",
+      "decayNote": "kehadiran memudar seiring laporan menua",
+      "kind": {
+        "house": "rumah",
+        "gathering": "berkumpul",
+        "tended": "dirawat",
+        "organ": "kerja"
+      }
     }
   },
   "_attunement": {


### PR DESCRIPTION
The map, as a face. A square grounds view renders all 22 place-cells (laid out from at-hati-suci, coloured by kind). Tap a place to be there; a GPS button finds the nearest place and reports it. Presence shows as dots that FADE with report age — solid <2min, gone by ~15min: knowing fades when circulation stops (lc-the-trace-is-the-memory, made visible). Backend exposes at_place_since; four tongues with parity. v1 uses the relative layout (not GPS-refined); continuous auto-reporting + a satellite base are next.