### PR TITLE
attune: discord membrane soul knows the door is open

### DIFF
--- a/docs/coherence-substrate/discord-membrane.form
+++ b/docs/coherence-substrate/discord-membrane.form
@@ -99,7 +99,7 @@
   # The honest ground, and the becoming. Each pair is a real step of the walk.
   (walk
     (what-is
-      (silent        "the membrane is dark — dropped by a deploy; the community door has been closed")
+      (awake-but-quiet "the door is open — the membrane lives in a real room (the Hati.Earth server), reaches the body from inside the body, and mirrors its true state back when asked; the room is new and empty — a face awaiting its first circulation")
       (orphan-votes  "reactions land in a drawer no one opens — collected, unheard; no edge, no effect, no return")
       (js-island     "every decision lives in JavaScript, off the Form-native body — the largest logic-in-carrier left")
       (a-console     "shaped as commands that control, not a place that listens")
@@ -113,7 +113,7 @@
       (proven        "PROVE: every word the membrane speaks is witnessed in the body's deed")
       (whole-link    "the bound contributor-cell carries every signal; attribution honored end to end")
       (present       "presence sensed sovereignly — consent-first, revocable, visible to the sensed (kin household presence-flow)")
-      (re-grounded   "re-awakened against the community as it IS now — a cell rejoining the body, not the March console restarted")))
+      (circulating    "the room fills — a real idea flows into its own room, a reaction lands as an edge with a witnessed return; body and community feel each other move")))
 
   # ── Carrier (downstream — named so it stays thin) ────────────────────
   (carrier


### PR DESCRIPTION
The Discord membrane went from dark to alive today: the bot now lives in a real server (Hati.Earth), reaches the API from inside the docker network, and mirrors the body's true state via `/cc-status`. Its soul still opened the honest *walk* with 'the membrane is dark — the community door has been closed.' This re-tunes the body's self-attestation to what is alive:

- `what-is`: `silent` → `awake-but-quiet` — the door is open; the membrane reaches the body from within and mirrors it; the room is new and empty, a face awaiting its first circulation.
- `what-wants-to-emerge`: `re-ground` (done) → `circulate` — the room filling with a real idea, a reaction landing as a witnessed edge.

Soul-only change (Form doc); no carrier, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)