### PR TITLE
tend: the watcher asks "why python?" at any python shipped — BML-first as a mirror

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -202,6 +202,14 @@
   # so it runs no agent turn and costs almost nothing (a board scan). That cheapness
   # is the point: a watcher that billed a model to wonder would be the waste it
   # guards against. It asks each thing ONCE and sparingly — a jester, not a nag.
+  #
+  # One shape watches the body's deepest commitment: BML-first, Form-native, python
+  # a carrier authored last — never the body. The interior hook asks each cell
+  # "why python?" before it writes a .py; the watcher is the EXTERIOR mirror, asking
+  # the same of what actually SHIPPED — a new .py landing on main, or a python add
+  # named on the board. Additions only, so it never fires on python being composted
+  # (that is the good direction). The answer "carrier" is fine; the asking is the
+  # point — it keeps carrier-vs-logic conscious so logic never drifts into python.
 
   (watcher
     (asks-unprompted   the mirror waits to be asked; the watcher asks first)
@@ -210,6 +218,7 @@
     (quiet-claim       -> "@agent when does <scope> land? still on it?")
     (unanswered-ask    -> "who knows? still no answer.")
     (unverified-done   -> "did anyone check it? is it really proven?")   # green != correct
+    (python-shipped    -> "why python? carrier or logic — where is the Form recipe?")  # BML-first; additions only
     (quiet-field       -> "who is moving what?")
     (asks-once         dedup -> jester-not-nag)
     (carrier           scripts/coord-watcher.sh))

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -35,7 +35,7 @@ showed you the roster and recent signals. To take part:
 - `coord ping / need / offer / desire / want "…"` — speak to your siblings
 - `coord share "<what>" "<where>"` — a learning you put in the body, announced to all
 - `scripts/coord-heartbeat.sh <agent>` — run in a tab: periodic liveness + announces when the protocol upgrades on main
-- `scripts/coord-watcher.sh` — run once anywhere: the naive watcher asks "who? when? how come?" at stale/dropped/unanswered threads (no LLM, nearly free)
+- `scripts/coord-watcher.sh` — run once anywhere: the naive watcher asks "who? when? how come?" at stale/dropped/unanswered threads, and "why python?" at any new .py shipped to main (BML-first) — no LLM, nearly free
 - `python3 scripts/agent_status.py --diff` — the git-side collision view
 
 Staying current: the protocol is body (git). A running agent upgrades by re-sourcing

