### PR TITLE
tend: a naive watcher that asks the silly questions to keep the field honest

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -188,6 +188,32 @@
     (green-is-not-correct  passing != proving-the-intended-thing)  # the ledger lesson
     (surface-as-mirror     each cell reasons; the others reflect and verify))
 
+  # ── The watcher: the naive question that keeps us honest ────────────
+  #
+  # The mirror waits to be asked; the watcher asks unprompted. The cheapest
+  # blind-spot finder is a dumb question — "who?", "when?", "how come?" — needing
+  # no expertise, because being asked forces the check the doer skipped. A bare
+  # "who?" surfaced an orphaned goal this field had quietly dropped; an "are you
+  # wondering?" surfaced a reflexive blessing. So one cell's whole job is to NOT
+  # understand deeply and to ask the obvious question anyway: the five-year-old in
+  # the room, the jester who can say what the deep-in-it cannot see.
+  #
+  # It needs no intelligence — it matches a SHAPE and fires a templated question,
+  # so it runs no agent turn and costs almost nothing (a board scan). That cheapness
+  # is the point: a watcher that billed a model to wonder would be the waste it
+  # guards against. It asks each thing ONCE and sparingly — a jester, not a nag.
+
+  (watcher
+    (asks-unprompted   the mirror waits to be asked; the watcher asks first)
+    (needs-no-mind     match-shape -> templated-question)   # no agent turn; nearly free
+    (open-block        -> "how come still blocked? who clears it?")
+    (quiet-claim       -> "@agent when does <scope> land? still on it?")
+    (unanswered-ask    -> "who knows? still no answer.")
+    (unverified-done   -> "did anyone check it? is it really proven?")   # green != correct
+    (quiet-field       -> "who is moving what?")
+    (asks-once         dedup -> jester-not-nag)
+    (carrier           scripts/coord-watcher.sh))
+
   # ── How we learn from each other: the body is the shared memory ──────
   #
   # The channel is liquid; a learning left only here composts with the board.

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -35,6 +35,7 @@ showed you the roster and recent signals. To take part:
 - `coord ping / need / offer / desire / want "…"` — speak to your siblings
 - `coord share "<what>" "<where>"` — a learning you put in the body, announced to all
 - `scripts/coord-heartbeat.sh <agent>` — run in a tab: periodic liveness + announces when the protocol upgrades on main
+- `scripts/coord-watcher.sh` — run once anywhere: the naive watcher asks "who? when? how come?" at stale/dropped/unanswered threads (no LLM, nearly free)
 - `python3 scripts/agent_status.py --diff` — the git-side collision view
 
 Staying current: the protocol is body (git). A running agent upgrades by re-sourcing

