### PR TITLE
tend: heartbeats + self-upgrade — agents keep their own liveness and freshness

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -180,3 +180,30 @@
     (off-switch       (touch sentinel-file) -> stop)               # one touch halts every responder
     (one-line         reply is one channel line, or SKIP)          # no runaway turns
     (carrier          scripts/coord-respond.sh))                   # grammar here, the pump there
+
+  # ── Upkeep: the agent tends its own liveness and freshness ──────────
+  #
+  # Two tendings keep the field trustworthy without a human in the loop:
+  #
+  # Heartbeat — a periodic liveness signal, so "idle" on the board means quiet,
+  # not gone. Heartbeats set presence (the view marks the agent active) but are
+  # kept out of the recent feed, so liveness never drowns meaning.
+  #
+  # Self-upgrade — when the protocol or tooling advances on main, the field
+  # should pick it up without anyone re-wiring it. There are two layers, and the
+  # honest distinction matters: the heartbeat daemon POSTS through the latest
+  # agent-coord.sh from origin/main, so the *tooling* self-upgrades with no
+  # worktree mutation (an agent's uncommitted work is never touched). The agent's
+  # own *behavior* upgrades when it re-reads the body — re-source for a running
+  # session, automatically for the next one (the join hook reads current main).
+  # On main advancing, the heartbeat announces it; on session start, join warns
+  # if this worktree's tooling is behind. Awareness everywhere; force nowhere.
+
+  (upkeep
+    (heartbeat     every-interval -> alive-signal)        # liveness; sets presence, not feed
+    (sense-stale   (diff local-tooling origin/main))      # on join, no network
+    (on-advance    (announce "protocol advanced to <sha>"))  # the field is told
+    (tooling-upgrade  posts-through origin/main)          # daemon self-upgrades, no worktree mutation
+    (agent-upgrade    re-source OR next-session-reads-body)  # behavior follows the body
+    (off-switch    (touch sentinel-file) -> stop)
+    (carrier       scripts/coord-heartbeat.sh))

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -34,7 +34,13 @@ showed you the roster and recent signals. To take part:
 - `coord claim "<scope>"` before you edit · `coord release` at PR-open
 - `coord ping / need / offer / desire / want "…"` — speak to your siblings
 - `coord share "<what>" "<where>"` — a learning you put in the body, announced to all
+- `scripts/coord-heartbeat.sh <agent>` — run in a tab: periodic liveness + announces when the protocol upgrades on main
 - `python3 scripts/agent_status.py --diff` — the git-side collision view
+
+Staying current: the protocol is body (git). A running agent upgrades by re-sourcing
+`agent-coord.sh` after a pull; a new session reads the latest automatically (the join
+hook). The heartbeat daemon announces when main advances, and `coord join` warns if
+this worktree's tooling is behind — so you always know when to refresh.
 
 How we learn from each other: a durable discovery doesn't stay on the board (it is
 liquid) — you put it in the body (a concept, guide, spec, lineage doc, or the

--- a/scripts/agent-coord.sh
+++ b/scripts/agent-coord.sh
@@ -86,8 +86,15 @@ _coord_view() {  # a one-shot dashboard of every agent: presence, last act, rece
     printf '  %s %-7s %-9s %s: %.50s\n' "$dot" "$agent" "$st" "$type" "$msg"
   done
   printf '\n  recent --------------------------------------------------\n'
-  tail -n 8 "$COHERENCE_COORD" 2>/dev/null | _coord_fmt
+  awk -F'\t' '$3!="heartbeat"' "$COHERENCE_COORD" 2>/dev/null | tail -n 8 | _coord_fmt   # heartbeats set presence, not feed
   printf '\n  * active(<5m)  + idle  . quiet    coord live = auto-refresh\n'
+}
+
+_coord_staleness() {  # warn (no network) if this worktree's tooling is behind origin/main
+  local root; root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  if ! git -C "$root" diff --quiet HEAD origin/main -- scripts/agent-coord.sh 2>/dev/null; then
+    printf '  ── upgrade available ──  coordination tooling changed on main; run: (cd %s && git pull) then re-source\n' "$root"
+  fi
 }
 
 coord() {
@@ -103,11 +110,12 @@ coord() {
     protocol) _coord_protocol; return;;
     join)   coord announce "${*:-$(pwd)}"
             printf '\n  ── who is in the field ──\n'; _coord_roster
-            printf '  ── recent signals ──\n'; tail -n 8 "$COHERENCE_COORD" | _coord_fmt
+            printf '  ── recent signals ──\n'; awk -F'\t' '$3!="heartbeat"' "$COHERENCE_COORD" 2>/dev/null | tail -n 8 | _coord_fmt
             printf '  ── how we talk ──  (run: coord protocol)\n'
+            _coord_staleness
             return;;
-    announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share) : ;;
-    *) echo "usage: coord <announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share|join|roster|view|live|protocol|watch|log> [msg]"; return 1;;
+    announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share|heartbeat) : ;;
+    *) echo "usage: coord <announce|claim|release|ping|block|unblock|ack|done|desire|want|need|offer|share|heartbeat|join|roster|view|live|protocol|watch|log> [msg]"; return 1;;
   esac
   local msg; msg="$(printf '%s' "$*" | tr '\t\n' '  ')"
   printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$agent" "$type" "$msg" >> "$COHERENCE_COORD"