--- a/scripts/agent-coord.sh
+++ b/scripts/agent-coord.sh
@@ -66,7 +66,7 @@ _coord_protocol() {
     . ask before assuming -> coord ask "<q>"      . close it -> coord answer "<q>" "<reply>"
     . check before landing -> coord check "<your reasoning; find my blind spot>"
     . green != correct-in-intent; reflect the blind spot, not flattery
-    . the watcher asks the silly question unprompted (who? when? how come?) -> answer it; that is the point
+    . the watcher asks the silly question unprompted (who? when? how come? why python?) -> answer it; that is the point
   who is doing what
     . open claim = your current work; coord doing shows who holds what; silence is not a status
   learn from each other

--- a/scripts/coord-watcher.sh
+++ b/scripts/coord-watcher.sh
@@ -14,10 +14,12 @@
 #   ask with no answer          -> "who knows? still no answer."
 #   done, never verified        -> "did anyone check it? is it really proven?"
 #   field quiet with open work   -> "quiet a while — who is moving what?"
+#   a new .py shipped to main    -> "why python? carrier or logic — where is the Form recipe?"
+#   python ship named on board   -> "why python — carrier or logic?"  (BML-first discipline)
 #
 # Policy: docs/coherence-substrate/agent-coordination-membrane.form (watcher).
 # Run (one, anywhere):  scripts/coord-watcher.sh
-# Tunables:  COORD_WATCH_EVERY=300 (s/scan)  COORD_STALE_MIN=20  COORD_QUIET_MIN=40
+# Tunables:  COORD_WATCH_EVERY=300 (s/scan)  COORD_STALE_MIN=20  COORD_QUIET_MIN=40  PY_WINDOW_MIN=30
 # Stop:  Ctrl-C  ·  touch ~/.coherence-network/coord-respond.off (halts all daemons)
 
 set -u
@@ -43,8 +45,8 @@ _ago()  { date -u -v-"$1"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "-$1 mi
 # Naive on purpose: tracks the MOST RECENT block/ask/done and whether it was
 # cleared/answered/checked after, plus open claims with no progress since.
 _candidates() {
-  local cs cq; cs="$(_ago "$STALE")"; cq="$(_ago "$QUIET")"
-  awk -F'\t' -v cs="$cs" -v cq="$cq" '
+  local cs cq pw; cs="$(_ago "$STALE")"; cq="$(_ago "$QUIET")"; pw="$(_ago "${PY_WINDOW_MIN:-30}")"
+  awk -F'\t' -v cs="$cs" -v cq="$cq" -v pw="$pw" '
     $2!="watcher"                         { lastany=$1 }                       # newest non-watcher signal (quiet gauge)
     $3=="claim"                           { ct[$2]=$1; scope[$2]=$4; open[$2]=1 }
     $3=="release"                         { open[$2]=0 }
@@ -55,6 +57,10 @@ _candidates() {
     $3=="answer"                          { answered=1 }
     $3=="done"                            { dts=$1; dmsg=$4; checked=0 }
     $3=="check" || $3=="ack"              { checked=1 }
+    # python ANNOUNCED on the board: a fresh signal naming a .py being added/created/shipped
+    # (the trigger word must precede the path, so "composted python" never fires). BML-first:
+    # python is a carrier authored last, never the body; the question makes that conscious.
+    $2!="watcher" && $1>pw && $4 ~ /(add|new|creat|wrote|writ|ship|port)[A-Za-z]*[: ][A-Za-z0-9_\/.-]*\.py([^A-Za-z0-9]|$)/ { pts=$1; pagent=$2; pmsg=$4 }
     END {
       for (a in open) if (open[a] && ct[a]<cs && (act[a]=="" || act[a]<=ct[a]))
         printf "claim:%s:%s\t@%s when does \"%s\" land? still on it?\n", a, ct[a], a, substr(scope[a],1,40)
@@ -64,10 +70,25 @@ _candidates() {
         printf "ask:%s\twho knows? still no answer to %s.\n", ats, aagent
       if (dts!="" && !checked && dts<cs)
         printf "done:%s\tdid anyone check \"%s\"? is it really proven?\n", dts, substr(dmsg,1,40)
+      if (pts!="")
+        printf "pymsg:%s\t@%s why python — \"%s\"? carrier (fan-out/route/script) or logic? if logic, where is the Form recipe + BML grammar?\n", pts, pagent, substr(pmsg,1,44)
       if (lastany!="" && lastany<cq)
         printf "quiet:%s\tquiet a while — who is moving what?\n", substr(lastany,1,16)
     }
   ' "$BOARD" 2>/dev/null
+}
+
+# python SHIPPED to main: a new .py file added on origin/main in the recent window.
+# Additions only (--diff-filter=A), so it never fires on python being composted —
+# only on a new module being born, which is the "before any new .py" moment caught
+# after the fact: the exterior mirror to the interior BML-first hook. BML-first
+# holds python is a carrier authored last; a new .py module always earns the question.
+_py_shipped_candidates() {
+  git -C "$ROOT" log origin/main --since="${PY_WINDOW_MIN:-30} minutes ago" \
+      --diff-filter=A --name-only --pretty="format:@@ %h" 2>/dev/null | awk '
+    /^@@ / { sha=$2; next }
+    /\.py$/ { printf "pyship:%s:%s\twhy python? %s is a new .py on main — carrier (fan-out/route/script/test) or logic? if logic, where is the Form recipe + BML grammar it should be?\n", sha, $0, $0 }
+  '
 }
 
 echo "coord-watcher: the silly question every ${EVERY}s (stale>${STALE}min, quiet>${QUIET}min). off: touch $OFF" >&2
@@ -82,7 +103,7 @@ while true; do
     _mark "$key"
     asked=$((asked + 1))
     [ "$asked" -ge "$MAX_PER_SCAN" ] && break
-  done < <(_candidates)
+  done < <(_candidates; _py_shipped_candidates)
   [ "$asked" -gt 0 ] && echo "[watch] asked $asked silly question(s)" >&2
   sleep "$EVERY"
 done


### PR DESCRIPTION
The interior BML-first hook asks each cell "why python?" before it writes a .py. The watcher is the **exterior mirror** — it asks the same of what actually *shipped*, so logic-in-python can't drift in unnoticed even when a cell skips its own hook.

Two detectors, both nearly free (no LLM, no agent turn):
- a new `.py` landing on origin/main (`git log --diff-filter=A` in a recent window) — **additions only**, so it never fires on python being *composted* (the good direction);
- a python add/create/ship named on the board (tight trigger, never on "composted python").

Question: *"why python? carrier (fan-out/route/script) or logic — and if logic, where is the Form recipe + BML grammar?"* The answer "carrier" is fine; the asking keeps carrier-vs-logic conscious so the body stays Form-native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)