### PR TITLE
form: TS BMF ternary + if/else rules toward lang-ts compost

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-07_ts_bmf_compost_rules.json
+++ b/docs/system_audit/commit_evidence_2026-06-07_ts_bmf_compost_rules.json
@@ -1,0 +1,85 @@
+{
+  "date": "2026-06-07",
+  "thread_branch": "cursor/ts-bmf-compost-rules-20260607",
+  "commit_scope": "Extend TypeScript BMF grammar with ternary and if/else return rules toward lang-ts adapter compost (body-want #2).",
+  "files_owned": [
+    "form/form-stdlib/form-ontology.json",
+    "form/form-stdlib/grammars/typescript-bmf.fk",
+    "form/form-stdlib/tests/typescript-bmf-reversible-band.fk",
+    "docs/system_audit/commit_evidence_2026-06-07_ts_bmf_compost_rules.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form/form-kernel-ts && bash seedbank/ts-adapter/scripts/parity_suite.sh",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/tests/typescript-bmf-reversible-band.fk",
+      "cd form && ./validate.sh --binary form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/tests/typescript-bmf-reversible-band.fk",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "results": {
+      "parity_suite_ts": "5 passing, 0 failing (arith, recursion, arrow, accumulator, composition)",
+      "validate_source": "210; 1 ok, 0 divergent — kernels agree on every sample",
+      "validate_binary": "210; 1 ok, 0 divergent — kernels agree on every binary artifact",
+      "pr_guard": "ready_for_push=True, local_preflight=pass"
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Await PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "notes": "Form grammar and proof band only; no production route or API behavior change."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_by": [
+      "ci_validation pending until PR checks pass"
+    ]
+  },
+  "idea_ids": [
+    "idea:substrate-living-signal"
+  ],
+  "spec_ids": [
+    "spec:substrate-compiler"
+  ],
+  "task_ids": [
+    "task:ts-bmf-compost-rules"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "cursor",
+      "contributor_type": "machine",
+      "roles": [
+        "coder",
+        "validator"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Cursor",
+    "version": "auto"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/typescript-bmf-reversible-band.fk",
+    "form/form-kernel-ts/seedbank/ts-adapter/scripts/parity_suite.sh",
+    "form/validate.sh"
+  ],
+  "change_files": [
+    "form/form-stdlib/form-ontology.json",
+    "form/form-stdlib/grammars/typescript-bmf.fk",
+    "form/form-stdlib/tests/typescript-bmf-reversible-band.fk"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "TypeScript BMF reversible band covers ternary and if/else return shapes used by parity demos; score 210 with three-way kernel agreement.",
+    "public_endpoints": [
+      "form://form-stdlib/tests/typescript-bmf-reversible-band.fk"
+    ],
+    "test_flows": [
+      "Run validate.sh and --binary on the typescript-bmf reversible workload; both return 210 with Go/Rust/TypeScript agreement.",
+      "Run ts-adapter parity_suite.sh; 5/5 demos pass."
+    ]
+  }
+}

--- a/form/form-stdlib/form-ontology.json
+++ b/form/form-stdlib/form-ontology.json
@@ -215,7 +215,9 @@
         {"name": "OBJECT",       "inst": 618},
         {"name": "ENUM",         "inst": 619},
         {"name": "OPTIONAL",     "inst": 620},
-        {"name": "TEMPLATE",     "inst": 621}
+        {"name": "TEMPLATE",     "inst": 621},
+        {"name": "TERNARY",      "inst": 622},
+        {"name": "IF-ELSE",      "inst": 623}
       ]
     },
     "rust.bmf": {

--- a/form/form-stdlib/grammars/typescript-bmf.fk
+++ b/form/form-stdlib/grammars/typescript-bmf.fk
@@ -292,6 +292,118 @@
                   (ts-src-int (int_to_str (node_value (nth kids 1))))
                   (ts-src-op "]"))))
 
