### PR TITLE
tend: name-check resolves local scope (params + let) — the resolver a compile gate needs

### DIFF
--- a/form/form-stdlib/name-check.fk
+++ b/form/form-stdlib/name-check.fk
@@ -74,23 +74,54 @@
             acc
             (nc-collect-kids (tail xs) (nc-collect (head xs) acc))))
 
-    ;; --- PASS 2: walk, resolving every FNCALL callee + IDENT value --------
-    ;; A reference that doesn't resolve is consed onto `acc`. Children are
-    ;; always walked (so FNCALL args are checked); the callee STRING trivial
-    ;; itself is a leaf with no children, so it is never double-counted.
+    ;; --- scope: the locals a node introduces ------------------------------
+    ;; PASS 2 must resolve like the evaluator, which binds params and `let`
+    ;; names into `env` by name (RB_IDENT looks up locals and globals the same
+    ;; way). So the walk threads a growing name-set: a FNDEF binds its params
+    ;; for its BODY (child scope); a LET binds its name for the siblings that
+    ;; FOLLOW it in the same block (sibling scope). Without this, every param
+    ;; and let-var reference would be reported as unresolved — a scope-blind
+    ;; checker that cannot gate a real compile. Node shapes (from the kernel):
+    ;; FNDEF kids = [name params body]; LET = BLOCK(type 9)/inst RBLK_LET(3),
+    ;; kids = [name value]; a params node's children are the param-name leaves.
+    (defn nc-FNDEF-params (n) (head (tail (node_children n))))           ; kids[1]
+    (defn nc-FNDEF-body   (n) (head (tail (tail (node_children n)))))    ; kids[2]
+    (defn nc-add-names (xs defs)
+        (if (nc-empty? xs)
+            defs
+            (nc-add-names (tail xs) (cons (node_value (head xs)) defs))))
+    (defn nc-let? (n)
+        (if (eq (node_type n) 9)                                         ; RB_BLOCK
+            (eq (node_inst (node_category n)) 3)                         ; RBLK_LET (category inst, not node inst)
+            false))
+    (defn nc-let-name (n) (node_value (head (node_children n))))         ; kids[0]
+    (defn nc-scope-after (n defs)
+        (if (nc-let? n) (cons (nc-let-name n) defs) defs))
+
+    ;; --- PASS 2: walk, scope-aware, resolving every FNCALL callee + IDENT --
+    ;; A reference outside the in-scope set is consed onto `acc`. A FNDEF checks
+    ;; only its BODY (its name + params are bindings, not references), with its
+    ;; params added to scope. Other nodes walk their children; nc-check-kids
+    ;; threads each LET's binding to the siblings after it.
     (defn nc-check (n defs acc)
-        (if (eq (node_type n) (nc-FNCALL))
-            (nc-check-ref (nc-head-name n) n defs acc)
-            (if (eq (node_type n) (nc-IDENT))
+        (if (eq (node_type n) (nc-FNDEF))
+            (nc-check (nc-FNDEF-body n)
+                      (nc-add-names (node_children (nc-FNDEF-params n)) defs)
+                      acc)
+            (if (eq (node_type n) (nc-FNCALL))
                 (nc-check-ref (nc-head-name n) n defs acc)
-                (nc-check-kids (node_children n) defs acc))))
+                (if (eq (node_type n) (nc-IDENT))
+                    (nc-check-ref (nc-head-name n) n defs acc)
+                    (nc-check-kids (node_children n) defs acc)))))
     (defn nc-check-ref (name n defs acc)
         (nc-check-kids (node_children n) defs
             (if (nc-member? name defs) acc (cons name acc))))
     (defn nc-check-kids (xs defs acc)
         (if (nc-empty? xs)
             acc
-            (nc-check-kids (tail xs) defs (nc-check (head xs) defs acc))))
+            (nc-check-kids (tail xs)
+                           (nc-scope-after (head xs) defs)
+                           (nc-check (head xs) defs acc))))
 
     ;; --- the surface: walk a program recipe, return its unresolved names ---
     ;; `known` seeds the resolvable set (the kernel natives + any already-loaded

--- a/form/form-stdlib/tests/name-check-band.fk
+++ b/form/form-stdlib/tests/name-check-band.fk
@@ -3,20 +3,27 @@
 ;
 ; preludes: form-stdlib/name-check.fk
 ;
-; Builds four programs with intern_node (so the test needs no source→recipe
+; Builds programs with intern_node (so the test needs no source→recipe
 ; reflection) and asserts name-check's verdict on each:
 ;   1. a call to the native `print`          → resolves (empty)
 ;   2. a call to an undefined name           → reported (one name)
 ;   3. a defn + a call to that defn          → resolves (empty)
 ;   4. the same defn + a call to a missing    → reported (one name)
-; Cases 1/2 prove the native test; 3/4 prove defn-collection + the walk. The
-; printed verdict is deterministic, so the three sibling kernels must agree.
+;   5. a defn whose body references its PARAM → resolves (empty)   [scope]
+;   6. a `let` then a use of the bound name   → resolves (empty)   [scope]
+;   7. a `let` then a use of a MISSING name   → reported (one name) [scope]
+; Cases 1/2 prove the native test; 3/4 prove defn-collection + the walk; 5/6/7
+; prove scope — a param is bound for its body, a let for the siblings that follow
+; it. Without scope, 5 and 6 would false-report, and the checker could not gate
+; real code. The printed verdict is deterministic, so the three siblings agree.
 
 (do
     (let fncall-cat (make_nodeid 1 2 32 1))
     (let fndef-cat  (make_nodeid 1 2 31 1))
+    (let ident-cat  (make_nodeid 1 2 33 1))
     (let seq-cat    (make_nodeid 1 2 9 2))
     (let do-cat     (make_nodeid 1 2 9 1))
+    (let let-cat    (make_nodeid 1 2 9 3))
 
     (let good (intern_node fncall-cat
                   (list (intern_trivial_string "print") (intern_trivial_int 1))))
@@ -32,6 +39,16 @@
     (let prog-ok  (intern_node do-cat (list fndef call-foo)))
     (let prog-bad (intern_node do-cat (list fndef call-bar)))
 
+    ;; case 5 — scope: (defn g (x) x), body references its own parameter
+    (let param-fn (intern_node fndef-cat
+                      (list (intern_trivial_string "g")
+                            (intern_node seq-cat (list (intern_trivial_string "x")))
+                            (intern_node ident-cat (list (intern_trivial_string "x"))))))
+    ;; cases 6/7 — scope: (do (let y 1) <ref>); the let binds y for the next sibling
+    (let let-bind (intern_node let-cat (list (intern_trivial_string "y") (intern_trivial_int 1))))
+    (let prog-let-ok  (intern_node do-cat (list let-bind (intern_node ident-cat (list (intern_trivial_string "y"))))))
+    (let prog-let-bad (intern_node do-cat (list let-bind (intern_node ident-cat (list (intern_trivial_string "z"))))))
+
     ;; `known` seeds the resolvable set with the builtin name this test uses.
     (let known (list "print"))
 
@@ -39,7 +56,10 @@
         (and (eq (len (name-check good known)) 0)
         (and (eq (len (name-check bad known)) 1)
         (and (eq (len (name-check prog-ok known)) 0)
-             (eq (len (name-check prog-bad known)) 1)))))
+        (and (eq (len (name-check prog-bad known)) 1)
+        (and (eq (len (name-check param-fn known)) 0)
+        (and (eq (len (name-check prog-let-ok known)) 0)
+             (eq (len (name-check prog-let-bad known)) 1))))))))
 
     (print (if pass "name-check-band: PASS" "name-check-band: FAIL"))
 )


### PR DESCRIPTION
**Why:** the body already has a Form-native resolution walk (`name-check.fk`, designed in `name-resolution-as-recipe.form`) — but it was scope-blind: it collected only `defn` names, so every parameter and `let`-bound reference was reported as unresolved. Proven by a new band case (a defn whose body uses its own parameter flagged the parameter). That's why it sat shelved and uncalled — wired as a gate it would block all real code.

**Fix:** the walk now threads scope like the evaluator's `env` — a FNDEF binds its params for its body (child scope); a LET binds its name for the siblings after it (sibling scope). LET is detected by *category* inst (`RBLK_LET=3` via `node_category`), not the node's content-addressed instance.

**Proof:** band extended 4 → 7 cases — param-in-body and let-then-use resolve clean; let-then-missing still reported. Three-way via `node_category`/`node_inst`, which Go/Rust/TS all carry. (Verified PASS on the rust kernel; CI runs the three-way.)

This is the resolver the compile-time gate needs. **Next PR:** wire `name-check-clean?` into the source-compile path so unbound symbols fail at compile, not at serve — the `health_route_from_class` class of silent rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)