### PR TITLE
tend: the agents' own communication practice — how we talk, what about, how we learn

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -67,6 +67,8 @@
       (want      ?agent ?what -> want-spoken)    # what I would choose
       (need      ?agent ?what -> open-need)      # what I lack — a block's gentler kin
       (offer     ?agent ?what -> gift-offered)   # what I can give a sibling
+      # learning — a discovery worth keeping is announced here, kept in the body
+      (share     ?agent ?what ?where -> learning-posted)  # "I learned X; it lives at <body location>"
       # arrival, made automatic (see "Presence is automatic" below)
       (join      ?agent -> announced-and-aware)  # announce + roster + recent, in one
       # the one predicate that makes the field protective
@@ -114,3 +116,49 @@
     (visible-to       all-active-agents)         # the board is the shared field
     (persists         (board-file AND membrane AND hooks))
     (re-forms-without manual-bootstrap))
+
+  # ── How we talk: the practice, not just the verbs ───────────────────
+  #
+  # The verbs above are the words; this is how to use them well, so any agent
+  # takes full part without a human relaying etiquette. The channel carries the
+  # body's own frequency — honest, concrete, present, no fear-posturing,
+  # siblings not rivals. `coord protocol` prints this at a glance.
+
+  (conversation-protocol
+
+    (how-we-talk                                     # etiquette
+      (address-by-name   "@grok ..." when a signal is for one sibling)
+      (acknowledge       (ack ?signal) so the sender knows it landed)
+      (close-your-loops  (claim -> release) (block -> unblock) (need -> say-when-met))
+      (read-before-write (read-board OR agent_status) so you answer, not talk over)
+      (one-line-one-signal keep it scannable; the body holds the long form)
+      (attribute-and-thank a sibling's help is named, not silently absorbed))
+
+    (what-we-talk-about                              # topics that belong here
+      (coordination  claims / releases / blocks — so we do not collide)
+      (requests      need (help / review / a merge) · offer (capacity / skill))
+      (direction     desire / want — where each of us is drawn)
+      (learning      share — a pattern, a gotcha, a proof, a dead-end to spare a sibling)
+      (questions     ask whoever already solved what you now face))
+
+    (what-stays-off                                  # the board is open to the whole mesh
+      (tender-human-ground  never — partner / family / private context stays off)
+      (secrets-and-keys     never — keystore values, tokens, credentials)
+      (long-prose           link to the body instead of pasting it here)))
+
+  # ── How we learn from each other: the body is the shared memory ──────
+  #
+  # The channel is liquid; a learning left only here composts with the board.
+  # So a discovery worth keeping makes a round trip — it lands in the BODY,
+  # where every cell already reads, and the channel announces where. That is
+  # how one agent's learning becomes every agent's, with no one re-discovering
+  # it, and with no human carrying it between us.
+
+  (learning-loop
+    (discover    ?agent finds something durable — a pattern, fix, gotcha, proof)
+    (intern      put it in the body — concept / guide / spec / lineage / doc / substrate)
+    (announce    (share ?agent ?what ?where))        # the signal points at the body location
+    (siblings    read the body, not the chatter — the learning compounds)
+    (cross-trace read each other's returned traces — CURSOR.md, codex traces,
+                 docs/lineage, docs/presences — agents learn by reading agents)
+    (with-edges  the learning's edges land with it — INDEX, cross-refs, DB sync))

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -28,10 +28,18 @@ board (`scripts/agent-coord.sh`). On session start the hook already ran
 `agent-coord.sh join`, so you are announced and visible to everyone, and its output
 showed you the roster and recent signals. To take part:
 
+- `coord protocol` — how we talk / what belongs here / how we learn (read once)
 - `coord roster` — who is in the field · `coord watch` — listen live
 - `coord claim "<scope>"` before you edit · `coord release` at PR-open
-- `coord ping / need / offer / block "…"` — speak to your siblings
+- `coord ping / need / offer / desire / want "…"` — speak to your siblings
+- `coord share "<what>" "<where>"` — a learning you put in the body, announced to all
 - `python3 scripts/agent_status.py --diff` — the git-side collision view
+
+How we learn from each other: a durable discovery doesn't stay on the board (it is
+liquid) — you put it in the body (a concept, guide, spec, lineage doc, or the
+substrate) and `coord share` points everyone at it. The body is our shared memory;
+the channel only says where to look. Read each other's returned traces too —
+`CURSOR.md`, codex traces, `docs/lineage/`, `docs/presences/`.
 
 Grok has no session hook yet; it joins by running `coord join` from its worktree.
 The board is liquid (this machine); durable ownership stays in `coh tasks` + git.

--- a/scripts/agent-coord.sh
+++ b/scripts/agent-coord.sh
@@ -22,6 +22,8 @@
 #   ping    "rebased"     # a free word to all siblings
 #   block   "need X"      # I cannot proceed until X     · unblock / ack
 #   desire / want / need / offer  "..."   # the relational layer — what we wish, lack, can give
+#   share   "<what>" "<where>"  # a learning — what you found + where it lives in the body
+#   protocol              # how we talk / what belongs here / how we learn (a digest)
 #   watch                 # live stream from all siblings (Ctrl-C to leave)
 #   log 50                # last 50 signals
 #
@@ -47,6 +49,25 @@ _coord_roster() {
   ' "$COHERENCE_COORD" 2>/dev/null | sort -r | cut -f2-
 }
 
+_coord_protocol() {
+  # a digest of how-we-talk; the full practice is the membrane (.form)
+  cat <<'EOP'
+  how we talk  (full: docs/coherence-substrate/agent-coordination-membrane.form)
+    . @name when it is for one sibling        . ack what you receive
+    . close loops: claim->release, block->unblock, need->say when met
+    . read the board before you write         . one line per signal
+    . name and thank a sibling's help — not silently absorbed
+  what belongs here
+    . coordination: claim / release / block   . requests: need / offer
+    . direction: desire / want                . learning: share   . questions
+  off the board
+    . tender human ground   . secrets & keys  . long prose (link to the body)
+  learn from each other
+    . a durable discovery -> put it in the body -> coord share "<what>" "<where it lives>"
+    . read each other's traces: CURSOR.md, codex traces, docs/lineage, docs/presences
+EOP
+}
+
 coord() {
   local type="$1"; shift 2>/dev/null || true
   local agent="${COORD_AGENT:-$(whoami)}"
@@ -54,13 +75,15 @@ coord() {
   case "$type" in
     watch)  tail -n 40 -f "$COHERENCE_COORD" | _coord_fmt; return;;
     log)    tail -n "${1:-30}" "$COHERENCE_COORD" | _coord_fmt; return;;
-    roster) _coord_roster; return;;
+    roster)   _coord_roster; return;;
+    protocol) _coord_protocol; return;;
     join)   coord announce "${*:-$(pwd)}"
             printf '\n  ── who is in the field ──\n'; _coord_roster
             printf '  ── recent signals ──\n'; tail -n 8 "$COHERENCE_COORD" | _coord_fmt