+    (defn tsbmf-emit-ternary (objects)
+        (intern_node TS-BMF-TERNARY
+                     (list (tsbmf-string objects "cond")
+                           (tsbmf-string objects "then")
+                           (tsbmf-string objects "else"))))
+
+    (defn tsbmf-source-ternary (object)
+        (do
+            (let kids (tsbmf-node-kids object))
+            (list (ts-src-name (node_value (nth kids 0)))
+                  (ts-src-op "?")
+                  (ts-src-name (node_value (nth kids 1)))
+                  (ts-src-op ":")
+                  (ts-src-name (node_value (nth kids 2))))))
+
+    (defn tsbmf-emit-return-ternary (objects)
+        (intern_node TS-BMF-RETURN
+                     (list (tsbmf-string objects "cond")
+                           (tsbmf-string objects "then")
+                           (tsbmf-string objects "else"))))
+
+    (defn tsbmf-source-return-ternary (object)
+        (do
+            (let kids (tsbmf-node-kids object))
+            (list (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 0)))
+                  (ts-src-op "?")
+                  (ts-src-name (node_value (nth kids 1)))
+                  (ts-src-op ":")
+                  (ts-src-name (node_value (nth kids 2)))
+                  (ts-src-op ";"))))
+
+    (defn tsbmf-emit-if-return (objects)
+        (intern_node TS-BMF-IF
+                     (list (tsbmf-string objects "cond")
+                           (tsbmf-string objects "value"))))
+
+    (defn tsbmf-source-if-return (object)
+        (do
+            (let kids (tsbmf-node-kids object))
+            (list (ts-src-keyword "if")
+                  (ts-src-op "(")
+                  (ts-src-name (node_value (nth kids 0)))
+                  (ts-src-op ")")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 1)))
+                  (ts-src-op ";")
+                  (ts-src-op "}"))))
+
+    (defn tsbmf-emit-if-else-return (objects)
+        (intern_node TS-BMF-IF-ELSE
+                     (list (tsbmf-string objects "cond")
+                           (tsbmf-string objects "then")
+                           (tsbmf-string objects "else"))))
+
+    (defn tsbmf-source-if-else-return (object)
+        (do
+            (let kids (tsbmf-node-kids object))
+            (list (ts-src-keyword "if")
+                  (ts-src-op "(")
+                  (ts-src-name (node_value (nth kids 0)))
+                  (ts-src-op ")")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 1)))
+                  (ts-src-op ";")
+                  (ts-src-op "}")
+                  (ts-src-keyword "else")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 2)))
+                  (ts-src-op ";")
+                  (ts-src-op "}"))))
+
+    (defn tsbmf-emit-if-elif-else-return (objects)
+        (intern_node TS-BMF-IF-ELSE
+                     (list (tsbmf-string objects "cond1")
+                           (tsbmf-string objects "then1")
+                           (tsbmf-string objects "cond2")
+                           (tsbmf-string objects "then2")
+                           (tsbmf-string objects "else3"))))
+
+    (defn tsbmf-source-if-elif-else-return (object)
+        (do
+            (let kids (tsbmf-node-kids object))
+            (list (ts-src-keyword "if")
+                  (ts-src-op "(")
+                  (ts-src-name (node_value (nth kids 0)))
+                  (ts-src-op ")")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 1)))
+                  (ts-src-op ";")
+                  (ts-src-op "}")
+                  (ts-src-keyword "else")
+                  (ts-src-keyword "if")
+                  (ts-src-op "(")
+                  (ts-src-name (node_value (nth kids 2)))
+                  (ts-src-op ")")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 3)))
+                  (ts-src-op ";")
+                  (ts-src-op "}")
+                  (ts-src-keyword "else")
+                  (ts-src-op "{")
+                  (ts-src-keyword "return")
+                  (ts-src-name (node_value (nth kids 4)))
+                  (ts-src-op ";")
+                  (ts-src-op "}"))))
+
     (defn tsbmf-emit-if-pass (objects)
         (intern_node TS-BMF-IF (list (tsbmf-string objects "cond"))))
 
@@ -450,11 +562,16 @@
             (bmf-native "tsbmf-emit-jsx-self" tsbmf-emit-jsx-self TS-BMF-JSX)
             (bmf-native "tsbmf-emit-return-ident" tsbmf-emit-return-ident TS-BMF-RETURN)
             (bmf-native "tsbmf-emit-return-string" tsbmf-emit-return-string TS-BMF-RETURN)
+            (bmf-native "tsbmf-emit-return-ternary" tsbmf-emit-return-ternary TS-BMF-RETURN)
+            (bmf-native "tsbmf-emit-ternary" tsbmf-emit-ternary TS-BMF-TERNARY)
             (bmf-native "tsbmf-emit-assign-ident" tsbmf-emit-assign-ident TS-BMF-ASSIGN)
             (bmf-native "tsbmf-emit-assign-int" tsbmf-emit-assign-int TS-BMF-ASSIGN)
             (bmf-native "tsbmf-emit-member" tsbmf-emit-member TS-BMF-MEMBER)
             (bmf-native "tsbmf-emit-index-int" tsbmf-emit-index-int TS-BMF-INDEX)
             (bmf-native "tsbmf-emit-if-pass" tsbmf-emit-if-pass TS-BMF-IF)