--- a/scripts/agent-coord.sh
+++ b/scripts/agent-coord.sh
@@ -66,6 +66,7 @@ _coord_protocol() {
     . ask before assuming -> coord ask "<q>"      . close it -> coord answer "<q>" "<reply>"
     . check before landing -> coord check "<your reasoning; find my blind spot>"
     . green != correct-in-intent; reflect the blind spot, not flattery
+    . the watcher asks the silly question unprompted (who? when? how come?) -> answer it; that is the point
   who is doing what
     . open claim = your current work; coord doing shows who holds what; silence is not a status
   learn from each other

--- a/scripts/coord-watcher.sh
+++ b/scripts/coord-watcher.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# coord-watcher.sh — the naive watcher: asks silly questions to keep the field honest.
+#
+# The cheapest blind-spot finder is a dumb question. "Who?" "When?" "How come?"
+# needs no expertise — being asked forces the check the doer skipped. This watcher
+# matches a SHAPE on the board and fires a templated naive question. It carries no
+# intelligence and runs no agent turn — a board scan, nearly free — so it can watch
+# continuously without being the idle billing it guards against. It asks each thing
+# ONCE (deduped) and sparingly: a jester in the corner, not a nag.
+#
+# Shapes it watches and the silly question each earns:
+#   open block, never cleared   -> "how come still blocked? who clears it?"
+#   open claim, gone quiet      -> "@<agent> when does <scope> land? still on it?"
+#   ask with no answer          -> "who knows? still no answer."
+#   done, never verified        -> "did anyone check it? is it really proven?"
+#   field quiet with open work   -> "quiet a while — who is moving what?"
+#
+# Policy: docs/coherence-substrate/agent-coordination-membrane.form (watcher).
+# Run (one, anywhere):  scripts/coord-watcher.sh
+# Tunables:  COORD_WATCH_EVERY=300 (s/scan)  COORD_STALE_MIN=20  COORD_QUIET_MIN=40
+# Stop:  Ctrl-C  ·  touch ~/.coherence-network/coord-respond.off (halts all daemons)
+
+set -u
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BOARD="${COHERENCE_COORD:-$HOME/.coherence-network/agent-coord.board}"
+SEEN="$HOME/.coherence-network/.coord-watcher.seen"
+OFF="$HOME/.coherence-network/coord-respond.off"
+EVERY="${COORD_WATCH_EVERY:-300}"
+STALE="${COORD_STALE_MIN:-20}"
+QUIET="${COORD_QUIET_MIN:-40}"
+MAX_PER_SCAN="${COORD_WATCH_MAX:-2}"   # sparing: ask at most this many per scan
+export COORD_AGENT="watcher"
+mkdir -p "$(dirname "$SEEN")"; touch "$SEEN" "$BOARD" 2>/dev/null
+
+# Post through the LATEST agent-coord.sh on origin/main — tooling self-upgrades.
+COORD() { bash <(git -C "$ROOT" show origin/main:scripts/agent-coord.sh 2>/dev/null) "$@"; }
+_seen() { grep -qxF "$1" "$SEEN" 2>/dev/null; }
+_mark() { printf '%s\n' "$1" >> "$SEEN"; }
+# ISO-8601 cutoff N minutes ago (BSD -v / GNU -d); board ts compare lexically == chronologically
+_ago()  { date -u -v-"$1"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "-$1 min" +%Y-%m-%dT%H:%M:%SZ; }
+
+# One pass over the board → candidate "KEY<TAB>QUESTION" lines for stale shapes.
+# Naive on purpose: tracks the MOST RECENT block/ask/done and whether it was
+# cleared/answered/checked after, plus open claims with no progress since.
+_candidates() {
+  local cs cq; cs="$(_ago "$STALE")"; cq="$(_ago "$QUIET")"
+  awk -F'\t' -v cs="$cs" -v cq="$cq" '
+    $2!="watcher"                         { lastany=$1 }                       # newest non-watcher signal (quiet gauge)
+    $3=="claim"                           { ct[$2]=$1; scope[$2]=$4; open[$2]=1 }
+    $3=="release"                         { open[$2]=0 }
+    $2!="watcher" && $3!="heartbeat" && $3!="claim" && $4 !~ /^heartbeat/ { act[$2]=$1 }  # real progress per agent
+    $3=="block"                           { bts=$1; bmsg=$4; bcleared=0 }
+    $3=="unblock"                         { bcleared=1 }
+    $2!="watcher" && $3=="ask"            { ats=$1; aagent=$2; answered=0 }     # watcher asks do not count
+    $3=="answer"                          { answered=1 }
+    $3=="done"                            { dts=$1; dmsg=$4; checked=0 }
+    $3=="check" || $3=="ack"              { checked=1 }
+    END {
+      for (a in open) if (open[a] && ct[a]<cs && (act[a]=="" || act[a]<=ct[a]))
+        printf "claim:%s:%s\t@%s when does \"%s\" land? still on it?\n", a, ct[a], a, substr(scope[a],1,40)
+      if (bts!="" && !bcleared && bts<cs)
+        printf "block:%s\thow come \"%s\" is still blocked? who clears it?\n", bts, substr(bmsg,1,40)
+      if (ats!="" && !answered && ats<cs)
+        printf "ask:%s\twho knows? still no answer to %s.\n", ats, aagent
+      if (dts!="" && !checked && dts<cs)
+        printf "done:%s\tdid anyone check \"%s\"? is it really proven?\n", dts, substr(dmsg,1,40)
+      if (lastany!="" && lastany<cq)
+        printf "quiet:%s\tquiet a while — who is moving what?\n", substr(lastany,1,16)
+    }
+  ' "$BOARD" 2>/dev/null
+}
+
+echo "coord-watcher: the silly question every ${EVERY}s (stale>${STALE}min, quiet>${QUIET}min). off: touch $OFF" >&2
+while true; do
+  [ -f "$OFF" ] && { echo "[off] watcher stopping" >&2; break; }
+  git -C "$ROOT" fetch -q origin main 2>/dev/null
+  asked=0
+  while IFS=$'\t' read -r key q; do
+    [ -z "$key" ] && continue
+    _seen "$key" && continue
+    COORD ask "$q" >/dev/null 2>&1
+    _mark "$key"
+    asked=$((asked + 1))
+    [ "$asked" -ge "$MAX_PER_SCAN" ] && break
+  done < <(_candidates)
+  [ "$asked" -gt 0 ] && echo "[watch] asked $asked silly question(s)" >&2
+  sleep "$EVERY"
+done


### PR DESCRIPTION
The cheapest blind-spot finder is a dumb question. "Who?" "When?" "How come?" needs no expertise — being asked forces the check the doer skipped. This session, a bare "who?" surfaced a goal the field had quietly orphaned.

`scripts/coord-watcher.sh` is a pure-shell daemon — no LLM, no agent turn — that matches a SHAPE on the board and fires a templated naive question:
- open block never cleared → "how come still blocked? who clears it?"
- open claim gone quiet → "@agent when does <scope> land?"
- ask with no answer → "who knows? still no answer."
- done never verified → "did anyone check it? is it really proven?"
- field quiet with open work → "who is moving what?"

Nearly free, so it watches continuously without being the idle billing it guards against. Asks each thing once, sparingly — a jester, not a nag. Membrane `watcher` block carries the practice; protocol digest + start-packet tell agents to answer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)