### PR TITLE
tend: route ts-eval through lang-typescript native eval

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-07_ts_eval_lang_typescript.json
+++ b/docs/system_audit/commit_evidence_2026-06-07_ts_eval_lang_typescript.json
@@ -1,0 +1,79 @@
+{
+  "date": "2026-06-07",
+  "thread_branch": "cursor/ts-bmf-compost-rules-20260607",
+  "commit_scope": "Route ts-eval through lang-typescript.ts native parser/evaluator; keep ts-compile/ts-run/ts-trace on legacy lang-ts until .fk emitter lands.",
+  "files_owned": [
+    "form/form-kernel-ts/seedbank/ts-adapter/src/main.ts",
+    "form/form-kernel-ts/src/lang-typescript.ts",
+    "docs/system_audit/commit_evidence_2026-06-07_ts_eval_lang_typescript.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form/form-kernel-ts && npx tsx src/lang-typescript.test.ts",
+      "cd form/form-kernel-ts && bash seedbank/ts-adapter/scripts/parity_suite.sh"
+    ],
+    "results": {
+      "lang_typescript_tests": "36/36 passed",
+      "parity_suite_ts": "5 passing, 0 failing (arith, recursion, arrow, accumulator, composition)"
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Await PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "notes": "Form-kernel-ts adapter path only; no production API route change."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_by": [
+      "ci_validation pending until PR checks pass",
+      "ts-compile/ts-run still emit via lang-ts-fk.ts — next compost slice"
+    ]
+  },
+  "idea_ids": [
+    "idea:substrate-living-signal"
+  ],
+  "spec_ids": [
+    "spec:substrate-compiler"
+  ],
+  "task_ids": [
+    "task:ts-bmf-compost-rules"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "cursor",
+      "contributor_type": "machine",
+      "roles": [
+        "coder",
+        "validator"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Cursor",
+    "version": "auto"
+  },
+  "evidence_refs": [
+    "form/form-kernel-ts/seedbank/ts-adapter/scripts/parity_suite.sh",
+    "form/form-kernel-ts/src/lang-typescript.test.ts"
+  ],
+  "change_files": [
+    "form/form-kernel-ts/seedbank/ts-adapter/src/main.ts",
+    "form/form-kernel-ts/src/lang-typescript.ts"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "ts-eval uses buildTypeScriptLanguage + evalTypeScriptValue; parity_suite stays 5/5 including arrow demo → 46.",
+    "public_endpoints": [
+      "form://form-kernel-ts/seedbank/ts-adapter/examples/ts_arrow_demo.ts"
+    ],
+    "test_flows": [
+      "npx tsx src/lang-typescript.test.ts — 36/36",
+      "bash seedbank/ts-adapter/scripts/parity_suite.sh — 5 passing"
+    ]
+  }
+}

--- a/form/form-kernel-ts/seedbank/ts-adapter/src/main.ts
+++ b/form/form-kernel-ts/seedbank/ts-adapter/src/main.ts
@@ -18,8 +18,13 @@ import { spawn } from "node:child_process";
 import { dirname, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Frame, Kernel, Trace, walk, type Value } from "../../../src/kernel.ts";
-import { evalTypeScript, parseTypeScript } from "./lang-ts.ts";
+import { parseTypeScript as parseTypeScriptLegacy } from "./lang-ts.ts";
 import { emitFk } from "./lang-ts-fk.ts";
+import {
+  buildTypeScriptLanguage,
+  parseTypeScript as parseTypeScriptNative,
+  evalTypeScriptValue,
+} from "../../../src/lang-typescript.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -57,7 +62,7 @@ async function runTsCompile(args: string[]): Promise<void> {
   const src = await readFile(inPath, "utf8");
 
   const k = new Kernel();