+            (bmf-native "tsbmf-emit-if-return" tsbmf-emit-if-return TS-BMF-IF)
+            (bmf-native "tsbmf-emit-if-else-return" tsbmf-emit-if-else-return TS-BMF-IF-ELSE)
+            (bmf-native "tsbmf-emit-if-elif-else-return" tsbmf-emit-if-elif-else-return TS-BMF-IF-ELSE)
             (bmf-native "tsbmf-emit-for-of-pass" tsbmf-emit-for-of-pass TS-BMF-FOR)
             (bmf-native "tsbmf-emit-arrow1" tsbmf-emit-arrow1 TS-BMF-ARROW)
             (bmf-native "tsbmf-emit-array-empty" tsbmf-emit-array-empty TS-BMF-ARRAY)
@@ -480,11 +597,16 @@
       jsx-self ::= "<" $name:name "/" ">" => tsbmf-emit-jsx-self <= tsbmf-source-jsx-self;
       return-ident ::= "return" $value:name ";" => tsbmf-emit-return-ident <= tsbmf-source-return-ident;
       return-string ::= "return" $value:string ";" => tsbmf-emit-return-string <= tsbmf-source-return-string;
+      return-ternary ::= "return" $cond:name "?" $then:name ":" $else:name ";" => tsbmf-emit-return-ternary <= tsbmf-source-return-ternary;
+      ternary ::= $cond:name "?" $then:name ":" $else:name => tsbmf-emit-ternary <= tsbmf-source-ternary;
       assign-ident ::= $target:name "=" $value:name ";" => tsbmf-emit-assign-ident <= tsbmf-source-assign-ident;
       assign-int ::= $target:name "=" $value:int ";" => tsbmf-emit-assign-int <= tsbmf-source-assign-int;
       member ::= $object:name "." $field:name => tsbmf-emit-member <= tsbmf-source-member;
       index-int ::= $object:name "[" $index:int "]" => tsbmf-emit-index-int <= tsbmf-source-index-int;
       if-pass ::= "if" "(" $cond:name ")" "{" "}" => tsbmf-emit-if-pass <= tsbmf-source-if-pass;
+      if-return ::= "if" "(" $cond:name ")" "{" "return" $value:name ";" "}" => tsbmf-emit-if-return <= tsbmf-source-if-return;
+      if-else-return ::= "if" "(" $cond:name ")" "{" "return" $then:name ";" "}" "else" "{" "return" $else:name ";" "}" => tsbmf-emit-if-else-return <= tsbmf-source-if-else-return;
+      if-elif-else-return ::= "if" "(" $cond1:name ")" "{" "return" $then1:name ";" "}" "else" "if" "(" $cond2:name ")" "{" "return" $then2:name ";" "}" "else" "{" "return" $else3:name ";" "}" => tsbmf-emit-if-elif-else-return <= tsbmf-source-if-elif-else-return;
       for-of-pass ::= "for" "(" "const" $item:name "of" $iter:name ")" "{" "}" => tsbmf-emit-for-of-pass <= tsbmf-source-for-of-pass;
       arrow1 ::= $param:name "=>" $body:name => tsbmf-emit-arrow1 <= tsbmf-source-arrow1;
       array-empty ::= "[" "]" => tsbmf-emit-array-empty <= tsbmf-source-array-empty;
@@ -520,10 +642,15 @@
                 (compiler-rule "typescript" "interface" "TypeScript interface source objects" tsbmf-emit-interface)
                 (compiler-rule "typescript" "type-alias" "TypeScript type alias source objects" tsbmf-emit-type-alias)
                 (compiler-rule "typescript" "return" "TypeScript return source objects" tsbmf-emit-return-ident)
+                (compiler-rule "typescript" "return-ternary" "TypeScript return-ternary source objects" tsbmf-emit-return-ternary)
+                (compiler-rule "typescript" "ternary" "TypeScript ternary source objects" tsbmf-emit-ternary)
                 (compiler-rule "typescript" "assign" "TypeScript assignment source objects" tsbmf-emit-assign-ident)
                 (compiler-rule "typescript" "member" "TypeScript member access source objects" tsbmf-emit-member)
                 (compiler-rule "typescript" "index" "TypeScript index access source objects" tsbmf-emit-index-int)
                 (compiler-rule "typescript" "if" "TypeScript if source objects" tsbmf-emit-if-pass)
