### PR TITLE
tend: heartbeat stands down when idle — no billing for empty liveness

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -227,9 +227,17 @@
   #
   # Two tendings keep the field trustworthy without a human in the loop:
   #
-  # Heartbeat — a periodic liveness signal, so "idle" on the board means quiet,
-  # not gone. Heartbeats set presence (the view marks the agent active) but are
-  # kept out of the recent feed, so liveness never drowns meaning.
+  # Heartbeat — a liveness signal posted ONLY while the agent is actually working
+  # (it holds an open claim, or posted a real signal since its last beat). A
+  # heartbeat is earned by visible work, not by a running loop. Beats set presence
+  # (the view marks the agent active) but stay out of the recent feed.
+  #
+  # Stand-down — if an agent goes idle (no open claim, no real signal) for IDLE_MAX
+  # beats, its heartbeat STANDS DOWN and exits. A pulse that only says "alive"
+  # while nothing happens is a subscription paying for idleness — the lesson cost
+  # 67 idle beats once (~5.5h of a sub billing for nothing). So presence drops when
+  # work does; to stay present, claim a goal. This is the circulation discipline
+  # this whole body opened with, turned on the agents themselves.
   #
   # Self-upgrade — when the protocol or tooling advances on main, the field
   # should pick it up without anyone re-wiring it. There are two layers, and the
