### PR TITLE
tend: surface subscription circulation to the collective body

### DIFF
--- a/api/app/routers/automation_usage.py
+++ b/api/app/routers/automation_usage.py
@@ -6,10 +6,19 @@ import asyncio
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
 
+from app.models.automation_usage import ProviderUsageSnapshot
 from app.services import automation_usage_service
 
 router = APIRouter()
+
+
+class LocalCirculationIngest(BaseModel):
+    """A laptop's subscription-circulation reading, pushed up to the collective body."""
+
+    host: str = Field(min_length=1, max_length=120)
+    snapshots: list[ProviderUsageSnapshot] = Field(default_factory=list)
 
 
 @router.get("/automation/usage", summary="Get Automation Usage")
@@ -63,6 +72,29 @@ async def get_automation_usage(
 @router.get("/automation/usage/snapshots", summary="Get Automation Usage Snapshots")
 async def get_automation_usage_snapshots(limit: int = Query(200, ge=1, le=2000)) -> dict:
     rows = automation_usage_service.list_usage_snapshots(limit=limit)
+    return {
+        "count": len(rows),
+        "snapshots": [row.model_dump(mode="json") for row in rows],
+    }
+
+
+@router.post(
+    "/automation/usage/local-circulation",
+    status_code=201,
+    summary="Ingest Local Subscription Circulation",
+)
+async def ingest_local_circulation(body: LocalCirculationIngest) -> dict:
+    """Receive a laptop's subscription circulation (from sense_subscription_circulation.py
+    --push) and store it so the collective /usage surface can see it."""
+    recorded = automation_usage_service.record_local_circulation_snapshots(
+        body.snapshots, host=body.host
+    )
+    return {"recorded": recorded, "host": body.host}
+
+
+@router.get("/automation/usage/local-circulation", summary="Get Local Subscription Circulation")
+async def get_local_circulation(limit: int = Query(200, ge=1, le=2000)) -> dict:
+    rows = automation_usage_service.latest_local_circulation_snapshots(limit=limit)
     return {
         "count": len(rows),
         "snapshots": [row.model_dump(mode="json") for row in rows],

--- a/api/app/services/automation_usage_service.py
+++ b/api/app/services/automation_usage_service.py
@@ -294,6 +294,46 @@ def _store_snapshot(snapshot: ProviderUsageSnapshot) -> None:
     _write_store(rows)
 
 
+def record_local_circulation_snapshots(
+    snapshots: list[ProviderUsageSnapshot], *, host: str
+) -> int:
+    """Persist subscription-circulation snapshots pushed from a developer laptop.
+
+    Reuses the canonical snapshot store; each is tagged via raw.source so it reads
+    back distinctly from the runner's own server-side provider snapshots. This is
+    how *this machine's* personal subscription circulation reaches the collective
+    body — the server cannot read a laptop's ~/.claude, so the laptop ships it up.
+    """
+    recorded = 0
+    for snap in snapshots:
+        snap.raw = {**(snap.raw or {}), "source": f"laptop:{host}"}
+        if snap.data_source == "unknown":
+            snap.data_source = "provider_cli"
+        _store_snapshot(snap)
+        recorded += 1
+    return recorded
+
+
+def latest_local_circulation_snapshots(limit: int = 200) -> list[ProviderUsageSnapshot]:
+    """Latest laptop-sourced circulation snapshot per (provider, host)."""
+    latest: dict[tuple[str, str], ProviderUsageSnapshot] = {}
+    for row in _read_store():
+        if not isinstance(row, dict):
+            continue
+        source = str((row.get("raw") or {}).get("source") or "")
+        if not source.startswith("laptop:"):
+            continue
+        try:
+            snap = ProviderUsageSnapshot(**row)
+        except Exception:
+            continue
+        key = (snap.provider, source)
+        prev = latest.get(key)
+        if prev is None or snap.collected_at > prev.collected_at:
+            latest[key] = snap
+    return sorted(latest.values(), key=lambda s: s.provider)[:limit]
+
+
 def _metric(
     *,
     id: str,

--- a/api/tests/test_automation_usage_api.py
+++ b/api/tests/test_automation_usage_api.py
@@ -70,3 +70,45 @@ async def test_automation_usage_endpoint_times_out_to_snapshot_fallback(monkeypa
     body = response.json()
     assert body["meta"]["data_source"] == "snapshot_fallback"
     assert body["meta"]["fallback_reason"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_local_circulation_ingest_and_readback() -> None:
+    """A laptop pushes its subscription circulation; the collective reads it back,
+    tagged by source, with vendor limits preserved."""
+    payload = {
+        "host": "laptop-test",
+        "snapshots": [
+            {
+                "id": "local_claude_1", "provider": "claude", "kind": "custom", "status": "ok",
+                "metrics": [
+                    {"id": "volume_32d", "label": "claude activity (32d)", "unit": "tokens",
+                     "used": 23900000000.0, "window": "32d", "evidence_source": "measured tokens"},
+                    {"id": "aligned_ratio", "label": "Coherence-aligned share", "unit": "ratio",
+                     "used": 1.0, "limit": 1.0},
+                ],
+                "data_source": "provider_cli", "notes": ["circulating, aligned"],
+                "raw": {"verdict": "FLOWING"},
+            },
+            {
+                "id": "local_codex_1", "provider": "codex", "kind": "custom", "status": "ok",
+                "metrics": [
+                    {"id": "limit_weekly", "label": "weekly limit", "unit": "ratio", "used": 0.22,
+                     "limit": 1.0, "remaining": 0.78, "window": "weekly", "evidence_source": "codex vendor"},
+                ],
+                "data_source": "provider_cli", "notes": ["on pace"], "raw": {"verdict": "FLOWING"},
+            },
+        ],
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        post = await client.post("/api/automation/usage/local-circulation", json=payload)
+        assert post.status_code == 201, post.text
+        assert post.json()["recorded"] == 2
+        get = await client.get("/api/automation/usage/local-circulation")
+    assert get.status_code == 200
+    body = get.json()
+    providers = {s["provider"]: s for s in body["snapshots"]}
+    assert "claude" in providers and "codex" in providers
+    assert providers["claude"]["raw"]["source"] == "laptop:laptop-test"
+    codex_limit = next(m for m in providers["codex"]["metrics"] if m["id"].startswith("limit_"))
+    assert codex_limit["used"] == pytest.approx(0.22)

--- a/scripts/sense_subscription_circulation.py
+++ b/scripts/sense_subscription_circulation.py
@@ -31,8 +31,10 @@ import glob
 import json
 import os
 import re
+import socket
 import sys
 import time
+import urllib.request
 from datetime import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -495,16 +497,83 @@ def to_payload(readings: list[Reading], days: float) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Push to the collective body — map readings to the canonical ProviderUsageSnapshot
+# shape and POST so the /usage surface (not just this CLI) can see the circulation.
+# ---------------------------------------------------------------------------
+
+_SNAPSHOT_UNIT = {"tokens": "tokens", "turns": "requests", "sessions": "tasks"}
+
+
+def snapshots_payload(readings: list[Reading], days: float) -> list[dict]:
+    out = []
+    for r in readings:
+        unit = _SNAPSHOT_UNIT.get(r.unit, "tasks")
+        metrics: list[dict] = []
+        if r.events:
+            metrics.append({
+                "id": f"volume_{int(days)}d", "label": f"{r.provider} activity ({int(days)}d)",
+                "unit": unit, "used": float(r.vol(days)), "window": f"{int(days)}d",
+                "evidence_source": r.fidelity,
+            })
+        a, s = r.alignment()
+        if a + s:
+            metrics.append({
+                "id": "aligned_ratio", "label": "Coherence-aligned share", "unit": "ratio",
+                "used": round(a / (a + s), 4), "limit": 1.0, "evidence_source": "cwd of each turn",
+            })
+        for lm in r.limits:
+            frac = round(lm.used_percent / 100.0, 4)
+            metrics.append({
+                "id": f"limit_{lm.label.replace(' ', '_')}", "label": f"{lm.label} limit",
+                "unit": "ratio", "used": frac, "limit": 1.0, "remaining": round(max(0.0, 1 - frac), 4),
+                "window": lm.label, "evidence_source": lm.source,
+            })
+        tag, sentence = verdict(r, days)
+        out.append({
+            "id": f"local_{r.provider}_{int(NOW)}", "provider": r.provider, "kind": "custom",
+            "status": "ok" if r.events else "unavailable", "metrics": metrics,
+            "data_source": "provider_cli",
+            "usage_per_time": f"{r.vol(1)} {unit}/24h" if r.events else None,
+            "notes": [sentence] + r.notes[:3],
+            "raw": {"verdict": tag, "fidelity": r.fidelity,
+                    "idle_days": round(r.idle_days, 2) if r.idle_days is not None else None,
+                    "alignment": {"aligned": a, "side": s}},
+        })
+    return out
+
+
+def push(readings: list[Reading], days: float, api_base: str, host: str) -> tuple[int, str]:
+    body = json.dumps({"host": host, "snapshots": snapshots_payload(readings, days)}).encode()
+    url = api_base.rstrip("/") + "/api/automation/usage/local-circulation"
+    req = urllib.request.Request(url, data=body,
+                                 headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return resp.status, resp.read().decode()[:200]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Sense subscription circulation from local CLI traces.")
     ap.add_argument("--days", type=float, default=32.0, help="window to sense over (default 32)")
     ap.add_argument("--json", action="store_true", help="emit machine payload")
+    ap.add_argument("--push", action="store_true",
+                    help="push the reading to the collective body's /usage store")
+    ap.add_argument("--api", default="https://api.coherencycoin.com",
+                    help="API base for --push (default prod)")
+    ap.add_argument("--host", default=socket.gethostname(),
+                    help="host label for pushed snapshots")
     args = ap.parse_args()
     readings = build_readings(args.days)
     if args.json:
         print(json.dumps(to_payload(readings, args.days), indent=2))
     else:
         render(readings, args.days)
+    if args.push:
+        try:
+            status, _ = push(readings, args.days, args.api, args.host)
+            print(f"  → pushed {len(readings)} snapshots to {args.api} as host={args.host} (HTTP {status})")
+        except Exception as e:
+            print(f"  → push failed: {type(e).__name__}: {e}")
     return 0
 
 

--- a/web/app/usage/data.ts
+++ b/web/app/usage/data.ts
@@ -207,6 +207,41 @@ export async function loadDailySummary(
   return { summary: DEFAULT_DAILY_SUMMARY, warnings: ["daily usage summary unavailable"] };
 }
 
+export type LocalCircMetric = {
+  id: string;
+  label: string;
+  unit: string;
+  used: number;
+  limit: number | null;
+  remaining: number | null;
+  window: string | null;
+  evidence_source: string | null;
+};
+
+export type LocalCircSnapshot = {
+  provider: string;
+  status: string;
+  data_source: string;
+  usage_per_time: string | null;
+  metrics: LocalCircMetric[];
+  notes: string[];
+  raw: {
+    verdict?: string;
+    fidelity?: string;
+    idle_days?: number | null;
+    alignment?: { aligned: number; side: number };
+    source?: string;
+  };
+};
+
+export async function loadLocalCirculation(apiBase: string): Promise<LocalCircSnapshot[]> {
+  const data = await fetchJsonOrNull<{ count: number; snapshots: LocalCircSnapshot[] }>(
+    `${apiBase}/api/automation/usage/local-circulation`,
+    PROVIDER_SNAPSHOT_FALLBACK_TIMEOUT_MS,
+  );
+  return data?.snapshots ?? [];
+}
+
 export async function loadViewPerformance(
   apiBase: string,
 ): Promise<WebViewPerformanceReport | null> {

--- a/web/app/usage/page.tsx
+++ b/web/app/usage/page.tsx
@@ -7,7 +7,14 @@ import {
   MAX_PAGE_SIZE,
   type UsageSearchParams,
 } from "./types";
-import { loadDailySummary, loadRuntimeSlice, loadViewPerformance, parsePositiveInt } from "./data";
+import {
+  loadDailySummary,
+  loadLocalCirculation,
+  loadRuntimeSlice,
+  loadViewPerformance,
+  parsePositiveInt,
+  type LocalCircSnapshot,
+} from "./data";
 import {
   FrictionSection,
   HostRunnerSection,
@@ -66,6 +73,20 @@ async function loadProviderStats(api: string): Promise<ProviderStatsResponse | n
 
 export const revalidate = 60;
 
+function compactNum(n: number): string {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(0)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return `${n}`;
+}
+
+function verdictTone(verdict: string): string {
+  if (verdict === "IDLE" || verdict === "BLIND") return "text-red-600 dark:text-red-400";
+  if (verdict === "NEAR LIMIT" || verdict === "COOLING" || verdict === "SIDE-HEAVY")
+    return "text-amber-600 dark:text-amber-400";
+  return "text-green-600 dark:text-green-400";
+}
+
 export default async function UsagePage({ searchParams }: { searchParams: UsageSearchParams }) {
   const resolved = await searchParams;
   const pageSize = Math.max(
@@ -76,12 +97,14 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
   const offset = (page - 1) * pageSize;
 
   const API = getApiBase();
-  const [runtimeSlice, dailySummaryResult, viewPerformance, providerStats] = await Promise.all([
-    loadRuntimeSlice(API, pageSize, offset),
-    loadDailySummary(API),
-    loadViewPerformance(API),
-    loadProviderStats(API),
-  ]);
+  const [runtimeSlice, dailySummaryResult, viewPerformance, providerStats, localCirculation] =
+    await Promise.all([
+      loadRuntimeSlice(API, pageSize, offset),
+      loadDailySummary(API),
+      loadViewPerformance(API),
+      loadProviderStats(API),
+      loadLocalCirculation(API),
+    ]);
 
   const runtime = runtimeSlice.runtime;
   const dailySummary = dailySummaryResult.summary;
@@ -133,6 +156,63 @@ export default async function UsagePage({ searchParams }: { searchParams: UsageS
         </section>
 
         <NavLinksSection />
+
+        {localCirculation.length > 0 ? (
+          <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-3">
+            <h2 className="text-xl font-semibold">Subscription circulation</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              How the paid AI subscriptions actually flow on contributor machines — recency, volume,
+              Coherence-alignment, and limit standing, read from each tool&apos;s local traces.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {[...localCirculation]
+                .sort((a, b) => a.provider.localeCompare(b.provider))
+                .map((s: LocalCircSnapshot) => {
+                  const vol = s.metrics.find((m) => m.id?.startsWith("volume"));
+                  const aligned = s.metrics.find((m) => m.id === "aligned_ratio");
+                  const limits = s.metrics.filter((m) => m.id?.startsWith("limit_"));
+                  const verdict = s.raw?.verdict ?? s.status;
+                  return (
+                    <div
+                      key={s.provider}
+                      className="rounded-xl border border-border/30 p-4 space-y-1.5"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-semibold capitalize">{s.provider}</span>
+                        <span className={`text-xs font-medium ${verdictTone(verdict)}`}>
+                          {verdict}
+                        </span>
+                      </div>
+                      {vol ? (
+                        <p className="text-sm text-muted-foreground">
+                          {compactNum(vol.used)} {vol.unit} · {vol.window}
+                        </p>
+                      ) : null}
+                      {aligned ? (
+                        <p className="text-xs text-muted-foreground">
+                          {Math.round(aligned.used * 100)}% Coherence-aligned
+                        </p>
+                      ) : null}
+                      {limits.map((l) => (
+                        <p key={l.id} className="text-xs text-muted-foreground">
+                          {l.window}: {Math.round(l.used * 100)}% used
+                          {l.remaining != null ? ` · ${Math.round(l.remaining * 100)}% left` : ""}
+                        </p>
+                      ))}
+                      {s.notes?.[0] ? (
+                        <p className="text-xs italic text-muted-foreground/80">{s.notes[0]}</p>
+                      ) : null}
+                    </div>
+                  );
+                })}
+            </div>
+            <p className="text-xs text-muted-foreground/70">
+              Source: contributor machines via <code>make circulation</code>{" "}
+              <code>--push</code>. Only Codex&apos;s trace carries vendor limits; others show what
+              their local trace can honestly report.
+            </p>
+          </section>
+        ) : null}
 
         <section className="rounded-2xl border border-border/30 bg-gradient-to-b from-card/60 to-card/30 p-6 space-y-3">
           <h2 className="text-xl font-semibold">Provider Health</h2>


### PR DESCRIPTION
## What

Builds the bridge so each contributor machine's **subscription circulation** (from `scripts/sense_subscription_circulation.py`) reaches the collective `/usage` surface.

- **service**: `record_local_circulation_snapshots` / `latest_local_circulation_snapshots` reuse the canonical `ProviderUsageSnapshot` store, tagged `raw.source=laptop:<host>` so laptop circulation reads back distinctly from the runner's own providers.
- **router**: `POST`/`GET /api/automation/usage/local-circulation` (ingest + readback).
- **sensor**: `--push` maps readings to the canonical snapshot shape and POSTs (stdlib urllib; `--api` defaults to prod, `--host` defaults to hostname).
- **web `/usage`**: a "Subscription circulation" section renders the pushed readings — recency, volume, Coherence-alignment, and (Codex) vendor limit standing.
- **test**: ingest→readback roundtrip preserves the source tag and vendor limits (`4 passed`).

## Why

The laptop sensor read the real circulation but kept it local; the server can't read a laptop's `~/.claude`. This is the push path + the collective surface, reusing the existing usage frame rather than building parallel machinery.

Follow-up: this PR is the second of the [`ba153221`](https://api.coherencycoin.com/api/ideas) circulation idea (first: [#2556](https://github.com/seeker71/Coherence-Network/pull/2556)). Remaining threads: route Grok to the runner; cost/value layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)