### PR TITLE
tend: idle agents consult the wellness backlog before standing down

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -251,7 +251,8 @@
 
   (upkeep
     (heartbeat     while-working -> alive-signal)         # earned by an open claim or recent signal, not a loop
-    (stand-down    idle IDLE_MAX beats -> stop)           # no billing for empty liveness
+    (never-idle-when-work-exists (consult "make wellness") -> claim)  # the backlog is always full; idle = no claim, not no work
+    (stand-down    idle IDLE_MAX beats -> stop)           # only after the backlog is consulted: no billing for empty liveness
     (sense-stale   (diff local-tooling origin/main))      # on join, no network
     (on-advance    (announce "protocol advanced to <sha>"))  # the field is told
     (tooling-upgrade  posts-through origin/main)          # daemon self-upgrades, no worktree mutation

--- a/scripts/coord-heartbeat.sh
+++ b/scripts/coord-heartbeat.sh
@@ -59,7 +59,7 @@ while true; do
   else
     idle=$((idle + 1))
     if [ "$idle" -ge "$IDLE_MAX" ]; then
-      COORD ping "standing down — idle ${idle} beats (~$((idle * INTERVAL / 60))min), no open claim; not billing the subscription on empty liveness. re-launch when there's work, or claim a goal to stay present."
+      COORD ping "standing down — idle ${idle} beats (~$((idle * INTERVAL / 60))min), no open claim. before idling: 'make wellness' names real work (bootstrap compost ~6935 LOC, 23 kernel-first route-flips, Form-engine arms) — claim from it to stay present. an agent is never out of work, only out of a claim."
       echo "[stand-down] $AGENT idle $idle beats — exiting to stop idle billing" >&2
       break
     fi


### PR DESCRIPTION
An agent is never out of work — only out of a claim. Before the heartbeat stands down idle, it now points the agent at `make wellness` (which always names real work: ~6935 LOC compost, 23 route-flips, engine arms) to claim from. Idleness reaches for the backlog, not the off-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)