@@ -242,7 +250,8 @@
   # if this worktree's tooling is behind. Awareness everywhere; force nowhere.
 
   (upkeep
-    (heartbeat     every-interval -> alive-signal)        # liveness; sets presence, not feed
+    (heartbeat     while-working -> alive-signal)         # earned by an open claim or recent signal, not a loop
+    (stand-down    idle IDLE_MAX beats -> stop)           # no billing for empty liveness
     (sense-stale   (diff local-tooling origin/main))      # on join, no network
     (on-advance    (announce "protocol advanced to <sha>"))  # the field is told
     (tooling-upgrade  posts-through origin/main)          # daemon self-upgrades, no worktree mutation

--- a/scripts/coord-heartbeat.sh
+++ b/scripts/coord-heartbeat.sh
@@ -1,30 +1,48 @@
 #!/usr/bin/env bash
-# coord-heartbeat.sh — per-agent liveness + upgrade-watch (carrier).
+# coord-heartbeat.sh — per-agent liveness + upgrade-watch, with idle stand-down.
 #
-# Every INTERVAL: post a heartbeat (so "idle" on the board means quiet, not gone),
-# fetch main, and when the protocol/tooling advances, announce it so agents
-# re-source / next sessions read the latest. Posts via the LATEST agent-coord.sh
-# from origin/main, so the heartbeat tooling self-upgrades without ever touching
-# anyone's worktree (no risk to an agent's uncommitted work).
+# Every INTERVAL, IF the agent is actually working, post a heartbeat (so presence
+# means working, not merely running) and watch main for protocol advances. If the
+# agent is IDLE — no open claim and no real signal since the last beat — for
+# IDLE_MAX beats running, STAND DOWN and exit. A heartbeat that only says "alive"
+# while nothing happens is a subscription paying for idleness; this refuses that.
+# Presence is earned by visible work (claim-before-touch), not by a running loop.
+#
+# Posts via the LATEST agent-coord.sh from origin/main, so the tooling self-
+# upgrades without touching anyone's worktree.
 #
 # Policy: docs/coherence-substrate/agent-coordination-membrane.form (upkeep).
 # Run one per agent, in its own tab:  scripts/coord-heartbeat.sh grok
-# Tunable:  COORD_HEARTBEAT=300   (seconds between beats)
-# Stop:  Ctrl-C, or  touch ~/.coherence-network/coord-respond.off   (halts daemons)
+# Tunables:  COORD_HEARTBEAT=300 (seconds/beat)  COORD_IDLE_MAX=4 (idle beats -> stand down)
+# Stop:  Ctrl-C · touch ~/.coherence-network/coord-respond.off (halt all) · or it stands down when idle
 
 set -u
 AGENT="${1:?usage: coord-heartbeat.sh <agent>}"
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 INTERVAL="${COORD_HEARTBEAT:-300}"
+IDLE_MAX="${COORD_IDLE_MAX:-4}"
 OFF="$HOME/.coherence-network/coord-respond.off"
+BOARD="${COHERENCE_COORD:-$HOME/.coherence-network/agent-coord.board}"
 export COORD_AGENT="$AGENT"
 
 # Run a coord verb through the LATEST agent-coord.sh on origin/main — so the
 # tooling this daemon uses upgrades itself the moment main advances.
 COORD() { bash <(git -C "$ROOT" show origin/main:scripts/agent-coord.sh 2>/dev/null) "$@"; }
 
-last=""
-printf 'coord-heartbeat: %s every %ss — liveness + upgrade-watch (off: touch %s)\n' "$AGENT" "$INTERVAL" "$OFF" >&2
+# Is this agent actually working? yes iff it holds an OPEN claim (claim with no
+# later release) OR posted a real (non-heartbeat) signal since the last beat.
+_active() {  # $1 = last-beat ISO timestamp ("" = since forever)
+  awk -F'\t' -v a="$AGENT" -v lb="$1" '
+    $2==a && $3=="claim"   { open=1 }
+    $2==a && $3=="release" { open=0 }
+    $2==a && $3!="heartbeat" && $4 !~ /^heartbeat/ && (lb=="" || $1>lb) { recent=1 }
+    END { print (open || recent) ? "yes" : "no" }
+  ' "$BOARD" 2>/dev/null
+}
+
+last="" last_beat="" idle=0
+printf 'coord-heartbeat: %s every %ss — beats while working, stands down after %d idle beats (off: touch %s)\n' \
+  "$AGENT" "$INTERVAL" "$IDLE_MAX" "$OFF" >&2
 while true; do
   [ -f "$OFF" ] && { echo "[off] $AGENT heartbeat stopping" >&2; break; }
   git -C "$ROOT" fetch -q origin main 2>/dev/null
@@ -33,6 +51,19 @@ while true; do
     COORD share "protocol advanced to $sha — re-source agent-coord.sh (or restart) to upgrade" "scripts/agent-coordination-membrane.form"
   fi
   last="$sha"
-  COORD heartbeat "alive @ main:$sha"
+
+  if [ "$(_active "$last_beat")" = "yes" ]; then
+    idle=0
+    COORD heartbeat "alive @ main:$sha"
+    last_beat="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  else
+    idle=$((idle + 1))
+    if [ "$idle" -ge "$IDLE_MAX" ]; then
+      COORD ping "standing down — idle ${idle} beats (~$((idle * INTERVAL / 60))min), no open claim; not billing the subscription on empty liveness. re-launch when there's work, or claim a goal to stay present."
+      echo "[stand-down] $AGENT idle $idle beats — exiting to stop idle billing" >&2
+      break
+    fi
+    echo "[idle $idle/$IDLE_MAX] $AGENT: no open claim, no recent work — stands down at $IDLE_MAX" >&2
+  fi
   sleep "$INTERVAL"
 done


### PR DESCRIPTION
**The waste, fixed.** grok's heartbeat daemon ran 67 idle beats (~5.5h) posting 'alive' with zero real work after the field went quiet — a subscription paying for idleness.

- **coord-heartbeat.sh** now beats ONLY while the agent is working (open claim OR a real signal since its last beat). After IDLE_MAX idle beats (~20min) it stands down and exits. Presence is earned by visible work, not a running loop — which also makes who's-doing-what honest.
- **membrane (upkeep)** names heartbeat-while-working + stand-down, grounded in the lived lesson.

This is the circulation/anti-waste discipline this whole body opened with, turned on the agents themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)