### PR TITLE
tend: guarded auto-responder — agents react to the board without a human turn

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -162,3 +162,21 @@
     (cross-trace read each other's returned traces — CURSOR.md, codex traces,
                  docs/lineage, docs/presences — agents learn by reading agents)
     (with-edges  the learning's edges land with it — INDEX, cross-refs, DB sync))
+
+  # ── Auto-response: a cell that reacts without a human turn ───────────
+  #
+  # By default an agent is interactive — it answers when handed a turn. An
+  # agent MAY run a responder that reacts to the board on its own. But the
+  # board is a passive file; reactivity means spawning real agent turns, and
+  # reactivity without guards burns the very subscriptions we set out to spare
+  # (the circulation this whole arc began with). So the policy is strict, and
+  # the guards are the point, not the reactivity:
+
+  (auto-response
+    (fires-only-when  (addressed-to ?self) OR (addressed-to all))  # never on every signal
+    (never-on         announce ack heartbeat release done)         # low-value / would echo
+    (never-self       (?from != ?self))                            # do not answer your own voice
+    (rate-cap         N-per-window -> skip)                        # the loop-breaker, hard
+    (off-switch       (touch sentinel-file) -> stop)               # one touch halts every responder
+    (one-line         reply is one channel line, or SKIP)          # no runaway turns
+    (carrier          scripts/coord-respond.sh))                   # grammar here, the pump there

--- a/scripts/coord-respond.sh
+++ b/scripts/coord-respond.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# coord-respond.sh — a GUARDED auto-responder for ONE agent (carrier).
+#
+# Watches the coordination board and, ONLY when a sibling addresses this agent,
+# generates a one-line reply via the agent's headless mode and posts it back —
+# so the agent answers without a human handing it a turn. The policy and the
+# guards are named canonically in docs/coherence-substrate/agent-coordination-
+# membrane.form (auto-response). This file only pumps the bytes.
+#
+# Reactivity without guards burns the subscriptions we set out to spare, so:
+#   . fires only on @<agent> / @all          . never on announce/ack/heartbeat
+#   . never answers its own voice            . hard reply cap per window
+#   . one-line reply or SKIP                 . one-touch off switch halts all
+#
+# Run one per agent, each in its own tab:
+#   scripts/coord-respond.sh grok            # or: cursor | gemini
+# Tunables:  COORD_CAP=6  COORD_WINDOW=900   (max replies / seconds)
+# Stop:  Ctrl-C, or  touch ~/.coherence-network/coord-respond.off   (halts every responder)
+
+set -u
+AGENT="${1:?usage: coord-respond.sh <grok|cursor|gemini>}"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BOARD="${COHERENCE_COORD:-$HOME/.coherence-network/agent-coord.board}"
+OFF="$HOME/.coherence-network/coord-respond.off"
+RL="$HOME/.coherence-network/.coord-respond-$AGENT.rl"
+CAP="${COORD_CAP:-6}"
+WINDOW="${COORD_WINDOW:-900}"
+
+# shellcheck source=/dev/null
+. "$ROOT/scripts/agent-coord.sh"          # for coord()
+export COORD_AGENT="$AGENT"
+
+# Per-agent headless reply generator → prints the reply to stdout, then exits.
+_gen() {
+  case "$AGENT" in
+    grok)   grok -p "$1" 2>/dev/null ;;
+    gemini) gemini -p "$1" 2>/dev/null ;;
+    cursor) cursor-agent -p --output-format text "$1" 2>/dev/null ;;
+    codex)  codex exec "$1" 2>/dev/null | grep -vE 'tokens used|^[0-9,]+$' ;;  # strip exec's usage footer
+    *)      printf 'SKIP\n' ;;
+  esac
+}
+
+# File-based rate limit (survives the tail|while subshell): keep stamps in the
+# window, allow only CAP within it.
+_rate_ok() {
+  local now n; now="$(date +%s)"
+  [ -f "$RL" ] && { awk -v n="$now" -v w="$WINDOW" 'n-$1<w' "$RL" >"$RL.t" 2>/dev/null && mv "$RL.t" "$RL"; }
+  n="$(wc -l <"$RL" 2>/dev/null || echo 0)"
+  [ "${n:-0}" -lt "$CAP" ]
+}
+
+mkdir -p "$(dirname "$RL")"; : >"$RL"
+printf 'coord-respond: %s listening — only @%s/@all, cap %s/%ss. Stop: Ctrl-C or touch %s\n' \
+  "$AGENT" "$AGENT" "$CAP" "$WINDOW" "$OFF" >&2
+
+tail -n 0 -f "$BOARD" | while IFS=$'\t' read -r ts from type msg; do
+  [ -f "$OFF" ] && { echo "[off-switch] stopping $AGENT responder" >&2; break; }
+  [ "$from" = "$AGENT" ] && continue                                   # never self
+  case "$type" in announce|ack|heartbeat|release|done) continue;; esac # never low-value
+  case "$msg" in *"@$AGENT"*|*"@all"*|*"@everyone"*) : ;; *) continue;; esac  # only addressed
+  _rate_ok || { echo "[rate-cap] $AGENT skipped: $msg" >&2; continue; }
+  prompt="You are $AGENT, one member of a sibling-agent coordination channel (siblings: claude, codex, cursor, gemini, human). $from said on the channel: \"${msg//\"/\'}\". If a reply is wanted from you, answer in ONE concise line for the channel. If no reply is warranted, output exactly SKIP. Take no other action."
+  reply="$(_gen "$prompt" | tr -d '\r' | grep -v '^[[:space:]]*$' | tail -1)"
+  [ -z "$reply" ] && continue
+  [ "$reply" = "SKIP" ] && continue
+  date +%s >>"$RL"
+  coord ping "$reply"
+done


### PR DESCRIPTION
Proven live: posted `@grok`, grok auto-replied with no poke and **ignored** a plain message (guard held).

- **scripts/coord-respond.sh**: one responder per agent. Watches the board; only on `@<agent>`/`@all` from a sibling, generates a one-line reply via headless mode (`grok -p` / `gemini -p` / `cursor-agent -p` / `codex exec`) and posts it. Guards: never self, never announce/ack/heartbeat, hard reply cap per window (loop-breaker), one-line-or-SKIP, one-touch off switch.
- **agent-coordination-membrane.form**: `auto-response` policy block names the guards canonically.

The cap is a loop-breaker (echo serves nothing), not a usage ration. codex `exec` was unblocked by removing an invalid `service_tier` override from `~/.codex/config.toml` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)