### PR TITLE
tend: a reaction is heard — votes reach the idea-cell (discord-membrane: listen)

### DIFF
--- a/api/app/models/idea.py
+++ b/api/app/models/idea.py
@@ -142,6 +142,12 @@ class IdeaQuestion(BaseModel):
     estimated_cost: float = Field(ge=0.0)
     answer: Optional[str] = None
     measured_delta: Optional[float] = None
+    # The community's reactions, HEARD on the idea-cell (discord-membrane.form:
+    # listen). votes = {positive, negative, excited}; resonance = how warmly the
+    # field holds the question, composed on the Form kernel (+1 per 👍, +2 per 🔥,
+    # −1 per 👎). Without these the votes land in memory and are never heard.
+    votes: Optional[dict] = None
+    resonance: Optional[int] = None
 
 
 class IdeaQuestionCreate(BaseModel):

--- a/api/app/routers/ideas.py
+++ b/api/app/routers/ideas.py
@@ -136,6 +136,46 @@ def _apply_lang_views(resp: IdeaPortfolioResponse, lang: str | None) -> IdeaPort
     return resp
 
 
+def _reaction_resonance_k(positive: int, negative: int, excited: int) -> int:
+    """Value-identical fallback for endpoint_reaction_resonance.fk."""
+    return positive + 2 * excited - negative
+
+
+def _reaction_resonance(positive: int, negative: int, excited: int) -> int:
+    """Compose the community's reactions into a felt sense — how warmly the field
+    holds a question (discord-membrane.form: compose). On the Form kernel
+    (endpoint_reaction_resonance.fk), Python the value-identical fallback."""
+    from app.services.form_kernel_bridge import serve_via_kernel
+    val, _runtime = serve_via_kernel(
+        "endpoint_reaction_resonance.fk",
+        bindings={"p": positive, "n": negative, "e": excited},
+        fallback=lambda: _reaction_resonance_k(positive, negative, excited),
+        parse=int,
+    )
+    return int(val)
+
+
+def _attach_question_votes(idea: IdeaWithScore) -> None:
+    """Let the community's reactions be HEARD on the idea-cell: for each open
+    question, read its stored vote-edges and surface them + the resonance.
+    Without this the votes land in memory and are never heard.
+    (discord-membrane.form: listen → compose → reaches the idea-cell.)"""
+    from app.services import discord_vote_service
+    questions = getattr(idea, "open_questions", None) or []
+    for idx, q in enumerate(questions):
+        try:
+            counts = discord_vote_service.get_counts(idea.id, idx)
+        except Exception:
+            continue
+        if counts.positive or counts.negative or counts.excited:
+            q.votes = {
+                "positive": counts.positive,
+                "negative": counts.negative,
+                "excited": counts.excited,
+            }
+            q.resonance = _reaction_resonance(counts.positive, counts.negative, counts.excited)
+
+
 def _apply_idea_view(idea: IdeaWithScore, lang: str | None) -> IdeaWithScore:
     """Project a single idea from its canonical entity view when present."""
     from app.services import translator_service
@@ -820,6 +860,7 @@ async def get_idea(
     idea = idea_service.get_idea(idea_id)
     if idea is None:
         raise HTTPException(status_code=404, detail="Idea not found")
+    _attach_question_votes(idea)        # the community's reactions, heard on the idea-cell
     return _apply_idea_view(idea, resolve_caller_lang(request, lang))
 
 

--- a/api/tests/test_discord_votes_heard.py
+++ b/api/tests/test_discord_votes_heard.py
@@ -1,0 +1,57 @@
+"""A Discord reaction is HEARD on the idea-cell (discord-membrane.form: listen).
+
+A vote stored in question_votes must REACH the idea: GET /api/ideas/{id} now
+surfaces each open question's vote counts + a resonance composed on the Form
+kernel (+1 per 👍 positive, +2 per 🔥 excited, −1 per 👎 negative). Before this
+stride, get_counts was dead code and the community's belief landed in a drawer
+no one opened.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_reaction_reaches_the_idea_cell():
+    iid = f"votes-heard-{uuid.uuid4().hex[:8]}"
+    created = client.post("/api/ideas", json={
+        "id": iid,
+        "name": "Heard idea",
+        "description": "does a reaction reach the idea-cell?",
+        "potential_value": 10.0,
+        "estimated_cost": 1.0,
+        "open_questions": [
+            {"question": "Is this worth doing?", "value_to_whole": 1.0, "estimated_cost": 1.0},
+        ],
+    })
+    if created.status_code not in (200, 201):
+        import pytest
+        pytest.skip(f"idea create unavailable in this env: {created.status_code} {created.text[:120]}")
+
+    # Before any reaction, the question is unvoted — votes/resonance absent.
+    before = client.get(f"/api/ideas/{iid}").json()
+    assert before["open_questions"][0].get("votes") in (None, {})
+    assert before["open_questions"][0].get("resonance") is None
+
+    # The community reacts: two 👍, one 🔥, one 👎 — distinct cells.
+    def vote(uid: str, polarity: str):
+        return client.post(
+            f"/api/ideas/{iid}/questions/0/vote",
+            json={"discord_user_id": uid, "polarity": polarity},
+        )
+    assert vote("u1", "positive").status_code == 200
+    assert vote("u2", "positive").status_code == 200
+    assert vote("u3", "excited").status_code == 200
+    assert vote("u4", "negative").status_code == 200
+
+    # The reactions are HEARD on the idea-cell.
+    after = client.get(f"/api/ideas/{iid}").json()
+    q0 = after["open_questions"][0]
+    assert q0["votes"] == {"positive": 2, "negative": 1, "excited": 1}
+    # resonance = +1·2 (👍) + 2·1 (🔥) − 1·1 (👎) = 3, composed on the Form kernel.
+    assert q0["resonance"] == 3

--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_reaction_resonance.fk
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_reaction_resonance.fk
@@ -1,0 +1,1 @@
+(do (defn resonance (p n e) (sub (add (add p e) e) n)) (let p 0) (let n 0) (let e 0) (resonance p n e))


### PR DESCRIPTION
First stride of the discord-membrane walk: from orphan-votes to heard. `get_counts` was dead code — community votes landed in a table never called or surfaced. Now `GET /api/ideas/{id}` surfaces each open question's vote counts + a **resonance** (how warmly the field holds it) composed on the Form kernel (`endpoint_reaction_resonance.fk`: +1 👍, +2 🔥, −1 👎), value-identical fallback. The carrier only reads the stored edges; the compose decision is Form. Flow test: 2 positive + 1 excited + 1 negative → votes {2,1,1}, resonance 3, heard. The community is felt now.