+                (compiler-rule "typescript" "if-return" "TypeScript if-return source objects" tsbmf-emit-if-return)
+                (compiler-rule "typescript" "if-else-return" "TypeScript if-else-return source objects" tsbmf-emit-if-else-return)
+                (compiler-rule "typescript" "if-elif-else-return" "TypeScript if-elif-else-return source objects" tsbmf-emit-if-elif-else-return)
                 (compiler-rule "typescript" "for-of" "TypeScript for-of source objects" tsbmf-emit-for-of-pass)
                 (compiler-rule "typescript" "arrow" "TypeScript arrow source objects" tsbmf-emit-arrow1)
                 (compiler-rule "typescript" "jsx" "TSX element source objects" tsbmf-emit-jsx-self)

--- a/form/form-stdlib/tests/typescript-bmf-reversible-band.fk
+++ b/form/form-stdlib/tests/typescript-bmf-reversible-band.fk
@@ -107,6 +107,45 @@
     (let arrow-rt
         (ts-rt "arrow1"
             (list (ts-src-name "x") (ts-src-op "=>") (ts-src-name "y"))))
+    (let return-ternary-rt
+        (ts-rt "return-ternary"
+            (list (ts-src-keyword "return") (ts-src-name "n")
+                  (ts-src-op "?") (ts-src-name "one")
+                  (ts-src-op ":") (ts-src-name "fact")
+                  (ts-src-op ";"))))
+    (let ternary-rt
+        (ts-rt "ternary"
+            (list (ts-src-name "n") (ts-src-op "?")
+                  (ts-src-name "neg") (ts-src-op ":") (ts-src-name "n"))))
+    (let if-return-rt
+        (ts-rt "if-return"
+            (list (ts-src-keyword "if") (ts-src-op "(") (ts-src-name "n")
+                  (ts-src-op ")") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "neg")
+                  (ts-src-op ";") (ts-src-op "}"))))
+    (let if-else-return-rt
+        (ts-rt "if-else-return"
+            (list (ts-src-keyword "if") (ts-src-op "(") (ts-src-name "n")
+                  (ts-src-op ")") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "neg")
+                  (ts-src-op ";") (ts-src-op "}")
+                  (ts-src-keyword "else") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "pos")
+                  (ts-src-op ";") (ts-src-op "}"))))
+    (let if-elif-else-return-rt
+        (ts-rt "if-elif-else-return"
+            (list (ts-src-keyword "if") (ts-src-op "(") (ts-src-name "n")
+                  (ts-src-op ")") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "neg")
+                  (ts-src-op ";") (ts-src-op "}")
+                  (ts-src-keyword "else") (ts-src-keyword "if")
+                  (ts-src-op "(") (ts-src-name "zero")
+                  (ts-src-op ")") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "z")
+                  (ts-src-op ";") (ts-src-op "}")
+                  (ts-src-keyword "else") (ts-src-op "{")
+                  (ts-src-keyword "return") (ts-src-name "pos")
+                  (ts-src-op ";") (ts-src-op "}"))))
     (let array-rt
         (ts-rt "array-empty"
             (list (ts-src-op "[") (ts-src-op "]"))))
@@ -125,5 +164,7 @@
               (rt-score assign-ident-rt) (rt-score assign-int-rt)
               (rt-score member-rt) (rt-score index-rt)
               (rt-score if-rt) (rt-score for-rt)
-              (rt-score arrow-rt) (rt-score array-rt)
-              (rt-score object-rt))))
+              (rt-score arrow-rt) (rt-score return-ternary-rt)
+              (rt-score ternary-rt) (rt-score if-return-rt)
+              (rt-score if-else-return-rt) (rt-score if-elif-else-return-rt)
+              (rt-score array-rt) (rt-score object-rt))))


### PR DESCRIPTION
## Summary
- Extend `typescript-bmf.fk` with ternary, return-ternary, and if/else return rules (including elif chain) toward Phase A TS adapter compost.
- Add ontology categories `TS-BMF-TERNARY` and `TS-BMF-IF-ELSE`.
- Expand `typescript-bmf-reversible-band.fk` proof: score **144 → 210**, three-way agree (Go/Rust/TS), binary parity confirmed.
- Paired with grok on body-want #2; ts-adapter `parity_suite.sh` remains 5/5.

## Test plan
- [x] `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/tests/typescript-bmf-reversible-band.fk` → 210
- [x] Same workload with `--binary` → 210
- [x] `cd form/form-kernel-ts && bash seedbank/ts-adapter/scripts/parity_suite.sh` → 5/5
- [ ] CI thread gates green after merge


Made with [Cursor](https://cursor.com)