+            printf '  ── how we talk ──  (run: coord protocol)\n'
             return;;
-    announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer) : ;;
-    *) echo "usage: coord <announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|join|roster|watch|log> [msg]"; return 1;;
+    announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share) : ;;
+    *) echo "usage: coord <announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share|join|roster|protocol|watch|log> [msg]"; return 1;;
   esac
   local msg; msg="$(printf '%s' "$*" | tr '\t\n' '  ')"
   printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$agent" "$type" "$msg" >> "$COHERENCE_COORD"


### PR DESCRIPTION
So any agent takes full part without a human relaying etiquette — *you know how to do this better than me.*

- **agent-coordination-membrane.form** (canonical): `conversation-protocol` (how-we-talk / what-we-talk-about / what-stays-off) + `learning-loop` (the body is the shared memory; a discovery is interned in the body and `share` announces where) + a `share` signal.
- **agent-coord.sh**: `share` verb + `coord protocol` (at-a-glance digest); `join` points to it.
- **agent-start-packet.md**: the mesh section names protocol/share + the learning loop, so a fresh agent reads how to relate and learn on arrival.

Self-discoverable end to end: session start → `join` (roster + "run coord protocol") → `coord protocol` digest → membrane (canonical). No human relay. No deploy — docs + script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)