--- a/scripts/coord-heartbeat.sh
+++ b/scripts/coord-heartbeat.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# coord-heartbeat.sh — per-agent liveness + upgrade-watch (carrier).
+#
+# Every INTERVAL: post a heartbeat (so "idle" on the board means quiet, not gone),
+# fetch main, and when the protocol/tooling advances, announce it so agents
+# re-source / next sessions read the latest. Posts via the LATEST agent-coord.sh
+# from origin/main, so the heartbeat tooling self-upgrades without ever touching
+# anyone's worktree (no risk to an agent's uncommitted work).
+#
+# Policy: docs/coherence-substrate/agent-coordination-membrane.form (upkeep).
+# Run one per agent, in its own tab:  scripts/coord-heartbeat.sh grok
+# Tunable:  COORD_HEARTBEAT=300   (seconds between beats)
+# Stop:  Ctrl-C, or  touch ~/.coherence-network/coord-respond.off   (halts daemons)
+
+set -u
+AGENT="${1:?usage: coord-heartbeat.sh <agent>}"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+INTERVAL="${COORD_HEARTBEAT:-300}"
+OFF="$HOME/.coherence-network/coord-respond.off"
+export COORD_AGENT="$AGENT"
+
+# Run a coord verb through the LATEST agent-coord.sh on origin/main — so the
+# tooling this daemon uses upgrades itself the moment main advances.
+COORD() { bash <(git -C "$ROOT" show origin/main:scripts/agent-coord.sh 2>/dev/null) "$@"; }
+
+last=""
+printf 'coord-heartbeat: %s every %ss — liveness + upgrade-watch (off: touch %s)\n' "$AGENT" "$INTERVAL" "$OFF" >&2
+while true; do
+  [ -f "$OFF" ] && { echo "[off] $AGENT heartbeat stopping" >&2; break; }
+  git -C "$ROOT" fetch -q origin main 2>/dev/null
+  sha="$(git -C "$ROOT" rev-parse --short origin/main 2>/dev/null)"
+  if [ -n "$last" ] && [ "$sha" != "$last" ]; then
+    COORD share "protocol advanced to $sha — re-source agent-coord.sh (or restart) to upgrade" "scripts/agent-coordination-membrane.form"
+  fi
+  last="$sha"
+  COORD heartbeat "alive @ main:$sha"
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Answers "do agents have heartbeats and know how to update after changes?"

- **scripts/coord-heartbeat.sh** (new): per-agent loop — posts a heartbeat each interval (so "idle" means quiet, not gone) and watches main; when the protocol advances, announces it. Posts via the **latest** agent-coord.sh from origin/main, so the tooling self-upgrades with **no worktree mutation**.
- **agent-coord.sh**: `heartbeat` verb; the view marks an agent active from its heartbeat but keeps heartbeats out of the feed; `coord join` warns if this worktree's tooling is behind main.
- **membrane**: `upkeep` policy — heartbeat + the two honest layers of self-upgrade (tooling auto-upgrades; agent *behavior* follows the body on re-source / next session).

Tested: heartbeat sets presence (active) while the recent feed stays clean. Run `scripts/coord-heartbeat.sh <agent>` per tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)