-  const tree = parseTypeScript(k, src);
+  const tree = parseTypeScriptLegacy(k, src);
   const fk = emitFk(k, tree);
 
   if (outArg === "-") {
@@ -80,7 +85,7 @@ async function runTsRun(args: string[]): Promise<void> {
   const src = await readFile(inPath, "utf8");
 
   const k = new Kernel();
-  const tree = parseTypeScript(k, src);
+  const tree = parseTypeScriptLegacy(k, src);
   const fk = emitFk(k, tree);
 
   const fkPath = inPath.endsWith(".ts")
@@ -116,9 +121,10 @@ async function runTsEval(args: string[]): Promise<void> {
   }
   const src = await readFile(args[0]!, "utf8");
   const k = new Kernel();
-  const tree = parseTypeScript(k, src);
-  const value = evalTypeScript(k, tree);
-  console.log(renderForParity(value));
+  const ts = buildTypeScriptLanguage(k);
+  const tree = parseTypeScriptNative(k, ts.grammar, src);
+  const value = evalTypeScriptValue(k, tree);
+  console.log(renderJsForParity(value));
 }
 
 async function runTsTrace(args: string[]): Promise<void> {
@@ -129,7 +135,7 @@ async function runTsTrace(args: string[]): Promise<void> {
   const src = await readFile(args[0]!, "utf8");
   const k = new Kernel();
   const parseStart = process.hrtime.bigint();
-  const tree = parseTypeScript(k, src);
+  const tree = parseTypeScriptLegacy(k, src);
   const parseNs = Number(process.hrtime.bigint() - parseStart);
 
   k.trace = new Trace();
@@ -149,10 +155,20 @@ async function runTsTrace(args: string[]): Promise<void> {
   console.log(JSON.stringify(report, null, 2));
 }
 
-// renderForParity — match the parity-comparison form. The TS demos end
-// with a bare expression; its value is what tsc / node prints when the
-// transpiled JS uses `console.log(<last>)`. Format here matches node's
-// default console output for primitive types.
+// renderJsForParity — lang-typescript.ts eval returns JS primitives.
+function renderJsForParity(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "number") return formatFloatJs(v);
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "string") return v;
+  if (typeof v === "bigint") return String(v);
+  if (Array.isArray(v)) return "[ " + v.map(renderJsForParity).join(", ") + " ]";
+  if (typeof v === "function") return "[Function]";
+  return String(v);
+}
+
+// renderForParity — legacy lang-ts.ts Value renderer (ts-trace / walk path).
 function renderForParity(v: Value): string {
   switch (v.kind) {
     case "f32":

--- a/form/form-kernel-ts/src/lang-typescript.ts
+++ b/form/form-kernel-ts/src/lang-typescript.ts
@@ -1867,18 +1867,29 @@ function applyBinOp(op: string, a: unknown, b: unknown): unknown {
 // evalTypeScript — walk a parsed program in a fresh environment seeded
 // with stdlib bindings. Returns the final environment so callers can
 // invoke declared functions.
-export function evalTypeScript(k: Kernel, recipe: NodeID): Env {
+function evalTypeScriptEnv(k: Kernel, recipe: NodeID): Env {
   const env = envNew();
   // Minimal stdlib bindings exercised by the test suite.
   env.vars.set("console", { log: (...args: unknown[]) => console.log(...args) });
   env.vars.set("Math", Math);
-  env.vars.set("JSON", JSON);
-  env.vars.set("Array", Array);
   env.vars.set("Map", Map);
   env.vars.set("Set", Set);
   env.vars.set("Promise", Promise);
+  env.vars.set("JSON", JSON);
+  env.vars.set("Array", Array);
+  return env;
+}
+
+export function evalTypeScript(k: Kernel, recipe: NodeID): Env {
+  const env = evalTypeScriptEnv(k, recipe);
   evalNode(k, recipe, env);
   return env;
+}
+
+// evalTypeScriptValue — last program value for parity gates (ts-eval).
+export function evalTypeScriptValue(k: Kernel, recipe: NodeID): unknown {
+  const env = evalTypeScriptEnv(k, recipe);
+  return evalNode(k, recipe, env);
 }
 
 export function callFunction(env: Env, name: string, ...args: unknown[]): unknown {


### PR DESCRIPTION
## Summary
- Switch `ts-eval` in the TS adapter to `lang-typescript.ts` (`buildTypeScriptLanguage`, `parseTypeScriptNative`, `evalTypeScriptValue`) instead of legacy `lang-ts.ts` walker
- Add `evalTypeScriptValue()` export for parity gates; keep `ts-compile` / `ts-run` / `ts-trace` on legacy path until `.fk` emitter lands
- Body-want #2 bootstrap compost: native eval path proven before full lang-ts replacement

## Test plan
- [x] `cd form/form-kernel-ts && npx tsx src/lang-typescript.test.ts` → 36/36
- [x] `cd form/form-kernel-ts && bash seedbank/ts-adapter/scripts/parity_suite.sh` → 5/5 (arrow demo → 46)
- [ ] CI green


Made with [Cursor](https://cursor.com)